### PR TITLE
Replication changes for materializing streams and doing batch gets and replica metadata request

### DIFF
--- a/ambry-coordinator/src/main/java/com.github.ambry.coordinator/GetOperation.java
+++ b/ambry-coordinator/src/main/java/com.github.ambry.coordinator/GetOperation.java
@@ -9,6 +9,7 @@ import com.github.ambry.shared.BlobId;
 import com.github.ambry.shared.ConnectionPool;
 import com.github.ambry.shared.GetRequest;
 import com.github.ambry.shared.GetResponse;
+import com.github.ambry.shared.PartitionRequestInfo;
 import com.github.ambry.shared.RequestOrResponse;
 import com.github.ambry.shared.Response;
 import com.github.ambry.shared.ServerErrorCode;
@@ -16,6 +17,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
@@ -63,7 +65,10 @@ public abstract class GetOperation extends Operation {
   GetRequest makeGetRequest() {
     ArrayList<BlobId> blobIds = new ArrayList<BlobId>(1);
     blobIds.add(blobId);
-    return new GetRequest(context.getCorrelationId(), context.getClientId(), flags, blobId.getPartition(), blobIds);
+    List<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
+    PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(blobId.getPartition(), blobIds);
+    partitionRequestInfoList.add(partitionRequestInfo);
+    return new GetRequest(context.getCorrelationId(), context.getClientId(), flags, partitionRequestInfoList);
   }
 
   @Override
@@ -136,9 +141,9 @@ abstract class GetOperationRequest extends OperationRequest {
       throws IOException, MessageFormatException {
     GetResponse getResponse = (GetResponse) response;
     if (response.getError() == ServerErrorCode.No_Error) {
-      if (getResponse.getMessageInfoList().size() != 1) {
-        String message =
-            "MessageInfoList indicates incorrect payload size. Should be 1: " + getResponse.getMessageInfoList().size();
+      if (getResponse.getPartitionResponseInfoList().get(0).getMessageInfoList().size() != 1) {
+        String message = "MessageInfoList indicates incorrect payload size. Should be 1: " + getResponse
+            .getPartitionResponseInfoList().get(0).getMessageInfoList().size();
         logger.error(message);
         throw new MessageFormatException(message, MessageFormatErrorCodes.Data_Corrupt);
       }

--- a/ambry-coordinator/src/main/java/com.github.ambry.coordinator/Operation.java
+++ b/ambry-coordinator/src/main/java/com.github.ambry.coordinator/Operation.java
@@ -240,6 +240,7 @@ abstract class OperationRequest implements Runnable {
       enqueueOperationResponse(new OperationResponse(replicaId, RequestResponseError.TIMEOUT_ERROR));
       countError(RequestResponseError.TIMEOUT_ERROR);
     } catch (Exception e) {
+      e.printStackTrace();
       logger.error(context + " " + replicaId + " Error processing request-response for BlobId " + blobId, e);
       enqueueOperationResponse(new OperationResponse(replicaId, RequestResponseError.UNEXPECTED_ERROR));
       countError(RequestResponseError.UNEXPECTED_ERROR);

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/CompositeMessageFormatSend.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/CompositeMessageFormatSend.java
@@ -1,0 +1,46 @@
+package com.github.ambry.messageformat;
+
+import com.github.ambry.network.Send;
+import java.io.IOException;
+import java.nio.channels.WritableByteChannel;
+import java.util.List;
+
+
+/**
+ * Holds multiple MessageFormatSend instances and sends them over the network
+ */
+public class CompositeMessageFormatSend implements Send {
+
+  private final List<MessageFormatSend> compositeMessageSet;
+  private long totalSizeToWrite;
+  private int currentIndexInProgress;
+
+  public CompositeMessageFormatSend(List<MessageFormatSend> compositeMessageSet) {
+    this.compositeMessageSet = compositeMessageSet;
+    this.currentIndexInProgress = 0;
+    for (MessageFormatSend messageFormatSend : compositeMessageSet) {
+      totalSizeToWrite += messageFormatSend.sizeInBytes();
+    }
+  }
+
+  @Override
+  public void writeTo(WritableByteChannel channel)
+      throws IOException {
+    if (currentIndexInProgress < compositeMessageSet.size()) {
+      compositeMessageSet.get(currentIndexInProgress).writeTo(channel);
+      if (compositeMessageSet.get(currentIndexInProgress).isSendComplete()) {
+        currentIndexInProgress++;
+      }
+    }
+  }
+
+  @Override
+  public boolean isSendComplete() {
+    return currentIndexInProgress == compositeMessageSet.size();
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return totalSizeToWrite;
+  }
+}

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatWriteSet.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatWriteSet.java
@@ -4,6 +4,7 @@ import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MessageWriteSet;
 import com.github.ambry.store.Write;
 
+import com.github.ambry.utils.ByteBufferInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.Channels;
@@ -24,14 +25,21 @@ public class MessageFormatWriteSet implements MessageWriteSet {
   private List<MessageInfo> streamInfo;
   private Logger logger = LoggerFactory.getLogger(getClass());
 
-  public MessageFormatWriteSet(InputStream stream, List<MessageInfo> streamInfo, long maxWriteTimeInMs) {
-    streamToWrite = stream;
+  public MessageFormatWriteSet(InputStream stream, List<MessageInfo> streamInfo, long maxWriteTimeInMs,
+      boolean materializeStream)
+      throws IOException {
     sizeToWrite = 0;
     for (MessageInfo info : streamInfo) {
       sizeToWrite += info.getSize();
     }
     this.streamInfo = streamInfo;
     this.maxWriteTimeInMs = maxWriteTimeInMs;
+    if (materializeStream) {
+      ByteBufferInputStream byteBufferInputStream = new ByteBufferInputStream(stream, (int) sizeToWrite);
+      streamToWrite = byteBufferInputStream;
+    } else {
+      streamToWrite = stream;
+    }
   }
 
   @Override

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatWriteSetTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatWriteSetTest.java
@@ -55,7 +55,7 @@ public class MessageFormatWriteSetTest {
     infoList.add(info1);
     infoList.add(info2);
     MessageFormatWriteSet set =
-        new MessageFormatWriteSet(new ByteBufferInputStream(ByteBuffer.wrap(buf)), infoList, 10000);
+        new MessageFormatWriteSet(new ByteBufferInputStream(ByteBuffer.wrap(buf)), infoList, 10000, false);
     MockWrite write = new MockWrite(2000);
     long written = set.writeTo(write);
     Assert.assertEquals(written, 2000);

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -23,6 +23,8 @@ import com.github.ambry.network.NetworkRequestMetrics;
 import com.github.ambry.network.RequestResponseChannel;
 import com.github.ambry.notification.BlobReplicaSourceType;
 import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.shared.PartitionResponseInfo;
+import com.github.ambry.shared.ReplicaMetadataResponseInfo;
 import com.github.ambry.shared.RequestOrResponseType;
 import com.github.ambry.replication.ReplicationManager;
 import com.github.ambry.shared.DeleteRequest;
@@ -37,6 +39,7 @@ import com.github.ambry.shared.PutResponse;
 import com.github.ambry.network.Request;
 import com.github.ambry.network.Send;
 import com.github.ambry.store.FindInfo;
+import com.github.ambry.store.FindToken;
 import com.github.ambry.store.FindTokenFactory;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.Store;
@@ -145,7 +148,7 @@ public class AmbryRequests implements RequestAPI {
         ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
         infoList.add(info);
         MessageFormatWriteSet writeset =
-            new MessageFormatWriteSet(stream, infoList, serverConfig.serverMaxPutWriteTimeMs);
+            new MessageFormatWriteSet(stream, infoList, serverConfig.serverMaxPutWriteTimeMs, false);
         Store storeToPut = storeManager.getStore(putRequest.getBlobId().getPartition());
         storeToPut.put(writeset);
         response = new PutResponse(putRequest.getCorrelationId(), putRequest.getClientId(), ServerErrorCode.No_Error);
@@ -220,19 +223,23 @@ public class AmbryRequests implements RequestAPI {
     long startTime = SystemTime.getInstance().milliseconds();
     GetResponse response = null;
     try {
-      ServerErrorCode error = validateRequest(getRequest.getPartition(), false);
+      ServerErrorCode error = validateRequest(getRequest.getPartitionInfoList().get(0).getPartition(), false);
       if (error != ServerErrorCode.No_Error) {
         logger.error("Validating get request failed with error {} for request {}", error, getRequest);
         response = new GetResponse(getRequest.getCorrelationId(), getRequest.getClientId(), error);
       } else {
-        Store storeToGet = storeManager.getStore(getRequest.getPartition());
-        StoreInfo info = storeToGet.get(getRequest.getBlobIds());
+        Store storeToGet = storeManager.getStore(getRequest.getPartitionInfoList().get(0).getPartition());
+        StoreInfo info = storeToGet.get(getRequest.getPartitionInfoList().get(0).getBlobIds());
         Send blobsToSend =
             new MessageFormatSend(info.getMessageReadSet(), getRequest.getMessageFormatFlag(), messageFormatMetrics,
                 storeKeyFactory);
-        response =
-            new GetResponse(getRequest.getCorrelationId(), getRequest.getClientId(), info.getMessageReadSetInfo(),
-                blobsToSend, ServerErrorCode.No_Error);
+        List<PartitionResponseInfo> partitionResponseInfoList = new ArrayList<PartitionResponseInfo>();
+        PartitionResponseInfo partitionResponseInfo =
+            new PartitionResponseInfo(getRequest.getPartitionInfoList().get(0).getPartition(),
+                info.getMessageReadSetInfo());
+        partitionResponseInfoList.add(partitionResponseInfo);
+        response = new GetResponse(getRequest.getCorrelationId(), getRequest.getClientId(), partitionResponseInfoList,
+            blobsToSend, ServerErrorCode.No_Error);
       }
     } catch (StoreException e) {
       if (e.getErrorCode() == StoreErrorCodes.ID_Not_Found) {
@@ -261,6 +268,7 @@ public class AmbryRequests implements RequestAPI {
       response = new GetResponse(getRequest.getCorrelationId(), getRequest.getClientId(),
           ErrorMapping.getMessageFormatErrorMapping(e.getErrorCode()));
     } catch (Exception e) {
+      e.printStackTrace();
       logger.error("Unknown exception for request " + getRequest, e);
       response =
           new GetResponse(getRequest.getCorrelationId(), getRequest.getClientId(), ServerErrorCode.Unknown_Error);
@@ -301,7 +309,7 @@ public class AmbryRequests implements RequestAPI {
         ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
         infoList.add(info);
         MessageFormatWriteSet writeset =
-            new MessageFormatWriteSet(stream, infoList, serverConfig.serverMaxDeleteWriteTimeMs);
+            new MessageFormatWriteSet(stream, infoList, serverConfig.serverMaxDeleteWriteTimeMs, false);
         Store storeToDelete = storeManager.getStore(deleteRequest.getBlobId().getPartition());
         storeToDelete.delete(writeset);
         response =
@@ -353,7 +361,8 @@ public class AmbryRequests implements RequestAPI {
     long startTime = SystemTime.getInstance().milliseconds();
     ReplicaMetadataResponse response = null;
     try {
-      ServerErrorCode error = validateRequest(replicaMetadataRequest.getPartitionId(), false);
+      ServerErrorCode error =
+          validateRequest(replicaMetadataRequest.getReplicaMetadataRequestInfoList().get(0).getPartitionId(), false);
       if (error != ServerErrorCode.No_Error) {
         logger.error("Validating replica metadata request failed with error {} for request {}", error,
             replicaMetadataRequest);
@@ -361,19 +370,24 @@ public class AmbryRequests implements RequestAPI {
             new ReplicaMetadataResponse(replicaMetadataRequest.getCorrelationId(), replicaMetadataRequest.getClientId(),
                 error);
       } else {
-        Store store = storeManager.getStore(replicaMetadataRequest.getPartitionId());
-        FindInfo findInfo = store.findEntriesSince(replicaMetadataRequest.getToken(),
-            replicaMetadataRequest.getMaxTotalSizeOfEntriesInBytes());
-        replicationManager.updateTotalBytesReadByRemoteReplica(replicaMetadataRequest.getPartitionId(),
-            replicaMetadataRequest.getHostName(), replicaMetadataRequest.getReplicaPath(),
+        PartitionId partitionId = replicaMetadataRequest.getReplicaMetadataRequestInfoList().get(0).getPartitionId();
+        FindToken findToken = replicaMetadataRequest.getReplicaMetadataRequestInfoList().get(0).getToken();
+        String hostName = replicaMetadataRequest.getReplicaMetadataRequestInfoList().get(0).getHostName();
+        String replicaPath = replicaMetadataRequest.getReplicaMetadataRequestInfoList().get(0).getReplicaPath();
+        Store store = storeManager.getStore(partitionId);
+        FindInfo findInfo = store.findEntriesSince(findToken, replicaMetadataRequest.getMaxTotalSizeOfEntriesInBytes());
+        replicationManager.updateTotalBytesReadByRemoteReplica(partitionId, hostName, replicaPath,
             findInfo.getFindToken().getBytesRead());
-        long remoteReplicaLagInBytes = replicationManager
-            .getRemoteReplicaLagInBytes(replicaMetadataRequest.getPartitionId(), replicaMetadataRequest.getHostName(),
-                replicaMetadataRequest.getReplicaPath());
+        long remoteReplicaLagInBytes =
+            replicationManager.getRemoteReplicaLagInBytes(partitionId, hostName, replicaPath);
+        List<ReplicaMetadataResponseInfo> replicaMetadataResponseList = new ArrayList<ReplicaMetadataResponseInfo>();
+        ReplicaMetadataResponseInfo replicaMetadataResponseInfo =
+            new ReplicaMetadataResponseInfo(partitionId, findInfo.getFindToken(), findInfo.getMessageEntries(),
+                remoteReplicaLagInBytes);
+        replicaMetadataResponseList.add(replicaMetadataResponseInfo);
         response =
             new ReplicaMetadataResponse(replicaMetadataRequest.getCorrelationId(), replicaMetadataRequest.getClientId(),
-                ServerErrorCode.No_Error, findInfo.getFindToken(), findInfo.getMessageEntries(),
-                remoteReplicaLagInBytes);
+                ServerErrorCode.No_Error, replicaMetadataResponseList);
       }
     } catch (StoreException e) {
       logger.error("Store exception on a put with error code " + e.getErrorCode() +

--- a/ambry-server/src/test/java/com.github.ambry.server/ServerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/ServerTest.java
@@ -21,6 +21,7 @@ import com.github.ambry.shared.DeleteRequest;
 import com.github.ambry.shared.DeleteResponse;
 import com.github.ambry.shared.GetRequest;
 import com.github.ambry.shared.GetResponse;
+import com.github.ambry.shared.PartitionRequestInfo;
 import com.github.ambry.shared.PutRequest;
 import com.github.ambry.shared.PutResponse;
 import com.github.ambry.shared.ServerErrorCode;
@@ -126,7 +127,11 @@ public class ServerTest {
       ArrayList<BlobId> ids = new ArrayList<BlobId>();
       MockPartitionId partition = (MockPartitionId) clusterMap.getWritablePartitionIdAt(0);
       ids.add(blobId1);
-      GetRequest getRequest1 = new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partition, ids);
+      ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
+      PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(partition, ids);
+      partitionRequestInfoList.add(partitionRequestInfo);
+      GetRequest getRequest1 =
+          new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partitionRequestInfoList);
       channel.send(getRequest1);
       InputStream stream = channel.receive();
       GetResponse resp1 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -139,7 +144,8 @@ public class ServerTest {
       }
 
       // get user metadata
-      GetRequest getRequest2 = new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, partition, ids);
+      GetRequest getRequest2 =
+          new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, partitionRequestInfoList);
       channel.send(getRequest2);
       stream = channel.receive();
       GetResponse resp2 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -170,7 +176,11 @@ public class ServerTest {
       ids = new ArrayList<BlobId>();
       partition = (MockPartitionId) clusterMap.getWritablePartitionIdAt(0);
       ids.add(new BlobId(partition));
-      GetRequest getRequest4 = new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partition, ids);
+      partitionRequestInfoList.clear();
+      partitionRequestInfo = new PartitionRequestInfo(partition, ids);
+      partitionRequestInfoList.add(partitionRequestInfo);
+      GetRequest getRequest4 =
+          new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partitionRequestInfoList);
       channel.send(getRequest4);
       stream = channel.receive();
       GetResponse resp4 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -268,7 +278,10 @@ public class ServerTest {
       ArrayList<BlobId> ids = new ArrayList<BlobId>();
       MockPartitionId partition = (MockPartitionId) clusterMap.getWritablePartitionIdAt(0);
       ids.add(blobId3);
-      GetRequest getRequest1 = new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partition, ids);
+      ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
+      PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(partition, ids);
+      partitionRequestInfoList.add(partitionRequestInfo);
+      GetRequest getRequest1 = new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partitionRequestInfoList);
       channel2.send(getRequest1);
       InputStream stream = channel2.receive();
       GetResponse resp1 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -283,7 +296,7 @@ public class ServerTest {
       // get user metadata
       ids.clear();
       ids.add(blobId2);
-      GetRequest getRequest2 = new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, partition, ids);
+      GetRequest getRequest2 = new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, partitionRequestInfoList);
       channel1.send(getRequest2);
       stream = channel1.receive();
       GetResponse resp2 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -298,7 +311,7 @@ public class ServerTest {
       // get blob
       ids.clear();
       ids.add(blobId1);
-      GetRequest getRequest3 = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partition, ids);
+      GetRequest getRequest3 = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList);
       channel3.send(getRequest3);
       stream = channel3.receive();
       GetResponse resp3 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -337,7 +350,10 @@ public class ServerTest {
       ids = new ArrayList<BlobId>();
       partition = (MockPartitionId) clusterMap.getWritablePartitionIdAt(0);
       ids.add(new BlobId(partition));
-      GetRequest getRequest4 = new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partition, ids);
+      partitionRequestInfoList.clear();
+      partitionRequestInfo = new PartitionRequestInfo(partition, ids);
+      partitionRequestInfoList.add(partitionRequestInfo);
+      GetRequest getRequest4 = new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partitionRequestInfoList);
       channel3.send(getRequest4);
       stream = channel3.receive();
       GetResponse resp4 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -353,7 +369,10 @@ public class ServerTest {
       notificationSystem.awaitBlobDeletions(blobId1.toString());
       ids = new ArrayList<BlobId>();
       ids.add(blobId1);
-      GetRequest getRequest5 = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partition, ids);
+      partitionRequestInfoList.clear();
+      partitionRequestInfo = new PartitionRequestInfo(partition, ids);
+      partitionRequestInfoList.add(partitionRequestInfo);
+      GetRequest getRequest5 = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList);
       channel3.send(getRequest5);
       stream = channel3.receive();
       GetResponse resp5 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -662,11 +681,15 @@ public class ServerTest {
           channel = channel3;
         }
 
+        ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
         for (int j = 0; j < blobIds.size(); j++) {
           ArrayList<BlobId> ids = new ArrayList<BlobId>();
           ids.add(blobIds.get(j));
+          partitionRequestInfoList.clear();
+          PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(blobIds.get(j).getPartition(), ids);
+          partitionRequestInfoList.add(partitionRequestInfo);
           GetRequest getRequest =
-              new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, blobIds.get(j).getPartition(), ids);
+              new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partitionRequestInfoList);
           channel.send(getRequest);
           InputStream stream = channel.receive();
           GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -681,8 +704,11 @@ public class ServerTest {
           // get user metadata
           ids.clear();
           ids.add(blobIds.get(j));
+          partitionRequestInfoList.clear();
+          partitionRequestInfo = new PartitionRequestInfo(blobIds.get(j).getPartition(), ids);
+          partitionRequestInfoList.add(partitionRequestInfo);
           getRequest =
-              new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, blobIds.get(j).getPartition(), ids);
+              new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, partitionRequestInfoList);
           channel.send(getRequest);
           stream = channel.receive();
           resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -697,7 +723,10 @@ public class ServerTest {
           // get blob
           ids.clear();
           ids.add(blobIds.get(j));
-          getRequest = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, blobIds.get(j).getPartition(), ids);
+          partitionRequestInfoList.clear();
+          partitionRequestInfo = new PartitionRequestInfo(blobIds.get(j).getPartition(), ids);
+          partitionRequestInfoList.add(partitionRequestInfo);
+          getRequest = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList);
           channel.send(getRequest);
           stream = channel.receive();
           resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -742,6 +771,7 @@ public class ServerTest {
       }
 
       Iterator<BlobId> iterator = blobsDeleted.iterator();
+      ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
       while (iterator.hasNext()) {
         BlobId deletedId = iterator.next();
         notificationSystem.awaitBlobDeletions(deletedId.toString());
@@ -756,8 +786,11 @@ public class ServerTest {
 
           ArrayList<BlobId> ids = new ArrayList<BlobId>();
           ids.add(deletedId);
+          partitionRequestInfoList.clear();
+          PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(deletedId.getPartition(), ids);
+          partitionRequestInfoList.add(partitionRequestInfo);
           GetRequest getRequest =
-              new GetRequest(1, "clientid2", MessageFormatFlags.Blob, deletedId.getPartition(), ids);
+              new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList);
           channel.send(getRequest);
           InputStream stream = channel.receive();
           GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -803,8 +836,11 @@ public class ServerTest {
         }
         ArrayList<BlobId> ids = new ArrayList<BlobId>();
         ids.add(blobIds.get(j));
+        partitionRequestInfoList.clear();
+        PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(blobIds.get(j).getPartition(), ids);
+        partitionRequestInfoList.add(partitionRequestInfo);
         GetRequest getRequest =
-            new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, blobIds.get(j).getPartition(), ids);
+            new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partitionRequestInfoList);
         channel1.send(getRequest);
         InputStream stream = channel1.receive();
         GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -823,8 +859,11 @@ public class ServerTest {
         // get user metadata
         ids.clear();
         ids.add(blobIds.get(j));
+        partitionRequestInfoList.clear();
+        partitionRequestInfo = new PartitionRequestInfo(blobIds.get(j).getPartition(), ids);
+        partitionRequestInfoList.add(partitionRequestInfo);
         getRequest =
-            new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, blobIds.get(j).getPartition(), ids);
+            new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, partitionRequestInfoList);
         channel1.send(getRequest);
         stream = channel1.receive();
         resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -842,7 +881,10 @@ public class ServerTest {
         // get blob
         ids.clear();
         ids.add(blobIds.get(j));
-        getRequest = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, blobIds.get(j).getPartition(), ids);
+        partitionRequestInfoList.clear();
+        partitionRequestInfo = new PartitionRequestInfo(blobIds.get(j).getPartition(), ids);
+        partitionRequestInfoList.add(partitionRequestInfo);
+        getRequest = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList);
         channel1.send(getRequest);
         stream = channel1.receive();
         resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -900,8 +942,11 @@ public class ServerTest {
         }
         ArrayList<BlobId> ids = new ArrayList<BlobId>();
         ids.add(blobIds.get(j));
+        partitionRequestInfoList.clear();
+        PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(blobIds.get(j).getPartition(), ids);
+        partitionRequestInfoList.add(partitionRequestInfo);
         GetRequest getRequest =
-            new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, blobIds.get(j).getPartition(), ids);
+            new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partitionRequestInfoList);
         channel1.send(getRequest);
         InputStream stream = channel1.receive();
         GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -920,8 +965,11 @@ public class ServerTest {
         // get user metadata
         ids.clear();
         ids.add(blobIds.get(j));
+        partitionRequestInfoList.clear();
+        partitionRequestInfo = new PartitionRequestInfo(blobIds.get(j).getPartition(), ids);
+        partitionRequestInfoList.add(partitionRequestInfo);
         getRequest =
-            new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, blobIds.get(j).getPartition(), ids);
+            new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, partitionRequestInfoList);
         channel1.send(getRequest);
         stream = channel1.receive();
         resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -939,7 +987,10 @@ public class ServerTest {
         // get blob
         ids.clear();
         ids.add(blobIds.get(j));
-        getRequest = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, blobIds.get(j).getPartition(), ids);
+        partitionRequestInfoList.clear();
+        partitionRequestInfo = new PartitionRequestInfo(blobIds.get(j).getPartition(), ids);
+        partitionRequestInfoList.add(partitionRequestInfo);
+        getRequest = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList);
         channel1.send(getRequest);
         stream = channel1.receive();
         resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -1044,6 +1095,7 @@ public class ServerTest {
     @Override
     public void run() {
       try {
+        ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
         while (requestsVerified.get() != totalRequests.get() && !cancelTest.get()) {
           Payload payload = blockingQueue.poll(1000, TimeUnit.MILLISECONDS);
           if (payload != null) {
@@ -1054,8 +1106,11 @@ public class ServerTest {
               channel1.connect();
               ArrayList<BlobId> ids = new ArrayList<BlobId>();
               ids.add(new BlobId(payload.blobId, clusterMap));
+              partitionRequestInfoList.clear();
+              PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(ids.get(0).getPartition(), ids);
+              partitionRequestInfoList.add(partitionRequestInfo);
               GetRequest getRequest =
-                  new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, ids.get(0).getPartition(), ids);
+                  new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partitionRequestInfoList);
               channel1.send(getRequest);
               InputStream stream = channel1.receive();
               GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -1084,8 +1139,11 @@ public class ServerTest {
               // get user metadata
               ids.clear();
               ids.add(new BlobId(payload.blobId, clusterMap));
+              partitionRequestInfoList.clear();
+              partitionRequestInfo = new PartitionRequestInfo(ids.get(0).getPartition(), ids);
+              partitionRequestInfoList.add(partitionRequestInfo);
               getRequest =
-                  new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, ids.get(0).getPartition(), ids);
+                  new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, partitionRequestInfoList);
               channel1.send(getRequest);
               stream = channel1.receive();
               resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -1107,7 +1165,10 @@ public class ServerTest {
               // get blob
               ids.clear();
               ids.add(new BlobId(payload.blobId, clusterMap));
-              getRequest = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, ids.get(0).getPartition(), ids);
+              partitionRequestInfoList.clear();
+              partitionRequestInfo = new PartitionRequestInfo(ids.get(0).getPartition(), ids);
+              partitionRequestInfoList.add(partitionRequestInfo);
+              getRequest = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList);
               channel1.send(getRequest);
               stream = channel1.receive();
               resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
@@ -1202,7 +1263,11 @@ public class ServerTest {
       throws IOException, MessageFormatException {
     ArrayList<BlobId> listIds = new ArrayList<BlobId>();
     listIds.add(blobId);
-    GetRequest getRequest3 = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, blobId.getPartition(), listIds);
+    ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
+    partitionRequestInfoList.clear();
+    PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(blobId.getPartition(), listIds);
+    partitionRequestInfoList.add(partitionRequestInfo);
+    GetRequest getRequest3 = new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList);
     channel.send(getRequest3);
     InputStream stream = channel.receive();
     GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), cluster.getClusterMap());

