### PR TITLE
Avoid repeated connection initializations in the NetworkClient.

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/network/Port.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/Port.java
@@ -37,4 +37,18 @@ public class Port {
   public String toString() {
     return "Port[" + getPort() + ":" + getPortType() + "]";
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Port p = (Port) o;
+    return p.port == port && p.type.equals(type);
+  }
 }

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
@@ -164,6 +164,7 @@ public class NetworkClient implements Closeable {
           }
         } else {
           if (requestMetadata.pendingConnectionId != null) {
+            pendingConnectionsToAssociatedRequests.remove(requestMetadata.pendingConnectionId);
             requestMetadata.pendingConnectionId = null;
           }
           logger.trace("Connection checkout succeeded for {}:{} with connectionId {} ", host, port, connId);

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -26,8 +26,6 @@ import java.util.concurrent.atomic.AtomicLong;
  * Metrics for the network layer
  */
 public class NetworkMetrics {
-  private final MetricRegistry registry;
-
   // Selector metrics
   public final Counter sendInFlight;
   public final Counter selectorConnectionClosed;
@@ -88,7 +86,6 @@ public class NetworkMetrics {
   private List<AtomicLong> networkClientPendingRequestList;
 
   public NetworkMetrics(MetricRegistry registry) {
-    this.registry = registry;
     sendInFlight = registry.counter(MetricRegistry.name(Selector.class, "SendInFlight"));
     selectorConnectionClosed = registry.counter(MetricRegistry.name(Selector.class, "SelectorConnectionClosed"));
     selectorConnectionCreated = registry.counter(MetricRegistry.name(Selector.class, "SelectorConnectionCreated"));

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -269,13 +269,13 @@ public class NetworkClientTest {
     Assert.assertEquals(4, selector.connectCallCount());
     Assert.assertEquals(1, responseInfoList.size());
     Assert.assertEquals(null, responseInfoList.get(0).getError());
-    Assert.assertEquals(2, ((MockSend)responseInfoList.get(0).getRequestInfo().getRequest()).getCorrelationId());
+    Assert.assertEquals(2, ((MockSend) responseInfoList.get(0).getRequestInfo().getRequest()).getCorrelationId());
     responseInfoList.clear();
     responseInfoList = networkClient.sendAndPoll(requestInfoList, 100);
     Assert.assertEquals(4, selector.connectCallCount());
     Assert.assertEquals(1, responseInfoList.size());
     Assert.assertEquals(null, responseInfoList.get(0).getError());
-    Assert.assertEquals(3, ((MockSend)responseInfoList.get(0).getRequestInfo().getRequest()).getCorrelationId());
+    Assert.assertEquals(3, ((MockSend) responseInfoList.get(0).getRequestInfo().getRequest()).getCorrelationId());
     responseInfoList.clear();
     selector.setState(MockSelectorState.Good);
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -222,6 +222,7 @@ class PutManager {
     ReplicaId replicaId = ((RouterRequestInfo) responseInfo.getRequestInfo()).getReplicaId();
     NetworkClientErrorCode networkClientErrorCode = responseInfo.getError();
     if (networkClientErrorCode != null) {
+      logger.trace("Network client returned an error, notifying response handler");
       responseHandler.onRequestResponseException(replicaId, new IOException("NetworkClient error"));
     } else {
       try {


### PR DESCRIPTION
Avoid repeated connection initializations for the same request in the
NetworkClient; fail a request immediately if a connection initialized
on its behalf fails.

--
This PR adds two changes:

1. Prevents repeated connection initializations for the same request, if one was already initiated. Before this patch, when the first request to a node comes in, the network client might end up establishing max number of connections to a destination - because the sendAndPoll() could happen several times before the first connection gets established.

2. Fails a request if a connection initiated on its behalf fails - similar to failing it if the send had already started. This is a "fail fast" approach - rather than waiting for checkoutTimeout to kick in which would be useless almost all of the time.

*Coverage*
is 100%. More importantly, added a test to verify the changed functionality.
```
NetworkClient	100% (2/ 2)    100% (12/ 12)    100% (108/ 108)
```