### PR TITLE
Changing invalid request state detection logic in NettyMessageProcessor.

### DIFF
--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -722,19 +722,16 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
       case Close:
         restResponseChannel.close();
         assertFalse("Request channel is not closed", request.isOpen());
-        assertTrue("Response should be marked complete", restResponseChannel.isResponseComplete());
         break;
       case CopyHeaders:
         copyHeaders(httpRequest);
         restResponseChannel.onResponseComplete(null);
         assertFalse("Request channel is not closed", request.isOpen());
-        assertTrue("Response should be marked complete", restResponseChannel.isResponseComplete());
         break;
       case ImmediateResponseComplete:
         restResponseChannel.onResponseComplete(null);
         assertEquals("ResponseStatus differs from default", ResponseStatus.Ok, restResponseChannel.getStatus());
         assertFalse("Request channel is not closed", request.isOpen());
-        assertTrue("Response should be marked complete", restResponseChannel.isResponseComplete());
         break;
       case FillWriteBuffer:
         ctx.channel().config().setWriteBufferLowWaterMark(1);
@@ -747,14 +744,12 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
       case MultipleClose:
         restResponseChannel.onResponseComplete(null);
         assertFalse("Request channel is not closed", request.isOpen());
-        assertTrue("Response should be marked complete", restResponseChannel.isResponseComplete());
         restResponseChannel.close();
         restResponseChannel.close();
         break;
       case MultipleOnResponseComplete:
         restResponseChannel.onResponseComplete(null);
         assertFalse("Request channel is not closed", request.isOpen());
-        assertTrue("Response should be marked complete", restResponseChannel.isResponseComplete());
         restResponseChannel.onResponseComplete(null);
         break;
       case OnResponseCompleteWithRestException:
@@ -764,7 +759,6 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
         assertEquals("ResponseStatus does not reflect error", ResponseStatus.getResponseStatus(errorCode),
             restResponseChannel.getStatus());
         assertFalse("Request channel is not closed", request.isOpen());
-        assertTrue("Response should be marked complete", restResponseChannel.isResponseComplete());
         break;
       case OnResponseCompleteWithNonRestException:
         restResponseChannel
@@ -772,7 +766,6 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
         assertEquals("ResponseStatus does not reflect error", ResponseStatus.InternalServerError,
             restResponseChannel.getStatus());
         assertFalse("Request channel is not closed", request.isOpen());
-        assertTrue("Response should be marked complete", restResponseChannel.isResponseComplete());
         break;
       case ResponseFailureMidway:
         ChannelWriteCallback callback = new ChannelWriteCallback();
@@ -792,12 +785,10 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
         restResponseChannel.setStatus(ResponseStatus.valueOf(HttpHeaders.getHeader(httpRequest, STATUS_HEADER_NAME)));
         restResponseChannel.onResponseComplete(null);
         assertFalse("Request channel is not closed", request.isOpen());
-        assertTrue("Response should be marked complete", restResponseChannel.isResponseComplete());
         break;
       case WriteAfterClose:
         restResponseChannel.close();
         assertFalse("Request channel is not closed", request.isOpen());
-        assertTrue("Response should be marked complete", restResponseChannel.isResponseComplete());
         callback = new ChannelWriteCallback();
         callback.compareWithFuture(
             restResponseChannel.write(ByteBuffer.wrap(TestingUri.WriteAfterClose.toString().getBytes()), callback));


### PR DESCRIPTION
Previously `NettyMessageProcessor` used to be ready for subsequent requests on the same channel only after `NettyResponseChannel` reported that responses had been fully sent out (including sending of `LastHttpContent`  which is an artifact of Netty and has no meaning in responses with Content-Length set). This created a race condition between the server and client in the scenario where clients detect that they have fully received a response and send another request while the server still hadn't realized that the response has been fully sent out. This race condition became more pronounced and started inducing errors when the `NonBlockingRouter` was used.

This commit fixes this problem by declaring the `NettyMessageProcessor` ready for subsequent requests
as soon as the current request is fully received from the client. This way, there are no race conditions
because `NettyMessageProcessor` is ready even before the response sending has started. The only way this can cause an error is if the client sends a request without waiting for the previous response in which
case that would be a bug with the client and not the server.

**Primary Reviewers: @pnarayanan**
**Expected time to review : 15 mins**

@pnarayanan debugged the issue with me and has tested the fix so he has the most context to review.

Built (`./gradlew build and ./gradlew test`) and formatted.