### PR TITLE
Make the router resilient to unexpected errors

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/network/Selectable.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/Selectable.java
@@ -57,6 +57,11 @@ public interface Selectable {
   public void close();
 
   /**
+   * Check whether the selector is open.
+   */
+  public boolean isOpen();
+
+  /**
    * Firstly initiate any sends provided, and then make progress on any other I/O operations in-flight (connections,
    * disconnections, existing sends, and receives)
    * @param timeoutMs The amount of time to block if there is nothing to do in ms

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
@@ -107,6 +107,7 @@ public class NetworkClient implements Closeable {
       selector.poll(pollTimeoutMs, sends);
       handleSelectorEvents(responseInfoList);
     } catch (Exception e) {
+      logger.error("Received an unexpected error during sendAndPoll(): ", e);
       networkMetrics.networkClientException.inc();
     } finally {
       numPendingRequests.set(pendingRequests.size());

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
@@ -91,7 +91,7 @@ public class NetworkClient implements Closeable {
    * @throws IllegalStateException if the NetworkClient is closed.
    */
   public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestInfos, int pollTimeoutMs) {
-    if (closed) {
+    if (closed || !selector.isOpen()) {
       throw new IllegalStateException("The NetworkClient is closed.");
     }
     long startTime = time.milliseconds();

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -84,6 +84,7 @@ public class NetworkMetrics {
 
   public final Counter connectionTimeOutError;
   public final Counter networkClientIOError;
+  public final Counter networkClientException;
   private List<AtomicLong> networkClientPendingRequestList;
 
   public NetworkMetrics(MetricRegistry registry) {
@@ -136,6 +137,7 @@ public class NetworkMetrics {
     requestResponseTotalTime = registry.histogram(MetricRegistry.name(NetworkClient.class, "RequestResponseTotalTime"));
     connectionTimeOutError = registry.counter(MetricRegistry.name(NetworkClient.class, "ConnectionTimeOutError"));
     networkClientIOError = registry.counter(MetricRegistry.name(NetworkClient.class, "NetworkClientIOError"));
+    networkClientException = registry.counter(MetricRegistry.name(NetworkClient.class, "NetworkClientException"));
 
     selectorActiveConnectionsList = new ArrayList<>();
     networkClientPendingRequestList = new ArrayList<>();

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -236,6 +236,16 @@ public class Selector implements Selectable {
   }
 
   /**
+   * Tells whether or not this selector is open.  </p>
+   *
+   * @return <tt>true</tt> if, and only if, this selector is open
+   */
+  @Override
+  public boolean isOpen() {
+    return nioSelector.isOpen();
+  }
+
+  /**
    * Queue the given request for sending in the subsequent {@poll(long)} calls
    * @param networkSend The NetworkSend that is ready to be sent
    */

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -491,6 +491,7 @@ class MockSelector extends Selector {
   private MockSelectorState state = MockSelectorState.Good;
   private boolean wakeUpCalled = false;
   private int connectCallCount = 0;
+  private boolean isOpen = true;
 
   /**
    * Create a MockSelector
@@ -499,6 +500,7 @@ class MockSelector extends Selector {
   MockSelector()
       throws IOException {
     super(new NetworkMetrics(new MetricRegistry()), new MockTime(), null);
+    super.close();
   }
 
   /**
@@ -671,5 +673,22 @@ class MockSelector extends Selector {
     if (connectionIds.contains(conn)) {
       disconnected.add(conn);
     }
+  }
+
+  /**
+   * Close the MockSelector.
+   */
+  @Override
+  public void close() {
+    isOpen = false;
+  }
+
+  /**
+   * Check whether the MockSelector is open.
+   * @return true, if the MockSelector is open.
+   */
+  @Override
+  public boolean isOpen() {
+    return isOpen;
   }
 }

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -196,7 +196,7 @@ public class NetworkClientTest {
     selector.setState(MockSelectorState.ThrowExceptionOnConnect);
     try {
       networkClient.sendAndPoll(requestInfoList, 100);
-    } catch (IOException e) {
+    } catch (Exception e) {
       Assert.fail("If selector throws on connect, sendAndPoll() should not throw");
     }
   }
@@ -327,8 +327,8 @@ public class NetworkClientTest {
     selector.setState(MockSelectorState.ThrowExceptionOnPoll);
     try {
       networkClient.sendAndPoll(requestInfoList, 100);
-      Assert.fail("If selector throws on poll, sendAndPoll() should throw as well");
-    } catch (IOException e) {
+    } catch (Exception e) {
+      Assert.fail("If selector throws on poll, sendAndPoll() should not throw.");
     }
     selector.setState(MockSelectorState.Good);
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -74,6 +74,10 @@ public class NonBlockingRouterMetrics {
   public final Counter unknownReplicaResponseError;
   public final Counter unknownErrorCountForOperation;
   public final Counter responseDeserializationErrorCount;
+  public final Counter operationManagerPollErrorCount;
+  public final Counter operationManagerHandleResponseErrorCount;
+  public final Counter requestResponseHandlerUnexpectedErrorCount;
+  public final Counter chunkFillerUnexpectedErrorCount;
 
   // Performance metrics for operation managers.
   public final Histogram putManagerPollTimeMs;
@@ -174,6 +178,14 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "UnknownErrorCountForOperation"));
     responseDeserializationErrorCount =
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "ResponseDeserializationErrorCount"));
+    operationManagerPollErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OperationManagerPollErrorCount"));
+    operationManagerHandleResponseErrorCount = metricRegistry
+        .counter(MetricRegistry.name(NonBlockingRouter.class, "OperationManagerHandleResponseErrorCount"));
+    requestResponseHandlerUnexpectedErrorCount = metricRegistry
+        .counter(MetricRegistry.name(NonBlockingRouter.class, "RequestResponseHandlerUnexpectedErrorCount"));
+    chunkFillerUnexpectedErrorCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "ChunkFillerUnexpectedErrorCount"));
 
     // Performance metrics for operation managers.
     putManagerPollTimeMs = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutManagerPollTimeMs"));

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -339,8 +339,9 @@ class PutManager {
             }
           }
         }
