### PR TITLE
Rewriting AmbryBlobStorageService to make callbacks cleaner

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetrics.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetrics.java
@@ -13,7 +13,9 @@
  */
 package com.github.ambry.rest;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 
 
@@ -24,29 +26,33 @@ import com.codahale.metrics.MetricRegistry;
  * used to track all requests of that type.
  */
 public class RestRequestMetrics {
-  protected static final String NIO_REQUEST_PROCESSING_TIME_SUFFIX = "NioRequestProcessingTimeInMs";
-  protected static final String NIO_RESPONSE_PROCESSING_TIME_SUFFIX = "NioResponseProcessingTimeInMs";
-  protected static final String NIO_ROUND_TRIP_TIME_SUFFIX = "NioRoundTripTimeInMs";
+  static final String NIO_REQUEST_PROCESSING_TIME_SUFFIX = "NioRequestProcessingTimeInMs";
+  static final String NIO_RESPONSE_PROCESSING_TIME_SUFFIX = "NioResponseProcessingTimeInMs";
+  static final String NIO_ROUND_TRIP_TIME_SUFFIX = "NioRoundTripTimeInMs";
 
-  protected static final String SC_REQUEST_PROCESSING_TIME_SUFFIX = "ScRequestProcessingTimeInMs";
-  protected static final String SC_REQUEST_PROCESSING_WAIT_TIME_SUFFIX = "ScRequestProcessingWaitTimeInMs";
-  protected static final String SC_RESPONSE_PROCESSING_TIME_SUFFIX = "ScResponseProcessingTimeInMs";
-  protected static final String SC_RESPONSE_PROCESSING_WAIT_TIME_SUFFIX = "ScResponseProcessingWaitTimeInMs";
-  protected static final String SC_ROUND_TRIP_TIME_SUFFIX = "ScRoundTripTimeInMs";
+  static final String SC_REQUEST_PROCESSING_TIME_SUFFIX = "ScRequestProcessingTimeInMs";
+  static final String SC_REQUEST_PROCESSING_WAIT_TIME_SUFFIX = "ScRequestProcessingWaitTimeInMs";
+  static final String SC_RESPONSE_PROCESSING_TIME_SUFFIX = "ScResponseProcessingTimeInMs";
+  static final String SC_RESPONSE_PROCESSING_WAIT_TIME_SUFFIX = "ScResponseProcessingWaitTimeInMs";
+  static final String SC_ROUND_TRIP_TIME_SUFFIX = "ScRoundTripTimeInMs";
 
-  protected static final String TOTAL_CPU_TIME_SUFFIX = "TotalCpuTimeInMs";
+  static final String TOTAL_CPU_TIME_SUFFIX = "TotalCpuTimeInMs";
+  static final String OPERATION_RATE_SUFFIX = "Rate";
+  static final String OPERATION_ERROR_SUFFIX = "Error";
 
-  protected final Histogram nioRequestProcessingTimeInMs;
-  protected final Histogram nioResponseProcessingTimeInMs;
-  protected final Histogram nioRoundTripTimeInMs;
+  final Histogram nioRequestProcessingTimeInMs;
+  final Histogram nioResponseProcessingTimeInMs;
+  final Histogram nioRoundTripTimeInMs;
 
-  protected final Histogram scRequestProcessingTimeInMs;
-  protected final Histogram scRequestProcessingWaitTimeInMs;
-  protected final Histogram scResponseProcessingTimeInMs;
-  protected final Histogram scResponseProcessingWaitTimeInMs;
-  protected final Histogram scRoundTripTimeInMs;
+  final Histogram scRequestProcessingTimeInMs;
+  final Histogram scRequestProcessingWaitTimeInMs;
+  final Histogram scResponseProcessingTimeInMs;
+  final Histogram scResponseProcessingWaitTimeInMs;
+  final Histogram scRoundTripTimeInMs;
 
-  protected final Histogram totalCpuTimeInMs;
+  final Histogram totalCpuTimeInMs;
+  final Meter operationRate;
+  final Counter operationError;
 
   /**
    * Creates an instance of RestRequestMetrics for {@code requestType} and attaches all the metrics related to the
@@ -81,5 +87,7 @@ public class RestRequestMetrics {
         metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + SC_ROUND_TRIP_TIME_SUFFIX));
 
     totalCpuTimeInMs = metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + TOTAL_CPU_TIME_SUFFIX));
+    operationRate = metricRegistry.meter(MetricRegistry.name(ownerClass, requestType + OPERATION_RATE_SUFFIX));
+    operationError = metricRegistry.counter(MetricRegistry.name(ownerClass, requestType + OPERATION_ERROR_SUFFIX));
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
@@ -198,6 +198,10 @@ public class RestRequestMetricsTracker {
     return totalCpuTimeInMs.addAndGet(delta);
   }
 
+  public void markFailure() {
+    metrics.operationError.inc();
+  }
+
   /**
    * Injects a {@link RestRequestMetrics} that can be used to track the metrics of the {@link RestRequest} that this
    * instance of RestRequestMetricsTracker is attached to.
@@ -207,6 +211,7 @@ public class RestRequestMetricsTracker {
   public void injectMetrics(RestRequestMetrics restRequestMetrics) {
     if (restRequestMetrics != null) {
       metrics = restRequestMetrics;
+      metrics.operationRate.mark();
     } else {
       throw new IllegalArgumentException("RestRequestMetrics provided cannot be null");
     }
@@ -232,6 +237,10 @@ public class RestRequestMetricsTracker {
         metrics.scRoundTripTimeInMs.update(scalingMetricsTracker.roundTripTimeInMs);
 
         metrics.totalCpuTimeInMs.update(totalCpuTimeInMs.get());
+        if (metrics == defaultMetrics) {
+          // track unknown requests rate.
+          metrics.operationRate.mark();
+        }
       }
     } else {
       throw new IllegalStateException("Could not record metrics because there is no metrics tracker");

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
@@ -86,6 +86,7 @@ public class RestRequestMetricsTrackerTest {
     TestMetrics testMetrics = new TestMetrics(requestMetrics);
     long additionalTime = 20;
     requestMetrics.addToTotalCpuTime(additionalTime);
+    requestMetrics.markFailure();
     requestMetrics.recordMetrics();
     String metricPrefix =
         RestRequestMetricsTracker.class.getCanonicalName() + "." + RestRequestMetricsTracker.DEFAULT_REQUEST_TYPE;
@@ -105,6 +106,7 @@ public class RestRequestMetricsTrackerTest {
     long additionalTime = 20;
     requestMetrics.addToTotalCpuTime(additionalTime);
     requestMetrics.injectMetrics(restRequestMetrics);
+    requestMetrics.markFailure();
     requestMetrics.recordMetrics();
     String metricPrefix = getClass().getCanonicalName() + "." + testRequestType;
     testMetrics.compareMetrics(metricPrefix, metricRegistry, additionalTime);
@@ -165,6 +167,10 @@ class TestMetrics {
 
     assertEquals("Request total CPU time unequal", totalTime,
         histograms.get(metricPrefix + RestRequestMetrics.TOTAL_CPU_TIME_SUFFIX).getSnapshot().getValues()[0]);
+    assertEquals("Rate metric has not fired", 1,
+        metricRegistry.getMeters().get(metricPrefix + RestRequestMetrics.OPERATION_RATE_SUFFIX).getCount());
+    assertEquals("Error metric has not fired", 1,
+        metricRegistry.getCounters().get(metricPrefix + RestRequestMetrics.OPERATION_ERROR_SUFFIX).getCount());
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -605,7 +605,7 @@ public class RestUtilsTest {
       boolean keyFromInputMap = inputUserMetadata.containsKey(key);
       assertTrue("Key " + key + " not found in input user metadata", keyFromInputMap);
       assertTrue("Values didn't match for key " + key + ", value from input map value " + inputUserMetadata.get(key)
-          + ", and output map value " + userMetadataMap.get(key),
+              + ", and output map value " + userMetadataMap.get(key),
           inputUserMetadata.get(key).equals(userMetadataMap.get(key)));
     }
   }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.frontend;
 
+import com.codahale.metrics.Histogram;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.messageformat.BlobInfo;
@@ -53,6 +54,16 @@ class AmbryBlobStorageService implements BlobStorageService {
   protected static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
   protected final FrontendMetrics frontendMetrics;
 
+  private static final String OPERATION_TYPE_INBOUND_ID_CONVERSION = "Inbound Id Conversion";
+  private static final String OPERATION_TYPE_OUTBOUND_ID_CONVERSION = "Outbound Id Conversion";
+  private static final String OPERATION_TYPE_GET_RESPONSE_SECURITY = "GET Response Security";
+  private static final String OPERATION_TYPE_HEAD_RESPONSE_SECURITY = "HEAD Response Security";
+  private static final String OPERATION_TYPE_HEAD_BEFORE_GET = "HEAD Before GET";
+  private static final String OPERATION_TYPE_GET = "GET";
+  private static final String OPERATION_TYPE_HEAD = "HEAD";
+  private static final String OPERATION_TYPE_DELETE = "DELETE";
+  private static final String OPERATION_TYPE_POST = "POST";
+
   private final ClusterMap clusterMap;
   private final RestResponseHandler responseHandler;
   private final Router router;
@@ -90,14 +101,17 @@ class AmbryBlobStorageService implements BlobStorageService {
   @Override
   public void start()
       throws InstantiationException {
+    long startupBeginTime = System.currentTimeMillis();
     idConverter = idConverterFactory.getIdConverter();
     securityService = securityServiceFactory.getSecurityService();
     isUp = true;
     logger.info("AmbryBlobStorageService has started");
+    frontendMetrics.blobStorageServiceStartupTimeInMs.update(System.currentTimeMillis() - startupBeginTime);
   }
 
   @Override
   public void shutdown() {
+    long shutdownBeginTime = System.currentTimeMillis();
     isUp = false;
     try {
       if (securityService != null) {
@@ -111,6 +125,8 @@ class AmbryBlobStorageService implements BlobStorageService {
       logger.info("AmbryBlobStorageService shutdown complete");
     } catch (IOException e) {
       logger.error("Downstream service close failed", e);
+    } finally {
+      frontendMetrics.blobStorageServiceShutdownTimeInMs.update(System.currentTimeMillis() - shutdownBeginTime);
     }
   }
 
@@ -120,7 +136,6 @@ class AmbryBlobStorageService implements BlobStorageService {
     long preProcessingTime = 0;
     handlePrechecks(restRequest, restResponseChannel);
     try {
-      frontendMetrics.getBlobRate.mark();
       logger.trace("Handling GET request - {}", restRequest.getUri());
       checkAvailable();
       RestUtils.SubResource subresource = RestUtils.getBlobSubResource(restRequest);
@@ -137,14 +152,12 @@ class AmbryBlobStorageService implements BlobStorageService {
         }
       }
       restRequest.getMetricsTracker().injectMetrics(requestMetrics);
+      HeadForGetCallback routerCallback = new HeadForGetCallback(restRequest, restResponseChannel, subresource);
       preProcessingTime = System.currentTimeMillis() - processingStartTime;
-      HeadForGetCallback routerCallback =
-          new HeadForGetCallback(this, restRequest, restResponseChannel, router, securityService, subresource);
       SecurityProcessRequestCallback securityCallback =
           new SecurityProcessRequestCallback(restRequest, restResponseChannel, routerCallback);
       securityService.processRequest(restRequest, securityCallback);
     } catch (Exception e) {
-      frontendMetrics.operationError.inc();
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       frontendMetrics.getPreProcessingTimeInMs.update(preProcessingTime);
@@ -157,7 +170,6 @@ class AmbryBlobStorageService implements BlobStorageService {
     long processingStartTime = System.currentTimeMillis();
     long preProcessingTime = 0;
     handlePrechecks(restRequest, restResponseChannel);
-    frontendMetrics.postBlobRate.mark();
     restRequest.getMetricsTracker().injectMetrics(frontendMetrics.postBlobMetrics);
     try {
       logger.trace("Handling POST request - {}", restRequest.getUri());
@@ -167,16 +179,13 @@ class AmbryBlobStorageService implements BlobStorageService {
       byte[] usermetadata = RestUtils.buildUsermetadata(restRequest);
       frontendMetrics.blobPropsBuildTimeInMs.update(System.currentTimeMillis() - propsBuildStartTime);
       logger.trace("Blob properties of blob being POSTed - {}", blobProperties);
-      logger.trace("Forwarding POST to the router");
+      PostCallback routerCallback = new PostCallback(restRequest, restResponseChannel, blobProperties);
       preProcessingTime = System.currentTimeMillis() - processingStartTime;
-      PostCallback routerCallback =
-          new PostCallback(this, restRequest, restResponseChannel, blobProperties, idConverter);
       SecurityProcessRequestCallback securityCallback =
           new SecurityProcessRequestCallback(restRequest, restResponseChannel, blobProperties, usermetadata,
               routerCallback);
       securityService.processRequest(restRequest, securityCallback);
     } catch (Exception e) {
-      frontendMetrics.operationError.inc();
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       frontendMetrics.postPreProcessingTimeInMs.update(preProcessingTime);
@@ -189,18 +198,16 @@ class AmbryBlobStorageService implements BlobStorageService {
     long processingStartTime = System.currentTimeMillis();
     long preProcessingTime = 0;
     handlePrechecks(restRequest, restResponseChannel);
-    frontendMetrics.deleteBlobRate.mark();
     restRequest.getMetricsTracker().injectMetrics(frontendMetrics.deleteBlobMetrics);
     try {
       logger.trace("Handling DELETE request - {}", restRequest.getUri());
       checkAvailable();
+      DeleteCallback routerCallback = new DeleteCallback(restRequest, restResponseChannel);
       preProcessingTime = System.currentTimeMillis() - processingStartTime;
-      DeleteCallback routerCallback = new DeleteCallback(this, restRequest, restResponseChannel);
       SecurityProcessRequestCallback securityCallback =
           new SecurityProcessRequestCallback(restRequest, restResponseChannel, routerCallback);
       securityService.processRequest(restRequest, securityCallback);
     } catch (Exception e) {
-      frontendMetrics.operationError.inc();
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       frontendMetrics.deletePreProcessingTimeInMs.update(preProcessingTime);
@@ -217,13 +224,12 @@ class AmbryBlobStorageService implements BlobStorageService {
     try {
       logger.trace("Handling HEAD request - {}", restRequest.getUri());
       checkAvailable();
+      HeadCallback routerCallback = new HeadCallback(restRequest, restResponseChannel);
       preProcessingTime = System.currentTimeMillis() - processingStartTime;
-      HeadCallback routerCallback = new HeadCallback(this, restRequest, restResponseChannel, securityService);
       SecurityProcessRequestCallback securityCallback =
           new SecurityProcessRequestCallback(restRequest, restResponseChannel, routerCallback);
       securityService.processRequest(restRequest, securityCallback);
     } catch (Exception e) {
-      frontendMetrics.operationError.inc();
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       frontendMetrics.headPreProcessingTimeInMs.update(preProcessingTime);
@@ -232,21 +238,21 @@ class AmbryBlobStorageService implements BlobStorageService {
   }
 
   /**
-   * Submits the  {@code response} (and any {@code exception})for the {@code restRequest} to the
+   * Submits the response and {@code responseBody} (and any {@code exception})for the {@code restRequest} to the
    * {@code responseHandler}.
-   * @param restRequest the {@link RestRequest} for which a a {@code response} is ready.
+   * @param restRequest the {@link RestRequest} for which a response is ready.
    * @param restResponseChannel the {@link RestResponseChannel} over which the response can be sent.
-   * @param response the response in the form of a {@link ReadableStreamChannel}.
+   * @param responseBody the body of the response in the form of a {@link ReadableStreamChannel}.
    * @param exception any {@link Exception} that occurred during the handling of {@code restRequest}.
    */
   protected void submitResponse(RestRequest restRequest, RestResponseChannel restResponseChannel,
-      ReadableStreamChannel response, Exception exception) {
+      ReadableStreamChannel responseBody, Exception exception) {
     try {
       if (exception != null && exception instanceof RouterException) {
         exception = new RestServiceException(exception,
             RestServiceErrorCode.getRestServiceErrorCode(((RouterException) exception).getErrorCode()));
       }
-      responseHandler.handleResponse(restRequest, restResponseChannel, response, exception);
+      responseHandler.handleResponse(restRequest, restResponseChannel, responseBody, exception);
     } catch (RestServiceException e) {
       frontendMetrics.responseSubmissionError.inc();
       if (exception != null) {
@@ -257,9 +263,9 @@ class AmbryBlobStorageService implements BlobStorageService {
       logger.error("Handling of request {} failed", restRequest.getUri(), exception);
       restResponseChannel.onResponseComplete(exception);
 
-      if (response != null) {
+      if (responseBody != null) {
         try {
-          response.close();
+          responseBody.close();
         } catch (IOException ioe) {
           frontendMetrics.resourceReleaseError.inc();
           logger.error("Error closing ReadableStreamChannel", e);
@@ -306,18 +312,19 @@ class AmbryBlobStorageService implements BlobStorageService {
     private final HeadForGetCallback headForGetCallback;
     private final HeadCallback headCallback;
     private final DeleteCallback deleteCallback;
+    private final CallbackTracker callbackTracker;
 
-    private InboundIdConverterCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
+    InboundIdConverterCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
         HeadForGetCallback callback) {
       this(restRequest, restResponseChannel, callback, null, null);
     }
 
-    private InboundIdConverterCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
+    InboundIdConverterCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
         HeadCallback callback) {
       this(restRequest, restResponseChannel, null, callback, null);
     }
 
-    private InboundIdConverterCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
+    InboundIdConverterCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
         DeleteCallback callback) {
       this(restRequest, restResponseChannel, null, null, callback);
     }
@@ -329,6 +336,9 @@ class AmbryBlobStorageService implements BlobStorageService {
       this.headForGetCallback = headForGetCallback;
       this.headCallback = headCallback;
       this.deleteCallback = deleteCallback;
+      callbackTracker = new CallbackTracker(restRequest, OPERATION_TYPE_INBOUND_ID_CONVERSION,
+          frontendMetrics.inboundIdConversionTimeInMs, frontendMetrics.inboundIdConversionCallbackProcessingTimeInMs);
+      callbackTracker.markOperationStart();
     }
 
     /**
@@ -338,29 +348,35 @@ class AmbryBlobStorageService implements BlobStorageService {
      */
     @Override
     public void onCompletion(String result, Exception exception) {
-      if (result == null && exception == null) {
-        throw new IllegalStateException("Both result and exception cannot be null");
-      } else if (exception != null) {
-        submitResponse(restRequest, restResponseChannel, null, exception);
-      } else {
-        RestMethod restMethod = restRequest.getRestMethod();
-        logger.trace("Forwarding {} of {} to the router", restMethod, result);
-        switch (restMethod) {
-          case GET:
-            headForGetCallback.markStartTime();
-            router.getBlobInfo(result, headForGetCallback);
-            break;
-          case HEAD:
-            headCallback.markStartTime();
-            router.getBlobInfo(result, headCallback);
-            break;
-          case DELETE:
-            deleteCallback.markStartTime();
-            router.deleteBlob(result, deleteCallback);
-            break;
-          default:
-            throw new IllegalStateException("Unrecognized RestMethod: " + restMethod);
+      callbackTracker.markOperationEnd();
+      try {
+        if (result == null && exception == null) {
+          throw new IllegalStateException("Both result and exception cannot be null");
+        } else if (exception != null) {
+          submitResponse(restRequest, restResponseChannel, null, exception);
+        } else {
+          RestMethod restMethod = restRequest.getRestMethod();
+          logger.trace("Forwarding {} of {} to the router", restMethod, result);
+          switch (restMethod) {
+            case GET:
+              headForGetCallback.setBlobId(result);
+              headForGetCallback.markStartTime();
+              router.getBlobInfo(result, headForGetCallback);
+              break;
+            case HEAD:
+              headCallback.markStartTime();
+              router.getBlobInfo(result, headCallback);
+              break;
+            case DELETE:
+              deleteCallback.markStartTime();
+              router.deleteBlob(result, deleteCallback);
+              break;
+            default:
+              throw new IllegalStateException("Unrecognized RestMethod: " + restMethod);
+          }
         }
+      } finally {
+        callbackTracker.markCallbackProcessingEnd();
       }
     }
   }
@@ -369,8 +385,14 @@ class AmbryBlobStorageService implements BlobStorageService {
    * Callback for {@link SecurityService#processRequest(RestRequest, Callback)}.
    */
   private class SecurityProcessRequestCallback implements Callback<Void> {
+    private static final String PROCESS_GET = "GET Request Security";
+    private static final String PROCESS_HEAD = "HEAD Request Security";
+    private static final String PROCESS_POST = "POST Request Security";
+    private static final String PROCESS_DELETE = "DELETE Request Security";
+
     private final RestRequest restRequest;
     private final RestResponseChannel restResponseChannel;
+    private final CallbackTracker callbackTracker;
 
     private HeadForGetCallback headForGetCallback;
     private HeadCallback headCallback;
@@ -380,35 +402,43 @@ class AmbryBlobStorageService implements BlobStorageService {
     private BlobProperties blobProperties;
     private byte[] userMetadata;
 
-    private SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
+    SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
         HeadForGetCallback callback) {
-      this(restRequest, restResponseChannel);
+      this(restRequest, restResponseChannel, PROCESS_GET, frontendMetrics.getSecurityRequestTimeInMs,
+          frontendMetrics.getSecurityRequestCallbackProcessingTimeInMs);
       this.headForGetCallback = callback;
     }
 
-    private SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
+    SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
         HeadCallback callback) {
-      this(restRequest, restResponseChannel);
+      this(restRequest, restResponseChannel, PROCESS_HEAD, frontendMetrics.headSecurityRequestTimeInMs,
+          frontendMetrics.headSecurityRequestCallbackProcessingTimeInMs);
       this.headCallback = callback;
     }
 
-    private SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
+    SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
         BlobProperties blobProperties, byte[] userMetadata, PostCallback callback) {
-      this(restRequest, restResponseChannel);
+      this(restRequest, restResponseChannel, PROCESS_POST, frontendMetrics.postSecurityRequestTimeInMs,
+          frontendMetrics.postSecurityRequestCallbackProcessingTimeInMs);
       this.blobProperties = blobProperties;
       this.userMetadata = userMetadata;
       this.postCallback = callback;
     }
 
-    private SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
+    SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
         DeleteCallback callback) {
-      this(restRequest, restResponseChannel);
+      this(restRequest, restResponseChannel, PROCESS_DELETE, frontendMetrics.deleteSecurityRequestTimeInMs,
+          frontendMetrics.deleteSecurityRequestCallbackProcessingTimeInMs);
       this.deleteCallback = callback;
     }
 
-    private SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel) {
+    private SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
+        String operationType, Histogram operationTimeTracker, Histogram callbackProcessingTimeTracker) {
       this.restRequest = restRequest;
       this.restResponseChannel = restResponseChannel;
+      callbackTracker =
+          new CallbackTracker(restRequest, operationType, operationTimeTracker, callbackProcessingTimeTracker);
+      callbackTracker.markOperationStart();
     }
 
     /**
@@ -421,512 +451,515 @@ class AmbryBlobStorageService implements BlobStorageService {
      */
     @Override
     public void onCompletion(Void result, Exception exception) {
-      if (exception != null) {
-        submitResponse(restRequest, restResponseChannel, null, exception);
-      } else {
-        RestMethod restMethod = restRequest.getRestMethod();
-        logger.trace("Forwarding {} to the IdConverter/Router", restMethod);
-        switch (restMethod) {
-          case GET:
-            String receivedId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
-            InboundIdConverterCallback idConverterCallback =
-                new InboundIdConverterCallback(restRequest, restResponseChannel, headForGetCallback);
-            idConverter.convert(restRequest, receivedId, idConverterCallback);
-            break;
-          case HEAD:
-            receivedId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
-            idConverterCallback = new InboundIdConverterCallback(restRequest, restResponseChannel, headCallback);
-            idConverter.convert(restRequest, receivedId, idConverterCallback);
-            break;
-          case POST:
-            postCallback.markStartTime();
-            router.putBlob(blobProperties, userMetadata, restRequest, postCallback);
-            break;
-          case DELETE:
-            receivedId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
-            idConverterCallback = new InboundIdConverterCallback(restRequest, restResponseChannel, deleteCallback);
-            idConverter.convert(restRequest, receivedId, idConverterCallback);
-            break;
-          default:
-            throw new IllegalStateException("Unrecognized RestMethod: " + restMethod);
+      try {
+        callbackTracker.markOperationEnd();
+        if (exception != null) {
+          submitResponse(restRequest, restResponseChannel, null, exception);
+        } else {
+          RestMethod restMethod = restRequest.getRestMethod();
+          logger.trace("Forwarding {} to the IdConverter/Router", restMethod);
+          switch (restMethod) {
+            case GET:
+              String receivedId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
+              InboundIdConverterCallback idConverterCallback =
+                  new InboundIdConverterCallback(restRequest, restResponseChannel, headForGetCallback);
+              idConverter.convert(restRequest, receivedId, idConverterCallback);
+              break;
+            case HEAD:
+              receivedId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
+              idConverterCallback = new InboundIdConverterCallback(restRequest, restResponseChannel, headCallback);
+              idConverter.convert(restRequest, receivedId, idConverterCallback);
+              break;
+            case POST:
+              postCallback.markStartTime();
+              router.putBlob(blobProperties, userMetadata, restRequest, postCallback);
+              break;
+            case DELETE:
+              receivedId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
+              idConverterCallback = new InboundIdConverterCallback(restRequest, restResponseChannel, deleteCallback);
+              idConverter.convert(restRequest, receivedId, idConverterCallback);
+              break;
+            default:
+              throw new IllegalStateException("Unrecognized RestMethod: " + restMethod);
+          }
+        }
+      } finally {
+        callbackTracker.markCallbackProcessingEnd();
+      }
+    }
+  }
+
+  /**
+   * Tracks metrics and logs progress of operations that accept callbacks.
+   */
+  private class CallbackTracker {
+    private long operationStartTime = 0;
+    private long processingStartTime = 0;
+
+    private final RestRequest restRequest;
+    private final String operationType;
+    private final Histogram operationTimeTracker;
+    private final Histogram callbackProcessingTimeTracker;
+    private final String blobId;
+
+    /**
+     * Create a CallbackTracker that tracks a particular operation.
+     * @param restRequest the {@link RestRequest} for the operation.
+     * @param operationType the type of operation.
+     * @param operationTimeTracker the {@link Histogram} of the time taken by the operation.
+     * @param callbackProcessingTimeTracker the {@link Histogram} of the time taken by the callback of the operation.
+     */
+    CallbackTracker(RestRequest restRequest, String operationType, Histogram operationTimeTracker,
+        Histogram callbackProcessingTimeTracker) {
+      this.restRequest = restRequest;
+      this.operationType = operationType;
+      this.operationTimeTracker = operationTimeTracker;
+      this.callbackProcessingTimeTracker = callbackProcessingTimeTracker;
+      blobId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
+    }
+
+    /**
+     * Marks that the operation being tracked has started.
+     */
+    void markOperationStart() {
+      logger.trace("{} started for {}", operationType, blobId);
+      operationStartTime = System.currentTimeMillis();
+    }
+
+    /**
+     * Marks that the operation being tracked has ended and callback processing has started.
+     */
+    void markOperationEnd() {
+      logger.trace("{} finished for {}", operationType, blobId);
+      processingStartTime = System.currentTimeMillis();
+      long operationTime = processingStartTime - operationStartTime;
+      operationTimeTracker.update(operationTime);
+      restRequest.getMetricsTracker().addToTotalCpuTime(operationTime);
+    }
+
+    /**
+     * Marks that the  callback processing has ended.
+     */
+    void markCallbackProcessingEnd() {
+      logger.trace("Callback for {} of {} finished", operationType, blobId);
+      long processingTime = System.currentTimeMillis() - processingStartTime;
+      callbackProcessingTimeTracker.update(processingTime);
+      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
+    }
+  }
+
+  /**
+   * Callback for HEAD that precedes GET operations. Updates headers and invokes GET with a new callback.
+   */
+  private class HeadForGetCallback implements Callback<BlobInfo> {
+    private final RestRequest restRequest;
+    private final RestResponseChannel restResponseChannel;
+    private final RestUtils.SubResource subResource;
+    private final CallbackTracker callbackTracker;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private String blobId;
+
+    /**
+     * Create a HEAD before GET callback.
+     * @param restRequest the {@link RestRequest} for whose response this is a callback.
+     * @param restResponseChannel the {@link RestResponseChannel} to set headers on.
+     * @param subResource the sub-resource requested.
+     */
+    HeadForGetCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
+        RestUtils.SubResource subResource) {
+      this.restRequest = restRequest;
+      this.restResponseChannel = restResponseChannel;
+      this.subResource = subResource;
+      callbackTracker =
+          new CallbackTracker(restRequest, OPERATION_TYPE_HEAD_BEFORE_GET, frontendMetrics.headForGetTimeInMs,
+              frontendMetrics.headForGetCallbackProcessingTimeInMs);
+      blobId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
+    }
+
+    /**
+     * If the request is not for a sub resource, makes a GET call to the router. If the request is for a sub resource,
+     * responds immediately. If there was no {@code routerResult} or if there was an exception, bails out.
+     * @param routerResult The result of the request i.e a {@link BlobInfo} object with the properties of the blob that
+     *                     is going to be scheduled for GET. This is non null if the request executed successfully.
+     * @param routerException The exception that was reported on execution of the request (if any).
+     */
+    @Override
+    public void onCompletion(final BlobInfo routerResult, Exception routerException) {
+      callbackTracker.markOperationEnd();
+      if (routerResult == null && routerException == null) {
+        frontendMetrics.routerCallbackError.inc();
+        callbackTracker.markCallbackProcessingEnd();
+        throw new IllegalStateException("Both response and exception are null");
+      }
+      try {
+        if (routerException == null) {
+          final CallbackTracker securityCallbackTracker =
+              new CallbackTracker(restRequest, OPERATION_TYPE_GET_RESPONSE_SECURITY,
+                  frontendMetrics.getSecurityResponseTimeInMs,
+                  frontendMetrics.getSecurityResponseCallbackProcessingTimeInMs);
+          securityCallbackTracker.markOperationStart();
+          securityService.processResponse(restRequest, restResponseChannel, routerResult, new Callback<Void>() {
+            @Override
+            public void onCompletion(Void securityResult, Exception securityException) {
+              securityCallbackTracker.markOperationEnd();
+              ReadableStreamChannel response = null;
+              try {
+                if (securityException == null) {
+                  if (subResource == null) {
+                    logger.trace("Forwarding GET after HEAD for {} to the router", blobId);
+                    router.getBlob(blobId, new GetCallback(restRequest, restResponseChannel));
+                  } else {
+                    // TODO: if old style, make RestUtils.getUserMetadata() just return null.
+                    Map<String, String> userMetadata = RestUtils.buildUserMetadata(routerResult.getUserMetadata());
+                    if (shouldSendMetadataAsContent(userMetadata)) {
+                      restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, "application/octet-stream");
+                      restResponseChannel
+                          .setHeader(RestUtils.Headers.CONTENT_LENGTH, routerResult.getUserMetadata().length);
+                      response = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(routerResult.getUserMetadata()));
+                    } else {
+                      setUserMetadataHeaders(userMetadata, restResponseChannel);
+                      restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
+                      response = new ByteBufferReadableStreamChannel(AmbryBlobStorageService.EMPTY_BUFFER);
+                    }
+                  }
+                }
+              } catch (RestServiceException e) {
+                frontendMetrics.getSecurityResponseCallbackProcessingError.inc();
+                securityException = e;
+              } finally {
+                securityCallbackTracker.markCallbackProcessingEnd();
+                if (response != null || securityException != null) {
+                  submitResponse(restRequest, restResponseChannel, response, securityException);
+                }
+              }
+            }
+          });
+        }
+      } catch (Exception e) {
+        frontendMetrics.headForGetCallbackProcessingError.inc();
+        routerException = e;
+      } finally {
+        callbackTracker.markCallbackProcessingEnd();
+        if (routerException != null) {
+          submitResponse(restRequest, restResponseChannel, null, routerException);
         }
       }
     }
+
+    /**
+     * Sets the blob ID that should be used for {@link Router#getBlob(String, Callback)}.
+     * @param blobId the blob ID that should be used for {@link Router#getBlob(String, Callback)}.
+     */
+    void setBlobId(String blobId) {
+      this.blobId = blobId;
+    }
+
+    /**
+     * Marks the start time of the operation.
+     */
+    void markStartTime() {
+      callbackTracker.markOperationStart();
+    }
+
+    /**
+     * Determines if user metadata should be sent as content by looking for any keys that are prefixed with
+     * {@link RestUtils.Headers#USER_META_DATA_OLD_STYLE_PREFIX}.
+     * @param userMetadata the user metadata that was constructed from the byte stream.
+     * @return {@code true} if any key is prefixed with {@link RestUtils.Headers#USER_META_DATA_OLD_STYLE_PREFIX}.
+     *         {@code false} otherwise.
+     */
+    private boolean shouldSendMetadataAsContent(Map<String, String> userMetadata) {
+      boolean shouldSendAsContent = false;
+      for (Map.Entry<String, String> entry : userMetadata.entrySet()) {
+        if (entry.getKey().startsWith(RestUtils.Headers.USER_META_DATA_OLD_STYLE_PREFIX)) {
+          shouldSendAsContent = true;
+          break;
+        }
+      }
+      return shouldSendAsContent;
+    }
+
+    /**
+     * Sets the user metadata in the headers of the response.
+     * @param userMetadata the user metadata that need to be set in the headers.
+     * @param restResponseChannel the {@link RestResponseChannel} that is used for sending the response.
+     * @throws RestServiceException if there are any problems setting the header.
+     */
+    private void setUserMetadataHeaders(Map<String, String> userMetadata, RestResponseChannel restResponseChannel)
+        throws RestServiceException {
+      for (Map.Entry<String, String> entry : userMetadata.entrySet()) {
+        restResponseChannel.setHeader(entry.getKey(), entry.getValue());
+      }
+    }
   }
-}
-
-/**
- * Callback for HEAD that precedes GET operations. Updates headers and invokes GET with a new callback.
- */
-class HeadForGetCallback implements Callback<BlobInfo> {
-  private final AmbryBlobStorageService ambryBlobStorageService;
-  private final RestRequest restRequest;
-  private final RestResponseChannel restResponseChannel;
-  private final Router router;
-  private final SecurityService securityService;
-  private final RestUtils.SubResource subResource;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
-  private long operationStartTime = 0;
 
   /**
-   * Create a HEAD before GET callback.
-   * @param ambryBlobStorageService the {@link AmbryBlobStorageService} instance to submit responses to.
-   * @param restRequest the {@link RestRequest} for whose response this is a callback.
-   * @param restResponseChannel the {@link RestResponseChannel} to set headers on.
-   * @param router the {@link Router} instance to use to make the GET call.
-   * @param securityService the {@link SecurityService} instance to use to verify the response.
-   * @param subResource the sub-resource requested.
+   * Callback for GET operations. Submits the response received to an instance of {@link RestResponseHandler}.
    */
-  public HeadForGetCallback(AmbryBlobStorageService ambryBlobStorageService, RestRequest restRequest,
-      RestResponseChannel restResponseChannel, Router router, SecurityService securityService,
-      RestUtils.SubResource subResource) {
-    this.ambryBlobStorageService = ambryBlobStorageService;
-    this.restRequest = restRequest;
-    this.restResponseChannel = restResponseChannel;
-    this.router = router;
-    this.securityService = securityService;
-    this.subResource = subResource;
+  private class GetCallback implements Callback<ReadableStreamChannel> {
+    private final RestRequest restRequest;
+    private final RestResponseChannel restResponseChannel;
+    private final CallbackTracker callbackTracker;
+
+    /**
+     * Create a GET callback.
+     * @param restRequest the {@link RestRequest} for whose response this is a callback.
+     * @param restResponseChannel the {@link RestResponseChannel} over which response to {@code restRequest} can be
+     *                            sent.
+     */
+    GetCallback(RestRequest restRequest, RestResponseChannel restResponseChannel) {
+      this.restRequest = restRequest;
+      this.restResponseChannel = restResponseChannel;
+      callbackTracker = new CallbackTracker(restRequest, OPERATION_TYPE_GET, frontendMetrics.getTimeInMs,
+          frontendMetrics.getCallbackProcessingTimeInMs);
+      callbackTracker.markOperationStart();
+    }
+
+    /**
+     * Submits the GET response to {@link RestResponseHandler} so that it can be sent (or the exception handled).
+     * @param routerResult The result of the request. This is the actual blob data as a {@link ReadableStreamChannel}.
+     *               This is non null if the request executed successfully.
+     * @param routerException The exception that was reported on execution of the request (if any).
+     */
+    @Override
+    public void onCompletion(ReadableStreamChannel routerResult, Exception routerException) {
+      callbackTracker.markOperationEnd();
+      if (routerResult == null && routerException == null) {
+        frontendMetrics.routerCallbackError.inc();
+        callbackTracker.markCallbackProcessingEnd();
+        throw new IllegalStateException("Both response and exception are null");
+      } else {
+        callbackTracker.markCallbackProcessingEnd();
+        submitResponse(restRequest, restResponseChannel, routerResult, routerException);
+      }
+    }
   }
 
   /**
-   * If the request is not for a sub resource, makes a GET call to the router. If the request is for a sub resource,
-   * responds immediately. If there was no {@code routerResult} or if there was an exception, bails out.
-   * @param routerResult The result of the request i.e a {@link BlobInfo} object with the properties of the blob that is going
-   *               to be scheduled for GET. This is non null if the request executed successfully.
-   * @param exception The exception that was reported on execution of the request (if any).
+   * Callback for POST operations. Sends the response received to the client. Submits response either to handle
+   * exceptions or to clean up after a response.
    */
-  @Override
-  public void onCompletion(final BlobInfo routerResult, Exception exception) {
-    long processingStartTime = System.currentTimeMillis();
-    try {
-      long routerTime = processingStartTime - operationStartTime;
-      ambryBlobStorageService.frontendMetrics.headForGetTimeInMs.update(routerTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(routerTime);
+  private class PostCallback implements Callback<String> {
+    private final RestRequest restRequest;
+    private final RestResponseChannel restResponseChannel;
+    private final BlobProperties blobProperties;
+    private final CallbackTracker callbackTracker;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
-      final String blobId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
-      logger.trace("Callback received for HEAD before GET of {}", blobId);
-      if (exception == null && routerResult != null) {
-        securityService.processResponse(restRequest, restResponseChannel, routerResult, new Callback<Void>() {
-          @Override
-          public void onCompletion(Void antivirusResult, Exception exception) {
-            ReadableStreamChannel response = null;
-            try {
-              if (exception == null) {
-                if (subResource == null) {
-                  logger.trace("Forwarding GET after HEAD for {} to the router", blobId);
-                  router.getBlob(blobId, new GetCallback(ambryBlobStorageService, restRequest, restResponseChannel));
-                } else {
-                  // TODO: if old style, make RestUtils.getUserMetadata() just return null.
-                  Map<String, String> userMetadata = RestUtils.buildUserMetadata(routerResult.getUserMetadata());
-                  if (shouldSendMetadataAsContent(userMetadata)) {
-                    restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, "application/octet-stream");
-                    restResponseChannel
-                        .setHeader(RestUtils.Headers.CONTENT_LENGTH, routerResult.getUserMetadata().length);
-                    response = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(routerResult.getUserMetadata()));
-                  } else {
-                    setUserMetadataHeaders(userMetadata, restResponseChannel);
-                    restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
-                    response = new ByteBufferReadableStreamChannel(AmbryBlobStorageService.EMPTY_BUFFER);
-                  }
+    /**
+     * Create a POST callback.
+     * @param restRequest the {@link RestRequest} for whose response this is a callback.
+     * @param restResponseChannel the {@link RestResponseChannel} over which response to {@code restRequest} can be
+     *                            sent.
+     * @param createdBlobProperties the {@link BlobProperties} of the blob that was asked to be POSTed.
+     */
+    PostCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
+        BlobProperties createdBlobProperties) {
+      this.restRequest = restRequest;
+      this.restResponseChannel = restResponseChannel;
+      this.blobProperties = createdBlobProperties;
+      callbackTracker = new CallbackTracker(restRequest, OPERATION_TYPE_POST, frontendMetrics.postTimeInMs,
+          frontendMetrics.postCallbackProcessingTimeInMs);
+    }
+
+    /**
+     * If there was no exception, updates the header with the location of the object. Submits the response either for
+     * exception handling or for cleanup.
+     * @param routerResult The result of the request. This is the blob ID of the blob. This is non null if the request
+     *               executed successfully.
+     * @param routerException The exception that was reported on execution of the request (if any).
+     */
+    @Override
+    public void onCompletion(String routerResult, Exception routerException) {
+      callbackTracker.markOperationEnd();
+      if (routerResult == null && routerException == null) {
+        frontendMetrics.routerCallbackError.inc();
+        callbackTracker.markCallbackProcessingEnd();
+        throw new IllegalStateException("Both response and exception are null");
+      }
+      try {
+        if (routerException == null) {
+          logger.trace("Successful POST of {}", routerResult);
+          final CallbackTracker idConversionCallbackTracker =
+              new CallbackTracker(restRequest, OPERATION_TYPE_OUTBOUND_ID_CONVERSION,
+                  frontendMetrics.outboundIdConversionTimeInMs,
+                  frontendMetrics.outboundIdConversionCallbackProcessingTimeInMs);
+          idConversionCallbackTracker.markOperationStart();
+          idConverter.convert(restRequest, routerResult, new Callback<String>() {
+            @Override
+            public void onCompletion(String idConversionResult, Exception idConversionException) {
+              idConversionCallbackTracker.markOperationEnd();
+              if (idConversionException == null) {
+                try {
+                  setResponseHeaders(idConversionResult);
+                } catch (RestServiceException e) {
+                  frontendMetrics.outboundIdConversionCallbackProcessingError.inc();
+                  idConversionException = e;
                 }
               }
-            } catch (Exception e) {
-              exception = e;
-            } finally {
-              if (response != null || exception != null) {
-                if (exception != null) {
-                  ambryBlobStorageService.frontendMetrics.operationError.inc();
-                }
-                ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, response, exception);
-              }
+              idConversionCallbackTracker.markCallbackProcessingEnd();
+              submitResponse(restRequest, restResponseChannel, null, idConversionException);
             }
-          }
-        });
-      } else if (exception == null) {
-        exception = new IllegalStateException("Both response and exception are null for HeadForGetCallback");
-      }
-    } catch (Exception e) {
-      ambryBlobStorageService.frontendMetrics.callbackProcessingError.inc();
-      if (exception != null) {
-        logger.error("Error while processing callback", e);
-      } else {
-        exception = e;
-      }
-    } finally {
-      long processingTime = System.currentTimeMillis() - processingStartTime;
-      ambryBlobStorageService.frontendMetrics.headForGetCallbackProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
-      if (exception != null) {
-        ambryBlobStorageService.frontendMetrics.operationError.inc();
-        ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, exception);
+          });
+        }
+      } catch (Exception e) {
+        frontendMetrics.postCallbackProcessingError.inc();
+        routerException = e;
+      } finally {
+        callbackTracker.markCallbackProcessingEnd();
+        if (routerException != null) {
+          submitResponse(restRequest, restResponseChannel, null, routerException);
+        }
       }
     }
-  }
 
-  /**
-   * Marks the start time of the operation.
-   */
-  protected void markStartTime() {
-    operationStartTime = System.currentTimeMillis();
-  }
-
-  /**
-   * Determines if user metadata should be sent as content by looking for any keys that are prefixed with
-   * {@link RestUtils.Headers#USER_META_DATA_OLD_STYLE_PREFIX}.
-   * @param userMetadata the user metadata that was constructed from the byte stream.
-   * @return {@code true} if any key is prefixed with {@link RestUtils.Headers#USER_META_DATA_OLD_STYLE_PREFIX}.
-   *         {@code false} otherwise.
-   */
-  private boolean shouldSendMetadataAsContent(Map<String, String> userMetadata) {
-    boolean shouldSendAsContent = false;
-    for (Map.Entry<String, String> entry : userMetadata.entrySet()) {
-      if (entry.getKey().startsWith(RestUtils.Headers.USER_META_DATA_OLD_STYLE_PREFIX)) {
-        shouldSendAsContent = true;
-        break;
-      }
+    /**
+     * Marks the start time of the operation.
+     */
+    void markStartTime() {
+      callbackTracker.markOperationStart();
     }
-    return shouldSendAsContent;
-  }
 
-  /**
-   * Sets the user metadata in the headers of the response.
-   * @param userMetadata the user metadata that need to be set in the headers.
-   * @param restResponseChannel the {@link RestResponseChannel} that is used for sending the response.
-   * @throws RestServiceException if there are any problems setting the header.
-   */
-  private void setUserMetadataHeaders(Map<String, String> userMetadata, RestResponseChannel restResponseChannel)
-      throws RestServiceException {
-    for (Map.Entry<String, String> entry : userMetadata.entrySet()) {
-      restResponseChannel.setHeader(entry.getKey(), entry.getValue());
-    }
-  }
-}
-
-/**
- * Callback for GET operations. Submits the response received to an instance of {@link RestResponseHandler}.
- */
-class GetCallback implements Callback<ReadableStreamChannel> {
-  private final AmbryBlobStorageService ambryBlobStorageService;
-  private final RestRequest restRequest;
-  private final RestResponseChannel restResponseChannel;
-  private final long operationStartTime = System.currentTimeMillis();
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
-  /**
-   * Create a GET callback.
-   * @param ambryBlobStorageService the {@link AmbryBlobStorageService} instance to submit responses to.
-   * @param restRequest the {@link RestRequest} for whose response this is a callback.
-   * @param restResponseChannel the {@link RestResponseChannel} over which response to {@code restRequest} can be sent.
-   */
-  public GetCallback(AmbryBlobStorageService ambryBlobStorageService, RestRequest restRequest,
-      RestResponseChannel restResponseChannel) {
-    this.ambryBlobStorageService = ambryBlobStorageService;
-    this.restRequest = restRequest;
-    this.restResponseChannel = restResponseChannel;
-  }
-
-  /**
-   * Submits the GET response to {@link RestResponseHandler} so that it can be sent (or the exception handled).
-   * @param result The result of the request. This is the actual blob data as a {@link ReadableStreamChannel}.
-   *               This is non null if the request executed successfully.
-   * @param exception The exception that was reported on execution of the request (if any).
-   */
-  @Override
-  public void onCompletion(ReadableStreamChannel result, Exception exception) {
-    long processingStartTime = System.currentTimeMillis();
-    try {
-      long routerTime = processingStartTime - operationStartTime;
-      ambryBlobStorageService.frontendMetrics.getTimeInMs.update(routerTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(routerTime);
-
-      String blobId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
-      logger.trace("Callback received for GET of {}", blobId);
-      if (exception == null && result != null) {
-        logger.trace("Successful GET of {}", blobId);
-      } else if (exception == null) {
-        exception = new IllegalStateException("Both response and exception are null for GetCallback");
-      }
-    } catch (Exception e) {
-      ambryBlobStorageService.frontendMetrics.callbackProcessingError.inc();
-      if (exception != null) {
-        logger.error("Error while processing callback", e);
-      } else {
-        exception = e;
-      }
-    } finally {
-      long processingTime = System.currentTimeMillis() - processingStartTime;
-      ambryBlobStorageService.frontendMetrics.getCallbackProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
-      if (exception != null) {
-        ambryBlobStorageService.frontendMetrics.operationError.inc();
-      }
-      ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, result, exception);
-    }
-  }
-}
-
-/**
- * Callback for POST operations. Sends the response received to the client. Submits response either to handle exceptions
- * or to clean up after a response.
- */
-class PostCallback implements Callback<String> {
-  private final AmbryBlobStorageService ambryBlobStorageService;
-  private final RestRequest restRequest;
-  private final RestResponseChannel restResponseChannel;
-  private final BlobProperties blobProperties;
-  private final IdConverter idConverter;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
-  private long operationStartTime = 0;
-
-  /**
-   * Create a POST callback.
-   * @param ambryBlobStorageService the {@link AmbryBlobStorageService} instance to submit responses to.
-   * @param restRequest the {@link RestRequest} for whose response this is a callback.
-   * @param restResponseChannel the {@link RestResponseChannel} over which response to {@code restRequest} can be sent.
-   * @param createdBlobProperties the {@link BlobProperties} of the blob that was asked to be POSTed.
-   * @param idConverter the {@link IdConverter} to use to convert IDs returned from the {@link Router}.
-   */
-  public PostCallback(AmbryBlobStorageService ambryBlobStorageService, RestRequest restRequest,
-      RestResponseChannel restResponseChannel, BlobProperties createdBlobProperties, IdConverter idConverter) {
-    this.ambryBlobStorageService = ambryBlobStorageService;
-    this.restRequest = restRequest;
-    this.restResponseChannel = restResponseChannel;
-    this.blobProperties = createdBlobProperties;
-    this.idConverter = idConverter;
-  }
-
-  /**
-   * If there was no exception, updates the header with the location of the object. Submits the response either for
-   * exception handling or for cleanup.
-   * @param result The result of the request. This is the blob ID of the blob. This is non null if the request executed
-   *               successfully.
-   * @param exception The exception that was reported on execution of the request (if any).
-   */
-  @Override
-  public void onCompletion(String result, Exception exception) {
-    long processingStartTime = System.currentTimeMillis();
-    try {
-      long routerTime = processingStartTime - operationStartTime;
-      ambryBlobStorageService.frontendMetrics.postTimeInMs.update(routerTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(routerTime);
-
-      logger.trace("Callback received for POST");
+    /**
+     * Sets the required headers in the response.
+     * @param location the location of the created resource.
+     * @throws RestServiceException if there was any problem setting the headers.
+     */
+    private void setResponseHeaders(String location)
+        throws RestServiceException {
       restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
-      if (exception == null && result != null) {
-        logger.trace("Successful POST of {}", result);
-        idConverter.convert(restRequest, result, new Callback<String>() {
-          @Override
-          public void onCompletion(String result, Exception exception) {
-            if (exception == null) {
-              try {
-                setResponseHeaders(result);
-              } catch (RestServiceException e) {
-                exception = e;
-              }
-            } else {
-              ambryBlobStorageService.frontendMetrics.operationError.inc();
+      restResponseChannel.setStatus(ResponseStatus.Created);
+      restResponseChannel.setHeader(RestUtils.Headers.LOCATION, location);
+      restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
+      restResponseChannel.setHeader(RestUtils.Headers.CREATION_TIME, new Date(blobProperties.getCreationTimeInMs()));
+    }
+  }
+
+  /**
+   * Callback for DELETE operations. Sends an ACCEPTED response to the client if operation is successful. Submits
+   * response either to handle exceptions or to clean up after a response.
+   */
+  private class DeleteCallback implements Callback<Void> {
+    private final RestRequest restRequest;
+    private final RestResponseChannel restResponseChannel;
+    private final CallbackTracker callbackTracker;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Create a DELETE callback.
+     * @param restRequest the {@link RestRequest} for whose response this is a callback.
+     * @param restResponseChannel the {@link RestResponseChannel} over which response to {@code restRequest} can be
+     *                            sent.
+     */
+    DeleteCallback(RestRequest restRequest, RestResponseChannel restResponseChannel) {
+      this.restRequest = restRequest;
+      this.restResponseChannel = restResponseChannel;
+      callbackTracker = new CallbackTracker(restRequest, OPERATION_TYPE_DELETE, frontendMetrics.deleteTimeInMs,
+          frontendMetrics.deleteCallbackProcessingTimeInMs);
+    }
+
+    /**
+     * If there was no exception, updates the header with the acceptance of the request. Submits the response either for
+     * exception handling or for cleanup.
+     * @param routerResult The result of the request. This is always null.
+     * @param routerException The exception that was reported on execution of the request (if any).
+     */
+    @Override
+    public void onCompletion(Void routerResult, Exception routerException) {
+      callbackTracker.markOperationEnd();
+      try {
+        if (routerException == null) {
+          restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
+          restResponseChannel.setStatus(ResponseStatus.Accepted);
+          restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
+        }
+      } catch (RestServiceException e) {
+        frontendMetrics.deleteCallbackProcessingError.inc();
+        routerException = e;
+      } finally {
+        callbackTracker.markCallbackProcessingEnd();
+        submitResponse(restRequest, restResponseChannel, null, routerException);
+      }
+    }
+
+    /**
+     * Marks the start time of the operation.
+     */
+    void markStartTime() {
+      callbackTracker.markOperationStart();
+    }
+  }
+
+  /**
+   * Callback for HEAD operations. Sends the headers to the client if operation is successful. Submits response either
+   * to handle exceptions or to clean up after a response.
+   */
+  private class HeadCallback implements Callback<BlobInfo> {
+    private final RestRequest restRequest;
+    private final RestResponseChannel restResponseChannel;
+    private final CallbackTracker callbackTracker;
+
+    /**
+     * Create a HEAD callback.
+     * @param restRequest the {@link RestRequest} for whose response this is a callback.
+     * @param restResponseChannel the {@link RestResponseChannel} over which response to {@code restRequest} can be
+     *                            sent.
+     */
+    HeadCallback(RestRequest restRequest, RestResponseChannel restResponseChannel) {
+      this.restRequest = restRequest;
+      this.restResponseChannel = restResponseChannel;
+      callbackTracker = new CallbackTracker(restRequest, OPERATION_TYPE_HEAD, frontendMetrics.headTimeInMs,
+          frontendMetrics.headCallbackProcessingTimeInMs);
+    }
+
+    /**
+     * If there was no exception, updates the header with the properties. Exceptions, if any, will be handled upon
+     * submission.
+     * @param routerResult The result of the request i.e a {@link BlobInfo} object with the properties of the blob. This is
+     *               non null if the request executed successfully.
+     * @param routerException The exception that was reported on execution of the request (if any).
+     */
+    @Override
+    public void onCompletion(BlobInfo routerResult, Exception routerException) {
+      callbackTracker.markOperationEnd();
+      if (routerResult == null && routerException == null) {
+        frontendMetrics.routerCallbackError.inc();
+        callbackTracker.markCallbackProcessingEnd();
+        throw new IllegalStateException("Both response and exception are null");
+      }
+      try {
+        if (routerException == null) {
+          final CallbackTracker securityCallbackTracker =
+              new CallbackTracker(restRequest, OPERATION_TYPE_HEAD_RESPONSE_SECURITY,
+                  frontendMetrics.headSecurityResponseTimeInMs,
+                  frontendMetrics.headSecurityResponseCallbackProcessingTimeInMs);
+          securityCallbackTracker.markOperationStart();
+          securityService.processResponse(restRequest, restResponseChannel, routerResult, new Callback<Void>() {
+            @Override
+            public void onCompletion(Void securityResult, Exception securityException) {
+              callbackTracker.markOperationEnd();
+              callbackTracker.markCallbackProcessingEnd();
+              submitResponse(restRequest, restResponseChannel, null, securityException);
             }
-            ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, exception);
-          }
-        });
-      } else if (exception == null) {
-        exception = new IllegalStateException("Both response and exception are null for PostCallback");
-      }
-    } catch (Exception e) {
-      ambryBlobStorageService.frontendMetrics.callbackProcessingError.inc();
-      if (exception != null) {
-        logger.error("Error while processing Router callback", e);
-      } else {
-        exception = e;
-      }
-    } finally {
-      long processingTime = System.currentTimeMillis() - processingStartTime;
-      ambryBlobStorageService.frontendMetrics.postCallbackProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
-      if (exception != null) {
-        ambryBlobStorageService.frontendMetrics.operationError.inc();
-        ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, exception);
+          });
+        }
+      } catch (Exception e) {
+        frontendMetrics.headCallbackProcessingError.inc();
+        routerException = e;
+      } finally {
+        callbackTracker.markCallbackProcessingEnd();
+        if (routerException != null) {
+          submitResponse(restRequest, restResponseChannel, null, routerException);
+        }
       }
     }
-  }
 
-  /**
-   * Marks the start time of the operation.
-   */
-  protected void markStartTime() {
-    operationStartTime = System.currentTimeMillis();
-  }
-
-  /**
-   * Sets the required headers in the response.
-   * @param location the location of the created resource.
-   * @throws RestServiceException if there was any problem setting the headers.
-   */
-  private void setResponseHeaders(String location)
-      throws RestServiceException {
-    restResponseChannel.setStatus(ResponseStatus.Created);
-    restResponseChannel.setHeader(RestUtils.Headers.LOCATION, location);
-    restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
-    restResponseChannel.setHeader(RestUtils.Headers.CREATION_TIME, new Date(blobProperties.getCreationTimeInMs()));
-  }
-}
-
-/**
- * Callback for DELETE operations. Sends an ACCEPTED response to the client if operation is successful. Submits response
- * either to handle exceptions or to clean up after a response.
- */
-class DeleteCallback implements Callback<Void> {
-  private final AmbryBlobStorageService ambryBlobStorageService;
-  private final RestRequest restRequest;
-  private final RestResponseChannel restResponseChannel;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
-  private long operationStartTime = 0;
-
-  /**
-   * Create a DELETE callback.
-   * @param ambryBlobStorageService the {@link AmbryBlobStorageService} instance to submit responses to.
-   * @param restRequest the {@link RestRequest} for whose response this is a callback.
-   * @param restResponseChannel the {@link RestResponseChannel} over which response to {@code restRequest} can be sent.
-   */
-  public DeleteCallback(AmbryBlobStorageService ambryBlobStorageService, RestRequest restRequest,
-      RestResponseChannel restResponseChannel) {
-    this.ambryBlobStorageService = ambryBlobStorageService;
-    this.restRequest = restRequest;
-    this.restResponseChannel = restResponseChannel;
-  }
-
-  /**
-   * If there was no exception, updates the header with the acceptance of the request. Submits the response either for
-   * exception handling or for cleanup.
-   * @param result The result of the request. This is always null.
-   * @param exception The exception that was reported on execution of the request (if any).
-   */
-  @Override
-  public void onCompletion(Void result, Exception exception) {
-    long processingStartTime = System.currentTimeMillis();
-    try {
-      long routerTime = processingStartTime - operationStartTime;
-      ambryBlobStorageService.frontendMetrics.deleteTimeInMs.update(routerTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(routerTime);
-
-      String blobId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
-      logger.trace("Callback received for DELETE of {}", blobId);
-      restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
-      if (exception == null) {
-        logger.trace("Successful DELETE of {}", blobId);
-        restResponseChannel.setStatus(ResponseStatus.Accepted);
-        restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
-      }
-    } catch (Exception e) {
-      ambryBlobStorageService.frontendMetrics.callbackProcessingError.inc();
-      if (exception != null) {
-        logger.error("Error while processing callback", e);
-      } else {
-        exception = e;
-      }
-    } finally {
-      long processingTime = System.currentTimeMillis() - processingStartTime;
-      ambryBlobStorageService.frontendMetrics.deleteCallbackProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
-      if (exception != null) {
-        ambryBlobStorageService.frontendMetrics.operationError.inc();
-      }
-      ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, exception);
+    /**
+     * Marks the start time of the operation.
+     */
+    void markStartTime() {
+      callbackTracker.markOperationStart();
     }
-  }
-
-  /**
-   * Marks the start time of the operation.
-   */
-  protected void markStartTime() {
-    operationStartTime = System.currentTimeMillis();
-  }
-}
-
-/**
- * Callback for HEAD operations. Sends the headers to the client if operation is successful. Submits response either to
- * handle exceptions or to clean up after a response.
- */
-class HeadCallback implements Callback<BlobInfo> {
-  private final AmbryBlobStorageService ambryBlobStorageService;
-  private final RestRequest restRequest;
-  private final RestResponseChannel restResponseChannel;
-  private final SecurityService securityService;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
-  private long operationStartTime = 0;
-
-  /**
-   * Create a HEAD callback.
-   * @param ambryBlobStorageService the {@link AmbryBlobStorageService} instance to submit responses to.
-   * @param restRequest the {@link RestRequest} for whose response this is a callback.
-   * @param restResponseChannel the {@link RestResponseChannel} over which response to {@code restRequest} can be sent.
-   * @param securityService the {@link SecurityService} instance to use to verify the response.
-   */
-  public HeadCallback(AmbryBlobStorageService ambryBlobStorageService, RestRequest restRequest,
-      RestResponseChannel restResponseChannel, SecurityService securityService) {
-    this.ambryBlobStorageService = ambryBlobStorageService;
-    this.restRequest = restRequest;
-    this.restResponseChannel = restResponseChannel;
-    this.securityService = securityService;
-  }
-
-  /**
-   * If there was no exception, updates the header with the properties. Exceptions, if any, will be handled upon
-   * submission.
-   * @param result The result of the request i.e a {@link BlobInfo} object with the properties of the blob. This is
-   *               non null if the request executed successfully.
-   * @param exception The exception that was reported on execution of the request (if any).
-   */
-  @Override
-  public void onCompletion(BlobInfo result, Exception exception) {
-    long processingStartTime = System.currentTimeMillis();
-    try {
-      long routerTime = processingStartTime - operationStartTime;
-      ambryBlobStorageService.frontendMetrics.headTimeInMs.update(routerTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(routerTime);
-
-      String blobId = RestUtils.getOperationOrBlobIdFromUri(restRequest);
-      logger.trace("Callback received for HEAD of {}", blobId);
-      if (exception == null && result != null) {
-        logger.trace("Successful HEAD of {}", blobId);
-        securityService.processResponse(restRequest, restResponseChannel, result, new Callback<Void>() {
-          @Override
-          public void onCompletion(Void result, Exception exception) {
-            if (exception != null) {
-              ambryBlobStorageService.frontendMetrics.operationError.inc();
-            }
-            ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, exception);
-          }
-        });
-      } else if (exception == null) {
-        exception = new IllegalStateException("Both response and exception are null for HeadCallback");
-      }
-    } catch (Exception e) {
-      ambryBlobStorageService.frontendMetrics.callbackProcessingError.inc();
-      if (exception != null) {
-        logger.error("Error while processing callback", e);
-      } else {
-        exception = e;
-      }
-    } finally {
-      long processingTime = System.currentTimeMillis() - processingStartTime;
-      ambryBlobStorageService.frontendMetrics.headCallbackProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
-      if (exception != null) {
-        ambryBlobStorageService.frontendMetrics.operationError.inc();
-        ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, exception);
-      }
-    }
-  }
-
-  /**
-   * Marks the start time of the operation.
-   */
-  protected void markStartTime() {
-    operationStartTime = System.currentTimeMillis();
   }
 }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryIdConverterFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryIdConverterFactory.java
@@ -78,7 +78,7 @@ public class AmbryIdConverterFactory implements IdConverterFactory {
       if (callback != null) {
         callback.onCompletion(convertedId, exception);
       }
-      frontendMetrics.idConverterRequestProcessingTimeInMs.update(System.currentTimeMillis() - startTimeInMs);
+      frontendMetrics.idConverterProcessingTimeInMs.update(System.currentTimeMillis() - startTimeInMs);
       return futureResult;
     }
   }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
@@ -40,19 +40,10 @@ class FrontendMetrics {
   public final RestRequestMetrics postBlobMetrics;
 
   // Rates
-  // AmbryBlobStorageService
-  // DELETE
-  public final Meter deleteBlobRate;
-  // HEAD
-  public final Meter headBlobRate;
-  // GET
-  public final Meter getBlobRate;
-  // POST
-  public final Meter postBlobRate;
-  // security service
+  // AmbrySecurityService
   public final Meter securityServiceProcessRequestRate;
   public final Meter securityServiceProcessResponseRate;
-  // Id converter
+  // AmbryIdConverter
   public final Meter idConverterRequestRate;
 
   // Latencies
@@ -72,27 +63,61 @@ class FrontendMetrics {
   // HeadCallback
   public final Histogram headCallbackProcessingTimeInMs;
   public final Histogram headTimeInMs;
+  public final Histogram headSecurityResponseTimeInMs;
+  public final Histogram headSecurityResponseCallbackProcessingTimeInMs;
   // HeadForGetCallback
   public final Histogram headForGetCallbackProcessingTimeInMs;
   public final Histogram headForGetTimeInMs;
+  public final Histogram getSecurityResponseCallbackProcessingTimeInMs;
+  public final Histogram getSecurityResponseTimeInMs;
   // GetCallback
   public final Histogram getCallbackProcessingTimeInMs;
   public final Histogram getTimeInMs;
   // PostCallback
+  public final Histogram outboundIdConversionCallbackProcessingTimeInMs;
+  public final Histogram outboundIdConversionTimeInMs;
   public final Histogram postCallbackProcessingTimeInMs;
   public final Histogram postTimeInMs;
-  // security service
+  // InboundIdConverterCallback
+  public final Histogram inboundIdConversionCallbackProcessingTimeInMs;
+  public final Histogram inboundIdConversionTimeInMs;
+  // SecurityProcessRequestCallback
+  public final Histogram deleteSecurityRequestCallbackProcessingTimeInMs;
+  public final Histogram getSecurityRequestCallbackProcessingTimeInMs;
+  public final Histogram headSecurityRequestCallbackProcessingTimeInMs;
+  public final Histogram postSecurityRequestCallbackProcessingTimeInMs;
+  public final Histogram deleteSecurityRequestTimeInMs;
+  public final Histogram getSecurityRequestTimeInMs;
+  public final Histogram headSecurityRequestTimeInMs;
+  public final Histogram postSecurityRequestTimeInMs;
+  // AmbrySecurityService
   public final Histogram securityServiceProcessRequestTimeInMs;
   public final Histogram securityServiceProcessResponseTimeInMs;
-  // Id converter
-  public final Histogram idConverterRequestProcessingTimeInMs;
+  // AmbryIdConverter
+  public final Histogram idConverterProcessingTimeInMs;
 
   // Errors
   // AmbryBlobStorageService
-  public final Counter callbackProcessingError;
-  public final Counter operationError;
   public final Counter responseSubmissionError;
   public final Counter resourceReleaseError;
+  public final Counter routerCallbackError;
+  // DeleteCallback
+  public final Counter deleteCallbackProcessingError;
+  // HeadCallback
+  public final Counter headCallbackProcessingError;
+  // HeadForGetCallback
+  public final Counter headForGetCallbackProcessingError;
+  public final Counter getSecurityResponseCallbackProcessingError;
+  // GetCallback
+  public final Counter getCallbackProcessingError;
+  // PostCallback
+  public final Counter postCallbackProcessingError;
+  public final Counter outboundIdConversionCallbackProcessingError;
+
+  // Other
+  // AmbryBlobStorageService
+  public final Histogram blobStorageServiceStartupTimeInMs;
+  public final Histogram blobStorageServiceShutdownTimeInMs;
 
   /**
    * Creates an instance of FrontendMetrics using the given {@code metricRegistry}.
@@ -112,23 +137,13 @@ class FrontendMetrics {
     postBlobMetrics = new RestRequestMetrics(AmbryBlobStorageService.class, "PostBlob", metricRegistry);
 
     // Rates
-    // AmbryBlobStorageService
-    // DELETE
-    deleteBlobRate = metricRegistry.meter(MetricRegistry.name(AmbryBlobStorageService.class, "DeleteBlobRate"));
-    // HEAD
-    headBlobRate = metricRegistry.meter(MetricRegistry.name(AmbryBlobStorageService.class, "HeadBlobRate"));
-    // GET
-    getBlobRate = metricRegistry.meter(MetricRegistry.name(AmbryBlobStorageService.class, "GetBlobRate"));
-    // POST
-    postBlobRate = metricRegistry.meter(MetricRegistry.name(AmbryBlobStorageService.class, "PostBlobRate"));
-    // security service
+    // AmbrySecurityService
     securityServiceProcessRequestRate =
-        metricRegistry.meter(MetricRegistry.name(AmbrySecurityService.class, "SecurityServiceProcessRequestRate"));
+        metricRegistry.meter(MetricRegistry.name(AmbrySecurityService.class, "ProcessRequestRate"));
     securityServiceProcessResponseRate =
-        metricRegistry.meter(MetricRegistry.name(AmbrySecurityService.class, "SecurityServiceProcessResponseRate"));
-    // Id converter
-    idConverterRequestRate =
-        metricRegistry.meter(MetricRegistry.name(AmbryIdConverterFactory.class, "IdConverterRequestRate"));
+        metricRegistry.meter(MetricRegistry.name(AmbrySecurityService.class, "ProcessResponseRate"));
+    // AmbryIdConverter
+    idConverterRequestRate = metricRegistry.meter(MetricRegistry.name(AmbryIdConverterFactory.class, "RequestRate"));
 
     // Latencies
     // AmbryBlobStorageService
@@ -147,42 +162,105 @@ class FrontendMetrics {
     postPreProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "PostPreProcessingTimeInMs"));
     // DeleteCallback
-    deleteCallbackProcessingTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(DeleteCallback.class, "ProcessingTimeInMs"));
-    deleteTimeInMs = metricRegistry.histogram(MetricRegistry.name(DeleteCallback.class, "ResultTimeInMs"));
+    deleteCallbackProcessingTimeInMs = metricRegistry
+        .histogram(MetricRegistry.name(AmbryBlobStorageService.class, "DeleteCallbackProcessingTimeInMs"));
+    deleteTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "DeleteCallbackResultTimeInMs"));
     // HeadCallback
     headCallbackProcessingTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HeadCallback.class, "ProcessingTimeInMs"));
-    headTimeInMs = metricRegistry.histogram(MetricRegistry.name(HeadCallback.class, "ResultTimeInMs"));
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "HeadCallbackProcessingTimeInMs"));
+    headTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "HeadCallbackResultTimeInMs"));
+    headSecurityResponseCallbackProcessingTimeInMs = metricRegistry.histogram(
+        MetricRegistry.name(AmbryBlobStorageService.class, "HeadSecurityResponseCallbackProcessingTimeInMs"));
+    headSecurityResponseTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "HeadSecurityResponseTimeInMs"));
     // HeadForGetCallback
-    headForGetCallbackProcessingTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(HeadForGetCallback.class, "ProcessingTimeInMs"));
-    headForGetTimeInMs = metricRegistry.histogram(MetricRegistry.name(HeadForGetCallback.class, "ResultTimeInMs"));
+    headForGetCallbackProcessingTimeInMs = metricRegistry
+        .histogram(MetricRegistry.name(AmbryBlobStorageService.class, "HeadForGetCallbackProcessingTimeInMs"));
+    headForGetTimeInMs = metricRegistry
+        .histogram(MetricRegistry.name(AmbryBlobStorageService.class, "HeadForGetCallbackResultTimeInMs"));
+    getSecurityResponseCallbackProcessingTimeInMs = metricRegistry
+        .histogram(MetricRegistry.name(AmbryBlobStorageService.class, "GetSecurityResponseCallbackProcessingTimeInMs"));
+    getSecurityResponseTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "GetSecurityResponseTimeInMs"));
     // GetCallback
     getCallbackProcessingTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(GetCallback.class, "ProcessingTimeInMs"));
-    getTimeInMs = metricRegistry.histogram(MetricRegistry.name(GetCallback.class, "ResultTimeInMs"));
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "GetCallbackProcessingTimeInMs"));
+    getTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "GetCallbackResultTimeInMs"));
     // PostCallback
+    outboundIdConversionCallbackProcessingTimeInMs = metricRegistry
+        .histogram(MetricRegistry.name(AmbryBlobStorageService.class, "OutboundIdCallbackProcessingTimeInMs"));
+    outboundIdConversionTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "OutboundIdConversionTimeInMs"));
     postCallbackProcessingTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(PostCallback.class, "ProcessingTimeInMs"));
-    postTimeInMs = metricRegistry.histogram(MetricRegistry.name(PostCallback.class, "ResultTimeInMs"));
-    // security service
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "PostCallbackProcessingTimeInMs"));
+    postTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "PostCallbackResultTimeInMs"));
+    // InboundIdConverterCallback
+    inboundIdConversionCallbackProcessingTimeInMs = metricRegistry
+        .histogram(MetricRegistry.name(AmbryBlobStorageService.class, "InboundIdCallbackProcessingTimeInMs"));
+    inboundIdConversionTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "InboundIdConversionTimeInMs"));
+    // SecurityProcessRequestCallback
+    deleteSecurityRequestCallbackProcessingTimeInMs = metricRegistry.histogram(
+        MetricRegistry.name(AmbryBlobStorageService.class, "DeleteSecurityRequestCallbackProcessingTimeInMs"));
+    deleteSecurityRequestTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "DeleteSecurityRequestTimeInMs"));
+    headSecurityRequestCallbackProcessingTimeInMs = metricRegistry
+        .histogram(MetricRegistry.name(AmbryBlobStorageService.class, "HeadSecurityRequestCallbackProcessingTimeInMs"));
+    headSecurityRequestTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "HeadSecurityRequestTimeInMs"));
+    getSecurityRequestCallbackProcessingTimeInMs = metricRegistry
+        .histogram(MetricRegistry.name(AmbryBlobStorageService.class, "GetSecurityRequestCallbackProcessingTimeInMs"));
+    getSecurityRequestTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "GetSecurityRequestTimeInMs"));
+    postSecurityRequestCallbackProcessingTimeInMs = metricRegistry
+        .histogram(MetricRegistry.name(AmbryBlobStorageService.class, "PostSecurityRequestCallbackProcessingTimeInMs"));
+    postSecurityRequestTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "PostSecurityRequestTimeInMs"));
+    // AmbrySecurityService
     securityServiceProcessRequestTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(AmbrySecurityService.class, "ProcessingTimeInMs"));
+        metricRegistry.histogram(MetricRegistry.name(AmbrySecurityService.class, "RequestProcessingTimeInMs"));
     securityServiceProcessResponseTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(AmbrySecurityService.class, "ProcessingTimeInMs"));
-    // Id converter
-    idConverterRequestProcessingTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbrySecurityService.class, "ResponseProcessingTimeInMs"));
+    // AmbryIdConverter
+    idConverterProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(AmbryIdConverterFactory.class, "ProcessingTimeInMs"));
 
     // Errors
     // AmbryBlobStorageService
-    callbackProcessingError =
-        metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "CallbackProcessingError"));
-    operationError = metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "OperationError"));
     responseSubmissionError =
         metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "ResponseSubmissionError"));
     resourceReleaseError =
         metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "ResourceReleaseError"));
+    routerCallbackError =
+        metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "RouterCallbackError"));
+    // DeleteCallback
+    deleteCallbackProcessingError =
+        metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "DeleteCallbackProcessingError"));
+    // HeadCallback
+    headCallbackProcessingError =
+        metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "HeadCallbackProcessingError"));
+    // HeadForGetCallback
+    headForGetCallbackProcessingError =
+        metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "HeadForGetCallbackProcessingError"));
+    getSecurityResponseCallbackProcessingError = metricRegistry
+        .counter(MetricRegistry.name(AmbryBlobStorageService.class, "GetSecurityResponseCallbackProcessingError"));
+    // GetCallback
+    getCallbackProcessingError =
+        metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "GetCallbackProcessingError"));
+    // PostCallback
+    postCallbackProcessingError =
+        metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "PostCallbackProcessingError"));
+    outboundIdConversionCallbackProcessingError = metricRegistry
+        .counter(MetricRegistry.name(AmbryBlobStorageService.class, "OutboundIdConversionCallbackProcessingError"));
+
+    // Other
+    blobStorageServiceStartupTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "StartupTimeInMs"));
+    blobStorageServiceShutdownTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "ShutdownTimeInMs"));
   }
 }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -88,11 +88,12 @@ public class AmbryBlobStorageServiceTest {
 
   private final MetricRegistry metricRegistry = new MetricRegistry();
   private final FrontendMetrics frontendMetrics = new FrontendMetrics(metricRegistry);
+  private final IdConverterFactory idConverterFactory;
+  private final SecurityServiceFactory securityServiceFactory;
+  private final FrontendTestResponseHandler responseHandler;
+  private final InMemoryRouter router;
+
   private AmbryBlobStorageService ambryBlobStorageService;
-  private IdConverterFactory idConverterFactory;
-  private SecurityServiceFactory securityServiceFactory;
-  private FrontendTestResponseHandler responseHandler;
-  private InMemoryRouter router;
 
   /**
    * Sets up the {@link AmbryBlobStorageService} instance before a test.
@@ -439,323 +440,47 @@ public class AmbryBlobStorageServiceTest {
   }
 
   /**
-   * Tests for non common case scenarios for {@link HeadForGetCallback}.
-   * @throws Exception
+   * Tests for cases where the {@link Router} returns valid {@link RouterException}.
+   * @throws InstantiationException
+   * @throws JSONException
    */
   @Test
-  public void headForGetCallbackTest()
+  public void routerExceptionPipelineTest()
       throws Exception {
+    FrontendTestRouter testRouter = new FrontendTestRouter();
     String exceptionMsg = UtilsTest.getRandomString(10);
-    SecurityService securityService = securityServiceFactory.getSecurityService();
-    responseHandler.reset();
-
-    // the good case is tested through the postGetHeadDeleteTest() (result non-null, exception null)
-    // Both arguments null
-    RestRequest restRequest = createRestRequest(RestMethod.GET, "/", null, null);
-    MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    HeadForGetCallback callback =
-        new HeadForGetCallback(ambryBlobStorageService, restRequest, restResponseChannel, router, securityService,
-            null);
-    callback.onCompletion(null, null);
-    // there should be an exception
-    assertEquals("Both arguments null should have thrown exception", IllegalStateException.class,
-        responseHandler.getException().getClass());
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Exception is not null.
-    responseHandler.reset();
-    restRequest = createRestRequest(RestMethod.GET, "/", null, null);
-    restResponseChannel = new MockRestResponseChannel();
-    callback =
-        new HeadForGetCallback(ambryBlobStorageService, restRequest, restResponseChannel, router, securityService,
-            null);
-    callback.onCompletion(null, new RuntimeException(exceptionMsg));
-    assertEquals("Unexpected exception message", exceptionMsg, responseHandler.getException().getMessage());
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Exception is RouterException.
-    responseHandler.reset();
-    restRequest = createRestRequest(RestMethod.GET, "/", null, null);
-    restResponseChannel = new MockRestResponseChannel();
-    callback =
-        new HeadForGetCallback(ambryBlobStorageService, restRequest, restResponseChannel, router, securityService,
-            null);
-    callback.onCompletion(null, new RouterException(exceptionMsg, RouterErrorCode.UnexpectedInternalError));
-    assertEquals("RouterException not converted to RestServiceException", RestServiceException.class,
-        responseHandler.getException().getClass());
-    if (!responseHandler.getException().getMessage().contains(exceptionMsg)) {
-      fail("Exception msg [" + responseHandler.getException().getMessage() + "] does contain expected substring ["
-          + exceptionMsg + "]");
+    testRouter.exceptionToReturn = new RouterException(exceptionMsg, RouterErrorCode.UnexpectedInternalError);
+    ambryBlobStorageService =
+        new AmbryBlobStorageService(frontendMetrics, CLUSTER_MAP, responseHandler, testRouter, idConverterFactory,
+            securityServiceFactory);
+    ambryBlobStorageService.start();
+    for (RestMethod restMethod : RestMethod.values()) {
+      switch (restMethod) {
+        case HEAD:
+          testRouter.exceptionOpType = FrontendTestRouter.OpType.GetBlobInfo;
+          checkRouterExceptionPipeline(exceptionMsg, createRestRequest(restMethod, "/", null, null));
+          break;
+        case GET:
+          testRouter.exceptionOpType = FrontendTestRouter.OpType.GetBlobInfo;
+          checkRouterExceptionPipeline(exceptionMsg, createRestRequest(restMethod, "/", null, null));
+          testRouter.exceptionOpType = FrontendTestRouter.OpType.GetBlob;
+          checkRouterExceptionPipeline(exceptionMsg, createRestRequest(restMethod, "/", null, null));
+          break;
+        case POST:
+          testRouter.exceptionOpType = FrontendTestRouter.OpType.PutBlob;
+          JSONObject headers = new JSONObject();
+          setAmbryHeaders(headers, 1, 7200, false, "routerExceptionPipelineTest", "application/octet-stream",
+              "routerExceptionPipelineTest");
+          checkRouterExceptionPipeline(exceptionMsg, createRestRequest(restMethod, "/", headers, null));
+          break;
+        case DELETE:
+          testRouter.exceptionOpType = FrontendTestRouter.OpType.DeleteBlob;
+          checkRouterExceptionPipeline(exceptionMsg, createRestRequest(restMethod, "/", null, null));
+          break;
+        default:
+          break;
+      }
     }
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Callback encounters a processing error (induced here via a bad RestRequest).
-    restRequest = new BadRestRequest();
-    // there is an exception already.
-    restResponseChannel = new MockRestResponseChannel();
-    callback =
-        new HeadForGetCallback(ambryBlobStorageService, restRequest, restResponseChannel, router, securityService,
-            null);
-    callback.onCompletion(null, new RuntimeException(exceptionMsg));
-    assertEquals("Unexpected exception message", exceptionMsg, restResponseChannel.getException().getMessage());
-
-    // there is no exception and the exception thrown in the callback is the primary exception.
-    restResponseChannel = new MockRestResponseChannel();
-    callback =
-        new HeadForGetCallback(ambryBlobStorageService, restRequest, restResponseChannel, router, securityService,
-            null);
-    BlobInfo blobInfo = new BlobInfo(null, null);
-    callback.onCompletion(blobInfo, null);
-    assertNotNull("There is no cause of failure", restResponseChannel.getException());
-  }
-
-  /**
-   * Tests for non common case scenarios for {@link GetCallback}.
-   * @throws Exception
-   */
-  @Test
-  public void getCallbackTest()
-      throws Exception {
-    String exceptionMsg = UtilsTest.getRandomString(10);
-    responseHandler.reset();
-
-    // the good case is tested through the postGetHeadDeleteTest() (result non-null, exception null)
-    // Both arguments null
-    RestRequest restRequest = createRestRequest(RestMethod.GET, "/", null, null);
-    MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    GetCallback callback = new GetCallback(ambryBlobStorageService, restRequest, restResponseChannel);
-    callback.onCompletion(null, null);
-    // there should be an exception
-    assertEquals("Both arguments null should have thrown exception", IllegalStateException.class,
-        responseHandler.getException().getClass());
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Exception is not null.
-    responseHandler.reset();
-    restRequest = createRestRequest(RestMethod.GET, "/", null, null);
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new GetCallback(ambryBlobStorageService, restRequest, restResponseChannel);
-    callback.onCompletion(null, new RuntimeException(exceptionMsg));
-    assertEquals("Unexpected exception message", exceptionMsg, responseHandler.getException().getMessage());
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Exception is RouterException.
-    responseHandler.reset();
-    restRequest = createRestRequest(RestMethod.GET, "/", null, null);
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new GetCallback(ambryBlobStorageService, restRequest, restResponseChannel);
-    callback.onCompletion(null, new RouterException(exceptionMsg, RouterErrorCode.UnexpectedInternalError));
-    assertEquals("RouterException not converted to RestServiceException", RestServiceException.class,
-        responseHandler.getException().getClass());
-    if (!responseHandler.getException().getMessage().contains(exceptionMsg)) {
-      fail("Exception msg [" + responseHandler.getException().getMessage() + "] does contain expected substring ["
-          + exceptionMsg + "]");
-    }
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Callback encounters a processing error (induced here via a bad RestRequest).
-    restRequest = new BadRestRequest();
-    // there is an exception already.
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new GetCallback(ambryBlobStorageService, restRequest, restResponseChannel);
-    callback.onCompletion(null, new RuntimeException(exceptionMsg));
-    assertEquals("Unexpected exception message", exceptionMsg, restResponseChannel.getException().getMessage());
-
-    // there is no exception and exception thrown in the callback.
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new GetCallback(ambryBlobStorageService, restRequest, restResponseChannel);
-    ReadableStreamChannel response = new ByteBufferReadableStreamChannel(ByteBuffer.allocate(0));
-    assertTrue("Response channel is not open", response.isOpen());
-    callback.onCompletion(response, null);
-    assertNotNull("There is no cause of failure", restResponseChannel.getException());
-  }
-
-  /**
-   * Tests for non common case scenarios for {@link PostCallback}.
-   * @throws Exception
-   */
-  @Test
-  public void postCallbackTest()
-      throws Exception {
-    BlobProperties blobProperties = new BlobProperties(0, "test-serviceId");
-    String exceptionMsg = UtilsTest.getRandomString(10);
-    IdConverter idConverter = idConverterFactory.getIdConverter();
-    responseHandler.reset();
-
-    // the good case is tested through the postGetHeadDeleteTest() (result non-null, exception null)
-    // Both arguments null
-    RestRequest restRequest = createRestRequest(RestMethod.POST, "/", null, null);
-    MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    PostCallback callback =
-        new PostCallback(ambryBlobStorageService, restRequest, restResponseChannel, blobProperties, idConverter);
-    callback.onCompletion(null, null);
-    // there should be an exception
-    assertEquals("Both arguments null should have thrown exception", IllegalStateException.class,
-        responseHandler.getException().getClass());
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Exception is not null.
-    responseHandler.reset();
-    restRequest = createRestRequest(RestMethod.POST, "/", null, null);
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new PostCallback(ambryBlobStorageService, restRequest, restResponseChannel, blobProperties, idConverter);
-    callback.onCompletion(null, new RuntimeException(exceptionMsg));
-    assertEquals("Unexpected exception message", exceptionMsg, responseHandler.getException().getMessage());
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Exception is RouterException.
-    responseHandler.reset();
-    restRequest = createRestRequest(RestMethod.POST, "/", null, null);
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new PostCallback(ambryBlobStorageService, restRequest, restResponseChannel, blobProperties, idConverter);
-    callback.onCompletion(null, new RouterException(exceptionMsg, RouterErrorCode.UnexpectedInternalError));
-    assertEquals("RouterException not converted to RestServiceException", RestServiceException.class,
-        responseHandler.getException().getClass());
-    if (!responseHandler.getException().getMessage().contains(exceptionMsg)) {
-      fail("Exception msg [" + responseHandler.getException().getMessage() + "] does contain expected substring ["
-          + exceptionMsg + "]");
-    }
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // There are no tests for callback processing failure here because there is no good way of inducing a failure
-    // and checking that the behavior is alright in PostCallback.
-  }
-
-  /**
-   * Tests for non common case scenarios for {@link DeleteCallback}.
-   * @throws Exception
-   */
-  @Test
-  public void deleteCallbackTest()
-      throws Exception {
-    String exceptionMsg = UtilsTest.getRandomString(10);
-    responseHandler.reset();
-    // the good case is tested through the postGetHeadDeleteTest() (result null, exception null)
-    // Exception is not null.
-    RestRequest restRequest = createRestRequest(RestMethod.DELETE, "/", null, null);
-    MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    DeleteCallback callback = new DeleteCallback(ambryBlobStorageService, restRequest, restResponseChannel);
-    callback.onCompletion(null, new RuntimeException(exceptionMsg));
-    assertEquals("Unexpected exception message", exceptionMsg, responseHandler.getException().getMessage());
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Exception is RouterException.
-    responseHandler.reset();
-    restRequest = createRestRequest(RestMethod.DELETE, "/", null, null);
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new DeleteCallback(ambryBlobStorageService, restRequest, restResponseChannel);
-    callback.onCompletion(null, new RouterException(exceptionMsg, RouterErrorCode.UnexpectedInternalError));
-    assertEquals("RouterException not converted to RestServiceException", RestServiceException.class,
-        responseHandler.getException().getClass());
-    if (!responseHandler.getException().getMessage().contains(exceptionMsg)) {
-      fail("Exception msg [" + responseHandler.getException().getMessage() + "] does contain expected substring ["
-          + exceptionMsg + "]");
-    }
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Callback encounters a processing error (induced here via a bad RestRequest).
-    restRequest = new BadRestRequest();
-    // there is an exception already.
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new DeleteCallback(ambryBlobStorageService, restRequest, restResponseChannel);
-    callback.onCompletion(null, new RuntimeException(exceptionMsg));
-    assertEquals("Unexpected exception message", exceptionMsg, restResponseChannel.getException().getMessage());
-
-    // there is no exception and exception thrown in the callback.
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new DeleteCallback(ambryBlobStorageService, restRequest, restResponseChannel);
-    callback.onCompletion(null, null);
-    assertNotNull("There is no cause of failure", restResponseChannel.getException());
-  }
-
-  /**
-   * Tests for non common case scenarios for {@link HeadCallback}.
-   * @throws Exception
-   */
-  @Test
-  public void headCallbackTest()
-      throws Exception {
-    String exceptionMsg = UtilsTest.getRandomString(10);
-    SecurityService securityService = securityServiceFactory.getSecurityService();
-    responseHandler.reset();
-    // the good case is tested through the postGetHeadDeleteTest() (result non-null, exception null)
-    // Both arguments null
-    RestRequest restRequest = createRestRequest(RestMethod.GET, "/", null, null);
-    MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    HeadCallback callback =
-        new HeadCallback(ambryBlobStorageService, restRequest, restResponseChannel, securityService);
-    callback.onCompletion(null, null);
-    // there should be an exception
-    assertEquals("Both arguments null should have thrown exception", IllegalStateException.class,
-        responseHandler.getException().getClass());
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Exception is not null.
-    responseHandler.reset();
-    restRequest = createRestRequest(RestMethod.GET, "/", null, null);
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new HeadCallback(ambryBlobStorageService, restRequest, restResponseChannel, securityService);
-    callback.onCompletion(null, new RuntimeException(exceptionMsg));
-    assertEquals("Unexpected exception message", exceptionMsg, responseHandler.getException().getMessage());
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Exception is RouterException.
-    responseHandler.reset();
-    restRequest = createRestRequest(RestMethod.GET, "/", null, null);
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new HeadCallback(ambryBlobStorageService, restRequest, restResponseChannel, securityService);
-    callback.onCompletion(null, new RouterException(exceptionMsg, RouterErrorCode.UnexpectedInternalError));
-    assertEquals("RouterException not converted to RestServiceException", RestServiceException.class,
-        responseHandler.getException().getClass());
-    if (!responseHandler.getException().getMessage().contains(exceptionMsg)) {
-      fail("Exception msg [" + responseHandler.getException().getMessage() + "] does contain expected substring ["
-          + exceptionMsg + "]");
-    }
-    // Nothing should be closed.
-    assertTrue("RestRequest channel is not open", restRequest.isOpen());
-    restRequest.close();
-
-    // Callback encounters a processing error (induced here via a bad RestRequest).
-    restRequest = new BadRestRequest();
-    // there is an exception already.
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new HeadCallback(ambryBlobStorageService, restRequest, restResponseChannel, securityService);
-    callback.onCompletion(null, new RuntimeException(exceptionMsg));
-    assertEquals("Unexpected exception message", exceptionMsg, restResponseChannel.getException().getMessage());
-
-    // there is no exception and exception thrown in the callback.
-    restResponseChannel = new MockRestResponseChannel();
-    callback = new HeadCallback(ambryBlobStorageService, restRequest, restResponseChannel, securityService);
-    BlobInfo blobInfo = new BlobInfo(new BlobProperties(0, "test-serviceId"), new byte[0]);
-    callback.onCompletion(blobInfo, null);
-    assertNotNull("There is no cause of failure", restResponseChannel.getException());
   }
 
   // helpers
@@ -1188,6 +913,43 @@ public class AmbryBlobStorageServiceTest {
       }
     }
   }
+
+  // routerExceptionPipelineTest() helpers.
+
+  /**
+   * Checks that the exception received by submitting {@code restRequest} to {@link AmbryBlobStorageService} matches
+   * what was expected.
+   * @param expectedExceptionMsg the expected exception message.
+   * @param restRequest the {@link RestRequest} to submit to {@link AmbryBlobStorageService}.
+   * @throws Exception
+   */
+  private void checkRouterExceptionPipeline(String expectedExceptionMsg, RestRequest restRequest)
+      throws Exception {
+    try {
+      doOperation(restRequest, new MockRestResponseChannel());
+      fail("Operation " + restRequest.getRestMethod()
+          + " should have failed because an external service would have thrown an exception");
+    } catch (RestServiceException e) {
+      // catching RestServiceException because RouterException should have been converted.
+      assertEquals("Unexpected exception message", expectedExceptionMsg, getRootCause(e).getMessage());
+      // Nothing should be closed.
+      assertTrue("RestRequest channel is not open", restRequest.isOpen());
+      restRequest.close();
+    }
+  }
+
+  /**
+   * Gets the root cause for {@code e}.
+   * @param e the {@link Exception} whose root cause is required.
+   * @return the root cause for {@code e}.
+   */
+  private Exception getRootCause(Exception e) {
+    Exception exception = e;
+    while (exception.getCause() != null) {
+      exception = (Exception) exception.getCause();
+    }
+    return exception;
+  }
 }
 
 /**
@@ -1483,10 +1245,23 @@ class BadRSC implements ReadableStreamChannel {
 }
 
 /**
- * Implementation of {@link Router} that does nothing except respond immediately.
+ * Implementation of {@link Router} that responds immediately or throws exceptions as required.
  */
 class FrontendTestRouter implements Router {
   private boolean isOpen = true;
+
+  /**
+   * Enumerates the different operation types in the router.
+   */
+  enum OpType {
+    DeleteBlob,
+    GetBlobInfo,
+    GetBlob,
+    PutBlob
+  }
+
+  public OpType exceptionOpType = null;
+  public Exception exceptionToReturn = null;
 
   @Override
   public Future<BlobInfo> getBlobInfo(String blobId) {
@@ -1495,7 +1270,8 @@ class FrontendTestRouter implements Router {
 
   @Override
   public Future<BlobInfo> getBlobInfo(String blobId, Callback<BlobInfo> callback) {
-    return completeOperation(new BlobInfo(new BlobProperties(0, "FrontendTestRouter"), new byte[0]), callback);
+    return completeOperation(new BlobInfo(new BlobProperties(0, "FrontendTestRouter"), new byte[0]), callback,
+        OpType.GetBlobInfo);
   }
 
   @Override
@@ -1505,7 +1281,7 @@ class FrontendTestRouter implements Router {
 
   @Override
   public Future<ReadableStreamChannel> getBlob(String blobId, Callback<ReadableStreamChannel> callback) {
-    return completeOperation(new ByteBufferReadableStreamChannel(ByteBuffer.allocate(0)), callback);
+    return completeOperation(new ByteBufferReadableStreamChannel(ByteBuffer.allocate(0)), callback, OpType.GetBlob);
   }
 
   @Override
@@ -1516,7 +1292,7 @@ class FrontendTestRouter implements Router {
   @Override
   public Future<String> putBlob(BlobProperties blobProperties, byte[] usermetadata, ReadableStreamChannel channel,
       Callback<String> callback) {
-    return completeOperation(UtilsTest.getRandomString(10), callback);
+    return completeOperation(UtilsTest.getRandomString(10), callback, OpType.PutBlob);
   }
 
   @Override
@@ -1526,7 +1302,7 @@ class FrontendTestRouter implements Router {
 
   @Override
   public Future<Void> deleteBlob(String blobId, Callback<Void> callback) {
-    return completeOperation(null, callback);
+    return completeOperation(null, callback, OpType.DeleteBlob);
   }
 
   @Override
@@ -1538,17 +1314,23 @@ class FrontendTestRouter implements Router {
    * Completes the operation by creating and invoking a {@link Future} and invoking the {@code callback} if non-null.
    * @param result the result to return.
    * @param callback the {@link Callback} to invoke. Can be null.
+   * @param opType the type of operation calling this function.
    * @param <T> the type of future/callback.
    * @return the created {@link Future}.
    */
-  private <T> Future<T> completeOperation(T result, Callback<T> callback) {
+  private <T> Future<T> completeOperation(T result, Callback<T> callback, OpType opType) {
     if (!isOpen) {
       throw new IllegalStateException("Router not open");
     }
+    Exception exception = null;
+    if (opType == exceptionOpType && exceptionToReturn != null) {
+      exception = exceptionToReturn;
+      result = null;
+    }
     FutureResult<T> futureResult = new FutureResult<T>();
-    futureResult.done(result, null);
+    futureResult.done(result, exception);
     if (callback != null) {
-      callback.onCompletion(result, null);
+      callback.onCompletion(result, exception);
     }
     return futureResult;
   }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -155,6 +155,9 @@ class NettyResponseChannel implements RestResponseChannel {
             chunkedWriteHandler.resumeTransfer();
           }
         } else {
+          if (request != null) {
+            request.getMetricsTracker().markFailure();
+          }
           // need to set writeFuture as failed in case writes have started or chunks have been queued.
           if (!writeFuture.isDone()) {
             writeFuture.setFailure(exception);

--- a/ambry-rest/src/main/java/com.github.ambry.rest/RestServerMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/RestServerMetrics.java
@@ -49,9 +49,6 @@ public class RestServerMetrics {
   // AsyncRequestResponseHandler
   public final Histogram requestWorkerSelectionTimeInMs;
 
-  // RestServer state
-  public Gauge<Boolean> restServerStatus;
-
   // Errors
   // AsyncRequestWorker
   public final Counter requestProcessingError;
@@ -193,10 +190,10 @@ public class RestServerMetrics {
         metricRegistry.histogram(MetricRegistry.name(RestServer.class, "RestServerStartTimeInMs"));
     routerCloseTime = metricRegistry.histogram(MetricRegistry.name(RestServer.class, "RouterCloseTimeInMs"));
 
-    restServerStatus = new Gauge<Boolean>() {
+    Gauge<Integer> restServerStatus = new Gauge<Integer>() {
       @Override
-      public Boolean getValue() {
-        return restServerState.isServiceUp();
+      public Integer getValue() {
+        return restServerState.isServiceUp() ? 1 : 0;
       }
     };
     metricRegistry.register(MetricRegistry.name(RestServer.class, "RestServerState"), restServerStatus);


### PR DESCRIPTION
Rewriting `AmbryBlobStorageService` to make callbacks cleaner, easier to understand and easier to add logging/metrics.

There are _no_ changes to functionality and therefore the tests succeed (are expected to) without modification. 

There are only indentation + metrics changes in `InboundIdConverterCallback` and `SecurityProcessRequestCallback`. The diffs of these will be easy to review. For `DeleteCallback`, `HeadBeforeGetCallback`, `HeadCallback`, `GetCallback` and `PostCallback`, it may be easier to just go through the callbacks rather the diff.

The flow should be
GET: SecurityProcessRequest -> IdConversion -> HeadBeforeGet -> SecurityProcessResponse -> Get
HEAD: SecurityProcessRequest -> IdConversion -> Head -> SecurityProcessResponse
POST: SecurityProcessRequest -> Post -> IdConversion
DELETE: SecurityProcessRequest -> IdConversion -> Delete

This patch includes a rewrite of `AmbryBlobStorageService` to make the callbacks more readable. In addition, this patch
1. Contains metrics additions and reworking.
2. Changes to `AdminBlobStorageServiceTest` (mostly removals).

**Primary reviewers: Siva, Priyesh
Expected time to review:  2-2.5 hrs**

**Unit testing results**
com.github.ambry.frontend   95.2% (20/ 21)  97.1% (68/ 70)  94.3% (500/ 530)
Class   Class, %    Method, %   Line, %
AmbryBlobStorageService 100% (13/ 13)   100% (50/ 50)   92.5% (347/ 375)
AmbryBlobStorageServiceFactory  100% (1/ 1) 100% (2/ 2) 100% (13/ 13)
AmbryIdConverterFactory 100% (2/ 2) 100% (5/ 5) 100% (15/ 15)
AmbrySecurityService    100% (1/ 1) 100% (7/ 7) 100% (67/ 67)
AmbrySecurityServiceFactory 100% (1/ 1) 100% (2/ 2) 100% (5/ 5)
FrontendConfig  100% (1/ 1) 100% (1/ 1) 100% (4/ 4)
FrontendMetrics 100% (1/ 1) 100% (1/ 1) 100% (49/ 49)
