### PR TITLE
Adding router-server integration tests

### DIFF
--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
@@ -78,7 +78,7 @@ public class MockReplicaId implements ReplicaId {
 
   @Override
   public long getCapacityInBytes() {
-    return 10000000;
+    return 100000000;
   }
 
   @Override

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
@@ -13,7 +13,7 @@
  */
 package com.github.ambry.server;
 
-import com.github.ambry.server.RouterServerTestFramework.OperationInfo;
+import com.github.ambry.server.RouterServerTestFramework.OperationChain;
 import com.github.ambry.server.RouterServerTestFramework.OperationType;
 import com.github.ambry.utils.SystemTime;
 import java.io.IOException;
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,9 +36,6 @@ public class RouterServerPlaintextTest {
   @BeforeClass
   public static void initializeTests()
       throws Exception {
-//    Logger.getRootLogger().setLevel(Level.ERROR);
-//    org.apache.log4j.BasicConfigurator.configure();
-
     MockNotificationSystem notificationSystem = new MockNotificationSystem(9);
     plaintextCluster = new MockCluster(notificationSystem, false, SystemTime.getInstance());
     plaintextCluster.startServers();
@@ -62,79 +57,112 @@ public class RouterServerPlaintextTest {
   @Test
   public void interleavedOperationsTest()
       throws Exception {
-    List<OperationInfo> opInfos = new ArrayList<>();
-    for (int i = 0; i < 100; i++) {
-      Queue<OperationType> opChain = new LinkedList<>();
-      opChain.add(OperationType.PUT_NB);
-      opChain.add(OperationType.AWAIT_CREATION);
-      opChain.add(OperationType.GET_INFO_NB);
-      opChain.add(OperationType.GET_NB);
-      opChain.add(OperationType.DELETE_NB);
-      opChain.add(OperationType.AWAIT_DELETION);
-      opChain.add(OperationType.GET_INFO_DELETED_NB);
-      opChain.add(OperationType.GET_DELETED_NB);
-      opInfos.add(testFramework.startOperationChain(32 * 1024, i, opChain));
+    List<OperationChain> opChains = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      Queue<OperationType> operations = new LinkedList<>();
+      switch (i % 4) {
+        case 0:
+          operations.add(OperationType.PUT_NB);
+          operations.add(OperationType.AWAIT_CREATION);
+          operations.add(OperationType.GET_NB);
+          operations.add(OperationType.GET_INFO_NB);
+          operations.add(OperationType.DELETE_NB);
+          operations.add(OperationType.AWAIT_DELETION);
+          operations.add(OperationType.GET_DELETED_NB);
+          operations.add(OperationType.GET_INFO_DELETED_NB);
+          break;
+        case 1:
+          operations.add(OperationType.PUT_NB);
+          operations.add(OperationType.AWAIT_CREATION);
+          operations.add(OperationType.GET_INFO_NB);
+          operations.add(OperationType.GET_NB);
+          operations.add(OperationType.GET_NB);
+          operations.add(OperationType.PUT_NB);
+          operations.add(OperationType.AWAIT_CREATION);
+          operations.add(OperationType.GET_INFO_NB);
+          operations.add(OperationType.GET_NB);
+          break;
+        case 2:
+          operations.add(OperationType.PUT_NB);
+          operations.add(OperationType.AWAIT_CREATION);
+          operations.add(OperationType.DELETE_NB);
+          operations.add(OperationType.AWAIT_DELETION);
+          operations.add(OperationType.GET_DELETED_NB);
+          operations.add(OperationType.GET_INFO_DELETED_NB);
+          operations.add(OperationType.GET_DELETED_NB);
+          operations.add(OperationType.GET_INFO_DELETED_NB);
+          break;
+        case 3:
+          operations.add(OperationType.PUT_NB);
+          operations.add(OperationType.AWAIT_CREATION);
+          operations.add(OperationType.GET_NB);
+          operations.add(OperationType.GET_NB);
+          operations.add(OperationType.GET_NB);
+          operations.add(OperationType.GET_INFO_NB);
+          break;
+      }
+      opChains.add(testFramework.startOperationChain(32 * 1024, i, operations));
     }
-    testFramework.checkOperationChains(opInfos);
+    testFramework.checkOperationChains(opChains);
   }
 
   @Test
   public void nonInterleavedOperationsTest()
       throws Exception {
     for (int i = 0; i < 10; i++) {
-      Queue<OperationType> opChain = new LinkedList<>();
-      opChain.add(OperationType.PUT_NB);
-      opChain.add(OperationType.AWAIT_CREATION);
-      opChain.add(OperationType.GET_INFO_NB);
-      opChain.add(OperationType.GET_NB);
-      opChain.add(OperationType.DELETE_NB);
-      opChain.add(OperationType.AWAIT_DELETION);
-      opChain.add(OperationType.GET_INFO_DELETED_NB);
-      opChain.add(OperationType.GET_DELETED_NB);
+      Queue<OperationType> operations = new LinkedList<>();
+      operations.add(OperationType.PUT_NB);
+      operations.add(OperationType.AWAIT_CREATION);
+      operations.add(OperationType.GET_INFO_NB);
+      operations.add(OperationType.GET_NB);
+      operations.add(OperationType.DELETE_NB);
+      operations.add(OperationType.AWAIT_DELETION);
+      operations.add(OperationType.GET_INFO_DELETED_NB);
+      operations.add(OperationType.GET_DELETED_NB);
       testFramework.checkOperationChains(
-          Collections.singletonList(testFramework.startOperationChain(32 * 1024, i, opChain)));
+          Collections.singletonList(testFramework.startOperationChain(32 * 1024, i, operations)));
     }
   }
 
   @Test
   public void largeBlobTest()
       throws Exception {
-    List<OperationInfo> opInfos = new ArrayList<>();
+    List<OperationChain> opChains = new ArrayList<>();
     for (int i = 0; i < 2; i++) {
-      Queue<OperationType> opChain = new LinkedList<>();
-      opChain.add(OperationType.PUT_NB);
-      opChain.add(OperationType.AWAIT_CREATION);
-      opChain.add(OperationType.GET_INFO_NB);
-      opChain.add(OperationType.GET_NB);
-      opChain.add(OperationType.DELETE_NB);
-      opChain.add(OperationType.AWAIT_DELETION);
-      opChain.add(OperationType.GET_INFO_DELETED_NB);
-      opChain.add(OperationType.GET_DELETED_NB);
-      opInfos.add(testFramework.startOperationChain(RouterServerTestFramework.CHUNK_SIZE * 4 + 1, i, opChain));
+      Queue<OperationType> operations = new LinkedList<>();
+      operations.add(OperationType.PUT_NB);
+      operations.add(OperationType.AWAIT_CREATION);
+      operations.add(OperationType.GET_INFO_NB);
+      operations.add(OperationType.GET_NB);
+      operations.add(OperationType.DELETE_NB);
+      operations.add(OperationType.AWAIT_DELETION);
+      operations.add(OperationType.GET_INFO_DELETED_NB);
+      operations.add(OperationType.GET_DELETED_NB);
+      opChains.add(testFramework.startOperationChain(RouterServerTestFramework.CHUNK_SIZE * 4 + 1, i, operations));
     }
-    testFramework.checkOperationChains(opInfos);
+    testFramework.checkOperationChains(opChains);
   }
 
   @Test
   public void coordinatorNonBlockingCompatibilityTest()
       throws Exception {
-    List<OperationInfo> opInfos = new ArrayList<>();
+    List<OperationChain> opChains = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
-      Queue<OperationType> opChain = new LinkedList<>();
-      opChain.add(i % 2 == 0 ? OperationType.PUT_NB : OperationType.PUT_COORD);
-      opChain.add(OperationType.AWAIT_CREATION);
-      opChain.add(OperationType.GET_INFO_COORD);
-      opChain.add(OperationType.GET_INFO_NB);
-      opChain.add(OperationType.GET_COORD);
-      opChain.add(OperationType.GET_NB);
-      opChain.add(i % 2 == 0 ? OperationType.DELETE_COORD : OperationType.DELETE_NB);
-      opChain.add(OperationType.AWAIT_DELETION);
-      opChain.add(OperationType.GET_INFO_DELETED_NB);
-      opChain.add(OperationType.GET_INFO_DELETED_COORD);
-      opChain.add(OperationType.GET_DELETED_NB);
-      opChain.add(OperationType.GET_DELETED_COORD);
-      opInfos.add(testFramework.startOperationChain(32 * 1024, i, opChain));
+      Queue<OperationType> operations = new LinkedList<>();
+      operations.add(i % 2 == 0 ? OperationType.PUT_NB : OperationType.PUT_COORD);
+      operations.add(OperationType.AWAIT_CREATION);
+      operations.add(OperationType.GET_INFO_COORD);
+      operations.add(OperationType.GET_INFO_NB);
+      operations.add(OperationType.GET_COORD);
+      operations.add(OperationType.GET_NB);
+      operations.add(i % 2 == 0 ? OperationType.DELETE_COORD : OperationType.DELETE_NB);
+      operations.add(OperationType.AWAIT_DELETION);
+      operations.add(OperationType.GET_INFO_DELETED_NB);
+      operations.add(OperationType.GET_INFO_DELETED_COORD);
+      operations.add(OperationType.GET_DELETED_NB);
+      operations.add(OperationType.GET_DELETED_COORD);
+      opChains.add(testFramework.startOperationChain(32 * 1024, i, operations));
     }
-    testFramework.checkOperationChains(opInfos);
+    testFramework.checkOperationChains(opChains);
   }
 }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
@@ -60,7 +60,7 @@ public class RouterServerPlaintextTest {
     List<OperationChain> opChains = new ArrayList<>();
     for (int i = 0; i < 20; i++) {
       Queue<OperationType> operations = new LinkedList<>();
-      switch (i % 4) {
+      switch (i % 3) {
         case 0:
           operations.add(OperationType.PUT_NB);
           operations.add(OperationType.AWAIT_CREATION);
@@ -74,17 +74,6 @@ public class RouterServerPlaintextTest {
         case 1:
           operations.add(OperationType.PUT_NB);
           operations.add(OperationType.AWAIT_CREATION);
-          operations.add(OperationType.GET_INFO_NB);
-          operations.add(OperationType.GET_NB);
-          operations.add(OperationType.GET_NB);
-          operations.add(OperationType.PUT_NB);
-          operations.add(OperationType.AWAIT_CREATION);
-          operations.add(OperationType.GET_INFO_NB);
-          operations.add(OperationType.GET_NB);
-          break;
-        case 2:
-          operations.add(OperationType.PUT_NB);
-          operations.add(OperationType.AWAIT_CREATION);
           operations.add(OperationType.DELETE_NB);
           operations.add(OperationType.AWAIT_DELETION);
           operations.add(OperationType.GET_DELETED_NB);
@@ -92,7 +81,7 @@ public class RouterServerPlaintextTest {
           operations.add(OperationType.GET_DELETED_NB);
           operations.add(OperationType.GET_INFO_DELETED_NB);
           break;
-        case 3:
+        case 2:
           operations.add(OperationType.PUT_NB);
           operations.add(OperationType.AWAIT_CREATION);
           operations.add(OperationType.GET_NB);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.server;
+
+import com.github.ambry.commons.LoggingNotificationSystem;
+import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.server.RouterServerTestFramework.OperationInfo;
+import com.github.ambry.server.RouterServerTestFramework.OperationType;
+import com.github.ambry.utils.SystemTime;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static com.github.ambry.server.RouterServerTestFramework.checkFutures;
+import static com.github.ambry.server.RouterServerTestFramework.getRouterProperties;
+
+
+public class RouterServerPlaintextTest {
+  private static MockCluster plaintextCluster;
+  private static RouterServerTestFramework testFramework;
+
+  @BeforeClass
+  public static void initializeTests()
+      throws Exception {
+//    Logger.getRootLogger().setLevel(Level.ERROR);
+//    org.apache.log4j.BasicConfigurator.configure();
+
+    NotificationSystem notificationSystem = new LoggingNotificationSystem();
+    plaintextCluster = new MockCluster(notificationSystem, false, SystemTime.getInstance());
+    plaintextCluster.startServers();
+    testFramework = new RouterServerTestFramework(getRouterProperties("DC1"), plaintextCluster, notificationSystem);
+  }
+
+  @AfterClass
+  public static void cleanup()
+      throws IOException {
+    testFramework.cleanup();
+    long start = System.currentTimeMillis();
+    System.out.println("About to invoke cluster.cleanup()");
+    if (plaintextCluster != null) {
+      plaintextCluster.cleanup();
+    }
+    System.out.println("cluster.cleanup() took " + (System.currentTimeMillis() - start) + " ms.");
+  }
+
+  @Test
+  public void interleavedOperationsTest()
+      throws Exception {
+    List<OperationInfo> opInfos = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      Queue<OperationType> opChain = new LinkedList<>();
+      opChain.add(OperationType.PUT_NB);
+      opChain.add(OperationType.GET_INFO_NB);
+      opChain.add(OperationType.GET_NB);
+      opChain.add(OperationType.DELETE_NB);
+      opChain.add(OperationType.WAIT);
+      opChain.add(OperationType.GET_INFO_DELETED_NB);
+      opChain.add(OperationType.GET_DELETED_NB);
+      opInfos.add(testFramework.startOperationChain(32 * 1024, i, opChain));
+    }
+    checkFutures(opInfos);
+  }
+
+  @Test
+  public void nonInterleavedOperationsTest()
+      throws Exception {
+    for (int i = 0; i < 10; i++) {
+      Queue<OperationType> opChain = new LinkedList<>();
+      opChain.add(OperationType.PUT_NB);
+      opChain.add(OperationType.GET_INFO_NB);
+      opChain.add(OperationType.GET_NB);
+      opChain.add(OperationType.DELETE_NB);
+      opChain.add(OperationType.WAIT);
+      opChain.add(OperationType.GET_INFO_DELETED_NB);
+      opChain.add(OperationType.GET_DELETED_NB);
+      checkFutures(Collections.singletonList(testFramework.startOperationChain(32 * 1024, i, opChain)));
+    }
+  }
+
+  @Test
+  public void largeBlobTest()
+      throws Exception {
+    List<OperationInfo> opInfos = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      Queue<OperationType> opChain = new LinkedList<>();
+      opChain.add(OperationType.PUT_NB);
+      opChain.add(OperationType.GET_INFO_NB);
+      opChain.add(OperationType.GET_NB);
+      opChain.add(OperationType.DELETE_NB);
+      opChain.add(OperationType.WAIT);
+      opChain.add(OperationType.GET_INFO_DELETED_NB);
+      opChain.add(OperationType.GET_DELETED_NB);
+      opInfos.add(testFramework.startOperationChain(RouterServerTestFramework.CHUNK_SIZE * 4 + 1, i, opChain));
+    }
+    checkFutures(opInfos);
+  }
+
+  @Test
+  public void coordinatorNonBlockingCompatibilityTest()
+      throws Exception {
+    List<OperationInfo> opInfos = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      Queue<OperationType> opChain = new LinkedList<>();
+      opChain.add(i % 2 == 0 ? OperationType.PUT_NB : OperationType.PUT_COORD);
+      opChain.add(OperationType.GET_INFO_COORD);
+      opChain.add(OperationType.GET_INFO_NB);
+      opChain.add(OperationType.GET_COORD);
+      opChain.add(OperationType.GET_NB);
+      opChain.add(i % 2 == 0 ? OperationType.DELETE_COORD : OperationType.DELETE_NB);
+      opChain.add(OperationType.WAIT);
+      opChain.add(OperationType.GET_INFO_DELETED_NB);
+      opChain.add(OperationType.GET_INFO_DELETED_COORD);
+      opChain.add(OperationType.GET_DELETED_NB);
+      opChain.add(OperationType.GET_DELETED_COORD);
+      opInfos.add(testFramework.startOperationChain(32 * 1024, i, opChain));
+    }
+    checkFutures(opInfos);
+  }
+}

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
@@ -138,7 +138,7 @@ public class RouterServerPlaintextTest {
       operations.add(OperationType.AWAIT_DELETION);
       operations.add(OperationType.GET_INFO_DELETED_NB);
       operations.add(OperationType.GET_DELETED_NB);
-      opChains.add(testFramework.startOperationChain(RouterServerTestFramework.CHUNK_SIZE * 4 + 1, i, operations));
+      opChains.add(testFramework.startOperationChain(RouterServerTestFramework.CHUNK_SIZE * 2 + 1, i, operations));
     }
     testFramework.checkOperationChains(opChains);
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerSSLTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerSSLTest.java
@@ -25,6 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Queue;
+import java.util.Random;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -63,10 +64,16 @@ public class RouterServerSSLTest {
     System.out.println("cluster.cleanup() took " + (System.currentTimeMillis() - start) + " ms.");
   }
 
+  /**
+   * Test that the non blocking router can handle a large number of concurrent (small blob) operations without errors.
+   * This test creates chains of operations without waiting for previous operations to finish.
+   * @throws Exception
+   */
   @Test
   public void interleavedOperationsTest()
       throws Exception {
     List<OperationChain> opChains = new ArrayList<>();
+    Random random = new Random();
     for (int i = 0; i < 10; i++) {
       Queue<OperationType> operations = new LinkedList<>();
       switch (i % 3) {
@@ -99,15 +106,23 @@ public class RouterServerSSLTest {
           operations.add(OperationType.GET_INFO_NB);
           break;
       }
-      opChains.add(testFramework.startOperationChain(32 * 1024, i, operations));
+      int blobSize = random.nextInt(100 * 1024);
+      opChains.add(testFramework.startOperationChain(blobSize, i, operations));
     }
     testFramework.checkOperationChains(opChains);
   }
 
+  /**
+   * Test that the coordinator-backed and non-blocking router are compatible with each other for operations on
+   * single-chunk blobs.  This performs puts and deletes with either the non-blocking or coordinator backed
+   * router and tests get operations with both types of routers.
+   * @throws Exception
+   */
   @Test
   public void coordinatorNonBlockingCompatibilityTest()
       throws Exception {
     List<OperationChain> opChains = new ArrayList<>();
+    Random random = new Random();
     for (int i = 0; i < 10; i++) {
       Queue<OperationType> operations = new LinkedList<>();
       operations.add(i % 2 == 0 ? OperationType.PUT_NB : OperationType.PUT_COORD);
@@ -122,7 +137,8 @@ public class RouterServerSSLTest {
       operations.add(OperationType.GET_INFO_DELETED_COORD);
       operations.add(OperationType.GET_DELETED_NB);
       operations.add(OperationType.GET_DELETED_COORD);
-      opChains.add(testFramework.startOperationChain(32 * 1024, i, operations));
+      int blobSize = random.nextInt(100 * 1024);
+      opChains.add(testFramework.startOperationChain(blobSize, i, operations));
     }
     testFramework.checkOperationChains(opChains);
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerSSLTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerSSLTest.java
@@ -69,7 +69,7 @@ public class RouterServerSSLTest {
     List<OperationChain> opChains = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       Queue<OperationType> operations = new LinkedList<>();
-      switch (i % 4) {
+      switch (i % 3) {
         case 0:
           operations.add(OperationType.PUT_NB);
           operations.add(OperationType.AWAIT_CREATION);
@@ -83,17 +83,6 @@ public class RouterServerSSLTest {
         case 1:
           operations.add(OperationType.PUT_NB);
           operations.add(OperationType.AWAIT_CREATION);
-          operations.add(OperationType.GET_INFO_NB);
-          operations.add(OperationType.GET_NB);
-          operations.add(OperationType.GET_NB);
-          operations.add(OperationType.PUT_NB);
-          operations.add(OperationType.AWAIT_CREATION);
-          operations.add(OperationType.GET_INFO_NB);
-          operations.add(OperationType.GET_NB);
-          break;
-        case 2:
-          operations.add(OperationType.PUT_NB);
-          operations.add(OperationType.AWAIT_CREATION);
           operations.add(OperationType.DELETE_NB);
           operations.add(OperationType.AWAIT_DELETION);
           operations.add(OperationType.GET_DELETED_NB);
@@ -101,7 +90,7 @@ public class RouterServerSSLTest {
           operations.add(OperationType.GET_DELETED_NB);
           operations.add(OperationType.GET_INFO_DELETED_NB);
           break;
-        case 3:
+        case 2:
           operations.add(OperationType.PUT_NB);
           operations.add(OperationType.AWAIT_CREATION);
           operations.add(OperationType.GET_NB);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerSSLTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerSSLTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.server;
+
+import com.github.ambry.commons.LoggingNotificationSystem;
+import com.github.ambry.network.SSLFactory;
+import com.github.ambry.network.TestSSLUtils;
+import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.server.RouterServerTestFramework.OperationInfo;
+import com.github.ambry.server.RouterServerTestFramework.OperationType;
+import com.github.ambry.utils.SystemTime;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Queue;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static com.github.ambry.server.RouterServerTestFramework.checkFutures;
+import static com.github.ambry.server.RouterServerTestFramework.getRouterProperties;
+
+
+public class RouterServerSSLTest {
+  private static MockCluster sslCluster;
+  private static RouterServerTestFramework testFramework;
+
+  @BeforeClass
+  public static void initializeTests()
+      throws Exception {
+//    Logger.getRootLogger().setLevel(Level.ERROR);
+//    org.apache.log4j.BasicConfigurator.configure();
+
+    File trustStoreFile = File.createTempFile("truststore", ".jks");
+    Properties serverSSLProps = new Properties();
+    TestSSLUtils.addSSLProperties(serverSSLProps, "DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server");
+    Properties routerProps = getRouterProperties("DC1");
+    TestSSLUtils.addSSLProperties(routerProps, "DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "router-client");
+    NotificationSystem notificationSystem = new LoggingNotificationSystem();
+    sslCluster =
+        new MockCluster(notificationSystem, true, "DC1,DC2,DC3", serverSSLProps, false, SystemTime.getInstance());
+    sslCluster.startServers();
+    testFramework = new RouterServerTestFramework(routerProps, sslCluster, notificationSystem);
+  }
+
+  @AfterClass
+  public static void cleanup()
+      throws IOException {
+    testFramework.cleanup();
+    long start = System.currentTimeMillis();
+    System.out.println("About to invoke cluster.cleanup()");
+    if (sslCluster != null) {
+      sslCluster.cleanup();
+    }
+    System.out.println("cluster.cleanup() took " + (System.currentTimeMillis() - start) + " ms.");
+  }
+
+  @Test
+  public void interleavedOperationsTest()
+      throws Exception {
+    List<OperationInfo> opInfos = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      Queue<OperationType> opChain = new LinkedList<>();
+      opChain.add(OperationType.PUT_NB);
+      opChain.add(OperationType.GET_INFO_NB);
+      opChain.add(OperationType.GET_NB);
+      opChain.add(OperationType.DELETE_NB);
+      opChain.add(OperationType.WAIT);
+      opChain.add(OperationType.GET_INFO_DELETED_NB);
+      opChain.add(OperationType.GET_DELETED_NB);
+      opChain.add(OperationType.DELETE_NB);
+      opInfos.add(testFramework.startOperationChain(32 * 1024, i, opChain));
+    }
+    checkFutures(opInfos);
+  }
+
+  @Test
+  public void coordinatorNonBlockingCompatibilityTest()
+      throws Exception {
+    List<OperationInfo> opInfos = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      Queue<OperationType> opChain = new LinkedList<>();
+      opChain.add(i % 2 == 0 ? OperationType.PUT_NB : OperationType.PUT_COORD);
+      opChain.add(OperationType.GET_INFO_COORD);
+      opChain.add(OperationType.GET_INFO_NB);
+      opChain.add(OperationType.GET_COORD);
+      opChain.add(OperationType.GET_NB);
+      opChain.add(i % 2 == 0 ? OperationType.DELETE_COORD : OperationType.DELETE_NB);
+      opChain.add(OperationType.WAIT);
+      opChain.add(OperationType.GET_INFO_DELETED_NB);
+      opChain.add(OperationType.GET_INFO_DELETED_COORD);
+      opChain.add(OperationType.GET_DELETED_NB);
+      opChain.add(OperationType.GET_DELETED_COORD);
+      opInfos.add(testFramework.startOperationChain(32 * 1024, i, opChain));
+    }
+    checkFutures(opInfos);
+  }
+}

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -23,7 +23,6 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.coordinator.AmbryCoordinator;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
-import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.CoordinatorBackedRouter;
 import com.github.ambry.router.CoordinatorBackedRouterMetrics;
@@ -39,12 +38,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Random;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 
 
@@ -274,23 +269,23 @@ class RouterServerTestFramework {
       switch (nextOp) {
         case PUT_NB:
         case PUT_COORD:
-          startPutBlob(nextOp.nonBlocking, opInfo);
+          startPutBlob(nextOp.nonBlockingRouter, opInfo);
           break;
         case GET_INFO_NB:
         case GET_INFO_DELETED_NB:
         case GET_INFO_COORD:
         case GET_INFO_DELETED_COORD:
-          startGetBlobInfo(nextOp.nonBlocking, nextOp.afterDelete, opInfo);
+          startGetBlobInfo(nextOp.nonBlockingRouter, nextOp.afterDelete, opInfo);
           break;
         case GET_NB:
         case GET_DELETED_NB:
         case GET_COORD:
         case GET_DELETED_COORD:
-          startGetBlob(nextOp.nonBlocking, nextOp.afterDelete, opInfo);
+          startGetBlob(nextOp.nonBlockingRouter, nextOp.afterDelete, opInfo);
           break;
         case DELETE_NB:
         case DELETE_COORD:
-          startDeleteBlob(nextOp.nonBlocking, opInfo);
+          startDeleteBlob(nextOp.nonBlockingRouter, opInfo);
           break;
         case AWAIT_CREATION:
           startAwaitCreation(opInfo);
@@ -369,11 +364,11 @@ class RouterServerTestFramework {
      */
     AWAIT_DELETION(false, false);
 
-    final boolean nonBlocking;
+    final boolean nonBlockingRouter;
     final boolean afterDelete;
 
-    OperationType(boolean nonBlocking, boolean afterDelete) {
-      this.nonBlocking = nonBlocking;
+    OperationType(boolean nonBlockingRouter, boolean afterDelete) {
+      this.nonBlockingRouter = nonBlockingRouter;
       this.afterDelete = afterDelete;
     }
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -1,6 +1,18 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 package com.github.ambry.server;
 
-import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
@@ -12,7 +24,6 @@ import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.CoordinatorBackedRouter;
-import com.github.ambry.router.CoordinatorBackedRouterFactory;
 import com.github.ambry.router.CoordinatorBackedRouterMetrics;
 import com.github.ambry.router.NonBlockingRouterFactory;
 import com.github.ambry.router.ReadableStreamChannel;
@@ -200,7 +211,7 @@ class RouterServerTestFramework {
               try {
                 future.get();
                 Assert.fail("Blob should have been deleted in operation: " + getOperationName());
-              } catch (Exception e) {
+              } catch (Exception ignored) {
               }
             } else {
               checkBlob(get(), opInfo, getOperationName());

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -241,6 +241,16 @@ class RouterServerTestFramework {
     }
   }
 
+  /**
+   * Generate a readable label for a router operation.  For example, for a "getBlob" operation after a delete on
+   * the coordinator backed-router, this function will generate the label "getBlob-deleted-coord". This is used
+   * by {@link TestFuture} to provide tracking info to the user if a test assertion fails.
+   * @param name the type of operation (i.e. putBlob, getBlob, etc.)
+   * @param nonBlocking {@code true} if the operation uses the non-blocking router, {@code false} if it uses the
+   *                    coordinator-backed router.
+   * @param afterDelete {@code true} if the operation comes after a blob was deleted.
+   * @return
+   */
   private static String genLabel(String name, boolean nonBlocking, boolean afterDelete) {
     return name + (afterDelete ? "-deleted" : "") + (nonBlocking ? "-nb" : "-coord");
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -1,0 +1,400 @@
+package com.github.ambry.server;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
+import com.github.ambry.commons.ByteBufferReadableStreamChannel;
+import com.github.ambry.config.RouterConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.coordinator.AmbryCoordinator;
+import com.github.ambry.messageformat.BlobInfo;
+import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.router.Callback;
+import com.github.ambry.router.CoordinatorBackedRouter;
+import com.github.ambry.router.CoordinatorBackedRouterFactory;
+import com.github.ambry.router.CoordinatorBackedRouterMetrics;
+import com.github.ambry.router.NonBlockingRouterFactory;
+import com.github.ambry.router.ReadableStreamChannel;
+import com.github.ambry.router.Router;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+
+
+class RouterServerTestFramework {
+  static final int CHUNK_SIZE = 1024 * 1024;
+  private final ScheduledExecutorService worker = Executors.newSingleThreadScheduledExecutor();
+  private final Router nonBlockingRouter;
+  private final Router coordinatorBackedRouter;
+
+  RouterServerTestFramework(Properties routerProps, MockCluster cluster, NotificationSystem notificationSystem)
+      throws Exception {
+    MockClusterMap clusterMap = cluster.getClusterMap();
+    VerifiableProperties routerVerifiableProps = new VerifiableProperties(routerProps);
+    this.nonBlockingRouter =
+        new NonBlockingRouterFactory(routerVerifiableProps, clusterMap, notificationSystem).getRouter();
+
+    RouterConfig routerConfig = new RouterConfig(routerVerifiableProps);
+    CoordinatorBackedRouterMetrics coordinatorBackedRouterMetrics =
+        new CoordinatorBackedRouterMetrics(clusterMap.getMetricRegistry());
+    AmbryCoordinator coordinator = new HelperCoordinator(routerVerifiableProps, clusterMap);
+    this.coordinatorBackedRouter =
+        new CoordinatorBackedRouter(routerConfig, coordinatorBackedRouterMetrics, coordinator);
+  }
+
+  void cleanup()
+      throws IOException {
+    worker.shutdown();
+    if (nonBlockingRouter != null) {
+      nonBlockingRouter.close();
+    }
+    if (coordinatorBackedRouter != null) {
+      coordinatorBackedRouter.close();
+    }
+  }
+
+  static void checkFutures(List<OperationInfo> opInfos)
+      throws Exception {
+    for (OperationInfo opInfo : opInfos) {
+      opInfo.latch.await();
+      synchronized (opInfo.futures) {
+        for (TestFuture future : opInfo.futures) {
+          future.check();
+        }
+      }
+    }
+  }
+
+  OperationInfo startOperationChain(int blobSize, int operationId, Queue<OperationType> opChain) {
+    byte[] userMetadata = new byte[1000];
+    byte[] data = new byte[blobSize];
+    new Random().nextBytes(userMetadata);
+    new Random().nextBytes(data);
+    BlobProperties properties = new BlobProperties(blobSize, "serviceid1");
+    OperationInfo opInfo = new OperationInfo(operationId, properties, userMetadata, data, opChain);
+    continueChain(opInfo);
+    return opInfo;
+  }
+
+  static Properties getRouterProperties(String routerDatacenter) {
+    Properties properties = new Properties();
+    properties.setProperty("router.hostname", "localhost");
+    properties.setProperty("router.datacenter.name", routerDatacenter);
+    properties.setProperty("router.connection.checkout.timeout.ms", "5000");
+    properties.setProperty("router.request.timeout.ms", "20000");
+    properties.setProperty("router.max.put.chunk.size.bytes", Integer.toString(CHUNK_SIZE));
+    properties.setProperty("router.put.success.target", "1");
+    properties.setProperty("coordinator.hostname", "localhost");
+    properties.setProperty("coordinator.datacenter.name", routerDatacenter);
+    return properties;
+  }
+
+  private static void checkBlobId(String blobId, String operationName) {
+    Assert.assertNotNull("Null blobId for operation: " + operationName, blobId);
+  }
+
+  private static void checkBlobInfo(BlobInfo blobInfo, OperationInfo operationInfo, String operationName) {
+    Assert.assertNotNull("Null blobInfo for operation: " + operationName, blobInfo);
+    Assert.assertEquals("Blob size in info does not match expected for operation: " + operationName,
+        operationInfo.properties.getBlobSize(), blobInfo.getBlobProperties().getBlobSize());
+    Assert.assertEquals("Service ID in info does not match expected for operation: " + operationName,
+        operationInfo.properties.getServiceId(), blobInfo.getBlobProperties().getServiceId());
+    Assert.assertArrayEquals("Unexpected user metadata for operation: " + operationName, operationInfo.userMetadata,
+        blobInfo.getUserMetadata());
+  }
+
+  private static void checkBlob(ReadableStreamChannel channel, OperationInfo operationInfo, String operationName) {
+    Assert.assertNotNull("Null channel for operation: " + operationName, channel);
+    try {
+      ByteBufferAsyncWritableChannel getChannel = new ByteBufferAsyncWritableChannel();
+      Future<Long> readIntoFuture = channel.readInto(getChannel, null);
+      int readBytes = 0;
+      do {
+        ByteBuffer buf = getChannel.getNextChunk();
+        int bufLength = buf.remaining();
+        Assert.assertTrue(
+            "total content read should not be greater than length of put content, operation: " + operationName,
+            readBytes + bufLength <= operationInfo.data.length);
+        while (buf.hasRemaining()) {
+          Assert.assertEquals("Get and Put blob content should match, operation: " + operationName,
+              operationInfo.data[readBytes++], buf.get());
+        }
+        getChannel.resolveOldestChunk(null);
+      } while (readBytes < operationInfo.data.length);
+      Assert.assertEquals(
+          "the returned length in the future should be the length of data written, operation: " + operationName,
+          (long) readBytes, (long) readIntoFuture.get());
+      Assert.assertNull("There should be no more data in the channel, operation: " + operationName,
+          getChannel.getNextChunk(0));
+    } catch (Exception e) {
+      Assert.fail("Exception while reading from getChannel from operation: " + operationName);
+    }
+  }
+
+  private static String genLabel(String name, boolean nonBlocking, boolean afterDelete) {
+    return name + (afterDelete ? "-deleted" : "") + (nonBlocking ? "-nb" : "-coord");
+  }
+
+  private void startPutBlob(boolean nonBlocking, OperationInfo opInfo) {
+    ReadableStreamChannel putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(opInfo.data));
+    Callback<String> callback = new TestCallback<String>(opInfo, false) {
+      @Override
+      void action(String result) {
+        opInfo.blobId = result;
+      }
+    };
+    Router router = nonBlocking ? nonBlockingRouter : coordinatorBackedRouter;
+    Future<String> future = router.putBlob(opInfo.properties, opInfo.userMetadata, putChannel, callback);
+    TestFuture<String> testFuture = new TestFuture<String>(future, genLabel("putBlob", nonBlocking, false), opInfo) {
+      @Override
+      void check() {
+        checkBlobId(get(), getOperationName());
+      }
+    };
+    opInfo.futures.add(testFuture);
+  }
+
+  private void startGetBlobInfo(boolean nonBlocking, final boolean afterDelete, final OperationInfo opInfo) {
+    Callback<BlobInfo> callback = new TestCallback<>(opInfo, afterDelete);
+    Router router = nonBlocking ? nonBlockingRouter : coordinatorBackedRouter;
+    Future<BlobInfo> future = router.getBlobInfo(opInfo.blobId, callback);
+    TestFuture<BlobInfo> testFuture =
+        new TestFuture<BlobInfo>(future, genLabel("getBlobInfo", nonBlocking, afterDelete), opInfo) {
+          @Override
+          void check() {
+            if (afterDelete) {
+              try {
+                future.get();
+                Assert.fail("Blob should have been deleted in operation: " + getOperationName());
+              } catch (Exception ignored) {
+              }
+            } else {
+              checkBlobInfo(get(), opInfo, getOperationName());
+            }
+          }
+        };
+    opInfo.futures.add(testFuture);
+  }
+
+  private void startGetBlob(boolean nonBlocking, final boolean afterDelete, final OperationInfo opInfo) {
+    Callback<ReadableStreamChannel> callback = new TestCallback<>(opInfo, afterDelete);
+    Router router = nonBlocking ? nonBlockingRouter : coordinatorBackedRouter;
+    Future<ReadableStreamChannel> future = router.getBlob(opInfo.blobId, callback);
+    TestFuture<ReadableStreamChannel> testFuture =
+        new TestFuture<ReadableStreamChannel>(future, genLabel("getBlob", nonBlocking, afterDelete), opInfo) {
+          @Override
+          void check() {
+            if (afterDelete) {
+              try {
+                future.get();
+                Assert.fail("Blob should have been deleted in operation: " + getOperationName());
+              } catch (Exception e) {
+              }
+            } else {
+              checkBlob(get(), opInfo, getOperationName());
+            }
+          }
+        };
+    opInfo.futures.add(testFuture);
+  }
+
+  private void startDeleteBlob(boolean nonBlocking, final OperationInfo opInfo) {
+    Callback<Void> callback = new TestCallback<>(opInfo, false);
+    Router router = nonBlocking ? nonBlockingRouter : coordinatorBackedRouter;
+    Future<Void> future = router.deleteBlob(opInfo.blobId, callback);
+    TestFuture<Void> testFuture = new TestFuture<Void>(future, genLabel("deleteBlob", nonBlocking, false), opInfo) {
+      @Override
+      void check() {
+        get();
+      }
+    };
+    opInfo.futures.add(testFuture);
+  }
+
+  private void startWait(final OperationInfo opInfo) {
+    final Callback<Void> callback = new TestCallback<>(opInfo, false);
+    Future<Void> future = worker.schedule(new Callable<Void>() {
+      @Override
+      public Void call() {
+        callback.onCompletion(null, null);
+        return null;
+      }
+    }, 1, TimeUnit.SECONDS);
+    TestFuture<Void> testFuture = new TestFuture<Void>(future, "wait", opInfo) {
+      @Override
+      void check() {
+        get();
+      }
+    };
+    opInfo.futures.add(testFuture);
+  }
+
+  private void continueChain(final OperationInfo opInfo) {
+    synchronized (opInfo.futures) {
+      OperationType nextOp = opInfo.opChain.poll();
+      if (nextOp == null) {
+        opInfo.latch.countDown();
+        return;
+      }
+      switch (nextOp) {
+        case PUT_NB:
+        case PUT_COORD:
+          startPutBlob(nextOp.nonBlocking, opInfo);
+          break;
+        case GET_INFO_NB:
+        case GET_INFO_DELETED_NB:
+        case GET_INFO_COORD:
+        case GET_INFO_DELETED_COORD:
+          startGetBlobInfo(nextOp.nonBlocking, nextOp.afterDelete, opInfo);
+          break;
+        case GET_NB:
+        case GET_DELETED_NB:
+        case GET_COORD:
+        case GET_DELETED_COORD:
+          startGetBlob(nextOp.nonBlocking, nextOp.afterDelete, opInfo);
+          break;
+        case DELETE_NB:
+        case DELETE_COORD:
+          startDeleteBlob(nextOp.nonBlocking, opInfo);
+          break;
+        case WAIT:
+          startWait(opInfo);
+          break;
+      }
+    }
+  }
+
+  enum OperationType {
+    PUT_NB(true, false),
+    GET_INFO_NB(true, false),
+    GET_NB(true, false),
+    DELETE_NB(true, false),
+    GET_INFO_DELETED_NB(true, true),
+    GET_DELETED_NB(true, true),
+    PUT_COORD(false, false),
+    GET_INFO_COORD(false, false),
+    GET_COORD(false, false),
+    DELETE_COORD(false, false),
+    GET_INFO_DELETED_COORD(false, true),
+    GET_DELETED_COORD(false, true),
+    WAIT(false, false);
+
+    final boolean nonBlocking;
+    final boolean afterDelete;
+
+    OperationType(boolean nonBlocking, boolean afterDelete) {
+      this.nonBlocking = nonBlocking;
+      this.afterDelete = afterDelete;
+    }
+  }
+
+  static class OperationInfo {
+    final int operationId;
+    final BlobProperties properties;
+    final byte[] userMetadata;
+    final byte[] data;
+    final Queue<OperationType> opChain;
+    final List<TestFuture> futures = new ArrayList<>();
+    final CountDownLatch latch = new CountDownLatch(1);
+    String blobId;
+
+    OperationInfo(int operationId, BlobProperties properties, byte[] userMetadata, byte[] data,
+        Queue<OperationType> opChain) {
+      this.operationId = operationId;
+      this.properties = properties;
+      this.userMetadata = userMetadata;
+      this.data = data;
+      this.opChain = opChain;
+    }
+  }
+
+  /**
+   * This class encapsulates a future and allows the user to define a check method that runs tests on
+   * the retrieved value in the future.
+   *
+   * @param <T> The type of the encapsulated future
+   */
+  private static abstract class TestFuture<T> {
+    final Future<T> future;
+    final String operationType;
+    final OperationInfo opInfo;
+
+    TestFuture(Future<T> future, String operationType, OperationInfo opInfo) {
+      this.future = future;
+      this.operationType = operationType;
+      this.opInfo = opInfo;
+    }
+
+    /**
+     * Generate a name for the tested operation
+     * @return the operation name
+     */
+    String getOperationName() {
+      return operationType + "-" + opInfo.operationId;
+    }
+
+    /**
+     * Return the value inside the future or throw an {@link AssertionError} if an exception
+     * occurred.
+     * @return the value inside the future
+     */
+    T get() {
+      try {
+        return this.future.get();
+      } catch (Exception e) {
+        e.printStackTrace();
+        Assert.fail("Exception occured in operation: " + getOperationName() + ", exception: " + e);
+        return null;
+      }
+    }
+
+    /**
+     * Implement any testing logic here.
+     */
+    abstract void check();
+  }
+
+  /**
+   * A callback for router operations that starts the next operation in the chain after completion.
+   * The user can define a custom action on the result of the operation by overriding the {@code action()} method.
+   * @param <T> The callback's result type
+   */
+  private class TestCallback<T> implements Callback<T> {
+    final OperationInfo opInfo;
+    final boolean expectError;
+
+    TestCallback(OperationInfo opInfo, boolean expectError) {
+      this.opInfo = opInfo;
+      this.expectError = expectError;
+    }
+
+    @Override
+    public void onCompletion(T result, Exception exception) {
+      if (exception != null && !expectError) {
+        opInfo.latch.countDown();
+        return;
+      }
+      action(result);
+      continueChain(opInfo);
+    }
+
+    /**
+     * Perform custom actions on the result of the operation here by overriding this method.
+     * @param result the result of the completed operation
+     */
+    void action(T result) {
+    }
+  }
+}

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerPlaintextTest.java
@@ -69,9 +69,8 @@ public class ServerPlaintextTest {
   public void endToEndTest()
       throws InterruptedException, IOException, InstantiationException, URISyntaxException, GeneralSecurityException {
     DataNodeId dataNodeId = plaintextCluster.getClusterMap().getDataNodeIds().get(0);
-    ServerTestUtil
-        .endToEndTest(new Port(dataNodeId.getPort(), PortType.PLAINTEXT), "DC1", "", plaintextCluster, null, null,
-            coordinatorProps);
+    ServerTestUtil.endToEndTest(new Port(dataNodeId.getPort(), PortType.PLAINTEXT), "DC1", "", plaintextCluster, null,
+        null, coordinatorProps);
   }
 
   @Test
@@ -90,8 +89,7 @@ public class ServerPlaintextTest {
   @Test
   public void endToEndReplicationWithMultiNodeMultiPartitionMultiDCTest()
       throws Exception {
-    ServerTestUtil
-        .endToEndReplicationWithMultiNodeMultiPartitionMultiDCTest("DC1", "", PortType.PLAINTEXT, plaintextCluster,
-            notificationSystem, coordinatorProps);
+    ServerTestUtil.endToEndReplicationWithMultiNodeMultiPartitionMultiDCTest("DC1", "", PortType.PLAINTEXT,
+        plaintextCluster, notificationSystem, coordinatorProps);
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,6 @@ project(':ambry-server') {
     dependencies {
         compile project(':ambry-clustermap'),
                 project(':ambry-coordinator'),
-                project(':ambry-router'),
                 project(':ambry-messageformat'),
                 project(':ambry-metrics'),
                 project(':ambry-network'),
@@ -137,6 +136,7 @@ project(':ambry-server') {
                 project(':ambry-utils'),
                 project(':ambry-replication')
         compile "com.codahale.metrics:metrics-core:$metricsVersion"
+        testCompile project(':ambry-router').sourceSets.main.output
         testCompile project(':ambry-utils').sourceSets.test.output
         testCompile project(':ambry-clustermap').sourceSets.test.output
         testCompile project(':ambry-network').sourceSets.test.output

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ project(':ambry-server') {
     dependencies {
         compile project(':ambry-clustermap'),
                 project(':ambry-coordinator'),
+                project(':ambry-router'),
                 project(':ambry-messageformat'),
                 project(':ambry-metrics'),
                 project(':ambry-network'),


### PR DESCRIPTION
Adding test cases and framework to test router operations with actual server (Issue #303):
- Framework for composing tests with chains of router operations
- Test interleaved/noninterleaved get, put, and del operations
- Test compatibility between coordinator-backed and non-blocking router
  operations
- Test large object support

**Reviewers:** @pnarayanan @xiahome 
**Time to review:** 30 min.