### PR TITLE
remove per node metrics in Selector

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -282,8 +282,6 @@ public class Selector implements Selectable {
         iter.remove();
 
         Transmissions transmissions = transmissions(key);
-        // register all per-node metrics at once
-        //metrics.initializeSelectorNodeMetricIfRequired(transmissions.remoteHostName, transmissions.remotePort);
         try {
           if (key.isConnectable()) {
             handleConnect(key, transmissions);
@@ -441,7 +439,6 @@ public class Selector implements Selectable {
     key.interestOps(key.interestOps() & ~SelectionKey.OP_CONNECT | SelectionKey.OP_READ);
     this.connected.add(transmissions.getConnectionId());
     this.metrics.selectorConnectionCreated.inc();
-    //this.metrics.initializeSelectorNodeMetricIfRequired(transmissions.remoteHostName, transmissions.remotePort);
   }
 
   /**
@@ -467,9 +464,6 @@ public class Selector implements Selectable {
 
       if (transmissions.receive.getReceivedBytes().isReadComplete()) {
         this.completedReceives.add(transmissions.receive);
-        //metrics.updateNodeReceiveMetric(transmissions.remoteHostName, transmissions.remotePort,
-        //    transmissions.receive.getReceivedBytes().getPayload().limit(),
-        //    time.milliseconds() - transmissions.receive.getReceiveStartTimeInMs());
         transmissions.clearReceive();
       }
     } finally {
@@ -501,8 +495,6 @@ public class Selector implements Selectable {
         networkSend.onSendComplete();
         this.completedSends.add(networkSend);
         metrics.sendInFlight.dec();
-        //metrics.updateNodeSendMetric(transmissions.remoteHostName, transmissions.remotePort, send.sizeInBytes(),
-        //    time.milliseconds() - networkSend.getSendStartTimeInMs());
         transmissions.clearSend();
         key.interestOps(key.interestOps() & ~SelectionKey.OP_WRITE | SelectionKey.OP_READ);
       }


### PR DESCRIPTION
I looked at the metrics of Selector and found the original metrics to track the bytes sent and received from each remote host and port doesn't make sense for SocketServer.

For SoecketServer, the remote host is frontend or another ambry server and port is random generated. It makes a lot of metrics since the connection may be disconnect and regenerated in another port.

So remove code to track these metrics.
