### PR TITLE
Introduces metrics framework for NB Router.

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -104,7 +104,6 @@ class DeleteManager {
       deleteOperations.add(deleteOperation);
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.operationAbortCount.inc();
       routerMetrics.deleteBlobErrorCount.inc();
       routerMetrics.countError(e);
       operationCompleteCallback.completeOperation(futureResult, callback, null, e);
@@ -160,7 +159,7 @@ class DeleteManager {
       routerMetrics.countError(e);
     }
     routerMetrics.operationDequeuingRate.mark();
-    routerMetrics.deleteBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmittedTimeMs());
+    routerMetrics.deleteBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmissionTimeMs());
     operationCompleteCallback
         .completeOperation(op.getFutureResult(), op.getCallback(), op.getOperationResult(), op.getOperationException());
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -155,7 +155,7 @@ class DeleteOperation {
     }
     ReplicaId replica = deleteRequestInfo.replica;
     RouterErrorCode routerErrorCode;
-    long requestLatencyMs = time.milliseconds() - deleteRequestInfo.getStartTimeMs();
+    long requestLatencyMs = time.milliseconds() - deleteRequestInfo.startTimeMs;
     NonBlockingRouterMetrics.NodeLevelMetrics dataNodeBasedMetrics =
         routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId());
     routerMetrics.routerRequestLatencyMs.update(requestLatencyMs);
@@ -202,16 +202,12 @@ class DeleteOperation {
    * A wrapper class that is used to check if a request has been expired.
    */
   private class DeleteRequestInfo {
-    final long startTimeMs;
-    final ReplicaId replica;
+    private final long startTimeMs;
+    private final ReplicaId replica;
 
     DeleteRequestInfo(long submissionTime, ReplicaId replica) {
       this.startTimeMs = submissionTime;
       this.replica = replica;
-    }
-
-    long getStartTimeMs() {
-      return startTimeMs;
     }
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.router;
 
-import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ResponseHandler;
@@ -158,9 +157,9 @@ class DeleteOperation {
     RouterErrorCode routerErrorCode;
     long requestLatencyMs = time.milliseconds() - deleteRequestInfo.getStartTimeMs();
     NonBlockingRouterMetrics.NodeLevelMetrics dataNodeBasedMetrics =
-        routerMetrics.getDataNodeBasedMetrics(deleteRequestInfo.replica.getDataNodeId());
+        routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId());
     routerMetrics.routerRequestLatencyMs.update(requestLatencyMs);
-    dataNodeBasedMetrics.putRequestLatencyMs.update(requestLatencyMs);
+    dataNodeBasedMetrics.deleteRequestLatencyMs.update(requestLatencyMs);
     // Check the error code from NetworkClient.
     if (responseInfo.getError() != null) {
       responseHandler.onRequestResponseException(replica, new IOException(("NetworkClient error.")));
@@ -176,7 +175,6 @@ class DeleteOperation {
           logger.error("The correlation id in the DeleteResponse " + deleteResponse.getCorrelationId()
               + " is not the same as the correlation id in the associated DeleteRequest: " + deleteRequest
               .getCorrelationId());
-          // @todo Discuss why this would complete the operation.
           routerMetrics.unknownReplicaResponseError.inc();
           setOperationException(
               new RouterException("Received wrong response that is not for the corresponding request.",
@@ -388,7 +386,6 @@ class DeleteOperation {
    */
   void setOperationException(Exception exception) {
     operationException.set(exception);
-    operationCompleted = true;
   }
 
   long getSubmissionTimeMs() {

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -131,7 +131,6 @@ class NonBlockingRouter implements Router {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.operationAbortCount.inc();
       routerMetrics.getBlobInfoErrorCount.inc();
       routerMetrics.countError(routerException);
       operationCompleteCallback.completeOperation(futureResult, callback, null, routerException);
@@ -168,7 +167,6 @@ class NonBlockingRouter implements Router {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.operationAbortCount.inc();
       routerMetrics.getBlobErrorCount.inc();
       routerMetrics.countError(routerException);
       operationCompleteCallback.completeOperation(futureResult, callback, null, routerException);
@@ -210,7 +208,6 @@ class NonBlockingRouter implements Router {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.operationAbortCount.inc();
       routerMetrics.putBlobErrorCount.inc();
       routerMetrics.countError(routerException);
       operationCompleteCallback.completeOperation(futureResult, callback, null, routerException);
@@ -247,7 +244,6 @@ class NonBlockingRouter implements Router {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.operationAbortCount.inc();
       routerMetrics.deleteBlobErrorCount.inc();
       routerMetrics.countError(routerException);
       operationCompleteCallback.completeOperation(futureResult, callback, null, routerException);
@@ -384,7 +380,6 @@ class NonBlockingRouter implements Router {
         RouterException routerException =
             new RouterException(" because Router is closed", RouterErrorCode.RouterClosed);
         routerMetrics.operationDequeuingRate.mark();
-        routerMetrics.operationAbortCount.inc();
         routerMetrics.putBlobErrorCount.inc();
         routerMetrics.countError(routerException);
         operationCompleteCallback.completeOperation(futureResult, callback, null, routerException);

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
@@ -64,7 +64,7 @@ public class NonBlockingRouterFactory implements RouterFactory {
     if (verifiableProperties != null && clusterMap != null && notificationSystem != null) {
       routerConfig = new RouterConfig(verifiableProperties);
       MetricRegistry registry = clusterMap.getMetricRegistry();
-      routerMetrics = new NonBlockingRouterMetrics(registry);
+      routerMetrics = new NonBlockingRouterMetrics(clusterMap);
       this.clusterMap = clusterMap;
       this.notificationSystem = notificationSystem;
       networkConfig = new NetworkConfig(verifiableProperties);

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -75,7 +75,7 @@ public class NonBlockingRouterMetrics {
   public final Counter blobDoesNotExistErrorCount;
   public final Counter blobExpiredErrorCount;
   public final Counter unknownReplicaResponseError;
-  public final Counter closeErrorCount;
+  public final Counter errorCountOnRouterClose;
   public final Counter unknownErrorCountForOperation;
 
   // Misc metrics.
@@ -153,7 +153,7 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BlobExpiredErrorCount"));
     unknownReplicaResponseError =
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "UnknownReplicaResponseError"));
-    closeErrorCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "CloseErrorCount"));
+    errorCountOnRouterClose = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "ErrorCountOnRouterClose"));
     unknownErrorCountForOperation =
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "UnknownErrorCountForOperation"));
 

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * {@link NonBlockingRouter} specific metrics tracking.
+ * {@link NonBlockingRouter}-specific metrics tracking.
  * <p/>
  * Exports metrics that are triggered by the {@link NonBlockingRouter} to the provided {@link MetricRegistry}
  */
@@ -81,6 +81,7 @@ public class NonBlockingRouterMetrics {
   // Misc metrics.
   public final Meter operationErrorRate;
   public final Counter slippedPutSuccessCount;
+  public final Counter ignoredResponseCount;
   public Gauge<Long> chunkFillerThreadRunning;
   public Gauge<Long> requestResponseHandlerThreadRunning;
   public Gauge<Integer> activeOperations;
@@ -94,72 +95,73 @@ public class NonBlockingRouterMetrics {
     metricRegistry = clusterMap.getMetricRegistry();
 
     // Operation Rate
-    putBlobOperationRate = metricRegistry.meter(MetricRegistry.name(PutManager.class, "-PutBlobRequestArrivalRate"));
+    putBlobOperationRate = metricRegistry.meter(MetricRegistry.name(PutManager.class, "PutBlobRequestArrivalRate"));
     getBlobInfoOperationRate =
-        metricRegistry.meter(MetricRegistry.name(GetManager.class, "-GetBlobInfoRequestArrivalRate"));
-    getBlobOperationRate = metricRegistry.meter(MetricRegistry.name(GetManager.class, "-GetBlobRequestArrivalRate"));
+        metricRegistry.meter(MetricRegistry.name(GetManager.class, "GetBlobInfoRequestArrivalRate"));
+    getBlobOperationRate = metricRegistry.meter(MetricRegistry.name(GetManager.class, "GetBlobRequestArrivalRate"));
     deleteBlobOperationRate =
-        metricRegistry.meter(MetricRegistry.name(DeleteManager.class, "-DeleteBlobRequestArrivalRate"));
-    operationQueuingRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "-OperationQueuingRate"));
+        metricRegistry.meter(MetricRegistry.name(DeleteManager.class, "DeleteBlobRequestArrivalRate"));
+    operationQueuingRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "OperationQueuingRate"));
     operationDequeuingRate =
-        metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "-OperationDequeuingRate"));
+        metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "OperationDequeuingRate"));
 
     // Latency
     putBlobOperationLatencyMs =
-        metricRegistry.histogram(MetricRegistry.name(PutManager.class, "-PutBlobOperationLatencyMs"));
+        metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutBlobOperationLatencyMs"));
     putChunkOperationLatencyMs =
-        metricRegistry.histogram(MetricRegistry.name(PutManager.class, "-PutChunkOperationLatencyMs"));
+        metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutChunkOperationLatencyMs"));
     getBlobInfoOperationLatencyMs =
-        metricRegistry.histogram(MetricRegistry.name(GetManager.class, "-GetBlobInfoOperationLatencyMs"));
+        metricRegistry.histogram(MetricRegistry.name(GetManager.class, "GetBlobInfoOperationLatencyMs"));
     getBlobOperationLatencyMs =
-        metricRegistry.histogram(MetricRegistry.name(GetManager.class, "-GetBlobOperationLatencyMs"));
+        metricRegistry.histogram(MetricRegistry.name(GetManager.class, "GetBlobOperationLatencyMs"));
     deleteBlobOperationLatencyMs =
-        metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "-DeleteBlobOperationLatencyMs"));
+        metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "DeleteBlobOperationLatencyMs"));
     routerRequestLatencyMs =
