### PR TITLE
Increasing the upper bound of router scaling unit count.

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -115,7 +115,7 @@ public class RouterConfig {
    * @param verifiableProperties the properties map to refer to.
    */
   public RouterConfig(VerifiableProperties verifiableProperties) {
-    routerScalingUnitCount = verifiableProperties.getIntInRange("router.scaling.unit.count", 1, 0, 10);
+    routerScalingUnitCount = verifiableProperties.getIntInRange("router.scaling.unit.count", 1, 0, 200);
     routerHostname = verifiableProperties.getString("router.hostname");
     routerDatacenterName = verifiableProperties.getString("router.datacenter.name");
     routerScalingUnitMaxConnectionsPerPortPlainText =

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -115,7 +115,7 @@ public class RouterConfig {
    * @param verifiableProperties the properties map to refer to.
    */
   public RouterConfig(VerifiableProperties verifiableProperties) {
-    routerScalingUnitCount = verifiableProperties.getIntInRange("router.scaling.unit.count", 1, 0, 200);
+    routerScalingUnitCount = verifiableProperties.getIntInRange("router.scaling.unit.count", 1, 1, 200);
     routerHostname = verifiableProperties.getString("router.hostname");
     routerDatacenterName = verifiableProperties.getString("router.datacenter.name");
     routerScalingUnitMaxConnectionsPerPortPlainText =


### PR DESCRIPTION
For the `CoordinatorBackedRouter` to not become a bottleneck it needs to have the same number of scaling units
as the requester pool size in the `Coordinator`. The default number for that is 100 and the ceiling of scaling
unit count has to be at least 100. This commit makes the ceiling 200.