### PR TITLE
Downgrading client caused exception logging to DEBUG

### DIFF
--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -101,6 +101,7 @@ public class NettyMetrics {
   // NettyMessageProcessor
   public final Histogram channelReadIntervalInMs;
   public final Counter idleConnectionCloseCount;
+  public final Counter ignoredExceptionCount;
   public final Counter processorExceptionCaughtCount;
   // NettyResponseChannel
   public final Counter badRequestCount;
@@ -244,6 +245,8 @@ public class NettyMetrics {
         metricRegistry.histogram(MetricRegistry.name(NettyMessageProcessor.class, "ChannelReadIntervalInMs"));
     idleConnectionCloseCount =
         metricRegistry.counter(MetricRegistry.name(NettyMessageProcessor.class, "IdleConnectionCloseCount"));
+    ignoredExceptionCount =
+        metricRegistry.counter(MetricRegistry.name(NettyMessageProcessor.class, "IgnoredExceptionCount"));
     processorExceptionCaughtCount =
         metricRegistry.counter(MetricRegistry.name(NettyMessageProcessor.class, "ExceptionCaughtCount"));
     // NettyResponseChannel

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -512,7 +512,7 @@ class NettyResponseChannel implements RestResponseChannel {
    * @param exception the {@link Exception} that has to be logged.
    */
   private void log(Exception exception) {
-    if(ctx.channel().isActive()) {
+    if (ctx.channel().isActive()) {
       String uri = "unknown";
       RestMethod restMethod = RestMethod.UNKNOWN;
       if (request != null) {


### PR DESCRIPTION
Clients may close connections at any time and if the server has not made any mistakes, this need not be logged at the `ERROR` level.

[Similar](https://issues.apache.org/jira/browse/KAFKA-2251) issue in Kafka with a similar solution (not Netty though). Instead of `WARN`, logging it at `DEBUG` level and a metric is introduced. 

**Primary reviewers: @pnarayanan**
**Expected time to review: < 5 mins**

Built and formatted. 