### PR TITLE
Cleaner logging in Coordinator

### DIFF
--- a/ambry-coordinator/src/main/java/com.github.ambry.coordinator/DeleteOperation.java
+++ b/ambry-coordinator/src/main/java/com.github.ambry.coordinator/DeleteOperation.java
@@ -1,20 +1,19 @@
 package com.github.ambry.coordinator;
 
 import com.github.ambry.clustermap.ReplicaId;
-import com.github.ambry.shared.ConnectionPool;
 import com.github.ambry.shared.BlobId;
+import com.github.ambry.shared.ConnectionPool;
 import com.github.ambry.shared.DeleteRequest;
-import com.github.ambry.shared.RequestOrResponse;
-import com.github.ambry.shared.ServerErrorCode;
-import com.github.ambry.shared.Response;
 import com.github.ambry.shared.DeleteResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.github.ambry.shared.RequestOrResponse;
+import com.github.ambry.shared.Response;
+import com.github.ambry.shared.ServerErrorCode;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -54,7 +53,8 @@ final public class DeleteOperation extends Operation {
       case Blob_Not_Found:
         blobNotFoundCount++;
         if (blobNotFoundCount == replicaIdCount) {
-          String message = "Blob not found : blobNotFoundCount == replicaIdCount == " + blobNotFoundCount + ".";
+          String message =
+              "DeleteOperation : Blob not found : blobNotFoundCount == replicaIdCount == " + blobNotFoundCount + ".";
           logger.trace(message);
           throw new CoordinatorException(message, CoordinatorError.BlobDoesNotExist);
         }

--- a/ambry-coordinator/src/main/java/com.github.ambry.coordinator/GetOperation.java
+++ b/ambry-coordinator/src/main/java/com.github.ambry.coordinator/GetOperation.java
@@ -78,7 +78,8 @@ public abstract class GetOperation extends Operation {
       case Blob_Not_Found:
         blobNotFoundCount++;
         if (blobNotFoundCount == replicaIdCount) {
-          String message = "Blob not found : blobNotFoundCount == replicaIdCount == " + blobNotFoundCount + ".";
+          String message =
+              "GetOperation : Blob not found : blobNotFoundCount == replicaIdCount == " + blobNotFoundCount + ".";
           logger.trace(message);
           throw new CoordinatorException(message, CoordinatorError.BlobDoesNotExist);
         }
@@ -86,8 +87,9 @@ public abstract class GetOperation extends Operation {
       case Blob_Deleted:
         blobDeletedCount++;
         if (blobDeletedCount >= min(Blob_Deleted_Count_Threshold, replicaIdCount)) {
-          String message = "Blob deleted : blobDeletedCount == " + blobDeletedCount + " >= min(deleteThreshold == "
-              + Blob_Deleted_Count_Threshold + ", replicaIdCount == " + replicaIdCount + ").";
+          String message =
+              "GetOperation : Blob deleted : blobDeletedCount == " + blobDeletedCount + " >= min(deleteThreshold == "
+                  + Blob_Deleted_Count_Threshold + ", replicaIdCount == " + replicaIdCount + ").";
           logger.trace(message);
           throw new CoordinatorException(message, CoordinatorError.BlobDeleted);
         }
@@ -95,8 +97,9 @@ public abstract class GetOperation extends Operation {
       case Blob_Expired:
         blobExpiredCount++;
         if (blobExpiredCount >= min(Blob_Expired_Count_Threshold, replicaIdCount)) {
-          String message = "Blob expired : blobExpiredCount == " + blobExpiredCount + " >= min(expiredThreshold == "
-              + Blob_Expired_Count_Threshold + ", replicaIdCount == " + replicaIdCount + ").";
+          String message =
+              "GetOperation : Blob expired : blobExpiredCount == " + blobExpiredCount + " >= min(expiredThreshold == "
+                  + Blob_Expired_Count_Threshold + ", replicaIdCount == " + replicaIdCount + ").";
           logger.trace(message);
           throw new CoordinatorException(message, CoordinatorError.BlobExpired);
         }

--- a/ambry-coordinator/src/main/java/com.github.ambry.coordinator/Operation.java
+++ b/ambry-coordinator/src/main/java/com.github.ambry.coordinator/Operation.java
@@ -143,14 +143,14 @@ public abstract class Operation {
         sendRequests();
       } catch (CoordinatorException e) {
         operationComplete.set(true);
-        logger.error(context + " operation threw CoordinatorException during execute", e);
+        logger.error(context + " operation threw CoordinatorException during execute: " + e);
         throw e;
       } catch (InterruptedException e) {
         operationComplete.set(true);
         // Slightly abuse the notion of "unexpected" internal error since InterruptedException does not indicate
         // something truly unexpected.
         logger.error(context + " operation interrupted during execute");
-        throw new CoordinatorException("Operation interrupted.", CoordinatorError.UnexpectedInternalError);
+        throw new CoordinatorException("Operation interrupted.", e, CoordinatorError.UnexpectedInternalError);
       }
     }
   }


### PR DESCRIPTION
- Do not print stack trace upon CoordinatorException in Operation
- Include operation type in exception messages so that just logging the message, rather than stack trace, is sufficient
