### PR TITLE
Ensure mountpaths are absolute paths

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Disk.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Disk.java
@@ -5,6 +5,8 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+
 
 /**
  * A Disk stores {@link Replica}s. Each Disk is hosted on one specific {@link DataNode}. Each Disk is uniquely
@@ -91,6 +93,10 @@ public class Disk implements DiskId {
     }
     if (mountPath.length() == 0) {
       throw new IllegalStateException("Mount path cannot be zero-length string.");
+    }
+    File mountPathFile = new File(mountPath);
+    if (!mountPathFile.isAbsolute()) {
+      throw new IllegalStateException("Mount path has to be an absolute path.");
     }
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DiskTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DiskTest.java
@@ -80,8 +80,11 @@ public class DiskTest {
       // Expected.
     }
 
-    // Bad mount path
+    // Bad mount path (empty)
     failValidation(TestUtils.getJsonDisk("", HardwareState.AVAILABLE, 100 * 1024 * 1024 * 1024L));
+
+    // Bad mount path (relative path)
+    failValidation(TestUtils.getJsonDisk("mnt1", HardwareState.AVAILABLE, 100 * 1024 * 1024 * 1024L));
 
     // Bad capacity (too small)
     failValidation(TestUtils.getJsonDisk("/mnt1", HardwareState.UNAVAILABLE, 0));


### PR DESCRIPTION
The original issue with trailing '/' in the mount paths in config couldn't be reproduced. We still want a check to ensure that the mount paths are absolute paths.
