### PR TITLE
Comment out Java 7 dependency. Fix intermittent test failure.

### DIFF
--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -103,7 +103,8 @@ public class MessageFormatRecordTest {
 
       // corrupt usermetadata record V1
       output.flip();
-      output.put(10, (byte)1);
+      Byte currentRandomByte = output.get(10);
+      output.put(10, (byte)(currentRandomByte+1));
       try {
         MessageFormatRecord.deserializeUserMetadata(new ByteBufferInputStream(output));
         Assert.assertEquals(true, false);
@@ -131,7 +132,8 @@ public class MessageFormatRecordTest {
 
       // corrupt blob record V1
       sData.flip();
-      sData.put(10, (byte)10);
+      currentRandomByte = sData.get(10);
+      sData.put(10, (byte)(currentRandomByte+1));
       try {
         MessageFormatRecord.deserializeBlob(new ByteBufferInputStream(sData));
         Assert.assertEquals(true, false);

--- a/ambry-tools/src/main/java/com.github.ambry.tools/perf/FileSystemWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/perf/FileSystemWritePerformance.java
@@ -1,19 +1,10 @@
 package com.github.ambry.tools.perf;
 
-import com.github.ambry.utils.SystemTime;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
-import java.util.Random;
-
 /**
  * Measures the file system performance using system cache and sync writes
  */
 public class FileSystemWritePerformance {
+  /* TODO: Remove dependency on Java 7
   public static void main(String[] args) {
     if (args.length != 1) {
       System.out.println("The number of args is not equal to 1. The path is required");
@@ -71,4 +62,5 @@ public class FileSystemWritePerformance {
     }
 
   }
+  */
 }


### PR DESCRIPTION
- Commented out FileSystemWritePerformance implementation since it depends on Java 7. Left TODO in code to fix.
- Fixed intermittent test failures in MessageFormatRecordTest.
