### PR TITLE
Moving two functions from RSC to RestRequest

### DIFF
--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
@@ -56,7 +56,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
-import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -1281,6 +1280,16 @@ class BadRestRequest extends BadRSC implements RestRequest {
   public RestRequestMetricsTracker getMetricsTracker() {
     return new RestRequestMetricsTracker();
   }
+
+  @Override
+  public void setDigestAlgorithm(String digestAlgorithm) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public byte[] getDigest() {
+    throw new IllegalStateException("Not implemented");
+  }
 }
 
 /**
@@ -1295,17 +1304,6 @@ class BadRSC implements ReadableStreamChannel {
 
   @Override
   public Future<Long> readInto(AsyncWritableChannel asyncWritableChannel, Callback<Long> callback) {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
-  public void setDigestAlgorithm(String digestAlgorithm)
-      throws NoSuchAlgorithmException {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
-  public byte[] getDigest() {
     throw new IllegalStateException("Not implemented");
   }
 

--- a/ambry-api/src/main/java/com.github.ambry/router/ReadableStreamChannel.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/ReadableStreamChannel.java
@@ -14,7 +14,6 @@
 package com.github.ambry.router;
 
 import java.nio.channels.Channel;
-import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.Future;
 
 
@@ -46,33 +45,4 @@ public interface ReadableStreamChannel extends Channel {
    * @return the {@link Future} that will eventually contain the result of the operation.
    */
   public Future<Long> readInto(AsyncWritableChannel asyncWritableChannel, Callback<Long> callback);
-
-  /**
-   * Set the digest algorithm to use on the data that is being streamed from the channel. Once the channel is emptied,
-   * the digest can be obtained via {@link #getDigest()}.
-   * <p/>
-   * This function is ideally called before {@link #readInto(AsyncWritableChannel, Callback)}. After a call to
-   * {@link #readInto(AsyncWritableChannel, Callback)}, some content may have been consumed and getting a digest may no
-   * longer be possible. The safety of doing otherwise depends on the implementation.
-   * @param digestAlgorithm the digest algorithm to use.
-   * @throws NoSuchAlgorithmException if the {@code digestAlgorithm} does not exist or is not supported.
-   * @throws IllegalStateException if {@link #readInto(AsyncWritableChannel, Callback)} has already been called.
-   */
-  public void setDigestAlgorithm(String digestAlgorithm)
-      throws NoSuchAlgorithmException;
-
-  /**
-   * Gets the digest as specified by the digest algorithm set through {@link #setDigestAlgorithm(String)}. If none was
-   * set, returns {@code null}.
-   * <p/>
-   * This function is ideally called after the channel is emptied completely. Otherwise, the complete digest may not
-   * have been calculated yet. The safety of doing otherwise depends on the implementation.
-   * <p/>
-   * "Emptying a channel" refers to awaiting on the future or getting the callback after a
-   * {@link #readInto(AsyncWritableChannel, Callback)} call.
-   * @return the digest as computed by the digest algorithm set through {@link #setDigestAlgorithm(String)}. If none
-   * was set, {@code null}.
-   * @throws IllegalStateException if called before the channel has been emptied.
-   */
-  public byte[] getDigest();
 }

--- a/ambry-api/src/main/java/com.github.ambry/router/RouterErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/RouterErrorCode.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.router;
 
-
 /**
  * All the error codes that accompany a {@link RouterException}.
  */

