### PR TITLE
Refactoring router error code unit tests and adding additional GetOperation unit tests

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -154,22 +154,6 @@ class GetBlobOperation extends GetOperation<ReadableStreamChannel> {
   }
 
   /**
-   * Get the total number of chunks for this operation.
-   * @return The total number of chunks.
-   */
-  int getNumChunksTotal() {
-    return numChunksTotal;
-  }
-
-  /**
-   * Get how many chunks have been retrieved so far in this operation.
-   * @return The number of chunks retrieved from the server.
-   */
-  int getNumChunksRetrieved() {
-    return numChunksRetrieved;
-  }
-
-  /**
    * Do all that needs to be done (cleanup, notification, etc.) on chunk completion and mark the state of the chunk
    * appropriately.
    * @param chunk the chunk that has completed.

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -154,6 +154,22 @@ class GetBlobOperation extends GetOperation<ReadableStreamChannel> {
   }
 
   /**
+   * Get the total number of chunks for this operation.
+   * @return The total number of chunks.
+   */
+  int getNumChunksTotal() {
+    return numChunksTotal;
+  }
+
+  /**
+   * Get how many chunks have been retrieved so far in this operation.
+   * @return The number of chunks retrieved from the server.
+   */
+  int getNumChunksRetrieved() {
+    return numChunksRetrieved;
+  }
+
+  /**
    * Do all that needs to be done (cleanup, notification, etc.) on chunk completion and mark the state of the chunk
    * appropriately.
    * @param chunk the chunk that has completed.

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -74,7 +74,7 @@ public class DeleteManagerTest {
       if (expectedError == null) {
         future.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
       } else {
-        checkErrorCode(future, expectedError);
+        assertFailureAndCheckErrorCode(future, expectedError);
       }
     }
   };
@@ -173,7 +173,7 @@ public class DeleteManagerTest {
     String[] input = {"123", "abcd", "", "/", null};
     for (String s : input) {
       future = router.deleteBlob(s);
-      checkErrorCode(future, RouterErrorCode.InvalidBlobId);
+      assertFailureAndCheckErrorCode(future, RouterErrorCode.InvalidBlobId);
     }
   }
 
@@ -337,7 +337,7 @@ public class DeleteManagerTest {
               // increment mock time
               mockTime.sleep(1000);
             } while (!operationCompleteLatch.await(10, TimeUnit.MILLISECONDS));
-            checkErrorCode(future, expectedError);
+            assertFailureAndCheckErrorCode(future, expectedError);
           }
         });
   }
@@ -368,7 +368,7 @@ public class DeleteManagerTest {
         // increment mock time
         mockTime.sleep(1000);
       } while (!operationCompleteLatch.await(10, TimeUnit.MILLISECONDS));
-      checkErrorCode(future, errorCodeHashMap.get(state));
+      assertFailureAndCheckErrorCode(future, errorCodeHashMap.get(state));
     }
   }
 
@@ -386,7 +386,7 @@ public class DeleteManagerTest {
               throws Exception {
             future = router.deleteBlob(blobIdString);
             router.close();
-            checkErrorCode(future, expectedError);
+            assertFailureAndCheckErrorCode(future, expectedError);
           }
         });
   }
@@ -432,11 +432,11 @@ public class DeleteManagerTest {
   }
 
   /**
-   * Check that a delete operation returns a router exception with the specified error code.
+   * Check that a delete operation has failed with a router exception with the specified error code.
    * @param future the {@link Future} for the delete operation
    * @param expectedError the expected {@link RouterErrorCode}
    */