--- a/ambry-shared/src/main/java/com.github.ambry.shared/PartitionRequestInfo.java
+++ b/ambry-shared/src/main/java/com.github.ambry.shared/PartitionRequestInfo.java
@@ -1,0 +1,79 @@
+package com.github.ambry.shared;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.store.StoreKey;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Contains the partition and the blob ids requested from a partition. This is used
+ * by get request to specify the blob ids in a partition
+ */
+public class PartitionRequestInfo {
+
+  private final PartitionId partitionId;
+  private final ArrayList<BlobId> blobIds;
+  private long totalIdSize;
+
+  private static final int Blob_Id_Count_Size_InBytes = 4;
+
+  public PartitionRequestInfo(PartitionId partitionId, ArrayList<BlobId> blobIds) {
+    this.partitionId = partitionId;
+    this.blobIds = blobIds;
+    totalIdSize = 0;
+    for (BlobId id : blobIds) {
+      totalIdSize += id.sizeInBytes();
+      if (!partitionId.equals(id.getPartition())) {
+        throw new IllegalArgumentException("Not all blob IDs in GetRequest are from the same partition.");
+      }
+    }
+  }
+
+  public PartitionId getPartition() {
+    return partitionId;
+  }
+
+  public List<? extends StoreKey> getBlobIds() {
+    return blobIds;
+  }
+
+  public static PartitionRequestInfo readFrom(DataInputStream stream, ClusterMap clusterMap)
+      throws IOException {
+    int blobCount = stream.readInt();
+    ArrayList<BlobId> ids = new ArrayList<BlobId>(blobCount);
+    PartitionId partitionId = null;
+    while (blobCount > 0) {
+      BlobId id = new BlobId(stream, clusterMap);
+      if (partitionId == null) {
+        partitionId = id.getPartition();
+      }
+      ids.add(id);
+      blobCount--;
+    }
+    return new PartitionRequestInfo(partitionId, ids);
+  }
+
+  public void writeTo(ByteBuffer byteBuffer) {
+    byteBuffer.putInt(blobIds.size());
+    for (BlobId blobId : blobIds) {
+      byteBuffer.put(blobId.toBytes());
+    }
+  }
+
+  public long sizeInBytes() {
+    return Blob_Id_Count_Size_InBytes + totalIdSize;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(", ").append("PartitionId=").append(partitionId);
+    sb.append("ListOfBlobIDs=").append(blobIds);
+    return sb.toString();
+  }
+}

