### PR TITLE
Making changes to AmbryMain and RestServerMain

### DIFF
--- a/ambry-rest/src/main/java/com.github.ambry.rest/RestServerMain.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/RestServerMain.java
@@ -18,15 +18,9 @@ import com.github.ambry.clustermap.ClusterMapManager;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.InvocationOptions;
 import com.github.ambry.utils.Utils;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Properties;
-import joptsimple.ArgumentAcceptingOptionSpec;
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
-import joptsimple.OptionSpec;
-import org.apache.log4j.PropertyConfigurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,9 +33,9 @@ public class RestServerMain {
 
   public static void main(String[] args) {
     final RestServer restServer;
+    int exitCode = 0;
     try {
       final InvocationOptions options = new InvocationOptions(args);
-      PropertyConfigurator.configure(options.logPropsFile);
       final Properties properties = Utils.loadProps(options.serverPropsFilePath);
       final VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
       final ClusterMap clusterMap =
@@ -52,7 +46,7 @@ public class RestServerMain {
       // attach shutdown handler to catch control-c
       Runtime.getRuntime().addShutdownHook(new Thread() {
         public void run() {
-          logger.info("Received shutdown signal. Requesting RestServer shutdown");
+          logger.info("Received shutdown signal. Shutting down RestServer");
           restServer.shutdown();
         }
       });
@@ -60,81 +54,11 @@ public class RestServerMain {
       restServer.awaitShutdown();
     } catch (Exception e) {
       logger.error("Exception during bootstrap of RestServer", e);
-    } finally {
-      logger.info("Exiting RestServerMain");
-      System.exit(0);
+      exitCode = 1;
     }
+    logger.info("Exiting RestServerMain");
+    System.exit(exitCode);
   }
 }
 
-/**
- * Abstraction class for all the parameters we expect to receive.
- */
-class InvocationOptions {
-  public final String hardwareLayoutFilePath;
-  public final String logPropsFile;
-  public final String partitionLayoutFilePath;
-  public final String serverPropsFilePath;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
 
-  /**
-   * Parses the arguments provided and extracts them into variables that can be retrieved through APIs.
-   * @param args the command line argument list.
-   * @throws InstantiationException if all required arguments were not provided.
-   * @throws IOException if help text could not be printed.
-   */
-  public InvocationOptions(String args[])
-      throws InstantiationException, IOException {
-    OptionParser parser = new OptionParser();
-    ArgumentAcceptingOptionSpec<String> hardwareLayoutFilePath =
-        parser.accepts("hardwareLayoutFilePath", "Path to hardware layout file").withRequiredArg()
-            .describedAs("hardwareLayoutFilePath").ofType(String.class);
-    ArgumentAcceptingOptionSpec<String> logPropsFilePath =
-        parser.accepts("logPropsFilePath", "Path to log4j properties file").withRequiredArg()
-            .describedAs("logPropsFilePath").ofType(String.class);
-    ArgumentAcceptingOptionSpec<String> partitionLayoutFilePath =
-        parser.accepts("partitionLayoutFilePath", "Path to partition layout file").withRequiredArg()
-            .describedAs("partitionLayoutFilePath").ofType(String.class);
-    ArgumentAcceptingOptionSpec<String> serverPropsFilePath =
-        parser.accepts("serverPropsFilePath", "Path to server properties file").withRequiredArg()
-            .describedAs("serverPropsFilePath").ofType(String.class);
-
-    ArrayList<OptionSpec<?>> requiredArgs = new ArrayList<OptionSpec<?>>();
-    requiredArgs.add(hardwareLayoutFilePath);
-    requiredArgs.add(logPropsFilePath);
-    requiredArgs.add(partitionLayoutFilePath);
-    requiredArgs.add(serverPropsFilePath);
-
-    OptionSet options = parser.parse(args);
-    if (hasRequiredOptions(requiredArgs, options)) {
-      this.hardwareLayoutFilePath = options.valueOf(hardwareLayoutFilePath);
-      logger.trace("Hardware layout file path: {}", this.hardwareLayoutFilePath);
-      this.logPropsFile = options.valueOf(logPropsFilePath);
-      logger.trace("Log4j properties file path: {}", this.logPropsFile);
-      this.partitionLayoutFilePath = options.valueOf(partitionLayoutFilePath);
-      logger.trace("Partition layout file path: {}", this.partitionLayoutFilePath);
-      this.serverPropsFilePath = options.valueOf(serverPropsFilePath);
-      logger.trace("Server properties file path: {}", this.serverPropsFilePath);
-    } else {
-      parser.printHelpOn(System.err);
-      throw new InstantiationException("Did not receive all required arguments for starting RestServer");
-    }
-  }
-
-  /**
-   * Checks if all required arguments are present. Prints the ones that are not.
-   * @param requiredArgs the list of required arguments.
-   * @param options the list of received options.
-   * @return whether required options are present.
-   */
-  private boolean hasRequiredOptions(ArrayList<OptionSpec<?>> requiredArgs, OptionSet options) {
-    boolean haveAll = true;
-    for (OptionSpec opt : requiredArgs) {
-      if (!options.has(opt)) {
-        System.err.println("Missing required argument " + opt);
-        haveAll = false;
-      }
-    }
-    return haveAll;
-  }
-}

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryMain.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryMain.java
@@ -17,42 +17,46 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapManager;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.InvocationOptions;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
 import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
- * Ambry main
+ * Start point for creating an instance of {@link AmbryServer} and starting/shutting it down.
  */
 public class AmbryMain {
-  public static void main(String args[]) {
-    if (args.length != 3) {
-      System.out.println("USAGE: java [options] " + AmbryMain.class.getCanonicalName() +
-          " server.properties hardwarelayout partitionlayout");
-      System.exit(1);
-    }
+  private static Logger logger = LoggerFactory.getLogger(AmbryMain.class);
 
+  public static void main(String[] args) {
+    final AmbryServer ambryServer;
+    int exitCode = 0;
     try {
-      Properties props = Utils.loadProps(args[0]);
-      VerifiableProperties vprops = new VerifiableProperties(props);
-
-      ClusterMap clusterMap = new ClusterMapManager(args[1], args[2], new ClusterMapConfig(vprops));
-
-      final AmbryServer server = new AmbryServer(vprops, clusterMap, SystemTime.getInstance());
-
+      final InvocationOptions options = new InvocationOptions(args);
+      final Properties properties = Utils.loadProps(options.serverPropsFilePath);
+      final VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+      final ClusterMap clusterMap =
+          new ClusterMapManager(options.hardwareLayoutFilePath, options.partitionLayoutFilePath,
+              new ClusterMapConfig(verifiableProperties));
+      logger.info("Bootstrapping AmbryServer");
+      ambryServer = new AmbryServer(verifiableProperties, clusterMap, SystemTime.getInstance());
       // attach shutdown handler to catch control-c
       Runtime.getRuntime().addShutdownHook(new Thread() {
         public void run() {
-          server.shutdown();
+          logger.info("Received shutdown signal. Shutting down AmbryServer");
+          ambryServer.shutdown();
         }
       });
-
-      server.startup();
-      server.awaitShutdown();
+      ambryServer.startup();
+      ambryServer.awaitShutdown();
     } catch (Exception e) {
-      System.out.println("error " + e);
+      logger.error("Exception during bootstrap of AmbryServer", e);
+      exitCode = 1;
     }
-    System.exit(0);
+    logger.info("Exiting RestServerMain");
+    System.exit(exitCode);
   }
 }

--- a/ambry-utils/src/main/java/com.github.ambry.utils/InvocationOptions.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/InvocationOptions.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.utils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import joptsimple.ArgumentAcceptingOptionSpec;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Abstraction class for all the parameters we expect to receive to start Ambry frontend and data nodes.
+ */
+public class InvocationOptions {
+  public final String hardwareLayoutFilePath;
+  public final String partitionLayoutFilePath;
+  public final String serverPropsFilePath;
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  /**
+   * Parses the arguments provided and extracts them into variables that can be retrieved through APIs.
+   * @param args the command line argument list.
+   * @throws InstantiationException if all required arguments were not provided.
+   * @throws IOException if help text could not be printed.
+   */
+  public InvocationOptions(String args[])
+      throws InstantiationException, IOException {
+    OptionParser parser = new OptionParser();
+    ArgumentAcceptingOptionSpec<String> hardwareLayoutFilePath =
+        parser.accepts("hardwareLayoutFilePath", "Path to hardware layout file").withRequiredArg()
+            .describedAs("hardwareLayoutFilePath").ofType(String.class);
+    ArgumentAcceptingOptionSpec<String> partitionLayoutFilePath =
+        parser.accepts("partitionLayoutFilePath", "Path to partition layout file").withRequiredArg()
+            .describedAs("partitionLayoutFilePath").ofType(String.class);
+    ArgumentAcceptingOptionSpec<String> serverPropsFilePath =
+        parser.accepts("serverPropsFilePath", "Path to server properties file").withRequiredArg()
+            .describedAs("serverPropsFilePath").ofType(String.class);
+
+    ArrayList<OptionSpec<?>> requiredArgs = new ArrayList<>();
+    requiredArgs.add(hardwareLayoutFilePath);
+    requiredArgs.add(partitionLayoutFilePath);
+    requiredArgs.add(serverPropsFilePath);
+
+    OptionSet options = parser.parse(args);
+    if (hasRequiredOptions(requiredArgs, options)) {
+      this.hardwareLayoutFilePath = options.valueOf(hardwareLayoutFilePath);
+      logger.trace("Hardware layout file path: {}", this.hardwareLayoutFilePath);
+      this.partitionLayoutFilePath = options.valueOf(partitionLayoutFilePath);
+      logger.trace("Partition layout file path: {}", this.partitionLayoutFilePath);
+      this.serverPropsFilePath = options.valueOf(serverPropsFilePath);
+      logger.trace("Server properties file path: {}", this.serverPropsFilePath);
+    } else {
+      parser.printHelpOn(System.err);
+      throw new InstantiationException("Did not receive all required arguments for starting RestServer");
+    }
+  }
+
+  /**
+   * Checks if all required arguments are present. Prints the ones that are not.
+   * @param requiredArgs the list of required arguments.
+   * @param options the list of received options.
+   * @return whether required options are present.
+   */
+  private boolean hasRequiredOptions(ArrayList<OptionSpec<?>> requiredArgs, OptionSet options) {
+    boolean haveAll = true;
+    for (OptionSpec opt : requiredArgs) {
+      if (!options.has(opt)) {
+        System.err.println("Missing required argument " + opt);
+        haveAll = false;
+      }
+    }
+    return haveAll;
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ project(':ambry-utils') {
     dependencies {
         compile "commons-codec:commons-codec:$commonsVersion"
         compile "org.json:json:$jsonVersion"
+        compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
     }
 }
 

--- a/config/frontend.properties
+++ b/config/frontend.properties
@@ -14,8 +14,8 @@
 rest.server.blob.storage.service.factory=com.github.ambry.frontend.AmbryBlobStorageServiceFactory
 
 # coordinator
+router.hostname=router
+router.datacenter.name=Data-Center
 coordinator.hostname=localhost
 coordinator.datacenter.name=Data-Center
-
-# netty
-netty.server.port=1174
+coordinator.operation.timeout.ms=10000


### PR DESCRIPTION
Changes to `AmbryMain` and `RestServerMain` to make them consistent with each other so that
the experience of starting these components in open source is consistent.

Changes in `RestServerMain`:
1. log4j props argument removed because it can be set up as a VM option.
2. Return right exit code in case of exceptions.

Changes in `AmbryMain`:
1. Argument receiving.
2. Exit code handling.
3. Now consistent with `RestServerMain`

No unit tests required. Built and tested. Also used the main function to bring up a `RestServer` and `AmbryServer`

**Primary reviewers: Casey
Expected time to review: < 10 mins.**

To test, please follow these steps (hardware layout and partition layout attached)

./gradlew allJar
cd target
(download the hardware layout and partition layout files here. They are attached as txt
[HardwareLayout.txt](https://github.com/linkedin/ambry/files/232565/HardwareLayout.txt)
[PartitionLayout.txt](https://github.com/linkedin/ambry/files/232564/PartitionLayout.txt)
)

To start `AmbryMain`:
java -Dlog4j.configuration=file:../config/log4j.properties -jar ambry.jar --serverPropsFilePath ../config/server.properties --hardwareLayoutFilePath HardwareLayout.json --partitionLayoutFilePath PartitionLayout.json
(Ctrl-c to shutdown)

To start `RestServerMain`:
java -Dlog4j.configuration=file:../config/log4j.properties -cp "*" com.github.ambry.frontend.AmbryFrontendMain --serverPropsFilePath ../config/frontend.properties --hardwareLayoutFilePath HardwareLayout.json --partitionLayoutFilePath PartitionLayout.json
(Ctrl-c to shutdown)
