### PR TITLE
Change to FutureResult to accept Exception instead of RuntimeException

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/router/FutureResult.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/FutureResult.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeoutException;
 public class FutureResult<T> implements Future<T> {
 
   private final CountDownLatch latch = new CountDownLatch(1);
-  private volatile RuntimeException error;
+  private volatile Exception error;
   private volatile T result;
 
   /**
@@ -21,7 +21,7 @@ public class FutureResult<T> implements Future<T> {
    * @param result The result for this request
    * @param error The error that occurred if there was one, or null.
    */
-  public void done(T result, RuntimeException error) {
+  public void done(T result, Exception error) {
     this.error = error;
     this.result = result;
     this.latch.countDown();
@@ -56,7 +56,7 @@ public class FutureResult<T> implements Future<T> {
   /**
    * The error thrown (generally on the server) while processing this request
    */
-  public RuntimeException error() {
+  public Exception error() {
     return error;
   }
 

--- a/ambry-api/src/test/java/com.github.ambry/router/InMemoryRouter.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/InMemoryRouter.java
@@ -215,11 +215,7 @@ public class InMemoryRouter implements Router {
    */
   protected static void completeOperation(FutureResult futureResult, Callback callback, Object operationResult,
       Exception exception) {
-    RuntimeException runtimeException = null;
-    if (exception != null) {
-      runtimeException = new RuntimeException(exception);
-    }
-    futureResult.done(operationResult, runtimeException);
+    futureResult.done(operationResult, exception);
     if (callback != null) {
       callback.onCompletion(operationResult, exception);
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/CoordinatorBackedRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/CoordinatorBackedRouter.java
@@ -216,11 +216,7 @@ public class CoordinatorBackedRouter implements Router {
       Exception exception) {
     long postProcessingStartTime = System.currentTimeMillis();
     try {
-      RuntimeException runtimeException = null;
-      if (exception != null) {
-        runtimeException = new RuntimeException(exception);
-      }
-      futureResult.done(operationResult, runtimeException);
+      futureResult.done(operationResult, exception);
       if (callback != null) {
         callback.onCompletion(operationResult, exception);
       }

--- a/ambry-router/src/test/java/com.github.ambry.router/CoordinatorBackedRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CoordinatorBackedRouterTest.java
@@ -198,8 +198,7 @@ public class CoordinatorBackedRouterTest {
       future.get();
       fail("Callback had an exception but future.get() did not throw exception");
     } catch (Exception e) {
-      assertEquals("Callback and future exceptions do not match", routerOperationCallback.getException(),
-          e.getCause().getCause());
+      assertEquals("Callback and future exceptions do not match", routerOperationCallback.getException(), e.getCause());
     }
   }
 


### PR DESCRIPTION
Based on one of Terry's comments in [PR204](https://github.com/linkedin/ambry/pull/204), we decided that `FutureResult` should accept `Exception` in its `done()` method instead of `RuntimeException` only (since the exception is later converted to `ExecutionException` anyway). Having it as `RuntimeException` only was creating code bloat also.

Primary reviewers: Terry
Expected time to review: 2-5 mins 
