### PR TITLE
Make sslConfig agnostic of ssl-enabled DCs and enable router ssl tests

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/DataNodeId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/DataNodeId.java
@@ -51,16 +51,6 @@ public abstract class DataNodeId implements Resource, Comparable<DataNodeId> {
   public abstract boolean hasSSLPort();
 
   /**
-   * Returns the {@link Port} to connect to based on the whether the {@link DataNodeId} belongs to the list of ssl-enabled
-   * Datacenters.
-   * @param sslEnabledDataCenters List of ssl enabled Datacenters.
-   * @return {@link Port} to which the caller can connect to.
-   * @deprecated This method is obsolete. Please use {@link #getPortToConnectTo()} instead.
-   */
-  @Deprecated
-  public abstract Port getPortToConnectTo(ArrayList<String> sslEnabledDataCenters);
-
-  /**
    * Returns the {@link Port} of this node to connect to.
    *
    * @return {@link Port} to which the caller can connect to.

--- a/ambry-api/src/main/java/com.github.ambry/config/SSLConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/SSLConfig.java
@@ -125,13 +125,6 @@ public class SSLConfig {
   @Default("")
   public final String sslCipherSuites;
 
-  /**
-   * List of Datacenters to which local node needs SSL encryption to communicate
-   */
-  @Config("ssl.enabled.datacenters")
-  @Default("")
-  public final String sslEnabledDatacenters;
-
   public SSLConfig(VerifiableProperties verifiableProperties) {
     sslContextProtocol = verifiableProperties.getString("ssl.context.protocol", "TLS");
     sslContextProvider = verifiableProperties.getString("ssl.context.provider", "");
@@ -148,6 +141,5 @@ public class SSLConfig {
     sslTruststorePath = verifiableProperties.getString("ssl.truststore.path", "");
     sslTruststorePassword = verifiableProperties.getString("ssl.truststore.password", "");
     sslCipherSuites = verifiableProperties.getString("ssl.cipher.suites", "");
-    sslEnabledDatacenters = verifiableProperties.getString("ssl.enabled.datacenters", "");
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DataNode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DataNode.java
@@ -156,29 +156,6 @@ public class DataNode extends DataNodeId {
   }
 
   /**
-   * Returns the {@link Port} to connect to based on the whether the {@link DataNodeId} belongs to the list of ssl-enabled
-   * Datacenters.
-   * @param sslEnabledDataCenters List of ssl enabled Datacenters.
-   * @return {@link Port} to which the caller can connect to.
-   * @throws IllegalStateException Thrown if the list dictates that an SSL port must be used, but the {@link DataNodeId}
-   * does not have an SSL port.
-   * @deprecated This method is obsolete. Please use {@link #getPortToConnectTo()} instead.
-   */
-  @Override
-  @Deprecated
-  public Port getPortToConnectTo(ArrayList<String> sslEnabledDataCenters) {
-    if (sslEnabledDataCenters.contains(datacenter.getName())) {
-      if (ports.containsKey(PortType.SSL)) {
-        return ports.get(PortType.SSL);
-      } else {
-        throw new IllegalStateException(
-            "An SSL port is needed but does not exist at data node " + hostname + ":" + portNum);
-      }
-    }
-    return ports.get(PortType.PLAINTEXT);
-  }
-
-  /**
    * Returns the {@link Port} of this node to connect to. A {@link Port} will be automatically selected based on if
    * there is a need of establishing an SSL connection.
    *

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -36,6 +36,8 @@ public class MockClusterMap implements ClusterMap {
   private final int numMountPointsPerNode;
   private final HashSet<String> dataCentersInClusterMap = new HashSet<>();
   private boolean partitionsUnavailable = false;
+  private boolean createNewRegistry = true;
+  private MetricRegistry metricRegistry;
 
   /**
    * The default constructor sets up a 9 node cluster with 3 mount points in each, with 3 partitions/replicas per
@@ -212,7 +214,18 @@ public class MockClusterMap implements ClusterMap {
   @Override
   public MetricRegistry getMetricRegistry() {
     // Each server that calls this mocked interface needs its own metric registry.
-    return new MetricRegistry();
+    if (createNewRegistry) {
+      metricRegistry = new MetricRegistry();
+    }
+    return metricRegistry;
+  }
+
+  /**
+   * Create a {@link MetricRegistry} and ensure that this is the one that is returned by {@link #getMetricRegistry()}
+   */
+  public void createAndSetPermanentMetricRegistry() {
+    metricRegistry = new MetricRegistry();
+    createNewRegistry = false;
   }
 
   public void cleanup()

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
@@ -28,7 +28,6 @@ public class MockDataNodeId extends DataNodeId {
   String hostname = "localhost";
   String datacenter;
   ArrayList<String> sslEnabledDataCenters = new ArrayList<String>();
-  boolean sslPortRequested = false;
 
   public MockDataNodeId(ArrayList<Port> ports, List<String> mountPaths, String dataCenter) {
     this.mountPaths = mountPaths;
@@ -59,22 +58,6 @@ public class MockDataNodeId extends DataNodeId {
    */
   public void setSslEnabledDataCenters(ArrayList<String> sslEnabledDataCenters) {
     this.sslEnabledDataCenters = sslEnabledDataCenters;
-  }
-
-  /**
-   * Set the status for whether an SSL port was requested from this datanode.
-   * @param status the status to set.
-   */
-  public void setSslPortRequestedStatus(boolean status) {
-    sslPortRequested = status;
-  }
-
-  /**
-   * Get the status for whether an SSL port was requested from this datanode.
-   * @return true if SSL port was requested; false otherwise.
-   */
-  public boolean sslPortWasRequested() {
-    return sslPortRequested;
   }
 
   @Override
@@ -108,7 +91,6 @@ public class MockDataNodeId extends DataNodeId {
   public Port getPortToConnectTo() {
     if (sslEnabledDataCenters.contains(datacenter)) {
       if (ports.containsKey(PortType.SSL)) {
-        setSslPortRequestedStatus(true);
         return ports.get(PortType.SSL);
       } else {
         throw new IllegalArgumentException("No SSL Port exists for the data node " + hostname + ":" + portNum);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
@@ -27,19 +27,14 @@ public class MockDataNodeId extends DataNodeId {
   List<String> mountPaths;
   String hostname = "localhost";
   String datacenter;
-  long rackId = -1;
   ArrayList<String> sslEnabledDataCenters = new ArrayList<String>();
+  boolean sslPortRequested = false;
 
   public MockDataNodeId(ArrayList<Port> ports, List<String> mountPaths, String dataCenter) {
     this.mountPaths = mountPaths;
     this.datacenter = dataCenter;
     this.ports = new HashMap<PortType, Port>();
     populatePorts(ports);
-  }
-
-  public MockDataNodeId(ArrayList<Port> ports, List<String> mountPaths, String dataCenter, int rackId) {
-    this(ports, mountPaths, dataCenter);
-    this.rackId = rackId;
   }
 
   private void populatePorts(ArrayList<Port> ports) {
@@ -54,6 +49,32 @@ public class MockDataNodeId extends DataNodeId {
     if (!plainTextPortFound) {
       throw new IllegalArgumentException("No Plain Text port found");
     }
+  }
+
+  /**
+   * Set the datacenters to which ssl is enabled. If the datacenter on which this datanode resides is
+   * part of the datacenters to which ssl is enabled, then this datanode will always return an SSL port in
+   * {@link #getPortToConnectTo()}
+   * @param sslEnabledDataCenters list of datacenters to which ssl is enabled.
+   */
+  public void setSslEnabledDataCenters(ArrayList<String> sslEnabledDataCenters) {
+    this.sslEnabledDataCenters = sslEnabledDataCenters;
+  }
+
+  /**
+   * Set the status for whether an SSL port was requested from this datanode.
+   * @param status the status to set.
+   */
+  public void setSslPortRequestedStatus(boolean status) {
+    sslPortRequested = status;
+  }
+
+  /**
+   * Get the status for whether an SSL port was requested from this datanode.
+   * @return true if SSL port was requested; false otherwise.
+   */
+  public boolean sslPortWasRequested() {
+    return sslPortRequested;
   }
 
   @Override
@@ -100,6 +121,7 @@ public class MockDataNodeId extends DataNodeId {
   public Port getPortToConnectTo() {
     if (sslEnabledDataCenters.contains(datacenter)) {
       if (ports.containsKey(PortType.SSL)) {
+        setSslPortRequestedStatus(true);
         return ports.get(PortType.SSL);
       } else {
         throw new IllegalArgumentException("No SSL Port exists for the data node " + hostname + ":" + portNum);
@@ -120,7 +142,7 @@ public class MockDataNodeId extends DataNodeId {
 
   @Override
   public long getRackId() {
-    return rackId;
+    return -1;
   }
 
   public List<String> getMountPaths() {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
@@ -105,19 +105,6 @@ public class MockDataNodeId extends DataNodeId {
   }
 
   @Override
-  @Deprecated
-  public Port getPortToConnectTo(ArrayList<String> sslEnabledDataCenters) {
-    if (sslEnabledDataCenters.contains(datacenter)) {
-      if (ports.containsKey(PortType.SSL)) {
-        return ports.get(PortType.SSL);
-      } else {
-        throw new IllegalArgumentException("No SSL Port exists for the data node " + hostname + ":" + portNum);
-      }
-    }
-    return new Port(portNum, PortType.PLAINTEXT);
-  }
-
-  @Override
   public Port getPortToConnectTo() {
     if (sslEnabledDataCenters.contains(datacenter)) {
       if (ports.containsKey(PortType.SSL)) {

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannel.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannel.java
@@ -13,16 +13,15 @@
  */
 package com.github.ambry.network;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SocketChannel;
 import java.nio.channels.WritableByteChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.InputStream;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.SocketException;
-import java.nio.channels.ClosedChannelException;
-import java.nio.channels.SocketChannel;
 
 
 /**
@@ -53,7 +52,7 @@ public class BlockingChannel implements ConnectedChannel {
   }
 
   public void connect()
-      throws SocketException, IOException {
+      throws IOException {
     synchronized (lock) {
       if (!connected) {
         channel = SocketChannel.open();

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLBlockingChannelTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLBlockingChannelTest.java
@@ -49,8 +49,10 @@ public class SSLBlockingChannelTest {
   public static void initializeTests()
       throws Exception {
     File trustStoreFile = File.createTempFile("truststore", ".jks");
-    SSLConfig sslConfig = TestSSLUtils.createSSLConfig("DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server");
-    clientSSLConfig = TestSSLUtils.createSSLConfig("DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client");
+    SSLConfig sslConfig =
+        new SSLConfig(TestSSLUtils.createSslProps("DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server"));
+    clientSSLConfig =
+        new SSLConfig(TestSSLUtils.createSslProps("DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client"));
 
     sslFactory = new SSLFactory(sslConfig);
     sslEchoServer = new EchoServer(sslFactory, sslPort);

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLFactoryTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLFactoryTest.java
@@ -41,9 +41,10 @@ public class SSLFactoryTest {
   public void testSSLFactory()
       throws Exception {
     File trustStoreFile = File.createTempFile("truststore", ".jks");
-    SSLConfig sslConfig = TestSSLUtils.createSSLConfig("DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server");
+    SSLConfig sslConfig =
+        new SSLConfig(TestSSLUtils.createSslProps("DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server"));
     SSLConfig clientSSLConfig =
-        TestSSLUtils.createSSLConfig("DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client");
+        new SSLConfig(TestSSLUtils.createSslProps("DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client"));
 
     SSLFactory sslFactory = new SSLFactory(sslConfig);
     SSLContext sslContext = sslFactory.getSSLContext();

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
@@ -43,9 +43,10 @@ public class SSLSelectorTest {
   public void setup()
       throws Exception {
     trustStoreFile = File.createTempFile("truststore", ".jks");
-    SSLConfig sslConfig = TestSSLUtils.createSSLConfig("DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server");
+    SSLConfig sslConfig =
+        new SSLConfig(TestSSLUtils.createSslProps("DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server"));
     SSLConfig clientSSLConfig =
-        TestSSLUtils.createSSLConfig("DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client");
+        new SSLConfig(TestSSLUtils.createSslProps("DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client"));
     SSLFactory serverSSLFactory = new SSLFactory(sslConfig);
     SSLFactory clientSSLFactory = new SSLFactory(clientSSLConfig);
     server = new EchoServer(serverSSLFactory, 18383);

--- a/ambry-network/src/test/java/com.github.ambry.network/SocketServerTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SocketServerTest.java
@@ -17,14 +17,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.NetworkConfig;
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.VerifiableProperties;
-import java.io.File;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import java.io.DataInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ServerSocket;
@@ -32,6 +26,12 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Properties;
 import java.util.Random;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 
 public class SocketServerTest {
@@ -48,8 +48,10 @@ public class SocketServerTest {
   public static void initializeTests()
       throws Exception {
     File trustStoreFile = File.createTempFile("truststore", ".jks");
-    serverSSLConfig = TestSSLUtils.createSSLConfig("DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server");
-    clientSSLConfig = TestSSLUtils.createSSLConfig("DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client");
+    serverSSLConfig =
+        new SSLConfig(TestSSLUtils.createSslProps("DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server"));
+    clientSSLConfig =
+        new SSLConfig(TestSSLUtils.createSslProps("DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client"));
     clientSSLFactory = new SSLFactory(clientSSLConfig);
     SSLContext sslContext = clientSSLFactory.getSSLContext();
     clientSSLSocketFactory = sslContext.getSocketFactory();

--- a/ambry-network/src/test/java/com.github.ambry.network/TestSSLUtils.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/TestSSLUtils.java
@@ -205,12 +205,13 @@ public class TestSSLUtils {
   }
 
   /**
-   * Creates SSLConfig based on the values passed and few other pre-populated values
+   * Creates VerifiableProperties with SSL related configs based on the values passed and few other
+   * pre-populated values
    * @param sslEnabledDatacenters Comma separated list of datacenters against which ssl connections should be
    *                              established
    * @param mode Represents if the caller is a client or server
    * @param trustStoreFile File path of the truststore file
-   * @param certAlias alais used for the certificate
+   * @param certAlias alias used for the certificate
    * @return {@link VerifiableProperties} with all the required values populated
    * @throws IOException
    * @throws GeneralSecurityException

--- a/ambry-network/src/test/java/com.github.ambry.network/TestSSLUtils.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/TestSSLUtils.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.network;
 
-import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.VerifiableProperties;
 import java.io.EOFException;
 import java.io.File;
@@ -202,7 +201,7 @@ public class TestSSLUtils {
     props.put("ssl.truststore.path", trustStoreFile.getPath());
     props.put("ssl.truststore.password", TRUSTSTORE_PASSWORD);
     props.put("ssl.cipher.suites", SSL_CIPHER_SUITES);
-    props.put("ssl.enabled.datacenters", sslEnabledDatacenters);
+    props.put("clustermap.ssl.enabled.datacenters", sslEnabledDatacenters);
   }
 
   /**
@@ -212,17 +211,16 @@ public class TestSSLUtils {
    * @param mode Represents if the caller is a client or server
    * @param trustStoreFile File path of the truststore file
    * @param certAlias alais used for the certificate
-   * @return {@SSLConfig} with all the required values populated
+   * @return {@link VerifiableProperties} with all the required values populated
    * @throws IOException
    * @throws GeneralSecurityException
    */
-  public static SSLConfig createSSLConfig(String sslEnabledDatacenters, SSLFactory.Mode mode, File trustStoreFile,
-      String certAlias)
+  public static VerifiableProperties createSslProps(String sslEnabledDatacenters, SSLFactory.Mode mode,
+      File trustStoreFile, String certAlias)
       throws IOException, GeneralSecurityException {
     Properties props = new Properties();
     addSSLProperties(props, sslEnabledDatacenters, mode, trustStoreFile, certAlias);
-    SSLConfig sslConfig = new SSLConfig(new VerifiableProperties(props));
-    return sslConfig;
+    return new VerifiableProperties(props);
   }
 
   public static void verifySSLConfig(SSLContext sslContext, SSLEngine sslEngine, boolean isClient) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -19,6 +19,7 @@ import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.ResponseHandler;
+import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.StoreConfig;
@@ -264,9 +265,9 @@ public final class ReplicationManager {
   private static final short Crc_Size = 8;
   private static final short Replication_Delay_Multiplier = 5;
 
-  public ReplicationManager(ReplicationConfig replicationConfig, SSLConfig sslConfig, StoreConfig storeConfig,
-      StoreManager storeManager, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap, Scheduler scheduler,
-      DataNodeId dataNode, ConnectionPool connectionPool, MetricRegistry metricRegistry,
+  public ReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
+      StoreConfig storeConfig, StoreManager storeManager, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap,
+      Scheduler scheduler, DataNodeId dataNode, ConnectionPool connectionPool, MetricRegistry metricRegistry,
       NotificationSystem requestNotification)
       throws ReplicationException {
 
@@ -288,7 +289,7 @@ public final class ReplicationManager {
       this.notification = requestNotification;
       this.metricRegistry = metricRegistry;
       this.dataNodeRemoteReplicaInfosPerDC = new HashMap<String, DataNodeRemoteReplicaInfos>();
-      this.sslEnabledDatacenters = Utils.splitString(sslConfig.sslEnabledDatacenters, ",");
+      this.sslEnabledDatacenters = Utils.splitString(clusterMapConfig.clusterMapSslEnabledDatacenters, ",");
       this.numberOfReplicaThreads = new HashMap<String, Integer>();
 
       // initialize all partitions
@@ -424,9 +425,7 @@ public final class ReplicationManager {
     PartitionInfo partitionInfo = partitionsToReplicate.get(partitionId);
     for (RemoteReplicaInfo remoteReplicaInfo : partitionInfo.getRemoteReplicaInfos()) {
       if (remoteReplicaInfo.getReplicaId().getReplicaPath().equals(replicaPath) && remoteReplicaInfo.getReplicaId()
-          .getDataNodeId()
-          .getHostname()
-          .equals(hostName)) {
+          .getDataNodeId().getHostname().equals(hostName)) {
         foundRemoteReplicaInfo = remoteReplicaInfo;
       }
     }
@@ -607,8 +606,9 @@ public final class ReplicationManager {
                 if (remoteReplicaInfo.getReplicaId().getDataNodeId().getHostname().equalsIgnoreCase(hostname) &&
                     remoteReplicaInfo.getReplicaId().getDataNodeId().getPort() == port &&
                     remoteReplicaInfo.getReplicaId().getReplicaPath().equals(replicaPath)) {
-                  logger.info("Read token for partition {} remote host {} port {} token {}", partitionId, hostname,
-                      port, token);
+                  logger
+                      .info("Read token for partition {} remote host {} port {} token {}", partitionId, hostname, port,
+                          token);
                   if (partitionInfo.getStore().getSizeInBytes() > 0) {
                     remoteReplicaInfo.initializeTokens(token);
                     remoteReplicaInfo.setTotalBytesReadFromLocalStore(totalBytesReadFromLocalStore);
@@ -644,8 +644,8 @@ public final class ReplicationManager {
         throw new ReplicationException("IO error while reading from replica token file " + e);
       } finally {
         stream.close();
-        replicationMetrics.remoteReplicaTokensRestoreTime.update(
-            SystemTime.getInstance().milliseconds() - readStartTimeMs);
+        replicationMetrics.remoteReplicaTokensRestoreTime
+            .update(SystemTime.getInstance().milliseconds() - readStartTimeMs);
       }
     }
 
@@ -705,8 +705,8 @@ public final class ReplicationManager {
         throw new ReplicationException("IO error while persisting replica tokens to disk ");
       } finally {
         writer.close();
-        replicationMetrics.remoteReplicaTokensPersistTime.update(
-            SystemTime.getInstance().milliseconds() - writeStartTimeMs);
+        replicationMetrics.remoteReplicaTokensPersistTime
+            .update(SystemTime.getInstance().milliseconds() - writeStartTimeMs);
       }
       logger.debug("Completed writing replica tokens to file {}", actual.getAbsolutePath());
     }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -21,11 +21,9 @@ import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
-import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.network.ConnectionPool;
 import com.github.ambry.network.Port;
-import com.github.ambry.network.PortType;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.store.FindToken;
 import com.github.ambry.store.FindTokenFactory;
@@ -305,7 +303,7 @@ public final class ReplicationManager {
                 new RemoteReplicaInfo(remoteReplica, replicaId, storeManager.getStore(replicaId.getPartitionId()),
                     factory.getNewFindToken(), storeConfig.storeDataFlushIntervalSeconds *
                     SystemTime.MsPerSec * Replication_Delay_Multiplier, SystemTime.getInstance(),
-                    getPortForReplica(remoteReplica, sslEnabledDatacenters));
+                    remoteReplica.getDataNodeId().getPortToConnectTo());
             replicationMetrics.addRemoteReplicaToLagMetrics(remoteReplicaInfo);
             replicationMetrics.createRemoteReplicaErrorMetrics(remoteReplicaInfo);
             remoteReplicas.add(remoteReplicaInfo);
@@ -363,22 +361,6 @@ public final class ReplicationManager {
           replicationConfig.replicationTokenFlushIntervalSeconds, TimeUnit.SECONDS);
     } catch (IOException e) {
       logger.error("IO error while starting replication");
-    }
-  }
-
-  /**
-   * Returns the port to be contacted for the remote replica according to the configs.
-   * @param replicaId Replica against which connection has to be establised
-   * @param sslEnabledDatacenters List of datacenters upon which SSL encryption should be enabled
-   * @return
-   */
-  public Port getPortForReplica(ReplicaId replicaId, ArrayList<String> sslEnabledDatacenters) {
-    if (sslEnabledDatacenters.contains(replicaId.getDataNodeId().getDatacenterName())) {
-      Port toReturn = new Port(replicaId.getDataNodeId().getSSLPort(), PortType.SSL);
-      logger.trace("Assigning ssl for remote replica " + replicaId);
-      return toReturn;
-    } else {
-      return new Port(replicaId.getDataNodeId().getPort(), PortType.PLAINTEXT);
     }
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -73,9 +73,7 @@ public class MockCluster {
         }
         initializeServer(dataNodeId, sslProps, enableHardDeletes, time);
       }
-    } catch (InstantiationException e)
-
-    {
+    } catch (InstantiationException e) {
       // clean up other servers which was started already
       cleanup();
       throw e;

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -51,27 +51,31 @@ public class MockCluster {
 
   public MockCluster(NotificationSystem notificationSystem, boolean enableHardDeletes, Time time)
       throws IOException, InstantiationException, URISyntaxException, GeneralSecurityException {
-    this(notificationSystem, false, "", new Properties(), enableHardDeletes, time);
+    this(notificationSystem, new Properties(), enableHardDeletes, time);
   }
 
-  public MockCluster(NotificationSystem notificationSystem, boolean enableSSL, String datacenters, Properties sslProps,
-      boolean enableHardDeletes, Time time)
+  public MockCluster(NotificationSystem notificationSystem, Properties sslProps, boolean enableHardDeletes, Time time)
       throws IOException, InstantiationException, URISyntaxException, GeneralSecurityException {
     // sslEnabledDatacenters represents comma separated list of datacenters to which ssl should be enabled
+    String sslEnabledDataCentersStr = sslProps.getProperty("clustermap.ssl.enabled.datacenters");
+    ArrayList<String> sslEnabledDataCenterList =
+        sslEnabledDataCentersStr != null ? Utils.splitString(sslEnabledDataCentersStr, ",") : new ArrayList<String>();
+
     this.notificationSystem = notificationSystem;
-    clusterMap = new MockClusterMap(enableSSL, 9, 3, 3);
+    clusterMap = new MockClusterMap(sslEnabledDataCentersStr != null, 9, 3, 3);
+
     serverList = new ArrayList<AmbryServer>();
-    ArrayList<String> datacenterList = Utils.splitString(datacenters, ",");
     List<MockDataNodeId> dataNodes = clusterMap.getDataNodes();
     try {
       for (MockDataNodeId dataNodeId : dataNodes) {
-        if (enableSSL) {
-          String sslEnabledDatacenters = getSSLEnabledDatacenterValue(dataNodeId.getDatacenterName(), datacenterList);
-          sslProps.setProperty("ssl.enabled.datacenters", sslEnabledDatacenters);
+        if (sslEnabledDataCentersStr != null) {
+          dataNodeId.setSslEnabledDataCenters(sslEnabledDataCenterList);
         }
         initializeServer(dataNodeId, sslProps, enableHardDeletes, time);
       }
-    } catch (InstantiationException e) {
+    } catch (InstantiationException e)
+
+    {
       // clean up other servers which was started already
       cleanup();
       throw e;
@@ -125,18 +129,6 @@ public class MockCluster {
       }
       clusterMap.cleanup();
     }
-  }
-
-  /**
-   * Find the value for sslEnabledDatacenter config for the given datacenter
-   * @param datacenter for which sslEnabledDatacenter config value has to be determinded
-   * @param sslEnabledDataCenterList list of datacenters upon which ssl should be enabled
-   * @return the config value for sslEnabledDatacenters for the given datacenter
-   */
-  private String getSSLEnabledDatacenterValue(String datacenter, ArrayList<String> sslEnabledDataCenterList) {
-    ArrayList<String> localCopy = new ArrayList<String>(sslEnabledDataCenterList);
-    localCopy.remove(datacenter);
-    return Utils.concatenateString(localCopy, ",");
   }
 
   public List<DataNodeId> getOneDataNodeFromEachDatacenter(ArrayList<String> datacenterList) {

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.server;
 
+import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.server.RouterServerTestFramework.OperationChain;
 import com.github.ambry.server.RouterServerTestFramework.OperationType;
 import com.github.ambry.utils.SystemTime;
@@ -40,7 +41,8 @@ public class RouterServerPlaintextTest {
     MockNotificationSystem notificationSystem = new MockNotificationSystem(9);
     plaintextCluster = new MockCluster(notificationSystem, false, SystemTime.getInstance());
     plaintextCluster.startServers();
-    testFramework = new RouterServerTestFramework(getRouterProperties("DC1"), plaintextCluster, notificationSystem);
+    MockClusterMap routerClusterMap = plaintextCluster.getClusterMap();
+    testFramework = new RouterServerTestFramework(getRouterProperties("DC1"), routerClusterMap, notificationSystem);
   }
 
   @AfterClass

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -67,13 +67,14 @@ class RouterServerTestFramework {
    * Instantiate a framework for testing router-server interaction. Creates a non-blocking router to interact with the
    * passed-in {@link MockCluster}.
    * @param routerProps All of the properties to be used when instantiating the router.
-   * @param cluster A {@link MockCluster} that contains the servers to be used in the tests.
+   * @param clusterMap A {@link MockClusterMap} to be used in the tests.
    * @param notificationSystem A {@link MockNotificationSystem} that is used to determine if
    * @throws Exception
    */
-  RouterServerTestFramework(Properties routerProps, MockCluster cluster, MockNotificationSystem notificationSystem)
+  RouterServerTestFramework(Properties routerProps, MockClusterMap clusterMap,
+      MockNotificationSystem notificationSystem)
       throws Exception {
-    clusterMap = cluster.getClusterMap();
+    this.clusterMap = clusterMap;
     this.notificationSystem = notificationSystem;
 
     VerifiableProperties routerVerifiableProps = new VerifiableProperties(routerProps);
@@ -123,7 +124,7 @@ class RouterServerTestFramework {
       double blobBalanceThreshold = BALANCE_FACTOR * Math.ceil(blobsPut / numPartitions);
       for (Map.Entry<PartitionId, Integer> entry : partitionCount.entrySet()) {
         Assert.assertTrue("Number of blobs is " + entry.getValue() + " on partition: " + entry.getKey()
-                + ", which is greater than the threshold of " + blobBalanceThreshold,
+            + ", which is greater than the threshold of " + blobBalanceThreshold,
             entry.getValue() <= blobBalanceThreshold);
       }
     }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -21,6 +21,7 @@ import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.network.Selector;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.GetBlobOptions;
 import com.github.ambry.router.GetBlobResult;
@@ -62,6 +63,12 @@ class RouterServerTestFramework {
   private final MockClusterMap clusterMap;
   private final MockNotificationSystem notificationSystem;
   private final Router router;
+
+  public static String sslSendBytesMetricName = Selector.class.getName() + "SslSendBytesRate";
+  public static String sslReceiveBytesMetricName = Selector.class.getName() + "SslReceiveBytesRate";
+  public static String plaintextSendBytesMetricName = Selector.class.getName() + "PlaintextSendBytesRate";
+  public static String plaintextReceiveBytesMetricName = Selector.class.getName() + "PlaintextReceiveBytesRate";
+
 
   /**
    * Instantiate a framework for testing router-server interaction. Creates a non-blocking router to interact with the

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -64,10 +64,10 @@ class RouterServerTestFramework {
   private final MockNotificationSystem notificationSystem;
   private final Router router;
 
-  public static String sslSendBytesMetricName = Selector.class.getName() + "SslSendBytesRate";
-  public static String sslReceiveBytesMetricName = Selector.class.getName() + "SslReceiveBytesRate";
-  public static String plaintextSendBytesMetricName = Selector.class.getName() + "PlaintextSendBytesRate";
-  public static String plaintextReceiveBytesMetricName = Selector.class.getName() + "PlaintextReceiveBytesRate";
+  public static String sslSendBytesMetricName = Selector.class.getName() + ".SslSendBytesRate";
+  public static String sslReceiveBytesMetricName = Selector.class.getName() + ".SslReceiveBytesRate";
+  public static String plaintextSendBytesMetricName = Selector.class.getName() + ".PlaintextSendBytesRate";
+  public static String plaintextReceiveBytesMetricName = Selector.class.getName() + ".PlaintextReceiveBytesRate";
 
 
   /**

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerSSLTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerSSLTest.java
@@ -53,16 +53,18 @@ public class ServerSSLTest {
   public static void initializeTests()
       throws Exception {
     trustStoreFile = File.createTempFile("truststore", ".jks");
-    clientSSLConfig1 = TestSSLUtils.createSSLConfig("DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client1");
-    clientSSLConfig2 = TestSSLUtils.createSSLConfig("DC1,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client2");
-    clientSSLConfig3 = TestSSLUtils.createSSLConfig("DC1,DC2", SSLFactory.Mode.CLIENT, trustStoreFile, "client3");
+    clientSSLConfig1 =
+        new SSLConfig(TestSSLUtils.createSslProps("DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client1"));
+    clientSSLConfig2 =
+        new SSLConfig(TestSSLUtils.createSslProps("DC1,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client2"));
+    clientSSLConfig3 =
+        new SSLConfig(TestSSLUtils.createSslProps("DC1,DC2", SSLFactory.Mode.CLIENT, trustStoreFile, "client3"));
     serverSSLProps = new Properties();
     TestSSLUtils.addSSLProperties(serverSSLProps, "DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server");
     routerProps = new Properties();
-    TestSSLUtils.addSSLProperties(routerProps, "", SSLFactory.Mode.CLIENT, trustStoreFile, "router-client");
+    TestSSLUtils.addSSLProperties(routerProps, "DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "router-client");
     notificationSystem = new MockNotificationSystem(9);
-    sslCluster =
-        new MockCluster(notificationSystem, true, "DC1,DC2,DC3", serverSSLProps, false, SystemTime.getInstance());
+    sslCluster = new MockCluster(notificationSystem, serverSSLProps, false, SystemTime.getInstance());
     sslCluster.startServers();
     //client
     sslFactory = new SSLFactory(clientSSLConfig1);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerSSLTokenTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerSSLTokenTest.java
@@ -49,14 +49,14 @@ public class ServerSSLTokenTest {
   public void initializeTests()
       throws Exception {
     trustStoreFile = File.createTempFile("truststore", ".jks");
-    clientSSLConfig = TestSSLUtils.createSSLConfig("DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client1");
+    clientSSLConfig =
+        new SSLConfig(TestSSLUtils.createSslProps("DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client1"));
     serverSSLProps = new Properties();
     TestSSLUtils.addSSLProperties(serverSSLProps, "DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server");
     routerProps = new Properties();
-    TestSSLUtils.addSSLProperties(routerProps, "", SSLFactory.Mode.CLIENT, trustStoreFile, "router-client");
+    TestSSLUtils.addSSLProperties(routerProps, "DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "router-client");
     notificationSystem = new MockNotificationSystem(9);
-    sslCluster =
-        new MockCluster(notificationSystem, true, "DC1,DC2,DC3", serverSSLProps, false, SystemTime.getInstance());
+    sslCluster = new MockCluster(notificationSystem, serverSSLProps, false, SystemTime.getInstance());
     sslCluster.startServers();
     //client
     sslFactory = new SSLFactory(clientSSLConfig);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -23,6 +23,7 @@ import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.ServerErrorCode;
+import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ConnectionPoolConfig;
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -750,10 +751,11 @@ public final class ServerTestUtil {
     assertEquals("Did not put expected number of blobs", numberOfRequestsToSend, payloadQueue.size());
     Properties sslProps = new Properties();
     sslProps.putAll(routerProps);
-    sslProps.setProperty("ssl.enabled.datacenters", sslEnabledDatacenters);
+    sslProps.setProperty("clustermap.ssl.enabled.datacenters", sslEnabledDatacenters);
+    VerifiableProperties vProps = new VerifiableProperties(sslProps);
     ConnectionPool connectionPool =
         new BlockingChannelConnectionPool(new ConnectionPoolConfig(new VerifiableProperties(new Properties())),
-            new SSLConfig(new VerifiableProperties(sslProps)), new MetricRegistry());
+            new SSLConfig(vProps), new ClusterMapConfig(vProps), new MetricRegistry());
     CountDownLatch verifierLatch = new CountDownLatch(numberOfVerifierThreads);
     AtomicInteger totalRequests = new AtomicInteger(numberOfRequestsToSend);
     AtomicInteger verifiedRequests = new AtomicInteger(0);

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
@@ -18,6 +18,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.commons.LoggingNotificationSystem;
+import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ConnectionPoolConfig;
 import com.github.ambry.config.NetworkConfig;
 import com.github.ambry.config.ReplicationConfig;
@@ -103,6 +104,7 @@ public class AmbryServer {
       ReplicationConfig replicationConfig = new ReplicationConfig(properties);
       ConnectionPoolConfig connectionPoolConfig = new ConnectionPoolConfig(properties);
       SSLConfig sslConfig = new SSLConfig(properties);
+      ClusterMapConfig clusterMapConfig = new ClusterMapConfig(properties);
       // verify the configs
       properties.verify();
 
@@ -122,12 +124,12 @@ public class AmbryServer {
               new BlobStoreRecovery(), new BlobStoreHardDelete(), time);
       storeManager.start();
 
-      connectionPool = new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, registry);
+      connectionPool = new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, clusterMapConfig, registry);
       connectionPool.start();
 
       replicationManager =
-          new ReplicationManager(replicationConfig, sslConfig, storeConfig, storeManager, storeKeyFactory, clusterMap,
-              scheduler, nodeId, connectionPool, registry, notificationSystem);
+          new ReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storeManager, storeKeyFactory,
+              clusterMap, scheduler, nodeId, connectionPool, registry, notificationSystem);
       replicationManager.start();
 
       ArrayList<Port> ports = new ArrayList<Port>();

--- a/ambry-tools/src/main/java/com.github.ambry.tools/admin/AdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/admin/AdminTool.java
@@ -58,11 +58,9 @@ import joptsimple.OptionSpec;
  */
 public class AdminTool {
   private final ConnectionPool connectionPool;
-  private final ArrayList<String> sslEnabledDatacentersList;
 
-  public AdminTool(ConnectionPool connectionPool, ArrayList<String> sslEnabledDatacentersList) {
+  public AdminTool(ConnectionPool connectionPool) {
     this.connectionPool = connectionPool;
-    this.sslEnabledDatacentersList = sslEnabledDatacentersList;
   }
 
   public static void main(String args[]) {
@@ -160,12 +158,10 @@ public class AdminTool {
           new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, clusterMapConfig, new MetricRegistry());
       String hardwareLayoutPath = options.valueOf(hardwareLayoutOpt);
       String partitionLayoutPath = options.valueOf(partitionLayoutOpt);
-      ClusterMap map = new ClusterMapManager(hardwareLayoutPath, partitionLayoutPath,
-          new ClusterMapConfig(new VerifiableProperties(new Properties())));
+      ClusterMap map = new ClusterMapManager(hardwareLayoutPath, partitionLayoutPath, clusterMapConfig);
 
       String blobIdStr = options.valueOf(ambryBlobIdOpt);
-      ArrayList<String> sslEnabledDatacentersList = Utils.splitString(sslEnabledDatacenters, ",");
-      AdminTool adminTool = new AdminTool(connectionPool, sslEnabledDatacentersList);
+      AdminTool adminTool = new AdminTool(connectionPool);
       BlobId blobId = new BlobId(blobIdStr, map);
       String typeOfOperation = options.valueOf(typeOfOperationOpt);
       boolean includeExpiredBlobs = Boolean.parseBoolean(options.valueOf(includeExpiredBlobsOpt));
@@ -227,7 +223,7 @@ public class AdminTool {
     GetOptions getOptions = (expiredBlobs) ? GetOptions.Include_Expired_Blobs : GetOptions.None;
 
     try {
-      Port port = replicaId.getDataNodeId().getPortToConnectTo(sslEnabledDatacentersList);
+      Port port = replicaId.getDataNodeId().getPortToConnectTo();
       connectedChannel = connectionPool.checkOutConnection(replicaId.getDataNodeId().getHostname(), port, 10000);
 
       GetRequest getRequest =
@@ -312,7 +308,7 @@ public class AdminTool {
     GetOptions getOptions = (expiredBlobs) ? GetOptions.Include_Expired_Blobs : GetOptions.None;
 
     try {
-      Port port = replicaId.getDataNodeId().getPortToConnectTo(sslEnabledDatacentersList);
+      Port port = replicaId.getDataNodeId().getPortToConnectTo();
       connectedChannel = connectionPool.checkOutConnection(replicaId.getDataNodeId().getHostname(), port, 10000);
 
       GetRequest getRequest = new GetRequest(correlationId.incrementAndGet(), "readverifier", MessageFormatFlags.Blob,
@@ -389,7 +385,7 @@ public class AdminTool {
     GetOptions getOptions = (expiredBlobs) ? GetOptions.Include_Expired_Blobs : GetOptions.None;
 
     try {
-      Port port = replicaId.getDataNodeId().getPortToConnectTo(sslEnabledDatacentersList);
+      Port port = replicaId.getDataNodeId().getPortToConnectTo();
       connectedChannel = connectionPool.checkOutConnection(replicaId.getDataNodeId().getHostname(), port, 10000);
 
       GetRequest getRequest =

--- a/ambry-tools/src/main/java/com.github.ambry.tools/admin/AdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/admin/AdminTool.java
@@ -151,10 +151,13 @@ public class AdminTool {
         sslProperties = new Properties();
       }
       Properties connectionPoolProperties = ToolUtils.createConnectionPoolProperties();
-      SSLConfig sslConfig = new SSLConfig(new VerifiableProperties(sslProperties));
       ConnectionPoolConfig connectionPoolConfig =
           new ConnectionPoolConfig(new VerifiableProperties(connectionPoolProperties));
-      connectionPool = new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, new MetricRegistry());
+      VerifiableProperties vProps = new VerifiableProperties(sslProperties);
+      SSLConfig sslConfig = new SSLConfig(vProps);
+      ClusterMapConfig clusterMapConfig = new ClusterMapConfig(vProps);
+      connectionPool =
+          new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, clusterMapConfig, new MetricRegistry());
       String hardwareLayoutPath = options.valueOf(hardwareLayoutOpt);
       String partitionLayoutPath = options.valueOf(partitionLayoutOpt);
       ClusterMap map = new ClusterMapManager(hardwareLayoutPath, partitionLayoutPath,

--- a/ambry-tools/src/main/java/com.github.ambry.tools/admin/BlobValidator.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/admin/BlobValidator.java
@@ -66,12 +66,10 @@ import joptsimple.OptionSpec;
  */
 public class BlobValidator {
   private final ConnectionPool connectionPool;
-  private final ArrayList<String> sslEnabledDatacentersList;
   private final Map<String, Exception> invalidBlobs;
 
-  public BlobValidator(ConnectionPool connectionPool, ArrayList<String> sslEnabledDatacentersList) {
+  public BlobValidator(ConnectionPool connectionPool) {
     this.connectionPool = connectionPool;
-    this.sslEnabledDatacentersList = sslEnabledDatacentersList;
     invalidBlobs = new HashMap<String, Exception>();
   }
 
@@ -192,8 +190,7 @@ public class BlobValidator {
       if (verbose) {
         System.out.println("Hardware layout and partition layout parsed");
       }
-      ClusterMap map = new ClusterMapManager(hardwareLayoutPath, partitionLayoutPath,
-          new ClusterMapConfig(new VerifiableProperties(new Properties())));
+      ClusterMap map = new ClusterMapManager(hardwareLayoutPath, partitionLayoutPath, clusterMapConfig);
 
       String blobIdListStr = options.valueOf(ambryBlobIdListOpt);
       ArrayList<String> blobList = new ArrayList<String>();
@@ -228,8 +225,7 @@ public class BlobValidator {
         System.out.println("ReplicPort " + replicaPort);
       }
 
-      ArrayList<String> sslEnabledDatacentersList = Utils.splitString(sslEnabledDatacenters, ",");
-      BlobValidator blobValidator = new BlobValidator(connectionPool, sslEnabledDatacentersList);
+      BlobValidator blobValidator = new BlobValidator(connectionPool);
 
       ArrayList<BlobId> blobIdList = blobValidator.generateBlobId(blobList, map);
       if (typeOfOperation.equalsIgnoreCase("VALIDATE_BLOB_ON_REPLICA")) {
@@ -398,7 +394,7 @@ public class BlobValidator {
       ReplicaId targetReplicaId = null;
       for (ReplicaId replicaId : blobId.getPartition().getReplicaIds()) {
         if (replicaId.getDataNodeId().getHostname().equals(replicaHost)) {
-          Port port = replicaId.getDataNodeId().getPortToConnectTo(sslEnabledDatacentersList);
+          Port port = replicaId.getDataNodeId().getPortToConnectTo();
           if (port.getPort() == replicaPort) {
             targetReplicaId = replicaId;
             break;
@@ -448,7 +444,7 @@ public class BlobValidator {
     GetOptions getOptions = (expiredBlobs) ? GetOptions.Include_Expired_Blobs : GetOptions.None;
 
     try {
-      Port port = replicaId.getDataNodeId().getPortToConnectTo(sslEnabledDatacentersList);
+      Port port = replicaId.getDataNodeId().getPortToConnectTo();
       connectedChannel = connectionPool.checkOutConnection(replicaId.getDataNodeId().getHostname(), port, 10000);
 
       GetRequest getRequest =

--- a/ambry-tools/src/main/java/com.github.ambry.tools/admin/BlobValidator.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/admin/BlobValidator.java
@@ -178,10 +178,13 @@ public class BlobValidator {
         sslProperties = new Properties();
       }
       Properties connectionPoolProperties = ToolUtils.createConnectionPoolProperties();
-      SSLConfig sslConfig = new SSLConfig(new VerifiableProperties(sslProperties));
+      VerifiableProperties vProps = new VerifiableProperties(sslProperties);
+      SSLConfig sslConfig = new SSLConfig(vProps);
+      ClusterMapConfig clusterMapConfig = new ClusterMapConfig(vProps);
       ConnectionPoolConfig connectionPoolConfig =
           new ConnectionPoolConfig(new VerifiableProperties(connectionPoolProperties));
-      connectionPool = new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, new MetricRegistry());
+      connectionPool =
+          new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, clusterMapConfig, new MetricRegistry());
 
       boolean verbose = Boolean.parseBoolean(options.valueOf(verboseOpt));
       String hardwareLayoutPath = options.valueOf(hardwareLayoutOpt);

--- a/ambry-tools/src/main/java/com.github.ambry.tools/admin/ServerTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/admin/ServerTool.java
@@ -70,9 +70,12 @@ public class ServerTool {
 
   public ServerTool()
       throws Exception {
-    ConnectionPoolConfig connectionPoolConfig = new ConnectionPoolConfig(new VerifiableProperties(new Properties()));
-    SSLConfig sslConfig = new SSLConfig(new VerifiableProperties(new Properties()));
-    connectionPool = new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, new MetricRegistry());
+    VerifiableProperties vProps = new VerifiableProperties(new Properties());
+    ConnectionPoolConfig connectionPoolConfig = new ConnectionPoolConfig(vProps);
+    SSLConfig sslConfig = new SSLConfig(vProps);
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(vProps);
+    connectionPool =
+        new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, clusterMapConfig, new MetricRegistry());
     connectionPool.start();
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry.tools/perf/ServerReadPerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/perf/ServerReadPerformance.java
@@ -194,8 +194,11 @@ public class ServerReadPerformance {
       String line;
       ConnectedChannel channel = null;
       ConnectionPoolConfig connectionPoolConfig = new ConnectionPoolConfig(new VerifiableProperties(new Properties()));
-      SSLConfig sslConfig = new SSLConfig(new VerifiableProperties(sslProperties));
-      connectionPool = new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, new MetricRegistry());
+      VerifiableProperties vProps = new VerifiableProperties(sslProperties);
+      SSLConfig sslConfig = new SSLConfig(vProps);
+      ClusterMapConfig clusterMapConfig = new ClusterMapConfig(vProps);
+      connectionPool =
+          new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, clusterMapConfig, new MetricRegistry());
       long totalNumberOfGetBlobs = 0;
       long totalLatencyForGetBlobs = 0;
       ArrayList<Long> latenciesForGetBlobs = new ArrayList<Long>();

--- a/ambry-tools/src/main/java/com.github.ambry.tools/perf/ServerReadPerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/perf/ServerReadPerformance.java
@@ -41,7 +41,6 @@ import com.github.ambry.tools.util.ToolUtils;
 import com.github.ambry.utils.ByteBufferOutputStream;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Throttler;
-import com.github.ambry.utils.Utils;
 import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.File;
@@ -168,9 +167,8 @@ public class ServerReadPerformance {
       String hardwareLayoutPath = options.valueOf(hardwareLayoutOpt);
       String partitionLayoutPath = options.valueOf(partitionLayoutOpt);
       ClusterMap map = new ClusterMapManager(hardwareLayoutPath, partitionLayoutPath,
-          new ClusterMapConfig(new VerifiableProperties(new Properties())));
+          new ClusterMapConfig(new VerifiableProperties(sslProperties)));
 
-      ArrayList<String> sslEnabledDatacentersList = Utils.splitString(sslEnabledDatacenters, ",");
       final AtomicLong totalTimeTaken = new AtomicLong(0);
       final AtomicLong totalReads = new AtomicLong(0);
       final AtomicBoolean shutdown = new AtomicBoolean(false);
@@ -220,7 +218,7 @@ public class ServerReadPerformance {
             partitionRequestInfoList.add(partitionRequestInfo);
             GetRequest getRequest =
                 new GetRequest(1, "getperf", MessageFormatFlags.Blob, partitionRequestInfoList, GetOptions.None);
-            Port port = replicaId.getDataNodeId().getPortToConnectTo(sslEnabledDatacentersList);
+            Port port = replicaId.getDataNodeId().getPortToConnectTo();
             channel = connectionPool.checkOutConnection(replicaId.getDataNodeId().getHostname(), port, 10000);
             startTimeGetBlob = SystemTime.getInstance().nanoseconds();
             channel.send(getRequest);

--- a/ambry-tools/src/main/java/com.github.ambry.tools/util/ToolUtils.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/util/ToolUtils.java
@@ -70,7 +70,7 @@ public final class ToolUtils {
     props.put("ssl.truststore.path", sslTruststorePath);
     props.put("ssl.truststore.password", sslTruststorePassword);
     props.put("ssl.cipher.suites", sslCipherSuites);
-    props.put("ssl.enabled.datacenters", sslEnabledDatacenters);
+    props.put("clustermap.ssl.enabled.datacenters", sslEnabledDatacenters);
     return props;
   }
 

--- a/config/admin.properties
+++ b/config/admin.properties
@@ -15,7 +15,7 @@ rest.server.blob.storage.service.factory=com.github.ambry.admin.AdminBlobStorage
 
 # router
 router.hostname=localhost
-router.datacenter.name=Data-Center
+router.datacenter.name=Datacenter
 
 # netty
 netty.server.port=16503

--- a/config/frontend.properties
+++ b/config/frontend.properties
@@ -15,6 +15,6 @@ rest.server.blob.storage.service.factory=com.github.ambry.frontend.AmbryBlobStor
 
 # router
 router.hostname=localhost
-router.datacenter.name=Datacenter
+router.datacenter.name=Data-Center
 router.put.success.target=1
 

--- a/config/frontend.properties
+++ b/config/frontend.properties
@@ -15,6 +15,6 @@ rest.server.blob.storage.service.factory=com.github.ambry.frontend.AmbryBlobStor
 
 # router
 router.hostname=localhost
-router.datacenter.name=Data-Center
+router.datacenter.name=Datacenter
 router.put.success.target=1
 

--- a/config/frontend.ssl.properties
+++ b/config/frontend.ssl.properties
@@ -17,7 +17,6 @@ rest.server.blob.storage.service.factory=com.github.ambry.frontend.AmbryBlobStor
 # router
 router.hostname=localhost
 router.datacenter.name=Datacenter
-ssl.enabled.datacenters=Datacenter
 router.put.success.target=1
 router.delete.success.target=1
 


### PR DESCRIPTION
- Remove ssl-enabled DC parameter from sslConfig and rely on the one in
the ClusterMapConfig (which is the right place for it).
- Reenable Router-Server SSL tests.

Fixes #447 and #448