### PR TITLE
Fix issue with replication thread count metric

### DIFF
--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -322,7 +322,7 @@ public final class ReplicationManager {
         }
       }
       replicationMetrics
-          .populatePerColoMetrics(dataNode.getDatacenterName(), numberOfReplicaThreads.keySet(), replicaThreadPools);
+          .populatePerColoMetrics(numberOfReplicaThreads.keySet());
     } catch (Exception e) {
       logger.error("Error on starting replication manager", e);
       throw new ReplicationException("Error on starting replication manager");
@@ -346,6 +346,7 @@ public final class ReplicationManager {
       // divide the nodes between the replica threads if the number of replica threads is less than or equal to the
       // number of nodes. Otherwise, assign one thread to one node.
       assignReplicasToThreadPool();
+      replicationMetrics.trackLiveThreadsCount(replicaThreadPools, dataNodeId.getDatacenterName());
 
       // start all replica threads
       for (List<ReplicaThread> replicaThreads : replicaThreadPools.values()) {
@@ -356,7 +357,6 @@ public final class ReplicationManager {
         }
       }
 
-      replicationMetrics.trackLiveThreadsCount(replicaThreadPools, dataNodeId.getDatacenterName());
 
       // start background persistent thread
       // start scheduler thread to persist index in the background

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -321,8 +321,7 @@ public final class ReplicationManager {
           partitionGroupedByMountPath.put(replicaId.getMountPath(), partitionInfos);
         }
       }
-      replicationMetrics
-          .populatePerColoMetrics(numberOfReplicaThreads.keySet());
+      replicationMetrics.populatePerColoMetrics(numberOfReplicaThreads.keySet());
     } catch (Exception e) {
       logger.error("Error on starting replication manager", e);
       throw new ReplicationException("Error on starting replication manager");
@@ -356,7 +355,6 @@ public final class ReplicationManager {
           replicaThread.start();
         }
       }
-
 
       // start background persistent thread
       // start scheduler thread to persist index in the background
