### PR TITLE
Discarding a CoordinatorBackedRouter test that is no longer relevant

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/CoordinatorBackedRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/CoordinatorBackedRouter.java
@@ -59,8 +59,7 @@ public class CoordinatorBackedRouter implements Router {
    * @param routerConfig the {@link RouterConfig} to refer to.
    * @param metrics the {@link CoordinatorBackedRouterMetrics} instance to use for metrics.
    * @param coordinator the {@link Coordinator} that will back this router.
-   * @throws IllegalArgumentException if any of the arguments received are null or if
-   * {@link RouterConfig#routerScalingUnitCount} is less than or equal to 0.
+   * @throws IllegalArgumentException if any of the arguments received are null.
    */
   public CoordinatorBackedRouter(RouterConfig routerConfig, CoordinatorBackedRouterMetrics metrics,
       Coordinator coordinator) {
@@ -78,12 +77,7 @@ public class CoordinatorBackedRouter implements Router {
       }
       throw new IllegalArgumentException(errorMessage.toString());
     }
-    if (routerConfig.routerScalingUnitCount > 0) {
-      this.operationPool = Executors.newFixedThreadPool(routerConfig.routerScalingUnitCount);
-    } else {
-      throw new IllegalArgumentException(
-          "Router scaling unit count defined in config should be > 0 (is " + routerConfig.routerScalingUnitCount + ")");
-    }
+    this.operationPool = Executors.newFixedThreadPool(routerConfig.routerScalingUnitCount);
     this.metrics = metrics;
     this.coordinator = coordinator;
     logger.trace("Instantiated CoordinatorBackedRouter");

--- a/ambry-router/src/test/java/com.github.ambry.router/CoordinatorBackedRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CoordinatorBackedRouterTest.java
@@ -77,16 +77,6 @@ public class CoordinatorBackedRouterTest {
       // expected. nothing to do.
     }
 
-    Properties properties = new Properties();
-    properties.setProperty("router.scaling.unit.count", "0");
-    verifiableProperties = getVProps(properties);
-    routerConfig = new RouterConfig(verifiableProperties);
-    try {
-      new CoordinatorBackedRouter(routerConfig, metrics, coordinator);
-    } catch (IllegalArgumentException e) {
-      // expected. nothing to do.
-    }
-
     // CoordinatorOperation instantiation test
     verifiableProperties = getVProps(new Properties());
     routerConfig = new RouterConfig(verifiableProperties);


### PR DESCRIPTION
After the lower bound of router scaling unit was made 1, the test for instantiation with the config
set to 0 is no longer relevant.

**Primary reviewer: Priyesh**

Built and formatted.