### PR TITLE
Incorporate ReadableStreamChannel interface changes within GetBlobResult

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -314,6 +314,16 @@ class GetBlobOperation extends GetOperation<ReadableStreamChannel> {
       isOpen = false;
     }
 
+    @Override
+    public void setDigestAlgorithm(String digestAlgorithm) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getDigest() {
+      throw new UnsupportedOperationException();
+    }
+
     /**
      * @return whether readInto() has been called yet.
      */


### PR DESCRIPTION
`ReadableStreamChannel` introduced two new digest related methods as part of a patch parallel to the Get patch that had an implementation of this interface.
Adding that to the `GetBlobResult` implementation.

Reviewer: Gopal, ~ 5 min.