### PR TITLE
Allow for ByteBufferInputStream to return underlying ByteBuffer

### DIFF
--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobData.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobData.java
@@ -13,7 +13,7 @@
  */
 package com.github.ambry.messageformat;
 
-import java.io.InputStream;
+import com.github.ambry.utils.ByteBufferInputStream;
 
 
 /**
@@ -22,29 +22,38 @@ import java.io.InputStream;
 public class BlobData {
   private final BlobType blobType;
   private final long size;
-  private final InputStream stream;
+  private final ByteBufferInputStream stream;
 
   /**
    * The blob data contains the stream and other required info
    * @param blobType {@link BlobType} of the blob
-   * @param size The size of the blob
-   * @param stream The stream that contains the blob
+   * @param size The size of the blob content.
+   * @param stream The {@link ByteBufferInputStream} containing the blob content.
    */
-  public BlobData(BlobType blobType, long size, InputStream stream) {
+  public BlobData(BlobType blobType, long size, ByteBufferInputStream stream) {
     this.blobType = blobType;
     this.size = size;
     this.stream = stream;
   }
 
+  /**
+   * @return the type of the blob.
+   */
   public BlobType getBlobType() {
     return this.blobType;
   }
 
+  /**
+   * @return the size of the blob content.
+   */
   public long getSize() {
     return size;
   }
 
-  public InputStream getStream() {
+  /**
+   * @return the {@link ByteBufferInputStream} containing the blob content.
+   */
+  public ByteBufferInputStream getStream() {
     return stream;
   }
 }

--- a/ambry-utils/src/main/java/com.github.ambry.utils/ByteBufferInputStream.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/ByteBufferInputStream.java
@@ -108,5 +108,16 @@ public class ByteBufferInputStream extends InputStream {
   public ByteBufferInputStream duplicate() {
     return new ByteBufferInputStream(byteBuffer.duplicate());
   }
+
+  /**
+   * Return the underlying read-only {@link ByteBuffer} associated with this ByteBufferInputStream.
+   * <br>
+   * Combining the reads from the returned {@link ByteBuffer} and the other read methods of this stream can lead to
+   * unexpected behavior.
+   * @return the underlying read-only {@link ByteBuffer} associated with this ByteBufferInputStream.
+   */
+  public ByteBuffer getByteBuffer() {
+    return byteBuffer.asReadOnlyBuffer();
+  }
 }
 

--- a/ambry-utils/src/test/java/com.github.ambry.utils/ByteBufferInputStreamTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/ByteBufferInputStreamTest.java
@@ -13,12 +13,12 @@
  */
 package com.github.ambry.utils;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
+import java.util.Random;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.nio.ByteBuffer;
-import java.util.Random;
-import java.io.IOException;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -61,6 +61,23 @@ public class ByteBufferInputStreamTest {
       Assert.assertEquals(output[i], buf[i + 1001]);
     }
     Assert.assertEquals(stream3.read(), -1);
+
+    ByteBuffer byteBuf = ByteBuffer.wrap(buf);
+    ByteBufferInputStream stream4 = new ByteBufferInputStream(byteBuf.duplicate());
+    // ByteBuffer class overrides equal() to do content comparison.
+    Assert.assertEquals("The returned byte buffer must have the same content as the one initialized with", byteBuf,
+        stream4.getByteBuffer());
+    byteBuf.rewind();
+    ByteBufferInputStream stream5 = new ByteBufferInputStream(byteBuf.duplicate());
+    ByteBufferInputStream stream6 = new ByteBufferInputStream(stream5, 1024);
+    Assert.assertEquals("The returned byte buffer must have the same content as the one initialized with", byteBuf,
+        stream6.getByteBuffer());
+
+    try {
+      stream6.getByteBuffer().put((byte) 0);
+      Assert.fail("Returned ByteBuffer from a ByteBufferInputStream must be read-only");
+    } catch (ReadOnlyBufferException e) {
+    }
   }
 
   @Test


### PR DESCRIPTION
This helps to avoid a copy if the `ByteBufferInpustStream` consumer needs to get the contents into a `ByteBuffer`. In particular, this will help avoid a copy when the router needs to convert the `ByteBufferInputStream` returned by `MessageFormat` into a `ByteBuffer`. Rather than read from this stream into an allocated `ByteBuffer`, the underlying `ByteBuffer` can be directly used once this patch goes in.

Ming, Gopal. ~10 minutes.

Built and tested on Linux and OS X, and formatted.