### PR TITLE
Adding REST api support for range requests

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/AdminConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/AdminConfig.java
@@ -26,7 +26,7 @@ public class AdminConfig {
    * Cache validity in seconds for non-private blobs for GET.
    */
   @Config("admin.cache.validity.seconds")
-  @Default("365*24*60*60")
+  @Default("365 * 24 * 60 * 60")
   public final long adminCacheValiditySeconds;
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
@@ -26,7 +26,7 @@ public class FrontendConfig {
    * Cache validity in seconds for non-private blobs for GET.
    */
   @Config("frontend.cache.validity.seconds")
-  @Default("365*24*60*60")
+  @Default("365 * 24 * 60 * 60")
   public final long frontendCacheValiditySeconds;
 
   /**
@@ -40,7 +40,7 @@ public class FrontendConfig {
    * The SecurityServiceFactory that needs to be used by AmbryBlobStorageService to validate requests.
    */
   @Config("frontend.security.service.factory")
-  @Default("com.github.ambry.frontend.AmbryIdConverterFactory")
+  @Default("com.github.ambry.frontend.AmbrySecurityServiceFactory")
   public final String frontendSecurityServiceFactory;
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/rest/ResponseStatus.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/ResponseStatus.java
@@ -30,7 +30,10 @@ public enum ResponseStatus {
    * 202 - Request was accepted.
    */
   Accepted,
-
+  /**
+   * 206 - Partial content.
+   */
+  PartialContent,
   // 3xx
   /**
    * 304 Not Modified
@@ -61,6 +64,10 @@ public enum ResponseStatus {
    * 410 Gone - Resource has been deleted or has expired.
    */
   Gone,
+  /**
+   * 416 Range Not Satisfiable - A range request is invalid or outside of the bounds of an object.
+   */
+  RangeNotSatisfiable,
 
   // 5xx
   /**
@@ -92,6 +99,8 @@ public enum ResponseStatus {
         return ResponseStatus.Unauthorized;
       case ResourceScanInProgress:
         return ResponseStatus.ProxyAuthenticationRequired;
+      case RangeNotSatisfiable:
+        return ResponseStatus.RangeNotSatisfiable;
       case IdConverterServiceError:
       case InternalServerError:
       case RequestChannelClosed:

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
@@ -86,7 +86,7 @@ public enum RestServiceErrorCode {
    */
   UnsupportedHttpMethod,
   /**
-   * Range request is not satisfiable (because the provided range is invalid or outside of the bounds of an object.
+   * Range request is not satisfiable (because the provided range is invalid or outside of the bounds of an object.)
    */
   RangeNotSatisfiable,
 
@@ -141,6 +141,7 @@ public enum RestServiceErrorCode {
       case OperationTimedOut:
       case RouterClosed:
       case UnexpectedInternalError:
+      case ChannelClosed:
       default:
         return InternalServerError;
     }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
@@ -85,6 +85,10 @@ public enum RestServiceErrorCode {
    * Client is requesting a HTTP method that is not supported.
    */
   UnsupportedHttpMethod,
+  /**
+   * Range request is not satisfiable (because the provided range is invalid or outside of the bounds of an object.
+   */
+  RangeNotSatisfiable,
 
   /**
    * Generic InternalServerError that is a result of problems on the server side that is not caused by the client and
@@ -130,6 +134,8 @@ public enum RestServiceErrorCode {
         return Deleted;
       case BlobDoesNotExist:
         return NotFound;
+      case RangeNotSatisfiable:
+        return RangeNotSatisfiable;
       case AmbryUnavailable:
       case InsufficientCapacity:
       case OperationTimedOut:

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -161,10 +161,11 @@ public class RestUtils {
     public final static String USER_METADATA_PART = "UserMetadata";
   }
 
+  public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
+  public static final String BYTE_RANGE_UNITS = "bytes";
   private static final int CRC_SIZE = 8;
   private static final short USER_METADATA_VERSION_V1 = 1;
-  private static final String BYTE_RANGE_PREFIX = "bytes=";
-  public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
+  private static final String BYTE_RANGE_PREFIX = BYTE_RANGE_UNITS + "=";
   private static Logger logger = LoggerFactory.getLogger(RestUtils.class);
 
   /**
@@ -364,7 +365,8 @@ public class RestUtils {
 
   /**
    * Build a {@link GetBlobOptions} object from an argument map for a certain sub-resource.
-   * @param args the arguments associated with the request.
+   * @param args the arguments associated with the request. This is typically a map of header names and query string
+   *             arguments to values.
    * @param subResource the {@link SubResource} for the request, or {@code null} if no sub-resource is requested.
    * @return a populated {@link GetBlobOptions} object.
    * @throws RestServiceException if the {@link GetBlobOptions} could not be constructed.
@@ -390,7 +392,8 @@ public class RestUtils {
    * @return the content range header value.
    */
   public static String buildContentRangeHeader(ByteRange resolvedByteRange, long blobSize) {
-    return "bytes " + resolvedByteRange.getStartOffset() + "-" + resolvedByteRange.getEndOffset() + "/" + blobSize;
+    return BYTE_RANGE_UNITS + " " + resolvedByteRange.getStartOffset() + "-" + resolvedByteRange.getEndOffset() + "/"
+        + blobSize;
   }
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -187,7 +187,6 @@ public class RestUtils {
             RestServiceErrorCode.InvalidArgs);
       }
     } catch (NumberFormatException e) {
-      System.out.println("WHAT HAPPENED? " + e);
       throw new RestServiceException(Headers.BLOB_SIZE + "[" + blobSizeStr + "] could not parsed into a number",
           RestServiceErrorCode.InvalidArgs);
     }
@@ -531,21 +530,23 @@ public class RestUtils {
       throw new RestServiceException("Invalid byte range syntax; does not start with '" + BYTE_RANGE_PREFIX + "'",
           RestServiceErrorCode.InvalidArgs);
     }
+    ByteRange range;
     try {
       int hyphenIndex = rangeHeaderValue.indexOf('-', BYTE_RANGE_PREFIX.length());
       String startOffsetStr = rangeHeaderValue.substring(BYTE_RANGE_PREFIX.length(), hyphenIndex);
       String endOffsetStr = rangeHeaderValue.substring(hyphenIndex + 1);
       if (startOffsetStr.isEmpty()) {
-        return ByteRange.fromLastNBytes(Long.parseLong(endOffsetStr));
+        range = ByteRange.fromLastNBytes(Long.parseLong(endOffsetStr));
       } else if (endOffsetStr.isEmpty()) {
-        return ByteRange.fromStartOffset(Long.parseLong(startOffsetStr));
+        range = ByteRange.fromStartOffset(Long.parseLong(startOffsetStr));
       } else {
-        return ByteRange.fromOffsetRange(Long.parseLong(startOffsetStr), Long.parseLong(endOffsetStr));
+        range = ByteRange.fromOffsetRange(Long.parseLong(startOffsetStr), Long.parseLong(endOffsetStr));
       }
     } catch (Exception e) {
       throw new RestServiceException(
           "Valid byte range could not be parsed from Range header value: " + rangeHeaderValue,
           RestServiceErrorCode.InvalidArgs);
     }
+    return range;
   }
 }

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -23,15 +23,12 @@ import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Random;
 import java.util.TimeZone;
 import org.json.JSONException;
