### PR TITLE
Router metrics framework

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -103,6 +103,7 @@ class DeleteManager {
           new DeleteOperation(routerConfig, responseHandler, blobId, futureResult, callback, time);
       deleteOperations.add(deleteOperation);
     } catch (RouterException e) {
+      routerMetrics.operationDequeuingRate.mark();
       operationCompleteCallback.completeOperation(futureResult, callback, null, e);
     }
   }
@@ -149,6 +150,7 @@ class DeleteManager {
     if (op.getOperationException() == null) {
       notificationSystem.onBlobDeleted(op.getBlobId().getID());
     }
+    routerMetrics.operationDequeuingRate.mark();
     operationCompleteCallback
         .completeOperation(op.getFutureResult(), op.getCallback(), op.getOperationResult(), op.getOperationException());
   }
@@ -163,6 +165,7 @@ class DeleteManager {
       // the RequestResponseHandler thread when it is in poll() or handleResponse(). In order to avoid the completion
       // from happening twice, complete it here only if the remove was successful.
       if (deleteOperations.remove(op)) {
+        routerMetrics.operationDequeuingRate.mark();
         operationCompleteCallback.completeOperation(op.getFutureResult(), op.getCallback(), null,
             new RouterException("Aborted operation because Router is closed.", RouterErrorCode.RouterClosed));
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -13,7 +13,12 @@
  */
 package com.github.ambry.router;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
@@ -22,10 +27,78 @@ import com.codahale.metrics.MetricRegistry;
  * Exports metrics that are triggered by the {@link NonBlockingRouter} to the provided {@link MetricRegistry}
  */
 public class NonBlockingRouterMetrics {
-  //@todo add metrics.
-  MetricRegistry registry;
+  private final MetricRegistry metricRegistry;
+  // @todo: Ensure all metrics here get updated appropriately.
+  // @todo: chunk filling rate metrics.
+  // @todo: More metrics for the RequestResponse handling (poll, handleResponse etc.)
+  // Rates
+  public final Meter putBlobOperationRate;
+  public final Meter operationQueuingRate;
+  public final Meter operationDequeuingRate;
 
-  public NonBlockingRouterMetrics(MetricRegistry registry) {
-    this.registry = registry;
+  public final Histogram putBlobOperationLatencyMs;
+  public final Histogram putChunkOperationLatencyMs;
+  public final Histogram routerRequestLatencyMs;
+
+  // Operation Errors
+  public final Counter slippedPutSuccessCount;
+  public final Counter putBlobErrorCount;
+  public final Counter operationAbortCount;
+
+  // Gauge
+  public Gauge<Long> chunkFillerThreadRunning;
+  public Gauge<Long> requestResponseHandlerThreadRunning;
+  public Gauge<Integer> activeOperations;
+
+  public NonBlockingRouterMetrics(MetricRegistry metricRegistry) {
+    this.metricRegistry = metricRegistry;
+    putBlobOperationRate = metricRegistry.meter(MetricRegistry.name(PutManager.class, "-PutBlobRequestArrivalRate"));
+    operationQueuingRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "-OperationQueuingRate"));
+    operationDequeuingRate =
+        metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "-OperationDequeuingRate"));
+
+    putBlobOperationLatencyMs =
+        metricRegistry.histogram(MetricRegistry.name(PutManager.class, "-PutBlobOperationLatencyMs"));
+    putChunkOperationLatencyMs =
+        metricRegistry.histogram(MetricRegistry.name(PutManager.class, "-PutChunkOperationLatencyMs"));
+    routerRequestLatencyMs =
+        metricRegistry.histogram(MetricRegistry.name(NonBlockingRouter.class, "-RouterRequestLatencyMs"));
+
+    slippedPutSuccessCount = metricRegistry.counter(MetricRegistry.name(PutManager.class, "-SlippedPutSuccessCount"));
+    putBlobErrorCount = metricRegistry.counter(MetricRegistry.name(PutManager.class, "-PutBlobErrorCount"));
+    operationAbortCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "-OperationAbortCount"));
+  }
+
+  public void initializeOperationControllerMetrics(final Thread requestResponseHandlerThread) {
+    requestResponseHandlerThreadRunning = new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return requestResponseHandlerThread.isAlive() ? 1L : 0L;
+      }
+    };
+    metricRegistry
+        .register(MetricRegistry.name(NonBlockingRouter.class, requestResponseHandlerThread.getName() + "-Running"),
+            requestResponseHandlerThreadRunning);
+  }
+
+  public void initializePutManagerMetrics(final Thread chunkFillerThread) {
+    chunkFillerThreadRunning = new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return chunkFillerThread.isAlive() ? 1L : 0L;
+      }
+    };
+    metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, chunkFillerThread.getName() + "-Running"),
+        chunkFillerThreadRunning);
+  }
+
+  public void initializeNumActiveOperationsMetrics(final AtomicInteger currentOperationsCount) {
+    activeOperations = new Gauge<Integer>() {
+      @Override
+      public Integer getValue() {
+        return currentOperationsCount.get();
+      }
+    };
+    metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "-NumActiveOperations"), activeOperations);
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -113,6 +113,7 @@ public class ChunkFillTest {
     VerifiableProperties vProps = getNonBlockingRouterProperties();
     MockClusterMap mockClusterMap = new MockClusterMap();
     RouterConfig routerConfig = new RouterConfig(vProps);
+    NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap.getMetricRegistry());
     ResponseHandler responseHandler = new ResponseHandler(mockClusterMap);
     BlobProperties putBlobProperties =
         new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
