### PR TITLE
Fix a bug with replication token persistence

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,7 @@ project(':ambry-replication') {
                 project(':ambry-network')
         compile "com.codahale.metrics:metrics-core:$metricsVersion"
         testCompile project(':ambry-clustermap').sourceSets.test.output
+        testCompile project(':ambry-utils').sourceSets.test.output
     }
 }
 


### PR DESCRIPTION
We found the cause of the issue of tokens getting reset unnecessarily during deployment, and causing the lag to go up. This pull request fixes that, and adds unit tests for testing the logic that determines what the token to persist should be at any point in time.

The cause: When the replication manager is started, all internal tokens within the class that determines the token to persist (`RemoteReplicaInfo`) are uninitialized. When the replication manager reads the tokens on disk and finds a valid token for a replica, it calls into this class to set the `currentToken` to the newly read token. However, the `currentToken` becomes eligible for persisting only after `tokenPersistInterval` has passed. This eventually happens usually. However, if a shutdown happens before this interval has passed, then this will not happen and the token that is persisted will be one of the uninitialized ones.

During deployment, we sometimes encounter such scenarios (of replication manager starting up and soon shutting down) when a subsequent component encounters an exception during its startup.

Primary reviewer: Gopal.