-      } catch (InterruptedException e) {
-        logger.error("ChunkFillerThread was interrupted", e);
+      } catch (Throwable e) {
+        logger.error("Aborting, chunkFillerThread received an unexpected error:", e);
+        routerMetrics.chunkFillerUnexpectedErrorCount.inc();
         if (isOpen.compareAndSet(true, false)) {
           completePendingOperations();
         }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -352,6 +352,7 @@ class PutOperation {
         }
       }
     } catch (Exception e) {
+      routerMetrics.chunkFillerUnexpectedErrorCount.inc();
       readyForPollCallback.onPollReady();
       setOperationExceptionAndComplete(new RouterException("PutOperation fillChunks encountered unexpected error", e,
           RouterErrorCode.UnexpectedInternalError));

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.fail;
 /**
  * Unit test for {@link DeleteManager} and {@link DeleteOperation}.
  */
+
 public class DeleteManagerTest {
   private static final int AWAIT_TIMEOUT_SECONDS = 2;
   private Time mockTime;
@@ -328,18 +329,18 @@ public class DeleteManagerTest {
     setServerResponse(false);
     testWithErrorCodes(Collections.singletonMap(ServerErrorCode.No_Error, 9), serverLayout,
         RouterErrorCode.OperationTimedOut, new ErrorCodeChecker() {
-          @Override
-          public void testAndAssert(RouterErrorCode expectedError)
-              throws Exception {
-            CountDownLatch operationCompleteLatch = new CountDownLatch(1);
-            future = router.deleteBlob(blobIdString, new ClientCallback(operationCompleteLatch));
-            do {
-              // increment mock time
-              mockTime.sleep(1000);
-            } while (!operationCompleteLatch.await(10, TimeUnit.MILLISECONDS));
-            assertFailureAndCheckErrorCode(future, expectedError);
-          }
-        });
+      @Override
+      public void testAndAssert(RouterErrorCode expectedError)
+          throws Exception {
+        CountDownLatch operationCompleteLatch = new CountDownLatch(1);
+        future = router.deleteBlob(blobIdString, new ClientCallback(operationCompleteLatch));
+        do {
+          // increment mock time
+          mockTime.sleep(1000);
+        } while (!operationCompleteLatch.await(10, TimeUnit.MILLISECONDS));
+        assertFailureAndCheckErrorCode(future, expectedError);
+      }
+    });
   }
 
   /**
@@ -353,9 +354,10 @@ public class DeleteManagerTest {
     Arrays.fill(serverErrorCodes, ServerErrorCode.No_Error);
     HashMap<MockSelectorState, RouterErrorCode> errorCodeHashMap = new HashMap<>();
     errorCodeHashMap.put(MockSelectorState.DisconnectOnSend, RouterErrorCode.OperationTimedOut);
-    errorCodeHashMap.put(MockSelectorState.ThrowExceptionOnAllPoll, RouterErrorCode.RouterClosed);
+    errorCodeHashMap.put(MockSelectorState.ThrowExceptionOnAllPoll, RouterErrorCode.OperationTimedOut);
     errorCodeHashMap.put(MockSelectorState.ThrowExceptionOnConnect, RouterErrorCode.OperationTimedOut);
-    errorCodeHashMap.put(MockSelectorState.ThrowExceptionOnSend, RouterErrorCode.RouterClosed);
+    errorCodeHashMap.put(MockSelectorState.ThrowExceptionOnSend, RouterErrorCode.OperationTimedOut);
+    errorCodeHashMap.put(MockSelectorState.ThrowThrowableOnSend, RouterErrorCode.RouterClosed);
     for (MockSelectorState state : MockSelectorState.values()) {
       if (state == MockSelectorState.Good) {
         continue;
@@ -381,14 +383,14 @@ public class DeleteManagerTest {
       throws Exception {
     testWithErrorCodes(Collections.singletonMap(ServerErrorCode.No_Error, 9), serverLayout,
         RouterErrorCode.RouterClosed, new ErrorCodeChecker() {
-          @Override
-          public void testAndAssert(RouterErrorCode expectedError)
-              throws Exception {
-            future = router.deleteBlob(blobIdString);
-            router.close();
-            assertFailureAndCheckErrorCode(future, expectedError);
-          }
-        });
+      @Override
+      public void testAndAssert(RouterErrorCode expectedError)
+          throws Exception {
+        future = router.deleteBlob(blobIdString);
+        router.close();
+        assertFailureAndCheckErrorCode(future, expectedError);
+      }
+    });
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -246,33 +246,31 @@ public class GetManagerTest {
     setOperationParams(chunkSize);
     String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel).get();
     mockSelectorState.set(MockSelectorState.ThrowExceptionOnSend);
-    FutureResult futureResult;
+    Future future;
     try {
-      futureResult = (FutureResult) router.getBlobInfo(blobId);
-      while (!futureResult.isDone()) {
+      future = router.getBlobInfo(blobId);
+      while (!future.isDone()) {
         mockTime.sleep(routerConfig.routerRequestTimeoutMs + 1);
         Thread.yield();
       }
-      futureResult.get();
+      future.get();
       Assert.fail("operation should have thrown");
     } catch (ExecutionException e) {
       RouterException routerException = (RouterException) e.getCause();
-      Assert.assertEquals("Exception received should be router closed error", RouterErrorCode.OperationTimedOut,
-          routerException.getErrorCode());
+      Assert.assertEquals(RouterErrorCode.OperationTimedOut, routerException.getErrorCode());
     }
 
     try {
-      futureResult = (FutureResult) router.getBlob(blobId);
-      while (!futureResult.isDone()) {
+      future = router.getBlob(blobId);
+      while (!future.isDone()) {
         mockTime.sleep(routerConfig.routerRequestTimeoutMs + 1);
         Thread.yield();
       }
-      futureResult.get();
+      future.get();
       Assert.fail("operation should have thrown");
     } catch (ExecutionException e) {
       RouterException routerException = (RouterException) e.getCause();
-      Assert.assertEquals("Exception received should be router closed error", RouterErrorCode.OperationTimedOut,
-          routerException.getErrorCode());
+      Assert.assertEquals(RouterErrorCode.OperationTimedOut, routerException.getErrorCode());
     }
     router.close();
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
@@ -67,8 +67,7 @@ class MockNetworkClient extends NetworkClient {
    * {@inheritDoc}
    */
   @Override
