### PR TITLE
Turn on MessageFormat BlobRecord Version2

### DIFF
--- a/ambry-coordinator/src/test/java/com.github.ambry.coordinator/Blob.java
+++ b/ambry-coordinator/src/test/java/com.github.ambry.coordinator/Blob.java
@@ -13,9 +13,8 @@
  */
 package com.github.ambry.coordinator;
 
-import com.github.ambry.messageformat.BlobOutput;
+import com.github.ambry.messageformat.BlobData;
 import com.github.ambry.messageformat.BlobProperties;
-
 import java.nio.ByteBuffer;
 
 
@@ -25,12 +24,12 @@ import java.nio.ByteBuffer;
 class Blob {
   private final BlobProperties blobProperties;
   private final ByteBuffer userMetadata;
-  private final BlobOutput blobOutput;
+  private final BlobData blobData;
 
-  public Blob(BlobProperties blobProperties, ByteBuffer userMetadata, BlobOutput blobOutput) {
+  public Blob(BlobProperties blobProperties, ByteBuffer userMetadata, BlobData blobData) {
     this.blobProperties = blobProperties;
     this.userMetadata = userMetadata;
-    this.blobOutput = blobOutput;
+    this.blobData = blobData;
   }
 
   public BlobProperties getBlobProperties() {
@@ -41,7 +40,7 @@ class Blob {
     return userMetadata;
   }
 
-  public BlobOutput getBlobOutput() {
-    return blobOutput;
+  public BlobData getBlobData() {
+    return blobData;
   }
 }

--- a/ambry-coordinator/src/test/java/com.github.ambry.coordinator/Blob.java
+++ b/ambry-coordinator/src/test/java/com.github.ambry.coordinator/Blob.java
@@ -13,7 +13,7 @@
  */
 package com.github.ambry.coordinator;
 
-import com.github.ambry.messageformat.BlobData;
+import com.github.ambry.messageformat.BlobOutput;
 import com.github.ambry.messageformat.BlobProperties;
 import java.nio.ByteBuffer;
 
@@ -24,12 +24,12 @@ import java.nio.ByteBuffer;
 class Blob {
   private final BlobProperties blobProperties;
   private final ByteBuffer userMetadata;
-  private final BlobData blobData;
+  private final BlobOutput blobOutput;
 
-  public Blob(BlobProperties blobProperties, ByteBuffer userMetadata, BlobData blobData) {
+  public Blob(BlobProperties blobProperties, ByteBuffer userMetadata, BlobOutput blobOutput) {
     this.blobProperties = blobProperties;
     this.userMetadata = userMetadata;
-    this.blobData = blobData;
+    this.blobOutput = blobOutput;
   }
 
   public BlobProperties getBlobProperties() {
@@ -40,7 +40,7 @@ class Blob {
     return userMetadata;
   }
 
-  public BlobData getBlobData() {
-    return blobData;
+  public BlobOutput getBlobOutput() {
+    return blobOutput;
   }
 }

--- a/ambry-coordinator/src/test/java/com.github.ambry.coordinator/MockBlockingChannel.java
+++ b/ambry-coordinator/src/test/java/com.github.ambry.coordinator/MockBlockingChannel.java
@@ -15,7 +15,7 @@ package com.github.ambry.coordinator;
 
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ServerErrorCode;
-import com.github.ambry.messageformat.BlobData;
+import com.github.ambry.messageformat.BlobOutput;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.network.BlockingChannel;
@@ -31,11 +31,9 @@ import com.github.ambry.protocol.PutRequest;
 import com.github.ambry.protocol.PutResponse;
 import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.store.MessageInfo;
-import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Crc32;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.SocketException;
@@ -108,16 +106,9 @@ class MockBlockingChannel extends BlockingChannel {
         BlobId blobId = putRequest.getBlobId();
         BlobProperties blobProperties = putRequest.getBlobProperties();
         ByteBuffer userMetadata = putRequest.getUsermetadata();
+        BlobOutput blobOutput = new BlobOutput(putRequest.getBlobSize(), putRequest.getBlobStream());
 
-        byte[] blobOutputBytes = new byte[(int) blobProperties.getBlobSize()];
-        new DataInputStream(putRequest.getBlobStream()).readFully(blobOutputBytes);
-        ByteBuffer blobStream = ByteBuffer.allocate((int) blobProperties.getBlobSize());
-        blobStream.put(blobOutputBytes);
-        blobStream.rewind();
-
-        BlobData blobData =
-            new BlobData(putRequest.getBlobType(), putRequest.getBlobSize(), new ByteBufferInputStream(blobStream));
-        ServerErrorCode error = mockDataNode.put(blobId, new Blob(blobProperties, userMetadata, blobData));
+        ServerErrorCode error = mockDataNode.put(blobId, new Blob(blobProperties, userMetadata, blobOutput));
         response = new PutResponse(putRequest.getCorrelationId(), putRequest.getClientId(), error);
         break;
       }
@@ -161,14 +152,13 @@ class MockBlockingChannel extends BlockingChannel {
             break;
 
           case Blob:
-            MockDataNode.BlobDataAndError bdae = mockDataNode.getData(blobId);
+            MockDataNode.BlobOutputAndError bdae = mockDataNode.getData(blobId);
             getResponseErrorCode = bdae.getError();
             if (getResponseErrorCode == ServerErrorCode.No_Error) {
-              BlobData blobData = bdae.getBlobData();
-              byteBufferSize = (int) MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(blobData.getSize());
+              BlobOutput blobData = bdae.getBlobOutput();
+              byteBufferSize = (int) MessageFormatRecord.Blob_Format_V1.getBlobRecordSize(blobData.getSize());
               byteBuffer = ByteBuffer.allocate(byteBufferSize);
-              MessageFormatRecord.Blob_Format_V2
-                  .serializePartialBlobRecord(byteBuffer, blobData.getSize(), blobData.getBlobType());
+              MessageFormatRecord.Blob_Format_V1.serializePartialBlobRecord(byteBuffer, blobData.getSize());
 
               byte[] blobDataBytes = new byte[(int) blobData.getSize()];
               blobData.getStream().read(blobDataBytes, 0, (int) blobData.getSize());

--- a/ambry-coordinator/src/test/java/com.github.ambry.coordinator/MockBlockingChannel.java
+++ b/ambry-coordinator/src/test/java/com.github.ambry.coordinator/MockBlockingChannel.java
@@ -17,6 +17,7 @@ import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ServerErrorCode;
 import com.github.ambry.messageformat.BlobOutput;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.messageformat.BlobType;
 import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.network.BlockingChannel;
 import com.github.ambry.network.ByteBufferSend;
@@ -155,13 +156,14 @@ class MockBlockingChannel extends BlockingChannel {
             MockDataNode.BlobOutputAndError bdae = mockDataNode.getData(blobId);
             getResponseErrorCode = bdae.getError();
             if (getResponseErrorCode == ServerErrorCode.No_Error) {
-              BlobOutput blobData = bdae.getBlobOutput();
-              byteBufferSize = (int) MessageFormatRecord.Blob_Format_V1.getBlobRecordSize(blobData.getSize());
+              BlobOutput blobOutput = bdae.getBlobOutput();
+              byteBufferSize = (int) MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(blobOutput.getSize());
               byteBuffer = ByteBuffer.allocate(byteBufferSize);
-              MessageFormatRecord.Blob_Format_V1.serializePartialBlobRecord(byteBuffer, blobData.getSize());
+              MessageFormatRecord.Blob_Format_V2
+                  .serializePartialBlobRecord(byteBuffer, blobOutput.getSize(), BlobType.DataBlob);
 
-              byte[] blobDataBytes = new byte[(int) blobData.getSize()];
-              blobData.getStream().read(blobDataBytes, 0, (int) blobData.getSize());
+              byte[] blobDataBytes = new byte[(int) blobOutput.getSize()];
+              blobOutput.getStream().read(blobDataBytes, 0, (int) blobOutput.getSize());
               byteBuffer.put(blobDataBytes);
 
               Crc32 crc = new Crc32();

--- a/ambry-coordinator/src/test/java/com.github.ambry.coordinator/MockBlockingChannel.java
+++ b/ambry-coordinator/src/test/java/com.github.ambry.coordinator/MockBlockingChannel.java
@@ -153,10 +153,10 @@ class MockBlockingChannel extends BlockingChannel {
             break;
 
           case Blob:
-            MockDataNode.BlobOutputAndError bdae = mockDataNode.getData(blobId);
-            getResponseErrorCode = bdae.getError();
+            MockDataNode.BlobOutputAndError boae = mockDataNode.getData(blobId);
+            getResponseErrorCode = boae.getError();
             if (getResponseErrorCode == ServerErrorCode.No_Error) {
-              BlobOutput blobOutput = bdae.getBlobOutput();
+              BlobOutput blobOutput = boae.getBlobOutput();
               byteBufferSize = (int) MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(blobOutput.getSize());
               byteBuffer = ByteBuffer.allocate(byteBufferSize);
               MessageFormatRecord.Blob_Format_V2

--- a/ambry-coordinator/src/test/java/com.github.ambry.coordinator/MockDataNode.java
+++ b/ambry-coordinator/src/test/java/com.github.ambry.coordinator/MockDataNode.java
@@ -16,8 +16,10 @@ package com.github.ambry.coordinator;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ServerErrorCode;
-import com.github.ambry.messageformat.BlobData;
+import com.github.ambry.messageformat.BlobOutput;
 import com.github.ambry.messageformat.BlobProperties;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -32,16 +34,36 @@ import java.util.Set;
 public class MockDataNode {
   private DataNodeId dataNodeId;
 
-  private Map<BlobId, Blob> blobs;
+  private Map<BlobId, MaterializedBlob> blobs;
   private Set<BlobId> deletedBlobs;
   private ServerErrorCode deleteErrorCode;
   private ServerErrorCode getErrorCode;
   private ServerErrorCode putErrorCode;
 
+  public class MaterializedBlob extends Blob {
+    final ByteBuffer materializedBlobOutput;
+
+    public MaterializedBlob(Blob blob)
+        throws IOException {
+      super(blob.getBlobProperties(), blob.getUserMetadata(), blob.getBlobOutput());
+
+      BlobOutput blobOutput = blob.getBlobOutput();
+      byte[] blobOutputBytes = new byte[(int) blobOutput.getSize()];
+      new DataInputStream(blobOutput.getStream()).readFully(blobOutputBytes);
+      this.materializedBlobOutput = ByteBuffer.allocate((int) blobOutput.getSize());
+      materializedBlobOutput.put(blobOutputBytes);
+    }
+
+    @Override
+    public BlobOutput getBlobOutput() {
+      return new BlobOutput(super.getBlobOutput().getSize(), new ByteArrayInputStream(materializedBlobOutput.array()));
+    }
+  }
+
   public MockDataNode(DataNodeId dataNodeId) {
     this.dataNodeId = dataNodeId;
 
-    blobs = new HashMap<BlobId, Blob>();
+    blobs = new HashMap<BlobId, MaterializedBlob>();
     deletedBlobs = new HashSet<BlobId>();
   }
 
@@ -53,7 +75,7 @@ public class MockDataNode {
     if (blobs.containsKey(blobId)) {
       return ServerErrorCode.Unknown_Error;
     }
-    blobs.put(blobId, blob);
+    blobs.put(blobId, new MaterializedBlob(blob));
     return ServerErrorCode.No_Error;
   }
 
@@ -117,17 +139,17 @@ public class MockDataNode {
     return new UserMetadataAndError(blobs.get(blobId).getUserMetadata(), ServerErrorCode.No_Error);
   }
 
-  public class BlobDataAndError {
-    private BlobData blobData;
+  public class BlobOutputAndError {
+    private BlobOutput blobOutput;
     private ServerErrorCode error;
 
-    BlobDataAndError(BlobData blobData, ServerErrorCode error) {
-      this.blobData = blobData;
+    BlobOutputAndError(BlobOutput blobOutput, ServerErrorCode error) {
+      this.blobOutput = blobOutput;
       this.error = error;
     }
 
-    public BlobData getBlobData() {
-      return blobData;
+    public BlobOutput getBlobOutput() {
+      return blobOutput;
     }
 
     public ServerErrorCode getError() {
@@ -135,19 +157,19 @@ public class MockDataNode {
     }
   }
 
-  public synchronized BlobDataAndError getData(BlobId blobId) {
+  public synchronized BlobOutputAndError getData(BlobId blobId) {
     if (getErrorCode != null) {
-      return new BlobDataAndError(null, getErrorCode);
+      return new BlobOutputAndError(null, getErrorCode);
     }
     if (deletedBlobs.contains(blobId)) {
-      return new BlobDataAndError(null, ServerErrorCode.Blob_Deleted);
+      return new BlobOutputAndError(null, ServerErrorCode.Blob_Deleted);
     }
 
     if (!blobs.containsKey(blobId)) {
-      return new BlobDataAndError(null, ServerErrorCode.Blob_Not_Found);
+      return new BlobOutputAndError(null, ServerErrorCode.Blob_Not_Found);
     }
 
-    return new BlobDataAndError(blobs.get(blobId).getBlobData(), ServerErrorCode.No_Error);
+    return new BlobOutputAndError(blobs.get(blobId).getBlobOutput(), ServerErrorCode.No_Error);
   }
 
   public synchronized ServerErrorCode delete(BlobId blobId) {
@@ -170,12 +192,12 @@ public class MockDataNode {
     StringBuilder sb = new StringBuilder();
     sb.append(dataNodeId).append(System.getProperty("line.separator"));
     sb.append("put blobs").append(System.getProperty("line.separator"));
-    for (Map.Entry<BlobId, Blob> entry : blobs.entrySet()) {
+    for (Map.Entry<BlobId, MaterializedBlob> entry : blobs.entrySet()) {
       sb.append("\t").append(entry.getKey()).append(" : ");
       Blob blob = entry.getValue();
       sb.append(blob.getBlobProperties().getBlobSize()).append(" / ");
       sb.append(blob.getUserMetadata().capacity()).append(" / ");
-      sb.append(blob.getBlobData().getSize()).append(System.getProperty("line.separator"));
+      sb.append(blob.getBlobOutput().getSize()).append(System.getProperty("line.separator"));
     }
     sb.append("deleted blobs").append(System.getProperty("line.separator"));
     for (BlobId blobId : deletedBlobs) {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/PutMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/PutMessageFormatInputStream.java
@@ -45,9 +45,7 @@ public class PutMessageFormatInputStream extends MessageFormatInputStream {
     int blobPropertiesRecordSize =
         MessageFormatRecord.BlobProperties_Format_V1.getBlobPropertiesRecordSize(blobProperties);
     int userMetadataSize = MessageFormatRecord.UserMetadata_Format_V1.getUserMetadataSize(userMetadata);
-    long blobSize = MessageFormatRecord.Blob_Format_V1.getBlobRecordSize(streamSize);
-    // TODO: Uncomment below lines when switching to blob format version 2
-    // long blobSize = MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(streamSize);
+    long blobSize = MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(streamSize);
 
     buffer = ByteBuffer.allocate(headerSize + key.sizeInBytes() + blobPropertiesRecordSize + userMetadataSize +
         (int) (blobSize - streamSize - MessageFormatRecord.Crc_Size));
@@ -61,9 +59,7 @@ public class PutMessageFormatInputStream extends MessageFormatInputStream {
     MessageFormatRecord.BlobProperties_Format_V1.serializeBlobPropertiesRecord(buffer, blobProperties);
     MessageFormatRecord.UserMetadata_Format_V1.serializeUserMetadataRecord(buffer, userMetadata);
     int bufferBlobStart = buffer.position();
-    MessageFormatRecord.Blob_Format_V1.serializePartialBlobRecord(buffer, streamSize);
-    // TODO: Uncomment below lines when switching to blob format version 2
-    // MessageFormatRecord.Blob_Format_V2.serializePartialBlobRecord(buffer, streamSize, blobType);
+    MessageFormatRecord.Blob_Format_V2.serializePartialBlobRecord(buffer, streamSize, blobType);
     Crc32 crc = new Crc32();
     crc.update(buffer.array(), bufferBlobStart, buffer.position() - bufferBlobStart);
     stream = new CrcInputStream(crc, blobStream);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
@@ -138,11 +138,11 @@ public class BlobStoreHardDeleteTest {
     private MessageFormatInputStream getPutMessage(StoreKey key, BlobProperties blobProperties, byte[] usermetadata,
         byte[] blob, int blobSize, short blobVersion, BlobType blobType)
         throws MessageFormatException {
-      if (blobVersion == MessageFormatRecord.Blob_Version_V1) {
+      if (blobVersion == MessageFormatRecord.Blob_Version_V2) {
         return new PutMessageFormatInputStream(key, blobProperties, ByteBuffer.wrap(usermetadata),
             new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize, blobType);
       } else {
-        return new PutMessageFormatBlobV2InputStream(key, blobProperties, ByteBuffer.wrap(usermetadata),
+        return new PutMessageFormatBlobV1InputStream(key, blobProperties, ByteBuffer.wrap(usermetadata),
             new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize, blobType);
       }
     }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
@@ -138,15 +138,12 @@ public class BlobStoreHardDeleteTest {
     private MessageFormatInputStream getPutMessage(StoreKey key, BlobProperties blobProperties, byte[] usermetadata,
         byte[] blob, int blobSize, short blobVersion, BlobType blobType)
         throws MessageFormatException {
-      switch (blobVersion) {
-        case MessageFormatRecord.Blob_Version_V1:
-          return new PutMessageFormatBlobV1InputStream(key, blobProperties, ByteBuffer.wrap(usermetadata),
-              new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize, blobType);
-        case MessageFormatRecord.Blob_Version_V2:
-          return new PutMessageFormatInputStream(key, blobProperties, ByteBuffer.wrap(usermetadata),
-              new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize, blobType);
-        default:
-          throw new IllegalStateException("Unsupported Blob version " + blobVersion);
+      if (blobVersion == MessageFormatRecord.Blob_Version_V2) {
+        return new PutMessageFormatInputStream(key, blobProperties, ByteBuffer.wrap(usermetadata),
+            new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize, blobType);
+      } else {
+        return new PutMessageFormatBlobV1InputStream(key, blobProperties, ByteBuffer.wrap(usermetadata),
+            new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize, blobType);
       }
     }
 

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
@@ -138,12 +138,15 @@ public class BlobStoreHardDeleteTest {
     private MessageFormatInputStream getPutMessage(StoreKey key, BlobProperties blobProperties, byte[] usermetadata,
         byte[] blob, int blobSize, short blobVersion, BlobType blobType)
         throws MessageFormatException {
-      if (blobVersion == MessageFormatRecord.Blob_Version_V2) {
-        return new PutMessageFormatInputStream(key, blobProperties, ByteBuffer.wrap(usermetadata),
-            new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize, blobType);
-      } else {
-        return new PutMessageFormatBlobV1InputStream(key, blobProperties, ByteBuffer.wrap(usermetadata),
-            new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize, blobType);
+      switch (blobVersion) {
+        case MessageFormatRecord.Blob_Version_V1:
+          return new PutMessageFormatBlobV1InputStream(key, blobProperties, ByteBuffer.wrap(usermetadata),
+              new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize, blobType);
+        case MessageFormatRecord.Blob_Version_V2:
+          return new PutMessageFormatInputStream(key, blobProperties, ByteBuffer.wrap(usermetadata),
+              new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize, blobType);
+        default:
+          throw new IllegalStateException("Unsupported Blob version " + blobVersion);
       }
     }
 

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
@@ -59,9 +59,9 @@ public class MessageFormatInputStreamTest {
     ByteBufferInputStream stream = new ByteBufferInputStream(ByteBuffer.wrap(data));
 
     MessageFormatInputStream messageFormatStream =
-        (blobVersion == MessageFormatRecord.Blob_Version_V1) ? new PutMessageFormatInputStream(key, prop,
+        (blobVersion == MessageFormatRecord.Blob_Version_V2) ? new PutMessageFormatInputStream(key, prop,
             ByteBuffer.wrap(usermetadata), stream, blobContentSize, blobType)
-            : new PutMessageFormatBlobV2InputStream(key, prop, ByteBuffer.wrap(usermetadata), stream, blobContentSize,
+            : new PutMessageFormatBlobV1InputStream(key, prop, ByteBuffer.wrap(usermetadata), stream, blobContentSize,
                 blobType);
 
     int headerSize = MessageFormatRecord.MessageHeader_Format_V1.getHeaderSize();

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
@@ -69,9 +69,9 @@ public class MessageSievingInputStreamTest {
     ByteBufferInputStream stream1 = new ByteBufferInputStream(ByteBuffer.wrap(data1));
 
     MessageFormatInputStream messageFormatStream1 =
-        (blobVersion == MessageFormatRecord.Blob_Version_V1) ? new PutMessageFormatInputStream(key1, prop1,
-            ByteBuffer.wrap(usermetadata1), stream1, blobContentSize)
-            : new PutMessageFormatBlobV2InputStream(key1, prop1, ByteBuffer.wrap(usermetadata1), stream1,
+        (blobVersion == MessageFormatRecord.Blob_Version_V2) ? new PutMessageFormatInputStream(key1, prop1,
+            ByteBuffer.wrap(usermetadata1), stream1, blobContentSize, blobType)
+            : new PutMessageFormatBlobV1InputStream(key1, prop1, ByteBuffer.wrap(usermetadata1), stream1,
                 blobContentSize, blobType);
 
     MessageInfo msgInfo1 = new MessageInfo(key1, messageFormatStream1.getSize(), false, -1);
@@ -92,9 +92,9 @@ public class MessageSievingInputStreamTest {
     ByteBufferInputStream stream2 = new ByteBufferInputStream(ByteBuffer.wrap(data2));
 
     MessageFormatInputStream messageFormatStream2 =
-        (blobVersion == MessageFormatRecord.Blob_Version_V1) ? new PutMessageFormatInputStream(key2, prop2,
-            ByteBuffer.wrap(usermetadata2), stream2, blobContentSize)
-            : new PutMessageFormatBlobV2InputStream(key2, prop2, ByteBuffer.wrap(usermetadata2), stream2,
+        (blobVersion == MessageFormatRecord.Blob_Version_V2) ? new PutMessageFormatInputStream(key2, prop2,
+            ByteBuffer.wrap(usermetadata2), stream2, blobContentSize, blobType)
+            : new PutMessageFormatBlobV1InputStream(key2, prop2, ByteBuffer.wrap(usermetadata2), stream2,
                 blobContentSize, blobType);
 
     MessageInfo msgInfo2 = new MessageInfo(key2, messageFormatStream2.getSize(), false, -1);
@@ -115,9 +115,9 @@ public class MessageSievingInputStreamTest {
     ByteBufferInputStream stream3 = new ByteBufferInputStream(ByteBuffer.wrap(data3));
 
     MessageFormatInputStream messageFormatStream3 =
-        (blobVersion == MessageFormatRecord.Blob_Version_V1) ? new PutMessageFormatInputStream(key3, prop3,
-            ByteBuffer.wrap(usermetadata3), stream3, blobContentSize)
-            : new PutMessageFormatBlobV2InputStream(key3, prop3, ByteBuffer.wrap(usermetadata3), stream3,
+        (blobVersion == MessageFormatRecord.Blob_Version_V2) ? new PutMessageFormatInputStream(key3, prop3,
+            ByteBuffer.wrap(usermetadata3), stream3, blobContentSize, blobType)
+            : new PutMessageFormatBlobV1InputStream(key3, prop3, ByteBuffer.wrap(usermetadata3), stream3,
                 blobContentSize, blobType);
 
     MessageInfo msgInfo3 = new MessageInfo(key3, messageFormatStream3.getSize(), false, -1);
@@ -211,9 +211,9 @@ public class MessageSievingInputStreamTest {
     ByteBufferInputStream stream1 = new ByteBufferInputStream(ByteBuffer.wrap(data1));
 
     MessageFormatInputStream messageFormatStream1 =
-        (blobVersion == MessageFormatRecord.Blob_Version_V1) ? new PutMessageFormatInputStream(key1, prop1,
-            ByteBuffer.wrap(usermetadata1), stream1, blobContentSize)
-            : new PutMessageFormatBlobV2InputStream(key1, prop1, ByteBuffer.wrap(usermetadata1), stream1,
+        (blobVersion == MessageFormatRecord.Blob_Version_V2) ? new PutMessageFormatInputStream(key1, prop1,
+            ByteBuffer.wrap(usermetadata1), stream1, blobContentSize, blobType)
+            : new PutMessageFormatBlobV1InputStream(key1, prop1, ByteBuffer.wrap(usermetadata1), stream1,
                 blobContentSize, blobType);
 
     MessageInfo msgInfo1 = new MessageInfo(key1, messageFormatStream1.getSize(), false, -1);
@@ -234,9 +234,9 @@ public class MessageSievingInputStreamTest {
     ByteBufferInputStream stream2 = new ByteBufferInputStream(ByteBuffer.wrap(data2));
 
     MessageFormatInputStream messageFormatStream2 =
-        (blobVersion == MessageFormatRecord.Blob_Version_V1) ? new PutMessageFormatInputStream(key2, prop2,
-            ByteBuffer.wrap(usermetadata2), stream2, blobContentSize)
-            : new PutMessageFormatBlobV2InputStream(key2, prop2, ByteBuffer.wrap(usermetadata2), stream2,
+        (blobVersion == MessageFormatRecord.Blob_Version_V2) ? new PutMessageFormatInputStream(key2, prop2,
+            ByteBuffer.wrap(usermetadata2), stream2, blobContentSize, blobType)
+            : new PutMessageFormatBlobV1InputStream(key2, prop2, ByteBuffer.wrap(usermetadata2), stream2,
                 blobContentSize, blobType);
 
     MessageInfo msgInfo2 = new MessageInfo(key2, messageFormatStream2.getSize(), false, -1);
@@ -263,9 +263,9 @@ public class MessageSievingInputStreamTest {
     ByteBufferInputStream stream3 = new ByteBufferInputStream(ByteBuffer.wrap(data3));
 
     MessageFormatInputStream messageFormatStream3 =
-        (blobVersion == MessageFormatRecord.Blob_Version_V1) ? new PutMessageFormatInputStream(key3, prop3,
-            ByteBuffer.wrap(usermetadata3), stream3, blobContentSize)
-            : new PutMessageFormatBlobV2InputStream(key3, prop3, ByteBuffer.wrap(usermetadata3), stream3,
+        (blobVersion == MessageFormatRecord.Blob_Version_V2) ? new PutMessageFormatInputStream(key3, prop3,
+            ByteBuffer.wrap(usermetadata3), stream3, blobContentSize, blobType)
+            : new PutMessageFormatBlobV1InputStream(key3, prop3, ByteBuffer.wrap(usermetadata3), stream3,
                 blobContentSize, blobType);
 
     MessageInfo msgInfo3 = new MessageInfo(key3, messageFormatStream3.getSize(), false, -1);
@@ -348,9 +348,9 @@ public class MessageSievingInputStreamTest {
       ByteBufferInputStream stream1 = new ByteBufferInputStream(ByteBuffer.wrap(data1));
 
       MessageFormatInputStream messageFormatStream1 =
-          (blobVersion == MessageFormatRecord.Blob_Version_V1) ? new PutMessageFormatInputStream(key1, prop1,
-              ByteBuffer.wrap(usermetadata1), stream1, blobContentSize)
-              : new PutMessageFormatBlobV2InputStream(key1, prop1, ByteBuffer.wrap(usermetadata1), stream1,
+          (blobVersion == MessageFormatRecord.Blob_Version_V2) ? new PutMessageFormatInputStream(key1, prop1,
+              ByteBuffer.wrap(usermetadata1), stream1, blobContentSize, blobType)
+              : new PutMessageFormatBlobV1InputStream(key1, prop1, ByteBuffer.wrap(usermetadata1), stream1,
                   blobContentSize, blobType);
 
       MessageInfo msgInfo1 = new MessageInfo(key1, messageFormatStream1.getSize(), false, -1);
@@ -377,9 +377,9 @@ public class MessageSievingInputStreamTest {
       ByteBufferInputStream stream3 = new ByteBufferInputStream(ByteBuffer.wrap(data3));
 
       MessageFormatInputStream messageFormatStream3 =
-          (blobVersion == MessageFormatRecord.Blob_Version_V1) ? new PutMessageFormatInputStream(key3, prop3,
-              ByteBuffer.wrap(usermetadata3), stream3, blobContentSize)
-              : new PutMessageFormatBlobV2InputStream(key3, prop3, ByteBuffer.wrap(usermetadata3), stream3,
+          (blobVersion == MessageFormatRecord.Blob_Version_V2) ? new PutMessageFormatInputStream(key3, prop3,
+              ByteBuffer.wrap(usermetadata3), stream3, blobContentSize, blobType)
+              : new PutMessageFormatBlobV1InputStream(key3, prop3, ByteBuffer.wrap(usermetadata3), stream3,
                   blobContentSize, blobType);
 
       MessageInfo msgInfo3 = new MessageInfo(key3, messageFormatStream3.getSize(), false, -1);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/PutMessageFormatBlobV1InputStream.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/PutMessageFormatBlobV1InputStream.java
@@ -21,19 +21,18 @@ import java.nio.ByteBuffer;
 
 
 /**
- * PutMessageFormatInputStream which uses Blob Format Version 2 instead of V1
- * // TODO: Once we switch from Blob format V1 to V2 in actual Put Flow, this class has to switch from V2 to V1
+ * PutMessageFormatInputStream which uses Blob Format V1 instead of the default V2
  */
-public class PutMessageFormatBlobV2InputStream extends MessageFormatInputStream {
+public class PutMessageFormatBlobV1InputStream extends MessageFormatInputStream {
 
-  public PutMessageFormatBlobV2InputStream(StoreKey key, BlobProperties blobProperties, ByteBuffer userMetadata,
+  public PutMessageFormatBlobV1InputStream(StoreKey key, BlobProperties blobProperties, ByteBuffer userMetadata,
       InputStream blobStream, long streamSize, BlobType blobType)
       throws MessageFormatException {
     int headerSize = MessageFormatRecord.MessageHeader_Format_V1.getHeaderSize();
     int blobPropertiesRecordSize =
         MessageFormatRecord.BlobProperties_Format_V1.getBlobPropertiesRecordSize(blobProperties);
     int userMetadataSize = MessageFormatRecord.UserMetadata_Format_V1.getUserMetadataSize(userMetadata);
-    long blobSize = MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(streamSize);
+    long blobSize = MessageFormatRecord.Blob_Format_V1.getBlobRecordSize(streamSize);
 
     buffer = ByteBuffer.allocate(headerSize + key.sizeInBytes() + blobPropertiesRecordSize + userMetadataSize +
         (int) (blobSize - streamSize - MessageFormatRecord.Crc_Size));
@@ -47,7 +46,7 @@ public class PutMessageFormatBlobV2InputStream extends MessageFormatInputStream 
     MessageFormatRecord.BlobProperties_Format_V1.serializeBlobPropertiesRecord(buffer, blobProperties);
     MessageFormatRecord.UserMetadata_Format_V1.serializeUserMetadataRecord(buffer, userMetadata);
     int bufferBlobStart = buffer.position();
-    MessageFormatRecord.Blob_Format_V2.serializePartialBlobRecord(buffer, streamSize, blobType);
+    MessageFormatRecord.Blob_Format_V1.serializePartialBlobRecord(buffer, streamSize);
     Crc32 crc = new Crc32();
     crc.update(buffer.array(), bufferBlobStart, buffer.position() - bufferBlobStart);
     stream = new CrcInputStream(crc, blobStream);
@@ -56,7 +55,7 @@ public class PutMessageFormatBlobV2InputStream extends MessageFormatInputStream 
     buffer.flip();
   }
 
-  public PutMessageFormatBlobV2InputStream(StoreKey key, BlobProperties blobProperties, ByteBuffer userMetadata,
+  public PutMessageFormatBlobV1InputStream(StoreKey key, BlobProperties blobProperties, ByteBuffer userMetadata,
       InputStream blobStream, long streamSize)
       throws MessageFormatException {
     this(key, blobProperties, userMetadata, blobStream, streamSize, BlobType.DataBlob);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -345,7 +345,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(4).getID());
 
     time.currentMilliseconds = time.currentMilliseconds + Time.SecsPerDay * Time.MsPerSec;
-    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198431);
+    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198443);
 
     MockPartitionId partition = (MockPartitionId) mockClusterMap.getWritablePartitionIds().get(0);
 
@@ -475,7 +475,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(6).getID());
 
     time.currentMilliseconds = time.currentMilliseconds + Time.SecsPerDay * Time.MsPerSec;
-    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 297905);
+    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 297923);
 
     partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
     partitionRequestInfo = new PartitionRequestInfo(partition, blobIdList);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -210,7 +210,8 @@ public final class ServerTestUtil {
       channel.send(getRequestExpired);
       InputStream streamExpired = channel.receive().getInputStream();
       GetResponse respExpired = GetResponse.readFrom(new DataInputStream(streamExpired), clusterMap);
-      Assert.assertEquals(ServerErrorCode.Blob_Expired, respExpired.getPartitionResponseInfoList().get(0).getErrorCode());
+      Assert
+          .assertEquals(ServerErrorCode.Blob_Expired, respExpired.getPartitionResponseInfoList().get(0).getErrorCode());
 
       // 2. With Include_Expired flag
       idsExpired = new ArrayList<BlobId>();
@@ -982,11 +983,11 @@ public final class ServerTestUtil {
       // read the replica file and check correctness
       // The token offset value of 13062 was derived as followed:
       // - Up to this point we have done 6 puts and 1 delete
-      // - Each put takes up 2177 bytes in the log (1000 data, 1000 user metadata, 177 ambry metadata)
+      // - Each put takes up 2179 bytes in the log (1000 data, 1000 user metadata, 179 ambry metadata)
       // - Each delete takes up 97 bytes in the log
       // - The offset stored in the token will be the position of the last entry in the log (the delete, in this case)
-      // - Thus, it will be at the end of the 6 puts: 6 * 2177 = 13062
-      checkReplicaTokens(clusterMap, dataNodeId, 13062, "0");
+      // - Thus, it will be at the end of the 6 puts: 6 * 2179 = 13074
+      checkReplicaTokens(clusterMap, dataNodeId, 13074, "0");
 
       // Shut down server 1
       cluster.getServers().get(0).shutdown();

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -981,7 +981,7 @@ public final class ServerTestUtil {
       // get the data node to inspect replication tokens on
       DataNodeId dataNodeId = clusterMap.getDataNodeId("localhost", interestedDataNodePortNumber);
       // read the replica file and check correctness
-      // The token offset value of 13062 was derived as followed:
+      // The token offset value of 13074 was derived as followed:
       // - Up to this point we have done 6 puts and 1 delete
       // - Each put takes up 2179 bytes in the log (1000 data, 1000 user metadata, 179 ambry metadata)
       // - Each delete takes up 97 bytes in the log


### PR DESCRIPTION
This patch turns on MessageFormat BlobRecord Version2. So, any new PUTs will be written in the new format. 

Note: Support to read blobs in new format is already in PROD (supports both versions of blobs)

Fixes going in with this patch:
1. Default Put is done using new format (Blob Record Version 2)
2. PutMessageFormatBlobV1InputStream, a test class to put in older format. (this was changed from version 2 to version 1)
3. Changes in MockBlockingChannel and MockDataNode since getBlob() returns BlobData instead of BlobOutput. (BlobData has BlobType in addition to what BlobOutput had)
4. Changes in some tests to adhere to the new format and some which had hard coded log end offsets for testing purposes.

Testing:
./gradlew build && ./gradlew test passed 
Deployed server and frontend locally. Put, get and delete tested. DumpData tested.

Reviewers: 
Gopal, Priyesh
SLA: 15 mins