-        metricRegistry.histogram(MetricRegistry.name(NonBlockingRouter.class, "-RouterRequestLatencyMs"));
+        metricRegistry.histogram(MetricRegistry.name(NonBlockingRouter.class, "RouterRequestLatencyMs"));
 
     // Operation error count.
-    putBlobErrorCount = metricRegistry.counter(MetricRegistry.name(PutManager.class, "-PutBlobErrorCount"));
-    getBlobInfoErrorCount = metricRegistry.counter(MetricRegistry.name(GetManager.class, "-GetBlobInfoErrorCount"));
-    getBlobErrorCount = metricRegistry.counter(MetricRegistry.name(GetManager.class, "-GetBlobErrorCount"));
-    deleteBlobErrorCount = metricRegistry.counter(MetricRegistry.name(DeleteManager.class, "-DeleteBlobErrorCount"));
-    operationAbortCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-OperationAbortCount"));
+    putBlobErrorCount = metricRegistry.counter(MetricRegistry.name(PutManager.class, "PutBlobErrorCount"));
+    getBlobInfoErrorCount = metricRegistry.counter(MetricRegistry.name(GetManager.class, "GetBlobInfoErrorCount"));
+    getBlobErrorCount = metricRegistry.counter(MetricRegistry.name(GetManager.class, "GetBlobErrorCount"));
+    deleteBlobErrorCount = metricRegistry.counter(MetricRegistry.name(DeleteManager.class, "DeleteBlobErrorCount"));
+    operationAbortCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OperationAbortCount"));
 
     // Count for various errors.
     ambryUnavailableErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-AmbryUnavailableErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "AmbryUnavailableErrorCount"));
     invalidBlobIdErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-InvalidBlobIdErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "InvalidBlobIdErrorCount"));
     invalidPutArgumentErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-InvalidPutArgumentErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "InvalidPutArgumentErrorCount"));
     operationTimedOutErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-OperationTimedOutErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OperationTimedOutErrorCount"));
     routerClosedErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-RouterClosedErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "RouterClosedErrorCount"));
     unexpectedInternalErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-UnexpectedInternalErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "UnexpectedInternalErrorCount"));
     blobTooLargeErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-BlobTooLargeErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BlobTooLargeErrorCount"));
     badInputChannelErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-BadInputChannelErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BadInputChannelErrorCount"));
     insufficientCapacityErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-InsufficientCapacityErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "InsufficientCapacityErrorCount"));
     blobDeletedErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-BlobDeletedErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BlobDeletedErrorCount"));
     blobDoesNotExistErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-BlobDoesNotExistErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BlobDoesNotExistErrorCount"));
     blobExpiredErrorCount =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-BlobExpiredErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "BlobExpiredErrorCount"));
     unknownReplicaResponseError =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-UnknownReplicaResponseError"));
-    closeErrorCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-CloseErrorCount"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "UnknownReplicaResponseError"));
+    closeErrorCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "CloseErrorCount"));
     unknownErrorCountForOperation =
-        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-UnknownErrorCountForOperation"));
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "UnknownErrorCountForOperation"));
 
     // Misc metrics.
     operationErrorRate =
-        metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "-OperationErrorArrivalRate"));
-    slippedPutSuccessCount = metricRegistry.counter(MetricRegistry.name(PutManager.class, "-SlippedPutSuccessCount"));
+        metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "OperationErrorArrivalRate"));
+    slippedPutSuccessCount = metricRegistry.counter(MetricRegistry.name(PutManager.class, "SlippedPutSuccessCount"));
+    ignoredResponseCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "IgnoredRequestCount"));
 
     // Track metrics at the DataNode level.
     dataNodeToMetrics = new HashMap<DataNodeId, NodeLevelMetrics>();
@@ -169,8 +171,7 @@ public class NonBlockingRouterMetrics {
       dataNodeToMetrics.put(dataNodeId, new NodeLevelMetrics(metricRegistry, dataNodeName));
     }
     // A null key corresponds to the NodeLevelMetrics for all unknown DataNodeId.
-    dataNodeToMetrics
-        .put(null, new NodeLevelMetrics(metricRegistry, "UnknownDataNode.UnknownHostName.UnknownPort"));
+    dataNodeToMetrics.put(null, new NodeLevelMetrics(metricRegistry, "UnknownDataNode.UnknownHostName.UnknownPort"));
   }
 
   public void initializeOperationControllerMetrics(final Thread requestResponseHandlerThread) {
@@ -181,7 +182,7 @@ public class NonBlockingRouterMetrics {
       }
     };
     metricRegistry
-        .register(MetricRegistry.name(NonBlockingRouter.class, requestResponseHandlerThread.getName() + "-Running"),
+        .register(MetricRegistry.name(NonBlockingRouter.class, requestResponseHandlerThread.getName() + "Running"),
             requestResponseHandlerThreadRunning);
   }
 
@@ -192,7 +193,7 @@ public class NonBlockingRouterMetrics {
         return chunkFillerThread.isAlive() ? 1L : 0L;
       }
     };
-    metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, chunkFillerThread.getName() + "-Running"),
+    metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, chunkFillerThread.getName() + "Running"),
         chunkFillerThreadRunning);
   }
 
@@ -203,115 +204,44 @@ public class NonBlockingRouterMetrics {
         return currentOperationsCount.get();
       }
     };
-    metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "-NumActiveOperations"), activeOperations);
+    metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "NumActiveOperations"), activeOperations);
   }
 
   /**
-   * Update opration latency for a given {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
-   * <p/>
-   * This method should be called when an {@code Operation} is fully completed (either successfully or unsuccessfully),
-   * which means the {@code operation} has gone through the complete process without being aborted in half way.
-   * @param latency The operation latency to be updated.
-   * @param operationType The {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}
-   *                      for which metrics will be updated.
-   */
-  void updateOperationLatency(long latency, NonBlockingRouter.RouterOperationType operationType) {
-    switch (operationType) {
-      case PutBlob:
-        putBlobOperationLatencyMs.update(latency);
-        break;
-      case GetBlobInfo:
-        getBlobInfoOperationLatencyMs.update(latency);
-        break;
-      case GetBlob:
-        getBlobOperationLatencyMs.update(latency);
-        break;
-      case DeleteBlob:
-        deleteBlobOperationLatencyMs.update(latency);
-        break;
-      default:
-        // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
-        logger.warn("Error for unknown RouterOperationType when updating operation latency: " + operationType);
-        break;
-    }
-  }
-
-  /**
-   * Update operation arrival rate for a given {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
-   * This method should be called when a request hits the router.
-   * @param operationType The {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}
-   *                      for which metrics will be updated.
-   */
-  void updateOperationRate(NonBlockingRouter.RouterOperationType operationType) {
-    switch (operationType) {
-      case PutBlob:
-        putBlobOperationRate.mark();
-        break;
-      case GetBlobInfo:
-        getBlobInfoOperationRate.mark();
-        break;
-      case GetBlob:
-        getBlobOperationRate.mark();
-        break;
-      case DeleteBlob:
-        deleteBlobOperationRate.mark();
-        break;
-      default:
-        // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
-        logger.warn("Error for unknown RouterOperationType when updating operation rate: " + operationType);
-        break;
-    }
-  }
-
-  /**
-   * Count error for a {@link NonBlockingRouter.RouterOperationType} based on error type. It will also update
-   * the error count for each {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
+   * Count error based on error type.
    * <p/>
    * This method should be called when an {@code Operation} is completed or aborted.
    * @param exception The exception to be counted.
-   * @param operationType The type of the operation that is associated with the given exception.
    */
