### PR TITLE
Adding metrics to track thread usage in Coordinator and Router

### DIFF
--- a/ambry-coordinator/src/main/java/com.github.ambry.coordinator/CoordinatorMetrics.java
+++ b/ambry-coordinator/src/main/java/com.github.ambry.coordinator/CoordinatorMetrics.java
@@ -21,11 +21,11 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.messageformat.MessageFormatErrorCodes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -76,6 +76,8 @@ public class CoordinatorMetrics {
   public final Counter totalCrossColoProxyCallCount;
 
   public final Gauge<Integer> crossDCCallsEnabled;
+  public final AtomicInteger totalRequestsInFlight = new AtomicInteger(0);
+  public final AtomicInteger totalRequestsInExecution = new AtomicInteger(0);
 
   private final Map<DataNodeId, RequestMetrics> requestMetrics;
 
@@ -151,6 +153,24 @@ public class CoordinatorMetrics {
     requestMetrics = new HashMap<DataNodeId, RequestMetrics>();
     for (DataNodeId dataNodeId : clusterMap.getDataNodeIds()) {
       requestMetrics.put(dataNodeId, new RequestMetrics(registry, dataNodeId));
+    }
+
+    if (!registry.getNames().contains(MetricRegistry.name(AmbryCoordinator.class, "totalRequestsInFlight"))) {
+      Gauge<Integer> requestsInFlight = new Gauge<Integer>() {
+        @Override
+        public Integer getValue() {
+          return totalRequestsInFlight.get();
+        }
+      };
+      registry.register(MetricRegistry.name(AmbryCoordinator.class, "totalRequestsInFlight"), requestsInFlight);
+
+      Gauge<Integer> requestsInExecution = new Gauge<Integer>() {
+        @Override
+        public Integer getValue() {
+          return totalRequestsInExecution.get();
+        }
+      };
+      registry.register(MetricRegistry.name(AmbryCoordinator.class, "totalRequestsInExecution"), requestsInExecution);
     }
   }
 

--- a/ambry-coordinator/src/main/java/com.github.ambry.coordinator/Operation.java
+++ b/ambry-coordinator/src/main/java/com.github.ambry.coordinator/Operation.java
@@ -355,9 +355,9 @@ abstract class OperationRequest implements Runnable {
       }
       markRequest();
       updateRequest(System.currentTimeMillis() - startTimeInMs);
+      context.getCoordinatorMetrics().totalRequestsInExecution.decrementAndGet();
+      context.getCoordinatorMetrics().totalRequestsInFlight.decrementAndGet();
     }
-    context.getCoordinatorMetrics().totalRequestsInExecution.decrementAndGet();
-    context.getCoordinatorMetrics().totalRequestsInFlight.decrementAndGet();
   }
 
   private void countError(MessageFormatErrorCodes error) {

--- a/ambry-router/src/main/java/com.github.ambry.router/CoordinatorBackedRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/CoordinatorBackedRouter.java
@@ -317,6 +317,7 @@ class CoordinatorOperation implements Runnable {
   @Override
   public void run() {
     long operationStartTime = System.currentTimeMillis();
+    router.metrics.totalOperationsInExecution.incrementAndGet();
     onDequeue();
     Histogram operationTotalTimeTracker = null;
     Object operationResult = null;
@@ -405,7 +406,6 @@ class CoordinatorOperation implements Runnable {
    * Tracks metrics on dequeuing of operation.
    */
   private void onDequeue() {
-    router.metrics.totalOperationsInExecution.incrementAndGet();
     if (operationQueueStartTime != null) {
       long queueTime = System.currentTimeMillis() - operationQueueStartTime;
       router.metrics.operationQueuingTimeInMs.update(queueTime);

--- a/ambry-router/src/main/java/com.github.ambry.router/CoordinatorBackedRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/CoordinatorBackedRouterMetrics.java
@@ -14,9 +14,11 @@
 package com.github.ambry.router;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
@@ -65,6 +67,9 @@ public class CoordinatorBackedRouterMetrics {
   // CoordinatorOperation
   public final Counter operationError;
   public final Counter queueStartTimeNotRecordedError;
+
+  public final AtomicInteger totalOperationsInFlight = new AtomicInteger(0);
+  public final AtomicInteger totalOperationsInExecution = new AtomicInteger(0);
 
   /**
    * Creates an instance of CoordinatorBackedRouterMetrics using the given {@code metricRegistry}.
@@ -125,5 +130,23 @@ public class CoordinatorBackedRouterMetrics {
     operationError = metricRegistry.counter(MetricRegistry.name(CoordinatorOperation.class, "OperationError"));
     queueStartTimeNotRecordedError =
         metricRegistry.counter(MetricRegistry.name(CoordinatorOperation.class, "QueueStartTimeNotRecordedError"));
+
+    Gauge<Integer> operationsInFlight = new Gauge<Integer>() {
+      @Override
+      public Integer getValue() {
+        return totalOperationsInFlight.get();
+      }
+    };
+    metricRegistry
+        .register(MetricRegistry.name(CoordinatorBackedRouter.class, "TotalOperationsInFlight"), operationsInFlight);
+
+    Gauge<Integer> operationsInExecution = new Gauge<Integer>() {
+      @Override
+      public Integer getValue() {
+        return totalOperationsInExecution.get();
+      }
+    };
+    metricRegistry.register(MetricRegistry.name(CoordinatorBackedRouter.class, "TotalOperationsInExecution"),
+        operationsInExecution);
   }
 }


### PR DESCRIPTION
These metrics track the usage of threads inside both `OperationRequest` and `CoordinatorBackedRouter` giving a better look at thread utilization.

Built and formatted.