@@ -562,7 +559,7 @@ public class RestUtilsTest {
     String[] badRanges = {"bytes=0-abcd", "bytes=0as23-44444444",
         "bytes=22-7777777777777777777777777777777777777777777", "bytes=22--53", "bytes=223-34", "bytes=-34ab",
         "bytes=--12", "bytes=-12-", "bytes=12ab-", "bytes=---", "btes=3-5", "bytes=345", "bytes=3.14-22",
-        "bytes=3-6.2"};
+        "bytes=3-6.2", "bytes=", "bytes=-", "bytes= -"};
     for (String badRange : badRanges) {
       doBuildGetBlobOptionsTest(badRange, null, false, false);
     }

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -561,7 +561,8 @@ public class RestUtilsTest {
     // bad ranges
     String[] badRanges = {"bytes=0-abcd", "bytes=0as23-44444444",
         "bytes=22-7777777777777777777777777777777777777777777", "bytes=22--53", "bytes=223-34", "bytes=-34ab",
-        "bytes=--12", "bytes=-12-", "bytes=12ab-", "bytes=---", "btes=3-5", "bytes=345"};
+        "bytes=--12", "bytes=-12-", "bytes=12ab-", "bytes=---", "btes=3-5", "bytes=345", "bytes=3.14-22",
+        "bytes=3-6.2"};
     for (String badRange : badRanges) {
       doBuildGetBlobOptionsTest(badRange, null, false, false);
     }

--- a/ambry-api/src/test/java/com.github.ambry/router/InMemoryRouter.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/InMemoryRouter.java
@@ -100,6 +100,9 @@ public class InMemoryRouter implements Router {
       return userMetadata;
     }
 
+    /**
+     * @return the entire blob as a {@link ByteBuffer}
+     */
     public ByteBuffer getBlob() {
       return ByteBuffer.wrap(blob.array());
     }
