### PR TITLE
complete router operations using a callback instead of the static method

### DIFF
--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -424,7 +424,7 @@ public class DeleteManagerTest {
         TestUtils.numThreadsByThisName("ChunkFillerThread"));
     Assert.assertEquals("No RequestResponseHandler should be running after the router is closed", 0,
         TestUtils.numThreadsByThisName("RequestResponseHandlerThread"));
-    Assert.assertEquals("All operations should have completed", 0, NonBlockingRouter.getOperationsCount());
+    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -115,7 +115,7 @@ public class GetBlobInfoOperationTest {
     if (networkClient != null) {
       networkClient.close();
     }
-    Assert.assertEquals("All operations should have completed", 0, NonBlockingRouter.getOperationsCount());
+    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -76,7 +76,7 @@ public class GetManagerTest {
   @After
   public void postCheck() {
     Assert.assertFalse("Router should be closed at the end of each test", router.isOpen());
-    Assert.assertEquals("Router operations count must be zero", 0, NonBlockingRouter.getOperationsCount());
+    Assert.assertEquals("Router operations count must be zero", 0, router.getOperationsCount());
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -163,7 +163,7 @@ public class NonBlockingRouterTest {
     if (expectedCount == 0) {
       Assert.assertFalse("Router should be closed if there are no worker threads running", router.isOpen());
       Assert
-          .assertEquals("All operations should have completed if the router is closed", 0, NonBlockingRouter.getOperationsCount());
+          .assertEquals("All operations should have completed if the router is closed", 0, router.getOperationsCount());
     }
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -202,7 +202,7 @@ public class PutManagerTest {
         TestUtils.numThreadsByThisName("ChunkFillerThread"));
     Assert.assertEquals("No RequestResponseHandler threads should be running after the router is closed", 0,
         TestUtils.numThreadsByThisName("RequestResponseHandlerThread"));
-    Assert.assertEquals("All operations should have completed", 0, NonBlockingRouter.getOperationsCount());
+    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
   }
 
   /**
@@ -483,7 +483,7 @@ public class PutManagerTest {
 
     // Ensure that the existing operation was completed.
     requestAndResultsList.get(0).result.await();
-    Assert.assertEquals("All operations should have completed", 0, NonBlockingRouter.getOperationsCount());
+    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
     Assert.assertTrue("Router should still be open", router.isOpen());
 
     // Now submit another job and ensure that the router gets closed.
@@ -501,7 +501,7 @@ public class PutManagerTest {
         TestUtils.numThreadsByThisName("ChunkFillerThread"));
     Assert.assertEquals("No RequestResponseHandler should be running after the router is closed", 0,
         TestUtils.numThreadsByThisName("RequestResponseHandlerThread"));
-    Assert.assertEquals("All operations should have completed", 0, NonBlockingRouter.getOperationsCount());
+    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
   }
 
   /**
@@ -540,7 +540,7 @@ public class PutManagerTest {
         TestUtils.numThreadsByThisName("ChunkFillerThread"));
     Assert.assertEquals("No RequestResponseHandler should be running after the router is closed", 0,
         TestUtils.numThreadsByThisName("RequestResponseHandlerThread"));
-    Assert.assertEquals("All operations should have completed", 0, NonBlockingRouter.getOperationsCount());
+    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
   }
 
   // Methods used by the tests
@@ -774,7 +774,7 @@ public class PutManagerTest {
         TestUtils.numThreadsByThisName("ChunkFillerThread"));
     Assert.assertEquals("No RequestResponseHandler should be running after the router is closed", 0,
         TestUtils.numThreadsByThisName("RequestResponseHandlerThread"));
-    Assert.assertEquals("All operations should have completed", 0, NonBlockingRouter.getOperationsCount());
+    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
   }
 
   private class RequestAndResult {


### PR DESCRIPTION
Currently, a static method in the router is used by the operation managers to complete operations (to invoke the operation callback and mark the future as done). This is a little problematic for a couple of reasons: the count maintained by the router which gets decremented from this method also has to be made static, as is the case with the method that exposes this count. This is not ideal as the same state gets used across router instantiations. This also poses a problem in writing tests since any test that needs to check for the count has to depend on the fact that other tests that do not care about this count (or cannot deal with this count correctly) have reset the state somehow.

Instead, create and pass in a callback that the operation managers can use to complete operations.

--------
Reviewer: Gopal

*Coverage*
No new tests necessary.