### PR TITLE
Miscellaneous fixes to the router

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -100,7 +100,7 @@ public class RouterConfig {
    * The maximum number of parallel requests allowed for a delete operation.
    */
   @Config("router.delete.request.parallelism")
-  @Default("12")
+  @Default("3")
   public final int routerDeleteRequestParallelism;
 
   /**
@@ -150,7 +150,7 @@ public class RouterConfig {
     routerPutRequestParallelism = verifiableProperties.getInt("router.put.request.parallelism", 3);
     routerPutSuccessTarget = verifiableProperties.getInt("router.put.success.target", 2);
     routerMaxSlippedPutAttempts = verifiableProperties.getInt("router.max.slipped.put.attempts", 1);
-    routerDeleteRequestParallelism = verifiableProperties.getInt("router.delete.request.parallelism", 12);
+    routerDeleteRequestParallelism = verifiableProperties.getInt("router.delete.request.parallelism", 3);
     routerDeleteSuccessTarget = verifiableProperties.getInt("router.delete.success.target", 2);
     routerGetRequestParallelism = verifiableProperties.getInt("router.get.request.parallelism", 2);
     routerGetSuccessTarget = verifiableProperties.getInt("router.get.success.target", 1);

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -23,7 +23,6 @@ import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.DeleteRequest;
 import com.github.ambry.protocol.DeleteResponse;
 import com.github.ambry.utils.Time;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -209,8 +208,9 @@ class DeleteOperation {
       DeleteRequestInfo deleteRequestInfo = itr.next().getValue();
       if (time.milliseconds() - deleteRequestInfo.startTimeMs > routerConfig.routerRequestTimeoutMs) {
         itr.remove();
-        responseHandler
-            .onRequestResponseException(deleteRequestInfo.replica, new IOException("Timed out waiting for a response"));
+        // Do not notify this as a failure to the response handler, as this timeout could simply be due to
+        // connection unavailability. If there is indeed a network error, it will get reported eventually and the
+        // response handler will be notified accordingly.
         updateOperationState(deleteRequestInfo.replica, RouterErrorCode.OperationTimedOut);
       }
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -209,8 +209,8 @@ class DeleteOperation {
       if (time.milliseconds() - deleteRequestInfo.startTimeMs > routerConfig.routerRequestTimeoutMs) {
         itr.remove();
         // Do not notify this as a failure to the response handler, as this timeout could simply be due to
-        // connection unavailability. If there is indeed a network error, it will get reported eventually and the
-        // response handler will be notified accordingly.
+        // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
+        // response and the response handler will be notified accordingly.
         updateOperationState(deleteRequestInfo.replica, RouterErrorCode.OperationTimedOut);
       }
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -116,8 +116,8 @@ class GetBlobInfoOperation extends GetOperation<BlobInfo> {
       if (time.milliseconds() - entry.getValue().startTimeMs > routerConfig.routerRequestTimeoutMs) {
         onErrorResponse(entry.getValue().replicaId);
         // Do not notify this as a failure to the response handler, as this timeout could simply be due to
-        // connection unavailability. If there is indeed a network error, it will get reported eventually and the
-        // response handler will be notified accordingly.
+        // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
+        // response and the response handler will be notified accordingly.
         setOperationException(
             new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut));
         inFlightRequestsIterator.remove();

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -115,8 +115,9 @@ class GetBlobInfoOperation extends GetOperation<BlobInfo> {
       Map.Entry<Integer, GetRequestInfo> entry = inFlightRequestsIterator.next();
       if (time.milliseconds() - entry.getValue().startTimeMs > routerConfig.routerRequestTimeoutMs) {
         onErrorResponse(entry.getValue().replicaId);
-        responseHandler.onRequestResponseException(entry.getValue().replicaId,
-            new IOException("Timed out waiting for a response"));
+        // Do not notify this as a failure to the response handler, as this timeout could simply be due to
+        // connection unavailability. If there is indeed a network error, it will get reported eventually and the
+        // response handler will be notified accordingly.
         setOperationException(
             new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut));
         inFlightRequestsIterator.remove();

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -519,8 +519,9 @@ class GetBlobOperation extends GetOperation<ReadableStreamChannel> {
         Map.Entry<Integer, GetRequestInfo> entry = inFlightRequestsIterator.next();
         if (time.milliseconds() - entry.getValue().startTimeMs > routerConfig.routerRequestTimeoutMs) {
           onErrorResponse(entry.getValue().replicaId);
-          responseHandler.onRequestResponseException(entry.getValue().replicaId,
-              new IOException("Timed out waiting for a response"));
+          // Do not notify this as a failure to the response handler, as this timeout could simply be due to
+          // connection unavailability. If there is indeed a network error, it will get reported eventually and the
+          // response handler will be notified accordingly.
           chunkException = new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut);
           inFlightRequestsIterator.remove();
         } else {

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -520,8 +520,8 @@ class GetBlobOperation extends GetOperation<ReadableStreamChannel> {
         if (time.milliseconds() - entry.getValue().startTimeMs > routerConfig.routerRequestTimeoutMs) {
           onErrorResponse(entry.getValue().replicaId);
           // Do not notify this as a failure to the response handler, as this timeout could simply be due to
-          // connection unavailability. If there is indeed a network error, it will get reported eventually and the
-          // response handler will be notified accordingly.
+          // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
+          // response and the response handler will be notified accordingly.
           chunkException = new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut);
           inFlightRequestsIterator.remove();
         } else {

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -826,8 +826,8 @@ class PutOperation {
         if (time.milliseconds() - entry.getValue().startTimeMs > routerConfig.routerRequestTimeoutMs) {
           onErrorResponse(entry.getValue().replicaId);
           // Do not notify this as a failure to the response handler, as this timeout could simply be due to
-          // connection unavailability. If there is indeed a network error, it will get reported eventually and the
-          // response handler will be notified accordingly.
+          // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
+          // response and the response handler will be notified accordingly.
           chunkException = new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut);
           inFlightRequestsIterator.remove();
         } else {

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -33,7 +33,6 @@ import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Time;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -826,8 +825,9 @@ class PutOperation {
         Map.Entry<Integer, ChunkPutRequestInfo> entry = inFlightRequestsIterator.next();
         if (time.milliseconds() - entry.getValue().startTimeMs > routerConfig.routerRequestTimeoutMs) {
           onErrorResponse(entry.getValue().replicaId);
-          responseHandler.onRequestResponseException(entry.getValue().replicaId,
-              new IOException("Timed out waiting for a response"));
+          // Do not notify this as a failure to the response handler, as this timeout could simply be due to
+          // connection unavailability. If there is indeed a network error, it will get reported eventually and the
+          // response handler will be notified accordingly.
           chunkException = new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut);
           inFlightRequestsIterator.remove();
         } else {

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -76,6 +76,7 @@ class RouterUtils {
         case BadInputChannel:
         case BlobDeleted:
         case BlobExpired:
+        case BlobDoesNotExist:
           isSystemHealthError = false;
           break;
       }

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -53,7 +53,7 @@ import static org.junit.Assert.fail;
  */
 
 public class DeleteManagerTest {
-  private static final int AWAIT_TIMEOUT_SECONDS = 2;
+  private static final int AWAIT_TIMEOUT_SECONDS = 200;
   private Time mockTime;
   private AtomicReference<MockSelectorState> mockSelectorState;
   private MockClusterMap clusterMap;
@@ -85,7 +85,7 @@ public class DeleteManagerTest {
   private static final int CHECKOUT_TIMEOUT_MS = 1000;
 
   // The maximum number of inflight requests for a single delete operation.
-  private static final String DELETE_PARALLELISM = "9";
+  private static final String DELETE_PARALLELISM = "3";
 
   /**
    * Initializes ClusterMap, Router, mock servers, and an {@code BlobId} to be deleted.

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -514,7 +514,7 @@ public class NonBlockingRouterTest {
         Assert.fail("Waited too long for requests.");
       }
       opHelper.pollOpManager(allRequests);
-      mockTime.sleep(CHECKOUT_TIMEOUT_MS * 3);
+      mockTime.sleep(REQUEST_TIMEOUT_MS + 1);
     }
     Assert.assertEquals("Successful notification should not have arrived for replicas that were up", 0,
         successfulResponseCount.get());

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
@@ -77,20 +77,22 @@ public class RouterUtilsTest {
    */
   @Test
   public void testSystemHealthErrorInterpretation() {
-    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.InvalidBlobId)));
-    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.InvalidPutArgument)));
-    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.BlobTooLarge)));
-    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.BadInputChannel)));
-    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.BlobDeleted)));
-    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.BlobDoesNotExist)));
-    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.BlobExpired)));
-
-    Assert.assertTrue(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.AmbryUnavailable)));
-    Assert.assertTrue(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.OperationTimedOut)));
-    Assert.assertTrue(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.RouterClosed)));
-    Assert
-        .assertTrue(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.UnexpectedInternalError)));
-    Assert.assertTrue(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.InsufficientCapacity)));
+    for (RouterErrorCode errorCode : RouterErrorCode.values()) {
+      switch (errorCode) {
+        case InvalidBlobId:
+        case InvalidPutArgument:
+        case BlobTooLarge:
+        case BadInputChannel:
+        case BlobDeleted:
+        case BlobDoesNotExist:
+        case BlobExpired:
+          Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", errorCode)));
+          break;
+        default:
+          Assert.assertTrue(RouterUtils.isSystemHealthError(new RouterException("", errorCode)));
+          break;
+      }
+    }
     Assert.assertTrue(RouterUtils.isSystemHealthError(new Exception()));
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
@@ -17,10 +17,10 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 
@@ -70,5 +70,27 @@ public class RouterUtilsTest {
     initialize();
     BlobId convertedBlobId = RouterUtils.getBlobIdFromString(blobIdStr, clusterMap);
     assertEquals("The converted BlobId should be the same as the original.", originalBlobId, convertedBlobId);
+  }
+
+  /**
+   * Test to ensure system health errors are interpreted correctly.
+   */
+  @Test
+  public void testSystemHealthErrorInterpretation() {
+    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.InvalidBlobId)));
+    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.InvalidPutArgument)));
+    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.BlobTooLarge)));
+    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.BadInputChannel)));
+    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.BlobDeleted)));
+    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.BlobDoesNotExist)));
+    Assert.assertFalse(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.BlobExpired)));
+
+    Assert.assertTrue(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.AmbryUnavailable)));
+    Assert.assertTrue(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.OperationTimedOut)));
+    Assert.assertTrue(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.RouterClosed)));
+    Assert
+        .assertTrue(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.UnexpectedInternalError)));
+    Assert.assertTrue(RouterUtils.isSystemHealthError(new RouterException("", RouterErrorCode.InsufficientCapacity)));
+    Assert.assertTrue(RouterUtils.isSystemHealthError(new Exception()));
   }
 }


### PR DESCRIPTION
- Do not count BlobDoesNotExist as a system health error.
- Do not notify the response handler in case of timeouts at the router
  as real network errors get notified eventually when the NetworkClient
  hands over a failed response.
- Change the default delete request parallelism to 3, same as for puts.
  Delete will continue to go cross-colo if blob is not found locally.