### PR TITLE
Performance optimizations for the router

### DIFF
--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +34,7 @@ public class MockClusterMap implements ClusterMap {
   private final Map<Long, PartitionId> partitions;
   private final List<MockDataNodeId> dataNodes;
   private final int numMountPointsPerNode;
+  private final HashSet<String> dataCentersInClusterMap = new HashSet<>();
 
   /**
    * The default constructor sets up a 9 node cluster with 3 mount points in each, with 3 partitions/replicas per
@@ -84,10 +86,12 @@ public class MockClusterMap implements ClusterMap {
       if (i % 3 == 0) {
         dcIndex++;
       }
+      String dcName = "DC" + dcIndex;
+      dataCentersInClusterMap.add(dcName);
       if (enableSSLPorts) {
-        dataNodes.add(createDataNode(getListOfPorts(currentPlainTextPort++, currentSSLPort++), "DC" + dcIndex));
+        dataNodes.add(createDataNode(getListOfPorts(currentPlainTextPort++, currentSSLPort++), dcName));
       } else {
-        dataNodes.add(createDataNode(getListOfPorts(currentPlainTextPort++), "DC" + dcIndex));
+        dataNodes.add(createDataNode(getListOfPorts(currentPlainTextPort++), dcName));
       }
     }
     partitions = new HashMap<Long, PartitionId>();
@@ -165,7 +169,7 @@ public class MockClusterMap implements ClusterMap {
 
   @Override
   public boolean hasDatacenter(String datacenterName) {
-    return true;
+    return dataCentersInClusterMap.contains(datacenterName);
   }
 
   @Override

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ByteBufferAsyncWritableChannel.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ByteBufferAsyncWritableChannel.java
@@ -31,10 +31,46 @@ import java.util.concurrent.locks.ReentrantLock;
  * retrieved and resolved by an external thread.
  */
 public class ByteBufferAsyncWritableChannel implements AsyncWritableChannel {
+
+  /**
+   * List of events of interest to the consumer of the content in this channel.
+   */
+  public enum EventType {
+    ChunkArrival,
+    Close,
+  }
+
+  /**
+   * Callback that can be used to listen to events that happen inside this channel.
+   */
+  public interface ChannelEventListener {
+    /**
+     * Called when an event of the given type completes within this channel.
+     * @param e the {@link EventType} of the event that completed.
+     */
+    public void onEvent(EventType e);
+  }
+
   private final LinkedBlockingQueue<ChunkData> chunks = new LinkedBlockingQueue<ChunkData>();
   private final Queue<ChunkData> chunksAwaitingResolution = new LinkedBlockingQueue<ChunkData>();
   private final ReentrantLock lock = new ReentrantLock();
   private final AtomicBoolean channelOpen = new AtomicBoolean(true);
+  private final ChannelEventListener channelEventListener;
+
+  /**
+   * Construct a ByteBufferAsyncWritableChannel with a null {@link ChannelEventListener}
+   */
+  public ByteBufferAsyncWritableChannel() {
+    this(null);
+  }
+
+  /**
+   * Construct a ByteBufferAsyncWritableChannel with the given {@link ChannelEventListener}
+   * @param channelEventListener the {@link ChannelEventListener} that will be notified on consumable events.
+   */
+  public ByteBufferAsyncWritableChannel(ChannelEventListener channelEventListener) {
+    this.channelEventListener = channelEventListener;
+  }
 
   /**
    * If the channel is open, simply queues the buffer to be handled later.
@@ -50,6 +86,9 @@ public class ByteBufferAsyncWritableChannel implements AsyncWritableChannel {
     }
     ChunkData chunkData = new ChunkData(src, callback);
     chunks.add(chunkData);
+    if (channelEventListener != null) {
+      channelEventListener.onEvent(EventType.ChunkArrival);
+    }
     if (!isOpen()) {
       resolveAllRemainingChunks(new ClosedChannelException());
     }
@@ -69,6 +108,9 @@ public class ByteBufferAsyncWritableChannel implements AsyncWritableChannel {
   public void close() {
     if (channelOpen.compareAndSet(true, false)) {
       resolveAllRemainingChunks(new ClosedChannelException());
+    }
+    if (channelEventListener != null) {
+      channelEventListener.onEvent(EventType.Close);
     }
   }
 

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ByteBufferAsyncWritableChannel.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ByteBufferAsyncWritableChannel.java
@@ -36,7 +36,7 @@ public class ByteBufferAsyncWritableChannel implements AsyncWritableChannel {
    * List of events of interest to the consumer of the content in this channel.
    */
   public enum EventType {
-    ChunkArrival,
+    Write,
     Close,
   }
 
@@ -87,7 +87,7 @@ public class ByteBufferAsyncWritableChannel implements AsyncWritableChannel {
     ChunkData chunkData = new ChunkData(src, callback);
     chunks.add(chunkData);
     if (channelEventListener != null) {
-      channelEventListener.onEvent(EventType.ChunkArrival);
+      channelEventListener.onEvent(EventType.Write);
     }
     if (!isOpen()) {
       resolveAllRemainingChunks(new ClosedChannelException());

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
@@ -193,6 +193,8 @@ public class ByteBufferAsyncWritableChannelTest {
             }
           }
         });
+    assertFalse("No chunk arrival notification should have come in before any write", chunkArrivalNotified.get());
+    assertFalse("No close event notification should have come in before a close", closeNotified.get());
     channel.write(ByteBuffer.allocate(5), null);
     assertTrue("Write should have been notified", chunkArrivalNotified.get());
     channel.close();

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
@@ -177,26 +177,29 @@ public class ByteBufferAsyncWritableChannelTest {
     assertNull("There should have been no chunk returned", channel.getNextChunk(0));
   }
 
+  /**
+   * Test to verify notification for all channel events.
+   */
   @Test
   public void testChannelEventNotification()
       throws Exception {
-    final AtomicBoolean chunkArrivalNotified = new AtomicBoolean(false);
+    final AtomicBoolean writeNotified = new AtomicBoolean(false);
     final AtomicBoolean closeNotified = new AtomicBoolean(false);
     ByteBufferAsyncWritableChannel channel =
         new ByteBufferAsyncWritableChannel(new ByteBufferAsyncWritableChannel.ChannelEventListener() {
           @Override
           public void onEvent(ByteBufferAsyncWritableChannel.EventType e) {
-            if (e == ByteBufferAsyncWritableChannel.EventType.ChunkArrival) {
-              chunkArrivalNotified.set(true);
+            if (e == ByteBufferAsyncWritableChannel.EventType.Write) {
+              writeNotified.set(true);
             } else if (e == ByteBufferAsyncWritableChannel.EventType.Close) {
               closeNotified.set(true);
             }
           }
         });
-    assertFalse("No chunk arrival notification should have come in before any write", chunkArrivalNotified.get());
-    assertFalse("No close event notification should have come in before a close", closeNotified.get());
+    assertFalse("No write notification should have come in before any write", writeNotified.get());
     channel.write(ByteBuffer.allocate(5), null);
-    assertTrue("Write should have been notified", chunkArrivalNotified.get());
+    assertTrue("Write should have been notified", writeNotified.get());
+    assertFalse("No close event notification should have come in before a close", closeNotified.get());
     channel.close();
     assertTrue("Close should have been notified", closeNotified.get());
   }

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
@@ -177,6 +177,28 @@ public class ByteBufferAsyncWritableChannelTest {
     assertNull("There should have been no chunk returned", channel.getNextChunk(0));
   }
 
+  @Test
+  public void testChannelEventNotification()
+      throws Exception {
+    final AtomicBoolean chunkArrivalNotified = new AtomicBoolean(false);
+    final AtomicBoolean closeNotified = new AtomicBoolean(false);
+    ByteBufferAsyncWritableChannel channel =
+        new ByteBufferAsyncWritableChannel(new ByteBufferAsyncWritableChannel.ChannelEventListener() {
+          @Override
+          public void onEvent(ByteBufferAsyncWritableChannel.EventType e) {
+            if (e == ByteBufferAsyncWritableChannel.EventType.ChunkArrival) {
+              chunkArrivalNotified.set(true);
+            } else if (e == ByteBufferAsyncWritableChannel.EventType.Close) {
+              closeNotified.set(true);
+            }
+          }
+        });
+    channel.write(ByteBuffer.allocate(5), null);
+    assertTrue("Write should have been notified", chunkArrivalNotified.get());
+    channel.close();
+    assertTrue("Close should have been notified", closeNotified.get());
+  }
+
   // helpers
 
   // checkoutMultipleChunksAndResolveTest() helpers.

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The NetworkClient provides a method for sending a list of requests in the form of {@link Send} to a host:port,
- * and receive responses for sent requests. Requests that come in via {@link #sendAndPoll(List)} call,
+ * and receive responses for sent requests. Requests that come in via {@link #sendAndPoll(List, int)} call,
  * that could not be immediately sent is queued and an attempt will be made in subsequent invocations of the call (or
  * until they time out).
  * (Note: We will empirically determine whether, rather than queueing a request,
@@ -49,7 +49,6 @@ public class NetworkClient implements Closeable {
   private final HashMap<String, RequestMetadata> connectionIdToRequestInFlight;
   private final AtomicLong numPendingRequests;
   private final int checkoutTimeoutMs;
-  private final int POLL_TIMEOUT_MS = 300;
   private boolean closed = false;
   private static final Logger logger = LoggerFactory.getLogger(NetworkClient.class);
 
@@ -84,12 +83,13 @@ public class NetworkClient implements Closeable {
    * attempt sending the requests in the queue (or time them out) and then attempt sending the newly added requests.
    * @param requestInfos the list of {@link RequestInfo} representing the requests that need to be sent out. This
    *                     could be empty.
+   * @param pollTimeoutMs the poll timeout.
    * @return a list of {@link ResponseInfo} representing the responses received for any requests that were sent out
    * so far.
    * @throws IOException if the {@link Selector} associated with this NetworkClient throws
    * @throws IllegalStateException if the NetworkClient is closed.
    */
-  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestInfos)
+  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestInfos, int pollTimeoutMs)
       throws IOException {
     long startTime = time.milliseconds();
     try {
@@ -104,7 +104,7 @@ public class NetworkClient implements Closeable {
         pendingRequests.add(new RequestMetadata(time.milliseconds(), requestInfo, clientNetworkRequestMetrics));
       }
       List<NetworkSend> sends = prepareSends(responseInfoList);
-      selector.poll(POLL_TIMEOUT_MS, sends);
+      selector.poll(pollTimeoutMs, sends);
       handleSelectorEvents(responseInfoList);
       return responseInfoList;
     } finally {
@@ -218,7 +218,10 @@ public class NetworkClient implements Closeable {
   }
 
   /**
-   * Wake up the NetworkClient if it is within a {@link #sendAndPoll(java.util.List)} sleep.
+   * Wake up the NetworkClient if it is within a {@link #sendAndPoll(List, int)} sleep. This wakes
+   * up the {@link Selector}, which in turn wakes up the {@link java.nio.channels.Selector}.
+   * <br>
+   * @see java.nio.channels.Selector#wakeup()
    */
   public void wakeup() {
     selector.wakeup();

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -218,6 +218,16 @@ public class NetworkClientTest {
   }
 
   /**
+   * Test that the NetworkClient wakeUp wakes up the associated Selector.
+   */
+  @Test
+  public void testWakeUp() {
+    Assert.assertFalse("Selector should not have been woken up at this point", selector.getWakeUpState());
+    networkClient.wakeup();
+    Assert.assertTrue("Selector should have been woken up at this point", selector.getWakeUpState());
+  }
+
+  /**
    * Test to ensure subsequent operations after a close throw an {@link IllegalStateException}.
    */
   @Test
@@ -347,6 +357,7 @@ class MockSelector extends Selector {
   private List<NetworkSend> sends = new ArrayList<NetworkSend>();
   private List<NetworkReceive> receives = new ArrayList<NetworkReceive>();
   private MockSelectorState state = MockSelectorState.Good;
+  private boolean wakeUpCalled = false;
 
   /**
    * Create a MockSelector
@@ -458,6 +469,28 @@ class MockSelector extends Selector {
     List<NetworkReceive> toReturn = receives;
     receives = new ArrayList<NetworkReceive>();
     return toReturn;
+  }
+
+  /**
+   * Clear the wakeup state of this NetworkClient.
+   */
+  public void clearWakeUpState() {
+    wakeUpCalled = false;
+  }
+
+  /**
+   * @return true if wakeup() was called.
+   */
+  public boolean getWakeUpState() {
+    return wakeUpCalled;
+  }
+
+  /**
+   * wakes up the MockSelector if sleeping.
+   */
+  @Override
+  public void wakeup() {
+    wakeUpCalled = true;
   }
 
   /**

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -222,9 +222,9 @@ public class NetworkClientTest {
    */
   @Test
   public void testWakeUp() {
-    Assert.assertFalse("Selector should not have been woken up at this point", selector.getWakeUpState());
+    Assert.assertFalse("Selector should not have been woken up at this point", selector.getAndClearWokenUpStatus());
     networkClient.wakeup();
-    Assert.assertTrue("Selector should have been woken up at this point", selector.getWakeUpState());
+    Assert.assertTrue("Selector should have been woken up at this point", selector.getAndClearWokenUpStatus());
   }
 
   /**
@@ -472,17 +472,13 @@ class MockSelector extends Selector {
   }
 
   /**
-   * Clear the wakeup state of this NetworkClient.
+   * Return whether wakeup() was called and clear the woken up status before returning.
+   * @return true if wakeup() was called previously.
    */
-  public void clearWakeUpState() {
+  public boolean getAndClearWokenUpStatus() {
+    boolean ret = wakeUpCalled;
     wakeUpCalled = false;
-  }
-
-  /**
-   * @return true if wakeup() was called.
-   */
-  public boolean getWakeUpState() {
-    return wakeUpCalled;
+    return ret;
   }
 
   /**

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -89,7 +89,7 @@ public class NetworkClientTest {
     int responseCount = 0;
 
     do {
-      responseInfoList = networkClient.sendAndPoll(requestInfoList);
+      responseInfoList = networkClient.sendAndPoll(requestInfoList, 100);
       requestInfoList.clear();
       for (ResponseInfo responseInfo : responseInfoList) {
         MockSend send = (MockSend) responseInfo.getRequest();
@@ -105,7 +105,7 @@ public class NetworkClientTest {
     } while (requestCount > responseCount);
     Assert.assertEquals("Should receive only as many responses as there were requests", requestCount, responseCount);
 
-    responseInfoList = networkClient.sendAndPoll(requestInfoList);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, 100);
     requestInfoList.clear();
     Assert.assertEquals("No responses are expected at this time", 0, responseInfoList.size());
   }
@@ -123,7 +123,7 @@ public class NetworkClientTest {
     int requestCount = requestInfoList.size();
     int responseCount = 0;
 
-    responseInfoList = networkClient.sendAndPoll(requestInfoList);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, 100);
     requestInfoList.clear();
     // The first sendAndPoll() initiates the connections. So, after the selector poll, new connections
     // would have been established, but no new responses or disconnects, so the NetworkClient should not have been
@@ -133,7 +133,7 @@ public class NetworkClientTest {
     time.sleep(CHECKOUT_TIMEOUT_MS + 1);
 
     do {
-      responseInfoList = networkClient.sendAndPoll(requestInfoList);
+      responseInfoList = networkClient.sendAndPoll(requestInfoList, 100);
       requestInfoList.clear();
       for (ResponseInfo responseInfo : responseInfoList) {
         NetworkClientErrorCode error = responseInfo.getError();
@@ -145,7 +145,7 @@ public class NetworkClientTest {
         responseCount++;
       }
     } while (requestCount > responseCount);
-    responseInfoList = networkClient.sendAndPoll(requestInfoList);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, 100);
     requestInfoList.clear();
     Assert.assertEquals("No responses are expected at this time", 0, responseInfoList.size());
   }
@@ -166,7 +166,7 @@ public class NetworkClientTest {
     // set beBad so that requests end up failing due to "network error".
     selector.setState(MockSelectorState.DisconnectOnSend);
     do {
-      responseInfoList = networkClient.sendAndPoll(requestInfoList);
+      responseInfoList = networkClient.sendAndPoll(requestInfoList, 100);
       requestInfoList.clear();
       for (ResponseInfo responseInfo : responseInfoList) {
         NetworkClientErrorCode error = responseInfo.getError();
@@ -178,7 +178,7 @@ public class NetworkClientTest {
         responseCount++;
       }
     } while (requestCount > responseCount);
-    responseInfoList = networkClient.sendAndPoll(requestInfoList);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, 100);
     requestInfoList.clear();
     Assert.assertEquals("No responses are expected at this time", 0, responseInfoList.size());
     selector.setState(MockSelectorState.Good);
@@ -194,7 +194,7 @@ public class NetworkClientTest {
     requestInfoList.add(new RequestInfo(host2, port2, new MockSend(4)));
     selector.setState(MockSelectorState.ThrowExceptionOnConnect);
     try {
-      networkClient.sendAndPoll(requestInfoList);
+      networkClient.sendAndPoll(requestInfoList, 100);
     } catch (IOException e) {
       Assert.fail("If selector throws on connect, sendAndPoll() should not throw");
     }
@@ -210,7 +210,7 @@ public class NetworkClientTest {
     requestInfoList.add(new RequestInfo(host2, port2, new MockSend(4)));
     selector.setState(MockSelectorState.ThrowExceptionOnPoll);
     try {
-      networkClient.sendAndPoll(requestInfoList);
+      networkClient.sendAndPoll(requestInfoList, 100);
       Assert.fail("If selector throws on poll, sendAndPoll() should throw as well");
     } catch (IOException e) {
     }
@@ -218,10 +218,10 @@ public class NetworkClientTest {
   }
 
   /**
-   * Test that the NetworkClient wakeUp wakes up the associated Selector.
+   * Test that the NetworkClient wakeup wakes up the associated Selector.
    */
   @Test
-  public void testWakeUp() {
+  public void testWakeup() {
     Assert.assertFalse("Selector should not have been woken up at this point", selector.getAndClearWokenUpStatus());
     networkClient.wakeup();
     Assert.assertTrue("Selector should have been woken up at this point", selector.getAndClearWokenUpStatus());
@@ -236,7 +236,7 @@ public class NetworkClientTest {
     List<RequestInfo> requestInfoList = new ArrayList<RequestInfo>();
     networkClient.close();
     try {
-      networkClient.sendAndPoll(requestInfoList);
+      networkClient.sendAndPoll(requestInfoList, 100);
       Assert.fail("Polling after close should throw");
     } catch (IllegalStateException e) {
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -46,7 +46,6 @@ class DeleteManager {
   private final ClusterMap clusterMap;
   private final RouterConfig routerConfig;
   private final OperationCompleteCallback operationCompleteCallback;
-  private final ReadyForPollCallback readyForPollCallback;
 
   private static final Logger logger = LoggerFactory.getLogger(DeleteManager.class);
 
@@ -75,20 +74,17 @@ class DeleteManager {
    * @param routerConfig The {@link RouterConfig} containing the configs for the DeleteManager.
    * @param routerMetrics The {@link NonBlockingRouterMetrics} to be used for reporting metrics.
    * @param operationCompleteCallback The {@link OperationCompleteCallback} to use to complete operations.
-   * @param readyForPollCallback The callback to be used to notify the router of any state changes within the
-   *                             operations.
    * @param time The {@link Time} instance to use.
    */
   DeleteManager(ClusterMap clusterMap, ResponseHandler responseHandler, NotificationSystem notificationSystem,
       RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
-      OperationCompleteCallback operationCompleteCallback, ReadyForPollCallback readyForPollCallback, Time time) {
+      OperationCompleteCallback operationCompleteCallback, Time time) {
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.notificationSystem = notificationSystem;
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
     this.operationCompleteCallback = operationCompleteCallback;
-    this.readyForPollCallback = readyForPollCallback;
     this.time = time;
     deleteOperations = Collections.newSetFromMap(new ConcurrentHashMap<DeleteOperation, Boolean>());
     correlationIdToDeleteOperation = new HashMap<Integer, DeleteOperation>();
@@ -106,7 +102,6 @@ class DeleteManager {
       DeleteOperation deleteOperation =
           new DeleteOperation(routerConfig, routerMetrics, responseHandler, blobId, futureResult, callback, time);
       deleteOperations.add(deleteOperation);
-      readyForPollCallback.onPollReady();
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
       routerMetrics.deleteBlobErrorCount.inc();

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -46,6 +46,7 @@ class DeleteManager {
   private final ClusterMap clusterMap;
   private final RouterConfig routerConfig;
   private final OperationCompleteCallback operationCompleteCallback;
+  private final ReadyForPollCallback readyForPollCallback;
 
   private static final Logger logger = LoggerFactory.getLogger(DeleteManager.class);
 
@@ -74,17 +75,20 @@ class DeleteManager {
    * @param routerConfig The {@link RouterConfig} containing the configs for the DeleteManager.
    * @param routerMetrics The {@link NonBlockingRouterMetrics} to be used for reporting metrics.
    * @param operationCompleteCallback The {@link OperationCompleteCallback} to use to complete operations.
+   * @param readyForPollCallback The callback to be used to notify the router of any state changes within the
+   *                             operations.
    * @param time The {@link Time} instance to use.
    */
   DeleteManager(ClusterMap clusterMap, ResponseHandler responseHandler, NotificationSystem notificationSystem,
       RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
-      OperationCompleteCallback operationCompleteCallback, Time time) {
+      OperationCompleteCallback operationCompleteCallback, ReadyForPollCallback readyForPollCallback, Time time) {
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.notificationSystem = notificationSystem;
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
     this.operationCompleteCallback = operationCompleteCallback;
+    this.readyForPollCallback = readyForPollCallback;
     this.time = time;
     deleteOperations = Collections.newSetFromMap(new ConcurrentHashMap<DeleteOperation, Boolean>());
     correlationIdToDeleteOperation = new HashMap<Integer, DeleteOperation>();
@@ -102,6 +106,7 @@ class DeleteManager {
       DeleteOperation deleteOperation =
           new DeleteOperation(routerConfig, routerMetrics, responseHandler, blobId, futureResult, callback, time);
       deleteOperations.add(deleteOperation);
+      readyForPollCallback.onPollReady();
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
       routerMetrics.deleteBlobErrorCount.inc();

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -216,8 +216,8 @@ class DeleteOperation {
       DeleteRequestInfo deleteRequestInfo = itr.next().getValue();
       if (time.milliseconds() - deleteRequestInfo.startTimeMs > routerConfig.routerRequestTimeoutMs) {
         itr.remove();
-        NonBlockingRouterMetrics.NodeLevelMetrics dataNodeBasedMetrics =
-            routerMetrics.getDataNodeBasedMetrics(deleteRequestInfo.replica.getDataNodeId());
+        responseHandler
+            .onRequestResponseException(deleteRequestInfo.replica, new IOException("Timed out waiting for a response"));
         updateOperationState(deleteRequestInfo.replica, RouterErrorCode.OperationTimedOut);
       }
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -117,8 +117,10 @@ class GetBlobInfoOperation extends GetOperation<BlobInfo> {
       Map.Entry<Integer, GetRequestInfo> entry = inFlightRequestsIterator.next();
       if (time.milliseconds() - entry.getValue().startTimeMs > routerConfig.routerRequestTimeoutMs) {
         onErrorResponse(entry.getValue().replicaId);
+        responseHandler.onRequestResponseException(entry.getValue().replicaId,
+            new IOException("Timed out waiting for a response"));
         setOperationException(
-            new RouterException("Timed out waiting for responses", RouterErrorCode.OperationTimedOut));
+            new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut));
         inFlightRequestsIterator.remove();
       } else {
         // the entries are ordered by correlation id and time. Break on the first request that has not timed out.

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -109,7 +109,6 @@ class GetManager {
           new GetBlobInfoOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, futureResult,
               callback, operationCompleteCallback, time);
       getOperations.add(getBlobInfoOperation);
-      readyForPollCallback.onPollReady();
     } catch (RouterException e) {
       routerMetrics.getBlobInfoErrorCount.inc();
       routerMetrics.countError(e);
@@ -131,7 +130,6 @@ class GetManager {
           new GetBlobOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, futureResult, callback,
               operationCompleteCallback, readyForPollCallback, blobIdFactory, time);
       getOperations.add(getBlobOperation);
-      readyForPollCallback.onPollReady();
     } catch (RouterException e) {
       routerMetrics.getBlobErrorCount.inc();
       routerMetrics.countError(e);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -55,6 +55,7 @@ class GetManager {
   private final ResponseHandler responseHandler;
   private final NonBlockingRouterMetrics routerMetrics;
   private final OperationCompleteCallback operationCompleteCallback;
+  private final ReadyForPollCallback readyForPollCallback;
 
   private class GetRequestRegistrationCallbackImpl implements RequestRegistrationCallback<GetOperation> {
     private List<RequestInfo> requestListToFill;
@@ -78,16 +79,20 @@ class GetManager {
    * @param routerConfig  The {@link RouterConfig} containing the configs for the PutManager.
    * @param routerMetrics The {@link NonBlockingRouterMetrics} to be used for reporting metrics.
    * @param operationCompleteCallback The {@link OperationCompleteCallback} to use to complete operations.
+   * @param readyForPollCallback The callback to be used to notify the router of any state changes within the
+   *                             operations.
    * @param time The {@link Time} instance to use.
    */
   GetManager(ClusterMap clusterMap, ResponseHandler responseHandler, RouterConfig routerConfig,
-      NonBlockingRouterMetrics routerMetrics, OperationCompleteCallback operationCompleteCallback, Time time) {
+      NonBlockingRouterMetrics routerMetrics, OperationCompleteCallback operationCompleteCallback,
+      ReadyForPollCallback readyForPollCallback, Time time) {
     this.clusterMap = clusterMap;
     blobIdFactory = new BlobIdFactory(clusterMap);
     this.responseHandler = responseHandler;
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
     this.operationCompleteCallback = operationCompleteCallback;
+    this.readyForPollCallback = readyForPollCallback;
     this.time = time;
     getOperations = Collections.newSetFromMap(new ConcurrentHashMap<GetOperation, Boolean>());
   }
@@ -104,6 +109,7 @@ class GetManager {
           new GetBlobInfoOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, futureResult,
               callback, operationCompleteCallback, time);
       getOperations.add(getBlobInfoOperation);
+      readyForPollCallback.onPollReady();
     } catch (RouterException e) {
       routerMetrics.getBlobInfoErrorCount.inc();
       routerMetrics.countError(e);
@@ -123,8 +129,9 @@ class GetManager {
     try {
       GetBlobOperation getBlobOperation =
           new GetBlobOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, futureResult, callback,
-              operationCompleteCallback, blobIdFactory, time);
+              operationCompleteCallback, readyForPollCallback, blobIdFactory, time);
       getOperations.add(getBlobOperation);
+      readyForPollCallback.onPollReady();
     } catch (RouterException e) {
       routerMetrics.getBlobErrorCount.inc();
       routerMetrics.countError(e);

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
@@ -63,6 +63,10 @@ public class NonBlockingRouterFactory implements RouterFactory {
       throws GeneralSecurityException, IOException {
     if (verifiableProperties != null && clusterMap != null && notificationSystem != null) {
       routerConfig = new RouterConfig(verifiableProperties);
+      if (!clusterMap.hasDatacenter(routerConfig.routerDatacenterName)) {
+        throw new IllegalStateException(
+            "Router datacenter " + routerConfig.routerDatacenterName + " is not part of the clustermap");
+      }
       MetricRegistry registry = clusterMap.getMetricRegistry();
       routerMetrics = new NonBlockingRouterMetrics(clusterMap);
       this.clusterMap = clusterMap;

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -14,6 +14,7 @@
 package com.github.ambry.router;
 
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.messageformat.BlobProperties;
@@ -46,6 +47,11 @@ class PutManager {
   private final NotificationSystem notificationSystem;
   private final Time time;
   private final Thread chunkFillerThread;
+  //private final AtomicInteger operationSetState = new AtomicInteger(0);
+  private final Object chunkFillerSynchronizer = new Object();
+  private volatile boolean isChunkFillerThreadAsleep = false;
+  private volatile boolean chunkFillerThreadSleepDisabled = false;
+  private volatile boolean areChunksAvailableForFilling = false;
   // This helps the PutManager quickly find the appropriate PutOperation to hand over the response to.
   // Requests are added before they are sent out and get cleaned up as and when responses come in.
   // Because there is a guaranteed response from the NetworkClient for every request sent out, entries
@@ -53,6 +59,8 @@ class PutManager {
   private final Map<Integer, PutOperation> correlationIdToPutOperation;
   private final AtomicBoolean isOpen = new AtomicBoolean(true);
   private final OperationCompleteCallback operationCompleteCallback;
+  private final ReadyForPollCallback readyForPollCallback;
+  private final ByteBufferAsyncWritableChannel.ChannelEventListener chunkArrivalListener;
 
   // shared by all PutOperations
   private final ClusterMap clusterMap;
@@ -83,18 +91,35 @@ class PutManager {
    * @param routerConfig  The {@link RouterConfig} containing the configs for the PutManager.
    * @param routerMetrics The {@link NonBlockingRouterMetrics} to be used for reporting metrics.
    * @param operationCompleteCallback The {@link OperationCompleteCallback} to use to complete operations.
+   * @param readyForPollCallback The callback to be used to notify the router of any state changes within the
+   *                             operations.
    * @param index the index of the {@link NonBlockingRouter.OperationController} in the {@link NonBlockingRouter}
    * @param time The {@link Time} instance to use.
    */
   PutManager(ClusterMap clusterMap, ResponseHandler responseHandler, NotificationSystem notificationSystem,
       RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
-      OperationCompleteCallback operationCompleteCallback, int index, Time time) {
+      OperationCompleteCallback operationCompleteCallback, ReadyForPollCallback readyForPollCallback, int index,
+      Time time) {
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.notificationSystem = notificationSystem;
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
     this.operationCompleteCallback = operationCompleteCallback;
+    this.readyForPollCallback = readyForPollCallback;
+    this.chunkArrivalListener = new ByteBufferAsyncWritableChannel.ChannelEventListener() {
+      @Override
+      public void onEvent(ByteBufferAsyncWritableChannel.EventType e) {
+        synchronized (chunkFillerSynchronizer) {
+          // At this point, the chunk for which this notification came in (if any) could already have been consumed by
+          // the chunk filler, and this might unnecessarily wake it up from its sleep, which should be okay.
+          areChunksAvailableForFilling = true;
+          if (isChunkFillerThreadAsleep) {
+            chunkFillerSynchronizer.notify();
+          }
+        }
+      }
+    };
     this.time = time;
     putOperations = Collections.newSetFromMap(new ConcurrentHashMap<PutOperation, Boolean>());
     correlationIdToPutOperation = new HashMap<Integer, PutOperation>();
@@ -116,7 +141,7 @@ class PutManager {
     try {
       PutOperation putOperation =
           new PutOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobProperties, userMetaData,
-              channel, futureResult, callback, time);
+              channel, futureResult, callback, readyForPollCallback, chunkArrivalListener, time);
       putOperations.add(putOperation);
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
@@ -221,6 +246,12 @@ class PutManager {
    */
   void close() {
     if (isOpen.compareAndSet(true, false)) {
+      synchronized (chunkFillerSynchronizer) {
+        if (isChunkFillerThreadAsleep) {
+          chunkFillerThreadSleepDisabled = true;
+          chunkFillerSynchronizer.notify();
+        }
+      }
       try {
         chunkFillerThread.join(NonBlockingRouter.SHUTDOWN_WAIT_MS);
       } catch (InterruptedException e) {
@@ -259,24 +290,28 @@ class PutManager {
    * by the {@link ReadableStreamChannel} associated with the operation.
    */
   private class ChunkFiller implements Runnable {
-    private final int sleepTimeWhenIdleMs = 10;
-
     public void run() {
       try {
         while (isOpen.get()) {
-          boolean allChunksFilled = true;
+          boolean idleIteration = true;
           for (PutOperation op : putOperations) {
             if (!op.isChunkFillComplete()) {
               op.fillChunks();
-              allChunksFilled = false;
+              idleIteration = false;
             }
           }
-          if (allChunksFilled) {
-            Thread.sleep(sleepTimeWhenIdleMs);
+          if (idleIteration && !areChunksAvailableForFilling && !chunkFillerThreadSleepDisabled) {
+            synchronized (chunkFillerSynchronizer) {
+              while (!areChunksAvailableForFilling && !chunkFillerThreadSleepDisabled) {
+                isChunkFillerThreadAsleep = true;
+                chunkFillerSynchronizer.wait();
+              }
+              isChunkFillerThreadAsleep = false;
+            }
           }
         }
       } catch (InterruptedException e) {
-        logger.error("ChunkFillerThread received exception", e);
+        logger.error("ChunkFillerThread was interrupted", e);
         if (isOpen.compareAndSet(true, false)) {
           completePendingOperations();
         }

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -112,8 +112,11 @@ public class ChunkFillTest {
     random.nextBytes(putUserMetadata);
     final MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize);
     FutureResult<String> futureResult = new FutureResult<String>();
+    MockTime time = new MockTime();
+    MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
-        putUserMetadata, putChannel, futureResult, null, new MockTime());
+        putUserMetadata, putChannel, futureResult, null,
+        new ReadyForPollCallback(networkClientFactory.getNetworkClient()), null, new MockTime());
     numChunks = op.getNumDataChunks();
     // largeBlobSize is not a multiple of chunkSize
     int expectedNumChunks = (int) (blobSize / chunkSize + 1);
@@ -194,8 +197,11 @@ public class ChunkFillTest {
     random.nextBytes(putContent);
     final ReadableStreamChannel putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(putContent));
     FutureResult<String> futureResult = new FutureResult<String>();
+    MockTime time = new MockTime();
+    MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
-        putUserMetadata, putChannel, futureResult, null, new MockTime());
+        putUserMetadata, putChannel, futureResult, null,
+        new ReadyForPollCallback(networkClientFactory.getNetworkClient()), null, time);
     numChunks = op.getNumDataChunks();
     compositeBuffers = new ByteBuffer[numChunks];
     final AtomicReference<Exception> operationException = new AtomicReference<Exception>(null);

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -117,6 +117,7 @@ public class ChunkFillTest {
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
         putUserMetadata, putChannel, futureResult, null,
         new ReadyForPollCallback(networkClientFactory.getNetworkClient()), null, new MockTime());
+    op.startReadingFromChannel();
     numChunks = op.getNumDataChunks();
     // largeBlobSize is not a multiple of chunkSize
     int expectedNumChunks = (int) (blobSize / chunkSize + 1);
@@ -202,6 +203,7 @@ public class ChunkFillTest {
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
         putUserMetadata, putChannel, futureResult, null,
         new ReadyForPollCallback(networkClientFactory.getNetworkClient()), null, time);
+    op.startReadingFromChannel();
     numChunks = op.getNumDataChunks();
     compositeBuffers = new ByteBuffer[numChunks];
     final AtomicReference<Exception> operationException = new AtomicReference<Exception>(null);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -432,10 +432,10 @@ public class GetBlobInfoOperationTest {
     List<ResponseInfo> responseList = new ArrayList<>();
     int sendCount = requestList.size();
     Collections.shuffle(requestList);
-    responseList.addAll(networkClient.sendAndPoll(requestList));
+    responseList.addAll(networkClient.sendAndPoll(requestList, 100));
     requestList.clear();
     while (responseList.size() < sendCount) {
-      responseList.addAll(networkClient.sendAndPoll(requestList));
+      responseList.addAll(networkClient.sendAndPoll(requestList, 100));
     }
     return responseList;
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -581,10 +581,10 @@ public class GetBlobOperationTest {
     // Shuffle the replicas to introduce randomness in the order in which responses arrive.
     Collections.shuffle(requestList);
     List<ResponseInfo> responseList = new ArrayList<>();
-    responseList.addAll(networkClient.sendAndPoll(requestList));
+    responseList.addAll(networkClient.sendAndPoll(requestList, 100));
     requestList.clear();
     while (responseList.size() < sendCount) {
-      responseList.addAll(networkClient.sendAndPoll(requestList));
+      responseList.addAll(networkClient.sendAndPoll(requestList, 100));
     }
     return responseList;
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
@@ -21,20 +21,34 @@ import com.github.ambry.utils.MockTime;
 import java.io.IOException;
 
 
+/**
+ * A mock class used simply for verifying whether certain methods of the {@link NetworkClient} gets called in certain
+ * tests.
+ */
 class MockNetworkClient extends NetworkClient {
   boolean wokenUp = false;
 
+  /**
+   * Construct a MockNetworkClient with mock components.
+   */
   MockNetworkClient()
       throws IOException {
     super(new MockSelector(new MockServerLayout(new MockClusterMap()), null, new MockTime()), null,
         new NetworkMetrics(new MetricRegistry()), 0, 0, 0, new MockTime());
   }
 
+  /**
+   * Wake up the MockNetworkClient. This simply sets a flag that indicates that the method was invoked.
+   */
   @Override
   public void wakeup() {
     wokenUp = true;
   }
 
+  /**
+   * This returns the wokenUp status of this object and clears the status.
+   * @return true if this MockNetworkClient was woken up since the last call to this method.
+   */
   boolean getAndClearWokenUpStatus() {
     boolean ret = wokenUp;
     wokenUp = false;

--- a/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.network.NetworkClient;
+import com.github.ambry.network.NetworkMetrics;
+import com.github.ambry.utils.MockTime;
+import java.io.IOException;
+
+
+class MockNetworkClient extends NetworkClient {
+  boolean wokenUp = false;
+
+  MockNetworkClient()
+      throws IOException {
+    super(new MockSelector(new MockServerLayout(new MockClusterMap()), null, new MockTime()), null,
+        new NetworkMetrics(new MetricRegistry()), 0, 0, 0, new MockTime());
+  }
+
+  @Override
+  public void wakeup() {
+    wokenUp = true;
+  }
+
+  boolean getAndClearWokenUpStatus() {
+    boolean ret = wokenUp;
+    wokenUp = false;
+    return ret;
+  }
+}
+

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.router;
 
-import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
@@ -52,10 +51,10 @@ public class NonBlockingRouterTest {
    * the {@link NonBlockingRouter}.
    * @return the created VerifiableProperties instance.
    */
-  private Properties getNonBlockingRouterProperties() {
+  private Properties getNonBlockingRouterProperties(String routerDataCenter) {
     Properties properties = new Properties();
     properties.setProperty("router.hostname", "localhost");
-    properties.setProperty("router.datacenter.name", "DC1");
+    properties.setProperty("router.datacenter.name", routerDataCenter);
     return properties;
   }
 
@@ -74,9 +73,19 @@ public class NonBlockingRouterTest {
   @Test
   public void testNonBlockingRouterFactory()
       throws Exception {
-    Properties props = getNonBlockingRouterProperties();
-    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
     MockClusterMap mockClusterMap = new MockClusterMap();
+    try {
+      Properties props = getNonBlockingRouterProperties("NotInClusterMap");
+      VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+      router = (NonBlockingRouter) new NonBlockingRouterFactory(verifiableProperties, mockClusterMap,
+          new LoggingNotificationSystem()).getRouter();
+      Assert.fail("NonBlockingRouterFactory instantiation should have failed because the router datacenter is not in "
+          + "the cluster map");
+    } catch (IllegalStateException e) {
+
+    }
+    Properties props = getNonBlockingRouterProperties("DC1");
+    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
     router = (NonBlockingRouter) new NonBlockingRouterFactory(verifiableProperties, mockClusterMap,
         new LoggingNotificationSystem()).getRouter();
     assertExpectedThreadCounts(1);
@@ -90,12 +99,11 @@ public class NonBlockingRouterTest {
   @Test
   public void testRouterBasic()
       throws Exception {
-    Properties props = getNonBlockingRouterProperties();
+    Properties props = getNonBlockingRouterProperties("DC1");
     VerifiableProperties verifiableProperties = new VerifiableProperties((props));
     MockClusterMap mockClusterMap = new MockClusterMap();
     MockTime mockTime = new MockTime();
-    router = new NonBlockingRouter(new RouterConfig(verifiableProperties),
-        new NonBlockingRouterMetrics(mockClusterMap),
+    router = new NonBlockingRouter(new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(verifiableProperties, null, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, new MockServerLayout(mockClusterMap), mockTime), new LoggingNotificationSystem(),
         mockClusterMap, mockTime);
@@ -106,11 +114,10 @@ public class NonBlockingRouterTest {
 
     // More extensive test for puts present elsewhere - these statements are here just to exercise the flow within the
     // NonBlockingRouter class, and to ensure that operations submitted to a router eventually completes.
-    router.putBlob(putBlobProperties, putUserMetadata, putChannel).get();
-    // @todo to be enabled when these operation managers are implemented.
-    // router.getBlob("nonExistentBlobId");
-    // router.getBlobInfo("nonExistentBlobid");
-    // router.deleteBlob("nonExistentBlobId");
+    String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel).get();
+    router.getBlob(blobId);
+    router.getBlobInfo(blobId);
+    router.deleteBlob(blobId);
     router.close();
     assertExpectedThreadCounts(0);
 
@@ -125,13 +132,12 @@ public class NonBlockingRouterTest {
   public void testMultipleScalingUnit()
       throws Exception {
     final int SCALING_UNITS = 3;
-    Properties props = getNonBlockingRouterProperties();
+    Properties props = getNonBlockingRouterProperties("DC1");
     props.setProperty("router.scaling.unit.count", Integer.toString(SCALING_UNITS));
     VerifiableProperties verifiableProperties = new VerifiableProperties((props));
     MockClusterMap mockClusterMap = new MockClusterMap();
     MockTime mockTime = new MockTime();
-    router = new NonBlockingRouter(new RouterConfig(verifiableProperties),
-        new NonBlockingRouterMetrics(mockClusterMap),
+    router = new NonBlockingRouter(new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(verifiableProperties, null, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, new MockServerLayout(mockClusterMap), mockTime), new LoggingNotificationSystem(),
         mockClusterMap, mockTime);

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -74,18 +74,17 @@ public class NonBlockingRouterTest {
   public void testNonBlockingRouterFactory()
       throws Exception {
     MockClusterMap mockClusterMap = new MockClusterMap();
+    Properties props = getNonBlockingRouterProperties("NotInClusterMap");
+    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
     try {
-      Properties props = getNonBlockingRouterProperties("NotInClusterMap");
-      VerifiableProperties verifiableProperties = new VerifiableProperties((props));
       router = (NonBlockingRouter) new NonBlockingRouterFactory(verifiableProperties, mockClusterMap,
           new LoggingNotificationSystem()).getRouter();
       Assert.fail("NonBlockingRouterFactory instantiation should have failed because the router datacenter is not in "
           + "the cluster map");
     } catch (IllegalStateException e) {
-
     }
-    Properties props = getNonBlockingRouterProperties("DC1");
-    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+    props = getNonBlockingRouterProperties("DC1");
+    verifiableProperties = new VerifiableProperties((props));
     router = (NonBlockingRouter) new NonBlockingRouterFactory(verifiableProperties, mockClusterMap,
         new LoggingNotificationSystem()).getRouter();
     assertExpectedThreadCounts(1);

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -100,6 +100,7 @@ public class PutOperationTest {
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobProperties, userMetadata,
             channel, future, null, new ReadyForPollCallback(mockNetworkClient), null, time);
+    op.startReadingFromChannel();
     List<RequestInfo> requestInfos = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestInfos;
     // Since this channel is in memory, one call to fill chunks would end up filling the maximum number of PutChunks.


### PR DESCRIPTION
This patch introduces two main changes: a) Adding a deterministic
wait-notify flow for the ChunkFiller thread to go to sleep and get
notified whenever there is work to be done. b) Adding a "wakeUp" for the
NetworkClient that will in turn wake up the associated Selector from its
poll if an operation manager becomes poll-eligible asynchronously to the
RequestResponseHandler thread.

Also adds couple of miscellaneous fixes.

Fixes #378 and #377 

**Coverage**
```
DeleteManager                   100% (2/ 2)     100% (10/ 10)   91.9% (68/ 74)
DeleteOperation                 100% (3/ 3)     100% (21/ 21)   92.9% (105/ 113)
GetBlobInfoOperation            100% (2/ 2)     100% (14/ 14)   91.7% (100/ 109)
GetBlobOperation                100% (7/ 7)     89.8% (44/ 49)  91.6% (230/ 251)
GetManager                      100% (2/ 2)     100% (12/ 12)   78.3% (54/ 69)
GetOperation                    100% (1/ 1)     100% (10/ 10)   100% (24/ 24)
GetRequestInfo                  100% (1/ 1)     100% (1/ 1)     100% (3/ 3)
NonBlockingRouter               100% (3/ 3)     100% (28/ 28)   86.4% (133/ 154)
NonBlockingRouterFactory        100% (1/ 1)     100% (3/ 3)     86.4% (19/ 22)
NonBlockingRouterMetrics        100% (6/ 6)     78.6% (11/ 14)  92% (103/ 112)
OperationCompleteCallback       100% (1/ 1)     100% (3/ 3)     100% (10/ 10)
PutManager                      100% (4/ 4)     100% (16/ 16)   90.3% (102/ 113)
PutOperation                    100% (7/ 7)     100% (62/ 62)   90% (288/ 320)
ReadyForPollCallback            100% (1/ 1)     100% (2/ 2)     100% (3/ 3)
```

Primary reviewers: Casey & Gopal
Estimate: ~ 30 min.