### PR TITLE
Ensure chunk buffers are reused only after associated sends are complete

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -178,8 +178,8 @@ class DeleteOperation {
    * A wrapper class that is used to check if a request has been expired.
    */
   private class InflightRequestInfo {
-    private long submissionTime;
-    private ReplicaId replica;
+    private final long submissionTime;
+    private final ReplicaId replica;
 
     InflightRequestInfo(long submissionTime, ReplicaId replica) {
       this.submissionTime = submissionTime;

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -823,9 +823,9 @@ class PutOperation {
      * A class that holds information about requests sent out by this PutChunk.
      */
     private class ChunkPutRequestInfo {
-      private ReplicaId replicaId;
-      private PutRequest putRequest;
-      private long startTimeMs;
+      private final ReplicaId replicaId;
+      private final PutRequest putRequest;
+      private final long startTimeMs;
 
       /**
        * Construct a ChunkPutRequestInfo

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -425,7 +425,7 @@ class PutOperation {
     // may not get overridden by a subsequent error, and this variable is meant to store the most relevant error.
     private RouterException chunkException;
     // the state of the current chunk.
-    protected ChunkState state;
+    protected volatile ChunkState state;
     // the ByteBuffer that has the data for the current chunk.
     protected ByteBuffer buf;
     // the OperationTracker used to track the status of requests for the current chunk.
@@ -439,6 +439,8 @@ class PutOperation {
     // map of correlation id to the request metadata for every request issued for the current chunk.
     private final Map<Integer, ChunkPutRequestInfo> correlationIdToChunkPutRequestInfo =
         new TreeMap<Integer, ChunkPutRequestInfo>();
+    // list of buffers that were once associated with this chunk and are not yet freed.
+    private final List<DefunctBufferInfo> defunctBufferInfos = new ArrayList<>();
     private final Logger logger = LoggerFactory.getLogger(PutChunk.class);
 
     /**
@@ -455,11 +457,59 @@ class PutOperation {
       chunkIndex = -1;
       chunkBlobId = null;
       chunkException = null;
-      state = ChunkState.Free;
       failedAttempts = 0;
       partitionId = null;
-      correlationIdToChunkPutRequestInfo.clear();
       attemptedPartitionIds.clear();
+      maybeUpdateDefunctBufferInfos();
+      correlationIdToChunkPutRequestInfo.clear();
+      // this assignment should be the last statement as this immediately makes this chunk available to the
+      // ChunkFiller thread for filling.
+      state = ChunkState.Free;
+    }
+
+    /**
+     * Go through the list of requests for which responses were not received, and if there are any that are not yet
+     * sent out completely, add the associated buffer to the defunct list for freeing in the future.
+     */
+    private void maybeUpdateDefunctBufferInfos() {
+      ArrayList<PutRequest> requestsAwaitingSendCompletion = null;
+      for (Map.Entry<Integer, ChunkPutRequestInfo> entry : correlationIdToChunkPutRequestInfo.entrySet()) {
+        if (!entry.getValue().putRequest.isSendComplete()) {
+          if (requestsAwaitingSendCompletion == null) {
+            requestsAwaitingSendCompletion = new ArrayList<>();
+          }
+          requestsAwaitingSendCompletion.add(entry.getValue().putRequest);
+        }
+      }
+
+      if (requestsAwaitingSendCompletion != null) {
+        // This means that the buffer associated with this PutChunk could get read by the NetworkClient in the
+        // future and assigning this PutChunk to a subsequent chunk of the overall blob could lead to this buffer
+        // getting read and written concurrently, or other undefined behavior. There are multiple ways to handle this,
+        // and the simplest way is to set the buf to null so that it gets allocated afresh if/when this PutChunk gets
+        // assigned for a subsequent chunk of the overall blob. Every time this chunk gets polled, an attempt to clear
+        // out the list will be made.
+        defunctBufferInfos.add(new DefunctBufferInfo(buf, requestsAwaitingSendCompletion));
+        buf = null;
+      }
+    }
+
+    /**
+     * Iterate defunctBufferInfos and possibly free up entries from it.
+     */
+    private void maybeFreeDefunctBuffers() {
+      for (Iterator<DefunctBufferInfo> iter = defunctBufferInfos.iterator(); iter.hasNext(); ) {
+        boolean canBeFreed = true;
+        for (PutRequest putRequest : iter.next().putRequests) {
+          if (!putRequest.isSendComplete()) {
+            canBeFreed = false;
+          }
+        }
+        if (canBeFreed) {
+          // this is where the buffer will be freed if the buffer pool is used. For now, simply remove the reference.
+          iter.remove();
+        }
+      }
     }
 
     /**
@@ -616,6 +666,7 @@ class PutOperation {
      *                            part of this poll operation.
      */
     void poll(PutRequestRegistrationCallback requestFillCallback) {
+      maybeFreeDefunctBuffers();
       //First, check if any of the existing requests have timed out.
       Iterator<Map.Entry<Integer, ChunkPutRequestInfo>> inFlightRequestsIterator =
           correlationIdToChunkPutRequestInfo.entrySet().iterator();
@@ -644,7 +695,8 @@ class PutOperation {
         PutRequest putRequest = createPutRequest();
         RequestInfo request = new RequestInfo(hostname, port, putRequest);
         int correlationId = putRequest.getCorrelationId();
-        correlationIdToChunkPutRequestInfo.put(correlationId, new ChunkPutRequestInfo(replicaId, time.milliseconds()));
+        correlationIdToChunkPutRequestInfo
+            .put(correlationId, new ChunkPutRequestInfo(replicaId, putRequest, time.milliseconds()));
         correlationIdToPutChunk.put(correlationId, this);
         requestFillCallback.registerRequestToSend(PutOperation.this, request);
         replicaIterator.remove();
@@ -772,6 +824,7 @@ class PutOperation {
      */
     private class ChunkPutRequestInfo {
       private ReplicaId replicaId;
+      private PutRequest putRequest;
       private long startTimeMs;
 
       /**
@@ -779,9 +832,32 @@ class PutOperation {
        * @param replicaId the replica to which this request is being sent.
        * @param startTimeMs the time at which this request was created.
        */
-      ChunkPutRequestInfo(ReplicaId replicaId, long startTimeMs) {
+      ChunkPutRequestInfo(ReplicaId replicaId, PutRequest putRequest, long startTimeMs) {
         this.replicaId = replicaId;
+        this.putRequest = putRequest;
         this.startTimeMs = startTimeMs;
+      }
+    }
+
+    /**
+     * Class that holds the buffer of a chunk that will no longer be used and is kept around only because the
+     * associated requests are not yet completely sent out.
+     */
+    private class DefunctBufferInfo {
+      // the buffer that is now defunct, but not yet freed.
+      ByteBuffer buf;
+      // Requests that are reading from this buffer.
+      List<PutRequest> putRequests;
+
+      /**
+       * Construct a DefunctBufferInfo
+       * @param buf the buffer that is now defunct and waiting to be freed.
+       * @param putRequests the requests associated with this buffer whose send completion blocks the freeing of this
+       *                    buffer.
+       */
+      DefunctBufferInfo(ByteBuffer buf, List<PutRequest> putRequests) {
+        this.buf = buf;
+        this.putRequests = putRequests;
       }
     }
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.commons.ByteBufferReadableStreamChannel;
+import com.github.ambry.commons.ResponseHandler;
+import com.github.ambry.config.RouterConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.network.NetworkReceive;
+import com.github.ambry.network.RequestInfo;
+import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.protocol.PutRequest;
+import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.utils.ByteBufferChannel;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.TreeMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class PutOperationTest {
+  private final RouterConfig routerConfig;
+  private final MockClusterMap mockClusterMap;
+  private final ResponseHandler responseHandler;
+  private final Time time;
+  private final Map<Integer, PutOperation> correlationIdToPutOperation = new TreeMap<>();
+  private final MockServer mockServer = new MockServer();
+
+  private class PutTestRequestRegistrationCallbackImpl implements PutRequestRegistrationCallback {
+    private List<RequestInfo> requestListToFill;
+
+    @Override
+    public void registerRequestToSend(PutOperation putOperation, RequestInfo requestInfo) {
+      requestListToFill.add(requestInfo);
+      correlationIdToPutOperation.put(((RequestOrResponse) requestInfo.getRequest()).getCorrelationId(), putOperation);
+    }
+  }
+
+  ;
+  private final PutTestRequestRegistrationCallbackImpl requestRegistrationCallback =
+      new PutTestRequestRegistrationCallbackImpl();
+
+  private final int chunkSize = 10;
+  private final int requestParallelism = 3;
+  private final int successTarget = 1;
+  private final Random random = new Random();
+
+  public PutOperationTest()
+      throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty("router.hostname", "localhost");
+    properties.setProperty("router.datacenter.name", "DC1");
+    properties.setProperty("router.max.put.chunk.size.bytes", Integer.toString(chunkSize));
+    properties.setProperty("router.put.request.parallelism", Integer.toString(requestParallelism));
+    properties.setProperty("router.put.success.target", Integer.toString(successTarget));
+    VerifiableProperties vProps = new VerifiableProperties(properties);
+    routerConfig = new RouterConfig(vProps);
+    mockClusterMap = new MockClusterMap();
+    responseHandler = new ResponseHandler(mockClusterMap);
+    time = new MockTime();
+  }
+
+  /**
+   * Ensure that if any of the requests associated with the buffer of a PutChunk is not completely read out even
+   * after the associated chunk is complete, the buffer is not reused even though the PutChunk is reused.
+   */
+  @Test
+  public void testSendIncomplete()
+      throws Exception {
+    BlobProperties blobProperties =
+        new BlobProperties(chunkSize * 5, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
+    byte[] userMetadata = new byte[10];
+    byte[] content = new byte[chunkSize * 5];
+    random.nextBytes(content);
+    ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content));
+    FutureResult<String> future = new FutureResult<>();
+    PutOperation op =
+        new PutOperation(routerConfig, mockClusterMap, responseHandler, blobProperties, userMetadata, channel, future,
+            null, time);
+    List<RequestInfo> requestInfos = new ArrayList<>();
+    requestRegistrationCallback.requestListToFill = requestInfos;
+    // Since this channel is in memory, one call to fill chunks would end up filling the maximum number of PutChunks (4).
+    op.fillChunks();
+    // A poll should therefore return requestParallelism number of requests from each chunk
+    op.poll(requestRegistrationCallback);
+    Assert.assertEquals(4 * requestParallelism, requestInfos.size());
+
+    // There are 5 data chunks for this blob (and a metadata chunk). The maximum number of in-memory PutChunk objects
+    // for an operation is 4. So, once the first chunk is completely sent out, the first PutChunk will be reused. What
+    // the test verifies is that the buffer of the first PutChunk does not get reused. It does this as follows:
+    // For the first chunk,
+    // 1. use first request to succeed the chunk (the successTarget is set to 1).
+    // 2. read and store from the second for comparing later.
+    // 3. read from the third after the first PutChunk gets reused and ensure that the data from the third is the
+    //    same as from what was saved off from the second. This means that the buffer was not reused by the first
+    //    PutChunk.
+
+    // 1.
+    op.handleResponse(getResponseInfo(requestInfos.get(0)));
+    // 2.
+    PutRequest putRequest = (PutRequest) requestInfos.get(1).getRequest();
+    ByteBuffer buf = ByteBuffer.allocate((int) putRequest.sizeInBytes());
+    ByteBufferChannel bufChannel = new ByteBufferChannel(buf);
+    // read it out (which also marks this request as complete).
+    putRequest.writeTo(bufChannel);
+    byte[] expectedRequestContent = buf.array();
+
+    //3.
+    // first save the third request
+    PutRequest savedRequest = (PutRequest) requestInfos.get(2).getRequest();
+
+    // succeed all the other requests.
+    for (int i = 3; i < requestInfos.size(); i++) {
+      op.handleResponse(getResponseInfo(requestInfos.get(i)));
+    }
+    // fill the first PutChunk with the 5th chunk.
+    op.fillChunks();
+    // Verify that the 5th chunk was filled.
+    requestInfos.clear();
+    op.poll(requestRegistrationCallback);
+    Assert.assertEquals(1 * requestParallelism, requestInfos.size());
+
+    // Verify that that the buffer of the third request is not affected.
+    buf = ByteBuffer.allocate((int) savedRequest.sizeInBytes());
+    bufChannel = new ByteBufferChannel(buf);
+    savedRequest.writeTo(bufChannel);
+    byte[] savedRequestContent = buf.array();
+
+    // reset the correlation id as they will be different between the two requests.
+    int offsetOfCorrelationId = 15;
+    expectedRequestContent[offsetOfCorrelationId] = 0;
+    savedRequestContent[offsetOfCorrelationId] = 0;
+    Assert
+        .assertArrayEquals("Underlying buffer should not have be reused", expectedRequestContent, savedRequestContent);
+
+    // now that all the requests associated with the original buffer have been read,
+    // the next poll will free this buffer. We cannot actually verify it via the tests directly, as this is very
+    // internal to the chunk (though this can be verified via coverage).
+    for (int i = 0; i < requestInfos.size(); i++) {
+      op.handleResponse(getResponseInfo(requestInfos.get(i)));
+    }
+    requestInfos.clear();
+    // this should return requests for the metadata chunk
+    op.poll(requestRegistrationCallback);
+    Assert.assertEquals(1 * requestParallelism, requestInfos.size());
+    Assert.assertFalse("Operation should not be complete yet", op.isOperationComplete());
+    // once the metadata request succeeds, it should complete the operation.
+    op.handleResponse(getResponseInfo(requestInfos.get(0)));
+    Assert.assertTrue("Operation should be complete at this time", op.isOperationComplete());
+  }
+
+  private ResponseInfo getResponseInfo(RequestInfo requestInfo)
+      throws IOException {
+    NetworkReceive networkReceive = new NetworkReceive(null, mockServer.send(requestInfo.getRequest()), time);
+    return new ResponseInfo(requestInfo.getRequest(), null, networkReceive.getReceivedBytes().getPayload());
+  }
+}
+

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -149,9 +149,8 @@ public class PutOperationTest {
     byte[] savedRequestContent = buf.array();
 
     // reset the correlation id as they will be different between the two requests.
-    int offsetOfCorrelationId = 15;
-    expectedRequestContent[offsetOfCorrelationId] = 0;
-    savedRequestContent[offsetOfCorrelationId] = 0;
+    resetCorrelationId(expectedRequestContent);
+    resetCorrelationId(savedRequestContent);
     Assert
         .assertArrayEquals("Underlying buffer should not have be reused", expectedRequestContent, savedRequestContent);
 
@@ -171,6 +170,22 @@ public class PutOperationTest {
     Assert.assertTrue("Operation should be complete at this time", op.isOperationComplete());
   }
 
+  /**
+   *  Reset the correlation id field of a {@link PutRequest} to 0.
+   */
+  private void resetCorrelationId(byte[] request) {
+    // correlation id is an int that comes after size (long), type (short) and version (short).
+    int offsetOfCorrelationId = 8 + 2 + 2;
+    ByteBuffer wrapped = ByteBuffer.wrap(request);
+    wrapped.putInt(offsetOfCorrelationId, 0);
+  }
+
+  /**
+   * Get the {@link ResponseInfo} for the given {@link RequestInfo} using tha {@link MockServer}
+   * @param requestInfo the {@link RequestInfo} for which the response is to be returned.
+   * @return the {@link ResponseInfo} the response for the request.
+   * @throws IOException if there is an error sending the request.
+   */
   private ResponseInfo getResponseInfo(RequestInfo requestInfo)
       throws IOException {
     NetworkReceive networkReceive = new NetworkReceive(null, mockServer.send(requestInfo.getRequest()), time);


### PR DESCRIPTION
The `Bytebuffer` associated with a `PutChunk` is reused for subsequent chunks that the `PutChunk` handles, just like most other data structures of the `PutChunk`. This avoids new object creation and allows for self management of memory (and not rely on the garbage collector). 

However, since this buffer is not copied when creating `PutRequests` (only duplicated - which is a shallow copy), if any `PutRequest` handed over to the `NetworkClient` is not completely sent out at the time of chunk completion (when the `PutChunk` state goes back to `Free`), then it cannot be reused immediately. This is because the buffer could be read out in the future by the `NetworkClient / Selector` and reusing could lead to undefined behavior - for example, if the buffer is written to by the `ChunkFillerThread` concurrently.

There are multiple ways in which this could be fixed, and the approach used by this patch is the following:

- At chunk completion, if it is detected that there are requests that were created that are not yet completely read out, the buffer is reset to null (the buffer will be reallocated if and when the `PutChunk` goes to `Building` state). The original buffer and the associated requests that were not sent out completely are added to a "defunct" list.

- During every poll of a `PutChunk`, the defunct list is iterated over so that these defunct buffers can be freed (a defunct buffer becomes eligible for freeing if every defunct request associated with it are send complete).

---

Coverage
Newly added test class (`PutOperationTest`) tests this scenario. Newly added prod code is covered 100%

---

Primary reviewer: Gopal (had shared the context with him).
Estimate: ~30-40 mins.