### PR TITLE
Adding metrics and conversion for the new ResponseStatus codes

### DIFF
--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -77,6 +77,8 @@ class NettyMetrics {
   public final Counter goneCount;
   public final Counter internalServerErrorCount;
   public final Counter notFoundCount;
+  public final Counter forbiddenCount;
+  public final Counter proxyAuthRequiredCount;
   public final Counter throwableCount;
   public final Counter unknownResponseStatusCount;
   // NettyServer
@@ -181,6 +183,9 @@ class NettyMetrics {
     internalServerErrorCount =
         metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "InternalServerErrorCount"));
     notFoundCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "NotFoundCount"));
+    forbiddenCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ForbiddenCount"));
+    proxyAuthRequiredCount =
+        metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ProxyAuthenticationRequiredCount"));
     throwableCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ThrowableCount"));
     unknownResponseStatusCount =
         metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "UnknownResponseStatusCount"));

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -364,6 +364,14 @@ class NettyResponseChannel implements RestResponseChannel {
         nettyMetrics.goneCount.inc();
         status = HttpResponseStatus.GONE;
         break;
+      case Forbidden:
+        nettyMetrics.forbiddenCount.inc();
+        status = HttpResponseStatus.FORBIDDEN;
+        break;
+      case ProxyAuthenticationRequired:
+        nettyMetrics.proxyAuthRequiredCount.inc();
+        status = HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED;
+        break;
       case InternalServerError:
         nettyMetrics.internalServerErrorCount.inc();
         status = HttpResponseStatus.INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
The conversion of the new ResponseStatus codes into Netty Status codes was omitted in #249. This patch adds those metrics.
