### PR TITLE
Adding support for using the IdConverter in AmbryBlobStorageService

### DIFF
--- a/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequest.java
@@ -70,6 +70,8 @@ public class MockRestRequest implements RestRequest {
     public void onEventComplete(MockRestRequest mockRestRequest, Event event);
   }
 
+  public static JSONObject DUMMY_DATA = new JSONObject();
+
   // main fields
   public static String REST_METHOD_KEY = "restMethod";
   public static String URI_KEY = "uri";
@@ -91,6 +93,15 @@ public class MockRestRequest implements RestRequest {
   private volatile ReadIntoCallbackWrapper callbackWrapper = null;
 
   private static String MULTIPLE_HEADER_VALUE_DELIMITER = ", ";
+
+  static {
+    try {
+      DUMMY_DATA.put(REST_METHOD_KEY, RestMethod.GET);
+      DUMMY_DATA.put(URI_KEY, "/");
+    } catch (JSONException e) {
+      throw new IllegalStateException(e);
+    }
+  }
 
   /**
    * Create a MockRestRequest.

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
@@ -4,8 +4,10 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.rest.BlobStorageService;
 import com.github.ambry.rest.BlobStorageServiceFactory;
+import com.github.ambry.rest.IdConverterFactory;
 import com.github.ambry.rest.RestResponseHandler;
 import com.github.ambry.router.Router;
+import com.github.ambry.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +24,7 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
   private final ClusterMap clusterMap;
   private final RestResponseHandler responseHandler;
   private final Router router;
+  private final IdConverterFactory idConverterFactory;
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   /**
@@ -32,9 +35,11 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
    *                        out.
    * @param router the {@link Router} to use.
    * @throws IllegalArgumentException if any of the arguments are null.
+   * @throws Exception if there is a problem instantiating dependent factories.
    */
   public AmbryBlobStorageServiceFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
-      RestResponseHandler responseHandler, Router router) {
+      RestResponseHandler responseHandler, Router router)
+      throws Exception {
     if (verifiableProperties == null || clusterMap == null || responseHandler == null || router == null) {
       throw new IllegalArgumentException("Null arguments were provided during instantiation!");
     } else {
@@ -43,6 +48,8 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
       this.clusterMap = clusterMap;
       this.responseHandler = responseHandler;
       this.router = router;
+      idConverterFactory =
+          Utils.getObj(frontendConfig.frontendIdConverterFactory, verifiableProperties, clusterMap.getMetricRegistry());
     }
     logger.trace("Instantiated AmbryBlobStorageServiceFactory");
   }
@@ -53,6 +60,7 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
    */
   @Override
   public BlobStorageService getBlobStorageService() {
-    return new AmbryBlobStorageService(frontendConfig, frontendMetrics, clusterMap, responseHandler, router);
+    return new AmbryBlobStorageService(frontendConfig, frontendMetrics, clusterMap, responseHandler, router,
+        idConverterFactory);
   }
 }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryIdConverterFactory.java
@@ -1,0 +1,48 @@
+package com.github.ambry.frontend;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.rest.IdConverter;
+import com.github.ambry.rest.IdConverterFactory;
+import com.github.ambry.rest.RestRequest;
+
+
+/**
+ * Factory that instantiates an {@link IdConverter} implementation for the frontend.
+ */
+public class AmbryIdConverterFactory implements IdConverterFactory {
+
+  public AmbryIdConverterFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry) {
+    // nothing to do.
+  }
+
+  @Override
+  public IdConverter getIdConverter() {
+    return new AmbryIdConverter();
+  }
+
+  private static class AmbryIdConverter implements IdConverter {
+    private boolean isOpen = true;
+
+    /**
+     * {@inheritDoc}
+     * Simply echoes {@code input}.
+     * @param restRequest {@link RestRequest} representing the request.
+     * @param input the ID that needs to be converted.
+     * @return {@code input}.
+     * @throws IllegalStateException if the {@link IdConverter} is closed.
+     */
+    @Override
+    public String convert(RestRequest restRequest, String input) {
+      if (!isOpen) {
+        throw new IllegalStateException("IdConverter is closed");
+      }
+      return input;
+    }
+
+    @Override
+    public void close() {
+      isOpen = false;
+    }
+  }
+}

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendConfig.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendConfig.java
@@ -20,7 +20,17 @@ class FrontendConfig {
   @Default("365*24*60*60")
   public final long frontendCacheValiditySeconds;
 
+  /**
+   * The {@link com.github.ambry.rest.IdConverterFactory} that needs to be used by {@link AmbryBlobStorageService} to
+   * convert IDs.
+   */
+  @Config("frontend.id.converter.factory")
+  @Default("com.github.ambry.frontend.AmbryIdConverterFactory")
+  public final String frontendIdConverterFactory;
+
   public FrontendConfig(VerifiableProperties verifiableProperties) {
     frontendCacheValiditySeconds = verifiableProperties.getLong("frontend.cache.validity.seconds", 365 * 24 * 60 * 60);
+    frontendIdConverterFactory = verifiableProperties
+        .getString("frontend.id.converter.factory", "com.github.ambry.frontend.AmbryIdConverterFactory");
   }
 }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