-  void countError(Exception exception, NonBlockingRouter.RouterOperationType operationType) {
-    if (exception == null) {
-      return;
-    }
+  void countError(Exception exception) {
     operationErrorRate.mark();
     if (exception instanceof RouterException) {
       switch (((RouterException) exception).getErrorCode()) {
         case AmbryUnavailable:
-          updateOperationErrorCount(operationType);
           ambryUnavailableErrorCount.inc();
           break;
         case InvalidBlobId:
-          updateOperationErrorCount(operationType);
           invalidBlobIdErrorCount.inc();
           break;
         case InvalidPutArgument:
-          updateOperationErrorCount(operationType);
           invalidPutArgumentErrorCount.inc();
           break;
         case OperationTimedOut:
-          updateOperationErrorCount(operationType);
           operationTimedOutErrorCount.inc();
           break;
         case RouterClosed:
-          updateOperationErrorCount(operationType);
           routerClosedErrorCount.inc();
           break;
         case UnexpectedInternalError:
-          updateOperationErrorCount(operationType);
           unexpectedInternalErrorCount.inc();
           break;
         case BlobTooLarge:
-          updateOperationErrorCount(operationType);
           blobTooLargeErrorCount.inc();
           break;
         case BadInputChannel:
-          updateOperationErrorCount(operationType);
           blobTooLargeErrorCount.inc();
           break;
         case InsufficientCapacity:
-          updateOperationErrorCount(operationType);
           insufficientCapacityErrorCount.inc();
           break;
         case BlobDeleted:
@@ -324,39 +254,11 @@ public class NonBlockingRouterMetrics {
           blobExpiredErrorCount.inc();
           break;
         default:
-          updateOperationErrorCount(operationType);
           unknownErrorCountForOperation.inc();
           break;
       }
     } else {
-      updateOperationErrorCount(operationType);
       unknownErrorCountForOperation.inc();
-    }
-  }
-
-  /**
-   * Update error count based on the operation type.
-   * @param operationType The {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}
-   *                      for which metrics will be updated.
-   */
-  private void updateOperationErrorCount(NonBlockingRouter.RouterOperationType operationType) {
-    switch (operationType) {
-      case PutBlob:
-        putBlobErrorCount.inc();
-        break;
-      case GetBlobInfo:
-        getBlobInfoErrorCount.inc();
-        break;
-      case GetBlob:
-        getBlobErrorCount.inc();
-        break;
-      case DeleteBlob:
-        deleteBlobErrorCount.inc();
-        break;
-      default:
-        // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
-        logger.warn("Error for unknown RouterOperationType when counting operation errors: " + operationType);
-        break;
     }
   }
 
@@ -422,210 +324,114 @@ public class NonBlockingRouterMetrics {
     public final Counter unknownReplicaResponseError;
 
     NodeLevelMetrics(MetricRegistry registry, String dataNodeName) {
-      dataNodeName = "-" + dataNodeName;
-
       // Request rate.
-      putRequestRate =
-          registry.meter(MetricRegistry.name(PutManager.class, dataNodeName, "-PutRequestArrivalRate"));
+      putRequestRate = registry.meter(MetricRegistry.name(PutManager.class, dataNodeName, "PutRequestArrivalRate"));
       getBlobInfoRequestRate =
-          registry.meter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetBlobInfoRequestArrivalRate"));
-      getRequestRate =
-          registry.meter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetRequestArrivalRate"));
+          registry.meter(MetricRegistry.name(GetManager.class, dataNodeName, "GetBlobInfoRequestArrivalRate"));
+      getRequestRate = registry.meter(MetricRegistry.name(GetManager.class, dataNodeName, "GetRequestArrivalRate"));
       deleteRequestRate =
-          registry.meter(MetricRegistry.name(DeleteManager.class, dataNodeName, "-DeleteRequestArrivalRate"));
+          registry.meter(MetricRegistry.name(DeleteManager.class, dataNodeName, "DeleteRequestArrivalRate"));
 
       // Request latency.
       putRequestLatencyMs =
-          registry.histogram(MetricRegistry.name(PutManager.class, dataNodeName, "-PutRequestLatencyMs"));
+          registry.histogram(MetricRegistry.name(PutManager.class, dataNodeName, "PutRequestLatencyMs"));
       getBlobInfoRequestLatencyMs =
-          registry.histogram(MetricRegistry.name(GetManager.class, dataNodeName, "-GetBlobInfoRequestLatencyMs"));
+          registry.histogram(MetricRegistry.name(GetManager.class, dataNodeName, "GetBlobInfoRequestLatencyMs"));
       getRequestLatencyMs =
-          registry.histogram(MetricRegistry.name(GetManager.class, dataNodeName, "-GetRequestLatencyMs"));
+          registry.histogram(MetricRegistry.name(GetManager.class, dataNodeName, "GetRequestLatencyMs"));
       deleteRequestLatencyMs =
-          registry.histogram(MetricRegistry.name(DeleteManager.class, dataNodeName, "-DeleteRequestLatencyMs"));
+          registry.histogram(MetricRegistry.name(DeleteManager.class, dataNodeName, "DeleteRequestLatencyMs"));
 
       // Request error count.
       putRequestErrorCount =
-          registry.counter(MetricRegistry.name(PutManager.class, dataNodeName, "-PutRequestErrorCount"));
+          registry.counter(MetricRegistry.name(PutManager.class, dataNodeName, "PutRequestErrorCount"));
       getBlobInfoRequestErrorCount =
-          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetBlobInfoRequestErrorCount"));
+          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "GetBlobInfoRequestErrorCount"));
       getRequestErrorCount =
-          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetRequestErrorCount"));
+          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "GetRequestErrorCount"));
       deleteRequestErrorCount =
-          registry.counter(MetricRegistry.name(DeleteManager.class, dataNodeName, "-DeleteRequestErrorCount"));
+          registry.counter(MetricRegistry.name(DeleteManager.class, dataNodeName, "DeleteRequestErrorCount"));
 
       // Timed-out request count.
       putRequestTimeoutCount =
-          registry.counter(MetricRegistry.name(PutManager.class, dataNodeName, "-PutRequestTimeoutCount"));
+          registry.counter(MetricRegistry.name(PutManager.class, dataNodeName, "PutRequestTimeoutCount"));
       getBlobInfoRequestTimeoutCount =
-          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetBlobInfoRequestTimeoutCount"));
+          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "GetBlobInfoRequestTimeoutCount"));
       getRequestTimeoutCount =
-          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetRequestTimeoutCount"));
+          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "GetRequestTimeoutCount"));
       deleteRequestTimeoutCount =
-          registry.counter(MetricRegistry.name(DeleteManager.class, dataNodeName, "-DeleteRequestTimeoutCount"));
+          registry.counter(MetricRegistry.name(DeleteManager.class, dataNodeName, "DeleteRequestTimeoutCount"));
 
       // Count for various errors at request level.
       ambryUnavailableErrorCountForRequest = registry
-          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-AmbryUnavailableErrorForRequest"));
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "AmbryUnavailableErrorForRequest"));
       invalidBlobIdErrorCountForRequest =
-          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-InvalidBlobIdErrorForRequest"));
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "InvalidBlobIdErrorForRequest"));
       invalidPutArgumentErrorCountForRequest = registry
-          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-InvalidPutArgumentErrorForRequest"));
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "InvalidPutArgumentErrorForRequest"));
       requestTimedOutErrorCountForRequest = registry
-          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-RequestTimedOutErrorForRequest"));
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "RequestTimedOutErrorForRequest"));
       routerClosedErrorCountForRequest =
-          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-RouterClosedErrorForRequest"));
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "RouterClosedErrorForRequest"));
       unexpectedInternalErrorCountForRequest = registry
-          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-UnexpectedInternalErrorForRequest"));
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "UnexpectedInternalErrorForRequest"));
       blobTooLargeErrorCountForRequest =
-          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-BlobTooLargeErrorForRequest"));
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "BlobTooLargeErrorForRequest"));
       badInputChannelErrorCountForRequest =
-          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-BadInputChannel"));
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "BadInputChannel"));
       insufficientCapacityErrorCountForRequest = registry
-          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-InsufficientCapacityErrorForRequest"));
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "InsufficientCapacityErrorForRequest"));
       blobDeletedErrorCountForRequest =
-          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-BlobDeletedErrorForRequest"));
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "BlobDeletedErrorForRequest"));
       blobDoesNotExistErrorCountForRequest = registry
