### PR TITLE
Fixing a bug in HealthCheckHandler that made requests hang on keep-alive

### DIFF
--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -34,6 +34,8 @@ import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Queue;
@@ -41,6 +43,8 @@ import java.util.concurrent.ExecutionException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.junit.Assert.*;
 
@@ -48,6 +52,7 @@ import static org.junit.Assert.*;
 /**
  * Integration tests for Ambry frontend.
  */
+@RunWith(Parameterized.class)
 public class FrontendIntegrationTest {
   private static final int SERVER_PORT = 1174;
   private static final ClusterMap CLUSTER_MAP;
@@ -62,6 +67,15 @@ public class FrontendIntegrationTest {
 
   private static RestServer ambryRestServer = null;
   private static NettyClient nettyClient = null;
+
+  /**
+   * Running it many times so that keep-alive bugs are caught.
+   * @return an array representing the number of times to run.
+   */
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[5][0]);
+  }
 
   /**
    * Sets up an Ambry frontend server.
@@ -138,6 +152,10 @@ public class FrontendIntegrationTest {
     getUserMetadataAndVerify(blobId, headers, usermetadata.array());
     getBlobInfoAndVerify(blobId, headers, usermetadata.array());
     getHeadAndVerify(blobId, headers);
+    deleteBlobAndVerify(blobId);
+
+    // check GET, HEAD and DELETE after delete.
+    verifyOperationsAfterDelete(blobId);
   }
 
   /*

--- a/ambry-rest/src/main/java/com.github.ambry.rest/HealthCheckHandler.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/HealthCheckHandler.java
@@ -25,11 +25,12 @@ import org.slf4j.LoggerFactory;
 public class HealthCheckHandler extends ChannelDuplexHandler {
   private final String healthCheckUri;
   private final RestServerState restServerState;
-  private HttpRequest request;
-  private FullHttpResponse response;
   private final byte[] goodBytes = "GOOD".getBytes();
   private final byte[] badBytes = "BAD".getBytes();
   private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  private HttpRequest request;
+  private FullHttpResponse response;
 
   public HealthCheckHandler(RestServerState restServerState) {
     this.restServerState = restServerState;
@@ -71,11 +72,12 @@ public class HealthCheckHandler extends ChannelDuplexHandler {
           future.addListener(ChannelFutureListener.CLOSE);
         }
         request = null;
+        response = null;
       } else {
         // request was not for health check uri
         forwardObj = true;
       }
-    } else {
+    } else if (request == null) {
       // http Content which is not LastHttpContent is not intended for this handler
       forwardObj = true;
     }


### PR DESCRIPTION
Due to incorrect resetting of state in `HealthCheckHandler`, requests had the possibility of getting stuck in `HealthCheckHandler`.
The bug was caught by the integration tests.

This change
1. Fixes the bug described.
2. Increases the number of times the Integration test is run so that keep-alive is tested thoroughly.

**Primary reviewers: Siva
Expected time to review: 2-3 mins**
