### PR TITLE
Fixes deadlock issue and refactoring in SimpleByteBufferPoolTest.

### DIFF
--- a/ambry-utils/src/test/java/com.github.ambry.utils/SimpleByteBufferPoolTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/SimpleByteBufferPoolTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.utils;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 
@@ -22,16 +23,18 @@ import static org.junit.Assert.*;
 
 
 /**
- * This class tests bounded {@link ByteBufferPool} implementation.
+ * This class tests {@link SimpleByteBufferPool} that implements {@link ByteBufferPool}.
  */
 public class SimpleByteBufferPoolTest {
 
   /**
-   * Scenario: simple non-blocking allocation and deallocation.
+   * This is a simple scenario where the {@link SimpleByteBufferPool} has enough buffer to allocate a certain amount
+   * of {@link ByteBuffer}, and then deallocated the same amount of {@link ByteBuffer} back to the buffer pool. No
+   * error should occur during this test.
    */
   @Test
   public void testSingleRequestAllocateDeallocate()
-      throws TimeoutException, InterruptedException {
+      throws Exception {
     final long capacity = 2 * 1024;
     final int size = 1024;
     long maxBlockTimeInMs = 200;
@@ -45,27 +48,30 @@ public class SimpleByteBufferPoolTest {
   }
 
   /**
-   * Scenario: requested size is larger than pool capacity.
+   * This scenario tests when a {@link SimpleByteBufferPool} tries to allocate a {@link ByteBuffer} that is larger
+   * than its capacity. This operation should occur an {@link IllegalArgumentException}.
    */
   @Test
   public void testRequestExceedPoolCapacity()
-      throws TimeoutException, InterruptedException {
+      throws Exception {
     final long capacity = 1024;
     final long maxBlockTimeInMs = 200;
     SimpleByteBufferPool pool = new SimpleByteBufferPool(capacity);
     try {
-      ByteBuffer buffer = pool.allocate((int) capacity + 1, maxBlockTimeInMs);
+      pool.allocate((int) capacity + 1, maxBlockTimeInMs);
       fail("Should have thrown!");
     } catch (IllegalArgumentException e) {
     }
   }
 
   /**
-   * Scenario: buffer pool exceeds its capacity after reclaiming buffers.
+   * This scenario tests when a {@link SimpleByteBufferPool} deallocates a {@link ByteBuffer} that will make the
+   * pool's total available memory to be larger than the pool's capacity. This operation should still suceed, and
+   * set the pool's available memory the same as its capacity.
    */
   @Test
   public void testDeallocateExceedPoolCapacity()
-      throws TimeoutException, InterruptedException {
+      throws Exception {
     final int capacity = 1024;
     SimpleByteBufferPool pool = new SimpleByteBufferPool(capacity);
     ByteBuffer singleBuffer = ByteBuffer.allocate(1);
@@ -74,45 +80,51 @@ public class SimpleByteBufferPoolTest {
   }
 
   /**
-   * Scenario: timeout after not enough memory.
+   * This scenario tests when a {@link SimpleByteBufferPool} tries to allocate a {@link ByteBuffer} that is smaller
+   * than the pool's capacity, but larger than the pool's current available memory. The operation will be blocking
+   * until eventually be timed out and throw {@link TimeoutException}.
    */
   @Test
   public void testNotEnoughMemory()
-      throws InterruptedException, TimeoutException {
+      throws Exception {
     final int size = 1024;
     final long capacity = 1024;
-    final long maxBlockTimeInMs = 20;
+    final long maxBlockTimeInMs = 10;
     SimpleByteBufferPool pool = new SimpleByteBufferPool(capacity);
-    ByteBuffer buffer1 = pool.allocate(size, maxBlockTimeInMs);
+    pool.allocate(size, maxBlockTimeInMs);
     try {
-      ByteBuffer buffer2 = pool.allocate(size, maxBlockTimeInMs);
+      pool.allocate(size, maxBlockTimeInMs);
       fail("should have thrown.");
     } catch (TimeoutException e) {
     }
   }
 
   /**
-   * Scenario: zero and negative timeout.
+   * This test ensures that the {@link SimpleByteBufferPool} behaves correctly when the {@code timeToBlockInMs}
+   * parameter set in {@link SimpleByteBufferPool#allocate(int, long)} is zero or a negative value.
    */
   @Test
   public void testNegativeBlockTime()
-      throws InterruptedException, TimeoutException {
+      throws Exception {
     final int size = 1024;
     final long capacity = 1024;
     final long maxBlockTimeInMs = 20;
     SimpleByteBufferPool pool = new SimpleByteBufferPool(capacity);
-    ByteBuffer buffer=pool.allocate(size, 0);
+    ByteBuffer buffer = pool.allocate(size, 0);
     pool.deallocate(buffer);
-    try{
-      buffer=pool.allocate(size, -maxBlockTimeInMs);
-    }catch(IllegalArgumentException e){
+    try {
+      buffer = pool.allocate(size, -maxBlockTimeInMs);
+    } catch (IllegalArgumentException e) {
     }
     pool.deallocate(buffer);
     assertEquals(size, pool.capacity());
   }
 
   /**
-   * Scenario: a request is first blocked, and then served before timeout.
+   * This scenario tests when a {@link SimpleByteBufferPool} tries to allocate a certain amount of memory in several
+   * stages. First, the requested amount of memory is not availeble, so the allocation operation is blocking. Before
+   * the operation is timed out, the requested amount of memory becomes available, and the allocation becomes successfully.
+   * No exception should occur during this test.
    */
   @Test
   public void testFirstBlockedThenSucceed()
@@ -130,13 +142,18 @@ public class SimpleByteBufferPoolTest {
       used[i] = new CountDownLatch(1);
       consumers[i] = new BufferConsumer(size, maxBlockTimeInMs, pool, allocated[i], used[i]);
       consumerThreads[i] = new Thread(consumers[i]);
-      consumerThreads[i].start();
     }
-    allocated[0].await();
+    consumerThreads[0].start();
+    if (!allocated[0].await(100, TimeUnit.MILLISECONDS)) {
+      fail("SimpleByteBufferPool takes too long time to allocate a buffer to BufferConsumer[0].");
+    }
     assertEquals(0, pool.availableMemory());
+    consumerThreads[1].start();
+    used[0].countDown();
+    consumerThreads[0].join();
+    used[1].countDown();
+    consumerThreads[1].join();
     for (int i = 0; i < 2; i++) {
-      used[i].countDown();
-      consumerThreads[i].join();
       if (consumers[i].exception != null) {
         throw consumers[i].exception;
       }
@@ -145,8 +162,9 @@ public class SimpleByteBufferPoolTest {
   }
 
   /**
-   * Scenario: n requests are first blocked, and then these requests are served after
-   * a large buffer is released back to the pool.
+   * This scenario tests when there is not enough memory, n requests are blocked during getting memory from a
+   * {@link SimpleByteBufferPool}. After a large amount of buffer is deallocated back to the buffer pool, all
+   * the n requests can be served successfully. There should be no exception during the test.
    */
   @Test
   public void testMultipleRequestedServedAfterBlocked()
@@ -163,7 +181,9 @@ public class SimpleByteBufferPoolTest {
     CountDownLatch smallUsed = new CountDownLatch(n);
     BufferConsumer largeConsumer = new BufferConsumer(largeSize, maxBlockTimeInMs, pool, largeAllocated, largeUsed);
     new Thread(largeConsumer).start();
-    largeAllocated.await();
+    if (!largeAllocated.await(100, TimeUnit.MILLISECONDS)) {
+      fail("SimpleByteBufferPool takes too long time to allocate a buffer to largeConsumer.");
+    }
     assertEquals(0, pool.availableMemory());
     BufferConsumer[] smallConsumers = new BufferConsumer[n];
     Thread[] smallConsumerThreads = new Thread[n];
@@ -173,7 +193,9 @@ public class SimpleByteBufferPoolTest {
       smallConsumerThreads[i].start();
     }
     largeUsed.countDown();
-    smallAllocated.await();
+    if (!smallAllocated.await(100, TimeUnit.MILLISECONDS)) {
+      fail("SimpleByteBufferPool takes too long time to allocate a buffer to smallConsumer.");
+    }
     assertEquals(0, pool.availableMemory());
     for (int i = 0; i < n; i++) {
       smallUsed.countDown();
@@ -193,12 +215,14 @@ public class SimpleByteBufferPoolTest {
   }
 
   /**
-   * Scenario: three requests R0, R1, and R2.
-   * t0: R0 served, R1 and R2 blocked.
-   * t1: R1 timeout.
-   * t2: R0 deallocated and R2 served.
+   * In this test scenario, there are three requests: R0, R1, and R2.
+   * At time t0: R0 is made and get served
+   * At time t0 + delta: R1 and R2 are made and get blocked.
+   * At time t1: R1 gets timeout.
+   * At time t2: R0 releases its buffer back to the buffer pool.
+   * At time t2 + delta: R2 gets served.
    */
-  //@Test
+  @Test
   public void testOneExpiredAnotherServed()
       throws Exception {
     final int size = 1024;
@@ -215,13 +239,18 @@ public class SimpleByteBufferPoolTest {
       used[i] = new CountDownLatch(1);
       consumers[i] = new BufferConsumer(size, blockTimeInMs[i], pool, allocated[i], used[i]);
       consumerThreads[i] = new Thread(consumers[i]);
-      consumerThreads[i].start();
     }
-    consumerThreads[1].join(); //wait until consumers[1] timeout
+    consumerThreads[0].start(); // Time t0
+    if (!allocated[0].await(100, TimeUnit.MILLISECONDS)) {
+      fail("SimpleByteBufferPool takes too long time to allocate a buffer to BufferConsumer[0].");
+    }
+    consumerThreads[1].start(); // Time t0 + delta
+    consumerThreads[2].start(); // Time t0 + delta
+    consumerThreads[1].join(); // wait until consumers[1] timeout
     if (!(consumers[1].exception instanceof TimeoutException)) {
       throw consumers[1].exception;
     }
-    used[0].countDown();
+    used[0].countDown(); // Time t2, R0 releases its buffer back to the buffer pool.
     used[2].countDown();
     consumerThreads[0].join();
     consumerThreads[2].join();
@@ -233,6 +262,11 @@ public class SimpleByteBufferPoolTest {
     assertEquals(capacity, pool.availableMemory());
   }
 
+  /**
+   * An entity that has its own thread to request and release {@link ByteBuffer} from a {@link SimpleByteBufferPool}.
+   * {@link CountDownLatch} is employed to ensure that a requested buffer has been allocated and the same buffer has
+   * been fully deallocated back to the buffer pool.
+   */
   private class BufferConsumer implements Runnable {
     final int size;
     final long maxBlockTimeInMs;

--- a/ambry-utils/src/test/java/com.github.ambry.utils/SimpleByteBufferPoolTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/SimpleByteBufferPoolTest.java
@@ -155,6 +155,8 @@ public class SimpleByteBufferPoolTest {
     }
     assertEquals(0, pool.availableMemory());
     consumerThreads[1].start();
+    Thread.sleep(1);
+    assertEquals(Thread.State.TIMED_WAITING, consumerThreads[1].getState());
     used[0].countDown();
     consumerThreads[0].join();
     used[1].countDown();

--- a/ambry-utils/src/test/java/com.github.ambry.utils/SimpleByteBufferPoolTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/SimpleByteBufferPoolTest.java
@@ -155,8 +155,7 @@ public class SimpleByteBufferPoolTest {
     }
     assertEquals(0, pool.availableMemory());
     consumerThreads[1].start();
-    Thread.sleep(1);
-    assertEquals(Thread.State.TIMED_WAITING, consumerThreads[1].getState());
+    assertEquals("BufferConsumer-1 should not have got buffer from the buffer pool.", 1, allocated[1].getCount());
     used[0].countDown();
     consumerThreads[0].join();
     used[1].countDown();


### PR DESCRIPTION
This issue was due to the random order of BufferConsumer execution. This patch specifies the order
of execution explicitly and removes the deadlock. Also refactors part of code.

Reviewer: Priyesh & Gopal

Test done:
count=0; while (./gradlew clean && ./gradlew build && [ $count -ne 200 ]); do ((count++)); printf "\n\nDone with %d iterations\n\n" $count; done
count=0; while (./gradlew :ambry-utils:clean && ./gradlew :ambry-utils:test && [ $count -ne 200 ]); do ((count++)); printf "\n\nDone with %d iterations\n\n" $count; done