### PR TITLE
Ensure exceptions are always set for failed router operations

### DIFF
--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -35,6 +35,7 @@ public class MockClusterMap implements ClusterMap {
   private final List<MockDataNodeId> dataNodes;
   private final int numMountPointsPerNode;
   private final HashSet<String> dataCentersInClusterMap = new HashSet<>();
+  private boolean partitionsUnhealthy = false;
 
   /**
    * The default constructor sets up a 9 node cluster with 3 mount points in each, with 3 partitions/replicas per
@@ -161,8 +162,10 @@ public class MockClusterMap implements ClusterMap {
   @Override
   public List<PartitionId> getWritablePartitionIds() {
     List<PartitionId> partitionIdList = new ArrayList<PartitionId>();
-    for (PartitionId partitionId : partitions.values()) {
-      partitionIdList.add(partitionId);
+    if (!partitionsUnhealthy) {
+      for (PartitionId partitionId : partitions.values()) {
+        partitionIdList.add(partitionId);
+      }
     }
     return partitionIdList;
   }
@@ -249,6 +252,11 @@ public class MockClusterMap implements ClusterMap {
     }
   }
 
+  public void markAllPartitionsUnavailable() {
+    partitionsUnhealthy = true;
+  }
+
+  @Override
   public void onReplicaEvent(ReplicaId replicaId, ReplicaEventType event) {
     switch (event) {
       case Disk_Error:

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -252,6 +252,9 @@ public class MockClusterMap implements ClusterMap {
     }
   }
 
+  /**
+   * Mark all partitions as unavailable.
+   */
   public void markAllPartitionsUnavailable() {
     partitionsUnavailable = true;
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -35,7 +35,7 @@ public class MockClusterMap implements ClusterMap {
   private final List<MockDataNodeId> dataNodes;
   private final int numMountPointsPerNode;
   private final HashSet<String> dataCentersInClusterMap = new HashSet<>();
-  private boolean partitionsUnhealthy = false;
+  private boolean partitionsUnavailable = false;
 
   /**
    * The default constructor sets up a 9 node cluster with 3 mount points in each, with 3 partitions/replicas per
@@ -162,7 +162,7 @@ public class MockClusterMap implements ClusterMap {
   @Override
   public List<PartitionId> getWritablePartitionIds() {
     List<PartitionId> partitionIdList = new ArrayList<PartitionId>();
-    if (!partitionsUnhealthy) {
+    if (!partitionsUnavailable) {
       for (PartitionId partitionId : partitions.values()) {
         partitionIdList.add(partitionId);
       }
@@ -253,7 +253,7 @@ public class MockClusterMap implements ClusterMap {
   }
 
   public void markAllPartitionsUnavailable() {
-    partitionsUnhealthy = true;
+    partitionsUnavailable = true;
   }
 
   @Override

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -323,7 +323,11 @@ class GetBlobInfoOperation extends GetOperation<BlobInfo> {
 
     if (operationCompleted) {
       Exception e = operationException.get();
+      if (operationResult == null && e == null) {
+        e = new RouterException("Operation failed, but exception was not set", RouterErrorCode.UnexpectedInternalError);
+      }
       if (e != null) {
+        operationResult = null;
         routerMetrics.onGetBlobInfoError(e);
       }
       routerMetrics.getBlobInfoOperationLatencyMs.update(time.milliseconds() - submissionTimeMs);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -325,6 +325,7 @@ class GetBlobInfoOperation extends GetOperation<BlobInfo> {
       Exception e = operationException.get();
       if (operationResult == null && e == null) {
         e = new RouterException("Operation failed, but exception was not set", RouterErrorCode.UnexpectedInternalError);
+        routerMetrics.operationFailureWithUnsetExceptionCount.inc();
       }
       if (e != null) {
         operationResult = null;

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -78,6 +78,7 @@ public class NonBlockingRouterMetrics {
   public final Counter operationManagerHandleResponseErrorCount;
   public final Counter requestResponseHandlerUnexpectedErrorCount;
   public final Counter chunkFillerUnexpectedErrorCount;
+  public final Counter operationFailureWithUnsetExceptionCount;
 
   // Performance metrics for operation managers.
   public final Histogram putManagerPollTimeMs;
@@ -186,6 +187,8 @@ public class NonBlockingRouterMetrics {
         .counter(MetricRegistry.name(NonBlockingRouter.class, "RequestResponseHandlerUnexpectedErrorCount"));
     chunkFillerUnexpectedErrorCount =
         metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "ChunkFillerUnexpectedErrorCount"));
+    operationFailureWithUnsetExceptionCount =
+        metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OperationFailureWithUnsetExceptionCount"));
 
     // Performance metrics for operation managers.
     putManagerPollTimeMs = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutManagerPollTimeMs"));

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -254,6 +254,7 @@ class PutManager {
     String blobId = op.getBlobIdString();
     if (blobId == null && e == null) {
       e = new RouterException("Operation failed, but exception was not set", RouterErrorCode.UnexpectedInternalError);
+      routerMetrics.operationFailureWithUnsetExceptionCount.inc();
     }
     if (e != null) {
       blobId = null;

--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -83,10 +83,6 @@ class SimpleOperationTracker implements OperationTracker {
     this.successTarget = successTarget;
     this.parallelism = parallelism;
     List<ReplicaId> replicas = partitionId.getReplicaIds();
-    if (replicas.size() < successTarget) {
-      throw new IllegalArgumentException(
-          "Total Replica count " + replicas.size() + " is less than success target " + successTarget);
-    }
     if (shuffleReplicas) {
       Collections.shuffle(replicas);
     }
@@ -101,6 +97,10 @@ class SimpleOperationTracker implements OperationTracker {
       }
     }
     totalReplicaCount = replicaPool.size();
+    if (totalReplicaCount < successTarget) {
+      throw new IllegalArgumentException(
+          "Total Replica count " + totalReplicaCount + " is less than success target " + successTarget);
+    }
     this.otIterator = new OpTrackerIterator();
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -103,11 +103,20 @@ public class NonBlockingRouterTest {
     return properties;
   }
 
+  /**
+   * Construct {@link Properties} and {@link MockServerLayout} and initialize and set the
+   * router with them.
+   */
   private void setRouter()
       throws IOException {
     setRouter(getNonBlockingRouterProperties("DC1"), new MockServerLayout(mockClusterMap));
   }
 
+  /**
+   * Initialize and set the router with the given {@link Properties} and {@link MockServerLayout}
+   * @param props the {@link Properties}
+   * @param mockServerLayout the {@link MockServerLayout}
+   */
   private void setRouter(Properties props, MockServerLayout mockServerLayout)
       throws IOException {
     VerifiableProperties verifiableProperties = new VerifiableProperties((props));
@@ -173,6 +182,9 @@ public class NonBlockingRouterTest {
     assertClosed();
   }
 
+  /**
+   * Test router put operation in a scenario where there are no partitions available.
+   */
   @Test
   public void testRouterPartitionsUnavailable()
       throws Exception {
@@ -192,6 +204,11 @@ public class NonBlockingRouterTest {
     assertClosed();
   }
 
+  /**
+   * Test router put operation in a scenario where there are partitions, but none in the local DC.
+   * This should not ideally happen unless there is a bad config, but the router should be resilient and
+   * just error out these operations.
+   */
   @Test
   public void testRouterNoPartitionInLocalDC()
       throws Exception {


### PR DESCRIPTION
Ensure exceptions are always set in the future and callback for failed
router operations. Guard against both being null by ensuring that at least
a general error is set if the operation fails and the exception is null.