### PR TITLE
Use SslFactory to simplify BlockingChannelConnectionPool and related …

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannel.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannel.java
@@ -38,7 +38,7 @@ public class BlockingChannel implements ConnectedChannel {
   protected boolean connected = false;
   protected InputStream readChannel = null;
   protected WritableByteChannel writeChannel = null;
-  protected Object lock = new Object();
+  protected final Object lock = new Object();
   protected Logger logger = LoggerFactory.getLogger(getClass());
   private SocketChannel channel = null;
 

--- a/ambry-network/src/main/java/com.github.ambry.network/SSLFactory.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/SSLFactory.java
@@ -182,6 +182,14 @@ public class SSLFactory {
     this.truststore = new SecurityStore(type, path, password);
   }
 
+  public String[] getSslEnabledProtocols() {
+    return enabledProtocols;
+  }
+
+  public String[] getCipherSuites() {
+    return cipherSuites;
+  }
+
   private class SecurityStore {
     private final String type;
     private final String path;

--- a/ambry-network/src/test/java/com.github.ambry.network/BlockingChannelConnectionPoolTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/BlockingChannelConnectionPoolTest.java
@@ -173,7 +173,7 @@ public class BlockingChannelConnectionPoolTest {
       throws InterruptedException, ConnectionPoolTimeoutException {
     BlockingChannelInfo channelInfo =
         new BlockingChannelInfo(new ConnectionPoolConfig(new VerifiableProperties(props)), host, port,
-            new MetricRegistry(), sslSocketFactory, sslConfig);
+            new MetricRegistry(), sslFactory);
     Assert.assertEquals(channelInfo.getNumberOfConnections(), 0);
     BlockingChannel blockingChannel = channelInfo.getBlockingChannel(1000);
     Assert.assertEquals(channelInfo.getNumberOfConnections(), 1);
@@ -187,7 +187,7 @@ public class BlockingChannelConnectionPoolTest {
     AtomicReference<Exception> exception = new AtomicReference<Exception>();
     BlockingChannelInfo channelInfo =
         new BlockingChannelInfo(new ConnectionPoolConfig(new VerifiableProperties(props)), host, port,
-            new MetricRegistry(), sslSocketFactory, sslConfig);
+            new MetricRegistry(), sslFactory);
 
     CountDownLatch channelCount = new CountDownLatch(maxConnectionsPerHost);
     CountDownLatch shouldRelease = new CountDownLatch(1);
@@ -227,7 +227,7 @@ public class BlockingChannelConnectionPoolTest {
     AtomicReference<Exception> exception = new AtomicReference<Exception>();
     BlockingChannelInfo channelInfo =
         new BlockingChannelInfo(new ConnectionPoolConfig(new VerifiableProperties(props)), host, port,
-            new MetricRegistry(), sslSocketFactory, sslConfig);
+            new MetricRegistry(), sslFactory);
     CountDownLatch channelCount = new CountDownLatch(underSubscriptionCount);
     CountDownLatch shouldRelease = new CountDownLatch(1);
     CountDownLatch releaseComplete = new CountDownLatch(underSubscriptionCount);

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLBlockingChannelTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLBlockingChannelTest.java
@@ -87,8 +87,7 @@ public class SSLBlockingChannelTest {
   public void testSendAndReceive()
       throws Exception {
     BlockingChannel channel =
-        new SSLBlockingChannel(hostName, sslPort, new MetricRegistry(), 10000, 10000, 10000, 2000, sslSocketFactory,
-            clientSSLConfig);
+        new SSLBlockingChannel(hostName, sslPort, new MetricRegistry(), 10000, 10000, 10000, 2000, sslFactory);
     sendAndReceive(channel);
     channel.disconnect();
   }
@@ -97,8 +96,7 @@ public class SSLBlockingChannelTest {
   public void testRenegotiation()
       throws Exception {
     BlockingChannel channel =
-        new SSLBlockingChannel(hostName, sslPort, new MetricRegistry(), 10000, 10000, 10000, 2000, sslSocketFactory,
-            clientSSLConfig);
+        new SSLBlockingChannel(hostName, sslPort, new MetricRegistry(), 10000, 10000, 10000, 2000, sslFactory);
     sendAndReceive(channel);
     sslEchoServer.renegotiate();
     sendAndReceive(channel);
@@ -109,8 +107,7 @@ public class SSLBlockingChannelTest {
   public void testWrongPortConnection()
       throws Exception {
     BlockingChannel channel =
-        new SSLBlockingChannel(hostName, sslPort + 1, new MetricRegistry(), 10000, 10000, 10000, 2000, sslSocketFactory,
-            clientSSLConfig);
+        new SSLBlockingChannel(hostName, sslPort + 1, new MetricRegistry(), 10000, 10000, 10000, 2000, sslFactory);
     try {
       // send request
       channel.connect();

--- a/ambry-network/src/test/java/com.github.ambry.network/SocketServerTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SocketServerTest.java
@@ -95,7 +95,7 @@ public class SocketServerTest {
     if (targetPort.getPortType() == PortType.SSL) {
       channel =
           new SSLBlockingChannel("localhost", targetPort.getPort(), new MetricRegistry(), 10000, 10000, 1000, 2000,
-              clientSSLSocketFactory, clientSSLConfig);
+              clientSSLFactory);
     } else {
       channel = new BlockingChannel("localhost", targetPort.getPort(), 10000, 10000, 1000, 2000);
     }

--- a/ambry-server/src/test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -255,7 +255,7 @@ public class ServerHardDeleteTest {
             new ByteBufferInputStream(ByteBuffer.wrap(data.get(0))), properties.get(0).getBlobSize(),
             BlobType.DataBlob);
     BlockingChannel channel = ServerTestUtil
-        .getBlockingChannelBasedOnPortType(new Port(dataNodeId.getPort(), PortType.PLAINTEXT), "localhost", null, null);
+        .getBlockingChannelBasedOnPortType(new Port(dataNodeId.getPort(), PortType.PLAINTEXT), "localhost", null);
     channel.connect();
     channel.send(putRequest0);
     InputStream putResponseStream = channel.receive().getInputStream();

--- a/ambry-server/src/test/java/com.github.ambry.server/ServerPlaintextTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/ServerPlaintextTest.java
@@ -69,9 +69,8 @@ public class ServerPlaintextTest {
   public void endToEndTest()
       throws InterruptedException, IOException, InstantiationException, URISyntaxException, GeneralSecurityException {
     DataNodeId dataNodeId = plaintextCluster.getClusterMap().getDataNodeIds().get(0);
-    ServerTestUtil
-        .endToEndTest(new Port(dataNodeId.getPort(), PortType.PLAINTEXT), "DC1", "", plaintextCluster, null, null,
-            coordinatorProps);
+    ServerTestUtil.endToEndTest(new Port(dataNodeId.getPort(), PortType.PLAINTEXT), "DC1", "", plaintextCluster, null,
+        coordinatorProps);
   }
 
   @Test
@@ -83,7 +82,7 @@ public class ServerPlaintextTest {
     ServerTestUtil.endToEndReplicationWithMultiNodeMultiPartitionTest(dataNode.getPort(),
         new Port(dataNodes.get(0).getPort(), PortType.PLAINTEXT),
         new Port(dataNodes.get(1).getPort(), PortType.PLAINTEXT),
-        new Port(dataNodes.get(2).getPort(), PortType.PLAINTEXT), plaintextCluster, null, null, null, null, null, null,
+        new Port(dataNodes.get(2).getPort(), PortType.PLAINTEXT), plaintextCluster, null, null, null,
         notificationSystem);
   }
 

--- a/ambry-server/src/test/java/com.github.ambry.server/ServerPlaintextTokenTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/ServerPlaintextTokenTest.java
@@ -48,7 +48,8 @@ public class ServerPlaintextTokenTest {
   }
 
   @After
-  public void cleanup() throws IOException {
+  public void cleanup()
+      throws IOException {
     long start = System.currentTimeMillis();
     System.out.println("About to invoke cluster.cleanup()");
     if (plaintextCluster != null) {
@@ -66,7 +67,7 @@ public class ServerPlaintextTokenTest {
     ServerTestUtil.endToEndReplicationWithMultiNodeSinglePartitionTest("DC1", "", dataNodeId.getPort(),
         new Port(dataNodes.get(0).getPort(), PortType.PLAINTEXT),
         new Port(dataNodes.get(1).getPort(), PortType.PLAINTEXT),
-        new Port(dataNodes.get(2).getPort(), PortType.PLAINTEXT), plaintextCluster, null,
-        null, notificationSystem, coordinatorProps);
+        new Port(dataNodes.get(2).getPort(), PortType.PLAINTEXT), plaintextCluster, null, notificationSystem,
+        coordinatorProps);
   }
 }

--- a/ambry-server/src/test/java/com.github.ambry.server/ServerSSLTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/ServerSSLTest.java
@@ -36,7 +36,9 @@ import org.junit.Test;
 
 
 public class ServerSSLTest {
-  private static SSLFactory sslFactory;
+  private static SSLFactory sslFactory1;
+  private static SSLFactory sslFactory2;
+  private static SSLFactory sslFactory3;
   private static SSLConfig clientSSLConfig1;
   private static SSLConfig clientSSLConfig2;
   private static SSLConfig clientSSLConfig3;
@@ -65,15 +67,9 @@ public class ServerSSLTest {
         new MockCluster(notificationSystem, true, "DC1,DC2,DC3", serverSSLProps, false, SystemTime.getInstance());
     sslCluster.startServers();
     //client
-    sslFactory = new SSLFactory(clientSSLConfig1);
-    SSLContext sslContext = sslFactory.getSSLContext();
-    clientSSLSocketFactory1 = sslContext.getSocketFactory();
-    sslFactory = new SSLFactory(clientSSLConfig2);
-    sslContext = sslFactory.getSSLContext();
-    clientSSLSocketFactory2 = sslContext.getSocketFactory();
-    sslFactory = new SSLFactory(clientSSLConfig3);
-    sslContext = sslFactory.getSSLContext();
-    clientSSLSocketFactory3 = sslContext.getSocketFactory();
+    sslFactory1 = new SSLFactory(clientSSLConfig1);
+    sslFactory2 = new SSLFactory(clientSSLConfig2);
+    sslFactory3 = new SSLFactory(clientSSLConfig3);
   }
 
   public ServerSSLTest()
@@ -103,8 +99,8 @@ public class ServerSSLTest {
       throws InterruptedException, IOException, InstantiationException, URISyntaxException, GeneralSecurityException {
     DataNodeId dataNodeId = sslCluster.getClusterMap().getDataNodeIds().get(3);
     ServerTestUtil
-        .endToEndTest(new Port(dataNodeId.getSSLPort(), PortType.SSL), "DC1", "DC2,DC3", sslCluster, clientSSLConfig1,
-            clientSSLSocketFactory1, coordinatorProps);
+        .endToEndTest(new Port(dataNodeId.getSSLPort(), PortType.SSL), "DC1", "DC2,DC3", sslCluster, sslFactory1,
+            coordinatorProps);
   }
 
   @Test
@@ -115,8 +111,7 @@ public class ServerSSLTest {
     List<DataNodeId> dataNodes = sslCluster.getOneDataNodeFromEachDatacenter(dataCenterList);
     ServerTestUtil.endToEndReplicationWithMultiNodeMultiPartitionTest(dataNode.getPort(),
         new Port(dataNodes.get(0).getSSLPort(), PortType.SSL), new Port(dataNodes.get(1).getSSLPort(), PortType.SSL),
-        new Port(dataNodes.get(2).getSSLPort(), PortType.SSL), sslCluster, clientSSLConfig1, clientSSLConfig2,
-        clientSSLConfig3, clientSSLSocketFactory1, clientSSLSocketFactory2, clientSSLSocketFactory3,
+        new Port(dataNodes.get(2).getSSLPort(), PortType.SSL), sslCluster, sslFactory1, sslFactory2, sslFactory3,
         notificationSystem);
   }
 

--- a/ambry-server/src/test/java/com.github.ambry.server/ServerSSLTokenTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/ServerSSLTokenTest.java
@@ -65,7 +65,8 @@ public class ServerSSLTokenTest {
   }
 
   @After
-  public void cleanup() throws IOException {
+  public void cleanup()
+      throws IOException {
     long start = System.currentTimeMillis();
     // cleanup appears to hang sometimes. And, it sometimes takes a long time. Printing some info until cleanup is fast
     // and reliable.
@@ -84,7 +85,7 @@ public class ServerSSLTokenTest {
     List<DataNodeId> dataNodes = sslCluster.getOneDataNodeFromEachDatacenter(dataCenterList);
     ServerTestUtil.endToEndReplicationWithMultiNodeSinglePartitionTest("DC1", "DC2,DC3", dataNodeId.getPort(),
         new Port(dataNodes.get(0).getSSLPort(), PortType.SSL), new Port(dataNodes.get(1).getSSLPort(), PortType.SSL),
-        new Port(dataNodes.get(2).getSSLPort(), PortType.SSL), sslCluster, clientSSLConfig, clientSSLSocketFactory,
-        notificationSystem, coordinatorProps);
+        new Port(dataNodes.get(2).getSSLPort(), PortType.SSL), sslCluster, sslFactory, notificationSystem,
+        coordinatorProps);
   }
 }


### PR DESCRIPTION
BlockingChannelConnectionPool used SslConfig and SslSocketFacotory to establish an Ssl connection. This patch simplifies the process by passing in SslFactory. This patch also makes corresponding changes in all related tests.

Test done: ./gradlew build

Reviewer: Priyesh & Siva