-  private void checkErrorCode(Future<Void> future, RouterErrorCode expectedError) {
+  private void assertFailureAndCheckErrorCode(Future<Void> future, RouterErrorCode expectedError) {
     try {
       future.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
       fail("Deletion should be unsuccessful. Exception is expected.");

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -576,7 +576,8 @@ public class GetBlobOperationTest {
               if (getChunksBeforeRead) {
                 try {
                   // wait for all chunks (data + metadata) to be received
-                  while (mockNetworkClient.getProcessedResponseCount() < numChunks * routerConfig.routerGetRequestParallelism) {
+                  while (mockNetworkClient.getProcessedResponseCount()
+                      < numChunks * routerConfig.routerGetRequestParallelism) {
                     Thread.sleep(10);
                   }
                 } catch (InterruptedException ignored) {

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -114,11 +114,11 @@ public class GetBlobOperationTest {
   private final OperationCompleteCallback operationCompleteCallback = new OperationCompleteCallback(operationsCount);
 
   /**
-   * An checker that either asserts that a get operation succeeds or returns the specified error code.
+   * A checker that either asserts that a get operation succeeds or returns the specified error code.
    */
-  private final ErrorCodeChecker defaultErrorCodeChecker = new ErrorCodeChecker() {
+  private final ErrorCodeChecker getErrorCodeChecker = new ErrorCodeChecker() {
     @Override
-    public void check(RouterErrorCode expectedError)
+    public void testAndAssert(RouterErrorCode expectedError)
         throws Exception {
       if (expectedError == null) {
         getAndAssertSuccess();
@@ -331,7 +331,7 @@ public class GetBlobOperationTest {
     testWithErrorCodes(Collections.singletonMap(ServerErrorCode.Blob_Not_Found, replicasCount), mockServerLayout,
         RouterErrorCode.BlobDoesNotExist, new ErrorCodeChecker() {
           @Override
-          public void check(RouterErrorCode expectedError)
+          public void testAndAssert(RouterErrorCode expectedError)
               throws Exception {
             GetBlobOperation op = createOperationAndComplete(null);
             Assert.assertEquals("Must have attempted sending requests to all replicas", replicasCount,
@@ -357,7 +357,7 @@ public class GetBlobOperationTest {
       Map<ServerErrorCode, Integer> errorCounts = new HashMap<>();
       errorCounts.put(ServerErrorCode.Blob_Not_Found, replicasCount - 1);
       errorCounts.put(entry.getKey(), 1);
-      testWithErrorCodes(errorCounts, mockServerLayout, entry.getValue(), defaultErrorCodeChecker);
+      testWithErrorCodes(errorCounts, mockServerLayout, entry.getValue(), getErrorCodeChecker);
     }
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -160,7 +160,7 @@ public class GetBlobOperationTest {
             CHECKOUT_TIMEOUT_MS, mockServerLayout, time);
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap), networkClientFactory,
         new LoggingNotificationSystem(), mockClusterMap, time);
-    mockNetworkClient = (MockNetworkClient) networkClientFactory.getNetworkClient();
+    mockNetworkClient = networkClientFactory.getMockNetworkClient();
     readyForPollCallback = new ReadyForPollCallback(mockNetworkClient);
   }
 
@@ -576,7 +576,7 @@ public class GetBlobOperationTest {
               if (getChunksBeforeRead) {
                 try {
                   // wait for all chunks (data + metadata) to be received
-                  while (mockNetworkClient.getProcessedResponseCount() < numChunks * 2) {
+                  while (mockNetworkClient.getProcessedResponseCount() < numChunks * routerConfig.routerGetRequestParallelism) {
                     Thread.sleep(10);
                   }
                 } catch (InterruptedException ignored) {

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -182,7 +182,7 @@ public class GetManagerTest {
    *                             callback should be inspected for correctness.
    * @throws Exception
    */
-  public void testBadCallback(Callback<ReadableStreamChannel> getBlobCallback, CountDownLatch getBlobCallbackCalled,
+  private void testBadCallback(Callback<ReadableStreamChannel> getBlobCallback, CountDownLatch getBlobCallbackCalled,
       Boolean checkBadCallbackBlob)
       throws Exception {
     router = getNonBlockingRouter();

--- a/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
@@ -59,7 +59,6 @@ class MockNetworkClient extends NetworkClient {
    */
   @Override
   public void wakeup() {
-    super.wakeup();
     wokenUp = true;
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClientFactory.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClientFactory.java
@@ -67,7 +67,7 @@ class MockNetworkClientFactory extends NetworkClientFactory {
   public NetworkClient getNetworkClient()
       throws IOException {
     MockSelector selector = new MockSelector(serverLayout, state, time);
-    return new NetworkClient(selector, networkConfig, new NetworkMetrics(new MetricRegistry()), maxPortsPlainText,
+    return new MockNetworkClient(selector, networkConfig, new NetworkMetrics(new MetricRegistry()), maxPortsPlainText,
         maxPortsSsl, checkoutTimeoutMs, time);
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClientFactory.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClientFactory.java
@@ -67,6 +67,18 @@ class MockNetworkClientFactory extends NetworkClientFactory {
   public NetworkClient getNetworkClient()
       throws IOException {
     MockSelector selector = new MockSelector(serverLayout, state, time);
+    return new NetworkClient(selector, networkConfig, new NetworkMetrics(new MetricRegistry()), maxPortsPlainText,
+        maxPortsSsl, checkoutTimeoutMs, time);
+  }
+
+  /**
+   * Return a {@link MockNetworkClient} instantiated with a {@link MockSelector}
+   * @return the constructed {@link MockNetworkClient}
+   * @throws IOException if the selector could not be constructed.
+   */
+  public MockNetworkClient getMockNetworkClient()
+      throws IOException {
+    MockSelector selector = new MockSelector(serverLayout, state, time);
     return new MockNetworkClient(selector, networkConfig, new NetworkMetrics(new MetricRegistry()), maxPortsPlainText,
         maxPortsSsl, checkoutTimeoutMs, time);
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
@@ -162,7 +162,8 @@ class MockServer {
     if (!getErrorOnDataBlobOnly || isDataBlob) {
       // getError could be at the server level or the partition level. For partition level errors,
       // set it in the partitionResponseInfo
-      if (getError == ServerErrorCode.No_Error || getError == ServerErrorCode.Blob_Expired || getError == ServerErrorCode.Blob_Deleted || getError == ServerErrorCode.Blob_Not_Found) {
+      if (getError == ServerErrorCode.No_Error || getError == ServerErrorCode.Blob_Expired
+          || getError == ServerErrorCode.Blob_Deleted || getError == ServerErrorCode.Blob_Not_Found) {
         partitionError = getError;
         serverError = ServerErrorCode.No_Error;
       } else {
@@ -203,15 +204,16 @@ class MockServer {
                 byteBufferSize =
                     (int) MessageFormatRecord.Blob_Format_V2.getBlobRecordSize((int) originalBlobPutReq.getBlobSize());
                 byteBuffer = ByteBuffer.allocate(byteBufferSize);
-                MessageFormatRecord.Blob_Format_V2.serializePartialBlobRecord(byteBuffer,
-                    (int) originalBlobPutReq.getBlobSize(), originalBlobPutReq.getBlobType());
+                MessageFormatRecord.Blob_Format_V2
+                    .serializePartialBlobRecord(byteBuffer, (int) originalBlobPutReq.getBlobSize(),
+                        originalBlobPutReq.getBlobType());
                 break;
               case MessageFormatRecord.Blob_Version_V1:
                 byteBufferSize =
                     (int) MessageFormatRecord.Blob_Format_V1.getBlobRecordSize((int) originalBlobPutReq.getBlobSize());
                 byteBuffer = ByteBuffer.allocate(byteBufferSize);
-                MessageFormatRecord.Blob_Format_V1.serializePartialBlobRecord(byteBuffer,
-                    (int) originalBlobPutReq.getBlobSize());
+                MessageFormatRecord.Blob_Format_V1
+                    .serializePartialBlobRecord(byteBuffer, (int) originalBlobPutReq.getBlobSize());
                 break;
               default:
                 throw new IllegalStateException("Blob format version " + blobFormatVersion + " not supported.");

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -231,7 +231,7 @@ public class NonBlockingRouterTest {
     String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel).get();
     router.close();
     for (MockServer mockServer : mockServerLayout.getMockServers()) {
-      mockServer.setBlobIdToServerErrorCode(blobId, ServerErrorCode.No_Error);
+      mockServer.setServerErrorForAllRequests(ServerErrorCode.No_Error);
     }
 
     NetworkClient networkClient =

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -703,13 +703,13 @@ public class PutManagerTest {
     // identical. In the process also fill in the map of blobId to serializedPutRequests.
     HashMap<String, ByteBuffer> allChunks = new HashMap<String, ByteBuffer>();
     for (MockServer mockServer : mockServerLayout.getMockServers()) {
-      for (Map.Entry<String, ByteBuffer> blobEntry : mockServer.getBlobs().entrySet()) {
+      for (Map.Entry<String, StoredBlob> blobEntry : mockServer.getBlobs().entrySet()) {
         ByteBuffer chunk = allChunks.get(blobEntry.getKey());
         if (chunk == null) {
-          allChunks.put(blobEntry.getKey(), blobEntry.getValue());
+          allChunks.put(blobEntry.getKey(), blobEntry.getValue().data);
         } else {
           Assert.assertTrue("All requests for the same blob id must be identical except for correlation id",
-              areIdenticalPutRequests(chunk.array(), blobEntry.getValue().array()));
+              areIdenticalPutRequests(chunk.array(), blobEntry.getValue().data.array()));
         }
       }
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
@@ -164,7 +164,6 @@ class RouterTestHelpers {
     }
   }
 
-
   /**
    * Set the blob format version that the server should respond to get requests with.
    * @param blobFormatVersion The blob format version to use.
@@ -201,6 +200,7 @@ class RouterTestHelpers {
       mockServer.setDataBlobGetLatch(dataBlobGetLatch);
     }
   }
+
   /**
    * Implement this interface to provide {@link #testWithErrorCodes} with custom verification logic.
    */

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
@@ -166,14 +166,14 @@ class RouterTestHelpers {
 
 
   /**
-   * Set whether all servers should respond to get requests with blob format v2.
-   * @param useBlobFormatV2 {@code true} if v2 should be used, otherwise use v1
+   * Set the blob format version that the server should respond to get requests with.
+   * @param blobFormatVersion The blob format version to use.
    * @param serverLayout A {@link MockServerLayout} containing the {@link MockServer}s to change settings on.
    */
-  static void setBlobFormatForAllServers(boolean useBlobFormatV2, MockServerLayout serverLayout) {
+  static void setBlobFormatVersionForAllServers(short blobFormatVersion, MockServerLayout serverLayout) {
     ArrayList<MockServer> mockServers = new ArrayList<>(serverLayout.getMockServers());
     for (MockServer mockServer : mockServers) {
-      mockServer.setBlobFormat(useBlobFormatV2);
+      mockServer.setBlobFormatVersion(blobFormatVersion);
     }
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
@@ -13,7 +13,16 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.commons.ServerErrorCode;
 import com.github.ambry.messageformat.BlobProperties;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -32,6 +41,139 @@ class RouterTestHelpers {
         a.isPrivate() == b.isPrivate() &&
         a.getTimeToLiveInSeconds() == b.getTimeToLiveInSeconds() &&
         a.getCreationTimeInMs() == b.getCreationTimeInMs();
+  }
+
+  /**
+   * Test that an operation returns a certain result when servers return error codes corresponding
+   * to {@code serverErrorCodeCounts}
+   * @param serverErrorCodeCounts A map from {@link ServerErrorCode}s to a count of how many servers should be set to
+   *                              that error code.
+   * @param serverLayout A {@link MockServerLayout} that is used to find the {@link MockServer}s to set error codes on.
+   * @param expectedError The {@link RouterErrorCode} expected, or null if no error is expected.
+   * @param errorCodeChecker Performs the checks that ensure that the expected {@link RouterErrorCode} is returned .
+   * @throws Exception
+   */
+  static void testWithErrorCodes(Map<ServerErrorCode, Integer> serverErrorCodeCounts, MockServerLayout serverLayout,
+      RouterErrorCode expectedError, ErrorCodeChecker errorCodeChecker)
+      throws Exception {
+    List<ServerErrorCode> serverErrorCodes = new ArrayList<>();
+    for (Map.Entry<ServerErrorCode, Integer> entry : serverErrorCodeCounts.entrySet()) {
+      for (int j = 0; j < entry.getValue(); j++) {
+        serverErrorCodes.add(entry.getKey());
+      }
+    }
+    Collections.shuffle(serverErrorCodes);
+    testWithErrorCodes(serverErrorCodes.toArray(new ServerErrorCode[0]), serverLayout, expectedError, errorCodeChecker);
+  }
+
+  /**
+   * Test that an operation returns a certain result when each server in the layout returns a certain error code.
+   * @param serverErrorCodesInOrder The error codes to set in the order of the servers in {@code serverLayout}.  If
+   *                                there are more values in this array than there are servers, an exception is thrown.
+   *                                If there are less, the rest of the servers are set to
+   *                                {@link ServerErrorCode#No_Error}
+   * @param serverLayout A {@link MockServerLayout} that is used to find the {@link MockServer}s to set error codes on.
+   * @param expectedError The {@link RouterErrorCode} expected, or null if no error is expected.
+   * @param errorCodeChecker Performs the checks that ensure that the expected {@link RouterErrorCode} is returned .
+   * @throws Exception
+   */
+  static void testWithErrorCodes(ServerErrorCode[] serverErrorCodesInOrder, MockServerLayout serverLayout,
+      RouterErrorCode expectedError, ErrorCodeChecker errorCodeChecker)
+      throws Exception {
+    setServerErrorCodes(serverErrorCodesInOrder, serverLayout);
+    errorCodeChecker.check(expectedError);
+    resetServerErrorCodes(serverLayout);
+  }
+
+  /**
+   * Test that an operation returns a certain result when each server in a partition returns a certain error code.
+   * @param serverErrorCodesInOrder The error codes to set in the order of the servers returned by
+   *                                {@link PartitionId#getReplicaIds()}. If there are more values in this array than
+   *                                there are servers, an exception is thrown. If there are less, the rest of the
+   *                                servers are set to {@link ServerErrorCode#No_Error}
+   * @param serverLayout A {@link MockServerLayout} that is used to find the {@link MockServer}s to set error codes on.
+   * @param expectedError The {@link RouterErrorCode} expected, or null if no error is expected.
+   * @param errorCodeChecker Performs the checks that ensure that the expected {@link RouterErrorCode} is returned .
+   * @throws Exception
+   */
+  static void testWithErrorCodes(ServerErrorCode[] serverErrorCodesInOrder, PartitionId partition,
+      MockServerLayout serverLayout, RouterErrorCode expectedError, ErrorCodeChecker errorCodeChecker)
+      throws Exception {
+    setServerErrorCodes(serverErrorCodesInOrder, partition, serverLayout);
+    errorCodeChecker.check(expectedError);
+    resetServerErrorCodes(serverLayout);
+  }
+
+  /**
+   * Set the servers in the specified layout to respond with the designated error codes.
+   * @param serverErrorCodesInOrder The error codes to set in the order of the servers in {@code serverLayout}.  If
+   *                                there are more values in this array than there are servers, an exception is thrown.
+   *                                If there are less, the rest of the servers are set to
+   *                                {@link ServerErrorCode#No_Error}
+   * @param serverLayout A {@link MockServerLayout} that is used to find the {@link MockServer}s to set error codes on.
+   * @throws Exception
+   */
+  static void setServerErrorCodes(ServerErrorCode[] serverErrorCodesInOrder, MockServerLayout serverLayout) {
+    Collection<MockServer> servers = serverLayout.getMockServers();
+    if (serverErrorCodesInOrder.length > servers.size()) {
+      throw new IllegalArgumentException("More server error codes provided than servers in cluster");
+    }
+    int i = 0;
+    for (MockServer server : servers) {
+      if (i < serverErrorCodesInOrder.length) {
+        server.setServerErrorForAllRequests(serverErrorCodesInOrder[i++]);
+      } else {
+        server.setServerErrorForAllRequests(ServerErrorCode.No_Error);
+      }
+    }
+  }
+
+  /**
+   * Set the servers in the specified partition to respond with the designated error codes.
+   * @param serverErrorCodesInOrder The error codes to set in the order of the servers returned by
+   *                                {@link PartitionId#getReplicaIds()}. If there are more values in this array than
+   *                                there are servers, an exception is thrown. If there are less, the rest of the
+   *                                servers are set to {@link ServerErrorCode#No_Error}
+   * @param serverLayout A {@link MockServerLayout} that is used to find the {@link MockServer}s to set error codes on.
+   * @throws Exception
+   */
+  static void setServerErrorCodes(ServerErrorCode[] serverErrorCodesInOrder, PartitionId partition,
+      MockServerLayout serverLayout) {
+    List<ReplicaId> replicas = partition.getReplicaIds();
+    if (serverErrorCodesInOrder.length > replicas.size()) {
+      throw new IllegalArgumentException("More server error codes provided than replicas in partition");
+    }
+    int i = 0;
+    for (ReplicaId replica : partition.getReplicaIds()) {
+      DataNodeId node = replica.getDataNodeId();
+      MockServer mockServer = serverLayout.getMockServer(node.getHostname(), node.getPort());
+      mockServer.setServerErrorForAllRequests(serverErrorCodesInOrder[i++]);
+    }
+  }
+
+  /**
+   * Reset all preset error codes on the servers in the specified layout.
+   * @param serverLayout A {@link MockServerLayout} that is used to find the {@link MockServer}s to reset error codes
+   *                     on.
+   */
+  static void resetServerErrorCodes(MockServerLayout serverLayout) {
+    for (MockServer server : serverLayout.getMockServers()) {
+      server.resetServerErrors();
+    }
+  }
+
+  /**
+   * Implement this interface to provide {@link #testWithErrorCodes} with custom verification logic.
+   */
+  interface ErrorCodeChecker {
+    /**
+     * Make assertions related to the expected error code.
+     * @param expectedError The {@link RouterErrorCode} that an operation is expected to report, or {@code null} if no
+     *                      error is expected.
+     * @throws Exception
+     */
+    void check(RouterErrorCode expectedError)
+        throws Exception;
   }
 }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
@@ -70,7 +70,7 @@ class RouterTestHelpers {
    * Test that an operation returns a certain result when each server in the layout returns a certain error code.
    * @param serverErrorCodesInOrder The error codes to set in the order of the servers in {@code serverLayout}.  If
    *                                there are more values in this array than there are servers, an exception is thrown.
-   *                                If there are less, the rest of the servers are set to
+   *                                If there are fewer, the rest of the servers are set to
    *                                {@link ServerErrorCode#No_Error}
    * @param serverLayout A {@link MockServerLayout} that is used to find the {@link MockServer}s to set error codes on.
    * @param expectedError The {@link RouterErrorCode} expected, or null if no error is expected.
@@ -81,7 +81,7 @@ class RouterTestHelpers {
       RouterErrorCode expectedError, ErrorCodeChecker errorCodeChecker)
       throws Exception {
     setServerErrorCodes(serverErrorCodesInOrder, serverLayout);
-    errorCodeChecker.check(expectedError);
+    errorCodeChecker.testAndAssert(expectedError);
     resetServerErrorCodes(serverLayout);
   }
 
@@ -89,8 +89,9 @@ class RouterTestHelpers {
    * Test that an operation returns a certain result when each server in a partition returns a certain error code.
    * @param serverErrorCodesInOrder The error codes to set in the order of the servers returned by
    *                                {@link PartitionId#getReplicaIds()}. If there are more values in this array than
-   *                                there are servers, an exception is thrown. If there are less, the rest of the
-   *                                servers are set to {@link ServerErrorCode#No_Error}
+   *                                there are servers containing the partition, an exception is thrown. If there are
+   *                                fewer, the rest of the servers are set to {@link ServerErrorCode#No_Error}
+   * @param partition The partition contained by the servers to set error codes on.
    * @param serverLayout A {@link MockServerLayout} that is used to find the {@link MockServer}s to set error codes on.
    * @param expectedError The {@link RouterErrorCode} expected, or null if no error is expected.
    * @param errorCodeChecker Performs the checks that ensure that the expected {@link RouterErrorCode} is returned .
@@ -100,18 +101,17 @@ class RouterTestHelpers {
       MockServerLayout serverLayout, RouterErrorCode expectedError, ErrorCodeChecker errorCodeChecker)
       throws Exception {
     setServerErrorCodes(serverErrorCodesInOrder, partition, serverLayout);
-    errorCodeChecker.check(expectedError);
+    errorCodeChecker.testAndAssert(expectedError);
     resetServerErrorCodes(serverLayout);
   }
 
   /**
    * Set the servers in the specified layout to respond with the designated error codes.
-   * @param serverErrorCodesInOrder The error codes to set in the order of the servers in {@code serverLayout}.  If
-   *                                there are more values in this array than there are servers, an exception is thrown.
-   *                                If there are less, the rest of the servers are set to
-   *                                {@link ServerErrorCode#No_Error}
+   * @param serverErrorCodesInOrder The error codes to set in the order of the servers in {@code serverLayout}.
+   *                                If there are fewer error codes in this array than there are servers,
+   *                                the rest of the servers are set to {@link ServerErrorCode#No_Error}
    * @param serverLayout A {@link MockServerLayout} that is used to find the {@link MockServer}s to set error codes on.
-   * @throws Exception
+   * @throws IllegalArgumentException If there are more error codes in the input array then there are servers.
    */
   static void setServerErrorCodes(ServerErrorCode[] serverErrorCodesInOrder, MockServerLayout serverLayout) {
     Collection<MockServer> servers = serverLayout.getMockServers();
@@ -129,13 +129,14 @@ class RouterTestHelpers {
   }
 
   /**
-   * Set the servers in the specified partition to respond with the designated error codes.
+   * Set the servers containing the specified partition to respond with the designated error codes.
    * @param serverErrorCodesInOrder The error codes to set in the order of the servers returned by
-   *                                {@link PartitionId#getReplicaIds()}. If there are more values in this array than
-   *                                there are servers, an exception is thrown. If there are less, the rest of the
-   *                                servers are set to {@link ServerErrorCode#No_Error}
+   *                                {@link PartitionId#getReplicaIds()}. If there are fewer error codes in this array
+   *                                than there are servers containing the partition, the rest of the servers are set to
+   *                                {@link ServerErrorCode#No_Error}
+   * @param partition The partition contained by the servers to set error codes on.
    * @param serverLayout A {@link MockServerLayout} that is used to find the {@link MockServer}s to set error codes on.
-   * @throws Exception
+   * @throws IllegalArgumentException If there are more error codes in the input array then there are servers.
    */
   static void setServerErrorCodes(ServerErrorCode[] serverErrorCodesInOrder, PartitionId partition,
       MockServerLayout serverLayout) {
@@ -167,12 +168,12 @@ class RouterTestHelpers {
    */
   interface ErrorCodeChecker {
     /**
-     * Make assertions related to the expected error code.
+     * Test and make assertions related to the expected error code.
      * @param expectedError The {@link RouterErrorCode} that an operation is expected to report, or {@code null} if no
      *                      error is expected.
      * @throws Exception
      */
-    void check(RouterErrorCode expectedError)
+    void testAndAssert(RouterErrorCode expectedError)
         throws Exception;
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 
 
 /**
@@ -163,6 +164,43 @@ class RouterTestHelpers {
     }
   }
 
+
+  /**
+   * Set whether all servers should respond to get requests with blob format v2.
+   * @param useBlobFormatV2 {@code true} if v2 should be used, otherwise use v1
+   * @param serverLayout A {@link MockServerLayout} containing the {@link MockServer}s to change settings on.
+   */
+  static void setBlobFormatForAllServers(boolean useBlobFormatV2, MockServerLayout serverLayout) {
+    ArrayList<MockServer> mockServers = new ArrayList<>(serverLayout.getMockServers());
+    for (MockServer mockServer : mockServers) {
+      mockServer.setBlobFormat(useBlobFormatV2);
+    }
+  }
+
+  /**
+   * Set whether all servers should send the preset error code on data blob get requests
+   * only
+   * @param getErrorOnDataBlobOnly {@code true} if the preset error code should only be used for data blobs requests
+   * @param serverLayout A {@link MockServerLayout} containing the {@link MockServer}s to change settings on.
+   */
+  static void setGetErrorOnDataBlobOnlyForAllServers(boolean getErrorOnDataBlobOnly, MockServerLayout serverLayout) {
+    ArrayList<MockServer> mockServers = new ArrayList<>(serverLayout.getMockServers());
+    for (MockServer mockServer : mockServers) {
+      mockServer.setGetErrorOnDataBlobOnly(getErrorOnDataBlobOnly);
+    }
+  }
+
+  /**
+   * Introduce a latch that all mock servers will wait for before performing data blob get operations.
+   * @param dataBlobGetLatch The {@link CountDownLatch} to wait for.
+   * @param serverLayout A {@link MockServerLayout} containing the {@link MockServer}s to change settings on.
+   */
+  static void setDataBlobGetLatchForAllServers(CountDownLatch dataBlobGetLatch, MockServerLayout serverLayout) {
+    ArrayList<MockServer> mockServers = new ArrayList<>(serverLayout.getMockServers());
+    for (MockServer mockServer : mockServers) {
+      mockServer.setDataBlobGetLatch(dataBlobGetLatch);
+    }
+  }
   /**
    * Implement this interface to provide {@link #testWithErrorCodes} with custom verification logic.
    */


### PR DESCRIPTION
- Introducing new helper methods to make tests that deal with setting
  server error codes and testing router responses cleaner.
- Made changes to `DeleteManagerTest` and `GetBlobOperationTest` to use
  these methods.
- Added unit tests to address todo test cases in `GetBlobOperationTest`

See issue #329 
*Coverage:*

| Element          | Class %    | Method %     | Line %       |
|------------------|------------|--------------|--------------|
| GetBlobOperation | 100% (1/1) | 100% (10/10) | 94% (54/57)  |
| GetOperation     | 100% (1/1) | 100% (10/10) | 100% (26/26) |

*Time to review:* 15-20 min.
*Reviewers:* @vgkholla, @pnarayanan 