### PR TITLE
Adding getStatus() and getHeader() APIs in RestResponseChannel

### DIFF
--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
@@ -362,7 +362,7 @@ public class AdminBlobStorageServiceTest {
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     ReadableStreamChannel channel = doGet(restRequest, restResponseChannel);
     String echoedText = getJsonizedResponseBody(channel).getString(EchoHandler.TEXT_KEY);
-    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getStatus());
     assertEquals("Unexpected Content-Type", "application/json",
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
     assertEquals("Did not get expected response", inputText, echoedText);
@@ -405,7 +405,7 @@ public class AdminBlobStorageServiceTest {
       RestRequest restRequest = createGetReplicasForBlobIdRestRequest(blobId.getID());
       MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
       ReadableStreamChannel channel = doGet(restRequest, restResponseChannel);
-      assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getResponseStatus());
+      assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getStatus());
       assertEquals("Unexpected Content-Type", "application/json",
           restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
       String returnedReplicasStr =
@@ -1056,7 +1056,7 @@ public class AdminBlobStorageServiceTest {
     RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers, contents);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doPost(restRequest, restResponseChannel);
-    assertEquals("Unexpected response status", ResponseStatus.Created, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.Created, restResponseChannel.getStatus());
     assertTrue("No Date header", restResponseChannel.getHeader(RestUtils.Headers.DATE) != null);
     assertTrue("No " + RestUtils.Headers.CREATION_TIME,
         restResponseChannel.getHeader(RestUtils.Headers.CREATION_TIME) != null);
@@ -1080,7 +1080,7 @@ public class AdminBlobStorageServiceTest {
     RestRequest restRequest = createRestRequest(RestMethod.GET, blobId, null, null);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     ReadableStreamChannel response = doGet(restRequest, restResponseChannel);
-    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getStatus());
     checkCommonGetHeadHeaders(restResponseChannel, expectedHeaders);
     CopyingAsyncWritableChannel channel = new CopyingAsyncWritableChannel((int) response.getSize());
     response.readInto(channel, null).get();
@@ -1098,7 +1098,7 @@ public class AdminBlobStorageServiceTest {
     RestRequest restRequest = createRestRequest(RestMethod.HEAD, blobId, null, null);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doHead(restRequest, restResponseChannel);
-    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getStatus());
     checkCommonGetHeadHeaders(restResponseChannel, expectedHeaders);
     assertEquals("Content-Length does not match blob size", expectedHeaders.getString(RestUtils.Headers.BLOB_SIZE),
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
@@ -1135,7 +1135,7 @@ public class AdminBlobStorageServiceTest {
     RestRequest restRequest = createRestRequest(RestMethod.DELETE, blobId, null, null);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doDelete(restRequest, restResponseChannel);
-    assertEquals("Unexpected response status", ResponseStatus.Accepted, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.Accepted, restResponseChannel.getStatus());
     assertTrue("No Date header", restResponseChannel.getHeader(RestUtils.Headers.DATE) != null);
     assertEquals("Content-Length is not 0", "0", restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
   }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestResponseChannel.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestResponseChannel.java
@@ -97,6 +97,12 @@ public interface RestResponseChannel extends AsyncWritableChannel {
       throws RestServiceException;
 
   /**
+   * Gets the current {@link ResponseStatus}.
+   * @return the response status.
+   */
+  public ResponseStatus getStatus();
+
+  /**
    * Sets header {@code headerName} to {@code headerValue}.
    * @param headerName the name of the header to set to {@code headerValue}.
    * @param headerValue the value of the header with name {@code headerName}.
@@ -104,4 +110,11 @@ public interface RestResponseChannel extends AsyncWritableChannel {
    */
   public void setHeader(String headerName, Object headerValue)
       throws RestServiceException;
+
+  /**
+   * Gets the current value of the header with {@code headerName}.
+   * @param headerName the name of the header whose value is required.
+   * @return the value of the header with name {@code headerName} if it exists. {@code null} otherwise.
+   */
+  public Object getHeader(String headerName);
 }

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockRestResponseChannel.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockRestResponseChannel.java
@@ -183,9 +183,36 @@ public class MockRestResponseChannel implements RestResponseChannel {
   }
 
   @Override
+  public synchronized ResponseStatus getStatus() {
+    ResponseStatus status = null;
+    try {
+      if (responseMetadata.has(RESPONSE_STATUS_KEY)) {
+        status = ResponseStatus.valueOf(responseMetadata.getString(RESPONSE_STATUS_KEY));
+      }
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+    return status;
+  }
+
+  @Override
   public synchronized void setHeader(String headerName, Object headerValue)
       throws RestServiceException {
     setHeader(headerName, headerValue, Event.SetHeader);
+  }
+
+  @Override
+  public synchronized String getHeader(String headerName) {
+    String headerValue = null;
+    try {
+      if (responseMetadata.has(RESPONSE_HEADERS_KEY) && responseMetadata.getJSONObject(RESPONSE_HEADERS_KEY)
+          .has(headerName)) {
+        headerValue = responseMetadata.getJSONObject(RESPONSE_HEADERS_KEY).getString(headerName);
+      }
+    } catch (JSONException e) {
+      throw new IllegalStateException(e);
+    }
+    return headerValue;
   }
 
   @Override
@@ -240,41 +267,6 @@ public class MockRestResponseChannel implements RestResponseChannel {
    */
   public synchronized byte[] getResponseBody() {
     return bodyBytes.toByteArray();
-  }
-
-  /**
-   * Gets the value of the header with {@code headerName} if it exists. If the response isn't finalized, headers can
-   * change.
-   * @param headerName the name of the header.
-   * @return the value of the header if it exists, null otherwise.
-   */
-  public synchronized String getHeader(String headerName) {
-    String headerValue = null;
-    try {
-      if (responseMetadata.has(RESPONSE_HEADERS_KEY) && responseMetadata.getJSONObject(RESPONSE_HEADERS_KEY)
-          .has(headerName)) {
-        headerValue = responseMetadata.getJSONObject(RESPONSE_HEADERS_KEY).getString(headerName);
-      }
-    } catch (JSONException e) {
-      // too bad.
-    }
-    return headerValue;
-  }
-
-  /**
-   * Gets the response status. If the response isn't finalized, status can change.
-   * @return the response status.
-   */
-  public synchronized ResponseStatus getResponseStatus() {
-    ResponseStatus status = null;
-    try {
-      if (responseMetadata.has(RESPONSE_STATUS_KEY)) {
-        status = ResponseStatus.valueOf(responseMetadata.getString(RESPONSE_STATUS_KEY));
-      }
-    } catch (Exception e) {
-      // too bad.
-    }
-    return status;
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockRestResponseChannel.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockRestResponseChannel.java
@@ -183,7 +183,7 @@ public class MockRestResponseChannel implements RestResponseChannel {
   }
 
   @Override
-  public synchronized ResponseStatus getStatus() {
+  public ResponseStatus getStatus() {
     ResponseStatus status = null;
     try {
       if (responseMetadata.has(RESPONSE_STATUS_KEY)) {
@@ -202,7 +202,7 @@ public class MockRestResponseChannel implements RestResponseChannel {
   }
 
   @Override
-  public synchronized String getHeader(String headerName) {
+  public String getHeader(String headerName) {
     String headerValue = null;
     try {
       if (responseMetadata.has(RESPONSE_HEADERS_KEY) && responseMetadata.getJSONObject(RESPONSE_HEADERS_KEY)

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -371,8 +371,7 @@ public class AmbryBlobStorageServiceTest {
       RestRequest restRequest = createRestRequest(RestMethod.GET, blobId + "/" + subResource, null, null);
       MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
       doOperation(restRequest, restResponseChannel);
-      assertEquals("Unexpected response status for " + subResource, ResponseStatus.Ok,
-          restResponseChannel.getResponseStatus());
+      assertEquals("Unexpected response status for " + subResource, ResponseStatus.Ok, restResponseChannel.getStatus());
       assertEquals("Unexpected Content-Type for " + subResource, "application/octet-stream",
           restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
       assertEquals("Unexpected Content-Length for " + subResource, usermetadata.length,
@@ -670,7 +669,7 @@ public class AmbryBlobStorageServiceTest {
     RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers, contents);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(restRequest, restResponseChannel);
-    assertEquals("Unexpected response status", ResponseStatus.Created, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.Created, restResponseChannel.getStatus());
     assertTrue("No Date header", restResponseChannel.getHeader(RestUtils.Headers.DATE) != null);
     assertTrue("No " + RestUtils.Headers.CREATION_TIME,
         restResponseChannel.getHeader(RestUtils.Headers.CREATION_TIME) != null);
@@ -694,7 +693,7 @@ public class AmbryBlobStorageServiceTest {
     RestRequest restRequest = createRestRequest(RestMethod.GET, blobId, null, null);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(restRequest, restResponseChannel);
-    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getStatus());
     checkCommonGetHeadHeaders(restResponseChannel);
     assertEquals(RestUtils.Headers.BLOB_SIZE + " does not match",
         expectedHeaders.getString(RestUtils.Headers.BLOB_SIZE),
@@ -721,7 +720,7 @@ public class AmbryBlobStorageServiceTest {
     RestRequest restRequest = createRestRequest(RestMethod.GET, blobId, headers, null);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(restRequest, restResponseChannel);
-    assertEquals("Unexpected response status", ResponseStatus.NotModified, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.NotModified, restResponseChannel.getStatus());
     assertTrue("No Date header", restResponseChannel.getHeader(RestUtils.Headers.DATE) != null);
     assertNull("No Last-Modified header expected", restResponseChannel.getHeader("Last-Modified"));
     assertNull(RestUtils.Headers.BLOB_SIZE + " should have been null ",
@@ -742,7 +741,7 @@ public class AmbryBlobStorageServiceTest {
         createRestRequest(RestMethod.GET, blobId + "/" + RestUtils.SubResource.UserMetadata, null, null);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(restRequest, restResponseChannel);
-    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getStatus());
     checkCommonGetHeadHeaders(restResponseChannel);
     assertEquals("Content-Length is not 0", "0", restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
     verifyUserMetadataHeaders(expectedHeaders, restResponseChannel);
@@ -760,7 +759,7 @@ public class AmbryBlobStorageServiceTest {
         createRestRequest(RestMethod.GET, blobId + "/" + RestUtils.SubResource.BlobInfo, null, null);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(restRequest, restResponseChannel);
-    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getStatus());
     checkCommonGetHeadHeaders(restResponseChannel);
     assertEquals("Content-Length is not 0", "0", restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
     verifyBlobProperties(expectedHeaders, restResponseChannel);
@@ -778,7 +777,7 @@ public class AmbryBlobStorageServiceTest {
     RestRequest restRequest = createRestRequest(RestMethod.HEAD, blobId, null, null);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(restRequest, restResponseChannel);
-    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getStatus());
     checkCommonGetHeadHeaders(restResponseChannel);
     assertEquals(RestUtils.Headers.CONTENT_LENGTH + " does not match " + RestUtils.Headers.BLOB_SIZE,
         expectedHeaders.getString(RestUtils.Headers.BLOB_SIZE),
@@ -892,7 +891,7 @@ public class AmbryBlobStorageServiceTest {
       throws Exception {
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(restRequest, restResponseChannel);
-    assertEquals("Unexpected response status", ResponseStatus.Accepted, restResponseChannel.getResponseStatus());
+    assertEquals("Unexpected response status", ResponseStatus.Accepted, restResponseChannel.getStatus());
     assertTrue("No Date header", restResponseChannel.getHeader(RestUtils.Headers.DATE) != null);
     assertEquals("Content-Length is not 0", "0", restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
   }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -190,7 +190,7 @@ public class AmbrySecurityServiceTest {
     securityService.processResponse(restRequest, restResponseChannel, blobInfo, callback).get();
     Assert.assertTrue("Call back should have been invoked", callback.callbackInvoked.get());
     Assert.assertNull("Exception should not have been thrown", callback.exception);
-    Assert.assertEquals("Response should have been set ", ResponseStatus.Ok, restResponseChannel.getResponseStatus());
+    Assert.assertEquals("Response should have been set ", ResponseStatus.Ok, restResponseChannel.getStatus());
     Assert.assertEquals("No body is expected in the response", 0, restResponseChannel.getResponseBody().length);
     verifyBlobPropertiesHeaders(blobInfo.getBlobProperties(), restResponseChannel);
 
@@ -517,9 +517,19 @@ public class AmbrySecurityServiceTest {
     }
 
     @Override
+    public ResponseStatus getStatus() {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
     public void setHeader(String headerName, Object headerValue)
         throws RestServiceException {
       throw new RestServiceException("Not Implemented", RestServiceErrorCode.InternalServerError);
+    }
+
+    @Override
+    public Object getHeader(String headerName) {
+      throw new IllegalStateException("Not implemented");
     }
   }
 }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -264,6 +264,7 @@ public class FrontendIntegrationTest {
       endMarkerFound = object instanceof LastHttpContent;
       ReferenceCountUtil.release(content);
     }
+    assertTrue("There should have been an end marker", endMarkerFound);
   }
 
   /**

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -214,6 +214,7 @@ class NettyRequest implements RestRequest {
         }
       } finally {
         contentLock.unlock();
+        restRequestMetricsTracker.nioMetricsTracker.markRequestCompleted();
         restRequestMetricsTracker.recordMetrics();
         if (callbackWrapper != null) {
           callbackWrapper.invokeCallback(channelException);

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -92,6 +92,13 @@ class NettyResponseChannel implements RestResponseChannel {
   private volatile boolean responseComplete = false;
   // marked as true if force close is required because close() was called.
   private volatile boolean forceClose = false;
+  // the ResponseStatus that will be sent (or has been sent) as a part of the response.
+  private volatile ResponseStatus responseStatus = ResponseStatus.Ok;
+  // the response metadata that was actually sent.
+  private volatile HttpResponse finalResponseMetadata = null;
+  // temp variable to hold the error response status which will be overwritten on responseStatus if the error response
+  // was successfully sent
+  private ResponseStatus errorResponseStatus = null;
 
   /**
    * Create an instance of NettyResponseChannel that will use {@code ctx} to return responses.
@@ -204,13 +211,28 @@ class NettyResponseChannel implements RestResponseChannel {
   public void setStatus(ResponseStatus status)
       throws RestServiceException {
     responseMetadata.setStatus(getHttpResponseStatus(status));
+    responseStatus = status;
     logger.trace("Set status to {} for response on channel {}", responseMetadata.getStatus(), ctx.channel());
+  }
+
+  @Override
+  public ResponseStatus getStatus() {
+    return responseStatus;
   }
 
   @Override
   public void setHeader(String headerName, Object headerValue)
       throws RestServiceException {
     setResponseHeader(headerName, headerValue);
+  }
+
+  @Override
+  public Object getHeader(String headerName) {
+    HttpResponse response = finalResponseMetadata;
+    if (response == null) {
+      response = responseMetadata;
+    }
+    return HttpHeaders.getHeader(response, headerName);
   }
 
   /**
@@ -274,6 +296,7 @@ class NettyResponseChannel implements RestResponseChannel {
       ChannelPromise writePromise = ctx.newPromise().addListener(listener);
       ctx.writeAndFlush(responseMetadata, writePromise);
       writtenThisTime = true;
+      finalResponseMetadata = responseMetadata;
       long writeProcessingTime = System.currentTimeMillis() - writeProcessingStartTime;
       nettyMetrics.responseMetadataProcessingTimeInMs.update(writeProcessingTime);
     }
@@ -321,6 +344,7 @@ class NettyResponseChannel implements RestResponseChannel {
     if (maybeWriteResponseMetadata(errorResponse,
         new ErrorResponseWriteListener(HttpHeaders.isKeepAlive(errorResponse)))) {
       logger.trace("Successfully sent error response on channel {}", ctx.channel());
+      responseStatus = errorResponseStatus;
       responseSent = true;
       long processingTime = System.currentTimeMillis() - processingStartTime;
       nettyMetrics.errorResponseProcessingTimeInMs.update(processingTime);
@@ -341,13 +365,15 @@ class NettyResponseChannel implements RestResponseChannel {
     StringBuilder errReason = new StringBuilder();
     if (cause instanceof RestServiceException) {
       RestServiceErrorCode restServiceErrorCode = ((RestServiceException) cause).getErrorCode();
-      status = getHttpResponseStatus(ResponseStatus.getResponseStatus(restServiceErrorCode));
+      errorResponseStatus = ResponseStatus.getResponseStatus(restServiceErrorCode);
+      status = getHttpResponseStatus(errorResponseStatus);
       if (status == HttpResponseStatus.BAD_REQUEST) {
         errReason.append(" [").append(Utils.getRootCause(cause).getMessage()).append("]");
       }
     } else {
       nettyMetrics.internalServerErrorCount.inc();
       status = HttpResponseStatus.INTERNAL_SERVER_ERROR;
+      errorResponseStatus = ResponseStatus.InternalServerError;
     }
     String fullMsg = "Failure: " + status + errReason;
     logger.trace("Constructed error response for the client - [{}]", fullMsg);
@@ -362,9 +388,9 @@ class NettyResponseChannel implements RestResponseChannel {
     HttpHeaders.setDate(response, new GregorianCalendar().getTime());
     HttpHeaders.setContentLength(response, fullMsg.length());
     HttpHeaders.setHeader(response, HttpHeaders.Names.CONTENT_TYPE, "text/plain; charset=UTF-8");
-    boolean keepAlive =
+    boolean keepAlive = HttpHeaders.isKeepAlive(responseMetadata) &&
         request != null && !request.getRestMethod().equals(RestMethod.POST) && !CLOSE_CONNECTION_ERROR_STATUSES
-            .contains(status);
+        .contains(status);
     HttpHeaders.setKeepAlive(response, keepAlive);
     return response;
   }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -268,7 +268,6 @@ class NettyResponseChannel implements RestResponseChannel {
    */
   private void closeRequest() {
     if (request != null && request.isOpen()) {
-      request.getMetricsTracker().nioMetricsTracker.markRequestCompleted();
       request.close();
     }
   }


### PR DESCRIPTION
The `RestResponseChannel` is passed around as a piece of data and can help avoid repeated code by simply exposing the headers that have been set. Components that pass a `RestResponseChannel` around can then start communicating by the presence, absence and value of headers.

This change also adds and refines some tests in `NettyResponseChannel`.

**Primary reviewers: Casey, Ming**
**Expected time to review: 20-30 mins**

**Unit test coverage**

Class | Class, % | Method, % | Line, %
------- | ------------ | -------------- | ----------
NettyResponseChannel | 100% (8/ 8) | 100% (37/ 37) | 96.3% (285/ 296)