--- a/ambry-shared/src/main/java/com.github.ambry.shared/PartitionResponseInfo.java
+++ b/ambry-shared/src/main/java/com.github.ambry.shared/PartitionResponseInfo.java
@@ -1,0 +1,51 @@
+package com.github.ambry.shared;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.store.MessageInfo;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+
+/**
+ * Contains the partition and the message info list for a partition. This is used by
+ * get response to specify the message info list in a partition
+ */
+public class PartitionResponseInfo {
+
+  private final PartitionId partitionId;
+  private final int messageInfoListSize;
+  private final MessageInfoListSerde messageInfoListSerDe;
+
+  public PartitionResponseInfo(PartitionId partitionId, List<MessageInfo> messageInfoList) {
+    this.messageInfoListSerDe = new MessageInfoListSerde(messageInfoList);
+    this.messageInfoListSize = messageInfoListSerDe.getMessageInfoListSize();
+    this.partitionId = partitionId;
+  }
+
+  public PartitionId getPartition() {
+    return partitionId;
+  }
+
+  public List<MessageInfo> getMessageInfoList() {
+    return messageInfoListSerDe.getMessageInfoList();
+  }
+
+  public static PartitionResponseInfo readFrom(DataInputStream stream, ClusterMap map)
+      throws IOException {
+    PartitionId partitionId = map.getPartitionIdFromStream(stream);
+    List<MessageInfo> messageInfoList = MessageInfoListSerde.deserializeMessageInfoList(stream, map);
+    return new PartitionResponseInfo(partitionId, messageInfoList);
+  }
+
+  public void writeTo(ByteBuffer byteBuffer) {
+    byteBuffer.put(partitionId.getBytes());
+    messageInfoListSerDe.serializeMessageInfoList(byteBuffer);
+  }
+
+  public long sizeInBytes() {
+    return partitionId.getBytes().length + messageInfoListSize;
+  }
+}

