### PR TITLE
Add chunkfilling related metrics

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -250,6 +250,7 @@ class GetBlobInfoOperation extends GetOperation<BlobInfo> {
    */
   void onErrorResponse(ReplicaId replicaId) {
     operationTracker.onResponse(replicaId, false);
+    routerMetrics.routerRequestErrorCount.inc();
     routerMetrics.getDataNodeBasedMetrics(replicaId.getDataNodeId()).getBlobInfoRequestErrorCount.inc();
   }
 
@@ -276,6 +277,7 @@ class GetBlobInfoOperation extends GetOperation<BlobInfo> {
    * @param errorCode the {@link ServerErrorCode} to process.
    */
   private void processServerError(ServerErrorCode errorCode) {
+    logger.trace("Server returned an error: ", errorCode);
     switch (errorCode) {
       case Blob_Deleted:
         logger.trace("Requested blob was deleted");

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -658,6 +658,7 @@ class GetBlobOperation extends GetOperation<ReadableStreamChannel> {
      */
     void onErrorResponse(ReplicaId replicaId) {
       chunkOperationTracker.onResponse(replicaId, false);
+      routerMetrics.routerRequestErrorCount.inc();
       routerMetrics.getDataNodeBasedMetrics(replicaId.getDataNodeId()).getRequestErrorCount.inc();
     }
 
@@ -668,6 +669,7 @@ class GetBlobOperation extends GetOperation<ReadableStreamChannel> {
      * @param errorCode the {@link ServerErrorCode} to process.
      */
     void processServerError(ServerErrorCode errorCode) {
+      logger.trace("Server returned an error: ", errorCode);
       setChunkException(new RouterException("Server returned: " + errorCode, RouterErrorCode.UnexpectedInternalError));
     }
 
@@ -790,17 +792,15 @@ class GetBlobOperation extends GetOperation<ReadableStreamChannel> {
      */
     @Override
     void processServerError(ServerErrorCode errorCode) {
+      logger.trace("Server returned an error: ", errorCode);
       switch (errorCode) {
         case Blob_Deleted:
-          logger.trace("Requested blob was deleted");
           setChunkException(new RouterException("Server returned: " + errorCode, RouterErrorCode.BlobDeleted));
           break;
         case Blob_Expired:
-          logger.trace("Requested blob is expired");
           setChunkException(new RouterException("Server returned: " + errorCode, RouterErrorCode.BlobExpired));
           break;
         case Blob_Not_Found:
-          logger.trace("Requested blob was not found on this server");
           setChunkException(new RouterException("Server returned: " + errorCode, RouterErrorCode.BlobDoesNotExist));
           break;
         default:

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -85,8 +85,6 @@ public class NonBlockingRouterMetrics {
   public final Histogram chunkFillTimeMs;
   // time spent waiting for a chunk to become available for filling once data is available.
   public final Histogram waitTimeForFreeChunkAvailabilityMs;
-  // time spent by a chunk waiting for data to become available in the channel.
-  public final Histogram waitTimeForChannelDataAvailabilityMs;
 
   // Misc metrics.
   public final Meter operationErrorRate;
@@ -183,8 +181,6 @@ public class NonBlockingRouterMetrics {
     chunkFillTimeMs = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "ChunkFillTimeMs"));
     waitTimeForFreeChunkAvailabilityMs =
         metricRegistry.histogram(MetricRegistry.name(PutManager.class, "WaitTimeForFreeChunkAvailabilityMs"));
-    waitTimeForChannelDataAvailabilityMs =
-        metricRegistry.histogram(MetricRegistry.name(PutManager.class, "WaitTimeForChannelDataAvailabilityMs"));
 
     // Misc metrics.
     operationErrorRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "OperationErrorRate"));

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -32,9 +32,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class NonBlockingRouterMetrics {
   private final MetricRegistry metricRegistry;
-  // @todo: Ensure all metrics here get updated appropriately.
-  // @todo: chunk filling rate metrics.
-  // @todo: More metrics for the RequestResponse handling (poll, handleResponse etc.)
 
   // Operation rate.
   public final Meter putBlobOperationRate;
@@ -83,6 +80,10 @@ public class NonBlockingRouterMetrics {
   public final Histogram putManagerHandleResponseTimeMs;
   public final Histogram getManagerHandleResponseTimeMs;
   public final Histogram deleteManagerHandleResponseTimeMs;
+  // time spent in getting a chunk filled once it is available. This is reported per chunk.
+  public final Histogram chunkFillTimeMs;
+  // time spent waiting for a free chunk. This is reported once per operation across all its chunks.
+  public final Histogram waitTimeForFreeChunkAvailabilityMs;
 
   // Misc metrics.
   public final Meter operationErrorRate;
@@ -174,6 +175,9 @@ public class NonBlockingRouterMetrics {
         metricRegistry.histogram(MetricRegistry.name(GetManager.class, "GetManagerHandleResponseTimeMs"));
     deleteManagerHandleResponseTimeMs =
         metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "DeleteManagerHandleResponseTimeMs"));
+    chunkFillTimeMs = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "ChunkFillTimeMs"));
+    waitTimeForFreeChunkAvailabilityMs =
+        metricRegistry.histogram(MetricRegistry.name(PutManager.class, "WaitTimeForFreeChunkAvailabilityMs"));
 
     // Misc metrics.
     operationErrorRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "OperationErrorRate"));

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -85,6 +85,8 @@ public class NonBlockingRouterMetrics {
   public final Histogram chunkFillTimeMs;
   // time spent waiting for a chunk to become available for filling once data is available.
   public final Histogram waitTimeForFreeChunkAvailabilityMs;
+  // time spent by a chunk waiting for data to become available in the channel.
+  public final Histogram waitTimeForChannelDataAvailabilityMs;
 
   // Misc metrics.
   public final Meter operationErrorRate;
@@ -181,6 +183,8 @@ public class NonBlockingRouterMetrics {
     chunkFillTimeMs = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "ChunkFillTimeMs"));
     waitTimeForFreeChunkAvailabilityMs =
         metricRegistry.histogram(MetricRegistry.name(PutManager.class, "WaitTimeForFreeChunkAvailabilityMs"));
+    waitTimeForChannelDataAvailabilityMs =
+        metricRegistry.histogram(MetricRegistry.name(PutManager.class, "WaitTimeForChannelDataAvailabilityMs"));
 
     // Misc metrics.
     operationErrorRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "OperationErrorRate"));

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -80,9 +80,9 @@ public class NonBlockingRouterMetrics {
   public final Histogram putManagerHandleResponseTimeMs;
   public final Histogram getManagerHandleResponseTimeMs;
   public final Histogram deleteManagerHandleResponseTimeMs;
-  // time spent in getting a chunk filled once it is available. This is reported per chunk.
+  // time spent in getting a chunk filled once it is available.
   public final Histogram chunkFillTimeMs;
-  // time spent waiting for a free chunk. This is reported once per operation across all its chunks.
+  // time spent waiting for a chunk to become available for filling once data is available.
   public final Histogram waitTimeForFreeChunkAvailabilityMs;
 
   // Misc metrics.

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -56,6 +56,7 @@ public class NonBlockingRouterMetrics {
   public final Counter getBlobErrorCount;
   public final Counter deleteBlobErrorCount;
   public final Counter operationAbortCount;
+  public final Counter routerRequestErrorCount;
 
   // Count for various errors.
   public final Counter ambryUnavailableErrorCount;
@@ -133,6 +134,8 @@ public class NonBlockingRouterMetrics {
     getBlobErrorCount = metricRegistry.counter(MetricRegistry.name(GetBlobOperation.class, "GetBlobErrorCount"));
     deleteBlobErrorCount = metricRegistry.counter(MetricRegistry.name(DeleteOperation.class, "DeleteBlobErrorCount"));
     operationAbortCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OperationAbortCount"));
+    routerRequestErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "RouterRequestErrorCount"));
 
     // Counters for various errors.
     ambryUnavailableErrorCount =

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -118,6 +118,7 @@ class PutOperation {
   private final long submissionTimeMs;
   // The point in time at which the most recent wait for free chunk availability started.
   private long startTimeForChunkAvailabilityWaitMs;
+  // The point in time at which the most recent wait for channel data availability started.
   private long startTimeForChannelDataAvailabilityMs;
   // The time spent in waiting for a chunk to become available to be filled when the channel had data.
   private long waitTimeForCurrentChunkAvailabilityMs;

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -118,7 +118,6 @@ class PutOperation {
   private final long submissionTimeMs;
   // The point in time at which the most recent wait for free chunk availability started.
   private long startTimeForChunkAvailabilityWaitMs;
-  // The point in time at which the most recent wait for channel data availability started.
   private long startTimeForChannelDataAvailabilityMs;
   // The time spent in waiting for a chunk to become available to be filled when the channel had data.
   private long waitTimeForCurrentChunkAvailabilityMs;

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -313,7 +313,7 @@ class PutOperation {
               bytesFilledSoFar += chunkToFill.fillFrom(channelReadBuffer);
               if (chunkToFill.isReady()) {
                 routerMetrics.waitTimeForFreeChunkAvailabilityMs.update(waitTimeForCurrentChunkAvailabilityMs);
-                waitTimeForCurrentChunkAvailabilityMs = 0;
+                resetWaitTimeTracking();
               }
               if (!channelReadBuffer.hasRemaining()) {
                 chunkFillerChannel.resolveOldestChunk(null);
@@ -357,6 +357,14 @@ class PutOperation {
       waitTimeForCurrentChunkAvailabilityMs = time.milliseconds() - startTimeForChunkAvailabilityWaitMs;
       startTimeForChunkAvailabilityWaitMs = 0;
     }
+  }
+
+  /**
+   * Reset time variables associated with tracking wait times.
+   */
+  private void resetWaitTimeTracking() {
+    startTimeForChunkAvailabilityWaitMs = 0;
+    waitTimeForCurrentChunkAvailabilityMs = 0;
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -313,7 +313,7 @@ class PutOperation {
               bytesFilledSoFar += chunkToFill.fillFrom(channelReadBuffer);
               if (chunkToFill.isReady()) {
                 routerMetrics.waitTimeForFreeChunkAvailabilityMs.update(waitTimeForCurrentChunkAvailabilityMs);
-                resetWaitTimeTracking();
+                waitTimeForCurrentChunkAvailabilityMs = 0;
               }
               if (!channelReadBuffer.hasRemaining()) {
                 chunkFillerChannel.resolveOldestChunk(null);
@@ -357,14 +357,6 @@ class PutOperation {
       waitTimeForCurrentChunkAvailabilityMs = time.milliseconds() - startTimeForChunkAvailabilityWaitMs;
       startTimeForChunkAvailabilityWaitMs = 0;
     }
-  }
-
-  /**
-   * Reset time variables associated with tracking wait times.
-   */
-  private void resetWaitTimeTracking() {
-    startTimeForChunkAvailabilityWaitMs = 0;
-    waitTimeForCurrentChunkAvailabilityMs = 0;
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -118,8 +118,11 @@ class PutOperation {
   private final long submissionTimeMs;
   // The point in time at which the most recent wait for free chunk availability started.
   private long startTimeForChunkAvailabilityWaitMs;
+  private long startTimeForChannelDataAvailabilityMs;
   // The time spent in waiting for a chunk to become available to be filled when the channel had data.
   private long waitTimeForCurrentChunkAvailabilityMs;
+  // The time spent by a chunk for data to be available in the channel.
+  private long waitTimeForChannelDataAvailabilityMs;
 
   private static final Logger logger = LoggerFactory.getLogger(PutOperation.class);
 
@@ -302,18 +305,18 @@ class PutOperation {
             channelReadBuffer = chunkFillerChannel.getNextChunk(0);
           }
           if (channelReadBuffer != null) {
+            maybeStopTrackingWaitForChannelDataTime();
             chunkToFill = getChunkToFill();
             if (chunkToFill == null) {
               // channel has data, but no chunks are free to be filled yet.
-              maybeStartTrackingWaitTime();
+              maybeStartTrackingWaitForChunkTime();
               break;
             } else {
               // channel has data, and there is a chunk that can be filled.
-              maybeUpdateTrackedWaitTime();
+              maybeStopTrackingWaitForChunkTime();
               bytesFilledSoFar += chunkToFill.fillFrom(channelReadBuffer);
               if (chunkToFill.isReady()) {
-                routerMetrics.waitTimeForFreeChunkAvailabilityMs.update(waitTimeForCurrentChunkAvailabilityMs);
-                resetWaitTimeTracking();
+                updateChunkFillerWaitTimeMetrics();
               }
               if (!channelReadBuffer.hasRemaining()) {
                 chunkFillerChannel.resolveOldestChunk(null);
@@ -322,6 +325,10 @@ class PutOperation {
             }
           } else {
             // channel does not have more data yet.
+            if (getFreeChunk() != null) {
+              // this means there is a chunk available to be filled, but no data in the channel.
+              maybeStartTrackingWaitForChannelDataTime();
+            }
             break;
           }
         } while (bytesFilledSoFar < blobSize);
@@ -338,7 +345,7 @@ class PutOperation {
   /**
    * Called whenever the channel has data but no free or building chunk is available to be filled.
    */
-  private void maybeStartTrackingWaitTime() {
+  private void maybeStartTrackingWaitForChunkTime() {
     if (startTimeForChunkAvailabilityWaitMs == 0) {
       // this is the first point in time after the last chunk filling (if any) when the filling was blocked due to
       // chunk unavailability, so mark this time.
@@ -351,7 +358,7 @@ class PutOperation {
   /**
    * Called whenever the channel has data and there is a free or building chunk available to be filled.
    */
-  private void maybeUpdateTrackedWaitTime() {
+  private void maybeStopTrackingWaitForChunkTime() {
     if (startTimeForChunkAvailabilityWaitMs != 0) {
       // this is the first point in time since the last wait that a chunk became available for filling.
       waitTimeForCurrentChunkAvailabilityMs = time.milliseconds() - startTimeForChunkAvailabilityWaitMs;
@@ -360,11 +367,38 @@ class PutOperation {
   }
 
   /**
-   * Reset time variables associated with tracking wait times.
+   * Called whenever a chunk is available to be filled but there is no data available in the channel.
    */
-  private void resetWaitTimeTracking() {
-    startTimeForChunkAvailabilityWaitMs = 0;
+  private void maybeStartTrackingWaitForChannelDataTime() {
+    if (startTimeForChannelDataAvailabilityMs == 0) {
+      // this is the first point in time after the last time data was read from the channel that data became
+      // unavailable in the channel, so mark this time.
+      startTimeForChannelDataAvailabilityMs = time.milliseconds();
+    } else {
+      // the wait was already initiated, so do nothing.
+    }
+  }
+
+  /**
+   * Called whenever data becomes available in the channel.
+   */
+  private void maybeStopTrackingWaitForChannelDataTime() {
+    if (startTimeForChannelDataAvailabilityMs != 0) {
+      // this is the first point in time since the last wait that data became available in the channel.
+      waitTimeForChannelDataAvailabilityMs += time.milliseconds() - startTimeForChannelDataAvailabilityMs;
+      startTimeForChannelDataAvailabilityMs = 0;
+    }
+  }
+
+  /**
+   * Update metrics related to how long a channel had to wait for a chunk to become available for filling, and
+   * how long the chunk had to wait for data to become available in the channel.
+   */
+  private void updateChunkFillerWaitTimeMetrics() {
+    routerMetrics.waitTimeForFreeChunkAvailabilityMs.update(waitTimeForCurrentChunkAvailabilityMs);
+    routerMetrics.waitTimeForChannelDataAvailabilityMs.update(waitTimeForChannelDataAvailabilityMs);
     waitTimeForCurrentChunkAvailabilityMs = 0;
+    waitTimeForChannelDataAvailabilityMs = 0;
   }
 
   /**
@@ -374,19 +408,26 @@ class PutOperation {
    * @return the chunk to fill, or null if there are no chunks eligible for filling.
    */
   private PutChunk getChunkToFill() {
-    if (chunkToFill != null && chunkToFill.isBuilding()) {
-      return chunkToFill;
-    }
-    chunkToFill = null;
-    for (PutChunk chunk : putChunks) {
-      if (chunk.isFree()) {
+    if (chunkToFill == null || !chunkToFill.isBuilding()) {
+      chunkToFill = getFreeChunk();
+      if (chunkToFill != null) {
         chunkCounter++;
-        chunk.prepareForBuilding(chunkCounter, getSizeOfChunkAt(chunkCounter));
-        chunkToFill = chunk;
-        break;
+        chunkToFill.prepareForBuilding(chunkCounter, getSizeOfChunkAt(chunkCounter));
       }
     }
     return chunkToFill;
+  }
+
+  /**
+   * @return A free chunk, if one is available; null otherwise.
+   */
+  private PutChunk getFreeChunk() {
+    for (PutChunk chunk : putChunks) {
+      if (chunk.isFree()) {
+        return chunk;
+      }
+    }
+    return null;
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -118,11 +118,8 @@ class PutOperation {
   private final long submissionTimeMs;
   // The point in time at which the most recent wait for free chunk availability started.
   private long startTimeForChunkAvailabilityWaitMs;
-  private long startTimeForChannelDataAvailabilityMs;
   // The time spent in waiting for a chunk to become available to be filled when the channel had data.
   private long waitTimeForCurrentChunkAvailabilityMs;
-  // The time spent by a chunk for data to be available in the channel.
-  private long waitTimeForChannelDataAvailabilityMs;
 
   private static final Logger logger = LoggerFactory.getLogger(PutOperation.class);
 
@@ -305,18 +302,18 @@ class PutOperation {
             channelReadBuffer = chunkFillerChannel.getNextChunk(0);
           }
           if (channelReadBuffer != null) {
-            maybeStopTrackingWaitForChannelDataTime();
             chunkToFill = getChunkToFill();
             if (chunkToFill == null) {
               // channel has data, but no chunks are free to be filled yet.
-              maybeStartTrackingWaitForChunkTime();
+              maybeStartTrackingWaitTime();
               break;
             } else {
               // channel has data, and there is a chunk that can be filled.
-              maybeStopTrackingWaitForChunkTime();
+              maybeUpdateTrackedWaitTime();
               bytesFilledSoFar += chunkToFill.fillFrom(channelReadBuffer);
               if (chunkToFill.isReady()) {
-                updateChunkFillerWaitTimeMetrics();
+                routerMetrics.waitTimeForFreeChunkAvailabilityMs.update(waitTimeForCurrentChunkAvailabilityMs);
+                resetWaitTimeTracking();
               }
               if (!channelReadBuffer.hasRemaining()) {
                 chunkFillerChannel.resolveOldestChunk(null);
@@ -325,10 +322,6 @@ class PutOperation {
             }
           } else {
             // channel does not have more data yet.
-            if (getFreeChunk() != null) {
-              // this means there is a chunk available to be filled, but no data in the channel.
-              maybeStartTrackingWaitForChannelDataTime();
-            }
             break;
           }
         } while (bytesFilledSoFar < blobSize);
@@ -345,7 +338,7 @@ class PutOperation {
   /**
    * Called whenever the channel has data but no free or building chunk is available to be filled.
    */
-  private void maybeStartTrackingWaitForChunkTime() {
+  private void maybeStartTrackingWaitTime() {
     if (startTimeForChunkAvailabilityWaitMs == 0) {
       // this is the first point in time after the last chunk filling (if any) when the filling was blocked due to
       // chunk unavailability, so mark this time.
@@ -358,7 +351,7 @@ class PutOperation {
   /**
    * Called whenever the channel has data and there is a free or building chunk available to be filled.
    */
-  private void maybeStopTrackingWaitForChunkTime() {
+  private void maybeUpdateTrackedWaitTime() {
     if (startTimeForChunkAvailabilityWaitMs != 0) {
       // this is the first point in time since the last wait that a chunk became available for filling.
       waitTimeForCurrentChunkAvailabilityMs = time.milliseconds() - startTimeForChunkAvailabilityWaitMs;
@@ -367,38 +360,11 @@ class PutOperation {
   }
 
   /**
-   * Called whenever a chunk is available to be filled but there is no data available in the channel.
+   * Reset time variables associated with tracking wait times.
    */
-  private void maybeStartTrackingWaitForChannelDataTime() {
-    if (startTimeForChannelDataAvailabilityMs == 0) {
-      // this is the first point in time after the last time data was read from the channel that data became
-      // unavailable in the channel, so mark this time.
-      startTimeForChannelDataAvailabilityMs = time.milliseconds();
-    } else {
-      // the wait was already initiated, so do nothing.
-    }
-  }
-
-  /**
-   * Called whenever data becomes available in the channel.
-   */
-  private void maybeStopTrackingWaitForChannelDataTime() {
-    if (startTimeForChannelDataAvailabilityMs != 0) {
-      // this is the first point in time since the last wait that data became available in the channel.
-      waitTimeForChannelDataAvailabilityMs += time.milliseconds() - startTimeForChannelDataAvailabilityMs;
-      startTimeForChannelDataAvailabilityMs = 0;
-    }
-  }
-
-  /**
-   * Update metrics related to how long a channel had to wait for a chunk to become available for filling, and
-   * how long the chunk had to wait for data to become available in the channel.
-   */
-  private void updateChunkFillerWaitTimeMetrics() {
-    routerMetrics.waitTimeForFreeChunkAvailabilityMs.update(waitTimeForCurrentChunkAvailabilityMs);
-    routerMetrics.waitTimeForChannelDataAvailabilityMs.update(waitTimeForChannelDataAvailabilityMs);
+  private void resetWaitTimeTracking() {
+    startTimeForChunkAvailabilityWaitMs = 0;
     waitTimeForCurrentChunkAvailabilityMs = 0;
-    waitTimeForChannelDataAvailabilityMs = 0;
   }
 
   /**
@@ -408,26 +374,19 @@ class PutOperation {
    * @return the chunk to fill, or null if there are no chunks eligible for filling.
    */
   private PutChunk getChunkToFill() {
-    if (chunkToFill == null || !chunkToFill.isBuilding()) {
-      chunkToFill = getFreeChunk();
-      if (chunkToFill != null) {
+    if (chunkToFill != null && chunkToFill.isBuilding()) {
+      return chunkToFill;
+    }
+    chunkToFill = null;
+    for (PutChunk chunk : putChunks) {
+      if (chunk.isFree()) {
         chunkCounter++;
-        chunkToFill.prepareForBuilding(chunkCounter, getSizeOfChunkAt(chunkCounter));
+        chunk.prepareForBuilding(chunkCounter, getSizeOfChunkAt(chunkCounter));
+        chunkToFill = chunk;
+        break;
       }
     }
     return chunkToFill;
-  }
-
-  /**
-   * @return A free chunk, if one is available; null otherwise.
-   */
-  private PutChunk getFreeChunk() {
-    for (PutChunk chunk : putChunks) {
-      if (chunk.isFree()) {
-        return chunk;
-      }
-    }
-    return null;
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -199,7 +199,6 @@ public class DeleteManagerTest {
     HashMap<ServerErrorCode, RouterErrorCode> map = new HashMap<>();
     map.put(ServerErrorCode.Blob_Expired, RouterErrorCode.BlobExpired);
     map.put(ServerErrorCode.Blob_Not_Found, RouterErrorCode.BlobDoesNotExist);
-    map.put(ServerErrorCode.Partition_Unknown, RouterErrorCode.BlobDoesNotExist);
     map.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
     for (ServerErrorCode serverErrorCode : ServerErrorCode.values()) {
       if (serverErrorCode != ServerErrorCode.No_Error && serverErrorCode != ServerErrorCode.Blob_Deleted


### PR DESCRIPTION
This PR adds a few chunk filling related metrics:
1. Total time spent in getting a chunk from FREE state to READY state. This includes the time the operation waits for its turn in the chunk filler thread's iteration (which should be minimal), the time spent waiting for data to arrive, and the time spent actually doing the writes (which should be minimal as well). 
2. Time spent waiting for a free chunk when there is data in the channel.
3. Time spent waiting for data to be available in the channel when there is a free chunk.
4. Metrics for errors encountered by request sent out by the router.

Note that the wait times are not very accurate (best effort) as data could become available in the channel, or a chunk can become free for an operation when the chunk filler thread is iterating over other operations.

Reviewers: Gopal, Ming
Estimate: 20 mins