--- a/ambry-api/src/test/java/com.github.ambry/router/ByteBufferRSC.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/ByteBufferRSC.java
@@ -16,8 +16,6 @@ package com.github.ambry.router;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -63,10 +61,6 @@ public class ByteBufferRSC implements ReadableStreamChannel {
 
   protected final ByteBuffer buffer;
   protected final int size;
-  private final int startPos;
-
-  private MessageDigest digest = null;
-  private byte[] digestBytes = null;
 
   /**
    * Constructs a {@link ReadableStreamChannel} whose read operations return data from the provided {@code buffer}.
@@ -75,7 +69,6 @@ public class ByteBufferRSC implements ReadableStreamChannel {
   public ByteBufferRSC(ByteBuffer buffer) {
     this.buffer = buffer;
     size = buffer.remaining();
-    startPos = buffer.position();
   }
 
   @Override
@@ -102,34 +95,6 @@ public class ByteBufferRSC implements ReadableStreamChannel {
     }
     onEventComplete(Event.ReadInto);
     return future;
-  }
-
-  @Override
-  public void setDigestAlgorithm(String digestAlgorithm)
-      throws NoSuchAlgorithmException {
-    if (digest != null && digest.getAlgorithm().equals(digestAlgorithm)) {
-      onEventComplete(Event.SetDigestAlgorithm);
-      return;
-    }
-    digest = MessageDigest.getInstance(digestAlgorithm);
-    digestBytes = null;
-    onEventComplete(Event.SetDigestAlgorithm);
-  }
-
-  @Override
-  public byte[] getDigest() {
-    if (digest == null) {
-      onEventComplete(Event.GetDigest);
-      return null;
-    } else if (digestBytes == null) {
-      int savedPosition = buffer.position();
-      buffer.position(startPos);
-      digest.update(buffer);
-      buffer.position(savedPosition);
-      digestBytes = digest.digest();
-    }
-    onEventComplete(Event.GetDigest);
-    return digestBytes;
   }
 
   @Override

--- a/ambry-api/src/test/java/com.github.ambry/router/ByteRangeTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/ByteRangeTest.java
@@ -16,7 +16,9 @@ package com.github.ambry.router;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 
 /**

--- a/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
@@ -16,7 +16,8 @@ package com.github.ambry.router;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 
 /**

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ByteBufferReadableStreamChannel.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ByteBufferReadableStreamChannel.java
@@ -20,8 +20,6 @@ import com.github.ambry.router.ReadableStreamChannel;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -34,10 +32,6 @@ public class ByteBufferReadableStreamChannel implements ReadableStreamChannel {
   private final AtomicBoolean channelEmptied = new AtomicBoolean(false);
   private final ByteBuffer buffer;
   private final int size;
-  private final int startPos;
-
-  private MessageDigest digest;
-  private byte[] digestBytes;
 
   /**
    * Constructs a {@link ReadableStreamChannel} whose read operations return data from the provided {@code buffer}.
@@ -46,7 +40,6 @@ public class ByteBufferReadableStreamChannel implements ReadableStreamChannel {
   public ByteBufferReadableStreamChannel(ByteBuffer buffer) {
     this.buffer = buffer;
     size = buffer.remaining();
-    startPos = buffer.position();
   }
 
   @Override
@@ -71,48 +64,6 @@ public class ByteBufferReadableStreamChannel implements ReadableStreamChannel {
       future = asyncWritableChannel.write(buffer, callback);
     }
     return future;
-  }
-
-  /**
-   * {@inheritDoc}
-   * <p/>
-   * This implementation supports setting the digest algorithm at any point in the lifecycle of the object. Digest
-   * algorithms can be changed at will and a subsequent call to {@link #getDigest()} will get the digest as computed
-   * by the algorithm that was set most recently.
-   * @param digestAlgorithm the digest algorithm to use.
-   * @throws NoSuchAlgorithmException if the {@code digestAlgorithm} does not exist or is not supported.
-   */
-  @Override
-  public void setDigestAlgorithm(String digestAlgorithm)
-      throws NoSuchAlgorithmException {
-    if (digest != null && digest.getAlgorithm().equals(digestAlgorithm)) {
-      return;
-    }
-    digest = MessageDigest.getInstance(digestAlgorithm);
-    digestBytes = null;
-  }
-
-  /**
-   * {@inheritDoc}
-   * <p/>
-   * This implementation supports getting the digest at any point in the lifecycle of the object. The digest is always
-   * that of all the data in the channel regardless of how much data has been consumed by
-   * {@link #readInto(AsyncWritableChannel, Callback)}.
-   * @return the digest as computed by the digest algorithm set through {@link #setDigestAlgorithm(String)}. If none
-   * was set, {@code null}.
-   */
-  @Override
-  public byte[] getDigest() {
-    if (digest == null) {
-      return null;
-    } else if (digestBytes == null) {
-      int savedPosition = buffer.position();
-      buffer.position(startPos);
-      digest.update(buffer);
-      buffer.position(savedPosition);
-      digestBytes = digest.digest();
-    }
-    return digestBytes;
   }
 
   @Override

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ReadableStreamChannelInputStreamTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ReadableStreamChannelInputStreamTest.java
@@ -218,16 +218,6 @@ class IncompleteReadReadableStreamChannel implements ReadableStreamChannel {
   }
 
   @Override
-  public void setDigestAlgorithm(String digestAlgorithm) {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
-  public byte[] getDigest() {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
   public boolean isOpen() {
     return channelOpen.get();
   }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -54,7 +54,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
-import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -1274,6 +1273,16 @@ class BadRestRequest extends BadRSC implements RestRequest {
   public RestRequestMetricsTracker getMetricsTracker() {
     return new RestRequestMetricsTracker();
   }
+
+  @Override
+  public void setDigestAlgorithm(String digestAlgorithm) {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public byte[] getDigest() {
+    throw new IllegalStateException("Not implemented");
+  }
 }
 
 /**
@@ -1288,17 +1297,6 @@ class BadRSC implements ReadableStreamChannel {
 
   @Override
   public Future<Long> readInto(AsyncWritableChannel asyncWritableChannel, Callback<Long> callback) {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
-  public void setDigestAlgorithm(String digestAlgorithm)
-      throws NoSuchAlgorithmException {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
-  public byte[] getDigest() {
     throw new IllegalStateException("Not implemented");
   }
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -118,7 +118,8 @@ public class AmbrySecurityServiceTest {
     // security service closed
     securityService.close();
     for (RestMethod restMethod : methods) {
-      testExceptionCasesProcessRequest(createRestRequest(restMethod, "/", null) ,RestServiceErrorCode.ServiceUnavailable);
+      testExceptionCasesProcessRequest(createRestRequest(restMethod, "/", null),
+          RestServiceErrorCode.ServiceUnavailable);
     }
   }
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
@@ -868,15 +868,6 @@ class IncompleteReadReadableStreamChannel implements ReadableStreamChannel {
   }
 
   @Override
-  public void setDigestAlgorithm(String digestAlgorithm) {
-  }
-
-  @Override
-  public byte[] getDigest() {
-    return null;
-  }
-
-  @Override
   public boolean isOpen() {
     return channelOpen.get();
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -341,16 +341,6 @@ class GetBlobOperation extends GetOperation {
       }
     }
 
-    @Override
-    public void setDigestAlgorithm(String digestAlgorithm) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public byte[] getDigest() {
-      throw new UnsupportedOperationException();
-    }
-
     /**
      * @return whether readInto() has been called yet.
      */

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -329,18 +329,18 @@ public class DeleteManagerTest {
     setServerResponse(false);
     testWithErrorCodes(Collections.singletonMap(ServerErrorCode.No_Error, 9), serverLayout,
         RouterErrorCode.OperationTimedOut, new ErrorCodeChecker() {
-      @Override
-      public void testAndAssert(RouterErrorCode expectedError)
-          throws Exception {
-        CountDownLatch operationCompleteLatch = new CountDownLatch(1);
-        future = router.deleteBlob(blobIdString, new ClientCallback(operationCompleteLatch));
-        do {
-          // increment mock time
-          mockTime.sleep(1000);
-        } while (!operationCompleteLatch.await(10, TimeUnit.MILLISECONDS));
-        assertFailureAndCheckErrorCode(future, expectedError);
-      }
-    });
+          @Override
+          public void testAndAssert(RouterErrorCode expectedError)
+              throws Exception {
+            CountDownLatch operationCompleteLatch = new CountDownLatch(1);
+            future = router.deleteBlob(blobIdString, new ClientCallback(operationCompleteLatch));
+            do {
+              // increment mock time
+              mockTime.sleep(1000);
+            } while (!operationCompleteLatch.await(10, TimeUnit.MILLISECONDS));
+            assertFailureAndCheckErrorCode(future, expectedError);
+          }
+        });
   }
 
   /**
@@ -383,14 +383,14 @@ public class DeleteManagerTest {
       throws Exception {
     testWithErrorCodes(Collections.singletonMap(ServerErrorCode.No_Error, 9), serverLayout,
         RouterErrorCode.RouterClosed, new ErrorCodeChecker() {
-      @Override
-      public void testAndAssert(RouterErrorCode expectedError)
-          throws Exception {
-        future = router.deleteBlob(blobIdString);
-        router.close();
-        assertFailureAndCheckErrorCode(future, expectedError);
-      }
-    });
+          @Override
+          public void testAndAssert(RouterErrorCode expectedError)
+              throws Exception {
+            future = router.deleteBlob(blobIdString);
+            router.close();
+            assertFailureAndCheckErrorCode(future, expectedError);
+          }
+        });
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -618,26 +618,26 @@ public class GetBlobOperationTest {
           callbackException.set(exception);
           readCompleteLatch.countDown();
         } else {
-            final ByteBufferAsyncWritableChannel writableChannel = new ByteBufferAsyncWritableChannel();
-            readIntoFuture.set(result.getBlobDataChannel().readInto(writableChannel, null));
-            Utils.newThread(new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  int chunksLeftToRead = numChunksToRead;
-                  while (chunksLeftToRead > 0) {
-                    writableChannel.getNextChunk();
-                    writableChannel.resolveOldestChunk(null);
-                    chunksLeftToRead--;
-                  }
-                  result.getBlobDataChannel().close();
-                } catch (Exception e) {
-                  callbackException.set(e);
-                } finally {
-                  readCompleteLatch.countDown();
+          final ByteBufferAsyncWritableChannel writableChannel = new ByteBufferAsyncWritableChannel();
+          readIntoFuture.set(result.getBlobDataChannel().readInto(writableChannel, null));
+          Utils.newThread(new Runnable() {
+            @Override
+            public void run() {
+              try {
+                int chunksLeftToRead = numChunksToRead;
+                while (chunksLeftToRead > 0) {
+                  writableChannel.getNextChunk();
+                  writableChannel.resolveOldestChunk(null);
+                  chunksLeftToRead--;
                 }
+                result.getBlobDataChannel().close();
+              } catch (Exception e) {
+                callbackException.set(e);
+              } finally {
+                readCompleteLatch.countDown();
               }
-            }, false).start();
+            }
+          }, false).start();
         }
       }
     };
@@ -654,8 +654,7 @@ public class GetBlobOperationTest {
       readIntoFuture.get().get();
       Assert.fail("Expected ExecutionException");
     } catch (ExecutionException e) {
-      Assert.assertTrue("Unexpected type for exception: " + e.getCause(),
-          e.getCause() instanceof RouterException);
+      Assert.assertTrue("Unexpected type for exception: " + e.getCause(), e.getCause() instanceof RouterException);
       Assert.assertEquals("Unexpected RouterErrorCode", RouterErrorCode.ChannelClosed,
           ((RouterException) e.getCause()).getErrorCode());
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
@@ -14,7 +14,6 @@
 package com.github.ambry.router;
 
 import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ServerErrorCode;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.BlobType;

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -895,16 +895,6 @@ class MockReadableStreamChannel implements ReadableStreamChannel {
     return returnedFuture;
   }
 
-  @Override
-  public void setDigestAlgorithm(String digestAlgorithm) {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
-  public byte[] getDigest() {
-    throw new IllegalStateException("Not implemented");
-  }
-
   /**
    * {@inheritDoc}
    */

--- a/ambry-tools/src/main/java/com.github.ambry.tools/perf/rest/PerfNioServer.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/perf/rest/PerfNioServer.java
@@ -30,7 +30,6 @@ import com.github.ambry.utils.Time;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -291,14 +290,13 @@ class PerfNioServer implements NioServer {
     }
 
     @Override
-    public void setDigestAlgorithm(String digestAlgorithm)
-        throws NoSuchAlgorithmException {
-      readableStreamChannel.setDigestAlgorithm(digestAlgorithm);
+    public void setDigestAlgorithm(String digestAlgorithm) {
+      // no op;
     }
 
     @Override
     public byte[] getDigest() {
-      return readableStreamChannel.getDigest();
+      return null;
     }
 
     /**

--- a/ambry-tools/src/main/java/com.github.ambry.tools/perf/rest/PerfRSC.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/perf/rest/PerfRSC.java
@@ -19,7 +19,6 @@ import com.github.ambry.router.FutureResult;
 import com.github.ambry.router.ReadableStreamChannel;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
-import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -74,17 +73,6 @@ class PerfRSC implements ReadableStreamChannel {
       throw new IllegalStateException("ReadInto should not be called more than once");
     }
     return futureResult;
-  }
-
-  @Override
-  public void setDigestAlgorithm(String digestAlgorithm)
-      throws NoSuchAlgorithmException {
-    // no op
-  }
-
-  @Override
-  public byte[] getDigest() {
-    return null;
   }
 
   @Override


### PR DESCRIPTION
Moving `setDigestAlgorithm()` and `getDigest()` from `ReadableStreamChannel` to `RestRequest`
After examining the use cases, this seems like the right move since not all channels
need to support digests. It is an overhead for many implementations of `ReadableStreamChannel`.

Built and formatted. 

No new tests required. Code was only removed and tests that were removed only tested the production code that was removed.

Addresses #391 

**Primary reviewers: @pnarayanan, @nsivabalan**
**Expected time to review: < 15 mins**  