### PR TITLE
Make gradle test print stacktrace on test failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,12 @@ allprojects {
 subprojects {
     apply plugin: 'java'
 
+    test {
+      testLogging {
+        exceptionFormat = 'full'
+      }
+    }
+
     dependencies {
         compile "log4j:log4j:$log4jVersion"
         compile "org.slf4j:slf4j-api:$slf4jVersion"


### PR DESCRIPTION
It helps to see the stacktrace on the console when tests fail. Currently gradle does not print that. We could add the `-i` option but that is very verbose. Instead, following the instruction from here: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.logging.TestLoggingContainer.html

With this change, we get the following on test failure (induced error):

```
com.github.ambry.router.PutManagerTest > testLaterChunkFailure FAILED
    java.lang.AssertionError: Exactly one chunkFiller thread should be running before the router is closed expected:<1> but was:<12>
        at org.junit.Assert.fail(Assert.java:91)
        at org.junit.Assert.failNotEquals(Assert.java:645)
        at org.junit.Assert.assertEquals(Assert.java:126)
        at org.junit.Assert.assertEquals(Assert.java:470)
        at com.github.ambry.router.PutManagerTest.assertCloseCleanup(PutManagerTest.java:773)
        at com.github.ambry.router.PutManagerTest.submitPutsAndAssertFailure(PutManagerTest.java:607)
        at com.github.ambry.router.PutManagerTest.testLaterChunkFailure(PutManagerTest.java:350)
```