### PR TITLE
Fix replicationLag metric name

### DIFF
--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import java.util.ArrayList;
@@ -346,9 +347,10 @@ public class ReplicationMetrics {
   }
 
   public void addRemoteReplicaToLagMetrics(final RemoteReplicaInfo remoteReplicaInfo) {
-    final String metricName = remoteReplicaInfo.getReplicaId().getDataNodeId().getHostname() + "-" +
-        remoteReplicaInfo.getReplicaId().getDataNodeId().getPort() + "-" +
-        remoteReplicaInfo.getReplicaId().getReplicaPath() + "-replicaLagInBytes";
+    ReplicaId replicaId = remoteReplicaInfo.getReplicaId();
+    DataNodeId dataNodeId = replicaId.getDataNodeId();
+    final String metricName =
+        dataNodeId.getHostname() + "-" + dataNodeId.getPort() + "-" + replicaId.getPartitionId() + "-replicaLagInBytes";
     Gauge<Long> replicaLag = new Gauge<Long>() {
       @Override
       public Long getValue() {


### PR DESCRIPTION
Changed name to include only the partition ID of interest and not the
entire mountpath. The only part of the mountpath that we needed to
identify a replica was the partition ID.

*Reviewers:* @pnarayanan, @nsivabalan 
*Time to review:* 5 min.