@@ -123,9 +124,8 @@ public class ChunkFillTest {
     random.nextBytes(putContent);
     final ReadableStreamChannel putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(putContent));
     FutureResult<String> futureResult = new FutureResult<String>();
-    PutOperation op =
-        new PutOperation(routerConfig, mockClusterMap, responseHandler, putBlobProperties, putUserMetadata, putChannel,
-            futureResult, null, new MockTime());
+    PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
+        putUserMetadata, putChannel, futureResult, null, new MockTime());
     numChunks = op.getNumDataChunks();
     compositeBuffers = new ByteBuffer[numChunks];
     final AtomicReference<Exception> operationException = new AtomicReference<Exception>(null);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -58,6 +58,7 @@ public class GetBlobInfoOperationTest {
   private int requestParallelism = 2;
   private int successTarget = 1;
   private RouterConfig routerConfig;
+  private NonBlockingRouterMetrics routerMetrics;
   private final MockClusterMap mockClusterMap;
   private final MockServerLayout mockServerLayout;
   private final int replicasCount;
@@ -92,6 +93,7 @@ public class GetBlobInfoOperationTest {
     VerifiableProperties vprops = new VerifiableProperties(getNonBlockingRouterProperties());
     routerConfig = new RouterConfig(vprops);
     mockClusterMap = new MockClusterMap();
+    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap.getMetricRegistry());
     mockServerLayout = new MockServerLayout(mockClusterMap);
     replicasCount = mockClusterMap.getWritablePartitionIds().get(0).getReplicaIds().size();
     responseHandler = new ResponseHandler(mockClusterMap);
@@ -135,8 +137,8 @@ public class GetBlobInfoOperationTest {
 
     // test a bad case
     try {
-      new GetBlobInfoOperation(routerConfig, mockClusterMap, responseHandler, "invalid_id", operationFuture,
-          operationCallback, time);
+      new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, "invalid_id",
+          operationFuture, operationCallback, time);
       Assert.fail("Instantiation of GetBlobInfo operation with an invalid blob id must fail");
     } catch (RouterException e) {
       Assert
@@ -146,8 +148,8 @@ public class GetBlobInfoOperationTest {
 
     // test a good case
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, mockClusterMap, responseHandler, blobIdStr, operationFuture,
-            operationCallback, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,
+            operationFuture, operationCallback, time);
 
     Assert.assertEquals("Callback must match", operationCallback, op.getCallback());
     Assert.assertEquals("Futures must match", operationFuture, op.getFuture());
@@ -162,7 +164,8 @@ public class GetBlobInfoOperationTest {
   public void testPollAndResponseHandling()
       throws Exception {
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, mockClusterMap, responseHandler, blobIdStr, operationFuture, null, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,
+            operationFuture, null, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
     op.poll(requestRegistrationCallback);
@@ -188,7 +191,8 @@ public class GetBlobInfoOperationTest {
   public void testRouterRequestTimeoutAllFailure()
       throws Exception {
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, mockClusterMap, responseHandler, blobIdStr, operationFuture, null, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,
+            operationFuture, null, time);
     requestRegistrationCallback.requestListToFill = new ArrayList<>();
     op.poll(requestRegistrationCallback);
     while (!op.isOperationComplete()) {
@@ -212,7 +216,8 @@ public class GetBlobInfoOperationTest {
   public void testNetworkClientTimeoutAllFailure()
       throws Exception {
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, mockClusterMap, responseHandler, blobIdStr, operationFuture, null, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,
+            operationFuture, null, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -247,7 +252,8 @@ public class GetBlobInfoOperationTest {
   public void testBlobNotFoundCase()
       throws Exception {
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, mockClusterMap, responseHandler, blobIdStr, operationFuture, null, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,
+            operationFuture, null, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -306,7 +312,8 @@ public class GetBlobInfoOperationTest {
   private void testErrorPrecedence(ServerErrorCode[] serverErrorCodesInOrder, RouterErrorCode expectedErrorCode)
       throws Exception {
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, mockClusterMap, responseHandler, blobIdStr, operationFuture, null, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,
+            operationFuture, null, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -361,7 +368,8 @@ public class GetBlobInfoOperationTest {
   private void testVariousErrors(String dcWherePutHappened)
       throws Exception {
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, mockClusterMap, responseHandler, blobIdStr, operationFuture, null, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,
+            operationFuture, null, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -156,10 +156,10 @@ public class NonBlockingRouterTest {
    * @param expectedCount the expected number of ChunkFiller and RequestResponseHandler threads.
    */
   private void assertExpectedThreadCounts(int expectedCount) {
-    Assert.assertEquals("Number of chunkFiller threads running should be as expected", expectedCount,
-        TestUtils.numThreadsByThisName("ChunkFillerThread"));
     Assert.assertEquals("Number of RequestResponseHandler threads running should be as expected", expectedCount,
         TestUtils.numThreadsByThisName("RequestResponseHandlerThread"));
+    Assert.assertEquals("Number of chunkFiller threads running should be as expected", expectedCount,
+        TestUtils.numThreadsByThisName("ChunkFillerThread"));
     if (expectedCount == 0) {
       Assert.assertFalse("Router should be closed if there are no worker threads running", router.isOpen());
       Assert

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -43,6 +43,8 @@ import org.junit.Test;
 public class PutOperationTest {
   private final RouterConfig routerConfig;
   private final MockClusterMap mockClusterMap = new MockClusterMap();
+  private final NonBlockingRouterMetrics routerMetrics =
+      new NonBlockingRouterMetrics(mockClusterMap.getMetricRegistry());
   private final ResponseHandler responseHandler;
   private final Time time;
   private final Map<Integer, PutOperation> correlationIdToPutOperation = new TreeMap<>();
@@ -96,8 +98,8 @@ public class PutOperationTest {
     ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content));
     FutureResult<String> future = new FutureResult<>();
     PutOperation op =
-        new PutOperation(routerConfig, mockClusterMap, responseHandler, blobProperties, userMetadata, channel, future,
-            null, time);
+        new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobProperties, userMetadata,
+            channel, future, null, time);
     List<RequestInfo> requestInfos = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestInfos;
     // Since this channel is in memory, one call to fill chunks would end up filling the maximum number of PutChunks.

--- a/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
@@ -18,14 +18,14 @@ package com.github.ambry.utils;
  */
 public class TestUtils {
   /**
-   * Return the number of threads currently running with the given name.
-   * @param name the name to compare
-   * @return the number of threads currently running with the given name.
+   * Return the number of threads currently running with a name containing the given pattern.
+   * @param pattern the pattern to compare
+   * @return the number of threads currently running with a name containing the given pattern.
    */
-  public static int numThreadsByThisName(String name) {
+  public static int numThreadsByThisName(String pattern) {
     int count = 0;
     for (Thread t : Thread.getAllStackTraces().keySet()) {
-      if (t.getName().equals(name)) {
+      if (t.getName().contains(pattern)) {
         count++;
       }
     }
@@ -33,14 +33,15 @@ public class TestUtils {
   }
 
   /**
-   * Return the thread with the given name. If there are multiple such threads, return the first thread by this name.
-   * @param name the name to compare
-   * @return the first thread with the given name.
+   * Return the thread with a name that contains the given name. If there are multiple such threads,
+   * return the first such thread.
+   * @param pattern the pattern to compare
+   * @return the first thread with a name that contains the given pattern.
    */
-  public static Thread getThreadByThisName(String name) {
+  public static Thread getThreadByThisName(String pattern) {
     Thread thread = null;
     for (Thread t : Thread.getAllStackTraces().keySet()) {
-      if (t.getName().equals(name)) {
+      if (t.getName().contains(pattern)) {
         thread = t;
         break;
       }


### PR DESCRIPTION
Initial patch for the router metrics. This includes the framework, with
metrics common to all the operations. Additionally, a few metrics
specific to put and get operations are included. This will be followed
up with more metrics.

Primary reviewers: Ming.

Some of this overlaps with #326, and this PR is provided for reference for now. We are going to discuss offline and figure out how to resolve this, so please hold off on the review until then.