### PR TITLE
Fix datanode and disk retry backoff values

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -68,12 +68,12 @@ public class ClusterMapConfig {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
     clusterMapFixedTimeoutDataNodeRetryBackoffMs = verifiableProperties
-        .getIntInRange("clustermap.fixedtimeout.datanode.retry.backoff.ms", 10000, 1, 5 * 60 * 1000);
+        .getIntInRange("clustermap.fixedtimeout.datanode.retry.backoff.ms", 5 * 60 * 1000, 1, 20 * 60 * 1000);
     clusterMapFixedTimeoutDiskWindowMs =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.disk.window.ms", 2000, 1, 100000);
     clusterMapFixedTimeoutDiskErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.disk.error.threshold", 1, 1, 100);
-    clusterMapFixedTimeoutDiskRetryBackoffMs =
-        verifiableProperties.getIntInRange("clustermap.fixedtimeout.disk.retry.backoff.ms", 10000, 1, 10 * 60 * 1000);
+    clusterMapFixedTimeoutDiskRetryBackoffMs = verifiableProperties
+        .getIntInRange("clustermap.fixedtimeout.disk.retry.backoff.ms", 10 * 60 * 1000, 1, 30 * 60 * 1000);
   }
 }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DataNodeTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DataNodeTest.java
@@ -127,7 +127,9 @@ public class DataNodeTest {
       throws JSONException, InterruptedException {
     JSONObject jsonObject =
         TestUtils.getJsonDataNode(TestUtils.getLocalHost(), 6666, HardwareState.AVAILABLE, getDisks());
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
+    Properties props = new Properties();
+    props.setProperty("clustermap.fixedtimeout.datanode.retry.backoff.ms", Integer.toString(2000));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     long windowMs = clusterMapConfig.clusterMapFixedTimeoutDatanodeWindowMs;
     int threshold = clusterMapConfig.clusterMapFixedTimeoutDatanodeErrorThreshold;
     long retryBackoffMs = clusterMapConfig.clusterMapFixedTimeoutDataNodeRetryBackoffMs;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DiskTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DiskTest.java
@@ -2,7 +2,9 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
+
 import java.util.Properties;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -110,7 +112,9 @@ public class DiskTest {
   public void testDiskSoftState()
       throws JSONException, InterruptedException {
     JSONObject jsonObject = TestUtils.getJsonDisk("/mnt1", HardwareState.AVAILABLE, 100 * 1024 * 1024 * 1024L);
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
+    Properties props = new Properties();
+    props.setProperty("clustermap.fixedtimeout.disk.retry.backoff.ms", Integer.toString(2000));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
 
     long windowMs = clusterMapConfig.clusterMapFixedTimeoutDiskWindowMs;
     int threshold = clusterMapConfig.clusterMapFixedTimeoutDiskErrorThreshold;


### PR DESCRIPTION
We override these through fabric.src, but let us still fix the defaults.
