### PR TITLE
Changes to not aggressively replicate from nodes that are down.

### DIFF
--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -5,6 +5,7 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.StoreConfig;
@@ -502,6 +503,7 @@ public final class ReplicationManager {
       numberOfReplicaThreads = replicasToReplicate.size();
     }
 
+    ResponseHandler responseHandler = new ResponseHandler(clusterMap);
     int numberOfNodesPerThread = replicasToReplicate.size() / numberOfReplicaThreads;
     int remainingNodes = replicasToReplicate.size() % numberOfReplicaThreads;
 
@@ -526,7 +528,7 @@ public final class ReplicationManager {
       ReplicaThread replicaThread =
           new ReplicaThread("Replica Thread-" + threadIdentity + "-" + i, replicasForThread, factory, clusterMap,
               correlationIdGenerator, dataNodeId, connectionPool, replicationConfig, replicationMetrics, notification,
-              storeKeyFactory, replicationConfig.replicationValidateMessageStream, metricRegistry);
+              storeKeyFactory, replicationConfig.replicationValidateMessageStream, metricRegistry, responseHandler);
       replicaThreadList.add(replicaThread);
     }
   }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -7,6 +7,7 @@ import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.commons.ServerErrorCode;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.StoreConfig;
@@ -613,7 +614,7 @@ public class ReplicationTest {
           new ReplicaThread("threadtest", replicasToReplicate, new MockFindTokenFactory(), clusterMap,
               new AtomicInteger(0), clusterMap.getDataNodeId("localhost", dataNode1.getPort()),
               new MockConnectionPool(replicaStores, replicaBuffers, 3), config, replicationMetrics, null,
-              storeKeyFactory, true, clusterMap.getMetricRegistry());
+              storeKeyFactory, true, clusterMap.getMetricRegistry(), new ResponseHandler(clusterMap));
       List<ReplicaThread.ExchangeMetadataResponse> response = replicaThread.exchangeMetadata(
           new MockConnection("localhost", dataNode2.getPort(), replicaStores.get("localhost" + dataNode2.getPort()),
               replicaBuffers.get("localhost" + dataNode2.getPort()), 5), replicasToReplicate.get(dataNodeId), false,
@@ -874,7 +875,7 @@ public class ReplicationTest {
           new ReplicaThread("threadtest", replicasToReplicate, new MockFindTokenFactory(), clusterMap,
               new AtomicInteger(0), clusterMap.getDataNodeId("localhost", dataNode1.getPort()),
               new MockConnectionPool(replicaStores, replicaBuffers, 3), config, replicationMetrics, null,
-              storeKeyFactory, true, clusterMap.getMetricRegistry());
+              storeKeyFactory, true, clusterMap.getMetricRegistry(), new ResponseHandler(clusterMap));
       List<ReplicaThread.ExchangeMetadataResponse> response = replicaThread.exchangeMetadata(
           new MockConnection("localhost", dataNode2.getPort(), replicaStores.get("localhost" + dataNode2.getPort()),
               replicaBuffers.get("localhost" + dataNode2.getPort()), 5), replicasToReplicate.get(dataNodeId), false,
@@ -1112,7 +1113,7 @@ public class ReplicationTest {
           new ReplicaThread("threadtest", replicasToReplicate, new MockFindTokenFactory(), clusterMap,
               new AtomicInteger(0), clusterMap.getDataNodeId("localhost", dataNode1.getPort()),
               new MockConnectionPool(replicaStores, replicaBuffers, 3), config, replicationMetrics, null,
-              storeKeyFactory, true, clusterMap.getMetricRegistry());
+              storeKeyFactory, true, clusterMap.getMetricRegistry(), new ResponseHandler(clusterMap));
       List<ReplicaThread.ExchangeMetadataResponse> response = replicaThread.exchangeMetadata(
           new MockConnection("localhost", dataNode2.getPort(), replicaStores.get("localhost" + dataNode2.getPort()),
               replicaBuffers.get("localhost" + dataNode2.getPort()), 5), replicasToReplicate.get(dataNodeId), false,


### PR DESCRIPTION
Nodes used to aggressively try to replicate from nodes that are down.
Now, we utilized `ResponseHandler` to detect failures and mark nodes as
down. This prevents the `ReplicaThread` from filling up the error log.

**Primary Reviewers:**  Ming, Gopal
**Expected Time to Review:** 10-15 min.

**Testing**
The existing unit testing framework cannot adequately handle testing 
behavior when nodes are down. However, I tested by running 3 instances 
of `AmbryMain` and deactivating/reactivating replicas.
