### PR TITLE
Cleaning up error logging and metrics

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -110,8 +110,7 @@ class DeleteManager {
       deleteOperations.add(deleteOperation);
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.deleteBlobErrorCount.inc();
-      routerMetrics.countError(e);
+      routerMetrics.onDeleteBlobError(e);
       operationCompleteCallback.completeOperation(futureResult, callback, null, e);
     }
   }
@@ -211,8 +210,7 @@ class DeleteManager {
     if (e == null) {
       notificationSystem.onBlobDeleted(op.getBlobId().getID());
     } else {
-      routerMetrics.deleteBlobErrorCount.inc();
-      routerMetrics.countError(e);
+      routerMetrics.onDeleteBlobError(e);
     }
     routerMetrics.operationDequeuingRate.mark();
     routerMetrics.deleteBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmissionTimeMs());
@@ -233,8 +231,7 @@ class DeleteManager {
         Exception e = new RouterException("Aborted operation because Router is closed.", RouterErrorCode.RouterClosed);
         routerMetrics.operationDequeuingRate.mark();
         routerMetrics.operationAbortCount.inc();
-        routerMetrics.deleteBlobErrorCount.inc();
-        routerMetrics.countError(e);
+        routerMetrics.onDeleteBlobError(e);
         operationCompleteCallback.completeOperation(op.getFutureResult(), op.getCallback(), null, e);
       }
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -324,8 +324,7 @@ class GetBlobInfoOperation extends GetOperation<BlobInfo> {
     if (operationCompleted) {
       Exception e = operationException.get();
       if (e != null) {
-        routerMetrics.getBlobInfoErrorCount.inc();
-        routerMetrics.countError(e);
+        routerMetrics.onGetBlobInfoError(e);
       }
       routerMetrics.getBlobInfoOperationLatencyMs.update(time.milliseconds() - submissionTimeMs);
       operationCompleteCallback.completeOperation(operationFuture, operationCallback, operationResult, e);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -175,8 +175,7 @@ class GetBlobOperation extends GetOperation<ReadableStreamChannel> {
         Exception e = getOperationException();
         getBlobResult = e == null ? new GetBlobResult() : null;
         if (e != null) {
-          routerMetrics.getBlobErrorCount.inc();
-          routerMetrics.countError(e);
+          routerMetrics.onGetBlobError(e);
         }
         operationCompleteCallback.completeOperation(operationFuture, operationCallback, getBlobResult, e);
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * GetManager manages GetBlob and GetBlobInfo operations. This is just a template for now.
+ * GetManager manages GetBlob and GetBlobInfo operations.
  * These methods have to be thread safe.
  */
 class GetManager {
@@ -117,8 +117,7 @@ class GetManager {
               callback, operationCompleteCallback, time);
       getOperations.add(getBlobInfoOperation);
     } catch (RouterException e) {
-      routerMetrics.getBlobInfoErrorCount.inc();
-      routerMetrics.countError(e);
+      routerMetrics.onGetBlobInfoError(e);
       routerMetrics.operationDequeuingRate.mark();
       operationCompleteCallback.completeOperation(futureResult, callback, null, e);
     }
@@ -138,8 +137,7 @@ class GetManager {
               operationCompleteCallback, readyForPollCallback, blobIdFactory, time);
       getOperations.add(getBlobOperation);
     } catch (RouterException e) {
-      routerMetrics.getBlobErrorCount.inc();
-      routerMetrics.countError(e);
+      routerMetrics.onGetBlobError(e);
       routerMetrics.operationDequeuingRate.mark();
       operationCompleteCallback.completeOperation(futureResult, callback, null, e);
     }
@@ -263,7 +261,11 @@ class GetManager {
     if (remove(op)) {
       op.abort(abortCause);
       routerMetrics.operationAbortCount.inc();
-      routerMetrics.countError(abortCause);
+      if (op instanceof GetBlobOperation) {
+        routerMetrics.onGetBlobError(abortCause);
+      } else {
+        routerMetrics.onGetBlobInfoError(abortCause);
+      }
     }
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -131,8 +131,7 @@ class NonBlockingRouter implements Router {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.getBlobInfoErrorCount.inc();
-      routerMetrics.countError(routerException);
+      routerMetrics.onGetBlobInfoError(routerException);
       operationCompleteCallback.completeOperation(futureResult, callback, null, routerException);
     }
     return futureResult;
@@ -167,8 +166,7 @@ class NonBlockingRouter implements Router {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.getBlobErrorCount.inc();
-      routerMetrics.countError(routerException);
+      routerMetrics.onGetBlobError(routerException);
       operationCompleteCallback.completeOperation(futureResult, callback, null, routerException);
     }
     return futureResult;
@@ -208,8 +206,7 @@ class NonBlockingRouter implements Router {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.putBlobErrorCount.inc();
-      routerMetrics.countError(routerException);
+      routerMetrics.onPutBlobError(routerException);
       operationCompleteCallback.completeOperation(futureResult, callback, null, routerException);
     }
     return futureResult;
@@ -244,8 +241,7 @@ class NonBlockingRouter implements Router {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.deleteBlobErrorCount.inc();
-      routerMetrics.countError(routerException);
+      routerMetrics.onDeleteBlobError(routerException);
       operationCompleteCallback.completeOperation(futureResult, callback, null, routerException);
     }
     return futureResult;
@@ -384,8 +380,7 @@ class NonBlockingRouter implements Router {
         RouterException routerException =
             new RouterException(" because Router is closed", RouterErrorCode.RouterClosed);
         routerMetrics.operationDequeuingRate.mark();
-        routerMetrics.putBlobErrorCount.inc();
-        routerMetrics.countError(routerException);
+        routerMetrics.onPutBlobError(routerException);
         operationCompleteCallback.completeOperation(futureResult, callback, null, routerException);
         // Close so that any existing operations are also disposed off.
         close();

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -268,26 +268,14 @@ public class NonBlockingRouterMetrics {
    * @param exception The exception to be counted.
    */
   void countError(Exception exception) {
-    operationErrorRate.mark();
     if (exception instanceof RouterException) {
       switch (((RouterException) exception).getErrorCode()) {
-        case AmbryUnavailable:
-          ambryUnavailableErrorCount.inc();
-          break;
+        // The following are user errors. Only increment the respective error metric.
         case InvalidBlobId:
           invalidBlobIdErrorCount.inc();
           break;
         case InvalidPutArgument:
           invalidPutArgumentErrorCount.inc();
-          break;
-        case OperationTimedOut:
-          operationTimedOutErrorCount.inc();
-          break;
-        case RouterClosed:
-          routerClosedErrorCount.inc();
-          break;
-        case UnexpectedInternalError:
-          unexpectedInternalErrorCount.inc();
           break;
         case BlobTooLarge:
           blobTooLargeErrorCount.inc();
@@ -295,24 +283,45 @@ public class NonBlockingRouterMetrics {
         case BadInputChannel:
           badInputChannelErrorCount.inc();
           break;
-        case InsufficientCapacity:
-          insufficientCapacityErrorCount.inc();
-          break;
         case BlobDeleted:
           blobDeletedErrorCount.inc();
-          break;
-        case BlobDoesNotExist:
-          blobDoesNotExistErrorCount.inc();
           break;
         case BlobExpired:
           blobExpiredErrorCount.inc();
           break;
+        // The following are possibly internal errors. Additionally increment operationErrorRate.
+        case AmbryUnavailable:
+          ambryUnavailableErrorCount.inc();
+          operationErrorRate.mark();
+          break;
+        case OperationTimedOut:
+          operationTimedOutErrorCount.inc();
+          operationErrorRate.mark();
+          break;
+        case RouterClosed:
+          routerClosedErrorCount.inc();
+          operationErrorRate.mark();
+          break;
+        case UnexpectedInternalError:
+          unexpectedInternalErrorCount.inc();
+          operationErrorRate.mark();
+          break;
+        case InsufficientCapacity:
+          insufficientCapacityErrorCount.inc();
+          operationErrorRate.mark();
+          break;
+        case BlobDoesNotExist:
+          blobDoesNotExistErrorCount.inc();
+          operationErrorRate.mark();
+          break;
         default:
           unknownErrorCountForOperation.inc();
+          operationErrorRate.mark();
           break;
       }
     } else {
       unknownErrorCountForOperation.inc();
+      operationErrorRate.mark();
     }
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -262,8 +262,7 @@ public class NonBlockingRouterMetrics {
   }
 
   /**
-   * Increment error metrics based on error type and return whether the error is indicative
-   * of the health of the system or is a user input error.
+   * Increment error metrics based on error type.
    * @param exception The exception associated with this error.
    */
   private void onError(Exception exception) {
@@ -359,6 +358,7 @@ public class NonBlockingRouterMetrics {
     onError(e);
     if (RouterUtils.isSystemHealthError(e)) {
       deleteBlobErrorCount.inc();
+      operationErrorRate.mark();
     }
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -267,9 +267,6 @@ public class NonBlockingRouterMetrics {
    * @param exception The exception associated with this error.
    */
   private void onError(Exception exception) {
-    if (RouterUtils.isSystemHealthError(exception)) {
-      operationErrorRate.mark();
-    }
     if (exception instanceof RouterException) {
       RouterErrorCode errorCode = ((RouterException) exception).getErrorCode();
       switch (errorCode) {
@@ -326,6 +323,7 @@ public class NonBlockingRouterMetrics {
     onError(e);
     if (RouterUtils.isSystemHealthError(e)) {
       putBlobErrorCount.inc();
+      operationErrorRate.mark();
     }
   }
 
@@ -337,6 +335,7 @@ public class NonBlockingRouterMetrics {
     onError(e);
     if (RouterUtils.isSystemHealthError(e)) {
       getBlobErrorCount.inc();
+      operationErrorRate.mark();
     }
   }
 
@@ -348,6 +347,7 @@ public class NonBlockingRouterMetrics {
     onError(e);
     if (RouterUtils.isSystemHealthError(e)) {
       getBlobInfoErrorCount.inc();
+      operationErrorRate.mark();
     }
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -150,8 +150,7 @@ class PutManager {
       putOperation.startReadingFromChannel();
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.putBlobErrorCount.inc();
-      routerMetrics.countError(e);
+      routerMetrics.onPutBlobError(e);
       operationCompleteCallback.completeOperation(futureResult, callback, null, e);
     }
   }
@@ -254,8 +253,7 @@ class PutManager {
     Exception e = op.getOperationException();
     if (e != null) {
       // @todo add blobs in the metadata chunk to ids_to_delete
-      routerMetrics.putBlobErrorCount.inc();
-      routerMetrics.countError(e);
+      routerMetrics.onPutBlobError(e);
     } else {
       notificationSystem.onBlobCreated(op.getBlobIdString(), op.getBlobProperties(), op.getUserMetadata());
     }
@@ -309,8 +307,7 @@ class PutManager {
         Exception e = new RouterException("Aborted operation because Router is closed.", RouterErrorCode.RouterClosed);
         routerMetrics.operationDequeuingRate.mark();
         routerMetrics.operationAbortCount.inc();
-        routerMetrics.putBlobErrorCount.inc();
-        routerMetrics.countError(e);
+        routerMetrics.onPutBlobError(e);
         operationCompleteCallback.completeOperation(op.getFuture(), op.getCallback(), null, e);
       }
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -42,7 +42,7 @@ class RouterUtils {
       blobId = new BlobId(blobIdString, clusterMap);
       logger.trace("BlobId created " + blobId + " with partition " + blobId.getPartition());
     } catch (Exception e) {
-      logger.error("Caller passed in invalid BlobId " + blobIdString);
+      logger.trace("Caller passed in invalid BlobId " + blobIdString);
       throw new RouterException("BlobId is invalid " + blobIdString, RouterErrorCode.InvalidBlobId);
     }
     return blobId;

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -40,9 +40,9 @@ class RouterUtils {
     BlobId blobId;
     try {
       blobId = new BlobId(blobIdString, clusterMap);
-      logger.trace("BlobId created " + blobId + " with partition " + blobId.getPartition());
+      logger.trace("BlobId {} created with partitionId {}", blobId, blobId.getPartition());
     } catch (Exception e) {
-      logger.trace("Caller passed in invalid BlobId " + blobIdString);
+      logger.trace("Caller passed in invalid BlobId {}", blobIdString);
       throw new RouterException("BlobId is invalid " + blobIdString, RouterErrorCode.InvalidBlobId);
     }
     return blobId;
@@ -57,5 +57,29 @@ class RouterUtils {
    */
   static boolean isRemoteReplica(RouterConfig routerConfig, ReplicaId replicaId) {
     return !routerConfig.routerDatacenterName.equals(replicaId.getDataNodeId().getDatacenterName());
+  }
+
+  /**
+   * Determine if an error is a user error and not indicative of the health of the system.
+   * @param exception The {@link Exception} to check.
+   * @return true if this is an internal error and not a user error; false otherwise.
+   */
+  static boolean isSystemHealthError(Exception exception) {
+    boolean isSystemHealthError = true;
+    if (exception instanceof RouterException) {
+      RouterErrorCode routerErrorCode = ((RouterException) exception).getErrorCode();
+      switch (routerErrorCode) {
+        // The following are user errors. Only increment the respective error metric.
+        case InvalidBlobId:
+        case InvalidPutArgument:
+        case BlobTooLarge:
+        case BadInputChannel:
+        case BlobDeleted:
+        case BlobExpired:
+          isSystemHealthError = false;
+          break;
+      }
+    }
+    return isSystemHealthError;
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -60,7 +60,7 @@ class RouterUtils {
   }
 
   /**
-   * Determine if an error is a user error and not indicative of the health of the system.
+   * Determine if an error is indicative of the health of the system, and not a user error.
    * @param exception The {@link Exception} to check.
    * @return true if this is an internal error and not a user error; false otherwise.
    */


### PR DESCRIPTION
Not counting user errors towards operation error metric (which is a common metric for router errors).
Avoiding an error logging for user error - these can fill up the logs unnecessarily.