### PR TITLE
Making some fixes to help quick start of Ambry

### DIFF
--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryMain.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryMain.java
@@ -56,7 +56,7 @@ public class AmbryMain {
       logger.error("Exception during bootstrap of AmbryServer", e);
       exitCode = 1;
     }
-    logger.info("Exiting RestServerMain");
+    logger.info("Exiting AmbryMain");
     System.exit(exitCode);
   }
 }

--- a/config/HardwareLayout.json
+++ b/config/HardwareLayout.json
@@ -14,8 +14,7 @@
                     ],
                     "hardwareState": "AVAILABLE",
                     "hostname": "localhost",
-                    "port": 6667,
-                    "sslport": 7667
+                    "port": 6667
                 }
             ],
             "name": "Datacenter"

--- a/config/HardwareLayoutSsl.json
+++ b/config/HardwareLayoutSsl.json
@@ -1,0 +1,24 @@
+{
+  "clusterName": "OneDiskOneReplica",
+  "version": 99,
+  "datacenters": [
+    {
+      "dataNodes": [
+        {
+          "disks": [
+            {
+              "capacityInBytes": 21474836480,
+              "hardwareState": "AVAILABLE",
+              "mountPath": "/tmp"
+            }
+          ],
+          "hardwareState": "AVAILABLE",
+          "hostname": "localhost",
+          "port": 6667,
+          "sslPort" : 7667
+        }
+      ],
+      "name": "Datacenter"
+    }
+  ]
+}

--- a/config/frontend.properties
+++ b/config/frontend.properties
@@ -13,9 +13,11 @@
 # rest server
 rest.server.blob.storage.service.factory=com.github.ambry.frontend.AmbryBlobStorageServiceFactory
 
+# router
+router.hostname=localhost
+router.datacenter.name=Datacenter
+
 # coordinator
-router.hostname=router
-router.datacenter.name=Data-Center
 coordinator.hostname=localhost
-coordinator.datacenter.name=Data-Center
+coordinator.datacenter.name=Datacenter
 coordinator.operation.timeout.ms=10000


### PR DESCRIPTION
There were bugs associated with the default clustermap and its use in starting up Ambry.
In addition, making changes to the default config files to make them work with the default clustermap.

**Primary reviewers: Siva
Expected time to review: < 5 mins**
