### PR TITLE
Adding connection stats handler

### DIFF
--- a/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
@@ -44,7 +44,7 @@ public class ConnectionStatsHandler extends ChannelDuplexHandler {
     return instance;
   }
 
-  public ConnectionStatsHandler(NettyMetrics metrics) {
+  private ConnectionStatsHandler(NettyMetrics metrics) {
     this.metrics = metrics;
     openConnections = new AtomicLong(0);
     metrics.registerConnectionsStatsHandler(openConnections);

--- a/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
@@ -13,9 +13,9 @@
  */
 package com.github.ambry.rest;
 
-import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * Handler that tracks connection establishment statistics.
  */
 @ChannelHandler.Sharable
-public class ConnectionStatsHandler extends ChannelDuplexHandler {
+public class ConnectionStatsHandler extends ChannelInboundHandlerAdapter {
   private final NettyMetrics metrics;
   private final AtomicLong openConnections;
   private static ConnectionStatsHandler instance = null;

--- a/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * Handler that tracks connection establishment statistics.
  */
 @ChannelHandler.Sharable
-class ConnectionStatsHandler extends ChannelDuplexHandler {
+public class ConnectionStatsHandler extends ChannelDuplexHandler {
   private final NettyMetrics metrics;
   private final AtomicLong openConnections;
   private static ConnectionStatsHandler instance = null;

--- a/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.rest;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Handler that tracks connection establishment statistics.
+ */
+@ChannelHandler.Sharable
+class ConnectionStatsHandler extends ChannelDuplexHandler {
+  private final NettyMetrics metrics;
+  private final AtomicLong openConnections;
+  private static ConnectionStatsHandler instance = null;
+
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  /**
+   * Instantiates and returns a singleton instance of {@link ConnectionStatsHandler} if not instantiated already.
+   * @param metrics the {@link NettyMetrics} instance to use
+   * @return an instance of {@link ConnectionStatsHandler}
+   */
+  public static ConnectionStatsHandler getInstance(NettyMetrics metrics) {
+    if (instance == null) {
+      instance = new ConnectionStatsHandler(metrics);
+    }
+    return instance;
+  }
+
+  public ConnectionStatsHandler(NettyMetrics metrics) {
+    this.metrics = metrics;
+    openConnections = new AtomicLong(0);
+    metrics.registerConnectionsStatsHandler(openConnections);
+  }
+
+  @Override
+  public void channelActive(ChannelHandlerContext ctx)
+      throws Exception {
+    logger.trace("Channel Active " + ctx.channel().remoteAddress());
+    metrics.connectionsConnectedCount.inc();
+    openConnections.incrementAndGet();
+    super.channelActive(ctx);
+  }
+
+  @Override
+  public void channelInactive(ChannelHandlerContext ctx)
+      throws Exception {
+    logger.trace("Channel Inactive " + ctx.channel().remoteAddress());
+    metrics.connectionsDisconnectedCount.inc();
+    openConnections.decrementAndGet();
+    super.channelInactive(ctx);
+  }
+}

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -260,7 +260,7 @@ public class NettyMetrics {
    * Registers the {@link ConnectionStatsHandler} to track open connections
    * @param openConnectionsCount open connections count to be tracked
    */
-  void registerConnectionsStatsHandler(AtomicLong openConnectionsCount) {
+  void registerConnectionsStatsHandler(final AtomicLong openConnectionsCount) {
     Gauge<Long> openConnections = new Gauge<Long>() {
       @Override
       public Long getValue() {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -116,7 +116,7 @@ public class NettyMetrics {
   public final Counter connectionsConnectedCount;
   public final Counter connectionsDisconnectedCount;
 
-  // PublicAccessLogRequestHandler
+  // PublicAccessLogHandler
   public final Counter publicAccessLogRequestDisconnectWhileInProgressCount;
   public final Counter publicAccessLogRequestCloseWhileRequestInProgressCount;
   // HealthCheckRequestHandler
@@ -260,7 +260,7 @@ public class NettyMetrics {
    * Registers the {@link ConnectionStatsHandler} to track open connections
    * @param openConnectionsCount open connections count to be tracked
    */
-  public void registerConnectionsStatsHandler(AtomicLong openConnectionsCount) {
+  void registerConnectionsStatsHandler(AtomicLong openConnectionsCount) {
     Gauge<Long> openConnections = new Gauge<Long>() {
       @Override
       public Long getValue() {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyServerFactory.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyServerFactory.java
@@ -58,8 +58,10 @@ public class NettyServerFactory implements NioServerFactory {
         @Override
         protected void initChannel(SocketChannel ch) {
           ch.pipeline()
-              // for http encoding/decoding. Note that we get content in 8KB chunks and a change to that number has
-              // to go here.
+              // connection stats handler to track connection related metrics
+              .addLast("ConnectionStatsHandler", ConnectionStatsHandler.getInstance(nettyMetrics))
+                  // for http encoding/decoding. Note that we get content in 8KB chunks and a change to that number has
+                  // to go here.
               .addLast("codec", new HttpServerCodec())
                   // for health check request handling
               .addLast("healthCheckHandler", new HealthCheckHandler(restServerState, nettyMetrics))

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
@@ -126,9 +126,9 @@ public class NettyServerTest {
       protected void initChannel(SocketChannel ch) {
         ch.pipeline()
             // connection stats handler to track connection related metrics
-            .addLast("ConnectionStatsHandler", new ConnectionStatsHandler(nettyMetrics))
-            // for http encoding/decoding. Note that we get content in 8KB chunks and a change to that number has
-            // to go here.
+            .addLast("ConnectionStatsHandler", ConnectionStatsHandler.getInstance(nettyMetrics))
+                // for http encoding/decoding. Note that we get content in 8KB chunks and a change to that number has
+                // to go here.
             .addLast("codec", new HttpServerCodec())
                 // for health check request handling
             .addLast("healthCheckHandler", new HealthCheckHandler(restServerState, nettyMetrics))

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
@@ -125,6 +125,8 @@ public class NettyServerTest {
       @Override
       protected void initChannel(SocketChannel ch) {
         ch.pipeline()
+            // connection stats handler to track connection related metrics
+            .addLast("ConnectionStatsHandler", new ConnectionStatsHandler(nettyMetrics))
             // for http encoding/decoding. Note that we get content in 8KB chunks and a change to that number has
             // to go here.
             .addLast("codec", new HttpServerCodec())


### PR DESCRIPTION
Adding connection stats handler to track open connections and disconnections.

Tested manually using jconsole that all 3 new metrics get updated. 

SLA: 5 mins
Reviewers: Casey, Ming