### PR TITLE
Handling the way BlockingChannelInfo handle connection failures

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
@@ -60,6 +60,14 @@ public class ConnectionPoolConfig {
   @Default("2")
   public final int connectionPoolMaxConnectionsPerPortSSL;
 
+  /**
+   * The maximum consecutive connect failures allowed before we clean up the available pool
+   */
+  @Config("connectionpool.max.connect.failures.to.clean.up.available.pool")
+  @Default("2")
+  public final int connectionPoolMaxConnectFailuresToCleanUpAvailablePool;
+
+
   public ConnectionPoolConfig(VerifiableProperties verifiableProperties) {
     connectionPoolReadBufferSizeBytes =
         verifiableProperties.getIntInRange("connectionpool.read.buffer.size.bytes", 1048576, 1, 1024 * 1024 * 1024);
@@ -72,5 +80,7 @@ public class ConnectionPoolConfig {
         verifiableProperties.getIntInRange("connectionpool.max.connections.per.port.plain.text", 5, 1, 20);
     connectionPoolMaxConnectionsPerPortSSL =
         verifiableProperties.getIntInRange("connectionpool.max.connections.per.port.ssl", 2, 1, 20);
+    connectionPoolMaxConnectFailuresToCleanUpAvailablePool =
+            verifiableProperties.getInt("connectionpool.max.connect.failures.to.clean.up.available.pool", 0);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
@@ -60,14 +60,6 @@ public class ConnectionPoolConfig {
   @Default("2")
   public final int connectionPoolMaxConnectionsPerPortSSL;
 
-  /**
-   * The maximum consecutive connect failures allowed before we clean up the available pool
-   */
-  @Config("connectionpool.max.connect.failures.to.clean.up.available.pool")
-  @Default("1")
-  public final int connectionPoolMaxConnectFailuresToCleanUpAvailablePool;
-
-
   public ConnectionPoolConfig(VerifiableProperties verifiableProperties) {
     connectionPoolReadBufferSizeBytes =
         verifiableProperties.getIntInRange("connectionpool.read.buffer.size.bytes", 1048576, 1, 1024 * 1024 * 1024);
@@ -80,7 +72,5 @@ public class ConnectionPoolConfig {
         verifiableProperties.getIntInRange("connectionpool.max.connections.per.port.plain.text", 5, 1, 20);
     connectionPoolMaxConnectionsPerPortSSL =
         verifiableProperties.getIntInRange("connectionpool.max.connections.per.port.ssl", 2, 1, 20);
-    connectionPoolMaxConnectFailuresToCleanUpAvailablePool =
-            verifiableProperties.getInt("connectionpool.max.connect.failures.to.clean.up.available.pool", 1);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
@@ -64,7 +64,7 @@ public class ConnectionPoolConfig {
    * The maximum consecutive connect failures allowed before we clean up the available pool
    */
   @Config("connectionpool.max.connect.failures.to.clean.up.available.pool")
-  @Default("2")
+  @Default("1")
   public final int connectionPoolMaxConnectFailuresToCleanUpAvailablePool;
 
 
@@ -81,6 +81,6 @@ public class ConnectionPoolConfig {
     connectionPoolMaxConnectionsPerPortSSL =
         verifiableProperties.getIntInRange("connectionpool.max.connections.per.port.ssl", 2, 1, 20);
     connectionPoolMaxConnectFailuresToCleanUpAvailablePool =
-            verifiableProperties.getInt("connectionpool.max.connect.failures.to.clean.up.available.pool", 0);
+            verifiableProperties.getInt("connectionpool.max.connect.failures.to.clean.up.available.pool", 1);
   }
 }

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelConnectionPool.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelConnectionPool.java
@@ -52,8 +52,8 @@ class BlockingChannelInfo {
   private final SSLConfig sslConfig;
   private final MetricRegistry registry;
 
-  public BlockingChannelInfo(ConnectionPoolConfig config, String host, Port port,  MetricRegistry registry, SSLSocketFactory sslSocketFactory,
-                             SSLConfig sslConfig) {
+  public BlockingChannelInfo(ConnectionPoolConfig config, String host, Port port, MetricRegistry registry,
+      SSLSocketFactory sslSocketFactory, SSLConfig sslConfig) {
     this.config = config;
     this.port = port;
     this.registry = registry;
@@ -77,9 +77,9 @@ class BlockingChannelInfo {
         return blockingChannelAvailableConnections.size();
       }
     };
-    registry
-        .register(MetricRegistry.name(BlockingChannelInfo.class, host + "-" + port.getPort() + "-availableConnections"),
-            availableConnections);
+    registry.register(
+        MetricRegistry.name(BlockingChannelInfo.class, host + "-" + port.getPort() + "-availableConnections"),
+        availableConnections);
 
     activeConnections = new Gauge<Integer>() {
       @Override
@@ -87,9 +87,9 @@ class BlockingChannelInfo {
         return blockingChannelActiveConnections.size();
       }
     };
-    registry
-        .register(MetricRegistry.name(BlockingChannelInfo.class, host + "-" + port.getPort() + "-activeConnections"),
-            activeConnections);
+    registry.register(
+        MetricRegistry.name(BlockingChannelInfo.class, host + "-" + port.getPort() + "-activeConnections"),
+        activeConnections);
 
     totalNumberOfConnections = new Gauge<Integer>() {
       @Override
@@ -115,7 +115,7 @@ class BlockingChannelInfo {
             blockingChannelAvailableConnections.size(), blockingChannelActiveConnections.size());
       } else {
         logger.error("Tried to add invalid connection. Channel does not belong in the active queue. Host {} port {}"
-            + " channel host {} channel port {}", host, port.getPort(), blockingChannel.getRemoteHost(),
+                + " channel host {} channel port {}", host, port.getPort(), blockingChannel.getRemoteHost(),
             blockingChannel.getRemotePort());
       }
     } finally {
@@ -204,7 +204,7 @@ class BlockingChannelInfo {
       boolean changed = blockingChannelActiveConnections.remove(blockingChannel);
       if (!changed) {
         logger.error("Invalid connection being destroyed. "
-            + "Channel does not belong to this queue. queue host {} port {} channel host {} port {}", host,
+                + "Channel does not belong to this queue. queue host {} port {} channel host {} port {}", host,
             port.getPort(), blockingChannel.getRemoteHost(), blockingChannel.getRemotePort());
         throw new IllegalArgumentException("Invalid connection. Channel does not belong to this queue");
       }
@@ -217,9 +217,8 @@ class BlockingChannelInfo {
       logger.trace("Destroying connection and adding new connection for host {} port {}", host, port.getPort());
       blockingChannelAvailableConnections.add(channel);
     } catch (Exception e) {
-      logger
-          .error("Connection failure to remote host {} and port {} when destroying and recreating the connection", host,
-              port.getPort());
+      logger.error("Connection failure to remote host {} and port {} when destroying and recreating the connection",
+          host, port.getPort());
       synchronized (lock) {
         // decrement the number of connections to the host and port. we were not able to maintain the count
         numberOfConnections.decrementAndGet();
@@ -345,10 +344,10 @@ public final class BlockingChannelConnectionPool implements ConnectionPool {
     };
     registry.register(MetricRegistry.name(BlockingChannelConnectionPool.class, "requestsWaitingToCheckoutConnection"),
         requestsWaitingToCheckoutConnection);
-    sslSocketFactoryClientInitializationCount = registry
-        .counter(MetricRegistry.name(BlockingChannelConnectionPool.class, "SslSocketFactoryClientInitializationCount"));
-    sslSocketFactoryClientInitializationErrorCount = registry
-        .counter(MetricRegistry.name(BlockingChannelConnectionPool.class, "SslSocketFactoryClientInitializationErrorCount"));
+    sslSocketFactoryClientInitializationCount = registry.counter(
+        MetricRegistry.name(BlockingChannelConnectionPool.class, "SslSocketFactoryClientInitializationCount"));
+    sslSocketFactoryClientInitializationErrorCount = registry.counter(
+        MetricRegistry.name(BlockingChannelConnectionPool.class, "SslSocketFactoryClientInitializationErrorCount"));
 
     if (sslConfig.sslEnabledDatacenters.length() > 0) {
       initializeSSLSocketFactory();

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelConnectionPool.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelConnectionPool.java
@@ -224,10 +224,14 @@ class BlockingChannelInfo {
         // decrement the number of connections to the host and port. we were not able to maintain the count
         numberOfConnections.decrementAndGet();
         // at this point we are good to clean up the available connections since re-creation failed
-          while(!blockingChannelAvailableConnections.isEmpty()){
-            blockingChannelAvailableConnections.poll().disconnect();
-            numberOfConnections.decrementAndGet();
+        do {
+          BlockingChannel channel = blockingChannelAvailableConnections.poll();
+          if (channel == null) {
+            break;
           }
+          channel.disconnect();
+          numberOfConnections.decrementAndGet();
+        } while (true);
       }
     } finally {
       rwlock.readLock().unlock();

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelConnectionPool.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelConnectionPool.java
@@ -45,8 +45,8 @@ class BlockingChannelInfo {
   private final Port port;
   private final Logger logger = LoggerFactory.getLogger(getClass());
   protected Gauge<Integer> availableConnections;
-  protected Gauge<Integer> activeConnections;
-  protected Gauge<Integer> totalNumberOfConnections;
+  private Gauge<Integer> activeConnections;
+  private Gauge<Integer> totalNumberOfConnections;
   private int maxConnectionsPerHostPerPort;
   private final int maxConnectFailuresToCleanUp;
   private final AtomicInteger currentConnectFailures;

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelConnectionPool.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelConnectionPool.java
@@ -49,7 +49,7 @@ class BlockingChannelInfo {
   protected Gauge<Integer> totalNumberOfConnections;
   private int maxConnectionsPerHostPerPort;
   private final int maxConnectFailuresToCleanUp;
-  private AtomicInteger currentConnectFailuresToCleanUp;
+  private final AtomicInteger currentConnectFailures;
   private final SSLSocketFactory sslSocketFactory;
   private final SSLConfig sslConfig;
   private final MetricRegistry registry;
@@ -68,7 +68,7 @@ class BlockingChannelInfo {
     this.blockingChannelActiveConnections = new ArrayBlockingQueue<BlockingChannel>(maxConnectionsPerHostPerPort);
     this.numberOfConnections = new AtomicInteger(0);
     this.maxConnectFailuresToCleanUp = config.connectionPoolMaxConnectFailuresToCleanUpAvailablePool;
-    currentConnectFailuresToCleanUp = new AtomicInteger(0);
+    currentConnectFailures = new AtomicInteger(0);
     this.rwlock = new ReentrantReadWriteLock();
     this.lock = new Object();
     this.host = host;
@@ -113,7 +113,7 @@ class BlockingChannelInfo {
     try {
       if (blockingChannelActiveConnections.remove(blockingChannel)) {
         blockingChannelAvailableConnections.add(blockingChannel);
-        currentConnectFailuresToCleanUp.set(0);
+        currentConnectFailures.set(0);
         logger.trace(
             "Adding connection to {}:{} back to pool. Current available connections {} Current active connections {}",
             blockingChannel.getRemoteHost(), blockingChannel.getRemotePort(),
@@ -156,7 +156,7 @@ class BlockingChannelInfo {
           BlockingChannel channel = getBlockingChannelBasedOnPortType(host, port.getPort());
           channel.connect();
           numberOfConnections.incrementAndGet();
-          currentConnectFailuresToCleanUp.set(0);
+          currentConnectFailures.set(0);
           logger.trace("Created a new connection for host {} and port {}. Number of connections {}", host, port,
               numberOfConnections.get());
           blockingChannelActiveConnections.add(channel);
@@ -222,7 +222,7 @@ class BlockingChannelInfo {
       channel.connect();
       logger.trace("Destroying connection and adding new connection for host {} port {}", host, port.getPort());
       blockingChannelAvailableConnections.add(channel);
-      currentConnectFailuresToCleanUp.set(0);
+      currentConnectFailures.set(0);
     } catch (Exception e) {
       logger
           .error("Connection failure to remote host {} and port {} when destroying and recreating the connection", host,
@@ -230,13 +230,14 @@ class BlockingChannelInfo {
       synchronized (lock) {
         // decrement the number of connections to the host and port. we were not able to maintain the count
         numberOfConnections.decrementAndGet();
-        currentConnectFailuresToCleanUp.incrementAndGet();
+        currentConnectFailures.incrementAndGet();
         // if we have reached the max count for connection failures, clean up the available connections
-        if(currentConnectFailuresToCleanUp.get() >= maxConnectFailuresToCleanUp) {
+        if(currentConnectFailures.get() >= maxConnectFailuresToCleanUp) {
           while(!blockingChannelAvailableConnections.isEmpty()){
             blockingChannelAvailableConnections.poll().disconnect();
+            numberOfConnections.decrementAndGet();
           }
-          currentConnectFailuresToCleanUp.set(0);
+          currentConnectFailures.set(0);
         }
       }
     } finally {

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
@@ -110,7 +110,6 @@ public class NetworkClient implements Closeable {
     } finally {
       numPendingRequests.set(pendingRequests.size());
       networkMetrics.networkClientSendAndPollTime.update(time.milliseconds() - startTime);
-      logger.trace("Completing a send and poll cycle ");
     }
   }
 

--- a/ambry-network/src/test/java/com.github.ambry.network/BlockingChannelConnectionPoolTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/BlockingChannelConnectionPoolTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.config.NetworkConfig;
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.VerifiableProperties;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -155,6 +156,77 @@ public class BlockingChannelConnectionPoolTest {
     testBlockingChannelInfo("127.0.0.1", new Port(7667, PortType.SSL), 5, 5);
   }
 
+  @Test
+  public void testConnectionFailureCases()
+      throws InterruptedException, ConnectionPoolTimeoutException, IOException {
+    int port = 6680;
+
+    Properties props = new Properties();
+    String maxConnectFailuresToCleanUp = "2";
+    props.put("connectionpool.max.connect.failures.to.clean.up.available.pool", maxConnectFailuresToCleanUp);
+    String host = "127.0.0.1";
+
+    SocketServer server = startServer(port);
+
+    BlockingChannelInfo channelInfo =
+        new BlockingChannelInfo(new ConnectionPoolConfig(new VerifiableProperties(props)), host,
+            new Port(port, PortType.PLAINTEXT), new MetricRegistry(), sslSocketFactory, sslConfig);
+
+    Assert.assertEquals(channelInfo.getNumberOfConnections(), 0);
+    BlockingChannel blockingChannel1 = channelInfo.getBlockingChannel(1000);
+    Assert.assertEquals(channelInfo.getNumberOfConnections(), 1);
+
+    BlockingChannel blockingChannel2 = channelInfo.getBlockingChannel(1000);
+    Assert.assertEquals(channelInfo.getNumberOfConnections(), 2);
+
+    BlockingChannel blockingChannel3 = channelInfo.getBlockingChannel(1000);
+    Assert.assertEquals(channelInfo.getNumberOfConnections(), 3);
+
+    BlockingChannel blockingChannel4 = channelInfo.getBlockingChannel(1000);
+    Assert.assertEquals(channelInfo.getNumberOfConnections(), 4);
+
+    BlockingChannel blockingChannel5 = channelInfo.getBlockingChannel(1000);
+    Assert.assertEquals(channelInfo.getNumberOfConnections(), 5);
+
+    channelInfo.releaseBlockingChannel(blockingChannel3);
+    channelInfo.releaseBlockingChannel(blockingChannel4);
+    channelInfo.releaseBlockingChannel(blockingChannel5);
+
+    Assert.assertEquals("Available connections count mismatch ", 3,
+        channelInfo.availableConnections.getValue().intValue());
+
+    // shutdown server
+    server.shutdown();
+
+    // destroy one of the connections and verify that the available connections are not yet cleaned up as the config
+    // value of interest is set to 2
+    channelInfo.destroyBlockingChannel(blockingChannel1);
+
+    Assert.assertEquals("Available connections should have not been cleaned up", 3,
+        channelInfo.availableConnections.getValue().intValue());
+
+    // start the server and verify that destroy connection will not trigger clean up of available connections as connection
+    // recreation should have passed
+    server = startServer(port);
+
+    channelInfo.destroyBlockingChannel(blockingChannel2);
+    Assert.assertEquals("Available connections should not have been cleaned up", 4,
+        channelInfo.availableConnections.getValue().intValue());
+
+    server.shutdown();
+
+    // destroy two connections and verify that all other available connections are cleaned up as the config
+    // value of interest is set to 2 and we have reached 2 failures
+
+    BlockingChannel blockingChannel = channelInfo.getBlockingChannel(1000);
+    channelInfo.destroyBlockingChannel(blockingChannel);
+    blockingChannel = channelInfo.getBlockingChannel(1000);
+    channelInfo.destroyBlockingChannel(blockingChannel);
+
+    Assert.assertEquals("Available connections should have been cleaned up", 0,
+        channelInfo.availableConnections.getValue().intValue());
+  }
+
   private void testBlockingChannelInfo(String host, Port port, int maxConnectionsPerPortPlainText,
       int maxConnectionsPerPortSSL)
       throws Exception {
@@ -244,6 +316,28 @@ public class BlockingChannelConnectionPoolTest {
     Assert.assertEquals(channelInfo.getNumberOfConnections(), underSubscriptionCount);
     channelInfo.cleanup();
     Assert.assertEquals(channelInfo.getNumberOfConnections(), 0);
+  }
+
+  /**
+   * Starts up an ambry server given a port number in localhost
+   *
+   * @param port the port number over which ambry server needs to be started
+   * @return the {@link SocketServer} referring to ambry's instance
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  private SocketServer startServer(int port)
+      throws IOException, InterruptedException {
+    Properties props = new Properties();
+    props.setProperty("port", "" + port);
+    VerifiableProperties propverify = new VerifiableProperties(props);
+    NetworkConfig config = new NetworkConfig(propverify);
+    ArrayList<Port> ports = new ArrayList<Port>();
+    ports.add(new Port(port, PortType.PLAINTEXT));
+    ports.add(new Port(port + 1000, PortType.SSL));
+    SocketServer server = new SocketServer(config, serverSSLConfig1, new MetricRegistry(), ports);
+    server.start();
+    return server;
   }
 
   class ConnectionPoolThread implements Runnable {

--- a/ambry-network/src/test/java/com.github.ambry.network/BlockingChannelConnectionPoolTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/BlockingChannelConnectionPoolTest.java
@@ -156,11 +156,15 @@ public class BlockingChannelConnectionPoolTest {
     testBlockingChannelInfo("127.0.0.1", new Port(7667, PortType.SSL), 5, 5);
   }
 
+  /**
+   * Tests how connection failures are handled by BlockingChannelInfo.
+   * To be specific it checks if available connections are cleaned up once a threshold of failures
+   * have reacehed based on the config.
+   */
   @Test
   public void testConnectionFailureCases()
       throws InterruptedException, ConnectionPoolTimeoutException, IOException {
     int port = 6680;
-
     Properties props = new Properties();
     String maxConnectFailuresToCleanUp = "2";
     props.put("connectionpool.max.connect.failures.to.clean.up.available.pool", maxConnectFailuresToCleanUp);


### PR DESCRIPTION
BlockingChannelInfo doesn't clean up available connections even when the destination node is down. During destroyConnection(), it tries to create new connection and swallow any exception. So, this might have a bad effect in the sense that, all future checkout calls will be returning stale connections. Until we run out of all stale connections, all new checkouts will be returning stale connections.

This PR fixes the same. BlockingChannelInfo keeps track of consecutive failures on connection attempts. Whenever we reach certain threshold, available connections are cleared out. But incase a connection attempt was successful within consecutive failures before reaching the threshold, no connections are cleaned up.

Coverage:  (all the new lines added have 100% coverage)
BlockingChannelInfo	100% (4/ 4)	85.7% (12/ 14)	83% (112/ 135)
BlockingChannelConnectionPool	100% (4/ 4)	64.3% (9/ 14)	65.6% (63/ 96)

SLA: 10 mins
Reviewers: Priyesh, Gopal