### PR TITLE
Avoid looking up a deleted key's delete status when processing replication requests

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
@@ -51,10 +51,6 @@ public class MessageInfo {
     return getExpirationTimeInMs() != Utils.Infinite_Time && System.currentTimeMillis() > getExpirationTimeInMs();
   }
 
-  public void setDeleted(boolean isDeleted) {
-    this.isDeleted = isDeleted;
-  }
-
   @Override
   public String toString() {
     StringBuilder stringBuilder = new StringBuilder();

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -749,10 +749,14 @@ public class PersistentIndex {
    */
   private void updateDeleteStateForMessages(List<MessageInfo> messageEntries)
       throws StoreException {
-    for (MessageInfo messageInfo : messageEntries) {
+    ListIterator<MessageInfo> messageEntriesIterator = messageEntries.listIterator();
+    while (messageEntriesIterator.hasNext()) {
+      MessageInfo messageInfo = messageEntriesIterator.next();
       if (!messageInfo.isDeleted()) {
         IndexValue indexValue = findKey(messageInfo.getStoreKey());
-        messageInfo.setDeleted(indexValue.isFlagSet(IndexValue.Flags.Delete_Index));
+        messageInfo = new MessageInfo(messageInfo.getStoreKey(), messageInfo.getSize(),
+            indexValue.isFlagSet(IndexValue.Flags.Delete_Index), messageInfo.getExpirationTimeInMs());
+        messageEntriesIterator.set(messageInfo);
       }
     }
   }


### PR DESCRIPTION
Three changes in this pull request:
1. We look up the delete state for every message and update it before sending them out as part of the replication response. Particularly in a disk repair scenario, where keys are being scanned from the beginning, we might end up looking up a lot of segments as part of findKey. Let us at least optimize it and avoid unnecessarily looking up keys that are already in the deleted state.
2. We use the number of entries in a segment as an indicator of whether it has been modified since it was last persisted. This is incorrect as when we delete a key, the number of entries remain unchanged and that change needs to be persisted. A correct indicator would be the log end offset that was saved previously for the segment.
3. Update a metric correctly.
