### PR TITLE
Refactor get blob operation test to avoid blocking selector poll

### DIFF
--- a/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
@@ -61,7 +61,6 @@ class MockServer {
   private boolean shouldRespond = true;
   private short blobFormatVersion = MessageFormatRecord.Blob_Version_V2;
   private boolean getErrorOnDataBlobOnly = false;
-  private CountDownLatch dataBlobGetLatch = null;
   private final ClusterMap clusterMap;
   private final String dataCenter;
 
@@ -150,13 +149,6 @@ class MockServer {
       String id = getRequest.getPartitionInfoList().get(0).getBlobIds().get(0).getID();
       isDataBlob = blobs.get(id).type == BlobType.DataBlob;
     } catch (Exception ignored) {
-    }
-
-    if (dataBlobGetLatch != null && isDataBlob) {
-      try {
-        dataBlobGetLatch.await();
-      } catch (InterruptedException ignored) {
-      }
     }
 
     if (!getErrorOnDataBlobOnly || isDataBlob) {
@@ -350,14 +342,6 @@ class MockServer {
    */
   public void setBlobFormatVersion(short blobFormatVersion) {
     this.blobFormatVersion = blobFormatVersion;
-  }
-
-  /**
-   * Introduce a latch that the server will wait for before responding to a data blob get request.
-   * @param dataBlobGetLatch The {@link CountDownLatch} to wait for.
-   */
-  public void setDataBlobGetLatch(CountDownLatch dataBlobGetLatch) {
-    this.dataBlobGetLatch = dataBlobGetLatch;
   }
 }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 
 
 /**
@@ -186,18 +185,6 @@ class RouterTestHelpers {
     ArrayList<MockServer> mockServers = new ArrayList<>(serverLayout.getMockServers());
     for (MockServer mockServer : mockServers) {
       mockServer.setGetErrorOnDataBlobOnly(getErrorOnDataBlobOnly);
-    }
-  }
-
-  /**
-   * Introduce a latch that all mock servers will wait for before performing data blob get operations.
-   * @param dataBlobGetLatch The {@link CountDownLatch} to wait for.
-   * @param serverLayout A {@link MockServerLayout} containing the {@link MockServer}s to change settings on.
-   */
-  static void setDataBlobGetLatchForAllServers(CountDownLatch dataBlobGetLatch, MockServerLayout serverLayout) {
-    ArrayList<MockServer> mockServers = new ArrayList<>(serverLayout.getMockServers());
-    for (MockServer mockServer : mockServers) {
-      mockServer.setDataBlobGetLatch(dataBlobGetLatch);
     }
   }
 


### PR DESCRIPTION
We should avoid causing the MockSelector to block. This will cause
tests to not test things in the intended way because if the selector
poll blocks, then the NetworkClient sendAndPoll() blocks, and the
RequestResponseHandler thread will not poll the operation managers,
thereby preventing system progress.

Tested in a loop and verified.