### PR TITLE
Removing a test assertion that is wrong.

### DIFF
--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
@@ -312,7 +312,6 @@ public class NettyMessageProcessorTest {
       fail("Post did not succeed after 100ms. There is an error or timeout needs to increase");
     }
     assertNotNull("Blob id operated on cannot be null", notificationSystem.blobIdOperatedOn);
-    assertTrue("Channel should be active", channel.isActive());
     return router.getActiveBlobs().get(notificationSystem.blobIdOperatedOn).getBlob();
   }
 


### PR DESCRIPTION
The assertion being removed is wrong and was only succeeding because a race condition.
This assertion is of no significance to the test as a whole