-          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-BlobDoesNotExistErrorForRequest"));
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "BlobDoesNotExistErrorForRequest"));
       blobExpiredErrorCountForRequest =
-          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-BlobExpiredErrorForRequest"));
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "BlobExpiredErrorForRequest"));
       unknownErrorCountForRequest =
-          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-UnknownRouterErrorForRequest"));
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "UnknownRouterErrorForRequest"));
 
       // Misc metrics at the DataNode level.
-      requestErrorRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "-RequestErrorArrivalRate"));
+      requestErrorRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "RequestErrorArrivalRate"));
       unknownReplicaResponseError =
-          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-UnknownReplicaResponseError"));
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "UnknownReplicaResponseError"));
     }
 
     /**
-     * Update the request arrival rate for a given {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
-     * This method should be called when a request to a {@link DataNodeId} is created.
-     */
-    void uopdateRequestRate(NonBlockingRouter.RouterOperationType operationType) {
-      switch (operationType) {
-        case PutBlob:
-          putRequestRate.mark();
-          break;
-        case GetBlobInfo:
-          getBlobInfoRequestRate.mark();
-          break;
-        case GetBlob:
-          getRequestRate.mark();
-          break;
-        case DeleteBlob:
-          deleteRequestRate.mark();
-          break;
-        default:
-          // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
-          logger.warn("Error for unknown RouterOperationType for counting request rate: " + operationType);
-          break;
-      }
-    }
-
-    /**
-     * Update request latency for a given {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
-     * This method should be called when a response of a request has been received and processed. This method should
-     * not be called when a request is aborted.
-     * @param latency Request latency.
-     * @param operationType {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
-     */
-    void updateRequestLatency(long latency, NonBlockingRouter.RouterOperationType operationType) {
-      switch (operationType) {
-        case PutBlob:
-          putRequestLatencyMs.update(latency);
-          break;
-        case GetBlobInfo:
-          getBlobInfoRequestLatencyMs.update(latency);
-          break;
-        case GetBlob:
-          getRequestLatencyMs.update(latency);
-          break;
-        case DeleteBlob:
-          deleteRequestLatencyMs.update(latency);
-          break;
-        default:
-          // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
-          logger.warn("Error for unknown RouterOperationType for updating request latency: " + operationType);
-          break;
-      }
-    }
-
-    /**
-     * Update the counter for timedout requests for a given {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
-     * @param operationType {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}
-     */
-    void updateRequestTimeoutCount(NonBlockingRouter.RouterOperationType operationType) {
-      switch (operationType) {
-        case PutBlob:
-          getBlobInfoRequestTimeoutCount.inc();
-          break;
-        case GetBlobInfo:
-          getBlobInfoRequestTimeoutCount.inc();
-          break;
-        case GetBlob:
-          getRequestTimeoutCount.inc();
-          break;
-        case DeleteBlob:
-          deleteRequestTimeoutCount.inc();
-          break;
-        default:
-          // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
-          logger.warn("Error for unknown RouterOperationType for updating timed-out request count: " + operationType);
-          break;
-      }
-    }
-
-    /**
-     * Count the {@link RouterException} caused by a request (or its response) for a given
-     * {@link NonBlockingRouter.RouterOperationType}. This {@link RouterException} may not be the final
-     * {@link RouterException} accompanied with the {@code Operation}, but such metrics can assist a
-     * root-cause analysis at the {@link DataNodeId} level.
+     * Count the {@link RouterException} caused by a request (or its response). This {@link RouterException}
+     * may not be the final {@link RouterException} accompanied with the {@code Operation}, but such metrics
+     * can assist a root-cause analysis at the {@link DataNodeId} level.
      * <p/>
      * This method should be called when a request is either completed or timed out.
      * @param error The {@link RouterErrorCode} of the exception to be counted.
-     * @param operationType The type of the operation that is associated with the given exception.
      */
-    void countError(RouterErrorCode error, NonBlockingRouter.RouterOperationType operationType) {
-      if (error == null) {
-        return;
-      }
+    void countError(RouterErrorCode error) {
       requestErrorRate.mark();
       switch (error) {
         case AmbryUnavailable:
-          updateRequestError(operationType);
           ambryUnavailableErrorCountForRequest.inc();
           break;
         case InvalidBlobId:
-          updateRequestError(operationType);
           invalidBlobIdErrorCountForRequest.inc();
           break;
         case InvalidPutArgument:
-          updateRequestError(operationType);
           invalidPutArgumentErrorCountForRequest.inc();
           break;
         case OperationTimedOut:
-          updateRequestError(operationType);
           requestTimedOutErrorCountForRequest.inc();
           break;
         case RouterClosed:
-          updateRequestError(operationType);
           routerClosedErrorCountForRequest.inc();
           break;
         case UnexpectedInternalError:
-          updateRequestError(operationType);
           unexpectedInternalErrorCountForRequest.inc();
           break;
         case BlobTooLarge:
-          updateRequestError(operationType);
           blobTooLargeErrorCountForRequest.inc();
           break;
         case BadInputChannel:
-          updateRequestError(operationType);
           badInputChannelErrorCountForRequest.inc();
           break;
         case InsufficientCapacity:
-          updateRequestError(operationType);
           insufficientCapacityErrorCountForRequest.inc();
           break;
         case BlobDeleted:
@@ -639,32 +445,6 @@ public class NonBlockingRouterMetrics {
           break;
         default:
           unknownErrorCountForRequest.inc();
-          updateRequestError(operationType);
-          break;
-      }
-    }
-
-    /**
-     * Update request error count based on {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
-     * @param operationType The {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}
-     *                      for which metrics will be updated.
-     */
-    private void updateRequestError(NonBlockingRouter.RouterOperationType operationType) {
-      switch (operationType) {
-        case PutBlob:
-          putRequestErrorCount.inc();
-          break;
-        case GetBlobInfo:
-          getBlobInfoRequestErrorCount.inc();
-          break;
-        case GetBlob:
-          getRequestErrorCount.inc();
-          break;
-        case DeleteBlob:
-          deleteRequestErrorCount.inc();
-          break;
-        default:
-          logger.warn("Error for unknown RouterOperationType being counted: " + operationType);
           break;
       }
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -19,6 +19,12 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import java.util.concurrent.atomic.AtomicInteger;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -31,42 +37,140 @@ public class NonBlockingRouterMetrics {
   // @todo: Ensure all metrics here get updated appropriately.
   // @todo: chunk filling rate metrics.
   // @todo: More metrics for the RequestResponse handling (poll, handleResponse etc.)
-  // Rates
+
+  // Operation rate.
   public final Meter putBlobOperationRate;
+  public final Meter getBlobInfoOperationRate;
+  public final Meter getBlobOperationRate;
+  public final Meter deleteBlobOperationRate;
   public final Meter operationQueuingRate;
   public final Meter operationDequeuingRate;
 
+  // Latency.
   public final Histogram putBlobOperationLatencyMs;
   public final Histogram putChunkOperationLatencyMs;
+  public final Histogram getBlobInfoOperationLatencyMs;
+  public final Histogram getBlobOperationLatencyMs;
+  public final Histogram deleteBlobOperationLatencyMs;
   public final Histogram routerRequestLatencyMs;
 
-  // Operation Errors
-  public final Counter slippedPutSuccessCount;
+  // Operation error count.
   public final Counter putBlobErrorCount;
+  public final Counter getBlobInfoErrorCount;
+  public final Counter getBlobErrorCount;
+  public final Counter deleteBlobErrorCount;
   public final Counter operationAbortCount;
 
-  // Gauge
+  // Count for various errors.
+  public final Counter ambryUnavailableErrorCount;
+  public final Counter invalidBlobIdErrorCount;
+  public final Counter invalidPutArgumentErrorCount;
+  public final Counter operationTimedOutErrorCount;
+  public final Counter routerClosedErrorCount;
+  public final Counter unexpectedInternalErrorCount;
+  public final Counter blobTooLargeErrorCount;
+  public final Counter badInputChannelErrorCount;
+  public final Counter insufficientCapacityErrorCount;
+  public final Counter blobDeletedErrorCount;
+  public final Counter blobDoesNotExistErrorCount;
+  public final Counter blobExpiredErrorCount;
+  public final Counter unknownReplicaResponseError;
+  public final Counter closeErrorCount;
+  public final Counter unknownErrorCountForOperation;
+
+  // Misc metrics.
+  public final Meter operationErrorRate;
+  public final Counter slippedPutSuccessCount;
   public Gauge<Long> chunkFillerThreadRunning;
   public Gauge<Long> requestResponseHandlerThreadRunning;
   public Gauge<Integer> activeOperations;
 
-  public NonBlockingRouterMetrics(MetricRegistry metricRegistry) {
-    this.metricRegistry = metricRegistry;
+  // Map that stores dataNode-level metrics.
+  private final Map<DataNodeId, NodeLevelMetrics> dataNodeToMetrics;
+
+  private Logger logger = LoggerFactory.getLogger(getClass());
+
+  public NonBlockingRouterMetrics(ClusterMap clusterMap) {
+    metricRegistry = clusterMap.getMetricRegistry();
+
+    // Operation Rate
     putBlobOperationRate = metricRegistry.meter(MetricRegistry.name(PutManager.class, "-PutBlobRequestArrivalRate"));
+    getBlobInfoOperationRate =
+        metricRegistry.meter(MetricRegistry.name(GetManager.class, "-GetBlobInfoRequestArrivalRate"));
+    getBlobOperationRate = metricRegistry.meter(MetricRegistry.name(GetManager.class, "-GetBlobRequestArrivalRate"));
+    deleteBlobOperationRate =
+        metricRegistry.meter(MetricRegistry.name(DeleteManager.class, "-DeleteBlobRequestArrivalRate"));
     operationQueuingRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "-OperationQueuingRate"));
     operationDequeuingRate =
         metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "-OperationDequeuingRate"));
 
+    // Latency
     putBlobOperationLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(PutManager.class, "-PutBlobOperationLatencyMs"));
     putChunkOperationLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(PutManager.class, "-PutChunkOperationLatencyMs"));
