### PR TITLE
Ensure segment rollover checks are done during store deletes

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -418,7 +418,7 @@ public class PersistentIndex {
   /**
    * Marks the index entry represented by the key for delete
    * @param id The id of the entry that needs to be deleted
-   * @param fileSpan The file range represented by this entry in the log
+   * @param fileSpan The file span represented by this entry in the log
    * @throws StoreException
    */
   public void markAsDeleted(StoreKey id, FileSpan fileSpan)
@@ -435,8 +435,7 @@ public class PersistentIndex {
     newValue.setFlag(IndexValue.Flags.Delete_Index);
     newValue.setNewOffset(fileSpan.getStartOffset());
     newValue.setNewSize(fileSpan.getEndOffset() - fileSpan.getStartOffset());
-    indexes.lastEntry().getValue().addEntry(new IndexEntry(id, newValue), fileSpan.getEndOffset());
-    journal.addEntry(fileSpan.getStartOffset(), id);
+    addToIndex(new IndexEntry(id, newValue), fileSpan);
   }
 
   /**


### PR DESCRIPTION
We should ensure that rollover checks are done during deletes as well - otherwise if only deletes happen for a while and no puts, the segment will continue growing. This is particularly true with read-only partitions. Besides, there is no real reason for deletes to not do the check, it was probably an omission.
