### PR TITLE
Add a config for router.delete.success.target

### DIFF
--- a/config/frontend.properties
+++ b/config/frontend.properties
@@ -17,4 +17,4 @@ rest.server.blob.storage.service.factory=com.github.ambry.frontend.AmbryBlobStor
 router.hostname=localhost
 router.datacenter.name=Datacenter
 router.put.success.target=1
-
+router.delete.success.target=1


### PR DESCRIPTION
For a default local deployment, a delete request will fail due to the mismatch
between router.delete.success.target and the actual number of replicas.

Local deployment tested.