### PR TITLE
Fixes to LastHttpContent generation in NettyResponseChannel

### DIFF
--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -27,6 +27,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -77,12 +78,11 @@ class NettyResponseChannel implements RestResponseChannel {
   // tracks whether onResponseComplete() has been called. Helps make it idempotent and also treats response channel as
   // closed if this is true.
   private final AtomicBoolean responseCompleteCalled = new AtomicBoolean(false);
-  // tracks whether response metadata write has been initated. Rejects any more attempts at writing metadata after this
+  // tracks whether response metadata write has been initiated. Rejects any more attempts at writing metadata after this
   // has been set to true.
   private final AtomicBoolean responseMetadataWriteInitiated = new AtomicBoolean(false);
   private final ResponseMetadataWriteListener responseMetadataWriteListener = new ResponseMetadataWriteListener();
-  private final CleanupCallback cleanupCallback = new CleanupCallback();
-  private final AtomicLong totalBytesWritten = new AtomicLong(0);
+  private final AtomicLong totalBytesReceived = new AtomicLong(0);
   private final Queue<Chunk> chunksToWrite = new ConcurrentLinkedQueue<Chunk>();
   private final Queue<Chunk> chunksAwaitingCallback = new ConcurrentLinkedQueue<Chunk>();
   private final AtomicLong chunksToWriteCount = new AtomicLong(0);
@@ -122,8 +122,28 @@ class NettyResponseChannel implements RestResponseChannel {
     if (!isOpen()) {
       // the isOpen() check is not before addition to the queue because chunks need to be acknowledged in the order
       // they were received. If we don't add it to the queue and clean up, chunks may be acknowledged out of order.
-      logger.debug("Scheduling a chunk cleanup on channel {}", ctx.channel());
-      writeFuture.addListener(cleanupCallback);
+      logger.debug("Scheduling a chunk cleanup on channel {} because response channel is closed", ctx.channel());
+      writeFuture.addListener(new CleanupCallback(new ClosedChannelException()));
+    } else if (finalResponseMetadata instanceof FullHttpResponse) {
+      logger.debug("Scheduling a chunk cleanup on channel {} because Content-Length is 0", ctx.channel());
+      Exception exception = null;
+      // this is only allowed to be a 0 sized buffer.
+      if (src.remaining() > 0) {
+        exception = new IllegalArgumentException("Provided non zero size content after setting Content-Length to 0");
+        if (!writeFuture.isDone()) {
+          writeFuture.setFailure(exception);
+        }
+      }
+      writeFuture.addListener(new CleanupCallback(exception));
+    } else if (HttpHeaders.isContentLengthSet(finalResponseMetadata) && totalBytesReceived.get() > HttpHeaders
+        .getContentLength(finalResponseMetadata)) {
+      Exception exception = new IllegalArgumentException(
+          "Size of provided content [" + totalBytesReceived.get() + "] is greater than Content-Length set ["
+              + HttpHeaders.getContentLength(finalResponseMetadata) + "]");
+      if (!writeFuture.isDone()) {
+        writeFuture.setFailure(exception);
+      }
+      writeFuture.addListener(new CleanupCallback(exception));
     } else {
       chunkedWriteHandler.resumeTransfer();
     }
@@ -278,12 +298,18 @@ class NettyResponseChannel implements RestResponseChannel {
       if (!HttpHeaders.isContentLengthSet(responseMetadata)) {
         // This makes sure that we don't stomp on any existing transfer-encoding.
         HttpHeaders.setTransferEncodingChunked(responseMetadata);
+      } else if (HttpHeaders.getContentLength(responseMetadata) == 0) {
+        // if the Content-Length is 0, we can send a FullHttpResponse since there is no content expected.
+        FullHttpResponse fullHttpResponse =
+            new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, responseMetadata.getStatus());
+        fullHttpResponse.headers().set(responseMetadata.headers());
+        responseMetadata = fullHttpResponse;
       }
       logger.trace("Sending response with status {} on channel {}", responseMetadata.getStatus(), ctx.channel());
+      finalResponseMetadata = responseMetadata;
       ChannelPromise writePromise = ctx.newPromise().addListener(listener);
       ctx.writeAndFlush(responseMetadata, writePromise);
       writtenThisTime = true;
-      finalResponseMetadata = responseMetadata;
       long writeProcessingTime = System.currentTimeMillis() - writeProcessingStartTime;
       nettyMetrics.responseMetadataProcessingTimeInMs.update(writeProcessingTime);
     }
@@ -328,8 +354,7 @@ class NettyResponseChannel implements RestResponseChannel {
     boolean responseSent = false;
     logger.trace("Sending error response to client on channel {}", ctx.channel());
     FullHttpResponse errorResponse = getErrorResponse(exception);
-    if (maybeWriteResponseMetadata(errorResponse,
-        new ErrorResponseWriteListener(HttpHeaders.isKeepAlive(errorResponse)))) {
+    if (maybeWriteResponseMetadata(errorResponse, new ErrorResponseWriteListener())) {
       logger.trace("Successfully sent error response on channel {}", ctx.channel());
       responseStatus = errorResponseStatus;
       responseSent = true;
@@ -475,19 +500,7 @@ class NettyResponseChannel implements RestResponseChannel {
         exception = (Exception) cause;
       }
       onResponseComplete(exception);
-
-      logger.trace("Cleaning up remaining chunks on write failure");
-      Chunk chunk = chunksAwaitingCallback.poll();
-      while (chunk != null) {
-        chunk.resolveChunk(exception);
-        chunk = chunksAwaitingCallback.poll();
-      }
-      chunk = chunksToWrite.poll();
-      while (chunk != null) {
-        chunk.onDequeue();
-        chunk.resolveChunk(exception);
-        chunk = chunksToWrite.poll();
-      }
+      cleanupChunks(exception);
     } finally {
       nettyMetrics.channelWriteFailureProcessingTimeInMs
           .update(System.currentTimeMillis() - writeFailureProcessingStartTime);
@@ -518,6 +531,25 @@ class NettyResponseChannel implements RestResponseChannel {
     }
   }
 
+  /**
+   * Cleans up all the chunks remaining by invoking their callabacks.
+   * @param exception the {@link Exception} to provide in the callback. Can be {@code null}.
+   */
+  private void cleanupChunks(Exception exception) {
+    logger.trace("Cleaning up remaining chunks");
+    Chunk chunk = chunksAwaitingCallback.poll();
+    while (chunk != null) {
+      chunk.resolveChunk(exception);
+      chunk = chunksAwaitingCallback.poll();
+    }
+    chunk = chunksToWrite.poll();
+    while (chunk != null) {
+      chunk.onDequeue();
+      chunk.resolveChunk(exception);
+      chunk = chunksToWrite.poll();
+    }
+  }
+
   // helper classes
 
   /**
@@ -539,9 +571,10 @@ class NettyResponseChannel implements RestResponseChannel {
     /**
      * If progress in {@link #writeFuture} becomes greater than this number, the future/callback will be triggered.
      */
-    public long writeCompleteThreshold;
+    public final long writeCompleteThreshold;
     private final Callback<Long> callback;
     private final long chunkQueueStartTime = System.currentTimeMillis();
+
     private long chunkWriteStartTime;
 
     /**
@@ -553,6 +586,7 @@ class NettyResponseChannel implements RestResponseChannel {
       this.buffer = buffer;
       bytesToBeWritten = buffer.remaining();
       this.callback = callback;
+      writeCompleteThreshold = totalBytesReceived.addAndGet(bytesToBeWritten);
       chunksToWriteCount.incrementAndGet();
     }
 
@@ -602,7 +636,13 @@ class NettyResponseChannel implements RestResponseChannel {
    */
   private class ChunkDispenser implements ChunkedInput<HttpContent> {
     // NOTE: Due to a bug in HttpChunkedInput, some code there has been reproduced here instead of using it directly.
+    private final long contentLength;
     private boolean sentLastChunk = false;
+
+    ChunkDispenser() {
+      // if we are here, it means that finalResponseMetadata has been set and there is no danger of it being null
+      contentLength = HttpHeaders.getContentLength(finalResponseMetadata, -1);
+    }
 
     /**
      * Determines if input has ended by examining response state and number of chunks pending for write.
@@ -611,7 +651,7 @@ class NettyResponseChannel implements RestResponseChannel {
      */
     @Override
     public boolean isEndOfInput() {
-      return allChunksWritten() && sentLastChunk;
+      return sentLastChunk;
     }
 
     @Override
@@ -634,9 +674,14 @@ class NettyResponseChannel implements RestResponseChannel {
       if (chunk != null) {
         chunk.onDequeue();
         ByteBuf buf = Unpooled.wrappedBuffer(chunk.buffer);
-        chunk.writeCompleteThreshold = totalBytesWritten.addAndGet(chunk.bytesToBeWritten);
         chunksAwaitingCallback.add(chunk);
-        content = new DefaultHttpContent(buf);
+        if (contentLength != -1 && chunk.writeCompleteThreshold >= contentLength) {
+          // this is the last piece of content.
+          content = new DefaultLastHttpContent(buf);
+          sentLastChunk = true;
+        } else {
+          content = new DefaultHttpContent(buf);
+        }
       } else if (allChunksWritten() && !sentLastChunk) {
         // Send last chunk for this input
         sentLastChunk = true;
@@ -710,9 +755,19 @@ class NettyResponseChannel implements RestResponseChannel {
     @Override
     public void operationComplete(ChannelFuture future) {
       if (future.isSuccess()) {
-        logger.trace("Starting ChunkedWriteHandler on channel {}", ctx.channel());
-        writeFuture.addListener(new CallbackInvoker());
-        ctx.writeAndFlush(new ChunkDispenser(), writeFuture);
+        if (finalResponseMetadata instanceof LastHttpContent) {
+          // this is the case if finalResponseMetadata is a FullHttpResponse.
+          // in this case there is nothing more to write.
+          if (!writeFuture.isDone()) {
+            writeFuture.setSuccess();
+            completeRequest(request == null || !request.isKeepAlive());
+          }
+        } else {
+          // otherwise there is some content to write.
+          logger.trace("Starting ChunkedWriteHandler on channel {}", ctx.channel());
+          writeFuture.addListener(new CallbackInvoker());
+          ctx.writeAndFlush(new ChunkDispenser(), writeFuture);
+        }
       } else {
         handleChannelWriteFailure(future.cause(), true);
       }
@@ -724,15 +779,6 @@ class NettyResponseChannel implements RestResponseChannel {
    */
   private class ErrorResponseWriteListener implements GenericFutureListener<ChannelFuture> {
     private final long responseWriteStartTime = System.currentTimeMillis();
-    private final boolean keepAlive;
-
-    /**
-     * Constructs a channel write listener for error responses.
-     * @param keepAlive {@code true} if the channel needs to be kept open. {@code false} otherwise.
-     */
-    ErrorResponseWriteListener(boolean keepAlive) {
-      this.keepAlive = keepAlive;
-    }
 
     @Override
     public void operationComplete(ChannelFuture future)
@@ -747,24 +793,38 @@ class NettyResponseChannel implements RestResponseChannel {
       if (request != null) {
         request.getMetricsTracker().nioMetricsTracker.addToResponseProcessingTime(channelWriteTime);
       }
-      completeRequest(!keepAlive || !future.isSuccess());
+      completeRequest(!HttpHeaders.isKeepAlive(finalResponseMetadata) || !future.isSuccess());
     }
   }
 
   /**
-   * Cleans up any chunks that were added after an error occurred. This is to guard against the case where
-   * {@link CallbackInvoker#operationComplete(ChannelProgressiveFuture)} might have finished already.
+   * Cleans up chunks that are remaining. This serves two purposes:
+   * 1. Guarding against the case where {@link CallbackInvoker#operationComplete(ChannelProgressiveFuture)} might have
+   * finished already.
+   * 2. Cleaning up any zero sized chunks when {@link HttpHeaders.Names#CONTENT_LENGTH} is 0 and a
+   * {@link FullHttpResponse} has been sent.
    */
   private class CleanupCallback implements GenericFutureListener<ChannelFuture> {
+    private final Exception exception;
+
+    /**
+     * Instantiate a CleanupCallback with an exception to return once cleanup is activated.
+     * @param exception the {@link Exception} to return as a part of the callback. Can be {@code null}. This can be
+     *                  overriden if the channel write ended in failure.
+     */
+    CleanupCallback(Exception exception) {
+      this.exception = exception;
+    }
 
     @Override
     public void operationComplete(ChannelFuture future)
         throws Exception {
-      Throwable cause = future.cause();
-      if (cause == null) {
-        cause = new ClosedChannelException();
+      Throwable cause = future.cause() == null ? exception : future.cause();
+      if (cause != null) {
+        handleChannelWriteFailure(cause, false);
+      } else {
+        cleanupChunks(null);
       }
-      handleChannelWriteFailure(cause, false);
       logger.debug("Chunk cleanup complete on channel {}", ctx.channel());
     }
   }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -129,7 +129,7 @@ class NettyResponseChannel implements RestResponseChannel {
       Exception exception = null;
       // this is only allowed to be a 0 sized buffer.
       if (src.remaining() > 0) {
-        exception = new IllegalArgumentException("Provided non zero size content after setting Content-Length to 0");
+        exception = new IllegalStateException("Provided non zero size content after setting Content-Length to 0");
         if (!writeFuture.isDone()) {
           writeFuture.setFailure(exception);
         }
@@ -137,7 +137,7 @@ class NettyResponseChannel implements RestResponseChannel {
       writeFuture.addListener(new CleanupCallback(exception));
     } else if (HttpHeaders.isContentLengthSet(finalResponseMetadata) && totalBytesReceived.get() > HttpHeaders
         .getContentLength(finalResponseMetadata)) {
-      Exception exception = new IllegalArgumentException(
+      Exception exception = new IllegalStateException(
           "Size of provided content [" + totalBytesReceived.get() + "] is greater than Content-Length set ["
               + HttpHeaders.getContentLength(finalResponseMetadata) + "]");
       if (!writeFuture.isDone()) {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -298,7 +298,8 @@ class NettyResponseChannel implements RestResponseChannel {
       if (!HttpHeaders.isContentLengthSet(responseMetadata)) {
         // This makes sure that we don't stomp on any existing transfer-encoding.
         HttpHeaders.setTransferEncodingChunked(responseMetadata);
-      } else if (HttpHeaders.getContentLength(responseMetadata) == 0) {
+      } else if (HttpHeaders.getContentLength(responseMetadata) == 0
+          && !(responseMetadata instanceof FullHttpResponse)) {
         // if the Content-Length is 0, we can send a FullHttpResponse since there is no content expected.
         FullHttpResponse fullHttpResponse =
             new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, responseMetadata.getStatus());

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.rest;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.router.Callback;
+import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -43,6 +44,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -79,17 +81,18 @@ public class NettyResponseChannelTest {
 
   /**
    * Tests the common workflow of the {@link NettyResponseChannel} i.e., add some content to response body via
-   * {@link NettyResponseChannel#write(ByteBuffer, Callback)} and then completes the response.
+   * {@link NettyResponseChannel#write(ByteBuffer, Callback)} and then complete the response.
    * <p/>
    * These responses have the header Transfer-Encoding set to chunked.
-   * @throws IOException
+   * @throws Exception
    */
   @Test
   public void responsesWithTransferEncodingChunkedTest()
-      throws IOException {
+      throws Exception {
     String content = "@@randomContent@@@";
     String lastContent = "@@randomLastContent@@@";
     EmbeddedChannel channel = createEmbeddedChannel();
+    MockNettyMessageProcessor processor = channel.pipeline().get(MockNettyMessageProcessor.class);
     AtomicLong contentIdGenerator = new AtomicLong(0);
 
     final int ITERATIONS = 10;
@@ -105,6 +108,7 @@ public class NettyResponseChannelTest {
         contents.add(contentToSend);
       }
       channel.writeInbound(createContent(lastContent, true));
+      verifyCallbacks(processor);
       // first outbound has to be response.
       HttpResponse response = (HttpResponse) channel.readOutbound();
       assertEquals("Unexpected response status", HttpResponseStatus.OK, response.getStatus());
@@ -122,9 +126,18 @@ public class NettyResponseChannelTest {
     }
   }
 
+  /**
+   * Tests the common workflow of the {@link NettyResponseChannel} i.e., add some content to response body via
+   * {@link NettyResponseChannel#write(ByteBuffer, Callback)} and then complete the response.
+   * <p/>
+   * These responses have the header Content-Length set.
+   * @throws Exception
+   */
   @Test
-  public void responsesWithContentLengthTest() {
+  public void responsesWithContentLengthTest()
+      throws Exception {
     EmbeddedChannel channel = createEmbeddedChannel();
+    MockNettyMessageProcessor processor = channel.pipeline().get(MockNettyMessageProcessor.class);
     final int ITERATIONS = 10;
     for (int i = 0; i < ITERATIONS; i++) {
       boolean isKeepAlive = i != (ITERATIONS - 1);
@@ -134,6 +147,7 @@ public class NettyResponseChannelTest {
           RestTestUtils.createRequest(HttpMethod.POST, TestingUri.ResponseWithContentLength.toString(), httpHeaders);
       HttpHeaders.setKeepAlive(httpRequest, isKeepAlive);
       channel.writeInbound(httpRequest);
+      verifyCallbacks(processor);
 
       // first outbound has to be response.
       HttpResponse response = (HttpResponse) channel.readOutbound();
@@ -237,24 +251,40 @@ public class NettyResponseChannelTest {
       channel.writeInbound(RestTestUtils.createRequest(HttpMethod.GET, "/", null));
       // channel gets closed because of write failure
       channel.writeInbound(createContent(content, true));
+      verifyCallbacks(processor);
       fail("Callback for write would have thrown an Exception");
     } catch (Exception e) {
       assertEquals("Exception not as expected", ExceptionOutboundHandler.EXCEPTION_MESSAGE, e.getMessage());
     }
 
     // writing to channel with a outbound handler that generates an Error
-    EmbeddedChannel channel = new EmbeddedChannel(new ErrorOutboundHandler(), new MockNettyMessageProcessor());
+    MockNettyMessageProcessor processor = new MockNettyMessageProcessor();
+    EmbeddedChannel channel = new EmbeddedChannel(new ErrorOutboundHandler(), processor);
     try {
       channel.writeInbound(
           RestTestUtils.createRequest(HttpMethod.GET, TestingUri.WriteFailureWithThrowable.toString(), null));
+      verifyCallbacks(processor);
     } catch (Error e) {
       assertEquals("Unexpected error", ErrorOutboundHandler.ERROR_MESSAGE, e.getMessage());
     }
 
     channel = createEmbeddedChannel();
+    processor = channel.pipeline().get(MockNettyMessageProcessor.class);
     channel
         .writeInbound(RestTestUtils.createRequest(HttpMethod.GET, TestingUri.ResponseFailureMidway.toString(), null));
+    verifyCallbacks(processor);
     assertFalse("Channel is not closed at the remote end", channel.isActive());
+  }
+
+  /**
+   * Asks the server to write more data than the set Content-Length and checks behavior.
+   * @throws Exception
+   */
+  @Test
+  public void writeMoreThanContentLengthTest()
+      throws Exception {
+    doWriteMoreThanContentLengthTest(0);
+    doWriteMoreThanContentLengthTest(5);
   }
 
   /**
@@ -464,6 +494,24 @@ public class NettyResponseChannelTest {
     return new EmbeddedChannel(chunkedWriteHandler, processor);
   }
 
+  /**
+   * Verifies any callbacks queued in the {@code processor}.
+   * @param processor the {@link MockNettyMessageProcessor} that contains the callbacks that need to be verified.
+   * @throws Exception
+   */
+  private void verifyCallbacks(MockNettyMessageProcessor processor)
+      throws Exception {
+    if (processor == null) {
+      assertNotNull("There is no MockNettyMessageProcessor in the channel", processor);
+    }
+    for (ChannelWriteCallback callback : processor.writeCallbacksToVerify) {
+      callback.compareWithFuture();
+      if (callback.exception != null) {
+        throw callback.exception;
+      }
+    }
+  }
+
   // badStateTransitionsTest() helpers
 
   /**
@@ -477,8 +525,10 @@ public class NettyResponseChannelTest {
   private void doBadStateTransitionTest(TestingUri uri, Class exceptionClass)
       throws Exception {
     EmbeddedChannel channel = createEmbeddedChannel();
+    MockNettyMessageProcessor processor = channel.pipeline().get(MockNettyMessageProcessor.class);
     try {
       channel.writeInbound(RestTestUtils.createRequest(HttpMethod.GET, uri.toString(), null));
+      verifyCallbacks(processor);
       fail("This test was expecting the handler in the channel to throw an exception");
     } catch (Exception e) {
       if (!exceptionClass.isInstance(e)) {
@@ -514,6 +564,39 @@ public class NettyResponseChannelTest {
     // no exception because onResponseComplete() swallows it.
     channel.writeInbound(RestTestUtils.createRequest(HttpMethod.GET, uri.toString(), null));
     assertFalse("Channel is not closed at the remote end", channel.isActive());
+  }
+
+  // writeMoreThanContentLengthTest() helpers.
+
+  /**
+   * Asks the server to write more data than the set Content-Length and checks behavior.
+   * @param chunkCount the number of chunks of {@link MockNettyMessageProcessor#CHUNK} to use to set Content-Length.
+   * @throws Exception
+   */
+  private void doWriteMoreThanContentLengthTest(int chunkCount)
+      throws Exception {
+    EmbeddedChannel channel = createEmbeddedChannel();
+    MockNettyMessageProcessor processor = channel.pipeline().get(MockNettyMessageProcessor.class);
+    HttpHeaders httpHeaders = new DefaultHttpHeaders();
+    httpHeaders.set(MockNettyMessageProcessor.CHUNK_COUNT_HEADER_NAME, chunkCount);
+    HttpRequest httpRequest =
+        RestTestUtils.createRequest(HttpMethod.POST, TestingUri.WriteMoreThanContentLength.toString(), httpHeaders);
+    HttpHeaders.setKeepAlive(httpRequest, false);
+    channel.writeInbound(httpRequest);
+
+    try {
+      verifyCallbacks(processor);
+      fail("One of the callbacks should have failed because the data written was more than Content-Length");
+    } catch (IllegalStateException e) {
+      // expected. Nothing to do.
+    }
+
+    // It doesn't matter what the response is - because it may either fail or succeed depending on certain race
+    // conditions. What matters is that the programming error is caught appropriately by NettyResponseChannel and it
+    // makes a callback with the right exception.
+    while (channel.readOutbound() != null) {
+    }
+    channel.close();
   }
 
   // headersPresenceTest() helpers
@@ -683,6 +766,10 @@ enum TestingUri {
    * When this request is received, a response with {@link RestUtils.Headers#CONTENT_LENGTH} set is returned.
    * The value of the header {@link MockNettyMessageProcessor#CHUNK_COUNT_HEADER_NAME} is used to determine the number
    * of chunks (each equal to {@link MockNettyMessageProcessor#CHUNK}) to return.
+   * <p/>
+   * The {@link RestUtils.Headers#CONTENT_LENGTH} is equal to the value in
+   * {@link MockNettyMessageProcessor#CHUNK_COUNT_HEADER_NAME} times the length of
+   * {@link MockNettyMessageProcessor#CHUNK}
    */
   ResponseWithContentLength,
   /**
@@ -706,6 +793,18 @@ enum TestingUri {
    * Fail a write with a {@link Throwable} to test reactions.
    */
   WriteFailureWithThrowable,
+  /**
+   * When this request is received, a response with {@link RestUtils.Headers#CONTENT_LENGTH} set is returned.
+   * The value of the header {@link MockNettyMessageProcessor#CHUNK_COUNT_HEADER_NAME} is used to determine the number
+   * of chunks (each equal to {@link MockNettyMessageProcessor#CHUNK}) to add to the response channel. The chunks added
+   * is one more than the value of {@link MockNettyMessageProcessor#CHUNK_COUNT_HEADER_NAME}. The last chunk write is
+   * checked for error.
+   * <p/>
+   * The {@link RestUtils.Headers#CONTENT_LENGTH} is equal to the value in
+   * {@link MockNettyMessageProcessor#CHUNK_COUNT_HEADER_NAME} times the length of
+   * {@link MockNettyMessageProcessor#CHUNK}
+   */
+  WriteMoreThanContentLength,
   /**
    * Catch all TestingUri.
    */
@@ -743,6 +842,9 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
   // 3. The last chunk will be sent as LastHttpContent.
   static final byte[] CHUNK = RestTestUtils.getRandomBytes(1024);
   static final String CHUNK_COUNT_HEADER_NAME = "chunkCount";
+
+  // the write callbacks to verify if any. This is reset at the beginning of every request.
+  final List<ChannelWriteCallback> writeCallbacksToVerify = new ArrayList<>();
 
   private ChannelHandlerContext ctx;
   private NettyRequest request;
@@ -787,6 +889,7 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
    */
   private void handleRequest(HttpRequest httpRequest)
       throws Exception {
+    writeCallbacksToVerify.clear();
     request = new NettyRequest(httpRequest, nettyMetrics);
     restResponseChannel = new NettyResponseChannel(ctx, nettyMetrics);
     restResponseChannel.setRequest(request);
@@ -805,8 +908,9 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
       case ImmediateResponseComplete:
         int chunkCount = HttpHeaders.getIntHeader(httpRequest, CHUNK_COUNT_HEADER_NAME, -1);
         if (chunkCount > 0) {
-          restResponseChannel.onResponseComplete(new IllegalStateException(
-              "Invalid value for header : [" + CHUNK_COUNT_HEADER_NAME + "]. Can only be 0 for [/" + uri + "]"));
+          restResponseChannel.onResponseComplete(new RestServiceException(
+              "Invalid value for header : [" + CHUNK_COUNT_HEADER_NAME + "]. Can only be 0 for [/" + uri + "]",
+              RestServiceErrorCode.BadRequest));
         } else if (chunkCount == 0) {
           restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
         }
@@ -850,9 +954,9 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
         break;
       case ResponseFailureMidway:
         ChannelWriteCallback callback = new ChannelWriteCallback();
-        callback.compareWithFuture(restResponseChannel
+        callback.setFuture(restResponseChannel
             .write(ByteBuffer.wrap(TestingUri.ResponseFailureMidway.toString().getBytes()), callback));
-        assertNull("There shouldn't have been any exceptions on the first write", callback.exception);
+        writeCallbacksToVerify.add(callback);
         restResponseChannel.onResponseComplete(new Exception());
         // this should close the channel and the test will check for that.
         break;
@@ -860,23 +964,20 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
         chunkCount = HttpHeaders.getIntHeader(httpRequest, CHUNK_COUNT_HEADER_NAME, -1);
         if (chunkCount == -1) {
           restResponseChannel.onResponseComplete(
-              new IllegalStateException("Request should contain header : [" + CHUNK_COUNT_HEADER_NAME + "]"));
+              new RestServiceException("Request should contain header : [" + CHUNK_COUNT_HEADER_NAME + "]",
+                  RestServiceErrorCode.BadRequest));
         } else {
           restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, chunkCount * CHUNK.length);
           if (chunkCount == 0) {
             // special case check
             callback = new ChannelWriteCallback();
-            callback.compareWithFuture(restResponseChannel.write(ByteBuffer.allocate(0), callback));
-            if (callback.exception != null) {
-              throw callback.exception;
-            }
+            callback.setFuture(restResponseChannel.write(ByteBuffer.allocate(0), callback));
+            writeCallbacksToVerify.add(callback);
           } else {
             for (int i = 0; i < chunkCount; i++) {
               callback = new ChannelWriteCallback();
-              callback.compareWithFuture(restResponseChannel.write(ByteBuffer.wrap(CHUNK), callback));
-              if (callback.exception != null) {
-                throw callback.exception;
-              }
+              callback.setFuture(restResponseChannel.write(ByteBuffer.wrap(CHUNK), callback));
+              writeCallbacksToVerify.add(callback);
             }
           }
           restResponseChannel.onResponseComplete(null);
@@ -898,16 +999,32 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
         restResponseChannel.close();
         assertFalse("Request channel is not closed", request.isOpen());
         callback = new ChannelWriteCallback();
-        callback.compareWithFuture(
+        callback.setFuture(
             restResponseChannel.write(ByteBuffer.wrap(TestingUri.WriteAfterClose.toString().getBytes()), callback));
-        if (callback.exception != null) {
-          throw callback.exception;
-        }
+        writeCallbacksToVerify.add(callback);
         break;
       case WriteFailureWithThrowable:
         callback = new ChannelWriteCallback();
-        callback.compareWithFuture(restResponseChannel
+        callback.setFuture(restResponseChannel
             .write(ByteBuffer.wrap(TestingUri.WriteFailureWithThrowable.toString().getBytes()), callback));
+        writeCallbacksToVerify.add(callback);
+        break;
+      case WriteMoreThanContentLength:
+        chunkCount = HttpHeaders.getIntHeader(httpRequest, CHUNK_COUNT_HEADER_NAME, -1);
+        if (chunkCount == -1) {
+          restResponseChannel.onResponseComplete(
+              new RestServiceException("Request should contain header : [" + CHUNK_COUNT_HEADER_NAME + "]",
+                  RestServiceErrorCode.BadRequest));
+        } else {
+          restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, chunkCount * CHUNK.length);
+          // write one more chunk than required.
+          for (int i = 0; i <= chunkCount; i++) {
+            callback = new ChannelWriteCallback();
+            callback.setFuture(restResponseChannel.write(ByteBuffer.wrap(CHUNK), callback));
+            writeCallbacksToVerify.add(callback);
+          }
+          restResponseChannel.onResponseComplete(null);
+        }
         break;
     }
   }
@@ -922,17 +1039,9 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
     if (request != null) {
       boolean isLast = httpContent instanceof LastHttpContent;
       ByteBuffer content = ByteBuffer.wrap(httpContent.content().array());
-      int bytesWritten = 0;
-      while (content.hasRemaining()) {
-        ChannelWriteCallback callback = new ChannelWriteCallback();
-        callback.compareWithFuture(restResponseChannel.write(content, callback));
-        if (callback.exception == null) {
-          bytesWritten += callback.result;
-        } else {
-          throw callback.exception;
-        }
-      }
-      assertEquals("Bytes written not equal to content size", httpContent.content().array().length, bytesWritten);
+      ChannelWriteCallback callback = new ChannelWriteCallback();
+      callback.setFuture(restResponseChannel.write(content, callback));
+      writeCallbacksToVerify.add(callback);
       if (isLast) {
         restResponseChannel.onResponseComplete(null);
         assertFalse("Request channel is not closed", request.isOpen());
@@ -1122,6 +1231,7 @@ class ChannelWriteCallback implements Callback<Long> {
    */
   public Exception exception = null;
   private CountDownLatch callbackReceived = new CountDownLatch(1);
+  private Future<Long> future;
 
   @Override
   public void onCompletion(Long result, Exception exception) {
@@ -1131,22 +1241,37 @@ class ChannelWriteCallback implements Callback<Long> {
   }
 
   /**
-   * Compares the data obtained from the callback with the data obtained from {@code future}.
-   * @param future the {@link Future} that represents the result of the same operation that this callback is meant for.
+   * Set the {@link Future} associated with the write for which this object is a callback.
+   * @param future the {@link Future} associated with the write for which this object is a callback.
+   */
+  void setFuture(Future<Long> future) {
+    this.future = future;
+  }
+
+  /**
+   * Compares the data obtained from the callback with the data obtained from future.
    * @throws InterruptedException
    * @throws TimeoutException
    */
-  public void compareWithFuture(Future<Long> future)
+  void compareWithFuture()
       throws InterruptedException, TimeoutException {
-    Long futureOutput;
+    Long futureResult = null;
+    Exception futureException = null;
     try {
-      futureOutput = future.get(1, TimeUnit.MILLISECONDS);
-      assertEquals("Future and callback results don't match", futureOutput, result);
+      futureResult = future.get(1, TimeUnit.MILLISECONDS);
     } catch (ExecutionException e) {
-      if (!callbackReceived.await(1, TimeUnit.MILLISECONDS)) {
-        throw new IllegalStateException("Callback has not been invoked even though future.get() has returned");
+      futureException = e;
+    }
+
+    if (!callbackReceived.await(1, TimeUnit.MILLISECONDS)) {
+      throw new IllegalStateException("Callback has not been invoked even though future.get() has returned");
+    } else {
+      if (futureException == null) {
+        assertEquals("Future and callback results don't match", futureResult, result);
+        assertNull("There should have been no exception in the callback", exception);
       } else {
-        assertEquals("Future and callback exceptions don't match", e.getCause().getMessage(), exception.getMessage());
+        assertEquals("Future and callback exceptions don't match", Utils.getRootCause(exception).getMessage(),
+            Utils.getRootCause(futureException).getMessage());
       }
     }
   }


### PR DESCRIPTION
Before this change, `LastHttpContent` was always empty and written to channel once all the real data had been written. With this change, empty `LastHttpContent` is written only in the case of responses with `Transfer-Encoding : Chunked`. If a response has `Content-Length` set, we now send back either a `FullHttpResponse` (in case `Content-Length` is 0) or make the last chunk `LastHttpContent` (if `Content-Length` > 0).

This continues the fix introduced in #345 and fixes another race condition. This also solves #346.
The race condition described in #346 can be detrimental if a new request arrives and the response to
that request starts being sent before the `LastHttpContent` of the previous request has been written out.

**Primary Reviewers : @pnarayanan**
**Expected time to review : 30 mins**

Built and formatted. 

**Unit test coverage**  

Class | Class, % | Method, % | Line, %
------- | ------------ | -------------- | ----------
NettyResponseChannel | 100% (8/ 8) | 100% (38/ 38) | 96.3% (313/ 325)

This is the race condition:-
The client has three events : 
1) Send a request with keep-alive requested.
2) Wait until response fully received (i.e. Content-Length number of bytes received).
3) Send the next request.

The front end (using `NettyResponseChannel`) has three events:
1) Receive request and send response (including headers and Content-Length number of bytes).
2) Finish up response by writing LastHttpContent to the channel.
3) Process the second request from the client and start sending response.

2) and 3) on the front end can happen in any order. If 3) happens before 2), we will have a problem