### PR TITLE
Support for multipart POST via the RestServer

### DIFF
--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminIntegrationTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminIntegrationTest.java
@@ -145,11 +145,10 @@ public class AdminIntegrationTest {
    * Tests blob POST, GET, HEAD and DELETE operations.
    * @throws ExecutionException
    * @throws InterruptedException
-   * @throws JSONException
    */
   @Test
   public void postGetHeadDeleteTest()
-      throws ExecutionException, InterruptedException, JSONException {
+      throws ExecutionException, InterruptedException {
     ByteBuffer content = ByteBuffer.wrap(RestTestUtils.getRandomBytes(1024));
     String serviceId = "postGetHeadDeleteServiceID";
     String contentType = "application/octet-stream";
@@ -200,8 +199,7 @@ public class AdminIntegrationTest {
    * @param contents the content of the response.
    * @return a {@link ByteBuffer} that contains all the data in {@code contents}.
    */
-  private ByteBuffer getContent(HttpResponse response, Queue<HttpObject> contents)
-      throws InterruptedException {
+  private ByteBuffer getContent(HttpResponse response, Queue<HttpObject> contents) {
     long contentLength = HttpHeaders.getContentLength(response, -1);
     if (contentLength == -1) {
       contentLength = HttpHeaders.getIntHeader(response, RestUtils.Headers.BLOB_SIZE, 0);
@@ -220,9 +218,8 @@ public class AdminIntegrationTest {
    * @param contents the content to discard.
    * @param expectedDiscardCount the number of {@link HttpObject}s that are expected to discarded.
    */
-  private void discardContent(Queue<HttpObject> contents, int expectedDiscardCount)
-      throws InterruptedException {
-    assertEquals("Objects that will be discarded are more than expected", expectedDiscardCount, contents.size());
+  private void discardContent(Queue<HttpObject> contents, int expectedDiscardCount) {
+    assertEquals("Objects that will be discarded differ from expected", expectedDiscardCount, contents.size());
     boolean endMarkerFound = false;
     for (HttpObject object : contents) {
       assertFalse("There should have been only a single end marker", endMarkerFound);
@@ -331,10 +328,9 @@ public class AdminIntegrationTest {
    * @param expectedHeaders the expected headers in the response.
    * @throws ExecutionException
    * @throws InterruptedException
-   * @throws JSONException
    */
   private void getHeadAndVerify(String blobId, HttpHeaders expectedHeaders)
-      throws ExecutionException, InterruptedException, JSONException {
+      throws ExecutionException, InterruptedException {
     FullHttpRequest httpRequest = buildRequest(HttpMethod.HEAD, blobId, null, null);
     Queue<HttpObject> responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
     HttpResponse response = (HttpResponse) responseParts.poll();
@@ -367,10 +363,8 @@ public class AdminIntegrationTest {
    * Verifies User metadata headers from output, to that sent in during input
    * @param expectedHeaders the expected headers in the response.
    * @param response the {@link HttpResponse} which contains the headers of the response.
-   * @throws JSONException
    */
-  private void verifyUserMetadataHeaders(HttpHeaders expectedHeaders, HttpResponse response)
-      throws JSONException {
+  private void verifyUserMetadataHeaders(HttpHeaders expectedHeaders, HttpResponse response) {
     for (Map.Entry<String, String> header : expectedHeaders) {
       String key = header.getKey();
       if (key.startsWith(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX)) {

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageService.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageService.java
@@ -152,19 +152,20 @@ public class MockBlobStorageService implements BlobStorageService {
     boolean shouldProceed = canHonorRequest(restRequest, restResponseChannel);
     if (shouldProceed) {
       String uri = restRequest.getUri();
-      // most testing Uri result in shouldProceed = false.
-      shouldProceed = false;
       ReadableStreamChannel response = null;
       Exception exception = null;
       if (uri.startsWith(ECHO_REST_METHOD)) {
         String responseStr = restRequest.getRestMethod().toString() + uri.substring(ECHO_REST_METHOD.length());
         ByteBuffer buffer = ByteBuffer.wrap(responseStr.getBytes());
         response = new ByteBufferRSC(buffer);
+        shouldProceed = false;
       } else if (THROW_RUNTIME_EXCEPTION.equals(uri)) {
         throw new RuntimeException(THROW_RUNTIME_EXCEPTION);
       } else if (SEND_RESPONSE_RUNTIME_EXCEPTION.equals(uri)) {
+        shouldProceed = false;
         exception = new RuntimeException(SEND_RESPONSE_RUNTIME_EXCEPTION);
       } else if (SEND_RESPONSE_REST_SERVICE_EXCEPTION.equals(uri)) {
+        shouldProceed = false;
         RestServiceErrorCode errorCode = RestServiceErrorCode.InternalServerError;
         try {
           errorCode = RestServiceErrorCode.valueOf(verifiableProperties.getString(REST_ERROR_CODE));
@@ -173,14 +174,16 @@ public class MockBlobStorageService implements BlobStorageService {
         }
         exception = new RestServiceException(SEND_RESPONSE_REST_SERVICE_EXCEPTION, errorCode);
       }
-      try {
-        if (exception == null) {
-          restResponseChannel.setStatus(ResponseStatus.Ok);
+      if (!shouldProceed) {
+        try {
+          if (exception == null) {
+            restResponseChannel.setStatus(ResponseStatus.Ok);
+          }
+        } catch (RestServiceException e) {
+          exception = e;
+        } finally {
+          handleResponse(restRequest, restResponseChannel, response, exception);
         }
-      } catch (RestServiceException e) {
-        throw new IllegalStateException(e);
-      } finally {
-        handleResponse(restRequest, restResponseChannel, response, exception);
       }
     }
     return shouldProceed;

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequestResponseHandler.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequestResponseHandler.java
@@ -57,6 +57,7 @@ public class MockRestRequestResponseHandler implements RestRequestHandler, RestR
       throws RestServiceException {
     if (shouldProceed(restRequest, restResponseChannel)) {
       RestMethod restMethod = restRequest.getRestMethod();
+      restRequest.prepare();
       switch (restMethod) {
         case GET:
           blobStorageService.handleGet(restRequest, restResponseChannel);

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -169,6 +169,23 @@ public class RestUtilsTest {
   }
 
   /**
+   * Tests building of User Metadata when the {@link RestRequest} contains an arg with name
+   * {@link RestUtils.MultipartPost#USER_METADATA_PART}.
+   * @throws Exception
+   */
+  @Test
+  public void getUserMetadataWithUserMetadataArgTest()
+      throws Exception {
+    byte[] original = new byte[100];
+    RANDOM.nextBytes(original);
+    JSONObject headers = new JSONObject();
+    headers.put(RestUtils.MultipartPost.USER_METADATA_PART, ByteBuffer.wrap(original));
+    RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
+    byte[] rcvd = RestUtils.buildUsermetadata(restRequest);
+    assertArrayEquals("Received user metadata does not match with original", original, rcvd);
+  }
+
+  /**
    * Tests building of User Metadata with unusual input
    * @throws Exception
    */

--- a/ambry-api/src/test/java/com.github.ambry/router/InMemoryRouterFactory.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/InMemoryRouterFactory.java
@@ -13,15 +13,17 @@ import com.github.ambry.notification.NotificationSystem;
  */
 public class InMemoryRouterFactory implements RouterFactory {
   private final VerifiableProperties verifiableProperties;
+  private final NotificationSystem notificationSystem;
 
   public InMemoryRouterFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
       NotificationSystem notificationSystem) {
     this.verifiableProperties = verifiableProperties;
+    this.notificationSystem = notificationSystem;
   }
 
   @Override
   public Router getRouter()
       throws InstantiationException {
-    return new InMemoryRouter(verifiableProperties);
+    return new InMemoryRouter(verifiableProperties, notificationSystem);
   }
 }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/AsyncRequestResponseHandler.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/AsyncRequestResponseHandler.java
@@ -397,8 +397,10 @@ class AsyncRequestWorker implements Runnable {
    * Processes the {@code asyncRequestInfo}. Discerns the type of {@link RestMethod} in the request and calls the right
    * function of the {@link BlobStorageService}.
    * @param asyncRequestInfo the currently dequeued {@link AsyncRequestInfo}.
+   * @throws RestServiceException if the request cannot be prepared for hand-off to the {@link BlobStorageService}.
    */
-  private void processRequest(AsyncRequestInfo asyncRequestInfo) {
+  private void processRequest(AsyncRequestInfo asyncRequestInfo)
+      throws RestServiceException {
     long processingStartTime = System.currentTimeMillis();
     // needed to avoid double counting.
     long blobStorageProcessingTime = 0;
@@ -407,6 +409,7 @@ class AsyncRequestWorker implements Runnable {
       onRequestDequeue(asyncRequestInfo);
       RestResponseChannel restResponseChannel = asyncRequestInfo.restResponseChannel;
       RestMethod restMethod = restRequest.getRestMethod();
+      restRequest.prepare();
       logger.trace("Processing request {} with RestMethod {}", restRequest.getUri(), restMethod);
       long blobStorageProcessingStartTime = System.currentTimeMillis();
       switch (restMethod) {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
@@ -6,6 +6,7 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import java.nio.channels.ClosedChannelException;
@@ -238,14 +239,21 @@ class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> {
         }
         // We need to maintain state about the request itself for the subsequent parts (if any) that come in. We will
         // attach content to the request as the content arrives.
-        request = new NettyRequest(httpRequest, nettyMetrics);
+        if (HttpPostRequestDecoder.isMultipart(httpRequest)) {
+          nettyMetrics.multipartPostRequestRate.mark();
+          request = new NettyMultipartRequest(httpRequest, nettyMetrics);
+        } else {
+          request = new NettyRequest(httpRequest, nettyMetrics);
+        }
         responseChannel.setRequest(request);
         logger.trace("Channel {} now handling request {}", ctx.channel(), request.getUri());
-        // We send POST for handling immediately since we expect valid content with it.
+        // We send POST that is not multipart for handling immediately since we expect valid content with it that will
+        // be streamed in. In the case of POST that is multipart, all the content has to be received for Netty's
+        // decoder and NettyMultipartRequest to work. So it is scheduled for handling when LastHttpContent is received.
         // With any other method that we support, we do not expect any valid content. LastHttpContent is a Netty thing.
         // So we wait for LastHttpContent (throw an error if we don't receive it or receive something else) and then
         // schedule the other methods for handling in handleContent().
-        if (request.getRestMethod().equals(RestMethod.POST)) {
+        if (request.getRestMethod().equals(RestMethod.POST) && !HttpPostRequestDecoder.isMultipart(httpRequest)) {
           requestHandler.handleRequest(request, responseChannel);
         }
       } finally {
@@ -290,7 +298,7 @@ class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> {
         nettyMetrics.requestChunkProcessingTimeInMs.update(chunkProcessingTime);
         request.getMetricsTracker().nioMetricsTracker.addToRequestProcessingTime(chunkProcessingTime);
       }
-      if (!request.getRestMethod().equals(RestMethod.POST)) {
+      if (!request.getRestMethod().equals(RestMethod.POST) || (request.isMultipart() && requestContentFullyReceived)) {
         requestHandler.handleRequest(request, responseChannel);
       }
     } else {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -19,6 +19,7 @@ class NettyMetrics {
   public final Meter channelCreationRate;
   public final Meter channelDestructionRate;
   public final Meter requestArrivalRate;
+  public final Meter multipartPostRequestRate;
   // NettyResponseChannel
   public final Meter bytesWriteRate;
   public final Meter requestCompletionRate;
@@ -93,6 +94,8 @@ class NettyMetrics {
     channelDestructionRate =
         metricRegistry.meter(MetricRegistry.name(NettyMessageProcessor.class, "ChannelDestructionRate"));
     requestArrivalRate = metricRegistry.meter(MetricRegistry.name(NettyMessageProcessor.class, "RequestArrivalRate"));
+    multipartPostRequestRate =
+        metricRegistry.meter(MetricRegistry.name(NettyMessageProcessor.class, "MultipartPostRequestRate"));
     // NettyResponseChannel
     bytesWriteRate = metricRegistry.meter(MetricRegistry.name(NettyResponseChannel.class, "BytesWriteRate"));
     requestCompletionRate =

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
@@ -1,9 +1,7 @@
 package com.github.ambry.rest;
 
-import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
-import com.github.ambry.router.ReadableStreamChannel;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
@@ -180,11 +178,11 @@ public class NettyMultipartRequest extends NettyRequest {
       throws RestServiceException {
     if (part.getHttpDataType() == InterfaceHttpData.HttpDataType.FileUpload) {
       FileUpload fileUpload = (FileUpload) part;
-      if (fileUpload.getName().equals(RestUtils.MultipartPost.Blob_Part)) {
+      if (fileUpload.getName().equals(RestUtils.MultipartPost.BLOB_PART)) {
         // this is actual data.
         if (hasBlob) {
           nettyMetrics.repeatedPartsError.inc();
-          throw new RestServiceException("Request has more than one " + RestUtils.MultipartPost.Blob_Part,
+          throw new RestServiceException("Request has more than one " + RestUtils.MultipartPost.BLOB_PART,
               RestServiceErrorCode.BadRequest);
         } else {
           hasBlob = true;
@@ -221,8 +219,7 @@ public class NettyMultipartRequest extends NettyRequest {
           // TODO: will avoid the copy.
           fileUpload.content().readBytes(buffer);
           buffer.flip();
-          ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(buffer);
-          allArgs.put(name, channel);
+          allArgs.put(name, buffer);
         }
       }
     } else {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -10,16 +10,17 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.util.ReferenceCountUtil;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -38,7 +39,7 @@ import org.slf4j.LoggerFactory;
 class NettyRequest implements RestRequest {
   protected final HttpRequest request;
   protected final NettyMetrics nettyMetrics;
-  protected final Map<String, Object> allArgs = new HashMap<String, Object>();
+  protected final Map<String, Object> allArgs = new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
   protected final Queue<HttpContent> requestContents = new LinkedBlockingQueue<HttpContent>();
   protected final ReentrantLock contentLock = new ReentrantLock();
 
@@ -313,6 +314,14 @@ class NettyRequest implements RestRequest {
    */
   protected boolean isKeepAlive() {
     return HttpHeaders.isKeepAlive(request);
+  }
+
+  /**
+   * Provides info on whether this request is multipart or not.
+   * @return {@code true} if multipart. {@code false} otherwise.
+   */
+  protected boolean isMultipart() {
+    return HttpPostRequestDecoder.isMultipart(request);
   }
 
   /**

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyClient.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyClient.java
@@ -20,6 +20,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.stream.ChunkedInput;
+import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.GenericFutureListener;
 import java.io.Closeable;
@@ -70,7 +71,7 @@ public class NettyClient implements Closeable {
       @Override
       public void initChannel(SocketChannel ch)
           throws Exception {
-        ch.pipeline().addLast(new HttpClientCodec()).addLast(communicationHandler);
+        ch.pipeline().addLast(new HttpClientCodec()).addLast(new ChunkedWriteHandler()).addLast(communicationHandler);
       }
     });
     createChannel();
@@ -87,11 +88,9 @@ public class NettyClient implements Closeable {
    * @param content the content accompanying the request. Can be null.
    * @param callback the callback to invoke when the response is available. Can be null.
    * @return a {@link Future} that tracks the arrival of the response for this request.
-   * @throws InterruptedException
    */
   public Future<Queue<HttpObject>> sendRequest(HttpRequest request, ChunkedInput<HttpContent> content,
-      Callback<Queue<HttpObject>> callback)
-      throws InterruptedException {
+      Callback<Queue<HttpObject>> callback) {
     this.request = request;
     this.content = content;
     this.callback = callback;

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
@@ -2,14 +2,16 @@ package com.github.ambry.rest;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.notification.BlobReplicaSourceType;
+import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.router.InMemoryRouter;
-import com.github.ambry.router.Router;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
-import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
@@ -18,25 +20,38 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory;
+import io.netty.handler.codec.http.multipart.FileUpload;
+import io.netty.handler.codec.http.multipart.HttpDataFactory;
+import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder;
+import io.netty.handler.codec.http.multipart.MemoryFileUpload;
 import io.netty.handler.stream.ChunkedWriteHandler;
+import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.After;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 
 /**
  * Unit tests for {@link NettyMessageProcessor}.
  */
 public class NettyMessageProcessorTest {
-  private final Router router;
+  private final InMemoryRouter router;
   private final BlobStorageService blobStorageService;
   private final MockRestRequestResponseHandler requestHandler;
+  private final HelperNotificationSystem notificationSystem = new HelperNotificationSystem();
 
   private static final AtomicLong requestIdGenerator = new AtomicLong(0);
 
@@ -49,7 +64,7 @@ public class NettyMessageProcessorTest {
       throws InstantiationException, IOException {
     VerifiableProperties verifiableProperties = new VerifiableProperties(new Properties());
     RestRequestMetricsTracker.setDefaults(new MetricRegistry());
-    router = new InMemoryRouter(verifiableProperties);
+    router = new InMemoryRouter(verifiableProperties, notificationSystem);
     requestHandler = new MockRestRequestResponseHandler();
     blobStorageService = new MockBlobStorageService(verifiableProperties, requestHandler, router);
     requestHandler.setBlobStorageService(blobStorageService);
@@ -65,6 +80,7 @@ public class NettyMessageProcessorTest {
       throws IOException {
     blobStorageService.shutdown();
     router.close();
+    notificationSystem.close();
   }
 
   /**
@@ -75,66 +91,118 @@ public class NettyMessageProcessorTest {
   public void requestHandleWithGoodInputTest()
       throws IOException {
     doRequestHandleWithoutKeepAlive(HttpMethod.GET, RestMethod.GET);
-    doRequestHandleWithoutKeepAlive(HttpMethod.POST, RestMethod.POST);
     doRequestHandleWithoutKeepAlive(HttpMethod.DELETE, RestMethod.DELETE);
     doRequestHandleWithoutKeepAlive(HttpMethod.HEAD, RestMethod.HEAD);
 
     EmbeddedChannel channel = createChannel();
     doRequestHandleWithKeepAlive(channel, HttpMethod.GET, RestMethod.GET);
-    doRequestHandleWithKeepAlive(channel, HttpMethod.POST, RestMethod.POST);
     doRequestHandleWithKeepAlive(channel, HttpMethod.DELETE, RestMethod.DELETE);
     doRequestHandleWithKeepAlive(channel, HttpMethod.HEAD, RestMethod.HEAD);
   }
 
   /**
-   * Tests for the case where request also contains content.
-   * @throws IOException
+   * Tests the case where raw bytes are POSTed as chunks.
+   * @throws InterruptedException
    */
   @Test
-  public void requestWithContentTest()
-      throws IOException {
-    EmbeddedChannel channel = createChannel();
-    long requestId = requestIdGenerator.getAndIncrement();
-    String uri = MockBlobStorageService.ECHO_REST_METHOD + requestId;
-    // request with content.
-    FullHttpRequest requestWithContent = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    HttpHeaders.setKeepAlive(requestWithContent, false);
-    channel.writeInbound(requestWithContent);
-    HttpResponse response = (HttpResponse) channel.readOutbound();
-    assertEquals("Unexpected response status", HttpResponseStatus.OK, response.getStatus());
-    // MockBlobStorageService echoes the RestMethod + request id.
-    String expectedResponse = HttpMethod.GET.toString() + requestId;
-    assertEquals("Unexpected content", expectedResponse,
-        RestTestUtils.getContentString((HttpContent) channel.readOutbound()));
-    assertTrue("End marker was expected", channel.readOutbound() instanceof LastHttpContent);
-    assertFalse("Channel not closed", channel.isOpen());
+  public void rawBytesPostTest()
+      throws InterruptedException {
+    Random random = new Random();
+    // request also contains content.
+    ByteBuffer content = ByteBuffer.wrap(RestTestUtils.getRandomBytes(random.nextInt(128) + 128));
+    HttpRequest postRequest =
+        new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/", Unpooled.wrappedBuffer(content));
+    HttpHeaders.setHeader(postRequest, RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
+    HttpHeaders.setHeader(postRequest, RestUtils.Headers.BLOB_SIZE, content.remaining());
+    postRequest = ReferenceCountUtil.retain(postRequest);
+    ByteBuffer receivedContent = doPostTest(postRequest, null);
+    compareContent(receivedContent, Collections.singletonList(content));
+
+    // request and content separate.
+    final int NUM_CONTENTS = 5;
+    postRequest = RestTestUtils.createRequest(HttpMethod.POST, "/", null);
+    List<ByteBuffer> contents = new ArrayList<ByteBuffer>(NUM_CONTENTS);
+    int blobSize = 0;
+    for (int i = 0; i < NUM_CONTENTS; i++) {
+      ByteBuffer buffer = ByteBuffer.wrap(RestTestUtils.getRandomBytes(random.nextInt(128) + 128));
+      blobSize += buffer.remaining();
+      contents.add(i, buffer);
+    }
+    HttpHeaders.setHeader(postRequest, RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
+    HttpHeaders.setHeader(postRequest, RestUtils.Headers.BLOB_SIZE, blobSize);
+    receivedContent = doPostTest(postRequest, contents);
+    compareContent(receivedContent, contents);
+  }
+
+  /**
+   * Tests the case where multipart upload is used.
+   * @throws Exception
+   */
+  @Test
+  public void multipartPostTest()
+      throws Exception {
+    Random random = new Random();
+    ByteBuffer content = ByteBuffer.wrap(RestTestUtils.getRandomBytes(random.nextInt(128) + 128));
+    HttpRequest httpRequest = RestTestUtils.createRequest(HttpMethod.POST, "/", null);
+    HttpHeaders.setHeader(httpRequest, RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
+    HttpHeaders.setHeader(httpRequest, RestUtils.Headers.BLOB_SIZE, content.remaining());
+    HttpPostRequestEncoder encoder = createEncoder(httpRequest, content);
+    HttpRequest postRequest = encoder.finalizeRequest();
+    List<ByteBuffer> contents = new ArrayList<ByteBuffer>();
+    while (!encoder.isEndOfInput()) {
+      // Sending null for ctx because the encoder is OK with that.
+      contents.add(encoder.readChunk(null).content().nioBuffer());
+    }
+    ByteBuffer receivedContent = doPostTest(postRequest, contents);
+    compareContent(receivedContent, Collections.singletonList(content));
   }
 
   /**
    * Tests for error handling flow when bad input streams are provided to the {@link NettyMessageProcessor}.
    */
   @Test
-  public void requestHandleWithBadInputTest() {
-    // content without request.
+  public void requestHandleWithBadInputTest()
+      throws IOException {
     String content = "@@randomContent@@@";
+    // content without request.
     EmbeddedChannel channel = createChannel();
     channel.writeInbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer(content.getBytes())));
     HttpResponse response = (HttpResponse) channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
+    assertFalse("Channel is still active", channel.isActive());
+
+    // content without request on a channel that was kept alive
+    channel = createChannel();
+    // send and receive response for a good request and keep the channel alive
+    channel.writeInbound(RestTestUtils.createRequest(HttpMethod.GET, MockBlobStorageService.ECHO_REST_METHOD, null));
+    channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
+    response = (HttpResponse) channel.readOutbound();
+    assertEquals("Unexpected response status", HttpResponseStatus.OK, response.getStatus());
+    // drain the content
+    while (channel.readOutbound() != null) {
+      ;
+    }
+    assertTrue("Channel is not active", channel.isActive());
+    // send content without request
+    channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
+    response = (HttpResponse) channel.readOutbound();
+    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
+    assertFalse("Channel is still active", channel.isActive());
 
     // content when no content is expected.
-    content = "@@randomContent@@@";
     channel = createChannel();
     channel.writeInbound(RestTestUtils.createRequest(HttpMethod.GET, "/", null));
     channel.writeInbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer(content.getBytes())));
     response = (HttpResponse) channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
+    assertFalse("Channel is still active", channel.isActive());
 
     // wrong HTTPObject.
     channel = createChannel();
     channel.writeInbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
     response = (HttpResponse) channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
+    assertFalse("Channel is still active", channel.isActive());
   }
 
   /**
@@ -197,12 +265,7 @@ public class NettyMessageProcessorTest {
     HttpRequest httpRequest = RestTestUtils.createRequest(httpMethod, uri, null);
     HttpHeaders.setKeepAlive(httpRequest, isKeepAlive);
     channel.writeInbound(httpRequest);
-    if (!restMethod.equals(RestMethod.POST)) {
-      // For POST, adding LastHttpContent will throw an exception simply because of the way ECHO_REST_METHOD works in
-      // MockBlobStorageService (doesn't wait for content and closes the RestRequest once response is written). Except
-      // POST, no one has this problem because NettyMessageProcessor waits for LastHttpContent.
-      channel.writeInbound(new DefaultLastHttpContent());
-    }
+    channel.writeInbound(new DefaultLastHttpContent());
     HttpResponse response = (HttpResponse) channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.getStatus());
     // MockBlobStorageService echoes the RestMethod + request id.
@@ -210,6 +273,53 @@ public class NettyMessageProcessorTest {
     assertEquals("Unexpected content", expectedResponse,
         RestTestUtils.getContentString((HttpContent) channel.readOutbound()));
     assertTrue("End marker was expected", channel.readOutbound() instanceof LastHttpContent);
+  }
+
+  /**
+   * Does the post test by sending the request and content to {@link NettyMessageProcessor} through an
+   * {@link EmbeddedChannel} and returns the data stored in the {@link InMemoryRouter} as a result of the post.
+   * @param postRequest the POST request as a {@link HttpRequest}.
+   * @param contentToSend the content to be sent as a part of the POST.
+   * @return the data stored in the {@link InMemoryRouter} as a result of the POST.
+   * @throws InterruptedException
+   */
+  private ByteBuffer doPostTest(HttpRequest postRequest, List<ByteBuffer> contentToSend)
+      throws InterruptedException {
+    EmbeddedChannel channel = createChannel();
+
+    // POST
+    notificationSystem.reset();
+    HttpHeaders.setHeader(postRequest, RestUtils.Headers.AMBRY_CONTENT_TYPE, "application/octet-stream");
+    HttpHeaders.setKeepAlive(postRequest, false);
+    channel.writeInbound(postRequest);
+    if (contentToSend != null) {
+      for (ByteBuffer content : contentToSend) {
+        channel.writeInbound(new DefaultHttpContent(Unpooled.wrappedBuffer(content)));
+      }
+      channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
+    }
+    if (!notificationSystem.operationCompleted.await(100, TimeUnit.MILLISECONDS)) {
+      fail("Post did not succeed after 100ms. There is an error or timeout needs to increase");
+    }
+    assertNotNull("Blob id operated on cannot be null", notificationSystem.blobIdOperatedOn);
+    return router.getActiveBlobs().get(notificationSystem.blobIdOperatedOn).getBlob();
+  }
+
+  /**
+   * Compares {@code contentToCheck} to {@code srcOfTruth}.
+   * @param contentToCheck the content that needs to be checked against the {@code srcOfTruth}.
+   * @param srcOfTruth the original content.
+   */
+  private void compareContent(ByteBuffer contentToCheck, List<ByteBuffer> srcOfTruth) {
+    ByteBuffer truth;
+    int counter = 0;
+    truth = srcOfTruth.get(counter++);
+    while (contentToCheck.hasRemaining()) {
+      if (!truth.hasRemaining()) {
+        truth = srcOfTruth.get(counter++);
+      }
+      assertEquals("Byte in actual content differs from original content", truth.get(), contentToCheck.get());
+    }
   }
 
   // requestHandleWithGoodInputTest() helpers
@@ -244,6 +354,27 @@ public class NettyMessageProcessorTest {
     }
   }
 
+  // multipartPostTest() helpers.
+
+  /**
+   * Creates a {@link HttpPostRequestEncoder} that encodes the given {@code request} and {@code blobContent}.
+   * @param request the {@link HttpRequest} containing headers and other metadata about the request.
+   * @param blobContent the {@link ByteBuffer} that represents the content of the blob.
+   * @return a {@link HttpPostRequestEncoder} that can encode the {@code request} and {@code blobContent}.
+   * @throws HttpPostRequestEncoder.ErrorDataEncoderException
+   * @throws IOException
+   */
+  private HttpPostRequestEncoder createEncoder(HttpRequest request, ByteBuffer blobContent)
+      throws HttpPostRequestEncoder.ErrorDataEncoderException, IOException {
+    HttpDataFactory httpDataFactory = new DefaultHttpDataFactory(false);
+    HttpPostRequestEncoder encoder = new HttpPostRequestEncoder(httpDataFactory, request, true);
+    FileUpload fileUpload = new MemoryFileUpload(RestUtils.MultipartPost.BLOB_PART, RestUtils.MultipartPost.BLOB_PART,
+        "application/octet-stream", "", Charset.forName("UTF-8"), blobContent.remaining());
+    fileUpload.setContent(Unpooled.wrappedBuffer(blobContent));
+    encoder.addBodyHttpData(fileUpload);
+    return encoder;
+  }
+
   // requestHandlerExceptionTest() helpers.
 
   /**
@@ -259,5 +390,54 @@ public class NettyMessageProcessorTest {
     // first outbound has to be response.
     HttpResponse response = (HttpResponse) channel.readOutbound();
     assertEquals("Unexpected response status", expectedStatus, response.getStatus());
+  }
+
+  /**
+   * A notification system that helps track events in the {@link InMemoryRouter}. Not thread safe and has to be
+   * {@link #reset()} before every operation for which it is used.
+   */
+  private class HelperNotificationSystem implements NotificationSystem {
+    /**
+     * The blob id of the blob that the last operation was on.
+     */
+    protected volatile String blobIdOperatedOn = null;
+    /**
+     * Latch for awaiting the completion of an operation.
+     */
+    protected volatile CountDownLatch operationCompleted = new CountDownLatch(1);
+
+    @Override
+    public void onBlobCreated(String blobId, BlobProperties blobProperties, byte[] userMetadata) {
+      blobIdOperatedOn = blobId;
+      operationCompleted.countDown();
+    }
+
+    @Override
+    public void onBlobDeleted(String blobId) {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public void onBlobReplicaCreated(String sourceHost, int port, String blobId, BlobReplicaSourceType sourceType) {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public void onBlobReplicaDeleted(String sourceHost, int port, String blobId, BlobReplicaSourceType sourceType) {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public void close() {
+      // no op.
+    }
+
+    /**
+     * Resets the state and prepares this instance for another operation.
+     */
+    protected void reset() {
+      blobIdOperatedOn = null;
+      operationCompleted = new CountDownLatch(1);
+    }
   }
 }

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
@@ -5,7 +5,6 @@ import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.CopyingAsyncWritableChannel;
-import com.github.ambry.router.ReadableStreamChannel;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpContent;
@@ -78,8 +77,8 @@ public class NettyMultipartRequestTest {
    * Tests that multipart requests are decoded successfully and verifies that the decoded data matches the source data.
    * Request kinds tested:
    * 1. Request without content.
-   * 2. Request without a {@link RestUtils.MultipartPost#Blob_Part} but with other parts.
-   * 3. Request with a {@link RestUtils.MultipartPost#Blob_Part} and with other parts.
+   * 2. Request without a {@link RestUtils.MultipartPost#BLOB_PART} but with other parts.
+   * 3. Request with a {@link RestUtils.MultipartPost#BLOB_PART} and with other parts.
    * @throws Exception
    */
   @Test
@@ -94,15 +93,16 @@ public class NettyMultipartRequestTest {
     Random random = new Random();
     InMemoryFile[] files = new InMemoryFile[NUM_TOTAL_PARTS];
     for (int i = 0; i < NUM_TOTAL_PARTS; i++) {
-      files[i] = new InMemoryFile("part-" + i, ByteBuffer.wrap(getRandomBytes(random.nextInt(128) + 128)));
+      files[i] =
+          new InMemoryFile("part-" + i, ByteBuffer.wrap(RestTestUtils.getRandomBytes(random.nextInt(128) + 128)));
     }
 
     // request without blob (but has other parts)
     doMultipartDecodeTest(0, files);
 
     // request with blob and other parts
-    files[NUM_TOTAL_PARTS - 1] =
-        new InMemoryFile(RestUtils.MultipartPost.Blob_Part, ByteBuffer.wrap(getRandomBytes(BLOB_PART_SIZE)));
+    files[NUM_TOTAL_PARTS - 1] = new InMemoryFile(RestUtils.MultipartPost.BLOB_PART,
+        ByteBuffer.wrap(RestTestUtils.getRandomBytes(BLOB_PART_SIZE)));
     doMultipartDecodeTest(BLOB_PART_SIZE, files);
   }
 
@@ -117,7 +117,7 @@ public class NettyMultipartRequestTest {
     NettyMultipartRequest requestCloseAfterPrepare = createRequest(null, null);
     List<HttpContent> httpContents = new ArrayList<HttpContent>(5);
     for (int i = 0; i < 5; i++) {
-      HttpContent httpContent = new DefaultHttpContent(Unpooled.wrappedBuffer(getRandomBytes(10)));
+      HttpContent httpContent = new DefaultHttpContent(Unpooled.wrappedBuffer(RestTestUtils.getRandomBytes(10)));
       requestCloseBeforePrepare.addContent(httpContent);
       requestCloseAfterPrepare.addContent(httpContent);
       assertEquals("Reference count is not as expected", 3, httpContent.refCnt());
@@ -159,7 +159,7 @@ public class NettyMultipartRequestTest {
     }
 
     try {
-      request.addContent(new DefaultHttpContent(Unpooled.wrappedBuffer(getRandomBytes(10))));
+      request.addContent(new DefaultHttpContent(Unpooled.wrappedBuffer(RestTestUtils.getRandomBytes(10))));
       fail("Content addition should have failed because request is closed");
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.RequestChannelClosed, e.getErrorCode());
@@ -217,7 +217,7 @@ public class NettyMultipartRequestTest {
     NettyMultipartRequest request = new NettyMultipartRequest(encoder.finalizeRequest(), nettyMetrics);
     assertTrue("Request channel is not open", request.isOpen());
     // insert random data
-    HttpContent httpContent = new DefaultHttpContent(Unpooled.wrappedBuffer(getRandomBytes(10)));
+    HttpContent httpContent = new DefaultHttpContent(Unpooled.wrappedBuffer(RestTestUtils.getRandomBytes(10)));
     request.addContent(httpContent);
     // prepare should fail
     try {
@@ -233,13 +233,13 @@ public class NettyMultipartRequestTest {
     HttpHeaders httpHeaders = new DefaultHttpHeaders();
     httpHeaders.set(RestUtils.Headers.BLOB_SIZE, 256);
     InMemoryFile[] files = new InMemoryFile[2];
-    files[0] = new InMemoryFile(RestUtils.MultipartPost.Blob_Part, ByteBuffer.wrap(getRandomBytes(256)));
-    files[1] = new InMemoryFile(RestUtils.MultipartPost.Blob_Part, ByteBuffer.wrap(getRandomBytes(256)));
+    files[0] = new InMemoryFile(RestUtils.MultipartPost.BLOB_PART, ByteBuffer.wrap(RestTestUtils.getRandomBytes(256)));
+    files[1] = new InMemoryFile(RestUtils.MultipartPost.BLOB_PART, ByteBuffer.wrap(RestTestUtils.getRandomBytes(256)));
     request = createRequest(httpHeaders, files);
     assertEquals("Request size does not match", 256, request.getSize());
     try {
       request.prepare();
-      fail("Prepare should have failed because there was more than one " + RestUtils.MultipartPost.Blob_Part);
+      fail("Prepare should have failed because there was more than one " + RestUtils.MultipartPost.BLOB_PART);
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.MalformedRequest, e.getErrorCode());
     } finally {
@@ -248,8 +248,8 @@ public class NettyMultipartRequestTest {
 
     // more than one part named "part-1"
     files = new InMemoryFile[2];
-    files[0] = new InMemoryFile("Part-1", ByteBuffer.wrap(getRandomBytes(256)));
-    files[1] = new InMemoryFile("Part-1", ByteBuffer.wrap(getRandomBytes(256)));
+    files[0] = new InMemoryFile("Part-1", ByteBuffer.wrap(RestTestUtils.getRandomBytes(256)));
+    files[1] = new InMemoryFile("Part-1", ByteBuffer.wrap(RestTestUtils.getRandomBytes(256)));
     request = createRequest(null, files);
     assertEquals("Request size does not match", 0, request.getSize());
     try {
@@ -265,11 +265,11 @@ public class NettyMultipartRequestTest {
     httpHeaders = new DefaultHttpHeaders();
     httpHeaders.set(RestUtils.Headers.BLOB_SIZE, 256);
     files = new InMemoryFile[1];
-    files[0] = new InMemoryFile(RestUtils.MultipartPost.Blob_Part, ByteBuffer.wrap(getRandomBytes(128)));
+    files[0] = new InMemoryFile(RestUtils.MultipartPost.BLOB_PART, ByteBuffer.wrap(RestTestUtils.getRandomBytes(128)));
     request = createRequest(httpHeaders, files);
     try {
       request.prepare();
-      fail("Prepare should have failed because there was more than one " + RestUtils.MultipartPost.Blob_Part);
+      fail("Prepare should have failed because there was more than one " + RestUtils.MultipartPost.BLOB_PART);
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.BadRequest, e.getErrorCode());
     } finally {
@@ -280,7 +280,7 @@ public class NettyMultipartRequestTest {
     httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
     HttpHeaders.setHeader(httpRequest, RestUtils.Headers.BLOB_SIZE, 256);
     files = new InMemoryFile[1];
-    files[0] = new InMemoryFile(RestUtils.MultipartPost.Blob_Part, ByteBuffer.wrap(getRandomBytes(256)));
+    files[0] = new InMemoryFile(RestUtils.MultipartPost.BLOB_PART, ByteBuffer.wrap(RestTestUtils.getRandomBytes(256)));
     encoder = createEncoder(httpRequest, files);
     encoder.addBodyAttribute("dummyKey", "dummyValue");
     request = new NettyMultipartRequest(encoder.finalizeRequest(), nettyMetrics);
@@ -359,17 +359,6 @@ public class NettyMultipartRequestTest {
   }
 
   /**
-   * Gets random bytes of length {@code size}
-   * @param size the length of random bytes required.
-   * @return a byte array of length {@code size} with random bytes.
-   */
-  private byte[] getRandomBytes(int size) {
-    byte[] bytes = new byte[size];
-    new Random().nextBytes(bytes);
-    return bytes;
-  }
-
-  /**
    * Gets the root cause for {@code e}.
    * @param e the {@link Exception} whose root cause is required.
    * @return the root cause for {@code e}.
@@ -409,16 +398,14 @@ public class NettyMultipartRequestTest {
     ByteBuffer blobData = ByteBuffer.allocate(0);
     if (files != null) {
       for (InMemoryFile file : files) {
-        if (file.name.equals(RestUtils.MultipartPost.Blob_Part)) {
+        if (file.name.equals(RestUtils.MultipartPost.BLOB_PART)) {
           blobData = file.content;
         } else {
           Object value = args.get(file.name);
           assertNotNull("Request does not contain " + file, value);
-          assertTrue("Argument value is not ReadableStreamChannel", value instanceof ReadableStreamChannel);
-          ReadableStreamChannel channel = (ReadableStreamChannel) value;
-          asyncWritableChannel = new CopyingAsyncWritableChannel(file.content.array().length);
-          channel.readInto(asyncWritableChannel, null).get();
-          readOutput = asyncWritableChannel.getData();
+          assertTrue("Argument value is not ByteBuffer", value instanceof ByteBuffer);
+          readOutput = new byte[((ByteBuffer) value).remaining()];
+          ((ByteBuffer) value).get(readOutput);
           assertArrayEquals(file.name + " content does not match", file.content.array(), readOutput);
         }
       }
@@ -426,7 +413,7 @@ public class NettyMultipartRequestTest {
     asyncWritableChannel = new CopyingAsyncWritableChannel(expectedRequestSize);
     request.readInto(asyncWritableChannel, null).get();
     readOutput = asyncWritableChannel.getData();
-    assertArrayEquals(RestUtils.MultipartPost.Blob_Part + " content does not match", blobData.array(), readOutput);
+    assertArrayEquals(RestUtils.MultipartPost.BLOB_PART + " content does not match", blobData.array(), readOutput);
     closeRequestAndValidate(request);
   }
 


### PR DESCRIPTION
This commit introduces multipart support for the `RestServer` using `NettyMultipartRequest`.
Also adds all associated unit and integration tests.

The production code is about 20-25 lines. The rest of it is test code.

**Primary reviewers: Siva, Priyesh
Expected time to review: ~60 mins**

**Unit test coverage**
Class                               Class, %        Method, %       Line, %
AsyncRequestResponseHandler         100% (1/ 1)     100% (11/ 11)   94.4% (84/ 89)
AsyncRequestWorker                  100% (3/ 3)     100% (13/ 13)   89.4% (110/ 123)
AsyncResponseHandler                100% (2/ 2)     100% (9/ 9)     89.8% (79/ 88)
NettyMessageProcessor               100% (1/ 1)     90% (9/ 10)     81.4% (92/ 113)
NettyMultipartRequest               100% (1/ 1)     100% (6/ 6)     92.9% (78/ 84)
NettyRequest                        100% (1/ 1)     94.4% (17/ 18)  94% (142/ 151)
RestUtils                           33.3% (1/ 3)    66.7% (6/ 9)    97.5% (119/ 122)
