### PR TITLE
Adding additional checks on Blob ID parsing

### DIFF
--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -91,10 +91,7 @@ public class BlobId extends StoreKey {
         throw new IllegalArgumentException("Partition ID cannot be null");
       }
       uuid = Utils.readIntString(stream);
-      if (uuid == null) {
-        throw new IllegalArgumentException("Could not parse uuid");
-      }
-      if (ensureFullyRead && stream.available() > 0) {
+      if (ensureFullyRead && stream.read() != -1) {
         throw new IllegalArgumentException("Stream should have no more available bytes to read");
       }
     } else {

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -18,7 +18,6 @@ import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Utils;
-
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -42,6 +41,9 @@ public class BlobId extends StoreKey {
    * @param partitionId of Partition in which blob is to be stored.
    */
   public BlobId(PartitionId partitionId) {
+    if (partitionId == null) {
+      throw new IllegalArgumentException("Partition ID cannot be null");
+    }
     this.partitionId = partitionId;
     this.uuid = UUID.randomUUID().toString();
   }
@@ -55,7 +57,7 @@ public class BlobId extends StoreKey {
    */
   public BlobId(String id, ClusterMap clusterMap)
       throws IOException {
-    this(new DataInputStream(new ByteBufferInputStream(ByteBuffer.wrap(Base64.decodeBase64(id)))), clusterMap);
+    this(new DataInputStream(new ByteBufferInputStream(ByteBuffer.wrap(Base64.decodeBase64(id)))), clusterMap, true);
   }
 
   /**
@@ -67,10 +69,34 @@ public class BlobId extends StoreKey {
    */
   public BlobId(DataInputStream stream, ClusterMap clusterMap)
       throws IOException {
+    this(stream, clusterMap, false);
+  }
+
+  /**
+   * Re-constructs existing blobId by deserializing from data input stream. This constructor includes an optional check
+   * that the stream has no more available bytes after reading.
+   *
+   * @param stream from which to deserialize the blobid
+   * @param clusterMap of the cluster that the blob id belongs to
+   * @param ensureFullyRead {@code true} if the stream should have no more available bytes after deserializing the blob
+   *                        ID.
+   * @throws IOException
+   */
+  private BlobId(DataInputStream stream, ClusterMap clusterMap, boolean ensureFullyRead)
+      throws IOException {
     this.version = stream.readShort();
     if (version == 1) {
-      this.partitionId = clusterMap.getPartitionIdFromStream(stream);
+      partitionId = clusterMap.getPartitionIdFromStream(stream);
+      if (partitionId == null) {
+        throw new IllegalArgumentException("Partition ID cannot be null");
+      }
       uuid = Utils.readIntString(stream);
+      if (uuid == null) {
+        throw new IllegalArgumentException("Could not parse uuid");
+      }
+      if (ensureFullyRead && stream.available() > 0) {
+        throw new IllegalArgumentException("Stream should have no more available bytes to read");
+      }
     } else {
       throw new IllegalArgumentException("version " + version + " not supported for blob id");
     }

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -13,17 +13,29 @@
  */
 package com.github.ambry.commons;
 
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.Partition;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.PartitionState;
+import com.github.ambry.utils.ByteBufferInputStream;
+import java.io.DataInputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 
 public class BlobIdTest {
   @Test
-  public void basicTest() {
+  public void basicTest()
+      throws Exception {
     final long id = 99;
     final long replicaCapacityInBytes = 1024 * 1024 * 1024;
     PartitionId partitionId = new Partition(id, PartitionState.READ_WRITE, replicaCapacityInBytes);
@@ -32,5 +44,95 @@ public class BlobIdTest {
     assertEquals(blobId.getPartition(), partitionId);
     System.out.println("Blob Id toString: " + blobId);
     System.out.println("Blob id sizeInBytes: " + blobId.toString().length());
+  }
+
+  /**
+   * Test the parsing of a valid blob ID from a string and stream.
+   * @throws Exception
+   */
+  @Test
+  public void goodIdTest()
+      throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    short goodVersion = 1;
+    PartitionId goodPartitionId = clusterMap.getWritablePartitionIds().get(0);
+    String goodUUID = UUID.randomUUID().toString();
+    String goodId = buildBlobIdLike(goodVersion, goodPartitionId, goodUUID.length(), goodUUID);
+    List<BlobId> blobIds = new ArrayList<>();
+    blobIds.add(new BlobId(goodId, clusterMap));
+    blobIds.add(new BlobId(getStreamFromBase64(goodId), clusterMap));
+    blobIds.add(new BlobId(getStreamFromBase64(goodId + "EXTRA"), clusterMap));
+    for (BlobId blobId : blobIds) {
+      assertEquals("Wrong partition ID in blob ID: " + blobId, goodPartitionId, blobId.getPartition());
+      assertEquals("Wrong base-64 ID in blob ID: " + blobId, goodId, blobId.getID());
+    }
+  }
+
+  /**
+   * Test various invalid blob IDs
+   * @throws Exception
+   */
+  @Test
+  public void badIdTest()
+      throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    List<String> blobIdLikes = new ArrayList<>();
+
+    short goodVersion = 1;
+    PartitionId goodPartitionId = clusterMap.getWritablePartitionIds().get(0);
+    PartitionId badPartitionId = new MockPartitionId(200000, Collections.EMPTY_LIST, 0);
+    String goodUUID = UUID.randomUUID().toString();
+
+    // Partition ID not in cluster map
+    blobIdLikes.add(buildBlobIdLike(goodVersion, badPartitionId, goodUUID.length(), goodUUID));
+    // UUID length too long
+    blobIdLikes.add(buildBlobIdLike(goodVersion, goodPartitionId, goodUUID.length() + 1, goodUUID));
+    // UUID length too short
+    blobIdLikes.add(buildBlobIdLike(goodVersion, goodPartitionId, goodUUID.length() - 1, goodUUID));
+    // UUID length is negative
+    blobIdLikes.add(buildBlobIdLike(goodVersion, goodPartitionId, -1, goodUUID));
+    // Extra characters after UUID
+    blobIdLikes.add(buildBlobIdLike(goodVersion, goodPartitionId, goodUUID.length(), goodUUID + "EXTRA"));
+    // Invalid version number
+    blobIdLikes.add(buildBlobIdLike((short) (goodVersion + 1), goodPartitionId, goodUUID.length(), goodUUID));
+    // Empty blob ID
+    blobIdLikes.add("");
+    // short Blob ID
+    blobIdLikes.add("AA");
+
+    for (String blobIdLike : blobIdLikes) {
+      try {
+        new BlobId(blobIdLike, clusterMap);
+        fail("Expected blob ID creation to fail with blob ID string " + blobIdLike);
+      } catch (Exception e) {
+      }
+    }
+  }
+
+  /**
+   * Build a string that resembles a blob ID, but with possibly invalid sections.
+   * @param version the version number to use in the blob ID
+   * @param partitionId the partition ID to use in the blob ID
+   * @param uuidLength the UUID length to use in the blob ID
+   * @param uuidLike the UUID to use in the blob ID
+   * @return a base-64 encoded {@link String} representing the blob ID
+   */
+  private String buildBlobIdLike(short version, PartitionId partitionId, int uuidLength, String uuidLike) {
+    final int idLength = 2 + partitionId.getBytes().length + 4 + uuidLike.length();
+    ByteBuffer idBuf = ByteBuffer.allocate(idLength);
+    idBuf.putShort(version);
+    idBuf.put(partitionId.getBytes());
+    idBuf.putInt(uuidLength);
+    idBuf.put(uuidLike.getBytes());
+    return Base64.encodeBase64URLSafeString(idBuf.array());
+  }
+
+  /**
+   * Convert a base-64 encoded string into a {@link DataInputStream}
+   * @param base64String the base-64 encoded {@link String}
+   * @return the {@link DataInputStream}
+   */
+  private DataInputStream getStreamFromBase64(String base64String) {
+    return new DataInputStream(new ByteBufferInputStream(ByteBuffer.wrap(Base64.decodeBase64(base64String))));
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -1707,7 +1707,7 @@ class StoreFindToken implements FindToken {
     // read sessionId
     String sessionId = Utils.readIntString(stream);
     UUID sessionIdUUID = null;
-    if (sessionId != null) {
+    if (!sessionId.isEmpty()) {
       sessionIdUUID = UUID.fromString(sessionId);
     }
     // read offset

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -57,8 +57,8 @@ public class Utils {
   public static String readShortString(DataInputStream input)
       throws IOException {
     Short size = input.readShort();
-    if (size <= 0) {
-      return null;
+    if (size < 0) {
+      throw new IllegalArgumentException("readShortString : the size cannot be negative");
     }
     byte[] bytes = new byte[size];
     int read = 0;
@@ -84,8 +84,8 @@ public class Utils {
   public static String readIntString(DataInputStream input)
       throws IOException {
     int size = input.readInt();
-    if (size <= 0) {
-      return null;
+    if (size < 0) {
+      throw new IllegalArgumentException("readIntString : the size cannot be negative");
     }
     byte[] bytes = new byte[size];
     int read = 0;
@@ -112,7 +112,7 @@ public class Utils {
       throws IOException {
     int size = input.readInt();
     if (size < 0) {
-      return null;
+      throw new IllegalArgumentException("readIntBuffer : the size cannot be negative");
     }
     ByteBuffer buffer = ByteBuffer.allocate(size);
     int read = 0;
@@ -139,7 +139,7 @@ public class Utils {
       throws IOException {
     short size = input.readShort();
     if (size < 0) {
-      return null;
+      throw new IllegalArgumentException("readShortBuffer : the size cannot be negative");
     }
     ByteBuffer buffer = ByteBuffer.allocate(size);
     int read = 0;

--- a/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
@@ -74,9 +74,15 @@ public class UtilsTest {
     buffer.flip();
     String outputString = Utils.readShortString(new DataInputStream(new ByteBufferInputStream(buffer)));
     Assert.assertEquals(s, outputString);
+    // 0-length
+    buffer.flip();
+    buffer.putShort((short) 0);
+    buffer.rewind();
+    outputString = Utils.readShortString(new DataInputStream(new ByteBufferInputStream(buffer)));
+    Assert.assertEquals("", outputString);
 
     // failed case
-    buffer.flip();
+    buffer.rewind();
     buffer.putShort((short) 10);
     buffer.put(s.getBytes());
     buffer.flip();
@@ -89,8 +95,11 @@ public class UtilsTest {
     buffer.flip();
     buffer.putShort((short) -1);
     buffer.flip();
-    outputString = Utils.readShortString(new DataInputStream(new ByteBufferInputStream(buffer)));
-    Assert.assertNull(outputString);
+    try {
+      outputString = Utils.readShortString(new DataInputStream(new ByteBufferInputStream(buffer)));
+      Assert.fail("Should have encountered exception with negative length.");
+    } catch (IllegalArgumentException e) {
+    }
 
     // good case
     buffer = ByteBuffer.allocate(40004);
@@ -100,9 +109,15 @@ public class UtilsTest {
     buffer.flip();
     outputString = Utils.readIntString(new DataInputStream(new ByteBufferInputStream(buffer)));
     Assert.assertEquals(s, outputString);
+    // 0-length
+    buffer.flip();
+    buffer.putInt(0);
+    buffer.rewind();
+    outputString = Utils.readShortString(new DataInputStream(new ByteBufferInputStream(buffer)));
+    Assert.assertEquals("", outputString);
 
     // failed case
-    buffer.flip();
+    buffer.rewind();
     buffer.putInt(50000);
     buffer.put(s.getBytes());
     buffer.flip();
@@ -115,8 +130,11 @@ public class UtilsTest {
     buffer.flip();
     buffer.putInt(-1);
     buffer.flip();
-    outputString = Utils.readIntString(new DataInputStream(new ByteBufferInputStream(buffer)));
-    Assert.assertNull(outputString);
+    try {
+      Utils.readIntString(new DataInputStream(new ByteBufferInputStream(buffer)));
+      Assert.fail("Should have encountered exception with negative length.");
+    } catch (IllegalArgumentException e) {
+    }
   }
 
   @Test
@@ -130,6 +148,19 @@ public class UtilsTest {
     for (int i = 0; i < 40000; i++) {
       Assert.assertEquals(buf[i + 4], outputBuf.array()[i]);
     }
+    // 0 size
+    inputBuf.rewind();
+    inputBuf.putInt(0, 0);
+    outputBuf = Utils.readIntBuffer(new DataInputStream(new ByteBufferInputStream(inputBuf)));
+    Assert.assertEquals("Output should be of length 0", 0, outputBuf.array().length);
+    // negative size
+    inputBuf.rewind();
+    inputBuf.putInt(0, -1);
+    try {
+      Utils.readIntBuffer(new DataInputStream(new ByteBufferInputStream(inputBuf)));
+      Assert.fail("Should have encountered exception with negative length.");
+    } catch (IllegalArgumentException e) {
+    }
 
     buf = new byte[10];
     new Random().nextBytes(buf);
@@ -138,6 +169,19 @@ public class UtilsTest {
     outputBuf = Utils.readShortBuffer(new DataInputStream(new ByteBufferInputStream(inputBuf)));
     for (int i = 0; i < 8; i++) {
       Assert.assertEquals(buf[i + 2], outputBuf.array()[i]);
+    }
+    // 0 size
+    inputBuf.rewind();
+    inputBuf.putShort(0, (short) 0);
+    outputBuf = Utils.readShortBuffer(new DataInputStream(new ByteBufferInputStream(inputBuf)));
+    Assert.assertEquals("Output should be of length 0", 0, outputBuf.array().length);
+    // negative size
+    inputBuf.rewind();
+    inputBuf.putShort(0, (short) -1);
+    try {
+      Utils.readShortBuffer(new DataInputStream(new ByteBufferInputStream(inputBuf)));
+      Assert.fail("Should have encountered exception with negative length.");
+    } catch (IllegalArgumentException e) {
     }
   }
 

--- a/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
@@ -75,11 +75,10 @@ public class UtilsTest {
     String outputString = Utils.readShortString(new DataInputStream(new ByteBufferInputStream(buffer)));
     Assert.assertEquals(s, outputString);
     // 0-length
-    buffer.flip();
-    buffer.putShort((short) 0);
     buffer.rewind();
+    buffer.putShort(0, (short) 0);
     outputString = Utils.readShortString(new DataInputStream(new ByteBufferInputStream(buffer)));
-    Assert.assertEquals("", outputString);
+    Assert.assertTrue(outputString.isEmpty());
 
     // failed case
     buffer.rewind();
@@ -92,9 +91,8 @@ public class UtilsTest {
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(true);
     }
-    buffer.flip();
-    buffer.putShort((short) -1);
-    buffer.flip();
+    buffer.rewind();
+    buffer.putShort(0, (short) -1);
     try {
       outputString = Utils.readShortString(new DataInputStream(new ByteBufferInputStream(buffer)));
       Assert.fail("Should have encountered exception with negative length.");
@@ -110,11 +108,10 @@ public class UtilsTest {
     outputString = Utils.readIntString(new DataInputStream(new ByteBufferInputStream(buffer)));
     Assert.assertEquals(s, outputString);
     // 0-length
-    buffer.flip();
-    buffer.putInt(0);
     buffer.rewind();
+    buffer.putInt(0, 0);
     outputString = Utils.readShortString(new DataInputStream(new ByteBufferInputStream(buffer)));
-    Assert.assertEquals("", outputString);
+    Assert.assertTrue(outputString.isEmpty());
 
     // failed case
     buffer.rewind();
@@ -127,9 +124,8 @@ public class UtilsTest {
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(true);
     }
-    buffer.flip();
-    buffer.putInt(-1);
-    buffer.flip();
+    buffer.rewind();
+    buffer.putInt(0, -1);
     try {
       Utils.readIntString(new DataInputStream(new ByteBufferInputStream(buffer)));
       Assert.fail("Should have encountered exception with negative length.");


### PR DESCRIPTION
- Ensures that partition IDs and UUIDs within blob IDs are always non-null.
- Ensures that blob IDs parsed from strings do not have extra characters afterwards.
- Adds additional BlobID testcases.

*Reviewer:* @pnarayanan 
*Time to review:* 10 min.