### PR TITLE
Fix server test cleanup and resource consumption issues.

### DIFF
--- a/ambry-server/src/test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/MockCluster.java
@@ -47,9 +47,9 @@ public class MockCluster {
   private NotificationSystem notificationSystem;
   private boolean serverInitialized = false;
 
-  public MockCluster(NotificationSystem notificationSystem, Time time)
+  public MockCluster(NotificationSystem notificationSystem, boolean enableHardDeletes, Time time)
       throws IOException, InstantiationException, URISyntaxException, GeneralSecurityException {
-    this(notificationSystem, false, "", new Properties(), true, time);
+    this(notificationSystem, false, "", new Properties(), enableHardDeletes, time);
   }
 
   public MockCluster(NotificationSystem notificationSystem, boolean enableSSL, String datacenters, Properties sslProps,
@@ -57,7 +57,7 @@ public class MockCluster {
       throws IOException, InstantiationException, URISyntaxException, GeneralSecurityException {
     // sslEnabledDatacenters represents comma separated list of datacenters to which ssl should be enabled
     this.notificationSystem = notificationSystem;
-    clusterMap = new MockClusterMap(enableSSL);
+    clusterMap = new MockClusterMap(enableSSL, 9, 3, 3);
     serverList = new ArrayList<AmbryServer>();
     ArrayList<String> datacenterList = Utils.splitString(datacenters, ",");
     List<MockDataNodeId> dataNodes = clusterMap.getDataNodes();
@@ -109,7 +109,8 @@ public class MockCluster {
     }
   }
 
-  public void cleanup() {
+  public void cleanup()
+      throws IOException {
     if (serverInitialized) {
       CountDownLatch shutdownLatch = new CountDownLatch(serverList.size());
       for (AmbryServer server : serverList) {
@@ -131,10 +132,9 @@ public class MockCluster {
    * @return the config value for sslEnabledDatacenters for the given datacenter
    */
   private String getSSLEnabledDatacenterValue(String datacenter, ArrayList<String> sslEnabledDataCenterList) {
-    ArrayList<String> localCopy = (ArrayList<String>) sslEnabledDataCenterList.clone();
+    ArrayList<String> localCopy = new ArrayList<String>(sslEnabledDataCenterList);
     localCopy.remove(datacenter);
-    String sslEnabledDatacenters = Utils.concatenateString(localCopy, ",");
-    return sslEnabledDatacenters;
+    return Utils.concatenateString(localCopy, ",");
   }
 
   public List<DataNodeId> getOneDataNodeFromEachDatacenter(ArrayList<String> datacenterList) {

--- a/ambry-server/src/test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ServerErrorCode;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobData;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.BlobType;
@@ -50,48 +51,50 @@ import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import java.util.Random;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 
 public class ServerHardDeleteTest {
-  private static MockNotificationSystem notificationSystem;
-  private static MockTime time;
-  private static MockCluster cluster;
+  private MockNotificationSystem notificationSystem;
+  private MockTime time;
+  private AmbryServer server;
+  private MockClusterMap mockClusterMap;
 
-  @BeforeClass
-  public static void initializeTests()
+  @Before
+  public void initialize()
       throws Exception {
-    notificationSystem = new MockNotificationSystem(9);
+    notificationSystem = new MockNotificationSystem(1);
+    mockClusterMap = new MockClusterMap(false, 1, 1, 1);
     time = new MockTime(SystemTime.getInstance().milliseconds());
-    cluster = new MockCluster(notificationSystem, time);
-    cluster.startServers();
+    Properties props = new Properties();
+    props.setProperty("host.name", mockClusterMap.getDataNodes().get(0).getHostname());
+    props.setProperty("port", Integer.toString(mockClusterMap.getDataNodes().get(0).getPort()));
+    props.setProperty("store.data.flush.interval.seconds", "1");
+    props.setProperty("store.enable.hard.delete", "true");
+    props.setProperty("store.deleted.message.retention.days", "1");
+    VerifiableProperties propverify = new VerifiableProperties(props);
+    server = new AmbryServer(propverify, mockClusterMap, notificationSystem, time);
+    server.startup();
   }
 
-  public ServerHardDeleteTest()
-      throws Exception {
+  @After
+  public void cleanup()
+      throws IOException {
+    server.shutdown();
+    mockClusterMap.cleanup();
   }
 
-  @AfterClass
-  public static void cleanup() {
-    long start = System.currentTimeMillis();
-    // cleanup appears to hang sometimes. And, it sometimes takes a long time. Printing some info until cleanup is fast
-    // and reliable.
-    System.out.println("About to invoke cluster.cleanup()");
-    if (cluster != null) {
-      cluster.cleanup();
-    }
-    System.out.println("cluster.cleanup() took " + (System.currentTimeMillis() - start) + " ms.");
-  }
-
-  void ensureCleanupTokenCatchesUp(String path, MockClusterMap clusterMap, long expectedTokenValue)
+  void ensureCleanupTokenCatchesUp(String path, MockClusterMap mockClusterMap, long expectedTokenValue)
       throws Exception {
     final int TIMEOUT = 10000;
     File cleanupTokenFile = new File(path, "cleanuptoken");
@@ -130,7 +133,7 @@ public class ServerHardDeleteTest {
         try {
           short version = stream.readShort();
           Assert.assertEquals(version, PersistentIndex.Cleanup_Token_Version_V1);
-          StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
+          StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", mockClusterMap);
           FindTokenFactory factory = Utils.getObj("com.github.ambry.store.StoreFindTokenFactory", storeKeyFactory);
 
           factory.getFindToken(stream);
@@ -185,18 +188,33 @@ public class ServerHardDeleteTest {
     Assert.assertEquals(expectedTokenValue, parsedTokenValue);
   }
 
+  /**
+   * Tests the hard delete functionality.
+   * <p>
+   * This test does the following:
+   * 1. Makes 6 puts, waits for notification.
+   * 2. Makes 2 deletes, waits for notification.
+   * 3. Waits for hard deletes to catch up to the expected token value.
+   * 4. Verifies that the two records that are deleted are zeroed out by hard deletes.
+   * 5. Makes 3 more puts, waits for notification.
+   * 6. Makes 3 deletes - 2 of records from the initial set of puts, and 1 from the new set.
+   * 7. Waits for hard deletes to catch up again to the expected token value.
+   * 8. Verifies that the three records that are deleted are zeroed out by hard deletes.
+   *
+   * @throws Exception
+   */
   @Test
   public void endToEndTestHardDeletes()
       throws Exception {
-    MockClusterMap clusterMap = cluster.getClusterMap();
-    DataNodeId dataNodeId = clusterMap.getDataNodeIds().get(0);
+    DataNodeId dataNodeId = mockClusterMap.getDataNodeIds().get(0);
     ArrayList<byte[]> usermetadata = new ArrayList<byte[]>(9);
     ArrayList<byte[]> data = new ArrayList<byte[]>(9);
+    Random random = new Random();
     for (int i = 0; i < 9; i++) {
       usermetadata.add(new byte[1000 + i]);
       data.add(new byte[31870 + i]);
-      new Random().nextBytes(usermetadata.get(i));
-      new Random().nextBytes(data.get(i));
+      random.nextBytes(usermetadata.get(i));
+      random.nextBytes(data.get(i));
     }
 
     ArrayList<BlobProperties> properties = new ArrayList<BlobProperties>(9);
@@ -210,7 +228,7 @@ public class ServerHardDeleteTest {
     properties.add(new BlobProperties(31877, "serviceid1"));
     properties.add(new BlobProperties(31878, "serviceid1"));
 
-    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+    List<PartitionId> partitionIds = mockClusterMap.getWritablePartitionIds();
     ArrayList<BlobId> blobIdList = new ArrayList<BlobId>(9);
     blobIdList.add(new BlobId(partitionIds.get(0)));
     blobIdList.add(new BlobId(partitionIds.get(0)));
@@ -318,11 +336,9 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(4).getID());
 
     time.currentMilliseconds = time.currentMilliseconds + Time.SecsPerDay * Time.MsPerSec;
-    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(0).getReplicaPath(), clusterMap, 198431);
-    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(1).getReplicaPath(), clusterMap, 132299);
-    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(2).getReplicaPath(), clusterMap, 132299);
+    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198431);
 
-    MockPartitionId partition = (MockPartitionId) clusterMap.getWritablePartitionIds().get(0);
+    MockPartitionId partition = (MockPartitionId) mockClusterMap.getWritablePartitionIds().get(0);
 
     ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
     ArrayList<BlobId> ids = new ArrayList<BlobId>();
@@ -339,7 +355,7 @@ public class ServerHardDeleteTest {
               GetOptions.Include_All);
       channel.send(getRequest);
       InputStream stream = channel.receive().getInputStream();
-      GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
+      GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
 
       for (int i = 0; i < 6; i++) {
         BlobProperties propertyOutput = MessageFormatRecord.deserializeBlobProperties(resp.getInputStream());
@@ -351,7 +367,7 @@ public class ServerHardDeleteTest {
           GetOptions.Include_All);
       channel.send(getRequest);
       stream = channel.receive().getInputStream();
-      resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
+      resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
 
       for (int i = 0; i < 6; i++) {
         ByteBuffer userMetadataOutput = MessageFormatRecord.deserializeUserMetadata(resp.getInputStream());
@@ -362,7 +378,7 @@ public class ServerHardDeleteTest {
           new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList, GetOptions.Include_All);
       channel.send(getRequest);
       stream = channel.receive().getInputStream();
-      resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
+      resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
 
       for (int i = 0; i < 6; i++) {
         BlobData blobData = MessageFormatRecord.deserializeBlob(resp.getInputStream());
@@ -450,9 +466,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(6).getID());
 
     time.currentMilliseconds = time.currentMilliseconds + Time.SecsPerDay * Time.MsPerSec;
-    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(0).getReplicaPath(), clusterMap, 297905);
-    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(1).getReplicaPath(), clusterMap, 231676);
-    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(2).getReplicaPath(), clusterMap, 231676);
+    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 297905);
 
     partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
     partitionRequestInfo = new PartitionRequestInfo(partition, blobIdList);
@@ -464,7 +478,7 @@ public class ServerHardDeleteTest {
               GetOptions.Include_All);
       channel.send(getRequest);
       InputStream stream = channel.receive().getInputStream();
-      GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
+      GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
 
       for (int i = 0; i < 9; i++) {
         BlobProperties propertyOutput = MessageFormatRecord.deserializeBlobProperties(resp.getInputStream());
@@ -476,7 +490,7 @@ public class ServerHardDeleteTest {
           GetOptions.Include_All);
       channel.send(getRequest);
       stream = channel.receive().getInputStream();
-      resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
+      resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
 
       for (int i = 0; i < 9; i++) {
         ByteBuffer userMetadataOutput = MessageFormatRecord.deserializeUserMetadata(resp.getInputStream());
@@ -487,7 +501,7 @@ public class ServerHardDeleteTest {
           new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList, GetOptions.Include_All);
       channel.send(getRequest);
       stream = channel.receive().getInputStream();
-      resp = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
+      resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
 
       for (int i = 0; i < 9; i++) {
         BlobData blobData = MessageFormatRecord.deserializeBlob(resp.getInputStream());

--- a/ambry-server/src/test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -94,6 +94,15 @@ public class ServerHardDeleteTest {
     mockClusterMap.cleanup();
   }
 
+  /**
+   * Waits and ensures that the hard delete cleanup token catches up to the expected token value.
+   * @param path the path to the cleanup token.
+   * @param mockClusterMap the {@link MockClusterMap} being used for the cluster.
+   * @param expectedTokenValue the expected value that the cleanup token should contain. Until this value is reached,
+   *                           the method will keep reopening the file and read the value or until a predefined
+   *                           timeout is reached.
+   * @throws Exception if there were any I/O errors or the sleep gets interrupted.
+   */
   void ensureCleanupTokenCatchesUp(String path, MockClusterMap mockClusterMap, long expectedTokenValue)
       throws Exception {
     final int TIMEOUT = 10000;

--- a/ambry-server/src/test/java/com.github.ambry.server/ServerPlaintextTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/ServerPlaintextTest.java
@@ -39,8 +39,7 @@ public class ServerPlaintextTest {
       throws Exception {
     coordinatorProps = new Properties();
     notificationSystem = new MockNotificationSystem(9);
-    plaintextCluster =
-        new MockCluster(notificationSystem, SystemTime.getInstance());
+    plaintextCluster = new MockCluster(notificationSystem, false, SystemTime.getInstance());
     plaintextCluster.startServers();
   }
 
@@ -49,7 +48,8 @@ public class ServerPlaintextTest {
   }
 
   @AfterClass
-  public static void cleanup() {
+  public static void cleanup()
+      throws IOException {
     long start = System.currentTimeMillis();
     // cleanup appears to hang sometimes. And, it sometimes takes a long time. Printing some info until cleanup is fast
     // and reliable.
@@ -70,7 +70,8 @@ public class ServerPlaintextTest {
       throws InterruptedException, IOException, InstantiationException, URISyntaxException, GeneralSecurityException {
     DataNodeId dataNodeId = plaintextCluster.getClusterMap().getDataNodeIds().get(0);
     ServerTestUtil
-        .endToEndTest(new Port(dataNodeId.getPort(), PortType.PLAINTEXT), "DC1", "", plaintextCluster, null, null, coordinatorProps);
+        .endToEndTest(new Port(dataNodeId.getPort(), PortType.PLAINTEXT), "DC1", "", plaintextCluster, null, null,
+            coordinatorProps);
   }
 
   @Test
@@ -82,8 +83,8 @@ public class ServerPlaintextTest {
     ServerTestUtil.endToEndReplicationWithMultiNodeSinglePartitionTest("DC1", "", dataNodeId.getPort(),
         new Port(dataNodes.get(0).getPort(), PortType.PLAINTEXT),
         new Port(dataNodes.get(1).getPort(), PortType.PLAINTEXT),
-        new Port(dataNodes.get(2).getPort(), PortType.PLAINTEXT), plaintextCluster, null,
-        null, notificationSystem, coordinatorProps);
+        new Port(dataNodes.get(2).getPort(), PortType.PLAINTEXT), plaintextCluster, null, null, notificationSystem,
+        coordinatorProps);
   }
 
   @Test
@@ -95,8 +96,8 @@ public class ServerPlaintextTest {
     ServerTestUtil.endToEndReplicationWithMultiNodeMultiPartitionTest(dataNode.getPort(),
         new Port(dataNodes.get(0).getPort(), PortType.PLAINTEXT),
         new Port(dataNodes.get(1).getPort(), PortType.PLAINTEXT),
-        new Port(dataNodes.get(2).getPort(), PortType.PLAINTEXT), plaintextCluster, null, null,
-        null, null, null, null, notificationSystem);
+        new Port(dataNodes.get(2).getPort(), PortType.PLAINTEXT), plaintextCluster, null, null, null, null, null, null,
+        notificationSystem);
   }
 
   @Test

--- a/ambry-server/src/test/java/com.github.ambry.server/ServerSSLTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/ServerSSLTest.java
@@ -81,7 +81,8 @@ public class ServerSSLTest {
   }
 
   @AfterClass
-  public static void cleanup() {
+  public static void cleanup()
+      throws IOException {
     long start = System.currentTimeMillis();
     // cleanup appears to hang sometimes. And, it sometimes takes a long time. Printing some info until cleanup is fast
     // and reliable.

--- a/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
@@ -712,7 +712,8 @@ public class PersistentIndexTest {
   }
 
   @Test
-  public void testRollingIndex() {
+  public void testRollingIndex()
+      throws IOException {
     MockClusterMap map = null;
     try {
       String logFile = tempFile().getParent();
@@ -846,7 +847,8 @@ public class PersistentIndexTest {
   }
 
   @Test
-  public void testExistsWithFileSpan() {
+  public void testExistsWithFileSpan()
+      throws IOException {
     MockClusterMap map = null;
     try {
       String logFile = tempFile().getParent();
@@ -989,7 +991,8 @@ public class PersistentIndexTest {
   }
 
   @Test
-  public void testFindEntries() {
+  public void testFindEntries()
+      throws IOException {
     // provide empty token and ensure we get everything till max
     StoreFindToken token = new StoreFindToken();
     MockClusterMap map = null;
@@ -1143,7 +1146,8 @@ public class PersistentIndexTest {
    * read from the latest segment.
    */
   @Test
-  public void testFindEntriesAdditional() {
+  public void testFindEntriesAdditional()
+      throws IOException {
     // provide token referencing an offset from before
     MockClusterMap map = null;
     try {
@@ -1502,7 +1506,8 @@ public class PersistentIndexTest {
   }
 
   @Test
-  public void testFindDeletedEntries() {
+  public void testFindDeletedEntries()
+      throws IOException {
     // provide empty token and ensure we get everything till max
     StoreFindToken token = new StoreFindToken();
     MockClusterMap map = null;
@@ -1850,7 +1855,8 @@ public class PersistentIndexTest {
           public void remove() {
             throw new UnsupportedOperationException();
           }
-        };
+        }
+
         return new MockMessageStoreHardDeleteIterator(readSet);
       }
 


### PR DESCRIPTION
This PR fixes a couple of problems with the server tests that we have been experiencing, specifically related to consumption of resources on the test machine and issues with tests intermittently hanging or failing.

Some of the issues found and fixed are:
- `MockClusterMap` always creates a cluster with 9 nodes, each with 3 disks (mount points), with 3 stores/replicas per disk for a total of 81 stores. This may be unnecessary in general, and is certainly unnecessary for the `ServerHardDeleteTest` (which is a very store-local test) as this would amount to 81 hard delete threads.
This patch allows for overriding these values in the `MockClusterMap` and fixes the issues with the hard delete test by only creating 1 node with 1 mount point and 1 store, bringing the number of hard delete threads down from 81 to 1. No change to these settings were made for the other server tests at this time.

- The `MockClusterMap` only cleans up if the tests complete normally. If the test is interrupted (for example, if you kill it with Ctrl-C) and the stores are not deleted, then the next test reuses the files and any dependency on the values of tokens or log end offsets etc. can fail.
This patch fixes this by always recreating stores afresh when a `MockClusterMap` is instantiated.

With this patch, the server test time reduced by ~50% on my mac (which has 4 cores) and never hangs or fails in my testing; and by ~20% on my Linux machine (which has 8 cores). Please test this out yourself as well if you could. You could use the command `./gradlew :ambry-server:clean && ./gradlew :ambry-server:test`

---

There is no change to coverage, since these are tests.

Primary reviewers:
Casey, Gopal.