### PR TITLE
BlobProperties cleanup (TTL and UserMetadataSize)

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/coordinator/Coordinator.java
+++ b/ambry-api/src/main/java/com.github.ambry/coordinator/Coordinator.java
@@ -57,6 +57,8 @@ public interface Coordinator {
    */
   ByteBuffer getBlobUserMetadata(String blobId) throws CoordinatorException;
 
+  // TODO: Add interface 'BlobInfo getBlobInfo(String blobId)' to coordinator
+
   /**
    * Gets the blob that corresponds to the specified blob id.
    *

--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -1,6 +1,7 @@
 package com.github.ambry.messageformat;
 
 import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Utils;
 
 /**
  * The properties of a blob that the client can set at time of put. The blob size and serviceId are mandatory fields and
@@ -13,12 +14,8 @@ public class BlobProperties {
   protected String ownerId;
   protected String contentType;
   protected boolean isPrivate;
-  protected long timeToLiveInMs;
-  protected int userMetadataSize;
+  protected long timeToLiveInSeconds;
   protected long creationTimeInMs;
-
-
-  public static final long Infinite_TTL = -1;
 
   /**
    * @param blobSize The size of the blob in bytes
@@ -30,8 +27,7 @@ public class BlobProperties {
          null,
          null,
          false,
-         0,
-         Infinite_TTL);
+         Utils.Infinite_Time);
   }
 
   /**
@@ -40,22 +36,18 @@ public class BlobProperties {
    * @param ownerId The owner of the blob (For example , memberId or groupId)
    * @param contentType The content type of the blob (eg: mime). Can be Null
    * @param isPrivate Is the blob secure
-   * @param usermetadataSize The size of the usermetadata stored with this blob.
-   *                         It is zero if there is no usermetadata
    */
   public BlobProperties(long blobSize,
                         String serviceId,
                         String ownerId,
                         String contentType,
-                        boolean isPrivate,
-                        int usermetadataSize) {
+                        boolean isPrivate) {
     this(blobSize,
          serviceId,
          ownerId,
          contentType,
          isPrivate,
-         usermetadataSize,
-         Infinite_TTL);
+         Utils.Infinite_Time);
   }
 
   /**
@@ -64,81 +56,45 @@ public class BlobProperties {
    * @param ownerId The owner of the blob (For example , memberId or groupId)
    * @param contentType The content type of the blob (eg: mime). Can be Null
    * @param isPrivate Is the blob secure
-   * @param usermetadataSize The size of the usermetadata stored with this blob.
-   *                         It is zero if there is no usermetadata
-   * @param timeToLiveInMs The System time in ms when the blob needs to be deleted
+   * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
    */
   public BlobProperties(long blobSize,
                         String serviceId,
                         String ownerId,
                         String contentType,
                         boolean isPrivate,
-                        int usermetadataSize,
-                        long timeToLiveInMs) {
+                        long timeToLiveInSeconds) {
     this.blobSize = blobSize;
     this.serviceId = serviceId;
     this.ownerId = ownerId;
     this.contentType = contentType;
     this.isPrivate = isPrivate;
-    this.timeToLiveInMs = timeToLiveInMs;
-    this.userMetadataSize = usermetadataSize;
+    this.timeToLiveInSeconds = timeToLiveInSeconds;
     this.creationTimeInMs = SystemTime.getInstance().milliseconds();
   }
 
