### PR TITLE
Adding backpressure support to NettyRequest

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
@@ -76,7 +76,7 @@ public class NettyConfig {
   /**
    * The threshold of the size of buffered data at which reading from a client channel will be suspended. If the size
    * drops below the threshold, reading will be resumed. This value is respected on a per-request basis.
-   * Note that the actual amount of data buffered will be >= this number.
+   * Note that the actual amount of data buffered may be >= this number.
    * If this is <=0, it is assumed that there is no limit on the size of buffered data.
    */
   @Config("netty.server.request.buffer.watermark")
@@ -92,6 +92,7 @@ public class NettyConfig {
     nettyServerMaxInitialLineLength = verifiableProperties.getInt("netty.server.max.initial.line.length", 4096);
     nettyServerMaxHeaderSize = verifiableProperties.getInt("netty.server.max.header.size", 8192);
     nettyServerMaxChunkSize = verifiableProperties.getInt("netty.server.max.chunk.size", 8192);
-    nettyServerRequestBufferWatermark = verifiableProperties.getInt("netty.server.request.buffer.watermark", 33554432);
+    nettyServerRequestBufferWatermark =
+        verifiableProperties.getInt("netty.server.request.buffer.watermark", 32 * 1024 * 1024);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
@@ -73,6 +73,16 @@ public class NettyConfig {
   @Default("8192")
   public final int nettyServerMaxChunkSize;
 
+  /**
+   * The threshold of the size of buffered data at which reading from a client channel will be suspended. If the size
+   * drops below the threshold, reading will be resumed. This value is respected on a per-request basis.
+   * Note that the actual amount of data buffered will be >= this number.
+   * If this is <=0, it is assumed that there is no limit on the size of buffered data.
+   */
+  @Config("netty.server.request.buffer.watermark")
+  @Default("32 * 1024 * 1024")
+  public final int nettyServerRequestBufferWatermark;
+
   public NettyConfig(VerifiableProperties verifiableProperties) {
     nettyServerBossThreadCount = verifiableProperties.getInt("netty.server.boss.thread.count", 1);
     nettyServerIdleTimeSeconds = verifiableProperties.getInt("netty.server.idle.time.seconds", 60);
@@ -82,5 +92,6 @@ public class NettyConfig {
     nettyServerMaxInitialLineLength = verifiableProperties.getInt("netty.server.max.initial.line.length", 4096);
     nettyServerMaxHeaderSize = verifiableProperties.getInt("netty.server.max.header.size", 8192);
     nettyServerMaxChunkSize = verifiableProperties.getInt("netty.server.max.chunk.size", 8192);
+    nettyServerRequestBufferWatermark = verifiableProperties.getInt("netty.server.request.buffer.watermark", 33554432);
   }
 }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -252,6 +252,8 @@ public class FrontendIntegrationTest {
         .put("rest.server.blob.storage.service.factory", "com.github.ambry.frontend.AmbryBlobStorageServiceFactory");
     properties.put("rest.server.router.factory", "com.github.ambry.router.InMemoryRouterFactory");
     properties.put("netty.server.port", Integer.toString(SERVER_PORT));
+    // to test that backpressure does not impede correct operation.
+    properties.put("netty.server.request.buffer.watermark", "1");
     return new VerifiableProperties(properties);
   }
 

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
@@ -17,6 +17,7 @@ import com.github.ambry.config.NettyConfig;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -283,7 +284,7 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
         try {
           // We need to maintain state about the request itself for the subsequent parts (if any) that come in. We will
           // attach content to the request as the content arrives.
-          if (HttpPostRequestDecoder.isMultipart(httpRequest)) {
+          if (HttpMethod.POST.equals(httpRequest.getMethod()) && HttpPostRequestDecoder.isMultipart(httpRequest)) {
             nettyMetrics.multipartPostRequestRate.mark();
             request = new NettyMultipartRequest(httpRequest, ctx.channel(), nettyMetrics);
           } else {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
@@ -285,9 +285,9 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
           // attach content to the request as the content arrives.
           if (HttpPostRequestDecoder.isMultipart(httpRequest)) {
             nettyMetrics.multipartPostRequestRate.mark();
-            request = new NettyMultipartRequest(httpRequest, nettyMetrics);
+            request = new NettyMultipartRequest(httpRequest, ctx.channel(), nettyMetrics);
           } else {
-            request = new NettyRequest(httpRequest, nettyMetrics);
+            request = new NettyRequest(httpRequest, ctx.channel(), nettyMetrics);
           }
           responseChannel.setRequest(request);
           logger.trace("Channel {} now handling request {}", ctx.channel(), request.getUri());

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -98,6 +98,7 @@ public class NettyMetrics {
   // NettyRequest
   public final Counter contentCopyCount;
   public final Histogram digestCalculationTimeInMs;
+  public final Counter watermarkOverflowCount;
   // NettyMessageProcessor
   public final Histogram channelReadIntervalInMs;
   public final Counter idleConnectionCloseCount;
@@ -245,6 +246,7 @@ public class NettyMetrics {
     contentCopyCount = metricRegistry.counter(MetricRegistry.name(NettyRequest.class, "ContentCopyCount"));
     digestCalculationTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(NettyRequest.class, "DigestCalculationTimeInMs"));
+    watermarkOverflowCount = metricRegistry.counter(MetricRegistry.name(NettyRequest.class, "WatermarkOverflowCount"));
     // NettyMessageProcessor
     channelReadIntervalInMs =
         metricRegistry.histogram(MetricRegistry.name(NettyMessageProcessor.class, "ChannelReadIntervalInMs"));

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
@@ -15,6 +15,7 @@ package com.github.ambry.rest;
 
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
@@ -55,15 +56,18 @@ class NettyMultipartRequest extends NettyRequest {
   /**
    * Wraps the {@code request} in a NettyMultipartRequest so that other layers can understand the request.
    * @param request the {@link HttpRequest} that needs to be wrapped.
+   * @param channel the {@link Channel} over which the {@code request} has been received.
    * @param nettyMetrics the {@link NettyMetrics} instance to use.
    * @throws IllegalArgumentException if {@code request} is null or if the HTTP method defined in {@code request} is
    *                                    anything other than POST.
    * @throws RestServiceException if the HTTP method defined in {@code request} is not recognized as a
    *                                {@link RestMethod}.
    */
-  public NettyMultipartRequest(HttpRequest request, NettyMetrics nettyMetrics)
+  public NettyMultipartRequest(HttpRequest request, Channel channel, NettyMetrics nettyMetrics)
       throws RestServiceException {
-    super(request, nettyMetrics);
+    super(request, channel, nettyMetrics);
+    // reset auto read state.
+    setAutoRead(true);
     if (!getRestMethod().equals(RestMethod.POST)) {
       throw new IllegalArgumentException("NettyMultipartRequest cannot be created for " + getRestMethod());
     }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -525,8 +525,10 @@ class NettyRequest implements RestRequest {
   }
 
   /**
-   * Continues reading from the channel if the buffer watermark has not been reached and if auto-read is off.
-   * @param delta number of bytes read from the channel in the current read.
+   * Invokes a read from the read channel if the number of bytes buffered is below the buffer watermark. No effect if
+   * auto-read is on.
+   * @param delta number of bytes read from the read channel in the current read (positive) or number of bytes written
+   *              to the write channel in the current write (negative).
    */
   private void continueReadIfPossible(long delta) {
     if (!channel.config().isAutoRead()) {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -16,6 +16,7 @@ package com.github.ambry.rest;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.FutureResult;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.http.CookieDecoder;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -52,9 +53,14 @@ import org.slf4j.LoggerFactory;
  * A wrapper over {@link HttpRequest} and all the {@link HttpContent} associated with the request.
  */
 class NettyRequest implements RestRequest {
+  // If the write of at least {@code bufferWatermark} amount of data is unacknowledged, reading from the channel will be
+  // temporarily suspended. It will be resumed when the amount of data unacknowledged drops below this number. If this
+  // is <=0, it is assumed that there is no limit on the size of unacknowledged data.
+  static int bufferWatermark = -1;
   private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
 
   protected final HttpRequest request;
+  protected final Channel channel;
   protected final NettyMetrics nettyMetrics;
   protected final Map<String, Object> allArgs = new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
   protected final Queue<HttpContent> requestContents = new LinkedBlockingQueue<HttpContent>();
@@ -64,11 +70,13 @@ class NettyRequest implements RestRequest {
   protected volatile Map<String, Object> allArgsReadOnly = null;
 
   private final long size;
+  private final int savedMaxMessagesPerRead;
   private final QueryStringDecoder query;
   private final RestMethod restMethod;
   private final RestRequestMetricsTracker restRequestMetricsTracker = new RestRequestMetricsTracker();
   private final AtomicBoolean channelOpen = new AtomicBoolean(true);
   private final AtomicLong bytesReceived = new AtomicLong(0);
+  private final AtomicLong bytesBuffered = new AtomicLong(0);
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   private MessageDigest digest;
@@ -92,22 +100,33 @@ class NettyRequest implements RestRequest {
    * If content size is set in the header (i.e. not -1), the actual content size should match that value. Otherwise, an
    * exception will be thrown.
    * @param request the {@link HttpRequest} that needs to be wrapped.
+   * @param channel the {@link Channel} over which the {@code request} has been received.
    * @param nettyMetrics the {@link NettyMetrics} instance to use.
    * @throws IllegalArgumentException if {@code request} is null.
    * @throws RestServiceException if the {@link HttpMethod} defined in {@code request} is not recognized as a
    *                                {@link RestMethod}.
    */
-  public NettyRequest(HttpRequest request, NettyMetrics nettyMetrics)
+  public NettyRequest(HttpRequest request, Channel channel, NettyMetrics nettyMetrics)
       throws RestServiceException {
-    if (request == null) {
-      throw new IllegalArgumentException("Received null HttpRequest");
+    if (request == null || channel == null) {
+      throw new IllegalArgumentException("Received null argument(s)");
     }
     restRequestMetricsTracker.nioMetricsTracker.markRequestReceived();
+    this.request = request;
+    query = new QueryStringDecoder(request.getUri());
+    this.channel = channel;
+    savedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    this.nettyMetrics = nettyMetrics;
+
     HttpMethod httpMethod = request.getMethod();
     if (httpMethod == HttpMethod.GET) {
       restMethod = RestMethod.GET;
     } else if (httpMethod == HttpMethod.POST) {
       restMethod = RestMethod.POST;
+      if (bufferWatermark > 0) {
+        setAutoRead(false);
+        continueReadIfPossible(0);
+      }
     } else if (httpMethod == HttpMethod.DELETE) {
       restMethod = RestMethod.DELETE;
     } else if (httpMethod == HttpMethod.HEAD) {
@@ -117,9 +136,6 @@ class NettyRequest implements RestRequest {
       throw new RestServiceException("http method not supported: " + httpMethod,
           RestServiceErrorCode.UnsupportedHttpMethod);
     }
-    this.request = request;
-    this.query = new QueryStringDecoder(request.getUri());
-    this.nettyMetrics = nettyMetrics;
 
     if (HttpHeaders.getHeader(request, RestUtils.Headers.BLOB_SIZE, null) != null) {
       size = Long.parseLong(HttpHeaders.getHeader(request, RestUtils.Headers.BLOB_SIZE));
@@ -210,6 +226,7 @@ class NettyRequest implements RestRequest {
   @Override
   public void close() {
     if (channelOpen.compareAndSet(true, false)) {
+      setAutoRead(true);
       contentLock.lock();
       try {
         logger.trace("Closing NettyRequest {} with {} content chunks unread", getUri(), requestContents.size());
@@ -345,14 +362,17 @@ class NettyRequest implements RestRequest {
       validateState(httpContent);
       contentLock.lock();
       try {
+        int size = httpContent.content().readableBytes();
         if (!isOpen()) {
           nettyMetrics.requestAlreadyClosedError.inc();
           throw new RestServiceException("The request has been closed and is not accepting content",
               RestServiceErrorCode.RequestChannelClosed);
         } else if (writeChannel != null) {
           writeContent(writeChannel, callbackWrapper, httpContent);
+          continueReadIfPossible(size);
         } else {
           requestContents.add(ReferenceCountUtil.retain(httpContent));
+          continueReadIfPossible(size);
         }
       } finally {
         contentLock.unlock();
@@ -389,6 +409,9 @@ class NettyRequest implements RestRequest {
     Callback<Long>[] writeCallbacks;
     // LastHttpContent in the end marker in netty http world.
     boolean isLast = httpContent instanceof LastHttpContent;
+    if (isLast) {
+      setAutoRead(true);
+    }
     if (httpContent.content().nioBufferCount() > 0) {
       // not a copy.
       httpContent = ReferenceCountUtil.retain(httpContent);
@@ -407,6 +430,7 @@ class NettyRequest implements RestRequest {
       logger.warn("HttpContent had to be copied because ByteBuf did not have a backing ByteBuffer");
       ByteBuffer contentBuffer = ByteBuffer.allocate(httpContent.content().readableBytes());
       httpContent.content().readBytes(contentBuffer);
+      contentBuffer.rewind();
       // no need to retain httpContent since we have a copy.
       ContentWriteCallback writeCallback = new ContentWriteCallback(null, isLast, callbackWrapper);
       contentBuffers = new ByteBuffer[]{contentBuffer};
@@ -431,6 +455,17 @@ class NettyRequest implements RestRequest {
       }
     }
     allContentReceived = isLast;
+  }
+
+  /**
+   * Switches auto reading from the channel on and off.
+   * @param autoRead {@code true} if auto read has to be switched on. {@code false} otherwise.
+   */
+  protected void setAutoRead(boolean autoRead) {
+    channel.config().setAutoRead(autoRead);
+    channel.config().setMaxMessagesPerRead(autoRead ? savedMaxMessagesPerRead : 1);
+    logger.trace("Setting auto-read to {} on channel {} and max messages per read to {}", channel.config().isAutoRead(),
+        channel, channel.config().getMaxMessagesPerRead());
   }
 
   /**
@@ -488,91 +523,106 @@ class NettyRequest implements RestRequest {
       }
     }
   }
-}
-
-/**
- * Callback for each write into the given {@link AsyncWritableChannel}.
- */
-class ContentWriteCallback implements Callback<Long> {
-  private final HttpContent httpContent;
-  private final boolean isLast;
-  private final ReadIntoCallbackWrapper callbackWrapper;
 
   /**
-   * Creates a new instance of ContentWriteCallback.
-   * @param httpContent the {@link HttpContent} whose bytes were just written. Should be null if the data from the
-   *                    original {@link HttpContent} was copied and not "retained".
-   * @param isLast if this is the last piece of {@link HttpContent} for this request.
-   * @param callbackWrapper the {@link ReadIntoCallbackWrapper} that will receive updates of bytes read and one that
-   *                        should be invoked in {@link #onCompletion(Long, Exception)} if {@code isLast} is
-   *                        {@code true} or exception passed is not null.
+   * Continues reading from the channel if the buffer watermark has not been reached and if auto-read is off.
+   * @param delta number of bytes read from the channel in the current read.
    */
-  public ContentWriteCallback(HttpContent httpContent, boolean isLast, ReadIntoCallbackWrapper callbackWrapper) {
-    this.httpContent = httpContent;
-    this.isLast = isLast;
-    this.callbackWrapper = callbackWrapper;
-  }
-
-  /**
-   * Decreases reference counts of content if required, updates the number of bytes read and invokes
-   * {@link ReadIntoCallbackWrapper#invokeCallback(Exception)} if {@code exception} is not {@code null} or if this is
-   * the last piece of content in the request.
-   * @param result The result of the request. This would be non null when the request executed successfully
-   * @param exception The exception that was reported on execution of the request
-   */
-  @Override
-  public void onCompletion(Long result, Exception exception) {
-    if (httpContent != null) {
-      ReferenceCountUtil.release(httpContent);
-    }
-    callbackWrapper.updateBytesRead(result);
-    if (exception != null || isLast) {
-      callbackWrapper.invokeCallback(exception);
+  private void continueReadIfPossible(long delta) {
+    if (!channel.config().isAutoRead()) {
+      if (bytesBuffered.addAndGet(delta) < bufferWatermark) {
+        channel.read();
+      } else {
+        nettyMetrics.watermarkOverflowCount.inc();
+      }
     }
   }
-}
-
-/**
- * Wrapper for callbacks provided to {@link NettyRequest#readInto(AsyncWritableChannel, Callback)}.
- */
-class ReadIntoCallbackWrapper {
-  /**
-   * The {@link Future} where the result of {@link NettyRequest#readInto(AsyncWritableChannel, Callback)} will
-   * eventually be updated.
-   */
-  public final FutureResult<Long> futureResult = new FutureResult<Long>();
-
-  private final Callback<Long> callback;
-  private final AtomicLong totalBytesRead = new AtomicLong(0);
-  private final AtomicBoolean callbackInvoked = new AtomicBoolean(false);
 
   /**
-   * Creates an instance of ReadIntoCallbackWrapper with the given {@code callback}.
-   * @param callback the {@link Callback} to invoke on operation completion.
+   * Callback for each write into the given {@link AsyncWritableChannel}.
    */
-  public ReadIntoCallbackWrapper(Callback<Long> callback) {
-    this.callback = callback;
+  protected class ContentWriteCallback implements Callback<Long> {
+    private final HttpContent httpContent;
+    private final boolean isLast;
+    private final ReadIntoCallbackWrapper callbackWrapper;
+
+    /**
+     * Creates a new instance of ContentWriteCallback.
+     * @param httpContent the {@link HttpContent} whose bytes were just written. Should be null if the data from the
+     *                    original {@link HttpContent} was copied and not "retained".
+     * @param isLast if this is the last piece of {@link HttpContent} for this request.
+     * @param callbackWrapper the {@link ReadIntoCallbackWrapper} that will receive updates of bytes read and one that
+     *                        should be invoked in {@link #onCompletion(Long, Exception)} if {@code isLast} is
+     *                        {@code true} or exception passed is not null.
+     */
+    public ContentWriteCallback(HttpContent httpContent, boolean isLast, ReadIntoCallbackWrapper callbackWrapper) {
+      this.httpContent = httpContent;
+      this.isLast = isLast;
+      this.callbackWrapper = callbackWrapper;
+    }
+
+    /**
+     * Decreases reference counts of content if required, updates the number of bytes read and invokes
+     * {@link ReadIntoCallbackWrapper#invokeCallback(Exception)} if {@code exception} is not {@code null} or if this is
+     * the last piece of content in the request.
+     * @param result The result of the request. This would be non null when the request executed successfully
+     * @param exception The exception that was reported on execution of the request
+     */
+    @Override
+    public void onCompletion(Long result, Exception exception) {
+      if (httpContent != null) {
+        ReferenceCountUtil.release(httpContent);
+      }
+      callbackWrapper.updateBytesRead(result);
+      continueReadIfPossible(-result);
+      if (exception != null || isLast) {
+        callbackWrapper.invokeCallback(exception);
+      }
+    }
   }
 
   /**
-   * Updates the number of bytes that have been successfully read into the given {@link AsyncWritableChannel}.
-   * @param delta the number of bytes read in the current invocation.
-   * @return the total number of bytes read until now.
+   * Wrapper for callbacks provided to {@link NettyRequest#readInto(AsyncWritableChannel, Callback)}.
    */
-  public long updateBytesRead(long delta) {
-    return totalBytesRead.addAndGet(delta);
-  }
+  protected class ReadIntoCallbackWrapper {
+    /**
+     * The {@link Future} where the result of {@link NettyRequest#readInto(AsyncWritableChannel, Callback)} will
+     * eventually be updated.
+     */
+    public final FutureResult<Long> futureResult = new FutureResult<Long>();
 
-  /**
-   * Invokes the callback and updates the future once this is called. This function ensures that the callback is invoked
-   * just once.
-   * @param exception the {@link Exception}, if any, to pass to the callback.
-   */
-  public void invokeCallback(Exception exception) {
-    if (callbackInvoked.compareAndSet(false, true)) {
-      futureResult.done(totalBytesRead.get(), exception);
-      if (callback != null) {
-        callback.onCompletion(totalBytesRead.get(), exception);
+    private final Callback<Long> callback;
+    private final AtomicLong totalBytesRead = new AtomicLong(0);
+    private final AtomicBoolean callbackInvoked = new AtomicBoolean(false);
+
+    /**
+     * Creates an instance of ReadIntoCallbackWrapper with the given {@code callback}.
+     * @param callback the {@link Callback} to invoke on operation completion.
+     */
+    public ReadIntoCallbackWrapper(Callback<Long> callback) {
+      this.callback = callback;
+    }
+
+    /**
+     * Updates the number of bytes that have been successfully read into the given {@link AsyncWritableChannel}.
+     * @param delta the number of bytes read in the current invocation.
+     * @return the total number of bytes read until now.
+     */
+    public long updateBytesRead(long delta) {
+      return totalBytesRead.addAndGet(delta);
+    }
+
+    /**
+     * Invokes the callback and updates the future once this is called. This function ensures that the callback is invoked
+     * just once.
+     * @param exception the {@link Exception}, if any, to pass to the callback.
+     */
+    public void invokeCallback(Exception exception) {
+      if (callbackInvoked.compareAndSet(false, true)) {
+        futureResult.done(totalBytesRead.get(), exception);
+        if (callback != null) {
+          callback.onCompletion(totalBytesRead.get(), exception);
+        }
       }
     }
   }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -119,17 +119,17 @@ class NettyRequest implements RestRequest {
     this.nettyMetrics = nettyMetrics;
 
     HttpMethod httpMethod = request.getMethod();
-    if (httpMethod == HttpMethod.GET) {
+    if (HttpMethod.GET.equals(httpMethod)) {
       restMethod = RestMethod.GET;
-    } else if (httpMethod == HttpMethod.POST) {
+    } else if (HttpMethod.POST.equals(httpMethod)) {
       restMethod = RestMethod.POST;
       if (bufferWatermark > 0) {
         setAutoRead(false);
         continueReadIfPossible(0);
       }
-    } else if (httpMethod == HttpMethod.DELETE) {
+    } else if (HttpMethod.DELETE.equals(httpMethod)) {
       restMethod = RestMethod.DELETE;
-    } else if (httpMethod == HttpMethod.HEAD) {
+    } else if (HttpMethod.HEAD.equals(httpMethod)) {
       restMethod = RestMethod.HEAD;
     } else {
       nettyMetrics.unsupportedHttpMethodError.inc();

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
@@ -61,6 +61,7 @@ public class NettyServer implements NioServer {
     this.nettyConfig = nettyConfig;
     this.nettyMetrics = nettyMetrics;
     this.channelInitializer = channelInitializer;
+    NettyRequest.bufferWatermark = nettyConfig.nettyServerRequestBufferWatermark;
     logger.trace("Instantiated NettyServer");
   }
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
@@ -15,6 +15,8 @@ package com.github.ambry.rest;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
+import com.github.ambry.config.NettyConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.CopyingAsyncWritableChannel;
@@ -43,6 +45,7 @@ import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import org.junit.Test;
@@ -55,11 +58,17 @@ import static org.junit.Assert.*;
  */
 public class NettyMultipartRequestTest {
 
-  private static final MetricRegistry metricRegistry = new MetricRegistry();
-  private static final NettyMetrics nettyMetrics = new NettyMetrics(metricRegistry);
+  private static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
+  private static final NettyMetrics NETTY_METRICS = new NettyMetrics(METRIC_REGISTRY);
+  private static final int DEFAULT_WATERMARK;
 
   static {
-    RestRequestMetricsTracker.setDefaults(metricRegistry);
+    DEFAULT_WATERMARK = new NettyConfig(new VerifiableProperties(new Properties())).nettyServerRequestBufferWatermark;
+    RestRequestMetricsTracker.setDefaults(METRIC_REGISTRY);
+  }
+
+  public NettyMultipartRequestTest() {
+    NettyRequest.bufferWatermark = DEFAULT_WATERMARK;
   }
 
   /**
@@ -72,15 +81,22 @@ public class NettyMultipartRequestTest {
   public void instantiationTest()
       throws RestServiceException {
     // POST will succeed.
+    NettyRequest.bufferWatermark = 1;
     HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
-    closeRequestAndValidate(new NettyMultipartRequest(httpRequest, nettyMetrics));
+    MockChannel channel = new MockChannel();
+    int expectedVal = channel.config().getMaxMessagesPerRead();
+    NettyMultipartRequest request = new NettyMultipartRequest(httpRequest, channel, NETTY_METRICS);
+    assertTrue("Auto-read should not have been changed", channel.config().isAutoRead());
+    assertEquals("Max messages per read should not have changed", expectedVal,
+        channel.config().getMaxMessagesPerRead());
+    closeRequestAndValidate(request);
 
     // Methods that will fail. Can include other methods, but these should be enough.
     HttpMethod[] methods = {HttpMethod.GET, HttpMethod.DELETE, HttpMethod.HEAD};
     for (HttpMethod method : methods) {
       httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, method, "/");
       try {
-        new NettyMultipartRequest(httpRequest, nettyMetrics);
+        new NettyMultipartRequest(httpRequest, new MockChannel(), NETTY_METRICS);
         fail("Creation of NettyMultipartRequest should have failed for " + method);
       } catch (IllegalArgumentException e) {
         // expected. Nothing to do.
@@ -232,7 +248,8 @@ public class NettyMultipartRequestTest {
     // prepare half baked data
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
     HttpPostRequestEncoder encoder = createEncoder(httpRequest, null);
-    NettyMultipartRequest request = new NettyMultipartRequest(encoder.finalizeRequest(), nettyMetrics);
+    NettyMultipartRequest request =
+        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS);
     assertTrue("Request channel is not open", request.isOpen());
     // insert random data
     HttpContent httpContent = new DefaultHttpContent(Unpooled.wrappedBuffer(RestTestUtils.getRandomBytes(10)));
@@ -300,7 +317,7 @@ public class NettyMultipartRequestTest {
     files[0] = new InMemoryFile(RestUtils.MultipartPost.BLOB_PART, ByteBuffer.wrap(RestTestUtils.getRandomBytes(256)));
     encoder = createEncoder(httpRequest, files);
     encoder.addBodyAttribute("dummyKey", "dummyValue");
-    request = new NettyMultipartRequest(encoder.finalizeRequest(), nettyMetrics);
+    request = new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS);
     assertTrue("Request channel is not open", request.isOpen());
     while (!encoder.isEndOfInput()) {
       // Sending null for ctx because the encoder is OK with that.
@@ -333,7 +350,8 @@ public class NettyMultipartRequestTest {
       httpRequest.headers().set(headers);
     }
     HttpPostRequestEncoder encoder = createEncoder(httpRequest, parts);
-    NettyMultipartRequest request = new NettyMultipartRequest(encoder.finalizeRequest(), nettyMetrics);
+    NettyMultipartRequest request =
+        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS);
     assertTrue("Request channel is not open", request.isOpen());
     while (!encoder.isEndOfInput()) {
       // Sending null for ctx because the encoder is OK with that.

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
@@ -944,15 +944,13 @@ public class NettyRequestTest {
         if (future == null && addedCount == numChunksToAddBeforeRead) {
           future = nettyRequest.readInto(writeChannel, callback);
         }
-        if (addedCount < httpContents.size()) {
-          final HttpContent httpContent = httpContents.get(addedCount);
-          bytesToVerify += (httpContent.content().readableBytes());
-          suspended = bytesToVerify >= NettyRequest.bufferWatermark;
-          addedCount++;
-          nettyRequest.addContent(httpContent);
-          int expectedRefCountOnAdd = future == null || httpContent.content().nioBufferCount() > 0 ? 2 : 1;
-          assertEquals("Reference count is not as expected", expectedRefCountOnAdd, httpContent.refCnt());
-        }
+        final HttpContent httpContent = httpContents.get(addedCount);
+        bytesToVerify += (httpContent.content().readableBytes());
+        suspended = bytesToVerify >= NettyRequest.bufferWatermark;
+        addedCount++;
+        nettyRequest.addContent(httpContent);
+        int expectedRefCountOnAdd = future == null || httpContent.content().nioBufferCount() > 0 ? 2 : 1;
+        assertEquals("Reference count is not as expected", expectedRefCountOnAdd, httpContent.refCnt());
       }
     }
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
@@ -15,6 +15,8 @@ package com.github.ambry.rest;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
+import com.github.ambry.config.NettyConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.FutureResult;
@@ -23,6 +25,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.buffer.UnpooledHeapByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.Cookie;
 import io.netty.handler.codec.http.DefaultCookie;
 import io.netty.handler.codec.http.DefaultHttpContent;
@@ -47,13 +55,18 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -67,6 +80,15 @@ public class NettyRequestTest {
 
   private static final int GENERATED_CONTENT_SIZE = 10240;
   private static final int GENERATED_CONTENT_PART_COUNT = 10;
+  private static final int DEFAULT_WATERMARK;
+
+  static {
+    DEFAULT_WATERMARK = new NettyConfig(new VerifiableProperties(new Properties())).nettyServerRequestBufferWatermark;
+  }
+
+  public NettyRequestTest() {
+    NettyRequest.bufferWatermark = DEFAULT_WATERMARK;
+  }
 
   /**
    * Tests conversion of {@link HttpRequest} to {@link NettyRequest} given good input.
@@ -121,26 +143,35 @@ public class NettyRequestTest {
     httpCookie = new DefaultCookie("CookieKey2", "CookieValue2");
     cookies.add(httpCookie);
     headers.add(RestUtils.Headers.COOKIE, getCookiesHeaderValue(cookies));
+    MockChannel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
 
     uri = "/GET" + uriAttachment;
-    nettyRequest = createNettyRequest(HttpMethod.GET, uri, headers);
-    validateRequest(nettyRequest, RestMethod.GET, uri, headers, params, cookies);
-    closeRequestAndValidate(nettyRequest);
+    nettyRequest = createNettyRequest(HttpMethod.GET, uri, headers, channel);
+    validateRequest(nettyRequest, RestMethod.GET, uri, headers, params, cookies, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
 
-    uri = "/POST" + uriAttachment;
-    nettyRequest = createNettyRequest(HttpMethod.POST, uri, headers);
-    validateRequest(nettyRequest, RestMethod.POST, uri, headers, params, cookies);
-    closeRequestAndValidate(nettyRequest);
+    int[] bufferWatermarks = {-1, 0, 1, DEFAULT_WATERMARK};
+    for (int bufferWatermark : bufferWatermarks) {
+      NettyRequest.bufferWatermark = bufferWatermark;
+      uri = "/POST" + uriAttachment;
+      nettyRequest = createNettyRequest(HttpMethod.POST, uri, headers, channel);
+      int maxMessagesPerRead = bufferWatermark > 0 ? 1 : expectedMaxMessagesPerRead;
+      validateRequest(nettyRequest, RestMethod.POST, uri, headers, params, cookies, channel, maxMessagesPerRead);
+      closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    }
+    NettyRequest.bufferWatermark = DEFAULT_WATERMARK;
 
     uri = "/DELETE" + uriAttachment;
-    nettyRequest = createNettyRequest(HttpMethod.DELETE, uri, headers);
-    validateRequest(nettyRequest, RestMethod.DELETE, uri, headers, params, cookies);
-    closeRequestAndValidate(nettyRequest);
+    nettyRequest = createNettyRequest(HttpMethod.DELETE, uri, headers, channel);
+    validateRequest(nettyRequest, RestMethod.DELETE, uri, headers, params, cookies, channel,
+        expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
 
     uri = "/HEAD" + uriAttachment;
-    nettyRequest = createNettyRequest(HttpMethod.HEAD, uri, headers);
-    validateRequest(nettyRequest, RestMethod.HEAD, uri, headers, params, cookies);
-    closeRequestAndValidate(nettyRequest);
+    nettyRequest = createNettyRequest(HttpMethod.HEAD, uri, headers, channel);
+    validateRequest(nettyRequest, RestMethod.HEAD, uri, headers, params, cookies, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
   }
 
   /**
@@ -151,17 +182,26 @@ public class NettyRequestTest {
   @Test
   public void conversionWithBadInputTest()
       throws RestServiceException {
+    HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "");
     // HttpRequest null.
     try {
-      new NettyRequest(null, new NettyMetrics(new MetricRegistry()));
+      new NettyRequest(null, new MockChannel(), new NettyMetrics(new MetricRegistry()));
       fail("Provided null HttpRequest to NettyRequest, yet it did not fail");
+    } catch (IllegalArgumentException e) {
+      // expected. nothing to do.
+    }
+
+    // Channel null.
+    try {
+      new NettyRequest(httpRequest, null, new NettyMetrics(new MetricRegistry()));
+      fail("Provided null Channel to NettyRequest, yet it did not fail");
     } catch (IllegalArgumentException e) {
       // expected. nothing to do.
     }
 
     // unknown http method
     try {
-      createNettyRequest(HttpMethod.TRACE, "/", null);
+      createNettyRequest(HttpMethod.TRACE, "/", null, new MockChannel());
       fail("Unknown http method was supplied to NettyRequest. It should have failed to construct");
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.UnsupportedHttpMethod, e.getErrorCode());
@@ -176,8 +216,10 @@ public class NettyRequestTest {
   @Test
   public void operationsAfterCloseTest()
       throws Exception {
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
-    closeRequestAndValidate(nettyRequest);
+    Channel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
 
     // operations that should be ok to do (does not include all operations).
     nettyRequest.close();
@@ -191,6 +233,7 @@ public class NettyRequestTest {
     } catch (ExecutionException e) {
       Exception exception = (Exception) Utils.getRootCause(e);
       assertTrue("Exception is not ClosedChannelException", exception instanceof ClosedChannelException);
+      callback.awaitCallback();
       assertEquals("Exceptions of callback and future differ", exception.getMessage(), callback.exception.getMessage());
     }
 
@@ -214,22 +257,39 @@ public class NettyRequestTest {
       throws Exception {
     String[] digestAlgorithms = {"", "MD5", "SHA-1", "SHA-256"};
     for (String digestAlgorithm : digestAlgorithms) {
-      contentAddAndReadTest(digestAlgorithm);
+      contentAddAndReadTest(digestAlgorithm, true);
+      contentAddAndReadTest(digestAlgorithm, false);
+    }
+  }
+
+  /**
+   * Tests {@link NettyRequest#addContent(HttpContent)} and
+   * {@link NettyRequest#readInto(AsyncWritableChannel, Callback)} with different digest algorithms (including a test
+   * with no digest algorithm) and checks that back pressure is applied correctly.
+   * @throws Exception
+   */
+  @Test
+  public void backPressureTest()
+      throws Exception {
+    String[] digestAlgorithms = {"", "MD5", "SHA-1", "SHA-256"};
+    for (String digestAlgorithm : digestAlgorithms) {
+      backPressureTest(digestAlgorithm, true);
+      backPressureTest(digestAlgorithm, false);
     }
   }
 
   /**
    * Tests exception scenarios of {@link NettyRequest#readInto(AsyncWritableChannel, Callback)} and behavior of
    * {@link NettyRequest} when {@link AsyncWritableChannel} instances fail.
-   * @throws InterruptedException
-   * @throws IOException
-   * @throws RestServiceException
+   * @throws Exception
    */
   @Test
   public void readIntoExceptionsTest()
-      throws InterruptedException, IOException, RestServiceException {
+      throws Exception {
+    Channel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     // try to call readInto twice.
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     AsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
     nettyRequest.readInto(writeChannel, null);
 
@@ -239,10 +299,11 @@ public class NettyRequestTest {
     } catch (IllegalStateException e) {
       // expected. Nothing to do.
     }
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
 
     // write into a channel that throws exceptions
     // non RuntimeException
-    nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     generateContent(httpContents);
     assertTrue("Not enough content has been generated", httpContents.size() > 2);
@@ -268,6 +329,7 @@ public class NettyRequestTest {
 
     writeChannel.close();
     verifyRefCnts(httpContents);
+    callback.awaitCallback();
     assertNotNull("Exception was not piped correctly", callback.exception);
     assertEquals("Exception message mismatch (callback)", expectedMsg, callback.exception.getMessage());
     try {
@@ -276,11 +338,11 @@ public class NettyRequestTest {
     } catch (ExecutionException e) {
       assertEquals("Exception message mismatch (future)", expectedMsg, Utils.getRootCause(e).getMessage());
     }
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
 
     // RuntimeException
     // during readInto
-    nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     httpContents = new ArrayList<HttpContent>();
     generateContent(httpContents);
     exception = new IllegalStateException(expectedMsg);
@@ -298,11 +360,11 @@ public class NettyRequestTest {
       assertEquals("Exception caught does not match expected exception", expectedMsg, e.getMessage());
     }
     writeChannel.close();
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
     verifyRefCnts(httpContents);
 
     // after readInto
-    nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     httpContents = new ArrayList<HttpContent>();
     generateContent(httpContents);
     exception = new IllegalStateException(expectedMsg);
@@ -319,7 +381,7 @@ public class NettyRequestTest {
       assertEquals("Exception caught does not match expected exception", expectedMsg, e.getMessage());
     }
     writeChannel.close();
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
     verifyRefCnts(httpContents);
   }
 
@@ -331,7 +393,9 @@ public class NettyRequestTest {
   @Test
   public void closeTest()
       throws RestServiceException {
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    Channel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     Queue<HttpContent> httpContents = new LinkedBlockingQueue<HttpContent>();
     for (int i = 0; i < 5; i++) {
       ByteBuffer content = ByteBuffer.wrap(RestTestUtils.getRandomBytes(1024));
@@ -339,7 +403,7 @@ public class NettyRequestTest {
       nettyRequest.addContent(httpContent);
       httpContents.add(httpContent);
     }
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
     while (httpContents.peek() != null) {
       assertEquals("Reference count of http content has changed", 1, httpContents.poll().refCnt());
     }
@@ -355,7 +419,7 @@ public class NettyRequestTest {
       throws RestServiceException {
     byte[] content = RestTestUtils.getRandomBytes(16);
     // adding non LastHttpContent to nettyRequest
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.GET, "/", null);
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.GET, "/", null, new MockChannel());
     try {
       nettyRequest.addContent(new DefaultHttpContent(Unpooled.wrappedBuffer(content)));
       fail("GET requests should not accept non-LastHTTPContent");
@@ -364,7 +428,7 @@ public class NettyRequestTest {
     }
 
     // adding LastHttpContent with some content to nettyRequest
-    nettyRequest = createNettyRequest(HttpMethod.GET, "/", null);
+    nettyRequest = createNettyRequest(HttpMethod.GET, "/", null, new MockChannel());
     try {
       nettyRequest.addContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(content)));
       fail("GET requests should not accept actual content in LastHTTPContent");
@@ -373,11 +437,11 @@ public class NettyRequestTest {
     }
 
     // should accept LastHttpContent just fine.
-    nettyRequest = createNettyRequest(HttpMethod.GET, "/", null);
+    nettyRequest = createNettyRequest(HttpMethod.GET, "/", null, new MockChannel());
     nettyRequest.addContent(new DefaultLastHttpContent());
 
     // should not accept LastHttpContent after close
-    nettyRequest = createNettyRequest(HttpMethod.GET, "/", null);
+    nettyRequest = createNettyRequest(HttpMethod.GET, "/", null, new MockChannel());
     nettyRequest.close();
     try {
       nettyRequest.addContent(new DefaultLastHttpContent());
@@ -390,18 +454,18 @@ public class NettyRequestTest {
   @Test
   public void keepAliveTest()
       throws RestServiceException {
-    NettyRequest request = createNettyRequest(HttpMethod.GET, "/", null);
+    NettyRequest request = createNettyRequest(HttpMethod.GET, "/", null, new MockChannel());
     // by default, keep-alive is true for HTTP 1.1
     assertTrue("Keep-alive not as expected", request.isKeepAlive());
 
     HttpHeaders headers = new DefaultHttpHeaders();
     headers.set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
-    request = createNettyRequest(HttpMethod.GET, "/", headers);
+    request = createNettyRequest(HttpMethod.GET, "/", headers, new MockChannel());
     assertTrue("Keep-alive not as expected", request.isKeepAlive());
 
     headers = new DefaultHttpHeaders();
     headers.set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE);
-    request = createNettyRequest(HttpMethod.GET, "/", headers);
+    request = createNettyRequest(HttpMethod.GET, "/", headers, new MockChannel());
     assertFalse("Keep-alive not as expected", request.isKeepAlive());
   }
 
@@ -413,7 +477,7 @@ public class NettyRequestTest {
   public void sizeTest()
       throws RestServiceException {
     // no length headers provided.
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.GET, "/", null);
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.GET, "/", null, new MockChannel());
     assertEquals("Size not as expected", -1, nettyRequest.getSize());
 
     // deliberate mismatch to check priorities.
@@ -423,20 +487,20 @@ public class NettyRequestTest {
     // Content-Length header set
     HttpHeaders headers = new DefaultHttpHeaders();
     headers.add(HttpHeaders.Names.CONTENT_LENGTH, contentLength);
-    nettyRequest = createNettyRequest(HttpMethod.GET, "/", headers);
+    nettyRequest = createNettyRequest(HttpMethod.GET, "/", headers, new MockChannel());
     assertEquals("Size not as expected", contentLength, nettyRequest.getSize());
 
     // xAmbryBlobSize set
     headers = new DefaultHttpHeaders();
     headers.add(RestUtils.Headers.BLOB_SIZE, xAmbryBlobSize);
-    nettyRequest = createNettyRequest(HttpMethod.GET, "/", headers);
+    nettyRequest = createNettyRequest(HttpMethod.GET, "/", headers, new MockChannel());
     assertEquals("Size not as expected", xAmbryBlobSize, nettyRequest.getSize());
 
     // both set
     headers = new DefaultHttpHeaders();
     headers.add(RestUtils.Headers.BLOB_SIZE, xAmbryBlobSize);
     headers.add(HttpHeaders.Names.CONTENT_LENGTH, contentLength);
-    nettyRequest = createNettyRequest(HttpMethod.GET, "/", headers);
+    nettyRequest = createNettyRequest(HttpMethod.GET, "/", headers, new MockChannel());
     assertEquals("Size not as expected", xAmbryBlobSize, nettyRequest.getSize());
   }
 
@@ -447,7 +511,9 @@ public class NettyRequestTest {
   @Test
   public void zeroSizeContentTest()
       throws Exception {
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    Channel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     HttpContent httpContent = new DefaultLastHttpContent();
 
     nettyRequest.addContent(httpContent);
@@ -458,9 +524,10 @@ public class NettyRequestTest {
     Future<Long> future = nettyRequest.readInto(writeChannel, callback);
     assertEquals("There should be no content", 0, writeChannel.getNextChunk().remaining());
     writeChannel.resolveOldestChunk(null);
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
     writeChannel.close();
     assertEquals("Reference count of http content has changed", 1, httpContent.refCnt());
+    callback.awaitCallback();
     if (callback.exception != null) {
       throw callback.exception;
     }
@@ -471,25 +538,25 @@ public class NettyRequestTest {
 
   /**
    * Tests reaction of NettyRequest when content size is different from the size specified in the headers.
-   * @throws InterruptedException
-   * @throws IOException
-   * @throws RestServiceException
+   * @throws Exception
    */
   @Test
   public void headerAndContentSizeMismatchTest()
-      throws InterruptedException, IOException, RestServiceException {
+      throws Exception {
     sizeInHeaderMoreThanContentTest();
     sizeInHeaderLessThanContentTest();
   }
 
   /**
-   * Does any left over tests for {@link ContentWriteCallback}
+   * Does any left over tests for {@link NettyRequest.ContentWriteCallback}
    */
   @Test
-  public void contentWriteCallbackTests() {
+  public void contentWriteCallbackTests()
+      throws RestServiceException {
     ReadIntoCallback readIntoCallback = new ReadIntoCallback();
-    ReadIntoCallbackWrapper wrapper = new ReadIntoCallbackWrapper(readIntoCallback);
-    ContentWriteCallback callback = new ContentWriteCallback(null, true, wrapper);
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.GET, "/", null, new MockChannel());
+    NettyRequest.ReadIntoCallbackWrapper wrapper = nettyRequest.new ReadIntoCallbackWrapper(readIntoCallback);
+    NettyRequest.ContentWriteCallback callback = nettyRequest.new ContentWriteCallback(null, true, wrapper);
     long bytesRead = new Random().nextInt(Integer.MAX_VALUE);
     // there should be no problem even though httpContent is null.
     callback.onCompletion(bytesRead, null);
@@ -518,10 +585,11 @@ public class NettyRequestTest {
    * @param httpMethod the {@link HttpMethod} desired.
    * @param uri the URI desired.
    * @param headers {@link HttpHeaders} that need to be a part of the request.
+   * @param channel the {@link Channel} that the request arrived over.
    * @return {@link NettyRequest} encapsulating a {@link HttpRequest} with the given parameters.
    * @throws RestServiceException if the {@code httpMethod} is not recognized by {@link NettyRequest}.
    */
-  private NettyRequest createNettyRequest(HttpMethod httpMethod, String uri, HttpHeaders headers)
+  private NettyRequest createNettyRequest(HttpMethod httpMethod, String uri, HttpHeaders headers, Channel channel)
       throws RestServiceException {
     MetricRegistry metricRegistry = new MetricRegistry();
     RestRequestMetricsTracker.setDefaults(metricRegistry);
@@ -529,16 +597,24 @@ public class NettyRequestTest {
     if (headers != null) {
       httpRequest.headers().set(headers);
     }
-    return new NettyRequest(httpRequest, new NettyMetrics(metricRegistry));
+    NettyRequest nettyRequest = new NettyRequest(httpRequest, channel, new NettyMetrics(metricRegistry));
+    assertEquals("Auto-read is in an invalid state",
+        !httpMethod.equals(HttpMethod.POST) || NettyRequest.bufferWatermark <= 0, channel.config().isAutoRead());
+    return nettyRequest;
   }
 
   /**
    * Closes the provided {@code nettyRequest} and validates that it is actually closed.
    * @param nettyRequest the {@link NettyRequest} that needs to be closed and validated.
+   * @param channel the {@link Channel} over which the request was received.
+   * @param expectedMaxMessagesPerRead the expected value of {@link ChannelConfig#getMaxMessagesPerRead()}.
    */
-  private void closeRequestAndValidate(NettyRequest nettyRequest) {
+  private void closeRequestAndValidate(NettyRequest nettyRequest, Channel channel, int expectedMaxMessagesPerRead) {
     nettyRequest.close();
     assertFalse("Request channel is not closed", nettyRequest.isOpen());
+    assertTrue("Auto-read is not as expected", channel.config().isAutoRead());
+    assertEquals("Max messages per read is in an invalid state", expectedMaxMessagesPerRead,
+        channel.config().getMaxMessagesPerRead());
   }
 
   /**
@@ -567,9 +643,11 @@ public class NettyRequestTest {
    * @param headers the {@link HttpHeaders} passed with the request that need to be in {@link NettyRequest#getArgs()}.
    * @param params the parameters passed with the request that need to be in {@link NettyRequest#getArgs()}.
    * @param httpCookies Set of {@link Cookie} set in the request
+   * @param channel the {@link Channel} over which the request was received.
+   * @param expectedMaxMessagesPerRead the expected value of {@link ChannelConfig#getMaxMessagesPerRead()}.
    */
   private void validateRequest(NettyRequest nettyRequest, RestMethod restMethod, String uri, HttpHeaders headers,
-      Map<String, List<String>> params, Set<Cookie> httpCookies) {
+      Map<String, List<String>> params, Set<Cookie> httpCookies, Channel channel, int expectedMaxMessagesPerRead) {
     long contentLength = headers.contains(HttpHeaders.Names.CONTENT_LENGTH) ? Long
         .parseLong(headers.get(HttpHeaders.Names.CONTENT_LENGTH)) : 0;
     assertTrue("Request channel is not open", nettyRequest.isOpen());
@@ -631,6 +709,11 @@ public class NettyRequestTest {
       assertEquals("Value count for key " + e.getKey() + " does not match", e.getValue().intValue(),
           receivedArgs.get(e.getKey()).size());
     }
+
+    assertEquals("Auto-read is in an invalid state",
+        !restMethod.equals(RestMethod.POST) || NettyRequest.bufferWatermark <= 0, channel.config().isAutoRead());
+    assertEquals("Max messages per read is in an invalid state", expectedMaxMessagesPerRead,
+        channel.config().getMaxMessagesPerRead());
   }
 
   /**
@@ -651,7 +734,7 @@ public class NettyRequestTest {
     }
   }
 
-  // contentAddAndReadTest() and readIntoExceptionsTest() helpers
+  // contentAddAndReadTest(), readIntoExceptionsTest() and backPressureTest() helpers
 
   /**
    * Tests {@link NettyRequest#addContent(HttpContent)} and
@@ -661,24 +744,26 @@ public class NettyRequestTest {
    * The read happens at different points of time w.r.t content addition (before, during, after).
    * @param digestAlgorithm the digest algorithm to use. Can be empty or {@code null} if digest checking is not
    *                        required.
+   * @param useCopyForcingByteBuf if {@code true}, uses {@link CopyForcingByteBuf} instead of the default
+   *                              {@link ByteBuf}.
    * @throws Exception
    */
-  private void contentAddAndReadTest(String digestAlgorithm)
+  private void contentAddAndReadTest(String digestAlgorithm, boolean useCopyForcingByteBuf)
       throws Exception {
     // non composite content
     // start reading before addition of content
-    List<HttpContent> httpContents = new ArrayList<HttpContent>();
-    ByteBuffer content = generateContent(httpContents);
+    List<HttpContent> httpContents = new ArrayList<>();
+    ByteBuffer content = generateContent(httpContents, useCopyForcingByteBuf);
     doContentAddAndReadTest(digestAlgorithm, content, httpContents, 0);
 
     // start reading in the middle of content add
     httpContents.clear();
-    content = generateContent(httpContents);
+    content = generateContent(httpContents, useCopyForcingByteBuf);
     doContentAddAndReadTest(digestAlgorithm, content, httpContents, httpContents.size() / 2);
 
     // start reading after all content added
     httpContents.clear();
-    content = generateContent(httpContents);
+    content = generateContent(httpContents, useCopyForcingByteBuf);
     doContentAddAndReadTest(digestAlgorithm, content, httpContents, httpContents.size());
 
     // composite content
@@ -694,18 +779,20 @@ public class NettyRequestTest {
    * @param content the complete content.
    * @param httpContents {@code content} in parts and as {@link HttpContent}. Should contain all the data in
    * {@code content}.
-   * @param numContentsToAddBeforeRead the number of {@link HttpContent} to add before making the
+   * @param numChunksToAddBeforeRead the number of {@link HttpContent} to add before making the
    * {@link NettyRequest#readInto(AsyncWritableChannel, Callback)} call.
    * @throws Exception
    */
   private void doContentAddAndReadTest(String digestAlgorithm, ByteBuffer content, List<HttpContent> httpContents,
-      int numContentsToAddBeforeRead)
+      int numChunksToAddBeforeRead)
       throws Exception {
-    if (numContentsToAddBeforeRead > httpContents.size()) {
-      throw new IllegalArgumentException("numContentsToAddBeforeRead is more than the pieces of content available");
+    if (numChunksToAddBeforeRead < 0 || numChunksToAddBeforeRead > httpContents.size()) {
+      throw new IllegalArgumentException("Illegal value of numChunksToAddBeforeRead");
     }
 
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    Channel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     byte[] wholeDigest = null;
     if (digestAlgorithm != null && !digestAlgorithm.isEmpty()) {
       MessageDigest digest = MessageDigest.getInstance(digestAlgorithm);
@@ -717,10 +804,11 @@ public class NettyRequestTest {
 
     int bytesToVerify = 0;
     int addedCount = 0;
-    for (; addedCount < numContentsToAddBeforeRead; addedCount++) {
+    for (; addedCount < numChunksToAddBeforeRead; addedCount++) {
       HttpContent httpContent = httpContents.get(addedCount);
       bytesToVerify += httpContent.content().readableBytes();
       nettyRequest.addContent(httpContent);
+      // ref count always 2 when added before calling readInto()
       assertEquals("Reference count is not as expected", 2, httpContent.refCnt());
     }
     ByteBufferAsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
@@ -733,11 +821,13 @@ public class NettyRequestTest {
       HttpContent httpContent = httpContents.get(addedCount);
       bytesToVerify += httpContent.content().readableBytes();
       nettyRequest.addContent(httpContent);
-      assertEquals("Reference count is not as expected", 2, httpContent.refCnt());
+      int expectedRefCountOnAdd = httpContent.content().nioBufferCount() > 0 ? 2 : 1;
+      assertEquals("Reference count is not as expected", expectedRefCountOnAdd, httpContent.refCnt());
     }
     readAndVerify(bytesToVerify, writeChannel, content);
     verifyRefCnts(httpContents);
     writeChannel.close();
+    callback.awaitCallback();
     if (callback.exception != null) {
       throw callback.exception;
     }
@@ -749,7 +839,142 @@ public class NettyRequestTest {
     for (int i = 0; i < 2; i++) {
       assertArrayEquals("Part by part digest should match digest of whole", wholeDigest, nettyRequest.getDigest());
     }
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+  }
+
+  /**
+   * Tests backpressure support in {@link NettyRequest} for different values of {@link NettyRequest#bufferWatermark}.
+   * @param digestAlgorithm the digest algorithm to use. Can be empty or {@code null} if digest checking is not
+   *                        required.
+   * @param useCopyForcingByteBuf if {@code true}, uses {@link CopyForcingByteBuf} instead of the default
+   *                              {@link ByteBuf}.
+   * @throws Exception
+   */
+  private void backPressureTest(String digestAlgorithm, boolean useCopyForcingByteBuf)
+      throws Exception {
+    List<HttpContent> httpContents = new ArrayList<HttpContent>();
+    byte[] contentBytes = RestTestUtils.getRandomBytes(GENERATED_CONTENT_SIZE);
+    ByteBuffer content = ByteBuffer.wrap(contentBytes);
+    splitContent(contentBytes, GENERATED_CONTENT_PART_COUNT, httpContents, useCopyForcingByteBuf);
+    int chunkSize = httpContents.get(0).content().readableBytes();
+    int[] bufferWatermarks = {1, chunkSize - 1, chunkSize,
+        chunkSize + 1, chunkSize * httpContents.size() / 2, content.limit() - 1, content.limit(), content.limit() + 1};
+    for (int bufferWatermark : bufferWatermarks) {
+      NettyRequest.bufferWatermark = bufferWatermark;
+      // start reading before addition of content
+      httpContents.clear();
+      content.rewind();
+      splitContent(contentBytes, GENERATED_CONTENT_PART_COUNT, httpContents, useCopyForcingByteBuf);
+      doBackPressureTest(digestAlgorithm, content, httpContents, 0);
+      // start reading in the middle of content add
+      httpContents.clear();
+      content.rewind();
+      splitContent(contentBytes, GENERATED_CONTENT_PART_COUNT, httpContents, useCopyForcingByteBuf);
+      doBackPressureTest(digestAlgorithm, content, httpContents, httpContents.size() / 2);
+      // start reading after all content added
+      httpContents.clear();
+      content.rewind();
+      splitContent(contentBytes, GENERATED_CONTENT_PART_COUNT, httpContents, useCopyForcingByteBuf);
+      doBackPressureTest(digestAlgorithm, content, httpContents, httpContents.size());
+    }
+  }
+
+  /**
+   * Does the backpressure test by ensuring that {@link Channel#read()} isn't called when the number of bytes buffered
+   * is above the {@link NettyRequest#bufferWatermark}. Also ensures that {@link Channel#read()} is called correctly
+   * when the number of buffered bytes falls below the {@link NettyRequest#bufferWatermark}.
+   * @param digestAlgorithm the digest algorithm to use. Can be empty or {@code null} if digest checking is not
+   *                        required.
+   * @param content the complete content.
+   * @param httpContents {@code content} in parts and as {@link HttpContent}. Should contain all the data in
+   * {@code content}.
+   * @param numChunksToAddBeforeRead the number of {@link HttpContent} to add before making the
+   * {@link NettyRequest#readInto(AsyncWritableChannel, Callback)} call.
+   * @throws Exception
+   */
+  private void doBackPressureTest(String digestAlgorithm, ByteBuffer content, List<HttpContent> httpContents,
+      int numChunksToAddBeforeRead)
+      throws Exception {
+    if (numChunksToAddBeforeRead < 0 || numChunksToAddBeforeRead > httpContents.size()) {
+      throw new IllegalArgumentException("Illegal value of numChunksToAddBeforeRead");
+    }
+
+    MockChannel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    final NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
+    byte[] wholeDigest = null;
+    if (digestAlgorithm != null && !digestAlgorithm.isEmpty()) {
+      MessageDigest digest = MessageDigest.getInstance(digestAlgorithm);
+      digest.update(content);
+      wholeDigest = digest.digest();
+      content.rewind();
+      nettyRequest.setDigestAlgorithm(digestAlgorithm);
+    }
+
+    final AtomicInteger queuedReads = new AtomicInteger(0);
+    ByteBufferAsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
+    ReadIntoCallback callback = new ReadIntoCallback();
+
+    channel.setChannelReadCallback(new MockChannel.ChannelReadCallback() {
+      @Override
+      public void onRead() {
+        queuedReads.incrementAndGet();
+      }
+    });
+
+    int addedCount = 0;
+    Future<Long> future = null;
+    boolean suspended = false;
+    int bytesToVerify = 0;
+    while (addedCount < httpContents.size()) {
+      if (suspended) {
+        assertEquals("There should have been no reads queued when over buffer watermark", 0, queuedReads.get());
+        if (future == null) {
+          future = nettyRequest.readInto(writeChannel, callback);
+        }
+        int chunksRead = readAndVerify(bytesToVerify, writeChannel, content);
+        assertEquals("Number of reads triggered is not as expected", chunksRead, queuedReads.get());
+        // collapse many reads into one
+        queuedReads.set(1);
+        bytesToVerify = 0;
+        suspended = false;
+      } else {
+        assertEquals("There should have been only one read queued", 1, queuedReads.get());
+        queuedReads.set(0);
+        if (future == null && addedCount == numChunksToAddBeforeRead) {
+          future = nettyRequest.readInto(writeChannel, callback);
+        }
+        if (addedCount < httpContents.size()) {
+          final HttpContent httpContent = httpContents.get(addedCount);
+          bytesToVerify += (httpContent.content().readableBytes());
+          suspended = bytesToVerify >= NettyRequest.bufferWatermark;
+          addedCount++;
+          nettyRequest.addContent(httpContent);
+          int expectedRefCountOnAdd = future == null || httpContent.content().nioBufferCount() > 0 ? 2 : 1;
+          assertEquals("Reference count is not as expected", expectedRefCountOnAdd, httpContent.refCnt());
+        }
+      }
+    }
+
+    if (future == null) {
+      future = nettyRequest.readInto(writeChannel, callback);
+    }
+    readAndVerify(bytesToVerify, writeChannel, content);
+    verifyRefCnts(httpContents);
+    writeChannel.close();
+    callback.awaitCallback();
+    if (callback.exception != null) {
+      throw callback.exception;
+    }
+    long futureBytesRead = future.get(1, TimeUnit.SECONDS);
+    assertEquals("Total bytes read does not match (callback)", content.limit(), callback.bytesRead);
+    assertEquals("Total bytes read does not match (future)", content.limit(), futureBytesRead);
+
+    // check twice to make sure the same digest is returned every time
+    for (int i = 0; i < 2; i++) {
+      assertArrayEquals("Part by part digest should match digest of whole", wholeDigest, nettyRequest.getDigest());
+    }
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
   }
 
   /**
@@ -758,16 +983,50 @@ public class NettyRequestTest {
    * @return the whole content as a {@link ByteBuffer} - serves as a source of truth.
    */
   private ByteBuffer generateContent(List<HttpContent> httpContents) {
-    int individualPartSize = GENERATED_CONTENT_SIZE / GENERATED_CONTENT_PART_COUNT;
+    return generateContent(httpContents, false);
+  }
+
+  /**
+   * Generates random content and fills it up (in parts) in {@code httpContents}.
+   * @param httpContents the {@link List<HttpContent>} that will contain all the content in parts.
+   * @param useCopyForcingByteBuf if {@code true}, uses {@link CopyForcingByteBuf} instead of the default
+   *                              {@link ByteBuf}.
+   * @return the whole content as a {@link ByteBuffer} - serves as a source of truth.
+   */
+  private ByteBuffer generateContent(List<HttpContent> httpContents, boolean useCopyForcingByteBuf) {
     byte[] contentBytes = RestTestUtils.getRandomBytes(GENERATED_CONTENT_SIZE);
-    for (int addedContentCount = 0; addedContentCount < GENERATED_CONTENT_PART_COUNT - 1; addedContentCount++) {
-      HttpContent httpContent = new DefaultHttpContent(
-          Unpooled.wrappedBuffer(contentBytes, addedContentCount * individualPartSize, individualPartSize));
-      httpContents.add(httpContent);
-    }
-    httpContents.add(new DefaultLastHttpContent(Unpooled
-        .wrappedBuffer(contentBytes, (GENERATED_CONTENT_PART_COUNT - 1) * individualPartSize, individualPartSize)));
+    splitContent(contentBytes, GENERATED_CONTENT_PART_COUNT, httpContents, useCopyForcingByteBuf);
     return ByteBuffer.wrap(contentBytes);
+  }
+
+  /**
+   * Splits the given {@code contentBytes} into {@code numChunks} chunks and stores them in {@code httpContents}.
+   * @param contentBytes the content that needs to be split.
+   * @param numChunks the number of chunks to split {@code contentBytes} into.
+   * @param httpContents the {@link List<HttpContent>} that will contain all the content in parts.
+   * @param useCopyForcingByteBuf if {@code true}, uses {@link CopyForcingByteBuf} instead of the default
+   *                              {@link ByteBuf}.
+   */
+  private void splitContent(byte[] contentBytes, int numChunks, List<HttpContent> httpContents,
+      boolean useCopyForcingByteBuf) {
+    int individualPartSize = contentBytes.length / numChunks;
+    ByteBuf content;
+    for (int addedContentCount = 0; addedContentCount < numChunks - 1; addedContentCount++) {
+      if (useCopyForcingByteBuf) {
+        content =
+            CopyForcingByteBuf.wrappedBuffer(contentBytes, addedContentCount * individualPartSize, individualPartSize);
+      } else {
+        content = Unpooled.wrappedBuffer(contentBytes, addedContentCount * individualPartSize, individualPartSize);
+      }
+      httpContents.add(new DefaultHttpContent(content));
+    }
+    if (useCopyForcingByteBuf) {
+      content =
+          CopyForcingByteBuf.wrappedBuffer(contentBytes, (numChunks - 1) * individualPartSize, individualPartSize);
+    } else {
+      content = Unpooled.wrappedBuffer(contentBytes, (numChunks - 1) * individualPartSize, individualPartSize);
+    }
+    httpContents.add(new DefaultLastHttpContent(content));
   }
 
   /**
@@ -802,11 +1061,13 @@ public class NettyRequestTest {
    * @param readLengthDesired desired length of bytes to read.
    * @param writeChannel the {@link ByteBufferAsyncWritableChannel} to read from.
    * @param content the original content that serves as the source of truth.
+   * @return the number of chunks read.
    * @throws InterruptedException
    */
-  private void readAndVerify(int readLengthDesired, ByteBufferAsyncWritableChannel writeChannel, ByteBuffer content)
+  private int readAndVerify(int readLengthDesired, ByteBufferAsyncWritableChannel writeChannel, ByteBuffer content)
       throws InterruptedException {
     int bytesRead = 0;
+    int chunksRead = 0;
     while (bytesRead < readLengthDesired) {
       ByteBuffer recvdContent = writeChannel.getNextChunk();
       while (recvdContent.hasRemaining()) {
@@ -814,54 +1075,51 @@ public class NettyRequestTest {
         bytesRead++;
       }
       writeChannel.resolveOldestChunk(null);
+      chunksRead++;
     }
+    return chunksRead;
   }
 
   // headerAndContentSizeMismatchTest() helpers
 
   /**
    * Tests reaction of NettyRequest when content size is less than the size specified in the headers.
-   * @throws InterruptedException
-   * @throws IOException
-   * @throws RestServiceException
+   * @throws Exception
    */
   private void sizeInHeaderMoreThanContentTest()
-      throws InterruptedException, IOException, RestServiceException {
+      throws Exception {
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     ByteBuffer content = generateContent(httpContents);
     HttpHeaders httpHeaders = new DefaultHttpHeaders();
     httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, content.limit() + 1);
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", httpHeaders);
-    doHeaderAndContentSizeMismatchTest(nettyRequest, httpContents);
+    doHeaderAndContentSizeMismatchTest(httpHeaders, httpContents);
   }
 
   /**
    * Tests reaction of NettyRequest when content size is more than the size specified in the headers.
-   * @throws InterruptedException
-   * @throws IOException
-   * @throws RestServiceException
+   * @throws Exception
    */
   private void sizeInHeaderLessThanContentTest()
-      throws InterruptedException, IOException, RestServiceException {
+      throws Exception {
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     ByteBuffer content = generateContent(httpContents);
     HttpHeaders httpHeaders = new DefaultHttpHeaders();
     int lastHttpContentSize = httpContents.get(httpContents.size() - 1).content().readableBytes();
     httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, content.limit() - lastHttpContentSize - 1);
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", httpHeaders);
-    doHeaderAndContentSizeMismatchTest(nettyRequest, httpContents);
+    doHeaderAndContentSizeMismatchTest(httpHeaders, httpContents);
   }
 
   /**
    * Tests reaction of NettyRequest when content size is different from the size specified in the headers.
-   * @param nettyRequest the {@link NettyRequest} to which content will be added.
+   * @param httpHeaders {@link HttpHeaders} that need to be a part of the request.
    * @param httpContents the {@link List<HttpContent>} that needs to be added to {@code nettyRequest}.
-   * @throws InterruptedException
-   * @throws IOException
-   * @throws RestServiceException
+   * @throws Exception
    */
-  private void doHeaderAndContentSizeMismatchTest(NettyRequest nettyRequest, List<HttpContent> httpContents)
-      throws InterruptedException, IOException, RestServiceException {
+  private void doHeaderAndContentSizeMismatchTest(HttpHeaders httpHeaders, List<HttpContent> httpContents)
+      throws Exception {
+    Channel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", httpHeaders, channel);
     AsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
     ReadIntoCallback callback = new ReadIntoCallback();
     Future<Long> future = nettyRequest.readInto(writeChannel, callback);
@@ -887,9 +1145,10 @@ public class NettyRequestTest {
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.BadRequest, e.getErrorCode());
     }
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
     writeChannel.close();
     verifyRefCnts(httpContents);
+    callback.awaitCallback();
     assertNotNull("There should be a RestServiceException in the callback", callback.exception);
     assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.BadRequest,
         ((RestServiceException) callback.exception).getErrorCode());
@@ -916,7 +1175,9 @@ public class NettyRequestTest {
       throws NoSuchAlgorithmException, RestServiceException {
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     generateContent(httpContents);
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    Channel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     ByteBufferAsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
     ReadIntoCallback callback = new ReadIntoCallback();
     nettyRequest.readInto(writeChannel, callback);
@@ -929,7 +1190,7 @@ public class NettyRequestTest {
     }
 
     writeChannel.close();
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
   }
 
   /**
@@ -940,14 +1201,16 @@ public class NettyRequestTest {
       throws RestServiceException {
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     generateContent(httpContents);
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    Channel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     try {
       nettyRequest.setDigestAlgorithm("NonExistentAlgorithm");
       fail("Setting a digest algorithm should have failed because the algorithm isn't valid");
     } catch (NoSuchAlgorithmException e) {
       // expected. Nothing to do.
     }
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
   }
 
   /**
@@ -959,7 +1222,9 @@ public class NettyRequestTest {
       throws RestServiceException {
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     generateContent(httpContents);
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    Channel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     ByteBufferAsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
     ReadIntoCallback callback = new ReadIntoCallback();
     nettyRequest.readInto(writeChannel, callback);
@@ -968,7 +1233,7 @@ public class NettyRequestTest {
       nettyRequest.addContent(httpContent);
     }
     assertNull("Digest should be null because no digest algorithm was set", nettyRequest.getDigest());
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
   }
 
   /**
@@ -983,7 +1248,9 @@ public class NettyRequestTest {
     // all content not added test.
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     generateContent(httpContents);
-    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    Channel channel = new MockChannel();
+    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     nettyRequest.setDigestAlgorithm("MD5");
 
     // add all except the LastHttpContent
@@ -1000,12 +1267,12 @@ public class NettyRequestTest {
     } catch (IllegalStateException e) {
       // expected. Nothing to do.
     }
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
 
     // content not processed test.
     httpContents.clear();
     generateContent(httpContents);
-    nettyRequest = createNettyRequest(HttpMethod.POST, "/", null);
+    nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     nettyRequest.setDigestAlgorithm("MD5");
 
     for (HttpContent httpContent : httpContents) {
@@ -1017,7 +1284,7 @@ public class NettyRequestTest {
     } catch (IllegalStateException e) {
       // expected. Nothing to do.
     }
-    closeRequestAndValidate(nettyRequest);
+    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
   }
 }
 
@@ -1028,14 +1295,28 @@ class ReadIntoCallback implements Callback<Long> {
   public volatile long bytesRead;
   public volatile Exception exception;
   private final AtomicBoolean callbackInvoked = new AtomicBoolean(false);
+  private final CountDownLatch latch = new CountDownLatch(1);
 
   @Override
   public void onCompletion(Long result, Exception exception) {
     if (callbackInvoked.compareAndSet(false, true)) {
       bytesRead = result;
       this.exception = exception;
+      latch.countDown();
     } else {
       this.exception = new IllegalStateException("Callback invoked more than once");
+    }
+  }
+
+  /**
+   * Waits for the callback to be received.
+   * @throws InterruptedException if there was any intteruption while waiting for the callback.
+   * @throws TimeoutException if the callback did not arrive within a particular timeout.
+   */
+  public void awaitCallback()
+      throws InterruptedException, TimeoutException {
+    if (!latch.await(1, TimeUnit.SECONDS)) {
+      throw new TimeoutException("Timed out waiting for callback to trigger");
     }
   }
 }
@@ -1090,5 +1371,90 @@ class BadAsyncWritableChannel implements AsyncWritableChannel {
       callback.onCompletion(totalBytesWritten, exception);
     }
     return futureResult;
+  }
+}
+
+/**
+ * A mock channel that can be configured to run custom code on {@link Channel#read()}.
+ */
+class MockChannel extends EmbeddedChannel {
+  /**
+   * Interface to provide code that is to be executed on {@link Channel#read()}.
+   */
+  public interface ChannelReadCallback {
+    /**
+     * This is called when {@link Channel#read()} is called. Should contain logic that needs to be executed on read.
+     */
+    public void onRead();
+  }
+
+  private final ChannelConfig config = new DefaultChannelConfig(this);
+  private ChannelReadCallback channelReadCallback = null;
+  private int queuedOnReads = 0;
+
+  MockChannel() {
+    // sending a placeholder handler to avoid NPE. This is of no consequence and saves us from having to implement
+    // needless functions.
+    super(new ConnectionStatsHandler(new NettyMetrics(new MetricRegistry())));
+    // setting max messages per read to something other than 1
+    config().setMaxMessagesPerRead(16);
+  }
+
+  /**
+   * Sets the {@link ChannelReadCallback}.
+   * @param channelReadCallback the {@link ChannelReadCallback} that will executed on {@link #read()}.
+   */
+  void setChannelReadCallback(ChannelReadCallback channelReadCallback) {
+    this.channelReadCallback = channelReadCallback;
+    for (; queuedOnReads > 0; queuedOnReads--) {
+      channelReadCallback.onRead();
+    }
+  }
+
+  @Override
+  public ChannelConfig config() {
+    return config;
+  }
+
+  @Override
+  public Channel read() {
+    if (channelReadCallback != null) {
+      channelReadCallback.onRead();
+    } else {
+      queuedOnReads++;
+    }
+    return this;
+  }
+}
+
+/**
+ * An implementation of {@link ByteBuf} that forces {@link NettyRequest} to make a copy of the data.
+ */
+class CopyForcingByteBuf extends UnpooledHeapByteBuf {
+  private static final ByteBufAllocator ALLOC = UnpooledByteBufAllocator.DEFAULT;
+
+  /**
+   * Returns a {@link ByteBuf} that will not expose the underlying buffer through {@link #nioBuffer()} if {@code length}
+   * is greater than 0.
+   * @param array the backing byte array.
+   * @param offset the offset in the array from which the data is valid.
+   * @param length the length of data in the array from the {@code offset} which is valid.
+   * @return a {@link ByteBuf} that will not expose the underlying buffer through {@link #nioBuffer()} if {@code length}
+   * is greater than 0.
+   */
+  public static ByteBuf wrappedBuffer(byte[] array, int offset, int length) {
+    if (length == 0) {
+      return Unpooled.EMPTY_BUFFER;
+    }
+    return new CopyForcingByteBuf(ALLOC, array, array.length).slice(offset, length);
+  }
+
+  protected CopyForcingByteBuf(ByteBufAllocator alloc, byte[] initialArray, int maxCapacity) {
+    super(alloc, initialArray, maxCapacity);
+  }
+
+  @Override
+  public int nioBufferCount() {
+    return -1;
   }
 }

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -893,7 +893,7 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
   private void handleRequest(HttpRequest httpRequest)
       throws Exception {
     writeCallbacksToVerify.clear();
-    request = new NettyRequest(httpRequest, nettyMetrics);
+    request = new NettyRequest(httpRequest, ctx.channel(), nettyMetrics);
     restResponseChannel = new NettyResponseChannel(ctx, nettyMetrics);
     restResponseChannel.setRequest(request);
     restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, "application/octet-stream");


### PR DESCRIPTION
This change adds backpressure support to `NettyRequest` allowing it to suspend (and resume) reading from the client based on a configurable watermark. This helps keep memory usage at the frontend in check.

This change also adds a test for the corner case where the underlying buffer from Netty's `ByteBuf` cannot be extracted and the data has to be copied.

Built and formatted.

**Primary reviewers : @pnarayanan, @xiahome**
**Expected time to review: 45 - 60 mins**

Adresses #299.  

**Unit test coverage:**

Class | Class, % | Method, % | Line, %
------- | ------------ | -------------- | ----------
NettyRequest | 100% (3/ 3) | 96.4% (27/ 28) | 98.7% (228/ 231)
NettyMultipartRequest | 100% (1/ 1) | 100% (6/ 6) | 92.9% (79/ 85)
