### PR TITLE
Delete successfully put data chunks of unsuccessful put operations.

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
@@ -15,6 +15,7 @@ package com.github.ambry.router;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.NetworkConfig;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.SSLConfig;
@@ -74,7 +75,8 @@ public class NonBlockingRouterFactory implements RouterFactory {
       networkConfig = new NetworkConfig(verifiableProperties);
       networkMetrics = new NetworkMetrics(registry);
       SSLConfig sslConfig = new SSLConfig(verifiableProperties);
-      sslFactory = sslConfig.sslEnabledDatacenters.length() > 0 ? new SSLFactory(sslConfig) : null;
+      ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+      sslFactory = clusterMapConfig.clusterMapSslEnabledDatacenters.length() > 0 ? new SSLFactory(sslConfig) : null;
       this.time = SystemTime.getInstance();
       networkClientFactory = new NetworkClientFactory(networkMetrics, networkConfig, sslFactory,
           routerConfig.routerScalingUnitMaxConnectionsPerPortPlainText,

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -64,7 +64,7 @@ class PutManager {
   private final AtomicBoolean isOpen = new AtomicBoolean(true);
   private final OperationCompleteCallback operationCompleteCallback;
   private final ReadyForPollCallback readyForPollCallback;
-  private final List<String> listToFillWithIdsToDelete;
+  private final List<String> idsToDeleteList;
   private final ByteBufferAsyncWritableChannel.ChannelEventListener chunkArrivalListener;
 
   // shared by all PutOperations
@@ -98,15 +98,15 @@ class PutManager {
    * @param operationCompleteCallback The {@link OperationCompleteCallback} to use to complete operations.
    * @param readyForPollCallback The callback to be used to notify the router of any state changes within the
    *                             operations.
-   * @param listToFillWithIdsToDelete The list to fill with ids of successfully put data chunks of an unsuccessful
-   *                                  overall put operation.
+   * @param idsToDeleteList The list to fill with ids of successfully put data chunks of an unsuccessful
+   *                        overall put operation.
    * @param index the index of the {@link NonBlockingRouter.OperationController} in the {@link NonBlockingRouter}
    * @param time The {@link Time} instance to use.
    */
   PutManager(ClusterMap clusterMap, ResponseHandler responseHandler, NotificationSystem notificationSystem,
       RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
       OperationCompleteCallback operationCompleteCallback, ReadyForPollCallback readyForPollCallback,
-      List<String> listToFillWithIdsToDelete, int index, Time time) {
+      List<String> idsToDeleteList, int index, Time time) {
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.notificationSystem = notificationSystem;
@@ -114,7 +114,7 @@ class PutManager {
     this.routerMetrics = routerMetrics;
     this.operationCompleteCallback = operationCompleteCallback;
     this.readyForPollCallback = readyForPollCallback;
-    this.listToFillWithIdsToDelete = listToFillWithIdsToDelete;
+    this.idsToDeleteList = idsToDeleteList;
     this.chunkArrivalListener = new ByteBufferAsyncWritableChannel.ChannelEventListener() {
       @Override
       public void onEvent(ByteBufferAsyncWritableChannel.EventType e) {
@@ -256,7 +256,7 @@ class PutManager {
     if (e != null) {
       blobId = null;
       routerMetrics.onPutBlobError(e);
-      listToFillWithIdsToDelete.addAll(op.getSuccessfullyPutChunkIds());
+      op.addSuccessfullyPutChunkIds(idsToDeleteList);
     } else {
       notificationSystem.onBlobCreated(op.getBlobIdString(), op.getBlobProperties(), op.getUserMetadata());
       updateChunkingAndSizeMetricsOnSuccessfulPut(op);

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -525,10 +525,13 @@ class PutOperation {
   }
 
   /**
-   * @return if this is a composite object, list of successfully put chunk ids; null otherwise.
+   * if this is a composite object, fill the list with successfully put chunk ids.
+   * @param chunkIdList the list to fill with chunk ids.
    */
-  ArrayList<String> getSuccessfullyPutChunkIds() {
-    return numDataChunks > 1 ? metadataPutChunk.getChunkIds() : new ArrayList<String>();
+  void addSuccessfullyPutChunkIds(List<String> chunkIdList) {
+    if (numDataChunks > 1) {
+      metadataPutChunk.addChunkIds(chunkIdList);
+    }
   }
 
   /**
@@ -1087,16 +1090,15 @@ class PutOperation {
     }
 
     /**
-     * @return all the successfully put chunk ids for the overall blob.
+     * Add all the successfully put chunk ids of the overall blob to the passed in list.
+     * @param chunkIdList list to fill with chunk ids.
      */
-    ArrayList<String> getChunkIds() {
-      ArrayList<String> chunkIdList = new ArrayList<>();
+    void addChunkIds(List<String> chunkIdList) {
       for (int i = 0; i <= maxFilledChunkIndex; i++) {
         if (chunkIds[i] != null) {
           chunkIdList.add(chunkIds[i].getID());
         }
       }
-      return chunkIdList;
     }
 
     /**


### PR DESCRIPTION
This patch ensures that if a composite blob put operation fails
after successfully putting one or more data chunks, then such chunks
are deleted in the background.

New code is getting covered 100%.

