### PR TITLE
Miscellaneous changes with rest request metrics tracking

### DIFF
--- a/ambry-admin/src/main/java/com.github.ambry.admin/AdminBlobStorageService.java
+++ b/ambry-admin/src/main/java/com.github.ambry.admin/AdminBlobStorageService.java
@@ -140,7 +140,6 @@ class AdminBlobStorageService implements BlobStorageService {
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       adminMetrics.getPreProcessingTimeInMs.update(preProcessingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(preProcessingTime);
     }
   }
 
@@ -167,7 +166,6 @@ class AdminBlobStorageService implements BlobStorageService {
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       adminMetrics.postPreProcessingTimeInMs.update(preProcessingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(preProcessingTime);
     }
   }
 
@@ -190,7 +188,6 @@ class AdminBlobStorageService implements BlobStorageService {
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       adminMetrics.deletePreProcessingTimeInMs.update(preProcessingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(preProcessingTime);
     }
   }
 
@@ -212,7 +209,6 @@ class AdminBlobStorageService implements BlobStorageService {
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       adminMetrics.headPreProcessingTimeInMs.update(preProcessingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(preProcessingTime);
     }
   }
 
@@ -325,7 +321,6 @@ class HeadForGetCallback implements Callback<BlobInfo> {
     try {
       long routerTime = processingStartTime - operationStartTime;
       adminBlobStorageService.adminMetrics.headForGetTimeInMs.update(routerTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(routerTime);
 
       String blobId = AdminBlobStorageService.getOperationOrBlobIdFromUri(restRequest);
       logger.trace("Callback received for HEAD before GET of {}", blobId);
@@ -348,7 +343,6 @@ class HeadForGetCallback implements Callback<BlobInfo> {
     } finally {
       long processingTime = System.currentTimeMillis() - processingStartTime;
       adminBlobStorageService.adminMetrics.headForGetCallbackProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
       if (exception != null) {
         adminBlobStorageService.adminMetrics.operationError.inc();
         adminBlobStorageService.submitResponse(restRequest, restResponseChannel, null, exception);
@@ -420,7 +414,6 @@ class GetCallback implements Callback<ReadableStreamChannel> {
     try {
       long routerTime = processingStartTime - operationStartTime;
       adminBlobStorageService.adminMetrics.getTimeInMs.update(routerTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(routerTime);
 
       String blobId = AdminBlobStorageService.getOperationOrBlobIdFromUri(restRequest);
       logger.trace("Callback received for GET of {}", blobId);
@@ -440,7 +433,6 @@ class GetCallback implements Callback<ReadableStreamChannel> {
     } finally {
       long processingTime = System.currentTimeMillis() - processingStartTime;
       adminBlobStorageService.adminMetrics.getCallbackProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
       if (exception != null) {
         adminBlobStorageService.adminMetrics.operationError.inc();
       }
@@ -489,7 +481,6 @@ class PostCallback implements Callback<String> {
     try {
       long routerTime = processingStartTime - operationStartTime;
       adminBlobStorageService.adminMetrics.postTimeInMs.update(routerTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(routerTime);
 
       logger.trace("Callback received for POST");
       restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
@@ -509,7 +500,6 @@ class PostCallback implements Callback<String> {
     } finally {
       long processingTime = System.currentTimeMillis() - processingStartTime;
       adminBlobStorageService.adminMetrics.postCallbackProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
       if (exception != null) {
         adminBlobStorageService.adminMetrics.operationError.inc();
       }
@@ -567,7 +557,6 @@ class DeleteCallback implements Callback<Void> {
     try {
       long routerTime = processingStartTime - operationStartTime;
       adminBlobStorageService.adminMetrics.deleteTimeInMs.update(routerTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(routerTime);
 
       String blobId = AdminBlobStorageService.getOperationOrBlobIdFromUri(restRequest);
       logger.trace("Callback received for DELETE of {}", blobId);
@@ -587,7 +576,6 @@ class DeleteCallback implements Callback<Void> {
     } finally {
       long processingTime = System.currentTimeMillis() - processingStartTime;
       adminBlobStorageService.adminMetrics.deleteCallbackProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
       if (exception != null) {
         adminBlobStorageService.adminMetrics.operationError.inc();
       }
@@ -633,7 +621,6 @@ class HeadCallback implements Callback<BlobInfo> {
     try {
       long routerTime = processingStartTime - operationStartTime;
       adminBlobStorageService.adminMetrics.headTimeInMs.update(routerTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(routerTime);
 
       String blobId = AdminBlobStorageService.getOperationOrBlobIdFromUri(restRequest);
       logger.trace("Callback received for HEAD of {}", blobId);
@@ -654,7 +641,6 @@ class HeadCallback implements Callback<BlobInfo> {
     } finally {
       long processingTime = System.currentTimeMillis() - processingStartTime;
       adminBlobStorageService.adminMetrics.headCallbackProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
       if (exception != null) {
         adminBlobStorageService.adminMetrics.operationError.inc();
       }

--- a/ambry-admin/src/main/java/com.github.ambry.admin/EchoHandler.java
+++ b/ambry-admin/src/main/java/com.github.ambry.admin/EchoHandler.java
@@ -62,7 +62,6 @@ class EchoHandler {
     } finally {
       long processingTime = System.currentTimeMillis() - startTime;
       adminMetrics.echoProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
     }
     return channel;
   }

--- a/ambry-admin/src/main/java/com.github.ambry.admin/GetReplicasForBlobIdHandler.java
+++ b/ambry-admin/src/main/java/com.github.ambry.admin/GetReplicasForBlobIdHandler.java
@@ -70,7 +70,6 @@ class GetReplicasForBlobIdHandler {
     } finally {
       long processingTime = System.currentTimeMillis() - startTime;
       adminMetrics.getReplicasForBlobIdProcessingTimeInMs.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
     }
     return channel;
   }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetrics.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetrics.java
@@ -36,7 +36,6 @@ public class RestRequestMetrics {
   static final String SC_RESPONSE_PROCESSING_WAIT_TIME_SUFFIX = "ScResponseProcessingWaitTimeInMs";
   static final String SC_ROUND_TRIP_TIME_SUFFIX = "ScRoundTripTimeInMs";
 
-  static final String TOTAL_CPU_TIME_SUFFIX = "TotalCpuTimeInMs";
   static final String OPERATION_RATE_SUFFIX = "Rate";
   static final String OPERATION_ERROR_SUFFIX = "Error";
 
@@ -50,7 +49,6 @@ public class RestRequestMetrics {
   final Histogram scResponseProcessingWaitTimeInMs;
   final Histogram scRoundTripTimeInMs;
 
-  final Histogram totalCpuTimeInMs;
   final Meter operationRate;
   final Counter operationError;
 
@@ -86,7 +84,6 @@ public class RestRequestMetrics {
     scRoundTripTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + SC_ROUND_TRIP_TIME_SUFFIX));
 
-    totalCpuTimeInMs = metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + TOTAL_CPU_TIME_SUFFIX));
     operationRate = metricRegistry.meter(MetricRegistry.name(ownerClass, requestType + OPERATION_RATE_SUFFIX));
     operationError = metricRegistry.counter(MetricRegistry.name(ownerClass, requestType + OPERATION_ERROR_SUFFIX));
   }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
@@ -70,8 +70,7 @@ public class RestRequestMetricsTracker {
     private long roundTripTimeInMs = 0;
 
     /**
-     * Adds to the time taken to process the request at the NIO layer. Also adds to the total time taken to service the
-     * request.
+     * Adds to the time taken to process the request at the NIO layer.
      * @param delta the time taken in ms to do the current piece of processing at the NIO layer for the request.
      * @return the total time taken in ms to process the request at the NIO layer, including the current piece, at this
      *          moment.
@@ -81,8 +80,7 @@ public class RestRequestMetricsTracker {
     }
 
     /**
-     * Adds to the time taken to process the response at the NIO layer. Also adds to the total time taken to service the
-     * request.
+     * Adds to the time taken to process the response at the NIO layer.
      * @param delta the time taken in ms to do the current piece of processing at the NIO layer for the response.
      * @return the total time taken in ms to process the response at the NIO layer, including the current piece, at this
      *          moment.
@@ -123,8 +121,7 @@ public class RestRequestMetricsTracker {
     private long roundTripTimeInMs = 0;
 
     /**
-     * Adds to the time taken to process a request at the scaling layer. Also adds to the total time taken to service
-     * the request.
+     * Adds to the time taken to process a request at the scaling layer.
      * @param delta the time taken in ms to do the current piece of processing at the scaling layer for the request.
      * @return the total time taken in ms to process this request at the scaling layer, including the current piece, at
      *          this moment.
@@ -134,8 +131,7 @@ public class RestRequestMetricsTracker {
     }
 
     /**
-     * Adds to the scaling layer processing wait time for a request. Also adds to the total time taken to service the
-     * request.
+     * Adds to the scaling layer processing wait time for a request.
      * @param delta the time in ms a request has spent waiting to be processed at the scaling layer.
      * @return the total time in ms this request has spent waiting to be processed at the scaling layer at this moment.
      */
@@ -144,8 +140,7 @@ public class RestRequestMetricsTracker {
     }
 
     /**
-     * Adds to the time taken to process a response at the scaling layer. Also adds to the total time taken to service
-     * the request.
+     * Adds to the time taken to process a response at the scaling layer.
      * @param delta the time taken in ms to do the current piece of processing at the scaling layer for the response.
      * @return the total time taken in ms to process the response at the scaling layer, including the current piece, at
      *          this moment.
@@ -155,8 +150,7 @@ public class RestRequestMetricsTracker {
     }
 
     /**
-     * Adds to the scaling layer processing wait time of a response. Also adds to the total time taken to service the
-     * request.
+     * Adds to the scaling layer processing wait time of a response.
      * @param delta the time in ms a response has spent waiting to be processed at the scaling layer.
      * @return the total time in ms this response has spent waiting to be processed at the scaling layer at this moment.
      */

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequestResponseHandler.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequestResponseHandler.java
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class MockRestRequestResponseHandler implements RestRequestHandler, RestResponseHandler {
   public static String RUNTIME_EXCEPTION_ON_HANDLE = "runtime.exception.on.handle";
   public static String REST_EXCEPTION_ON_HANDLE = "rest.exception.on.handle";
-  public static String CLOSE_REQUEST_ON_HANDLE = "close.request.on.handle";
 
   private boolean isRunning = false;
   private VerifiableProperties failureProperties = null;
@@ -178,13 +177,6 @@ public class MockRestRequestResponseHandler implements RestRequestHandler, RestR
           // it's alright.
         }
         throw new RestServiceException(REST_EXCEPTION_ON_HANDLE, errorCode);
-      } else if (failureProperties.containsKey(CLOSE_REQUEST_ON_HANDLE) && failureProperties
-          .getBoolean(CLOSE_REQUEST_ON_HANDLE)) {
-        try {
-          restRequest.close();
-        } catch (IOException e) {
-          throw new IllegalStateException(e);
-        }
       }
     }
     return failureProperties == null;

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
@@ -124,7 +124,7 @@ class TestMetrics {
   private final long scRequestProcessingWaitTime = random.nextInt(Integer.MAX_VALUE);
   private final long scResponseProcessingWaitTime = random.nextInt(Integer.MAX_VALUE);
 
-  private final long failedCount;
+  private final long operationErrorCount;
 
   /**
    * Creates a new instance by generating new random metrics and updating it in the given {@code requestMetrics}.
@@ -133,7 +133,7 @@ class TestMetrics {
    */
   protected TestMetrics(RestRequestMetricsTracker requestMetrics, boolean induceFailure) {
     updateMetrics(requestMetrics, induceFailure);
-    failedCount = induceFailure ? 1 : 0;
+    operationErrorCount = induceFailure ? 1 : 0;
   }
 
   /**
@@ -165,7 +165,7 @@ class TestMetrics {
 
     assertEquals("Rate metric has not fired", 1,
         metricRegistry.getMeters().get(metricPrefix + RestRequestMetrics.OPERATION_RATE_SUFFIX).getCount());
-    assertEquals("Error metric value is not as expected", failedCount,
+    assertEquals("Error metric value is not as expected", operationErrorCount,
         metricRegistry.getCounters().get(metricPrefix + RestRequestMetrics.OPERATION_ERROR_SUFFIX).getCount());
   }
 

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
@@ -34,8 +34,10 @@ public class RestRequestMetricsTrackerTest {
    */
   @Test
   public void commonCaseTest() {
-    withDefaultsTest();
-    withInjectedMetricsTest();
+    withDefaultsTest(false);
+    withDefaultsTest(true);
+    withInjectedMetricsTest(false);
+    withInjectedMetricsTest(true);
   }
 
   /**
@@ -78,38 +80,34 @@ public class RestRequestMetricsTrackerTest {
 
   /**
    * Tests recording of metrics without setting a custom {@link RestRequestMetrics}.
+   * @param induceFailure if {@code true}, the request is marked as failed.
    */
-  private void withDefaultsTest() {
+  private void withDefaultsTest(boolean induceFailure) {
     MetricRegistry metricRegistry = new MetricRegistry();
     RestRequestMetricsTracker.setDefaults(metricRegistry);
     RestRequestMetricsTracker requestMetrics = new RestRequestMetricsTracker();
-    TestMetrics testMetrics = new TestMetrics(requestMetrics);
-    long additionalTime = 20;
-    requestMetrics.addToTotalCpuTime(additionalTime);
-    requestMetrics.markFailure();
+    TestMetrics testMetrics = new TestMetrics(requestMetrics, induceFailure);
     requestMetrics.recordMetrics();
     String metricPrefix =
         RestRequestMetricsTracker.class.getCanonicalName() + "." + RestRequestMetricsTracker.DEFAULT_REQUEST_TYPE;
-    testMetrics.compareMetrics(metricPrefix, metricRegistry, additionalTime);
+    testMetrics.compareMetrics(metricPrefix, metricRegistry);
   }
 
   /**
    * Tests recording of metrics after setting a custom {@link RestRequestMetrics}.
+   * @param induceFailure if {@code true}, the request is marked as failed.
    */
-  private void withInjectedMetricsTest() {
+  private void withInjectedMetricsTest(boolean induceFailure) {
     MetricRegistry metricRegistry = new MetricRegistry();
     RestRequestMetricsTracker.setDefaults(metricRegistry);
     String testRequestType = "Test";
     RestRequestMetricsTracker requestMetrics = new RestRequestMetricsTracker();
     RestRequestMetrics restRequestMetrics = new RestRequestMetrics(getClass(), testRequestType, metricRegistry);
-    TestMetrics testMetrics = new TestMetrics(requestMetrics);
-    long additionalTime = 20;
-    requestMetrics.addToTotalCpuTime(additionalTime);
+    TestMetrics testMetrics = new TestMetrics(requestMetrics, induceFailure);
     requestMetrics.injectMetrics(restRequestMetrics);
-    requestMetrics.markFailure();
     requestMetrics.recordMetrics();
     String metricPrefix = getClass().getCanonicalName() + "." + testRequestType;
-    testMetrics.compareMetrics(metricPrefix, metricRegistry, additionalTime);
+    testMetrics.compareMetrics(metricPrefix, metricRegistry);
   }
 }
 
@@ -126,25 +124,25 @@ class TestMetrics {
   private final long scRequestProcessingWaitTime = random.nextInt(Integer.MAX_VALUE);
   private final long scResponseProcessingWaitTime = random.nextInt(Integer.MAX_VALUE);
 
+  private final long failedCount;
+
   /**
    * Creates a new instance by generating new random metrics and updating it in the given {@code requestMetrics}.
    * @param requestMetrics the instance of {@link RestRequestMetricsTracker} where metrics have to be updated.
+   * @param induceFailure if {@code true}, the request is marked as failed.
    */
-  protected TestMetrics(RestRequestMetricsTracker requestMetrics) {
-    updateMetrics(requestMetrics);
+  protected TestMetrics(RestRequestMetricsTracker requestMetrics, boolean induceFailure) {
+    updateMetrics(requestMetrics, induceFailure);
+    failedCount = induceFailure ? 1 : 0;
   }
 
   /**
    * Compares metrics generated inside this instance with what was recorded in the given {@code metricRegistry}.
    * @param metricPrefix the prefix of the metrics to look for.
    * @param metricRegistry the {@link MetricRegistry} where metrics were recorded.
-   * @param additionalTime any additional time added to the total time via a call to
-   *                        {@link RestRequestMetricsTracker#addToTotalCpuTime(long)}.
    */
-  protected void compareMetrics(String metricPrefix, MetricRegistry metricRegistry, long additionalTime) {
-    long totalTime = getTotalTime() + additionalTime;
+  protected void compareMetrics(String metricPrefix, MetricRegistry metricRegistry) {
     Map<String, Histogram> histograms = metricRegistry.getHistograms();
-
     assertEquals("NIO request processing time unequal", nioLayerRequestProcessingTime,
         histograms.get(metricPrefix + RestRequestMetrics.NIO_REQUEST_PROCESSING_TIME_SUFFIX).getSnapshot()
             .getValues()[0]);
@@ -165,19 +163,19 @@ class TestMetrics {
         histograms.get(metricPrefix + RestRequestMetrics.SC_RESPONSE_PROCESSING_WAIT_TIME_SUFFIX).getSnapshot()
             .getValues()[0]);
 
-    assertEquals("Request total CPU time unequal", totalTime,
-        histograms.get(metricPrefix + RestRequestMetrics.TOTAL_CPU_TIME_SUFFIX).getSnapshot().getValues()[0]);
     assertEquals("Rate metric has not fired", 1,
         metricRegistry.getMeters().get(metricPrefix + RestRequestMetrics.OPERATION_RATE_SUFFIX).getCount());
-    assertEquals("Error metric has not fired", 1,
+    assertEquals("Error metric value is not as expected", failedCount,
         metricRegistry.getCounters().get(metricPrefix + RestRequestMetrics.OPERATION_ERROR_SUFFIX).getCount());
   }
 
   /**
    * Updates the generated metrics in the given {@code restRequestMetricsTracker}.
-   * @param restRequestMetricsTracker the instance of {@link RestRequestMetricsTracker} where metrics have to be updated.
+   * @param restRequestMetricsTracker the instance of {@link RestRequestMetricsTracker} where metrics have to be
+   *                                  updated.
+   * @param induceFailure if {@code true}, the request is marked as failed.
    */
-  private void updateMetrics(RestRequestMetricsTracker restRequestMetricsTracker) {
+  private void updateMetrics(RestRequestMetricsTracker restRequestMetricsTracker, boolean induceFailure) {
     restRequestMetricsTracker.nioMetricsTracker.addToRequestProcessingTime(nioLayerRequestProcessingTime);
     restRequestMetricsTracker.nioMetricsTracker.addToResponseProcessingTime(nioLayerResponseProcessingTime);
 
@@ -185,14 +183,9 @@ class TestMetrics {
     restRequestMetricsTracker.scalingMetricsTracker.addToResponseProcessingTime(scResponseProcessingTime);
     restRequestMetricsTracker.scalingMetricsTracker.addToRequestProcessingWaitTime(scRequestProcessingWaitTime);
     restRequestMetricsTracker.scalingMetricsTracker.addToResponseProcessingWaitTime(scResponseProcessingWaitTime);
-  }
 
-  /**
-   * Gets the total time by adding all the metrics generated by this instance.
-   * @return the total time obtained by adding all the metrics generated by this instance.
-   */
-  private long getTotalTime() {
-    return nioLayerRequestProcessingTime + nioLayerResponseProcessingTime + scRequestProcessingTime +
-        scResponseProcessingTime + scRequestProcessingWaitTime + scResponseProcessingWaitTime;
+    if (induceFailure) {
+      restRequestMetricsTracker.markFailure();
+    }
   }
 }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -161,7 +161,6 @@ class AmbryBlobStorageService implements BlobStorageService {
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       frontendMetrics.getPreProcessingTimeInMs.update(preProcessingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(preProcessingTime);
     }
   }
 
@@ -190,7 +189,6 @@ class AmbryBlobStorageService implements BlobStorageService {
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       frontendMetrics.postPreProcessingTimeInMs.update(preProcessingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(preProcessingTime);
     }
   }
 
@@ -212,7 +210,6 @@ class AmbryBlobStorageService implements BlobStorageService {
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       frontendMetrics.deletePreProcessingTimeInMs.update(preProcessingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(preProcessingTime);
     }
   }
 
@@ -234,7 +231,6 @@ class AmbryBlobStorageService implements BlobStorageService {
       submitResponse(restRequest, restResponseChannel, null, e);
     } finally {
       frontendMetrics.headPreProcessingTimeInMs.update(preProcessingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(preProcessingTime);
     }
   }
 
@@ -547,7 +543,6 @@ class AmbryBlobStorageService implements BlobStorageService {
       processingStartTime = System.currentTimeMillis();
       long operationTime = processingStartTime - operationStartTime;
       operationTimeTracker.update(operationTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(operationTime);
     }
 
     /**
@@ -557,7 +552,6 @@ class AmbryBlobStorageService implements BlobStorageService {
       logger.trace("Callback for {} of {} finished", operationType, blobId);
       long processingTime = System.currentTimeMillis() - processingStartTime;
       callbackProcessingTimeTracker.update(processingTime);
-      restRequest.getMetricsTracker().addToTotalCpuTime(processingTime);
     }
   }
 

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
@@ -154,6 +154,7 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
             ctx.fireExceptionCaught(cause);
           }
         }
+        ctx.close();
       }
     } catch (Exception e) {
       String uri = (request != null) ? request.getUri() : null;
@@ -204,16 +205,17 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
     long currentTime = System.currentTimeMillis();
 
     boolean recognized = false;
+    boolean success = true;
     if (obj instanceof HttpRequest) {
       recognized = true;
-      handleRequest((HttpRequest) obj);
+      success = handleRequest((HttpRequest) obj);
     }
     // this is an if and not an else-if because a HttpObject can be both HttpRequest and HttpContent.
-    if (obj instanceof HttpContent) {
+    if (success && obj instanceof HttpContent) {
       recognized = true;
-      handleContent((HttpContent) obj);
+      success = handleContent((HttpContent) obj);
     }
-    if (!recognized) {
+    if (success && !recognized) {
       logger.warn("Received null/unrecognized HttpObject {} on channel {}", obj, ctx.channel());
       nettyMetrics.unknownHttpObjectError.inc();
       if (responseChannel == null || requestContentFullyReceived) {
@@ -238,10 +240,12 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
    * <p/>
    * In case of POST, delegates handling of {@link RestRequest} to the {@link RestRequestHandler}.
    * @param httpRequest the {@link HttpRequest} that needs to be handled.
+   * @return {@code true} if the handling succeeded without problems.
    * @throws RestServiceException if there is an error handling the current {@link HttpRequest}.
    */
-  private void handleRequest(HttpRequest httpRequest)
+  private boolean handleRequest(HttpRequest httpRequest)
       throws RestServiceException {
+    boolean success = true;
     if (responseChannel == null || requestContentFullyReceived) {
       // Once all content associated with a request has been received, this channel is clear to receive new requests.
       // If the client sends a request without waiting for the response, it is possible to screw things up a little
@@ -250,44 +254,49 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
       resetState();
       nettyMetrics.requestArrivalRate.mark();
       if (!httpRequest.getDecoderResult().isSuccess()) {
+        success = false;
         logger.warn("Decoder failed because of malformed request on channel {}", ctx.channel());
         nettyMetrics.malformedRequestError.inc();
-        throw new RestServiceException("Decoder failed because of malformed request",
-            RestServiceErrorCode.MalformedRequest);
-      }
-      try {
-        // We need to maintain state about the request itself for the subsequent parts (if any) that come in. We will
-        // attach content to the request as the content arrives.
-        if (HttpPostRequestDecoder.isMultipart(httpRequest)) {
-          nettyMetrics.multipartPostRequestRate.mark();
-          request = new NettyMultipartRequest(httpRequest, nettyMetrics);
-        } else {
-          request = new NettyRequest(httpRequest, nettyMetrics);
-        }
-        responseChannel.setRequest(request);
-        logger.trace("Channel {} now handling request {}", ctx.channel(), request.getUri());
-        // We send POST that is not multipart for handling immediately since we expect valid content with it that will
-        // be streamed in. In the case of POST that is multipart, all the content has to be received for Netty's
-        // decoder and NettyMultipartRequest to work. So it is scheduled for handling when LastHttpContent is received.
-        // With any other method that we support, we do not expect any valid content. LastHttpContent is a Netty thing.
-        // So we wait for LastHttpContent (throw an error if we don't receive it or receive something else) and then
-        // schedule the other methods for handling in handleContent().
-        if (request.getRestMethod().equals(RestMethod.POST) && !HttpPostRequestDecoder.isMultipart(httpRequest)) {
-          requestHandler.handleRequest(request, responseChannel);
-        }
-      } finally {
-        if (request != null) {
-          request.getMetricsTracker().nioMetricsTracker
-              .addToRequestProcessingTime(System.currentTimeMillis() - processingStartTime);
+        responseChannel.onResponseComplete(new RestServiceException("Decoder failed because of malformed request",
+            RestServiceErrorCode.MalformedRequest));
+      } else {
+        try {
+          // We need to maintain state about the request itself for the subsequent parts (if any) that come in. We will
+          // attach content to the request as the content arrives.
+          if (HttpPostRequestDecoder.isMultipart(httpRequest)) {
+            nettyMetrics.multipartPostRequestRate.mark();
+            request = new NettyMultipartRequest(httpRequest, nettyMetrics);
+          } else {
+            request = new NettyRequest(httpRequest, nettyMetrics);
+          }
+          responseChannel.setRequest(request);
+          logger.trace("Channel {} now handling request {}", ctx.channel(), request.getUri());
+          // We send POST that is not multipart for handling immediately since we expect valid content with it that will
+          // be streamed in. In the case of POST that is multipart, all the content has to be received for Netty's
+          // decoder and NettyMultipartRequest to work. So it is scheduled for handling when LastHttpContent is received.
+          // With any other method that we support, we do not expect any valid content. LastHttpContent is a Netty thing.
+          // So we wait for LastHttpContent (throw an error if we don't receive it or receive something else) and then
+          // schedule the other methods for handling in handleContent().
+          if (request.getRestMethod().equals(RestMethod.POST) && !HttpPostRequestDecoder.isMultipart(httpRequest)) {
+            requestHandler.handleRequest(request, responseChannel);
+          }
+        } finally {
+          if (request != null) {
+            request.getMetricsTracker().nioMetricsTracker
+                .addToRequestProcessingTime(System.currentTimeMillis() - processingStartTime);
+          }
         }
       }
     } else {
-      // We have received a request when we were not expecting one. This shouldn't happen and there is no good way to
-      // deal with it. So just update a metric and log an error.
-      logger.warn("Discarding unexpected request on channel {}. Request under processing: {}. Unexpected request: {}",
-          ctx.channel(), request.getUri(), httpRequest.getUri());
+      // We have received a request when we were not expecting one. This shouldn't happen and the channel is closed
+      // because it is in a bad state.
+      success = false;
+      logger.error("New request received when previous request is yet to be fully received on channel {}. Request under"
+          + " processing: {}. Unexpected request: {}", ctx.channel(), request.getUri(), httpRequest.getUri());
       nettyMetrics.duplicateRequestError.inc();
+      ctx.close();
     }
+    return success;
   }
 
   /**
@@ -298,10 +307,12 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
    * If the HTTP method for the request is something other than POST, delegates handling of {@link RestRequest} to the
    * {@link RestRequestHandler} when {@link LastHttpContent} is received.
    * @param httpContent the {@link HttpContent} that needs to be handled.
+   * @return {@code true} if the handling succeeded without problems.
    * @throws RestServiceException if there is an error handling the current {@link HttpContent}.
    */
-  private void handleContent(HttpContent httpContent)
+  private boolean handleContent(HttpContent httpContent)
       throws RestServiceException {
+    boolean success = true;
     if (request != null && !requestContentFullyReceived) {
       long processingStartTime = System.currentTimeMillis();
       nettyMetrics.bytesReadRate.mark(httpContent.content().readableBytes());
@@ -310,23 +321,27 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
       try {
         request.addContent(httpContent);
       } catch (IllegalStateException e) {
+        success = false;
         nettyMetrics.contentAdditionError.inc();
-        throw new RestServiceException(e, RestServiceErrorCode.InvalidRequestState);
+        responseChannel.onResponseComplete(new RestServiceException(e, RestServiceErrorCode.InvalidRequestState));
       } finally {
         long chunkProcessingTime = System.currentTimeMillis() - processingStartTime;
         nettyMetrics.requestChunkProcessingTimeInMs.update(chunkProcessingTime);
         request.getMetricsTracker().nioMetricsTracker.addToRequestProcessingTime(chunkProcessingTime);
       }
-      if (!request.getRestMethod().equals(RestMethod.POST) || (request.isMultipart() && requestContentFullyReceived)) {
+      if (success && (!request.getRestMethod().equals(RestMethod.POST) || (request.isMultipart()
+          && requestContentFullyReceived))) {
         requestHandler.handleRequest(request, responseChannel);
       }
     } else {
+      success = false;
       resetState();
       logger.warn("Received content when it was not expected on channel {}", ctx.channel());
       nettyMetrics.noRequestError.inc();
       responseChannel.onResponseComplete(
           new RestServiceException("Received content without a request", RestServiceErrorCode.InvalidRequestState));
     }
+    return success;
   }
 
   /**

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -57,6 +57,7 @@ public class NettyMetrics {
   public final Histogram errorResponseProcessingTimeInMs;
   public final Histogram headerSetTimeInMs;
   public final Histogram responseFinishProcessingTimeInMs;
+  public final Histogram responseMetadataAfterWriteProcessingTimeInMs;
   public final Histogram responseMetadataProcessingTimeInMs;
   public final Histogram writeProcessingTimeInMs;
   // PublicAccessLogHandler
@@ -167,6 +168,8 @@ public class NettyMetrics {
     headerSetTimeInMs = metricRegistry.histogram(MetricRegistry.name(NettyResponseChannel.class, "HeaderSetTimeInMs"));
     responseFinishProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(NettyResponseChannel.class, "ResponseFinishProcessingTimeInMs"));
+    responseMetadataAfterWriteProcessingTimeInMs = metricRegistry
+        .histogram(MetricRegistry.name(NettyResponseChannel.class, "ResponseMetadataAfterWriteProcessingTimeInMs"));
     responseMetadataProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(NettyResponseChannel.class, "ResponseMetadataProcessingTimeInMs"));
     writeProcessingTimeInMs =

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -81,7 +81,6 @@ class NettyResponseChannel implements RestResponseChannel {
   // tracks whether response metadata write has been initiated. Rejects any more attempts at writing metadata after this
   // has been set to true.
   private final AtomicBoolean responseMetadataWriteInitiated = new AtomicBoolean(false);
-  private final ResponseMetadataWriteListener responseMetadataWriteListener = new ResponseMetadataWriteListener();
   private final AtomicLong totalBytesReceived = new AtomicLong(0);
   private final Queue<Chunk> chunksToWrite = new ConcurrentLinkedQueue<Chunk>();
   private final Queue<Chunk> chunksAwaitingCallback = new ConcurrentLinkedQueue<Chunk>();
@@ -115,7 +114,7 @@ class NettyResponseChannel implements RestResponseChannel {
   public Future<Long> write(ByteBuffer src, Callback<Long> callback) {
     long writeProcessingStartTime = System.currentTimeMillis();
     if (!responseMetadataWriteInitiated.get()) {
-      maybeWriteResponseMetadata(responseMetadata, responseMetadataWriteListener);
+      maybeWriteResponseMetadata(responseMetadata, new ResponseMetadataWriteListener());
     }
     Chunk chunk = new Chunk(src, callback);
     chunksToWrite.add(chunk);
@@ -184,7 +183,7 @@ class NettyResponseChannel implements RestResponseChannel {
         logger.trace("Finished responding to current request on channel {}", ctx.channel());
         nettyMetrics.requestCompletionRate.mark();
         if (exception == null) {
-          if (!maybeWriteResponseMetadata(responseMetadata, responseMetadataWriteListener)) {
+          if (!maybeWriteResponseMetadata(responseMetadata, new ResponseMetadataWriteListener())) {
             // There were other writes. Let ChunkedWriteHandler finish if it has been kicked off.
             chunkedWriteHandler.resumeTransfer();
           }
@@ -751,6 +750,7 @@ class NettyResponseChannel implements RestResponseChannel {
    * Callback for writes of response metadata.
    */
   private class ResponseMetadataWriteListener implements GenericFutureListener<ChannelFuture> {
+    private final long responseWriteStartTime = System.currentTimeMillis();
 
     /**
      * If the operation completed successfully, a write via the {@link ChunkedWriteHandler} is initiated. Otherwise,
@@ -759,13 +759,14 @@ class NettyResponseChannel implements RestResponseChannel {
      */
     @Override
     public void operationComplete(ChannelFuture future) {
+      long writeFinishTime = System.currentTimeMillis();
       if (future.isSuccess()) {
         if (finalResponseMetadata instanceof LastHttpContent) {
           // this is the case if finalResponseMetadata is a FullHttpResponse.
           // in this case there is nothing more to write.
           if (!writeFuture.isDone()) {
             writeFuture.setSuccess();
-            completeRequest(request == null || !request.isKeepAlive());
+            completeRequest(!HttpHeaders.isKeepAlive(finalResponseMetadata));
           }
         } else {
           // otherwise there is some content to write.
@@ -775,6 +776,14 @@ class NettyResponseChannel implements RestResponseChannel {
         }
       } else {
         handleChannelWriteFailure(future.cause(), true);
+      }
+      long responseAfterWriteProcessingTime = System.currentTimeMillis() - writeFinishTime;
+      long channelWriteTime = writeFinishTime - responseWriteStartTime;
+      nettyMetrics.channelWriteTimeInMs.update(channelWriteTime);
+      nettyMetrics.responseMetadataAfterWriteProcessingTimeInMs.update(responseAfterWriteProcessingTime);
+      if (request != null) {
+        request.getMetricsTracker().nioMetricsTracker.addToResponseProcessingTime(channelWriteTime);
+        request.getMetricsTracker().nioMetricsTracker.addToResponseProcessingTime(responseAfterWriteProcessingTime);
       }
     }
   }
@@ -788,17 +797,20 @@ class NettyResponseChannel implements RestResponseChannel {
     @Override
     public void operationComplete(ChannelFuture future)
         throws Exception {
-      long channelWriteTime = System.currentTimeMillis() - responseWriteStartTime;
-      if (!future.isSuccess()) {
-        logger.error("Swallowing write exception encountered while sending error response to client on channel {}",
-            ctx.channel(), future.cause());
-        nettyMetrics.channelWriteError.inc();
+      long writeFinishTime = System.currentTimeMillis();
+      long channelWriteTime = writeFinishTime - responseWriteStartTime;
+      if (future.isSuccess()) {
+        completeRequest(!HttpHeaders.isKeepAlive(finalResponseMetadata));
+      } else {
+        handleChannelWriteFailure(future.cause(), true);
       }
+      long responseAfterWriteProcessingTime = System.currentTimeMillis() - writeFinishTime;
       nettyMetrics.channelWriteTimeInMs.update(channelWriteTime);
+      nettyMetrics.responseMetadataAfterWriteProcessingTimeInMs.update(responseAfterWriteProcessingTime);
       if (request != null) {
         request.getMetricsTracker().nioMetricsTracker.addToResponseProcessingTime(channelWriteTime);
+        request.getMetricsTracker().nioMetricsTracker.addToResponseProcessingTime(responseAfterWriteProcessingTime);
       }
-      completeRequest(!HttpHeaders.isKeepAlive(finalResponseMetadata) || !future.isSuccess());
     }
   }
 

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -636,8 +636,8 @@ class NettyResponseChannel implements RestResponseChannel {
       nettyMetrics.channelWriteTimeInMs.update(chunkWriteTime);
       nettyMetrics.chunkResolutionProcessingTimeInMs.update(chunkResolutionProcessingTime);
       if (request != null) {
-        request.getMetricsTracker().nioMetricsTracker.addToResponseProcessingTime(chunkWriteTime);
-        request.getMetricsTracker().nioMetricsTracker.addToResponseProcessingTime(chunkResolutionProcessingTime);
+        request.getMetricsTracker().nioMetricsTracker
+            .addToResponseProcessingTime(chunkWriteTime + chunkResolutionProcessingTime);
       }
     }
   }
@@ -782,8 +782,8 @@ class NettyResponseChannel implements RestResponseChannel {
       nettyMetrics.channelWriteTimeInMs.update(channelWriteTime);
       nettyMetrics.responseMetadataAfterWriteProcessingTimeInMs.update(responseAfterWriteProcessingTime);
       if (request != null) {
-        request.getMetricsTracker().nioMetricsTracker.addToResponseProcessingTime(channelWriteTime);
-        request.getMetricsTracker().nioMetricsTracker.addToResponseProcessingTime(responseAfterWriteProcessingTime);
+        request.getMetricsTracker().nioMetricsTracker
+            .addToResponseProcessingTime(channelWriteTime + responseAfterWriteProcessingTime);
       }
     }
   }
@@ -808,8 +808,8 @@ class NettyResponseChannel implements RestResponseChannel {
       nettyMetrics.channelWriteTimeInMs.update(channelWriteTime);
       nettyMetrics.responseMetadataAfterWriteProcessingTimeInMs.update(responseAfterWriteProcessingTime);
       if (request != null) {
-        request.getMetricsTracker().nioMetricsTracker.addToResponseProcessingTime(channelWriteTime);
-        request.getMetricsTracker().nioMetricsTracker.addToResponseProcessingTime(responseAfterWriteProcessingTime);
+        request.getMetricsTracker().nioMetricsTracker
+            .addToResponseProcessingTime(channelWriteTime + responseAfterWriteProcessingTime);
       }
     }
   }

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
@@ -233,12 +233,6 @@ public class NettyMessageProcessorTest {
           RestServiceErrorCode.InternalServerError.toString());
       requestHandler.breakdown(new VerifiableProperties(properties));
       doRequestHandlerExceptionTest(HttpMethod.GET, HttpResponseStatus.INTERNAL_SERVER_ERROR);
-
-      // ClosedChannelException
-      properties.clear();
-      properties.setProperty(MockRestRequestResponseHandler.CLOSE_REQUEST_ON_HANDLE, "true");
-      requestHandler.breakdown(new VerifiableProperties(properties));
-      doRequestHandlerExceptionTest(HttpMethod.POST, HttpResponseStatus.INTERNAL_SERVER_ERROR);
     } finally {
       requestHandler.fix();
     }


### PR DESCRIPTION
1. Removed the "Total CPU time" metric. It is not very useful and requires an additional call to record and creates room for error and confusion.
2. Fixing the way request rates are tracked. If a more fine grained metrics object is injected after a coarse grained one had been injected before, both their rate metrics used to fire. This is fixed.
3. Accounted for some latencies that were untracked and flying under the radar in `NettyResponseChannel`.
4. Removed double logging in `NettyMessageProcessor`, fixed some `try..finally` blocks and removed some unnecessary code.

Built and formatted. Metrics verified via Jconsole.

**Primary reviewers: @nsivabalan , @cgtz**
**Expected time to review: 20 mins**

**Unit test coverage**  

Class | Class, % | Method, % | Line, %
------- | ------------ | -------------- | ----------
`RestRequestMetricsTracker` | 100% (3/ 3) | 100% (17/ 17) | 98% (50/ 51)
`NettyMessageProcessor` | 100% (1/ 1) | 88.9% (8/ 9) | 75.7% (81/ 107)
`NettyResponseChannel` | 100% (8/ 8) | 100% (38/ 38) | 96.4% (325/ 337)