### PR TITLE
Removing NettyServerDeployer to simplify code in NettyServer

### DIFF
--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyConfig.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyConfig.java
@@ -41,14 +41,6 @@ class NettyConfig {
   public final int nettyServerSoBacklog;
 
   /**
-   * Startup wait time (in seconds). If the netty server does not start up within this time, the startup is considered
-   * failed.
-   */
-  @Config("netty.server.startup.wait.seconds")
-  @Default("30")
-  public final long nettyServerStartupWaitSeconds;
-
-  /**
    * Number of netty worker threads.
    */
   @Config("netty.server.worker.thread.count")
@@ -60,7 +52,6 @@ class NettyConfig {
     nettyServerIdleTimeSeconds = verifiableProperties.getInt("netty.server.idle.time.seconds", 60);
     nettyServerPort = verifiableProperties.getInt("netty.server.port", 1174);
     nettyServerSoBacklog = verifiableProperties.getInt("netty.server.sobacklog", 100);
-    nettyServerStartupWaitSeconds = verifiableProperties.getLong("netty.server.startup.wait.seconds", 30);
     nettyServerWorkerThreadCount = verifiableProperties.getInt("netty.server.worker.thread.count", 1);
   }
 }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
@@ -1,7 +1,6 @@
 package com.github.ambry.rest;
 
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -13,7 +12,6 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,8 +33,11 @@ import org.slf4j.LoggerFactory;
 class NettyServer implements NioServer {
   private final NettyConfig nettyConfig;
   private final NettyMetrics nettyMetrics;
-  private final NettyServerDeployer nettyServerDeployer;
-  private final Thread nettyServerDeployerThread;
+  private final EventLoopGroup bossGroup;
+  private final EventLoopGroup workerGroup;
+  private final RestRequestHandler requestHandler;
+  private final PublicAccessLogger publicAccessLogger;
+  private final RestServerState restServerState;
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   /**
@@ -44,92 +45,26 @@ class NettyServer implements NioServer {
    * @param nettyConfig the {@link NettyConfig} instance that defines the configuration parameters for the NettyServer.
    * @param nettyMetrics the {@link NettyMetrics} instance to use to record metrics.
    * @param requestHandler the {@link RestRequestHandler} that can be used to submit requests that need to be handled.
+   * @param publicAccessLogger the {@link PublicAccessLogger} that can be used for public access logging
+   * @param restServerState the {@link RestServerState} that can be used to check the health of the system
+   *                              to respond to health check requests
    */
   public NettyServer(NettyConfig nettyConfig, NettyMetrics nettyMetrics, RestRequestHandler requestHandler,
       PublicAccessLogger publicAccessLogger, RestServerState restServerState) {
     this.nettyConfig = nettyConfig;
     this.nettyMetrics = nettyMetrics;
-    nettyServerDeployer =
-        new NettyServerDeployer(nettyConfig, nettyMetrics, requestHandler, publicAccessLogger, restServerState);
-    nettyServerDeployerThread = new Thread(nettyServerDeployer);
+    this.requestHandler = requestHandler;
+    this.publicAccessLogger = publicAccessLogger;
+    this.restServerState = restServerState;
+    bossGroup = new NioEventLoopGroup(nettyConfig.nettyServerBossThreadCount);
+    workerGroup = new NioEventLoopGroup(nettyConfig.nettyServerWorkerThreadCount);
     logger.trace("Instantiated NettyServer");
   }
 
   @Override
   public void start()
       throws InstantiationException {
-    if (!nettyServerDeployerThread.isAlive()) {
-      logger.info("Starting NettyServer");
-      long startupBeginTime = System.currentTimeMillis();
-      try {
-        nettyServerDeployerThread.start();
-        if (!(nettyServerDeployer.awaitStartup(nettyConfig.nettyServerStartupWaitSeconds, TimeUnit.SECONDS))) {
-          nettyMetrics.nettyServerStartError.inc();
-          throw new InstantiationException("Netty server start timed out");
-        } else if (nettyServerDeployer.getException() != null) {
-          logger.error("Exception during deployment of NettyServer", nettyServerDeployer.getException());
-          nettyMetrics.nettyServerStartError.inc();
-          throw new InstantiationException(
-              "NettyServer start failed - " + nettyServerDeployer.getException().getLocalizedMessage());
-        }
-      } catch (InterruptedException e) {
-        logger.error("NettyServer start await was interrupted. It might not have started", e);
-        nettyMetrics.nettyServerStartError.inc();
-        throw new InstantiationException("Netty server start might have failed - " + e.getLocalizedMessage());
-      } finally {
-        long startupTime = System.currentTimeMillis() - startupBeginTime;
-        logger.info("NettyServer start took {} ms", startupTime);
-        nettyMetrics.nettyServerStartTimeInMs.update(startupTime);
-      }
-    }
-  }
-
-  @Override
-  public void shutdown() {
-    if (nettyServerDeployerThread.isAlive()) {
-      nettyServerDeployer.shutdown();
-    }
-  }
-}
-
-/**
- * Deploys netty HTTP server in a separate thread so that the main thread is unblocked.
- */
-class NettyServerDeployer implements Runnable {
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-  private final CountDownLatch startupDone = new CountDownLatch(1);
-  private final EventLoopGroup bossGroup;
-  private final EventLoopGroup workerGroup;
-  private final NettyConfig nettyConfig;
-  private final NettyMetrics nettyMetrics;
-  private final RestRequestHandler requestHandler;
-  private final PublicAccessLogger publicAccessLogger;
-  private final RestServerState restServerState;
-  private Exception exception = null;
-
-  /**
-   * Create a new instance of NettyServerDeployer.
-   * @param nettyConfig the {@link NettyConfig} instance that defines the configuration parameters for the NettyServer.
-   * @param nettyMetrics the {@link NettyMetrics} instance to use to record metrics.
-   * @param requestHandler the {@link RestRequestHandler} that can be used to submit requests that need to be handled.
-   * @param publicAccessLogger the {@link PublicAccessLogger} that can be used for public access logging
-   * @param restServerState the {@link RestServerState} that can be used to check the health of the system
-   *                              to respond to health check requests
-   */
-  public NettyServerDeployer(NettyConfig nettyConfig, NettyMetrics nettyMetrics, RestRequestHandler requestHandler,
-      PublicAccessLogger publicAccessLogger, RestServerState restServerState) {
-    this.nettyConfig = nettyConfig;
-    this.nettyMetrics = nettyMetrics;
-    this.requestHandler = requestHandler;
-    bossGroup = new NioEventLoopGroup(nettyConfig.nettyServerBossThreadCount);
-    workerGroup = new NioEventLoopGroup(nettyConfig.nettyServerWorkerThreadCount);
-    this.publicAccessLogger = publicAccessLogger;
-    this.restServerState = restServerState;
-    logger.trace("Instantiated NettyServerDeployer");
-  }
-
-  @Override
-  public void run() {
+    long startupBeginTime = System.currentTimeMillis();
     try {
       logger.trace("Starting NettyServer deployment");
       ServerBootstrap b = new ServerBootstrap();
@@ -157,41 +92,21 @@ class NettyServerDeployer implements Runnable {
               .addLast("processor", new NettyMessageProcessor(nettyMetrics, nettyConfig, requestHandler));
         }
       });
-      ChannelFuture f = b.bind(nettyConfig.nettyServerPort).sync();
+      b.bind(nettyConfig.nettyServerPort).sync();
       logger.info("NettyServer now listening on port {}", nettyConfig.nettyServerPort);
-      // let the parent know that startup is complete and so that it can proceed.
-      startupDone.countDown();
-      // this is blocking
-      f.channel().closeFuture().sync();
-    } catch (Exception e) {
-      exception = e;
-      startupDone.countDown();
+    } catch (InterruptedException e) {
+      logger.error("NettyServer start await was interrupted", e);
+      nettyMetrics.nettyServerStartError.inc();
+      throw new InstantiationException(
+          "Netty server bind to port [" + nettyConfig.nettyServerPort + "] was interrupted");
+    } finally {
+      long startupTime = System.currentTimeMillis() - startupBeginTime;
+      logger.info("NettyServer start took {} ms", startupTime);
+      nettyMetrics.nettyServerStartTimeInMs.update(startupTime);
     }
   }
 
