### PR TITLE
Changing APIs of buildBlobProps and buildUm in RestUtils

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Ambry is a distributed object store that supports storage of trillion of small i
 ## Documentation
 Detailed documentation is available at https://github.com/linkedin/ambry/wiki
 
+## Research
+Paper introducing Ambry at [SIGMOD 2016](http://sigmod2016.org/) -> http://dprg.cs.uiuc.edu/docs/SIGMOD2016-a/ambry.pdf
+
+Reach out to us at ambrydev@googlegroups.com if you would like us to list a paper that is based off of research on Ambry.
+
 ## Getting Started
 ##### Step 1: Download the code, build it and prepare for deployment.
 To get the latest code and build it, do

--- a/ambry-admin/src/main/java/com.github.ambry.admin/AdminBlobStorageService.java
+++ b/ambry-admin/src/main/java/com.github.ambry.admin/AdminBlobStorageService.java
@@ -175,8 +175,8 @@ class AdminBlobStorageService implements BlobStorageService {
       logger.trace("Handling POST request - {}", restRequest.getUri());
       checkAvailable();
       long propsBuildStartTime = System.currentTimeMillis();
-      BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest);
-      byte[] usermetadata = RestUtils.buildUsermetadata(restRequest);
+      BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
+      byte[] usermetadata = RestUtils.buildUsermetadata(restRequest.getArgs());
       adminMetrics.blobPropsBuildTimeInMs.update(System.currentTimeMillis() - propsBuildStartTime);
       logger.trace("Blob properties of blob being POSTed - {}", blobProperties);
       PostCallback routerCallback =

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -144,16 +144,14 @@ public class RestUtils {
   private static Logger logger = LoggerFactory.getLogger(RestUtils.class);
 
   /**
-   * Builds {@link BlobProperties} given a {@link RestRequest}.
-   * @param restRequest the {@link RestRequest} to use.
-   * @return the {@link BlobProperties} extracted from {@code restRequest}.
-   * @throws RestServiceException if required headers aren't present or if they aren't in the format or number
+   * Builds {@link BlobProperties} given the arguments associated with a request.
+   * @param args the arguments associated with the request.
+   * @return the {@link BlobProperties} extracted from the arguments.
+   * @throws RestServiceException if required arguments aren't present or if they aren't in the format or number
    *                                    expected.
    */
-  public static BlobProperties buildBlobProperties(RestRequest restRequest)
+  public static BlobProperties buildBlobProperties(Map<String, Object> args)
       throws RestServiceException {
-    Map<String, Object> args = restRequest.getArgs();
-
     String blobSizeStr = null;
     long blobSize;
     try {
@@ -232,14 +230,14 @@ public class RestUtils {
    */
 
   /**
-   * Builds user metadata given a {@link RestRequest}.
-   * @param restRequest the {@link RestRequest} to use.
-   * @return the user metadata extracted from {@code restRequest}.
+   * Builds user metadata given the arguments associated with a request.
+   * @param args the arguments associated with the request.
+   * @return the user metadata extracted from arguments.
+   * @throws RestServiceException if usermetadata arguments have null values.
    */
-  public static byte[] buildUsermetadata(RestRequest restRequest)
+  public static byte[] buildUsermetadata(Map<String, Object> args)
       throws RestServiceException {
     ByteBuffer userMetadata;
-    Map<String, Object> args = restRequest.getArgs();
     if (args.containsKey(MultipartPost.USER_METADATA_PART)) {
       userMetadata = (ByteBuffer) args.get(MultipartPost.USER_METADATA_PART);
     } else {

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageService.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageService.java
@@ -95,8 +95,8 @@ public class MockBlobStorageService implements BlobStorageService {
   public void handlePost(RestRequest restRequest, RestResponseChannel restResponseChannel) {
     if (shouldProceed(restRequest, restResponseChannel)) {
       try {
-        BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest);
-        byte[] usermetadata = RestUtils.buildUsermetadata(restRequest);
+        BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
+        byte[] usermetadata = RestUtils.buildUsermetadata(restRequest.getArgs());
         router.putBlob(blobProperties, usermetadata, restRequest,
             new MockPostCallback(this, restRequest, restResponseChannel, blobProperties));
       } catch (RestServiceException e) {

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -161,7 +161,7 @@ public class RestUtilsTest {
   @Test
   public void getUserMetadataTest()
       throws Exception {
-    byte[] usermetadata = RestUtils.buildUsermetadata(createRestRequest(RestMethod.POST, "/", null));
+    byte[] usermetadata = RestUtils.buildUsermetadata(new HashMap<String, Object>());
     assertArrayEquals("Unexpected user metadata", new byte[0], usermetadata);
   }
 
@@ -179,7 +179,6 @@ public class RestUtilsTest {
     userMetadata.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key1", "value1");
     userMetadata.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key2", "value2");
     setUserMetadataHeaders(headers, userMetadata);
-    verifyBlobPropertiesConstructionSuccess(headers);
     verifyUserMetadataConstructionSuccess(headers, userMetadata);
   }
 
@@ -196,7 +195,7 @@ public class RestUtilsTest {
     JSONObject headers = new JSONObject();
     headers.put(RestUtils.MultipartPost.USER_METADATA_PART, ByteBuffer.wrap(original));
     RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
-    byte[] rcvd = RestUtils.buildUsermetadata(restRequest);
+    byte[] rcvd = RestUtils.buildUsermetadata(restRequest.getArgs());
     assertArrayEquals("Received user metadata does not match with original", original, rcvd);
   }
 
@@ -220,10 +219,9 @@ public class RestUtilsTest {
     // empty value
     userMetadata.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key4", "");
     setUserMetadataHeaders(headers, userMetadata);
-    verifyBlobPropertiesConstructionSuccess(headers);
 
     RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
-    byte[] userMetadataByteArray = RestUtils.buildUsermetadata(restRequest);
+    byte[] userMetadataByteArray = RestUtils.buildUsermetadata(restRequest.getArgs());
     Map<String, String> userMetadataMap = RestUtils.buildUserMetadata(userMetadataByteArray);
 
     // key1, output should be same as input
@@ -251,10 +249,9 @@ public class RestUtilsTest {
         Boolean.toString(RANDOM.nextBoolean()), generateRandomString(10), "image/gif", generateRandomString(10));
     Map<String, String> userMetadata = new HashMap<String, String>();
     setUserMetadataHeaders(headers, userMetadata);
-    verifyBlobPropertiesConstructionSuccess(headers);
 
     RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
-    byte[] userMetadataByteArray = RestUtils.buildUsermetadata(restRequest);
+    byte[] userMetadataByteArray = RestUtils.buildUsermetadata(restRequest.getArgs());
     Map<String, String> userMetadataMap = RestUtils.buildUserMetadata(userMetadataByteArray);
     assertNull("UserMetadata should have been null ", userMetadataMap);
   }
@@ -573,7 +570,7 @@ public class RestUtilsTest {
   private void verifyBlobPropertiesConstructionSuccess(JSONObject headers)
       throws Exception {
     RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
-    BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest);
+    BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
     assertEquals("Blob size does not match", headers.getLong(RestUtils.Headers.BLOB_SIZE),
         blobProperties.getBlobSize());
     long expectedTTL = Utils.Infinite_Time;
@@ -605,7 +602,7 @@ public class RestUtilsTest {
   private void verifyUserMetadataConstructionSuccess(JSONObject headers, Map<String, String> inputUserMetadata)
       throws Exception {
     RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
-    byte[] userMetadata = RestUtils.buildUsermetadata(restRequest);
+    byte[] userMetadata = RestUtils.buildUsermetadata(restRequest.getArgs());
     Map<String, String> userMetadataMap = RestUtils.buildUserMetadata(userMetadata);
     assertEquals("Total number of entries doesnt match ", inputUserMetadata.size(), userMetadataMap.size());
     for (String key : userMetadataMap.keySet()) {
@@ -620,7 +617,7 @@ public class RestUtilsTest {
   // getBlobPropertiesVariedInputTest() helpers.
 
   /**
-   * Verifies that {@link RestUtils#buildBlobProperties(RestRequest)} fails if given a request with bad headers.
+   * Verifies that {@link RestUtils#buildBlobProperties(Map<String,Object>)} fails if given a request with bad headers.
    * @param headers the headers that were provided to the request.
    * @param expectedCode the expected {@link RestServiceErrorCode} because of the failure.
    * @throws JSONException
@@ -631,7 +628,7 @@ public class RestUtilsTest {
       throws JSONException, UnsupportedEncodingException, URISyntaxException {
     try {
       RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
-      RestUtils.buildBlobProperties(restRequest);
+      RestUtils.buildBlobProperties(restRequest.getArgs());
       fail("An exception was expected but none were thrown");
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", expectedCode, e.getErrorCode());
@@ -651,7 +648,7 @@ public class RestUtilsTest {
     String uri = "?" + extraValueHeader + "=extraVal1&" + extraValueHeader + "=extraVal2";
     try {
       RestRequest restRequest = createRestRequest(RestMethod.POST, uri, headers);
-      RestUtils.buildBlobProperties(restRequest);
+      RestUtils.buildBlobProperties(restRequest.getArgs());
       fail("An exception was expected but none were thrown");
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.InvalidArgs, e.getErrorCode());

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -44,7 +44,7 @@ public class RestUtilsTest {
   private static final String ALPHABET = "abcdefghijklmnopqrstuvwxyz";
 
   /**
-   * Tests building of {@link BlobProperties} given good input (all headers in the number and format expected).
+   * Tests building of {@link BlobProperties} given good input (all arguments in the number and format expected).
    * @throws Exception
    */
   @Test
@@ -617,7 +617,8 @@ public class RestUtilsTest {
   // getBlobPropertiesVariedInputTest() helpers.
 
   /**
-   * Verifies that {@link RestUtils#buildBlobProperties(Map<String,Object>)} fails if given a request with bad headers.
+   * Verifies that {@link RestUtils#buildBlobProperties(Map<String,Object>)} fails if given a request with bad
+   * arguments.
    * @param headers the headers that were provided to the request.
    * @param expectedCode the expected {@link RestServiceErrorCode} because of the failure.
    * @throws JSONException
@@ -668,6 +669,9 @@ public class RestUtilsTest {
     }
   }
 
+  /**
+   * Tests {@link RestUtils#toSecondsPrecisionInMs(long)}.
+   */
   @Test
   public void toSecondsPrecisionInMsTest() {
     assertEquals(0, RestUtils.toSecondsPrecisionInMs(999));
@@ -675,6 +679,9 @@ public class RestUtilsTest {
     assertEquals(1000, RestUtils.toSecondsPrecisionInMs(1001));
   }
 
+  /**
+   * Tests {@link RestUtils#getTimeFromDateString(String)}.
+   */
   @Test
   public void getTimeFromDateStringTest() {
     SimpleDateFormat dateFormatter = new SimpleDateFormat(RestUtils.HTTP_DATE_FORMAT, Locale.ENGLISH);

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -174,8 +174,8 @@ class AmbryBlobStorageService implements BlobStorageService {
       logger.trace("Handling POST request - {}", restRequest.getUri());
       checkAvailable();
       long propsBuildStartTime = System.currentTimeMillis();
-      BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest);
-      byte[] usermetadata = RestUtils.buildUsermetadata(restRequest);
+      BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
+      byte[] usermetadata = RestUtils.buildUsermetadata(restRequest.getArgs());
       frontendMetrics.blobPropsBuildTimeInMs.update(System.currentTimeMillis() - propsBuildStartTime);
       logger.trace("Blob properties of blob being POSTed - {}", blobProperties);
       PostCallback routerCallback =


### PR DESCRIPTION
Also adding the Ambry paper to the README.

Changing the API because the whole `RestRequest` is not needed to construct the blob properties and user metadata, only the arguments are required.

**Primary reviewers : @nsivabalan @cgtz**
**Expected time to review: 10 mins** 