--- a/ambry-shared/src/main/java/com.github.ambry.shared/ReplicaMetadataRequestInfo.java
+++ b/ambry-shared/src/main/java/com.github.ambry.shared/ReplicaMetadataRequestInfo.java
@@ -1,0 +1,84 @@
+package com.github.ambry.shared;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.store.FindToken;
+import com.github.ambry.store.FindTokenFactory;
+import com.github.ambry.utils.Utils;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+
+/**
+ * Contains the token, hostname, replicapath for a local partition. This is used
+ * by replica metadata request to specify token in a partition
+ */
+public class ReplicaMetadataRequestInfo {
+  private FindToken token;
+  private String hostName;
+  private String replicaPath;
+  private PartitionId partitionId;
+
+  private static final int ReplicaPath_Field_Size_In_Bytes = 4;
+  private static final int HostName_Field_Size_In_Bytes = 4;
+
+  public ReplicaMetadataRequestInfo(PartitionId partitionId, FindToken token, String hostName, String replicaPath) {
+    this.partitionId = partitionId;
+    this.token = token;
+    this.hostName = hostName;
+    this.replicaPath = replicaPath;
+  }
+
+  public static ReplicaMetadataRequestInfo readFrom(DataInputStream stream, ClusterMap clusterMap,
+      FindTokenFactory factory)
+      throws IOException {
+    String hostName = Utils.readIntString(stream);
+    String replicaPath = Utils.readIntString(stream);
+    PartitionId partitionId = clusterMap.getPartitionIdFromStream(stream);
+    FindToken token = factory.getFindToken(stream);
+    return new ReplicaMetadataRequestInfo(partitionId, token, hostName, replicaPath);
+  }
+
+  public void writeTo(ByteBuffer buffer) {
+    buffer.putInt(hostName.getBytes().length);
+    buffer.put(hostName.getBytes());
+    buffer.putInt(replicaPath.getBytes().length);
+    buffer.put(replicaPath.getBytes());
+    buffer.put(partitionId.getBytes());
+    buffer.put(token.toBytes());
+  }
+
+  public long sizeInBytes() {
+    return HostName_Field_Size_In_Bytes + hostName.getBytes().length + ReplicaPath_Field_Size_In_Bytes + replicaPath
+        .getBytes().length +
+        +partitionId.getBytes().length + token.toBytes().length;
+  }
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Token=").append(token);
+    sb.append(", ").append("PartitionId=").append(partitionId);
+    sb.append(", ").append("HostName=").append(hostName);
+    sb.append(", ").append("ReplicaPath=").append(replicaPath);
+    return sb.toString();
+  }
+
+  public FindToken getToken() {
+    return token;
+  }
+
+  public String getHostName() {
+    return this.hostName;
+  }
+
+  public String getReplicaPath() {
+    return this.replicaPath;
+  }
+
+  public PartitionId getPartitionId() {
+    return partitionId;
+  }
+}

