### PR TITLE
Adding API support for generating digests in ReadableStreamChannel

### DIFF
--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
@@ -1267,7 +1267,7 @@ class AdminTestResponseHandler implements RestResponseHandler {
 /**
  * A bad implementation of {@link RestRequest}. Just throws exceptions.
  */
-class BadRestRequest implements RestRequest {
+class BadRestRequest extends BadRSC implements RestRequest {
 
   @Override
   public RestMethod getRestMethod() {
@@ -1295,29 +1295,8 @@ class BadRestRequest implements RestRequest {
   }
 
   @Override
-  public boolean isOpen() {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
-  public void close()
-      throws IOException {
-    throw new IOException("Not implemented");
-  }
-
-  @Override
   public RestRequestMetricsTracker getMetricsTracker() {
     return new RestRequestMetricsTracker();
-  }
-
-  @Override
-  public long getSize() {
-    return -1;
-  }
-
-  @Override
-  public Future<Long> readInto(AsyncWritableChannel asyncWritableChannel, Callback<Long> callback) {
-    throw new IllegalStateException("Not implemented");
   }
 }
 
@@ -1333,6 +1312,16 @@ class BadRSC implements ReadableStreamChannel {
 
   @Override
   public Future<Long> readInto(AsyncWritableChannel asyncWritableChannel, Callback<Long> callback) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public void setDigestAlgorithm(String digestAlgorithm) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public byte[] getDigest() {
     throw new IllegalStateException("Not implemented");
   }
 

--- a/ambry-api/src/main/java/com.github.ambry/router/ReadableStreamChannel.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/ReadableStreamChannel.java
@@ -52,7 +52,7 @@ public interface ReadableStreamChannel extends Channel {
    * the digest can be obtained via {@link #getDigest()}.
    * <p/>
    * This function is ideally called before {@link #readInto(AsyncWritableChannel, Callback)}. After a call to
-   * {@link #readInto(AsyncWritableChannel, Callback)}, some content may have been discarded and getting a digest may
+   * {@link #readInto(AsyncWritableChannel, Callback)}, some content may have been consumed and getting a digest may no
    * longer be possible. The safety of doing otherwise depends on the implementation.
    * @param digestAlgorithm the digest algorithm to use.
    * @throws NoSuchAlgorithmException if the {@code digestAlgorithm} does not exist or is not supported.
@@ -70,7 +70,7 @@ public interface ReadableStreamChannel extends Channel {
    * <p/>
    * "Emptying a channel" refers to awaiting on the future or getting the callback after a
    * {@link #readInto(AsyncWritableChannel, Callback)} call.
-   * @return the digest as specified by the digest algorithm set through {@link #setDigestAlgorithm(String)}. If none
+   * @return the digest as computed by the digest algorithm set through {@link #setDigestAlgorithm(String)}. If none
    * was set, {@code null}.
    * @throws IllegalStateException if called before the channel has been emptied.
    */

--- a/ambry-api/src/main/java/com.github.ambry/router/ReadableStreamChannel.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/ReadableStreamChannel.java
@@ -14,6 +14,7 @@
 package com.github.ambry.router;
 
 import java.nio.channels.Channel;
+import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.Future;
 
 
@@ -45,4 +46,33 @@ public interface ReadableStreamChannel extends Channel {
    * @return the {@link Future} that will eventually contain the result of the operation.
    */
   public Future<Long> readInto(AsyncWritableChannel asyncWritableChannel, Callback<Long> callback);
+
+  /**
+   * Set the digest algorithm to use on the data that is being streamed from the channel. Once the channel is emptied,
+   * the digest can be obtained via {@link #getDigest()}.
+   * <p/>
+   * This function is ideally called before {@link #readInto(AsyncWritableChannel, Callback)}. After a call to
+   * {@link #readInto(AsyncWritableChannel, Callback)}, some content may have been discarded and getting a digest may
+   * longer be possible. The safety of doing otherwise depends on the implementation.
+   * @param digestAlgorithm the digest algorithm to use.
+   * @throws NoSuchAlgorithmException if the {@code digestAlgorithm} does not exist or is not supported.
+   * @throws IllegalStateException if {@link #readInto(AsyncWritableChannel, Callback)} has already been called.
+   */
+  public void setDigestAlgorithm(String digestAlgorithm)
+      throws NoSuchAlgorithmException;
+
+  /**
+   * Gets the digest as specified by the digest algorithm set through {@link #setDigestAlgorithm(String)}. If none was
+   * set, returns {@code null}.
+   * <p/>
+   * This function is ideally called after the channel is emptied completely. Otherwise, the complete digest may not
+   * have been calculated yet. The safety of doing otherwise depends on the implementation.
+   * <p/>
+   * "Emptying a channel" refers to awaiting on the future or getting the callback after a
+   * {@link #readInto(AsyncWritableChannel, Callback)} call.
+   * @return the digest as specified by the digest algorithm set through {@link #setDigestAlgorithm(String)}. If none
+   * was set, {@code null}.
+   * @throws IllegalStateException if called before the channel has been emptied.
+   */
+  public byte[] getDigest();
 }

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ByteBufferReadableStreamChannel.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ByteBufferReadableStreamChannel.java
@@ -36,8 +36,8 @@ public class ByteBufferReadableStreamChannel implements ReadableStreamChannel {
   private final int size;
   private final int startPos;
 
-  private MessageDigest digest = null;
-  private byte[] digestBytes = null;
+  private MessageDigest digest;
+  private byte[] digestBytes;
 
   /**
    * Constructs a {@link ReadableStreamChannel} whose read operations return data from the provided {@code buffer}.
@@ -73,6 +73,15 @@ public class ByteBufferReadableStreamChannel implements ReadableStreamChannel {
     return future;
   }
 
+  /**
+   * {@inheritDoc}
+   * <p/>
+   * This implementation supports setting the digest algorithm at any point in the lifecycle of the object. Digest
+   * algorithms can be changed at will and a subsequent call to {@link #getDigest()} will get the digest as computed
+   * by the algorithm that was set most recently.
+   * @param digestAlgorithm the digest algorithm to use.
+   * @throws NoSuchAlgorithmException if the {@code digestAlgorithm} does not exist or is not supported.
+   */
   @Override
   public void setDigestAlgorithm(String digestAlgorithm)
       throws NoSuchAlgorithmException {
@@ -83,6 +92,15 @@ public class ByteBufferReadableStreamChannel implements ReadableStreamChannel {
     digestBytes = null;
   }
 
+  /**
+   * {@inheritDoc}
+   * <p/>
+   * This implementation supports getting the digest at any point in the lifecycle of the object. The digest is always
+   * that of all the data in the channel regardless of how much data has been consumed by
+   * {@link #readInto(AsyncWritableChannel, Callback)}.
+   * @return the digest as computed by the digest algorithm set through {@link #setDigestAlgorithm(String)}. If none
+   * was set, {@code null}.
+   */
   @Override
   public byte[] getDigest() {
     if (digest == null) {

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferReadableStreamChannelTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferReadableStreamChannelTest.java
@@ -20,6 +20,9 @@ import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -44,7 +47,10 @@ public class ByteBufferReadableStreamChannelTest {
   @Test
   public void commonCaseTest()
       throws Exception {
-    readToAWCTest();
+    String[] digestAlgorithms = {"", "MD5", "SHA-1", "SHA-256"};
+    for (String digestAlgorithm : digestAlgorithms) {
+      readToAWCTest(digestAlgorithm);
+    }
   }
 
   /**
@@ -145,6 +151,68 @@ public class ByteBufferReadableStreamChannelTest {
     assertFalse("ByteBufferReadableStreamChannel is not closed", byteBufferReadableStreamChannel.isOpen());
   }
 
+  /**
+   * {@link ByteBufferReadableStreamChannel} has no restrictions on when and what algorithms can be used to generate
+   * the digest. This function tests the correctness of such support.
+   * @throws Exception
+   */
+  @Test
+  public void changingAlgorithmsTest()
+      throws Exception {
+    String[] digestAlgorithms = {"MD5", "SHA-1", "SHA-256"};
+    ByteBuffer content = ByteBuffer.wrap(fillRandomBytes(new byte[1024]));
+    Map<String, ByteBuffer> truthDigests = new HashMap<>();
+    for (String digestAlgorithm : digestAlgorithms) {
+      MessageDigest digest = MessageDigest.getInstance(digestAlgorithm);
+      digest.update(content.array());
+      truthDigests.put(digestAlgorithm, ByteBuffer.wrap(digest.digest()));
+    }
+    ByteBufferReadableStreamChannel readableStreamChannel = new ByteBufferReadableStreamChannel(content);
+    assertTrue("ByteBufferReadableStreamChannel is not open", readableStreamChannel.isOpen());
+    for (String digestAlgorithm : digestAlgorithms) {
+      readableStreamChannel.setDigestAlgorithm(digestAlgorithm);
+      assertArrayEquals("Digest from channel should match original", truthDigests.get(digestAlgorithm).array(),
+          readableStreamChannel.getDigest());
+    }
+    ByteBufferAsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
+    ReadIntoCallback callback = new ReadIntoCallback();
+    Future<Long> future = readableStreamChannel.readInto(writeChannel, callback);
+    ByteBuffer contentWrapper = ByteBuffer.wrap(content.array());
+    while (contentWrapper.hasRemaining()) {
+      ByteBuffer recvdContent = writeChannel.getNextChunk();
+      assertNotNull("Written content lesser than original content", recvdContent);
+      for (String digestAlgorithm : digestAlgorithms) {
+        readableStreamChannel.setDigestAlgorithm(digestAlgorithm);
+        assertArrayEquals("Digest from channel should match original", truthDigests.get(digestAlgorithm).array(),
+            readableStreamChannel.getDigest());
+      }
+      while (recvdContent.hasRemaining()) {
+        // getting any digest at any time is ok.
+        for (String digestAlgorithm : digestAlgorithms) {
+          readableStreamChannel.setDigestAlgorithm(digestAlgorithm);
+          assertArrayEquals("Digest from channel should match original", truthDigests.get(digestAlgorithm).array(),
+              readableStreamChannel.getDigest());
+        }
+        assertTrue("Written content is more than original content", contentWrapper.hasRemaining());
+        assertEquals("Unexpected byte", contentWrapper.get(), recvdContent.get());
+      }
+      writeChannel.resolveOldestChunk(null);
+    }
+    assertNull("There should have been no more data in the channel", writeChannel.getNextChunk(0));
+    writeChannel.close();
+    if (callback.exception != null) {
+      throw callback.exception;
+    }
+    long futureBytesRead = future.get();
+    assertEquals("Total bytes written does not match (callback)", content.limit(), callback.bytesRead);
+    assertEquals("Total bytes written does not match (future)", content.limit(), futureBytesRead);
+    for (String digestAlgorithm : digestAlgorithms) {
+      readableStreamChannel.setDigestAlgorithm(digestAlgorithm);
+      assertArrayEquals("Digest from channel should match original", truthDigests.get(digestAlgorithm).array(),
+          readableStreamChannel.getDigest());
+    }
+  }
+
   // helpers
   // general
 
@@ -162,15 +230,25 @@ public class ByteBufferReadableStreamChannelTest {
 
   /**
    * Tests reading into a {@link AsyncWritableChannel}.
+   * @param digestAlgorithm the digest algorithm to use. Can be empty or {@code null} if digest checking is not
+   *                        required.
    * @throws Exception
    */
-  private void readToAWCTest()
+  private void readToAWCTest(String digestAlgorithm)
       throws Exception {
     ByteBuffer content = ByteBuffer.wrap(fillRandomBytes(new byte[1024]));
+    byte[] truthDigest = null;
     ByteBufferReadableStreamChannel readableStreamChannel = new ByteBufferReadableStreamChannel(content);
+    if (digestAlgorithm != null && !digestAlgorithm.isEmpty()) {
+      MessageDigest digest = MessageDigest.getInstance(digestAlgorithm);
+      digest.update(content.array());
+      truthDigest = digest.digest();
+      readableStreamChannel.setDigestAlgorithm(digestAlgorithm);
+    }
     assertTrue("ByteBufferReadableStreamChannel is not open", readableStreamChannel.isOpen());
     assertEquals("Size returned by ByteBufferReadableStreamChannel did not match source array size", content.capacity(),
         readableStreamChannel.getSize());
+    assertArrayEquals("Digest from channel should match original", truthDigest, readableStreamChannel.getDigest());
     ByteBufferAsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
     ReadIntoCallback callback = new ReadIntoCallback();
     Future<Long> future = readableStreamChannel.readInto(writeChannel, callback);
@@ -178,7 +256,10 @@ public class ByteBufferReadableStreamChannelTest {
     while (contentWrapper.hasRemaining()) {
       ByteBuffer recvdContent = writeChannel.getNextChunk();
       assertNotNull("Written content lesser than original content", recvdContent);
+      assertArrayEquals("Digest from channel should match original", truthDigest, readableStreamChannel.getDigest());
       while (recvdContent.hasRemaining()) {
+        // getting a digest at any time is ok.
+        assertArrayEquals("Digest from channel should match original", truthDigest, readableStreamChannel.getDigest());
         assertTrue("Written content is more than original content", contentWrapper.hasRemaining());
         assertEquals("Unexpected byte", contentWrapper.get(), recvdContent.get());
       }
@@ -192,6 +273,7 @@ public class ByteBufferReadableStreamChannelTest {
     long futureBytesRead = future.get();
     assertEquals("Total bytes written does not match (callback)", content.limit(), callback.bytesRead);
     assertEquals("Total bytes written does not match (future)", content.limit(), futureBytesRead);
+    assertArrayEquals("Digest from channel should match original", truthDigest, readableStreamChannel.getDigest());
   }
 }
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -52,6 +52,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
+import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -1217,7 +1218,7 @@ class FrontendTestIdConverterFactory implements IdConverterFactory {
 /**
  * A bad implementation of {@link RestRequest}. Just throws exceptions.
  */
-class BadRestRequest implements RestRequest {
+class BadRestRequest extends BadRSC implements RestRequest {
 
   @Override
   public RestMethod getRestMethod() {
@@ -1245,29 +1246,8 @@ class BadRestRequest implements RestRequest {
   }
 
   @Override
-  public boolean isOpen() {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
-  public void close()
-      throws IOException {
-    throw new IOException("Not implemented");
-  }
-
-  @Override
   public RestRequestMetricsTracker getMetricsTracker() {
     return new RestRequestMetricsTracker();
-  }
-
-  @Override
-  public long getSize() {
-    return -1;
-  }
-
-  @Override
-  public Future<Long> readInto(AsyncWritableChannel asyncWritableChannel, Callback<Long> callback) {
-    throw new IllegalStateException("Not implemented");
   }
 }
 
@@ -1283,6 +1263,17 @@ class BadRSC implements ReadableStreamChannel {
 
   @Override
   public Future<Long> readInto(AsyncWritableChannel asyncWritableChannel, Callback<Long> callback) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public void setDigestAlgorithm(String digestAlgorithm)
+      throws NoSuchAlgorithmException {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public byte[] getDigest() {
     throw new IllegalStateException("Not implemented");
   }
 

--- a/ambry-rest/src/main/java/com.github.ambry.rest/AsyncRequestResponseHandler.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/AsyncRequestResponseHandler.java
@@ -703,7 +703,7 @@ class AsyncResponseHandler implements Closeable {
           restServerMetrics.responseCallbackWaitTimeInMs.update(callbackWaitTime);
           restRequest.getMetricsTracker().scalingMetricsTracker.addToResponseProcessingWaitTime(callbackWaitTime);
           inFlightResponsesCount.decrementAndGet();
-          if (exception == null && (result == null || result != response.getSize())) {
+          if (exception == null && (result == null || (response.getSize() != -1 && result != response.getSize()))) {
             exception = new IllegalStateException("Response write incomplete");
           }
           onResponseComplete(restRequest, restResponseChannel, response, exception);

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -91,6 +91,7 @@ public class NettyMetrics {
   // Other
   // NettyRequest
   public final Counter contentCopyCount;
+  public final Histogram digestCalculationTimeInMs;
   // NettyMessageProcessor
   public final Histogram channelReadIntervalInMs;
   public final Counter idleConnectionCloseCount;
@@ -215,6 +216,10 @@ public class NettyMetrics {
         metricRegistry.counter(MetricRegistry.name(HealthCheckHandler.class, "ChannelCloseOnWriteCount"));
 
     // Other
+    // NettyRequest
+    contentCopyCount = metricRegistry.counter(MetricRegistry.name(NettyRequest.class, "ContentCopyCount"));
+    digestCalculationTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(NettyRequest.class, "DigestCalculationTimeInMs"));
     // NettyMessageProcessor
     channelReadIntervalInMs =
         metricRegistry.histogram(MetricRegistry.name(NettyMessageProcessor.class, "ChannelReadIntervalInMs"));
@@ -222,8 +227,6 @@ public class NettyMetrics {
         metricRegistry.counter(MetricRegistry.name(NettyMessageProcessor.class, "IdleConnectionCloseCount"));
     processorExceptionCaughtCount =
         metricRegistry.counter(MetricRegistry.name(NettyMessageProcessor.class, "ExceptionCaughtCount"));
-    // NettyRequest
-    contentCopyCount = metricRegistry.counter(MetricRegistry.name(NettyRequest.class, "ContentCopyCount"));
     // NettyResponseChannel
     badRequestCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "BadRequestCount"));
     unauthorizedCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "UnauthorizedCount"));

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -159,10 +159,12 @@ public class NettyMetrics {
         metricRegistry.histogram(MetricRegistry.name(NettyResponseChannel.class, "ResponseMetadataProcessingTimeInMs"));
     writeProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(NettyResponseChannel.class, "WriteProcessingTimeInMs"));
+    // PublicAccessLogHandler
     publicAccessLogRequestProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(PublicAccessLogHandler.class, "RequestProcessingTimeInMs"));
     publicAccessLogResponseProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(PublicAccessLogHandler.class, "ResponseProcessingTimeInMs"));
+    // HealthCheckHandler
     healthCheckRequestProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(HealthCheckHandler.class, "RequestProcessingTimeInMs"));
     healthCheckRequestRoundTripTimeInMs =
@@ -208,10 +210,12 @@ public class NettyMetrics {
     // NettyServer
     nettyServerShutdownError = metricRegistry.counter(MetricRegistry.name(NettyServer.class, "ShutdownError"));
     nettyServerStartError = metricRegistry.counter(MetricRegistry.name(NettyServer.class, "StartError"));
+    // PublicAccessLogHandler
     publicAccessLogRequestDisconnectWhileInProgressCount = metricRegistry
-        .counter(MetricRegistry.name(HealthCheckHandler.class, "ChannelDisconnectWhileRequestInProgressCount"));
+        .counter(MetricRegistry.name(PublicAccessLogHandler.class, "ChannelDisconnectWhileRequestInProgressCount"));
     publicAccessLogRequestCloseWhileRequestInProgressCount = metricRegistry
-        .counter(MetricRegistry.name(HealthCheckHandler.class, "ChannelCloseWhileRequestInProgressCount"));
+        .counter(MetricRegistry.name(PublicAccessLogHandler.class, "ChannelCloseWhileRequestInProgressCount"));
+    // HealthCheckHandler
     healthCheckHandlerChannelCloseOnWriteCount =
         metricRegistry.counter(MetricRegistry.name(HealthCheckHandler.class, "ChannelCloseOnWriteCount"));
 

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -71,8 +71,8 @@ class NettyRequest implements RestRequest {
   private final AtomicLong bytesReceived = new AtomicLong(0);
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
-  private MessageDigest digest = null;
-  private byte[] digestBytes = null;
+  private MessageDigest digest;
+  private byte[] digestBytes;
   private long digestCalculationTimeInMs = -1;
 
   private volatile AsyncWritableChannel writeChannel = null;

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -27,6 +27,8 @@ import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.util.ReferenceCountUtil;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -69,8 +71,13 @@ class NettyRequest implements RestRequest {
   private final AtomicLong bytesReceived = new AtomicLong(0);
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
+  private MessageDigest digest = null;
+  private byte[] digestBytes = null;
+  private long digestCalculationTimeInMs = -1;
+
   private volatile AsyncWritableChannel writeChannel = null;
   private volatile Exception channelException = CLOSED_CHANNEL_EXCEPTION;
+  private volatile boolean allContentReceived = false;
 
   protected static String MULTIPLE_HEADER_VALUE_DELIMITER = ", ";
 
@@ -215,6 +222,9 @@ class NettyRequest implements RestRequest {
       } finally {
         contentLock.unlock();
         restRequestMetricsTracker.recordMetrics();
+        if (digestCalculationTimeInMs >= 0) {
+          nettyMetrics.digestCalculationTimeInMs.update(digestCalculationTimeInMs);
+        }
         if (callbackWrapper != null) {
           callbackWrapper.invokeCallback(channelException);
         }
@@ -276,6 +286,30 @@ class NettyRequest implements RestRequest {
       contentLock.unlock();
     }
     return tempWrapper.futureResult;
+  }
+
+  @Override
+  public void setDigestAlgorithm(String digestAlgorithm)
+      throws NoSuchAlgorithmException {
+    if (callbackWrapper != null) {
+      throw new IllegalStateException("Cannot create a digest because some content has already been discarded");
+    }
+    digest = MessageDigest.getInstance(digestAlgorithm);
+  }
+
+  @Override
+  public byte[] getDigest() {
+    if (digest == null) {
+      return null;
+    } else if (!allContentReceived) {
+      throw new IllegalStateException("Cannot calculate digest yet because all the content has not been processed");
+    }
+    if (digestBytes == null) {
+      long startTime = System.currentTimeMillis();
+      digestBytes = digest.digest();
+      digestCalculationTimeInMs += (System.currentTimeMillis() - startTime);
+    }
+    return digestBytes;
   }
 
   /**
@@ -364,6 +398,13 @@ class NettyRequest implements RestRequest {
     boolean asyncWritesCalled = false;
     try {
       for (int i = 0; i < contentBuffers.length; i++) {
+        if (digest != null) {
+          long startTime = System.currentTimeMillis();
+          int savedPosition = contentBuffers[i].position();
+          digest.update(contentBuffers[i]);
+          contentBuffers[i].position(savedPosition);
+          digestCalculationTimeInMs += (System.currentTimeMillis() - startTime);
+        }
         writeChannel.write(contentBuffers[i], writeCallbacks[i]);
       }
       asyncWritesCalled = true;
@@ -372,6 +413,7 @@ class NettyRequest implements RestRequest {
         ReferenceCountUtil.release(httpContent);
       }
     }
+    allContentReceived = isLast;
   }
 
   /**

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -288,15 +288,31 @@ class NettyRequest implements RestRequest {
     return tempWrapper.futureResult;
   }
 
+  /**
+   * {@inheritDoc}
+   * <p/>
+   * This function can only be called before {@link #readInto(AsyncWritableChannel, Callback)}.
+   * @param digestAlgorithm the digest algorithm to use.
+   * @throws NoSuchAlgorithmException if the {@code digestAlgorithm} does not exist or is not supported.
+   * @throws IllegalStateException if {@link #readInto(AsyncWritableChannel, Callback)} has already been called.
+   */
   @Override
   public void setDigestAlgorithm(String digestAlgorithm)
       throws NoSuchAlgorithmException {
     if (callbackWrapper != null) {
-      throw new IllegalStateException("Cannot create a digest because some content has already been discarded");
+      throw new IllegalStateException("Cannot create a digest because some content may have been consumed");
     }
     digest = MessageDigest.getInstance(digestAlgorithm);
   }
 
+  /**
+   * {@inheritDoc}
+   * <p/>
+   * This function can only be called once the channel has been emptied.
+   * @return the digest as computed by the digest algorithm set through {@link #setDigestAlgorithm(String)}. If none
+   * was set, {@code null}.
+   * @throws IllegalStateException if called before the channel has been emptied.
+   */
   @Override
   public byte[] getDigest() {
     if (digest == null) {

--- a/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
@@ -783,24 +783,14 @@ class EventMonitor<T> implements MockRestResponseChannel.EventListener, MockRest
 /**
  * Object that wraps another {@link ReadableStreamChannel} and simply blocks on read until released.
  */
-class HaltingRSC implements ReadableStreamChannel {
-  private final ByteBuffer buffer;
-  private final long size;
+class HaltingRSC extends ByteBufferRSC implements ReadableStreamChannel {
   private final CountDownLatch release;
   private final ExecutorService executorService;
 
-  private volatile boolean isOpen = true;
-
   public HaltingRSC(ByteBuffer buffer, CountDownLatch releaseRead, ExecutorService executorService) {
-    this.buffer = buffer;
-    size = buffer.remaining();
+    super(buffer);
     this.release = releaseRead;
     this.executorService = executorService;
-  }
-
-  @Override
-  public long getSize() {
-    return size;
   }
 
   @Override
@@ -829,16 +819,6 @@ class HaltingRSC implements ReadableStreamChannel {
       }
     });
     return future;
-  }
-
-  @Override
-  public boolean isOpen() {
-    return isOpen;
-  }
-
-  @Override
-  public void close() {
-    isOpen = false;
   }
 }
 
@@ -888,6 +868,15 @@ class IncompleteReadReadableStreamChannel implements ReadableStreamChannel {
       callback.onCompletion(bytesRead, exception);
     }
     return futureResult;
+  }
+
+  @Override
+  public void setDigestAlgorithm(String digestAlgorithm) {
+  }
+
+  @Override
+  public byte[] getDigest() {
+    return null;
   }
 
   @Override
@@ -956,6 +945,16 @@ class BadRestRequest implements RestRequest {
 
   @Override
   public Future<Long> readInto(AsyncWritableChannel asyncWritableChannel, Callback<Long> callback) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public void setDigestAlgorithm(String digestAlgorithm) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public byte[] getDigest() {
     throw new IllegalStateException("Not implemented");
   }
 }

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
@@ -428,10 +428,7 @@ public class NettyMultipartRequestTest {
     request.readInto(asyncWritableChannel, null).get();
     readOutput = asyncWritableChannel.getData();
     assertArrayEquals(RestUtils.MultipartPost.BLOB_PART + " content does not match", blobData.array(), readOutput);
-    byte[] partByPartDigest = request.getDigest();
-    if (partByPartDigest != null) {
-      assertArrayEquals("Part by part digest should match digest of whole", wholeDigest, partByPartDigest);
-    }
+    assertArrayEquals("Part by part digest should match digest of whole", wholeDigest, request.getDigest());
     closeRequestAndValidate(request);
   }
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.Charset;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -98,26 +99,29 @@ public class NettyMultipartRequestTest {
   @Test
   public void multipartRequestDecodeTest()
       throws Exception {
-    // request without content
-    doMultipartDecodeTest(0, null);
+    String[] digestAlgorithms = {"", "MD5", "SHA-1", "SHA-256"};
+    for (String digestAlgorithm : digestAlgorithms) {
+      // request without content
+      doMultipartDecodeTest(0, null, digestAlgorithm);
 
-    final int BLOB_PART_SIZE = 1024;
-    // number of parts including the Blob
-    final int NUM_TOTAL_PARTS = 5;
-    Random random = new Random();
-    InMemoryFile[] files = new InMemoryFile[NUM_TOTAL_PARTS];
-    for (int i = 0; i < NUM_TOTAL_PARTS; i++) {
-      files[i] =
-          new InMemoryFile("part-" + i, ByteBuffer.wrap(RestTestUtils.getRandomBytes(random.nextInt(128) + 128)));
+      final int BLOB_PART_SIZE = 1024;
+      // number of parts including the Blob
+      final int NUM_TOTAL_PARTS = 5;
+      Random random = new Random();
+      InMemoryFile[] files = new InMemoryFile[NUM_TOTAL_PARTS];
+      for (int i = 0; i < NUM_TOTAL_PARTS; i++) {
+        files[i] =
+            new InMemoryFile("part-" + i, ByteBuffer.wrap(RestTestUtils.getRandomBytes(random.nextInt(128) + 128)));
+      }
+
+      // request without blob (but has other parts)
+      doMultipartDecodeTest(0, files, digestAlgorithm);
+
+      // request with blob and other parts
+      files[NUM_TOTAL_PARTS - 1] = new InMemoryFile(RestUtils.MultipartPost.BLOB_PART,
+          ByteBuffer.wrap(RestTestUtils.getRandomBytes(BLOB_PART_SIZE)));
+      doMultipartDecodeTest(BLOB_PART_SIZE, files, digestAlgorithm);
     }
-
-    // request without blob (but has other parts)
-    doMultipartDecodeTest(0, files);
-
-    // request with blob and other parts
-    files[NUM_TOTAL_PARTS - 1] = new InMemoryFile(RestUtils.MultipartPost.BLOB_PART,
-        ByteBuffer.wrap(RestTestUtils.getRandomBytes(BLOB_PART_SIZE)));
-    doMultipartDecodeTest(BLOB_PART_SIZE, files);
   }
 
   /**
@@ -382,9 +386,11 @@ public class NettyMultipartRequestTest {
    * {@link NettyMultipartRequest#getArgs()} and verifies them against the source data ({@code files}).
    * @param expectedRequestSize the value expected on a call to {@link NettyMultipartRequest#getSize()}.
    * @param files the {@link InMemoryFile}s that form the parts of the multipart request.
+   * @param digestAlgorithm the digest algorithm to use. Can be empty or {@code null} if digest checking is not
+   *                        required.
    * @throws Exception
    */
-  private void doMultipartDecodeTest(int expectedRequestSize, InMemoryFile[] files)
+  private void doMultipartDecodeTest(int expectedRequestSize, InMemoryFile[] files, String digestAlgorithm)
       throws Exception {
     HttpHeaders httpHeaders = new DefaultHttpHeaders();
     httpHeaders.set(RestUtils.Headers.BLOB_SIZE, expectedRequestSize);
@@ -396,10 +402,18 @@ public class NettyMultipartRequestTest {
     byte[] readOutput;
     Map<String, Object> args = request.getArgs();
     ByteBuffer blobData = ByteBuffer.allocate(0);
+    byte[] wholeDigest = null;
     if (files != null) {
       for (InMemoryFile file : files) {
         if (file.name.equals(RestUtils.MultipartPost.BLOB_PART)) {
           blobData = file.content;
+          if (digestAlgorithm != null && !digestAlgorithm.isEmpty()) {
+            MessageDigest digest = MessageDigest.getInstance(digestAlgorithm);
+            digest.update(blobData);
+            wholeDigest = digest.digest();
+            blobData.rewind();
+            request.setDigestAlgorithm(digestAlgorithm);
+          }
         } else {
           Object value = args.get(file.name);
           assertNotNull("Request does not contain " + file, value);
@@ -414,6 +428,10 @@ public class NettyMultipartRequestTest {
     request.readInto(asyncWritableChannel, null).get();
     readOutput = asyncWritableChannel.getData();
     assertArrayEquals(RestUtils.MultipartPost.BLOB_PART + " content does not match", blobData.array(), readOutput);
+    byte[] partByPartDigest = request.getDigest();
+    if (partByPartDigest != null) {
+      assertArrayEquals("Part by part digest should match digest of whole", wholeDigest, partByPartDigest);
+    }
     closeRequestAndValidate(request);
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -34,7 +34,6 @@ import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -880,8 +879,7 @@ class MockReadableStreamChannel implements ReadableStreamChannel {
   }
 
   @Override
-  public void setDigestAlgorithm(String digestAlgorithm)
-      throws NoSuchAlgorithmException {
+  public void setDigestAlgorithm(String digestAlgorithm) {
     throw new IllegalStateException("Not implemented");
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -34,6 +34,7 @@ import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -876,6 +877,17 @@ class MockReadableStreamChannel implements ReadableStreamChannel {
     this.callback = callback;
     this.returnedFuture = new FutureResult<Long>();
     return returnedFuture;
+  }
+
+  @Override
+  public void setDigestAlgorithm(String digestAlgorithm)
+      throws NoSuchAlgorithmException {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public byte[] getDigest() {
+    throw new IllegalStateException("Not implemented");
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/ReadableStreamChannelInputStreamTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ReadableStreamChannelInputStreamTest.java
@@ -215,6 +215,15 @@ class IncompleteReadReadableStreamChannel implements ReadableStreamChannel {
   }
 
   @Override
+  public void setDigestAlgorithm(String digestAlgorithm) {
+  }
+
+  @Override
+  public byte[] getDigest() {
+    return null;
+  }
+
+  @Override
   public boolean isOpen() {
     return channelOpen.get();
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/ReadableStreamChannelInputStreamTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ReadableStreamChannelInputStreamTest.java
@@ -216,11 +216,12 @@ class IncompleteReadReadableStreamChannel implements ReadableStreamChannel {
 
   @Override
   public void setDigestAlgorithm(String digestAlgorithm) {
+    throw new IllegalStateException("Not implemented");
   }
 
   @Override
   public byte[] getDigest() {
-    return null;
+    throw new IllegalStateException("Not implemented");
   }
 
   @Override


### PR DESCRIPTION
For some use cases, generating the digest of the data that passes through the `ReadableStreamChannel` is useful.
This change adds the APIs in the interface and the implementation support in all the implementations.
In particular, `NettyRequest` and `ByteBufferReadableStreamChannel` can now generate digests if required.

**Primary reviewers: Siva, Priyesh**
**Expected time to review: 30 - 45 mins**

**Note:** #308 adds a new implementation of `ReadableStreamChannel`. One the two PRs will have to add the APIs to the new implementation before merge.

**Unit test coverage**

Class | Class, % | Method, % | Line, %
------- | ------------ | -------------- | ----------
ByteBufferReadableStreamChannel | 100% (1/ 1) | 100% (7/ 7) | 100% (34/ 34)
NettyRequest | 100% (1/ 1) | 95.2% (20/ 21) | 95.7% (180/ 188)
