### PR TITLE
Updating gradle version to 2.12

### DIFF
--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -11,11 +11,11 @@ repositories {
     repositories {
         // For license plugin.
         maven {
-            url 'http://dl.bintray.com/content/netflixoss/external-gradle-plugins/'
+            url "https://plugins.gradle.org/m2/"
         }
     }
 }
 
 dependencies {
-    classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.6.1'
+    classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -14,4 +14,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.6-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.12-bin.zip


### PR DESCRIPTION
Hi team, I was wondering if we wanted to upgrade our gradle version so that we can build without issues with Java 8.
- Updated gradle version to allow project to be built with Java 8.
- Updated license plugin version to be compatible with newer gradle
  version

**Reviewers**: Priyesh, Siva, Ming
**Testing**: `./gradlew build` still works with Java 7/8
**Time to review**: 5 min.
