### PR TITLE
Fixing interim disconnections in Selector

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -72,7 +72,7 @@ public class Selector implements Selectable {
   private final List<NetworkSend> completedSends;
   private final List<NetworkReceive> completedReceives;
   private final List<String> disconnected;
-  private final List<String> interimDisconnectedList;
+  private final List<String> closedConnections;
   private final List<String> connected;
   private final Set<String> unreadyConnections;
   private final Time time;
@@ -93,7 +93,7 @@ public class Selector implements Selectable {
     this.completedReceives = new ArrayList<NetworkReceive>();
     this.connected = new ArrayList<String>();
     this.disconnected = new ArrayList<String>();
-    this.interimDisconnectedList = new ArrayList<>();
+    this.closedConnections = new ArrayList<>();
     this.metrics = metrics;
     this.IdGenerator = new AtomicLong(0);
     numActiveConnections = new AtomicLong(0);
@@ -361,8 +361,8 @@ public class Selector implements Selectable {
       checkUnreadyConnectionsStatus();
       this.metrics.selectorIORate.inc();
     }
-    disconnected.addAll(interimDisconnectedList);
-    interimDisconnectedList.clear();
+    disconnected.addAll(closedConnections);
+    closedConnections.clear();
     long endIo = time.milliseconds();
     this.metrics.selectorIOTime.update(endIo - endSelect);
   }
@@ -479,7 +479,7 @@ public class Selector implements Selectable {
     Transmission transmission = getTransmission(key);
     if (transmission != null) {
       logger.debug("Closing connection from {}", transmission.getConnectionId());
-      interimDisconnectedList.add(transmission.getConnectionId());
+      closedConnections.add(transmission.getConnectionId());
       keyMap.remove(transmission.getConnectionId());
       numActiveConnections.set(keyMap.size());
       unreadyConnections.remove(transmission.getConnectionId());

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -72,6 +72,7 @@ public class Selector implements Selectable {
   private final List<NetworkSend> completedSends;
   private final List<NetworkReceive> completedReceives;
   private final List<String> disconnected;
+  private final List<String> interimDisconnectedList;
   private final List<String> connected;
   private final Set<String> unreadyConnections;
   private final Time time;
@@ -92,6 +93,7 @@ public class Selector implements Selectable {
     this.completedReceives = new ArrayList<NetworkReceive>();
     this.connected = new ArrayList<String>();
     this.disconnected = new ArrayList<String>();
+    this.interimDisconnectedList = new ArrayList<>();
     this.metrics = metrics;
     this.IdGenerator = new AtomicLong(0);
     numActiveConnections = new AtomicLong(0);
@@ -359,6 +361,8 @@ public class Selector implements Selectable {
       checkUnreadyConnectionsStatus();
       this.metrics.selectorIORate.inc();
     }
+    disconnected.addAll(interimDisconnectedList);
+    interimDisconnectedList.clear();
     long endIo = time.milliseconds();
     this.metrics.selectorIOTime.update(endIo - endSelect);
   }
@@ -430,10 +434,10 @@ public class Selector implements Selectable {
    * Clear the results from the prior poll
    */
   private void clear() {
-    this.completedSends.clear();
-    this.completedReceives.clear();
-    this.connected.clear();
-    this.disconnected.clear();
+    completedSends.clear();
+    completedReceives.clear();
+    connected.clear();
+    disconnected.clear();
   }
 
   /**
@@ -475,8 +479,8 @@ public class Selector implements Selectable {
     Transmission transmission = getTransmission(key);
     if (transmission != null) {
       logger.debug("Closing connection from {}", transmission.getConnectionId());
-      this.disconnected.add(transmission.getConnectionId());
-      this.keyMap.remove(transmission.getConnectionId());
+      interimDisconnectedList.add(transmission.getConnectionId());
+      keyMap.remove(transmission.getConnectionId());
       numActiveConnections.set(keyMap.size());
       unreadyConnections.remove(transmission.getConnectionId());
       try {

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
@@ -219,6 +219,7 @@ public class SSLSelectorTest {
     String connectionId =
         selector.connect(new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE, PortType.SSL);
     selector.close(connectionId);
+    selector.poll(0);
     Assert.assertTrue("Channel should have been added to disconnected list",
         selector.disconnected().contains(connectionId));
   }

--- a/ambry-network/src/test/java/com.github.ambry.network/SelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SelectorTest.java
@@ -92,17 +92,17 @@ public class SelectorTest {
   }
 
   /**
-   * Validate that the client's connectionId is returned via disconnected list after closing
+   * Validate that a closed connectionId is returned via disconnected list after close
    */
   @Test
-  public void testClientClose()
+  public void testDisconnectedListOnClose()
       throws Exception {
     String connectionId = blockingConnect();
     selector.close(connectionId);
-    selector.poll(10);
-    assertEquals("Request should not have succeeded", 0, selector.completedSends().size());
+    selector.poll(0);
     assertEquals("There should be a disconnect", 1, selector.disconnected().size());
-    assertTrue("The disconnect should be from our node", selector.disconnected().contains(connectionId));
+    assertTrue("Expected connectionId " + connectionId + " missing from selector's disconnected list ",
+        selector.disconnected().contains(connectionId));
     connectionId = blockingConnect();
     assertEquals("hello2", blockingRequest(connectionId, "hello2"));
   }

--- a/ambry-network/src/test/java/com.github.ambry.network/SelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SelectorTest.java
@@ -103,6 +103,9 @@ public class SelectorTest {
     assertEquals("There should be a disconnect", 1, selector.disconnected().size());
     assertTrue("Expected connectionId " + connectionId + " missing from selector's disconnected list ",
         selector.disconnected().contains(connectionId));
+    // make sure that the connection id is not returned via disconnected list after another poll()
+    selector.poll(0);
+    assertEquals("Disconnect list should be empty", 0, selector.disconnected().size());
   }
 
   /**

--- a/ambry-network/src/test/java/com.github.ambry.network/SelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SelectorTest.java
@@ -98,6 +98,7 @@ public class SelectorTest {
   public void testDisconnectedListOnClose()
       throws Exception {
     String connectionId = blockingConnect();
+    assertEquals("Disconnect list should be empty", 0, selector.disconnected().size());
     selector.close(connectionId);
     selector.poll(0);
     assertEquals("There should be a disconnect", 1, selector.disconnected().size());

--- a/ambry-network/src/test/java/com.github.ambry.network/SelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SelectorTest.java
@@ -103,8 +103,6 @@ public class SelectorTest {
     assertEquals("There should be a disconnect", 1, selector.disconnected().size());
     assertTrue("Expected connectionId " + connectionId + " missing from selector's disconnected list ",
         selector.disconnected().contains(connectionId));
-    connectionId = blockingConnect();
-    assertEquals("hello2", blockingRequest(connectionId, "hello2"));
   }
 
   /**


### PR DESCRIPTION
Selector's disconnected list is cleared at the starting of every poll(). But it means that any disconnections, i.e. close that happens in between poll() calls are ignored. This patch fixes that.
Also, removed dead code in NetworkMetrics. Those metrics were never used. Their intention was to update Selector send/receive related metrics on per destination host basis which might be over kill. Hence removing it.

SLA: 10 mins
Reviewers: Gopal, Casey