### PR TITLE
Keeping connections alive on GONE and NOT_FOUND responses.

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
@@ -27,6 +27,7 @@ import com.github.ambry.router.RouterErrorCode;
  * {@link ResponseStatus#InternalServerError}
  * {@link ResponseStatus#Forbidden}
  * {@link ResponseStatus#ProxyAuthenticationRequired}
+ * {@link ResponseStatus#Unauthorized}
  * <p/>
  * About logging:
  * Generally, error codes not belonging to the group {@link #InternalServerError} are logged at DEBUG level.
@@ -53,6 +54,11 @@ public enum RestServiceErrorCode {
   ResourceDirty,
 
   /**
+   * Client has sent a request that cannot be processed due to authorization failure.
+   */
+  Unauthorized,
+
+  /**
    * Generic BadRequest error code when a client provides a request that is not fit for processing.
    */
   BadRequest,
@@ -76,10 +82,6 @@ public enum RestServiceErrorCode {
    */
   MissingArgs,
   /**
-   * Client has sent a request that cannot be processed due to authorization failure.
-   */
-  Unauthorized,
-  /**
    * Indicates that HttpObject received was not of a recognized type (Currently this is internal to Netty and this
    * error indicates that the received HttpObject was neither HttpRequest nor HttpContent).
    */
@@ -94,14 +96,14 @@ public enum RestServiceErrorCode {
   UnsupportedOperation,
 
   /**
-   * Indicates that {@link IdConverter} encountered some exception during ID conversion
-   */
-  IdConverterServiceError,
-  /**
    * Generic InternalServerError that is a result of problems on the server side that is not caused by the client and
    * there is nothing that a client can do about it.
    */
   InternalServerError,
+  /**
+   * Indicates that {@link IdConverter} encountered some exception during ID conversion
+   */
+  IdConverterServiceError,
   /**
    * Indicates that an object that is needed for the request could not be created due to an internal server error.
    */

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
@@ -43,17 +43,19 @@ public enum RestServiceErrorCode {
   NotFound,
 
   /**
-   * Generic BadRequest error code when a client provides a request that is not fit for processing.
-   */
-  BadRequest,
-  /**
    * Resource scan still in progress and result not yet available
    */
   ResourceScanInProgress,
+
   /**
    * Resource scan has deducted that the resource is not safe for serving
    */
   ResourceDirty,
+
+  /**
+   * Generic BadRequest error code when a client provides a request that is not fit for processing.
+   */
+  BadRequest,
   /**
    * Client has sent arguments (whether in the URI or in the headers) that are not in the format that is expected or if
    * the number of values for an argument expected by the server does not match what the client sent.

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -325,6 +325,7 @@ public class FrontendIntegrationTest {
       fail("postBlobAndVerify did not return a blob ID");
     }
     discardContent(responseParts, 1);
+    assertTrue("Channel should be active", HttpHeaders.isKeepAlive(response));
     return blobId;
   }
 
@@ -349,6 +350,7 @@ public class FrontendIntegrationTest {
         response.headers().get(RestUtils.Headers.BLOB_SIZE));
     ByteBuffer responseContent = getContent(response, responseParts);
     assertArrayEquals("GET content does not match original content", expectedContent.array(), responseContent.array());
+    assertTrue("Channel should be active", HttpHeaders.isKeepAlive(response));
   }
 
   /**
@@ -368,6 +370,7 @@ public class FrontendIntegrationTest {
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.getStatus());
     checkCommonGetHeadHeaders(response.headers());
     verifyUserMetadata(expectedHeaders, response, usermetadata, responseParts);
+    assertTrue("Channel should be active", HttpHeaders.isKeepAlive(response));
   }
 
   /**
@@ -388,6 +391,7 @@ public class FrontendIntegrationTest {
     checkCommonGetHeadHeaders(response.headers());
     verifyBlobProperties(expectedHeaders, response);
     verifyUserMetadata(expectedHeaders, response, usermetadata, responseParts);
+    assertTrue("Channel should be active", HttpHeaders.isKeepAlive(response));
   }
 
   /**
@@ -411,6 +415,7 @@ public class FrontendIntegrationTest {
         HttpHeaders.getHeader(response, HttpHeaders.Names.CONTENT_TYPE));
     verifyBlobProperties(expectedHeaders, response);
     discardContent(responseParts, 1);
+    assertTrue("Channel should be active", HttpHeaders.isKeepAlive(response));
   }
 
   /**
@@ -516,6 +521,7 @@ public class FrontendIntegrationTest {
     assertEquals("Unexpected response status", expectedStatusCode, response.getStatus());
     assertTrue("No Date header", HttpHeaders.getDateHeader(response, HttpHeaders.Names.DATE, null) != null);
     discardContent(responseParts, 1);
+    assertTrue("Channel should be active", HttpHeaders.isKeepAlive(response));
   }
 
   /**
@@ -552,6 +558,7 @@ public class FrontendIntegrationTest {
       fail("postBlobAndVerify did not return a blob ID");
     }
     discardContent(responseParts, 1);
+    assertTrue("Channel should be active", HttpHeaders.isKeepAlive(response));
     return blobId;
   }
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyClient.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyClient.java
@@ -230,7 +230,7 @@ public class NettyClient implements Closeable {
       } else if (in.getDecoderResult().isFailure()) {
         Throwable cause = in.getDecoderResult().cause();
         if (cause instanceof Exception) {
-          exception = (Exception) in.getDecoderResult().cause();
+          exception = (Exception) cause;
         } else {
           exception =
               new Exception("Encountered Throwable when trying to decode response. Message: " + cause.getMessage());

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyClient.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyClient.java
@@ -225,8 +225,17 @@ public class NettyClient implements Closeable {
       // Make sure that we increase refCnt because we are going to process it async. The other end has to release
       // after processing.
       responseParts.offer(ReferenceCountUtil.retain(in));
-      if (in instanceof HttpResponse) {
+      if (in instanceof HttpResponse && in.getDecoderResult().isSuccess()) {
         isKeepAlive = HttpHeaders.isKeepAlive((HttpResponse) in);
+      } else if (in.getDecoderResult().isFailure()) {
+        Throwable cause = in.getDecoderResult().cause();
+        if (cause instanceof Exception) {
+          exception = (Exception) in.getDecoderResult().cause();
+        } else {
+          exception =
+              new Exception("Encountered Throwable when trying to decode response. Message: " + cause.getMessage());
+        }
+        invokeFutureAndCallback();
       }
       if (in instanceof LastHttpContent) {
         if (isKeepAlive) {

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
@@ -183,7 +183,6 @@ public class NettyMessageProcessorTest {
     channel.writeInbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer(content.getBytes())));
     HttpResponse response = (HttpResponse) channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
-    assertFalse("Channel is still active", channel.isActive());
 
     // content without request on a channel that was kept alive
     channel = createChannel();
@@ -201,7 +200,6 @@ public class NettyMessageProcessorTest {
     channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
     response = (HttpResponse) channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
-    assertFalse("Channel is still active", channel.isActive());
 
     // content when no content is expected.
     channel = createChannel();
@@ -209,14 +207,12 @@ public class NettyMessageProcessorTest {
     channel.writeInbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer(content.getBytes())));
     response = (HttpResponse) channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
-    assertFalse("Channel is still active", channel.isActive());
 
     // wrong HTTPObject.
     channel = createChannel();
     channel.writeInbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
     response = (HttpResponse) channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
-    assertFalse("Channel is still active", channel.isActive());
   }
 
   /**
@@ -316,6 +312,7 @@ public class NettyMessageProcessorTest {
       fail("Post did not succeed after 100ms. There is an error or timeout needs to increase");
     }
     assertNotNull("Blob id operated on cannot be null", notificationSystem.blobIdOperatedOn);
+    assertTrue("Channel should be active", channel.isActive());
     return router.getActiveBlobs().get(notificationSystem.blobIdOperatedOn).getBlob();
   }
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -123,15 +124,28 @@ public class NettyResponseChannelTest {
   @Test
   public void onResponseCompleteWithExceptionTest() {
     // Throws BadRequest RestServiceException. There should be a BAD_REQUEST HTTP response.
-    doOnResponseCompleteWithExceptionTest(TestingUri.OnResponseCompleteWithBadRequest, HttpResponseStatus.BAD_REQUEST);
+    doOnResponseCompleteWithExceptionTest(RestServiceErrorCode.BadRequest, HttpResponseStatus.BAD_REQUEST, true);
+
+    // Throws Deleted RestServiceException. There should be a GONE HTTP response.
+    doOnResponseCompleteWithExceptionTest(RestServiceErrorCode.Deleted, HttpResponseStatus.GONE, false);
+
+    // Throws NotFound RestServiceException. There should be a NOT_FOUND HTTP response.
+    doOnResponseCompleteWithExceptionTest(RestServiceErrorCode.NotFound, HttpResponseStatus.NOT_FOUND, false);
+
+    // Throws ResourceScanInProgress RestServiceException. There should be a PROXY_AUTHENTICATION_REQUIRED HTTP
+    // response.
+    doOnResponseCompleteWithExceptionTest(RestServiceErrorCode.ResourceScanInProgress,
+        HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED, true);
+
+    // Throws ResourceDirty RestServiceException. There should be a FORBIDDEN HTTP response.
+    doOnResponseCompleteWithExceptionTest(RestServiceErrorCode.ResourceDirty, HttpResponseStatus.FORBIDDEN, true);
 
     // Throws InternalServerError RestServiceException. There should be a INTERNAL_SERVER_ERROR HTTP response.
-    doOnResponseCompleteWithExceptionTest(TestingUri.OnResponseCompleteWithInternalServerError,
-        HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    doOnResponseCompleteWithExceptionTest(RestServiceErrorCode.InternalServerError,
+        HttpResponseStatus.INTERNAL_SERVER_ERROR, true);
 
     // Throws RuntimeException. There should be a INTERNAL_SERVER_ERROR HTTP response.
-    doOnResponseCompleteWithExceptionTest(TestingUri.OnResponseCompleteWithNonRestException,
-        HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    doOnResponseCompleteWithExceptionTest(null, HttpResponseStatus.INTERNAL_SERVER_ERROR, true);
   }
 
   /**
@@ -166,7 +180,7 @@ public class NettyResponseChannelTest {
   public void behaviourUnderWriteFailuresTest()
       throws Exception {
     onResponseCompleteUnderWriteFailureTest(TestingUri.ImmediateResponseComplete);
-    onResponseCompleteUnderWriteFailureTest(TestingUri.OnResponseCompleteWithBadRequest);
+    onResponseCompleteUnderWriteFailureTest(TestingUri.OnResponseCompleteWithNonRestException);
 
     // writing to channel with a outbound handler that generates an Exception
     try {
@@ -342,19 +356,31 @@ public class NettyResponseChannelTest {
   // onResponseCompleteWithExceptionTest() helpers
 
   /**
-   * Creates a channel and sends the request to the {@link EmbeddedChannel}. Checks the response for the expected
-   * status code.
-   * @param uri the uri to hit.
+   * Creates a channel and sends a request (that induces an exception) to the {@link EmbeddedChannel}. Checks the
+   * response for the {@code expectedResponseStatus}.
+   * @param restServiceErrorCode the {@link RestServiceErrorCode} to set in the header. If {@code null}, the testing uri
+   *                             {@link TestingUri#OnResponseCompleteWithNonRestException} is used. Otherwise the
+   *                             testing uri {@link TestingUri#OnResponseCompleteWithRestException} is used.
    * @param expectedResponseStatus the response status that is expected.
+   * @param shouldClose {@code true} if the channel should have been closed on this exception. {@code false} if not.
    */
-  private void doOnResponseCompleteWithExceptionTest(TestingUri uri, HttpResponseStatus expectedResponseStatus) {
+  private void doOnResponseCompleteWithExceptionTest(RestServiceErrorCode restServiceErrorCode,
+      HttpResponseStatus expectedResponseStatus, boolean shouldClose) {
+    HttpHeaders httpHeaders = new DefaultHttpHeaders();
+    TestingUri uri = TestingUri.OnResponseCompleteWithNonRestException;
+    if (restServiceErrorCode != null) {
+      uri = TestingUri.OnResponseCompleteWithRestException;
+      httpHeaders.set(MockNettyMessageProcessor.REST_SERVICE_ERROR_CODE_HEADER_NAME, restServiceErrorCode);
+    }
     EmbeddedChannel channel = createEmbeddedChannel();
-    channel.writeInbound(RestTestUtils.createRequest(HttpMethod.GET, uri.toString(), null));
+    channel.writeInbound(RestTestUtils.createRequest(HttpMethod.GET, uri.toString(), httpHeaders));
 
     HttpResponse response = (HttpResponse) channel.readOutbound();
     assertEquals("Unexpected response status", expectedResponseStatus, response.getStatus());
-    // Channel should be closed.
-    assertFalse("Channel not closed on the server", channel.isActive());
+    assertEquals("Channel state (open/close) not as expected", shouldClose, !channel.isActive());
+    assertEquals("Connection header should be consistent with channel state", shouldClose,
+        !HttpHeaders.isKeepAlive(response));
+    channel.close();
   }
 
   // badStateTransitionsTest() helpers
@@ -505,16 +531,11 @@ enum TestingUri {
   MultipleOnResponseComplete,
   /**
    * When this request is received, {@link RestResponseChannel#onResponseComplete(Exception)} is called
-   * immediately with a {@link RestServiceException} as {@code cause}. The exception message is the URI string and the
-   * error code is {@link RestServiceErrorCode#BadRequest}.
+   * immediately with a {@link RestServiceException} as {@code cause}. The exception message and error code is the
+   * {@link RestServiceErrorCode} passed in as the value of the header
+   * {@link MockNettyMessageProcessor#REST_SERVICE_ERROR_CODE_HEADER_NAME}.
    */
-  OnResponseCompleteWithBadRequest,
-  /**
-   * When this request is received, {@link RestResponseChannel#onResponseComplete(Exception)} is called
-   * immediately with a {@link RestServiceException} as {@code cause}. The exception message is the URI string and the
-   * error code is {@link RestServiceErrorCode#InternalServerError}.
-   */
-  OnResponseCompleteWithInternalServerError,
+  OnResponseCompleteWithRestException,
   /**
    * When this request is received, {@link RestResponseChannel#onResponseComplete(Exception)} is called
    * immediately with a {@link RuntimeException} as {@code cause}. The exception message is the URI string.
@@ -570,9 +591,10 @@ enum TestingUri {
  * Exposes some URI strings through which a predefined flow can be executed and verified.
  */
 class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> {
-  public static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
-  public static final String CUSTOM_HEADER_NAME = "customHeader";
-  public static final String STATUS_HEADER_NAME = "status";
+  static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
+  static final String CUSTOM_HEADER_NAME = "customHeader";
+  static final String STATUS_HEADER_NAME = "status";
+  static final String REST_SERVICE_ERROR_CODE_HEADER_NAME = "restServiceErrorCode";
 
   private ChannelHandlerContext ctx;
   private NettyRequest request;
@@ -651,16 +673,10 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
         assertFalse("Request channel is not closed", request.isOpen());
         restResponseChannel.onResponseComplete(null);
         break;
-      case OnResponseCompleteWithBadRequest:
-        restResponseChannel.onResponseComplete(
-            new RestServiceException(TestingUri.OnResponseCompleteWithBadRequest.toString(),
-                RestServiceErrorCode.BadRequest));
-        assertFalse("Request channel is not closed", request.isOpen());
-        break;
-      case OnResponseCompleteWithInternalServerError:
-        restResponseChannel.onResponseComplete(
-            new RestServiceException(TestingUri.OnResponseCompleteWithInternalServerError.toString(),
-                RestServiceErrorCode.InternalServerError));
+      case OnResponseCompleteWithRestException:
+        String errorCodeStr = (String) request.getArgs().get(REST_SERVICE_ERROR_CODE_HEADER_NAME);
+        RestServiceErrorCode errorCode = RestServiceErrorCode.valueOf(errorCodeStr);
+        restResponseChannel.onResponseComplete(new RestServiceException(errorCodeStr, errorCode));
         assertFalse("Request channel is not closed", request.isOpen());
         break;
       case OnResponseCompleteWithNonRestException:

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -62,21 +62,17 @@ import static org.junit.Assert.*;
  * {@link MockNettyMessageProcessor#handleContent(HttpContent)}
  */
 public class NettyResponseChannelTest {
-  private static final Map<RestServiceErrorCode, HttpResponseStatus> REST__ERROR_CODE_TO_HTTP__STATUS = new HashMap<>();
+  private static final Map<RestServiceErrorCode, HttpResponseStatus> REST_ERROR_CODE_TO_HTTP_STATUS = new HashMap<>();
 
   static {
-    REST__ERROR_CODE_TO_HTTP__STATUS
-        .put(RestServiceErrorCode.BadRequest, HttpResponseStatus.BAD_REQUEST);
-    REST__ERROR_CODE_TO_HTTP__STATUS
-        .put(RestServiceErrorCode.Unauthorized, HttpResponseStatus.UNAUTHORIZED);
-    REST__ERROR_CODE_TO_HTTP__STATUS.put(RestServiceErrorCode.Deleted, HttpResponseStatus.GONE);
-    REST__ERROR_CODE_TO_HTTP__STATUS
-        .put(RestServiceErrorCode.NotFound, HttpResponseStatus.NOT_FOUND);
-    REST__ERROR_CODE_TO_HTTP__STATUS
+    REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.BadRequest, HttpResponseStatus.BAD_REQUEST);
+    REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.Unauthorized, HttpResponseStatus.UNAUTHORIZED);
+    REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.Deleted, HttpResponseStatus.GONE);
+    REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.NotFound, HttpResponseStatus.NOT_FOUND);
+    REST_ERROR_CODE_TO_HTTP_STATUS
         .put(RestServiceErrorCode.ResourceScanInProgress, HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED);
-    REST__ERROR_CODE_TO_HTTP__STATUS
-        .put(RestServiceErrorCode.ResourceDirty, HttpResponseStatus.FORBIDDEN);
-    REST__ERROR_CODE_TO_HTTP__STATUS
+    REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.ResourceDirty, HttpResponseStatus.FORBIDDEN);
+    REST_ERROR_CODE_TO_HTTP_STATUS
         .put(RestServiceErrorCode.InternalServerError, HttpResponseStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -144,8 +140,7 @@ public class NettyResponseChannelTest {
    */
   @Test
   public void onResponseCompleteWithExceptionTest() {
-    for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST__ERROR_CODE_TO_HTTP__STATUS
-        .entrySet()) {
+    for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST_ERROR_CODE_TO_HTTP_STATUS.entrySet()) {
       boolean shouldClose = NettyResponseChannel.CLOSE_CONNECTION_ERROR_STATUSES.contains(entry.getValue());
       doOnResponseCompleteWithExceptionTest(entry.getKey(), entry.getValue(), shouldClose);
     }
@@ -335,8 +330,7 @@ public class NettyResponseChannelTest {
   @Test
   public void noBodyForHeadTest() {
     EmbeddedChannel channel = createEmbeddedChannel();
-    for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST__ERROR_CODE_TO_HTTP__STATUS
-        .entrySet()) {
+    for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST_ERROR_CODE_TO_HTTP_STATUS.entrySet()) {
       HttpHeaders httpHeaders = new DefaultHttpHeaders();
       httpHeaders.set(MockNettyMessageProcessor.REST_SERVICE_ERROR_CODE_HEADER_NAME, entry.getKey());
       channel.writeInbound(RestTestUtils
@@ -371,8 +365,7 @@ public class NettyResponseChannelTest {
     HttpMethod[] HTTP_METHODS = {HttpMethod.POST, HttpMethod.GET, HttpMethod.HEAD, HttpMethod.DELETE};
     EmbeddedChannel channel = createEmbeddedChannel();
     for (HttpMethod httpMethod : HTTP_METHODS) {
-      for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST__ERROR_CODE_TO_HTTP__STATUS
-          .entrySet()) {
+      for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST_ERROR_CODE_TO_HTTP_STATUS.entrySet()) {
         HttpHeaders httpHeaders = new DefaultHttpHeaders();
         httpHeaders.set(MockNettyMessageProcessor.REST_SERVICE_ERROR_CODE_HEADER_NAME, entry.getKey());
         channel.writeInbound(RestTestUtils

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -62,22 +62,21 @@ import static org.junit.Assert.*;
  * {@link MockNettyMessageProcessor#handleContent(HttpContent)}
  */
 public class NettyResponseChannelTest {
-  private static final Map<RestServiceErrorCode, HttpResponseStatus>
-      REST_SERVICE_ERROR_CODE_TO_HTTP_RESPONSE_STATUS_MAP = new HashMap<>();
+  private static final Map<RestServiceErrorCode, HttpResponseStatus> REST__ERROR_CODE_TO_HTTP__STATUS = new HashMap<>();
 
   static {
-    REST_SERVICE_ERROR_CODE_TO_HTTP_RESPONSE_STATUS_MAP
+    REST__ERROR_CODE_TO_HTTP__STATUS
         .put(RestServiceErrorCode.BadRequest, HttpResponseStatus.BAD_REQUEST);
-    REST_SERVICE_ERROR_CODE_TO_HTTP_RESPONSE_STATUS_MAP
+    REST__ERROR_CODE_TO_HTTP__STATUS
         .put(RestServiceErrorCode.Unauthorized, HttpResponseStatus.UNAUTHORIZED);
-    REST_SERVICE_ERROR_CODE_TO_HTTP_RESPONSE_STATUS_MAP.put(RestServiceErrorCode.Deleted, HttpResponseStatus.GONE);
-    REST_SERVICE_ERROR_CODE_TO_HTTP_RESPONSE_STATUS_MAP
+    REST__ERROR_CODE_TO_HTTP__STATUS.put(RestServiceErrorCode.Deleted, HttpResponseStatus.GONE);
+    REST__ERROR_CODE_TO_HTTP__STATUS
         .put(RestServiceErrorCode.NotFound, HttpResponseStatus.NOT_FOUND);
-    REST_SERVICE_ERROR_CODE_TO_HTTP_RESPONSE_STATUS_MAP
+    REST__ERROR_CODE_TO_HTTP__STATUS
         .put(RestServiceErrorCode.ResourceScanInProgress, HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED);
-    REST_SERVICE_ERROR_CODE_TO_HTTP_RESPONSE_STATUS_MAP
+    REST__ERROR_CODE_TO_HTTP__STATUS
         .put(RestServiceErrorCode.ResourceDirty, HttpResponseStatus.FORBIDDEN);
-    REST_SERVICE_ERROR_CODE_TO_HTTP_RESPONSE_STATUS_MAP
+    REST__ERROR_CODE_TO_HTTP__STATUS
         .put(RestServiceErrorCode.InternalServerError, HttpResponseStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -145,7 +144,7 @@ public class NettyResponseChannelTest {
    */
   @Test
   public void onResponseCompleteWithExceptionTest() {
-    for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST_SERVICE_ERROR_CODE_TO_HTTP_RESPONSE_STATUS_MAP
+    for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST__ERROR_CODE_TO_HTTP__STATUS
         .entrySet()) {
       boolean shouldClose = NettyResponseChannel.CLOSE_CONNECTION_ERROR_STATUSES.contains(entry.getValue());
       doOnResponseCompleteWithExceptionTest(entry.getKey(), entry.getValue(), shouldClose);
@@ -336,7 +335,7 @@ public class NettyResponseChannelTest {
   @Test
   public void noBodyForHeadTest() {
     EmbeddedChannel channel = createEmbeddedChannel();
-    for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST_SERVICE_ERROR_CODE_TO_HTTP_RESPONSE_STATUS_MAP
+    for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST__ERROR_CODE_TO_HTTP__STATUS
         .entrySet()) {
       HttpHeaders httpHeaders = new DefaultHttpHeaders();
       httpHeaders.set(MockNettyMessageProcessor.REST_SERVICE_ERROR_CODE_HEADER_NAME, entry.getKey());
@@ -372,7 +371,7 @@ public class NettyResponseChannelTest {
     HttpMethod[] HTTP_METHODS = {HttpMethod.POST, HttpMethod.GET, HttpMethod.HEAD, HttpMethod.DELETE};
     EmbeddedChannel channel = createEmbeddedChannel();
     for (HttpMethod httpMethod : HTTP_METHODS) {
-      for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST_SERVICE_ERROR_CODE_TO_HTTP_RESPONSE_STATUS_MAP
+      for (Map.Entry<RestServiceErrorCode, HttpResponseStatus> entry : REST__ERROR_CODE_TO_HTTP__STATUS
           .entrySet()) {
         HttpHeaders httpHeaders = new DefaultHttpHeaders();
         httpHeaders.set(MockNettyMessageProcessor.REST_SERVICE_ERROR_CODE_HEADER_NAME, entry.getKey());


### PR DESCRIPTION
Keeping connections alive on error responses.

The current code closes connections on all error responses which is wasteful.

With these changes, we keep connections alive when we have errors on non-POST requests.

Also fixes a bug where a HEAD request for a deleted blob returned a body (HEAD is not supposed to return a body).
Also adds some more keep-alive tests.

**Primary reviewers: Siva, Priyesh**
**Expected time to review: ~15 mins**

Unit test coverage
NettyResponseChannel	100% (8/ 8)	97.1% (33/ 34)	95.5% (252/ 264)

New lines are 100% covered.