### PR TITLE
Fixing blob size header validation issue

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -435,12 +435,24 @@ public class RestUtils {
   }
 
   /**
+   * Reduces the precision of a time in milliseconds to seconds precision. Result returned is in milliseconds with last
+   * three digits 000. Useful for comparing times kept in milliseconds that get converted to seconds and back (as is
+   * done with HTTP date format).
+   *
+   * @param ms time that needs to be parsed
+   * @return milliseconds with seconds precision (last three digits 000).
+   */
+  public static long toSecondsPrecisionInMs(long ms) {
+    return ms - (ms % 1000);
+  }
+
+  /**
    * Parse a blob size string and return the blob size as a number, if valid.
    * @param blobSizeStr a string representing the blob size.
    * @return the blob size as a {@code long}.
    * @throws RestServiceException if a valid blob size could not be parsed.
    */
-  public static long getBlobSize(String blobSizeStr)
+  static long getBlobSize(String blobSizeStr)
       throws RestServiceException {
     try {
       long blobSize = Long.parseLong(blobSizeStr);
@@ -453,17 +465,5 @@ public class RestUtils {
       throw new RestServiceException(Headers.BLOB_SIZE + "[" + blobSizeStr + "] could not parsed into a number",
           RestServiceErrorCode.InvalidArgs);
     }
-  }
-
-  /**
-   * Reduces the precision of a time in milliseconds to seconds precision. Result returned is in milliseconds with last
-   * three digits 000. Useful for comparing times kept in milliseconds that get converted to seconds and back (as is
-   * done with HTTP date format).
-   *
-   * @param ms time that needs to be parsed
-   * @return milliseconds with seconds precision (last three digits 000).
-   */
-  public static long toSecondsPrecisionInMs(long ms) {
-    return ms - (ms % 1000);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -103,6 +103,10 @@ public class RestUtils {
      */
     public final static String CREATION_TIME = "x-ambry-creation-time";
     /**
+     * not allowed in request. Detailed message about an error in an error response.
+     */
+    public final static String FAILURE_REASON = "x-ambry-failure-reason";
+    /**
      * prefix for any header to be set as user metadata for the given blob
      */
     public final static String USER_META_DATA_HEADER_PREFIX = "x-ambry-um-";

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -159,20 +159,7 @@ public class RestUtils {
    */
   public static BlobProperties buildBlobProperties(Map<String, Object> args)
       throws RestServiceException {
-    String blobSizeStr = null;
-    long blobSize;
-    try {
-      blobSizeStr = getHeader(args, Headers.BLOB_SIZE, true);
-      blobSize = Long.parseLong(blobSizeStr);
-      if (blobSize < 0) {
-        throw new RestServiceException(Headers.BLOB_SIZE + "[" + blobSize + "] is less than 0",
-            RestServiceErrorCode.InvalidArgs);
-      }
-    } catch (NumberFormatException e) {
-      throw new RestServiceException(Headers.BLOB_SIZE + "[" + blobSizeStr + "] could not parsed into a number",
-          RestServiceErrorCode.InvalidArgs);
-    }
-
+    long blobSize = getBlobSize(getHeader(args, Headers.BLOB_SIZE, true));
     long ttl = Utils.Infinite_Time;
     String ttlStr = getHeader(args, Headers.TTL, false);
     if (ttlStr != null) {
@@ -444,6 +431,27 @@ public class RestUtils {
     } catch (ParseException e) {
       logger.warn("Could not parse milliseconds from an HTTP date header (" + dateString + ").");
       return null;
+    }
+  }
+
+  /**
+   * Parse a blob size string and return the blob size as a number, if valid.
+   * @param blobSizeStr a string representing the blob size.
+   * @return the blob size as a {@code long}.
+   * @throws RestServiceException if a valid blob size could not be parsed.
+   */
+  public static long getBlobSize(String blobSizeStr)
+      throws RestServiceException {
+    try {
+      long blobSize = Long.parseLong(blobSizeStr);
+      if (blobSize < 0) {
+        throw new RestServiceException(Headers.BLOB_SIZE + "[" + blobSize + "] is less than 0",
+            RestServiceErrorCode.InvalidArgs);
+      }
+      return blobSize;
+    } catch (NumberFormatException e) {
+      throw new RestServiceException(Headers.BLOB_SIZE + "[" + blobSizeStr + "] could not parsed into a number",
+          RestServiceErrorCode.InvalidArgs);
     }
   }
 

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -704,23 +704,4 @@ public class RestUtilsTest {
 
     assertEquals("Should have returned null", null, RestUtils.getTimeFromDateString("abc"));
   }
-
-  /**
-   * Tests {@link RestUtils#getBlobSize(String)}.
-   * @throws RestServiceException
-   */
-  @Test
-  public void getBlobSizeTest()
-      throws RestServiceException {
-    Assert.assertEquals("Unexpected blob size parsed", 2345, RestUtils.getBlobSize("2345"));
-    String[] invalidBlobSizeStrs = {"aba123", "12ab", "-1", "ddsdd", "999999999999999999999999999"};
-    for (String blobSizeStr : invalidBlobSizeStrs) {
-      try {
-        RestUtils.getBlobSize(blobSizeStr);
-        fail("blobSize parsing should not have succeeded");
-      } catch (RestServiceException e) {
-        assertEquals("Unexpected error code", RestServiceErrorCode.InvalidArgs, e.getErrorCode());
-      }
-    }
-  }
 }

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.TimeZone;
+import junit.framework.Assert;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -702,5 +703,20 @@ public class RestUtilsTest {
     assertEquals("Should have returned null", null, RestUtils.getTimeFromDateString(dateStr));
 
     assertEquals("Should have returned null", null, RestUtils.getTimeFromDateString("abc"));
+  }
+
+  @Test
+  public void getBlobSizeTest()
+      throws Exception {
+    Assert.assertEquals("Unexpected blob size parsed", 2345, RestUtils.getBlobSize("2345"));
+    String[] invalidBlobSizeStrs = {"aba123", "12ab", "-1", "ddsdd", "999999999999999999999999999"};
+    for (String blobSizeStr : invalidBlobSizeStrs) {
+      try {
+        RestUtils.getBlobSize(blobSizeStr);
+        fail("blobSize parsing should not have succeeded");
+      } catch (RestServiceException e) {
+        assertEquals("Unexpected error code", RestServiceErrorCode.InvalidArgs, e.getErrorCode());
+      }
+    }
   }
 }

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -29,7 +29,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.TimeZone;
-import junit.framework.Assert;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -705,9 +705,13 @@ public class RestUtilsTest {
     assertEquals("Should have returned null", null, RestUtils.getTimeFromDateString("abc"));
   }
 
+  /**
+   * Tests {@link RestUtils#getBlobSize(String)}.
+   * @throws RestServiceException
+   */
   @Test
   public void getBlobSizeTest()
-      throws Exception {
+      throws RestServiceException {
     Assert.assertEquals("Unexpected blob size parsed", 2345, RestUtils.getBlobSize("2345"));
     String[] invalidBlobSizeStrs = {"aba123", "12ab", "-1", "ddsdd", "999999999999999999999999999"};
     for (String blobSizeStr : invalidBlobSizeStrs) {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -142,12 +142,12 @@ class NettyRequest implements RestRequest {
       try {
         size = Long.parseLong(blobSizeStr);
         if (size < 0) {
-          throw new RestServiceException(RestUtils.Headers.BLOB_SIZE + "[" + size + "] is less than 0",
+          throw new RestServiceException(RestUtils.Headers.BLOB_SIZE + " [" + size + "] is less than 0",
               RestServiceErrorCode.InvalidArgs);
         }
       } catch (NumberFormatException e) {
         throw new RestServiceException(
-            RestUtils.Headers.BLOB_SIZE + "[" + blobSizeStr + "] could not parsed into a number",
+            RestUtils.Headers.BLOB_SIZE + " [" + blobSizeStr + "] could not parsed into a number",
             RestServiceErrorCode.InvalidArgs);
       }
     } else {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -104,7 +104,7 @@ class NettyRequest implements RestRequest {
    * @param nettyMetrics the {@link NettyMetrics} instance to use.
    * @throws IllegalArgumentException if {@code request} is null.
    * @throws RestServiceException if the {@link HttpMethod} defined in {@code request} is not recognized as a
-   *                                {@link RestMethod}.
+   *                                {@link RestMethod} or if the {@link RestUtils.Headers#BLOB_SIZE} header is invalid.
    */
   public NettyRequest(HttpRequest request, Channel channel, NettyMetrics nettyMetrics)
       throws RestServiceException {
@@ -138,7 +138,7 @@ class NettyRequest implements RestRequest {
     }
 
     if (HttpHeaders.getHeader(request, RestUtils.Headers.BLOB_SIZE, null) != null) {
-      size = Long.parseLong(HttpHeaders.getHeader(request, RestUtils.Headers.BLOB_SIZE));
+      size = RestUtils.getBlobSize(HttpHeaders.getHeader(request, RestUtils.Headers.BLOB_SIZE));
     } else {
       size = HttpHeaders.getContentLength(request, -1);
     }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -137,8 +137,19 @@ class NettyRequest implements RestRequest {
           RestServiceErrorCode.UnsupportedHttpMethod);
     }
 
-    if (HttpHeaders.getHeader(request, RestUtils.Headers.BLOB_SIZE, null) != null) {
-      size = RestUtils.getBlobSize(HttpHeaders.getHeader(request, RestUtils.Headers.BLOB_SIZE));
+    String blobSizeStr = HttpHeaders.getHeader(request, RestUtils.Headers.BLOB_SIZE, null);
+    if (blobSizeStr != null) {
+      try {
+        size = Long.parseLong(blobSizeStr);
+        if (size < 0) {
+          throw new RestServiceException(RestUtils.Headers.BLOB_SIZE + "[" + size + "] is less than 0",
+              RestServiceErrorCode.InvalidArgs);
+        }
+      } catch (NumberFormatException e) {
+        throw new RestServiceException(
+            RestUtils.Headers.BLOB_SIZE + "[" + blobSizeStr + "] could not parsed into a number",
+            RestServiceErrorCode.InvalidArgs);
+      }
     } else {
       size = HttpHeaders.getContentLength(request, -1);
     }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -401,12 +401,12 @@ class NettyResponseChannel implements RestResponseChannel {
     String fullMsg = "Failure: " + status + errReason;
     logger.trace("Constructed error response for the client - [{}]", fullMsg);
     FullHttpResponse response;
-    if (request != null && !request.getRestMethod().equals(RestMethod.HEAD)) {
-      response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, Unpooled.wrappedBuffer(fullMsg.getBytes()));
-    } else {
+    if (request != null && request.getRestMethod().equals(RestMethod.HEAD)) {
       // for HEAD, we cannot send the actual body but we need to return what the length would have been if this was GET.
       // https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html (Section 9.4)
       response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status);
+    } else {
+      response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, Unpooled.wrappedBuffer(fullMsg.getBytes()));
     }
     HttpHeaders.setDate(response, new GregorianCalendar().getTime());
     HttpHeaders.setContentLength(response, fullMsg.length());

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -65,6 +65,8 @@ import org.slf4j.LoggerFactory;
  * will be accepted and all scheduled writes will be notified of the failure.
  */
 class NettyResponseChannel implements RestResponseChannel {
+  // Detailed message about an error in an error response.
+  static final String FAILURE_REASON_HEADER = "x-failure-reason";
   // add to this list if the connection needs to be closed on certain errors on GET, DELETE and HEAD.
   // for a POST, we always close the connection on error because we expect the channel to be in a bad state.
   static final List<HttpResponseStatus> CLOSE_CONNECTION_ERROR_STATUSES = new ArrayList<>();
@@ -406,12 +408,12 @@ class NettyResponseChannel implements RestResponseChannel {
     HttpHeaders.setDate(response, new GregorianCalendar().getTime());
     HttpHeaders.setContentLength(response, 0);
     if (errReason != null) {
-      HttpHeaders.setHeader(response, RestUtils.Headers.FAILURE_REASON, errReason);
+      HttpHeaders.setHeader(response, FAILURE_REASON_HEADER, errReason);
     }
     HttpHeaders.setHeader(response, HttpHeaders.Names.CONTENT_TYPE, "text/plain; charset=UTF-8");
-    boolean keepAlive = !forceClose && HttpHeaders.isKeepAlive(responseMetadata) &&
-        request != null && !request.getRestMethod().equals(RestMethod.POST) && !CLOSE_CONNECTION_ERROR_STATUSES
-        .contains(status);
+    boolean keepAlive =
+        !forceClose && HttpHeaders.isKeepAlive(responseMetadata) && request != null && !request.getRestMethod()
+            .equals(RestMethod.POST) && !CLOSE_CONNECTION_ERROR_STATUSES.contains(status);
     HttpHeaders.setKeepAlive(response, keepAlive);
     return response;
   }

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
@@ -207,13 +207,16 @@ public class NettyRequestTest {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.UnsupportedHttpMethod, e.getErrorCode());
     }
 
-    // bad blob size
-    try {
-      createNettyRequest(HttpMethod.GET, "/", new DefaultHttpHeaders().add(RestUtils.Headers.BLOB_SIZE, "bad"),
-          new MockChannel());
-      fail("Bad blob size header was supplied to NettyRequest. It should have failed to construct");
-    } catch (RestServiceException e) {
-      assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.InvalidArgs, e.getErrorCode());
+    String[] invalidBlobSizeStrs = {"aba123", "12ab", "-1", "ddsdd", "999999999999999999999999999"};
+    for (String blobSizeStr : invalidBlobSizeStrs) {
+      // bad blob size
+      try {
+        createNettyRequest(HttpMethod.GET, "/", new DefaultHttpHeaders().add(RestUtils.Headers.BLOB_SIZE, blobSizeStr),
+            new MockChannel());
+        fail("Bad blob size header was supplied to NettyRequest. It should have failed to construct");
+      } catch (RestServiceException e) {
+        assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.InvalidArgs, e.getErrorCode());
+      }
     }
   }
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
@@ -206,6 +206,15 @@ public class NettyRequestTest {
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.UnsupportedHttpMethod, e.getErrorCode());
     }
+
+    // bad blob size
+    try {
+      createNettyRequest(HttpMethod.GET, "/", new DefaultHttpHeaders().add(RestUtils.Headers.BLOB_SIZE, "bad"),
+          new MockChannel());
+      fail("Bad blob size header was supplied to NettyRequest. It should have failed to construct");
+    } catch (RestServiceException e) {
+      assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.InvalidArgs, e.getErrorCode());
+    }
   }
 
   /**

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
@@ -207,7 +207,7 @@ public class NettyRequestTest {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.UnsupportedHttpMethod, e.getErrorCode());
     }
 
-    String[] invalidBlobSizeStrs = {"aba123", "12ab", "-1", "ddsdd", "999999999999999999999999999"};
+    String[] invalidBlobSizeStrs = {"aba123", "12ab", "-1", "ddsdd", "999999999999999999999999999", "1.234"};
     for (String blobSizeStr : invalidBlobSizeStrs) {
       // bad blob size
       try {

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -413,7 +413,7 @@ public class NettyResponseChannelTest {
           .createRequest(HttpMethod.HEAD, TestingUri.OnResponseCompleteWithRestException.toString(), httpHeaders));
       HttpResponse response = (HttpResponse) channel.readOutbound();
       assertEquals("Unexpected response status", entry.getValue(), response.getStatus());
-      boolean containsFailureReasonHeader = response.headers().contains(RestUtils.Headers.FAILURE_REASON);
+      boolean containsFailureReasonHeader = response.headers().contains(NettyResponseChannel.FAILURE_REASON_HEADER);
       if (entry.getValue() == HttpResponseStatus.BAD_REQUEST) {
         assertTrue("Could not find failure reason header.", containsFailureReasonHeader);
       } else {


### PR DESCRIPTION
Previously, providing blob size headers with non-parsable values would result in empty responses. This fixes the issue so that the response code is correctly set to 400.

*Time to review:* 5 min.
*Primary reviewers:* @nsivabalan, @vgkholla 
*Testing:* Unit tests and local deployment/curl testing