### PR TITLE
Fixing arraylist initialization in ReplicationManager

### DIFF
--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -212,7 +212,7 @@ public class ReplicationMetrics {
    *                           replicating from that datacenter
    */
   public void populatePerColoMetrics(String localDatacenter, Set<String> datacenters,
-      final Map<String, List<ReplicaThread>> replicaThreadPools) {
+      final Map<String, ArrayList<ReplicaThread>> replicaThreadPools) {
     trackLiveThreadsCount(replicaThreadPools, localDatacenter);
     for (String datacenter : datacenters) {
       Meter interColoReplicationBytesRatePerDC =
@@ -315,7 +315,7 @@ public class ReplicationMetrics {
     }
   }
 
-  private void trackLiveThreadsCount(final Map<String, List<ReplicaThread>> replicaThreadPools,
+  private void trackLiveThreadsCount(final Map<String, ArrayList<ReplicaThread>> replicaThreadPools,
       String localDatacenter) {
     for (final String datacenter : replicaThreadPools.keySet()) {
       Gauge<Integer> liveThreadsPerDatacenter = new Gauge<Integer>() {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -612,7 +612,7 @@ public class ReplicationTest {
       }
       ReplicationConfig config = new ReplicationConfig(new VerifiableProperties(new Properties()));
 
-      Map<String, List<ReplicaThread>> replicaThreadMap = new HashMap<String, List<ReplicaThread>>();
+      Map<String, ArrayList<ReplicaThread>> replicaThreadMap = new HashMap<String, ArrayList<ReplicaThread>>();
       replicaThreadMap.put("localhost", new ArrayList<ReplicaThread>());
       ReplicationMetrics replicationMetrics = new ReplicationMetrics(new MetricRegistry(), replicaIds);
       replicationMetrics
@@ -868,7 +868,7 @@ public class ReplicationTest {
         }
       }
       ReplicationConfig config = new ReplicationConfig(new VerifiableProperties(new Properties()));
-      Map<String, List<ReplicaThread>> replicaThreadMap = new HashMap<String, List<ReplicaThread>>();
+      Map<String, ArrayList<ReplicaThread>> replicaThreadMap = new HashMap<String, ArrayList<ReplicaThread>>();
       replicaThreadMap.put("localhost", new ArrayList<ReplicaThread>());
       ReplicationMetrics replicationMetrics = new ReplicationMetrics(new MetricRegistry(), replicaIds);
       replicationMetrics
@@ -1099,7 +1099,7 @@ public class ReplicationTest {
         }
       }
       ReplicationConfig config = new ReplicationConfig(new VerifiableProperties(new Properties()));
-      Map<String, List<ReplicaThread>> replicaThreadMap = new HashMap<String, List<ReplicaThread>>();
+      Map<String, ArrayList<ReplicaThread>> replicaThreadMap = new HashMap<String, ArrayList<ReplicaThread>>();
       replicaThreadMap.put("localhost", new ArrayList<ReplicaThread>());
       ReplicationMetrics replicationMetrics = new ReplicationMetrics(new MetricRegistry(), replicaIds);
       replicationMetrics


### PR DESCRIPTION
One of the datastructures in ReplicationManager was declared as a Map of String mapped to a List. During initialization, Arrays.asList() was used which was returning a abstract list. But for more than one ReplicaThread per pool, adding new replica threads was failing.

SLA: 2 mins
Reviewers: Priyesh