-  public void setTimeToLiveInMs(long timeToLiveInMs) {
-    this.timeToLiveInMs = timeToLiveInMs;
-  }
-
-  public long getTimeToLiveInMs() {
-    return timeToLiveInMs;
-  }
-
-  public void setBlobSize(long blobSize) {
-    this.blobSize = blobSize;
+  public long getTimeToLiveInSeconds() {
+    return timeToLiveInSeconds;
   }
 
   public long getBlobSize() {
     return blobSize;
   }
 
-  public void setPrivate() {
-    isPrivate = true;
-  }
-
   public boolean isPrivate() {
     return isPrivate;
-  }
-
-  public void setOwnerId(String id) {
-    ownerId = id;
   }
 
   public String getOwnerId() {
     return ownerId;
   }
 
-  public void setContentType(String contentType) {
-    this.contentType = contentType;
-  }
-
   public String getContentType() {
     return contentType;
   }
 
-  public void setServiceId(String serviceId) {
-    this.serviceId = serviceId;
-  }
-
   public String getServiceId() {
     return serviceId;
-  }
-
-  public void setUserMetadataSize(int usermetadataSize) {
-    this.userMetadataSize = usermetadataSize;
-  }
-
-  public int getUserMetadataSize() {
-    return userMetadataSize;
   }
 
   public long getCreationTimeInMs() {

--- a/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
@@ -6,22 +6,22 @@ package com.github.ambry.store;
 public class MessageInfo {
   private StoreKey key;
   private long size;
-  private long timeToLiveInMs;
+  private long expirationTimeInMs;
   private boolean isDeleted;
 
-  public MessageInfo(StoreKey key, long size, long timeToLiveInMs) {
-    this(key, size, false, timeToLiveInMs);
+  public MessageInfo(StoreKey key, long size, long expirationTimeInMs) {
+    this(key, size, false, expirationTimeInMs);
   }
 
   public MessageInfo(StoreKey key, long size, boolean deleted) {
     this(key, size, deleted, -1);
   }
 
-  public MessageInfo(StoreKey key, long size, boolean deleted, long timeToLiveInMs) {
+  public MessageInfo(StoreKey key, long size, boolean deleted, long expirationTimeInMs) {
     this.key = key;
     this.size = size;
     this.isDeleted = deleted;
-    this.timeToLiveInMs = timeToLiveInMs;
+    this.expirationTimeInMs = expirationTimeInMs;
   }
 
   public MessageInfo(StoreKey key, long size) {
@@ -36,8 +36,8 @@ public class MessageInfo {
     return size;
   }
 
-  public long getTimeToLiveInMs() {
-    return timeToLiveInMs;
+  public long getExpirationTimeInMs() {
+    return expirationTimeInMs;
   }
 
   public boolean isDeleted() {

--- a/ambry-coordinator/src/main/java/com.github.ambry.coordinator/CancelTTLOperation.java
+++ b/ambry-coordinator/src/main/java/com.github.ambry.coordinator/CancelTTLOperation.java
@@ -1,8 +1,8 @@
 package com.github.ambry.coordinator;
 
 import com.github.ambry.clustermap.ReplicaId;
-import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.shared.*;
+import com.github.ambry.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +36,7 @@ final public class CancelTTLOperation extends Operation {
   @Override
   protected OperationRequest makeOperationRequest(ReplicaId replicaId) {
     TTLRequest ttlRequest = new TTLRequest(context.getCorrelationId(), context.getClientId(), blobId,
-                                           BlobProperties.Infinite_TTL);
+                                           Utils.Infinite_Time);
     return new CancelTTLOperationRequest(connectionPool,
                                          responseQueue,
                                          context,

--- a/ambry-coordinator/src/test/java/com.github.ambry.coordinator/CoordinatorTest.java
+++ b/ambry-coordinator/src/test/java/com.github.ambry.coordinator/CoordinatorTest.java
@@ -9,6 +9,7 @@ import com.github.ambry.messageformat.BlobOutput;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.store.StoreException;
 import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.Utils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -566,7 +567,12 @@ public class CoordinatorTest {
 
   void PutGetDelete(AmbryCoordinator ac) throws InterruptedException, StoreException, IOException,
           CoordinatorException {
-    BlobProperties putBlobProperties = new BlobProperties(100, "serviceId", "memberId", "contentType", false, 0, -1);
+    BlobProperties putBlobProperties = new BlobProperties(100,
+                                                          "serviceId",
+                                                          "memberId",
+                                                          "contentType",
+                                                          false,
+                                                          Utils.Infinite_Time);
     ByteBuffer putUserMetadata = ByteBuffer.allocate(10);
     for (byte b = 0; b < 10; b++) {
       putUserMetadata.put(b);
@@ -660,7 +666,12 @@ public class CoordinatorTest {
   void PutRemoteGetDelete(AmbryCoordinator acOne,
                           AmbryCoordinator acTwo) throws InterruptedException, StoreException, IOException,
           CoordinatorException {
-    BlobProperties putBlobProperties = new BlobProperties(100, "serviceId", "memberId", "contentType", false, 0, -1);
+    BlobProperties putBlobProperties = new BlobProperties(100,
+                                                          "serviceId",
+                                                          "memberId",
+                                                          "contentType",
+                                                          false,
+                                                          Utils.Infinite_Time);
     ByteBuffer putUserMetadata = ByteBuffer.allocate(10);
     for (byte b = 0; b < 10; b++) {
       putUserMetadata.put(b);

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertySerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertySerDe.java
@@ -1,9 +1,10 @@
 package com.github.ambry.messageformat;
 
 import com.github.ambry.utils.Utils;
+
 import java.io.DataInputStream;
-import java.nio.ByteBuffer;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 // A class that derives from blob properties. It is mainly used to set
 // properties in BlobProperties that are not user editable
@@ -13,13 +14,13 @@ class SystemMetadata extends BlobProperties {
                         String ownerId,
                         String contentType,
                         boolean isPrivate,
-                        long timeToLiveInMs,
-                        int userMetadataSize,
+                        long timeToLiveInSeconds,
                         long creationTime) {
-    super(blobSize, serviceId, ownerId, contentType, isPrivate, userMetadataSize, timeToLiveInMs);
+    super(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds);
     this.creationTimeInMs = creationTime;
   }
 }
+
 /**
  * Serializes and deserializes BlobProperties
  */
@@ -30,14 +31,12 @@ public class BlobPropertySerDe {
   public static final int CreationTime_Field_Size_In_Bytes = 8;
   public static final int Variable_Field_Size_In_Bytes = 4;
   public static final int BlobSize_Field_Size_In_Bytes = 8;
-  public static final int UserMetadataSize_Field_Size_In_Bytes = 4;
 
   public static int getBlobPropertySize(BlobProperties properties) {
     return TTL_Field_Size_In_Bytes +
            Private_Field_Size_In_Bytes +
            CreationTime_Field_Size_In_Bytes +
            BlobSize_Field_Size_In_Bytes +
-           UserMetadataSize_Field_Size_In_Bytes +
            Variable_Field_Size_In_Bytes + Utils.getNullableStringLength(properties.getContentType()) +
            Variable_Field_Size_In_Bytes + Utils.getNullableStringLength(properties.getOwnerId()) +
            Variable_Field_Size_In_Bytes + Utils.getNullableStringLength(properties.getServiceId());
@@ -48,19 +47,17 @@ public class BlobPropertySerDe {
     boolean isPrivate = stream.readByte() == 1 ? true : false;
     long creationTime = stream.readLong();
     long blobSize = stream.readLong();
-    int userMetadataSize = stream.readInt();
     String contentType = Utils.readIntString(stream);
     String ownerId = Utils.readIntString(stream);
     String serviceId = Utils.readIntString(stream);
-    return new SystemMetadata(blobSize, serviceId, ownerId, contentType, isPrivate, ttl, userMetadataSize, creationTime);
+    return new SystemMetadata(blobSize, serviceId, ownerId, contentType, isPrivate, ttl, creationTime);
   }
 
   public static void putBlobPropertyToBuffer(ByteBuffer outputBuffer, BlobProperties properties) {
-    outputBuffer.putLong(properties.getTimeToLiveInMs());
-    outputBuffer.put(properties.isPrivate() ? (byte) 1 : (byte) 0);
+    outputBuffer.putLong(properties.getTimeToLiveInSeconds());
+    outputBuffer.put(properties.isPrivate() ? (byte)1 : (byte)0);
     outputBuffer.putLong(properties.getCreationTimeInMs());
     outputBuffer.putLong(properties.getBlobSize());
-    outputBuffer.putInt(properties.getUserMetadataSize());
     Utils.serializeNullableString(outputBuffer, properties.getContentType());
     Utils.serializeNullableString(outputBuffer, properties.getOwnerId());
     Utils.serializeNullableString(outputBuffer, properties.getServiceId());

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
@@ -1,6 +1,7 @@
 package com.github.ambry.messageformat;
 
 import com.github.ambry.store.*;
+import com.github.ambry.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,9 +54,11 @@ public class BlobStoreRecovery implements MessageStoreRecovery {
               // for validity
               MessageFormatRecord.deserializeUserMetadata(stream);
               MessageFormatRecord.deserializeBlob(stream);
-              MessageInfo info = new MessageInfo(key,
-                                                 header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
-                                                 properties.getTimeToLiveInMs());
+              MessageInfo info =
+                      new MessageInfo(key,
+                                      header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
+                                      Utils.addSecondsToEpochTime(properties.getCreationTimeInMs(),
+                                                                  properties.getTimeToLiveInSeconds()));
               messageRecovered.add(info);
             }
             else if (headerFormat.getTTLRecordRelativeOffset() != MessageFormatRecord.Message_Header_Invalid_Relative_Offset) {
@@ -93,7 +96,7 @@ public class BlobStoreRecovery implements MessageStoreRecovery {
     if (logger.isInfoEnabled()) {
       for (MessageInfo messageInfo : messageRecovered)
         logger.info("Message Recovered key {} size {} ttl {} deleted {}",
-                messageInfo.getStoreKey(), messageInfo.getSize(), messageInfo.getTimeToLiveInMs(), messageInfo.isDeleted());
+                messageInfo.getStoreKey(), messageInfo.getSize(), messageInfo.getExpirationTimeInMs(), messageInfo.isDeleted());
     }
     return messageRecovered;
   }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/TTLMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/TTLMessageFormatInputStream.java
@@ -1,6 +1,7 @@
 package com.github.ambry.messageformat;
 
 import com.github.ambry.store.StoreKey;
+import com.github.ambry.utils.Utils;
 
 import java.nio.ByteBuffer;
 
@@ -20,7 +21,7 @@ import java.nio.ByteBuffer;
 public class TTLMessageFormatInputStream extends MessageFormatInputStream {
 
   public TTLMessageFormatInputStream(StoreKey key, long timeToLiveInMs) throws MessageFormatException {
-    if (timeToLiveInMs < BlobProperties.Infinite_TTL) {
+    if (timeToLiveInMs < Utils.Infinite_Time) {
       logger.error("Invalid TTL {}", timeToLiveInMs);
       throw new IllegalArgumentException("Invalid TTL " + timeToLiveInMs);
     }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -1,19 +1,19 @@
 package com.github.ambry.messageformat;
 
-import java.nio.ByteBuffer;
-import java.util.Random;
-
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Crc32;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
 
 public class MessageFormatRecordTest {
   @Test
   public void deserializeTest() {
     try {
       // Test Blob property V1 Record
-      BlobProperties properties = new BlobProperties(1234, "id", "member", "test", true, 0, 1234);
+      BlobProperties properties = new BlobProperties(1234, "id", "member", "test", true, 1234);
       ByteBuffer stream = ByteBuffer.allocate(MessageFormatRecord.BlobProperty_Format_V1.getBlobPropertyRecordSize(properties));
       MessageFormatRecord.BlobProperty_Format_V1.serializeBlobPropertyRecord(stream, properties);
       stream.flip();

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -163,7 +163,7 @@ public class ReplicationTest {
       messageInfoList.set(index, new MessageInfo(messageInfoFound.getStoreKey(),
               messageInfoFound.getSize(),
               true,
-              messageInfoFound.getTimeToLiveInMs()));
+              messageInfoFound.getExpirationTimeInMs()));
     }
 
     @Override

--- a/ambry-server/src/test/java/com.github.ambry.server/ServerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/ServerTest.java
@@ -1,14 +1,32 @@
 package com.github.ambry.server;
 
-import com.github.ambry.clustermap.*;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockPartitionId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.coordinator.AmbryCoordinator;
 import com.github.ambry.coordinator.Coordinator;
 import com.github.ambry.coordinator.CoordinatorException;
-import com.github.ambry.messageformat.*;
-import com.github.ambry.replication.ReplicationException;
-import com.github.ambry.shared.*;
-import com.github.ambry.store.*;
+import com.github.ambry.messageformat.BlobOutput;
+import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.messageformat.MessageFormatException;
+import com.github.ambry.messageformat.MessageFormatFlags;
+import com.github.ambry.messageformat.MessageFormatRecord;
+import com.github.ambry.shared.BlobId;
+import com.github.ambry.shared.BlockingChannel;
+import com.github.ambry.shared.DeleteRequest;
+import com.github.ambry.shared.DeleteResponse;
+import com.github.ambry.shared.GetRequest;
+import com.github.ambry.shared.GetResponse;
+import com.github.ambry.shared.PutRequest;
+import com.github.ambry.shared.PutResponse;
+import com.github.ambry.shared.ServerErrorCode;
+import com.github.ambry.store.FindToken;
+import com.github.ambry.store.FindTokenFactory;
+import com.github.ambry.store.StoreException;
+import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.CrcInputStream;
 import com.github.ambry.utils.Utils;
@@ -16,12 +34,16 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.Random;
-import java.util.List;
 
 public class ServerTest {
 
@@ -410,7 +432,7 @@ public class ServerTest {
             FindToken token = factory.getFindToken(dataInputStream);
             ByteBuffer bytebufferToken = ByteBuffer.wrap(token.toBytes());
             Assert.assertEquals(bytebufferToken.getShort(), 0);
-            Assert.assertEquals(bytebufferToken.getLong(), 13086);
+            Assert.assertEquals(bytebufferToken.getLong(), 13062);
           }
           long crc = crcStream.getValue();
           Assert.assertEquals(crc, dataInputStream.readLong());

--- a/ambry-shared/src/main/java/com.github.ambry.shared/MessageInfoListSerde.java
+++ b/ambry-shared/src/main/java/com.github.ambry.shared/MessageInfoListSerde.java
@@ -1,13 +1,13 @@
 package com.github.ambry.shared;
 
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.store.MessageInfo;
+
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.store.MessageInfo;
 
 /**
  * A serde for serializing and deserializing list of message info
@@ -45,7 +45,7 @@ public class MessageInfoListSerde {
       for (MessageInfo messageInfo : messageInfoList) {
         outputBuffer.put(messageInfo.getStoreKey().toBytes());
         outputBuffer.putLong(messageInfo.getSize());
-        outputBuffer.putLong(messageInfo.getTimeToLiveInMs());
+        outputBuffer.putLong(messageInfo.getExpirationTimeInMs());
         outputBuffer.put(messageInfo.isDeleted() ? (byte)1 : 0);
       }
     }

--- a/ambry-shared/src/test/java/com/github/ambry/shared/RequestResponseTest.java
+++ b/ambry-shared/src/test/java/com/github/ambry/shared/RequestResponseTest.java
@@ -5,6 +5,7 @@ import com.github.ambry.clustermap.PartitionState;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.Utils;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -41,8 +42,7 @@ public class RequestResponseTest {
                                                        "memberId",
                                                        "contentType",
                                                        false,
-                                                       0,
-                                                       BlobProperties.Infinite_TTL);
+                                                       Utils.Infinite_Time);
 
     PutRequest request = new PutRequest(correlationId,
             clientId,

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobIndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobIndexValue.java
@@ -1,5 +1,8 @@
 package com.github.ambry.store;
 
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Utils;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -18,8 +21,6 @@ public class BlobIndexValue {
 
   public static int Index_Value_Size_In_Bytes = Blob_Size_In_Bytes + Offset_Size_In_Bytes +
                                                 Flag_Size_In_Bytes + Time_To_Live_Size_In_Bytes;
-
-  public static final int TTL_Infinite = -1;
 
   private ByteBuffer value;
 
@@ -43,7 +44,7 @@ public class BlobIndexValue {
   }
 
   public BlobIndexValue(long size, long offset) {
-    this(size, offset, (byte)0, TTL_Infinite);
+    this(size, offset, (byte)0, Utils.Infinite_Time);
   }
 
   public long getSize() {
@@ -64,6 +65,14 @@ public class BlobIndexValue {
 
   public long getTimeToLiveInMs() {
     return value.getLong(Blob_Size_In_Bytes + Offset_Size_In_Bytes + Flag_Size_In_Bytes);
+  }
+
+  public boolean isExpired() {
+    if (getTimeToLiveInMs() != Utils.Infinite_Time &&
+        SystemTime.getInstance().milliseconds() > getTimeToLiveInMs()) {
+      return true;
+    }
+    return false;
   }
 
   public void setTimeToLive(long timeToLiveInMs) {

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -141,7 +141,7 @@ public class BlobStore implements Store {
           BlobIndexValue value = new BlobIndexValue(info.getSize(),
                                                     writeStartOffset,
                                                     (byte)0,
-                                                    info.getTimeToLiveInMs());
+                                                    info.getExpirationTimeInMs());
           BlobIndexEntry entry = new BlobIndexEntry(info.getStoreKey(), value);
           indexEntries.add(entry) ;
           writeStartOffset += info.getSize();
@@ -190,7 +190,7 @@ public class BlobStore implements Store {
         List<MessageInfo> infoList = messageSetToUpdateTTL.getMessageSetInfo();
         for (MessageInfo info : infoList) {
           FileSpan fileSpan = new FileSpan(log.getLogEndOffset() - info.getSize(), log.getLogEndOffset());
-          index.updateTTL(info.getStoreKey(), info.getTimeToLiveInMs(), fileSpan);
+          index.updateTTL(info.getStoreKey(), info.getExpirationTimeInMs(), fileSpan);
         }
       }
       catch (IOException e) {

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobIndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobIndexTest.java
@@ -228,14 +228,14 @@ public class BlobIndexTest {
                 throws IOException {
           List<MessageInfo> infos = new ArrayList<MessageInfo>();
           infos.add(new MessageInfo(blobId4, 1000, true));
-          infos.add(new MessageInfo(blobId5, 1000, BlobIndexValue.TTL_Infinite));
+          infos.add(new MessageInfo(blobId5, 1000, Utils.Infinite_Time));
           return infos;
         }
       });
       value4 = indexNew.getValue(blobId4);
       value5 = indexNew.getValue(blobId5);
       Assert.assertEquals(value4.isFlagSet(BlobIndexValue.Flags.Delete_Index), true);
-      Assert.assertEquals(value5.getTimeToLiveInMs(), BlobIndexValue.TTL_Infinite);
+      Assert.assertEquals(value5.getTimeToLiveInMs(), Utils.Infinite_Time);
       indexNew.stopScheduler();
       indexNew.deleteAll();
       indexNew.close();

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobPersistentIndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobPersistentIndexTest.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class BlobPersistantIndexTest {
+public class BlobPersistentIndexTest {
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
@@ -363,14 +363,14 @@ public class BlobPersistantIndexTest {
         public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory) throws IOException {
           List<MessageInfo> infos = new ArrayList<MessageInfo>();
           infos.add(new MessageInfo(blobId4, 100, true));
-          infos.add(new MessageInfo(blobId5, 100, BlobIndexValue.TTL_Infinite));
+          infos.add(new MessageInfo(blobId5, 100, Utils.Infinite_Time));
           return infos;
         }
       });
       value4 = indexNew.getValue(blobId4);
       value5 = indexNew.getValue(blobId5);
       Assert.assertEquals(value4.isFlagSet(BlobIndexValue.Flags.Delete_Index), true);
-      Assert.assertEquals(value5.getTimeToLiveInMs(), BlobIndexValue.TTL_Infinite);
+      Assert.assertEquals(value5.getTimeToLiveInMs(), Utils.Infinite_Time);
       Assert.assertEquals(value4.getSize(), 1000);
       Assert.assertEquals(value4.getOffset(), 5000);
       Assert.assertEquals(value5.getSize(), 1000);
@@ -444,7 +444,7 @@ public class BlobPersistantIndexTest {
         public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory) throws IOException {
           List<MessageInfo> infos = new ArrayList<MessageInfo>();
           infos.add(new MessageInfo(blobId4, 100, true));
-          infos.add(new MessageInfo(blobId5, 100, BlobIndexValue.TTL_Infinite));
+          infos.add(new MessageInfo(blobId5, 100, Utils.Infinite_Time));
           return infos;
 
         }
@@ -881,7 +881,7 @@ public class BlobPersistantIndexTest {
       List<MessageInfo> messageEntries = info.getMessageEntries();
       Assert.assertEquals(messageEntries.get(0).getStoreKey(), blobId1);
       Assert.assertEquals(messageEntries.get(0).getSize(), 100);
-      Assert.assertEquals(messageEntries.get(0).getTimeToLiveInMs(), 12345);
+      Assert.assertEquals(messageEntries.get(0).getExpirationTimeInMs(), 12345);
       Assert.assertEquals(messageEntries.size(), 12);
       Assert.assertEquals(messageEntries.get(messageEntries.size() - 1).getStoreKey(), blobId12);
 

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -24,10 +24,17 @@ import java.util.Random;
  * A set of utility methods
  */
 public class Utils {
+  /**
+   * Constant to define "infinite" time.
+   * <p/>
+   * Currently used in lieu of either an epoch based ms expiration time or a seconds based TTL (relative to creation
+   * time).
+   */
+  public static final long Infinite_Time = -1;
 
   public static String readShortString(DataInputStream input) throws IOException {
     Short size = input.readShort();
-    if(size <= 0)
+    if (size <= 0)
       return null;
     byte[] bytes = new byte[size];
     // TODO: Why not 'input.readFully(bytes);' instead of next 3 lines?
@@ -40,7 +47,7 @@ public class Utils {
 
   public static String readIntString(DataInputStream input) throws IOException {
     int size = input.readInt();
-    if(size <= 0)
+    if (size <= 0)
       return null;
     byte[] bytes = new byte[size];
     int read = input.read(bytes);
@@ -65,17 +72,18 @@ public class Utils {
   public static ByteBuffer readShortBuffer(DataInputStream input) throws IOException {
     short size = input.readShort();
     if (size < 0)
-        return null;
+      return null;
     ByteBuffer buffer = ByteBuffer.allocate(size);
     int read = input.read(buffer.array());
     if (read != size) {
-        throw new IllegalArgumentException("readShortBuffer the size of the input does not match the actual data size");
+      throw new IllegalArgumentException("readShortBuffer the size of the input does not match the actual data size");
     }
     return buffer;
   }
 
   /**
    * Create a new thread
+   *
    * @param runnable The work for the thread to do
    * @param daemon Should the thread block JVM shutdown?
    * @return The unstarted thread
@@ -84,15 +92,16 @@ public class Utils {
     Thread thread = new Thread(runnable);
     thread.setDaemon(daemon);
     thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-            public void uncaughtException(Thread t, Throwable e) {
-              //error("Uncaught exception in thread '" + t.getName + "':", e)
-          }
-        });
+      public void uncaughtException(Thread t, Throwable e) {
+        //error("Uncaught exception in thread '" + t.getName + "':", e)
+      }
+    });
     return thread;
   }
 
   /**
    * Create a new thread
+   *
    * @param name The name of the thread
    * @param runnable The work for the thread to do
    * @param daemon Should the thread block JVM shutdown?
@@ -102,15 +111,16 @@ public class Utils {
     Thread thread = new Thread(runnable, name);
     thread.setDaemon(daemon);
     thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-            public void uncaughtException(Thread t, Throwable e) {
-              e.printStackTrace();
-          }
-        });
+      public void uncaughtException(Thread t, Throwable e) {
+        e.printStackTrace();
+      }
+    });
     return thread;
   }
 
   /**
    * Create a daemon thread
+   *
    * @param runnable The runnable to execute in the background
    * @return The unstarted thread
    */
@@ -120,6 +130,7 @@ public class Utils {
 
   /**
    * Create a daemon thread
+   *
    * @param name The name of the thread
    * @param runnable The runnable to execute in the background
    * @return The unstarted thread
@@ -132,7 +143,7 @@ public class Utils {
    * Open a channel for the given file
    */
   public static FileChannel openChannel(File file, boolean mutable) throws FileNotFoundException {
-    if(mutable)
+    if (mutable)
       return new RandomAccessFile(file, "rw").getChannel();
     else
       return new FileInputStream(file).getChannel();
@@ -141,18 +152,16 @@ public class Utils {
   /**
    * Instantiate a class instance from a given className with an arg
    */
-   public static <T> T getObj(String className, Object arg)
-           throws ClassNotFoundException, InstantiationException,
-           IllegalAccessException, NoSuchMethodException, InvocationTargetException {
-     for (Constructor<?> ctor : Class.forName(className).getDeclaredConstructors())
-     {
-       if (ctor.getParameterTypes().length == 1 && ctor.getParameterTypes()[0].isAssignableFrom(arg.getClass()))
-       {
-         return (T)ctor.newInstance(arg);
-       }
-     }
-     return null;
-   }
+  public static <T> T getObj(String className, Object arg)
+          throws ClassNotFoundException, InstantiationException,
+          IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+    for (Constructor<?> ctor : Class.forName(className).getDeclaredConstructors()) {
+      if (ctor.getParameterTypes().length == 1 && ctor.getParameterTypes()[0].isAssignableFrom(arg.getClass())) {
+        return (T)ctor.newInstance(arg);
+      }
+    }
+    return null;
+  }
 
   /**
    * Instantiate a class instance from a given className.
@@ -166,22 +175,23 @@ public class Utils {
   /**
    * Compute the hash code for the given items
    */
-   public static int hashcode(Object[] items) {
-     if(items == null)
-       return 0;
-     int h = 1;
-     int i = 0;
-     while(i < items.length) {
-       if(items[i] != null) {
-         h = 31 * h + items[i].hashCode();
-         i += 1;
-       }
-     }
-     return h;
-   }
+  public static int hashcode(Object[] items) {
+    if (items == null)
+      return 0;
+    int h = 1;
+    int i = 0;
+    while (i < items.length) {
+      if (items[i] != null) {
+        h = 31 * h + items[i].hashCode();
+        i += 1;
+      }
+    }
+    return h;
+  }
 
   /**
    * Compute the CRC32 of the byte array
+   *
    * @param bytes The array to compute the checksum for
    * @return The CRC32
    */
@@ -191,6 +201,7 @@ public class Utils {
 
   /**
    * Compute the CRC32 of the segment of the byte array given by the specificed size and offset
+   *
    * @param bytes The bytes to checksum
    * @param offset the offset at which to begin checksumming
    * @param size the number of bytes to checksum
@@ -204,6 +215,7 @@ public class Utils {
 
   /**
    * Read a properties file from the given path
+   *
    * @param filename The path of the file to read
    */
   public static Properties loadProps(String filename) throws FileNotFoundException, IOException {
@@ -215,6 +227,7 @@ public class Utils {
 
   /**
    * Serializes a nullable string into byte buffer
+   *
    * @param outputBuffer The output buffer to serialize the value to
    * @param value The value to serialize
    */
@@ -229,6 +242,7 @@ public class Utils {
 
   /**
    * Returns the length of a nullable string
+   *
    * @param value The string whose length is needed
    * @return The length of the string. 0 if null.
    */
@@ -249,7 +263,8 @@ public class Utils {
       File clusterFile = new File(path);
       fileWriter = new FileWriter(clusterFile);
       fileWriter.write(string);
-    } finally {
+    }
+    finally {
       if (fileWriter != null) {
         fileWriter.close();
       }
@@ -322,7 +337,7 @@ public class Utils {
       RandomAccessFile rfile = null;
       try {
         rfile = new RandomAccessFile(file, "rw");
-     }
+      }
       finally {
         if (rfile != null)
           rfile.close();
@@ -331,23 +346,36 @@ public class Utils {
   }
 
   /**
-   * Get a pseudo-random long uniformly between 0 and n-1. Stolen from
-   * {@link java.util.Random#nextInt()}.
+   * Get a pseudo-random long uniformly between 0 and n-1. Stolen from {@link java.util.Random#nextInt()}.
    *
    * @param n the bound
    * @return a value select randomly from the range {@code [0..n)}.
    */
   public static long getRandomLong(long n) {
-    if (n<=0) {
+    if (n <= 0) {
       throw new IllegalArgumentException("Cannot generate random long in range [0,n) for n<=0.");
     }
 
     final int BITS_PER_LONG = 63;
-      long bits, val;
-      do {
-        bits = new Random().nextLong() & (~(1L << BITS_PER_LONG));
-        val = bits % n;
-      } while (bits - val + (n - 1) < 0L);
-      return val;
+    long bits, val;
+    do {
+      bits = new Random().nextLong() & (~(1L << BITS_PER_LONG));
+      val = bits % n;
+    } while (bits - val + (n - 1) < 0L);
+    return val;
+  }
+
+  /**
+   * Adds some number of seconds to an epoch time in ms.
+   *
+   * @param epochTimeInMs
+   * @param deltaTimeInSeconds
+   * @return epoch time in milliseconds or Infinite_Time.
+   */
+  public static long addSecondsToEpochTime(long epochTimeInMs, long deltaTimeInSeconds) {
+    if (deltaTimeInSeconds == Infinite_Time || epochTimeInMs == Infinite_Time) {
+      return Infinite_Time;
+    }
+    return epochTimeInMs + (deltaTimeInSeconds * Time.MsPerSec);
   }
 }


### PR DESCRIPTION
- Change BlobProperties TTL to be specified in seconds relative to creation time
- Remove "UserMetadataSize" from BlobProperties
- Standardize on BlobProperties.Infinite_TTL throughout code base
- Other minor cleanup
