### PR TITLE
add two more metrics

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -73,6 +73,8 @@ public class NetworkMetrics {
   public final Histogram sslSendTimePerKB;
   public final Histogram sslEncryptionTimePerKB;
   public final Histogram sslDecryptionTimePerKB;
+  public final Histogram sslEncryptionBytes;
+  public final Histogram sslDecryptionBytes;
   // the count of renegotiation after initial handshake done
   public final Counter sslRenegotiationCount;
 
@@ -123,6 +125,8 @@ public class NetworkMetrics {
     sslSendBytesRate = registry.histogram(MetricRegistry.name(Selector.class, "SslSendBytesRate"));
     sslEncryptionTimePerKB = registry.histogram(MetricRegistry.name(Selector.class, "SslEncryptionTimePerKB"));
     sslDecryptionTimePerKB = registry.histogram(MetricRegistry.name(Selector.class, "SslDecryptionTimePerKB"));
+    sslEncryptionBytes = registry.histogram(MetricRegistry.name(Selector.class, "SslEncryptionBytes"));
+    sslDecryptionBytes = registry.histogram(MetricRegistry.name(Selector.class, "SslDecryptionBytes"));
     sslReceiveTimePerKB = registry.histogram(MetricRegistry.name(Selector.class, "SslReceiveTimePerKB"));
     sslSendTimePerKB = registry.histogram(MetricRegistry.name(Selector.class, "SslSendTimePerKB"));
     sslFactoryInitializationCount =

--- a/ambry-network/src/main/java/com.github.ambry.network/SSLTransmission.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/SSLTransmission.java
@@ -429,6 +429,7 @@ public class SSLTransmission extends Transmission implements ReadableByteChannel
         SSLEngineResult unwrapResult = sslEngine.unwrap(netReadBuffer, appReadBuffer);
         long decryptionTimeMs = SystemTime.getInstance().milliseconds() - startTimeMs;
         logger.trace("SSL decryption time: {} ms for {} bytes", decryptionTimeMs, unwrapResult.bytesProduced());
+        metrics.sslDecryptionBytes.update(unwrapResult.bytesProduced());
         if (unwrapResult.bytesProduced() > 0) {
           metrics.sslDecryptionTimePerKB.update(decryptionTimeMs * 1024 / unwrapResult.bytesProduced());
         }
@@ -529,6 +530,7 @@ public class SSLTransmission extends Transmission implements ReadableByteChannel
     SSLEngineResult wrapResult = sslEngine.wrap(src, netWriteBuffer);
     long encryptionTimeMs = SystemTime.getInstance().milliseconds() - startTimeMs;
     logger.trace("SSL encryption time: {} ms for {} bytes", encryptionTimeMs, wrapResult.bytesConsumed());
+    metrics.sslEncryptionBytes.update(wrapResult.bytesConsumed());
     if (wrapResult.bytesConsumed() > 0) {
       metrics.sslEncryptionTimePerKB.update(encryptionTimeMs * 1024 / wrapResult.bytesConsumed());
     }


### PR DESCRIPTION
Based on the profiling result, we think we need to track the number of bytes encrypted or decrypted in each wrap or unwrap call.
