### PR TITLE
Fixing how selector handles preparation of ssl connections

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -330,7 +330,7 @@ public class Selector implements Selectable {
           /* if channel is not ready, finish prepare */
           if (transmission.isConnected() && !transmission.ready()) {
             transmission.prepare();
-            break;
+            continue;
           }
 
           if (key.isReadable() && transmission.ready()) {

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
@@ -213,6 +213,10 @@ public class SSLSelectorTest {
     Assert.assertTrue("Channel should have been ready by now ", selector.isChannelReady(connectionId));
   }
 
+  /**
+   * Test that preparation of a ssl connection doesn't starve other connections in queue
+   * @throws IOException
+   */
   @Test
   public void testSSLPrepare()
       throws IOException {
@@ -220,17 +224,17 @@ public class SSLSelectorTest {
     String connectionIdPlainText =
         selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.PLAINTEXT);
 
-    String connectionId =
+    String connectionIdSsl =
         selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.SSL);
 
     selector.poll(10000L);
-    Assert.assertTrue("Plain text channel should have been ready by now ",
-        selector.isChannelReady(connectionIdPlainText));
+    Assert.assertTrue("Plain text channel should been added to connected list ",
+        selector.connected().contains(connectionIdPlainText));
 
-    while (!selector.connected().contains(connectionId)) {
+    while (!selector.connected().contains(connectionIdSsl)) {
       selector.poll(10000L);
     }
-    Assert.assertTrue("Channel should have been ready by now ", selector.isChannelReady(connectionId));
+    Assert.assertTrue("Channel should have been ready by now ", selector.isChannelReady(connectionIdSsl));
   }
 
   @Test

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
@@ -213,30 +213,6 @@ public class SSLSelectorTest {
     Assert.assertTrue("Channel should have been ready by now ", selector.isChannelReady(connectionId));
   }
 
-  /**
-   * Test that preparation of a ssl connection doesn't starve other connections in queue
-   * @throws IOException
-   */
-  @Test
-  public void testSSLPrepare()
-      throws IOException {
-    // plain text connection should not starve or wait until ssl connection completes handshake
-    String connectionIdPlainText =
-        selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.PLAINTEXT);
-
-    String connectionIdSsl =
-        selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.SSL);
-
-    selector.poll(10000L);
-    Assert.assertTrue("Plain text channel should have been added to connected list ",
-        selector.connected().contains(connectionIdPlainText));
-
-    while (!selector.connected().contains(connectionIdSsl)) {
-      selector.poll(10000L);
-    }
-    Assert.assertTrue("Channel should have been ready by now ", selector.isChannelReady(connectionIdSsl));
-  }
-
   @Test
   public void testCloseAfterConnectCall()
       throws IOException {

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
@@ -214,6 +214,26 @@ public class SSLSelectorTest {
   }
 
   @Test
+  public void testSSLPrepare()
+      throws IOException {
+    // plain text connection should not starve or wait until ssl connection completes handshake
+    String connectionIdPlainText =
+        selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.PLAINTEXT);
+
+    String connectionId =
+        selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.SSL);
+
+    selector.poll(10000L);
+    Assert.assertTrue("Plain text channel should have been ready by now ",
+        selector.isChannelReady(connectionIdPlainText));
+
+    while (!selector.connected().contains(connectionId)) {
+      selector.poll(10000L);
+    }
+    Assert.assertTrue("Channel should have been ready by now ", selector.isChannelReady(connectionId));
+  }
+
+  @Test
   public void testCloseAfterConnectCall()
       throws IOException {
     String connectionId =

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
@@ -228,7 +228,7 @@ public class SSLSelectorTest {
         selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.SSL);
 
     selector.poll(10000L);
-    Assert.assertTrue("Plain text channel should been added to connected list ",
+    Assert.assertTrue("Plain text channel should have been added to connected list ",
         selector.connected().contains(connectionIdPlainText));
 
     while (!selector.connected().contains(connectionIdSsl)) {

--- a/config/frontend.ssl.properties
+++ b/config/frontend.ssl.properties
@@ -19,6 +19,7 @@ router.hostname=localhost
 router.datacenter.name=Datacenter
 ssl.enabled.datacenters=Datacenter
 router.put.success.target=1
+router.delete.success.target=1
 
 # coordinator
 coordinator.hostname=localhost


### PR DESCRIPTION
Selector breaks the while loop (when going through the selected keys) if any connection is not ready yet, after triggering a prepare() call. Ideally we should continue and not break as this would starve all other requests. 

SLA: 3 mins
Reviewers: Gopal, Ming