-  /**
-   * Wait for the specified time for the startup to complete.
-   * @param timeout time to wait for startup.
-   * @param timeUnit unit of {@code timeout}.
-   * @return {@code true} if startup was completed within the {@code timeout}, {@code false} otherwise.
-   * @throws InterruptedException if the wait for startup is interrupted.
-   */
-  public boolean awaitStartup(long timeout, TimeUnit timeUnit)
-      throws InterruptedException {
-    return startupDone.await(timeout, timeUnit);
-  }
-
-  /**
-   * Gets exceptions that occurred during startup if any.
-   * @return null if no {@link Exception} occurred during startup, the exception that occurred otherwise.
-   */
-  public Exception getException() {
-    return exception;
-  }
-
-  /**
-   * Shuts down the NettyServerDeployer.
-   */
+  @Override
   public void shutdown() {
     if (!bossGroup.isTerminated() || !workerGroup.isTerminated()) {
       logger.info("Shutting down NettyServer");

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
@@ -71,7 +71,7 @@ public class NettyServerTest {
     try {
       nioServer.start();
       fail("NettyServer start() should have failed because of bad nettyServerPort value");
-    } catch (InstantiationException e) {
+    } catch (IllegalArgumentException e) {
       // nothing to do. expected.
     } finally {
       if (nioServer != null) {


### PR DESCRIPTION
`NettyServerDeployer` contained a thread that was blocked for its whole lifetime for no reason at all.
This change removes that paradigm and simplifies the code in `NettyServer`

This is a very isolated change that changes no APIs and only changes the implementation of `NettyServer`. Builds on mac and linux have succeeded.

Class   Class, %    Method, %   Line, %
NettyServer 100% (2/ 2) 80% (4/ 5)  75.6% (31/ 41)
(the lines not covered are the edge cases like shutdown hanging or getting interrupted that cannot be mocked).

**Primary reviewers: Siva
Expected time to review: 10 mins**
