### PR TITLE
Adding trace logging to resource state policy

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/FixedBackoffResourceStatePolicy.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/FixedBackoffResourceStatePolicy.java
@@ -55,7 +55,7 @@ class FixedBackoffResourceStatePolicy implements ResourceStatePolicy {
       if (count == failureCountThreshold) {
         logger.error("Resource " + resource + " has gone down");
       }
-      logger.trace("Adding downtime " + retryBackoffMs + " ms to " + resource);
+      logger.trace("Resource " + resource + " remains in down state at time " + SystemTime.getInstance().milliseconds() + "; Adding downtime of " + retryBackoffMs + " ms");
       downUntil.set(SystemTime.getInstance().milliseconds() + retryBackoffMs);
     }
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/FixedBackoffResourceStatePolicy.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/FixedBackoffResourceStatePolicy.java
@@ -55,6 +55,7 @@ class FixedBackoffResourceStatePolicy implements ResourceStatePolicy {
       if (count == failureCountThreshold) {
         logger.error("Resource " + resource + " has gone down");
       }
+      logger.trace("Adding downtime " + retryBackoffMs + " ms to " + resource);
       downUntil.set(SystemTime.getInstance().milliseconds() + retryBackoffMs);
     }
   }
@@ -87,6 +88,11 @@ class FixedBackoffResourceStatePolicy implements ResourceStatePolicy {
         down = true;
       }
     }
+    logger.trace("Resource " + resource + " is " + (down ? "down" : "not down")
+        + "; failureCount: " + failureCount.get()
+        + "; failureCountThreshold: " + failureCountThreshold
+        + "; remaining time: " + (downUntil.get() - SystemTime.getInstance().milliseconds())
+        + "; hard down: " + hardDown);
     return down;
   }
 


### PR DESCRIPTION
Added trace logging messages to help debug FixedBackoffResourceStatePolicy::isDown()

*Time to review:* 5 min
*Reviewers:* @xiahome, @dniq 