### PR TITLE
Removing a PutManager test that is now irrelevant

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -58,8 +58,8 @@ class DeleteManager {
     @Override
     public void registerRequestToSend(DeleteOperation deleteOperation, RequestInfo requestInfo) {
       requestListToFill.add(requestInfo);
-      correlationIdToDeleteOperation.put(((RequestOrResponse) requestInfo.getRequest()).getCorrelationId(),
-          deleteOperation);
+      correlationIdToDeleteOperation
+          .put(((RequestOrResponse) requestInfo.getRequest()).getCorrelationId(), deleteOperation);
     }
   }
 
@@ -183,8 +183,8 @@ class DeleteManager {
     }
     routerMetrics.operationDequeuingRate.mark();
     routerMetrics.deleteBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmissionTimeMs());
-    operationCompleteCallback.completeOperation(op.getFutureResult(), op.getCallback(), op.getOperationResult(),
-        op.getOperationException());
+    operationCompleteCallback
+        .completeOperation(op.getFutureResult(), op.getCallback(), op.getOperationResult(), op.getOperationException());
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -36,7 +36,6 @@ import java.io.InputStream;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -166,8 +166,8 @@ class GetManager {
           remove(op);
         }
       } catch (Exception e) {
-        removeAndAbort(op, new RouterException("Get poll encountered unexpected error", e,
-            RouterErrorCode.UnexpectedInternalError));
+        removeAndAbort(op,
+            new RouterException("Get poll encountered unexpected error", e, RouterErrorCode.UnexpectedInternalError));
       }
     }
     routerMetrics.getManagerPollTimeMs.update(time.milliseconds() - startTime);

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -144,8 +144,9 @@ class PutOperation {
     submissionTimeMs = time.milliseconds();
     blobSize = blobProperties.getBlobSize();
     if (channel.getSize() != blobSize) {
-      throw new RouterException("Channel size: " + channel.getSize() + " different from size in BlobProperties: "
-          + blobProperties.getBlobSize(), RouterErrorCode.BadInputChannel);
+      throw new RouterException(
+          "Channel size: " + channel.getSize() + " different from size in BlobProperties: " + blobProperties
+              .getBlobSize(), RouterErrorCode.BadInputChannel);
     }
     // Set numDataChunks
     // the max blob size that can be supported is technically limited by the max chunk size configured.
@@ -732,8 +733,8 @@ class PutOperation {
         PutRequest putRequest = createPutRequest();
         RequestInfo request = new RequestInfo(hostname, port, putRequest);
         int correlationId = putRequest.getCorrelationId();
-        correlationIdToChunkPutRequestInfo.put(correlationId,
-            new ChunkPutRequestInfo(replicaId, putRequest, time.milliseconds()));
+        correlationIdToChunkPutRequestInfo
+            .put(correlationId, new ChunkPutRequestInfo(replicaId, putRequest, time.milliseconds()));
         correlationIdToPutChunk.put(correlationId, this);
         requestRegistrationCallback.registerRequestToSend(PutOperation.this, request);
         replicaIterator.remove();
@@ -790,13 +791,13 @@ class PutOperation {
       }
       long requestLatencyMs = time.milliseconds() - chunkPutRequestInfo.startTimeMs;
       routerMetrics.routerRequestLatencyMs.update(requestLatencyMs);
-      routerMetrics.getDataNodeBasedMetrics(chunkPutRequestInfo.replicaId.getDataNodeId()).putRequestLatencyMs.update(
-          requestLatencyMs);
+      routerMetrics.getDataNodeBasedMetrics(chunkPutRequestInfo.replicaId.getDataNodeId()).putRequestLatencyMs
+          .update(requestLatencyMs);
       boolean isSuccessful;
       if (responseInfo.getError() != null) {
         setChunkException(new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut));
-        responseHandler.onRequestResponseException(chunkPutRequestInfo.replicaId,
-            new IOException("NetworkClient error"));
+        responseHandler
+            .onRequestResponseException(chunkPutRequestInfo.replicaId, new IOException("NetworkClient error"));
         isSuccessful = false;
       } else {
         try {


### PR DESCRIPTION
One of the PutManager tests verifies that the router gets closed when the chunk filler thread receives an exception. This is no longer the behavior, with the recent change to only fail the operation getting filled when the chunk filler thread receives an exception. That makes this test incorrect, and it fails frequently (the reason it does not always fail is that the exception induced by the test can get thrown outside of `op.fillChunks()` and in those cases the test succeeds).

Also made some formatting changes.

Reviewer: Casey
Estimate: 5 mins.