### PR TITLE
Adding a new method prepare() in RestRequest

### DIFF
--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
@@ -1302,6 +1302,11 @@ class BadRestRequest implements RestRequest {
   }
 
   @Override
+  public void prepare() {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
   public boolean isOpen() {
     throw new IllegalStateException("Not implemented");
   }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequest.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequest.java
@@ -48,6 +48,16 @@ public interface RestRequest extends ReadableStreamChannel {
   public Map<String, Object> getArgs();
 
   /**
+   * Prepares the request for reading.
+   * <p/>
+   * Any CPU bound tasks (decoding, decryption) can be performed in this method as it is expected to be called in a CPU
+   * bound thread. Calling this from an I/O bound thread will impact throughput.
+   * @throws RestServiceException if request channel is closed or if the request could not be prepared for reading.
+   */
+  public void prepare()
+      throws RestServiceException;
+
+  /**
    * Closes this request channel and releases all of the resources associated with it. Also records some metrics via
    * the {@link RestRequestMetricsTracker} instance attached to this RestRequest.
    * <p/>

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequest.java
@@ -141,6 +141,11 @@ public class MockRestRequest implements RestRequest {
     return args;
   }
 
+  @Override
+  public void prepare() {
+    // no op.
+  }
+
   /**
    * Returns the value of the ambry specific content length header ({@link RestUtils.Headers#BLOB_SIZE}. If there is
    * no such header, returns length in the "Content-Length" header. If there is no such header, returns 0.

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -1112,6 +1112,11 @@ class BadRestRequest implements RestRequest {
   }
 
   @Override
+  public void prepare() {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
   public boolean isOpen() {
     throw new IllegalStateException("Not implemented");
   }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
@@ -122,11 +122,12 @@ public class NettyMultipartRequest extends NettyRequest {
   }
 
   /**
-   * Prepares the request for reading by decoding all the content added via {@link #addContent(HttpContent)}.
+   * {@inheritDoc}
    * <p/>
-   * This is a CPU bound task and should not be called in a I/O bound thread.
-   * @throws RestServiceException if request channel has been closed or if the request could not be decoded/processed.
+   * Prepares the request for reading by decoding all the content added via {@link #addContent(HttpContent)}.
+   * @throws RestServiceException if request channel is closed or if the request could not be decoded/prepared.
    */
+  @Override
   public void prepare()
       throws RestServiceException {
     if (!isOpen()) {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -189,6 +189,12 @@ class NettyRequest implements RestRequest {
   }
 
   @Override
+  public void prepare()
+      throws RestServiceException {
+    // no op.
+  }
+
+  @Override
   public boolean isOpen() {
     return channelOpen.get();
   }

--- a/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
@@ -924,6 +924,11 @@ class BadRestRequest implements RestRequest {
   }
 
   @Override
+  public void prepare() {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
   public boolean isOpen() {
     throw new IllegalStateException("Not implemented");
   }


### PR DESCRIPTION
This method will be used to perform CPU bound tasks (decoding, decryption) etc. Its current application will be to support decoding of Multipart requests. This is intended to be called from `AsyncRequestWorker::processRequest()`.

**Primary reviewers: Priyesh/Siva (whichever one of you has 2-5 mins to spare)
Expected time to review: 2-5 mins**

_Very_ short review. So one reviewer should be enough. No new tests required. Code is formatted and built and tested.
