### PR TITLE
Making the IdConverter interface async

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/IdConverter.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/IdConverter.java
@@ -1,12 +1,15 @@
 package com.github.ambry.rest;
 
+import com.github.ambry.router.Callback;
 import java.io.Closeable;
+import java.util.concurrent.Future;
 
 
 /**
  * This is a service that can be used to convert IDs across different formats.
  * </p>
- * Typical usage will be to add extensions, tailor IDs for different use-cases or encrypt/obfuscate IDs.
+ * Typical usage will be to add extensions, tailor IDs for different use-cases, encrypt/obfuscate IDs or get name
+ * mappings.
  */
 public interface IdConverter extends Closeable {
 
@@ -14,7 +17,8 @@ public interface IdConverter extends Closeable {
    * Converts an ID.
    * @param restRequest {@link RestRequest} representing the request.
    * @param input the ID that needs to be converted.
-   * @return an ID that has been appropriately converted.
+   * @param callback the {@link Callback} to invoke once the converted ID is available. Can be null.
+   * @return a {@link Future} that will eventually contain the converted ID.
    */
-  public String convert(RestRequest restRequest, String input);
+  public Future<String> convert(RestRequest restRequest, String input, Callback<String> callback);
 }

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequest.java
@@ -70,6 +70,8 @@ public class MockRestRequest implements RestRequest {
     public void onEventComplete(MockRestRequest mockRestRequest, Event event);
   }
 
+  public static final JSONObject DUMMY_DATA = new JSONObject();
+
   // main fields
   public static String REST_METHOD_KEY = "restMethod";
   public static String URI_KEY = "uri";
@@ -91,6 +93,15 @@ public class MockRestRequest implements RestRequest {
   private volatile ReadIntoCallbackWrapper callbackWrapper = null;
 
   private static String MULTIPLE_HEADER_VALUE_DELIMITER = ", ";
+
+  static {
+    try {
+      DUMMY_DATA.put(REST_METHOD_KEY, RestMethod.GET);
+      DUMMY_DATA.put(URI_KEY, "/");
+    } catch (JSONException e) {
+      throw new IllegalStateException(e);
+    }
+  }
 
   /**
    * Create a MockRestRequest.

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryIdConverterFactory.java
@@ -1,0 +1,62 @@
+package com.github.ambry.frontend;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.rest.IdConverter;
+import com.github.ambry.rest.IdConverterFactory;
+import com.github.ambry.rest.RestRequest;
+import com.github.ambry.rest.RestServiceErrorCode;
+import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.router.Callback;
+import com.github.ambry.router.FutureResult;
+import java.util.concurrent.Future;
+
+
+/**
+ * Factory that instantiates an {@link IdConverter} implementation for the frontend.
+ */
+public class AmbryIdConverterFactory implements IdConverterFactory {
+
+  public AmbryIdConverterFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry) {
+    // nothing to do.
+  }
+
+  @Override
+  public IdConverter getIdConverter() {
+    return new AmbryIdConverter();
+  }
+
+  private static class AmbryIdConverter implements IdConverter {
+    private boolean isOpen = true;
+
+    @Override
+    public void close() {
+      isOpen = false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * Simply echoes {@code input}.
+     * @param restRequest {@link RestRequest} representing the request.
+     * @param input the ID that needs to be converted.
+     * @param callback the {@link Callback} to invoke once the converted ID is available. Can be null.
+     * @return a {@link Future} that will eventually contain the converted ID.
+     */
+    @Override
+    public Future<String> convert(RestRequest restRequest, String input, Callback<String> callback) {
+      FutureResult<String> futureResult = new FutureResult<String>();
+      String convertedId = null;
+      Exception exception = null;
+      if (!isOpen) {
+        exception = new RestServiceException("IdConverter is closed", RestServiceErrorCode.ServiceUnavailable);
+      } else {
+        convertedId = input;
+      }
+      futureResult.done(convertedId, exception);
+      if (callback != null) {
+        callback.onCompletion(convertedId, exception);
+      }
+      return futureResult;
+    }
+  }
+}

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryIdConverterFactoryTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryIdConverterFactoryTest.java
@@ -1,0 +1,86 @@
+package com.github.ambry.frontend;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.rest.IdConverter;
+import com.github.ambry.rest.MockRestRequest;
+import com.github.ambry.rest.RestRequest;
+import com.github.ambry.rest.RestServiceErrorCode;
+import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.router.Callback;
+import com.github.ambry.utils.UtilsTest;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+
+/**
+ * Unit tests for {@link AmbryIdConverterFactory}.
+ */
+public class AmbryIdConverterFactoryTest {
+
+  /**
+   * Tests the instantiation and use of the {@link IdConverter} instance returned through the
+   * {@link AmbryIdConverterFactory}.
+   * @throws Exception
+   */
+  @Test
+  public void ambryIdConverterTest()
+      throws Exception {
+    // dud properties. server should pick up defaults
+    Properties properties = new Properties();
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+    IdConversionCallback callback = new IdConversionCallback();
+
+    AmbryIdConverterFactory ambryIdConverterFactory =
+        new AmbryIdConverterFactory(verifiableProperties, new MetricRegistry());
+    IdConverter idConverter = ambryIdConverterFactory.getIdConverter();
+    assertNotNull("No IdConverter returned", idConverter);
+
+    String input = UtilsTest.getRandomString(10);
+    callback.reset();
+    assertEquals("IdConverter should not have converted ID (Future)", input,
+        idConverter.convert(new MockRestRequest(MockRestRequest.DUMMY_DATA, null), input, callback).get());
+    assertEquals("IdConverter should not have converted ID (Callback)", input, callback.result);
+
+    idConverter.close();
+    callback.reset();
+    try {
+      idConverter.convert(new MockRestRequest(MockRestRequest.DUMMY_DATA, null), input, callback).get();
+      fail("ID conversion should have failed because IdConverter is closed");
+    } catch (ExecutionException e) {
+      RestServiceException re = (RestServiceException) e.getCause();
+      assertEquals("Unexpected RestServerErrorCode (Future)", RestServiceErrorCode.ServiceUnavailable,
+          re.getErrorCode());
+      re = (RestServiceException) callback.exception;
+      assertEquals("Unexpected RestServerErrorCode (Callback)", RestServiceErrorCode.ServiceUnavailable,
+          re.getErrorCode());
+    }
+  }
+
+  /**
+   * Callback implementation for testing {@link IdConverter#convert(RestRequest, String, Callback)}.
+   */
+  private static class IdConversionCallback implements Callback<String> {
+    protected String result = null;
+    protected Exception exception = null;
+
+    @Override
+    public void onCompletion(String result, Exception exception) {
+      this.result = result;
+      this.exception = exception;
+    }
+
+    /**
+     * Resets the state of this callback.
+     */
+    protected void reset() {
+      result = null;
+      exception = null;
+    }
+  }
+}


### PR DESCRIPTION
The `IdConverter` interface was non-async earlier to keep it simple.
But contacting any external name mapping services requires the interface to be async.

This change also adds a default implementation of `IdConverter`.

**Primary reviewers: Siva
Expected time to review: 5-10min**

AmbryIdConverterFactory 100% (2/ 2) 100% (5/ 5) 100% (15/ 15)