@@ -8,7 +8,6 @@ import com.github.ambry.rest.MockRestRequestResponseHandler;
 import com.github.ambry.rest.RestResponseHandler;
 import com.github.ambry.router.InMemoryRouter;
 import com.github.ambry.router.Router;
-import java.io.IOException;
 import java.util.Properties;
 import org.junit.Test;
 
@@ -25,11 +24,11 @@ public class AmbryBlobStorageServiceFactoryTest {
   /**
    * Tests the instantiation of an {@link AmbryBlobStorageService} instance through the
    * {@link AmbryBlobStorageServiceFactory}.
-   * @throws IOException
+   * @throws Exception
    */
   @Test
   public void getAmbryBlobStorageServiceTest()
-      throws IOException {
+      throws Exception {
     // dud properties. server should pick up defaults
     Properties properties = new Properties();
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
@@ -45,11 +44,11 @@ public class AmbryBlobStorageServiceFactoryTest {
 
   /**
    * Tests instantiation of {@link AmbryBlobStorageServiceFactory} with bad input.
-   * @throws IOException
+   * @throws Exception
    */
   @Test
   public void getAmbryBlobStorageServiceFactoryWithBadInputTest()
-      throws IOException {
+      throws Exception {
     // dud properties. server should pick up defaults
     Properties properties = new Properties();
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryIdConverterFactoryTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryIdConverterFactoryTest.java
@@ -1,0 +1,49 @@
+package com.github.ambry.frontend;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.rest.IdConverter;
+import com.github.ambry.rest.MockRestRequest;
+import com.github.ambry.utils.UtilsTest;
+import java.util.Properties;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+
+/**
+ * Unit tests for {@link AmbryIdConverterFactory}.
+ */
+public class AmbryIdConverterFactoryTest {
+
+  /**
+   * Tests the instantiation and use of the {@link IdConverter} instance returned through the
+   * {@link AmbryIdConverterFactory}.
+   * @throws Exception
+   */
+  @Test
+  public void ambryIdConverterTest()
+      throws Exception {
+    // dud properties. server should pick up defaults
+    Properties properties = new Properties();
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+
+    AmbryIdConverterFactory ambryIdConverterFactory =
+        new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry());
+    IdConverter idConverter = ambryIdConverterFactory.getIdConverter();
+    assertNotNull("No IdConverter returned", idConverter);
+    String input = UtilsTest.getRandomString(10);
+    assertEquals("IdConverter should not have converted ID", input, idConverter.convert(null, input));
+    assertEquals("IdConverter should not have converted ID", input,
+        idConverter.convert(new MockRestRequest(MockRestRequest.DUMMY_DATA, null), input));
+    idConverter.close();
+    try {
+      idConverter.convert(new MockRestRequest(MockRestRequest.DUMMY_DATA, null), input);
+      fail("ID conversion should have failed because IdConverter is closed");
+    } catch (IllegalStateException e) {
+      // expected. Nothing to do.
+    }
+  }
+}


### PR DESCRIPTION
This change wires in the `IdConverter` into `AmbryBlobStorageService`. This allows IDs to be converted on the way in and out.

Built and formatted.

**Primary reviewers: Siva
Expected time to review:  20 mins**

**Unit testing**
Package
com.github.ambry.frontend   92.3% (12/ 13)  95.1% (39/ 41)  96.9% (404/ 417)

Class   Class, %    Method, %   Line, %
AmbryBlobStorageService 100% (2/ 2) 100% (15/ 15)   98.7% (157/ 159)
AmbryBlobStorageServiceFactory  100% (1/ 1) 100% (2/ 2) 100% (12/ 12)
AmbryIdConverterFactory 100% (2/ 2) 100% (5/ 5) 100% (8/ 8)
DeleteCallback  100% (1/ 1) 100% (2/ 2) 100% (29/ 29)
FrontendConfig  100% (1/ 1) 100% (1/ 1) 100% (3/ 3)
FrontendMetrics 100% (1/ 1) 100% (1/ 1) 100% (30/ 30)
GetCallback 100% (1/ 1) 100% (2/ 2) 100% (29/ 29)
HeadCallback    100% (1/ 1) 100% (3/ 3) 100% (37/ 37)
HeadForGetCallback  100% (1/ 1) 100% (5/ 5) 94.5% (69/ 73)
PostCallback    100% (1/ 1) 100% (3/ 3) 85.7% (30/ 35)
