### PR TITLE
Simplifying the APIs and usage of ByteBufferAsyncWritableChannel.

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/router/AsyncWritableChannel.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/AsyncWritableChannel.java
@@ -25,6 +25,7 @@ public interface AsyncWritableChannel extends Channel {
    * <p/>
    * {@code src} can be reused only after the {@code callback} is invoked (or after {@code future.get()} returns).
    * <p/>
+   * Concurrent write calls may result in unexpected behavior.
    * @param src the data that needs to be written to the channel.
    * @param callback the {@link Callback} that will be invoked once the write succeeds/fails. This can be null.
    * @return a {@link Future} that will eventually contain the result of the write operation (the number of bytes

--- a/ambry-api/src/test/java/com.github.ambry/router/ByteBufferAWC.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/ByteBufferAWC.java
@@ -33,15 +33,9 @@ public class ByteBufferAWC implements AsyncWritableChannel {
       throw new IllegalArgumentException("Source buffer cannot be null");
     }
     ChunkData chunkData = new ChunkData(src, callback);
-    lock.lock();
-    try {
-      if (!isOpen()) {
-        chunkData.resolveChunk(new ClosedChannelException());
-      } else {
-        chunks.add(chunkData);
-      }
-    } finally {
-      lock.unlock();
+    chunks.add(chunkData);
+    if (!isOpen()) {
+      resolveAllRemainingChunks(new ClosedChannelException());
     }
     return chunkData.future;
   }
@@ -58,13 +52,7 @@ public class ByteBufferAWC implements AsyncWritableChannel {
   @Override
   public void close() {
     if (channelOpen.compareAndSet(true, false)) {
-      lock.lock();
-      try {
-        resolveAllRemainingChunks(new ClosedChannelException());
-        chunks.add(new ChunkData(null, null));
-      } finally {
-        lock.unlock();
-      }
+      resolveAllRemainingChunks(new ClosedChannelException());
     }
   }
 
@@ -79,24 +67,11 @@ public class ByteBufferAWC implements AsyncWritableChannel {
    */
   public ByteBuffer getNextChunk()
       throws InterruptedException {
-    ByteBuffer chunk = null;
+    ByteBuffer chunkBuf = null;
     if (isOpen()) {
-      ChunkData chunkData = chunks.take();
-      if (chunkData.buffer != null) {
-        lock.lock();
-        try {
-          if (isOpen()) {
-            chunk = chunkData.buffer;
-            chunksAwaitingResolution.add(chunkData);
-          } else {
-            chunkData.resolveChunk(new ClosedChannelException());
-          }
-        } finally {
-          lock.unlock();
-        }
-      }
+      chunkBuf = getChunkBuffer(chunks.take());
     }
-    return chunk;
+    return chunkBuf;
   }
 
   /**
@@ -112,47 +87,41 @@ public class ByteBufferAWC implements AsyncWritableChannel {
    */
   public ByteBuffer getNextChunk(long timeoutInMs)
       throws InterruptedException {
-    ByteBuffer chunk = null;
+    ByteBuffer chunkBuf = null;
     if (isOpen()) {
-      ChunkData chunkData = chunks.poll(timeoutInMs, TimeUnit.MILLISECONDS);
-      if (chunkData != null && chunkData.buffer != null) {
-        lock.lock();
-        try {
-          if (isOpen()) {
-            chunk = chunkData.buffer;
-            chunksAwaitingResolution.add(chunkData);
-          } else {
-            chunkData.resolveChunk(new ClosedChannelException());
-          }
-        } finally {
-          lock.unlock();
-        }
-      }
+      chunkBuf = getChunkBuffer(chunks.poll(timeoutInMs, TimeUnit.MILLISECONDS));
     }
-    return chunk;
+    return chunkBuf;
   }
 
   /**
-   * Marks a chunk as handled and invokes the callback and future that accompanied this chunk of data. Once a chunk is
-   * resolved, the data inside it is considered void.
-   * <p/>
-   * This function assumes that chunks are resolved in the same order that they were obtained.
-   * @param chunk the {@link ByteBuffer} that represents the chunk that was handled.
+   * Resolves the oldest "checked-out" chunk and invokes the callback and future that accompanied the chunk. Once a
+   * chunk is resolved, the data inside it is considered void. If no chunks have been "checked-out" yet, does nothing.
    * @param exception any {@link Exception} that occurred during the handling that needs to be notified.
-   * @throws IllegalArgumentException if {@code chunk} is not a valid chunk that is eligible for resolution.
    */
-  public void resolveChunk(ByteBuffer chunk, Exception exception) {
-    lock.lock();
-    try {
-      if (isOpen()) {
-        if (chunksAwaitingResolution.peek() == null || chunksAwaitingResolution.peek().buffer != chunk) {
-          throw new IllegalArgumentException("Unrecognized chunk");
-        }
-        chunksAwaitingResolution.poll().resolveChunk(exception);
-      }
-    } finally {
-      lock.unlock();
+  public void resolveOldestChunk(Exception exception) {
+    ChunkData chunkData = chunksAwaitingResolution.poll();
+    if (chunkData != null) {
+      chunkData.resolveChunk(exception);
     }
+  }
+
+  /**
+   * Gets the buffer associated with the chunk if there is one. Also updates internal state.
+   * @param chunkData the data associated with the chunk whose buffer needs to be returned.
+   * @return the buffer inside {@code chunkData} if there is one.
+   */
+  private ByteBuffer getChunkBuffer(ChunkData chunkData) {
+    ByteBuffer chunkBuf = null;
+    if (chunkData != null && chunkData.buffer != null) {
+      chunkBuf = chunkData.buffer;
+      chunksAwaitingResolution.add(chunkData);
+      if (!isOpen()) {
+        chunkBuf = null;
+        resolveAllRemainingChunks(new ClosedChannelException());
+      }
+    }
+    return chunkBuf;
   }
 
   /**
@@ -160,17 +129,27 @@ public class ByteBufferAWC implements AsyncWritableChannel {
    * @param e the exception to use to resolve all the chunks.
    */
   private void resolveAllRemainingChunks(Exception e) {
-    while (chunksAwaitingResolution.peek() != null) {
-      chunksAwaitingResolution.poll().resolveChunk(e);
-    }
-    while (chunks.peek() != null) {
-      chunks.poll().resolveChunk(e);
+    lock.lock();
+    try {
+      ChunkData chunkData = chunksAwaitingResolution.poll();
+      while (chunkData != null) {
+        chunkData.resolveChunk(e);
+        chunkData = chunksAwaitingResolution.poll();
+      }
+      chunkData = chunks.poll();
+      while (chunkData != null) {
+        chunkData.resolveChunk(e);
+        chunkData = chunks.poll();
+      }
+      chunks.add(new ChunkData(null, null));
+    } finally {
+      lock.unlock();
     }
   }
 
   /**
-   * Representation of all the data associated with a chunk i.e. the actual bytes and the future and callback that need
-   * to be invoked on resolution.
+   * Representation of all the data associated with a chunk i.e. the actual bytes and the future and callback that need to
+   * be invoked on resolution.
    */
   private static class ChunkData {
     /**
@@ -181,6 +160,7 @@ public class ByteBufferAWC implements AsyncWritableChannel {
      * The bytes associated with this chunk.
      */
     public final ByteBuffer buffer;
+
     private final int startPos;
     private final Callback<Long> callback;
 
@@ -205,10 +185,12 @@ public class ByteBufferAWC implements AsyncWritableChannel {
      * @param exception the reason for chunk handling failure.
      */
     public void resolveChunk(Exception exception) {
-      long bytesWritten = buffer.position() - startPos;
-      future.done(bytesWritten, exception);
-      if (callback != null) {
-        callback.onCompletion(bytesWritten, exception);
+      if (buffer != null) {
+        long bytesWritten = buffer.position() - startPos;
+        future.done(bytesWritten, exception);
+        if (callback != null) {
+          callback.onCompletion(bytesWritten, exception);
+        }
       }
     }
   }

--- a/ambry-api/src/test/java/com.github.ambry/router/InMemoryRouter.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/InMemoryRouter.java
@@ -274,7 +274,7 @@ class InMemoryBlobPoster implements Runnable {
       } else {
         blobData.put(chunk);
       }
-      channel.resolveChunk(chunk, exception);
+      channel.resolveOldestChunk(exception);
       if (exception != null) {
         channel.close();
         throw exception;

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
@@ -37,7 +37,7 @@ public class ByteBufferAsyncWritableChannelTest {
       byte[] readChunk = new byte[writtenChunk.length];
       chunk.get(readChunk);
       assertArrayEquals("Data unequal", writtenChunk, readChunk);
-      channel.resolveChunk(chunk, null);
+      channel.resolveOldestChunk(null);
       assertEquals("Unexpected write size (future)", chunkSize, writeData.future.get().longValue());
       assertEquals("Unexpected write size (callback)", chunkSize, writeData.writeCallback.bytesWritten);
       chunkCount++;
@@ -51,6 +51,27 @@ public class ByteBufferAsyncWritableChannelTest {
   }
 
   @Test
+  public void checkoutMultipleChunksAndResolveTest()
+      throws Exception {
+    ByteBufferAsyncWritableChannel channel = new ByteBufferAsyncWritableChannel();
+    ChannelWriter channelWriter = new ChannelWriter(channel);
+    channelWriter.writeToChannel(5);
+
+    // get all chunks without resolving any
+    ByteBuffer chunk = channel.getNextChunk(0);
+    while (chunk != null) {
+      chunk = channel.getNextChunk(0);
+    }
+
+    // now resolve them one by one and check that ordering is respected.
+    for (int i = 0; i < channelWriter.writes.size(); i++) {
+      channel.resolveOldestChunk(null);
+      ensureCallbackOrder(channelWriter, i);
+    }
+    channel.close();
+  }
+
+  @Test
   public void closeBeforeFullReadTest()
       throws Exception {
     ByteBufferAsyncWritableChannel channel = new ByteBufferAsyncWritableChannel();
@@ -61,7 +82,8 @@ public class ByteBufferAsyncWritableChannelTest {
     // read some chunks
     int i = 0;
     for (; i < 3; i++) {
-      channel.resolveChunk(channel.getNextChunk(), null);
+      channel.getNextChunk(0);
+      channel.resolveOldestChunk(null);
     }
     channel.close();
     assertFalse("Channel is still open", channel.isOpen());
@@ -91,10 +113,11 @@ public class ByteBufferAsyncWritableChannelTest {
     }
 
     // exception should be piped correctly.
-    WriteCallback writeCallback = new WriteCallback();
+    WriteCallback writeCallback = new WriteCallback(0);
     Future<Long> future = channel.write(ByteBuffer.allocate(1), writeCallback);
     String errMsg = "@@randomMsg@@";
-    channel.resolveChunk(channel.getNextChunk(), new Exception(errMsg));
+    channel.getNextChunk(0);
+    channel.resolveOldestChunk(new Exception(errMsg));
 
     try {
       future.get();
@@ -103,32 +126,6 @@ public class ByteBufferAsyncWritableChannelTest {
       assertEquals("Unexpected exception message (future)", errMsg, exception.getMessage());
       assertEquals("Unexpected exception message (callback)", errMsg, writeCallback.exception.getMessage());
     }
-  }
-
-  @Test
-  public void resolveChunkExceptionTest()
-      throws InterruptedException {
-    ByteBufferAsyncWritableChannel channel = new ByteBufferAsyncWritableChannel();
-    ByteBuffer bogusChunk = ByteBuffer.allocate(5);
-    // before any chunks are added.
-    try {
-      channel.resolveChunk(bogusChunk, null);
-      fail("Resolving unknown chunks should throw exception");
-    } catch (IllegalArgumentException e) {
-      // expected. Nothing to do.
-    }
-
-    ByteBuffer validChunk = ByteBuffer.allocate(5);
-    channel.write(validChunk, null);
-    channel.getNextChunk();
-    // resolving an unknown chunk.
-    try {
-      channel.resolveChunk(bogusChunk, null);
-      fail("Resolving unknown chunks should throw exception");
-    } catch (IllegalArgumentException e) {
-      // expected. Nothing to do.
-    }
-    channel.close();
   }
 
   /**
@@ -140,7 +137,7 @@ public class ByteBufferAsyncWritableChannelTest {
       throws Exception {
     ByteBufferAsyncWritableChannel channel = new ByteBufferAsyncWritableChannel();
     channel.write(ByteBuffer.allocate(5), null);
-    ByteBuffer chunk = channel.getNextChunk();
+    channel.getNextChunk();
     channel.close();
     assertFalse("Channel is still open", channel.isOpen());
 
@@ -148,10 +145,10 @@ public class ByteBufferAsyncWritableChannelTest {
     channel.close();
 
     // ok to resolve chunk
-    channel.resolveChunk(chunk, null);
+    channel.resolveOldestChunk(null);
 
     // not ok to write.
-    WriteCallback writeCallback = new WriteCallback();
+    WriteCallback writeCallback = new WriteCallback(0);
     try {
       channel.write(ByteBuffer.allocate(0), writeCallback).get();
       fail("Write should have failed");
@@ -181,8 +178,28 @@ public class ByteBufferAsyncWritableChannelTest {
     }
     return exception;
   }
+
+  // checkoutMultipleChunksAndResolveTest() helpers.
+
+  /**
+   * Ensures that the callback with {@code expectedCallbackId} is invoked but callbacks for chunks younger than the
+   * expected one (i.e. id > {@code expectedCallbackId}) have not been invoked.
+   * @param channelWriter the {@link ChannelWriter} that wrote to the channel.
+   * @param expectedCallbackId the id of the callback expected to be invoked.
+   */
+  private void ensureCallbackOrder(ChannelWriter channelWriter, int expectedCallbackId) {
+    WriteCallback writeCallback = channelWriter.writes.get(expectedCallbackId).writeCallback;
+    assertTrue("Callback for the expected oldest chunk not invoked", writeCallback.callbackInvoked.get());
+    for (int i = expectedCallbackId + 1; i < channelWriter.writes.size(); i++) {
+      writeCallback = channelWriter.writes.get(i).writeCallback;
+      assertFalse("Callback for a chunk younger than the expected is invoked", writeCallback.callbackInvoked.get());
+    }
+  }
 }
 
+/**
+ * Writes some random data to the provided {@link ByteBufferAsyncWritableChannel}.
+ */
 class ChannelWriter {
   public final List<WriteData> writes = new ArrayList<WriteData>();
   private final ByteBufferAsyncWritableChannel channel;
@@ -192,9 +209,13 @@ class ChannelWriter {
     this.channel = channel;
   }
 
+  /**
+   * Writes {@code writeCount} number of random chunks to the given {@link ByteBufferAsyncWritableChannel}.
+   * @param writeCount the number of chunks to write.
+   */
   public void writeToChannel(int writeCount) {
     for (int i = 0; i < writeCount; i++) {
-      WriteCallback writeCallback = new WriteCallback();
+      WriteCallback writeCallback = new WriteCallback(i);
       byte[] data = new byte[100];
       random.nextBytes(data);
       ByteBuffer chunk = ByteBuffer.wrap(data);
@@ -204,6 +225,9 @@ class ChannelWriter {
   }
 }
 
+/**
+ * Represents the data associated with a write.
+ */
 class WriteData {
   public final byte[] writtenChunk;
   public final Future<Long> future;
@@ -220,9 +244,18 @@ class WriteData {
  * Callback for all write operations on {@link ByteBufferAsyncWritableChannel}.
  */
 class WriteCallback implements Callback<Long> {
+  public volatile int writeId;
   public volatile long bytesWritten;
   public volatile Exception exception;
-  private final AtomicBoolean callbackInvoked = new AtomicBoolean(false);
+  public final AtomicBoolean callbackInvoked = new AtomicBoolean(false);
+
+  /**
+   * Create a write callback.
+   * @param writeId the id to attach to the callback.
+   */
+  public WriteCallback(int writeId) {
+    this.writeId = writeId;
+  }
 
   @Override
   public void onCompletion(Long result, Exception exception) {

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferReadableStreamChannelTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferReadableStreamChannelTest.java
@@ -100,7 +100,7 @@ public class ByteBufferReadableStreamChannelTest {
     Future<Long> future = readableStreamChannel.readInto(writeChannel, callback);
     ByteBuffer chunk = writeChannel.getNextChunk(0);
     while (chunk != null) {
-      writeChannel.resolveChunk(chunk, null);
+      writeChannel.resolveOldestChunk(null);
       chunk = writeChannel.getNextChunk(0);
     }
     assertEquals("There should have no bytes to read (future)", 0, future.get().longValue());
@@ -181,7 +181,7 @@ public class ByteBufferReadableStreamChannelTest {
         assertTrue("Written content is more than original content", contentWrapper.hasRemaining());
         assertEquals("Unexpected byte", contentWrapper.get(), recvdContent.get());
       }
-      writeChannel.resolveChunk(recvdContent, null);
+      writeChannel.resolveOldestChunk(null);
     }
     assertNull("There should have been no more data in the channel", writeChannel.getNextChunk(0));
     writeChannel.close();

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
@@ -709,7 +709,7 @@ public class NettyRequestTest {
         assertEquals("Unexpected byte", content.get(), recvdContent.get());
         bytesRead++;
       }
-      writeChannel.resolveChunk(recvdContent, null);
+      writeChannel.resolveOldestChunk(null);
     }
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/ReadableStreamChannelInputStream.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/ReadableStreamChannelInputStream.java
@@ -90,7 +90,7 @@ class ReadableStreamChannelInputStream extends InputStream {
       throws IOException {
     if (currentChunk == null || !currentChunk.hasRemaining()) {
       if (currentChunk != null) {
-        asyncWritableChannel.resolveChunk(currentChunk, null);
+        asyncWritableChannel.resolveOldestChunk(null);
       }
       try {
         currentChunk = asyncWritableChannel.getNextChunk();


### PR DESCRIPTION
In one the previous PRs, Priyesh had a [comment](https://github.com/linkedin/ambry/pull/204#discussion_r53051137) on how the APIs of `ByteBufferAsyncWritableChannel` can be simplifed. Those suggestions are implemented in this change. In addition, locking has been removed from the common case path and might improve performance.

**Primary reviewers: Priyesh**
**Expected time to review: 10-15 mins**

Unit tests:
ByteBufferAsyncWritableChannel  100% (2/ 2) 100% (11/ 11)   96.6% (56/ 58)
