### PR TITLE
Changing return type of getArgs() in RestRequest.

### DIFF
--- a/ambry-admin/src/main/java/com.github.ambry.admin/EchoHandler.java
+++ b/ambry-admin/src/main/java/com.github.ambry.admin/EchoHandler.java
@@ -8,7 +8,6 @@ import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.ReadableStreamChannel;
 import java.nio.ByteBuffer;
-import java.util.List;
 import java.util.Map;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -64,9 +63,9 @@ class EchoHandler {
    */
   private static JSONObject echo(RestRequest restRequest, AdminMetrics adminMetrics)
       throws RestServiceException {
-    Map<String, List<String>> parameters = restRequest.getArgs();
+    Map<String, Object> parameters = restRequest.getArgs();
     if (parameters != null && parameters.containsKey(TEXT_KEY)) {
-      String text = parameters.get(TEXT_KEY).get(0);
+      String text = parameters.get(TEXT_KEY).toString();
       logger.trace("Text to echo for request {} is {}", restRequest.getUri(), text);
       try {
         return packageResult(text);

--- a/ambry-admin/src/main/java/com.github.ambry.admin/GetReplicasForBlobIdHandler.java
+++ b/ambry-admin/src/main/java/com.github.ambry.admin/GetReplicasForBlobIdHandler.java
@@ -74,9 +74,9 @@ class GetReplicasForBlobIdHandler {
   private static JSONObject getReplicasForBlobId(RestRequest restRequest, ClusterMap clusterMap,
       AdminMetrics adminMetrics)
       throws RestServiceException {
-    Map<String, List<String>> parameters = restRequest.getArgs();
+    Map<String, Object> parameters = restRequest.getArgs();
     if (parameters != null && parameters.containsKey(BLOB_ID_KEY)) {
-      String blobIdStr = parameters.get(BLOB_ID_KEY).get(0);
+      String blobIdStr = parameters.get(BLOB_ID_KEY).toString();
       logger.trace("BlobId for request {} is {}", restRequest.getUri(), blobIdStr);
       try {
         PartitionId partitionId = new BlobId(blobIdStr, clusterMap).getPartition();

--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
@@ -1297,7 +1297,7 @@ class BadRestRequest implements RestRequest {
   }
 
   @Override
-  public Map<String, List<String>> getArgs() {
+  public Map<String, Object> getArgs() {
     throw new IllegalStateException("Not implemented");
   }
 

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequest.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequest.java
@@ -2,7 +2,6 @@ package com.github.ambry.rest;
 
 import com.github.ambry.router.ReadableStreamChannel;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 
@@ -46,7 +45,7 @@ public interface RestRequest extends ReadableStreamChannel {
    * header values etc. or a combination of any of these.
    * @return the arguments and their values (if any) as a map.
    */
-  public Map<String, List<String>> getArgs();
+  public Map<String, Object> getArgs();
 
   /**
    * Closes this request channel and releases all of the resources associated with it. Also records some metrics via

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -6,7 +6,6 @@ import com.github.ambry.utils.Utils;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,7 +110,7 @@ public class RestUtils {
    */
   public static BlobProperties buildBlobProperties(RestRequest restRequest)
       throws RestServiceException {
-    Map<String, List<String>> args = restRequest.getArgs();
+    Map<String, Object> args = restRequest.getArgs();
 
     String blobSizeStr = null;
     long blobSize;
@@ -197,10 +196,10 @@ public class RestUtils {
    */
   public static byte[] buildUsermetadata(RestRequest restRequest)
       throws RestServiceException {
-    Map<String, List<String>> args = restRequest.getArgs();
+    Map<String, Object> args = restRequest.getArgs();
     Map<String, String> userMetadataMap = new HashMap<String, String>();
     int sizeToAllocate = 0;
-    for (Map.Entry<String, List<String>> entry : args.entrySet()) {
+    for (Map.Entry<String, Object> entry : args.entrySet()) {
       String key = entry.getKey();
       if (key.startsWith(Headers.UserMetaData_Header_Prefix)) {
         // key size
@@ -299,7 +298,7 @@ public class RestUtils {
   /**
    * Returns a default representation of user metadata that is not in the expected format
    * @param userMetadata byte[] which contains the user metadata in old style
-   * @return Map<String, String> user metadata in the form of Map<String, String>
+   * @return user metadata in the form of Map<String, String>
    */
   private static Map<String, String> getOldStyleUserMetadataAsHashMap(byte[] userMetadata) {
     int totalSize = userMetadata.length;
@@ -328,19 +327,14 @@ public class RestUtils {
    *                                    {@code args} or if there is more than one value for {@code header} in
    *                                    {@code args}.
    */
-  private static String getHeader(Map<String, List<String>> args, String header, boolean required)
+  private static String getHeader(Map<String, Object> args, String header, boolean required)
       throws RestServiceException {
     String value = null;
     if (args.containsKey(header)) {
-      List<String> values = args.get(header);
-      if (values.size() == 1) {
-        value = values.get(0);
-        if (value == null && required) {
-          throw new RestServiceException("Request has null value for header: " + header,
-              RestServiceErrorCode.InvalidArgs);
-        }
-      } else {
-        throw new RestServiceException("Request has too many values for header: " + header,
+      Object valueObj = args.get(header);
+      value = valueObj != null ? valueObj.toString() : null;
+      if (value == null && required) {
+        throw new RestServiceException("Request has null value for header: " + header,
             RestServiceErrorCode.InvalidArgs);
       }
     } else if (required) {

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -105,15 +105,12 @@ public class RestUtilsTest {
     setAmbryHeaders(headers, contentLength, ttl, isPrivate, serviceId, null, ownerId);
     headers.put(RestUtils.Headers.AMBRY_CONTENT_TYPE, JSONObject.NULL);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
-    // too many values for all headers.
+    // too many values for some headers.
     headers = new JSONObject();
     setAmbryHeaders(headers, contentLength, ttl, isPrivate, serviceId, contentType, ownerId);
     tooManyValuesTest(headers, RestUtils.Headers.BLOB_SIZE);
     tooManyValuesTest(headers, RestUtils.Headers.TTL);
     tooManyValuesTest(headers, RestUtils.Headers.PRIVATE);
-    tooManyValuesTest(headers, RestUtils.Headers.SERVICE_ID);
-    tooManyValuesTest(headers, RestUtils.Headers.AMBRY_CONTENT_TYPE);
-    tooManyValuesTest(headers, RestUtils.Headers.OWNER_ID);
 
     // no failures.
     // ttl missing. Should be infinite time by default.

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -1107,7 +1107,7 @@ class BadRestRequest implements RestRequest {
   }
 
   @Override
-  public Map<String, List<String>> getArgs() {
+  public Map<String, Object> getArgs() {
     throw new IllegalStateException("Not implemented");
   }
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
@@ -915,7 +915,7 @@ class BadRestRequest implements RestRequest {
   }
 
   @Override
-  public Map<String, List<String>> getArgs() {
+  public Map<String, Object> getArgs() {
     return null;
   }
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
@@ -19,7 +19,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -47,11 +49,14 @@ public class NettyRequestTest {
   public void conversionWithGoodInputTest()
       throws IOException, RestServiceException {
     // headers
-    HttpHeaders headers = new DefaultHttpHeaders();
+    HttpHeaders headers = new DefaultHttpHeaders(false);
+    headers.add(HttpHeaders.Names.CONTENT_LENGTH, new Random().nextInt(Integer.MAX_VALUE));
     headers.add("headerKey", "headerValue1");
     headers.add("headerKey", "headerValue2");
     headers.add("overLoadedKey", "headerOverloadedValue");
-    headers.add(HttpHeaders.Names.CONTENT_LENGTH, new Random().nextLong());
+    headers.add("paramNoValueInUriButValueInHeader", "paramValueInHeader");
+    headers.add("headerNoValue", (Object) null);
+    headers.add("headerNoValueButValueInUri", (Object) null);
 
     // params
     Map<String, List<String>> params = new HashMap<String, List<String>>();
@@ -62,11 +67,20 @@ public class NettyRequestTest {
     values = new ArrayList<String>(1);
     values.add("paramOverloadedValue");
     params.put("overLoadedKey", values);
+    values = new ArrayList<String>(1);
+    values.add("headerValueInUri");
+    params.put("headerNoValueButValueInUri", values);
+    params.put("paramNoValue", null);
+    params.put("paramNoValueInUriButValueInHeader", null);
 
     StringBuilder uriAttachmentBuilder = new StringBuilder("?");
     for (Map.Entry<String, List<String>> param : params.entrySet()) {
-      for (String value : param.getValue()) {
-        uriAttachmentBuilder.append(param.getKey()).append("=").append(value).append("&");
+      if (param.getValue() != null) {
+        for (String value : param.getValue()) {
+          uriAttachmentBuilder.append(param.getKey()).append("=").append(value).append("&");
+        }
+      } else {
+        uriAttachmentBuilder.append(param.getKey()).append("&");
       }
     }
     uriAttachmentBuilder.deleteCharAt(uriAttachmentBuilder.length() - 1);
@@ -487,7 +501,7 @@ public class NettyRequestTest {
       throws RestServiceException {
     MetricRegistry metricRegistry = new MetricRegistry();
     RestRequestMetricsTracker.setDefaults(metricRegistry);
-    HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, httpMethod, uri);
+    HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, httpMethod, uri, false);
     if (headers != null) {
       httpRequest.headers().set(headers);
     }
@@ -549,17 +563,47 @@ public class NettyRequestTest {
     assertEquals("Mismatch in path", uri.substring(0, uri.indexOf("?")), nettyRequest.getPath());
     assertEquals("Mismatch in uri", uri, nettyRequest.getUri());
 
-    Map<String, List<String>> args = nettyRequest.getArgs();
+    Map<String, List<String>> receivedArgs = new HashMap<String, List<String>>();
+    for (Map.Entry<String, Object> e : nettyRequest.getArgs().entrySet()) {
+      if (!receivedArgs.containsKey(e.getKey())) {
+        receivedArgs.put(e.getKey(), new LinkedList<String>());
+      }
+      if (e.getValue() != null) {
+        List<String> values =
+            Arrays.asList(e.getValue().toString().split(NettyRequest.MULTIPLE_HEADER_VALUE_DELIMITER));
+        receivedArgs.get(e.getKey()).addAll(values);
+      }
+    }
+    Map<String, Integer> keyValueCount = new HashMap<String, Integer>();
     for (Map.Entry<String, List<String>> param : params.entrySet()) {
-      assertTrue("Did not find key: " + param.getKey(), args.containsKey(param.getKey()));
-      boolean containsAllValues = args.get(param.getKey()).containsAll(param.getValue());
-      assertTrue("Did not find all values expected for key: " + param.getKey(), containsAllValues);
+      assertTrue("Did not find key: " + param.getKey(), receivedArgs.containsKey(param.getKey()));
+      if (!keyValueCount.containsKey(param.getKey())) {
+        keyValueCount.put(param.getKey(), 0);
+      }
+
+      if (param.getValue() != null) {
+        boolean containsAllValues = receivedArgs.get(param.getKey()).containsAll(param.getValue());
+        assertTrue("Did not find all values expected for key: " + param.getKey(), containsAllValues);
+        keyValueCount.put(param.getKey(), keyValueCount.get(param.getKey()) + param.getValue().size());
+      }
     }
 
     for (Map.Entry<String, String> e : headers) {
-      assertTrue("Did not find key: " + e.getKey(), args.containsKey(e.getKey()));
-      boolean containsValue = args.get(e.getKey()).contains(e.getValue());
-      assertTrue("Did not find value '" + e.getValue() + "' expected for key: '" + e.getKey() + "'", containsValue);
+      assertTrue("Did not find key: " + e.getKey(), receivedArgs.containsKey(e.getKey()));
+      if (!keyValueCount.containsKey(e.getKey())) {
+        keyValueCount.put(e.getKey(), 0);
+      }
+      if (headers.get(e.getKey()) != null) {
+        assertTrue("Did not find value '" + e.getValue() + "' expected for key: '" + e.getKey() + "'",
+            receivedArgs.get(e.getKey()).contains(e.getValue()));
+        keyValueCount.put(e.getKey(), keyValueCount.get(e.getKey()) + 1);
+      }
+    }
+
+    assertEquals("Number of args does not match", keyValueCount.size(), receivedArgs.size());
+    for (Map.Entry<String, Integer> e : keyValueCount.entrySet()) {
+      assertEquals("Value count for key " + e.getKey() + " does not match", e.getValue().intValue(),
+          receivedArgs.get(e.getKey()).size());
     }
   }
 


### PR DESCRIPTION
`RestRequest::getArgs()` return type was previously `Map<String, List<String>>`. Turning that into `Map<String, Object>` makes it more generic and flexible.

**Primary reviewers: Ming, Siva
Expected time to review: 15-30 mins**