+    getBlobInfoOperationLatencyMs =
+        metricRegistry.histogram(MetricRegistry.name(GetManager.class, "-GetBlobInfoOperationLatencyMs"));
+    getBlobOperationLatencyMs =
+        metricRegistry.histogram(MetricRegistry.name(GetManager.class, "-GetBlobOperationLatencyMs"));
+    deleteBlobOperationLatencyMs =
+        metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "-DeleteBlobOperationLatencyMs"));
     routerRequestLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(NonBlockingRouter.class, "-RouterRequestLatencyMs"));
 
-    slippedPutSuccessCount = metricRegistry.counter(MetricRegistry.name(PutManager.class, "-SlippedPutSuccessCount"));
+    // Operation error count.
     putBlobErrorCount = metricRegistry.counter(MetricRegistry.name(PutManager.class, "-PutBlobErrorCount"));
+    getBlobInfoErrorCount = metricRegistry.counter(MetricRegistry.name(GetManager.class, "-GetBlobInfoErrorCount"));
+    getBlobErrorCount = metricRegistry.counter(MetricRegistry.name(GetManager.class, "-GetBlobErrorCount"));
+    deleteBlobErrorCount = metricRegistry.counter(MetricRegistry.name(DeleteManager.class, "-DeleteBlobErrorCount"));
     operationAbortCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-OperationAbortCount"));
+
+    // Count for various errors.
+    ambryUnavailableErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-AmbryUnavailableErrorCount"));
+    invalidBlobIdErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-InvalidBlobIdErrorCount"));
+    invalidPutArgumentErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-InvalidPutArgumentErrorCount"));
+    operationTimedOutErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-OperationTimedOutErrorCount"));
+    routerClosedErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-RouterClosedErrorCount"));
+    unexpectedInternalErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-UnexpectedInternalErrorCount"));
+    blobTooLargeErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-BlobTooLargeErrorCount"));
+    badInputChannelErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-BadInputChannelErrorCount"));
+    insufficientCapacityErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-InsufficientCapacityErrorCount"));
+    blobDeletedErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-BlobDeletedErrorCount"));
+    blobDoesNotExistErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-BlobDoesNotExistErrorCount"));
+    blobExpiredErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-BlobExpiredErrorCount"));
+    unknownReplicaResponseError =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-UnknownReplicaResponseError"));
+    closeErrorCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-CloseErrorCount"));
+    unknownErrorCountForOperation =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-UnknownErrorCountForOperation"));
+
+    // Misc metrics.
+    operationErrorRate =
+        metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "-OperationErrorArrivalRate"));
+    slippedPutSuccessCount = metricRegistry.counter(MetricRegistry.name(PutManager.class, "-SlippedPutSuccessCount"));
+
+    // Track metrics at the DataNode level.
+    dataNodeToMetrics = new HashMap<DataNodeId, NodeLevelMetrics>();
+    for (DataNodeId dataNodeId : clusterMap.getDataNodeIds()) {
+      String dataNodeName = dataNodeId.getDatacenterName() + "." + dataNodeId.getHostname() + "." + Integer
+          .toString(dataNodeId.getPort());
+      dataNodeToMetrics.put(dataNodeId, new NodeLevelMetrics(metricRegistry, dataNodeName));
+    }
+    // A null key corresponds to the NodeLevelMetrics for all unknown DataNodeId.
+    dataNodeToMetrics
+        .put(null, new NodeLevelMetrics(metricRegistry, "UnknownDataNode.UnknownHostName.UnknownPort"));
   }
 
   public void initializeOperationControllerMetrics(final Thread requestResponseHandlerThread) {
@@ -100,5 +204,469 @@ public class NonBlockingRouterMetrics {
       }
     };
     metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "-NumActiveOperations"), activeOperations);
