### PR TITLE
Always inform the failure detector when responses come in from the network client

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/FixedBackoffResourceStatePolicy.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/FixedBackoffResourceStatePolicy.java
@@ -14,8 +14,6 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.utils.SystemTime;
-import java.util.ArrayDeque;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;

--- a/ambry-network/src/main/java/com.github.ambry.network/ResponseInfo.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/ResponseInfo.java
@@ -23,27 +23,27 @@ import java.nio.ByteBuffer;
  * request.
  */
 public class ResponseInfo {
-  private final Send request;
+  private final RequestInfo requestInfo;
   private final NetworkClientErrorCode error;
   private final ByteBuffer response;
 
   /**
    * Constructs a ResponseInfo with the given parameters.
-   * @param request the request associated with this response.
+   * @param requestInfo the {@link RequestInfo} associated with this response.
    * @param error the error encountered in sending this request, if there is any.
    * @param response the response received for this request.
    */
-  public ResponseInfo(Send request, NetworkClientErrorCode error, ByteBuffer response) {
-    this.request = request;
+  public ResponseInfo(RequestInfo requestInfo, NetworkClientErrorCode error, ByteBuffer response) {
+    this.requestInfo = requestInfo;
     this.error = error;
     this.response = response;
   }
 
   /**
-   * @return the request associated with this response.
+   * @return the {@link RequestInfo} associated with this response.
    */
-  public Send getRequest() {
-    return request;
+  public RequestInfo getRequestInfo() {
+    return requestInfo;
   }
 
   /**

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -92,7 +92,7 @@ public class NetworkClientTest {
       responseInfoList = networkClient.sendAndPoll(requestInfoList, 100);
       requestInfoList.clear();
       for (ResponseInfo responseInfo : responseInfoList) {
-        MockSend send = (MockSend) responseInfo.getRequest();
+        MockSend send = (MockSend) responseInfo.getRequestInfo().getRequest();
         NetworkClientErrorCode error = responseInfo.getError();
         ByteBuffer response = responseInfo.getResponse();
         Assert.assertNull("Should not have encountered an error", error);

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -195,6 +195,7 @@ class DeleteManager {
       } catch (Exception e) {
         // Ignore. There is no value in notifying the response handler.
         logger.error("Response deserialization received unexpected error", e);
+        routerMetrics.responseDeserializationErrorCount.inc();
       }
     }
     return deleteResponse;

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -14,15 +14,21 @@
 package com.github.ambry.router;
 
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.RouterConfig;
+import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.protocol.DeleteRequest;
+import com.github.ambry.protocol.DeleteResponse;
 import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Time;
+import java.io.DataInputStream;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -144,13 +150,15 @@ class DeleteManager {
    */
   void handleResponse(ResponseInfo responseInfo) {
     long startTime = time.milliseconds();
-    int correlationId = ((DeleteRequest) responseInfo.getRequest()).getCorrelationId();
+    DeleteResponse deleteReponse = extractDeleteResponseAndNotifyResponseHandler(responseInfo);
+    RouterRequestInfo routerRequestInfo = (RouterRequestInfo) responseInfo.getRequestInfo();
+    int correlationId = ((DeleteRequest) routerRequestInfo.getRequest()).getCorrelationId();
     DeleteOperation deleteOperation = correlationIdToDeleteOperation.remove(correlationId);
     // If it is still an active operation, hand over the response. Otherwise, ignore.
     if (deleteOperations.contains(deleteOperation)) {
       boolean exceptionEncountered = false;
       try {
-        deleteOperation.handleResponse(responseInfo);
+        deleteOperation.handleResponse(responseInfo, deleteReponse);
       } catch (Exception e) {
         exceptionEncountered = true;
         deleteOperation.setOperationException(
@@ -166,6 +174,30 @@ class DeleteManager {
     } else {
       routerMetrics.ignoredResponseCount.inc();
     }
+  }
+
+  /**
+   * Extract the {@link DeleteResponse} from the given {@link ResponseInfo}
+   * @param responseInfo the {@link ResponseInfo} from which the {@link DeleteResponse} is to be extracted.
+   * @return the extracted {@link DeleteResponse} if there is one; null otherwise.
+   */
+  private DeleteResponse extractDeleteResponseAndNotifyResponseHandler(ResponseInfo responseInfo) {
+    DeleteResponse deleteResponse = null;
+    ReplicaId replicaId = ((RouterRequestInfo) responseInfo.getRequestInfo()).getReplicaId();
+    NetworkClientErrorCode networkClientErrorCode = responseInfo.getError();
+    if (networkClientErrorCode != null) {
+      responseHandler.onRequestResponseException(replicaId, new IOException("NetworkClient error"));
+    } else {
+      try {
+        deleteResponse =
+            DeleteResponse.readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())));
+        responseHandler.onRequestResponseError(replicaId, deleteResponse.getError());
+      } catch (Exception e) {
+        // Ignore. There is no value in notifying the response handler.
+        logger.error("Response deserialization received unexpected error", e);
+      }
+    }
+    return deleteResponse;
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -19,13 +19,10 @@ import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.commons.ServerErrorCode;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.network.Port;
-import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.DeleteRequest;
 import com.github.ambry.protocol.DeleteResponse;
-import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Time;
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -121,7 +118,7 @@ class DeleteOperation {
       Port port = replica.getDataNodeId().getPortToConnectTo();
       DeleteRequest deleteRequest = createDeleteRequest();
       deleteRequestInfos.put(deleteRequest.getCorrelationId(), new DeleteRequestInfo(time.milliseconds(), replica));
-      RequestInfo requestInfo = new RequestInfo(hostname, port, deleteRequest);
+      RouterRequestInfo requestInfo = new RouterRequestInfo(hostname, port, deleteRequest, replica);
       requestRegistrationCallback.registerRequestToSend(this, requestInfo);
       replicaIterator.remove();
       if (RouterUtils.isRemoteReplica(routerConfig, replica)) {
@@ -147,10 +144,11 @@ class DeleteOperation {
    * can be different cases during handling a response. For the same delete operation, it is possible
    * that different {@link ServerErrorCode} are received from different replicas. These error codes
    * are eventually resolved to a single {@link RouterErrorCode}.
-   * @param responseInfo The response to be handled.
+   * @param responseInfo The {@link ResponseInfo} to be handled.
+   * @param deleteResponse The {@link DeleteResponse} associated with this response.
    */
-  void handleResponse(ResponseInfo responseInfo) {
-    DeleteRequest deleteRequest = (DeleteRequest) responseInfo.getRequest();
+  void handleResponse(ResponseInfo responseInfo, DeleteResponse deleteResponse) {
+    DeleteRequest deleteRequest = (DeleteRequest) responseInfo.getRequestInfo().getRequest();
     DeleteRequestInfo deleteRequestInfo = deleteRequestInfos.remove(deleteRequest.getCorrelationId());
     // deleteRequestInfo can be null if this request was timed out before this response is received. No
     // metric is updated here, as corresponding metrics have been updated when the request was timed out.
@@ -163,12 +161,11 @@ class DeleteOperation {
     routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId()).deleteRequestLatencyMs.update(requestLatencyMs);
     // Check the error code from NetworkClient.
     if (responseInfo.getError() != null) {
-      responseHandler.onRequestResponseException(replica, new IOException(("NetworkClient error.")));
       updateOperationState(replica, RouterErrorCode.OperationTimedOut);
     } else {
-      try {
-        DeleteResponse deleteResponse =
-            DeleteResponse.readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())));
+      if (deleteResponse == null) {
+        updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
+      } else {
         // The true case below should not really happen. This means a response has been received
         // not for its original request. We will immediately fail this operation.
         if (deleteResponse.getCorrelationId() != deleteRequest.getCorrelationId()) {
@@ -181,13 +178,9 @@ class DeleteOperation {
                   RouterErrorCode.UnexpectedInternalError));
           updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
         } else {
-          responseHandler.onRequestResponseError(replica, deleteResponse.getError());
           // The status of operation tracker will be updated within the processServerError method.
           processServerError(replica, deleteResponse.getError());
         }
-      } catch (IOException e) {
-        logger.error("Unable to recover a deleteResponse from received stream.");
-        updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
       }
     }
     checkAndMaybeComplete();

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -200,6 +200,7 @@ class GetBlobInfoOperation extends GetOperation<BlobInfo> {
           } catch (IOException | MessageFormatException e) {
             // This should really not happen. Again, we do not notify the ResponseHandler responsible for failure
             // detection.
+            routerMetrics.responseDeserializationErrorCount.inc();
             setOperationException(new RouterException("Response deserialization received an unexpected error", e,
                 RouterErrorCode.UnexpectedInternalError));
             onErrorResponse(getRequestInfo.replicaId);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -618,6 +618,7 @@ class GetBlobOperation extends GetOperation<ReadableStreamChannel> {
             } catch (IOException | MessageFormatException e) {
               // This should really not happen. Again, we do not notify the ResponseHandler responsible for failure
               // detection.
+              routerMetrics.responseDeserializationErrorCount.inc();
               chunkException = new RouterException("Response deserialization received an unexpected error", e,
                   RouterErrorCode.UnexpectedInternalError);
               onErrorResponse(getRequestInfo.replicaId);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -234,6 +234,7 @@ class GetManager {
       } catch (Exception e) {
         // Ignore. There is no value in notifying the response handler.
         logger.error("Response deserialization received unexpected error", e);
+        routerMetrics.responseDeserializationErrorCount.inc();
       }
     }
     return getResponse;

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -14,15 +14,22 @@
 package com.github.ambry.router;
 
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobIdFactory;
 import com.github.ambry.commons.ResponseHandler;
+import com.github.ambry.commons.ServerErrorCode;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.messageformat.BlobInfo;
+import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.GetRequest;
+import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Time;
+import java.io.DataInputStream;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -184,11 +191,13 @@ class GetManager {
    */
   void handleResponse(ResponseInfo responseInfo) {
     long startTime = time.milliseconds();
-    GetRequest getRequest = (GetRequest) responseInfo.getRequest();
+    GetResponse getResponse = extractPutResponseAndNotifyResponseHandler(responseInfo);
+    RouterRequestInfo routerRequestInfo = (RouterRequestInfo) responseInfo.getRequestInfo();
+    GetRequest getRequest = (GetRequest) routerRequestInfo.getRequest();
     GetOperation getOperation = correlationIdToGetOperation.remove(getRequest.getCorrelationId());
     if (getOperations.contains(getOperation)) {
       try {
-        getOperation.handleResponse(responseInfo);
+        getOperation.handleResponse(responseInfo, getResponse);
         if (getOperation.isOperationComplete()) {
           remove(getOperation);
         }
@@ -200,6 +209,34 @@ class GetManager {
     } else {
       routerMetrics.ignoredResponseCount.inc();
     }
+  }
+
+  /**
+   * Extract the {@link GetResponse} from the given {@link ResponseInfo}
+   * @param responseInfo the {@link ResponseInfo} from which the {@link GetResponse} is to be extracted.
+   * @return the extracted {@link GetResponse} if there is one; null otherwise.
+   */
+  private GetResponse extractPutResponseAndNotifyResponseHandler(ResponseInfo responseInfo) {
+    GetResponse getResponse = null;
+    ReplicaId replicaId = ((RouterRequestInfo) responseInfo.getRequestInfo()).getReplicaId();
+    NetworkClientErrorCode networkClientErrorCode = responseInfo.getError();
+    if (networkClientErrorCode != null) {
+      responseHandler.onRequestResponseException(replicaId, new IOException("NetworkClient error"));
+    } else {
+      try {
+        getResponse = GetResponse
+            .readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), clusterMap);
+        ServerErrorCode serverError = getResponse.getError();
+        if (serverError == ServerErrorCode.No_Error) {
+          serverError = getResponse.getPartitionResponseInfoList().get(0).getErrorCode();
+        }
+        responseHandler.onRequestResponseError(replicaId, serverError);
+      } catch (Exception e) {
+        // Ignore. There is no value in notifying the response handler.
+        logger.error("Response deserialization received unexpected error", e);
+      }
+    }
+    return getResponse;
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -23,6 +23,7 @@ import com.github.ambry.messageformat.MessageFormatFlags;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.GetOptions;
 import com.github.ambry.protocol.GetRequest;
+import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.PartitionRequestInfo;
 import com.github.ambry.utils.Time;
 import java.util.Collections;
@@ -143,8 +144,9 @@ abstract class GetOperation<T> {
   /**
    * Handle the given {@link ResponseInfo} received for a request that was sent out.
    * @param responseInfo the {@link ResponseInfo} to be handled.
+   * @param getResponse the {@link GetResponse} associated with this response.
    */
-  abstract void handleResponse(ResponseInfo responseInfo);
+  abstract void handleResponse(ResponseInfo responseInfo, GetResponse getResponse);
 
   /**
    * Abort operation by invoking any callbacks and updating futures with an exception.

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -85,7 +85,7 @@ class NonBlockingRouter implements Router {
     this.networkClientFactory = networkClientFactory;
     this.notificationSystem = notificationSystem;
     this.clusterMap = clusterMap;
-    this.responseHandler = new ResponseHandler(clusterMap);
+    responseHandler = new ResponseHandler(clusterMap);
     this.time = time;
     ocList = new ArrayList<OperationController>(routerConfig.routerScalingUnitCount);
     for (int i = 0; i < routerConfig.routerScalingUnitCount; i++) {
@@ -452,7 +452,8 @@ class NonBlockingRouter implements Router {
      */
     private void onResponse(List<ResponseInfo> responseInfoList) {
       for (ResponseInfo responseInfo : responseInfoList) {
-        RequestOrResponseType type = ((RequestOrResponse) responseInfo.getRequest()).getRequestType();
+        RouterRequestInfo routerRequestInfo = (RouterRequestInfo) responseInfo.getRequestInfo();
+        RequestOrResponseType type = ((RequestOrResponse) routerRequestInfo.getRequest()).getRequestType();
         switch (type) {
           case PutRequest:
             putManager.handleResponse(responseInfo);

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -73,6 +73,7 @@ public class NonBlockingRouterMetrics {
   public final Counter blobExpiredErrorCount;
   public final Counter unknownReplicaResponseError;
   public final Counter unknownErrorCountForOperation;
+  public final Counter responseDeserializationErrorCount;
 
   // Performance metrics for operation managers.
   public final Histogram putManagerPollTimeMs;
@@ -171,6 +172,8 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "UnknownReplicaResponseError"));
     unknownErrorCountForOperation =
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "UnknownErrorCountForOperation"));
+    responseDeserializationErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "ResponseDeserializationErrorCount"));
 
     // Performance metrics for operation managers.
     putManagerPollTimeMs = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutManagerPollTimeMs"));

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -230,6 +230,7 @@ class PutManager {
       } catch (Exception e) {
         // Ignore. There is no value in notifying the response handler.
         logger.error("Response deserialization received unexpected error", e);
+        routerMetrics.responseDeserializationErrorCount.inc();
       }
     }
     return putResponse;

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterRequestInfo.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterRequestInfo.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.network.Port;
+import com.github.ambry.network.RequestInfo;
+import com.github.ambry.network.Send;
+
+
+/**
+ * {@link RequestInfo} class extension specifically for the requests sent out by a router. This adds
+ * additional information about the {@link ReplicaId} to which this request will be sent.
+ */
+class RouterRequestInfo extends RequestInfo {
+  private final ReplicaId replicaId;
+
+  /**
+   * Construct a RouterRequestInfo.
+   * @param host the host associated with the request.
+   * @param port the port on the host associated with the request.
+   * @param request the {@link Send} object that is the request payload.
+   * @param replicaId the {@link ReplicaId} to which this request is targeted.
+   */
+  RouterRequestInfo(String host, Port port, Send request, ReplicaId replicaId) {
+    super(host, port, request);
+    this.replicaId = replicaId;
+  }
+
+  /**
+   * @return the {@link ReplicaId} associated with this request.
+   */
+  ReplicaId getReplicaId() {
+    return replicaId;
+  }
+}
+

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.router;
 
-import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.PartitionId;
@@ -201,8 +200,8 @@ public class DeleteManagerTest {
     map.put(ServerErrorCode.Blob_Not_Found, RouterErrorCode.BlobDoesNotExist);
     map.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
     for (ServerErrorCode serverErrorCode : ServerErrorCode.values()) {
-      if (serverErrorCode != ServerErrorCode.No_Error && serverErrorCode != ServerErrorCode.Blob_Deleted
-          && !map.containsKey(serverErrorCode)) {
+      if (serverErrorCode != ServerErrorCode.No_Error && serverErrorCode != ServerErrorCode.Blob_Deleted && !map
+          .containsKey(serverErrorCode)) {
         map.put(serverErrorCode, RouterErrorCode.UnexpectedInternalError);
       }
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.router;
 
-import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
@@ -28,9 +27,12 @@ import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -179,8 +181,10 @@ public class GetBlobInfoOperationTest {
         correlationIdToGetOperation.size());
 
     List<ResponseInfo> responses = sendAndWaitForResponses(requestListToFill);
-    for (ResponseInfo response : responses) {
-      op.handleResponse(response);
+    for (ResponseInfo responseInfo : responses) {
+      GetResponse getResponse = responseInfo.getError() == null ? GetResponse
+          .readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap) : null;
+      op.handleResponse(responseInfo, getResponse);
       if (op.isOperationComplete()) {
         break;
       }
@@ -232,9 +236,8 @@ public class GetBlobInfoOperationTest {
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
       for (RequestInfo requestInfo : requestListToFill) {
-        ResponseInfo fakeResponse =
-            new ResponseInfo(requestInfo.getRequest(), NetworkClientErrorCode.NetworkError, null);
-        op.handleResponse(fakeResponse);
+        ResponseInfo fakeResponse = new ResponseInfo(requestInfo, NetworkClientErrorCode.NetworkError, null);
+        op.handleResponse(fakeResponse, null);
         if (op.isOperationComplete()) {
           break;
         }
@@ -273,8 +276,11 @@ public class GetBlobInfoOperationTest {
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
       List<ResponseInfo> responses = sendAndWaitForResponses(requestListToFill);
-      for (ResponseInfo response : responses) {
-        op.handleResponse(response);
+      for (ResponseInfo responseInfo : responses) {
+        GetResponse getResponse = responseInfo.getError() == null ? GetResponse
+            .readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap)
+            : null;
+        op.handleResponse(responseInfo, getResponse);
         if (op.isOperationComplete()) {
           break;
         }
@@ -335,8 +341,11 @@ public class GetBlobInfoOperationTest {
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
       List<ResponseInfo> responses = sendAndWaitForResponses(requestListToFill);
-      for (ResponseInfo response : responses) {
-        op.handleResponse(response);
+      for (ResponseInfo responseInfo : responses) {
+        GetResponse getResponse = responseInfo.getError() == null ? GetResponse
+            .readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap)
+            : null;
+        op.handleResponse(responseInfo, getResponse);
         if (op.isOperationComplete()) {
           break;
         }
@@ -408,8 +417,11 @@ public class GetBlobInfoOperationTest {
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
       List<ResponseInfo> responses = sendAndWaitForResponses(requestListToFill);
-      for (ResponseInfo response : responses) {
-        op.handleResponse(response);
+      for (ResponseInfo responseInfo : responses) {
+        GetResponse getResponse = responseInfo.getError() == null ? GetResponse
+            .readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap)
+            : null;
+        op.handleResponse(responseInfo, getResponse);
         if (op.isOperationComplete()) {
           break;
         }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -28,9 +28,12 @@ import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -292,9 +295,8 @@ public class GetBlobOperationTest {
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
       for (RequestInfo requestInfo : requestListToFill) {
-        ResponseInfo fakeResponse =
-            new ResponseInfo(requestInfo.getRequest(), NetworkClientErrorCode.NetworkError, null);
-        op.handleResponse(fakeResponse);
+        ResponseInfo fakeResponse = new ResponseInfo(requestInfo, NetworkClientErrorCode.NetworkError, null);
+        op.handleResponse(fakeResponse, null);
         if (op.isOperationComplete()) {
           break;
         }
@@ -334,8 +336,11 @@ public class GetBlobOperationTest {
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
       List<ResponseInfo> responses = sendAndWaitForResponses(requestListToFill);
-      for (ResponseInfo response : responses) {
-        op.handleResponse(response);
+      for (ResponseInfo responseInfo : responses) {
+        GetResponse getResponse = responseInfo.getError() == null ? GetResponse
+            .readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap)
+            : null;
+        op.handleResponse(responseInfo, getResponse);
         if (op.isOperationComplete()) {
           break;
         }
@@ -398,8 +403,11 @@ public class GetBlobOperationTest {
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
       List<ResponseInfo> responses = sendAndWaitForResponses(requestListToFill);
-      for (ResponseInfo response : responses) {
-        op.handleResponse(response);
+      for (ResponseInfo responseInfo : responses) {
+        GetResponse getResponse = responseInfo.getError() == null ? GetResponse
+            .readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap)
+            : null;
+        op.handleResponse(responseInfo, getResponse);
         if (op.isOperationComplete()) {
           break;
         }
@@ -513,8 +521,11 @@ public class GetBlobOperationTest {
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
       List<ResponseInfo> responses = sendAndWaitForResponses(requestListToFill);
-      for (ResponseInfo response : responses) {
-        op.handleResponse(response);
+      for (ResponseInfo responseInfo : responses) {
+        GetResponse getResponse = responseInfo.getError() == null ? GetResponse
+            .readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap)
+            : null;
+        op.handleResponse(responseInfo, getResponse);
       }
     }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -222,7 +222,13 @@ public class GetManagerTest {
     compareContent(router.getBlob(blobId).get());
   }
 
-  private void compareContent(ReadableStreamChannel readableStreamChannel) throws Exception {
+  /**
+   * Compare and assert that the content in the given {@link ReadableStreamChannel} is exactly the same as
+   * the original put content.
+   * @param readableStreamChannel the {@link ReadableStreamChannel} that is the candidate for comparison.
+   */
+  private void compareContent(ReadableStreamChannel readableStreamChannel)
+      throws Exception {
     ByteBufferAsyncWritableChannel getChannel = new ByteBufferAsyncWritableChannel();
     Future<Long> readIntoFuture = readableStreamChannel.readInto(getChannel, null);
     int readBytes = 0;

--- a/ambry-router/src/test/java/com.github.ambry.router/MockSelector.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockSelector.java
@@ -109,7 +109,7 @@ class MockSelector extends Selector {
         } else {
           MockServer server = connIdToServer.get(send.getConnectionId());
           BoundedByteBufferReceive receive = server.send(send.getPayload());
-          if(receive != null) {
+          if (receive != null) {
             receives.add(new NetworkReceive(send.getConnectionId(), receive, time));
           }
         }

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -14,18 +14,30 @@
 package com.github.ambry.router;
 
 import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
+import com.github.ambry.commons.ResponseHandler;
+import com.github.ambry.commons.ServerErrorCode;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.network.NetworkClient;
+import com.github.ambry.network.RequestInfo;
+import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,8 +49,15 @@ public class NonBlockingRouterTest {
   private static final int MAX_PORTS_PLAIN_TEXT = 3;
   private static final int MAX_PORTS_SSL = 3;
   private static final int CHECKOUT_TIMEOUT_MS = 1000;
+  private static final int PUT_REQUEST_PARALLELISM = 3;
+  private static final int PUT_SUCCESS_TARGET = 2;
+  private static final int GET_REQUEST_PARALLELISM = 2;
+  private static final int GET_SUCCESS_TARGET = 1;
+  private static final int DELETE_REQUEST_PARALLELISM = 3;
+  private static final int DELETE_SUCCESS_TARGET = 2;
   private final Random random = new Random();
   private NonBlockingRouter router;
+  private AtomicReference<MockSelectorState> mockSelectorState = new AtomicReference<MockSelectorState>();
 
   // Request params;
   BlobProperties putBlobProperties;
@@ -55,6 +74,12 @@ public class NonBlockingRouterTest {
     Properties properties = new Properties();
     properties.setProperty("router.hostname", "localhost");
     properties.setProperty("router.datacenter.name", routerDataCenter);
+    properties.setProperty("router.put.request.parallelism", Integer.toString(PUT_REQUEST_PARALLELISM));
+    properties.setProperty("router.put.success.target", Integer.toString(PUT_SUCCESS_TARGET));
+    properties.setProperty("router.get.request.parallelism", Integer.toString(GET_REQUEST_PARALLELISM));
+    properties.setProperty("router.get.success.target", Integer.toString(GET_SUCCESS_TARGET));
+    properties.setProperty("router.delete.request.parallelism", Integer.toString(DELETE_REQUEST_PARALLELISM));
+    properties.setProperty("router.delete.success.target", Integer.toString(DELETE_SUCCESS_TARGET));
     return properties;
   }
 
@@ -154,6 +179,277 @@ public class NonBlockingRouterTest {
     //submission after closing should return a future that is already done.
     setOperationParams();
     assertClosed();
+  }
+
+  /**
+   * Test that response handler is correctly notified for all responses regardless of the order in which successful
+   * and failed responses arrive.
+   */
+  @Test
+  public void testResponseHandlerNotification()
+      throws Exception {
+    Properties props = getNonBlockingRouterProperties("DC1");
+    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+    MockClusterMap mockClusterMap = new MockClusterMap();
+    MockTime mockTime = new MockTime();
+    setOperationParams();
+    final List<ReplicaId> failedReplicaIds = new ArrayList<>();
+    final AtomicInteger successfulResponseCount = new AtomicInteger(0);
+    final AtomicBoolean invalidResponse = new AtomicBoolean(false);
+    ResponseHandler mockResponseHandler = new ResponseHandler(mockClusterMap) {
+      @Override
+      public void onRequestResponseException(ReplicaId replicaId, Exception e) {
+        failedReplicaIds.add(replicaId);
+      }
+
+      @Override
+      public void onRequestResponseError(ReplicaId replicaId, ServerErrorCode serverErrorCode) {
+        if (serverErrorCode == ServerErrorCode.No_Error) {
+          successfulResponseCount.incrementAndGet();
+        } else {
+          invalidResponse.set(true);
+        }
+      }
+    };
+
+    // Instantiate a router just to put a blob successfully.
+    MockServerLayout mockServerLayout = new MockServerLayout(mockClusterMap);
+    router = new NonBlockingRouter(new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
+        new MockNetworkClientFactory(verifiableProperties, null, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
+            CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), new LoggingNotificationSystem(), mockClusterMap,
+        mockTime);
+    setOperationParams();
+
+    // More extensive test for puts present elsewhere - these statements are here just to exercise the flow within the
+    // NonBlockingRouter class, and to ensure that operations submitted to a router eventually completes.
+    String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel).get();
+    router.close();
+    for (MockServer mockServer : mockServerLayout.getMockServers()) {
+      mockServer.setBlobIdToServerErrorCode(blobId, ServerErrorCode.No_Error);
+    }
+
+    NetworkClient networkClient =
+        new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
+            CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime).getNetworkClient();
+
+    PutManager putManager = new PutManager(mockClusterMap, mockResponseHandler, new LoggingNotificationSystem(),
+        new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
+        new OperationCompleteCallback(new AtomicInteger(0)), new ReadyForPollCallback(networkClient), 0, mockTime);
+    testPutResponseNotification(putManager, networkClient, failedReplicaIds, successfulResponseCount, invalidResponse,
+        -1);
+    // Test that if a failed response comes before the operation is completed, failure detector is notified.
+    testPutResponseNotification(putManager, networkClient, failedReplicaIds, successfulResponseCount, invalidResponse,
+        0);
+    // Test that if a failed response comes after the operation is completed, failure detector is notified.
+    testPutResponseNotification(putManager, networkClient, failedReplicaIds, successfulResponseCount, invalidResponse,
+        PUT_REQUEST_PARALLELISM - 1);
+
+    GetManager getManager = new GetManager(mockClusterMap, mockResponseHandler, new RouterConfig(verifiableProperties),
+        new NonBlockingRouterMetrics(mockClusterMap), new OperationCompleteCallback(new AtomicInteger(0)),
+        new ReadyForPollCallback(networkClient), mockTime);
+    testGetResponseNotification(getManager, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+        invalidResponse, -1);
+    // Test that if a failed response comes before the operation is completed, failure detector is notified.
+    testGetResponseNotification(getManager, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+        invalidResponse, 0);
+    // Test that if a failed response comes after the operation is completed, failure detector is notified.
+    testGetResponseNotification(getManager, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+        invalidResponse, GET_REQUEST_PARALLELISM - 1);
+
+    DeleteManager deleteManager =
+        new DeleteManager(mockClusterMap, mockResponseHandler, new LoggingNotificationSystem(),
+            new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
+            new OperationCompleteCallback(new AtomicInteger(0)), mockTime);
+    testDeleteResponseNotification(deleteManager, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+        invalidResponse, -1);
+    // Test that if a failed response comes before the operation is completed, failure detector is notified.
+    testDeleteResponseNotification(deleteManager, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+        invalidResponse, 0);
+    // Test that if a failed response comes after the operation is completed, failure detector is notified.
+    testDeleteResponseNotification(deleteManager, networkClient, failedReplicaIds, blobId, successfulResponseCount,
+        invalidResponse, DELETE_REQUEST_PARALLELISM - 1);
+    putManager.close();
+    getManager.close();
+    deleteManager.close();
+  }
+
+  /**
+   * Test that the failure handler is notified for put responses.
+   * @param putManager the {@link PutManager}
+   * @param networkClient the {@link NetworkClient}
+   * @param failedReplicaIds the list that will contain all the replicas for which failure was notified.
+   * @param successfulResponseCount the AtomicInteger that will contain the count of replicas for which success was
+   *                                notified.
+   * @param invalidResponse the AtomicBoolean that will contain whether an unexpected failure was notified.
+   * @param indexToFail the index representing which response for which failure is to be simulated. For example,
+   *                    if index is 0, then the first response will be failed. If the index is -1, no responses will be
+   *                    failed.
+   */
+  void testPutResponseNotification(PutManager putManager, NetworkClient networkClient, List<ReplicaId> failedReplicaIds,
+      AtomicInteger successfulResponseCount, AtomicBoolean invalidResponse, int indexToFail)
+      throws Exception {
+    ReadableStreamChannel putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(putContent));
+    FutureResult<String> futureResult = new FutureResult<>();
+    putManager.submitPutBlobOperation(putBlobProperties, putUserMetadata, putChannel, futureResult, null);
+    List<RequestInfo> allRequests = new ArrayList<>();
+    while (allRequests.size() < PUT_REQUEST_PARALLELISM) {
+      putManager.poll(allRequests);
+    }
+    ReplicaId replicaIdToFail =
+        indexToFail == -1 ? null : ((RouterRequestInfo) allRequests.get(indexToFail)).getReplicaId();
+    for (RequestInfo requestInfo : allRequests) {
+      if (replicaIdToFail != null && replicaIdToFail.equals(((RouterRequestInfo) requestInfo).getReplicaId())) {
+        mockSelectorState.set(MockSelectorState.DisconnectOnSend);
+      } else {
+        mockSelectorState.set(MockSelectorState.Good);
+      }
+      List<RequestInfo> requestInfoListToSend = new ArrayList<>();
+      requestInfoListToSend.add(requestInfo);
+      List<ResponseInfo> responseInfoList;
+      do {
+        responseInfoList = networkClient.sendAndPoll(requestInfoListToSend, 10);
+        requestInfoListToSend.clear();
+      } while (responseInfoList.size() == 0);
+      putManager.handleResponse(responseInfoList.get(0));
+    }
+    futureResult.await();
+    if (indexToFail == -1) {
+      Assert.assertEquals("Successful notification should have arrived for replicas that were up",
+          PUT_REQUEST_PARALLELISM, successfulResponseCount.get());
+      Assert.assertEquals("Failure detector should not have been notified", 0, failedReplicaIds.size());
+      Assert.assertFalse("There should be no notifications of any other kind", invalidResponse.get());
+    } else {
+      Assert.assertEquals("Failure detector should have been notified", 1, failedReplicaIds.size());
+      Assert.assertEquals("Failed notification should have arrived for the failed replica", replicaIdToFail,
+          failedReplicaIds.get(0));
+      Assert.assertEquals("Successful notification should have arrived for replicas that were up",
+          PUT_REQUEST_PARALLELISM - 1, successfulResponseCount.get());
+      Assert.assertFalse("There should be no notifications of any other kind", invalidResponse.get());
+    }
+    failedReplicaIds.clear();
+    successfulResponseCount.set(0);
+    invalidResponse.set(false);
+    mockSelectorState.set(MockSelectorState.Good);
+  }
+
+  /**
+   * Test that the failure handler is notified for get responses.
+   * @param getManager the {@link GetManager}
+   * @param networkClient the {@link NetworkClient}
+   * @param failedReplicaIds the list that will contain all the replicas for which failure was notified.
+   * @param blobId the id of the blob to delete.
+   * @param successfulResponseCount the AtomicInteger that will contain the count of replicas for which success was
+   *                                notified.
+   * @param invalidResponse the AtomicBoolean that will contain whether an unexpected failure was notified.
+   * @param indexToFail the index representing which response for which failure is to be simulated. For example,
+   *                    if index is 0, then the first response will be failed. If the index is -1, no responses will be
+   *                    failed.
+   */
+  private void testGetResponseNotification(GetManager getManager, NetworkClient networkClient,
+      List<ReplicaId> failedReplicaIds, String blobId, AtomicInteger successfulResponseCount,
+      AtomicBoolean invalidResponse, int indexToFail)
+      throws Exception {
+    FutureResult<BlobInfo> futureResult = new FutureResult<>();
+    getManager.submitGetBlobInfoOperation(blobId, futureResult, null);
+    List<RequestInfo> allRequests = new ArrayList<>();
+    while (allRequests.size() < GET_REQUEST_PARALLELISM) {
+      getManager.poll(allRequests);
+    }
+    ReplicaId replicaIdToFail =
+        indexToFail == -1 ? null : ((RouterRequestInfo) allRequests.get(indexToFail)).getReplicaId();
+    for (RequestInfo requestInfo : allRequests) {
+      if (replicaIdToFail != null && replicaIdToFail.equals(((RouterRequestInfo) requestInfo).getReplicaId())) {
+        mockSelectorState.set(MockSelectorState.DisconnectOnSend);
+      } else {
+        mockSelectorState.set(MockSelectorState.Good);
+      }
+      List<RequestInfo> requestInfoListToSend = new ArrayList<>();
+      requestInfoListToSend.add(requestInfo);
+      List<ResponseInfo> responseInfoList;
+      do {
+        responseInfoList = networkClient.sendAndPoll(requestInfoListToSend, 10);
+        requestInfoListToSend.clear();
+      } while (responseInfoList.size() == 0);
+      getManager.handleResponse(responseInfoList.get(0));
+    }
+    futureResult.get();
+    if (indexToFail == -1) {
+      Assert.assertEquals("Successful notification should have arrived for replicas that were up",
+          GET_REQUEST_PARALLELISM, successfulResponseCount.get());
+      Assert.assertEquals("Failure detector should not have been notified", 0, failedReplicaIds.size());
+      Assert.assertFalse("There should be no notifications of any other kind", invalidResponse.get());
+    } else {
+      Assert.assertEquals("Failure detector should have been notified", 1, failedReplicaIds.size());
+      Assert.assertEquals("Failed notification should have arrived for the failed replica", replicaIdToFail,
+          failedReplicaIds.get(0));
+      Assert.assertEquals("Successful notification should have arrived for replicas that were up",
+          GET_REQUEST_PARALLELISM - 1, successfulResponseCount.get());
+      Assert.assertFalse("There should be no notifications of any other kind", invalidResponse.get());
+    }
+    failedReplicaIds.clear();
+    successfulResponseCount.set(0);
+    invalidResponse.set(false);
+    mockSelectorState.set(MockSelectorState.Good);
+  }
+
+  /**
+   * Test that the failure handler is notified for delete responses.
+   * @param deleteManager the {@link DeleteManager}
+   * @param networkClient the {@link NetworkClient}
+   * @param failedReplicaIds the list that will contain all the replicas for which failure was notified.
+   * @param blobId the id of the blob to delete.
+   * @param successfulResponseCount the AtomicInteger that will contain the count of replicas for which success was
+   *                                notified.
+   * @param invalidResponse the AtomicBoolean that will contain whether an unexpected failure was notified.
+   * @param indexToFail the index representing which response for which failure is to be simulated. For example,
+   *                    if index is 0, then the first response will be failed. If the index is -1, no responses will be
+   *                    failed.
+   */
+  private void testDeleteResponseNotification(DeleteManager deleteManager, NetworkClient networkClient,
+      List<ReplicaId> failedReplicaIds, String blobId, AtomicInteger successfulResponseCount,
+      AtomicBoolean invalidResponse, int indexToFail)
+      throws Exception {
+    FutureResult<Void> futureResult = new FutureResult<>();
+    deleteManager.submitDeleteBlobOperation(blobId, futureResult, null);
+    List<RequestInfo> allRequests = new ArrayList<>();
+    while (allRequests.size() < DELETE_REQUEST_PARALLELISM) {
+      deleteManager.poll(allRequests);
+    }
+    ReplicaId replicaIdToFail =
+        indexToFail == -1 ? null : ((RouterRequestInfo) allRequests.get(indexToFail)).getReplicaId();
+    for (RequestInfo requestInfo : allRequests) {
+      if (replicaIdToFail != null && replicaIdToFail.equals(((RouterRequestInfo) requestInfo).getReplicaId())) {
+        mockSelectorState.set(MockSelectorState.DisconnectOnSend);
+      } else {
+        mockSelectorState.set(MockSelectorState.Good);
+      }
+      List<RequestInfo> requestInfoListToSend = new ArrayList<>();
+      requestInfoListToSend.add(requestInfo);
+      List<ResponseInfo> responseInfoList;
+      do {
+        responseInfoList = networkClient.sendAndPoll(requestInfoListToSend, 10);
+        requestInfoListToSend.clear();
+      } while (responseInfoList.size() == 0);
+      deleteManager.handleResponse(responseInfoList.get(0));
+    }
+    futureResult.await();
+    if (indexToFail == -1) {
+      Assert.assertEquals("Successful notification should have arrived for replicas that were up",
+          DELETE_REQUEST_PARALLELISM, successfulResponseCount.get());
+      Assert.assertEquals("Failure detector should not have been notified", 0, failedReplicaIds.size());
+      Assert.assertFalse("There should be no notifications of any other kind", invalidResponse.get());
+    } else {
+      Assert.assertEquals("Failure detector should have been notified", 1, failedReplicaIds.size());
+      Assert.assertEquals("Failed notification should have arrived for the failed replica", replicaIdToFail,
+          failedReplicaIds.get(0));
+      Assert.assertEquals("Successful notification should have arrived for replicas that were up",
+          DELETE_REQUEST_PARALLELISM - 1, successfulResponseCount.get());
+      Assert.assertFalse("There should be no notifications of any other kind", invalidResponse.get());
+    }
+    failedReplicaIds.clear();
+    successfulResponseCount.set(0);
+    invalidResponse.set(false);
+    mockSelectorState.set(MockSelectorState.Good);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -283,7 +283,7 @@ public class NonBlockingRouterTest {
 
   /**
    * Test that the failure handler is notified for put responses.
-   * @param opHelper the {@link OperationType}
+   * @param opHelper the {@link OperationHelper}
    * @param networkClient the {@link NetworkClient}
    * @param failedReplicaIds the list that will contain all the replicas for which failure was notified.
    * @param blobId the id of the blob to get/delete. For puts, this will be null.


### PR DESCRIPTION
When NetworkClient hands over a response, the operation managers may
ignore it - if the request timed out internally, or if the operation
itself completed. However, the response handler responsible for failure
detection should be notified about these responses, regardless.

--
*Coverage*
```
DeleteManager           100% (2/ 2)     100% (11/ 11)   93% (80/ 86)
DeleteOperation         100% (3/ 3)     100% (21/ 21)   95.4% (103/ 108)
GetBlobInfoOperation    100% (2/ 2)     100% (14/ 14)   92.7% (101/ 109)
GetBlobOperation        100% (7/ 7)     89.8% (44/ 49)  90.4% (227/ 251)
GetManager              100% (2/ 2)     100% (13/ 13)   78.6% (66/ 84)
GetOperation            100% (1/ 1)     100% (10/ 10)   100% (24/ 24)
NonBlockingRouter       100% (3/ 3)     100% (28/ 28)   86.8% (138/ 159)
PutManager              100% (4/ 4)     100% (17/ 17)   89.9% (133/ 148)
PutOperation            100% (7/ 7)     100% (62/ 62)   92.4% (292/ 316)
RouterRequestInfo       100% (1/ 1)     100% (2/ 2)     100% (3/ 3)
```