### PR TITLE
Abstracting the creation of netty channel handlers

### DIFF
--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
@@ -15,17 +15,18 @@ package com.github.ambry.rest;
 
 import com.github.ambry.config.NettyConfig;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
-import io.netty.handler.stream.ChunkedWriteHandler;
-import io.netty.handler.timeout.IdleStateHandler;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,27 +50,20 @@ class NettyServer implements NioServer {
   private final NettyMetrics nettyMetrics;
   private final EventLoopGroup bossGroup;
   private final EventLoopGroup workerGroup;
-  private final RestRequestHandler requestHandler;
-  private final PublicAccessLogger publicAccessLogger;
-  private final RestServerState restServerState;
+  private final ArrayList<Map.Entry<String, ChannelHandler>> channelHandlers;
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   /**
    * Creates a new instance of NettyServer.
    * @param nettyConfig the {@link NettyConfig} instance that defines the configuration parameters for the NettyServer.
    * @param nettyMetrics the {@link NettyMetrics} instance to use to record metrics.
-   * @param requestHandler the {@link RestRequestHandler} that can be used to submit requests that need to be handled.
-   * @param publicAccessLogger the {@link PublicAccessLogger} that can be used for public access logging
-   * @param restServerState the {@link RestServerState} that can be used to check the health of the system
-   *                              to respond to health check requests
+   * @param channelHandlers list of {@link io.netty.channel.ChannelHandler}s to be used in the channel pipeline
    */
-  public NettyServer(NettyConfig nettyConfig, NettyMetrics nettyMetrics, RestRequestHandler requestHandler,
-      PublicAccessLogger publicAccessLogger, RestServerState restServerState) {
+  public NettyServer(NettyConfig nettyConfig, NettyMetrics nettyMetrics,
+      ArrayList<Map.Entry<String, ChannelHandler>> channelHandlers) {
     this.nettyConfig = nettyConfig;
     this.nettyMetrics = nettyMetrics;
-    this.requestHandler = requestHandler;
-    this.publicAccessLogger = publicAccessLogger;
-    this.restServerState = restServerState;
+    this.channelHandlers = channelHandlers;
     bossGroup = new NioEventLoopGroup(nettyConfig.nettyServerBossThreadCount);
     workerGroup = new NioEventLoopGroup(nettyConfig.nettyServerWorkerThreadCount);
     logger.trace("Instantiated NettyServer");
@@ -90,20 +84,11 @@ class NettyServer implements NioServer {
         @Override
         public void initChannel(SocketChannel ch)
             throws Exception {
-          ch.pipeline()
-              // for http encoding/decoding. Note that we get content in 8KB chunks and a change to that number has
-              // to go here.
-              .addLast("codec", new HttpServerCodec())
-                  // for health check request handling
-              .addLast("HealthCheckHandler", new HealthCheckHandler(restServerState, nettyMetrics))
-                  // for public access logging
-              .addLast("PublicAccessLogHandler", new PublicAccessLogRequestHandler(publicAccessLogger, nettyMetrics))
-                  // for detecting connections that have been idle too long - probably because of an error.
-              .addLast("idleStateHandler", new IdleStateHandler(0, 0, nettyConfig.nettyServerIdleTimeSeconds))
-                  // for safe writing of chunks for responses
-              .addLast("chunker", new ChunkedWriteHandler())
-                  // custom processing class that interfaces with a BlobStorageService.
-              .addLast("processor", new NettyMessageProcessor(nettyMetrics, nettyConfig, requestHandler));
+          Iterator<Map.Entry<String, ChannelHandler>> channelHandlerIter = channelHandlers.iterator();
+          while (channelHandlerIter.hasNext()) {
+            Map.Entry<String, ChannelHandler> entry = channelHandlerIter.next();
+            ch.pipeline().addLast(entry.getKey(), entry.getValue());
+          }
         }
       });
       b.bind(nettyConfig.nettyServerPort).sync();

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
@@ -24,8 +24,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
-import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -50,20 +49,21 @@ class NettyServer implements NioServer {
   private final NettyMetrics nettyMetrics;
   private final EventLoopGroup bossGroup;
   private final EventLoopGroup workerGroup;
-  private final ArrayList<Map.Entry<String, ChannelHandler>> channelHandlers;
+  private final LinkedHashMap<String, ChannelHandler> channelHandlerInfoList;
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   /**
    * Creates a new instance of NettyServer.
    * @param nettyConfig the {@link NettyConfig} instance that defines the configuration parameters for the NettyServer.
    * @param nettyMetrics the {@link NettyMetrics} instance to use to record metrics.
-   * @param channelHandlers list of {@link io.netty.channel.ChannelHandler}s to be used in the channel pipeline
+   * @param channelHandlerInfoList Linkedin list of pairs of {@link ChannelHandler} name and {@link ChannelHandler}s to
+   *                               be used in the channel pipeline
    */
   public NettyServer(NettyConfig nettyConfig, NettyMetrics nettyMetrics,
-      ArrayList<Map.Entry<String, ChannelHandler>> channelHandlers) {
+      LinkedHashMap<String, ChannelHandler> channelHandlerInfoList) {
     this.nettyConfig = nettyConfig;
     this.nettyMetrics = nettyMetrics;
-    this.channelHandlers = channelHandlers;
+    this.channelHandlerInfoList = channelHandlerInfoList;
     bossGroup = new NioEventLoopGroup(nettyConfig.nettyServerBossThreadCount);
     workerGroup = new NioEventLoopGroup(nettyConfig.nettyServerWorkerThreadCount);
     logger.trace("Instantiated NettyServer");
@@ -84,9 +84,7 @@ class NettyServer implements NioServer {
         @Override
         public void initChannel(SocketChannel ch)
             throws Exception {
-          Iterator<Map.Entry<String, ChannelHandler>> channelHandlerIter = channelHandlers.iterator();
-          while (channelHandlerIter.hasNext()) {
-            Map.Entry<String, ChannelHandler> entry = channelHandlerIter.next();
+          for (Map.Entry<String, ChannelHandler> entry : channelHandlerInfoList.entrySet()) {
             ch.pipeline().addLast(entry.getKey(), entry.getValue());
           }
         }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
@@ -56,8 +56,8 @@ class NettyServer implements NioServer {
    * Creates a new instance of NettyServer.
    * @param nettyConfig the {@link NettyConfig} instance that defines the configuration parameters for the NettyServer.
    * @param nettyMetrics the {@link NettyMetrics} instance to use to record metrics.
-   * @param channelHandlerInfoList Linked list of pairs of {@link ChannelHandler} name and {@link ChannelHandler}s to
-   *                               be used in the channel pipeline
+   * @param channelHandlerInfoList An ordered list of pairs of {@link ChannelHandler} name and {@link ChannelHandler}s
+   *                               to be used in the channel pipeline
    */
   public NettyServer(NettyConfig nettyConfig, NettyMetrics nettyMetrics,
       LinkedHashMap<String, ChannelHandler> channelHandlerInfoList) {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
@@ -56,7 +56,7 @@ class NettyServer implements NioServer {
    * Creates a new instance of NettyServer.
    * @param nettyConfig the {@link NettyConfig} instance that defines the configuration parameters for the NettyServer.
    * @param nettyMetrics the {@link NettyMetrics} instance to use to record metrics.
-   * @param channelHandlerInfoList Linkedin list of pairs of {@link ChannelHandler} name and {@link ChannelHandler}s to
+   * @param channelHandlerInfoList Linked list of pairs of {@link ChannelHandler} name and {@link ChannelHandler}s to
    *                               be used in the channel pipeline
    */
   public NettyServer(NettyConfig nettyConfig, NettyMetrics nettyMetrics,

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyServerFactory.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyServerFactory.java
@@ -20,9 +20,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Map;
+import java.util.LinkedHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +35,8 @@ public class NettyServerFactory implements NioServerFactory {
 
   private final NettyConfig nettyConfig;
   private final NettyMetrics nettyMetrics;
-  private ArrayList<Map.Entry<String, ChannelHandler>> channelHandlers;
+  // linked hashmap as we need a deterministic order while iterating through the map
+  private LinkedHashMap<String, ChannelHandler> channelHandlerInfoList;
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   /**
@@ -91,24 +90,21 @@ public class NettyServerFactory implements NioServerFactory {
    */
   private void initializeChannelHandlers(NettyMetrics nettyMetrics, NettyConfig nettyConfig,
       RestRequestHandler requestHandler, PublicAccessLogger publicAccessLogger, RestServerState restServerState) {
-    channelHandlers = new ArrayList<>();
+    channelHandlerInfoList = new LinkedHashMap<>();
     // for http encoding/decoding. Note that we get content in 8KB chunks and a change to that number has
     // to go here.
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("codec", new HttpServerCodec()));
+    channelHandlerInfoList.put("codec", new HttpServerCodec());
     // for health check request handling
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("HealthCheckHandler",
-        new HealthCheckHandler(restServerState, nettyMetrics)));
+    channelHandlerInfoList.put("HealthCheckHandler", new HealthCheckHandler(restServerState, nettyMetrics));
     // for public access logging
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("PublicAccessLogHandler",
-        new PublicAccessLogRequestHandler(publicAccessLogger, nettyMetrics)));
+    channelHandlerInfoList
+        .put("PublicAccessLogHandler", new PublicAccessLogRequestHandler(publicAccessLogger, nettyMetrics));
     // for detecting connections that have been idle too long - probably because of an error.
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("idleStateHandler",
-        new IdleStateHandler(0, 0, nettyConfig.nettyServerIdleTimeSeconds)));
+    channelHandlerInfoList.put("idleStateHandler", new IdleStateHandler(0, 0, nettyConfig.nettyServerIdleTimeSeconds));
     // for safe writing of chunks for responses
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("chunker", new ChunkedWriteHandler()));
+    channelHandlerInfoList.put("chunker", new ChunkedWriteHandler());
     // custom processing class that interfaces with a BlobStorageService.
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("processor",
-        new NettyMessageProcessor(nettyMetrics, nettyConfig, requestHandler)));
+    channelHandlerInfoList.put("processor", new NettyMessageProcessor(nettyMetrics, nettyConfig, requestHandler));
   }
 
   /**
@@ -117,6 +113,6 @@ public class NettyServerFactory implements NioServerFactory {
    */
   @Override
   public NioServer getNioServer() {
-    return new NettyServer(nettyConfig, nettyMetrics, channelHandlers);
+    return new NettyServer(nettyConfig, nettyMetrics, channelHandlerInfoList);
   }
 }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyServerFactory.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyServerFactory.java
@@ -36,14 +36,14 @@ public class NettyServerFactory implements NioServerFactory {
   private final NettyConfig nettyConfig;
   private final NettyMetrics nettyMetrics;
   // linked hashmap as we need a deterministic order while iterating through the map
-  private LinkedHashMap<String, ChannelHandler> channelHandlerInfoList;
+  private final LinkedHashMap<String, ChannelHandler> channelHandlerInfoList = new LinkedHashMap<>();
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   /**
    * Creates a new instance of NettyServerFactory.
    * @param verifiableProperties the in-memory {@link VerifiableProperties} to use.
    * @param metricRegistry the {@link MetricRegistry} to use.
-   * @param requestHandler the {@link RestRequestHandler} that can be used to submit requests that need to be handled.
+   * @param requestHandler the {@link RestRequestHandler} that handles general requests.
    * @param publicAccessLogger the {@link PublicAccessLogger} that can be used for public access logging
    * @param restServerState the {@link RestServerState} that can be used to check the health of the system
    *                              to respond to health check requests
@@ -81,8 +81,8 @@ public class NettyServerFactory implements NioServerFactory {
 
   /**
    * Initialize the {@link ChannelHandler}s to be used in the netty pipeline
-   * @param nettyConfig the {@link NettyConfig} instance that defines the configuration parameters for the NettyServer.
    * @param nettyMetrics the {@link NettyMetrics} instance to use to record metrics.
+   * @param nettyConfig the {@link NettyConfig} instance that defines the configuration parameters for the NettyServer.
    * @param requestHandler the {@link RestRequestHandler} that can be used to submit requests that need to be handled.
    * @param publicAccessLogger the {@link PublicAccessLogger} that can be used for public access logging
    * @param restServerState the {@link RestServerState} that can be used to check the health of the system
@@ -90,7 +90,6 @@ public class NettyServerFactory implements NioServerFactory {
    */
   private void initializeChannelHandlers(NettyMetrics nettyMetrics, NettyConfig nettyConfig,
       RestRequestHandler requestHandler, PublicAccessLogger publicAccessLogger, RestServerState restServerState) {
-    channelHandlerInfoList = new LinkedHashMap<>();
     // for http encoding/decoding. Note that we get content in 8KB chunks and a change to that number has
     // to go here.
     channelHandlerInfoList.put("codec", new HttpServerCodec());

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
@@ -127,9 +127,9 @@ public class NettyServerTest {
 
   /**
    * Initialize the {@link ChannelHandler}s to be used in the netty pipeline
-   * @param nettyConfig the {@link NettyConfig} instance that defines the configuration parameters for the NettyServer.
    * @param nettyMetrics the {@link NettyMetrics} instance to use to record metrics.
-   * @param requestHandler the {@link RestRequestHandler} that can be used to submit requests that need to be handled.
+   * @param nettyConfig the {@link NettyConfig} instance that defines the configuration parameters for the NettyServer.
+   * @param requestHandler the {@link RestRequestHandler} that handles general requests.
    * @param publicAccessLogger the {@link PublicAccessLogger} that can be used for public access logging
    * @param restServerState the {@link RestServerState} that can be used to check the health of the system
    *                              to respond to health check requests

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
@@ -133,7 +133,7 @@ public class NettyServerTest {
    * @param publicAccessLogger the {@link PublicAccessLogger} that can be used for public access logging
    * @param restServerState the {@link RestServerState} that can be used to check the health of the system
    *                              to respond to health check requests
-   * @return Linkedin list of pairs of {@link ChannelHandler} name and {@link ChannelHandler}s to
+   * @return Linked list of pairs of {@link ChannelHandler} name and {@link ChannelHandler}s to
    *                               be used in the channel pipeline
    */
   private LinkedHashMap<String, ChannelHandler> initializeChannelHandlers(NettyMetrics nettyMetrics,

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
@@ -21,9 +21,7 @@ import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import java.io.IOException;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.Properties;
 import org.junit.Test;
 
@@ -135,28 +133,27 @@ public class NettyServerTest {
    * @param publicAccessLogger the {@link PublicAccessLogger} that can be used for public access logging
    * @param restServerState the {@link RestServerState} that can be used to check the health of the system
    *                              to respond to health check requests
+   * @return Linkedin list of pairs of {@link ChannelHandler} name and {@link ChannelHandler}s to
+   *                               be used in the channel pipeline
    */
-  private ArrayList<Map.Entry<String, ChannelHandler>> initializeChannelHandlers(NettyMetrics nettyMetrics,
+  private LinkedHashMap<String, ChannelHandler> initializeChannelHandlers(NettyMetrics nettyMetrics,
       NettyConfig nettyConfig, RestRequestHandler requestHandler, PublicAccessLogger publicAccessLogger,
       RestServerState restServerState) {
-    ArrayList<Map.Entry<String, ChannelHandler>> channelHandlers = new ArrayList<>();
+    LinkedHashMap<String, ChannelHandler> channelHandlerInfoList = new LinkedHashMap<>();
     // for http encoding/decoding. Note that we get content in 8KB chunks and a change to that number has
     // to go here.
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("codec", new HttpServerCodec()));
+    channelHandlerInfoList.put("codec", new HttpServerCodec());
     // for health check request handling
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("HealthCheckHandler",
-        new HealthCheckHandler(restServerState, nettyMetrics)));
+    channelHandlerInfoList.put("HealthCheckHandler", new HealthCheckHandler(restServerState, nettyMetrics));
     // for public access logging
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("PublicAccessLogHandler",
-        new PublicAccessLogRequestHandler(publicAccessLogger, nettyMetrics)));
+    channelHandlerInfoList
+        .put("PublicAccessLogHandler", new PublicAccessLogRequestHandler(publicAccessLogger, nettyMetrics));
     // for detecting connections that have been idle too long - probably because of an error.
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("idleStateHandler",
-        new IdleStateHandler(0, 0, nettyConfig.nettyServerIdleTimeSeconds)));
+    channelHandlerInfoList.put("idleStateHandler", new IdleStateHandler(0, 0, nettyConfig.nettyServerIdleTimeSeconds));
     // for safe writing of chunks for responses
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("chunker", new ChunkedWriteHandler()));
+    channelHandlerInfoList.put("chunker", new ChunkedWriteHandler());
     // custom processing class that interfaces with a BlobStorageService.
-    channelHandlers.add(new AbstractMap.SimpleEntry<String, ChannelHandler>("processor",
-        new NettyMessageProcessor(nettyMetrics, nettyConfig, requestHandler)));
-    return channelHandlers;
+    channelHandlerInfoList.put("processor", new NettyMessageProcessor(nettyMetrics, nettyConfig, requestHandler));
+    return channelHandlerInfoList;
   }
 }


### PR DESCRIPTION
Creation of handlers was hardcoded in NettyServer. This patch abstracts it in the NettyServerFactory so that any other implementation of NioServer have the flexibility to define their own handlers.

SLA: 5 mins
Reviewers: Priyesh, Ming