### PR TITLE
Handle exceptions in operation poll/handleResponse

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -170,8 +170,10 @@ class DeleteManager {
     }
     routerMetrics.operationDequeuingRate.mark();
     routerMetrics.deleteBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmissionTimeMs());
-    operationCompleteCallback.completeOperation(op.getFutureResult(), op.getCallback(), op.getOperationResult(),
-        op.getOperationException());
+    if (op.setCallbackInvoked()) {
+      operationCompleteCallback.completeOperation(op.getFutureResult(), op.getCallback(), op.getOperationResult(),
+          op.getOperationException());
+    }
   }
 
   /**
@@ -199,7 +201,9 @@ class DeleteManager {
       routerMetrics.operationAbortCount.inc();
       routerMetrics.deleteBlobErrorCount.inc();
       routerMetrics.countError(abortCause);
-      operationCompleteCallback.completeOperation(op.getFutureResult(), op.getCallback(), null, abortCause);
+      if (op.setCallbackInvoked()) {
+        operationCompleteCallback.completeOperation(op.getFutureResult(), op.getCallback(), null, abortCause);
+      }
     }
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -202,12 +202,4 @@ class DeleteManager {
       }
     }
   }
-
-  /**
-   * Remove an operation from the set and abort.
-   * @param op the operation to abort
-   * @param abortCause the reason for aborting
-   */
-  private void removeAndAbort(DeleteOperation op, Exception abortCause) {
-  }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -66,8 +66,6 @@ class DeleteOperation {
   // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable
   // failure.
   private final AtomicReference<Exception> operationException = new AtomicReference<Exception>();
-  private final OperationCompleteCallback operationCompleteCallback;
-  private final AtomicBoolean operationCallbackInvoked = new AtomicBoolean(false);
   // RouterErrorCode that is resolved from all the received ServerErrorCode for this operation.
   private RouterErrorCode resolvedRouterErrorCode;
   // Denotes whether the operation is complete.
@@ -86,8 +84,7 @@ class DeleteOperation {
    * @param time A {@link Time} reference.
    */
   DeleteOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ResponseHandler responsehandler,
-      BlobId blobId, FutureResult<Void> futureResult, Callback<Void> callback,
-      OperationCompleteCallback operationCompleteCallback, Time time) {
+      BlobId blobId, FutureResult<Void> futureResult, Callback<Void> callback, Time time) {
     this.submissionTimeMs = time.milliseconds();
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
@@ -95,7 +92,6 @@ class DeleteOperation {
     this.blobId = blobId;
     this.futureResult = futureResult;
     this.callback = callback;
-    this.operationCompleteCallback = operationCompleteCallback;
     this.time = time;
     this.deleteRequestInfos = new HashMap<Integer, DeleteRequestInfo>();
     this.operationTracker = new SimpleOperationTracker(routerConfig.routerDatacenterName, blobId.getPartition(), true,
@@ -372,28 +368,6 @@ class DeleteOperation {
    */
   void setOperationException(Exception exception) {
     operationException.set(exception);
-  }
-
-  /**
-   * Invoke the {@link OperationCompleteCallback} with a specified exception if it has not been invoked yet
-   * for this operation.
-   * @param exception Send this exception to the callback
-   */
-  void invokeOperationCompleteCallback(Exception exception) {
-    if (operationCompleteCallback != null && operationCallbackInvoked.compareAndSet(false, true)) {
-      operationCompleteCallback.completeOperation(getFutureResult(), getCallback(), null, exception);
-    }
-  }
-
-  /**
-   * Invoke the {@link OperationCompleteCallback} with the operation result and exception if it has not been invoked yet
-   * for this operation.
-   */
-  void invokeOperationCompleteCallback() {
-    if (operationCompleteCallback != null && operationCallbackInvoked.compareAndSet(false, true)) {
-      operationCompleteCallback.completeOperation(getFutureResult(), getCallback(), getOperationResult(),
-          getOperationException());
-    }
   }
 
   long getSubmissionTimeMs() {

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -48,7 +48,6 @@ import org.slf4j.LoggerFactory;
  */
 class GetBlobInfoOperation extends GetOperation<BlobInfo> {
   private final OperationCompleteCallback operationCompleteCallback;
-  private final AtomicBoolean operationCallbackInvoked = new AtomicBoolean(false);
   private final SimpleOperationTracker operationTracker;
   // map of correlation id to the request metadata for every request issued for this operation.
   private final Map<Integer, GetRequestInfo> correlationIdToGetRequestInfo = new TreeMap<Integer, GetRequestInfo>();
@@ -81,9 +80,7 @@ class GetBlobInfoOperation extends GetOperation<BlobInfo> {
 
   @Override
   void abort(Exception abortCause) {
-    if (operationCallbackInvoked.compareAndSet(false, true)) {
-      operationCompleteCallback.completeOperation(operationFuture, operationCallback, null, abortCause);
-    }
+    operationCompleteCallback.completeOperation(operationFuture, operationCallback, null, abortCause);
     operationCompleted = true;
   }
 
@@ -311,7 +308,7 @@ class GetBlobInfoOperation extends GetOperation<BlobInfo> {
       operationCompleted = true;
     }
 
-    if (operationCompleted && operationCallbackInvoked.compareAndSet(false, true)) {
+    if (operationCompleted) {
       Exception e = operationException.get();
       if (e != null) {
         routerMetrics.getBlobInfoErrorCount.inc();

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -216,7 +216,7 @@ class GetManager {
     if (remove(op)) {
       op.abort(abortCause);
       routerMetrics.operationAbortCount.inc();
-      routerMetrics.countError(e);
+      routerMetrics.countError(abortCause);
     }
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -117,7 +117,7 @@ class PutManager {
     try {
       PutOperation putOperation =
           new PutOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobProperties, userMetaData,
-              channel, futureResult, callback, time);
+              channel, futureResult, callback, operationCompleteCallback, time);
       putOperations.add(putOperation);
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
@@ -200,10 +200,7 @@ class PutManager {
     }
     routerMetrics.operationDequeuingRate.mark();
     routerMetrics.putBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmissionTimeMs());
-    if (op.setCallbackInvoked()) {
-      operationCompleteCallback.completeOperation(op.getFuture(), op.getCallback(), op.getBlobIdString(),
-          op.getOperationException());
-    }
+    op.invokeOperationCompleteCallback();
   }
 
   /**
@@ -257,9 +254,7 @@ class PutManager {
       routerMetrics.putBlobErrorCount.inc();
       routerMetrics.countError(abortCause);
       op.setOperationException(abortCause);
-      if (op.setCallbackInvoked()) {
-        operationCompleteCallback.completeOperation(op.getFuture(), op.getCallback(), null, abortCause);
-      }
+      op.invokeOperationCompleteCallback(abortCause);
     }
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -117,7 +117,7 @@ class PutManager {
     try {
       PutOperation putOperation =
           new PutOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobProperties, userMetaData,
-              channel, futureResult, callback, operationCompleteCallback, time);
+              channel, futureResult, callback, time);
       putOperations.add(putOperation);
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
@@ -140,14 +140,16 @@ class PutManager {
     for (PutOperation op : putOperations) {
       try {
         op.poll(requestRegistrationCallback);
-        if (op.isOperationComplete() && putOperations.remove(op)) {
-          // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
-          // operation actually gets removed from the set of operations. See comment within closePendingOperations().
-          onComplete(op);
-        }
       } catch (Exception e) {
-        removeAndAbort(op,
+        // This call sets the operation as completed.  If this is changed, we will need a flag to ensure the callback
+        // is called.
+        op.setOperationException(
             new RouterException("Put poll encountered unexpected error", e, RouterErrorCode.UnexpectedInternalError));
+      }
+      if (op.isOperationComplete() && putOperations.remove(op)) {
+        // In order to ensure that an operation is completed only once, call onComplete() only at the place where the
+        // operation actually gets removed from the set of operations. See comment within closePendingOperations().
+        onComplete(op);
       }
     }
   }
@@ -164,12 +166,14 @@ class PutManager {
     if (putOperations.contains(putOperation)) {
       try {
         putOperation.handleResponse(responseInfo);
-        if (putOperation.isOperationComplete() && putOperations.remove(putOperation)) {
-          onComplete(putOperation);
-        }
       } catch (Exception e) {
-        removeAndAbort(putOperation, new RouterException("Put handleResponse encountered unexpected error", e,
+        // This call sets the operation as completed.  If this is changed, we will need a flag to ensure the callback
+        // is called.
+        putOperation.setOperationException(new RouterException("Put handleResponse encountered unexpected error", e,
             RouterErrorCode.UnexpectedInternalError));
+      }
+      if (putOperation.isOperationComplete() && putOperations.remove(putOperation)) {
+        onComplete(putOperation);
       }
     } else {
       routerMetrics.ignoredResponseCount.inc();
@@ -200,7 +204,8 @@ class PutManager {
     }
     routerMetrics.operationDequeuingRate.mark();
     routerMetrics.putBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmissionTimeMs());
-    op.invokeOperationCompleteCallback();
+    operationCompleteCallback.completeOperation(op.getFuture(), op.getCallback(), op.getBlobIdString(),
+        op.getOperationException());
   }
 
   /**
@@ -234,27 +239,17 @@ class PutManager {
    */
   void completePendingOperations() {
     for (PutOperation op : putOperations) {
-      removeAndAbort(op,
-          new RouterException("Aborted operation because Router is closed.", RouterErrorCode.RouterClosed));
-    }
-  }
-
-  /**
-   * Remove an operation from the set and abort.
-   * @param op the operation to abort
-   * @param abortCause the reason for aborting
-   */
-  private void removeAndAbort(PutOperation op, Exception abortCause) {
-    // There is a rare scenario where the operation gets removed from this set and gets completed concurrently by
-    // the RequestResponseHandler thread when it is in poll() or handleResponse(). In order to avoid the completion
-    // from happening twice, complete it here only if the remove was successful.
-    if (putOperations.remove(op)) {
-      routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.operationAbortCount.inc();
-      routerMetrics.putBlobErrorCount.inc();
-      routerMetrics.countError(abortCause);
-      op.setOperationException(abortCause);
-      op.invokeOperationCompleteCallback(abortCause);
+      // There is a rare scenario where the operation gets removed from this set and gets completed concurrently by
+      // the RequestResponseHandler thread when it is in poll() or handleResponse(). In order to avoid the completion
+      // from happening twice, complete it here only if the remove was successful.
+      if (putOperations.remove(op)) {
+        Exception e = new RouterException("Aborted operation because Router is closed.", RouterErrorCode.RouterClosed);
+        routerMetrics.operationDequeuingRate.mark();
+        routerMetrics.operationAbortCount.inc();
+        routerMetrics.putBlobErrorCount.inc();
+        routerMetrics.countError(e);
+        operationCompleteCallback.completeOperation(op.getFuture(), op.getCallback(), null, e);
+      }
     }
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -141,9 +141,7 @@ class PutManager {
       try {
         op.poll(requestRegistrationCallback);
       } catch (Exception e) {
-        // This call sets the operation as completed.  If this is changed, we will need a flag to ensure the callback
-        // is called.
-        op.setOperationException(
+        op.setOperationExceptionAndComplete(
             new RouterException("Put poll encountered unexpected error", e, RouterErrorCode.UnexpectedInternalError));
       }
       if (op.isOperationComplete() && putOperations.remove(op)) {
@@ -167,9 +165,7 @@ class PutManager {
       try {
         putOperation.handleResponse(responseInfo);
       } catch (Exception e) {
-        // This call sets the operation as completed.  If this is changed, we will need a flag to ensure the callback
-        // is called.
-        putOperation.setOperationException(new RouterException("Put handleResponse encountered unexpected error", e,
+        putOperation.setOperationExceptionAndComplete(new RouterException("Put handleResponse encountered unexpected error", e,
             RouterErrorCode.UnexpectedInternalError));
       }
       if (putOperation.isOperationComplete() && putOperations.remove(putOperation)) {

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -179,9 +179,9 @@ class PutOperation {
       @Override
       public void onCompletion(Long result, Exception exception) {
         if (exception != null) {
-          setOperationException(exception);
+          setOperationExceptionAndComplete(exception);
         } else if (result != blobSize) {
-          setOperationException(new RouterException("Incorrect number of bytes: " + result +
+          setOperationExceptionAndComplete(new RouterException("Incorrect number of bytes: " + result +
               " read in from the channel, expected: " + blobSize, RouterErrorCode.BadInputChannel));
         }
       }
@@ -317,7 +317,7 @@ class PutOperation {
         }
       }
     } catch (Exception e) {
-      setOperationException(new RouterException("PutOperation fillChunks encountered unexpected error", e,
+      setOperationExceptionAndComplete(new RouterException("PutOperation fillChunks encountered unexpected error", e,
           RouterErrorCode.UnexpectedInternalError));
     }
   }
@@ -423,7 +423,7 @@ class PutOperation {
    * Set the irrecoverable exception associated with this operation. When this is called, the operation has failed.
    * @param exception the irrecoverable exception associated with this operation.
    */
-  void setOperationException(Exception exception) {
+  void setOperationExceptionAndComplete(Exception exception) {
     operationException.set(exception);
     operationCompleted = true;
   }
@@ -620,7 +620,7 @@ class PutOperation {
         correlationIdToChunkPutRequestInfo.clear();
         state = ChunkState.Ready;
       } catch (RouterException e) {
-        setOperationException(e);
+        setOperationExceptionAndComplete(e);
       }
     }
 
@@ -670,7 +670,7 @@ class PutOperation {
           } else {
             // this chunk could not be successfully put. The whole operation has to fail.
             chunkBlobId = null;
-            setOperationException(chunkException);
+            setOperationExceptionAndComplete(chunkException);
             done = true;
           }
         } else {

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,6 +113,8 @@ class PutOperation {
   // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable
   // failure.
   private final AtomicReference<Exception> operationException = new AtomicReference<Exception>();
+  // marks if the callback has been invoked
+  private final AtomicBoolean operationCallbackInvoked = new AtomicBoolean(false);
   // To find the PutChunk to hand over the response quickly.
   private final Map<Integer, PutChunk> correlationIdToPutChunk = new HashMap<Integer, PutChunk>();
   // The time at which the operation was submitted.
@@ -426,6 +429,14 @@ class PutOperation {
   void setOperationException(Exception exception) {
     operationException.set(exception);
     operationCompleted = true;
+  }
+
+  /**
+   * Return {@code true} if callback has not been invoked yet and mark the callback as invoked.
+   * @return {@code true} if callback has not been invoked, {@code false} otherwise
+   */
+  boolean setCallbackInvoked() {
+    return operationCallbackInvoked.compareAndSet(false, true);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -113,7 +113,7 @@ public class ChunkFillTest {
     final MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize);
     FutureResult<String> futureResult = new FutureResult<String>();
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
-        putUserMetadata, putChannel, futureResult, null, null, new MockTime());
+        putUserMetadata, putChannel, futureResult, null, new MockTime());
     numChunks = op.getNumDataChunks();
     // largeBlobSize is not a multiple of chunkSize
     int expectedNumChunks = (int) (blobSize / chunkSize + 1);
@@ -195,7 +195,7 @@ public class ChunkFillTest {
     final ReadableStreamChannel putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(putContent));
     FutureResult<String> futureResult = new FutureResult<String>();
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
-        putUserMetadata, putChannel, futureResult, null, null, new MockTime());
+        putUserMetadata, putChannel, futureResult, null, new MockTime());
     numChunks = op.getNumDataChunks();
     compositeBuffers = new ByteBuffer[numChunks];
     final AtomicReference<Exception> operationException = new AtomicReference<Exception>(null);

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -113,7 +113,7 @@ public class ChunkFillTest {
     final MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize);
     FutureResult<String> futureResult = new FutureResult<String>();
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
-        putUserMetadata, putChannel, futureResult, null, new MockTime());
+        putUserMetadata, putChannel, futureResult, null, null, new MockTime());
     numChunks = op.getNumDataChunks();
     // largeBlobSize is not a multiple of chunkSize
     int expectedNumChunks = (int) (blobSize / chunkSize + 1);
@@ -195,7 +195,7 @@ public class ChunkFillTest {
     final ReadableStreamChannel putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(putContent));
     FutureResult<String> futureResult = new FutureResult<String>();
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
-        putUserMetadata, putChannel, futureResult, null, new MockTime());
+        putUserMetadata, putChannel, futureResult, null, null, new MockTime());
     numChunks = op.getNumDataChunks();
     compositeBuffers = new ByteBuffer[numChunks];
     final AtomicReference<Exception> operationException = new AtomicReference<Exception>(null);

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -26,6 +26,7 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -121,20 +122,30 @@ public class DeleteManagerTest {
     Arrays.fill(serverErrorCodes, ServerErrorCode.No_Error);
     presetServerErrorCode(serverErrorCodes);
     final CountDownLatch callbackCalled = new CountDownLatch(1);
-    router.deleteBlob(blobIdString, new Callback<Void>() {
-      @Override
-      public void onCompletion(Void result, Exception exception) {
-        callbackCalled.countDown();
-        throw new RuntimeException("Throwing an exception in the user callback");
+    List<Future> futures = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      if (i == 1) {
+        futures.add(router.deleteBlob(blobIdString, new Callback<Void>() {
+          @Override
+          public void onCompletion(Void result, Exception exception) {
+            callbackCalled.countDown();
+            throw new RuntimeException("Throwing an exception in the user callback");
+          }
+        }));
+      } else {
+        futures.add(router.deleteBlob(blobIdString));
       }
-    }).get();
+    }
+    for (Future future : futures) {
+      future.get();
+    }
     Assert.assertTrue("Callback not called.", callbackCalled.await(2, TimeUnit.SECONDS));
     Assert.assertEquals("All operations should be finished.", 0, router.getOperationsCount());
     Assert.assertTrue("Router should not be closed", router.isOpen());
 
     //Test that DeleteManager is still operational
-    future = router.deleteBlob(blobIdString, new ClientCallback());
-    future.get();
+    router.deleteBlob(blobIdString, new ClientCallback()).get();
+    Assert.assertTrue("Callback not called.", operationCompleteLatch.await(2, TimeUnit.SECONDS));
   }
 
   /**
@@ -191,8 +202,8 @@ public class DeleteManagerTest {
     map.put(ServerErrorCode.Partition_Unknown, RouterErrorCode.BlobDoesNotExist);
     map.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
     for (ServerErrorCode serverErrorCode : ServerErrorCode.values()) {
-      if (serverErrorCode != ServerErrorCode.No_Error && serverErrorCode != ServerErrorCode.Blob_Deleted && !map
-          .containsKey(serverErrorCode)) {
+      if (serverErrorCode != ServerErrorCode.No_Error && serverErrorCode != ServerErrorCode.Blob_Deleted
+          && !map.containsKey(serverErrorCode)) {
         map.put(serverErrorCode, RouterErrorCode.UnexpectedInternalError);
       }
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -99,7 +99,7 @@ public class PutOperationTest {
     FutureResult<String> future = new FutureResult<>();
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobProperties, userMetadata,
-            channel, future, null, null, time);
+            channel, future, null, time);
     List<RequestInfo> requestInfos = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestInfos;
     // Since this channel is in memory, one call to fill chunks would end up filling the maximum number of PutChunks.

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -152,8 +152,8 @@ public class PutOperationTest {
     // reset the correlation id as they will be different between the two requests.
     resetCorrelationId(expectedRequestContent);
     resetCorrelationId(savedRequestContent);
-    Assert
-        .assertArrayEquals("Underlying buffer should not have be reused", expectedRequestContent, savedRequestContent);
+    Assert.assertArrayEquals("Underlying buffer should not have be reused", expectedRequestContent,
+        savedRequestContent);
 
     // now that all the requests associated with the original buffer have been read,
     // the next poll will free this buffer. We cannot actually verify it via the tests directly, as this is very

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -99,7 +99,7 @@ public class PutOperationTest {
     FutureResult<String> future = new FutureResult<>();
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobProperties, userMetadata,
-            channel, future, null, time);
+            channel, future, null, null, time);
     List<RequestInfo> requestInfos = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestInfos;
     // Since this channel is in memory, one call to fill chunks would end up filling the maximum number of PutChunks.


### PR DESCRIPTION
This addresses issue #333.

**Changes:**
- Catch unhandled exceptions within `poll` and `handleResponse` methods for `GetBlob/GetBlobInfo/Put/DeleteOperations`. This ensures that operation managers do not crash when a single operation fails in an unexpected way. Operations are completed and removed from the operation list if this occurs.
- Catch unhandled exceptions in PutOperation's `fillChunk` method. *NOTE:* I'm not completely sure what the correct course of action should be when things fail in the chunk filler thread.  We can discuss this. Right now, I set the operation exception and complete the operation.
- Add an `UnexpectedErrorCount` metric.
- Errors in user provided callbacks were already caught within `OperationCompleteCallback::completeOperation(...)`

**Reviewers:** @pnarayanan (Sorry for sending so many reviews your way), @vgkholla
**Time to review:** 29 min.
**Testing:** Added unit tests with induced runtime exceptions for all operation types.  `./gradlew build && ./gradlew test` passes.