### PR TITLE
Fixing a bug with the way channel pipelines were abstracted

### DIFF
--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerTest.java
@@ -16,12 +16,12 @@ package com.github.ambry.rest;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.NettyConfig;
 import com.github.ambry.config.VerifiableProperties;
-import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import java.io.IOException;
-import java.util.LinkedHashMap;
 import java.util.Properties;
 import org.junit.Test;
 
@@ -116,44 +116,29 @@ public class NettyServerTest {
       properties = new Properties();
     }
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
-    NettyConfig nettyConfig = new NettyConfig(verifiableProperties);
-    NettyMetrics nettyMetrics = new NettyMetrics(new MetricRegistry());
-    RestRequestHandler requestHandler = new MockRestRequestResponseHandler();
-    PublicAccessLogger publicAccessLogger = new PublicAccessLogger(new String[]{}, new String[]{});
-    RestServerState restServerState = new RestServerState("/healthCheck");
-    return new NettyServer(nettyConfig, nettyMetrics,
-        initializeChannelHandlers(nettyMetrics, nettyConfig, requestHandler, publicAccessLogger, restServerState));
-  }
-
-  /**
-   * Initialize the {@link ChannelHandler}s to be used in the netty pipeline
-   * @param nettyMetrics the {@link NettyMetrics} instance to use to record metrics.
-   * @param nettyConfig the {@link NettyConfig} instance that defines the configuration parameters for the NettyServer.
-   * @param requestHandler the {@link RestRequestHandler} that handles general requests.
-   * @param publicAccessLogger the {@link PublicAccessLogger} that can be used for public access logging
-   * @param restServerState the {@link RestServerState} that can be used to check the health of the system
-   *                              to respond to health check requests
-   * @return Linked list of pairs of {@link ChannelHandler} name and {@link ChannelHandler}s to
-   *                               be used in the channel pipeline
-   */
-  private LinkedHashMap<String, ChannelHandler> initializeChannelHandlers(NettyMetrics nettyMetrics,
-      NettyConfig nettyConfig, RestRequestHandler requestHandler, PublicAccessLogger publicAccessLogger,
-      RestServerState restServerState) {
-    LinkedHashMap<String, ChannelHandler> channelHandlerInfoList = new LinkedHashMap<>();
-    // for http encoding/decoding. Note that we get content in 8KB chunks and a change to that number has
-    // to go here.
-    channelHandlerInfoList.put("codec", new HttpServerCodec());
-    // for health check request handling
-    channelHandlerInfoList.put("HealthCheckHandler", new HealthCheckHandler(restServerState, nettyMetrics));
-    // for public access logging
-    channelHandlerInfoList
-        .put("PublicAccessLogHandler", new PublicAccessLogRequestHandler(publicAccessLogger, nettyMetrics));
-    // for detecting connections that have been idle too long - probably because of an error.
-    channelHandlerInfoList.put("idleStateHandler", new IdleStateHandler(0, 0, nettyConfig.nettyServerIdleTimeSeconds));
-    // for safe writing of chunks for responses
-    channelHandlerInfoList.put("chunker", new ChunkedWriteHandler());
-    // custom processing class that interfaces with a BlobStorageService.
-    channelHandlerInfoList.put("processor", new NettyMessageProcessor(nettyMetrics, nettyConfig, requestHandler));
-    return channelHandlerInfoList;
+    final NettyConfig nettyConfig = new NettyConfig(verifiableProperties);
+    final NettyMetrics nettyMetrics = new NettyMetrics(new MetricRegistry());
+    final RestRequestHandler requestHandler = new MockRestRequestResponseHandler();
+    final PublicAccessLogger publicAccessLogger = new PublicAccessLogger(new String[]{}, new String[]{});
+    final RestServerState restServerState = new RestServerState("/healthCheck");
+    return new NettyServer(nettyConfig, nettyMetrics, new ChannelInitializer<SocketChannel>() {
+      @Override
+      protected void initChannel(SocketChannel ch) {
+        ch.pipeline()
+            // for http encoding/decoding. Note that we get content in 8KB chunks and a change to that number has
+            // to go here.
+            .addLast("codec", new HttpServerCodec())
+                // for health check request handling
+            .addLast("healthCheckHandler", new HealthCheckHandler(restServerState, nettyMetrics))
+                // for public access logging
+            .addLast("publicAccessLogHandler", new PublicAccessLogRequestHandler(publicAccessLogger, nettyMetrics))
+                // for detecting connections that have been idle too long - probably because of an error.
+            .addLast("idleStateHandler", new IdleStateHandler(0, 0, nettyConfig.nettyServerIdleTimeSeconds))
+                // for safe writing of chunks for responses
+            .addLast("chunker", new ChunkedWriteHandler())
+                // custom processing class that interfaces with a BlobStorageService.
+            .addLast("processor", new NettyMessageProcessor(nettyMetrics, nettyConfig, requestHandler));
+      }
+    });
   }
 }


### PR DESCRIPTION
Channel piplines were being created with the same instance of the handlers. Netty requires that each channel
have its own instance of all the handlers unless the handler is sharable. This change fixes the problem.

**Primary reviewers: Siva**
**Expected time to review: 10 mins**