### PR TITLE
Fixing the way Selector handles SSL connection handshakes

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -128,10 +128,10 @@ public class NetworkMetrics {
   /**
    * Initializes few network metrics for the selector
    * @param activeConnections count of current active connections
-   * @param pendingSslHandshakes List of {@link SSLTransmission}s that are awaiting for handshake completion
+   * @param pendingHandshakeTransmissions List of {@link Transmission}s that are awaiting for handshake completion
    */
   public void initializeSelectorMetricsIfRequired(final AtomicLong activeConnections,
-      final List<SSLTransmission> pendingSslHandshakes) {
+      final Map<String, PendingHandshakeTransmission> pendingHandshakeTransmissions) {
     selectorActiveConnections = new Gauge<Long>() {
       @Override
       public Long getValue() {
@@ -141,7 +141,7 @@ public class NetworkMetrics {
     selectorPendingHandshakes = new Gauge<Integer>() {
       @Override
       public Integer getValue() {
-        return pendingSslHandshakes.size();
+        return pendingHandshakeTransmissions.size();
       }
     };
   }

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -46,7 +46,7 @@ public class NetworkMetrics {
   public final Counter selectorCloseKeyErrorCount;
   public final Counter selectorCloseSocketErrorCount;
   public Gauge<Long> selectorActiveConnections;
-  public Gauge<Integer> selectorPendingHandshakes;
+  public Gauge<Long> selectorConnectionsPendingHandshake;
   public final Map<String, SelectorNodeMetric> selectorNodeMetricMap;
 
   // Plaintext metrics
@@ -128,20 +128,20 @@ public class NetworkMetrics {
   /**
    * Initializes a few network metrics for the selector
    * @param activeConnections count of current active connections
-   * @param pendingHandshakeTransmissions List of {@link Transmission}s that are awaiting handshake completion
+   * @param connectionsPendingHandshakeCount Count of connections that are awaiting handshake completion
    */
   public void initializeSelectorMetricsIfRequired(final AtomicLong activeConnections,
-      final Map<String, TransmissionPendingHandshake> pendingHandshakeTransmissions) {
+      final AtomicLong connectionsPendingHandshakeCount) {
     selectorActiveConnections = new Gauge<Long>() {
       @Override
       public Long getValue() {
         return activeConnections.get();
       }
     };
-    selectorPendingHandshakes = new Gauge<Integer>() {
+    selectorConnectionsPendingHandshake = new Gauge<Long>() {
       @Override
-      public Integer getValue() {
-        return pendingHandshakeTransmissions.size();
+      public Long getValue() {
+        return connectionsPendingHandshakeCount.get();
       }
     };
   }

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -126,9 +126,9 @@ public class NetworkMetrics {
   }
 
   /**
-   * Initializes few network metrics for the selector
+   * Initializes a few network metrics for the selector
    * @param activeConnections count of current active connections
-   * @param pendingHandshakeTransmissions List of {@link Transmission}s that are awaiting for handshake completion
+   * @param pendingHandshakeTransmissions List of {@link Transmission}s that are awaiting handshake completion
    */
   public void initializeSelectorMetricsIfRequired(final AtomicLong activeConnections,
       final Map<String, PendingHandshakeTransmission> pendingHandshakeTransmissions) {

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -38,6 +38,7 @@ public class NetworkMetrics {
   public final Histogram selectorSelectTime;
   public final Counter selectorIORate;
   public final Histogram selectorIOTime;
+  public final Histogram selectorPerceivedSslHandshakeTime;
   public final Counter selectorNioCloseErrorCount;
   public final Counter selectorDisconnectedErrorCount;
   public final Counter selectorIOErrorCount;
@@ -45,6 +46,7 @@ public class NetworkMetrics {
   public final Counter selectorCloseKeyErrorCount;
   public final Counter selectorCloseSocketErrorCount;
   public Gauge<Long> selectorActiveConnections;
+  public Gauge<Integer> selectorPendingHandshakes;
   public final Map<String, SelectorNodeMetric> selectorNodeMetricMap;
 
   // Plaintext metrics
@@ -87,6 +89,8 @@ public class NetworkMetrics {
     selectorIORate = registry.counter(MetricRegistry.name(Selector.class, "SelectorIORate"));
     selectorSelectTime = registry.histogram(MetricRegistry.name(Selector.class, "SelectorSelectTime"));
     selectorIOTime = registry.histogram(MetricRegistry.name(Selector.class, "SelectorIOTime"));
+    selectorPerceivedSslHandshakeTime =
+        registry.histogram(MetricRegistry.name(Selector.class, "SelectorSslHandshakeTime"));
     selectorNioCloseErrorCount = registry.counter(MetricRegistry.name(Selector.class, "SelectorNioCloseErrorCount"));
     selectorDisconnectedErrorCount =
         registry.counter(MetricRegistry.name(Selector.class, "SelectorDisconnectedErrorCount"));
@@ -121,11 +125,23 @@ public class NetworkMetrics {
     selectorNodeMetricMap = new HashMap<String, SelectorNodeMetric>();
   }
 
-  public void initializeSelectorMetricsIfRequired(final AtomicLong activeConnections) {
+  /**
+   * Initializes few network metrics for the selector
+   * @param activeConnections count of current active connections
+   * @param pendingSslHandshakes List of {@link Transmission}s that are awaiting for handshake completion
+   */
+  public void initializeSelectorMetricsIfRequired(final AtomicLong activeConnections,
+      final List<Transmission> pendingSslHandshakes) {
     selectorActiveConnections = new Gauge<Long>() {
       @Override
       public Long getValue() {
         return activeConnections.get();
+      }
+    };
+    selectorPendingHandshakes = new Gauge<Integer>() {
+      @Override
+      public Integer getValue() {
+        return pendingSslHandshakes.size();
       }
     };
   }

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -125,7 +125,7 @@ public class NetworkMetrics {
    * Initializes a few network metrics for the selector
    * @param activeConnections count of current active connections
    */
-  public void initializeSelectorMetrics(final AtomicLong activeConnections) {
+  void initializeSelectorMetrics(final AtomicLong activeConnections) {
     numActiveConnections = new Gauge<Long>() {
       @Override
       public Long getValue() {

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -128,10 +128,10 @@ public class NetworkMetrics {
   /**
    * Initializes few network metrics for the selector
    * @param activeConnections count of current active connections
-   * @param pendingSslHandshakes List of {@link Transmission}s that are awaiting for handshake completion
+   * @param pendingSslHandshakes List of {@link SSLTransmission}s that are awaiting for handshake completion
    */
   public void initializeSelectorMetricsIfRequired(final AtomicLong activeConnections,
-      final List<Transmission> pendingSslHandshakes) {
+      final List<SSLTransmission> pendingSslHandshakes) {
     selectorActiveConnections = new Gauge<Long>() {
       @Override
       public Long getValue() {

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -131,7 +131,7 @@ public class NetworkMetrics {
    * @param pendingHandshakeTransmissions List of {@link Transmission}s that are awaiting handshake completion
    */
   public void initializeSelectorMetricsIfRequired(final AtomicLong activeConnections,
-      final Map<String, PendingHandshakeTransmission> pendingHandshakeTransmissions) {
+      final Map<String, TransmissionPendingHandshake> pendingHandshakeTransmissions) {
     selectorActiveConnections = new Gauge<Long>() {
       @Override
       public Long getValue() {

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -45,7 +45,6 @@ public class NetworkMetrics {
   public final Counter selectorCloseKeyErrorCount;
   public final Counter selectorCloseSocketErrorCount;
   public Gauge<Long> numActiveConnections;
-  public Gauge<Long> numConnectionsPendingHandshake;
   public final Map<String, SelectorNodeMetric> selectorNodeMetricMap;
 
   // Plaintext metrics
@@ -125,20 +124,12 @@ public class NetworkMetrics {
   /**
    * Initializes a few network metrics for the selector
    * @param activeConnections count of current active connections
-   * @param connectionsPendingHandshake Count of connections that are awaiting handshake completion
    */
-  public void initializeSelectorMetrics(final AtomicLong activeConnections,
-      final AtomicLong connectionsPendingHandshake) {
+  public void initializeSelectorMetrics(final AtomicLong activeConnections) {
     numActiveConnections = new Gauge<Long>() {
       @Override
       public Long getValue() {
         return activeConnections.get();
-      }
-    };
-    numConnectionsPendingHandshake = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return connectionsPendingHandshake.get();
       }
     };
   }

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -38,7 +38,6 @@ public class NetworkMetrics {
   public final Histogram selectorSelectTime;
   public final Counter selectorIORate;
   public final Histogram selectorIOTime;
-  public final Histogram selectorPerceivedSslHandshakeTime;
   public final Counter selectorNioCloseErrorCount;
   public final Counter selectorDisconnectedErrorCount;
   public final Counter selectorIOErrorCount;
@@ -89,8 +88,6 @@ public class NetworkMetrics {
     selectorIORate = registry.counter(MetricRegistry.name(Selector.class, "SelectorIORate"));
     selectorSelectTime = registry.histogram(MetricRegistry.name(Selector.class, "SelectorSelectTime"));
     selectorIOTime = registry.histogram(MetricRegistry.name(Selector.class, "SelectorIOTime"));
-    selectorPerceivedSslHandshakeTime =
-        registry.histogram(MetricRegistry.name(Selector.class, "SelectorSslHandshakeTime"));
     selectorNioCloseErrorCount = registry.counter(MetricRegistry.name(Selector.class, "SelectorNioCloseErrorCount"));
     selectorDisconnectedErrorCount =
         registry.counter(MetricRegistry.name(Selector.class, "SelectorDisconnectedErrorCount"));

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -45,8 +45,8 @@ public class NetworkMetrics {
   public final Counter selectorKeyOperationErrorCount;
   public final Counter selectorCloseKeyErrorCount;
   public final Counter selectorCloseSocketErrorCount;
-  public Gauge<Long> selectorActiveConnections;
-  public Gauge<Long> selectorConnectionsPendingHandshake;
+  public Gauge<Long> numActiveConnections;
+  public Gauge<Long> numConnectionsPendingHandhsake;
   public final Map<String, SelectorNodeMetric> selectorNodeMetricMap;
 
   // Plaintext metrics
@@ -128,20 +128,20 @@ public class NetworkMetrics {
   /**
    * Initializes a few network metrics for the selector
    * @param activeConnections count of current active connections
-   * @param connectionsPendingHandshakeCount Count of connections that are awaiting handshake completion
+   * @param numConnectionsPendingHandhsake Count of connections that are awaiting handshake completion
    */
   public void initializeSelectorMetricsIfRequired(final AtomicLong activeConnections,
-      final AtomicLong connectionsPendingHandshakeCount) {
-    selectorActiveConnections = new Gauge<Long>() {
+      final AtomicLong numConnectionsPendingHandhsake) {
+    numActiveConnections = new Gauge<Long>() {
       @Override
       public Long getValue() {
         return activeConnections.get();
       }
     };
-    selectorConnectionsPendingHandshake = new Gauge<Long>() {
+    this.numConnectionsPendingHandhsake = new Gauge<Long>() {
       @Override
       public Long getValue() {
-        return connectionsPendingHandshakeCount.get();
+        return numConnectionsPendingHandhsake.get();
       }
     };
   }

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -45,7 +45,7 @@ public class NetworkMetrics {
   public final Counter selectorCloseKeyErrorCount;
   public final Counter selectorCloseSocketErrorCount;
   public Gauge<Long> numActiveConnections;
-  public Gauge<Long> numConnectionsPendingHandhsake;
+  public Gauge<Long> numConnectionsPendingHandshake;
   public final Map<String, SelectorNodeMetric> selectorNodeMetricMap;
 
   // Plaintext metrics
@@ -125,20 +125,20 @@ public class NetworkMetrics {
   /**
    * Initializes a few network metrics for the selector
    * @param activeConnections count of current active connections
-   * @param numConnectionsPendingHandhsake Count of connections that are awaiting handshake completion
+   * @param connectionsPendingHandshake Count of connections that are awaiting handshake completion
    */
   public void initializeSelectorMetricsIfRequired(final AtomicLong activeConnections,
-      final AtomicLong numConnectionsPendingHandhsake) {
+      final AtomicLong connectionsPendingHandshake) {
     numActiveConnections = new Gauge<Long>() {
       @Override
       public Long getValue() {
         return activeConnections.get();
       }
     };
-    this.numConnectionsPendingHandhsake = new Gauge<Long>() {
+    numConnectionsPendingHandshake = new Gauge<Long>() {
       @Override
       public Long getValue() {
-        return numConnectionsPendingHandhsake.get();
+        return connectionsPendingHandshake.get();
       }
     };
   }

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -127,7 +127,7 @@ public class NetworkMetrics {
    * @param activeConnections count of current active connections
    * @param connectionsPendingHandshake Count of connections that are awaiting handshake completion
    */
-  public void initializeSelectorMetricsIfRequired(final AtomicLong activeConnections,
+  public void initializeSelectorMetrics(final AtomicLong activeConnections,
       final AtomicLong connectionsPendingHandshake) {
     numActiveConnections = new Gauge<Long>() {
       @Override

--- a/ambry-network/src/main/java/com.github.ambry.network/PlainTextTransmission.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/PlainTextTransmission.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * Transmission used to speak plain text to the underlying channel.
  */
 public class PlainTextTransmission extends Transmission {
-  private static final Logger logger = LoggerFactory.getLogger(SSLTransmission.class);
+  private static final Logger logger = LoggerFactory.getLogger(PlainTextTransmission.class);
 
   public PlainTextTransmission(String connectionId, SocketChannel socketChannel, SelectionKey key, Time time,
       NetworkMetrics metrics) {

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -73,7 +73,7 @@ public class Selector implements Selectable {
   private final List<NetworkReceive> completedReceives;
   private final List<String> disconnected;
   private final List<String> connected;
-  private final Set<String> unreadycConnections;
+  private final Set<String> unreadyConnections;
   private final Time time;
   private final NetworkMetrics metrics;
   private final AtomicLong IdGenerator;
@@ -95,7 +95,7 @@ public class Selector implements Selectable {
     this.metrics = metrics;
     this.IdGenerator = new AtomicLong(0);
     numActiveConnections = new AtomicLong(0);
-    unreadycConnections = new HashSet<>();
+    unreadyConnections = new HashSet<>();
     metrics.initializeSelectorMetrics(numActiveConnections);
     this.sslFactory = sslFactory;
   }
@@ -323,7 +323,7 @@ public class Selector implements Selectable {
               connected.add(transmission.getConnectionId());
               metrics.selectorConnectionCreated.inc();
             } else {
-              unreadycConnections.add(transmission.getConnectionId());
+              unreadyConnections.add(transmission.getConnectionId());
             }
           }
 
@@ -367,7 +367,7 @@ public class Selector implements Selectable {
    * Check readiness for unready connections and add to completed list if ready
    */
   private void checkUnreadyConnectionsStatus() {
-    Iterator<String> iterator = unreadycConnections.iterator();
+    Iterator<String> iterator = unreadyConnections.iterator();
     while (iterator.hasNext()) {
       String connId = iterator.next();
       if (isChannelReady(connId)) {
@@ -478,7 +478,7 @@ public class Selector implements Selectable {
       this.disconnected.add(transmission.getConnectionId());
       this.keyMap.remove(transmission.getConnectionId());
       numActiveConnections.set(keyMap.size());
-      unreadycConnections.remove(transmission.getConnectionId());
+      unreadyConnections.remove(transmission.getConnectionId());
       try {
         transmission.close();
       } catch (IOException e) {

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -77,7 +77,7 @@ public class Selector implements Selectable {
   private final Time time;
   private final NetworkMetrics metrics;
   private final AtomicLong IdGenerator;
-  private AtomicLong numActiveConnections;
+  private final AtomicLong numActiveConnections;
   private final SSLFactory sslFactory;
 
   /**

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -364,7 +364,7 @@ public class Selector implements Selectable {
   }
 
   /**
-   * Add those Ssl connections to connected list on handshake completion
+   * Add Ssl connections to connected list on handshake completion
    */
   private void completeSslHandshakes() {
     Iterator<PendingHandshakeTransmission> pendingSslTransIter = pendingHandshakeTransmissions.values().iterator();
@@ -479,14 +479,9 @@ public class Selector implements Selectable {
       this.disconnected.add(transmission.getConnectionId());
       this.keyMap.remove(transmission.getConnectionId());
       activeConnections.set(this.keyMap.size());
-      try {
-        transmission.close();
-        if (pendingHandshakeTransmissions.get(transmission.getConnectionId()) != null) {
-          pendingHandshakeTransmissions.remove(transmission.getConnectionId());
-        }
-      } catch (IOException e) {
-        logger.error("IOException thrown during closing of transmission with connectionId {} :",
-            transmission.getConnectionId(), e);
+      transmission.close();
+      if (pendingHandshakeTransmissions.get(transmission.getConnectionId()) != null) {
+        pendingHandshakeTransmissions.remove(transmission.getConnectionId());
       }
     } else {
       key.attach(null);

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -76,8 +76,8 @@ public class Selector implements Selectable {
   private final Time time;
   private final NetworkMetrics metrics;
   private final AtomicLong IdGenerator;
-  private AtomicLong activeConnections;
-  private AtomicLong connectionsPendingHandshakeCount;
+  private AtomicLong numActiveConnections;
+  private AtomicLong numConnectionsPendingHandshake;
   private final SSLFactory sslFactory;
 
   /**
@@ -94,10 +94,10 @@ public class Selector implements Selectable {
     this.disconnected = new ArrayList<String>();
     this.metrics = metrics;
     this.IdGenerator = new AtomicLong(0);
-    activeConnections = new AtomicLong(0);
-    connectionsPendingHandshakeCount = new AtomicLong(0);
+    numActiveConnections = new AtomicLong(0);
+    numConnectionsPendingHandshake = new AtomicLong(0);
     connectionPendingHandshakes = new ArrayList<>();
-    metrics.initializeSelectorMetricsIfRequired(activeConnections, connectionsPendingHandshakeCount);
+    metrics.initializeSelectorMetricsIfRequired(numActiveConnections, numConnectionsPendingHandshake);
     this.sslFactory = sslFactory;
   }
 
@@ -167,7 +167,7 @@ public class Selector implements Selectable {
     }
     key.attach(transmission);
     this.keyMap.put(connectionId, key);
-    activeConnections.set(this.keyMap.size());
+    numActiveConnections.set(this.keyMap.size());
     return connectionId;
   }
 
@@ -194,7 +194,7 @@ public class Selector implements Selectable {
     }
     key.attach(transmission);
     this.keyMap.put(connectionId, key);
-    activeConnections.set(this.keyMap.size());
+    numActiveConnections.set(this.keyMap.size());
     return connectionId;
   }
 
@@ -325,7 +325,7 @@ public class Selector implements Selectable {
               metrics.selectorConnectionCreated.inc();
             } else {
               connectionPendingHandshakes.add(transmission.getConnectionId());
-              connectionsPendingHandshakeCount.incrementAndGet();
+              numConnectionsPendingHandshake.incrementAndGet();
             }
           }
 
@@ -376,7 +376,7 @@ public class Selector implements Selectable {
         connected.add(connId);
         iterator.remove();
         metrics.selectorConnectionCreated.inc();
-        connectionsPendingHandshakeCount.decrementAndGet();
+        numConnectionsPendingHandshake.decrementAndGet();
       }
     }
   }
@@ -425,8 +425,8 @@ public class Selector implements Selectable {
     return this.connected;
   }
 
-  public long getActiveConnections() {
-    return activeConnections.get();
+  public long getNumActiveConnections() {
+    return numActiveConnections.get();
   }
 
   /**
@@ -480,7 +480,7 @@ public class Selector implements Selectable {
       logger.debug("Closing connection from {}", transmission.getConnectionId());
       this.disconnected.add(transmission.getConnectionId());
       this.keyMap.remove(transmission.getConnectionId());
-      activeConnections.set(this.keyMap.size());
+      numActiveConnections.set(this.keyMap.size());
       connectionPendingHandshakes.remove(transmission.getConnectionId());
       transmission.close();
     } else {

--- a/ambry-network/src/main/java/com.github.ambry.network/Transmission.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Transmission.java
@@ -132,8 +132,7 @@ public abstract class Transmission {
   /**
    * Close the connection for the socket channel
    */
-  public abstract void close()
-      throws IOException;
+  public abstract void close();
 
   public String getConnectionId() {
     return connectionId;

--- a/ambry-network/src/main/java/com.github.ambry.network/Transmission.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Transmission.java
@@ -132,7 +132,8 @@ public abstract class Transmission {
   /**
    * Close the connection for the socket channel
    */
-  public abstract void close();
+  public abstract void close()
+      throws IOException;
 
   public String getConnectionId() {
     return connectionId;

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
@@ -214,7 +214,7 @@ public class SSLSelectorTest {
   }
 
   @Test
-  public void testCloseDuringSslHandshake()
+  public void testCloseAfterConnectCall()
       throws IOException {
     String connectionId =
         selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.SSL);

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
@@ -220,10 +220,7 @@ public class SSLSelectorTest {
       throws IOException {
     String connectionId =
         selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.SSL);
-    Assert.assertFalse("Channel should not be ready by now (until handshake completes)",
-        selector.isChannelReady(connectionId));
-    selector.poll(10000L);
-    Assert.assertFalse("Channel shouldn't have been added to connect list w/o handshake",
+    Assert.assertFalse("Channel shouldn't have been added to connect list w/o completing handshake",
         selector.connected().contains(connectionId));
     selector.close(connectionId);
     Assert.assertFalse("Channel should not have been added to connected list ",

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
@@ -22,8 +22,8 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import junit.framework.Assert;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,16 +48,16 @@ public class SSLSelectorTest {
         TestSSLUtils.createSSLConfig("DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client");
     SSLFactory serverSSLFactory = new SSLFactory(sslConfig);
     SSLFactory clientSSLFactory = new SSLFactory(clientSSLConfig);
-    this.server = new EchoServer(serverSSLFactory, 18383);
-    this.server.start();
-    this.selector = new Selector(new NetworkMetrics(new MetricRegistry()), SystemTime.getInstance(), clientSSLFactory);
+    server = new EchoServer(serverSSLFactory, 18383);
+    server.start();
+    selector = new Selector(new NetworkMetrics(new MetricRegistry()), SystemTime.getInstance(), clientSSLFactory);
   }
 
   @After
   public void teardown()
       throws Exception {
-    this.selector.close();
-    this.server.close();
+    selector.close();
+    server.close();
   }
 
   /**
@@ -71,7 +71,7 @@ public class SSLSelectorTest {
     assertEquals("hello", blockingRequest(connectionId, "hello"));
 
     // disconnect
-    this.server.closeConnections();
+    server.closeConnections();
     while (!selector.disconnected().contains(connectionId)) {
       selector.poll(1000L);
     }
@@ -207,8 +207,6 @@ public class SSLSelectorTest {
       throws IOException {
     String connectionId =
         selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.SSL);
-    Assert.assertFalse("Channel should not be ready by now (until handshake completes)",
-        selector.isChannelReady(connectionId));
     while (!selector.connected().contains(connectionId)) {
       selector.poll(10000L);
     }
@@ -220,11 +218,7 @@ public class SSLSelectorTest {
       throws IOException {
     String connectionId =
         selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.SSL);
-    Assert.assertFalse("Channel shouldn't have been added to connect list w/o completing handshake",
-        selector.connected().contains(connectionId));
     selector.close(connectionId);
-    Assert.assertFalse("Channel should not have been added to connected list ",
-        selector.connected().contains(connectionId));
     Assert.assertTrue("Channel should have been added to disconnected list",
         selector.disconnected().contains(connectionId));
   }


### PR DESCRIPTION
Currently, for connections over SSL, the ambry selector returns an established connection after a poll even before the handshake is completed. This is not very useful as the caller will then have to repeatedly check outside of the selector poll on whether the handshake is complete, which is not ideal.

This patch fixes this issue.
The selector will only return a connection after the connection is established and the handshake is complete. If the handshake does not complete for any reason, then it should be treated as a connection establishment failure. This way the callers of the selector can be agnostic to SSL, and can interact with the selector in a completely non-blocking way.

Coverage:
Selector	100% (1/ 1)	96.4% (27/ 28)	84.5% (191/ 226)
All the new lines are covered

SLA: 10 mins
Reviewers: Priyesh, Ming

Addresses issue #297 