+  }
+
+  /**
+   * Update opration latency for a given {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
+   * <p/>
+   * This method should be called when an {@code Operation} is fully completed (either successfully or unsuccessfully),
+   * which means the {@code operation} has gone through the complete process without being aborted in half way.
+   * @param latency The operation latency to be updated.
+   * @param operationType The {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}
+   *                      for which metrics will be updated.
+   */
+  void updateOperationLatency(long latency, NonBlockingRouter.RouterOperationType operationType) {
+    switch (operationType) {
+      case PutBlob:
+        putBlobOperationLatencyMs.update(latency);
+        break;
+      case GetBlobInfo:
+        getBlobInfoOperationLatencyMs.update(latency);
+        break;
+      case GetBlob:
+        getBlobOperationLatencyMs.update(latency);
+        break;
+      case DeleteBlob:
+        deleteBlobOperationLatencyMs.update(latency);
+        break;
+      default:
+        // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
+        logger.warn("Error for unknown RouterOperationType when updating operation latency: " + operationType);
+        break;
+    }
+  }
+
+  /**
+   * Update operation arrival rate for a given {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
+   * This method should be called when a request hits the router.
+   * @param operationType The {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}
+   *                      for which metrics will be updated.
+   */
+  void updateOperationRate(NonBlockingRouter.RouterOperationType operationType) {
+    switch (operationType) {
+      case PutBlob:
+        putBlobOperationRate.mark();
+        break;
+      case GetBlobInfo:
+        getBlobInfoOperationRate.mark();
+        break;
+      case GetBlob:
+        getBlobOperationRate.mark();
+        break;
+      case DeleteBlob:
+        deleteBlobOperationRate.mark();
+        break;
+      default:
+        // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
+        logger.warn("Error for unknown RouterOperationType when updating operation rate: " + operationType);
+        break;
+    }
+  }
+
+  /**
+   * Count error for a {@link NonBlockingRouter.RouterOperationType} based on error type. It will also update
+   * the error count for each {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
+   * <p/>
+   * This method should be called when an {@code Operation} is completed or aborted.
+   * @param exception The exception to be counted.
+   * @param operationType The type of the operation that is associated with the given exception.
+   */
+  void countError(Exception exception, NonBlockingRouter.RouterOperationType operationType) {
+    if (exception == null) {
+      return;
+    }
+    operationErrorRate.mark();
+    if (exception instanceof RouterException) {
+      switch (((RouterException) exception).getErrorCode()) {
+        case AmbryUnavailable:
+          updateOperationErrorCount(operationType);
+          ambryUnavailableErrorCount.inc();
+          break;
+        case InvalidBlobId:
+          updateOperationErrorCount(operationType);
+          invalidBlobIdErrorCount.inc();
+          break;
+        case InvalidPutArgument:
+          updateOperationErrorCount(operationType);
+          invalidPutArgumentErrorCount.inc();
+          break;
+        case OperationTimedOut:
+          updateOperationErrorCount(operationType);
+          operationTimedOutErrorCount.inc();
+          break;
+        case RouterClosed:
+          updateOperationErrorCount(operationType);
+          routerClosedErrorCount.inc();
+          break;
+        case UnexpectedInternalError:
+          updateOperationErrorCount(operationType);
+          unexpectedInternalErrorCount.inc();
+          break;
+        case BlobTooLarge:
+          updateOperationErrorCount(operationType);
+          blobTooLargeErrorCount.inc();
+          break;
+        case BadInputChannel:
+          updateOperationErrorCount(operationType);
+          blobTooLargeErrorCount.inc();
+          break;
+        case InsufficientCapacity:
+          updateOperationErrorCount(operationType);
+          insufficientCapacityErrorCount.inc();
+          break;
+        case BlobDeleted:
+          blobDeletedErrorCount.inc();
+          break;
+        case BlobDoesNotExist:
+          blobDoesNotExistErrorCount.inc();
+          break;
+        case BlobExpired:
+          blobExpiredErrorCount.inc();
+          break;
+        default:
+          updateOperationErrorCount(operationType);
+          unknownErrorCountForOperation.inc();
+          break;
+      }
+    } else {
+      updateOperationErrorCount(operationType);
+      unknownErrorCountForOperation.inc();
+    }
+  }
+
+  /**
+   * Update error count based on the operation type.
+   * @param operationType The {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}
+   *                      for which metrics will be updated.
+   */
+  private void updateOperationErrorCount(NonBlockingRouter.RouterOperationType operationType) {
+    switch (operationType) {
+      case PutBlob:
+        putBlobErrorCount.inc();
+        break;
+      case GetBlobInfo:
+        getBlobInfoErrorCount.inc();
+        break;
+      case GetBlob:
+        getBlobErrorCount.inc();
+        break;
+      case DeleteBlob:
+        deleteBlobErrorCount.inc();
+        break;
+      default:
+        // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
+        logger.warn("Error for unknown RouterOperationType when counting operation errors: " + operationType);
+        break;
+    }
+  }
+
+  /**
+   * Get {@link NodeLevelMetrics} for a given {@link DataNodeId}. If the {@link DataNodeId} as the key does not exist,
+   * a {@link NodeLevelMetrics} corresponding to an unknown {@link DataNodeId} will be returned.
+   * @param dataNodeId The {@link DataNodeId} to be indexed.
+   * @return The {@link NodeLevelMetrics}.
+   */
+  NodeLevelMetrics getDataNodeBasedMetrics(DataNodeId dataNodeId) {
+    return dataNodeToMetrics.containsKey(dataNodeId) ? dataNodeToMetrics.get(dataNodeId) : dataNodeToMetrics.get(null);
+  }
+
+  /**
+   * A metrics class that tracks at the {@link DataNodeId} level. These metrics are collected based on the operation
+   * requests sent to individual {@link DataNodeId}. An operation request is part of an operation, and conveys an actual
+   * request to a {@link com.github.ambry.clustermap.ReplicaId} in a {@link DataNodeId}. An operation request can be
+   * either for a metadata blob, or for a datachunk.
+   */
+  public class NodeLevelMetrics {
+
+    // Request rate.
+    public final Meter putRequestRate;
+    public final Meter getBlobInfoRequestRate;
+    public final Meter getRequestRate;
+    public final Meter deleteRequestRate;
+
+    // Request latency.
+    public final Histogram putRequestLatencyMs;
+    public final Histogram getBlobInfoRequestLatencyMs;
+    public final Histogram getRequestLatencyMs;
+    public final Histogram deleteRequestLatencyMs;
+
+    // Request error count.
+    public final Counter putRequestErrorCount;
+    public final Counter getBlobInfoRequestErrorCount;
+    public final Counter getRequestErrorCount;
+    public final Counter deleteRequestErrorCount;
+
+    // Timed-out request count for each operation type.
+    public final Counter putRequestTimeoutCount;
+    public final Counter getBlobInfoRequestTimeoutCount;
+    public final Counter getRequestTimeoutCount;
+    public final Counter deleteRequestTimeoutCount;
+
+    // Count for various errors at request level.
+    public final Counter ambryUnavailableErrorCountForRequest;
+    public final Counter invalidBlobIdErrorCountForRequest;
+    public final Counter invalidPutArgumentErrorCountForRequest;
+    public final Counter requestTimedOutErrorCountForRequest;
+    public final Counter routerClosedErrorCountForRequest;
+    public final Counter unexpectedInternalErrorCountForRequest;
+    public final Counter blobTooLargeErrorCountForRequest;
+    public final Counter badInputChannelErrorCountForRequest;
+    public final Counter insufficientCapacityErrorCountForRequest;
+    public final Counter blobDeletedErrorCountForRequest;
+    public final Counter blobDoesNotExistErrorCountForRequest;
+    public final Counter blobExpiredErrorCountForRequest;
+    public final Counter unknownErrorCountForRequest;
+
+    // Misc metrics at the DataNode level.
+    public final Meter requestErrorRate;
+    public final Counter unknownReplicaResponseError;
+
+    NodeLevelMetrics(MetricRegistry registry, String dataNodeName) {
+      dataNodeName = "-" + dataNodeName;
+
+      // Request rate.
+      putRequestRate =
+          registry.meter(MetricRegistry.name(PutManager.class, dataNodeName, "-PutRequestArrivalRate"));
+      getBlobInfoRequestRate =
+          registry.meter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetBlobInfoRequestArrivalRate"));
+      getRequestRate =
+          registry.meter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetRequestArrivalRate"));
+      deleteRequestRate =
+          registry.meter(MetricRegistry.name(DeleteManager.class, dataNodeName, "-DeleteRequestArrivalRate"));
+
+      // Request latency.
+      putRequestLatencyMs =
+          registry.histogram(MetricRegistry.name(PutManager.class, dataNodeName, "-PutRequestLatencyMs"));
+      getBlobInfoRequestLatencyMs =
+          registry.histogram(MetricRegistry.name(GetManager.class, dataNodeName, "-GetBlobInfoRequestLatencyMs"));
+      getRequestLatencyMs =
+          registry.histogram(MetricRegistry.name(GetManager.class, dataNodeName, "-GetRequestLatencyMs"));
+      deleteRequestLatencyMs =
+          registry.histogram(MetricRegistry.name(DeleteManager.class, dataNodeName, "-DeleteRequestLatencyMs"));
+
+      // Request error count.
+      putRequestErrorCount =
+          registry.counter(MetricRegistry.name(PutManager.class, dataNodeName, "-PutRequestErrorCount"));
+      getBlobInfoRequestErrorCount =
+          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetBlobInfoRequestErrorCount"));
+      getRequestErrorCount =
+          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetRequestErrorCount"));
+      deleteRequestErrorCount =
+          registry.counter(MetricRegistry.name(DeleteManager.class, dataNodeName, "-DeleteRequestErrorCount"));
+
+      // Timed-out request count.
+      putRequestTimeoutCount =
+          registry.counter(MetricRegistry.name(PutManager.class, dataNodeName, "-PutRequestTimeoutCount"));
+      getBlobInfoRequestTimeoutCount =
+          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetBlobInfoRequestTimeoutCount"));
+      getRequestTimeoutCount =
+          registry.counter(MetricRegistry.name(GetManager.class, dataNodeName, "-GetRequestTimeoutCount"));
+      deleteRequestTimeoutCount =
+          registry.counter(MetricRegistry.name(DeleteManager.class, dataNodeName, "-DeleteRequestTimeoutCount"));
+
+      // Count for various errors at request level.
+      ambryUnavailableErrorCountForRequest = registry
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-AmbryUnavailableErrorForRequest"));
+      invalidBlobIdErrorCountForRequest =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-InvalidBlobIdErrorForRequest"));
+      invalidPutArgumentErrorCountForRequest = registry
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-InvalidPutArgumentErrorForRequest"));
+      requestTimedOutErrorCountForRequest = registry
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-RequestTimedOutErrorForRequest"));
+      routerClosedErrorCountForRequest =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-RouterClosedErrorForRequest"));
+      unexpectedInternalErrorCountForRequest = registry
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-UnexpectedInternalErrorForRequest"));
+      blobTooLargeErrorCountForRequest =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-BlobTooLargeErrorForRequest"));
+      badInputChannelErrorCountForRequest =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-BadInputChannel"));
+      insufficientCapacityErrorCountForRequest = registry
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-InsufficientCapacityErrorForRequest"));
+      blobDeletedErrorCountForRequest =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-BlobDeletedErrorForRequest"));
+      blobDoesNotExistErrorCountForRequest = registry
+          .counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-BlobDoesNotExistErrorForRequest"));
+      blobExpiredErrorCountForRequest =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-BlobExpiredErrorForRequest"));
+      unknownErrorCountForRequest =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-UnknownRouterErrorForRequest"));
+
+      // Misc metrics at the DataNode level.
+      requestErrorRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "-RequestErrorArrivalRate"));
+      unknownReplicaResponseError =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, dataNodeName, "-UnknownReplicaResponseError"));
+    }
+
+    /**
+     * Update the request arrival rate for a given {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
+     * This method should be called when a request to a {@link DataNodeId} is created.
+     */
+    void uopdateRequestRate(NonBlockingRouter.RouterOperationType operationType) {
+      switch (operationType) {
+        case PutBlob:
+          putRequestRate.mark();
+          break;
+        case GetBlobInfo:
+          getBlobInfoRequestRate.mark();
+          break;
+        case GetBlob:
+          getRequestRate.mark();
+          break;
+        case DeleteBlob:
+          deleteRequestRate.mark();
+          break;
+        default:
+          // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
+          logger.warn("Error for unknown RouterOperationType for counting request rate: " + operationType);
+          break;
+      }
+    }
+
+    /**
+     * Update request latency for a given {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
+     * This method should be called when a response of a request has been received and processed. This method should
+     * not be called when a request is aborted.
+     * @param latency Request latency.
+     * @param operationType {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
+     */
+    void updateRequestLatency(long latency, NonBlockingRouter.RouterOperationType operationType) {
+      switch (operationType) {
+        case PutBlob:
+          putRequestLatencyMs.update(latency);
+          break;
+        case GetBlobInfo:
+          getBlobInfoRequestLatencyMs.update(latency);
+          break;
+        case GetBlob:
+          getRequestLatencyMs.update(latency);
+          break;
+        case DeleteBlob:
+          deleteRequestLatencyMs.update(latency);
+          break;
+        default:
+          // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
+          logger.warn("Error for unknown RouterOperationType for updating request latency: " + operationType);
+          break;
+      }
+    }
+
+    /**
+     * Update the counter for timedout requests for a given {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
+     * @param operationType {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}
+     */
+    void updateRequestTimeoutCount(NonBlockingRouter.RouterOperationType operationType) {
+      switch (operationType) {
+        case PutBlob:
+          getBlobInfoRequestTimeoutCount.inc();
+          break;
+        case GetBlobInfo:
+          getBlobInfoRequestTimeoutCount.inc();
+          break;
+        case GetBlob:
+          getRequestTimeoutCount.inc();
+          break;
+        case DeleteBlob:
+          deleteRequestTimeoutCount.inc();
+          break;
+        default:
+          // We simply log the error here and do not add a metrics to record this, as the default case should not happen.
+          logger.warn("Error for unknown RouterOperationType for updating timed-out request count: " + operationType);
+          break;
+      }
+    }
+
+    /**
+     * Count the {@link RouterException} caused by a request (or its response) for a given
+     * {@link NonBlockingRouter.RouterOperationType}. This {@link RouterException} may not be the final
+     * {@link RouterException} accompanied with the {@code Operation}, but such metrics can assist a
+     * root-cause analysis at the {@link DataNodeId} level.
+     * <p/>
+     * This method should be called when a request is either completed or timed out.
+     * @param error The {@link RouterErrorCode} of the exception to be counted.
+     * @param operationType The type of the operation that is associated with the given exception.
+     */
+    void countError(RouterErrorCode error, NonBlockingRouter.RouterOperationType operationType) {
+      if (error == null) {
+        return;
+      }
+      requestErrorRate.mark();
+      switch (error) {
+        case AmbryUnavailable:
+          updateRequestError(operationType);
+          ambryUnavailableErrorCountForRequest.inc();
+          break;
+        case InvalidBlobId:
+          updateRequestError(operationType);
+          invalidBlobIdErrorCountForRequest.inc();
+          break;
+        case InvalidPutArgument:
+          updateRequestError(operationType);
+          invalidPutArgumentErrorCountForRequest.inc();
+          break;
+        case OperationTimedOut:
+          updateRequestError(operationType);
+          requestTimedOutErrorCountForRequest.inc();
+          break;
+        case RouterClosed:
+          updateRequestError(operationType);
+          routerClosedErrorCountForRequest.inc();
+          break;
+        case UnexpectedInternalError:
+          updateRequestError(operationType);
+          unexpectedInternalErrorCountForRequest.inc();
+          break;
+        case BlobTooLarge:
+          updateRequestError(operationType);
+          blobTooLargeErrorCountForRequest.inc();
+          break;
+        case BadInputChannel:
+          updateRequestError(operationType);
+          badInputChannelErrorCountForRequest.inc();
+          break;
+        case InsufficientCapacity:
+          updateRequestError(operationType);
+          insufficientCapacityErrorCountForRequest.inc();
+          break;
+        case BlobDeleted:
+          blobDeletedErrorCountForRequest.inc();
+          break;
+        case BlobDoesNotExist:
+          blobDoesNotExistErrorCountForRequest.inc();
+          break;
+        case BlobExpired:
+          blobExpiredErrorCountForRequest.inc();
+          break;
+        default:
+          unknownErrorCountForRequest.inc();
+          updateRequestError(operationType);
+          break;
+      }
+    }
+
+    /**
+     * Update request error count based on {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}.
+     * @param operationType The {@link com.github.ambry.router.NonBlockingRouter.RouterOperationType}
+     *                      for which metrics will be updated.
+     */
+    private void updateRequestError(NonBlockingRouter.RouterOperationType operationType) {
+      switch (operationType) {
+        case PutBlob:
+          putRequestErrorCount.inc();
+          break;
+        case GetBlobInfo:
+          getBlobInfoRequestErrorCount.inc();
+          break;
+        case GetBlob:
+          getRequestErrorCount.inc();
+          break;
+        case DeleteBlob:
+          deleteRequestErrorCount.inc();
+          break;
+        default:
+          logger.warn("Error for unknown RouterOperationType being counted: " + operationType);
+          break;
+      }
+    }
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -172,6 +172,13 @@ public class NonBlockingRouterMetrics {
     }
   }
 