--- a/ambry-shared/src/main/java/com.github.ambry.shared/ReplicaMetadataResponse.java
+++ b/ambry-shared/src/main/java/com.github.ambry.shared/ReplicaMetadataResponse.java
@@ -10,6 +10,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -19,42 +20,29 @@ import java.util.List;
  */
 public class ReplicaMetadataResponse extends Response {
 
-  private FindToken token;
-  private MessageInfoListSerde messageInfoListSerDe;
-  private final int messageInfoListSize;
-  private final long remoteReplicaLagInBytes;
-  private static final int Remote_Replica_Lag_Size_In_Bytes = 8;
+  private List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList;
+  private int replicaMetadataResponseInfoListSizeInBytes;
 
-  public ReplicaMetadataResponse(int correlationId, String clientId, ServerErrorCode error, FindToken token,
-      List<MessageInfo> messageInfoList, long remoteReplicaLag) {
+  private static int Replica_Metadata_Response_Info_List_Size_In_Bytes = 4;
+
+  public ReplicaMetadataResponse(int correlationId, String clientId, ServerErrorCode error,
+      List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList) {
     super(RequestOrResponseType.ReplicaMetadataResponse, Request_Response_Version, correlationId, clientId, error);
-    if (token == null || messageInfoList == null) {
-      throw new IllegalArgumentException("Invalid token or message info list");
+    this.replicaMetadataResponseInfoList = replicaMetadataResponseInfoList;
+    this.replicaMetadataResponseInfoListSizeInBytes = 0;
+    for (ReplicaMetadataResponseInfo replicaMetadataResponseInfo : replicaMetadataResponseInfoList) {
+      this.replicaMetadataResponseInfoListSizeInBytes += replicaMetadataResponseInfo.sizeInBytes();
     }
-    this.token = token;
-    this.messageInfoListSerDe = new MessageInfoListSerde(messageInfoList);
-    this.messageInfoListSize = messageInfoListSerDe.getMessageInfoListSize();
-    this.remoteReplicaLagInBytes = remoteReplicaLag;
   }
 
   public ReplicaMetadataResponse(int correlationId, String clientId, ServerErrorCode error) {
     super(RequestOrResponseType.ReplicaMetadataResponse, Request_Response_Version, correlationId, clientId, error);
-    token = null;
-    this.messageInfoListSerDe = new MessageInfoListSerde(null);
-    this.messageInfoListSize = messageInfoListSerDe.getMessageInfoListSize();
-    this.remoteReplicaLagInBytes = 0;
+    replicaMetadataResponseInfoList = null;
+    replicaMetadataResponseInfoListSizeInBytes = 0;
   }
 
-  public List<MessageInfo> getMessageInfoList() {
-    return messageInfoListSerDe.getMessageInfoList();
-  }
-
-  public FindToken getFindToken() {
-    return token;
-  }
-
-  public long getRemoteReplicaLagInBytes() {
-    return remoteReplicaLagInBytes;
+  public List<ReplicaMetadataResponseInfo> getReplicaMetadataResponseInfoList() {
+    return replicaMetadataResponseInfoList;
   }
 
   public static ReplicaMetadataResponse readFrom(DataInputStream stream, FindTokenFactory factory,
@@ -68,12 +56,20 @@ public class ReplicaMetadataResponse extends Response {
     int correlationId = stream.readInt();
     String clientId = Utils.readIntString(stream);
     ServerErrorCode error = ServerErrorCode.values()[stream.readShort()];
-    FindToken token = factory.getFindToken(stream);
-    List<MessageInfo> messageInfoList = MessageInfoListSerde.deserializeMessageInfoList(stream, clusterMap);
-    long remoteReplicaLag = stream.readLong();
-
-    // ignore version for now
-    return new ReplicaMetadataResponse(correlationId, clientId, error, token, messageInfoList, remoteReplicaLag);
+    int replicaMetadataResponseInfoListCount = stream.readInt();
+    ArrayList<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList =
+        new ArrayList<ReplicaMetadataResponseInfo>(replicaMetadataResponseInfoListCount);
+    for (int i = 0; i < replicaMetadataResponseInfoListCount; i++) {
+      ReplicaMetadataResponseInfo replicaMetadataResponseInfo =
+          ReplicaMetadataResponseInfo.readFrom(stream, factory, clusterMap);
+      replicaMetadataResponseInfoList.add(replicaMetadataResponseInfo);
+    }
+    if (error != ServerErrorCode.No_Error) {
+      return new ReplicaMetadataResponse(correlationId, clientId, error);
+    } else {
+      // ignore version for now
+      return new ReplicaMetadataResponse(correlationId, clientId, error, replicaMetadataResponseInfoList);
+    }
   }
 
   @Override
@@ -82,11 +78,10 @@ public class ReplicaMetadataResponse extends Response {
     if (bufferToSend == null) {
       bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
       writeHeader();
-      if (token != null) {
-        bufferToSend.put(token.toBytes());
-        messageInfoListSerDe.serializeMessageInfoList(bufferToSend);
+      bufferToSend.putInt(replicaMetadataResponseInfoList.size());
+      for (ReplicaMetadataResponseInfo replicaMetadataResponseInfo : replicaMetadataResponseInfoList) {
+        replicaMetadataResponseInfo.writeTo(bufferToSend);
       }
-      bufferToSend.putLong(remoteReplicaLagInBytes);
       bufferToSend.flip();
     }
     if (bufferToSend.remaining() > 0) {
@@ -101,19 +96,19 @@ public class ReplicaMetadataResponse extends Response {
 
   @Override
   public long sizeInBytes() {
-    return super.sizeInBytes() + messageInfoListSize + (token == null ? 0 : token.toBytes().length)
-        + Remote_Replica_Lag_Size_In_Bytes;
+    return super.sizeInBytes() + Replica_Metadata_Response_Info_List_Size_In_Bytes
+        + replicaMetadataResponseInfoListSizeInBytes;
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("ReplicaMetadataResponse[");
-    if (token != null) {
-      sb.append("Token=").append(token);
+    sb.append("ServerErrorCode=").append(getError());
+    sb.append(" ReplicaMetadataResponseInfo ");
+    for (ReplicaMetadataResponseInfo replicaMetadataResponseInfo : replicaMetadataResponseInfoList) {
+      sb.append(replicaMetadataResponseInfo.toString());
     }
-    sb.append(" ServerErrorCode=").append(getError());
-    sb.append(" RemoteReplicaLagInBytes=").append(remoteReplicaLagInBytes);
     sb.append("]");
     return sb.toString();
   }

--- a/ambry-shared/src/main/java/com.github.ambry.shared/ReplicaMetadataResponseInfo.java
+++ b/ambry-shared/src/main/java/com.github.ambry.shared/ReplicaMetadataResponseInfo.java
@@ -1,0 +1,89 @@
+package com.github.ambry.shared;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.store.FindToken;
+import com.github.ambry.store.FindTokenFactory;
+import com.github.ambry.store.MessageInfo;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+
+/**
+ * Contains the token, messageInfoList, remoteReplicaLag for a local partition. This is used
+ * by replica metadata response to specify information for a partition
+ */
+public class ReplicaMetadataResponseInfo {
+  private FindToken token;
+  private MessageInfoListSerde messageInfoListSerDe;
+  private final int messageInfoListSize;
+  private final long remoteReplicaLagInBytes;
+  private PartitionId partitionId;
+
+  private static final int Remote_Replica_Lag_Size_In_Bytes = 8;
+
+  public ReplicaMetadataResponseInfo(PartitionId partitionId, FindToken findToken, List<MessageInfo> messageInfoList,
+      long remoteReplicaLagInBytes) {
+    if (partitionId == null || findToken == null || messageInfoList == null) {
+      throw new IllegalArgumentException("Invalid partition or token or message info list");
+    }
+    this.partitionId = partitionId;
+    this.remoteReplicaLagInBytes = remoteReplicaLagInBytes;
+    messageInfoListSerDe = new MessageInfoListSerde(messageInfoList);
+    messageInfoListSize = messageInfoListSerDe.getMessageInfoListSize();
+    this.token = findToken;
+  }
+
+  public PartitionId getPartitionId() {
+    return partitionId;
+  }
+
+  public List<MessageInfo> getMessageInfoList() {
+    return messageInfoListSerDe.getMessageInfoList();
+  }
+
+  public FindToken getFindToken() {
+    return token;
+  }
+
+  public long getRemoteReplicaLagInBytes() {
+    return remoteReplicaLagInBytes;
+  }
+
+  public static ReplicaMetadataResponseInfo readFrom(DataInputStream stream, FindTokenFactory factory,
+      ClusterMap clusterMap)
+      throws IOException {
+    PartitionId partitionId = clusterMap.getPartitionIdFromStream(stream);
+    FindToken token = factory.getFindToken(stream);
+    List<MessageInfo> messageInfoList = MessageInfoListSerde.deserializeMessageInfoList(stream, clusterMap);
+    long remoteReplicaLag = stream.readLong();
+    return new ReplicaMetadataResponseInfo(partitionId, token, messageInfoList, remoteReplicaLag);
+  }
+
+  public void writeTo(ByteBuffer buffer) {
+    buffer.put(partitionId.getBytes());
+    if (token != null) {
+      buffer.put(token.toBytes());
+      messageInfoListSerDe.serializeMessageInfoList(buffer);
+    }
+    buffer.putLong(remoteReplicaLagInBytes);
+  }
+
+  public long sizeInBytes() {
+    return messageInfoListSize + (token == null ? 0 : token.toBytes().length) + Remote_Replica_Lag_Size_In_Bytes
+        + partitionId.getBytes().length;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(partitionId);
+    if (token != null) {
+      sb.append(" Token=").append(token);
+    }
+    sb.append(" RemoteReplicaLagInBytes=").append(remoteReplicaLagInBytes);
+    return sb.toString();
+  }
+}

--- a/ambry-tools/src/main/java/com.github.ambry.tools/perf/ServerReadPerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/perf/ServerReadPerformance.java
@@ -19,6 +19,7 @@ import com.github.ambry.shared.ConnectedChannel;
 import com.github.ambry.shared.ConnectionPool;
 import com.github.ambry.shared.GetRequest;
 import com.github.ambry.shared.GetResponse;
+import com.github.ambry.shared.PartitionRequestInfo;
 import com.github.ambry.utils.ByteBufferOutputStream;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Throttler;
@@ -137,9 +138,13 @@ public class ServerReadPerformance {
         blobIds.add(blobId);
         for (ReplicaId replicaId : blobId.getPartition().getReplicaIds()) {
           long startTimeGetBlob = 0;
+          ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
           try {
+            partitionRequestInfoList.clear();
+            PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(blobId.getPartition(), blobIds);
+            partitionRequestInfoList.add(partitionRequestInfo);
             GetRequest getRequest =
-                new GetRequest(1, "getperf", MessageFormatFlags.Blob, blobId.getPartition(), blobIds);
+                new GetRequest(1, "getperf", MessageFormatFlags.Blob, partitionRequestInfoList);
             channel = connectionPool
                 .checkOutConnection(replicaId.getDataNodeId().getHostname(), replicaId.getDataNodeId().getPort(),
                     10000);
@@ -174,8 +179,11 @@ public class ServerReadPerformance {
               minLatencyForGetBlobs = Long.MAX_VALUE;
             }
 
+            partitionRequestInfoList.clear();
+            partitionRequestInfo = new PartitionRequestInfo(blobId.getPartition(), blobIds);
+            partitionRequestInfoList.add(partitionRequestInfo);
             GetRequest getRequestProperties =
-                new GetRequest(1, "getperf", MessageFormatFlags.BlobProperties, blobId.getPartition(), blobIds);
+                new GetRequest(1, "getperf", MessageFormatFlags.BlobProperties, partitionRequestInfoList);
             long startTimeGetBlobProperties = SystemTime.getInstance().nanoseconds();
             channel.send(getRequestProperties);
             InputStream receivePropertyStream = channel.receive();
@@ -184,8 +192,11 @@ public class ServerReadPerformance {
                 MessageFormatRecord.deserializeBlobProperties(getResponseProperty.getInputStream());
             long endTimeGetBlobProperties = SystemTime.getInstance().nanoseconds() - startTimeGetBlobProperties;
 
+            partitionRequestInfoList.clear();
+            partitionRequestInfo = new PartitionRequestInfo(blobId.getPartition(), blobIds);
+            partitionRequestInfoList.add(partitionRequestInfo);
             GetRequest getRequestUserMetadata =
-                new GetRequest(1, "getperf", MessageFormatFlags.BlobUserMetadata, blobId.getPartition(), blobIds);
+                new GetRequest(1, "getperf", MessageFormatFlags.BlobUserMetadata, partitionRequestInfoList);
 
             long startTimeGetBlobUserMetadata = SystemTime.getInstance().nanoseconds();
             channel.send(getRequestUserMetadata);


### PR DESCRIPTION
1. Add a way to materialize the stream for MessageFormatWriteSet
2. Add CompositeMessageFormatSend that can send multiple messages across partitions
3. Add rpcs to support batch gets and batch replica metadata request
4. Update unit tests for changes. The changes are required to support batch replication that would happen as a later patch
