### PR TITLE
Ensure ChannelClosed exception not set when channel is fully read.

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -335,7 +335,8 @@ class GetBlobOperation extends GetOperation {
       if (isOpen) {
         isOpen = false;
         if (numChunksWrittenOut != numChunksTotal) {
-          abort(new RouterException("The ReadableStreamChannel for blob data has been closed by the user.",
+          abort(new RouterException(
+              "The ReadableStreamChannel for blob data has been closed by the user before all chunks were written out.",
               RouterErrorCode.ChannelClosed));
         }
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -333,7 +333,7 @@ class GetBlobOperation extends GetOperation {
     public void close()
         throws IOException {
       isOpen = false;
-      if (!operationCompleted) {
+      if (!readIntoCallbackCalled.get()) {
         abort(new RouterException("The ReadableStreamChannel for blob data has been closed by the user.",
             RouterErrorCode.ChannelClosed));
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -332,10 +332,12 @@ class GetBlobOperation extends GetOperation {
     @Override
     public void close()
         throws IOException {
-      isOpen = false;
-      if (!readIntoCallbackCalled.get()) {
-        abort(new RouterException("The ReadableStreamChannel for blob data has been closed by the user.",
-            RouterErrorCode.ChannelClosed));
+      if (isOpen) {
+        isOpen = false;
+        if (numChunksWrittenOut != numChunksTotal) {
+          abort(new RouterException("The ReadableStreamChannel for blob data has been closed by the user.",
+              RouterErrorCode.ChannelClosed));
+        }
       }
     }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -162,10 +162,17 @@ abstract class GetOperation {
    * previously received exception.
    * @param exception the {@link RouterException} to possibly set.
    */
-  void setOperationException(RouterException exception) {
-    if (operationException.get() == null || exception.getErrorCode() == RouterErrorCode.BlobDeleted
-        || exception.getErrorCode() == RouterErrorCode.BlobExpired) {
-      operationException.set(exception);
+  void setOperationException(Exception exception) {
+    if (exception instanceof RouterException) {
+      RouterErrorCode routerErrorCode = ((RouterException) exception).getErrorCode();
+      if (operationException.get() == null || routerErrorCode == RouterErrorCode.BlobDeleted
+          || routerErrorCode == RouterErrorCode.BlobExpired) {
+        operationException.set(exception);
+      }
+    } else {
+      if (operationException.get() == null) {
+        operationException.set(exception);
+      }
     }
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -652,6 +652,7 @@ public class GetBlobOperationTest {
     }
     try {
       readIntoFuture.get().get();
+      Assert.fail("Expected ExecutionException");
     } catch (ExecutionException e) {
       Assert.assertTrue("Unexpected type for exception: " + e.getCause(),
           e.getCause() instanceof RouterException);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -646,7 +646,7 @@ public class GetBlobOperationTest {
     doPut();
     GetBlobOperation op = createOperationAndComplete(callback);
 
-    readCompleteLatch.await();
+    Assert.assertTrue(readCompleteLatch.await(2, TimeUnit.SECONDS));
     if (callbackException.get() != null) {
       throw callbackException.get();
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -780,7 +780,7 @@ public class GetBlobOperationTest {
               Future<Long> readIntoFuture = initiateReadBeforeChunkGet ? preSetReadIntoFuture
                   : result.getBlobDataChannel().readInto(asyncWritableChannel, new Callback<Long>() {
                     @Override
-                    public void onCompletion(Long p, Exception exception) {
+                    public void onCompletion(Long bytesWritten, Exception exception) {
                       try {
                         result.getBlobDataChannel().close();
                       } catch (IOException e) {

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -581,6 +581,11 @@ public class GetBlobOperationTest {
     testRangeRequestFromStartOffset(maxChunkSize + maxChunkSize / 2, true);
   }
 
+  /**
+   * Test that the operation is completed and an exception with the error code {@link RouterErrorCode#ChannelClosed} is
+   * set when the {@link ReadableStreamChannel} is closed before all chunks are read.
+   * @throws Exception
+   */
   @Test
   public void testEarlyReadableStreamChannelClose()
       throws Exception {

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -646,7 +646,7 @@ public class GetBlobOperationTest {
     doPut();
     GetBlobOperation op = createOperationAndComplete(callback);
 
-    Assert.assertTrue(readCompleteLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue("Timeout waiting for read to complete", readCompleteLatch.await(2, TimeUnit.SECONDS));
     if (callbackException.get() != null) {
       throw callbackException.get();
     }


### PR DESCRIPTION
Previously, a ChannelClosed error could be set even if the channel was fully read because the `readIntoCallback` was called before `operationCompleted` was set. This commit fixes that issue.

**Time to review:** 5 min.
**Reviewer:** @pnarayanan 