### PR TITLE
Adding OperationTracker for NB Router.

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/OperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/OperationTracker.java
@@ -9,9 +9,8 @@ import java.util.Iterator;
  * will then send requests to multiple replicas. An operation succeeds if a pre-set number of
  * successful responses are received from the replicas, or fails if this number cannot be met.
  *
- * An {@code OperationTracker} tracks and determines the status of an operation (succeeded or
- * done), and decides the next replica to send a request. An {@code OperationTracker} one-to-one
- * tracks an operation.
+ * An {@code OperationTracker} tracks and determines the status of an operation, and decides the
+ * next replica to send a request.
  *
  * When an operation is progressing by receiving responses from replicas, its {@code OperationTracker}
  * needs to be informed by calling {@link #onResponse(ReplicaId, Exception)}.

--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -45,14 +45,14 @@ import java.util.NoSuchElementException;
 class SimpleOperationTracker implements OperationTracker {
   private final int successTarget;
   private final int parallelism;
+  private final LinkedList<ReplicaId> replicaPool = new LinkedList<ReplicaId>();
+  private final OpTrackerIterator otIterator;
 
   private int totalReplicaCount = 0;
   private int inflightCount = 0;
   private int succeededCount = 0;
   private int failedCount = 0;
   private Iterator<ReplicaId> replicaIterator;
-  private final LinkedList<ReplicaId> replicaPool = new LinkedList<ReplicaId>();
-  private final OpTrackerIterator otIterator;
 
   /**
    * Constructor for an {@code SimpleOperationTracker}.
@@ -61,8 +61,8 @@ class SimpleOperationTracker implements OperationTracker {
    * @param partitionId The partition on which the operation is performed.
    * @param crossColoEnabled {@code true} if requests can be sent to remote replicas, {@code false}
    *                                otherwise.
-   * @param successTarget The number of successful responses received to succeed the operation.
-   * @param parallelism The maximum number of inflight requests sent to all replicas.
+   * @param successTarget The number of successful responses required to succeed the operation.
+   * @param parallelism The maximum number of inflight requests at any point of time.
    */
   SimpleOperationTracker(String datacenterName, PartitionId partitionId, boolean crossColoEnabled, int successTarget,
       int parallelism) {
@@ -132,6 +132,6 @@ class SimpleOperationTracker implements OperationTracker {
   }
 
   private boolean hasFailed() {
-    return (totalReplicaCount - failedCount < successTarget);
+    return (totalReplicaCount - failedCount ) < successTarget;
   }
 }


### PR DESCRIPTION
Addressed comments for OperationTracker
1. Changed interface;
2. Redefined the way of usage through iterator;
3. Implementation-wise, a single list for all unsent replicas;
4. Implementation-wise, a single parallelism parameter is employed without differentiating local and remote replicas. However, PUT manager it only considers local replicas.
5. Use an inner class for iterator of operation tracker.

Example usage:

``` Java
  SimpleOperationTracker operationTracker = new SimpleOperationTracker(datacenterName,
  partitionId, crossColoEnabled, successTarget, parallelism);
  Iterator<ReplicaId> itr = operationTracker.getIterator();
  while (itr.hasNext()) {
    ReplicaId nextReplica = itr.next();
    //determine if the request can ben sent, i.e., connection available.
    if(send is successful) {
      itr.remove();
    }
  }
```

Test done:
./gradlew build
