### PR TITLE
Adding rack-aware partition allocation algorithm

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapManager.java
@@ -345,11 +345,10 @@ public class ClusterMapManager implements ClusterMap {
     Set<DataNode> nodesToExclude = new HashSet<>();
     List<DataNode> dataNodes = new ArrayList<>(datacenter.getDataNodes());
     for (int i = 0; i < replicaCountPerDatacenter; i++) {
-      Disk diskCandidate =
-          getBestDiskCandidate(dataNodes, nodesToExclude, replicaCapacityInBytes, rackAware, NUM_CHOICES);
-      if (diskCandidate != null) {
-        disksToAllocate.add(diskCandidate);
-        nodesToExclude.add(diskCandidate.getDataNode());
+      Disk bestDisk = getBestDiskCandidate(dataNodes, nodesToExclude, replicaCapacityInBytes, rackAware, NUM_CHOICES);
+      if (bestDisk != null) {
+        disksToAllocate.add(bestDisk);
+        nodesToExclude.add(bestDisk.getDataNode());
       } else {
         break;
       }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapManager.java
@@ -284,44 +284,49 @@ public class ClusterMapManager implements ClusterMap {
   }
 
   /**
-   * Get a sampling of {@code numDisks} random disks from a list of {@link DataNode}s.
+   * Get a sampling of {@code numChoices} random disks from a list of {@link DataNode}s and choose the
+   * {@link Disk} on the {@link DataNode} with the most free space.
    * NOTE 1: This method will change the ordering of the nodes in {@code dataNodes}
-   * NOTE 2: If {@code numDisks} valid disks could not be found, the returned list could be shorter than
-   *         {@code numDisks}
+   * NOTE 2: This method can return null, if a disk with enough free space could not be found.
    *
    * @param dataNodes the list of {@link DataNode}s to sample from
    * @param dataNodesUsed the set of {@link DataNode}s to exclude from the sample
    * @param replicaCapacityInBytes the minimum amount of free space that a disk in the sample should have
    * @param rackAware if {@code true}, only return disks in nodes that do not share racks with the nodes
    *                  in {@code dataNodesUsed}
-   * @param numDisks how many disks to return in the sample
-   * @return a list of {@link Disk}s of length {@code numDisks}, or fewer if {@code numDisks} valid samples could not
-   *         be found
+   * @param numChoices how many disks in the sample to choose between
+   * @return The {@link Disk} on the {@link DataNode} in the sample with the most free space, or {@code null } if a disk
+   *         with enough free space could not be found.
    */
-  private List<Disk> getRandomDiskCandidateSample(List<DataNode> dataNodes, Set<DataNode> dataNodesUsed,
-      long replicaCapacityInBytes, boolean rackAware, int numDisks) {
+  private Disk getBestDiskCandidate(List<DataNode> dataNodes, Set<DataNode> dataNodesUsed, long replicaCapacityInBytes,
+      boolean rackAware, int numChoices) {
     Set<Long> rackIdsUsed = new HashSet<>();
     if (rackAware) {
       for (DataNode dataNode : dataNodesUsed) {
         rackIdsUsed.add(dataNode.getRackId());
       }
     }
-    List<Disk> diskCandidates = new ArrayList<>();
+    int numFound = 0;
     int selectionBound = dataNodes.size();
     Random randomGen = new Random();
-    while ((selectionBound > 0) && (diskCandidates.size() < numDisks)) {
+    Disk bestDisk = null;
+    while ((selectionBound > 0) && (numFound < numChoices)) {
       int selectionIndex = randomGen.nextInt(selectionBound);
       DataNode candidate = dataNodes.get(selectionIndex);
       if (!dataNodesUsed.contains(candidate) && !rackIdsUsed.contains(candidate.getRackId())) {
-        Disk diskWithMostCapacity = getDiskWithMostUnallocatedRawCapacity(candidate, replicaCapacityInBytes);
-        if (diskWithMostCapacity != null) {
-          diskCandidates.add(diskWithMostCapacity);
+        Disk diskCandidate = getDiskWithMostUnallocatedRawCapacity(candidate, replicaCapacityInBytes);
+        if (diskCandidate != null) {
+          if ((bestDisk == null) || (getUnallocatedRawCapacityInBytes(diskCandidate.getDataNode())
+              >= getUnallocatedRawCapacityInBytes(bestDisk.getDataNode()))) {
+            bestDisk = diskCandidate;
+          }
+          numFound++;
         }
       }
       selectionBound--;
       Collections.swap(dataNodes, selectionIndex, selectionBound);
     }
-    return diskCandidates;
+    return bestDisk;
   }
 
   /**
@@ -334,18 +339,17 @@ public class ClusterMapManager implements ClusterMap {
    * @param rackAware if {@code true}, attempt a rack-aware allocation
    * @return A list of {@link Disk}s
    */
-  private List<Disk> allocateDisksForPartition(int replicaCountPerDatacenter, long replicaCapacityInBytes,
+  private List<Disk> getDiskCandidatesForPartition(int replicaCountPerDatacenter, long replicaCapacityInBytes,
       Datacenter datacenter, boolean rackAware) {
     ArrayList<Disk> disksToAllocate = new ArrayList<Disk>();
     Set<DataNode> nodesToExclude = new HashSet<>();
     List<DataNode> dataNodes = new ArrayList<>(datacenter.getDataNodes());
     for (int i = 0; i < replicaCountPerDatacenter; i++) {
-      List<Disk> diskCandidates =
-          getRandomDiskCandidateSample(dataNodes, nodesToExclude, replicaCapacityInBytes, rackAware, NUM_CHOICES);
-      if (diskCandidates.size() > 0) {
-        Disk diskToAdd = Collections.max(diskCandidates, diskCapacityComparator);
-        disksToAllocate.add(diskToAdd);
-        nodesToExclude.add(diskToAdd.getDataNode());
+      Disk diskCandidate =
+          getBestDiskCandidate(dataNodes, nodesToExclude, replicaCapacityInBytes, rackAware, NUM_CHOICES);
+      if (diskCandidate != null) {
+        disksToAllocate.add(diskCandidate);
+        nodesToExclude.add(diskCandidate.getDataNode());
       } else {
         break;
       }
@@ -355,31 +359,32 @@ public class ClusterMapManager implements ClusterMap {
 
   /**
    * Return a list of disks for a new partition in the specified {@link Datacenter}. Retry a non rack-aware allocation
-   * in certain cases described below if {@code retryIfNotRackAware} is enabled.
+   * in certain cases described below if {@code attemptNonRackAwareOnFailure} is enabled.
    *
    * @param replicaCountPerDatacenter how many replicas to attempt to allocate in the datacenter
    * @param replicaCapacityInBytes the minimum amount of free space on a disk for a replica
    * @param datacenter the {@link Datacenter} to allocate replicas in
-   * @param retryIfNotRackAware {@code true} if we should attempt a non rack-aware allocation if a rack-aware one
-   *                            is not possible.
+   * @param attemptNonRackAwareOnFailure {@code true} if we should attempt a non rack-aware allocation if a rack-aware
+   *                                     one is not possible.
    * @return a list of {@code replicaCountPerDatacenter} or fewer disks that can be allocated for a new partition in
    *         the specified datacenter
    */
-  private List<Disk> allocateDisksForPartitionWithPotentialRetry(int replicaCountPerDatacenter,
-      long replicaCapacityInBytes, Datacenter datacenter, boolean retryIfNotRackAware) {
+  private List<Disk> allocateDisksForPartition(int replicaCountPerDatacenter, long replicaCapacityInBytes,
+      Datacenter datacenter, boolean attemptNonRackAwareOnFailure) {
     List<Disk> disks;
     if (datacenter.isRackAware()) {
-      disks = allocateDisksForPartition(replicaCountPerDatacenter, replicaCapacityInBytes, datacenter, true);
-      if ((disks.size() < replicaCountPerDatacenter) && retryIfNotRackAware) {
+      disks = getDiskCandidatesForPartition(replicaCountPerDatacenter, replicaCapacityInBytes, datacenter, true);
+      if ((disks.size() < replicaCountPerDatacenter) && attemptNonRackAwareOnFailure) {
         System.err.println("Rack-aware allocation failed for a partition on datacenter:" + datacenter.getName()
             + "; attempting to perform a non rack-aware allocation.");
-        disks = allocateDisksForPartition(replicaCountPerDatacenter, replicaCapacityInBytes, datacenter, false);
+        disks = getDiskCandidatesForPartition(replicaCountPerDatacenter, replicaCapacityInBytes, datacenter, false);
       }
-    } else if (!retryIfNotRackAware) {
-      throw new IllegalArgumentException("retryIfNotRackAware is false, but the datacenter: " + datacenter.getName()
-          + " does not have rack information");
+    } else if (!attemptNonRackAwareOnFailure) {
+      throw new IllegalArgumentException(
+          "attemptNonRackAwareOnFailure is false, but the datacenter: " + datacenter.getName()
+              + " does not have rack information");
     } else {
-      disks = allocateDisksForPartition(replicaCountPerDatacenter, replicaCapacityInBytes, datacenter, false);
+      disks = getDiskCandidatesForPartition(replicaCountPerDatacenter, replicaCapacityInBytes, datacenter, false);
     }
 
     if (disks.size() < replicaCountPerDatacenter) {
@@ -396,20 +401,19 @@ public class ClusterMapManager implements ClusterMap {
    * @param numPartitions How many partitions to allocate.
    * @param replicaCountPerDatacenter The number of replicas per partition on each datacenter
    * @param replicaCapacityInBytes How large each replica (of a partition) should be
-   * @param retryIfNotRackAware {@code true} if we should attempt a non rack-aware allocation if a rack-aware one
-   *                            is not possible.
+   * @param attemptNonRackAwareOnFailure {@code true} if we should attempt a non rack-aware allocation if a rack-aware
+   *                                     one is not possible.
    * @return A list of the new {@link PartitionId}s.
    */
   public List<PartitionId> allocatePartitions(int numPartitions, int replicaCountPerDatacenter,
-      long replicaCapacityInBytes, boolean retryIfNotRackAware) {
+      long replicaCapacityInBytes, boolean attemptNonRackAwareOnFailure) {
     ArrayList<PartitionId> partitions = new ArrayList<PartitionId>(numPartitions);
 
     while (checkEnoughUnallocatedRawCapacity(replicaCountPerDatacenter, replicaCapacityInBytes) && numPartitions > 0) {
       List<Disk> disksToAllocate = new ArrayList<>();
       for (Datacenter datacenter : hardwareLayout.getDatacenters()) {
-        List<Disk> disks =
-            allocateDisksForPartitionWithPotentialRetry(replicaCountPerDatacenter, replicaCapacityInBytes, datacenter,
-                retryIfNotRackAware);
+        List<Disk> disks = allocateDisksForPartition(replicaCountPerDatacenter, replicaCapacityInBytes, datacenter,
+            attemptNonRackAwareOnFailure);
         disksToAllocate.addAll(disks);
       }
       partitions.add(partitionLayout.addNewPartition(disksToAllocate, replicaCapacityInBytes));
@@ -422,12 +426,12 @@ public class ClusterMapManager implements ClusterMap {
   /**
    * Add a set of replicas on a new datacenter for an existing partition.
    *
-   * @param partitionId The partition to add the new datacenter to
+   * @param partitionId The partition to add to the new datacenter
    * @param dataCenterName The name of the new datacenter
-   * @param retryIfNotRackAware {@code true} if we should attempt a non rack-aware allocation if a rack-aware one
+   * @param attemptNonRackAwareOnFailure {@code true} if a non rack-aware allocation should be attempted if a rack-aware one
    *                            is not possible.
    */
-  public void addReplicas(PartitionId partitionId, String dataCenterName, boolean retryIfNotRackAware) {
+  public void addReplicas(PartitionId partitionId, String dataCenterName, boolean attemptNonRackAwareOnFailure) {
     List<ReplicaId> replicaIds = partitionId.getReplicaIds();
     Map<String, Integer> replicaCountByDatacenter = new HashMap<String, Integer>();
     long capacityOfReplicasInBytes = 0;
@@ -462,8 +466,8 @@ public class ClusterMapManager implements ClusterMap {
     }
     Datacenter datacenterToAdd = hardwareLayout.findDatacenter(dataCenterName);
     List<Disk> disksForReplicas =
-        allocateDisksForPartitionWithPotentialRetry(numberOfReplicasPerDatacenter, capacityOfReplicasInBytes,
-            datacenterToAdd, retryIfNotRackAware);
+        allocateDisksForPartition(numberOfReplicasPerDatacenter, capacityOfReplicasInBytes, datacenterToAdd,
+            attemptNonRackAwareOnFailure);
     partitionLayout.addNewReplicas((Partition) partitionId, disksForReplicas);
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapManager.java
@@ -337,10 +337,6 @@ public class ClusterMapManager implements ClusterMap {
   private List<Disk> allocateDisksForPartition(int replicaCountPerDatacenter, long replicaCapacityInBytes,
       Datacenter datacenter, boolean rackAware) {
     ArrayList<Disk> disksToAllocate = new ArrayList<Disk>();
-    if (!datacenter.isRackAware() && rackAware) {
-      throw new IllegalArgumentException(
-          "Rack awareness enabled, but the datacenter: " + datacenter.getName() + " does not have rack information");
-    }
     Set<DataNode> nodesToExclude = new HashSet<>();
     List<DataNode> dataNodes = new ArrayList<>(datacenter.getDataNodes());
     for (int i = 0; i < replicaCountPerDatacenter; i++) {
@@ -374,7 +370,7 @@ public class ClusterMapManager implements ClusterMap {
     List<Disk> disks;
     if (datacenter.isRackAware()) {
       disks = allocateDisksForPartition(replicaCountPerDatacenter, replicaCapacityInBytes, datacenter, true);
-      if (retryIfNotRackAware && (disks.size() < replicaCountPerDatacenter)) {
+      if ((disks.size() < replicaCountPerDatacenter) && retryIfNotRackAware) {
         System.err.println("Rack-aware allocation failed for a partition on datacenter:" + datacenter.getName()
             + "; attempting to perform a non rack-aware allocation.");
         disks = allocateDisksForPartition(replicaCountPerDatacenter, replicaCapacityInBytes, datacenter, false);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapManager.java
@@ -49,18 +49,6 @@ public class ClusterMapManager implements ClusterMap {
   private Logger logger = LoggerFactory.getLogger(getClass());
 
   /**
-   * Comparator for comparing unallocated capacity in two disks
-   */
-  private final Comparator<Disk> diskCapacityComparator = new Comparator<Disk>() {
-    @Override
-    public int compare(Disk o1, Disk o2) {
-      long o1Capacity = getUnallocatedRawCapacityInBytes(o1);
-      long o2Capacity = getUnallocatedRawCapacityInBytes(o2);
-      return (o1Capacity < o2Capacity) ? -1 : (o1Capacity == o2Capacity) ? 0 : 1;
-    }
-  };
-
-  /**
    * How many data nodes to put in a random sample for partition allocation. 2 node samples provided the best balance
    * of speed and allocation quality in testing. Larger samples (ie 3 nodes) took longer to generate but did not
    * improve the quality of the allocated partitions.

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapManagerTest.java
@@ -162,21 +162,20 @@ public class ClusterMapManagerTest {
 
     // Allocate five partitions that fit within cluster's capacity
     allocatedPartitions =
-        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, true, false);
+        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, true);
     assertEquals(allocatedPartitions.size(), 5);
     assertEquals(clusterMapManager.getWritablePartitionIds().size(), 5);
 
     // Allocate "too many" partitions (1M) to exhaust capacity. Capacity is not exhausted evenly across nodes so some
     // "free" but unusable capacity may be left after trying to allocate these partitions.
     allocatedPartitions =
-        clusterMapManager.allocatePartitions(1000 * 1000, replicaCountPerDataCenter, replicaCapacityInBytes, true,
-            false);
+        clusterMapManager.allocatePartitions(1000 * 1000, replicaCountPerDataCenter, replicaCapacityInBytes, true);
     assertEquals(allocatedPartitions.size() + 5, clusterMapManager.getWritablePartitionIds().size());
     System.out.println(freeCapacityDump(clusterMapManager, testHardwareLayout.getHardwareLayout()));
 
     // Capacity is already exhausted...
     allocatedPartitions =
-        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, true, false);
+        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, true);
     assertEquals(allocatedPartitions.size(), 0);
   }
 
@@ -194,7 +193,7 @@ public class ClusterMapManagerTest {
 
     // Allocate five partitions that fit within cluster's capacity
     allocatedPartitions =
-        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, false, false);
+        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, false);
     assertEquals(allocatedPartitions.size(), 5);
     assertEquals(clusterMapManager.getWritablePartitionIds().size(), 5);
     checkRackUsage(allocatedPartitions);
@@ -203,15 +202,14 @@ public class ClusterMapManagerTest {
     // Allocate "too many" partitions (1M) to exhaust capacity. Capacity is not exhausted evenly across nodes so some
     // "free" but unusable capacity may be left after trying to allocate these partitions.
     allocatedPartitions =
-        clusterMapManager.allocatePartitions(1000 * 1000, replicaCountPerDataCenter, replicaCapacityInBytes, false,
-            false);
+        clusterMapManager.allocatePartitions(1000 * 1000, replicaCountPerDataCenter, replicaCapacityInBytes, false);
     assertEquals(allocatedPartitions.size() + 5, clusterMapManager.getWritablePartitionIds().size());
     System.out.println(freeCapacityDump(clusterMapManager, testHardwareLayout.getHardwareLayout()));
     checkRackUsage(allocatedPartitions);
 
     // Capacity is already exhausted...
     allocatedPartitions =
-        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, false, false);
+        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, false);
     assertEquals(allocatedPartitions.size(), 0);
   }
 
@@ -227,15 +225,15 @@ public class ClusterMapManagerTest {
     List<PartitionId> allocatedPartitions;
     // Require more replicas than there are racks
     allocatedPartitions =
-        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, false, false);
+        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, false);
     assertEquals(allocatedPartitions.size(), 5);
     checkNumReplicasPerDatacenter(allocatedPartitions, 3);
     checkRackUsage(allocatedPartitions);
 
-    // Test with bestEffort enabled.  We should be able to allocate 4 replicas per datacenter b/c we do no longer
-    // require unique racks
+    // Test with retryIfNotRackAware enabled.  We should be able to allocate 4 replicas per datacenter b/c we no
+    // longer require unique racks
     allocatedPartitions =
-        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, false, true);
+        clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, true);
     assertEquals(allocatedPartitions.size(), 5);
     checkNumReplicasPerDatacenter(allocatedPartitions, 4);
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapManagerTest.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import junit.framework.Assert;
 import org.json.JSONException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -160,6 +161,16 @@ public class ClusterMapManagerTest {
     ClusterMapManager clusterMapManager = new ClusterMapManager(partitionLayout);
     List<PartitionId> allocatedPartitions;
 
+    try {
+      // Test with retryIfNotRackAware set to false, this should throw an exception
+      clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, false);
+      Assert.fail("allocatePartitions should not succeed when datacenters are missing rack info "
+          + "and retryIfNotRackAware is false");
+    } catch (IllegalArgumentException e) {
+      // This should be thrown
+    } catch (Throwable e) {
+      Assert.fail("Unexpected exception thrown: " + e);
+    }
     // Allocate five partitions that fit within cluster's capacity
     allocatedPartitions =
         clusterMapManager.allocatePartitions(5, replicaCountPerDataCenter, replicaCapacityInBytes, true);
@@ -214,7 +225,8 @@ public class ClusterMapManagerTest {
   }
 
   @Test
-  public void rackAwareOverAllocationTest() throws JSONException, IOException {
+  public void rackAwareOverAllocationTest()
+      throws JSONException, IOException {
     int replicaCountPerDataCenter = 4;
     long replicaCapacityInBytes = 100 * 1024 * 1024 * 1024L;
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapManagerTest.java
@@ -168,8 +168,6 @@ public class ClusterMapManagerTest {
           + "and retryIfNotRackAware is false");
     } catch (IllegalArgumentException e) {
       // This should be thrown
-    } catch (Throwable e) {
-      Assert.fail("Unexpected exception thrown: " + e);
     }
     // Allocate five partitions that fit within cluster's capacity
     allocatedPartitions =

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DatacenterTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DatacenterTest.java
@@ -79,7 +79,7 @@ public class DatacenterTest {
 
   JSONArray getDataNodesRackAware()
       throws JSONException {
-    return TestUtils.getJsonArrayDataNodesRackAware(dataNodeCount, TestUtils.getLocalHost(), 6666, 7666,
+    return TestUtils.getJsonArrayDataNodesRackAware(dataNodeCount, TestUtils.getLocalHost(), 6666, 7666, 3,
         HardwareState.AVAILABLE, getDisks());
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -15,11 +15,7 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -648,8 +644,7 @@ public class TestUtils {
     List<PartitionId> allocatedPartitions;
 
     allocatedPartitions =
-        clusterMapManager.allocatePartitions(partitionCount, replicaCountPerDatacenter, replicaCapacityInBytes, true,
-            false);
+        clusterMapManager.allocatePartitions(partitionCount, replicaCountPerDatacenter, replicaCapacityInBytes, true);
     assertEquals(allocatedPartitions.size(), 5);
 
     return clusterMapManager;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -189,9 +189,9 @@ public class TestUtils {
       throws JSONException {
     JSONArray jsonArray = new JSONArray();
     for (int i = 0; i < dataNodeCount; ++i) {
-      JSONObject jsonDataNode = (i % 2 == 0)?
-          getJsonDataNode(hostname, basePort + i, sslPort + i, i, hardwareState, disks) :
-          getJsonDataNode(hostname, basePort + i, sslPort + i, hardwareState, disks);
+      JSONObject jsonDataNode =
+          (i % 2 == 0) ? getJsonDataNode(hostname, basePort + i, sslPort + i, i, hardwareState, disks)
+              : getJsonDataNode(hostname, basePort + i, sslPort + i, hardwareState, disks);
       jsonArray.put(jsonDataNode);
     }
     return jsonArray;
@@ -375,8 +375,8 @@ public class TestUtils {
     protected JSONArray getDataNodes(int basePort, int sslPort, JSONArray disks)
         throws JSONException {
       if (rackAware) {
-        return getJsonArrayDataNodesRackAware(dataNodeCount, getLocalHost(), basePort, sslPort,
-            HardwareState.AVAILABLE, disks);
+        return getJsonArrayDataNodesRackAware(dataNodeCount, getLocalHost(), basePort, sslPort, HardwareState.AVAILABLE,
+            disks);
       }
       return getJsonArrayDataNodes(dataNodeCount, getLocalHost(), basePort, sslPort, HardwareState.AVAILABLE, disks);
     }
@@ -648,7 +648,8 @@ public class TestUtils {
     List<PartitionId> allocatedPartitions;
 
     allocatedPartitions =
-        clusterMapManager.allocatePartitions(partitionCount, replicaCountPerDatacenter, replicaCapacityInBytes, false, false);
+        clusterMapManager.allocatePartitions(partitionCount, replicaCountPerDatacenter, replicaCapacityInBytes, true,
+            false);
     assertEquals(allocatedPartitions.size(), 5);
 
     return clusterMapManager;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -150,17 +150,18 @@ public class TestUtils {
    * @param hostname the hostname for each node in the array
    * @param basePort the starting standard port number for nodes generated
    * @param sslPort the starting SSL port number for nodes generated
+   * @param numRacks how many distinct racks the data nodes should use
    * @param hardwareState a {@link HardwareLayout} value for each node
    * @param disks a {@link JSONArray} of disks for each node
    * @return a {@link JSONArray} of nodes
    * @throws JSONException
    */
   public static JSONArray getJsonArrayDataNodesRackAware(int dataNodeCount, String hostname, int basePort, int sslPort,
-      HardwareState hardwareState, JSONArray disks)
+      int numRacks, HardwareState hardwareState, JSONArray disks)
       throws JSONException {
     JSONArray jsonArray = new JSONArray();
     for (int i = 0; i < dataNodeCount; ++i) {
-      jsonArray.put(getJsonDataNode(hostname, basePort + i, sslPort + i, i % 3, hardwareState, disks));
+      jsonArray.put(getJsonDataNode(hostname, basePort + i, sslPort + i, i % numRacks, hardwareState, disks));
     }
     return jsonArray;
   }
@@ -347,11 +348,12 @@ public class TestUtils {
   }
 
   public static class TestHardwareLayout {
-    private static final int defaultDiskCount = 10; // per DataNode
-    private static final long defaultDiskCapacityInBytes = 1000 * 1024 * 1024 * 1024L;
-    private static final int defaultDataNodeCount = 4; // per Datacenter
-    private static final int defaultDatacenterCount = 3;
-    private static final int defaultBasePort = 6666;
+    private static final int DEFAULT_DISK_COUNT = 10; // per DataNode
+    private static final long DEFAULT_DISK_CAPACITY_IN_BYTES = 1000 * 1024 * 1024 * 1024L;
+    private static final int DEFAULT_DATA_NODE_COUNT = 4; // per Datacenter
+    private static final int DEFAULT_DATACENTER_COUNT = 3;
+    private static final int DEFAULT_BASE_PORT = 6666;
+    private static final int DEFAULT_NUM_RACKS = 3;
 
     private long version;
     private int diskCount;
@@ -359,6 +361,7 @@ public class TestUtils {
     private int dataNodeCount;
     private int datacenterCount;
     private int basePort;
+    private int numRacks;
     private boolean rackAware;
 
     private HardwareLayout hardwareLayout;
@@ -371,8 +374,8 @@ public class TestUtils {
     protected JSONArray getDataNodes(int basePort, int sslPort, JSONArray disks)
         throws JSONException {
       if (rackAware) {
-        return getJsonArrayDataNodesRackAware(dataNodeCount, getLocalHost(), basePort, sslPort, HardwareState.AVAILABLE,
-            disks);
+        return getJsonArrayDataNodesRackAware(dataNodeCount, getLocalHost(), basePort, sslPort, numRacks,
+            HardwareState.AVAILABLE, disks);
       }
       return getJsonArrayDataNodes(dataNodeCount, getLocalHost(), basePort, sslPort, HardwareState.AVAILABLE, disks);
     }
@@ -394,13 +397,14 @@ public class TestUtils {
     }
 
     public TestHardwareLayout(String clusterName, int diskCount, long diskCapacityInBytes, int dataNodeCount,
-        int datacenterCount, int basePort, boolean rackAware)
+        int datacenterCount, int basePort, int numRacks, boolean rackAware)
         throws JSONException {
       this.diskCount = diskCount;
       this.diskCapacityInBytes = diskCapacityInBytes;
       this.dataNodeCount = dataNodeCount;
       this.datacenterCount = datacenterCount;
       this.basePort = basePort;
+      this.numRacks = numRacks;
       this.rackAware = rackAware;
 
       this.hardwareLayout = new HardwareLayout(getJsonHardwareLayout(clusterName, getDatacenters()),
@@ -416,8 +420,8 @@ public class TestUtils {
      */
     public TestHardwareLayout(String clusterName, boolean rackAware)
         throws JSONException {
-      this(clusterName, defaultDiskCount, defaultDiskCapacityInBytes, defaultDataNodeCount, defaultDatacenterCount,
-          defaultBasePort, rackAware);
+      this(clusterName, DEFAULT_DISK_COUNT, DEFAULT_DISK_CAPACITY_IN_BYTES, DEFAULT_DATA_NODE_COUNT,
+          DEFAULT_DATACENTER_COUNT, DEFAULT_BASE_PORT, DEFAULT_NUM_RACKS, rackAware);
     }
 
     /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -350,51 +350,6 @@ public class TestUtils {
     return jsonObject;
   }
 
-  /**
-   * Verify that the partitions in the list are on unique racks for each datacenter.
-   *
-   * @param allocatedPartitions the list of partitions to check
-   */
-  public static void checkRackUsage(List<PartitionId> allocatedPartitions) {
-    for (PartitionId partition : allocatedPartitions) {
-      Map<String, Set<Long>> rackSetByDatacenter = new HashMap<>();
-      for (ReplicaId replica : partition.getReplicaIds()) {
-        String datacenter = replica.getDataNodeId().getDatacenterName();
-        Set<Long> rackSet = rackSetByDatacenter.get(datacenter);
-        if (rackSet == null) {
-          rackSet = new HashSet<>();
-          rackSetByDatacenter.put(datacenter, rackSet);
-        }
-
-        long rackId = replica.getDataNodeId().getRackId();
-        if (rackId >= 0) {
-          assertFalse("Allocation was not on unique racks", rackSet.contains(rackId));
-          rackSet.add(rackId);
-        }
-      }
-    }
-  }
-
-  /**
-   * Verify that the partitions in the list have {@code numReplicas} per datacenter
-   *
-   * @param allocatedPartitions the list of partitions to check
-   * @param numReplicas how many replicas a partition should have in each datacenter
-   */
-  public static void checkNumReplicasPerDatacenter(List<PartitionId> allocatedPartitions, int numReplicas) {
-    for (PartitionId partition : allocatedPartitions) {
-      Map<String, Integer> numReplicasMap = new HashMap<>();
-      for (ReplicaId replica : partition.getReplicaIds()) {
-        String datacenter = replica.getDataNodeId().getDatacenterName();
-        Integer replicasInDatacenter = numReplicasMap.containsKey(datacenter)? numReplicasMap.get(datacenter) : 0;
-        numReplicasMap.put(datacenter, replicasInDatacenter+1);
-      }
-      for (int replicasInDatacenter : numReplicasMap.values()) {
-        assertEquals("Datacenter does not have expected number of replicas", numReplicas, replicasInDatacenter);
-      }
-    }
-  }
-
   public static class TestHardwareLayout {
     private static final int defaultDiskCount = 10; // per DataNode
     private static final long defaultDiskCapacityInBytes = 1000 * 1024 * 1024 * 1024L;

--- a/ambry-tools/src/main/java/com.github.ambry.tools/admin/PartitionManager.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/admin/PartitionManager.java
@@ -119,7 +119,7 @@ public class PartitionManager {
         int numberOfPartitions = options.valueOf(numberOfPartitionsOpt);
         int numberOfReplicas = options.valueOf(numberOfReplicasPerDatacenterOpt);
         long replicaCapacityInBytes = options.valueOf(replicaCapacityInBytesOpt);
-        manager.allocatePartitions(numberOfPartitions, numberOfReplicas, replicaCapacityInBytes);
+        manager.allocatePartitions(numberOfPartitions, numberOfReplicas, replicaCapacityInBytes, true, false);
       } else if (operationType.compareToIgnoreCase("AddReplicas") == 0) {
         listOpt.add(partitionIdsToAddReplicasToOpt);
         listOpt.add(datacenterToAddReplicasToOpt);
@@ -135,14 +135,14 @@ public class PartitionManager {
         String datacenterToAddReplicasTo = options.valueOf(datacenterToAddReplicasToOpt);
         if (partitionIdsToAddReplicas.compareToIgnoreCase(".") == 0) {
           for (PartitionId partitionId : manager.getAllPartitions()) {
-            manager.addReplicas(partitionId, datacenterToAddReplicasTo);
+            manager.addReplicas(partitionId, datacenterToAddReplicasTo, true, false);
           }
         } else {
           String[] partitionIds = partitionIdsToAddReplicas.split(",");
           for (String partitionId : partitionIds) {
             for (PartitionId partitionInCluster : manager.getAllPartitions()) {
               if (partitionInCluster.isEqual(partitionId)) {
-                manager.addReplicas(partitionInCluster, datacenterToAddReplicasTo);
+                manager.addReplicas(partitionInCluster, datacenterToAddReplicasTo, true, false);
               }
             }
           }

--- a/ambry-tools/src/main/java/com.github.ambry.tools/admin/PartitionManager.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/admin/PartitionManager.java
@@ -41,34 +41,45 @@ public class PartitionManager {
 
       ArgumentAcceptingOptionSpec<String> operationTypeOpt = parser.accepts("operationType",
           " REQUIRED: The type of operation to perform on the partition. Currently supported"
-              + " operations are 'AddPartition', 'AddReplicas'").withRequiredArg().describedAs("operation_type")
+              + " operations are 'AddPartition', 'AddReplicas'")
+          .withRequiredArg()
+          .describedAs("operation_type")
           .ofType(String.class);
 
-      ArgumentAcceptingOptionSpec<String> hardwareLayoutPathOpt = parser.accepts("hardwareLayoutPath",
-          " REQUIRED: The path to the hardware layout map")
-          .withRequiredArg().describedAs("hardware_layout_path").ofType(String.class);
+      ArgumentAcceptingOptionSpec<String> hardwareLayoutPathOpt =
+          parser.accepts("hardwareLayoutPath", " REQUIRED: The path to the hardware layout map")
+              .withRequiredArg()
+              .describedAs("hardware_layout_path")
+              .ofType(String.class);
 
       ArgumentAcceptingOptionSpec<String> partitionLayoutPathOpt = parser.accepts("partitionLayoutPath",
           "REQUIRED: The path to the partition layout map. If outputPartitionLayoutPath is not defined,"
-              + "this file is updated with the new partitions").withRequiredArg().describedAs("partition_layout_path")
+              + "this file is updated with the new partitions")
+          .withRequiredArg()
+          .describedAs("partition_layout_path")
           .ofType(String.class);
 
       ArgumentAcceptingOptionSpec<String> outputPartitionLayoutPathOpt = parser.accepts("outputPartitionLayoutPath",
-          "The path to the output partition layout map. The file is updated with the new partitions").withOptionalArg()
-          .describedAs("output_partition_layout_path").ofType(String.class);
+          "The path to the output partition layout map. The file is updated with the new partitions")
+          .withOptionalArg()
+          .describedAs("output_partition_layout_path")
+          .ofType(String.class);
 
       ArgumentAcceptingOptionSpec<Integer> numberOfPartitionsOpt =
-          parser.accepts("numberOfPartitionsToAdd", "The number of partitions to add").withOptionalArg()
+          parser.accepts("numberOfPartitionsToAdd", "The number of partitions to add")
+              .withOptionalArg()
               .ofType(Integer.class);
 
-      ArgumentAcceptingOptionSpec<Integer> numberOfReplicasPerDatacenterOpt = parser
-          .accepts("numberOfReplicasPerDatacenter",
-              "The number of replicas for the partition per datacenter when adding partitions").withOptionalArg()
-          .ofType(Integer.class);
+      ArgumentAcceptingOptionSpec<Integer> numberOfReplicasPerDatacenterOpt =
+          parser.accepts("numberOfReplicasPerDatacenter",
+              "The number of replicas for the partition per datacenter when adding partitions")
+              .withOptionalArg()
+              .ofType(Integer.class);
 
       ArgumentAcceptingOptionSpec<Long> replicaCapacityInBytesOpt =
           parser.accepts("replicaCapacityInBytes", "The capacity of each replica in bytes for the partitions to add")
-              .withOptionalArg().ofType(Long.class);
+              .withOptionalArg()
+              .ofType(Long.class);
 
       ArgumentAcceptingOptionSpec<String> partitionIdsToAddReplicasToOpt =
           parser.accepts("partitionIdToAddReplicasTo", "The partitionIds to add replicas to. This can either take a " +
@@ -77,10 +88,11 @@ public class PartitionManager {
 
       ArgumentAcceptingOptionSpec<String> datacenterToAddReplicasToOpt =
           parser.accepts("datacenterToAddReplicasTo", "The data center to which replicas need to be added to")
-              .withOptionalArg().ofType(String.class);
+              .withOptionalArg()
+              .ofType(String.class);
 
-      String retryIfNotRackAwareFlag = "retryIfNotRackAware";
-      parser.accepts(retryIfNotRackAwareFlag,
+      String attemptNonRackAwareOnFailureFlag = "attemptNonRackAwareOnFailure";
+      parser.accepts(attemptNonRackAwareOnFailureFlag,
           "If a rack-aware partition allocation cannot be found, attempt a non rack-aware one");
 
       OptionSet options = parser.parse(args);
@@ -98,10 +110,11 @@ public class PartitionManager {
       }
       String hardwareLayoutPath = options.valueOf(hardwareLayoutPathOpt);
       String partitionLayoutPath = options.valueOf(partitionLayoutPathOpt);
-      String outputPartitionLayoutPath = options.has(outputPartitionLayoutPathOpt) ?
-          options.valueOf(outputPartitionLayoutPathOpt) : partitionLayoutPath;
+      String outputPartitionLayoutPath =
+          options.has(outputPartitionLayoutPathOpt) ? options.valueOf(outputPartitionLayoutPathOpt)
+              : partitionLayoutPath;
       String operationType = options.valueOf(operationTypeOpt);
-      boolean retryIfNotRackAware = options.has(retryIfNotRackAwareFlag);
+      boolean attemptNonRackAwareOnFailure = options.has(attemptNonRackAwareOnFailureFlag);
 
       String fileString = null;
       try {
@@ -131,7 +144,8 @@ public class PartitionManager {
         int numberOfPartitions = options.valueOf(numberOfPartitionsOpt);
         int numberOfReplicas = options.valueOf(numberOfReplicasPerDatacenterOpt);
         long replicaCapacityInBytes = options.valueOf(replicaCapacityInBytesOpt);
-        manager.allocatePartitions(numberOfPartitions, numberOfReplicas, replicaCapacityInBytes, retryIfNotRackAware);
+        manager.allocatePartitions(numberOfPartitions, numberOfReplicas, replicaCapacityInBytes,
+            attemptNonRackAwareOnFailure);
       } else if (operationType.compareToIgnoreCase("AddReplicas") == 0) {
         listOpt.add(partitionIdsToAddReplicasToOpt);
         listOpt.add(datacenterToAddReplicasToOpt);
@@ -147,14 +161,14 @@ public class PartitionManager {
         String datacenterToAddReplicasTo = options.valueOf(datacenterToAddReplicasToOpt);
         if (partitionIdsToAddReplicas.compareToIgnoreCase(".") == 0) {
           for (PartitionId partitionId : manager.getAllPartitions()) {
-            manager.addReplicas(partitionId, datacenterToAddReplicasTo, retryIfNotRackAware);
+            manager.addReplicas(partitionId, datacenterToAddReplicasTo, attemptNonRackAwareOnFailure);
           }
         } else {
           String[] partitionIds = partitionIdsToAddReplicas.split(",");
           for (String partitionId : partitionIds) {
             for (PartitionId partitionInCluster : manager.getAllPartitions()) {
               if (partitionInCluster.isEqual(partitionId)) {
-                manager.addReplicas(partitionInCluster, datacenterToAddReplicasTo, retryIfNotRackAware);
+                manager.addReplicas(partitionInCluster, datacenterToAddReplicasTo, attemptNonRackAwareOnFailure);
               }
             }
           }

--- a/ambry-tools/src/main/java/com.github.ambry.tools/admin/PartitionManager.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/admin/PartitionManager.java
@@ -79,11 +79,9 @@ public class PartitionManager {
           parser.accepts("datacenterToAddReplicasTo", "The data center to which replicas need to be added to")
               .withOptionalArg().ofType(String.class);
 
-      String disableRackAwarenessFlag = "disableRackAwareness";
-      parser.accepts(disableRackAwarenessFlag, "Disable rack-aware partition allocation");
-
-      String bestEffortFlag = "bestEffort";
-      parser.accepts(bestEffortFlag, "If rack-aware partition allocation fails, attempt a non rack-aware allocation");
+      String retryIfNotRackAwareFlag = "retryIfNotRackAware";
+      parser.accepts(retryIfNotRackAwareFlag,
+          "If a rack-aware partition allocation cannot be found, attempt a non rack-aware one");
 
       OptionSet options = parser.parse(args);
 
@@ -103,8 +101,7 @@ public class PartitionManager {
       String outputPartitionLayoutPath = options.has(outputPartitionLayoutPathOpt) ?
           options.valueOf(outputPartitionLayoutPathOpt) : partitionLayoutPath;
       String operationType = options.valueOf(operationTypeOpt);
-      boolean disableRackAwareness = options.has(disableRackAwarenessFlag);
-      boolean bestEffort = options.has(bestEffortFlag);
+      boolean retryIfNotRackAware = options.has(retryIfNotRackAwareFlag);
 
       String fileString = null;
       try {
@@ -134,8 +131,7 @@ public class PartitionManager {
         int numberOfPartitions = options.valueOf(numberOfPartitionsOpt);
         int numberOfReplicas = options.valueOf(numberOfReplicasPerDatacenterOpt);
         long replicaCapacityInBytes = options.valueOf(replicaCapacityInBytesOpt);
-        manager.allocatePartitions(numberOfPartitions, numberOfReplicas, replicaCapacityInBytes,
-            disableRackAwareness, bestEffort);
+        manager.allocatePartitions(numberOfPartitions, numberOfReplicas, replicaCapacityInBytes, retryIfNotRackAware);
       } else if (operationType.compareToIgnoreCase("AddReplicas") == 0) {
         listOpt.add(partitionIdsToAddReplicasToOpt);
         listOpt.add(datacenterToAddReplicasToOpt);
@@ -151,14 +147,14 @@ public class PartitionManager {
         String datacenterToAddReplicasTo = options.valueOf(datacenterToAddReplicasToOpt);
         if (partitionIdsToAddReplicas.compareToIgnoreCase(".") == 0) {
           for (PartitionId partitionId : manager.getAllPartitions()) {
-            manager.addReplicas(partitionId, datacenterToAddReplicasTo, disableRackAwareness, bestEffort);
+            manager.addReplicas(partitionId, datacenterToAddReplicasTo, retryIfNotRackAware);
           }
         } else {
           String[] partitionIds = partitionIdsToAddReplicas.split(",");
           for (String partitionId : partitionIds) {
             for (PartitionId partitionInCluster : manager.getAllPartitions()) {
               if (partitionInCluster.isEqual(partitionId)) {
-                manager.addReplicas(partitionInCluster, datacenterToAddReplicasTo, disableRackAwareness, bestEffort);
+                manager.addReplicas(partitionInCluster, datacenterToAddReplicasTo, retryIfNotRackAware);
               }
             }
           }


### PR DESCRIPTION
- Added implementations of rack-aware partition allocation algorithms to ClusterMapManager

- Added associated test code for rack-aware allocation

- Added CLI with rack-aware options to PartitionManager

Previously, I had two rack-aware allocator implementations for testing/evaluation purposes.  One used the random choice strategy described here (http://marios.io/2011/08/31/multiple_choice_paradigm/), and the other (currently unused) first shuffled the nodes and then tried the node with the most free space.  The former performed better in testing, so I removed the latter from the PR.

*Time to review:* 30-40 Min.
*Primary Reviewers*: Gopal, Priyesh
*Coverage*: 100% branch/line coverage for newly added lines in ClusterMapManager (`allocatePartitions`, `allocateDisksForPartitionWithPotentialRetry`, `allocateDisksForPartition`, `getRandomDiskCandidateSample`).  No unit tests for PartitionManager and other CLI tools in ambry-tools

| Class | Class, % | Method, % | Line, % |
| --- | --- | --- | --- |
| ClusterMapManager | 66.7% (2/ 3) | 80.6% (29/ 36) | 71.6% (156/ 218) |

*Truncated generated rack aware partition layout:* https://gist.github.com/cgtz/dfeb53fc8d4ea1d2d972b3b9daee2187

*Layout analyzer output on generated partition layout:* https://gist.github.com/cgtz/608af99f02e30d3ca4702bd16cc36afd