@@ -108,17 +111,12 @@ public class InMemoryRouter implements Router {
      * @param range the {@link ByteRange} for the blob, or null.
      * @return the blob content within the provided range, or the entire blob, if the range is null.
      */
-    public ByteBuffer getBlobRange(ByteRange range) {
-//      ByteBuffer blobBuffer = getBlob();
+    public ByteBuffer getBlob(ByteRange range) {
       if (range == null) {
         return getBlob();
       }
       ByteRange resolvedRange = range.toResolvedByteRange(blob.array().length);
-      return ByteBuffer.wrap(Arrays
-          .copyOfRange(blob.array(), (int) resolvedRange.getStartOffset(), (int) resolvedRange.getEndOffset() + 1));
-//      blobBuffer.position((int) resolvedRange.getStartOffset());
-//      blobBuffer.limit((int) resolvedRange.getEndOffset() + 1);
-//      return blobBuffer.slice();
+      return ByteBuffer.wrap(blob.array(), (int) resolvedRange.getStartOffset(), (int) resolvedRange.getRangeSize());
     }
   }
 
@@ -147,13 +145,13 @@ public class InMemoryRouter implements Router {
           InMemoryBlob blob = blobs.get(blobId);
           switch (options.getOperationType()) {
             case Data:
-              blobDataChannel = new ByteBufferRSC(blob.getBlobRange(options.getRange()));
+              blobDataChannel = new ByteBufferRSC(blob.getBlob(options.getRange()));
               break;
             case BlobInfo:
               blobInfo = new BlobInfo(blob.getBlobProperties(), blob.getUserMetadata());
               break;
             case All:
-              blobDataChannel = new ByteBufferRSC(blob.getBlobRange(options.getRange()));
+              blobDataChannel = new ByteBufferRSC(blob.getBlob(options.getRange()));
               blobInfo = new BlobInfo(blob.getBlobProperties(), blob.getUserMetadata());
               break;
           }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -32,7 +32,6 @@ import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.rest.SecurityService;
 import com.github.ambry.rest.SecurityServiceFactory;
-import com.github.ambry.router.ByteRange;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.GetBlobOptions;
 import com.github.ambry.router.GetBlobResult;

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -27,6 +27,7 @@ import com.github.ambry.rest.SecurityService;
 import com.github.ambry.router.ByteRange;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.FutureResult;
+import com.github.ambry.router.GetBlobOptions;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.util.Date;
@@ -108,7 +109,8 @@ class AmbrySecurityService implements SecurityService {
             responseChannel.setStatus(ResponseStatus.Ok);
             responseChannel.setHeader(RestUtils.Headers.LAST_MODIFIED,
                 new Date(blobInfo.getBlobProperties().getCreationTimeInMs()));
-            setHeadResponseHeaders(blobInfo, responseChannel);
+            setHeadResponseHeaders(blobInfo, RestUtils.buildGetBlobOptions(restRequest.getArgs(), null),
+                responseChannel);
             break;
           case GET:
             responseChannel.setStatus(ResponseStatus.Ok);
@@ -121,9 +123,13 @@ class AmbrySecurityService implements SecurityService {
                 responseChannel.setStatus(ResponseStatus.NotModified);
                 responseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
               } else {
+                GetBlobOptions options = RestUtils.buildGetBlobOptions(restRequest.getArgs(), null);
+                if (options.getRange() != null) {
+                  responseChannel.setStatus(ResponseStatus.PartialContent);
+                }
                 responseChannel.setHeader(RestUtils.Headers.LAST_MODIFIED,
                     new Date(blobInfo.getBlobProperties().getCreationTimeInMs()));
-                setGetBlobResponseHeaders(blobInfo, restRequest, responseChannel);
+                setGetBlobResponseHeaders(blobInfo, options, responseChannel);
               }
               responseChannel.setHeader(RestUtils.Headers.ACCEPT_RANGES, "bytes");
             } else {
@@ -176,9 +182,12 @@ class AmbrySecurityService implements SecurityService {
   /**
    * Sets the required headers in the HEAD response.
    * @param blobInfo the {@link BlobInfo} to refer to while setting headers.
+   * @param options the {@link GetBlobOptions} associated with the request.
+   * @param restResponseChannel the {@link RestResponseChannel} to set headers on.
    * @throws RestServiceException if there was any problem setting the headers.
    */
-  private void setHeadResponseHeaders(BlobInfo blobInfo, RestResponseChannel restResponseChannel)
+  private void setHeadResponseHeaders(BlobInfo blobInfo, GetBlobOptions options,
+      RestResponseChannel restResponseChannel)
       throws RestServiceException {
     BlobProperties blobProperties = blobInfo.getBlobProperties();
     restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, blobProperties.getBlobSize());
@@ -186,30 +195,29 @@ class AmbrySecurityService implements SecurityService {
       restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, blobProperties.getContentType());
     }
     restResponseChannel.setHeader(RestUtils.Headers.ACCEPT_RANGES, "bytes");
+    if (options.getRange() != null) {
+      setContentRangeHeader(options.getRange(), blobProperties.getBlobSize(), restResponseChannel);
+    }
     setBlobPropertiesHeaders(blobProperties, restResponseChannel);
   }
 
   /**
    * Sets the required headers in the response.
    * @param blobInfo the {@link BlobInfo} to refer to while setting headers.
+   * @param options the {@link GetBlobOptions} associated with the request.
+   * @param restResponseChannel the {@link RestResponseChannel} to set headers on.
    * @throws RestServiceException if there was any problem setting the headers.
    */
-  private void setGetBlobResponseHeaders(BlobInfo blobInfo, RestRequest restRequest,
+  private void setGetBlobResponseHeaders(BlobInfo blobInfo, GetBlobOptions options,
       RestResponseChannel restResponseChannel)
       throws RestServiceException {
     BlobProperties blobProperties = blobInfo.getBlobProperties();
     restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, blobProperties.getBlobSize());
-    long blobSize = blobProperties.getBlobSize();
-    long contentLength = blobSize;
-    if (restRequest.getArgs().containsKey(RestUtils.Headers.RANGE)) {
-      restResponseChannel.setStatus(ResponseStatus.PartialContent);
-      ByteRange range =
-          RestUtils.buildByteRange(restRequest.getArgs()).toResolvedByteRange(blobSize);
-      contentLength = range.getRangeSize();
-      restResponseChannel.setHeader(RestUtils.Headers.CONTENT_RANGE,
-          RestUtils.buildContentRangeHeader(range, blobSize));
+    long contentLength = blobProperties.getBlobSize();
+    if (options.getRange() != null) {
+      contentLength = setContentRangeHeader(options.getRange(), blobProperties.getBlobSize(), restResponseChannel);
     }
-    if (blobProperties.getBlobSize() < frontendConfig.frontendChunkedGetResponseThresholdInBytes) {
+    if (contentLength < frontendConfig.frontendChunkedGetResponseThresholdInBytes) {
       restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, contentLength);
     }
     if (blobProperties.getContentType() != null) {
@@ -229,6 +237,27 @@ class AmbrySecurityService implements SecurityService {
       restResponseChannel
           .setHeader(RestUtils.Headers.CACHE_CONTROL, "max-age=" + frontendConfig.frontendCacheValiditySeconds);
     }
+  }
+
+  /**
+   * Set the Content-Range header in the response to reflect the given {@link ByteRange} and blob size.
+   * @param range the {@link ByteRange} for the request.
+   * @param blobSize the total size of the blob, in bytes.
+   * @param restResponseChannel the {@link RestResponseChannel} to set the header on.
+   * @return the total size of the requested range, in bytes.
+   * @throws RestServiceException if the range could not be resolved with the given blob size, or the header could not
+   *                              be set.
+   */
+  private long setContentRangeHeader(ByteRange range, long blobSize, RestResponseChannel restResponseChannel)
+      throws RestServiceException {
+    try {
+      range = range.toResolvedByteRange(blobSize);
+    } catch (IllegalArgumentException e) {
+      throw new RestServiceException("Range provided was not satisfiable.", e,
+          RestServiceErrorCode.RangeNotSatisfiable);
+    }
+    restResponseChannel.setHeader(RestUtils.Headers.CONTENT_RANGE, RestUtils.buildContentRangeHeader(range, blobSize));
+    return range.getRangeSize();
   }
 
   /**

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -131,7 +131,6 @@ class AmbrySecurityService implements SecurityService {
                     new Date(blobInfo.getBlobProperties().getCreationTimeInMs()));
                 setGetBlobResponseHeaders(blobInfo, options, responseChannel);
               }
-              responseChannel.setHeader(RestUtils.Headers.ACCEPT_RANGES, "bytes");
             } else {
               responseChannel.setHeader(RestUtils.Headers.LAST_MODIFIED,
                   new Date(blobInfo.getBlobProperties().getCreationTimeInMs()));
@@ -190,14 +189,15 @@ class AmbrySecurityService implements SecurityService {
       RestResponseChannel restResponseChannel)
       throws RestServiceException {
     BlobProperties blobProperties = blobInfo.getBlobProperties();
-    restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, blobProperties.getBlobSize());
     if (blobProperties.getContentType() != null) {
       restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, blobProperties.getContentType());
     }
-    restResponseChannel.setHeader(RestUtils.Headers.ACCEPT_RANGES, "bytes");
+    restResponseChannel.setHeader(RestUtils.Headers.ACCEPT_RANGES, RestUtils.BYTE_RANGE_UNITS);
+    long contentLength = blobProperties.getBlobSize();
     if (options.getRange() != null) {
-      setContentRangeHeader(options.getRange(), blobProperties.getBlobSize(), restResponseChannel);
+      contentLength = setContentRangeHeader(options.getRange(), blobProperties.getBlobSize(), restResponseChannel);
     }
+    restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, contentLength);
     setBlobPropertiesHeaders(blobProperties, restResponseChannel);
   }
 
@@ -213,6 +213,7 @@ class AmbrySecurityService implements SecurityService {
       throws RestServiceException {
     BlobProperties blobProperties = blobInfo.getBlobProperties();
     restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, blobProperties.getBlobSize());
+    restResponseChannel.setHeader(RestUtils.Headers.ACCEPT_RANGES, RestUtils.BYTE_RANGE_UNITS);
     long contentLength = blobProperties.getBlobSize();
     if (options.getRange() != null) {
       contentLength = setContentRangeHeader(options.getRange(), blobProperties.getBlobSize(), restResponseChannel);

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -269,8 +269,8 @@ public class AmbryBlobStorageServiceTest {
       RestRequest restRequest = createRestRequest(RestMethod.GET, "/", null, null);
       assertTrue("RestRequest channel is not open", restRequest.isOpen());
       MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
-      ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null,
-          new RuntimeException(exceptionMsg));
+      ambryBlobStorageService
+          .submitResponse(restRequest, restResponseChannel, null, new RuntimeException(exceptionMsg));
       assertEquals("Unexpected exception message", exceptionMsg, restResponseChannel.getException().getMessage());
 
       // there is no exception and exception thrown when the response is submitted.
@@ -1214,7 +1214,8 @@ class FrontendTestSecurityServiceFactory implements SecurityServiceFactory {
     /**
      * Works in {@link SecurityService#processRequest(RestRequest, Callback)}.
      */
-    Request, /**
+    Request,
+    /**
      * Works in {@link SecurityService#processResponse(RestRequest, RestResponseChannel, BlobInfo, Callback)}.
      */
     Response
@@ -1414,7 +1415,9 @@ class FrontendTestRouter implements Router {
    * Enumerates the different operation types in the router.
    */
   enum OpType {
-    DeleteBlob, GetBlob, PutBlob
+    DeleteBlob,
+    GetBlob,
+    PutBlob
   }
 
   public OpType exceptionOpType = null;

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -497,7 +497,7 @@ public class AmbryBlobStorageServiceTest {
       doOperation(createRestRequest(RestMethod.GET, "/", headers, null), new MockRestResponseChannel());
       fail("GET operation should have failed because of an invalid range header");
     } catch (RestServiceException e) {
-      assertEquals("Unexpected error code", RestServiceErrorCode.RangeNotSatisfiable, e.getErrorCode());
+      assertEquals("Unexpected error code", RestServiceErrorCode.InvalidArgs, e.getErrorCode());
     }
   }
   // helpers

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -488,6 +488,10 @@ public class AmbryBlobStorageServiceTest {
     doRouterExceptionPipelineTest(testRouter, exceptionMsg);
   }
 
+  /**
+   * Test that GET operations fail with the expected error code when a bad range header is provided.
+   * @throws Exception
+   */
   @Test
   public void badRangeHeaderTest()
       throws Exception {
@@ -765,8 +769,7 @@ public class AmbryBlobStorageServiceTest {
         restResponseChannel.getHeader(RestUtils.Headers.BLOB_SIZE));
     assertNull("Content-Type should have been null", restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
     assertEquals("No content expected as blob is not modified", 0, restResponseChannel.getResponseBody().length);
-    assertEquals("Accept-Ranges not set correctly", "bytes",
-        restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
+    assertNull("Accept-Ranges should not be set", restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
     assertNull("Content-Range header should not be set",
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
   }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -372,8 +372,8 @@ public class AmbrySecurityServiceTest {
     Assert.assertTrue("Callback should have been invoked", callback.callbackLatch.await(1, TimeUnit.SECONDS));
     Assert.assertNull("Exception should not have been thrown", callback.exception);
     if (ifModifiedSinceMs >= blobInfo.getBlobProperties().getCreationTimeInMs()) {
-      Assert.assertEquals("Not modified response expected", ResponseStatus.NotModified,
-          restResponseChannel.getStatus());
+      Assert
+          .assertEquals("Not modified response expected", ResponseStatus.NotModified, restResponseChannel.getStatus());
       verifyHeadersForGetBlobNotModified(restResponseChannel);
     } else {
       Assert.assertEquals("Not modified response should not be returned", ResponseStatus.Ok,
@@ -472,8 +472,8 @@ public class AmbrySecurityServiceTest {
     securityService.processResponse(restRequest, restResponseChannel, DEFAULT_INFO, callback).get();
     Assert.assertTrue("Callback should have been invoked", callback.callbackLatch.await(1, TimeUnit.SECONDS));
     Assert.assertNull("Exception should not have been thrown", callback.exception);
-    Assert.assertEquals("Response status should have been set", ResponseStatus.Created,
-        restResponseChannel.getStatus());
+    Assert
+        .assertEquals("Response status should have been set", ResponseStatus.Created, restResponseChannel.getStatus());
     Assert.assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
     Assert.assertEquals("Creation time should have been set correctly",
         RestUtils.toSecondsPrecisionInMs(DEFAULT_INFO.getBlobProperties().getCreationTimeInMs()),
@@ -610,8 +610,8 @@ public class AmbrySecurityServiceTest {
       Assert.assertEquals("Cache-Control value not as expected",
           "max-age=" + FRONTEND_CONFIG.frontendCacheValiditySeconds,
           restResponseChannel.getHeader(RestUtils.Headers.CACHE_CONTROL));
-      Assert.assertNull("Pragma value should not have been set",
-          restResponseChannel.getHeader(RestUtils.Headers.PRAGMA));
+      Assert
+          .assertNull("Pragma value should not have been set", restResponseChannel.getHeader(RestUtils.Headers.PRAGMA));
     }
   }
 
@@ -625,8 +625,8 @@ public class AmbrySecurityServiceTest {
     Assert.assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
     Assert.assertEquals("Content length should have been 0", "0",
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
-    Assert.assertNull("Accept-Ranges should not be set",
-        restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
+    Assert
+        .assertNull("Accept-Ranges should not be set", restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
     Assert.assertNull("Content-Range header should not be set",
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
     verifyAbsenceOfHeaders(restResponseChannel, RestUtils.Headers.LAST_MODIFIED, RestUtils.Headers.BLOB_SIZE,

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -28,6 +28,7 @@ import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.rest.SecurityService;
+import com.github.ambry.router.ByteRange;
 import com.github.ambry.router.Callback;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
@@ -42,6 +43,7 @@ import java.util.TimeZone;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import junit.framework.Assert;
@@ -118,7 +120,8 @@ public class AmbrySecurityServiceTest {
     // security service closed
     securityService.close();
     for (RestMethod restMethod : methods) {
-      testExceptionCasesProcessRequest(createRestRequest(restMethod, "/", null) ,RestServiceErrorCode.ServiceUnavailable);
+      testExceptionCasesProcessRequest(createRestRequest(restMethod, "/", null),
+          RestServiceErrorCode.ServiceUnavailable);
     }
   }
 
@@ -194,27 +197,27 @@ public class AmbrySecurityServiceTest {
     blobInfo = new BlobInfo(
         new BlobProperties(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes - 1, SERVICE_ID, OWNER_ID,
             "image/gif", false, 10000), null);
-    testGetBlob(blobInfo);
+    testGetBlobWithVariousRanges(blobInfo);
     // == chunk threshold size
     blobInfo = new BlobInfo(
         new BlobProperties(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes, SERVICE_ID, OWNER_ID,
             "image/gif", false, 10000), null);
-    testGetBlob(blobInfo);
+    testGetBlobWithVariousRanges(blobInfo);
     // more than chunk threshold size
     blobInfo = new BlobInfo(
         new BlobProperties(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes * 2, SERVICE_ID, OWNER_ID,
             "image/gif", false, 10000), null);
-    testGetBlob(blobInfo);
+    testGetBlobWithVariousRanges(blobInfo);
     // Get blob with content type null
     blobInfo = new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, null, true, 10000), null);
-    testGetBlob(blobInfo);
+    testGetBlobWithVariousRanges(blobInfo);
     // Get blob for a private blob
     blobInfo =
         new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, Utils.Infinite_Time), null);
-    testGetBlob(blobInfo);
+    testGetBlobWithVariousRanges(blobInfo);
     // Get blob for a public blob with content type as "text/html"
     blobInfo = new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, "text/html", true, 10000), null);
-    testGetBlob(blobInfo);
+    testGetBlobWithVariousRanges(blobInfo);
     // not modified response
     // > creation time (in secs).
     testGetNotModifiedBlob(DEFAULT_INFO, DEFAULT_INFO.getBlobProperties().getCreationTimeInMs() + 1000);
@@ -299,20 +302,54 @@ public class AmbrySecurityServiceTest {
 
   /**
    * Tests {@link SecurityService#processResponse(RestRequest, RestResponseChannel, BlobInfo, Callback)} for a Get blob
-   * with the passed in {@link BlobInfo}
-   * @param blobInfo the {@link BlobInfo} to be used for the {@link RestRequest}
+   * with the passed in {@link BlobInfo} and various range settings, including no set range (entire blob).
+   * @param blobInfo the {@link BlobInfo} to be used for the {@link RestRequest}s
    * @throws Exception
    */
-  private void testGetBlob(BlobInfo blobInfo)
+  private void testGetBlobWithVariousRanges(BlobInfo blobInfo)
+      throws Exception {
+    long blobSize = blobInfo.getBlobProperties().getBlobSize();
+    testGetBlob(blobInfo, null);
+    testGetBlob(blobInfo, ByteRange.fromStartOffset(ThreadLocalRandom.current().nextLong(blobSize)));
+    testGetBlob(blobInfo, ByteRange.fromLastNBytes(ThreadLocalRandom.current().nextLong(blobSize + 1)));
+    long random1 = ThreadLocalRandom.current().nextLong(blobSize);
+    long random2 = ThreadLocalRandom.current().nextLong(blobSize);
+    testGetBlob(blobInfo, ByteRange.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2)));
+  }
+
+  /**
+   * Tests {@link SecurityService#processResponse(RestRequest, RestResponseChannel, BlobInfo, Callback)} for a Get blob
+   * with the passed in {@link BlobInfo} and {@link ByteRange}
+   * @param blobInfo the {@link BlobInfo} to be used for the {@link RestRequest}
+   * @param range the {@link ByteRange} for the {@link RestRequest}
+   * @throws Exception
+   */
+  private void testGetBlob(BlobInfo blobInfo, ByteRange range)
       throws Exception {
     SecurityServiceCallback callback = new SecurityServiceCallback();
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    RestRequest restRequest = createRestRequest(RestMethod.GET, "/", null);
+    JSONObject headers = null;
+    if (range != null) {
+      headers = new JSONObject();
+      switch (range.getType()) {
+        case LAST_N_BYTES:
+          headers.put(RestUtils.Headers.RANGE, "bytes=-" + range.getLastNBytes());
+          break;
+        case FROM_START_OFFSET:
+          headers.put(RestUtils.Headers.RANGE, "bytes=" + range.getStartOffset() + "-");
+          break;
+        case OFFSET_RANGE:
+          headers.put(RestUtils.Headers.RANGE, "bytes=" + range.getStartOffset() + "-" + range.getEndOffset());
+          break;
+      }
+    }
+    RestRequest restRequest = createRestRequest(RestMethod.GET, "/", headers);
     securityService.processResponse(restRequest, restResponseChannel, blobInfo, callback).get();
     Assert.assertTrue("Callback should have been invoked", callback.callbackLatch.await(1, TimeUnit.SECONDS));
     Assert.assertNull("Exception should not have been thrown", callback.exception);
-    Assert.assertEquals("Response should have been set ", ResponseStatus.Ok, restResponseChannel.getStatus());
-    verifyHeadersForGetBlob(blobInfo.getBlobProperties(), restResponseChannel);
+    Assert.assertEquals("Response should have been set",
+        range == null ? ResponseStatus.Ok : ResponseStatus.PartialContent, restResponseChannel.getStatus());
+    verifyHeadersForGetBlob(blobInfo.getBlobProperties(), range, restResponseChannel);
   }
 
   /**
@@ -343,7 +380,7 @@ public class AmbrySecurityServiceTest {
     } else {
       Assert.assertEquals("Not modified response should not be returned", ResponseStatus.Ok,
           restResponseChannel.getStatus());
-      verifyHeadersForGetBlob(blobInfo.getBlobProperties(), restResponseChannel);
+      verifyHeadersForGetBlob(blobInfo.getBlobProperties(), null, restResponseChannel);
     }
   }
 
@@ -388,7 +425,8 @@ public class AmbrySecurityServiceTest {
     } else {
       verifyAbsenceOfHeaders(restResponseChannel, RestUtils.Headers.PRIVATE, RestUtils.Headers.TTL,
           RestUtils.Headers.SERVICE_ID, RestUtils.Headers.OWNER_ID, RestUtils.Headers.AMBRY_CONTENT_TYPE,
-          RestUtils.Headers.CREATION_TIME, RestUtils.Headers.BLOB_SIZE);
+          RestUtils.Headers.CREATION_TIME, RestUtils.Headers.BLOB_SIZE, RestUtils.Headers.ACCEPT_RANGES,
+          RestUtils.Headers.CONTENT_RANGE);
     }
   }
 
@@ -471,7 +509,8 @@ public class AmbrySecurityServiceTest {
    * @param restResponseChannel {@link MockRestResponseChannel} from which headers are to be verified
    * @throws RestServiceException if there was any problem getting the headers.
    */
-  private void verifyHeadersForGetBlob(BlobProperties blobProperties, MockRestResponseChannel restResponseChannel)
+  private void verifyHeadersForGetBlob(BlobProperties blobProperties, ByteRange range,
+      MockRestResponseChannel restResponseChannel)
       throws RestServiceException {
     Assert.assertEquals("Blob size mismatch ", blobProperties.getBlobSize(),
         Long.parseLong(restResponseChannel.getHeader(RestUtils.Headers.BLOB_SIZE)));
@@ -490,8 +529,22 @@ public class AmbrySecurityServiceTest {
       }
     }
 
+    Assert.assertEquals("Accept ranges header not set correctly", "bytes",
+        restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
+    ByteRange resolvedByteRange = null;
+    if (range != null) {
+      resolvedByteRange = range.toResolvedByteRange(blobProperties.getBlobSize());
+      Assert.assertEquals("Content range header not set correctly for range " + range,
+          RestUtils.buildContentRangeHeader(resolvedByteRange, blobProperties.getBlobSize()),
+          restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
+    } else {
+      Assert.assertNull("Content range header should not be set",
+          restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
+    }
+
     if (blobProperties.getBlobSize() < FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes) {
-      Assert.assertEquals("Content length value mismatch", blobProperties.getBlobSize(),
+      Assert.assertEquals("Content length value mismatch",
+          resolvedByteRange == null ? blobProperties.getBlobSize() : resolvedByteRange.getRangeSize(),
           Integer.parseInt(restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH)));
     } else {
       Assert.assertNull("Content length value should not be set",
@@ -527,6 +580,10 @@ public class AmbrySecurityServiceTest {
     Assert.assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
     Assert.assertEquals("Content length should have been 0", "0",
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
+    Assert.assertEquals("Accept-Ranges not set correctly", "bytes",
+        restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
+    Assert.assertNull("Content-Range header should not be set",
+        restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
     verifyAbsenceOfHeaders(restResponseChannel, RestUtils.Headers.LAST_MODIFIED, RestUtils.Headers.BLOB_SIZE,
         RestUtils.Headers.CONTENT_TYPE, RestUtils.Headers.EXPIRES, RestUtils.Headers.CACHE_CONTROL,
         RestUtils.Headers.PRAGMA);

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -589,7 +589,7 @@ public class AmbrySecurityServiceTest {
     Assert.assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
     Assert.assertEquals("Content length should have been 0", "0",
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
-    Assert.assertEquals("Accept-Ranges not set correctly", "bytes",
+    Assert.assertNull("Accept-Ranges should not be set",
         restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
     Assert.assertNull("Content-Range header should not be set",
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -250,8 +250,8 @@ public class FrontendIntegrationTest {
    */
   private static VerifiableProperties buildFrontendVProps() {
     Properties properties = new Properties();
-    properties.put("rest.server.blob.storage.service.factory",
-        "com.github.ambry.frontend.AmbryBlobStorageServiceFactory");
+    properties
+        .put("rest.server.blob.storage.service.factory", "com.github.ambry.frontend.AmbryBlobStorageServiceFactory");
     properties.put("rest.server.router.factory", "com.github.ambry.router.InMemoryRouterFactory");
     properties.put("netty.server.port", Integer.toString(SERVER_PORT));
     // to test that backpressure does not impede correct operation.

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -428,7 +428,7 @@ public class FrontendIntegrationTest {
     assertEquals("Unexpected response status", HttpResponseStatus.NOT_MODIFIED, response.getStatus());
     assertTrue("No Date header", response.headers().get(RestUtils.Headers.DATE) != null);
     assertNull("No Last-Modified header expected", response.headers().get("Last-Modified"));
-    assertEquals("Accept-Ranges not set correctly", "bytes", response.headers().get(RestUtils.Headers.ACCEPT_RANGES));
+    assertNull("Accept-Ranges should not be set", response.headers().get(RestUtils.Headers.ACCEPT_RANGES));
     assertNull("Content-Range header should not be set", response.headers().get(RestUtils.Headers.CONTENT_RANGE));
     assertNull(RestUtils.Headers.BLOB_SIZE + " should have been null ",
         response.headers().get(RestUtils.Headers.BLOB_SIZE));

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -113,6 +113,7 @@ public class NettyMetrics {
   public final Counter acceptedCount;
   public final Counter createdCount;
   public final Counter okCount;
+  public final Counter partialContentCount;
   public final Counter notModifiedCount;
   public final Counter badRequestCount;
   public final Counter unauthorizedCount;
@@ -121,6 +122,7 @@ public class NettyMetrics {
   public final Counter notFoundCount;
   public final Counter forbiddenCount;
   public final Counter proxyAuthRequiredCount;
+  public final Counter rangeNotSatisfiableCount;
   public final Counter throwableCount;
   public final Counter unknownResponseStatusCount;
   // NettyServer
@@ -272,6 +274,8 @@ public class NettyMetrics {
     acceptedCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "AcceptedCount"));
     createdCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "CreatedCount"));
     okCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "OkCount"));
+    partialContentCount =
+        metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "PartialContentCount"));
     notModifiedCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "NotModifiedCount"));
     badRequestCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "BadRequestCount"));
     unauthorizedCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "UnauthorizedCount"));
@@ -282,6 +286,8 @@ public class NettyMetrics {
     forbiddenCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ForbiddenCount"));
     proxyAuthRequiredCount =
         metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ProxyAuthenticationRequiredCount"));
+    rangeNotSatisfiableCount =
+        metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "RangeNotSatisfiableCount"));
     throwableCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ThrowableCount"));
     unknownResponseStatusCount =
         metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "UnknownResponseStatusCount"));

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -438,6 +438,10 @@ class NettyResponseChannel implements RestResponseChannel {
         nettyMetrics.acceptedCount.inc();
         status = HttpResponseStatus.ACCEPTED;
         break;
+      case PartialContent:
+        nettyMetrics.partialContentCount.inc();
+        status = HttpResponseStatus.PARTIAL_CONTENT;
+        break;
       case NotModified:
         nettyMetrics.notModifiedCount.inc();
         status = HttpResponseStatus.NOT_MODIFIED;
@@ -465,6 +469,10 @@ class NettyResponseChannel implements RestResponseChannel {
       case ProxyAuthenticationRequired:
         nettyMetrics.proxyAuthRequiredCount.inc();
         status = HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED;
+        break;
+      case RangeNotSatisfiable:
+        nettyMetrics.rangeNotSatisfiableCount.inc();
+        status = HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE;
         break;
       case InternalServerError:
         nettyMetrics.internalServerErrorCount.inc();

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -77,6 +77,8 @@ public class NettyResponseChannelTest {
     REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.ResourceDirty, HttpResponseStatus.FORBIDDEN);
     REST_ERROR_CODE_TO_HTTP_STATUS
         .put(RestServiceErrorCode.InternalServerError, HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    REST_ERROR_CODE_TO_HTTP_STATUS
+        .put(RestServiceErrorCode.RangeNotSatisfiable, HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
   }
 
   /**
@@ -695,9 +697,9 @@ public class NettyResponseChannelTest {
         while (channel.readOutbound() != null) {
         }
       }
-      boolean shouldBeAlive = keepAlive &&
-          !httpMethod.equals(HttpMethod.POST) && !NettyResponseChannel.CLOSE_CONNECTION_ERROR_STATUSES
-          .contains(expectedResponseStatus);
+      boolean shouldBeAlive =
+          keepAlive && !httpMethod.equals(HttpMethod.POST) && !NettyResponseChannel.CLOSE_CONNECTION_ERROR_STATUSES
+              .contains(expectedResponseStatus);
       assertEquals("Channel state (open/close) not as expected", shouldBeAlive, channel.isActive());
       assertEquals("Connection header should be consistent with channel state", shouldBeAlive,
           HttpHeaders.isKeepAlive(response));

--- a/ambry-rest/src/test/java/com.github.ambry.rest/RestTestUtils.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/RestTestUtils.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.rest;
 
+import com.github.ambry.router.ByteRange;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -66,5 +67,21 @@ public class RestTestUtils {
     byte[] bytes = new byte[size];
     new Random().nextBytes(bytes);
     return bytes;
+  }
+
+  /**
+   * Build the range header value from a {@link ByteRange}
+   * @param range the {@link ByteRange} representing the range
+   * @return
+   */
+  public static String getRangeHeaderString(ByteRange range) {
+    switch (range.getType()) {
+      case LAST_N_BYTES:
+        return "bytes=-" + range.getLastNBytes();
+      case FROM_START_OFFSET:
+        return "bytes=" + range.getStartOffset() + "-";
+      default:
+        return "bytes=" + range.getStartOffset() + "-" + range.getEndOffset();
+    }
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -938,9 +938,7 @@ public class GetBlobOperationTest {
       // If a range is set, compare the result against the specified byte range.
       if (options != null && options.getRange() != null) {
         ByteRange range = options.getRange().toResolvedByteRange(blobSize);
-        int startOffset = (int) range.getStartOffset();
-        int endOffset = (int) range.getEndOffset();
-        putContentBuf = ByteBuffer.wrap(putContent, startOffset, endOffset - startOffset + 1);
+        putContentBuf = ByteBuffer.wrap(putContent, (int) range.getStartOffset(), (int) range.getRangeSize());
       }
       long written;
       Assert.assertTrue("ReadyForPollCallback should have been invoked as readInto() was called",

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -331,9 +331,7 @@ public class GetManagerTest {
     // If a range is set, compare the result against the specified byte range.
     if (options.getRange() != null) {
       ByteRange range = options.getRange().toResolvedByteRange(putContent.length);
-      int startOffset = (int) range.getStartOffset();
-      int endOffset = (int) range.getEndOffset();
-      putContentBuf = ByteBuffer.wrap(putContent, startOffset, endOffset - startOffset + 1);
+      putContentBuf = ByteBuffer.wrap(putContent, (int) range.getStartOffset(), (int) range.getRangeSize());
     }
     ByteBufferAsyncWritableChannel getChannel = new ByteBufferAsyncWritableChannel();
     Future<Long> readIntoFuture = readableStreamChannel.readInto(getChannel, null);


### PR DESCRIPTION
- Added utilities for parsing range headers
- Added support for range related status codes (206/416)
- Added code for setting range option and relevant response headers in
  ambry-frontend.
- Added unit/integration tests for range requests.

**Time to review:** 30 min.

**Primary reviewers:** @vgkholla, @xiahome 

**Coverage:**
All new lines covered.

| Class                   | Class, %      | Method, %      | Line, %          |
|-------------------------|---------------|----------------|------------------|
| NettyMetrics            | 100% (2/ 2)   | 75% (3/ 4)     | 99.3% (134/ 135) |
| NettyResponseChannel    | 100% (8/ 8)   | 100% (40/ 40)  | 96.7% (350/ 362) |
| ResponseStatus          | 100% (2/ 2)   | 100% (4/ 4)    | 100% (24/ 24)    |
| RestServiceErrorCode    | 100% (2/ 2)   | 100% (4/ 4)    | 84.6% (22/ 26)   |
| RestUtils               | 50% (2/ 4)    | 82.4% (14/ 17) | 98.1% (156/ 159) |
| AmbryBlobStorageService | 100% (13/ 13) | 100% (52/ 52)  | 96.2% (350/ 364) |
| AmbrySecurityService    | 100% (2/ 2)   | 100% (9/ 9)    | 100% (119/ 119)  |
