### PR TITLE
Adding an abstraction for log segments

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/store/Read.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/Read.java
@@ -23,7 +23,8 @@ import java.io.IOException;
 public interface Read {
 
   /**
-   * Read from the underlying store(file) into the buffer starting at the given position in the store
+   * Read from the underlying store(file) into the buffer starting at the given position in the store. Reads
+   * exactly {@code buffer.remaining()} amount of data or throws an exception.
    * @param buffer The buffer into which the read needs to write to
    * @param position The position to start the read from
    * @throws IOException

--- a/ambry-api/src/main/java/com.github.ambry/store/Write.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/Write.java
@@ -42,15 +42,4 @@ public interface Write {
    */
   void appendFrom(ReadableByteChannel channel, long size)
       throws IOException;
-
-  /**
-   * Writes the channel to the underlying write interface at the given offset.
-   * Writes "size" number of bytes to the interface at the offset.
-   * @param channel The channel from which data needs to be written from.
-   * @param offset The offset at which to write in the underlying write interface.
-   * @param size The amount of data in bytes to be written from the channel.
-   * @throws IOException
-   */
-  void writeFrom(ReadableByteChannel channel, long offset, long size)
-      throws IOException;
 }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatWriteSetTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatWriteSetTest.java
@@ -51,13 +51,6 @@ public class MessageFormatWriteSetTest {
       channel.read(buf);
     }
 
-    @Override
-    public void writeFrom(ReadableByteChannel channel, long offset, long size)
-        throws IOException {
-      buf.position((int)offset);
-      channel.read(buf);
-    }
-
     public ByteBuffer getBuffer() {
       buf.flip();
       return buf;

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -155,12 +155,6 @@ public class ReplicationTest {
         }
         // @TODO: Is this doing the right thing?
       }
-
-      @Override
-      public void writeFrom(ReadableByteChannel channel, long offset, long size)
-          throws IOException {
-        throw new IllegalArgumentException("Not implemented");
-      }
     }
 
     DummyLog log;