+  /**
+   * Initializes a {@link Gauge} metric for the status of {@code RequestResponseHandlerThread} of an
+   * {@link com.github.ambry.router.NonBlockingRouter.OperationController}, to indicate if it is running
+   * or not.
+   * @param requestResponseHandlerThread The {@code RequestResponseHandlerThread} of which the status is
+   *                                     to be monitored.
+   */
   public void initializeOperationControllerMetrics(final Thread requestResponseHandlerThread) {
     requestResponseHandlerThreadRunning = new Gauge<Long>() {
       @Override
@@ -184,6 +191,11 @@ public class NonBlockingRouterMetrics {
             requestResponseHandlerThreadRunning);
   }
 
+  /**
+   * Initializes a {@link Gauge} metric for the status of {@code ChunkFillerThread} of a {@link PutManager}, to
+   * indicate if it is running or not.
+   * @param chunkFillerThread The {@code ChunkFillerThread} of which the status is to be monitored.
+   */
   public void initializePutManagerMetrics(final Thread chunkFillerThread) {
     chunkFillerThreadRunning = new Gauge<Long>() {
       @Override
@@ -195,6 +207,11 @@ public class NonBlockingRouterMetrics {
         chunkFillerThreadRunning);
   }
 
+  /**
+   * Initializes a {@link Gauge} metric to monitor the number of running
+   * {@link com.github.ambry.router.NonBlockingRouter.OperationController} of a {@link NonBlockingRouter}.
+   * @param currentOperationsCount The counter of {@link com.github.ambry.router.NonBlockingRouter.OperationController}.
+   */
   public void initializeNumActiveOperationsMetrics(final AtomicInteger currentOperationsCount) {
     activeOperations = new Gauge<Integer>() {
       @Override

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -121,7 +121,6 @@ class PutManager {
       putOperations.add(putOperation);
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.operationAbortCount.inc();
       routerMetrics.putBlobErrorCount.inc();
       routerMetrics.countError(e);
       operationCompleteCallback.completeOperation(futureResult, callback, null, e);

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -696,7 +696,7 @@ class PutOperation {
           correlationIdToChunkPutRequestInfo.entrySet().iterator();
       while (inFlightRequestsIterator.hasNext()) {
         Map.Entry<Integer, ChunkPutRequestInfo> entry = inFlightRequestsIterator.next();
-        if (time.milliseconds() - entry.getValue().getStartTimeMs() > routerConfig.routerRequestTimeoutMs) {
+        if (time.milliseconds() - entry.getValue().startTimeMs > routerConfig.routerRequestTimeoutMs) {
           operationTracker.onResponse(entry.getValue().replicaId, false);
           chunkException = new RouterException("Timed out waiting for responses", RouterErrorCode.OperationTimedOut);
           NonBlockingRouterMetrics.NodeLevelMetrics dataNodeBasedMetrics =
@@ -778,7 +778,7 @@ class PutOperation {
         // - the response is for an earlier chunk held by this PutChunk.
         return;
       }
-      long requestLatencyMs = time.milliseconds() - chunkPutRequestInfo.getStartTimeMs();
+      long requestLatencyMs = time.milliseconds() - chunkPutRequestInfo.startTimeMs;
       NonBlockingRouterMetrics.NodeLevelMetrics dataNodeBasedMetrics =
           routerMetrics.getDataNodeBasedMetrics(chunkPutRequestInfo.replicaId.getDataNodeId());
       routerMetrics.routerRequestLatencyMs.update(requestLatencyMs);
@@ -861,9 +861,9 @@ class PutOperation {
      * A class that holds information about requests sent out by this PutChunk.
      */
     private class ChunkPutRequestInfo {
-      final ReplicaId replicaId;
-      final PutRequest putRequest;
-      final long startTimeMs;
+      private final ReplicaId replicaId;
+      private final PutRequest putRequest;
+      private final long startTimeMs;
 
       /**
        * Construct a ChunkPutRequestInfo
@@ -874,10 +874,6 @@ class PutOperation {
         this.replicaId = replicaId;
         this.putRequest = putRequest;
         this.startTimeMs = startTimeMs;
-      }
-
-      long getStartTimeMs() {
-        return startTimeMs;
       }
     }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -103,7 +103,7 @@ public class ChunkFillTest {
     VerifiableProperties vProps = getNonBlockingRouterProperties();
     MockClusterMap mockClusterMap = new MockClusterMap();
     RouterConfig routerConfig = new RouterConfig(vProps);
-    NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap.getMetricRegistry());
+    NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
     ResponseHandler responseHandler = new ResponseHandler(mockClusterMap);
     BlobProperties putBlobProperties =
         new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -183,7 +183,7 @@ public class ChunkFillTest {
     VerifiableProperties vProps = getNonBlockingRouterProperties();
     MockClusterMap mockClusterMap = new MockClusterMap();
     RouterConfig routerConfig = new RouterConfig(vProps);
-    NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap.getMetricRegistry());
+    NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
     ResponseHandler responseHandler = new ResponseHandler(mockClusterMap);
     BlobProperties putBlobProperties =
         new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -80,7 +80,7 @@ public class DeleteManagerTest {
     mockSelectorState = new AtomicReference<MockSelectorState>(MockSelectorState.Good);
     clusterMap = new MockClusterMap();
     serverLayout = new MockServerLayout(clusterMap);
-    router = new NonBlockingRouter(new RouterConfig(vProps), new NonBlockingRouterMetrics(new MetricRegistry()),
+    router = new NonBlockingRouter(new RouterConfig(vProps), new NonBlockingRouterMetrics(clusterMap),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), new LoggingNotificationSystem(), clusterMap, mockTime);
     List<PartitionId> mockPartitions = clusterMap.getWritablePartitionIds();
@@ -282,7 +282,7 @@ public class DeleteManagerTest {
     Properties props = getNonBlockingRouterProperties();
     props.setProperty("router.delete.request.parallelism", "3");
     VerifiableProperties vProps = new VerifiableProperties(props);
-    router = new NonBlockingRouter(new RouterConfig(vProps), new NonBlockingRouterMetrics(new MetricRegistry()),
+    router = new NonBlockingRouter(new RouterConfig(vProps), new NonBlockingRouterMetrics(clusterMap),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), new LoggingNotificationSystem(), clusterMap, mockTime);
     ServerErrorCode[] serverErrorCodes = new ServerErrorCode[9];

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -98,13 +98,13 @@ public class GetBlobInfoOperationTest {
     VerifiableProperties vprops = new VerifiableProperties(getNonBlockingRouterProperties());
     routerConfig = new RouterConfig(vprops);
     mockClusterMap = new MockClusterMap();
-    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap.getMetricRegistry());
+    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
     mockServerLayout = new MockServerLayout(mockClusterMap);
     replicasCount = mockClusterMap.getWritablePartitionIds().get(0).getReplicaIds().size();
     responseHandler = new ResponseHandler(mockClusterMap);
     networkClientFactory = new MockNetworkClientFactory(vprops, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
         CHECKOUT_TIMEOUT_MS, mockServerLayout, time);
-    router = new NonBlockingRouter(new RouterConfig(vprops), new NonBlockingRouterMetrics(new MetricRegistry()),
+    router = new NonBlockingRouter(new RouterConfig(vprops), new NonBlockingRouterMetrics(mockClusterMap),
         networkClientFactory, new LoggingNotificationSystem(), mockClusterMap, time);
     blobProperties = new BlobProperties(BLOB_SIZE, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
     userMetadata = new byte[BLOB_USER_METADATA_SIZE];

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -127,7 +127,7 @@ public class GetBlobOperationTest {
     routerConfig = new RouterConfig(vprops);
     mockClusterMap = new MockClusterMap();
     blobIdFactory = new BlobIdFactory(mockClusterMap);
-    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap.getMetricRegistry());
+    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
     mockServerLayout = new MockServerLayout(mockClusterMap);
     replicasCount = mockClusterMap.getWritablePartitionIds().get(0).getReplicaIds().size();
     responseHandler = new ResponseHandler(mockClusterMap);
@@ -135,7 +135,7 @@ public class GetBlobOperationTest {
         new MockNetworkClientFactory(vprops, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, time);
     router =
-        new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(new MetricRegistry()), networkClientFactory,
+        new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap), networkClientFactory,
             new LoggingNotificationSystem(), mockClusterMap, time);
     networkClient = networkClientFactory.getNetworkClient();
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -186,7 +186,7 @@ public class GetManagerTest {
     properties.setProperty("router.put.success.target", Integer.toString(successTarget));
     VerifiableProperties vProps = new VerifiableProperties(properties);
     router = new NonBlockingRouter(new RouterConfig(vProps),
-        new NonBlockingRouterMetrics(mockClusterMap.getMetricRegistry()),
+        new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), new LoggingNotificationSystem(), mockClusterMap,
         mockTime);

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -95,7 +95,7 @@ public class NonBlockingRouterTest {
     MockClusterMap mockClusterMap = new MockClusterMap();
     MockTime mockTime = new MockTime();
     router = new NonBlockingRouter(new RouterConfig(verifiableProperties),
-        new NonBlockingRouterMetrics(new MetricRegistry()),
+        new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(verifiableProperties, null, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, new MockServerLayout(mockClusterMap), mockTime), new LoggingNotificationSystem(),
         mockClusterMap, mockTime);
@@ -131,7 +131,7 @@ public class NonBlockingRouterTest {
     MockClusterMap mockClusterMap = new MockClusterMap();
     MockTime mockTime = new MockTime();
     router = new NonBlockingRouter(new RouterConfig(verifiableProperties),
-        new NonBlockingRouterMetrics(new MetricRegistry()),
+        new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(verifiableProperties, null, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, new MockServerLayout(mockClusterMap), mockTime), new LoggingNotificationSystem(),
         mockClusterMap, mockTime);

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -560,7 +560,7 @@ public class PutManagerTest {
     properties.setProperty("router.put.request.parallelism", Integer.toString(requestParallelism));
     properties.setProperty("router.put.success.target", Integer.toString(successTarget));
     VerifiableProperties vProps = new VerifiableProperties(properties);
-    router = new NonBlockingRouter(new RouterConfig(vProps), new NonBlockingRouterMetrics(new MetricRegistry()),
+    router = new NonBlockingRouter(new RouterConfig(vProps), new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), new LoggingNotificationSystem(), mockClusterMap,
         mockTime);

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -44,7 +44,7 @@ public class PutOperationTest {
   private final RouterConfig routerConfig;
   private final MockClusterMap mockClusterMap = new MockClusterMap();
   private final NonBlockingRouterMetrics routerMetrics =
-      new NonBlockingRouterMetrics(mockClusterMap.getMetricRegistry());
+      new NonBlockingRouterMetrics(mockClusterMap);
   private final ResponseHandler responseHandler;
   private final Time time;
   private final Map<Integer, PutOperation> correlationIdToPutOperation = new TreeMap<>();


### PR DESCRIPTION
This patch introduces a metrics framework for NB Router, and it is rebased on PR/327. It has two major parts:
    1. General metrics and metrics-updating methods at the router level. It makes clear and avoids missing general metrics by using the general metrics-updating method (changed the way suggested from a previous discussion to update metrics by directly referencing the individual metrics);
    2. General metrics and metrics-updating methods at the NodeId level. This will help to conduct root-cause analysis by tracking metrics of an individual request to a specific node.
    3. Collect metrics for Put and Delete.
    
This is intended to be an early effort for router metrics, and I tried to limit the size of this PR. More metrics are yet to be collected, and new PR will be made to update each.
    
Reviewer: Priyesh & Siva
Estimated review time: 40min
Test: No specific tests are made for this patch, however ./gradlew build passes.