@@ -426,7 +424,9 @@ public final class ReplicationManager {
     PartitionInfo partitionInfo = partitionsToReplicate.get(partitionId);
     for (RemoteReplicaInfo remoteReplicaInfo : partitionInfo.getRemoteReplicaInfos()) {
       if (remoteReplicaInfo.getReplicaId().getReplicaPath().equals(replicaPath) && remoteReplicaInfo.getReplicaId()
-          .getDataNodeId().getHostname().equals(hostName)) {
+          .getDataNodeId()
+          .getHostname()
+          .equals(hostName)) {
         foundRemoteReplicaInfo = remoteReplicaInfo;
       }
     }
@@ -607,9 +607,8 @@ public final class ReplicationManager {
                 if (remoteReplicaInfo.getReplicaId().getDataNodeId().getHostname().equalsIgnoreCase(hostname) &&
                     remoteReplicaInfo.getReplicaId().getDataNodeId().getPort() == port &&
                     remoteReplicaInfo.getReplicaId().getReplicaPath().equals(replicaPath)) {
-                  logger
-                      .info("Read token for partition {} remote host {} port {} token {}", partitionId, hostname, port,
-                          token);
+                  logger.info("Read token for partition {} remote host {} port {} token {}", partitionId, hostname,
+                      port, token);
                   if (partitionInfo.getStore().getSizeInBytes() > 0) {
                     remoteReplicaInfo.initializeTokens(token);
                     remoteReplicaInfo.setTotalBytesReadFromLocalStore(totalBytesReadFromLocalStore);
@@ -645,8 +644,8 @@ public final class ReplicationManager {
         throw new ReplicationException("IO error while reading from replica token file " + e);
       } finally {
         stream.close();
-        replicationMetrics.remoteReplicaTokensRestoreTime
-            .update(SystemTime.getInstance().milliseconds() - readStartTimeMs);
+        replicationMetrics.remoteReplicaTokensRestoreTime.update(
+            SystemTime.getInstance().milliseconds() - readStartTimeMs);
       }
     }
 
@@ -706,8 +705,8 @@ public final class ReplicationManager {
         throw new ReplicationException("IO error while persisting replica tokens to disk ");
       } finally {
         writer.close();
-        replicationMetrics.remoteReplicaTokensPersistTime
-            .update(SystemTime.getInstance().milliseconds() - writeStartTimeMs);
+        replicationMetrics.remoteReplicaTokensPersistTime.update(
+            SystemTime.getInstance().milliseconds() - writeStartTimeMs);
       }
       logger.debug("Completed writing replica tokens to file {}", actual.getAbsolutePath());
     }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -356,6 +356,8 @@ public final class ReplicationManager {
         }
       }
 
+      replicationMetrics.trackLiveThreadsCount(replicaThreadPools, dataNodeId.getDatacenterName());
+
       // start background persistent thread
       // start scheduler thread to persist index in the background
       this.scheduler.schedule("replica token persistor", persistor, replicationConfig.replicationTokenFlushDelaySeconds,

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -206,13 +206,9 @@ public class ReplicationMetrics {
 
   /**
    * Updates per colo metrics for each thread pool
-   * @param localDatacenter from which replication happens
    * @param datacenters List of datacenters to replicate from
-   * @param replicaThreadPools Mapping of datacenter to List of {@link ReplicaThread} that is responsible for
-   *                           replicating from that datacenter
    */
-  public void populatePerColoMetrics(String localDatacenter, Set<String> datacenters,
-      final Map<String, ArrayList<ReplicaThread>> replicaThreadPools) {
+  public void populatePerColoMetrics(Set<String> datacenters) {
     for (String datacenter : datacenters) {
       Meter interColoReplicationBytesRatePerDC =
           registry.meter(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-ReplicationBytesRate"));
@@ -314,6 +310,13 @@ public class ReplicationMetrics {
     }
   }
 
+  /**
+   * Register metrics for measuring the number of active intra and inter colo replica threads.
+   *
+   * @param replicaThreadPools A map of datacenter names to {@link ReplicaThread}s handling replication from that
+   *                           datacenter
+   * @param localDatacenter The datacenter on which the {@link ReplicationManager} is running
+   */
   void trackLiveThreadsCount(final Map<String, ArrayList<ReplicaThread>> replicaThreadPools,
       String localDatacenter) {
     for (final String datacenter : replicaThreadPools.keySet()) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -174,8 +174,8 @@ public class ReplicationMetrics {
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoReplicationWaitTime"));
     intraColoReplicationMetadataRequestTime =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "IntraColoReplicationMetadataRequestTime"));
-    plainTextIntraColoReplicationMetadataRequestTime = registry
-        .histogram(MetricRegistry.name(ReplicaThread.class, "PlainTextIntraColoReplicationMetadataRequestTime"));
+    plainTextIntraColoReplicationMetadataRequestTime = registry.histogram(
+        MetricRegistry.name(ReplicaThread.class, "PlainTextIntraColoReplicationMetadataRequestTime"));
     sslIntraColoReplicationMetadataRequestTime =
         registry.histogram(MetricRegistry.name(ReplicaThread.class, "SslIntraColoReplicationMetadataRequestTime"));
     intraColoCheckMissingKeysTime =
@@ -213,8 +213,8 @@ public class ReplicationMetrics {
       Meter interColoReplicationBytesRatePerDC =
           registry.meter(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-ReplicationBytesRate"));
       interColoReplicationBytesRate.put(datacenter, interColoReplicationBytesRatePerDC);
-      Meter plainTextInterColoReplicationBytesRatePerDC = registry
-          .meter(MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-ReplicationBytesRate"));
+      Meter plainTextInterColoReplicationBytesRatePerDC = registry.meter(
+          MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-ReplicationBytesRate"));
       plainTextInterColoReplicationBytesRate.put(datacenter, plainTextInterColoReplicationBytesRatePerDC);
       Meter sslInterColoReplicationBytesRatePerDC =
           registry.meter(MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-ReplicationBytesRate"));
@@ -225,23 +225,23 @@ public class ReplicationMetrics {
       Counter interColoBlobsReplicatedCountPerDC =
           registry.counter(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-ReplicationBlobsCount"));
       interColoBlobsReplicatedCount.put(datacenter, interColoBlobsReplicatedCountPerDC);
-      Counter plainTextInterColoMetadataExchangeCountPerDC = registry
-          .counter(MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-MetadataExchangeCount"));
+      Counter plainTextInterColoMetadataExchangeCountPerDC = registry.counter(
+          MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-MetadataExchangeCount"));
       plainTextInterColoMetadataExchangeCount.put(datacenter, plainTextInterColoMetadataExchangeCountPerDC);
-      Counter plainTextInterColoBlobsReplicatedCountPerDC = registry
-          .counter(MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-BlobsReplicatedCount"));
+      Counter plainTextInterColoBlobsReplicatedCountPerDC = registry.counter(
+          MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-BlobsReplicatedCount"));
       plainTextInterColoBlobsReplicatedCount.put(datacenter, plainTextInterColoBlobsReplicatedCountPerDC);
-      Counter sslInterColoMetadataExchangeCountPerDC = registry
-          .counter(MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-MetadataExchangeCount"));
+      Counter sslInterColoMetadataExchangeCountPerDC = registry.counter(
+          MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-MetadataExchangeCount"));
       sslInterColoMetadataExchangeCount.put(datacenter, sslInterColoMetadataExchangeCountPerDC);
-      Counter sslInterColoBlobsReplicatedCountPerDC = registry
-          .counter(MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-BlobsReplicatedCount"));
+      Counter sslInterColoBlobsReplicatedCountPerDC = registry.counter(
+          MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-BlobsReplicatedCount"));
       sslInterColoBlobsReplicatedCount.put(datacenter, sslInterColoBlobsReplicatedCountPerDC);
       Timer interColoReplicationLatencyPerDC =
           registry.timer(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-ReplicationLatency"));
       interColoReplicationLatency.put(datacenter, interColoReplicationLatencyPerDC);
-      Timer plainTextInterColoReplicationLatencyPerDC = registry
-          .timer(MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-ReplicationLatency"));
+      Timer plainTextInterColoReplicationLatencyPerDC = registry.timer(
+          MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-ReplicationLatency"));
       plainTextInterColoReplicationLatency.put(datacenter, plainTextInterColoReplicationLatencyPerDC);
       Timer sslInterColoReplicationLatencyPerDC =
           registry.timer(MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-ReplicationLatency"));
@@ -252,39 +252,39 @@ public class ReplicationMetrics {
       Histogram plainTextInterColoExchangeMetadataTimePerDC = registry.histogram(
           MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-ExchangeMetadataTime"));
       plainTextInterColoExchangeMetadataTime.put(datacenter, plainTextInterColoExchangeMetadataTimePerDC);
-      Histogram sslInterColoExchangeMetadataTimePerDC = registry
-          .histogram(MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-ExchangeMetadataTime"));
+      Histogram sslInterColoExchangeMetadataTimePerDC = registry.histogram(
+          MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-ExchangeMetadataTime"));
       sslInterColoExchangeMetadataTime.put(datacenter, sslInterColoExchangeMetadataTimePerDC);
       Histogram interColoFixMissingKeysTimePerDC =
           registry.histogram(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-FixMissingKeysTime"));
       interColoFixMissingKeysTime.put(datacenter, interColoFixMissingKeysTimePerDC);
-      Histogram plainTextInterColoFixMissingKeysTimePerDC = registry
-          .histogram(MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-FixMissingKeysTime"));
+      Histogram plainTextInterColoFixMissingKeysTimePerDC = registry.histogram(
+          MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-FixMissingKeysTime"));
       plainTextInterColoFixMissingKeysTime.put(datacenter, plainTextInterColoFixMissingKeysTimePerDC);
-      Histogram sslInterColoFixMissingKeysTimePerDC = registry
-          .histogram(MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-FixMissingKeysTime"));
+      Histogram sslInterColoFixMissingKeysTimePerDC = registry.histogram(
+          MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-FixMissingKeysTime"));
       sslInterColoFixMissingKeysTime.put(datacenter, sslInterColoFixMissingKeysTimePerDC);
       Histogram interColoReplicationMetadataRequestTimePerDC = registry.histogram(
           MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-ReplicationMetadataRequestTime"));
       interColoReplicationMetadataRequestTime.put(datacenter, interColoReplicationMetadataRequestTimePerDC);
       Histogram plainTextInterColoReplicationMetadataRequestTimePerDC = registry.histogram(
           MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-ReplicationMetadataRequestTime"));
-      plainTextInterColoReplicationMetadataRequestTime
-          .put(datacenter, plainTextInterColoReplicationMetadataRequestTimePerDC);
+      plainTextInterColoReplicationMetadataRequestTime.put(datacenter,
+          plainTextInterColoReplicationMetadataRequestTimePerDC);
       Histogram sslInterColoReplicationMetadataRequestTimePerDC = registry.histogram(
           MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-ReplicationMetadataRequestTime"));
       sslInterColoReplicationMetadataRequestTime.put(datacenter, sslInterColoReplicationMetadataRequestTimePerDC);
       Histogram interColoCheckMissingKeysTimePerDC =
           registry.histogram(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-CheckMissingKeysTime"));
       interColoCheckMissingKeysTime.put(datacenter, interColoCheckMissingKeysTimePerDC);
-      Histogram interColoProcessMetadataResponseTimePerDC = registry
-          .histogram(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-ProcessMetadataResponseTime"));
+      Histogram interColoProcessMetadataResponseTimePerDC = registry.histogram(
+          MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-ProcessMetadataResponseTime"));
       interColoProcessMetadataResponseTime.put(datacenter, interColoProcessMetadataResponseTimePerDC);
       Histogram interColoGetRequestTimePerDC =
           registry.histogram(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-GetRequestTime"));
       interColoGetRequestTime.put(datacenter, interColoGetRequestTimePerDC);
-      Histogram plainTextInterColoGetRequestTimePerDC = registry
-          .histogram(MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-GetRequestTime"));
+      Histogram plainTextInterColoGetRequestTimePerDC = registry.histogram(
+          MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-GetRequestTime"));
       plainTextInterColoGetRequestTime.put(datacenter, plainTextInterColoGetRequestTimePerDC);
       Histogram sslInterColoGetRequestTimePerDC =
           registry.histogram(MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-GetRequestTime"));
@@ -292,11 +292,11 @@ public class ReplicationMetrics {
       Histogram interColoBatchStoreWriteTimePerDC =
           registry.histogram(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-BatchStoreWriteTime"));
       interColoBatchStoreWriteTime.put(datacenter, interColoBatchStoreWriteTimePerDC);
-      Histogram plainTextInterColoBatchStoreWriteTimePerDC = registry
-          .histogram(MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-BatchStoreWriteTime"));
+      Histogram plainTextInterColoBatchStoreWriteTimePerDC = registry.histogram(
+          MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-BatchStoreWriteTime"));
       plainTextInterColoBatchStoreWriteTime.put(datacenter, plainTextInterColoBatchStoreWriteTimePerDC);
-      Histogram sslInterColoBatchStoreWriteTimePerDC = registry
-          .histogram(MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-BatchStoreWriteTime"));
+      Histogram sslInterColoBatchStoreWriteTimePerDC = registry.histogram(
+          MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-BatchStoreWriteTime"));
       sslInterColoBatchStoreWriteTime.put(datacenter, sslInterColoBatchStoreWriteTimePerDC);
       Histogram interColoTotalReplicationTimePerDC =
           registry.histogram(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-TotalReplicationTime"));
@@ -304,8 +304,8 @@ public class ReplicationMetrics {
       Histogram plainTextInterColoTotalReplicationTimePerDC = registry.histogram(
           MetricRegistry.name(ReplicaThread.class, "PlainTextInter-" + datacenter + "-TotalReplicationTime"));
       plainTextInterColoTotalReplicationTime.put(datacenter, plainTextInterColoTotalReplicationTimePerDC);
-      Histogram sslInterColoTotalReplicationTimePerDC = registry
-          .histogram(MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-TotalReplicationTime"));
+      Histogram sslInterColoTotalReplicationTimePerDC = registry.histogram(
+          MetricRegistry.name(ReplicaThread.class, "SslInter-" + datacenter + "-TotalReplicationTime"));
       sslInterColoTotalReplicationTime.put(datacenter, sslInterColoTotalReplicationTimePerDC);
     }
   }
@@ -317,8 +317,7 @@ public class ReplicationMetrics {
    *                           datacenter
    * @param localDatacenter The datacenter on which the {@link ReplicationManager} is running
    */
-  void trackLiveThreadsCount(final Map<String, ArrayList<ReplicaThread>> replicaThreadPools,
-      String localDatacenter) {
+  void trackLiveThreadsCount(final Map<String, ArrayList<ReplicaThread>> replicaThreadPools, String localDatacenter) {
     for (final String datacenter : replicaThreadPools.keySet()) {
       Gauge<Integer> liveThreadsPerDatacenter = new Gauge<Integer>() {
         @Override

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -213,7 +213,6 @@ public class ReplicationMetrics {
    */
   public void populatePerColoMetrics(String localDatacenter, Set<String> datacenters,
       final Map<String, ArrayList<ReplicaThread>> replicaThreadPools) {
-    trackLiveThreadsCount(replicaThreadPools, localDatacenter);
     for (String datacenter : datacenters) {
       Meter interColoReplicationBytesRatePerDC =
           registry.meter(MetricRegistry.name(ReplicaThread.class, "Inter-" + datacenter + "-ReplicationBytesRate"));
@@ -315,7 +314,7 @@ public class ReplicationMetrics {
     }
   }
 
-  private void trackLiveThreadsCount(final Map<String, ArrayList<ReplicaThread>> replicaThreadPools,
+  void trackLiveThreadsCount(final Map<String, ArrayList<ReplicaThread>> replicaThreadPools,
       String localDatacenter) {
     for (final String datacenter : replicaThreadPools.keySet()) {
       Gauge<Integer> liveThreadsPerDatacenter = new Gauge<Integer>() {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -430,8 +430,7 @@ public class ReplicationTest {
       if (metadataRequest != null) {
         List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList =
             new ArrayList<ReplicaMetadataResponseInfo>();
-        for (ReplicaMetadataRequestInfo replicaMetadataRequestInfo : metadataRequest
-            .getReplicaMetadataRequestInfoList()) {
+        for (ReplicaMetadataRequestInfo replicaMetadataRequestInfo : metadataRequest.getReplicaMetadataRequestInfoList()) {
           List<MessageInfo> messageInfoToReturn = new ArrayList<MessageInfo>();
           int startIndex = ((MockFindToken) (replicaMetadataRequestInfo.getToken())).getIndex();
           int endIndex = Math.min(messageInfoForPartition.get(replicaMetadataRequestInfo.getPartitionId()).size(),
@@ -615,8 +614,7 @@ public class ReplicationTest {
       Map<String, ArrayList<ReplicaThread>> replicaThreadMap = new HashMap<String, ArrayList<ReplicaThread>>();
       replicaThreadMap.put("localhost", new ArrayList<ReplicaThread>());
       ReplicationMetrics replicationMetrics = new ReplicationMetrics(new MetricRegistry(), replicaIds);
-      replicationMetrics
-          .populatePerColoMetrics(new HashSet<String>(Arrays.asList("localhost")));
+      replicationMetrics.populatePerColoMetrics(new HashSet<String>(Arrays.asList("localhost")));
       StoreKeyFactory storeKeyFactory = null;
       try {
         storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
@@ -871,8 +869,7 @@ public class ReplicationTest {
       Map<String, ArrayList<ReplicaThread>> replicaThreadMap = new HashMap<String, ArrayList<ReplicaThread>>();
       replicaThreadMap.put("localhost", new ArrayList<ReplicaThread>());
       ReplicationMetrics replicationMetrics = new ReplicationMetrics(new MetricRegistry(), replicaIds);
-      replicationMetrics
-          .populatePerColoMetrics(new HashSet<String>(Arrays.asList("localhost")));
+      replicationMetrics.populatePerColoMetrics(new HashSet<String>(Arrays.asList("localhost")));
       StoreKeyFactory storeKeyFactory = null;
       try {
         storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
@@ -1102,8 +1099,7 @@ public class ReplicationTest {
       Map<String, ArrayList<ReplicaThread>> replicaThreadMap = new HashMap<String, ArrayList<ReplicaThread>>();
       replicaThreadMap.put("localhost", new ArrayList<ReplicaThread>());
       ReplicationMetrics replicationMetrics = new ReplicationMetrics(new MetricRegistry(), replicaIds);
-      replicationMetrics
-          .populatePerColoMetrics(new HashSet<String>(Arrays.asList("localhost")));
+      replicationMetrics.populatePerColoMetrics(new HashSet<String>(Arrays.asList("localhost")));
       StoreKeyFactory storeKeyFactory = null;
       try {
         storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -616,7 +616,7 @@ public class ReplicationTest {
       replicaThreadMap.put("localhost", new ArrayList<ReplicaThread>());
       ReplicationMetrics replicationMetrics = new ReplicationMetrics(new MetricRegistry(), replicaIds);
       replicationMetrics
-          .populatePerColoMetrics("localhost", new HashSet<String>(Arrays.asList("localhost")), replicaThreadMap);
+          .populatePerColoMetrics(new HashSet<String>(Arrays.asList("localhost")));
       StoreKeyFactory storeKeyFactory = null;
       try {
         storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
@@ -872,7 +872,7 @@ public class ReplicationTest {
       replicaThreadMap.put("localhost", new ArrayList<ReplicaThread>());
       ReplicationMetrics replicationMetrics = new ReplicationMetrics(new MetricRegistry(), replicaIds);
       replicationMetrics
-          .populatePerColoMetrics("localhost", new HashSet<String>(Arrays.asList("localhost")), replicaThreadMap);
+          .populatePerColoMetrics(new HashSet<String>(Arrays.asList("localhost")));
       StoreKeyFactory storeKeyFactory = null;
       try {
         storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
@@ -1103,7 +1103,7 @@ public class ReplicationTest {
       replicaThreadMap.put("localhost", new ArrayList<ReplicaThread>());
       ReplicationMetrics replicationMetrics = new ReplicationMetrics(new MetricRegistry(), replicaIds);
       replicationMetrics
-          .populatePerColoMetrics("localhost", new HashSet<String>(Arrays.asList("localhost")), replicaThreadMap);
+          .populatePerColoMetrics(new HashSet<String>(Arrays.asList("localhost")));
       StoreKeyFactory storeKeyFactory = null;
       try {
         storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);


### PR DESCRIPTION
Previously `replicationMetrics.trackLiveThreadsCount()` was being called before `replicaThreadPools` was populated. This fixes that.

**Reviewer:** @nsivabalan 
**Time:** 5 min.