--- a/ambry-rest/src/test/java/com.github.ambry.rest/RestTestUtils.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/RestTestUtils.java
@@ -62,7 +62,9 @@ public class RestTestUtils {
    * Gets a byte array of length {@code size} with random bytes.
    * @param size the required length of the random byte array.
    * @return a byte array of length {@code size} with random bytes.
+   * @deprecated use {@link com.github.ambry.utils.TestUtils#getRandomBytes(int)} instead.
    */
+  @Deprecated
   public static byte[] getRandomBytes(int size) {
     byte[] bytes = new byte[size];
     new Random().nextBytes(bytes);
@@ -72,7 +74,7 @@ public class RestTestUtils {
   /**
    * Build the range header value from a {@link ByteRange}
    * @param range the {@link ByteRange} representing the range
-   * @return
+   * @return the range header value corresponding to {@code range}.
    */
   public static String getRangeHeaderString(ByteRange range) {
     switch (range.getType()) {

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -119,8 +119,7 @@ public class Log implements Read, Write {
         bytesWritten);
   }
 
-  @Override
-  public void writeFrom(ReadableByteChannel channel, long offset, long size)
+  void writeFrom(ReadableByteChannel channel, long offset, long size)
       throws IOException {
     logger.trace("Log : {} currentWriteOffset {} capacityInBytes {} sizeToAppend {} offset to append at {}",
         file.getAbsolutePath(), currentWriteOffset, capacityInBytes, size, offset);

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -119,6 +119,14 @@ public class Log implements Read, Write {
         bytesWritten);
   }
 
+  /**
+   * Writes {@code size} number of bytes from the channel {@code channel} into the log at {@code offset}.
+   * @param channel The channel from which data needs to be written from.
+   * @param offset The offset in the segment at which to start writing.
+   * @param size The amount of data in bytes to be written from the channel.
+   * @throws IOException if data could not be written because of I/O errors
+   *
+   */
   void writeFrom(ReadableByteChannel channel, long offset, long size)
       throws IOException {
     logger.trace("Log : {} currentWriteOffset {} capacityInBytes {} sizeToAppend {} offset to append at {}",

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -189,20 +189,9 @@ class LogSegment implements Read, Write {
    * Gets the {@link File} and {@link FileChannel} backing this log segment. Also increments a ref count.
    * <p/>
    * The expectation is that a matching {@link #closeView()} will be called eventually to decrement the ref count.
-   * <p/>
-   * The {@code offset} is intended only for validation in order to fail early. It is up to to the caller to ensure that
-   * the eventual read operation on the {@link FileChannel} occurs at the same offset.
-   * @param offset the offset that will used to start the eventual read operation from the {@link FileChannel} obtained
-   *               from the view.
    * @return the {@link File} and {@link FileChannel} backing this log segment.
-   * @throws IndexOutOfBoundsException if {@code offset} < 0 or is >= {@link #getEndOffset()}.
    */
-  Pair<File, FileChannel> getView(long offset) {
-    if (offset < 0 || offset >= getEndOffset()) {
-      throw new IndexOutOfBoundsException(
-          "Provided offset [" + offset + "] is out of bounds for the segment [" + file.getAbsolutePath()
-              + "] with end offset [" + getEndOffset() + "]");
-    }
+  Pair<File, FileChannel> getView() {
     refCount.incrementAndGet();
     return segmentView;
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -347,6 +347,13 @@ class LogSegment implements Read, Write {
   }
 
   /**
+   * @return the total capacity, in bytes, of this log segment.
+   */
+  long getCapacityInBytes() {
+    return capacityInBytes;
+  }
+
+  /**
    * Flushes the backing file to disk.
    * @throws IOException if there is an I/O error while flushing.
    */

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -65,19 +65,18 @@ class LogSegment implements Read, Write {
 
   /**
    * Creates a LogSegment abstraction.
-   * @param dataDir the directory to look in for the file named {@code name}
-   * @param name the name of the backing file. The file is allocated with size {@code capacityInBytes} if it does not
-   *             exist
+   * @param name the desired name of the segment.
+   * @param file the backing file for this segment.
    * @param capacityInBytes the intended capacity of the segment
    * @param metrics the {@link StoreMetrics} instance to use.
    * @throws IOException if the file cannot be read or created
    */
-  LogSegment(String dataDir, String name, long capacityInBytes, StoreMetrics metrics)
+  LogSegment(String name, File file, long capacityInBytes, StoreMetrics metrics)
       throws IOException {
-    file = new File(dataDir, name);
     if (!file.exists() || !file.isFile()) {
-      throw new IllegalArgumentException("No file with name [" + name + "] exists in directory [" + dataDir + "]");
+      throw new IllegalArgumentException(file.getAbsolutePath() + " does not exist or is not a file");
     }
+    this.file = file;
     this.name = name;
     this.capacityInBytes = capacityInBytes;
     this.metrics = metrics;

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -333,7 +333,14 @@ class LogSegment implements Read, Write {
   }
 
   /**
-   * @return the end offset of this log segment.
+   * @return the offset in this log segment from which there is valid data.
+   */
+  long getStartOffset() {
+    return 0;
+  }
+
+  /**
+   * @return the offset in this log segment until which there is valid data.
    */
   long getEndOffset() {
     return endOffset.get();

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -1,0 +1,364 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.codahale.metrics.Counter;
+import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Represents a segment of a log. The segment is represented by its relative position in the log and the generation
+ * number of the segment. Each segment knows the segment that "follows" it logically (if such a segment exists) and can
+ * transparently redirect operations if required. A segment can be in one of the states represented by {@link State}.
+ */
+class LogSegment implements Read, Write {
+  /**
+   * Used to describe the state of the LogSegment.
+   */
+  enum State {
+    FREE,
+    ACTIVE,
+    SEALED
+  }
+
+  private final FileChannel fileChannel;
+  private final File file;
+  private final long capacityInBytes;
+  private final String name;
+  private final Pair<File, FileChannel> segmentView;
+  private final StoreMetrics metrics;
+  private final AtomicLong endOffset;
+  private final AtomicLong refCount = new AtomicLong(0);
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  /**
+   * The state of the segment.
+   * <p/>
+   * A LogSegment once instantiated can only go from FREE -> ACTIVE -> SEALED in the natural course of operations, never
+   * backward. However it can be externally manipulated to move in any direction.
+   */
+  State state;
+  /**
+   * Reference to the segment that logically "follows" this segment.
+   */
+  LogSegment next = null;
+
+  /**
+   * Creates a LogSegment abstraction.
+   * @param dataDir the directory to look in for the file named {@code name}
+   * @param name the name of the backing file. The file is allocated with size {@code capacityInBytes} if it does not
+   *             exist
+   * @param capacityInBytes the intended capacity of the segment
+   * @param metrics the {@link StoreMetrics} instance to use.
+   * @throws IOException if the file cannot be read or created
+   */
+  LogSegment(String dataDir, String name, long capacityInBytes, StoreMetrics metrics)
+      throws IOException {
+    file = new File(dataDir, name);
+    if (!file.exists() || !file.isFile()) {
+      throw new IllegalArgumentException("No file with name [" + name + "] exists in directory [" + dataDir + "]");
+    }
+    this.name = name;
+    this.capacityInBytes = capacityInBytes;
+    this.metrics = metrics;
+    fileChannel = Utils.openChannel(file, true);
+    segmentView = new Pair<>(file, fileChannel);
+    // state is always initialized to FREE and the end offset is always initialized to 0.
+    // externals will set the correct values for these two variables
+    state = State.FREE;
+    endOffset = new AtomicLong(0);
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p/>
+   * Guarantees that the {@code buffer} is either written in its entirety in this segment or is transparently forwarded
+   * to the next segment (if one exists). A write is not started if it cannot be completed.
+   * <p/>
+   * Can cause state change from {@link State#FREE} -> {@link State#ACTIVE} if this is the first write to the segment.
+   * Can cause state change from {@link State#ACTIVE} -> {@link State#SEALED} if this write cannot be accommodated in
+   * the segment.
+   * @param buffer The buffer from which data needs to be written from
+   * @return the number of bytes written.
+   * @throws IllegalArgumentException if there is not enough space for {@code buffer} and forwarding is not possible
+   * @throws IOException if data could not be written to the file because of I/O errors
+   * @throws UnsupportedOperationException if this LogSegment is intended to be swap space
+   */
+  @Override
+  public int appendFrom(ByteBuffer buffer)
+      throws IOException {
+    int bytesWritten = 0;
+    if (state.equals(State.SEALED)) {
+      ensureNext(metrics.overflowWriteError);
+      bytesWritten = next.appendFrom(buffer);
+    } else if (endOffset.get() + buffer.remaining() > capacityInBytes) {
+      // maintain the invariant that there are no "partial" writes. A log segment should write the data that it receives
+      // completely and the data that was provided in a single call cannot be written across multiple segments.
+      logger.info("{} : Writing data of size {} from a buffer. Current end offset is {} and capacity is {}",
+          file.getAbsolutePath(), buffer.remaining(), getEndOffset(), capacityInBytes);
+      ensureNext(metrics.overflowWriteError);
+      state = State.SEALED;
+      bytesWritten = next.appendFrom(buffer);
+    } else {
+      state = State.ACTIVE;
+      while (buffer.hasRemaining()) {
+        bytesWritten += fileChannel.write(buffer, endOffset.get());
+      }
+      endOffset.addAndGet(bytesWritten);
+    }
+    return bytesWritten;
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p/>
+   * Guarantees that the {@code buffer} is either written in its entirety in this segment or is transparently forwarded
+   * to the next segment (if one exists). A write is not started if it cannot be completed.
+   * <p/>
+   * Can cause state change from {@link State#FREE} -> {@link State#ACTIVE} if this is the first write to the segment.
+   * Can cause state change from {@link State#ACTIVE} -> {@link State#SEALED} if this write cannot be accommodated in
+   * the segment.
+   * @param channel The channel from which data needs to be written from
+   * @param size The amount of data in bytes to be written from the channel
+   * @throws IllegalArgumentException if there is not enough space for {@code size} data and forwarding is not possible
+   * @throws IOException if data could not be written to the file because of I/O errors
+   * @throws UnsupportedOperationException if this LogSegment is intended to be swap space
+   */
+  @Override
+  public void appendFrom(ReadableByteChannel channel, long size)
+      throws IOException {
+    if (state.equals(State.SEALED)) {
+      ensureNext(metrics.overflowWriteError);
+      next.appendFrom(channel, size);
+    } else if (endOffset.get() + size > capacityInBytes) {
+      // maintain the invariant that there are no "partial" writes. A log segment should write the data that it receives
+      // completely and the data that was provided in a single call cannot be written across multiple segments.
+      logger.info("{} : Writing data of size {} from a channel. Current end offset is {} and capacity is {}",
+          file.getAbsolutePath(), size, getEndOffset(), capacityInBytes);
+      ensureNext(metrics.overflowWriteError);
+      state = State.SEALED;
+      next.appendFrom(channel, size);
+    } else {
+      state = State.ACTIVE;
+      long bytesWritten = 0;
+      while (bytesWritten < size) {
+        bytesWritten += fileChannel.transferFrom(channel, endOffset.get() + bytesWritten, size - bytesWritten);
+      }
+      endOffset.addAndGet(bytesWritten);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p/>
+   * If {@code offset} + {@code size} exceeds the capacity of the current segment, bytes are written starting from
+   * {@code offset} until capacity is reached. The rest of the bytes upto {@code size} are forwarded to the next segment
+   * (if one exists). A write is not started if it cannot be completed.
+   * <p/>
+   * The assumption with this function is that the caller is sure of the arguments and understands the implications of
+   * writing at particular offsets and of writing to specific log segment.
+   * <p/>
+   * Using this function does not cause any state changes i.e. this function is expected to be used mostly for
+   * overwriting and not for appending the log.
+   * @param channel The channel from which data needs to be written from.
+   * @param offset The offset at which to write in the underlying write interface.
+   * @param size The amount of data in bytes to be written from the channel.
+   * @throws IllegalArgumentException if {@code offset} < 0 or if there is not enough space for {@code offset } +
+   * {@code size} data and forwarding is not possible
+   * @throws IOException if data could not be written to the file because of I/O errors
+   * @throws UnsupportedOperationException if this LogSegment is intended to be swap space or if it is supposed to free
+   *
+   */
+  @Override
+  public void writeFrom(ReadableByteChannel channel, long offset, long size)
+      throws IOException {
+    if (offset < 0 || offset > capacityInBytes) {
+      throw new IllegalArgumentException(
+          "Provided offset [" + offset + "] is out of bounds for the segment [" + file.getAbsolutePath()
+              + "] with capacity [" + capacityInBytes + "]");
+    }
+    if (offset + size > capacityInBytes) {
+      logger
+          .info("{} : Writing data of size {} from offset {} from a channel and capacity is {}", file.getAbsolutePath(),
+              size, offset, capacityInBytes);
+      ensureNext(metrics.overflowWriteError);
+    }
+    long sizeToBeWritten = Math.min(size, capacityInBytes - offset);
+    long sizeLeft = size - sizeToBeWritten;
+    long bytesWritten = 0;
+    while (bytesWritten < sizeToBeWritten) {
+      bytesWritten += fileChannel.transferFrom(channel, offset + bytesWritten, sizeToBeWritten - bytesWritten);
+    }
+    if (offset + sizeToBeWritten > endOffset.get()) {
+      endOffset.set(offset + sizeToBeWritten);
+    }
+    if (sizeLeft > 0) {
+      next.writeFrom(channel, 0, sizeLeft);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p/>
+   * If {@code position} + {@code buffer.remaining()} exceeds the capacity of the current segment, bytes are read
+   * starting from {@code position} until capacity is reached. The rest of the bytes upto {@code buffer.remaining()} are
+   * read from the next segment (if one exists). A read is not started if it cannot be completed.
+   * <p/>
+   * Using this function does not cause any state changes
+   * @param buffer The buffer into which the read needs to write to
+   * @param position The position to start the read from
+   * @throws IllegalArgumentException if {@code position} < 0 or if {@code buffer} size is greater than the data
+   * available for read.
+   * @throws IOException if data could not be written to the file because of I/O errors
+   * @throws UnsupportedOperationException if this LogSegment is intended to be swap space or if it is supposed to free
+   */
+  @Override
+  public void readInto(ByteBuffer buffer, long position)
+      throws IOException {
+    if (position < 0 || position > getEndOffset()) {
+      throw new IllegalArgumentException(
+          "Provided position [" + position + "] is out of bounds for the segment [" + file.getAbsolutePath()
+              + "] with end offset [" + getEndOffset() + "]");
+    }
+    if (position + buffer.remaining() > getEndOffset()) {
+      logger.info("{} : Trying to read from position {} into a buffer of size {} when end offset is {}",
+          file.getAbsolutePath(), position, buffer.remaining(), getEndOffset());
+      ensureNext(metrics.overflowReadError);
+    }
+    long sizeToBeRead = Math.min(buffer.remaining(), getEndOffset() - position);
+    long sizeLeft = buffer.remaining() - sizeToBeRead;
+    long bytesRead = 0;
+    int savedLimit = buffer.limit();
+    buffer.limit(buffer.position() + (int) sizeToBeRead);
+    try {
+      while (bytesRead < sizeToBeRead) {
+        bytesRead += fileChannel.read(buffer, position + bytesRead);
+      }
+    } finally {
+      buffer.limit(savedLimit);
+    }
+    if (sizeLeft > 0) {
+      next.readInto(buffer, 0);
+    }
+  }
+
+  /**
+   * Gets the {@link File} and {@link FileChannel} backing this log segment. Also increments a ref count.
+   * <p/>
+   * The expectation is that a matching {@link #closeView()} will be called eventually to decrement the ref count.
+   * @param offset the offset that will used to start the read operation from.
+   * @return the {@link File} and {@link FileChannel} backing this log segment.
+   * @throws IllegalArgumentException if {@code offset} < 0 or is > {@link #getEndOffset()}.
+   */
+  Pair<File, FileChannel> getView(long offset) {
+    if (offset < 0 || offset > getEndOffset()) {
+      throw new IllegalArgumentException("Provided offset [" + offset + "] is out of segment range");
+    }
+    refCount.incrementAndGet();
+    return segmentView;
+  }
+
+  /**
+   * Closes view that was obtained (decrements ref count).
+   */
+  void closeView() {
+    refCount.decrementAndGet();
+  }
+
+  /**
+   * @return size of the backing file on disk.
+   * @throws IOException if the size could not be obtained due to I/O error.
+   */
+  long sizeInBytes()
+      throws IOException {
+    return fileChannel.size();
+  }
+
+  /**
+   * @return the name of this segment.
+   */
+  String getName() {
+    return name;
+  }
+
+  /**
+   * Sets the end offset of this segment. This can be lesser than the actual size of the file and represents the offset
+   * until which data that is readable is stored.
+   * @param endOffset the end offset of this log.
+   * @throws IllegalArgumentException if {@code endOffset} < 0 or {@code endOffset} > the size of the file.
+   * @throws IOException if there is any I/O error.
+   */
+  void setEndOffset(long endOffset)
+      throws IOException {
+    long fileSize = sizeInBytes();
+    if (endOffset < 0 || endOffset > fileSize) {
+      throw new IllegalArgumentException(file.getAbsolutePath() + ": EndOffset [" + endOffset +
+          "] outside the file size [" + fileSize + "]");
+    }
+    fileChannel.position(endOffset);
+    this.endOffset.set(endOffset);
+  }
+
+  /**
+   * @return the end offset of this log segment.
+   */
+  long getEndOffset() {
+    return endOffset.get();
+  }
+
+  /**
+   * @return the reference count of this log segment.
+   */
+  long refCount() {
+    return refCount.get();
+  }
+
+  /**
+   * Flushes the backing file to disk.
+   * @throws IOException if there is an I/O error while flushing.
+   */
+  void flush()
+      throws IOException {
+    fileChannel.force(true);
+  }
+
+  /**
+   * Closes this log segment
+   */
+  void close()
+      throws IOException {
+    fileChannel.close();
+  }
+
+  /**
+   * Checks to make sure that {@link #next} is not {@code null}
+   * @param errorCounter the error counter to increment if {@link #next} is {@code null}.
+   * @throws IllegalStateException if {@link #next} is {@code null}
+   */
+  private void ensureNext(Counter errorCounter) {
+    if (next == null) {
+      errorCounter.inc();
+      throw new IllegalStateException(file.getAbsolutePath() + ": Cannot perform operation beyond total capacity");
+    }
+  }
+}

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -21,8 +21,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.util.concurrent.atomic.AtomicLong;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -39,16 +37,11 @@ class LogSegment implements Read, Write {
   private final StoreMetrics metrics;
   private final AtomicLong endOffset;
   private final AtomicLong refCount = new AtomicLong(0);
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
-  /**
-   * Reference to the segment that logically "follows" this segment.
-   */
-  LogSegment next = null;
 
   /**
    * Creates a LogSegment abstraction.
-   * @param name the desired name of the segment.
+   * @param name the desired name of the segment. The name signifies the handle/ID of the LogSegment and may be
+   *             different from the filename of the {@code file}.
    * @param file the backing {@link File} for this segment.
    * @param capacityInBytes the intended capacity of the segment
    * @param metrics the {@link StoreMetrics} instance to use.

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -163,7 +163,7 @@ class LogSegment implements Read, Write {
    * {@inheritDoc}
    * <p/>
    * The read is not started if it cannot be completed.
-   * @param buffer The buffer into which the read needs to write to
+   * @param buffer The buffer into which the data needs to be written
    * @param position The position to start the read from
    * @throws IllegalArgumentException if {@code position} < 0 or > {@link #getEndOffset()} or if {@code buffer} size is
    * greater than the data available for read.
@@ -196,7 +196,7 @@ class LogSegment implements Read, Write {
    * <p/>
    * The write is not started if it cannot be completed.
    * @param channel The channel from which data needs to be written from.
-   * @param offset The offset in the segment at which tho start writing.
+   * @param offset The offset in the segment at which to start writing.
    * @param size The amount of data in bytes to be written from the channel.
    * @throws IllegalArgumentException if {@code offset} < 0 or if there is not enough space for {@code offset } +
    * {@code size} data.
@@ -333,7 +333,7 @@ class LogSegment implements Read, Write {
    */
   private void ensureActive() {
     if (!state.equals(State.ACTIVE)) {
-      throw new IllegalStateException("Segment is not in ACTIVE state");
+      throw new IllegalStateException("Segment is not in an ACTIVE state");
     }
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -81,19 +81,22 @@ public class LogSegmentTest {
       int written = segment.appendFrom(ByteBuffer.wrap(buf, 0, writeSize));
       assertEquals("Size written did not match size of buffer provided", writeSize, written);
       assertEquals("End offset is not equal to the cumulative bytes written", writeSize, segment.getEndOffset());
+      readAndEnsureMatch(segment, 0, Arrays.copyOfRange(buf, 0, writeSize));
 
       // append with channel
       segment.appendFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(buf, writeSize, writeSize))),
           writeSize);
       assertEquals("End offset is not equal to the cumulative bytes written", 2 * writeSize, segment.getEndOffset());
+      readAndEnsureMatch(segment, writeSize, Arrays.copyOfRange(buf, writeSize, 2 * writeSize));
 
       // use writeFrom
       segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(buf, 2 * writeSize, writeSize))),
           segment.getEndOffset(), writeSize);
       assertEquals("End offset is not equal to the cumulative bytes written", 3 * writeSize, segment.getEndOffset());
+      readAndEnsureMatch(segment, 2 * writeSize, Arrays.copyOfRange(buf, 2 * writeSize, buf.length));
 
       readAndEnsureMatch(segment, 0, buf);
-      // test that file size and end offset
+      // check file size and end offset (they will not match)
       assertEquals("End offset is not equal to the cumulative bytes written", 3 * writeSize, segment.getEndOffset());
       assertEquals("Size in bytes is not equal to size of the file", STANDARD_SEGMENT_SIZE, segment.sizeInBytes());
 

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -577,18 +577,19 @@ public class LogSegmentTest {
       closeSegmentAndDeleteFile(segment);
     }
   }
+
+  /**
+   * Interface for abstracting append operations.
+   */
+  private interface Appender {
+    /**
+     * Appends the data of {@code buffer} to {@code segment}.
+     * @param segment the {@link LogSegment} to append {@code buffer} to.
+     * @param buffer the data to append to {@code segment}.
+     * @throws IOException
+     */
+    void append(LogSegment segment, ByteBuffer buffer)
+        throws IOException;
+  }
 }
 
-/**
- * Interface for abstracting append operations.
- */
-interface Appender {
-  /**
-   * Appends the data of {@code buffer} to {@code segment}.
-   * @param segment the {@link LogSegment} to append {@code buffer} to.
-   * @param buffer the data to append to {@code segment}.
-   * @throws IOException
-   */
-  void append(LogSegment segment, ByteBuffer buffer)
-      throws IOException;
-}

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -74,6 +74,7 @@ public class LogSegmentTest {
     String segmentName = "log_current";
     LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE);
     try {
+      assertEquals("Start offset is not as expected", 0, segment.getStartOffset());
       assertEquals("Name of segment is inconsistent with what was provided", segmentName, segment.getName());
       assertEquals("Capacity of segment is inconsistent with what was provided", STANDARD_SEGMENT_SIZE,
           segment.getCapacityInBytes());

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -75,6 +75,8 @@ public class LogSegmentTest {
     LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE);
     try {
       assertEquals("Name of segment is inconsistent with what was provided", segmentName, segment.getName());
+      assertEquals("Capacity of segment is inconsistent with what was provided", STANDARD_SEGMENT_SIZE,
+          segment.getCapacityInBytes());
       int writeSize = 100;
       byte[] buf = TestUtils.getRandomBytes(3 * writeSize);
       // append with buffer

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -546,6 +546,7 @@ public class LogSegmentTest {
   private void closeSegmentAndDeleteFile(LogSegment segment)
       throws IOException {
     segment.close();
+    assertFalse("File channel is not closed", segment.getView(0).getSecond().isOpen());
     File segmentFile = new File(tempDir, segment.getName());
     assertTrue("The segment file [" + segmentFile.getAbsolutePath() + "] could not be deleted", segmentFile.delete());
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -45,7 +45,7 @@ public class LogSegmentTest {
   private final StoreMetrics metrics;
 
   /**
-   * Sets up a temporary file and directory that can be used.
+   * Sets up a temporary directory that can be used.
    * @throws IOException
    */
   public LogSegmentTest()
@@ -56,7 +56,7 @@ public class LogSegmentTest {
   }
 
   /**
-   * Deletes the temporary file that was created.
+   * Deletes the temporary directory that was created.
    */
   @After
   public void cleanup() {

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -493,7 +493,10 @@ public class LogSegmentTest {
   private LogSegment getSegment(String segmentName, long capacityInBytes)
       throws IOException {
     File file = new File(tempDirName, segmentName);
-    assertTrue("Segment file could not be created", file.createNewFile());
+    if (file.exists()) {
+      assertTrue(file.getAbsolutePath() + " already exists and could not be deleted", file.delete());
+    }
+    assertTrue("Segment file could not be created at path " + file.getAbsolutePath(), file.createNewFile());
     file.deleteOnExit();
     try (RandomAccessFile raf = new RandomAccessFile(tempDirName + File.separator + segmentName, "rw")) {
       raf.setLength(capacityInBytes);

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -1,0 +1,700 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.TestUtils;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Tests for {@link LogSegment}.
+ */
+public class LogSegmentTest {
+  private static final int STANDARD_SEGMENT_SIZE = 1024;
+
+  private final String tempDirName;
+  private final File tempFile;
+  private final StoreMetrics metrics;
+
+  /**
+   * Sets up a temporary file and directory that can be used.
+   * @throws IOException
+   */
+  public LogSegmentTest()
+      throws IOException {
+    tempFile = File.createTempFile("ambry", ".tmp");
+    tempFile.deleteOnExit();
+    tempDirName = tempFile.getParent();
+    metrics = new StoreMetrics(tempDirName, new MetricRegistry());
+  }
+
+  /**
+   * Deletes the temporary file that was created.
+   */
+  @After
+  public void cleanup() {
+    assertTrue("The temporary file [" + tempFile.getAbsolutePath() + "] could not be deleted", tempFile.delete());
+  }
+
+  /**
+   * Tests appending and reading to make sure data is written and the data read is consistent with the data written.
+   * @throws IOException
+   */
+  @Test
+  public void basicWriteAndReadTest()
+      throws IOException {
+    String segmentName = "log_current";
+    LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE);
+    try {
+      assertEquals("Name of segment is inconsistent with what was provided", segmentName, segment.getName());
+      int writeSize = 100;
+      byte[] buf = TestUtils.getRandomBytes(3 * writeSize);
+      // append with buffer
+      int written = segment.appendFrom(ByteBuffer.wrap(buf, 0, writeSize));
+      assertEquals("Size written did not match size of buffer provided", writeSize, written);
+      assertEquals("End offset is not equal to the cumulative bytes written", writeSize, segment.getEndOffset());
+
+      // append with channel
+      segment.appendFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(buf, writeSize, writeSize))),
+          writeSize);
+      assertEquals("End offset is not equal to the cumulative bytes written", 2 * writeSize, segment.getEndOffset());
+
+      // use writeFrom
+      segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(buf, 2 * writeSize, writeSize))),
+          segment.getEndOffset(), writeSize);
+      assertEquals("End offset is not equal to the cumulative bytes written", 3 * writeSize, segment.getEndOffset());
+
+      readAndEnsureMatch(segment, 0, buf);
+      // test that file size and end offset
+      assertEquals("End offset is not equal to the cumulative bytes written", 3 * writeSize, segment.getEndOffset());
+      assertEquals("Size in bytes is not equal to size of the file", STANDARD_SEGMENT_SIZE, segment.sizeInBytes());
+
+      // ensure flush doesn't throw any errors.
+      segment.flush();
+      // close and reopen segment and ensure persistence.
+      segment.close();
+      segment = new LogSegment(tempDirName, segmentName, STANDARD_SEGMENT_SIZE, metrics);
+      segment.state = LogSegment.State.ACTIVE;
+      segment.setEndOffset(buf.length);
+      readAndEnsureMatch(segment, 0, buf);
+    } finally {
+      closeSegmentAndDeleteFile(segment);
+    }
+  }
+
+  /**
+   * Verifies getting and closing views and makes sure that data and ref counts are consistent.
+   * @throws IOException
+   */
+  @Test
+  public void viewAndRefCountTest()
+      throws IOException {
+    String segmentName = "log_current";
+    LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE);
+    try {
+      int readSize = 100;
+      int viewCount = 5;
+      byte[] data = appendRandomData(segment, readSize * viewCount);
+
+      for (int i = 0; i < viewCount; i++) {
+        getAndVerifyView(segment, i * readSize, data, i + 1);
+      }
+
+      for (int i = 0; i < viewCount; i++) {
+        segment.closeView();
+        assertEquals("Ref count is not as expected", viewCount - i - 1, segment.refCount());
+      }
+
+      // test boundary offsets
+      getAndVerifyView(segment, 0, data, 1);
+      segment.closeView();
+      getAndVerifyView(segment, (int) segment.getEndOffset(), data, 1);
+      segment.closeView();
+
+      // cannot open views at invalid offsets
+      int[] invalidOffsets = {-1, (int) (segment.getEndOffset() + 1)};
+      for (int offset : invalidOffsets) {
+        try {
+          segment.getView(offset);
+          fail("Getting a view at an invalid offset [" + offset + "] should have failed");
+        } catch (IllegalArgumentException e) {
+          // expected. Nothing to do.
+        }
+      }
+    } finally {
+      closeSegmentAndDeleteFile(segment);
+    }
+  }
+
+  /**
+   * Tests setting end offset - makes sure legal values are set correctly and illegal values are rejected.
+   * @throws IOException
+   */
+  @Test
+  public void endOffsetTest()
+      throws IOException {
+    String segmentName = "log_current";
+    LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE);
+    try {
+      int segmentSize = 500;
+      appendRandomData(segment, segmentSize);
+      assertEquals("End offset is not equal to the cumulative bytes written", segmentSize, segment.getEndOffset());
+
+      // should be able to set end offset to something >= 0 and < file size
+      int[] offsetsToSet = {0, segmentSize / 2, segmentSize};
+      for (int offset : offsetsToSet) {
+        segment.setEndOffset(offset);
+        assertEquals("End offset is not equal to what was set", offset, segment.getEndOffset());
+        assertEquals("File channel positioning is incorrect", offset, segment.getView(0).getSecond().position());
+      }
+
+      // cannot set end offset to illegal values (< 0 or > file size)
+      int[] invalidOffsets = {-1, (int) (segment.sizeInBytes() + 1)};
+      for (int offset : invalidOffsets) {
+        try {
+          segment.setEndOffset(offset);
+          fail("Setting log end offset an invalid offset [" + offset + "] should have failed");
+        } catch (IllegalArgumentException e) {
+          // expected. Nothing to do.
+        }
+      }
+    } finally {
+      closeSegmentAndDeleteFile(segment);
+    }
+  }
+
+  /**
+   * Tests {@link LogSegment#appendFrom(ByteBuffer)} and {@link LogSegment#appendFrom(ReadableByteChannel, long)} for
+   * various cases and state changes.
+   * @throws IOException
+   */
+  @Test
+  public void appendTest()
+      throws IOException {
+    // buffer append
+    doAppendTest(new Appender() {
+      @Override
+      public void append(LogSegment segment, ByteBuffer buffer)
+          throws IOException {
+        int writeSize = buffer.remaining();
+        int written = segment.appendFrom(buffer);
+        assertEquals("Size written did not match size of buffer provided", writeSize, written);
+      }
+    });
+
+    // channel append
+    doAppendTest(new Appender() {
+      @Override
+      public void append(LogSegment segment, ByteBuffer buffer)
+          throws IOException {
+        int writeSize = buffer.remaining();
+        segment.appendFrom(Channels.newChannel(new ByteBufferInputStream(buffer)), writeSize);
+        assertFalse("The buffer was not completely written", buffer.hasRemaining());
+      }
+    });
+  }
+
+  /**
+   * Tests {@link LogSegment#readInto(ByteBuffer, long)} for various cases.
+   * @throws IOException
+   */
+  @Test
+  public void readTest()
+      throws IOException {
+    Random random = new Random();
+    String currSegmentName = "log_current";
+    String nextSegmentName = "log_next";
+    LogSegment currSegment = getSegment(currSegmentName, STANDARD_SEGMENT_SIZE);
+    LogSegment nextSegment = getSegment(nextSegmentName, STANDARD_SEGMENT_SIZE);
+    try {
+      // setup the segments by writing some data and connecting them logically.
+      byte[] currData = appendRandomData(currSegment, 2 * STANDARD_SEGMENT_SIZE / 3);
+      byte[] nextData = appendRandomData(nextSegment, STANDARD_SEGMENT_SIZE / 2);
+      byte[] combined = new byte[currData.length + nextData.length];
+      System.arraycopy(currData, 0, combined, 0, currData.length);
+      System.arraycopy(nextData, 0, combined, currData.length, nextData.length);
+      currSegment.state = LogSegment.State.SEALED;
+      currSegment.next = nextSegment;
+
+      // read data in current segment only
+      readAndEnsureMatch(currSegment, 0, currData);
+      // read data across both segments
+      readAndEnsureMatch(currSegment, 0, combined);
+      // read at end offset of current segment (edge case)
+      readAndEnsureMatch(currSegment, currSegment.getEndOffset(), nextData);
+
+      int readCount = 10;
+      for (int i = 0; i < readCount; i++) {
+        int position = random.nextInt(currData.length);
+        int size = random.nextInt(currData.length - position);
+        // read randomly within current segment
+        readAndEnsureMatch(currSegment, position, Arrays.copyOfRange(currData, position, position + size));
+        // read randomly across both the current segment and next segment
+        readAndEnsureMatch(currSegment, position,
+            Arrays.copyOfRange(combined, position, position + size + nextData.length));
+      }
+
+      // error scenarios
+      ByteBuffer readBuf = ByteBuffer.wrap(new byte[combined.length]);
+      // read position < 0
+      try {
+        currSegment.readInto(readBuf, -1);
+        fail("Should have failed to read because position provided < 0");
+      } catch (IllegalArgumentException e) {
+        assertEquals("Position of buffer has changed", 0, readBuf.position());
+      }
+
+      // read position > endOffset
+      try {
+        currSegment.readInto(readBuf, currSegment.getEndOffset() + 1);
+        fail("Should have failed to read because position provided > end offset");
+      } catch (IllegalArgumentException e) {
+        assertEquals("Position of buffer has changed", 0, readBuf.position());
+      }
+
+      currSegment.next = null;
+      // try to read more than what is available in the current segment
+      long readOverFlowCount = metrics.overflowReadError.getCount();
+      try {
+        currSegment.readInto(readBuf, 0);
+        fail("Should have failed to read because buffer size is more than current segment size");
+      } catch (IllegalStateException e) {
+        assertEquals("Read overflow should have been reported", readOverFlowCount + 1,
+            metrics.overflowReadError.getCount());
+        assertEquals("Position of buffer has changed", 0, readBuf.position());
+      }
+
+      currSegment.close();
+      // read after close
+      ByteBuffer buffer = ByteBuffer.allocate(1);
+      try {
+        currSegment.readInto(buffer, 0);
+        fail("Should have failed to read because segment is closed");
+      } catch (ClosedChannelException e) {
+        assertEquals("Position of buffer has changed", 0, buffer.position());
+      }
+    } finally {
+      // no state changes should have occurred.
+      assertEquals("Current segment should be in SEALED state", LogSegment.State.SEALED, currSegment.state);
+      assertEquals("Next segment should be in ACTIVE state", LogSegment.State.ACTIVE, nextSegment.state);
+      closeSegmentAndDeleteFile(currSegment);
+      closeSegmentAndDeleteFile(nextSegment);
+    }
+  }
+
+  /**
+   * Tests {@link LogSegment#writeFrom(ReadableByteChannel, long, long)} for various cases.
+   * @throws IOException
+   */
+  @Test
+  public void writeFromTest()
+      throws IOException {
+    String currSegmentName = "log_current";
+    String nextSegmentName = "log_next";
+    LogSegment currSegment = getSegment(currSegmentName, STANDARD_SEGMENT_SIZE);
+    LogSegment nextSegment = getSegment(nextSegmentName, STANDARD_SEGMENT_SIZE);
+    try {
+      byte[] fullBuf =
+          TestUtils.getRandomBytes(STANDARD_SEGMENT_SIZE / 2 + STANDARD_SEGMENT_SIZE / 3 + STANDARD_SEGMENT_SIZE / 2);
+
+      // first write will fit into current segment.
+      int firstWriteSize = STANDARD_SEGMENT_SIZE / 2;
+      ByteBuffer firstBuf = ByteBuffer.wrap(fullBuf, 0, firstWriteSize);
+      // second write will fit into current segment.
+      int secondWriteSize = STANDARD_SEGMENT_SIZE / 3;
+      ByteBuffer secondBuf = ByteBuffer.wrap(fullBuf, firstWriteSize, secondWriteSize);
+      // third write will not fit into current segment and will need to be written across current and next
+      int thirdWriteSize = STANDARD_SEGMENT_SIZE / 2;
+      ByteBuffer thirdBuf = ByteBuffer.wrap(fullBuf, firstWriteSize + secondWriteSize, thirdWriteSize);
+
+      // do the first write. Fits in current segment
+      currSegment.writeFrom(Channels.newChannel(new ByteBufferInputStream(firstBuf)), currSegment.getEndOffset(),
+          firstWriteSize);
+      assertEquals("End offset in current segment is not equal to the cumulative bytes written", firstWriteSize,
+          currSegment.getEndOffset());
+
+      // do the second write. Fits in current segment
+      currSegment.writeFrom(Channels.newChannel(new ByteBufferInputStream(secondBuf)), currSegment.getEndOffset(),
+          secondWriteSize);
+      assertEquals("End offset in current segment is not equal to the cumulative bytes written",
+          firstWriteSize + secondWriteSize, currSegment.getEndOffset());
+
+      // try to do the third write on the current segment. Should fail because the data won't fit and there is no next
+      long writeOverFlowCount = metrics.overflowWriteError.getCount();
+      try {
+        currSegment.writeFrom(Channels.newChannel(new ByteBufferInputStream(thirdBuf)), currSegment.getEndOffset(),
+            thirdWriteSize);
+        fail("WriteFrom should have failed because data won't fit in the current segment and there is no next");
+      } catch (IllegalStateException e) {
+        assertEquals("Write overflow should have been reported", writeOverFlowCount + 1,
+            metrics.overflowWriteError.getCount());
+        assertEquals("Position of buffer has changed", firstWriteSize + secondWriteSize, thirdBuf.position());
+      }
+
+      // now add a next so that writes can be transparently forwarded
+      currSegment.next = nextSegment;
+      currSegment.writeFrom(Channels.newChannel(new ByteBufferInputStream(thirdBuf)), currSegment.getEndOffset(),
+          thirdWriteSize);
+
+      // the write would have fit partially in the current segment. The rest go into the next segment
+      assertEquals("End offset of current segment is incorrect", STANDARD_SEGMENT_SIZE, currSegment.getEndOffset());
+      assertEquals("End offset of next segment is incorrect", fullBuf.length - STANDARD_SEGMENT_SIZE,
+          nextSegment.getEndOffset());
+
+      // read and ensure data matches
+      readAndEnsureMatch(currSegment, 0, Arrays.copyOfRange(fullBuf, 0, STANDARD_SEGMENT_SIZE));
+      readAndEnsureMatch(nextSegment, 0, Arrays.copyOfRange(fullBuf, STANDARD_SEGMENT_SIZE, fullBuf.length));
+
+      // data cannot be written at invalid offsets.
+      // <0
+      ByteBuffer buffer = ByteBuffer.wrap(TestUtils.getRandomBytes(1));
+      try {
+        currSegment.writeFrom(Channels.newChannel(new ByteBufferInputStream(buffer)), -1, buffer.remaining());
+        fail("WriteFrom should have failed because offset provided for write < 0");
+      } catch (IllegalArgumentException e) {
+        assertEquals("Position of buffer has changed", 0, buffer.position());
+      }
+
+      // > capacity
+      try {
+        currSegment.writeFrom(Channels.newChannel(new ByteBufferInputStream(buffer)), STANDARD_SEGMENT_SIZE + 1,
+            buffer.remaining());
+        fail("WriteFrom should have failed because offset provided was greater than capacity");
+      } catch (IllegalArgumentException e) {
+        assertEquals("Position of buffer has changed", 0, buffer.position());
+      }
+
+      // overwrite and check
+      byte[] overwriteBuf = TestUtils.getRandomBytes(STANDARD_SEGMENT_SIZE / 2);
+      ByteBuffer overwriteBuffer = ByteBuffer.wrap(overwriteBuf);
+      int offsetToWrite = STANDARD_SEGMENT_SIZE / 3;
+      // write isolated to single segment
+      currSegment.writeFrom(Channels.newChannel(new ByteBufferInputStream(overwriteBuffer)), offsetToWrite,
+          overwriteBuffer.remaining());
+      assertEquals("End offset in current segment should not have changed", STANDARD_SEGMENT_SIZE,
+          currSegment.getEndOffset());
+      assertEquals("End offset of next segment should not have changed", fullBuf.length - STANDARD_SEGMENT_SIZE,
+          nextSegment.getEndOffset());
+      readAndEnsureMatch(currSegment, offsetToWrite, overwriteBuf);
+
+      // write is across segments
+      overwriteBuffer.rewind();
+      // move end offset to make sure that end offset is updated correctly when writeFroms happen.
+      offsetToWrite = 2 * STANDARD_SEGMENT_SIZE / 3;
+      currSegment.setEndOffset(STANDARD_SEGMENT_SIZE - 1);
+      currSegment.writeFrom(Channels.newChannel(new ByteBufferInputStream(overwriteBuffer)), offsetToWrite,
+          overwriteBuffer.remaining());
+      assertEquals("End offset in current segment is incorrect", STANDARD_SEGMENT_SIZE, currSegment.getEndOffset());
+      assertEquals("End offset of next segment should not have changed", fullBuf.length - STANDARD_SEGMENT_SIZE,
+          nextSegment.getEndOffset());
+      readAndEnsureMatch(currSegment, offsetToWrite,
+          Arrays.copyOfRange(overwriteBuf, 0, STANDARD_SEGMENT_SIZE - offsetToWrite));
+      readAndEnsureMatch(nextSegment, 0,
+          Arrays.copyOfRange(overwriteBuf, STANDARD_SEGMENT_SIZE - offsetToWrite, overwriteBuf.length));
+
+      // write is at capacity of current segment (edge case)
+      overwriteBuffer.rewind();
+      currSegment.writeFrom(Channels.newChannel(new ByteBufferInputStream(overwriteBuffer)), STANDARD_SEGMENT_SIZE,
+          overwriteBuffer.remaining());
+      assertEquals("End offset in current segment should not have changed", STANDARD_SEGMENT_SIZE,
+          currSegment.getEndOffset());
+      assertEquals("End offset of next segment should be equal to cumulative data written", overwriteBuf.length,
+          nextSegment.getEndOffset());
+      readAndEnsureMatch(nextSegment, 0, overwriteBuf);
+
+      currSegment.close();
+      // ensure that writeFrom fails.
+      try {
+        currSegment.writeFrom(Channels.newChannel(new ByteBufferInputStream(buffer)), 0, buffer.remaining());
+        fail("WriteFrom should have failed because segments are closed");
+      } catch (ClosedChannelException e) {
+        assertEquals("Position of buffer has changed", 0, buffer.position());
+      }
+    } finally {
+      // no state changes should have occurred.
+      assertEquals("Current segment should be in FREE state", LogSegment.State.FREE, currSegment.state);
+      assertEquals("Next segment should be in FREE state", LogSegment.State.FREE, nextSegment.state);
+      closeSegmentAndDeleteFile(currSegment);
+      closeSegmentAndDeleteFile(nextSegment);
+    }
+  }
+
+  /**
+   * Tests for bad construction cases of {@link LogSegment}.
+   * @throws IOException
+   */
+  @Test
+  public void badConstructionTest()
+      throws IOException {
+    // try to construct with a file that does not exist.
+    try {
+      new LogSegment(tempDirName, "log_non_existent", STANDARD_SEGMENT_SIZE, metrics);
+      fail("Construction should have failed because the backing file does not exist");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+
+    // try to construct with a file that is a directory
+    File tempDir = Files.createTempDirectory("temp_dir").toFile();
+    tempDir.deleteOnExit();
+    try {
+      new LogSegment(tempDir.getParent(), tempDir.getName(), STANDARD_SEGMENT_SIZE, metrics);
+      fail("Construction should have failed because the backing file does not exist");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    } finally {
+      assertTrue("The temp directory [" + tempDir.getAbsolutePath() + "] could not be deleted", tempDir.delete());
+    }
+  }
+
+  // helpers
+  // general
+
+  /**
+   * Creates and gets a {@link LogSegment}.
+   * @param segmentName the name of the segment as well as the file backing the segment.
+   * @param capacityInBytes the capacity of the file/segment.
+   * @return instance of {@link LogSegment} that is backed by the file with name {@code segmentName} of capacity
+   * {@code capacityInBytes}.
+   * @throws IOException
+   */
+  private LogSegment getSegment(String segmentName, long capacityInBytes)
+      throws IOException {
+    try (RandomAccessFile raf = new RandomAccessFile(tempDirName + File.separator + segmentName, "rw")) {
+      raf.setLength(capacityInBytes);
+      LogSegment segment = new LogSegment(tempDirName, segmentName, capacityInBytes, metrics);
+      segment.setEndOffset(0);
+      return segment;
+    } finally {
+      new File(tempDirName, segmentName).deleteOnExit();
+    }
+  }
+
+  /**
+   * Appends random data of size {@code size} to given {@code segment}.
+   * @param segment the {@link LogSegment} to append data to.
+   * @param size the size of the data that should be appended.
+   * @return the data that was appended.
+   * @throws IOException
+   */
+  private byte[] appendRandomData(LogSegment segment, int size)
+      throws IOException {
+    byte[] buf = TestUtils.getRandomBytes(size);
+    segment.appendFrom(ByteBuffer.wrap(buf));
+    return buf;
+  }
+
+  /**
+   * Reads data starting from {@code offsetToStartRead} of {@code segment} and matches it with {@code original}.
+   * @param segment the {@link LogSegment} to read from.
+   * @param offsetToStartRead the offset in {@code segment} to start reading from.
+   * @param original the byte array to compare against.
+   * @throws IOException
+   */
+  private void readAndEnsureMatch(LogSegment segment, long offsetToStartRead, byte[] original)
+      throws IOException {
+    ByteBuffer readBuf = ByteBuffer.wrap(new byte[original.length]);
+    segment.readInto(readBuf, offsetToStartRead);
+    assertArrayEquals("Data read does not match data written", original, readBuf.array());
+  }
+
+  /**
+   * Closes the {@code segment} and deletes the backing file.
+   * @param segment the {@link LogSegment} that needs to be closed and whose backing file needs to be deleted.
+   * @throws IOException
+   */
+  private void closeSegmentAndDeleteFile(LogSegment segment)
+      throws IOException {
+    segment.close();
+    File segmentFile = new File(tempDirName, segment.getName());
+    assertTrue("The segment file [" + segmentFile.getAbsolutePath() + "] could not be deleted", segmentFile.delete());
+  }
+
+  // viewAndRefCountTest() helpers
+
+  /**
+   * Gets a view of the given {@code segment} and verifies the ref count and the data obtained from the view against
+   * {@code expectedRefCount} and {@code dataInSegment} respectively.
+   * @param segment the {@link LogSegment} to get a view from.
+   * @param offset the offset for which a view is required.
+   * @param dataInSegment the entire data in the {@link LogSegment}.
+   * @param expectedRefCount the expected return value of {@link LogSegment#refCount()} once the view is obtained from
+   *                         the {@code segment}
+   * @throws IOException
+   */
+  private void getAndVerifyView(LogSegment segment, int offset, byte[] dataInSegment, long expectedRefCount)
+      throws IOException {
+    Random random = new Random();
+    Pair<File, FileChannel> view = segment.getView(offset);
+    assertNotNull("File object received in view is null", view.getFirst());
+    assertNotNull("FileChannel object received in view is null", view.getSecond());
+    assertEquals("Ref count is not as expected", expectedRefCount, segment.refCount());
+    int sizeToRead = random.nextInt(dataInSegment.length - offset + 1);
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[sizeToRead]);
+    view.getSecond().read(buffer, offset);
+    assertArrayEquals("Data read from file does not match data written",
+        Arrays.copyOfRange(dataInSegment, offset, offset + sizeToRead), buffer.array());
+  }
+
+  // appendTest() helpers
+
+  /**
+   * Using the given {@code appender}'s {@link Appender#append(LogSegment, ByteBuffer)} function, tests for various
+   * state changes and cases for append operations.
+   * @param appender the {@link Appender} to use
+   * @throws IOException
+   */
+  private void doAppendTest(Appender appender)
+      throws IOException {
+    String currSegmentName = "log_current";
+    String nextSegmentName = "log_next";
+    LogSegment currSegment = getSegment(currSegmentName, STANDARD_SEGMENT_SIZE);
+    LogSegment nextSegment = getSegment(nextSegmentName, STANDARD_SEGMENT_SIZE);
+    try {
+      byte[] fullBuf =
+          TestUtils.getRandomBytes(STANDARD_SEGMENT_SIZE / 2 + STANDARD_SEGMENT_SIZE / 3 + STANDARD_SEGMENT_SIZE - 1);
+
+      // first write will fit into current segment. Will cause state transition for current segment (FREE -> ACTIVE).
+      int firstWriteSize = STANDARD_SEGMENT_SIZE / 2;
+      ByteBuffer firstBuf = ByteBuffer.wrap(fullBuf, 0, firstWriteSize);
+      // second write will fit into current segment. Will not cause any state transitions.
+      int secondWriteSize = STANDARD_SEGMENT_SIZE / 3;
+      ByteBuffer secondBuf = ByteBuffer.wrap(fullBuf, firstWriteSize, secondWriteSize);
+      // third write will not fit into current segment and will need to forwarded. Will cause state transition for
+      // current segment (ACTIVE -> SEALED), for next segment (FREE -> ACTIVE).
+      int thirdWriteSize = STANDARD_SEGMENT_SIZE / 2;
+      ByteBuffer thirdBuf = ByteBuffer.wrap(fullBuf, firstWriteSize + secondWriteSize, thirdWriteSize);
+      // fourth write will be forwarded to the next segment (where it will fit). Will not cause any state transitions.
+      int fourthWriteSize = fullBuf.length - thirdWriteSize - secondWriteSize - firstWriteSize;
+      ByteBuffer fourthBuf = ByteBuffer.wrap(fullBuf, fullBuf.length - fourthWriteSize, fourthWriteSize);
+
+      // do the first write. Fits in current segment
+      appender.append(currSegment, firstBuf);
+      assertEquals("End offset in current segment is not equal to the cumulative bytes written", firstWriteSize,
+          currSegment.getEndOffset());
+      assertEquals("Current segment should be in ACTIVE state", LogSegment.State.ACTIVE, currSegment.state);
+
+      // do the second write. Fits in current segment
+      appender.append(currSegment, secondBuf);
+      assertEquals("End offset in current segment is not equal to the cumulative bytes written",
+          firstWriteSize + secondWriteSize, currSegment.getEndOffset());
+      assertEquals("Current segment should be in ACTIVE state", LogSegment.State.ACTIVE, currSegment.state);
+
+      // try to do the third write on the current segment. Should fail because the data won't fit and there is no next
+      long writeOverFlowCount = metrics.overflowWriteError.getCount();
+      try {
+        appender.append(currSegment, thirdBuf);
+        fail("Append should have failed because data won't fit in the current segment and there is no next");
+      } catch (IllegalStateException e) {
+        assertEquals("Write overflow should have been reported", writeOverFlowCount + 1,
+            metrics.overflowWriteError.getCount());
+        assertEquals("Position of buffer has changed", firstWriteSize + secondWriteSize, thirdBuf.position());
+      }
+
+      // currSegment should be still ACTIVE
+      assertEquals("Current segment should be in ACTIVE state", LogSegment.State.ACTIVE, currSegment.state);
+      // now add a next so that writes can be transparently forwarded
+      currSegment.next = nextSegment;
+      appender.append(currSegment, thirdBuf);
+      assertEquals("Current segment should be in SEALED state", LogSegment.State.SEALED, currSegment.state);
+      assertEquals("Next segment should be in ACTIVE state", LogSegment.State.ACTIVE, nextSegment.state);
+
+      // the whole write should have gone to the next segment i.e. no partial writes
+      assertEquals("End offset of current segment is incorrect", firstWriteSize + secondWriteSize,
+          currSegment.getEndOffset());
+      assertEquals("End offset of next segment is incorrect", thirdWriteSize, nextSegment.getEndOffset());
+
+      // remove next again to check that writes to segments that are sealed fail
+      currSegment.next = null;
+      // current segment is sealed, so the write will fail.
+      writeOverFlowCount = metrics.overflowWriteError.getCount();
+      try {
+        appender.append(currSegment, fourthBuf);
+        fail("Append should have failed because current segment is sealed and there is no next");
+      } catch (IllegalStateException e) {
+        assertEquals("Write overflow should have been reported", writeOverFlowCount + 1,
+            metrics.overflowWriteError.getCount());
+        assertEquals("Position of buffer has changed", fullBuf.length - fourthWriteSize, fourthBuf.position());
+      }
+      // currSegment should be still SEALED
+      assertEquals("Current segment should be in SEALED state", LogSegment.State.SEALED, currSegment.state);
+
+      // add next back again so that writes are forwarded.
+      currSegment.next = nextSegment;
+      appender.append(currSegment, fourthBuf);
+      assertEquals("Current segment should be in SEALED state", LogSegment.State.SEALED, currSegment.state);
+      assertEquals("Next segment should be in ACTIVE state", LogSegment.State.ACTIVE, nextSegment.state);
+
+      // the whole write should have gone to the next segment i.e. no partial writes
+      assertEquals("End offset of current segment is incorrect", firstWriteSize + secondWriteSize,
+          currSegment.getEndOffset());
+      assertEquals("End offset of next segment is incorrect", thirdWriteSize + fourthWriteSize,
+          nextSegment.getEndOffset());
+
+      // read and ensure data matches
+      readAndEnsureMatch(currSegment, 0, Arrays.copyOfRange(fullBuf, 0, firstWriteSize));
+      readAndEnsureMatch(currSegment, firstWriteSize,
+          Arrays.copyOfRange(fullBuf, firstWriteSize, firstWriteSize + secondWriteSize));
+      readAndEnsureMatch(nextSegment, 0,
+          Arrays.copyOfRange(fullBuf, firstWriteSize + secondWriteSize, fullBuf.length - fourthWriteSize));
+      readAndEnsureMatch(nextSegment, thirdWriteSize,
+          Arrays.copyOfRange(fullBuf, fullBuf.length - fourthWriteSize, fullBuf.length));
+
+      currSegment.close();
+      nextSegment.close();
+      // ensure that append fails.
+      ByteBuffer buffer = ByteBuffer.wrap(TestUtils.getRandomBytes(1));
+      try {
+        appender.append(currSegment, buffer);
+        fail("Append should have failed because segments are closed");
+      } catch (ClosedChannelException e) {
+        assertEquals("Position of buffer has changed", 0, buffer.position());
+      }
+    } finally {
+      closeSegmentAndDeleteFile(currSegment);
+      closeSegmentAndDeleteFile(nextSegment);
+    }
+  }
+
+  /**
+   * Interface for abstracting append operations.
+   */
+  private interface Appender {
+    /**
+     * Appends the data of {@code buffer} to {@code segment}.
+     * @param segment the {@link LogSegment} to append {@code buffer} to.
+     * @param buffer the data to append to {@code segment}.
+     * @throws IOException
+     */
+    void append(LogSegment segment, ByteBuffer buffer)
+        throws IOException;
+  }
+}


### PR DESCRIPTION
This commit adds the abstraction for representing log segments. Log segments will
form the components of a larger log abstraction. For design and discussion please
refer to https://github.com/linkedin/ambry/issues/469.

Please use the current implementation of [`Log`](https://github.com/linkedin/ambry/blob/e85e3a2fbf190ceca91a8f808663f7bf0b195ed7/ambry-store/src/main/java/com.github.ambry.store/Log.java) as a reference.

Built (`./gradlew build && ./gradlew test`) and formatted.

**Primary reviewers: @pnarayanan, @nsivabalan**
**Expected time to review: 60-90 mins**

**Unit testing**

Class | Class, % | Method, % | Line, %
------- | ------------ | -------------- | ----------
`LogSegment` | 100% (2/ 2) | 100% (17/ 17) | 100% (94/ 94)
  

