### PR TITLE
Ensure operation tracker does not eliminate down replicas

### DIFF
--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
@@ -26,7 +26,7 @@ public class MockReplicaId implements ReplicaId {
   private PartitionId partitionId;
   private MockDataNodeId dataNodeId;
   private MockDiskId diskId;
-  private boolean markedDown = false;
+  private boolean isMarkedDown = false;
 
   public MockReplicaId() {
   }
@@ -92,7 +92,7 @@ public class MockReplicaId implements ReplicaId {
    */
   @Override
   public boolean isDown() {
-    return markedDown || getDataNodeId().getState() == HardwareState.UNAVAILABLE
+    return isMarkedDown || getDataNodeId().getState() == HardwareState.UNAVAILABLE
         || getDiskId().getState() == HardwareState.UNAVAILABLE;
   }
 
@@ -111,9 +111,9 @@ public class MockReplicaId implements ReplicaId {
 
   /**
    * Mark a replica as down or up.
-   * @param status if true, marks the replica as down; if false, marks it as up.
+   * @param isDown if true, marks the replica as down; if false, marks it as up.
    */
-  public void markReplicaDownStatus(boolean status) {
-    markedDown = status;
+  public void markReplicaDownStatus(boolean isDown) {
+    isMarkedDown = isDown;
   }
 }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
@@ -26,6 +26,7 @@ public class MockReplicaId implements ReplicaId {
   private PartitionId partitionId;
   private MockDataNodeId dataNodeId;
   private MockDiskId diskId;
+  private boolean markedDown = false;
 
   public MockReplicaId() {
   }
@@ -86,9 +87,12 @@ public class MockReplicaId implements ReplicaId {
     return diskId;
   }
 
+  /**
+   * @return true if the replica is down; false otherwise.
+   */
   @Override
   public boolean isDown() {
-    return getDataNodeId().getState() == HardwareState.UNAVAILABLE
+    return markedDown || getDataNodeId().getState() == HardwareState.UNAVAILABLE
         || getDiskId().getState() == HardwareState.UNAVAILABLE;
   }
 
@@ -103,5 +107,13 @@ public class MockReplicaId implements ReplicaId {
       replica.delete();
     }
     replicaDir.delete();
+  }
+
+  /**
+   * Mark a replica as down or up.
+   * @param status if true, marks the replica as down; if false, marks it as up.
+   */
+  public void markReplicaDownStatus(boolean status) {
+    markedDown = status;
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -82,20 +82,32 @@ class SimpleOperationTracker implements OperationTracker {
       int parallelism, boolean shuffleReplicas) {
     this.successTarget = successTarget;
     this.parallelism = parallelism;
+    // Order the replicas so that local healthy partitions are ordered and returned first,
+    // then the remote healthy ones, and finally the possibly down replicas.
+    // The operation tracker ensures that "possibly" down replicas are attempted only as a last resort.
     List<ReplicaId> replicas = partitionId.getReplicaIds();
+    LinkedList<ReplicaId> downReplicas = new LinkedList<>();
     if (shuffleReplicas) {
       Collections.shuffle(replicas);
     }
     for (ReplicaId replicaId : replicas) {
+      String replicaDcName = replicaId.getDataNodeId().getDatacenterName();
       if (!replicaId.isDown()) {
-        String replicaDcName = replicaId.getDataNodeId().getDatacenterName();
         if (replicaDcName.equals(datacenterName)) {
-          replicaPool.add(0, replicaId);
+          replicaPool.addFirst(replicaId);
         } else if (crossColoEnabled) {
-          replicaPool.add(replicaId);
+          replicaPool.addLast(replicaId);
+        }
+      } else {
+        if (replicaDcName.equals(datacenterName)) {
+          downReplicas.addFirst(replicaId);
+        } else if (crossColoEnabled) {
+          downReplicas.addLast(replicaId);
         }
       }
     }
+    // Add down replicas to the end of the list so that they are attempted in the worst case.
+    replicaPool.addAll(downReplicas);
     totalReplicaCount = replicaPool.size();
     if (totalReplicaCount < successTarget) {
       throw new IllegalArgumentException(

--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -82,9 +82,8 @@ class SimpleOperationTracker implements OperationTracker {
       int parallelism, boolean shuffleReplicas) {
     this.successTarget = successTarget;
     this.parallelism = parallelism;
-    // Order the replicas so that local healthy partitions are ordered and returned first,
-    // then the remote healthy ones, and finally the possibly down replicas.
-    // The operation tracker ensures that "possibly" down replicas are attempted only as a last resort.
+    // Order the replicas so that local healthy replicas are ordered and returned first,
+    // then the remote healthy ones, and finally the possibly down ones.
     List<ReplicaId> replicas = partitionId.getReplicaIds();
     LinkedList<ReplicaId> downReplicas = new LinkedList<>();
     if (shuffleReplicas) {
@@ -106,7 +105,6 @@ class SimpleOperationTracker implements OperationTracker {
         }
       }
     }
-    // Add down replicas to the end of the list so that they are attempted in the worst case.
     replicaPool.addAll(downReplicas);
     totalReplicaCount = replicaPool.size();
     if (totalReplicaCount < successTarget) {

--- a/ambry-router/src/test/java/com.github.ambry.router/SimpleOperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/SimpleOperationTrackerTest.java
@@ -400,6 +400,7 @@ public class SimpleOperationTrackerTest {
     List<String> mountPaths = Arrays.asList("mockMountPath");
     datanodes = new ArrayList<>();
     datanodes.add(new MockDataNodeId(portList, mountPaths, "local-0"));
+    datanodes.add(new MockDataNodeId(portList, mountPaths, "remote-0"));
     mockPartition = new MockPartitionId();
     int replicaCount = 6;
     populateReplicaList(mockPartition, replicaCount, datanodes);

--- a/ambry-router/src/test/java/com.github.ambry.router/SimpleOperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/SimpleOperationTrackerTest.java
@@ -390,11 +390,11 @@ public class SimpleOperationTrackerTest {
   }
 
   /**
-   * Test to ensure that replicas that are down are also returned by the operation tracker, but they are only
-   * attempted after the healthy replicas.
+   * Test to ensure that replicas that are down are also returned by the operation tracker, but they are
+   * ordered after the healthy replicas.
    */
   @Test
-  public void downReplicasAttemptedTest() {
+  public void downReplicasOrderingTest() {
     ArrayList<Port> portList = new ArrayList<>();
     portList.add(new Port(6666, PortType.PLAINTEXT));
     List<String> mountPaths = Arrays.asList("mockMountPath");

--- a/ambry-router/src/test/java/com.github.ambry.router/SimpleOperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/SimpleOperationTrackerTest.java
@@ -21,9 +21,11 @@ import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -385,6 +387,63 @@ public class SimpleOperationTrackerTest {
     ot.onResponse(inflightReplicas.poll(), true);
     assertTrue(ot.hasSucceeded());
     assertTrue(ot.isDone());
+  }
+
+  /**
+   * Test to ensure that replicas that are down are also returned by the operation tracker, but they are only
+   * attempted after the healthy replicas.
+   */
+  @Test
+  public void downReplicasAttemptedTest() {
+    ArrayList<Port> portList = new ArrayList<>();
+    portList.add(new Port(6666, PortType.PLAINTEXT));
+    List<String> mountPaths = Arrays.asList("mockMountPath");
+    datanodes = new ArrayList<>();
+    datanodes.add(new MockDataNodeId(portList, mountPaths, "local-0"));
+    mockPartition = new MockPartitionId();
+    int replicaCount = 6;
+    populateReplicaList(mockPartition, replicaCount, datanodes);
+    // Test scenarios with various number of replicas down
+    for (int i = 0; i < replicaCount; i++) {
+      testReplicaDown(replicaCount, i);
+    }
+  }
+
+  /**
+   * Test replica down scenario
+   * @param totalReplicaCount total replicas for the partition.
+   * @param downReplicaCount partitions to be marked down.
+   */
+  private void testReplicaDown(int totalReplicaCount, int downReplicaCount) {
+    ArrayList<Boolean> downStatus = new ArrayList<>(totalReplicaCount);
+    for (int i = 0; i < downReplicaCount; i++) {
+      downStatus.add(true);
+    }
+    for (int i = downReplicaCount; i < totalReplicaCount; i++) {
+      downStatus.add(false);
+    }
+    Collections.shuffle(downStatus);
+    List<ReplicaId> mockReplicaIds = mockPartition.getReplicaIds();
+    for (int i = 0; i < totalReplicaCount; i++) {
+      ((MockReplicaId) mockReplicaIds.get(i)).markReplicaDownStatus(downStatus.get(i));
+    }
+    localDcName = datanodes.get(0).getDatacenterName();
+    ot = new SimpleOperationTracker(localDcName, mockPartition, true, 2, 3);
+    // The iterator should return all replicas, with the first half being the up replicas
+    // and the last half being the down replicas.
+    Iterator<ReplicaId> itr = ot.getReplicaIterator();
+    ReplicaId nextReplica;
+    int count = 0;
+    while (itr.hasNext()) {
+      nextReplica = itr.next();
+      if (count < totalReplicaCount - downReplicaCount) {
+        Assert.assertEquals(false, nextReplica.isDown());
+      } else {
+        Assert.assertEquals(true, nextReplica.isDown());
+      }
+      count++;
+    }
+    Assert.assertEquals(totalReplicaCount, count);
   }
 
   /**


### PR DESCRIPTION
Operation tracker should not avoid returning down replicas. That is
a decision to be made by the router, if at all. Operation tracker
should however ensure that down replicas are ordered last.

This will ensure that even if the failure detector marks all partitions
as unhealthy (which can happen if servers are all restarted within a
short timespan for example), operations have a chance to succeed.