### PR TITLE
Prevent NetworkClient from returning duplicate failed responses

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
@@ -137,6 +137,10 @@ public class NetworkClient implements Closeable {
         logger.trace("Failing request to host {} port {} due to connection unavailability",
             requestMetadata.requestInfo.getHost(), requestMetadata.requestInfo.getPort());
         iter.remove();
+        if (requestMetadata.pendingConnectionId != null) {
+          pendingConnectionsToAssociatedRequests.remove(requestMetadata.pendingConnectionId);
+          requestMetadata.pendingConnectionId = null;
+        }
         networkMetrics.connectionTimeOutError.inc();
       } else {
         // Since requests are ordered by time, once the first request that cannot be dropped is found,

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -310,6 +310,8 @@ public class NetworkClientTest {
     time.sleep(2000);
     responseInfoList = networkClient.sendAndPoll(requestInfoList, 100);
     Assert.assertEquals(1, responseInfoList.size());
+    Assert.assertEquals("Error received should be ConnectionUnavailable", NetworkClientErrorCode.ConnectionUnavailable,
+        responseInfoList.get(0).getError());
     responseInfoList.clear();
     selector.setState(MockSelectorState.Good);
   }


### PR DESCRIPTION
Fix a bug in the NetworkClient which causes duplicate responses to
be returned if a disconnection happens for a pending request in the
same sendAndPoll cycle as when the request times out.