### PR TITLE
Moving hard delete classes out of PersistentIndex

### DIFF
--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -39,7 +39,7 @@ import com.github.ambry.protocol.PutRequest;
 import com.github.ambry.protocol.PutResponse;
 import com.github.ambry.store.FindToken;
 import com.github.ambry.store.FindTokenFactory;
-import com.github.ambry.store.PersistentIndex;
+import com.github.ambry.store.HardDeleter;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.CrcInputStream;
@@ -140,7 +140,7 @@ public class ServerHardDeleteTest {
         DataInputStream stream = new DataInputStream(crcStream);
         try {
           short version = stream.readShort();
-          Assert.assertEquals(version, PersistentIndex.Cleanup_Token_Version_V1);
+          Assert.assertEquals(version, HardDeleter.Cleanup_Token_Version_V1);
           StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", mockClusterMap);
           FindTokenFactory factory = Utils.getObj("com.github.ambry.store.StoreFindTokenFactory", storeKeyFactory);
 

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -1,0 +1,645 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.codahale.metrics.Timer;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.utils.CrcInputStream;
+import com.github.ambry.utils.CrcOutputStream;
+import com.github.ambry.utils.Throttler;
+import com.github.ambry.utils.Time;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Class that provides functionality to perform hard deletes.
+ */
+public class HardDeleter implements Runnable {
+
+  public static final short Cleanup_Token_Version_V1 = 0;
+  private static final String Cleanup_Token_Filename = "cleanuptoken";
+
+  final AtomicBoolean running = new AtomicBoolean(true);
+
+  private final StoreMetrics metrics;
+  private final String dataDir;
+  private final Log log;
+  private final PersistentIndex index;
+  private final MessageStoreHardDelete hardDelete;
+  private final StoreKeyFactory factory;
+  private final Time time;
+  private final int scanSizeInBytes;
+  private final int messageRetentionSeconds;
+  //how long to sleep if token does not advance.
+  private final long hardDeleterSleepTimeWhenCaughtUpMs = 10 * Time.MsPerSec;
+  private final CountDownLatch shutdownLatch = new CountDownLatch(1);
+  private final Object lock = new Object();
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  /* A range of entries is maintained during the hard delete operation. All the entries corresponding to an ongoing
+   * hard delete will be from this range. The reason to keep this range is to finish off any incomplete and ongoing
+   * hard deletes when we do a crash recovery.
+   * Following tokens are maintained:
+   * startTokenSafeToPersist <= startTokenBeforeLogFlush <= startToken <= endToken
+   *
+   * Ongoing hard deletes are for entries within startToken and endToken. These keep getting incremented as and when
+   * hard deletes happen. The cleanup token that is persisted periodically is used during recovery to figure out the
+   * range on which recovery is to be done. The end token to persist is the endToken that we maintain. However, the
+   * start token that is persisted has to be a token up to which the hard deletes that were performed have been
+   * flushed. Since the index persistor runs asynchronously to the hard delete thread, a few other tokens are used to
+   * help safely persist tokens:
+   *
+   * startTokenSafeToPersist:  This will always be a value up to which the log has been flushed, and is a token safe
+   *                           to be persisted in the cleanupToken file. The 'current' start token can be greater than
+   *                           this value.
+   * startTokenBeforeLogFlush: This token is set to the current start token just before log flush and once the log is
+   *                           flushed, this is used to set startTokenSafeToPersist.
+   */
+  private FindToken startToken;
+  private FindToken startTokenBeforeLogFlush;
+  private FindToken startTokenSafeToPersist;
+  private FindToken endToken;
+  private StoreFindToken recoveryEndToken;
+  private HardDeletePersistInfo hardDeleteRecoveryRange = new HardDeletePersistInfo();
+  private Throttler throttler;
+  boolean isCaughtUp = false;
+
+  HardDeleter(StoreConfig config, StoreMetrics metrics, String dataDir, Log log, PersistentIndex index,
+      MessageStoreHardDelete hardDelete, StoreKeyFactory factory, Time time) {
+    this.metrics = metrics;
+    this.dataDir = dataDir;
+    this.log = log;
+    this.index = index;
+    this.hardDelete = hardDelete;
+    this.factory = factory;
+    this.time = time;
+    throttler = new Throttler(config.storeHardDeleteBytesPerSec, 10, true, time);
+    scanSizeInBytes = config.storeHardDeleteBytesPerSec * 10;
+    messageRetentionSeconds = config.storeDeletedMessageRetentionDays * Time.SecsPerDay;
+  }
+
+  @Override
+  public void run() {
+    try {
+      while (running.get()) {
+        try {
+          if (!hardDelete()) {
+            isCaughtUp = true;
+            synchronized (lock) {
+              if (!running.get()) {
+                break;
+              }
+              time.wait(lock, hardDeleterSleepTimeWhenCaughtUpMs);
+            }
+          } else if (isCaughtUp) {
+            isCaughtUp = false;
+            logger.info("Resumed hard deletes for {} after having caught up", dataDir);
+          }
+        } catch (StoreException e) {
+          if (e.getErrorCode() != StoreErrorCodes.Store_Shutting_Down) {
+            logger.error("Caught store exception: ", e);
+          } else {
+            logger.trace("Caught exception during hard deletes", e);
+          }
+        } catch (InterruptedException e) {
+          logger.trace("Caught exception during hard deletes", e);
+        }
+      }
+    } finally {
+      close();
+    }
+  }
+
+  /**
+   * Does the recovery of hard deleted blobs (means redoing the hard deletes)
+   *
+   * This method first populates hardDeleteRecoveryRange with the blob information read from the cleanup
+   * token file. It then passes the messageStoreRecoveryInfo to the MessageStoreHardDelete component so that the latter
+   * can use it for recovering the information that may be required to hard delete the messages that are being hard
+   * deleted as part of recovery.
+   *
+   * @throws StoreException on version mismatch.
+   */
+  void performRecovery()
+      throws StoreException {
+    try {
+      readCleanupTokenAndPopulateRecoveryRange();
+      if (hardDeleteRecoveryRange.getSize() == 0) {
+        return;
+      }
+
+        /* First create the readOptionsList */
+      List<BlobReadOptions> readOptionsList = hardDeleteRecoveryRange.getBlobReadOptionsList();
+
+        /* Next, perform the log write. The token file does not have to be persisted again as only entries that are
+           currently in it are being hard deleted as part of recovery. */
+      StoreMessageReadSet readSet = log.getView(readOptionsList);
+      Iterator<HardDeleteInfo> hardDeleteIterator =
+          hardDelete.getHardDeleteMessages(readSet, factory, hardDeleteRecoveryRange.getMessageStoreRecoveryInfoList());
+
+      Iterator<BlobReadOptions> readOptionsIterator = readOptionsList.iterator();
+      while (hardDeleteIterator.hasNext()) {
+        if (!running.get()) {
+          throw new StoreException("Aborting hard deletes as store is shutting down",
+              StoreErrorCodes.Store_Shutting_Down);
+        }
+        HardDeleteInfo hardDeleteInfo = hardDeleteIterator.next();
+        BlobReadOptions readOptions = readOptionsIterator.next();
+        if (hardDeleteInfo == null) {
+          metrics.hardDeleteFailedCount.inc(1);
+        } else {
+          log.writeFrom(hardDeleteInfo.getHardDeleteChannel(),
+              readOptions.getOffset() + hardDeleteInfo.getStartOffsetInMessage(),
+              hardDeleteInfo.getHardDeletedMessageSize());
+          metrics.hardDeleteDoneCount.inc(1);
+        }
+      }
+    } catch (IOException e) {
+      metrics.hardDeleteExceptionsCount.inc();
+      throw new StoreException("IO exception while performing hard delete ", e, StoreErrorCodes.IOError);
+    }
+      /* Now that all the blobs in the range were successfully hard deleted, the next time hard deletes can be resumed
+         at recoveryEndToken. */
+    startToken = endToken = recoveryEndToken;
+  }
+
+  /**
+   * Prunes the hardDeleteRecoveryRange so that all the information for keys before startTokenSafeToPersist are
+   * removed. This is safe as the hard deleted writes of those keys are guaranteed to have been flushed in the log.
+   * All the entries from startTokenSafeToPersist to endToken must be maintained in hardDeleteRecoveryRange.
+   * hardDeleteRecoveryRange may still have information of keys that have been persisted in certain cases, but this
+   * does not affect the safety.
+   * Note that we don't need any synchronization for this method as the hardDeleteRecoveryRange and all other
+   * variables except startTokenSafeToPersist are only modified by the hardDeleteThread. Since startTokenSafeToPersist
+   * gets modified by the IndexPersistorThread while this operation is in progress, we save it off first and use the
+   * saved off value subsequently.
+   */
+  void pruneHardDeleteRecoveryRange() {
+    StoreFindToken logFlushedTillToken = (StoreFindToken) startTokenSafeToPersist;
+    if (logFlushedTillToken != null && !logFlushedTillToken.isUninitialized()) {
+      if (logFlushedTillToken.equals(endToken)) {
+        hardDeleteRecoveryRange.clear();
+      } else if (logFlushedTillToken.getStoreKey() != null) {
+          /* Avoid pruning if the token is journal based as it is complicated and unnecessary. This is because, in the
+             recovery range, keys are stored not offsets. It should be okay to not prune though, as there is no
+             correctness issue. Additionally, since this token is journal based, it is highly likely that this token
+             will soon become equal to endtoken, in which case we will prune everything (in the "if case" above).
+             If the token is index based, safely prune off entries that have already been flushed in the log */
+        hardDeleteRecoveryRange.pruneTill(logFlushedTillToken.getStoreKey());
+      }
+    }
+  }
+
+  /**
+   * Finds deleted entries from the index, persists tokens and calls performHardDelete to delete the corresponding put
+   * records in the log.
+   * Note: At this time, expired blobs are not hard deleted.
+   *
+   * Sp is the token till which log is persisted and is therefore safe to be used as the start point during recovery.
+   * (S, E] represents the range of elements being hard deleted at any given time.
+   *
+   * The algorithm is as follows:
+   * 1. Start at the current token S.
+   * 2. {E, entries} = findDeletedEntriesSince(S).
+   * 3. Persist {Sp, E} and at least all the entries in the range (Sp, E] to help with recovery if we crash.
+   * 4. perform hard deletes of entries in this range.
+   * 5. set S = E
+   * 6. Index Persistor runs in the background and
+   *    a) saves Sf = S
+   *    b) flushes log (so everything up to Sf is surely flushed in the log)
+   *    c) sets Sp = Sf
+   *
+   * The guarantee provided is that for any persisted token pair (Sp, E):
+   *    - all the hard deletes till point Sp have been flushed in the log; and
+   *    - all ongoing hard deletes and unflushed hard deletes are somewhere between Sp and E, so during recovery this
+   *    is the range to be recovered.
+   *
+   * @return true if the token moved forward, false otherwise.
+   */
+  boolean hardDelete()
+      throws StoreException {
+    if (index.getCurrentEndOffset() > 0) {
+      final Timer.Context context = metrics.hardDeleteTime.time();
+      try {
+        FindInfo info =
+            index.findDeletedEntriesSince(startToken, scanSizeInBytes, time.seconds() - messageRetentionSeconds);
+        endToken = info.getFindToken();
+        pruneHardDeleteRecoveryRange();
+        if (!endToken.equals(startToken)) {
+          if (!info.getMessageEntries().isEmpty()) {
+            performHardDeletes(info.getMessageEntries());
+          }
+          startToken = endToken;
+          return true;
+        }
+      } catch (StoreException e) {
+        if (e.getErrorCode() != StoreErrorCodes.Store_Shutting_Down) {
+          metrics.hardDeleteExceptionsCount.inc();
+        }
+        throw e;
+      } finally {
+        context.stop();
+      }
+    }
+    return false;
+  }
+
+  /**
+   * This method will be called before the log is flushed.
+   */
+  void preLogFlush() {
+      /* Save the current start token before the log gets flushed */
+    startTokenBeforeLogFlush = startToken;
+  }
+
+  /**
+   * This method will be called after the log is flushed.
+   */
+  void postLogFlush() {
+      /* start token saved before the flush is now safe to be persisted */
+    startTokenSafeToPersist = startTokenBeforeLogFlush;
+  }
+
+  /**
+   * Gets the number of bytes processed so far
+   * @return the number of bytes processed so far as represented by the start token. Note that if the token is
+   * index based, this is at segment granularity.
+   */
+  long getProgress() {
+    StoreFindToken token = (StoreFindToken) startToken;
+    if (token.isUninitialized()) {
+      return 0;
+    } else if (token.getOffset() != StoreFindToken.Uninitialized_Offset) {
+      return token.getOffset();
+    } else {
+      return token.getIndexStartOffset();
+    }
+  }
+
+  /**
+   * Returns true if the hard delete is currently running.
+   * @return true if running, false otherwise.
+   */
+  public boolean hardDeleteThreadRunning() {
+    return shutdownLatch.getCount() != 0;
+  }
+
+  /**
+   * Returns true if the hard delete thread has caught up, that is if the token did not advance in the last iteration
+   * @return true if caught up, false otherwise.
+   */
+  boolean isCaughtUp() {
+    return isCaughtUp;
+  }
+
+  void shutdown()
+      throws InterruptedException, StoreException, IOException {
+    if (running.get()) {
+      running.set(false);
+      synchronized (lock) {
+        lock.notify();
+      }
+      throttler.close();
+      shutdownLatch.await();
+      pruneHardDeleteRecoveryRange();
+      persistCleanupToken();
+    }
+  }
+
+  void close() {
+    running.set(false);
+    shutdownLatch.countDown();
+  }
+
+  /**
+   * Reads from the cleanupToken file and adds into hardDeleteRecoveryRange the info for all the messages persisted
+   * in the file. If cleanupToken is non-existent or if there is a crc failure, resets the token.
+   * This method calls into MessageStoreHardDelete interface to let it read the persisted recovery metadata from the
+   * stream.
+   * @throws StoreException on version mismatch.
+   */
+  private void readCleanupTokenAndPopulateRecoveryRange()
+      throws IOException, StoreException {
+    File cleanupTokenFile = new File(dataDir, Cleanup_Token_Filename);
+    StoreFindToken recoveryStartToken = recoveryEndToken = new StoreFindToken();
+    startToken = startTokenBeforeLogFlush = startTokenSafeToPersist = endToken = new StoreFindToken();
+    if (cleanupTokenFile.exists()) {
+      CrcInputStream crcStream = new CrcInputStream(new FileInputStream(cleanupTokenFile));
+      DataInputStream stream = new DataInputStream(crcStream);
+      try {
+        short version = stream.readShort();
+        switch (version) {
+          case Cleanup_Token_Version_V1:
+            recoveryStartToken = StoreFindToken.fromBytes(stream, factory);
+            recoveryEndToken = StoreFindToken.fromBytes(stream, factory);
+            hardDeleteRecoveryRange = new HardDeletePersistInfo(stream, factory);
+            break;
+          default:
+            hardDeleteRecoveryRange.clear();
+            metrics.hardDeleteIncompleteRecoveryCount.inc();
+            throw new StoreException("Invalid version in cleanup token " + dataDir,
+                StoreErrorCodes.Index_Version_Error);
+        }
+        long crc = crcStream.getValue();
+        if (crc != stream.readLong()) {
+          hardDeleteRecoveryRange.clear();
+          metrics.hardDeleteIncompleteRecoveryCount.inc();
+          throw new StoreException(
+              "Crc check does not match for cleanup token file for dataDir " + dataDir + " aborting. ",
+              StoreErrorCodes.Illegal_Index_State);
+        }
+      } catch (IOException e) {
+        hardDeleteRecoveryRange.clear();
+        metrics.hardDeleteIncompleteRecoveryCount.inc();
+        throw new StoreException("Failed to read cleanup token ", e, StoreErrorCodes.Initialization_Error);
+      } finally {
+        stream.close();
+      }
+    }
+      /* If all the information was successfully read and there are no crc check failures, then the next time hard
+         deletes are done, it can start at least at the recoveryStartToken.
+       */
+    startToken = startTokenBeforeLogFlush = startTokenSafeToPersist = endToken = recoveryStartToken;
+  }
+
+  private void persistCleanupToken()
+      throws IOException, StoreException {
+        /* The cleanup token format is as follows:
+           --
+           token_version
+           startTokenForRecovery
+           endTokenForRecovery
+           numBlobsInRange
+           --
+           blob1_blobReadOptions {version, offset, sz, ttl, key}
+           blob2_blobReadOptions
+           ....
+           blobN_blobReadOptions
+           --
+           length_of_blob1_messageStoreRecoveryInfo
+           blob1_messageStoreRecoveryInfo {headerVersion, userMetadataVersion, userMetadataSize, blobRecordVersion, blobStreamSize}
+           length_of_blob2_messageStoreRecoveryInfo
+           blob2_messageStoreRecoveryInfo
+           ....
+           length_of_blobN_messageStoreRecoveryInfo
+           blobN_messageStoreRecoveryInfo
+           --
+           crc
+           ---
+         */
+    if (endToken == null || ((StoreFindToken) endToken).isUninitialized()) {
+      return;
+    }
+    final Timer.Context context = metrics.cleanupTokenFlushTime.time();
+    File tempFile = new File(dataDir, Cleanup_Token_Filename + ".tmp");
+    File actual = new File(dataDir, Cleanup_Token_Filename);
+    FileOutputStream fileStream = new FileOutputStream(tempFile);
+    CrcOutputStream crc = new CrcOutputStream(fileStream);
+    DataOutputStream writer = new DataOutputStream(crc);
+    try {
+      // write the current version
+      writer.writeShort(Cleanup_Token_Version_V1);
+      writer.write(startTokenSafeToPersist.toBytes());
+      writer.write(endToken.toBytes());
+      writer.write(hardDeleteRecoveryRange.toBytes());
+      long crcValue = crc.getValue();
+      writer.writeLong(crcValue);
+
+      fileStream.getChannel().force(true);
+      tempFile.renameTo(actual);
+    } catch (IOException e) {
+      throw new StoreException("IO error while persisting cleanup tokens to disk " + tempFile.getAbsoluteFile(),
+          StoreErrorCodes.IOError);
+    } finally {
+      writer.close();
+      context.stop();
+    }
+    logger.debug("Completed writing cleanup tokens to file {}", actual.getAbsolutePath());
+  }
+
+  /**
+   * Performs hard deletes of all the messages in the messageInfoList.
+   * Gets a view of the records in the log for those messages and calls cleanup to get the appropriate replacement
+   * records, and then replaces the records in the log with the corresponding replacement records.
+   * @param messageInfoList: The messages to be hard deleted in the log.
+   */
+  private void performHardDeletes(List<MessageInfo> messageInfoList)
+      throws StoreException {
+    try {
+      EnumSet<StoreGetOptions> getOptions = EnumSet.of(StoreGetOptions.Store_Include_Deleted);
+      List<BlobReadOptions> readOptionsList = new ArrayList<BlobReadOptions>(messageInfoList.size());
+
+        /* First create the readOptionsList */
+      for (MessageInfo info : messageInfoList) {
+        if (!running.get()) {
+          throw new StoreException("Aborting, store is shutting down", StoreErrorCodes.Store_Shutting_Down);
+        }
+        try {
+          BlobReadOptions readInfo = index.getBlobReadInfo(info.getStoreKey(), getOptions);
+          readOptionsList.add(readInfo);
+        } catch (StoreException e) {
+          logger.error("Failed to read blob info for blobid {} during hard deletes, ignoring. Caught exception {}",
+              info.getStoreKey(), e);
+          metrics.hardDeleteExceptionsCount.inc();
+        }
+      }
+
+      List<LogWriteInfo> logWriteInfoList = new ArrayList<LogWriteInfo>();
+
+      StoreMessageReadSet readSet = log.getView(readOptionsList);
+      Iterator<HardDeleteInfo> hardDeleteIterator = hardDelete.getHardDeleteMessages(readSet, factory, null);
+      Iterator<BlobReadOptions> readOptionsIterator = readOptionsList.iterator();
+
+        /* Next, get the information to persist hard delete recovery info. Get all the information and save it, as only
+         * after the whole range is persisted can we start with the actual log write */
+      while (hardDeleteIterator.hasNext()) {
+        if (!running.get()) {
+          throw new StoreException("Aborting hard deletes as store is shutting down",
+              StoreErrorCodes.Store_Shutting_Down);
+        }
+        HardDeleteInfo hardDeleteInfo = hardDeleteIterator.next();
+        BlobReadOptions readOptions = readOptionsIterator.next();
+        if (hardDeleteInfo == null) {
+          metrics.hardDeleteFailedCount.inc(1);
+        } else {
+          hardDeleteRecoveryRange.addMessageInfo(readOptions, hardDeleteInfo.getRecoveryInfo());
+          logWriteInfoList.add(new LogWriteInfo(hardDeleteInfo.getHardDeleteChannel(),
+              readOptions.getOffset() + hardDeleteInfo.getStartOffsetInMessage(),
+              hardDeleteInfo.getHardDeletedMessageSize()));
+        }
+      }
+
+      if (readOptionsIterator.hasNext()) {
+        metrics.hardDeleteExceptionsCount.inc(1);
+        throw new IllegalStateException("More number of blobReadOptions than hardDeleteMessages");
+      }
+
+      persistCleanupToken();
+
+        /* Finally, write the hard delete stream into the Log */
+      for (LogWriteInfo logWriteInfo : logWriteInfoList) {
+        if (!running.get()) {
+          throw new StoreException("Aborting hard deletes as store is shutting down",
+              StoreErrorCodes.Store_Shutting_Down);
+        }
+
+        log.writeFrom(logWriteInfo.channel, logWriteInfo.offset, logWriteInfo.size);
+        metrics.hardDeleteDoneCount.inc(1);
+        throttler.maybeThrottle(logWriteInfo.size);
+      }
+    } catch (InterruptedException e) {
+      if (running.get()) {
+        // We throw here because we do not want the tokens to be updated.
+        throw new StoreException("Got interrupted during hard deletes", StoreErrorCodes.Unknown_Error);
+      } else {
+        throw new StoreException("Got interrupted as store is shutting down", StoreErrorCodes.Store_Shutting_Down);
+      }
+    } catch (IOException e) {
+      throw new StoreException("IO exception while performing hard delete ", e, StoreErrorCodes.IOError);
+    }
+  }
+
+  /**
+   * A class to hold the information required to write hard delete stream to the Log.
+   */
+  private class LogWriteInfo {
+    ReadableByteChannel channel;
+    long offset;
+    long size;
+
+    LogWriteInfo(ReadableByteChannel channel, long offset, long size) {
+      this.channel = channel;
+      this.offset = offset;
+      this.size = size;
+    }
+  }
+
+  /**
+   * An object of this class contains all the information required for performing the hard delete recovery for the
+   * associated blob. This is the information that is persisted from time to time.
+   */
+  private class HardDeletePersistInfo {
+    private List<BlobReadOptions> blobReadOptionsList;
+    private List<byte[]> messageStoreRecoveryInfoList;
+
+    HardDeletePersistInfo() {
+      this.blobReadOptionsList = new ArrayList<BlobReadOptions>();
+      this.messageStoreRecoveryInfoList = new ArrayList<byte[]>();
+    }
+
+    HardDeletePersistInfo(DataInputStream stream, StoreKeyFactory storeKeyFactory)
+        throws IOException {
+      this();
+      int numBlobsToRecover = stream.readInt();
+      for (int i = 0; i < numBlobsToRecover; i++) {
+        blobReadOptionsList.add(BlobReadOptions.fromBytes(stream, storeKeyFactory));
+      }
+
+      for (int i = 0; i < numBlobsToRecover; i++) {
+        int lengthOfRecoveryInfo = stream.readInt();
+        byte[] messageStoreRecoveryInfo = new byte[lengthOfRecoveryInfo];
+        if (stream.read(messageStoreRecoveryInfo) != lengthOfRecoveryInfo) {
+          throw new IOException("Token file could not be read correctly");
+        }
+        messageStoreRecoveryInfoList.add(messageStoreRecoveryInfo);
+      }
+    }
+
+    void addMessageInfo(BlobReadOptions blobReadOptions, byte[] messageStoreRecoveryInfo) {
+      this.blobReadOptionsList.add(blobReadOptions);
+      this.messageStoreRecoveryInfoList.add(messageStoreRecoveryInfo);
+    }
+
+    void clear() {
+      blobReadOptionsList.clear();
+      messageStoreRecoveryInfoList.clear();
+    }
+
+    int getSize() {
+      return blobReadOptionsList.size();
+    }
+
+    /**
+     * @return A serialized byte array containing the information required for hard delete recovery.
+     */
+    byte[] toBytes()
+        throws IOException {
+      ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+      DataOutputStream dataOutputStream = new DataOutputStream(outStream);
+
+      /* Write the number of entries */
+      dataOutputStream.writeInt(blobReadOptionsList.size());
+
+      /* Write all the blobReadOptions */
+      for (BlobReadOptions blobReadOptions : blobReadOptionsList) {
+        dataOutputStream.write(blobReadOptions.toBytes());
+      }
+
+      /* Write all the messageStoreRecoveryInfos */
+      for (byte[] recoveryInfo : messageStoreRecoveryInfoList) {
+        /* First write the size of the recoveryInfo */
+        dataOutputStream.writeInt(recoveryInfo.length);
+
+        /* Now, write the recoveryInfo */
+        dataOutputStream.write(recoveryInfo);
+      }
+
+      return outStream.toByteArray();
+    }
+
+    /**
+     * Prunes entries in the range from the start up to, but excluding, the entry with the passed in key.
+     */
+    void pruneTill(StoreKey storeKey) {
+      Iterator<BlobReadOptions> blobReadOptionsListIterator = blobReadOptionsList.iterator();
+      Iterator<byte[]> messageStoreRecoveryListIterator = messageStoreRecoveryInfoList.iterator();
+      while (blobReadOptionsListIterator.hasNext()) {
+      /* Note: In the off chance that there are multiple presence of the same key in this range due to prior software
+         bugs, note that this method prunes only till the first occurrence of the key. If it so happens that a
+         later occurrence is the one really associated with this token, it does not affect the safety.
+         Persisting more than what is required is okay as hard deleting a blob is an idempotent operation. */
+        messageStoreRecoveryListIterator.next();
+        if (blobReadOptionsListIterator.next().getStoreKey().equals(storeKey)) {
+          break;
+        } else {
+          blobReadOptionsListIterator.remove();
+          messageStoreRecoveryListIterator.remove();
+        }
+      }
+    }
+
+    private List<BlobReadOptions> getBlobReadOptionsList() {
+      return blobReadOptionsList;
+    }
+
+    private List<byte[]> getMessageStoreRecoveryInfoList() {
+      return messageStoreRecoveryInfoList;
+    }
+  }
+}

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -306,7 +306,7 @@ public class HardDeleter implements Runnable {
    * Returns true if the hard delete is currently running.
    * @return true if running, false otherwise.
    */
-  public boolean hardDeleteThreadRunning() {
+  public boolean isRunning() {
     return shutdownLatch.getCount() != 0;
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -15,28 +15,19 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.Timer;
 import com.github.ambry.config.StoreConfig;
-import com.github.ambry.utils.CrcInputStream;
-import com.github.ambry.utils.CrcOutputStream;
 import com.github.ambry.utils.Scheduler;
-import com.github.ambry.utils.Throttler;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
-import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -45,9 +36,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,9 +52,7 @@ public class PersistentIndex {
   public static final String Index_File_Name_Suffix = "index";
   public static final String Bloom_File_Name_Suffix = "bloom";
   private static final String Clean_Shutdown_Filename = "cleanshutdown";
-  private static final String Cleanup_Token_Filename = "cleanuptoken";
   public static final short version = 0;
-  public static final short Cleanup_Token_Version_V1 = 0;
 
   protected Scheduler scheduler;
   protected ConcurrentSkipListMap<Long, IndexSegment> indexes = new ConcurrentSkipListMap<Long, IndexSegment>();
@@ -77,7 +64,7 @@ public class PersistentIndex {
   private String dataDir;
   private Logger logger = LoggerFactory.getLogger(getClass());
   private IndexPersistor persistor;
-  protected HardDeleteThread hardDeleter;
+  protected HardDeleter hardDeleter;
   private Thread hardDeleteThread;
   private MessageStoreHardDelete hardDelete;
   private StoreKeyFactory factory;
@@ -150,7 +137,7 @@ public class PersistentIndex {
       this.factory = factory;
       this.config = config;
       persistor = new IndexPersistor();
-      hardDeleter = new HardDeleteThread();
+      hardDeleter = new HardDeleter(config, metrics, datadir, log, this, hardDelete, factory, time);
       this.hardDelete = hardDelete;
       this.journal = journal;
       Arrays.sort(indexFiles, new Comparator<File>() {
@@ -237,7 +224,7 @@ public class PersistentIndex {
       } else {
         hardDeleter.close();
       }
-      metrics.initializeHardDeleteMetric(this, log);
+      metrics.initializeHardDeleteMetric(hardDeleter, log);
     } catch (StoreException e) {
       throw e;
     } catch (Exception e) {
@@ -894,7 +881,7 @@ public class PersistentIndex {
       throws StoreException {
     persistor.write();
     try {
-      hardDeleter.shutDown();
+      hardDeleter.shutdown();
     } catch (Exception e) {
       logger.error("Index : " + dataDir + " error while persisting cleanup token ", e);
     }
@@ -1075,604 +1062,6 @@ public class PersistentIndex {
         logger.error("Index : " + dataDir + " error while persisting the index to disk ", e);
       }
     }
-  }
-
-  /**
-   * An object of this class contains all the information required for performing the hard delete recovery for the
-   * associated blob. This is the information that is persisted from time to time.
-   */
-  private class HardDeletePersistInfo {
-    private List<BlobReadOptions> blobReadOptionsList;
-    private List<byte[]> messageStoreRecoveryInfoList;
-
-    HardDeletePersistInfo() {
-      this.blobReadOptionsList = new ArrayList<BlobReadOptions>();
-      this.messageStoreRecoveryInfoList = new ArrayList<byte[]>();
-    }
-
-    HardDeletePersistInfo(DataInputStream stream, StoreKeyFactory storeKeyFactory)
-        throws IOException {
-      this();
-      int numBlobsToRecover = stream.readInt();
-      for (int i = 0; i < numBlobsToRecover; i++) {
-        blobReadOptionsList.add(BlobReadOptions.fromBytes(stream, storeKeyFactory));
-      }
-
-      for (int i = 0; i < numBlobsToRecover; i++) {
-        int lengthOfRecoveryInfo = stream.readInt();
-        byte[] messageStoreRecoveryInfo = new byte[lengthOfRecoveryInfo];
-        if (stream.read(messageStoreRecoveryInfo) != lengthOfRecoveryInfo) {
-          throw new IOException("Token file could not be read correctly");
-        }
-        messageStoreRecoveryInfoList.add(messageStoreRecoveryInfo);
-      }
-    }
-
-    void addMessageInfo(BlobReadOptions blobReadOptions, byte[] messageStoreRecoveryInfo) {
-      this.blobReadOptionsList.add(blobReadOptions);
-      this.messageStoreRecoveryInfoList.add(messageStoreRecoveryInfo);
-    }
-
-    private List<BlobReadOptions> getBlobReadOptionsList() {
-      return blobReadOptionsList;
-    }
-
-    private List<byte[]> getMessageStoreRecoveryInfoList() {
-      return messageStoreRecoveryInfoList;
-    }
-
-    void clear() {
-      blobReadOptionsList.clear();
-      messageStoreRecoveryInfoList.clear();
-    }
-
-    int getSize() {
-      return blobReadOptionsList.size();
-    }
-
-    /**
-     * @return A serialized byte array containing the information required for hard delete recovery.
-     */
-    byte[] toBytes()
-        throws IOException {
-      ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-      DataOutputStream dataOutputStream = new DataOutputStream(outStream);
-
-      /* Write the number of entries */
-      dataOutputStream.writeInt(blobReadOptionsList.size());
-
-      /* Write all the blobReadOptions */
-      for (BlobReadOptions blobReadOptions : blobReadOptionsList) {
-        dataOutputStream.write(blobReadOptions.toBytes());
-      }
-
-      /* Write all the messageStoreRecoveryInfos */
-      for (byte[] recoveryInfo : messageStoreRecoveryInfoList) {
-        /* First write the size of the recoveryInfo */
-        dataOutputStream.writeInt(recoveryInfo.length);
-
-        /* Now, write the recoveryInfo */
-        dataOutputStream.write(recoveryInfo);
-      }
-
-      return outStream.toByteArray();
-    }
-
-    /**
-     * Prunes entries in the range from the start up to, but excluding, the entry with the passed in key.
-     */
-    void pruneTill(StoreKey storeKey) {
-      Iterator<BlobReadOptions> blobReadOptionsListIterator = blobReadOptionsList.iterator();
-      Iterator<byte[]> messageStoreRecoveryListIterator = messageStoreRecoveryInfoList.iterator();
-      while (blobReadOptionsListIterator.hasNext()) {
-      /* Note: In the off chance that there are multiple presence of the same key in this range due to prior software
-         bugs, note that this method prunes only till the first occurrence of the key. If it so happens that a
-         later occurrence is the one really associated with this token, it does not affect the safety.
-         Persisting more than what is required is okay as hard deleting a blob is an idempotent operation. */
-        messageStoreRecoveryListIterator.next();
-        if (blobReadOptionsListIterator.next().getStoreKey().equals(storeKey)) {
-          break;
-        } else {
-          blobReadOptionsListIterator.remove();
-          messageStoreRecoveryListIterator.remove();
-        }
-      }
-    }
-  }
-
-  protected class HardDeleteThread implements Runnable {
-    /** A range of entries is maintained during the hard delete operation. All the entries corresponding to an ongoing
-     * hard delete will be from this range. The reason to keep this range is to finish off any incomplete and ongoing
-     * hard deletes when we do a crash recovery.
-     * Following tokens are maintained:
-     * startTokenSafeToPersist <= startTokenBeforeLogFlush <= startToken <= endToken
-     *
-     * Ongoing hard deletes are for entries within startToken and endToken. These keep getting incremented as and when
-     * hard deletes happen. The cleanup token that is persisted periodically is used during recovery to figure out the
-     * range on which recovery is to be done. The end token to persist is the endToken that we maintain. However, the
-     * start token that is persisted has to be a token up to which the hard deletes that were performed have been
-     * flushed. Since the index persistor runs asynchronously to the hard delete thread, a few other tokens are used to
-     * help safely persist tokens:
-     *
-     * startTokenSafeToPersist:  This will always be a value up to which the log has been flushed, and is a token safe
-     *                           to be persisted in the cleanupToken file. The 'current' start token can be greater than
-     *                           this value.
-     * startTokenBeforeLogFlush: This token is set to the current start token just before log flush and once the log is
-     *                           flushed, this is used to set startTokenSafeToPersist.
-     */
-    private FindToken startToken;
-    private FindToken startTokenBeforeLogFlush;
-    private FindToken startTokenSafeToPersist;
-    private FindToken endToken;
-    private StoreFindToken recoveryStartToken;
-    private StoreFindToken recoveryEndToken;
-    private HardDeletePersistInfo hardDeleteRecoveryRange = new HardDeletePersistInfo();
-    private final int scanSizeInBytes = config.storeHardDeleteBytesPerSec * 10;
-    private final int messageRetentionSeconds = config.storeDeletedMessageRetentionDays * time.SecsPerDay;
-    private Throttler throttler;
-    private final CountDownLatch shutdownLatch = new CountDownLatch(1);
-    protected AtomicBoolean running = new AtomicBoolean(true);
-    boolean isCaughtUp = false;
-
-    //how long to sleep if token does not advance.
-    private final long hardDeleterSleepTimeWhenCaughtUpMs = 10 * time.MsPerSec;
-    private final long throttlerCheckIntervalMs = 10;
-
-    HardDeleteThread() {
-      this.throttler = new Throttler(config.storeHardDeleteBytesPerSec, throttlerCheckIntervalMs, true, time);
-    }
-
-    /**
-     * A class to hold the information required to write hard delete stream to the Log.
-     */
-    private class LogWriteInfo {
-      ReadableByteChannel channel;
-      long offset;
-      long size;
-
-      LogWriteInfo(ReadableByteChannel channel, long offset, long size) {
-        this.channel = channel;
-        this.offset = offset;
-        this.size = size;
-      }
-    }
-
-    /**
-     * Does the recovery of hard deleted blobs (means redoing the hard deletes)
-     *
-     * This method first populates hardDeleteRecoveryRange with the blob information read from the cleanup
-     * token file. It then passes the messageStoreRecoveryInfo to the MessageStoreHardDelete component so that the latter
-     * can use it for recovering the information that may be required to hard delete the messages that are being hard
-     * deleted as part of recovery.
-     *
-     * @throws StoreException on version mismatch.
-     */
-    protected void performRecovery()
-        throws StoreException {
-      try {
-        readCleanupTokenAndPopulateRecoveryRange();
-        if (hardDeleteRecoveryRange.getSize() == 0) {
-          return;
-        }
-
-        /* First create the readOptionsList */
-        List<BlobReadOptions> readOptionsList = hardDeleteRecoveryRange.getBlobReadOptionsList();
-
-        /* Next, perform the log write. The token file does not have to be persisted again as only entries that are
-           currently in it are being hard deleted as part of recovery. */
-        StoreMessageReadSet readSet = log.getView(readOptionsList);
-        Iterator<HardDeleteInfo> hardDeleteIterator = hardDelete
-            .getHardDeleteMessages(readSet, factory, hardDeleteRecoveryRange.getMessageStoreRecoveryInfoList());
-
-        Iterator<BlobReadOptions> readOptionsIterator = readOptionsList.iterator();
-        while (hardDeleteIterator.hasNext()) {
-          if (!running.get()) {
-            throw new StoreException("Aborting hard deletes as store is shutting down",
-                StoreErrorCodes.Store_Shutting_Down);
-          }
-          HardDeleteInfo hardDeleteInfo = hardDeleteIterator.next();
-          BlobReadOptions readOptions = readOptionsIterator.next();
-          if (hardDeleteInfo == null) {
-            metrics.hardDeleteFailedCount.inc(1);
-          } else {
-            log.writeFrom(hardDeleteInfo.getHardDeleteChannel(),
-                readOptions.getOffset() + hardDeleteInfo.getStartOffsetInMessage(),
-                hardDeleteInfo.getHardDeletedMessageSize());
-            metrics.hardDeleteDoneCount.inc(1);
-          }
-        }
-      } catch (IOException e) {
-        metrics.hardDeleteExceptionsCount.inc();
-        throw new StoreException("IO exception while performing hard delete ", e, StoreErrorCodes.IOError);
-      }
-      /* Now that all the blobs in the range were successfully hard deleted, the next time hard deletes can be resumed
-         at recoveryEndToken. */
-      startToken = endToken = recoveryEndToken;
-    }
-
-    /**
-     * Reads from the cleanupToken file and adds into hardDeleteRecoveryRange the info for all the messages persisted
-     * in the file. If cleanupToken is non-existent or if there is a crc failure, resets the token.
-     * This method calls into MessageStoreHardDelete interface to let it read the persisted recovery metadata from the
-     * stream.
-     * @throws StoreException on version mismatch.
-     */
-    private void readCleanupTokenAndPopulateRecoveryRange()
-        throws IOException, StoreException {
-      File cleanupTokenFile = new File(dataDir, Cleanup_Token_Filename);
-      recoveryStartToken = recoveryEndToken = new StoreFindToken();
-      startToken = startTokenBeforeLogFlush = startTokenSafeToPersist = endToken = new StoreFindToken();
-      if (cleanupTokenFile.exists()) {
-        CrcInputStream crcStream = new CrcInputStream(new FileInputStream(cleanupTokenFile));
-        DataInputStream stream = new DataInputStream(crcStream);
-        try {
-          short version = stream.readShort();
-          switch (version) {
-            case Cleanup_Token_Version_V1:
-              recoveryStartToken = StoreFindToken.fromBytes(stream, factory);
-              recoveryEndToken = StoreFindToken.fromBytes(stream, factory);
-              hardDeleteRecoveryRange = new HardDeletePersistInfo(stream, factory);
-              break;
-            default:
-              hardDeleteRecoveryRange.clear();
-              metrics.hardDeleteIncompleteRecoveryCount.inc();
-              throw new StoreException("Invalid version in cleanup token " + dataDir,
-                  StoreErrorCodes.Index_Version_Error);
-          }
-          long crc = crcStream.getValue();
-          if (crc != stream.readLong()) {
-            hardDeleteRecoveryRange.clear();
-            metrics.hardDeleteIncompleteRecoveryCount.inc();
-            throw new StoreException(
-                "Crc check does not match for cleanup token file for dataDir " + dataDir + " aborting. ",
-                StoreErrorCodes.Illegal_Index_State);
-          }
-        } catch (IOException e) {
-          hardDeleteRecoveryRange.clear();
-          metrics.hardDeleteIncompleteRecoveryCount.inc();
-          throw new StoreException("Failed to read cleanup token ", e, StoreErrorCodes.Initialization_Error);
-        } finally {
-          stream.close();
-        }
-      }
-      /* If all the information was successfully read and there are no crc check failures, then the next time hard
-         deletes are done, it can start at least at the recoveryStartToken.
-       */
-      startToken = startTokenBeforeLogFlush = startTokenSafeToPersist = endToken = recoveryStartToken;
-    }
-
-    /**
-     * This method will be called before the log is flushed.
-     */
-    protected void preLogFlush() {
-      /* Save the current start token before the log gets flushed */
-      startTokenBeforeLogFlush = startToken;
-    }
-
-    /**
-     * This method will be called after the log is flushed.
-     */
-    protected void postLogFlush() {
-      /* start token saved before the flush is now safe to be persisted */
-      startTokenSafeToPersist = startTokenBeforeLogFlush;
-    }
-
-    private void persistCleanupToken()
-        throws IOException, StoreException {
-        /* The cleanup token format is as follows:
-           --
-           token_version
-           startTokenForRecovery
-           endTokenForRecovery
-           numBlobsInRange
-           --
-           blob1_blobReadOptions {version, offset, sz, ttl, key}
-           blob2_blobReadOptions
-           ....
-           blobN_blobReadOptions
-           --
-           length_of_blob1_messageStoreRecoveryInfo
-           blob1_messageStoreRecoveryInfo {headerVersion, userMetadataVersion, userMetadataSize, blobRecordVersion, blobStreamSize}
-           length_of_blob2_messageStoreRecoveryInfo
-           blob2_messageStoreRecoveryInfo
-           ....
-           length_of_blobN_messageStoreRecoveryInfo
-           blobN_messageStoreRecoveryInfo
-           --
-           crc
-           ---
-         */
-      if (endToken == null || ((StoreFindToken) endToken).isUninitialized()) {
-        return;
-      }
-      final Timer.Context context = metrics.cleanupTokenFlushTime.time();
-      File tempFile = new File(dataDir, Cleanup_Token_Filename + ".tmp");
-      File actual = new File(dataDir, Cleanup_Token_Filename);
-      FileOutputStream fileStream = new FileOutputStream(tempFile);
-      CrcOutputStream crc = new CrcOutputStream(fileStream);
-      DataOutputStream writer = new DataOutputStream(crc);
-      try {
-        // write the current version
-        writer.writeShort(Cleanup_Token_Version_V1);
-        writer.write(startTokenSafeToPersist.toBytes());
-        writer.write(endToken.toBytes());
-        writer.write(hardDeleteRecoveryRange.toBytes());
-        long crcValue = crc.getValue();
-        writer.writeLong(crcValue);
-
-        fileStream.getChannel().force(true);
-        tempFile.renameTo(actual);
-      } catch (IOException e) {
-        throw new StoreException("IO error while persisting cleanup tokens to disk " + tempFile.getAbsoluteFile(),
-            StoreErrorCodes.IOError);
-      } finally {
-        writer.close();
-        context.stop();
-      }
-      logger.debug("Completed writing cleanup tokens to file {}", actual.getAbsolutePath());
-    }
-
-    /**
-     * Prunes the hardDeleteRecoveryRange so that all the information for keys before startTokenSafeToPersist are
-     * removed. This is safe as the hard deleted writes of those keys are guaranteed to have been flushed in the log.
-     * All the entries from startTokenSafeToPersist to endToken must be maintained in hardDeleteRecoveryRange.
-     * hardDeleteRecoveryRange may still have information of keys that have been persisted in certain cases, but this
-     * does not affect the safety.
-     * Note that we don't need any synchronization for this method as the hardDeleteRecoveryRange and all other
-     * variables except startTokenSafeToPersist are only modified by the hardDeleteThread. Since startTokenSafeToPersist
-     * gets modified by the IndexPersistorThread while this operation is in progress, we save it off first and use the
-     * saved off value subsequently.
-     */
-    protected void pruneHardDeleteRecoveryRange() {
-      StoreFindToken logFlushedTillToken = (StoreFindToken) startTokenSafeToPersist;
-      if (logFlushedTillToken != null && !logFlushedTillToken.isUninitialized()) {
-        if (logFlushedTillToken.equals(endToken)) {
-          hardDeleteRecoveryRange.clear();
-        } else if (logFlushedTillToken.getStoreKey() != null) {
-          /* Avoid pruning if the token is journal based as it is complicated and unnecessary. This is because, in the
-             recovery range, keys are stored not offsets. It should be okay to not prune though, as there is no
-             correctness issue. Additionally, since this token is journal based, it is highly likely that this token
-             will soon become equal to endtoken, in which case we will prune everything (in the "if case" above).
-             If the token is index based, safely prune off entries that have already been flushed in the log */
-          hardDeleteRecoveryRange.pruneTill(logFlushedTillToken.getStoreKey());
-        }
-      }
-    }
-
-    /**
-     * Performs hard deletes of all the messages in the messageInfoList.
-     * Gets a view of the records in the log for those messages and calls cleanup to get the appropriate replacement
-     * records, and then replaces the records in the log with the corresponding replacement records.
-     * @param messageInfoList: The messages to be hard deleted in the log.
-     */
-    private void performHardDeletes(List<MessageInfo> messageInfoList)
-        throws StoreException {
-      try {
-        EnumSet<StoreGetOptions> getOptions = EnumSet.of(StoreGetOptions.Store_Include_Deleted);
-        List<BlobReadOptions> readOptionsList = new ArrayList<BlobReadOptions>(messageInfoList.size());
-
-        /* First create the readOptionsList */
-        for (MessageInfo info : messageInfoList) {
-          if (!running.get()) {
-            throw new StoreException("Aborting, store is shutting down", StoreErrorCodes.Store_Shutting_Down);
-          }
-          try {
-            BlobReadOptions readInfo = getBlobReadInfo(info.getStoreKey(), getOptions);
-            readOptionsList.add(readInfo);
-          } catch (StoreException e) {
-            logger.error("Failed to read blob info for blobid {} during hard deletes, ignoring. Caught exception {}",
-                info.getStoreKey(), e);
-            metrics.hardDeleteExceptionsCount.inc();
-          }
-        }
-
-        List<LogWriteInfo> logWriteInfoList = new ArrayList<LogWriteInfo>();
-
-        StoreMessageReadSet readSet = log.getView(readOptionsList);
-        Iterator<HardDeleteInfo> hardDeleteIterator = hardDelete.getHardDeleteMessages(readSet, factory, null);
-        Iterator<BlobReadOptions> readOptionsIterator = readOptionsList.iterator();
-
-        /* Next, get the information to persist hard delete recovery info. Get all the information and save it, as only
-         * after the whole range is persisted can we start with the actual log write */
-        while (hardDeleteIterator.hasNext()) {
-          if (!running.get()) {
-            throw new StoreException("Aborting hard deletes as store is shutting down",
-                StoreErrorCodes.Store_Shutting_Down);
-          }
-          HardDeleteInfo hardDeleteInfo = hardDeleteIterator.next();
-          BlobReadOptions readOptions = readOptionsIterator.next();
-          if (hardDeleteInfo == null) {
-            metrics.hardDeleteFailedCount.inc(1);
-          } else {
-            hardDeleteRecoveryRange.addMessageInfo(readOptions, hardDeleteInfo.getRecoveryInfo());
-            logWriteInfoList.add(new LogWriteInfo(hardDeleteInfo.getHardDeleteChannel(),
-                readOptions.getOffset() + hardDeleteInfo.getStartOffsetInMessage(),
-                hardDeleteInfo.getHardDeletedMessageSize()));
-          }
-        }
-
-        if (readOptionsIterator.hasNext()) {
-          metrics.hardDeleteExceptionsCount.inc(1);
-          throw new IllegalStateException("More number of blobReadOptions than hardDeleteMessages");
-        }
-
-        persistCleanupToken();
-
-        /* Finally, write the hard delete stream into the Log */
-        for (LogWriteInfo logWriteInfo : logWriteInfoList) {
-          if (!running.get()) {
-            throw new StoreException("Aborting hard deletes as store is shutting down",
-                StoreErrorCodes.Store_Shutting_Down);
-          }
-
-          log.writeFrom(logWriteInfo.channel, logWriteInfo.offset, logWriteInfo.size);
-          metrics.hardDeleteDoneCount.inc(1);
-          throttler.maybeThrottle(logWriteInfo.size);
-        }
-      } catch (InterruptedException e) {
-        if (running.get()) {
-          // We throw here because we do not want the tokens to be updated.
-          throw new StoreException("Got interrupted during hard deletes", StoreErrorCodes.Unknown_Error);
-        } else {
-          throw new StoreException("Got interrupted as store is shutting down", StoreErrorCodes.Store_Shutting_Down);
-        }
-      } catch (IOException e) {
-        throw new StoreException("IO exception while performing hard delete ", e, StoreErrorCodes.IOError);
-      }
-    }
-
-    /**
-     * Finds deleted entries from the index, persists tokens and calls performHardDelete to delete the corresponding put
-     * records in the log.
-     * Note: At this time, expired blobs are not hard deleted.
-     *
-     * Sp is the token till which log is persisted and is therefore safe to be used as the start point during recovery.
-     * (S, E] represents the range of elements being hard deleted at any given time.
-     *
-     * The algorithm is as follows:
-     * 1. Start at the current token S.
-     * 2. {E, entries} = findDeletedEntriesSince(S).
-     * 3. Persist {Sp, E} and at least all the entries in the range (Sp, E] to help with recovery if we crash.
-     * 4. perform hard deletes of entries in this range.
-     * 5. set S = E
-     * 6. Index Persistor runs in the background and
-     *    a) saves Sf = S
-     *    b) flushes log (so everything up to Sf is surely flushed in the log)
-     *    c) sets Sp = Sf
-     *
-     * The guarantee provided is that for any persisted token pair (Sp, E):
-     *    - all the hard deletes till point Sp have been flushed in the log; and
-     *    - all ongoing hard deletes and unflushed hard deletes are somewhere between Sp and E, so during recovery this
-     *    is the range to be recovered.
-     *
-     * @return true if the token moved forward, false otherwise.
-     */
-    protected boolean hardDelete()
-        throws StoreException {
-      if (indexes.size() > 0) {
-        final Timer.Context context = metrics.hardDeleteTime.time();
-        try {
-          FindInfo info =
-              findDeletedEntriesSince(startToken, scanSizeInBytes, time.seconds() - messageRetentionSeconds);
-          endToken = info.getFindToken();
-          pruneHardDeleteRecoveryRange();
-          if (!endToken.equals(startToken)) {
-            if (!info.getMessageEntries().isEmpty()) {
-              performHardDeletes(info.getMessageEntries());
-            }
-            startToken = endToken;
-            return true;
-          }
-        } catch (StoreException e) {
-          if (e.getErrorCode() != StoreErrorCodes.Store_Shutting_Down) {
-            metrics.hardDeleteExceptionsCount.inc();
-          }
-          throw e;
-        } finally {
-          context.stop();
-        }
-      }
-      return false;
-    }
-
-    /**
-     * Gets the number of bytes processed so far
-     * @return the number of bytes processed so far as represented by the start token. Note that if the token is
-     * index based, this is at segment granularity.
-     */
-    public long getProgress() {
-      StoreFindToken token = (StoreFindToken) startToken;
-      if (token.isUninitialized()) {
-        return 0;
-      } else if (token.getOffset() != StoreFindToken.Uninitialized_Offset) {
-        return token.getOffset();
-      } else {
-        return token.getIndexStartOffset();
-      }
-    }
-
-    /**
-     * Returns true if the hard delete thread has caught up, that is if the token did not advance in the last iteration
-     * @return true if caught up, false otherwise.
-     */
-    public boolean isCaughtUp() {
-      return isCaughtUp;
-    }
-
-    @Override
-    public void run() {
-      try {
-        while (running.get()) {
-          try {
-            if (!hardDelete()) {
-              isCaughtUp = true;
-              synchronized (hardDeleteThread) {
-                if (!running.get()) {
-                  break;
-                }
-                time.wait(hardDeleteThread, hardDeleterSleepTimeWhenCaughtUpMs);
-              }
-            } else if (isCaughtUp) {
-              isCaughtUp = false;
-              logger.info("Resumed hard deletes for {} after having caught up", dataDir);
-            }
-          } catch (StoreException e) {
-            if (e.getErrorCode() != StoreErrorCodes.Store_Shutting_Down) {
-              logger.error("Caught store exception: ", e);
-            } else {
-              logger.trace("Caught exception during hard deletes", e);
-            }
-          } catch (InterruptedException e) {
-            logger.trace("Caught exception during hard deletes", e);
-          }
-        }
-      } finally {
-        close();
-      }
-    }
-
-    public void shutDown()
-        throws InterruptedException, StoreException, IOException {
-      if (running.get()) {
-        running.set(false);
-        synchronized (hardDeleteThread) {
-          hardDeleteThread.notify();
-        }
-        throttler.close();
-        shutdownLatch.await();
-        pruneHardDeleteRecoveryRange();
-        persistCleanupToken();
-      }
-    }
-
-    public void close() {
-      running.set(false);
-      shutdownLatch.countDown();
-    }
-  }
-
-  /**
-   * Gets the total number of bytes processed so far by the hard delete thread.
-   * @return the total number of bytes processed so far by the hard delete thread.
-   */
-  public long getHardDeleteProgress() {
-    return hardDeleter.getProgress();
-  }
-
-  /**
-   * Returns true if the hard delete thread is currently running.
-   * @return true if running, false otherwise.
-   */
-  public boolean hardDeleteThreadRunning() {
-    return hardDeleter.shutdownLatch.getCount() != 0;
-  }
-
-  /**
-   * Returns true if the hard delete thread is caught up.
-   * @return true if caught up, false otherwise.
-   */
-  public boolean hardDeleteCaughtUp() {
-    return hardDeleter.isCaughtUp();
   }
 }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -131,7 +131,7 @@ public class StoreMetrics {
     hardDeleteThreadRunning = new Gauge<Long>() {
       @Override
       public Long getValue() {
-        return hardDeleter.hardDeleteThreadRunning() ? 1L : 0L;
+        return hardDeleter.isRunning() ? 1L : 0L;
       }
     };
     registry.register(MetricRegistry.name(PersistentIndex.class, name + "HardDeleteThreadRunning"),

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -109,11 +109,11 @@ public class StoreMetrics {
     registry.register(MetricRegistry.name(Log.class, name + "PercentageUsedCapacity"), percentageUsedCapacity);
   }
 
-  public void initializeHardDeleteMetric(final PersistentIndex index, final Log log) {
+  public void initializeHardDeleteMetric(final HardDeleter hardDeleter, final Log log) {
     currentHardDeleteProgress = new Gauge<Long>() {
       @Override
       public Long getValue() {
-        return index.getHardDeleteProgress();
+        return hardDeleter.getProgress();
       }
     };
     registry.register(MetricRegistry.name(PersistentIndex.class, name + "CurrentHardDeleteProgress"),
@@ -122,7 +122,7 @@ public class StoreMetrics {
     percentageHardDeleteCompleted = new Gauge<Double>() {
       @Override
       public Double getValue() {
-        return ((double) index.getHardDeleteProgress() / log.getLogEndOffset()) * 100;
+        return ((double) hardDeleter.getProgress() / log.getLogEndOffset()) * 100;
       }
     };
     registry.register(MetricRegistry.name(Log.class, name + "PercentageHardDeleteCompleted"),
@@ -131,7 +131,7 @@ public class StoreMetrics {
     hardDeleteThreadRunning = new Gauge<Long>() {
       @Override
       public Long getValue() {
-        return index.hardDeleteThreadRunning() ? 1L : 0L;
+        return hardDeleter.hardDeleteThreadRunning() ? 1L : 0L;
       }
     };
     registry.register(MetricRegistry.name(PersistentIndex.class, name + "HardDeleteThreadRunning"),
@@ -140,7 +140,7 @@ public class StoreMetrics {
     hardDeleteCaughtUp = new Gauge<Long>() {
       @Override
       public Long getValue() {
-        return index.hardDeleteCaughtUp() ? 1L : 0L;
+        return hardDeleter.isCaughtUp() ? 1L : 0L;
       }
     };
     registry.register(MetricRegistry.name(PersistentIndex.class, name + "HardDeleteCaughtUp"), hardDeleteCaughtUp);

--- a/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
@@ -1,0 +1,295 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.Scheduler;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Tests for {@link HardDeleter}.
+ */
+public class HardDeleterTest {
+
+  @Test
+  public void testHardDelete() {
+    // Create a mock index with regular log.
+    // perform puts to the index.
+    // perform deletes to the index.
+    // call hardDelete() explicitly (set the thread frequency time to a large number if required) -
+    // that will do findDeleted, prune and performHardDelete()
+    // perform will need a messageStoreHardDelete implementation that just returns something
+    // that will be written back. - need to implement that.
+    // disable index persistor if that can be done.
+    // call persist cleanup token and close the index. Reopen it to execute recovery path.
+    // perform hard deletes upto some point.
+    // perform more deletes.
+    // do recovery.
+
+    class HardDeleteTestHelper implements MessageStoreHardDelete {
+      private long nextOffset;
+      private long sizeOfEntry;
+      private MockIndex index;
+      private Log log;
+      HashMap<Long, MessageInfo> offsetMap;
+
+      HardDeleteTestHelper(long offset, long size) {
+        nextOffset = offset;
+        sizeOfEntry = size;
+        offsetMap = new HashMap<Long, MessageInfo>();
+      }
+
+      void setIndex(MockIndex index, Log log) {
+        this.index = index;
+        this.log = log;
+      }
+
+      void add(MockId id)
+          throws IOException, StoreException {
+        index.addToIndex(new IndexEntry(id, new IndexValue(sizeOfEntry, nextOffset, (byte) 0, 12345)),
+            new FileSpan(nextOffset, nextOffset + sizeOfEntry));
+        ByteBuffer byteBuffer = ByteBuffer.allocate((int) sizeOfEntry);
+        log.appendFrom(byteBuffer);
+        offsetMap.put(nextOffset, new MessageInfo(id, sizeOfEntry));
+        nextOffset += sizeOfEntry;
+      }
+
+      void delete(MockId id)
+          throws IOException, StoreException {
+        index.markAsDeleted(id, new FileSpan(nextOffset, nextOffset + sizeOfEntry));
+        ByteBuffer byteBuffer = ByteBuffer.allocate((int) sizeOfEntry);
+        log.appendFrom(byteBuffer);
+        nextOffset += sizeOfEntry;
+      }
+
+      @Override
+      public Iterator<HardDeleteInfo> getHardDeleteMessages(MessageReadSet readSet, StoreKeyFactory factory,
+          List<byte[]> recoveryInfoList) {
+        class MockMessageStoreHardDeleteIterator implements Iterator<HardDeleteInfo> {
+          int count;
+          MessageReadSet readSet;
+
+          MockMessageStoreHardDeleteIterator(MessageReadSet readSet) {
+            this.readSet = readSet;
+            this.count = readSet.count();
+          }
+
+          @Override
+          public boolean hasNext() {
+            return count > 0;
+          }
+
+          @Override
+          public HardDeleteInfo next() {
+            if (!hasNext()) {
+              throw new NoSuchElementException();
+            }
+            --count;
+            ByteBuffer buf = ByteBuffer.allocate((int) sizeOfEntry);
+            byte[] recoveryInfo = new byte[100];
+            Arrays.fill(recoveryInfo, (byte) 0);
+            ByteBufferInputStream stream = new ByteBufferInputStream(buf);
+            ReadableByteChannel channel = Channels.newChannel(stream);
+            HardDeleteInfo hardDeleteInfo = new HardDeleteInfo(channel, 100, 100, recoveryInfo);
+            return hardDeleteInfo;
+          }
+
+          @Override
+          public void remove() {
+            throw new UnsupportedOperationException();
+          }
+        }
+
+        return new MockMessageStoreHardDeleteIterator(readSet);
+      }
+
+      @Override
+      public MessageInfo getMessageInfo(Read read, long offset, StoreKeyFactory factory) {
+        return offsetMap.get(offset);
+      }
+    }
+
+    try {
+      String logFile = tempFile().getParent();
+      File indexFile = new File(logFile);
+      for (File c : indexFile.listFiles()) {
+        c.delete();
+      }
+      Scheduler scheduler = new Scheduler(1, false);
+      scheduler.startup();
+      Log log = new Log(logFile, 10000, new StoreMetrics(logFile, new MetricRegistry()));
+      Properties props = new Properties();
+      // the test will set the tokens, so disable the index persistor.
+      props.setProperty("store.data.flush.interval.seconds", "3600");
+      props.setProperty("store.deleted.message.retention.days", "1");
+      props.setProperty("store.index.max.number.of.inmem.elements", "2");
+      // the following determines the number of entries that will be fetched at most. We need this to test the
+      // case where the endToken does not reach the journal.
+      props.setProperty("store.hard.delete.bytes.per.sec", "40");
+      StoreConfig config = new StoreConfig(new VerifiableProperties(props));
+      StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
+      MockTime time = new MockTime(SystemTime.getInstance().milliseconds());
+
+      HardDeleteTestHelper helper = new HardDeleteTestHelper(0, 200);
+      MockIndex index = new MockIndex(logFile, scheduler, log, config, factory, helper, time);
+      helper.setIndex(index, log);
+      // Setting this below will not enable the hard delete thread. This being a unit test, the methods
+      // are going to be called directly. We simply want to set the running flag to avoid those methods
+      // from bailing out prematurely.
+      index.setHardDeleteRunningStatus(true);
+
+      MockId blobId01 = new MockId("id01");
+      MockId blobId02 = new MockId("id02");
+      MockId blobId03 = new MockId("id03");
+      MockId blobId04 = new MockId("id04");
+      MockId blobId05 = new MockId("id05");
+      MockId blobId06 = new MockId("id06");
+      MockId blobId07 = new MockId("id07");
+      MockId blobId08 = new MockId("id08");
+      MockId blobId09 = new MockId("id09");
+      MockId blobId10 = new MockId("id10");
+
+      helper.add(blobId01);
+      helper.add(blobId02);
+      helper.add(blobId03);
+      helper.add(blobId04);
+
+      helper.delete(blobId03);
+
+      helper.add(blobId05);
+      helper.add(blobId06);
+      helper.add(blobId07);
+
+      helper.delete(blobId02);
+      helper.delete(blobId06);
+
+      helper.add(blobId08);
+      helper.add(blobId09);
+      helper.add(blobId10);
+
+      helper.delete(blobId10);
+      helper.delete(blobId01);
+      helper.delete(blobId08);
+
+      // Let enough time to pass so that the above records become eligible for hard deletes.
+      time.currentMilliseconds = time.currentMilliseconds + 2 * Time.SecsPerDay * Time.MsPerSec;
+
+      // The first * shows where startTokenSafeToPersist is
+      // The second * shows where startToken/endToken are before the operations.
+      // Note since we are only depicting values before and after hardDelete() is done, startToken and endToken
+      // will be the same.
+
+      // indexes: **[1 2] [3 4] [3d 5] [6 7] [2d 6d] [8 9] [1d 10d] [8]
+      // journal:                                       [10 10d 1d 8]
+      boolean tokenMovedForward = index.hardDelete();
+      Assert.assertTrue(tokenMovedForward);
+      // startToken = endToken = 2.
+
+      // call into the log flush hooks so that startTokenSafeToPersist = startToken = 2.
+      index.persistAndAdvanceStartTokenSafeToPersist();
+
+      // indexes: [1 2**] [3 4] [3d 5] [6 7] [2d 6d] [8 9] [1d 10d] [8]
+      // journal:                                       [10 10d 1d 8]
+      tokenMovedForward = index.hardDelete();
+      Assert.assertTrue(tokenMovedForward);
+      // startToken = endToken = 4.
+
+      // indexes: [1 2*] [3 4*] [3d 5] [6 7] [2d 6d] [8 9] [1d 10d] [8]
+      // journal:                                       [10 10d 1d 8]
+      tokenMovedForward = index.hardDelete();
+      Assert.assertTrue(tokenMovedForward);
+      // startToken = 5, endToken = 5, startTokenSafeToPersist = 2
+
+      // indexes: [1 2*] [3 4] [3d 5*] [6 7] [2d 6d] [8 9] [1d 10d] [8]
+      // journal:                                       [10 10d 1d 8]
+      index.persistAndAdvanceStartTokenSafeToPersist();
+      tokenMovedForward = index.hardDelete();
+      Assert.assertTrue(tokenMovedForward);
+      // startToken = 7, endToken = 7, starttokenSafeToPersist = 5
+      // 3d just got pruned.
+
+      // indexes: [1 2] [3 4] [3d 5*] [6 7*] [2d 6d] [8 9] [1d 10d] [8]
+      // journal:                                       [10 10d 1d 8]
+      tokenMovedForward = index.hardDelete();
+      Assert.assertTrue(tokenMovedForward);
+
+      // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d*] [8 9] [1d 10d] [8]
+      // journal:                                       [10 10d 1d 8]
+      tokenMovedForward = index.hardDelete();
+      Assert.assertTrue(tokenMovedForward);
+
+      // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d] [8 9*] [1d 10d] [8]
+      // journal:                                       [10 10d 1d 8]
+      index.persistAndAdvanceStartTokenSafeToPersist();
+      tokenMovedForward = index.hardDelete();
+      Assert.assertTrue(tokenMovedForward);
+
+      // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d] [8 9] [1d 10d] [8]
+      // journal:                                       [10 10d* 1d 8]
+
+      tokenMovedForward = index.hardDelete();
+      Assert.assertTrue(tokenMovedForward);
+
+      // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d] [8 9] [1d 10d] [8]
+      // journal:                                       [10 10d 1d 8*]
+      // All caught up, so token should not have moved forward.
+      tokenMovedForward = index.hardDelete();
+      Assert.assertFalse(tokenMovedForward);
+
+      index.persistAndAdvanceStartTokenSafeToPersist();
+
+      // directly prune the recovery range completely (which should happen since we flushed till the endToken).
+      index.pruneHardDeleteRecoveryRange(); //
+
+      // Test recovery - this tests reading from the persisted token, filling up the hard delete recovery range and
+      // then actually redoing the hard deletes on the range.
+      index.performHardDeleteRecovery();
+
+      index.close();
+    } catch (Exception e) {
+      e.printStackTrace();
+      org.junit.Assert.assertEquals(false, true);
+    }
+  }
+
+  /**
+   * Create a temporary file
+   */
+  File tempFile()
+      throws IOException {
+    File f = File.createTempFile("ambry", ".tmp");
+    f.deleteOnExit();
+    return f;
+  }
+}

--- a/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
@@ -19,8 +19,6 @@ import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.metrics.MetricsRegistryMap;
 import com.github.ambry.metrics.ReadableMetricsRegistry;
-import com.github.ambry.utils.ByteBufferInputStream;
-import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Scheduler;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Time;
@@ -28,16 +26,10 @@ import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
-import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
@@ -61,84 +53,6 @@ public class PersistentIndexTest {
     File f = File.createTempFile("ambry", ".tmp");
     f.deleteOnExit();
     return f;
-  }
-
-  class MockIndex extends PersistentIndex {
-    public MockIndex(String datadir, Scheduler scheduler, Log log, StoreConfig config, StoreKeyFactory factory,
-        MessageStoreHardDelete messageStoreHardDelete, Time time)
-        throws StoreException {
-      super(datadir, scheduler, log, config, factory, new DummyMessageStoreRecovery(), messageStoreHardDelete,
-          new StoreMetrics(datadir, new MetricRegistry()), time);
-    }
-
-    public MockIndex(String datadir, Scheduler scheduler, Log log, StoreConfig config, StoreKeyFactory factory)
-        throws StoreException {
-      this(datadir, scheduler, log, config, factory, new DummyMessageStoreHardDelete(), SystemTime.getInstance());
-    }
-
-    public MockIndex(String datadir, Scheduler scheduler, Log log, StoreConfig config, StoreKeyFactory factory,
-        Journal journal)
-        throws StoreException {
-      super(datadir, scheduler, log, config, factory, new DummyMessageStoreRecovery(),
-          new DummyMessageStoreHardDelete(), new StoreMetrics(datadir, new MetricRegistry()), journal,
-          SystemTime.getInstance());
-    }
-
-    public void setHardDeleteRunningStatus(boolean status) {
-      super.hardDeleter.running.set(status);
-    }
-
-    public boolean hardDelete()
-        throws StoreException {
-      return super.hardDeleter.hardDelete();
-    }
-
-    public void persistAndAdvanceStartTokenSafeToPersist() {
-      super.hardDeleter.preLogFlush();
-      // no flushing to do.
-      super.hardDeleter.postLogFlush();
-    }
-
-    public void pruneHardDeleteRecoveryRange() {
-      super.hardDeleter.pruneHardDeleteRecoveryRange();
-    }
-
-    public void performHardDeleteRecovery()
-        throws StoreException {
-      super.hardDeleter.performRecovery();
-    }
-
-    public MockIndex(String datadir, Scheduler scheduler, Log log, StoreConfig config, StoreKeyFactory factory,
-        MessageStoreRecovery recovery, MessageStoreHardDelete cleanup)
-        throws StoreException {
-      super(datadir, scheduler, log, config, factory, recovery, cleanup,
-          new StoreMetrics(datadir, new MetricRegistry()), SystemTime.getInstance());
-    }
-
-    IndexValue getValue(StoreKey key)
-        throws StoreException {
-      return findKey(key);
-    }
-
-    public void deleteAll() {
-      indexes.clear();
-    }
-
-    public void stopScheduler() {
-      scheduler.shutdown();
-    }
-
-    public boolean isEmpty() {
-      return indexes.size() == 0;
-    }
-
-    public Journal getJournal() {
-      return super.journal;
-    }
-
-    public IndexSegment getLastSegment() {
-      return super.indexes.lastEntry().getValue();
-    }
   }
 
   @Test
@@ -1776,247 +1690,82 @@ public class PersistentIndexTest {
       }
     }
   }
+}
 
-  @Test
-  public void testHardDelete() {
-    // Create a mock index with regular log.
-    // perform puts to the index.
-    // perform deletes to the index.
-    // call hardDelete() explicitly (set the thread frequency time to a large number if required) -
-    // that will do findDeleted, prune and performHardDelete()
-    // perform will need a messageStoreHardDelete implementation that just returns something
-    // that will be written back. - need to implement that.
-    // disable index persistor if that can be done.
-    // call persist cleanup token and close the index. Reopen it to execute recovery path.
-    // perform hard deletes upto some point.
-    // perform more deletes.
-    // do recovery.
+class MockIndex extends PersistentIndex {
+  public MockIndex(String datadir, Scheduler scheduler, Log log, StoreConfig config, StoreKeyFactory factory,
+      MessageStoreHardDelete messageStoreHardDelete, Time time)
+      throws StoreException {
+    super(datadir, scheduler, log, config, factory, new DummyMessageStoreRecovery(), messageStoreHardDelete,
+        new StoreMetrics(datadir, new MetricRegistry()), time);
+  }
 
-    class HardDeleteTestHelper implements MessageStoreHardDelete {
-      private long nextOffset;
-      private long sizeOfEntry;
-      private MockIndex index;
-      private Log log;
-      HashMap<Long, MessageInfo> offsetMap;
+  public MockIndex(String datadir, Scheduler scheduler, Log log, StoreConfig config, StoreKeyFactory factory)
+      throws StoreException {
+    this(datadir, scheduler, log, config, factory, new DummyMessageStoreHardDelete(), SystemTime.getInstance());
+  }
 
-      HardDeleteTestHelper(long offset, long size) {
-        nextOffset = offset;
-        sizeOfEntry = size;
-        offsetMap = new HashMap<Long, MessageInfo>();
-      }
+  public MockIndex(String datadir, Scheduler scheduler, Log log, StoreConfig config, StoreKeyFactory factory,
+      Journal journal)
+      throws StoreException {
+    super(datadir, scheduler, log, config, factory, new DummyMessageStoreRecovery(), new DummyMessageStoreHardDelete(),
+        new StoreMetrics(datadir, new MetricRegistry()), journal, SystemTime.getInstance());
+  }
 
-      void setIndex(MockIndex index, Log log) {
-        this.index = index;
-        this.log = log;
-      }
+  public void setHardDeleteRunningStatus(boolean status) {
+    super.hardDeleter.running.set(status);
+  }
 
-      void add(MockId id)
-          throws IOException, StoreException {
-        index.addToIndex(new IndexEntry(id, new IndexValue(sizeOfEntry, nextOffset, (byte) 0, 12345)),
-            new FileSpan(nextOffset, nextOffset + sizeOfEntry));
-        ByteBuffer byteBuffer = ByteBuffer.allocate((int) sizeOfEntry);
-        log.appendFrom(byteBuffer);
-        offsetMap.put(nextOffset, new MessageInfo(id, sizeOfEntry));
-        nextOffset += sizeOfEntry;
-      }
+  public boolean hardDelete()
+      throws StoreException {
+    return super.hardDeleter.hardDelete();
+  }
 
-      void delete(MockId id)
-          throws IOException, StoreException {
-        index.markAsDeleted(id, new FileSpan(nextOffset, nextOffset + sizeOfEntry));
-        ByteBuffer byteBuffer = ByteBuffer.allocate((int) sizeOfEntry);
-        log.appendFrom(byteBuffer);
-        nextOffset += sizeOfEntry;
-      }
+  public void persistAndAdvanceStartTokenSafeToPersist() {
+    super.hardDeleter.preLogFlush();
+    // no flushing to do.
+    super.hardDeleter.postLogFlush();
+  }
 
-      @Override
-      public Iterator<HardDeleteInfo> getHardDeleteMessages(MessageReadSet readSet, StoreKeyFactory factory,
-          List<byte[]> recoveryInfoList) {
-        class MockMessageStoreHardDeleteIterator implements Iterator<HardDeleteInfo> {
-          int count;
-          MessageReadSet readSet;
+  public void pruneHardDeleteRecoveryRange() {
+    super.hardDeleter.pruneHardDeleteRecoveryRange();
+  }
 
-          MockMessageStoreHardDeleteIterator(MessageReadSet readSet) {
-            this.readSet = readSet;
-            this.count = readSet.count();
-          }
+  public void performHardDeleteRecovery()
+      throws StoreException {
+    super.hardDeleter.performRecovery();
+  }
 
-          @Override
-          public boolean hasNext() {
-            return count > 0;
-          }
+  public MockIndex(String datadir, Scheduler scheduler, Log log, StoreConfig config, StoreKeyFactory factory,
+      MessageStoreRecovery recovery, MessageStoreHardDelete cleanup)
+      throws StoreException {
+    super(datadir, scheduler, log, config, factory, recovery, cleanup, new StoreMetrics(datadir, new MetricRegistry()),
+        SystemTime.getInstance());
+  }
 
-          @Override
-          public HardDeleteInfo next() {
-            if (!hasNext()) {
-              throw new NoSuchElementException();
-            }
-            --count;
-            ByteBuffer buf = ByteBuffer.allocate((int) sizeOfEntry);
-            byte[] recoveryInfo = new byte[100];
-            Arrays.fill(recoveryInfo, (byte) 0);
-            ByteBufferInputStream stream = new ByteBufferInputStream(buf);
-            ReadableByteChannel channel = Channels.newChannel(stream);
-            HardDeleteInfo hardDeleteInfo = new HardDeleteInfo(channel, 100, 100, recoveryInfo);
-            return hardDeleteInfo;
-          }
+  IndexValue getValue(StoreKey key)
+      throws StoreException {
+    return findKey(key);
+  }
 
-          @Override
-          public void remove() {
-            throw new UnsupportedOperationException();
-          }
-        }
+  public void deleteAll() {
+    indexes.clear();
+  }
 
-        return new MockMessageStoreHardDeleteIterator(readSet);
-      }
+  public void stopScheduler() {
+    scheduler.shutdown();
+  }
 
-      @Override
-      public MessageInfo getMessageInfo(Read read, long offset, StoreKeyFactory factory) {
-        return offsetMap.get(offset);
-      }
-    }
+  public boolean isEmpty() {
+    return indexes.size() == 0;
+  }
 
-    StoreFindToken token = new StoreFindToken();
-    MockClusterMap map = null;
-    try {
-      String logFile = tempFile().getParent();
-      File indexFile = new File(logFile);
-      for (File c : indexFile.listFiles()) {
-        c.delete();
-      }
-      Scheduler scheduler = new Scheduler(1, false);
-      scheduler.startup();
-      Log log = new Log(logFile, 10000, new StoreMetrics(logFile, new MetricRegistry()));
-      Properties props = new Properties();
-      // the test will set the tokens, so disable the index persistor.
-      props.setProperty("store.data.flush.interval.seconds", "3600");
-      props.setProperty("store.deleted.message.retention.days", "1");
-      props.setProperty("store.index.max.number.of.inmem.elements", "2");
-      // the following determines the number of entries that will be fetched at most. We need this to test the
-      // case where the endToken does not reach the journal.
-      props.setProperty("store.hard.delete.bytes.per.sec", "40");
-      StoreConfig config = new StoreConfig(new VerifiableProperties(props));
-      StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      MockTime time = new MockTime(SystemTime.getInstance().milliseconds());
+  public Journal getJournal() {
+    return super.journal;
+  }
 
-      HardDeleteTestHelper helper = new HardDeleteTestHelper(0, 200);
-      MockIndex index = new MockIndex(logFile, scheduler, log, config, factory, helper, time);
-      helper.setIndex(index, log);
-      // Setting this below will not enable the hard delete thread. This being a unit test, the methods
-      // are going to be called directly. We simply want to set the running flag to avoid those methods
-      // from bailing out prematurely.
-      index.setHardDeleteRunningStatus(true);
-
-      MockId blobId01 = new MockId("id01");
-      MockId blobId02 = new MockId("id02");
-      MockId blobId03 = new MockId("id03");
-      MockId blobId04 = new MockId("id04");
-      MockId blobId05 = new MockId("id05");
-      MockId blobId06 = new MockId("id06");
-      MockId blobId07 = new MockId("id07");
-      MockId blobId08 = new MockId("id08");
-      MockId blobId09 = new MockId("id09");
-      MockId blobId10 = new MockId("id10");
-
-      helper.add(blobId01);
-      helper.add(blobId02);
-      helper.add(blobId03);
-      helper.add(blobId04);
-
-      helper.delete(blobId03);
-
-      helper.add(blobId05);
-      helper.add(blobId06);
-      helper.add(blobId07);
-
-      helper.delete(blobId02);
-      helper.delete(blobId06);
-
-      helper.add(blobId08);
-      helper.add(blobId09);
-      helper.add(blobId10);
-
-      helper.delete(blobId10);
-      helper.delete(blobId01);
-      helper.delete(blobId08);
-
-      // Let enough time to pass so that the above records become eligible for hard deletes.
-      time.currentMilliseconds = time.currentMilliseconds + 2 * Time.SecsPerDay * Time.MsPerSec;
-
-      // The first * shows where startTokenSafeToPersist is
-      // The second * shows where startToken/endToken are before the operations.
-      // Note since we are only depicting values before and after hardDelete() is done, startToken and endToken
-      // will be the same.
-
-      // indexes: **[1 2] [3 4] [3d 5] [6 7] [2d 6d] [8 9] [1d 10d] [8]
-      // journal:                                       [10 10d 1d 8]
-      boolean tokenMovedForward = index.hardDelete();
-      Assert.assertTrue(tokenMovedForward);
-      // startToken = endToken = 2.
-
-      // call into the log flush hooks so that startTokenSafeToPersist = startToken = 2.
-      index.persistAndAdvanceStartTokenSafeToPersist();
-
-      // indexes: [1 2**] [3 4] [3d 5] [6 7] [2d 6d] [8 9] [1d 10d] [8]
-      // journal:                                       [10 10d 1d 8]
-      tokenMovedForward = index.hardDelete();
-      Assert.assertTrue(tokenMovedForward);
-      // startToken = endToken = 4.
-
-      // indexes: [1 2*] [3 4*] [3d 5] [6 7] [2d 6d] [8 9] [1d 10d] [8]
-      // journal:                                       [10 10d 1d 8]
-      tokenMovedForward = index.hardDelete();
-      Assert.assertTrue(tokenMovedForward);
-      // startToken = 5, endToken = 5, startTokenSafeToPersist = 2
-
-      // indexes: [1 2*] [3 4] [3d 5*] [6 7] [2d 6d] [8 9] [1d 10d] [8]
-      // journal:                                       [10 10d 1d 8]
-      index.persistAndAdvanceStartTokenSafeToPersist();
-      tokenMovedForward = index.hardDelete();
-      Assert.assertTrue(tokenMovedForward);
-      // startToken = 7, endToken = 7, starttokenSafeToPersist = 5
-      // 3d just got pruned.
-
-      // indexes: [1 2] [3 4] [3d 5*] [6 7*] [2d 6d] [8 9] [1d 10d] [8]
-      // journal:                                       [10 10d 1d 8]
-      tokenMovedForward = index.hardDelete();
-      Assert.assertTrue(tokenMovedForward);
-
-      // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d*] [8 9] [1d 10d] [8]
-      // journal:                                       [10 10d 1d 8]
-      tokenMovedForward = index.hardDelete();
-      Assert.assertTrue(tokenMovedForward);
-
-      // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d] [8 9*] [1d 10d] [8]
-      // journal:                                       [10 10d 1d 8]
-      index.persistAndAdvanceStartTokenSafeToPersist();
-      tokenMovedForward = index.hardDelete();
-      Assert.assertTrue(tokenMovedForward);
-
-      // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d] [8 9] [1d 10d] [8]
-      // journal:                                       [10 10d* 1d 8]
-
-      tokenMovedForward = index.hardDelete();
-      Assert.assertTrue(tokenMovedForward);
-
-      // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d] [8 9] [1d 10d] [8]
-      // journal:                                       [10 10d 1d 8*]
-      // All caught up, so token should not have moved forward.
-      tokenMovedForward = index.hardDelete();
-      Assert.assertFalse(tokenMovedForward);
-
-      index.persistAndAdvanceStartTokenSafeToPersist();
-
-      // directly prune the recovery range completely (which should happen since we flushed till the endToken).
-      index.pruneHardDeleteRecoveryRange(); //
-
-      // Test recovery - this tests reading from the persisted token, filling up the hard delete recovery range and
-      // then actually redoing the hard deletes on the range.
-      index.performHardDeleteRecovery();
-
-      index.close();
-    } catch (Exception e) {
-      e.printStackTrace();
-      org.junit.Assert.assertEquals(false, true);
-    }
+  public IndexSegment getLastSegment() {
+    return super.indexes.lastEntry().getValue();
   }
 }
+


### PR DESCRIPTION
Moving hard delete functionality out of PersistentIndex because of the logical seperation
Also helps reason about log segmentation and compaction changes down the line

`./gradlew build && ./gradlew test` have passed.
Formatted.

No core code has been changed. Some class variables have been added and qualifiers of some functions have changed.