### PR TITLE
Fix the way exceptions are printed during hard delete iteration

### DIFF
--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
@@ -183,7 +183,7 @@ class BlobStoreHardDeleteIterator implements Iterator<HardDeleteInfo> {
               "Unknown header version during hard delete" + version + "storeKey " + readSet.getKeyAt(readSetIndex));
       }
     } catch (Exception e) {
-      logger.error("Exception when reading blob: {}", e);
+      logger.error("Exception when reading blob", e);
     }
     return hardDeleteInfo;
   }


### PR DESCRIPTION
While testing out hard deletes in EI, noticed that a lot of the iterations end up as exceptions which we ignore and proceed. Unfortunately, the exceptions are not printed correctly. Fixing that.