-  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestInfos, int pollTimeoutMs)
-      throws IOException {
+  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestInfos, int pollTimeoutMs) {
     processedResponseCount = responseCount;
     List<ResponseInfo> responseInfoList = super.sendAndPoll(requestInfos, pollTimeoutMs);
     responseCount += responseInfoList.size();

--- a/ambry-router/src/test/java/com.github.ambry.router/MockSelector.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockSelector.java
@@ -43,6 +43,7 @@ class MockSelector extends Selector {
   private final Time time;
   private final AtomicReference<MockSelectorState> state;
   private final MockServerLayout serverLayout;
+  private boolean isOpen = true;
 
   /**
    *
@@ -179,9 +180,21 @@ class MockSelector extends Selector {
     }
   }
 
+  /**
+   * Close the MockSelector
+   */
   @Override
   public void close() {
-    // no op.
+    isOpen = false;
+  }
+
+  /**
+   * Check whether the MockSelector is open.
+   * @return true if the MockSelector is open.
+   */
+  @Override
+  public boolean isOpen() {
+    return isOpen;
   }
 }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/MockSelector.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockSelector.java
@@ -104,6 +104,9 @@ class MockSelector extends Selector {
         if (state.get() == MockSelectorState.ThrowExceptionOnSend) {
           throw new IOException("Mock exception on send");
         }
+        if (state.get() == MockSelectorState.ThrowThrowableOnSend) {
+          throw new Error("Mock throwable on send");
+        }
         if (state.get() == MockSelectorState.DisconnectOnSend) {
           disconnected.add(send.getConnectionId());
         } else {
@@ -207,5 +210,9 @@ enum MockSelectorState {
    * not.
    */
   ThrowExceptionOnAllPoll,
+  /**
+   * Throw a throwable during poll that sends.
+   */
+  ThrowThrowableOnSend,
 }
 


### PR DESCRIPTION
Ensure that exceptions are not propagated outside of the operation
manager poll(), handleResponse() and the networkClient sendAndPoll()
methods, as these can bring down the router. Exceptions are unexpected
in these methods, so track them via metrics but do not aggressively
shut down the router, as there is a high chance that these are
recoverable errors, or errors isolated to a particular operation.