### PR TITLE
Adding keep-alive support

### DIFF
--- a/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageService.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageService.java
@@ -156,8 +156,9 @@ public class MockBlobStorageService implements BlobStorageService {
       shouldProceed = false;
       ReadableStreamChannel response = null;
       Exception exception = null;
-      if (ECHO_REST_METHOD.equals(uri)) {
-        ByteBuffer buffer = ByteBuffer.wrap(restRequest.getRestMethod().toString().getBytes());
+      if (uri.startsWith(ECHO_REST_METHOD)) {
+        String responseStr = restRequest.getRestMethod().toString() + uri.substring(ECHO_REST_METHOD.length());
+        ByteBuffer buffer = ByteBuffer.wrap(responseStr.getBytes());
         response = new ByteBufferRSC(buffer);
       } else if (THROW_RUNTIME_EXCEPTION.equals(uri)) {
         throw new RuntimeException(THROW_RUNTIME_EXCEPTION);

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
@@ -52,6 +52,7 @@ class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> {
   // variables that will live for the life of a single request.
   private volatile NettyRequest request = null;
   private volatile NettyResponseChannel responseChannel = null;
+  private volatile boolean requestContentFullyReceived = false;
 
   // variables that live for one channelRead0
   private volatile Long lastChannelReadTime = null;
@@ -184,33 +185,26 @@ class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> {
       throws RestServiceException {
     logger.trace("Reading on channel {}", ctx.channel());
     long currentTime = System.currentTimeMillis();
-    if (lastChannelReadTime != null) {
-      nettyMetrics.channelReadIntervalInMs.update(currentTime - lastChannelReadTime);
-      logger.trace("Delay between channel reads is {} ms", (currentTime - lastChannelReadTime));
-    }
-    lastChannelReadTime = currentTime;
 
-    if (request == null) {
-      responseChannel = new NettyResponseChannel(ctx, nettyMetrics);
-      logger.trace("Created RestResponseChannel for channel {}", ctx.channel());
-    }
     if (obj instanceof HttpRequest) {
-      if (obj.getDecoderResult().isSuccess()) {
-        handleRequest((HttpRequest) obj);
-      } else {
-        logger.warn("Decoder failed because of malformed request on channel {}", ctx.channel());
-        nettyMetrics.malformedRequestError.inc();
-        throw new RestServiceException("Decoder failed because of malformed request",
-            RestServiceErrorCode.MalformedRequest);
-      }
+      handleRequest((HttpRequest) obj);
     } else if (obj instanceof HttpContent) {
       handleContent((HttpContent) obj);
     } else {
       logger.warn("Received null/unrecognized HttpObject {} on channel {}", obj, ctx.channel());
       nettyMetrics.unknownHttpObjectError.inc();
+      if (responseChannel == null || responseChannel.isResponseComplete()) {
+        resetState();
+      }
       throw new RestServiceException("HttpObject received is null or not of a known type",
           RestServiceErrorCode.UnknownHttpObject);
     }
+
+    if (lastChannelReadTime != null) {
+      nettyMetrics.channelReadIntervalInMs.update(currentTime - lastChannelReadTime);
+      logger.trace("Delay between channel reads is {} ms", (currentTime - lastChannelReadTime));
+    }
+    lastChannelReadTime = currentTime;
   }
 
   /**
@@ -225,25 +219,32 @@ class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> {
    */
   private void handleRequest(HttpRequest httpRequest)
       throws RestServiceException {
-    // We need to maintain state about the request itself for the subsequent parts (if any) that come in. We will attach
-    // content to the request as the content arrives.
-    if (request == null) {
+    if (responseChannel == null || responseChannel.isResponseComplete()) {
       long processingStartTime = System.currentTimeMillis();
       try {
+        resetState();
         nettyMetrics.requestArrivalRate.mark();
+        if (!httpRequest.getDecoderResult().isSuccess()) {
+          logger.warn("Decoder failed because of malformed request on channel {}", ctx.channel());
+          nettyMetrics.malformedRequestError.inc();
+          throw new RestServiceException("Decoder failed because of malformed request",
+              RestServiceErrorCode.MalformedRequest);
+        }
+        // We need to maintain state about the request itself for the subsequent parts (if any) that come in. We will
+        // attach content to the request as the content arrives.
         request = new NettyRequest(httpRequest, nettyMetrics);
         responseChannel.setRequest(request);
         logger.trace("Channel {} now handling request {}", ctx.channel(), request.getUri());
+        // We send POST for handling immediately since we expect valid content with it.
+        // With any other method that we support, we do not expect any valid content. LastHttpContent is a Netty thing.
+        // So we wait for LastHttpContent (throw an error if we don't receive it or receive something else) and then
+        // schedule the other methods for handling in handleContent().
+        if (request.getRestMethod().equals(RestMethod.POST)) {
+          requestHandler.handleRequest(request, responseChannel);
+        }
       } finally {
         request.getMetricsTracker().nioMetricsTracker
             .addToRequestProcessingTime(System.currentTimeMillis() - processingStartTime);
-      }
-      // We send POST for handling immediately since we expect valid content with it.
-      // With any other method that we support, we do not expect any valid content. LastHttpContent is a Netty thing.
-      // So we wait for LastHttpContent (throw an error if we don't receive it or receive something else) and then
-      // schedule the other methods for handling in handleContent().
-      if (request.getRestMethod().equals(RestMethod.POST)) {
-        requestHandler.handleRequest(request, responseChannel);
       }
     } else {
       // We have received a request when we were not expecting one. This shouldn't happen and there is no good way to
@@ -266,12 +267,13 @@ class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> {
    */
   private void handleContent(HttpContent httpContent)
       throws RestServiceException {
-    if (request != null) {
+    if (request != null && !requestContentFullyReceived) {
       long processingStartTime = System.currentTimeMillis();
       nettyMetrics.bytesReadRate.mark(httpContent.content().readableBytes());
       try {
         logger.trace("Received content for request - {}", request.getUri());
         try {
+          requestContentFullyReceived = httpContent instanceof LastHttpContent;
           request.addContent(httpContent);
         } catch (IllegalStateException e) {
           nettyMetrics.contentAdditionError.inc();
@@ -290,7 +292,8 @@ class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> {
         requestHandler.handleRequest(request, responseChannel);
       }
     } else {
-      logger.warn("Received content without a request on channel {}", ctx.channel());
+      resetState();
+      logger.warn("Received content when it was not expected on channel {}", ctx.channel());
       nettyMetrics.noRequestError.inc();
       throw new RestServiceException("Received content without a request", RestServiceErrorCode.InvalidRequestState);
     }
@@ -302,7 +305,7 @@ class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> {
    */
   private void onRequestAborted(Exception exception) {
     if (responseChannel != null) {
-      if (request != null) {
+      if (request != null && !responseChannel.isResponseComplete()) {
         logger.trace("Request {} is aborted", request.getUri());
       }
       responseChannel.onResponseComplete(exception);
@@ -318,5 +321,16 @@ class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> {
       nettyMetrics.missingResponseChannelError.inc();
       ctx.close();
     }
+  }
+
+  /**
+   * Resets the state of the processor in preparation for the next request.
+   */
+  private void resetState() {
+    request = null;
+    lastChannelReadTime = null;
+    requestContentFullyReceived = false;
+    responseChannel = new NettyResponseChannel(ctx, nettyMetrics);
+    logger.trace("Refreshed state for channel {}", ctx.channel());
   }
 }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -262,6 +262,14 @@ class NettyRequest implements RestRequest {
   }
 
   /**
+   * Provides info on whether this request desires keep-alive or not.
+   * @return {@code true} if keep-alive. {@code false} otherwise.
+   */
+  protected boolean isKeepAlive() {
+    return HttpHeaders.isKeepAlive(request);
+  }
+
+  /**
    * Writes the data in the provided {@code httpContent} to the given {@code writeChannel}.
    * @param writeChannel the {@link AsyncWritableChannel} to write the data of {@code httpContent} to.
    * @param callbackWrapper the {@link ReadIntoCallbackWrapper} for the read operation.

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
@@ -437,6 +437,24 @@ public class NettyRequestTest {
     }
   }
 
+  @Test
+  public void keepAliveTest()
+      throws RestServiceException {
+    NettyRequest request = createNettyRequest(HttpMethod.GET, "/", null);
+    // by default, keep-alive is true for HTTP 1.1
+    assertTrue("Keep-alive not as expected", request.isKeepAlive());
+
+    HttpHeaders headers = new DefaultHttpHeaders();
+    headers.set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+    request = createNettyRequest(HttpMethod.GET, "/", headers);
+    assertTrue("Keep-alive not as expected", request.isKeepAlive());
+
+    headers = new DefaultHttpHeaders();
+    headers.set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE);
+    request = createNettyRequest(HttpMethod.GET, "/", headers);
+    assertFalse("Keep-alive not as expected", request.isKeepAlive());
+  }
+
   /**
    * Tests the {@link NettyRequest#getSize()} function to see that it respects priorities.
    * @throws RestServiceException


### PR DESCRIPTION
This change adds keep-alive support for the RestServer. Connections will now be kept alive if there were no exceptions. Also handles sending the right headers to the client depending on whether the server is able to keep the connection alive or not.

**Primary reviewers: Terry, Priyesh
Expected time to review: 30-45 mins**
