### PR TITLE
Refactor ResponseHandler class that does failure detection

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/network/NetworkClientErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/NetworkClientErrorCode.java
@@ -14,7 +14,7 @@
 package com.github.ambry.network;
 
 /**
- * Errors that the {@link NetworkClient} can encounter.
+ * Errors that can be received from the NetworkClient.
  */
 public enum NetworkClientErrorCode {
   /**

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -196,7 +196,7 @@ class ReplicaThread implements Runnable {
                 // exception happened in checkout connection phase
                 checkoutConnectionTimeInMs = SystemTime.getInstance().milliseconds() - startTimeInMs;
                 // recording an exception for any replica on a node will record a node timeout failure
-                responseHandler.onRequestResponseException(activeReplicasPerNode.get(0).getReplicaId(), e);
+                responseHandler.onEvent(activeReplicasPerNode.get(0).getReplicaId(), e);
               } else if (exchangeMetadataTimeInMs == -1) {
                 // exception happened in exchange metadata phase
                 exchangeMetadataTimeInMs = SystemTime.getInstance().milliseconds() - startTimeInMs;
@@ -286,8 +286,7 @@ class ReplicaThread implements Runnable {
           RemoteReplicaInfo remoteReplicaInfo = replicasToReplicatePerNode.get(i);
           ReplicaMetadataResponseInfo replicaMetadataResponseInfo =
               response.getReplicaMetadataResponseInfoList().get(i);
-          responseHandler
-              .onRequestResponseError(remoteReplicaInfo.getReplicaId(), replicaMetadataResponseInfo.getError());
+          responseHandler.onEvent(remoteReplicaInfo.getReplicaId(), replicaMetadataResponseInfo.getError());
           if (replicaMetadataResponseInfo.getError() == ServerErrorCode.No_Error) {
             try {
               logger.trace("Remote node: {} Thread name: {} Remote replica: {} Token from remote: {} Replica lag: {} ",
@@ -307,7 +306,7 @@ class ReplicaThread implements Runnable {
               replicationMetrics.updateLocalStoreError(remoteReplicaInfo.getReplicaId());
               logger.error("Remote node: " + remoteNode + " Thread name: " + threadName +
                   " Remote replica: " + remoteReplicaInfo.getReplicaId(), e);
-              responseHandler.onRequestResponseException(remoteReplicaInfo.getReplicaId(), e);
+              responseHandler.onEvent(remoteReplicaInfo.getReplicaId(), e);
               ExchangeMetadataResponse exchangeMetadataResponse =
                   new ExchangeMetadataResponse(ServerErrorCode.Unknown_Error);
               exchangeMetadataResponseList.add(exchangeMetadataResponse);
@@ -423,7 +422,7 @@ class ReplicaThread implements Runnable {
       }
       return response;
     } catch (IOException e) {
-      responseHandler.onRequestResponseException(replicasToReplicatePerNode.get(0).getReplicaId(), e);
+      responseHandler.onEvent(replicasToReplicatePerNode.get(0).getReplicaId(), e);
       throw e;
     }
   }
@@ -635,7 +634,7 @@ class ReplicaThread implements Runnable {
       }
       return getResponse;
     } catch (IOException e) {
-      responseHandler.onRequestResponseException(replicasToReplicatePerNode.get(0).getReplicaId(), e);
+      responseHandler.onEvent(replicasToReplicatePerNode.get(0).getReplicaId(), e);
       throw e;
     }
   }
@@ -661,8 +660,7 @@ class ReplicaThread implements Runnable {
         if (exchangeMetadataResponse.missingStoreKeys.size() > 0) {
           PartitionResponseInfo partitionResponseInfo =
               getResponse.getPartitionResponseInfoList().get(partitionResponseInfoIndex);
-          responseHandler
-              .onRequestResponseError(remoteReplicaInfo.getReplicaId(), partitionResponseInfo.getErrorCode());
+          responseHandler.onEvent(remoteReplicaInfo.getReplicaId(), partitionResponseInfo.getErrorCode());
           partitionResponseInfoIndex++;
           if (partitionResponseInfo.getPartition().compareTo(remoteReplicaInfo.getReplicaId().getPartitionId()) != 0) {
             throw new IllegalStateException("The partition id from partitionResponseInfo " +

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -28,7 +28,6 @@ import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Time;
 import java.io.DataInputStream;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -188,15 +187,14 @@ class DeleteManager {
       try {
         deleteResponse =
             DeleteResponse.readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())));
-        responseHandler.onRequestResponseError(replicaId, deleteResponse.getError());
+        responseHandler.onEvent(replicaId, deleteResponse.getError());
       } catch (Exception e) {
         // Ignore. There is no value in notifying the response handler.
         logger.error("Response deserialization received unexpected error", e);
         routerMetrics.responseDeserializationErrorCount.inc();
       }
-    } else if (networkClientErrorCode == NetworkClientErrorCode.NetworkError) {
-      logger.trace("Network client returned a network error, notifying response handler");
-      responseHandler.onRequestResponseException(replicaId, new IOException("NetworkClient error"));
+    } else {
+      responseHandler.onEvent(replicaId, networkClientErrorCode);
     }
     return deleteResponse;
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -28,7 +28,6 @@ import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Time;
 import java.io.DataInputStream;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -115,8 +114,9 @@ class GetManager {
     try {
       GetOperation getOperation;
       if (options.getOperationType() == GetBlobOptions.OperationType.BlobInfo) {
-        getOperation = new GetBlobInfoOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId,
-            options, futureResult, callback, operationCompleteCallback, time);
+        getOperation =
+            new GetBlobInfoOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options,
+                futureResult, callback, operationCompleteCallback, time);
       } else {
         getOperation = new GetBlobOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options,
             futureResult, callback, operationCompleteCallback, readyForPollCallback, blobIdFactory, time);
@@ -212,15 +212,14 @@ class GetManager {
         if (serverError == ServerErrorCode.No_Error) {
           serverError = getResponse.getPartitionResponseInfoList().get(0).getErrorCode();
         }
-        responseHandler.onRequestResponseError(replicaId, serverError);
+        responseHandler.onEvent(replicaId, serverError);
       } catch (Exception e) {
         // Ignore. There is no value in notifying the response handler.
         logger.error("Response deserialization received unexpected error", e);
         routerMetrics.responseDeserializationErrorCount.inc();
       }
-    } else if (networkClientErrorCode == NetworkClientErrorCode.NetworkError) {
-      logger.trace("Network client returned a network error, notifying response handler");
-      responseHandler.onRequestResponseException(replicaId, new IOException("NetworkClient error"));
+    } else {
+      responseHandler.onEvent(replicaId, networkClientErrorCode);
     }
     return getResponse;
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -30,7 +30,6 @@ import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -227,15 +226,14 @@ class PutManager {
     if (networkClientErrorCode == null) {
       try {
         putResponse = PutResponse.readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())));
-        responseHandler.onRequestResponseError(replicaId, putResponse.getError());
+        responseHandler.onEvent(replicaId, putResponse.getError());
       } catch (Exception e) {
         // Ignore. There is no value in notifying the response handler.
         logger.error("Response deserialization received unexpected error", e);
         routerMetrics.responseDeserializationErrorCount.inc();
       }
-    } else if (networkClientErrorCode == NetworkClientErrorCode.NetworkError) {
-      logger.trace("Network client returned a network error, notifying response handler");
-      responseHandler.onRequestResponseException(replicaId, new IOException("NetworkClient error"));
+    } else {
+      responseHandler.onEvent(replicaId, networkClientErrorCode);
     }
     return putResponse;
   }


### PR DESCRIPTION
Add intelligence to the ResponseHandler class to deal with NetworkClient errors; ensure that artificial exceptions and errors do not have to be created by the caller; alleviate the caller from determining whether or not the ResponseHandler should be notified. ResponseHandler is the one that will decide on whether an error or an exception implies Node-Down, Node-Up, Disk-Down and such scenarios, so ensure that that contract is maintained.

Coverage is 100%. Built and tested.