### PR TITLE
Changes to the Log to support log segmentation

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -89,6 +89,13 @@ public class StoreConfig {
   @Default("false")
   public final boolean storeEnableHardDelete;
 
+  /**
+   * The size of a single segment in the log. Only relevant for first startup of a {@link com.github.ambry.store.Store}.
+   */
+  @Config("store.segment.size.in.bytes")
+  @Default("9223372036854775807")
+  public final long storeSegmentSizeInBytes;
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -103,6 +110,8 @@ public class StoreConfig {
     storeDeletedMessageRetentionDays = verifiableProperties.getInt("store.deleted.message.retention.days", 7);
     storeHardDeleteBytesPerSec = verifiableProperties.getInt("store.hard.delete.bytes.per.sec", 1 * 1024 * 1024);
     storeEnableHardDelete = verifiableProperties.getBoolean("store.enable.hard.delete", false);
+    storeSegmentSizeInBytes =
+        verifiableProperties.getLongInRange("store.segment.size.in.bytes", Long.MAX_VALUE, 1, Long.MAX_VALUE);
   }
 }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  * The blob store that controls the log and index
  */
 class BlobStore implements Store {
+  static final String SEPARATOR = "_";
 
   private Log log;
   private PersistentIndex index;
@@ -42,7 +43,7 @@ class BlobStore implements Store {
   private final DiskIOScheduler diskIOScheduler;
   private Logger logger = LoggerFactory.getLogger(getClass());
   /* A lock that prevents concurrent writes to the log */
-  private Object lock = new Object();
+  private final Object lock = new Object();
   private boolean started;
   private StoreConfig config;
   private long capacityInBytes;
@@ -101,11 +102,10 @@ class BlobStore implements Store {
               "Failed to acquire lock on file " + dataDir + ". Another process or thread is using this directory.",
               StoreErrorCodes.Initialization_Error);
         }
-        log = new Log(dataDir, capacityInBytes, metrics);
+        log = new Log(dataDir, capacityInBytes, config.storeSegmentSizeInBytes, metrics);
         index = new PersistentIndex(dataDir, taskScheduler, log, config, factory, recovery, hardDelete, metrics, time);
-        // set the log end offset to the recovered offset from the index after initializing it
-        log.setLogEndOffset(index.getCurrentEndOffset());
-        metrics.initializeCapacityUsedMetric(log, capacityInBytes);
+        setSegmentStatesAndEndOffsets();
+        metrics.initializeLogGauges(log, capacityInBytes);
         started = true;
       } catch (Exception e) {
         metrics.storeStartFailure.inc();
@@ -142,9 +142,6 @@ class BlobStore implements Store {
       return new StoreInfo(readSet, messageInfoList);
     } catch (StoreException e) {
       throw e;
-    } catch (IOException e) {
-      throw new StoreException("IO error while trying to fetch blobs from store " + dataDir, e,
-          StoreErrorCodes.IOError);
     } catch (Exception e) {
       throw new StoreException("Unknown exception while trying to fetch blobs from store " + dataDir, e,
           StoreErrorCodes.Unknown_Error);
@@ -182,7 +179,8 @@ class BlobStore implements Store {
             }
           }
         }
-        long writeStartOffset = log.getLogEndOffset();
+        // TODO (Index changes): Working under the assumption that there is only one log segment.
+        long writeStartOffset = log.getLogEndOffset().getOffset();
         messageSetToWrite.writeTo(log);
         logger.trace("Store : {} message set written to log", dataDir);
         List<MessageInfo> messageInfo = messageSetToWrite.getMessageSetInfo();
@@ -193,7 +191,7 @@ class BlobStore implements Store {
           indexEntries.add(entry);
           writeStartOffset += info.getSize();
         }
-        FileSpan fileSpan = new FileSpan(indexEntries.get(0).getValue().getOffset(), log.getLogEndOffset());
+        FileSpan fileSpan = new FileSpan(indexEntries.get(0).getValue().getOffset(), writeStartOffset);
         index.addToIndex(indexEntries, fileSpan);
         logger.trace("Store : {} message set written to index ", dataDir);
       }
@@ -241,7 +239,8 @@ class BlobStore implements Store {
             }
           }
         }
-        long writeStartOffset = log.getLogEndOffset();
+        // TODO (Index changes): Working under the assumption that there is only one log segment.
+        long writeStartOffset = log.getLogEndOffset().getOffset();
         messageSetToDelete.writeTo(log);
         logger.trace("Store : {} delete mark written to log", dataDir);
         for (MessageInfo info : infoList) {
@@ -307,7 +306,7 @@ class BlobStore implements Store {
 
   @Override
   public long getSizeInBytes() {
-    return log.getLogEndOffset();
+    return log.getUsedCapacity();
   }
 
   @Override
@@ -344,5 +343,18 @@ class BlobStore implements Store {
     if (!started) {
       throw new StoreException("Store not started", StoreErrorCodes.Store_Not_Started);
     }
+  }
+
+  /**
+   * Sets the end offsets and states for all the segments (by setting the active segment).
+   * @throws IOException if there is an I/O error while setting the end offsets.
+   */
+  private void setSegmentStatesAndEndOffsets()
+      throws IOException {
+    // TODO (Index Changes): Since the index works under the assumption that there is only one log segment, the code
+    // TODO (Index Changes): here does the same. Once the index can handle multiple segments, this will change.
+    LogSegment firstSegment = log.getSegmentIterator().next().getValue();
+    firstSegment.setEndOffset(index.getCurrentEndOffset());
+    log.setActiveSegment(firstSegment.getName());
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -354,7 +354,7 @@ class BlobStore implements Store {
       throws IOException {
     // TODO (Index Changes): Since the index works under the assumption that there is only one log segment, the code
     // TODO (Index Changes): here does the same. Once the index can handle multiple segments, this will change.
-    LogSegment firstSegment = log.getSegmentIterator().next().getValue();
+    LogSegment firstSegment = log.getFirstSegment();
     firstSegment.setEndOffset(index.getCurrentEndOffset());
     log.setActiveSegment(firstSegment.getName());
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -97,7 +97,7 @@ public class HardDeleter implements Runnable {
     this.metrics = metrics;
     this.dataDir = dataDir;
     this.log = log;
-    logSegment = log.getSegmentIterator().next().getValue();
+    logSegment = log.getFirstSegment();
     this.index = index;
     this.hardDelete = hardDelete;
     this.factory = factory;

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -56,6 +56,8 @@ public class HardDeleter implements Runnable {
   private final Time time;
   private final int scanSizeInBytes;
   private final int messageRetentionSeconds;
+  // TODO (HardDelete Changes): This will stay until the HardDelete is rewritten to handle multiple segments.
+  private final LogSegment logSegment;
   //how long to sleep if token does not advance.
   private final long hardDeleterSleepTimeWhenCaughtUpMs = 10 * Time.MsPerSec;
   private final CountDownLatch shutdownLatch = new CountDownLatch(1);
@@ -95,6 +97,7 @@ public class HardDeleter implements Runnable {
     this.metrics = metrics;
     this.dataDir = dataDir;
     this.log = log;
+    logSegment = log.getSegmentIterator().next().getValue();
     this.index = index;
     this.hardDelete = hardDelete;
     this.factory = factory;
@@ -174,7 +177,7 @@ public class HardDeleter implements Runnable {
         if (hardDeleteInfo == null) {
           metrics.hardDeleteFailedCount.inc(1);
         } else {
-          log.writeFrom(hardDeleteInfo.getHardDeleteChannel(),
+          logSegment.writeFrom(hardDeleteInfo.getHardDeleteChannel(),
               readOptions.getOffset() + hardDeleteInfo.getStartOffsetInMessage(),
               hardDeleteInfo.getHardDeletedMessageSize());
           metrics.hardDeleteDoneCount.inc(1);
@@ -509,7 +512,7 @@ public class HardDeleter implements Runnable {
               StoreErrorCodes.Store_Shutting_Down);
         }
 
-        log.writeFrom(logWriteInfo.channel, logWriteInfo.offset, logWriteInfo.size);
+        logSegment.writeFrom(logWriteInfo.channel, logWriteInfo.offset, logWriteInfo.size);
         metrics.hardDeleteDoneCount.inc(1);
         throttler.maybeThrottle(logWriteInfo.size);
       }

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -135,10 +134,24 @@ class Log implements Write {
   }
 
   /**
-   * @return a segment iterator that can iterate over all the log segments in this log
+   * @return the first {@link LogSegment} instance in the log.
    */
-  Iterator<Map.Entry<String, LogSegment>> getSegmentIterator() {
-    return segmentsByName.entrySet().iterator();
+  LogSegment getFirstSegment() {
+    return segmentsByName.firstEntry().getValue();
+  }
+
+  /**
+   * Returns the {@link LogSegment} that is logically after the given {@code segment}.
+   * @param segment the {@link LogSegment} whose "next" segment is required.
+   * @return the {@link LogSegment} that is logically after the given {@code segment}.
+   */
+  LogSegment getNextSegment(LogSegment segment) {
+    String name = segment.getName();
+    if (!segmentsByName.containsKey(name)) {
+      throw new IllegalArgumentException("Invalid log segment name: " + name);
+    }
+    Map.Entry<String, LogSegment> nextEntry = segmentsByName.higherEntry(name);
+    return nextEntry == null ? null : nextEntry.getValue();
   }
 
   /**
@@ -153,7 +166,7 @@ class Log implements Write {
    * @return the start offset of the log abstraction.
    */
   Offset getStartOffset() {
-    LogSegment segment = getSegmentIterator().next().getValue();
+    LogSegment segment = getFirstSegment();
     return new Offset(segment.getName(), segment.getStartOffset());
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -202,12 +202,12 @@ class Log implements Write {
    * positive, else, unless equal, it is negative
    */
   long getDifference(Offset o1, Offset o2) {
-    if (!segmentsByName.containsKey(o1.getName()) || !segmentsByName.containsKey(o2.getName())) {
+    LogSegment firstSegment = segmentsByName.get(o1.getName());
+    LogSegment secondSegment = segmentsByName.get(o2.getName());
+    if (firstSegment == null || secondSegment == null) {
       throw new IllegalArgumentException("One of the log segments provided [" + o1.getName() + ", " + o2.getName() +
           "] does not belong to this log");
     }
-    LogSegment firstSegment = segmentsByName.get(o1.getName());
-    LogSegment secondSegment = segmentsByName.get(o2.getName());
     if (o1.getOffset() > firstSegment.getEndOffset() || o2.getOffset() > secondSegment.getEndOffset()) {
       throw new IllegalArgumentException("One of the offsets provided [" + o1.getOffset() + ", " + o2.getOffset() +
           "] is out of range of the segment it refers to [" + firstSegment.getEndOffset() + ", " +
@@ -340,7 +340,7 @@ class Log implements Write {
   }
 
   /**
-   * Rolls the active log segment over if required. Also ensures enough capacity.
+   * Rolls the active log segment over if required. If rollover is required, a new segment is allocated.
    * @param writeSize the size of the incoming write.
    * @throws IllegalArgumentException if the {@code writeSize} is greater than a single segment's size
    * @throws IllegalStateException if there is no more capacity in the log.
@@ -361,8 +361,8 @@ class Log implements Write {
   }
 
   /**
-   * Ensures that there is enough capacity of a write of size {@code writeSize}. As a part of ensuring capacity, this
-   * function will also allocate more segments if required.
+   * Ensures that there is enough capacity for a write of size {@code writeSize} in the log. As a part of ensuring
+   * capacity, this function will also allocate more segments if required.
    * @param writeSize the size of a subsequent write on the active log segment.
    * @throws IllegalArgumentException if the {@code writeSize} is greater than a single segment's size
    * @throws IllegalStateException if there no more capacity in the log.

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -141,9 +141,17 @@ class Log implements Write {
   }
 
   /**
+   * @return the start offset of the log abstraction.
+   */
+  Offset getStartOffset() {
+    LogSegment segment = getSegmentIterator().next().getValue();
+    return new Offset(segment.getName(), segment.getStartOffset());
+  }
+
+  /**
    * @return the end offset of the log abstraction.
    */
-  Offset getLogEndOffset() {
+  Offset getEndOffset() {
     LogSegment segment = activeSegment;
     return new Offset(segment.getName(), segment.getEndOffset());
   }
@@ -265,6 +273,7 @@ class Log implements Write {
       logger.info("Rolling over writes to {} from {} on write of data of size {}. End offset was {} and capacity is {}",
           nextActiveSegment.getName(), activeSegment.getName(), writeSize, activeSegment.getEndOffset(),
           activeSegment.getCapacityInBytes());
+      activeSegment.flush();
       activeSegment = nextActiveSegment;
     }
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -13,161 +13,304 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
- * The underlying file is backed by a log abstraction. This allows writes as append only operations.
- * For pre-allocated files, this tracks the end of valid file to ensure appends happen correctly.
- * It provides ability to read from arbitrary offset into the file. It can also provide a static view
- * of the log for a given set of offset,size pairs.
+ * The Log is an abstraction over a group of files that are loaded as {@link LogSegment} instances. It provides a
+ * unified view of these segments and provides a way to interact and query different properties of this group of
+ * segments.
  */
-class Log implements Read, Write {
-
-  private AtomicLong currentWriteOffset;
-  private final FileChannel fileChannel;
-  private final File file;
+class Log implements Write {
+  private final String dataDir;
   private final long capacityInBytes;
-  private static final String Log_File_Name = "log_current";
-  private Logger logger = LoggerFactory.getLogger(getClass());
   private final StoreMetrics metrics;
+  private final AtomicLong remainingUnallocatedCapacity;
+  private final ConcurrentSkipListMap<String, LogSegment> segmentsByName =
+      new ConcurrentSkipListMap<>(LogSegmentNameHelper.COMPARATOR);
+  private final Logger logger = LoggerFactory.getLogger(getClass());
 
-  public Log(String dataDir, long capacityInBytes, StoreMetrics metrics)
+  private LogSegment activeSegment;
+
+  /**
+   * Create a Log instance
+   * @param dataDir the directory where the segments of the log need to be created.
+   * @param totalCapacityInBytes the total capacity of this log.
+   * @param segmentCapacityInBytes the capacity of a single segment in the log.
+   * @param metrics the {@link StoreMetrics} instance to use.
+   * @throws IOException if there is any I/O error loading the segment files.
+   * @throws IllegalArgumentException if {@code totalCapacityInBytes} or {@code segmentCapacityInBytes} <= 0 or if
+   * {@code totalCapacityInBytes} > {@code segmentCapacityInBytes} and {@code totalCapacityInBytes} is not a perfect
+   * multiple of {@code segmentCapacityInBytes}.
+   */
+  public Log(String dataDir, long totalCapacityInBytes, long segmentCapacityInBytes, StoreMetrics metrics)
       throws IOException {
-    file = new File(dataDir, Log_File_Name);
-    if (!file.exists()) {
-      // if the file does not exist, preallocate it
-      Utils.preAllocateFileIfNeeded(file, capacityInBytes);
+    if (totalCapacityInBytes <= 0 || segmentCapacityInBytes <= 0) {
+      throw new IllegalArgumentException(
+          "One of totalCapacityInBytes [" + totalCapacityInBytes + "] or " + "segmentCapacityInBytes ["
+              + segmentCapacityInBytes + "] is <=0");
     }
-    this.capacityInBytes = capacityInBytes;
-    fileChannel = Utils.openChannel(file, true);
-    logger.trace("Log : {} file size on start {} ", dataDir, fileChannel.size());
-    // A log's write offset will always be set to the start of the log.
-    // External components is responsible for setting it the right value
-    currentWriteOffset = new AtomicLong(0);
+    long segmentCapacity = Math.min(totalCapacityInBytes, segmentCapacityInBytes);
+    // all segments should be the same size.
+    if (totalCapacityInBytes % segmentCapacity != 0) {
+      throw new IllegalArgumentException(
+          "Capacity of log [" + totalCapacityInBytes + "] should be a perfect multiple of segment capacity ["
+              + segmentCapacityInBytes + "]");
+    }
+    this.dataDir = dataDir;
+    this.capacityInBytes = totalCapacityInBytes;
     this.metrics = metrics;
+    remainingUnallocatedCapacity = new AtomicLong(totalCapacityInBytes);
+    long numSegments = (totalCapacityInBytes - 1) / segmentCapacityInBytes + 1;
+    loadSegments(segmentCapacity, numSegments);
   }
 
-  StoreMessageReadSet getView(List<BlobReadOptions> readOptions)
-      throws IOException {
-    return new StoreMessageReadSet(file, fileChannel, readOptions, currentWriteOffset.get());
-  }
-
-  public long sizeInBytes()
-      throws IOException {
-    return fileChannel.size();
-  }
-
-  public void setLogEndOffset(long endOffset)
-      throws IOException {
-    long fileSize = fileChannel.size();
-    if (endOffset < 0 || endOffset > fileSize) {
-      throw new IllegalArgumentException("Log : " + file.getAbsolutePath() + " endOffset " + endOffset +
-          " outside the file size " + fileSize);
-    }
-    fileChannel.position(endOffset);
-    logger.trace("Log : {} setting log end offset {}", file.getAbsolutePath(), endOffset);
-    this.currentWriteOffset.set(endOffset);
-  }
-
-  public long getLogEndOffset() {
-    return currentWriteOffset.get();
-  }
-
+  /**
+   * {@inheritDoc}
+   * <p/>
+   * Appends the given {@code buffer} to the active log segment. The {@code buffer} will be written to a single log
+   * segment i.e. its data will not exist across segments.
+   * @param buffer The buffer from which data needs to be written from
+   * @return the number of bytes written.
+   * @throws IllegalArgumentException if the {@code buffer.remaining()} is greater than a single segment's size.
+   * @throws IllegalStateException if there no more capacity in the log.
+   * @throws IOException if there was an I/O error while writing.
+   */
   @Override
   public int appendFrom(ByteBuffer buffer)
       throws IOException {
-    if (currentWriteOffset.get() + buffer.remaining() > capacityInBytes) {
-      metrics.overflowWriteError.inc(1);
-      throw new IllegalArgumentException(
-          "Log : " + file.getAbsolutePath() + " error trying to append to log from buffer since new data size " +
-              buffer.remaining() + " exceeds total log size " + capacityInBytes);
-    }
-    int bytesWritten = fileChannel.write(buffer, currentWriteOffset.get());
-    currentWriteOffset.addAndGet(bytesWritten);
-    logger.trace("Log: {} bytes appended to the log from bytebuffer byteswritten : {}", file.getAbsolutePath(),
-        bytesWritten);
-    return bytesWritten;
+    rollOverIfRequired(buffer.remaining());
+    return activeSegment.appendFrom(buffer);
   }
 
+  /**
+   * {@inheritDoc}
+   * <p/>
+   * Appends the given data to the active log segment. The data will be written to a single log segment i.e. the data
+   * will not exist across segments.
+   * @param channel The channel from which data needs to be written from
+   * @param size The amount of data in bytes to be written from the channel
+   * @throws IllegalArgumentException if the {@code size} is greater than a single segment's size.
+   * @throws IllegalStateException if there no more capacity in the log.
+   * @throws IOException if there was an I/O error while writing.
+   */
   @Override
   public void appendFrom(ReadableByteChannel channel, long size)
       throws IOException {
-    logger.trace("Log : {} currentWriteOffset {} capacityInBytes {} sizeToAppend {}", file.getAbsolutePath(),
-        currentWriteOffset, capacityInBytes, size);
-    if (currentWriteOffset.get() + size > capacityInBytes) {
-      metrics.overflowWriteError.inc(1);
-      throw new IllegalArgumentException("Log : " + file.getAbsolutePath() + " error trying to append to log " +
-          "from channel since new data size " + size + "exceeds total log size " + capacityInBytes);
-    }
-    long bytesWritten = 0;
-    while (bytesWritten < size) {
-      bytesWritten += fileChannel.transferFrom(channel, currentWriteOffset.get() + bytesWritten, size - bytesWritten);
-    }
-    currentWriteOffset.addAndGet(bytesWritten);
-    logger.trace("Log : {} bytes appended to the log from read channel bytesWritten: {}", file.getAbsolutePath(),
-        bytesWritten);
+    rollOverIfRequired(size);
+    activeSegment.appendFrom(channel, size);
   }
 
   /**
-   * Writes {@code size} number of bytes from the channel {@code channel} into the log at {@code offset}.
-   * @param channel The channel from which data needs to be written from.
-   * @param offset The offset in the segment at which to start writing.
-   * @param size The amount of data in bytes to be written from the channel.
-   * @throws IOException if data could not be written because of I/O errors
-   *
+   * Sets the active segment in the log.
+   * @param name the name of the log segment that is to be marked active.
    */
-  void writeFrom(ReadableByteChannel channel, long offset, long size)
-      throws IOException {
-    logger.trace("Log : {} currentWriteOffset {} capacityInBytes {} sizeToAppend {} offset to append at {}",
-        file.getAbsolutePath(), currentWriteOffset, capacityInBytes, size, offset);
-    if (offset < 0 || offset + size > currentWriteOffset.get()) {
-      metrics.overflowWriteError.inc(1);
-      throw new IllegalArgumentException("Log : " + file.getAbsolutePath() + " error trying to write to log " +
-          "from channel since new data size " + size + "exceeds log end offset " + currentWriteOffset.get());
+  void setActiveSegment(String name) {
+    if (!segmentsByName.containsKey(name)) {
+      throw new IllegalArgumentException("There is no log segment with name: " + name);
     }
-    long bytesWritten = 0;
-    while (bytesWritten < size) {
-      bytesWritten += fileChannel.transferFrom(channel, offset + bytesWritten, size - bytesWritten);
-    }
-    logger.trace("Log : {} bytes written to the log from read channel at {}, bytesWritten: {}", file.getAbsolutePath(),
-        offset, bytesWritten);
+    activeSegment = segmentsByName.get(name);
   }
 
   /**
-   * Close this log
+   * @return a segment iterator that can iterate over all the log segments in this log
+   */
+  Iterator<Map.Entry<String, LogSegment>> getSegmentIterator() {
+    return segmentsByName.entrySet().iterator();
+  }
+
+  /**
+   * @param name the name of the segment required.
+   * @return a {@link LogSegment} with {@code name} if it exists.
+   */
+  LogSegment getSegment(String name) {
+    return segmentsByName.get(name);
+  }
+
+  /**
+   * @return the end offset of the log abstraction.
+   */
+  Offset getLogEndOffset() {
+    LogSegment segment = activeSegment;
+    return new Offset(segment.getName(), segment.getEndOffset());
+  }
+
+  /**
+   * @return the currently capacity used of the log abstraction. Includes "wasted" space at the end of
+   * {@link LogSegment} instances that are not fully filled.
+   */
+  long getUsedCapacity() {
+    long usedCapacity = 0;
+    for (Map.Entry<String, LogSegment> entry : segmentsByName.entrySet()) {
+      LogSegment segment = entry.getValue();
+      if (segment != activeSegment) {
+        usedCapacity += segment.getCapacityInBytes();
+      } else {
+        usedCapacity += segment.getEndOffset();
+        break;
+      }
+    }
+    return usedCapacity;
+  }
+
+  /**
+   * @return the number of valid segments starting from the first segment.
+   */
+  long getSegmentCount() {
+    return segmentsByName.size();
+  }
+
+  /**
+   * Flushes the Log and all its segments.
+   * @throws IOException if the flush encountered an I/O error.
+   */
+  void flush()
+      throws IOException {
+    for (Map.Entry<String, LogSegment> entry : segmentsByName.entrySet()) {
+      entry.getValue().flush();
+    }
+  }
+
+  /**
+   * Closes the Log and all its segments.
+   * @throws IOException if the flush encountered an I/O error.
    */
   void close()
       throws IOException {
-    fileChannel.close();
-  }
-
-  public void flush()
-      throws IOException {
-    fileChannel.force(true);
-  }
-
-  @Override
-  public void readInto(ByteBuffer buffer, long position)
-      throws IOException {
-    if (sizeInBytes() < position || (position + buffer.remaining() > sizeInBytes())) {
-      metrics.overflowReadError.inc(1);
-      logger.error("Log: {} Error trying to read outside the log range. log end position {} input buffer size {}",
-          file.getAbsolutePath(), sizeInBytes(), buffer.remaining());
-      throw new IllegalArgumentException("Log : " + file.getAbsolutePath() + " error trying to read outside " +
-          "the log range. log end position " + sizeInBytes() + " input buffer size " + buffer.remaining());
+    for (Map.Entry<String, LogSegment> entry : segmentsByName.entrySet()) {
+      entry.getValue().close();
     }
-    fileChannel.read(buffer, position);
+  }
+
+  /**
+   * Loads segment files (if they exist) and creates {@link LogSegment} instances. If no segment files exist, the first
+   * segment file is created.
+   * @param segmentCapacity the intended capacity of each log segment. This is of importance on first startup.
+   * @param numSegments the total number of segments that the log abstraction will contain.
+   * @throws IOException if there is an I/O error creating/loading the segment files or creating the {@link LogSegment}
+   * instances
+   */
+  private void loadSegments(long segmentCapacity, long numSegments)
+      throws IOException {
+    File dir = new File(dataDir);
+    File[] segmentFiles = dir.listFiles(LogSegmentNameHelper.LOG_FILE_FILTER);
+    if (segmentFiles == null || segmentFiles.length == 0) {
+      String firstSegmentName = LogSegmentNameHelper.generateFirstSegmentName(numSegments);
+      File segmentFile = allocate(LogSegmentNameHelper.nameToFilename(firstSegmentName), segmentCapacity);
+      // to be backwards compatible, headers are not written for a log segment if it is the only log segment.
+      LogSegment segment = new LogSegment(firstSegmentName, segmentFile, segmentCapacity, metrics, numSegments > 1);
+      segmentsByName.put(segment.getName(), segment);
+    } else {
+      for (File segmentFile : segmentFiles) {
+        String name = LogSegmentNameHelper.nameFromFilename(segmentFile.getName());
+        LogSegment segment;
+        if (numSegments == 1) {
+          // for backwards compatibility, a single segment log is loaded by providing capacity since the old logs have
+          // no headers
+          segment = new LogSegment(name, segmentFile, segmentCapacity, metrics, false);
+        } else {
+          segment = new LogSegment(name, segmentFile, metrics);
+        }
+        segmentsByName.put(segment.getName(), segment);
+        remainingUnallocatedCapacity.addAndGet(-segmentCapacity);
+      }
+    }
+    activeSegment = segmentsByName.firstEntry().getValue();
+  }
+
+  /**
+   * Allocates a file named {@code filename} and of capacity {@code size}.
+   * @param filename the intended filename of the file.
+   * @param size the intended size of the file.
+   * @return a {@link File} instance that points to the created file named {@code filename} and capacity {@code size}.
+   * @throws IOException if the there is any I/O error in allocating the file.
+   */
+  private File allocate(String filename, long size)
+      throws IOException {
+    // TODO (DiskManager changes): This is intended to "request" the segment file from the DiskManager which will have
+    // TODO (DiskManager changes): a pool of segments.
+    File segmentFile = new File(dataDir, filename);
+    Utils.preAllocateFileIfNeeded(segmentFile, size);
+    remainingUnallocatedCapacity.addAndGet(-size);
+    return segmentFile;
+  }
+
+  /**
+   * Rolls the log segment over if required. Also ensures enough capacity.
+   * @param writeSize the size of the incoming write.
+   * @throws IllegalArgumentException if the {@code writeSize} is greater than a single segment's size
+   * @throws IllegalStateException if there no more capacity in the log.
+   * @throws IOException if any I/O error occurred as a part of ensuring capacity.
+   *
+   */
+  private void rollOverIfRequired(long writeSize)
+      throws IOException {
+    if (activeSegment.getCapacityInBytes() - activeSegment.getEndOffset() < writeSize) {
+      ensureCapacity(writeSize);
+      // this cannot be null since capacity has either been ensured or has thrown.
+      LogSegment nextActiveSegment = segmentsByName.higherEntry(activeSegment.getName()).getValue();
+      logger.info("Rolling over writes to {} from {} on write of data of size {}. End offset was {} and capacity is {}",
+          nextActiveSegment.getName(), activeSegment.getName(), writeSize, activeSegment.getEndOffset(),
+          activeSegment.getCapacityInBytes());
+      activeSegment = nextActiveSegment;
+    }
+  }
+
+  /**
+   * Ensures that there is enough capacity of a write of size {@code writeSize}.
+   * @param writeSize the size of a subsequent write on the active log segment.
+   * @throws IllegalArgumentException if the {@code writeSize} is greater than a single segment's size
+   * @throws IllegalStateException if there no more capacity in the log.
+   * @throws IOException if any I/O error occurred as a part of ensuring capacity.
+   */
+  private void ensureCapacity(long writeSize)
+      throws IOException {
+    if (segmentsByName.higherEntry(activeSegment.getName()) != null) {
+      return;
+    }
+    // all segments are (should be) the same size.
+    long segmentCapacity = activeSegment.getCapacityInBytes();
+    if (segmentCapacity > remainingUnallocatedCapacity.get()) {
+      metrics.overflowWriteError.inc();
+      throw new IllegalStateException(
+          "There is no more capacity left in [" + dataDir + "]. Max capacity is [" + capacityInBytes + "]");
+    }
+    if (writeSize > segmentCapacity - LogSegment.HEADER_SIZE) {
+      metrics.overflowWriteError.inc();
+      throw new IllegalArgumentException("Write of size [" + writeSize + "] cannot be serviced because it is greater "
+          + "than a single segment's capacity [" + (segmentCapacity - LogSegment.HEADER_SIZE) + "]");
+    }
+    String lastSegmentName = segmentsByName.lastEntry().getKey();
+    String newSegmentName = LogSegmentNameHelper.getNextPositionName(lastSegmentName);
+    File newSegmentFile = allocate(LogSegmentNameHelper.nameToFilename(newSegmentName), segmentCapacity);
+    LogSegment newSegment = new LogSegment(newSegmentName, newSegmentFile, segmentCapacity, metrics, true);
+    segmentsByName.put(newSegmentName, newSegment);
+  }
+
+  /**
+   * Gets a {@link StoreMessageReadSet} with the file and file channel of the first segment of the log.
+   * @param readOptions the {@link BlobReadOptions} to include in the {@link StoreMessageReadSet}.
+   * @return a {@link StoreMessageReadSet} with the file and file channel of the first segment and the given {@code }
+   * @deprecated this function is deprecated and is available for use until {@link PersistentIndex} and
+   * {@link HardDeleter} are rewritten to understand segmented logs.
+   */
+  @Deprecated
+  StoreMessageReadSet getView(List<BlobReadOptions> readOptions) {
+    LogSegment firstSegment = segmentsByName.firstEntry().getValue();
+    Pair<File, FileChannel> view = firstSegment.getView();
+    return new StoreMessageReadSet(view.getFirst(), view.getSecond(), readOptions, firstSegment.getEndOffset());
   }
 }
-

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -246,6 +246,7 @@ class Log implements Write {
    */
   void close() throws IOException {
     for (LogSegment segment : segmentsByName.values()) {
+      segment.flush();
       segment.close();
     }
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -54,8 +54,7 @@ class Log implements Write {
    * {@code totalCapacityInBytes} > {@code segmentCapacityInBytes} and {@code totalCapacityInBytes} is not a perfect
    * multiple of {@code segmentCapacityInBytes}.
    */
-  public Log(String dataDir, long totalCapacityInBytes, long segmentCapacityInBytes, StoreMetrics metrics)
-      throws IOException {
+  Log(String dataDir, long totalCapacityInBytes, long segmentCapacityInBytes, StoreMetrics metrics) throws IOException {
     this.dataDir = dataDir;
     this.capacityInBytes = totalCapacityInBytes;
     this.metrics = metrics;
@@ -86,8 +85,7 @@ class Log implements Write {
    * @throws IOException if there was an I/O error while writing.
    */
   @Override
-  public int appendFrom(ByteBuffer buffer)
-      throws IOException {
+  public int appendFrom(ByteBuffer buffer) throws IOException {
     rollOverIfRequired(buffer.remaining());
     return activeSegment.appendFrom(buffer);
   }
@@ -104,8 +102,7 @@ class Log implements Write {
    * @throws IOException if there was an I/O error while writing.
    */
   @Override
-  public void appendFrom(ReadableByteChannel channel, long size)
-      throws IOException {
+  public void appendFrom(ReadableByteChannel channel, long size) throws IOException {
     rollOverIfRequired(size);
     activeSegment.appendFrom(channel, size);
   }
@@ -119,8 +116,7 @@ class Log implements Write {
    * @throws IllegalArgumentException if there no segment with name {@code name}.
    * @throws IOException if there is any I/O error freeing segments.
    */
-  void setActiveSegment(String name)
-      throws IOException {
+  void setActiveSegment(String name) throws IOException {
     if (!segmentsByName.containsKey(name)) {
       throw new IllegalArgumentException("There is no log segment with name: " + name);
     }
@@ -205,13 +201,13 @@ class Log implements Write {
     LogSegment firstSegment = segmentsByName.get(o1.getName());
     LogSegment secondSegment = segmentsByName.get(o2.getName());
     if (firstSegment == null || secondSegment == null) {
-      throw new IllegalArgumentException("One of the log segments provided [" + o1.getName() + ", " + o2.getName() +
-          "] does not belong to this log");
+      throw new IllegalArgumentException(
+          "One of the log segments provided [" + o1.getName() + ", " + o2.getName() + "] does not belong to this log");
     }
     if (o1.getOffset() > firstSegment.getEndOffset() || o2.getOffset() > secondSegment.getEndOffset()) {
-      throw new IllegalArgumentException("One of the offsets provided [" + o1.getOffset() + ", " + o2.getOffset() +
-          "] is out of range of the segment it refers to [" + firstSegment.getEndOffset() + ", " +
-          secondSegment.getEndOffset() + "]");
+      throw new IllegalArgumentException("One of the offsets provided [" + o1.getOffset() + ", " + o2.getOffset()
+          + "] is out of range of the segment it refers to [" + firstSegment.getEndOffset() + ", "
+          + secondSegment.getEndOffset() + "]");
     }
     if (o1.getName().equals(o2.getName())) {
       return o1.getOffset() - o2.getOffset();
@@ -233,8 +229,7 @@ class Log implements Write {
    * Flushes the Log and all its segments.
    * @throws IOException if the flush encountered an I/O error.
    */
-  void flush()
-      throws IOException {
+  void flush() throws IOException {
     for (LogSegment segment : segmentsByName.values()) {
       segment.flush();
     }
@@ -244,8 +239,7 @@ class Log implements Write {
    * Closes the Log and all its segments.
    * @throws IOException if the flush encountered an I/O error.
    */
-  void close()
-      throws IOException {
+  void close() throws IOException {
     for (LogSegment segment : segmentsByName.values()) {
       segment.close();
     }
@@ -258,8 +252,7 @@ class Log implements Write {
    * @param segmentCapacity the intended capacity of each segment of the log.
    * @throws IOException if there is an I/O error creating the segment files or creating {@link LogSegment} instances.
    */
-  private void checkArgsAndAllocateFirstSegment(long totalCapacity, long segmentCapacity)
-      throws IOException {
+  private void checkArgsAndAllocateFirstSegment(long totalCapacity, long segmentCapacity) throws IOException {
     if (totalCapacity <= 0 || segmentCapacity <= 0) {
       throw new IllegalArgumentException(
           "One of totalCapacityInBytes [" + totalCapacity + "] or " + "segmentCapacityInBytes [" + segmentCapacity + "]"
@@ -286,8 +279,7 @@ class Log implements Write {
    * @param totalCapacity the total capacity of the log. This is used only if this is a single segment log.
    * @throws IOException if there is an I/O error loading the segment files or creating {@link LogSegment} instances.
    */
-  private void loadSegments(File[] segmentFiles, long totalCapacity)
-      throws IOException {
+  private void loadSegments(File[] segmentFiles, long totalCapacity) throws IOException {
     long totalSegments = -1;
     for (File segmentFile : segmentFiles) {
       String name = LogSegmentNameHelper.nameFromFilename(segmentFile.getName());
@@ -313,8 +305,7 @@ class Log implements Write {
    * @return a {@link File} instance that points to the created file named {@code filename} and capacity {@code size}.
    * @throws IOException if the there is any I/O error in allocating the file.
    */
-  private File allocate(String filename, long size)
-      throws IOException {
+  private File allocate(String filename, long size) throws IOException {
     // TODO (DiskManager changes): This is intended to "request" the segment file from the DiskManager which will have
     // TODO (DiskManager changes): a pool of segments.
     File segmentFile = new File(dataDir, filename);
@@ -328,8 +319,7 @@ class Log implements Write {
    * @param logSegment the {@link LogSegment} instance whose backing file needs to be freed.
    * @throws IOException if there is any I/O error freeing the log segment.
    */
-  private void free(LogSegment logSegment)
-      throws IOException {
+  private void free(LogSegment logSegment) throws IOException {
     // TODO (DiskManager changes): This will actually return the segment to the DiskManager pool.
     File segmentFile = logSegment.getView().getFirst();
     logSegment.close();
@@ -347,8 +337,7 @@ class Log implements Write {
    * @throws IOException if any I/O error occurred as part of ensuring capacity.
    *
    */
-  private void rollOverIfRequired(long writeSize)
-      throws IOException {
+  private void rollOverIfRequired(long writeSize) throws IOException {
     if (activeSegment.getCapacityInBytes() - activeSegment.getEndOffset() < writeSize) {
       ensureCapacity(writeSize);
       // this cannot be null since capacity has either been ensured or has thrown.
@@ -368,8 +357,7 @@ class Log implements Write {
    * @throws IllegalStateException if there no more capacity in the log.
    * @throws IOException if any I/O error occurred as a part of ensuring capacity.
    */
-  private void ensureCapacity(long writeSize)
-      throws IOException {
+  private void ensureCapacity(long writeSize) throws IOException {
     if (remainingUnallocatedSegments == 0) {
       metrics.overflowWriteError.inc();
       throw new IllegalStateException(

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -13,11 +13,17 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.Crc32;
+import com.github.ambry.utils.CrcInputStream;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.util.concurrent.atomic.AtomicLong;
@@ -29,25 +35,34 @@ import java.util.concurrent.atomic.AtomicLong;
  * transparently redirect operations if required.
  */
 class LogSegment implements Read, Write {
+  private static final short VERSION = 0;
+  private static final int VERSION_HEADER_SIZE = 2;
+  private static final int CAPACITY_HEADER_SIZE = 8;
+  private static final int CRC_SIZE = 8;
+
+  static final int HEADER_SIZE = VERSION_HEADER_SIZE + CAPACITY_HEADER_SIZE + CRC_SIZE;
+
   private final FileChannel fileChannel;
   private final File file;
   private final long capacityInBytes;
   private final String name;
   private final Pair<File, FileChannel> segmentView;
   private final StoreMetrics metrics;
+  private final long startOffset;
   private final AtomicLong endOffset;
   private final AtomicLong refCount = new AtomicLong(0);
 
   /**
-   * Creates a LogSegment abstraction.
+   * Creates a LogSegment abstraction with the given capacity.
    * @param name the desired name of the segment. The name signifies the handle/ID of the LogSegment and may be
    *             different from the filename of the {@code file}.
    * @param file the backing {@link File} for this segment.
    * @param capacityInBytes the intended capacity of the segment
    * @param metrics the {@link StoreMetrics} instance to use.
+   * @param writeHeader if {@code true}, headers are written that provide metadata about the segment.
    * @throws IOException if the file cannot be read or created
    */
-  LogSegment(String name, File file, long capacityInBytes, StoreMetrics metrics)
+  LogSegment(String name, File file, long capacityInBytes, StoreMetrics metrics, boolean writeHeader)
       throws IOException {
     if (!file.exists() || !file.isFile()) {
       throw new IllegalArgumentException(file.getAbsolutePath() + " does not exist or is not a file");
@@ -58,9 +73,51 @@ class LogSegment implements Read, Write {
     this.metrics = metrics;
     fileChannel = Utils.openChannel(file, true);
     segmentView = new Pair<>(file, fileChannel);
-    // the end offset is always initialized to 0.
-    // externals will set the correct value
+    // externals will set the correct value of end offset.
     endOffset = new AtomicLong(0);
+    if (writeHeader) {
+      // this will update end offset
+      writeHeader(capacityInBytes);
+    }
+    startOffset = endOffset.get();
+  }
+
+  /**
+   * Creates a LogSegment abstraction with the given file. Obtains capacity from the headers in the file.
+   * @param name the desired name of the segment. The name signifies the handle/ID of the LogSegment and may be
+   *             different from the filename of the {@code file}.
+   * @param file the backing {@link File} for this segment.
+   * @param metrics he {@link StoreMetrics} instance to use.
+   * @throws IOException
+   */
+  LogSegment(String name, File file, StoreMetrics metrics)
+      throws IOException {
+    if (!file.exists() || !file.isFile()) {
+      throw new IllegalArgumentException(file.getAbsolutePath() + " does not exist or is not a file");
+    }
+    CrcInputStream crcStream = new CrcInputStream(new FileInputStream(file));
+    try (DataInputStream stream = new DataInputStream(crcStream)) {
+      switch (stream.readShort()) {
+        case 0:
+          capacityInBytes = stream.readLong();
+          long computedCrc = crcStream.getValue();
+          long crcFromFile = stream.readLong();
+          if (crcFromFile != computedCrc) {
+            throw new IllegalStateException("CRC from the segment file does not match computed CRC of header");
+          }
+          startOffset = HEADER_SIZE;
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown version in segment [" + file.getAbsolutePath() + "]");
+      }
+    }
+    this.file = file;
+    this.name = name;
+    this.metrics = metrics;
+    fileChannel = Utils.openChannel(file, true);
+    segmentView = new Pair<>(file, fileChannel);
+    // externals will set the correct value of end offset.
+    endOffset = new AtomicLong(startOffset);
   }
 
   /**
@@ -129,13 +186,13 @@ class LogSegment implements Read, Write {
    * @param buffer The buffer into which the data needs to be written
    * @param position The position to start the read from
    * @throws IOException if data could not be written to the file because of I/O errors
-   * @throws IndexOutOfBoundsException if {@code position} < 0 or >= {@link #getEndOffset()} or if {@code buffer} size is
-   * greater than the data available for read.
+   * @throws IndexOutOfBoundsException if {@code position} < header size or >= {@link #getEndOffset()} or if
+   * {@code buffer} size is greater than the data available for read.
    */
   @Override
   public void readInto(ByteBuffer buffer, long position)
       throws IOException {
-    if (position < 0 || position >= getEndOffset()) {
+    if (position < startOffset || position >= getEndOffset()) {
       throw new IndexOutOfBoundsException(
           "Provided position [" + position + "] is out of bounds for the segment [" + file.getAbsolutePath()
               + "] with end offset [" + getEndOffset() + "]");
@@ -160,13 +217,13 @@ class LogSegment implements Read, Write {
    * @param offset The offset in the segment at which to start writing.
    * @param size The amount of data in bytes to be written from the channel.
    * @throws IOException if data could not be written to the file because of I/O errors
-   * @throws IndexOutOfBoundsException if {@code offset} < 0 or if there is not enough space for {@code offset } +
-   * {@code size} data.
+   * @throws IndexOutOfBoundsException if {@code offset} < header size or if there is not enough space for
+   * {@code offset } + {@code size} data.
    *
    */
   void writeFrom(ReadableByteChannel channel, long offset, long size)
       throws IOException {
-    if (offset < 0 || offset >= capacityInBytes) {
+    if (offset < startOffset || offset >= capacityInBytes) {
       throw new IndexOutOfBoundsException(
           "Provided offset [" + offset + "] is out of bounds for the segment [" + file.getAbsolutePath()
               + "] with capacity [" + capacityInBytes + "]");
@@ -224,13 +281,13 @@ class LogSegment implements Read, Write {
    * until which data that is readable is stored (exclusive) and the offset (inclusive) from which the next append will
    * begin.
    * @param endOffset the end offset of this log.
-   * @throws IllegalArgumentException if {@code endOffset} < 0 or {@code endOffset} > the size of the file.
+   * @throws IllegalArgumentException if {@code endOffset} < header size or {@code endOffset} > the size of the file.
    * @throws IOException if there is any I/O error.
    */
   void setEndOffset(long endOffset)
       throws IOException {
     long fileSize = sizeInBytes();
-    if (endOffset < 0 || endOffset > fileSize) {
+    if (endOffset < startOffset || endOffset > fileSize) {
       throw new IllegalArgumentException(file.getAbsolutePath() + ": EndOffset [" + endOffset +
           "] outside the file size [" + fileSize + "]");
     }
@@ -242,7 +299,7 @@ class LogSegment implements Read, Write {
    * @return the offset in this log segment from which there is valid data.
    */
   long getStartOffset() {
-    return 0;
+    return startOffset;
   }
 
   /**
@@ -281,5 +338,22 @@ class LogSegment implements Read, Write {
   void close()
       throws IOException {
     fileChannel.close();
+  }
+
+  /**
+   * Writes a header describing the segment.
+   * @param capacityInBytes the intended capacity of the segment.
+   * @throws IOException if there is any I/O error writing to the file.
+   */
+  private void writeHeader(long capacityInBytes)
+      throws IOException {
+    Crc32 crc = new Crc32();
+    ByteBuffer buffer = ByteBuffer.allocate(HEADER_SIZE);
+    buffer.putShort(VERSION);
+    buffer.putLong(capacityInBytes);
+    crc.update(buffer.array(), 0, HEADER_SIZE - CRC_SIZE);
+    buffer.putLong(crc.getValue());
+    buffer.flip();
+    appendFrom(Channels.newChannel(new ByteBufferInputStream(buffer)), buffer.remaining());
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegmentNameHelper.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegmentNameHelper.java
@@ -89,7 +89,7 @@ class LogSegmentNameHelper {
     if (name.isEmpty()) {
       throw new IllegalArgumentException("Name provided cannot be empty");
     }
-    return Long.parseLong(name.substring(name.indexOf(BlobStore.SEPARATOR) + 1, name.length()));
+    return Long.parseLong(name.substring(name.indexOf(BlobStore.SEPARATOR) + 1));
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegmentNameHelper.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegmentNameHelper.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.Comparator;
+
+
+/**
+ * Helper for working with log segment names.
+ * <p/>
+ * Log segments will have a name "pos_gen" where pos represents their relative position and "gen" represents the
+ * generation number of the log segment at "pos".
+ * <p/>
+ * The file name is a combination of the segment name and a suffix "_log"
+ */
+class LogSegmentNameHelper {
+  static final String SUFFIX = BlobStore.SEPARATOR + "log";
+  /**
+   * {@link Comparator} for two log segment names.
+   */
+  static final Comparator<String> COMPARATOR = new Comparator<String>() {
+    @Override
+    public int compare(String name1, String name2) {
+      // special case for log_current (one segment logs)
+      if (name1.isEmpty() && name2.isEmpty()) {
+        return 0;
+      }
+      long pos1 = getPosition(name1);
+      long pos2 = getPosition(name2);
+      int compare = Long.compare(pos1, pos2);
+      if (compare == 0) {
+        long gen1 = getGeneration(name1);
+        long gen2 = getGeneration(name2);
+        compare = Long.compare(gen1, gen2);
+      }
+      return compare;
+    }
+  };
+  /**
+   * Filter for getting all log files from a particular directory.
+   */
+  static final FilenameFilter LOG_FILE_FILTER = new FilenameFilter() {
+    @Override
+    public boolean accept(File dir, String name) {
+      return name.endsWith(LogSegmentNameHelper.SUFFIX) || name.equals(SINGLE_SEGMENT_LOG_FILE_NAME);
+    }
+  };
+
+  // for backwards compatibility, if the log contains only a single segment, the segment will have a special name.
+  private static final String SINGLE_SEGMENT_LOG_FILE_NAME = "log_current";
+
+  /**
+   * @param name the name of the log segment.
+   * @return the hashcode of {@code name}.
+   */
+  static int hashcode(String name) {
+    return name.hashCode();
+  }
+
+  /**
+   * @param name the name of the log segment.
+   * @return the relative position of the log segment.
+   */
+  static long getPosition(String name) {
+    if (name.isEmpty()) {
+      throw new IllegalArgumentException("Name provided cannot be empty");
+    }
+    return Long.parseLong(name.substring(0, name.indexOf(BlobStore.SEPARATOR)));
+  }
+
+  /**
+   * @param name the name of the log segment.
+   * @return the generation number of the log segment.
+   */
+  static long getGeneration(String name) {
+    if (name.isEmpty()) {
+      throw new IllegalArgumentException("Name provided cannot be empty");
+    }
+    return Long.parseLong(name.substring(name.indexOf(BlobStore.SEPARATOR) + 1, name.length()));
+  }
+
+  /**
+   * @param pos the relative position of the log segment.
+   * @param gen the generation of the log segment.
+   * @return the name of a log segment with position {@code pos} and generation number {@code gen}.
+   */
+  static String getName(long pos, long gen) {
+    return pos + BlobStore.SEPARATOR + gen;
+  }
+
+  /**
+   * @param name the name of the log segment.
+   * @return what should be the name of the log segment that is exactly one position higher than {@code name}.
+   */
+  static String getNextPositionName(String name) {
+    long pos = getPosition(name);
+    long gen = getGeneration(name);
+    return getName(pos + 1, gen);
+  }
+
+  /**
+   * @param name the name of the log segment.
+   * @return what should be the name of the log segment that is exactly one generation higher than {@code name}.
+   */
+  static String getNextGenerationName(String name) {
+    long pos = getPosition(name);
+    long gen = getGeneration(name);
+    return getName(pos, gen + 1);
+  }
+
+  /**
+   * @param numSegments the total number of segments in the log.
+   * @return what should be the name of the first segment.
+   */
+  static String generateFirstSegmentName(long numSegments) {
+    if (numSegments <= 0) {
+      throw new IllegalArgumentException("Number of segments <=0");
+    }
+    if (numSegments == 1) {
+      return "";
+    }
+    return getName(0, 0);
+  }
+
+  /**
+   * @param name the name of the log segment.
+   * @return the name of the file that backs the log segment.
+   */
+  static String nameToFilename(String name) {
+    if (name.isEmpty()) {
+      return SINGLE_SEGMENT_LOG_FILE_NAME;
+    }
+    return name + SUFFIX;
+  }
+
+  /**
+   * @param filename the name of the file that backs the log segment.
+   * @return the name of the log segment.
+   */
+  static String nameFromFilename(String filename) {
+    if (filename.equals(SINGLE_SEGMENT_LOG_FILE_NAME)) {
+      return "";
+    }
+    if (!filename.endsWith(SUFFIX)) {
+      throw new IllegalArgumentException("The filename of the log segment does not end with [" + SUFFIX + "]");
+    }
+    return filename.substring(0, filename.length() - SUFFIX.length());
+  }
+}

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegmentNameHelper.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegmentNameHelper.java
@@ -157,6 +157,18 @@ class LogSegmentNameHelper {
     if (!filename.endsWith(SUFFIX)) {
       throw new IllegalArgumentException("The filename of the log segment does not end with [" + SUFFIX + "]");
     }
-    return filename.substring(0, filename.length() - SUFFIX.length());
+    String name = filename.substring(0, filename.length() - SUFFIX.length());
+    validate(name);
+    return name;
+  }
+
+  /**
+   * Validates that the name provided is a valid log segment name.
+   * @param name the log segment name.
+   */
+  private static void validate(String name) {
+    if (!name.equals(getName(getPosition(name), getGeneration(name)))) {
+      throw new IllegalArgumentException("Invalid name: " + name);
+    }
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegmentNameHelper.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegmentNameHelper.java
@@ -25,6 +25,9 @@ import java.util.Comparator;
  * generation number of the log segment at "pos".
  * <p/>
  * The file name is a combination of the segment name and a suffix "_log"
+ * <p/>
+ * If the file name format changes, the version of {@link LogSegment} has to be updated and this class updated to
+ * handle the new and old versions.
  */
 class LogSegmentNameHelper {
   static final String SUFFIX = BlobStore.SEPARATOR + "log";

--- a/ambry-store/src/main/java/com.github.ambry.store/Offset.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Offset.java
@@ -36,11 +36,11 @@ class Offset implements Comparable<Offset> {
    * Construct an Offset that refers to a position in Log.
    * @param name the name of segment being referred to.
    * @param offset the offset within the segment.
-   * @throws IllegalArgumentException if {@code name} is {@code null} or empty or {@code offset} < 0.
+   * @throws IllegalArgumentException if {@code name} is {@code null} or {@code offset} < 0.
    */
   Offset(String name, long offset) {
-    if (name == null || name.isEmpty() || offset < 0) {
-      throw new IllegalArgumentException("Name [" + name + "] is null/empty or offset [" + offset + "] < 0");
+    if (name == null || offset < 0) {
+      throw new IllegalArgumentException("Name [" + name + "] is null or offset [" + offset + "] < 0");
     }
     this.name = name;
     this.offset = offset;
@@ -49,7 +49,7 @@ class Offset implements Comparable<Offset> {
   /**
    * Constructs an Offset from a stream.
    * @param stream the {@link DataInputStream} that will contain the serialized form of this object.
-   * @throws IllegalArgumentException if {@code name} is {@code null} or empty or {@code offset} < 0 or if the version
+   * @throws IllegalArgumentException if {@code name} is {@code null} or {@code offset} < 0 or if the version
    * of the record is not recognized.
    * @throws IOException if there are I/O problems reading from the stream.
    */
@@ -102,9 +102,8 @@ class Offset implements Comparable<Offset> {
 
   @Override
   public int compareTo(Offset o) {
-    // TODO (Log Segmentation): once LogSegment is coded and can resolve the relative position of a log segment based
-    // TODO (Log Segmentation): on its name, compare names also.
-    return Long.compare(offset, o.getOffset());
+    int compare = LogSegmentNameHelper.COMPARATOR.compare(name, o.name);
+    return compare == 0 ? Long.compare(offset, o.offset) : compare;
   }
 
   @Override
@@ -122,8 +121,9 @@ class Offset implements Comparable<Offset> {
 
   @Override
   public int hashCode() {
-    // TODO (Log Segmentation):  Include name in the hash code once compareTo() can handle names.
-    return (int) (offset ^ (offset >>> 32));
+    int result = LogSegmentNameHelper.hashcode(name);
+    result = 31 * result + (int) (offset ^ (offset >>> 32));
+    return result;
   }
 
   @Override

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -134,7 +134,7 @@ class PersistentIndex {
       this.time = time;
       this.scheduler = scheduler;
       this.metrics = metrics;
-      logSegment = log.getSegmentIterator().next().getValue();
+      logSegment = log.getFirstSegment();
       File indexDir = new File(datadir);
       File[] indexFiles = indexDir.listFiles(new IndexFilter());
       this.factory = factory;

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -60,7 +60,6 @@ class PersistentIndex {
 
   private long maxInMemoryIndexSizeInBytes;
   private int maxInMemoryNumElements;
-  private Log log;
   private String dataDir;
   private Logger logger = LoggerFactory.getLogger(getClass());
   private IndexPersistor persistor;
@@ -74,6 +73,9 @@ class PersistentIndex {
   private long logEndOffsetOnStartup;
   private final StoreMetrics metrics;
   private Time time;
+
+  // TODO (Index Changes): This will stay until the index is rewritten to handle multiple segments.
+  private final LogSegment logSegment;
 
   private class IndexFilter implements FilenameFilter {
     @Override
@@ -132,7 +134,7 @@ class PersistentIndex {
       this.time = time;
       this.scheduler = scheduler;
       this.metrics = metrics;
-      this.log = log;
+      logSegment = log.getSegmentIterator().next().getValue();
       File indexDir = new File(datadir);
       File[] indexFiles = indexDir.listFiles(new IndexFilter());
       this.factory = factory;
@@ -178,21 +180,21 @@ class PersistentIndex {
         indexes.put(info.getStartOffset(), info);
       }
       this.dataDir = datadir;
-      logger.info("Index : " + datadir + " log end offset of index  before recovery " + log.getLogEndOffset());
+      logger.info("Index : " + datadir + " log end offset of index  before recovery " + logSegment.getEndOffset());
       // perform recovery if required
       final Timer.Context context = metrics.recoveryTime.time();
       // Recover the last messages in the log into the index, if any.
       if (indexes.size() > 0) {
         IndexSegment lastSegment = indexes.lastEntry().getValue();
         // recover last segment
-        recover(lastSegment, log.sizeInBytes(), recovery);
+        recover(lastSegment, logSegment.sizeInBytes(), recovery);
       } else {
-        recover(null, log.sizeInBytes(), recovery);
+        recover(null, logSegment.sizeInBytes(), recovery);
       }
       context.stop();
       // set the log end offset to the recovered offset from the index after initializing it
-      log.setLogEndOffset(getCurrentEndOffset());
-      logEndOffsetOnStartup = log.getLogEndOffset();
+      logSegment.setEndOffset(getCurrentEndOffset());
+      logEndOffsetOnStartup = logSegment.getEndOffset();
 
       // After recovering the last messages, and setting the log end offset, let the hard delete thread do its recovery.
       // NOTE: It is safe to do the hard delete recovery after the regular recovery because we ensure that hard deletes
@@ -252,7 +254,9 @@ class PersistentIndex {
     }
     logger.info("Index : {} performing recovery on index with start offset {} and end offset {}", dataDir,
         startOffsetForRecovery, endOffset);
-    List<MessageInfo> messagesRecovered = recovery.recover(log, startOffsetForRecovery, endOffset, factory);
+    // TODO (Index Changes): This currently works on the assumption that there is only one log segment. Will
+    // TODO (Index Changes): be rewritten.
+    List<MessageInfo> messagesRecovered = recovery.recover(logSegment, startOffsetForRecovery, endOffset, factory);
     if (messagesRecovered.size() > 0) {
       metrics.nonzeroMessageRecovery.inc(1);
     }
@@ -492,7 +496,10 @@ class PersistentIndex {
         // original message offset and ends at the delete message's start offset (the original message surely cannot go
         // beyond the start offset of the delete message.
         try {
-          MessageInfo deletedBlobInfo = hardDelete.getMessageInfo(log, value.getOriginalMessageOffset(), factory);
+          // TODO (Index Changes): This currently works on the assumption that there is only one log segment. Will
+          // TODO (Index Changes): be rewritten.
+          MessageInfo deletedBlobInfo =
+              hardDelete.getMessageInfo(logSegment, value.getOriginalMessageOffset(), factory);
           return new BlobReadOptions(value.getOriginalMessageOffset(), deletedBlobInfo.getSize(),
               deletedBlobInfo.getExpirationTimeInMs(), deletedBlobInfo.getStoreKey());
         } catch (IOException e) {
@@ -543,7 +550,7 @@ class PersistentIndex {
     long startTimeInMs = time.milliseconds();
     try {
       boolean tokenWasReset = false;
-      long logEndOffsetBeforeFind = log.getLogEndOffset();
+      long logEndOffsetBeforeFind = logSegment.getEndOffset();
       StoreFindToken storeToken = (StoreFindToken) token;
       // validate token
       if (storeToken.getSessionId() == null || storeToken.getSessionId().compareTo(sessionId) != 0) {
@@ -1021,7 +1028,7 @@ class PersistentIndex {
           Map.Entry<Long, IndexSegment> lastEntry = indexes.lastEntry();
           IndexSegment currentInfo = lastEntry.getValue();
           long currentIndexEndOffsetBeforeFlush = currentInfo.getEndOffset();
-          long logEndOffsetBeforeFlush = log.getLogEndOffset();
+          long logEndOffsetBeforeFlush = logSegment.getEndOffset();
           if (logEndOffsetBeforeFlush < currentIndexEndOffsetBeforeFlush) {
             throw new StoreException("LogEndOffset " + logEndOffsetBeforeFlush + " before flush cannot be less than "
                 + "currentEndOffSet of index " + currentIndexEndOffsetBeforeFlush, StoreErrorCodes.Illegal_Index_State);
@@ -1030,13 +1037,13 @@ class PersistentIndex {
           hardDeleter.preLogFlush();
 
           // flush the log to ensure everything till the fileEndPointerBeforeFlush is flushed
-          log.flush();
+          logSegment.flush();
 
           hardDeleter.postLogFlush();
 
           long lastOffset = lastEntry.getKey();
           IndexSegment prevInfo = indexes.size() > 1 ? indexes.lowerEntry(lastOffset).getValue() : null;
-          long currentLogEndPointer = log.getLogEndOffset();
+          long currentLogEndPointer = logSegment.getEndOffset();
           while (prevInfo != null && !prevInfo.isMapped()) {
             if (prevInfo.getEndOffset() > currentLogEndPointer) {
               String message = "The read only index cannot have a file end pointer " + prevInfo.getEndOffset()

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
@@ -117,8 +117,7 @@ class StoreMessageReadSet implements MessageReadSet {
   private Logger logger = LoggerFactory.getLogger(getClass());
 
   public StoreMessageReadSet(File file, FileChannel fileChannel, List<BlobReadOptions> readOptions,
-      long fileEndPosition)
-      throws IOException {
+      long fileEndPosition) {
 
     Collections.sort(readOptions);
     for (BlobReadOptions readOption : readOptions) {

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -25,8 +25,6 @@ import com.codahale.metrics.Timer;
  * Metrics for a specific store.
  */
 public class StoreMetrics {
-  private final MetricRegistry registry;
-  private final String name;
   public final Timer getResponse;
   public final Timer putResponse;
   public final Timer deleteResponse;
@@ -50,13 +48,10 @@ public class StoreMetrics {
   public final Counter hardDeleteFailedCount;
   public final Counter hardDeleteIncompleteRecoveryCount;
   public final Counter hardDeleteExceptionsCount;
-  public Gauge<Long> currentCapacityUsed;
-  public Gauge<Long> currentHardDeleteProgress;
-  public Gauge<Long> hardDeleteThreadRunning;
-  public Gauge<Long> hardDeleteCaughtUp;
   public final Histogram segmentSizeForExists;
-  public Gauge<Double> percentageUsedCapacity;
-  public Gauge<Double> percentageHardDeleteCompleted;
+
+  private final MetricRegistry registry;
+  private final String name;
 
   public StoreMetrics(String storeId, MetricRegistry registry) {
     this.registry = registry;
@@ -95,25 +90,32 @@ public class StoreMetrics {
     segmentSizeForExists = registry.histogram(MetricRegistry.name(IndexSegment.class, name + "SegmentSizeForExists"));
   }
 
-  public void initializeCapacityUsedMetric(final Log log, final long capacityInBytes) {
-    currentCapacityUsed = new Gauge<Long>() {
+  void initializeLogGauges(final Log log, final long capacityInBytes) {
+    Gauge<Long> currentCapacityUsed = new Gauge<Long>() {
       @Override
       public Long getValue() {
-        return log.getLogEndOffset();
+        return log.getUsedCapacity();
       }
     };
     registry.register(MetricRegistry.name(Log.class, name + "CurrentCapacityUsed"), currentCapacityUsed);
-    percentageUsedCapacity = new Gauge<Double>() {
+    Gauge<Double> percentageUsedCapacity = new Gauge<Double>() {
       @Override
       public Double getValue() {
-        return ((double) log.getLogEndOffset() / capacityInBytes) * 100;
+        return ((double) log.getUsedCapacity() / capacityInBytes) * 100;
       }
     };
     registry.register(MetricRegistry.name(Log.class, name + "PercentageUsedCapacity"), percentageUsedCapacity);
+    Gauge<Long> currentSegmentCount = new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return log.getSegmentCount();
+      }
+    };
+    registry.register(MetricRegistry.name(Log.class, name + "CurrentSegmentCount"), currentSegmentCount);
   }
 
-  public void initializeHardDeleteMetric(final HardDeleter hardDeleter, final Log log) {
-    currentHardDeleteProgress = new Gauge<Long>() {
+  void initializeHardDeleteMetric(final HardDeleter hardDeleter, final Log log) {
+    Gauge<Long> currentHardDeleteProgress = new Gauge<Long>() {
       @Override
       public Long getValue() {
         return hardDeleter.getProgress();
@@ -122,16 +124,16 @@ public class StoreMetrics {
     registry.register(MetricRegistry.name(PersistentIndex.class, name + "CurrentHardDeleteProgress"),
         currentHardDeleteProgress);
 
-    percentageHardDeleteCompleted = new Gauge<Double>() {
+    Gauge<Double> percentageHardDeleteCompleted = new Gauge<Double>() {
       @Override
       public Double getValue() {
-        return ((double) hardDeleter.getProgress() / log.getLogEndOffset()) * 100;
+        return ((double) hardDeleter.getProgress() / log.getUsedCapacity()) * 100;
       }
     };
     registry.register(MetricRegistry.name(Log.class, name + "PercentageHardDeleteCompleted"),
         percentageHardDeleteCompleted);
 
-    hardDeleteThreadRunning = new Gauge<Long>() {
+    Gauge<Long> hardDeleteThreadRunning = new Gauge<Long>() {
       @Override
       public Long getValue() {
         return hardDeleter.isRunning() ? 1L : 0L;
@@ -140,7 +142,7 @@ public class StoreMetrics {
     registry.register(MetricRegistry.name(PersistentIndex.class, name + "HardDeleteThreadRunning"),
         hardDeleteThreadRunning);
 
-    hardDeleteCaughtUp = new Gauge<Long>() {
+    Gauge<Long> hardDeleteCaughtUp = new Gauge<Long>() {
       @Override
       public Long getValue() {
         return hardDeleter.isCaughtUp() ? 1L : 0L;

--- a/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
@@ -147,7 +147,7 @@ public class HardDeleterTest {
         c.delete();
       }
       ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
-      Log log = new Log(logFile, 10000, new StoreMetrics(logFile, new MetricRegistry()));
+      Log log = new Log(logFile, 10000, 10000, new StoreMetrics(logFile, new MetricRegistry()));
       Properties props = new Properties();
       // the test will set the tokens, so disable the index persistor.
       props.setProperty("store.data.flush.interval.seconds", "3600");

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentNameHelperTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentNameHelperTest.java
@@ -1,0 +1,286 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+/**
+ * Tests the helper functions of {@link LogSegmentNameHelper}
+ */
+public class LogSegmentNameHelperTest {
+
+  /**
+   * Tests the comparator in {@link LogSegmentNameHelper} for correctness.
+   */
+  @Test
+  public void comparatorTest() {
+    Comparator<String> comparator = LogSegmentNameHelper.COMPARATOR;
+    // compare empty name with empty name
+    assertEquals("Empty names should be equal", 0, comparator.compare("", ""));
+    // create sample names
+    String[] names = {LogSegmentNameHelper.getName(0, 0), LogSegmentNameHelper.getName(0, 1), LogSegmentNameHelper
+        .getName(1, 0), LogSegmentNameHelper.getName(1, 1)};
+    for (int i = 0; i < names.length; i++) {
+      for (int j = 0; j < names.length; j++) {
+        int expectCompare = i == j ? 0 : i > j ? 1 : -1;
+        assertEquals("Unexpected value on compare", expectCompare, comparator.compare(names[i], names[j]));
+        assertEquals("Unexpected value on compare", -1 * expectCompare, comparator.compare(names[j], names[i]));
+      }
+    }
+    // empty name cannot be compared with anything else
+    String validName = LogSegmentNameHelper.getName(0, 0);
+    try {
+      comparator.compare(validName, "");
+      fail("Should not have been able to compare empty name with anything else");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+    try {
+      comparator.compare("", validName);
+      fail("Should not have been able to compare empty name with anything else");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+  }
+
+  /**
+   * Checks the file name filter in {@link LogSegmentNameHelper} for correctness by creating valid and invalid files
+   * and checking that the invalid ones are filtered out and the valid ones correctly picked up.
+   * @throws IOException
+   */
+  @Test
+  public void filenameFilterTest()
+      throws IOException {
+    File tempFile = File.createTempFile("ambry", ".tmp");
+    tempFile.deleteOnExit();
+
+    int validFileCount = 10;
+    int invalidFileCount = 5;
+    Set<File> validFiles = new HashSet<>(validFileCount);
+    File tempDir = Files.createTempDirectory("nameHelper-" + UtilsTest.getRandomString(10)).toFile();
+    tempDir.deleteOnExit();
+    try {
+      String filename = LogSegmentNameHelper.nameToFilename("");
+      File file = createFile(tempDir, filename);
+      validFiles.add(file);
+      for (int i = 1; i < validFileCount; i++) {
+        long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+        long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+        filename = LogSegmentNameHelper.nameToFilename(LogSegmentNameHelper.getName(pos, gen));
+        file = createFile(tempDir, filename);
+        validFiles.add(file);
+      }
+      for (int i = 0; i < invalidFileCount; i++) {
+        filename = UtilsTest.getRandomString(10);
+        switch (i) {
+          case 0:
+            filename = filename + "_index";
+            break;
+          case 1:
+            filename = filename + LogSegmentNameHelper.SUFFIX + "_temp";
+            break;
+          default:
+            break;
+        }
+        createFile(tempDir, filename);
+      }
+      Set<File> filteredFiles = new HashSet<>(Arrays.asList(tempDir.listFiles(LogSegmentNameHelper.LOG_FILE_FILTER)));
+      assertEquals("Filtered files do not have the valid files", validFiles, filteredFiles);
+    } finally {
+      File[] files = tempDir.listFiles();
+      if (files != null) {
+        for (File file : files) {
+          assertTrue("The file [" + file.getAbsolutePath() + "] could not be deleted", file.delete());
+        }
+      }
+      assertTrue("The directory [" + tempDir.getAbsolutePath() + "] could not be deleted", tempDir.delete());
+    }
+  }
+
+  /**
+   * Tests correctness of {@link LogSegmentNameHelper#hashcode(String)}
+   */
+  @Test
+  public void hashCodeTest() {
+    String name = UtilsTest.getRandomString(10);
+    assertEquals("Hashcode is not as expected", name.hashCode(), LogSegmentNameHelper.hashcode(name));
+  }
+
+  /**
+   * Tests correctness of {@link LogSegmentNameHelper#getPosition(String)} and
+   * {@link LogSegmentNameHelper#getGeneration(String)}.
+   */
+  @Test
+  public void getPositionAndGenerationTest() {
+    for (int i = 0; i < 10; i++) {
+      long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+      long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+      checkPosAndGeneration(LogSegmentNameHelper.getName(pos, gen), pos, gen);
+    }
+    try {
+      LogSegmentNameHelper.getPosition("");
+      fail("Should have failed to get position for empty log segment name");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+    try {
+      LogSegmentNameHelper.getGeneration("");
+      fail("Should have failed to get generation for empty log segment name");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+  }
+
+  /**
+   * Tests correctness of {@link LogSegmentNameHelper#getName(long, long)}.
+   */
+  @Test
+  public void getNameTest() {
+    for (int i = 0; i < 10; i++) {
+      long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+      long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+      assertEquals("Did not get expected name", pos + BlobStore.SEPARATOR + gen,
+          LogSegmentNameHelper.getName(pos, gen));
+    }
+  }
+
+  /**
+   * Tests correctness of {@link LogSegmentNameHelper#getNextPositionName(String)} and
+   * {@link LogSegmentNameHelper#getNextGenerationName(String)}.
+   */
+  @Test
+  public void getNextPositionAndGenerationTest() {
+    for (int i = 0; i < 10; i++) {
+      long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+      long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+      String name = LogSegmentNameHelper.getName(pos, gen);
+      checkPosAndGeneration(LogSegmentNameHelper.getNextPositionName(name), pos + 1, gen);
+      checkPosAndGeneration(LogSegmentNameHelper.getNextGenerationName(name), pos, gen + 1);
+    }
+    try {
+      LogSegmentNameHelper.getNextPositionName("");
+      fail("Should have failed to get next position for empty log segment name");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+    try {
+      LogSegmentNameHelper.getNextGenerationName("");
+      fail("Should have failed to get next generation for empty log segment name");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+  }
+
+  /**
+   * Tests correctness of {@link LogSegmentNameHelper#generateFirstSegmentName(long)} for different numbers of log
+   * segments (including invalid ones).
+   */
+  @Test
+  public void generateFirstSegmentNameTest() {
+    assertEquals("Did not get expected name", "", LogSegmentNameHelper.generateFirstSegmentName(1));
+    String firstSegmentName = LogSegmentNameHelper.getName(0, 0);
+    for (int i = 0; i < 10; i++) {
+      long numSegments = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+      assertEquals("Did not get expected name", firstSegmentName,
+          LogSegmentNameHelper.generateFirstSegmentName(numSegments));
+    }
+    int[] invalidNumSegments = {0, -1};
+    for (int numSegments : invalidNumSegments) {
+      try {
+        LogSegmentNameHelper.generateFirstSegmentName(numSegments);
+        fail("Should have failed to get the first segment name for [" + numSegments + "] segments");
+      } catch (IllegalArgumentException e) {
+        // expected. Nothing to do.
+      }
+    }
+  }
+
+  /**
+   * Tests correctness of {@link LogSegmentNameHelper#nameFromFilename(String)}.
+   */
+  @Test
+  public void nameFromFilenameTest() {
+    assertEquals("Did not get expected name", "", LogSegmentNameHelper.nameFromFilename("log_current"));
+    String name = LogSegmentNameHelper.getName(0, 0);
+    String filename = LogSegmentNameHelper.nameToFilename(name);
+    assertEquals("Did not get expected name", name, LogSegmentNameHelper.nameFromFilename(filename));
+    name = UtilsTest.getRandomString(10);
+    try {
+      LogSegmentNameHelper.nameFromFilename(name);
+      fail("Should have failed to get name for filename [" + filename + "]");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+  }
+
+  /**
+   * Tests correctness of {@link LogSegmentNameHelper#nameToFilename(String)}.
+   */
+  @Test
+  public void nameToFilenameTest() {
+    assertEquals("Did not get expected file name", "log_current", LogSegmentNameHelper.nameToFilename(""));
+    String name = UtilsTest.getRandomString(10);
+    assertEquals("Did not get expected file name", name + LogSegmentNameHelper.SUFFIX,
+        LogSegmentNameHelper.nameToFilename(name));
+  }
+
+  // helpers
+  // general
+
+  /**
+   * Checks the position and generation obtained from {@code name} match {@code expectedPos} and {@code expectedGen}
+   * respectively.
+   * @param name the name whose position and generation needs to be checked.
+   * @param expectedPos the expected return value from {@link LogSegmentNameHelper#getPosition(String)}.
+   * @param expectedGen the expected return value from {@link LogSegmentNameHelper#getGeneration(String)}.
+   */
+  private void checkPosAndGeneration(String name, long expectedPos, long expectedGen) {
+    assertEquals("Did not get expected position", expectedPos, LogSegmentNameHelper.getPosition(name));
+    assertEquals("Did not get expected generation number", expectedGen, LogSegmentNameHelper.getGeneration(name));
+  }
+
+  // filenameFilterTest() helpers
+
+  /**
+   * Creates a file in {@code parentDir} with name {@code filename} and configures it to be deleted on exit.
+   * @param parentDir the directory where a file with {@code filename} needs to be created.
+   * @param filename the name of the file to be created.
+   * @return a reference to the created {@link File}.
+   * @throws IOException
+   */
+  private File createFile(File parentDir, String filename)
+      throws IOException {
+    File file = new File(parentDir, filename);
+    if (!file.exists()) {
+      assertTrue("File could not be created at path " + file.getAbsolutePath(), file.createNewFile());
+    }
+    file.deleteOnExit();
+    return file;
+  }
+}

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentNameHelperTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentNameHelperTest.java
@@ -77,9 +77,6 @@ public class LogSegmentNameHelperTest {
   @Test
   public void filenameFilterTest()
       throws IOException {
-    File tempFile = File.createTempFile("ambry", ".tmp");
-    tempFile.deleteOnExit();
-
     int validFileCount = 10;
     int invalidFileCount = 5;
     Set<File> validFiles = new HashSet<>(validFileCount);

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentNameHelperTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentNameHelperTest.java
@@ -230,12 +230,18 @@ public class LogSegmentNameHelperTest {
     String name = LogSegmentNameHelper.getName(0, 0);
     String filename = LogSegmentNameHelper.nameToFilename(name);
     assertEquals("Did not get expected name", name, LogSegmentNameHelper.nameFromFilename(filename));
-    name = UtilsTest.getRandomString(10);
-    try {
-      LogSegmentNameHelper.nameFromFilename(name);
-      fail("Should have failed to get name for filename [" + filename + "]");
-    } catch (IllegalArgumentException e) {
-      // expected. Nothing to do.
+
+    // bad file names
+    String badNameBase = UtilsTest.getRandomString(10);
+    String[] badNames = {badNameBase,
+        badNameBase + LogSegmentNameHelper.SUFFIX, name + BlobStore.SEPARATOR + "123" + LogSegmentNameHelper.SUFFIX};
+    for (String badName : badNames) {
+      try {
+        LogSegmentNameHelper.nameFromFilename(badName);
+        fail("Should have failed to get name for filename [" + badName + "]");
+      } catch (IllegalArgumentException | StringIndexOutOfBoundsException e) {
+        // expected. Nothing to do.
+      }
     }
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -417,7 +417,7 @@ public class LogSegmentTest {
     }
 
     // unknown version
-    LogSegment segment = getSegment("log_current", STANDARD_SEGMENT_SIZE, true);
+    LogSegment segment = getSegment("dummy_log", STANDARD_SEGMENT_SIZE, true);
     file = segment.getView().getFirst();
     byte[] header = getHeader(segment);
     byte savedByte = header[0];

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -78,44 +78,46 @@ public class LogSegmentTest {
   public void basicWriteAndReadTest()
       throws IOException {
     String segmentName = "log_current";
-    LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE);
+    LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE, true);
     try {
-      assertEquals("Start offset is not as expected", 0, segment.getStartOffset());
       assertEquals("Name of segment is inconsistent with what was provided", segmentName, segment.getName());
       assertEquals("Capacity of segment is inconsistent with what was provided", STANDARD_SEGMENT_SIZE,
           segment.getCapacityInBytes());
+      assertEquals("Start offset is not equal to header size", LogSegment.HEADER_SIZE, segment.getStartOffset());
       int writeSize = 100;
       byte[] buf = TestUtils.getRandomBytes(3 * writeSize);
+      long writeStartOffset = segment.getStartOffset();
       // append with buffer
       int written = segment.appendFrom(ByteBuffer.wrap(buf, 0, writeSize));
       assertEquals("Size written did not match size of buffer provided", writeSize, written);
-      assertEquals("End offset is not equal to the cumulative bytes written", writeSize, segment.getEndOffset());
-      readAndEnsureMatch(segment, 0, Arrays.copyOfRange(buf, 0, writeSize));
+      assertEquals("End offset is not as expected", writeStartOffset + writeSize, segment.getEndOffset());
+      readAndEnsureMatch(segment, writeStartOffset, Arrays.copyOfRange(buf, 0, writeSize));
 
       // append with channel
       segment.appendFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(buf, writeSize, writeSize))),
           writeSize);
-      assertEquals("End offset is not equal to the cumulative bytes written", 2 * writeSize, segment.getEndOffset());
-      readAndEnsureMatch(segment, writeSize, Arrays.copyOfRange(buf, writeSize, 2 * writeSize));
+      assertEquals("End offset is not as expected", writeStartOffset + 2 * writeSize, segment.getEndOffset());
+      readAndEnsureMatch(segment, writeStartOffset + writeSize, Arrays.copyOfRange(buf, writeSize, 2 * writeSize));
 
       // use writeFrom
       segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(buf, 2 * writeSize, writeSize))),
           segment.getEndOffset(), writeSize);
-      assertEquals("End offset is not equal to the cumulative bytes written", 3 * writeSize, segment.getEndOffset());
-      readAndEnsureMatch(segment, 2 * writeSize, Arrays.copyOfRange(buf, 2 * writeSize, buf.length));
+      assertEquals("End offset is not as expected", writeStartOffset + 3 * writeSize, segment.getEndOffset());
+      readAndEnsureMatch(segment, writeStartOffset + 2 * writeSize, Arrays.copyOfRange(buf, 2 * writeSize, buf.length));
 
-      readAndEnsureMatch(segment, 0, buf);
+      readAndEnsureMatch(segment, writeStartOffset, buf);
       // check file size and end offset (they will not match)
-      assertEquals("End offset is not equal to the cumulative bytes written", 3 * writeSize, segment.getEndOffset());
+      assertEquals("End offset is not equal to the cumulative bytes written", writeStartOffset + 3 * writeSize,
+          segment.getEndOffset());
       assertEquals("Size in bytes is not equal to size of the file", STANDARD_SEGMENT_SIZE, segment.sizeInBytes());
 
       // ensure flush doesn't throw any errors.
       segment.flush();
       // close and reopen segment and ensure persistence.
       segment.close();
-      segment = new LogSegment(segmentName, new File(tempDir, segmentName), STANDARD_SEGMENT_SIZE, metrics);
-      segment.setEndOffset(buf.length);
-      readAndEnsureMatch(segment, 0, buf);
+      segment = new LogSegment(segmentName, new File(tempDir, segmentName), metrics);
+      segment.setEndOffset(writeStartOffset + buf.length);
+      readAndEnsureMatch(segment, writeStartOffset, buf);
     } finally {
       closeSegmentAndDeleteFile(segment);
     }
@@ -129,14 +131,15 @@ public class LogSegmentTest {
   public void viewAndRefCountTest()
       throws IOException {
     String segmentName = "log_current";
-    LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE);
+    LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE, true);
     try {
+      long startOffset = segment.getStartOffset();
       int readSize = 100;
       int viewCount = 5;
       byte[] data = appendRandomData(segment, readSize * viewCount);
 
       for (int i = 0; i < viewCount; i++) {
-        getAndVerifyView(segment, i * readSize, data, i + 1);
+        getAndVerifyView(segment, startOffset, i * readSize, data, i + 1);
       }
 
       for (int i = 0; i < viewCount; i++) {
@@ -156,22 +159,23 @@ public class LogSegmentTest {
   public void endOffsetTest()
       throws IOException {
     String segmentName = "log_current";
-    LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE);
+    LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE, true);
     try {
+      long writeStartOffset = segment.getStartOffset();
       int segmentSize = 500;
       appendRandomData(segment, segmentSize);
-      assertEquals("End offset is not equal to the cumulative bytes written", segmentSize, segment.getEndOffset());
+      assertEquals("End offset is not as expected", writeStartOffset + segmentSize, segment.getEndOffset());
 
-      // should be able to set end offset to something > 0 and < file size
-      int[] offsetsToSet = {1, segmentSize / 2, segmentSize};
+      // should be able to set end offset to something >= initial offset and <= file size
+      int[] offsetsToSet = {(int) (writeStartOffset), segmentSize / 2, segmentSize};
       for (int offset : offsetsToSet) {
         segment.setEndOffset(offset);
         assertEquals("End offset is not equal to what was set", offset, segment.getEndOffset());
         assertEquals("File channel positioning is incorrect", offset, segment.getView().getSecond().position());
       }
 
-      // cannot set end offset to illegal values (< 0 or > file size)
-      int[] invalidOffsets = {-1, (int) (segment.sizeInBytes() + 1)};
+      // cannot set end offset to illegal values (< initial offset or > file size)
+      int[] invalidOffsets = {(int) (writeStartOffset - 1), (int) (segment.sizeInBytes() + 1)};
       for (int offset : invalidOffsets) {
         try {
           segment.setEndOffset(offset);
@@ -225,21 +229,22 @@ public class LogSegmentTest {
       throws IOException {
     Random random = new Random();
     String segmentName = "log_current";
-    LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE);
+    LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE, true);
     try {
+      long writeStartOffset = segment.getStartOffset();
       byte[] data = appendRandomData(segment, 2 * STANDARD_SEGMENT_SIZE / 3);
-      readAndEnsureMatch(segment, 0, data);
+      readAndEnsureMatch(segment, writeStartOffset, data);
       int readCount = 10;
       for (int i = 0; i < readCount; i++) {
         int position = random.nextInt(data.length);
         int size = random.nextInt(data.length - position);
-        readAndEnsureMatch(segment, position, Arrays.copyOfRange(data, position, position + size));
+        readAndEnsureMatch(segment, writeStartOffset + position, Arrays.copyOfRange(data, position, position + size));
       }
 
       // error scenarios
       ByteBuffer readBuf = ByteBuffer.wrap(new byte[data.length]);
       // data cannot be read at invalid offsets.
-      long[] invalidOffsets = {-1, segment.getEndOffset(), segment.getEndOffset() + 1};
+      long[] invalidOffsets = {writeStartOffset - 1, segment.getEndOffset(), segment.getEndOffset() + 1};
       ByteBuffer buffer = ByteBuffer.wrap(TestUtils.getRandomBytes(1));
       for (long invalidOffset : invalidOffsets) {
         try {
@@ -253,7 +258,7 @@ public class LogSegmentTest {
       // position + buffer.remaining() > endOffset.
       long readOverFlowCount = metrics.overflowReadError.getCount();
       try {
-        segment.readInto(readBuf, 1);
+        segment.readInto(readBuf, writeStartOffset + 1);
         fail("Should have failed to read because position + buffer.remaining() > endOffset");
       } catch (IndexOutOfBoundsException e) {
         assertEquals("Read overflow should have been reported", readOverFlowCount + 1,
@@ -265,7 +270,7 @@ public class LogSegmentTest {
       // read after close
       buffer = ByteBuffer.allocate(1);
       try {
-        segment.readInto(buffer, 0);
+        segment.readInto(buffer, writeStartOffset);
         fail("Should have failed to read because segment is closed");
       } catch (ClosedChannelException e) {
         assertEquals("Position of buffer has changed", 0, buffer.position());
@@ -283,40 +288,48 @@ public class LogSegmentTest {
   public void writeFromTest()
       throws IOException {
     String currSegmentName = "log_current";
-    LogSegment segment = getSegment(currSegmentName, STANDARD_SEGMENT_SIZE);
+    LogSegment segment = getSegment(currSegmentName, STANDARD_SEGMENT_SIZE, true);
     try {
+      long writeStartOffset = segment.getStartOffset();
       byte[] bufOne = TestUtils.getRandomBytes(STANDARD_SEGMENT_SIZE / 3);
       byte[] bufTwo = TestUtils.getRandomBytes(STANDARD_SEGMENT_SIZE / 2);
 
-      segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(bufOne))), 0, bufOne.length);
-      assertEquals("End offset in current segment is not as expected", bufOne.length, segment.getEndOffset());
-      readAndEnsureMatch(segment, 0, bufOne);
+      segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(bufOne))), writeStartOffset,
+          bufOne.length);
+      assertEquals("End offset is not as expected", writeStartOffset + bufOne.length, segment.getEndOffset());
+      readAndEnsureMatch(segment, writeStartOffset, bufOne);
 
       // overwrite using bufTwo
-      segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(bufTwo))), 0, bufTwo.length);
-      assertEquals("End offset in current segment is not as expected", bufTwo.length, segment.getEndOffset());
-      readAndEnsureMatch(segment, 0, bufTwo);
+      segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(bufTwo))), writeStartOffset,
+          bufTwo.length);
+      assertEquals("End offset is not as expected", writeStartOffset + bufTwo.length, segment.getEndOffset());
+      readAndEnsureMatch(segment, writeStartOffset, bufTwo);
 
       // overwrite using bufOne
-      segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(bufOne))), 0, bufOne.length);
+      segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(bufOne))), writeStartOffset,
+          bufOne.length);
       // end offset should not have changed
-      assertEquals("End offset in current segment is not as expected", bufTwo.length, segment.getEndOffset());
-      readAndEnsureMatch(segment, 0, bufOne);
-      readAndEnsureMatch(segment, bufOne.length, Arrays.copyOfRange(bufTwo, bufOne.length, bufTwo.length));
+      assertEquals("End offset is not as expected", writeStartOffset + bufTwo.length, segment.getEndOffset());
+      readAndEnsureMatch(segment, writeStartOffset, bufOne);
+      readAndEnsureMatch(segment, writeStartOffset + bufOne.length,
+          Arrays.copyOfRange(bufTwo, bufOne.length, bufTwo.length));
 
       // write at random locations
       for (int i = 0; i < 10; i++) {
-        long offset = Utils.getRandomLong(TestUtils.RANDOM, segment.getCapacityInBytes() - bufOne.length);
+        long offset = writeStartOffset + Utils
+            .getRandomLong(TestUtils.RANDOM, segment.getCapacityInBytes() - bufOne.length - writeStartOffset);
         segment
             .writeFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(bufOne))), offset, bufOne.length);
         readAndEnsureMatch(segment, offset, bufOne);
       }
 
       // try to overwrite using a channel that won't fit
-      ByteBuffer failBuf = ByteBuffer.wrap(TestUtils.getRandomBytes(STANDARD_SEGMENT_SIZE + 1));
+      ByteBuffer failBuf =
+          ByteBuffer.wrap(TestUtils.getRandomBytes((int) (STANDARD_SEGMENT_SIZE - writeStartOffset + 1)));
       long writeOverFlowCount = metrics.overflowWriteError.getCount();
       try {
-        segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(failBuf)), 0, failBuf.remaining());
+        segment
+            .writeFrom(Channels.newChannel(new ByteBufferInputStream(failBuf)), writeStartOffset, failBuf.remaining());
         fail("WriteFrom should have failed because data won't fit");
       } catch (IndexOutOfBoundsException e) {
         assertEquals("Write overflow should have been reported", writeOverFlowCount + 1,
@@ -325,7 +338,7 @@ public class LogSegmentTest {
       }
 
       // data cannot be written at invalid offsets.
-      long[] invalidOffsets = {-1, STANDARD_SEGMENT_SIZE, STANDARD_SEGMENT_SIZE + 1};
+      long[] invalidOffsets = {writeStartOffset - 1, STANDARD_SEGMENT_SIZE, STANDARD_SEGMENT_SIZE + 1};
       ByteBuffer buffer = ByteBuffer.wrap(TestUtils.getRandomBytes(1));
       for (long invalidOffset : invalidOffsets) {
         try {
@@ -339,7 +352,7 @@ public class LogSegmentTest {
       segment.close();
       // ensure that writeFrom fails.
       try {
-        segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(buffer)), 0, buffer.remaining());
+        segment.writeFrom(Channels.newChannel(new ByteBufferInputStream(buffer)), writeStartOffset, buffer.remaining());
         fail("WriteFrom should have failed because segments are closed");
       } catch (ClosedChannelException e) {
         assertEquals("Position of buffer has changed", 0, buffer.position());
@@ -350,6 +363,17 @@ public class LogSegmentTest {
   }
 
   /**
+   * Tests for special constructor cases.
+   * @throws IOException
+   */
+  @Test
+  public void constructorTest()
+      throws IOException {
+    LogSegment segment = getSegment("log_current", STANDARD_SEGMENT_SIZE, false);
+    assertEquals("Start offset should be 0 when no headers are written", 0, segment.getStartOffset());
+  }
+
+  /**
    * Tests for bad construction cases of {@link LogSegment}.
    * @throws IOException
    */
@@ -357,20 +381,84 @@ public class LogSegmentTest {
   public void badConstructionTest()
       throws IOException {
     // try to construct with a file that does not exist.
+    String name = "log_non_existent";
+    File file = new File(tempDir, name);
     try {
-      new LogSegment("log_non_existent", new File(tempDir, "log_non_existent"), STANDARD_SEGMENT_SIZE, metrics);
+      new LogSegment(name, file, STANDARD_SEGMENT_SIZE, metrics, true);
+      fail("Construction should have failed because the backing file does not exist");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+
+    try {
+      new LogSegment(name, file, metrics);
       fail("Construction should have failed because the backing file does not exist");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
     }
 
     // try to construct with a file that is a directory
+    name = tempDir.getName();
+    file = new File(tempDir.getParent(), name);
     try {
-      new LogSegment(tempDir.getName(), new File(tempDir.getParent(), tempDir.getName()), STANDARD_SEGMENT_SIZE,
-          metrics);
+      new LogSegment(name, file, STANDARD_SEGMENT_SIZE, metrics, true);
       fail("Construction should have failed because the backing file does not exist");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
+    }
+
+    name = tempDir.getName();
+    file = new File(tempDir.getParent(), name);
+    try {
+      new LogSegment(name, file, metrics);
+      fail("Construction should have failed because the backing file does not exist");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+
+    // unknown version
+    LogSegment segment = getSegment("log_current", STANDARD_SEGMENT_SIZE, true);
+    file = segment.getView().getFirst();
+    byte[] header = getHeader(segment);
+    byte savedByte = header[0];
+    // mess with version
+    header[0] = (byte) (header[0] + 10);
+    writeHeader(segment, header);
+    try {
+      new LogSegment(name, file, metrics);
+      fail("Construction should have failed because version is unknown");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+
+    // bad CRC
+    // fix version but mess with data after version
+    header[0] = savedByte;
+    header[2] = header[2] == (byte) 1 ? (byte) 0 : (byte) 1;
+    writeHeader(segment, header);
+    try {
+      new LogSegment(name, file, metrics);
+      fail("Construction should have failed because crc check should have failed");
+    } catch (IllegalStateException e) {
+      // expected. Nothing to do.
+    }
+    closeSegmentAndDeleteFile(segment);
+  }
+
+  private byte[] getHeader(LogSegment segment)
+      throws IOException {
+    FileChannel channel = segment.getView().getSecond();
+    ByteBuffer header = ByteBuffer.allocate(LogSegment.HEADER_SIZE);
+    channel.read(header, 0);
+    return header.array();
+  }
+
+  private void writeHeader(LogSegment segment, byte[] buf)
+      throws IOException {
+    FileChannel channel = segment.getView().getSecond();
+    ByteBuffer buffer = ByteBuffer.wrap(buf);
+    while (buffer.hasRemaining()) {
+      channel.write(buffer, 0);
     }
   }
 
@@ -381,11 +469,12 @@ public class LogSegmentTest {
    * Creates and gets a {@link LogSegment}.
    * @param segmentName the name of the segment as well as the file backing the segment.
    * @param capacityInBytes the capacity of the file/segment.
+   * @param writeHeaders if {@code true}, writes headers for the segment.
    * @return instance of {@link LogSegment} that is backed by the file with name {@code segmentName} of capacity
    * {@code capacityInBytes}.
    * @throws IOException
    */
-  private LogSegment getSegment(String segmentName, long capacityInBytes)
+  private LogSegment getSegment(String segmentName, long capacityInBytes, boolean writeHeaders)
       throws IOException {
     File file = new File(tempDir, segmentName);
     if (file.exists()) {
@@ -395,9 +484,7 @@ public class LogSegmentTest {
     file.deleteOnExit();
     try (RandomAccessFile raf = new RandomAccessFile(tempDir + File.separator + segmentName, "rw")) {
       raf.setLength(capacityInBytes);
-      LogSegment segment = new LogSegment(segmentName, file, capacityInBytes, metrics);
-      segment.setEndOffset(0);
-      return segment;
+      return new LogSegment(segmentName, file, capacityInBytes, metrics, writeHeaders);
     }
   }
 
@@ -448,13 +535,15 @@ public class LogSegmentTest {
    * Gets a view of the given {@code segment} and verifies the ref count and the data obtained from the view against
    * {@code expectedRefCount} and {@code dataInSegment} respectively.
    * @param segment the {@link LogSegment} to get a view from.
+   * @param writeStartOffset the offset at which write was started on the segment.
    * @param offset the offset for which a view is required.
    * @param dataInSegment the entire data in the {@link LogSegment}.
    * @param expectedRefCount the expected return value of {@link LogSegment#refCount()} once the view is obtained from
    *                         the {@code segment}
    * @throws IOException
    */
-  private void getAndVerifyView(LogSegment segment, int offset, byte[] dataInSegment, long expectedRefCount)
+  private void getAndVerifyView(LogSegment segment, long writeStartOffset, int offset, byte[] dataInSegment,
+      long expectedRefCount)
       throws IOException {
     Random random = new Random();
     Pair<File, FileChannel> view = segment.getView();
@@ -463,7 +552,7 @@ public class LogSegmentTest {
     assertEquals("Ref count is not as expected", expectedRefCount, segment.refCount());
     int sizeToRead = random.nextInt(dataInSegment.length - offset + 1);
     ByteBuffer buffer = ByteBuffer.wrap(new byte[sizeToRead]);
-    view.getSecond().read(buffer, offset);
+    view.getSecond().read(buffer, writeStartOffset + offset);
     assertArrayEquals("Data read from file does not match data written",
         Arrays.copyOfRange(dataInSegment, offset, offset + sizeToRead), buffer.array());
   }
@@ -479,21 +568,22 @@ public class LogSegmentTest {
   private void doAppendTest(Appender appender)
       throws IOException {
     String currSegmentName = "log_current";
-    LogSegment segment = getSegment(currSegmentName, STANDARD_SEGMENT_SIZE);
+    LogSegment segment = getSegment(currSegmentName, STANDARD_SEGMENT_SIZE, true);
     try {
+      long writeStartOffset = segment.getStartOffset();
       byte[] bufOne = TestUtils.getRandomBytes(STANDARD_SEGMENT_SIZE / 2);
       byte[] bufTwo = TestUtils.getRandomBytes(STANDARD_SEGMENT_SIZE / 3);
 
       appender.append(segment, ByteBuffer.wrap(bufOne));
-      assertEquals("End offset in current segment is not equal to the cumulative bytes written", bufOne.length,
-          segment.getEndOffset());
+      assertEquals("End offset is not as expected", writeStartOffset + bufOne.length, segment.getEndOffset());
 
       appender.append(segment, ByteBuffer.wrap(bufTwo));
-      assertEquals("End offset in current segment is not equal to the cumulative bytes written",
-          bufOne.length + bufTwo.length, segment.getEndOffset());
+      assertEquals("End offset is not as expected", writeStartOffset + bufOne.length + bufTwo.length,
+          segment.getEndOffset());
 
       // try to do a write that won't fit
-      ByteBuffer failBuf = ByteBuffer.wrap(TestUtils.getRandomBytes(STANDARD_SEGMENT_SIZE + 1));
+      ByteBuffer failBuf =
+          ByteBuffer.wrap(TestUtils.getRandomBytes((int) (STANDARD_SEGMENT_SIZE - writeStartOffset + 1)));
       long writeOverFlowCount = metrics.overflowWriteError.getCount();
       try {
         appender.append(segment, failBuf);
@@ -505,8 +595,8 @@ public class LogSegmentTest {
       }
 
       // read and ensure data matches
-      readAndEnsureMatch(segment, 0, bufOne);
-      readAndEnsureMatch(segment, bufOne.length, bufTwo);
+      readAndEnsureMatch(segment, writeStartOffset, bufOne);
+      readAndEnsureMatch(segment, writeStartOffset + bufOne.length, bufTwo);
 
       segment.close();
       // ensure that append fails.

--- a/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
@@ -202,7 +202,8 @@ public class LogTest {
     Log log = new Log(tempDir.getAbsolutePath(), LOG_CAPACITY, SEGMENT_CAPACITY, metrics);
     long numSegments = LOG_CAPACITY / SEGMENT_CAPACITY;
     Offset badSegmentOffset = new Offset(LogSegmentNameHelper.getName(numSegments + 1, 0), 0);
-    Offset badOffsetOffset = new Offset(log.getFirstSegment().getName(), log.getFirstSegment().getEndOffset() + 1);
+    Offset badOffsetOffset =
+        new Offset(log.getFirstSegment().getName(), log.getFirstSegment().getCapacityInBytes() + 1);
     List<Pair<Offset, Offset>> pairsToCheck = new ArrayList<>();
     pairsToCheck.add(new Pair<>(log.getStartOffset(), badSegmentOffset));
     pairsToCheck.add(new Pair<>(badSegmentOffset, log.getEndOffset()));

--- a/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
@@ -14,212 +14,486 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.utils.ByteBufferChannel;
 import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
-import java.nio.channels.ClosedChannelException;
-import java.util.Random;
-import org.junit.Assert;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
 import org.junit.Test;
 
+import static org.junit.Assert.*;
 
+
+/**
+ * Tests for {@link Log}.
+ */
 public class LogTest {
+  private static final long LOG_CAPACITY = 5 * 1024;
+  private static final long SEGMENT_CAPACITY = 1024;
+  private static final Appender BUFFER_APPENDER = new Appender() {
+    @Override
+    public void append(Log log, ByteBuffer buffer)
+        throws IOException {
+      int writeSize = buffer.remaining();
+      int written = log.appendFrom(buffer);
+      assertEquals("Size written did not match size of buffer provided", writeSize, written);
+    }
+  };
+  private static final Appender CHANNEL_APPENDER = new Appender() {
+    @Override
+    public void append(Log log, ByteBuffer buffer)
+        throws IOException {
+      int writeSize = buffer.remaining();
+      log.appendFrom(Channels.newChannel(new ByteBufferInputStream(buffer)), writeSize);
+      assertFalse("The buffer was not completely written", buffer.hasRemaining());
+    }
+  };
+
+  private final File tempDir;
+  private final StoreMetrics metrics;
 
   /**
-   * Create a temporary file
+   * Creates a temporary directory to store the segment files.
+   * @throws IOException
    */
-  File tempFile()
+  public LogTest()
       throws IOException {
-    File f = File.createTempFile("ambry", ".tmp");
-    f.deleteOnExit();
-    return f;
+    tempDir = Files.createTempDirectory("logDir-" + UtilsTest.getRandomString(10)).toFile();
+    tempDir.deleteOnExit();
+    metrics = new StoreMetrics(tempDir.getName(), new MetricRegistry());
   }
 
+  /**
+   * Cleans up the temporary directory and deletes it.
+   */
+  @After
+  public void cleanup() {
+    cleanDirectory(tempDir);
+    assertTrue("The directory [" + tempDir.getAbsolutePath() + "] could not be deleted", tempDir.delete());
+  }
+
+  /**
+   * Tests almost all the functions and cases of {@link Log}.
+   * </p>
+   * Each individual test has the following variable parameters.
+   * 1. The capacity of each segment.
+   * 2. The size of the write on the log.
+   * 3. The segment that is being marked as active (beginning, middle, end etc).
+   * 4. The number of segment files that have been created and already exist in the folder.
+   * 5. The type of append operation being used.
+   * @throws IOException
+   */
   @Test
-  public void logBasicTest() {
-    try {
-      File tempFile = tempFile();
-      RandomAccessFile randomFile = new RandomAccessFile(tempFile.getParent() + File.separator + "log_current", "rw");
-      // preallocate file
-      randomFile.setLength(5000);
-      File logFile = new File(tempFile.getParent(), "log_current");
-      logFile.deleteOnExit();
-      Log logTest =
-          new Log(tempFile.getParent(), 5000, new StoreMetrics(tempFile.getParent(), new MetricRegistry()));
-      byte[] testbuf = new byte[1000];
-      new Random().nextBytes(testbuf);
-      // append to log from byte buffer
-      int written = logTest.appendFrom(ByteBuffer.wrap(testbuf));
-      Assert.assertEquals(written, 1000);
-      Assert.assertEquals(logTest.getLogEndOffset(), 1000);
-      // append to log from channel
-      logTest.appendFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(testbuf))), 1000);
-      Assert.assertEquals(logTest.getLogEndOffset(), 2000);
-      written = logTest.appendFrom(ByteBuffer.wrap(testbuf));
-      Assert.assertEquals(written, 1000);
-      Assert.assertEquals(logTest.getLogEndOffset(), 3000);
-      ByteBuffer result = ByteBuffer.allocate(3000);
-      logTest.readInto(result, 0);
-      byte[] expectedAns = new byte[3000];
-      System.arraycopy(testbuf, 0, expectedAns, 0, 1000);
-      System.arraycopy(testbuf, 0, expectedAns, 1000, 1000);
-      System.arraycopy(testbuf, 0, expectedAns, 2000, 1000);
-      Assert.assertArrayEquals(result.array(), expectedAns);
-
-      // read arbitrary offsets from the log and ensure they are consistent
-      result.clear();
-      result.limit(1000);
-      logTest.readInto(result, 0);
-      Assert.assertEquals(result.limit(), 1000);
-      result.limit(2000);
-      logTest.readInto(result, 1000);
-      Assert.assertEquals(result.limit(), 2000);
-      result.limit(3000);
-      logTest.readInto(result, 2000);
-      Assert.assertEquals(result.limit(), 3000);
-      Assert.assertArrayEquals(result.array(), expectedAns);
-
-      // flush the file and ensure the write offset is different from file size
-      logTest.flush();
-      Assert.assertEquals(randomFile.length(), 5000);
-      Assert.assertEquals(logTest.getLogEndOffset(), 3000);
-      tempFile.delete();
-    } catch (Exception e) {
-      Assert.assertEquals(false, true);
+  public void comprehensiveTest()
+      throws IOException {
+    Appender[] appenders = {BUFFER_APPENDER, CHANNEL_APPENDER};
+    for (Appender appender : appenders) {
+      // for single segment log
+      setupAndDoComprehensiveTest(LOG_CAPACITY, LOG_CAPACITY, appender);
+      setupAndDoComprehensiveTest(LOG_CAPACITY, LOG_CAPACITY + 1, appender);
+      // for multiple segment log
+      setupAndDoComprehensiveTest(LOG_CAPACITY, SEGMENT_CAPACITY, appender);
     }
   }
 
+  /**
+   * Tests cases where bad arguments are provided to the {@link Log} constructor.
+   * @throws IOException
+   */
   @Test
-  public void logAppendTest() {
-    try {
-      File tempFile = tempFile();
-      RandomAccessFile randomFile = new RandomAccessFile(tempFile.getParent() + File.separator + "log_current", "rw");
-      File logFile = new File(tempFile.getParent(), "log_current");
-      logFile.deleteOnExit();
-      // preallocate file
-      randomFile.setLength(5000);
-      MetricRegistry registry = new MetricRegistry();
-      Log logTest = new Log(tempFile.getParent(), 5000, new StoreMetrics(tempFile.getParent(), registry));
-      byte[] testbuf = new byte[2000];
-      new Random().nextBytes(testbuf);
-      // append to log from byte buffer
-      int written = logTest.appendFrom(ByteBuffer.wrap(testbuf));
-      Assert.assertEquals(written, 2000);
-      Assert.assertEquals(logTest.getLogEndOffset(), 2000);
-      // append to log from channel
-      logTest.appendFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(testbuf))), 2000);
-      Assert.assertEquals(logTest.getLogEndOffset(), 4000);
+  public void constructionBadArgsTest()
+      throws IOException {
+    List<Pair<Long, Long>> logAndSegmentSizes = new ArrayList<>();
+    // <=0 values for capacities
+    logAndSegmentSizes.add(new Pair<>(-1L, SEGMENT_CAPACITY));
+    logAndSegmentSizes.add(new Pair<>(LOG_CAPACITY, -1L));
+    logAndSegmentSizes.add(new Pair<>(0L, SEGMENT_CAPACITY));
+    logAndSegmentSizes.add(new Pair<>(LOG_CAPACITY, 0L));
+    // log capacity is not perfectly divisible by segment capacity
+    logAndSegmentSizes.add(new Pair<>(LOG_CAPACITY, LOG_CAPACITY - 1));
 
-      // write more and verify we fail to write
+    for (Pair<Long, Long> logAndSegmentSize : logAndSegmentSizes) {
       try {
-        logTest.appendFrom(ByteBuffer.wrap(testbuf));
-        Assert.assertTrue(false);
+        new Log(tempDir.getAbsolutePath(), logAndSegmentSize.getFirst(), logAndSegmentSize.getSecond(), metrics);
+        fail("Construction should have failed");
       } catch (IllegalArgumentException e) {
-        Assert.assertEquals(registry.getCounters().
-            get("com.github.ambry.store.Log." + tempFile.getParent() + ".OverflowWriteError").getCount(), 1);
+        // expected. Nothing to do.
       }
-
-      // append to log from buffer and check overflow
-      // write more and verify we fail to write
-      try {
-        logTest.appendFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(testbuf))), 2000);
-        Assert.assertTrue(false);
-      } catch (IllegalArgumentException e) {
-        Assert.assertEquals(registry.getCounters().
-            get("com.github.ambry.store.Log." + tempFile.getParent() + ".OverflowWriteError").getCount(), 2);
-      }
-
-      logTest.close();
-      // ensure we fail to append
-      try {
-        logTest.appendFrom(Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(testbuf))), 1000);
-        Assert.assertTrue(false);
-      } catch (ClosedChannelException e) {
-        Assert.assertTrue(true);
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.assertEquals(true, false);
     }
   }
 
+  /**
+   * Tests cases where bad arguments are provided to the append operations.
+   * @throws IOException
+   */
   @Test
-  public void logReadTest() {
+  public void appendErrorCasesTest()
+      throws IOException {
+    Log log = new Log(tempDir.getAbsolutePath(), LOG_CAPACITY, SEGMENT_CAPACITY, metrics);
     try {
-      File tempFile = tempFile();
-      RandomAccessFile randomFile = new RandomAccessFile(tempFile.getParent() + File.separator + "log_current", "rw");
-      // preallocate file
-      randomFile.setLength(5000);
-      File logFile = new File(tempFile.getParent(), "log_current");
-      logFile.deleteOnExit();
-      Log logTest =
-          new Log(tempFile.getParent(), 5000, new StoreMetrics(tempFile.getParent(), new MetricRegistry()));
-      byte[] testbuf = new byte[2000];
-      new Random().nextBytes(testbuf);
-      // append to log from byte buffer
-      int written = logTest.appendFrom(ByteBuffer.wrap(testbuf));
-      Assert.assertEquals(written, 2000);
-      Assert.assertEquals(logTest.getLogEndOffset(), 2000);
+      // write exceeds size of a single segment.
+      ByteBuffer buffer =
+          ByteBuffer.wrap(TestUtils.getRandomBytes((int) (SEGMENT_CAPACITY + 1 - LogSegment.HEADER_SIZE)));
+      try {
+        log.appendFrom(buffer);
+        fail("Cannot append a write of size greater than log segment size");
+      } catch (IllegalArgumentException e) {
+        assertEquals("Position of buffer has changed", 0, buffer.position());
+      }
 
-      ByteBuffer buffer = ByteBuffer.allocate(1000);
-      logTest.readInto(buffer, 0);
-      for (int i = 0; i < 1000; i++) {
-        Assert.assertEquals(buffer.array()[i], testbuf[i]);
-      }
-      buffer.clear();
-      logTest.readInto(buffer, 1000);
-      for (int i = 0; i < 1000; i++) {
-        Assert.assertEquals(buffer.array()[i], testbuf[i + 1000]);
-      }
       try {
-        buffer.clear();
-        logTest.readInto(buffer, 5000);
-        Assert.assertTrue(false);
+        log.appendFrom(Channels.newChannel(new ByteBufferInputStream(buffer)), buffer.remaining());
+        fail("Cannot append a write of size greater than log segment size");
       } catch (IllegalArgumentException e) {
-        Assert.assertTrue(true);
+        assertEquals("Position of buffer has changed", 0, buffer.position());
       }
-      buffer.clear();
-      try {
-        logTest.readInto(buffer, 5000);
-        Assert.assertFalse(false);
-      } catch (IllegalArgumentException e) {
-        Assert.assertTrue(true);
-      }
-    } catch (Exception e) {
-      Assert.assertEquals(true, false);
+    } finally {
+      log.close();
+      cleanDirectory(tempDir);
     }
   }
 
+  /**
+   * Tests cases where bad arguments are provided to {@link Log#setActiveSegment(String)}.
+   * @throws IOException
+   */
   @Test
-  public void setOffsetTest() {
+  public void setActiveSegmentBadArgsTest()
+      throws IOException {
+    Log log = new Log(tempDir.getAbsolutePath(), LOG_CAPACITY, SEGMENT_CAPACITY, metrics);
+    long numSegments = LOG_CAPACITY / SEGMENT_CAPACITY;
     try {
-      File tempFile = tempFile();
-      RandomAccessFile randomFile = new RandomAccessFile(tempFile.getParent() + File.separator + "log_current", "rw");
-      // preallocate file
-      randomFile.setLength(5000);
-      File logFile = new File(tempFile.getParent(), "log_current");
-      logFile.deleteOnExit();
-      Log logTest =
-          new Log(tempFile.getParent(), 5000, new StoreMetrics(tempFile.getParent(), new MetricRegistry()));
-      byte[] testbuf = new byte[2000];
-      new Random().nextBytes(testbuf);
-      // append to log from byte buffer
-      int written = logTest.appendFrom(ByteBuffer.wrap(testbuf));
-      Assert.assertEquals(written, 2000);
-      Assert.assertEquals(logTest.getLogEndOffset(), 2000);
-      logTest.setLogEndOffset(4000);
-      Assert.assertEquals(logTest.getLogEndOffset(), 4000);
-      try {
-        logTest.setLogEndOffset(6000);
-        Assert.assertTrue(false);
-      } catch (IllegalArgumentException e) {
-        Assert.assertTrue(true);
-      }
-    } catch (Exception e) {
-      Assert.assertEquals(true, false);
+      log.setActiveSegment(LogSegmentNameHelper.getName(numSegments + 1, 0));
+      fail("Should have failed to set a non exsistent segment as active");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    } finally {
+      log.close();
+      cleanDirectory(tempDir);
     }
+  }
+
+  /**
+   * Tests the deprecated {@link Log#getView(List)} function.
+   * @throws IOException
+   */
+  @Test
+  public void getViewTest()
+      throws IOException {
+    Log log = new Log(tempDir.getAbsolutePath(), LOG_CAPACITY, SEGMENT_CAPACITY, metrics);
+    try {
+      long writeStartOffset = log.getLogEndOffset().getOffset();
+      long writeSize = (int) (SEGMENT_CAPACITY - writeStartOffset);
+      byte[] buf = TestUtils.getRandomBytes((int) (writeSize));
+      log.appendFrom(ByteBuffer.wrap(buf));
+      List<BlobReadOptions> list = new ArrayList<>();
+      list.add(new BlobReadOptions(writeStartOffset, writeSize, -1, null));
+      StoreMessageReadSet readSet = log.getView(list);
+      ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate(buf.length));
+      readSet.writeTo(0, channel, 0, buf.length);
+      assertArrayEquals("Data read does not match data written", buf, channel.getBuffer().array());
+    } finally {
+      log.close();
+      cleanDirectory(tempDir);
+    }
+  }
+
+  // helpers
+
+  // general
+
+  /**
+   * Deletes all the files in {@code tempDir}.
+   * @param tempDir the directory whose files have to be deleted.
+   */
+  private void cleanDirectory(File tempDir) {
+    File[] files = tempDir.listFiles();
+    if (files != null) {
+      for (File file : files) {
+        assertTrue("The file [" + file.getAbsolutePath() + "] could not be deleted", file.delete());
+      }
+    }
+  }
+
+  // comprehensiveTest() helpers
+
+  /**
+   * Sets up all the required variables for the comprehensive test.
+   * @param logCapacity the capacity of the log.
+   * @param segmentCapacity the capacity of a single segment in the log.
+   * @param appender the {@link Appender} to use.
+   * @throws IOException
+   */
+  private void setupAndDoComprehensiveTest(long logCapacity, long segmentCapacity, Appender appender)
+      throws IOException {
+    long numSegments = (logCapacity - 1) / segmentCapacity + 1;
+    long maxWriteSize = Math.min(logCapacity, segmentCapacity);
+    if (numSegments > 1) {
+      // backwards compatibility.
+      maxWriteSize -= LogSegment.HEADER_SIZE;
+    }
+    long[] writeSizes = {1, maxWriteSize, Utils.getRandomLong(TestUtils.RANDOM, maxWriteSize - 2) + 2};
+    // the number of segment files to create before creating the log.
+    for (int i = 0; i <= numSegments; i++) {
+      // the sizes of the writes to the log.
+      for (long writeSize : writeSizes) {
+        // the index of the pre-created segment file that will be marked as active.
+        for (int j = 0; j <= i; j++) {
+          List<String> expectedSegmentNames;
+          if (i == 0) {
+            // first startup case - segment file is not pre-created but will be created by the Log.
+            expectedSegmentNames = new ArrayList<>();
+            expectedSegmentNames.add(LogSegmentNameHelper.generateFirstSegmentName(numSegments));
+          } else if (i == j) {
+            // invalid index for anything other than i == 0.
+            break;
+          } else {
+            // subsequent startup cases where there have been a few segments created and maybe some are filled.
+            expectedSegmentNames = createSegmentFiles(i, numSegments, segmentCapacity);
+          }
+          expectedSegmentNames = Collections.unmodifiableList(expectedSegmentNames);
+          doComprehensiveTest(logCapacity, segmentCapacity, writeSize, expectedSegmentNames, j, appender);
+        }
+      }
+    }
+  }
+
+  /**
+   * Creates {@code numToCreate} segment files on disk.
+   * @param numToCreate the number of segment files to create.
+   * @param numFinalSegments the total number of segment files in the log.
+   * @return the names of the created files.
+   * @throws IOException
+   */
+  private List<String> createSegmentFiles(int numToCreate, long numFinalSegments, long segmentCapacity)
+      throws IOException {
+    if (numToCreate > numFinalSegments) {
+      throw new IllegalArgumentException("num segments to create cannot be more than num final segments");
+    }
+    List<String> segmentNames = new ArrayList<>(numToCreate);
+    if (numFinalSegments == 1) {
+      String name = LogSegmentNameHelper.generateFirstSegmentName(numFinalSegments);
+      create(LogSegmentNameHelper.nameToFilename(name), segmentCapacity);
+      segmentNames.add(name);
+    } else {
+      for (int i = 0; i < numToCreate; i++) {
+        long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+        long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+        String name = LogSegmentNameHelper.getName(pos, gen);
+        create(LogSegmentNameHelper.nameToFilename(name), segmentCapacity);
+        segmentNames.add(name);
+      }
+    }
+    Collections.sort(segmentNames, LogSegmentNameHelper.COMPARATOR);
+    return segmentNames;
+  }
+
+  /**
+   * Creates a file with name {@code filename}.
+   * @param filename the desired name of the file to be created.
+   * @param capacityInBytes the capacity of the file in bytes. The file is not preallocated, but this information is
+   *                        used to write the {@link LogSegment} headers.
+   * @return a {@link File} instance pointing the newly created file named {@code filename}.
+   * @throws IOException
+   */
+  private File create(String filename, long capacityInBytes)
+      throws IOException {
+    File file = new File(tempDir, filename);
+    if (file.exists()) {
+      assertTrue(file.getAbsolutePath() + " already exists and could not be deleted", file.delete());
+    }
+    assertTrue("Segment file could not be created at path " + file.getAbsolutePath(), file.createNewFile());
+    file.deleteOnExit();
+    // create a log segment so that it writes the headers
+    LogSegment segment =
+        new LogSegment(LogSegmentNameHelper.nameFromFilename(filename), file, capacityInBytes, metrics, true);
+    segment.close();
+    return file;
+  }
+
+  /**
+   * Does the comprehensive test.
+   * 1. Creates the log.
+   * 2. Checks that the pre created segment files (if any) have been picked up.
+   * 3. Sets the active segment.
+   * 4. Performs writes until the log is filled and checks end offsets and segment names/counts.
+   * 5. Flushes, closes and validates close.
+   * @param logCapacity the log capacity.
+   * @param segmentCapacity the capacity of each segment.
+   * @param writeSize the size of each write to the log.
+   * @param expectedSegmentNames the expected names of the segments in the log.
+   * @param segmentIdxToMarkActive the index of the name of the active segment in {@code expectedSegmentNames}. Also its
+   *                               absolute index in the {@link Log}.
+   * @param appender the {@link Appender} to use.
+   * @throws IOException
+   */
+  private void doComprehensiveTest(long logCapacity, long segmentCapacity, long writeSize,
+      List<String> expectedSegmentNames, int segmentIdxToMarkActive, Appender appender)
+      throws IOException {
+    long numSegments = (logCapacity - 1) / segmentCapacity + 1;
+    Log log = new Log(tempDir.getAbsolutePath(), logCapacity, segmentCapacity, metrics);
+    try {
+      // only preloaded segments should be in expectedSegmentNames.
+      checkLog(log, Math.min(logCapacity, segmentCapacity), expectedSegmentNames);
+      String activeSegmentName = expectedSegmentNames.get(segmentIdxToMarkActive);
+      log.setActiveSegment(activeSegmentName);
+      List<String> allSegmentNames = getSegmentNames(numSegments, expectedSegmentNames);
+      writeAndCheckLog(log, logCapacity, Math.min(logCapacity, segmentCapacity), numSegments - segmentIdxToMarkActive,
+          writeSize, allSegmentNames, segmentIdxToMarkActive, appender);
+      // log full - so all segments should be there
+      assertEquals("Unexpected number of segments", numSegments, allSegmentNames.size());
+      checkLog(log, Math.min(logCapacity, segmentCapacity), allSegmentNames);
+      flushCloseAndValidate(log);
+    } finally {
+      log.close();
+      cleanDirectory(tempDir);
+    }
+  }
+
+  /**
+   * Checks the log to ensure segment names, capacities and count.
+   * @param log the {@link Log} instance to check.
+   * @param expectedSegmentCapacity the expected capacity of each segment.
+   * @param expectedSegmentNames the expected names of all segments that should have been created in the {@code log}.
+   * @throws IOException
+   */
+  private void checkLog(Log log, long expectedSegmentCapacity, List<String> expectedSegmentNames)
+      throws IOException {
+    // get all log segments from the log and validates them
+    for (String segmentName : expectedSegmentNames) {
+      LogSegment segment = log.getSegment(segmentName);
+      assertEquals("Segment name is not as expected", segmentName, segment.getName());
+      assertEquals("Segment capacity not as expected", expectedSegmentCapacity, segment.getCapacityInBytes());
+      assertEquals("Segment returned by getSegment() is incorrect", segment, log.getSegment(segment.getName()));
+    }
+    assertEquals("Log segments reported is wrong", expectedSegmentNames.size(), log.getSegmentCount());
+  }
+
+  /**
+   * Writes data to the log and checks for end offset (segment and log), roll over and used capacity.
+   * @param log the {@link Log} instance to use.
+   * @param logCapacity the total capacity of the {@code log}.
+   * @param segmentCapacity the capacity of each segment in the {@code log}.
+   * @param segmentsLeft the number of segments in the log that still have capacity remaining.
+   * @param writeSize the size of each write to the log.
+   * @param segmentNames the names of *all* the segments in the log including the ones that may not yet have been
+   *                     created.
+   * @param activeSegmentIdx the index of the name of the active segment in {@code segmentNames}. Also its absolute
+   *                         index in the {@link Log}.
+   * @param appender the {@link Appender} to use.
+   * @throws IOException
+   */
+  private void writeAndCheckLog(Log log, long logCapacity, long segmentCapacity, long segmentsLeft, long writeSize,
+      List<String> segmentNames, int activeSegmentIdx, Appender appender)
+      throws IOException {
+    byte[] buf = TestUtils.getRandomBytes((int) writeSize);
+    long expectedUsedCapacity = logCapacity - segmentCapacity * segmentsLeft;
+    int nextSegmentIdx = activeSegmentIdx + 1;
+    String expectedNextSegmentName = null;
+    LogSegment expectedActiveSegment = log.getSegment(segmentNames.get(activeSegmentIdx));
+    if (segmentNames.size() > nextSegmentIdx) {
+      expectedNextSegmentName = segmentNames.get(nextSegmentIdx);
+    }
+    // add header space (if any) from the active segment.
+    long currentSegmentWriteSize = expectedActiveSegment.getEndOffset();
+    expectedUsedCapacity += currentSegmentWriteSize;
+    while (expectedUsedCapacity + writeSize <= logCapacity) {
+      appender.append(log, ByteBuffer.wrap(buf));
+      currentSegmentWriteSize += writeSize;
+      expectedUsedCapacity += writeSize;
+      if (currentSegmentWriteSize > segmentCapacity) {
+        // calculate the end offset to ensure no partial writes.
+        currentSegmentWriteSize =
+            LogSegment.HEADER_SIZE + currentSegmentWriteSize - expectedActiveSegment.getEndOffset();
+        // add the "wasted" space to expectedUsedCapacity
+        expectedUsedCapacity += LogSegment.HEADER_SIZE + segmentCapacity - expectedActiveSegment.getEndOffset();
+        expectedActiveSegment = log.getSegment(segmentNames.get(nextSegmentIdx));
+        assertNotNull("Next active segment is null", expectedActiveSegment);
+        assertEquals("Next active segment name does not match", expectedNextSegmentName,
+            expectedActiveSegment.getName());
+        nextSegmentIdx++;
+        if (segmentNames.size() > nextSegmentIdx) {
+          expectedNextSegmentName = segmentNames.get(nextSegmentIdx);
+        }
+      }
+      assertEquals("Active segment end offset not as expected", currentSegmentWriteSize,
+          expectedActiveSegment.getEndOffset());
+      assertEquals("End offset not as expected", new Offset(expectedActiveSegment.getName(), currentSegmentWriteSize),
+          log.getLogEndOffset());
+      assertEquals("Used capacity not as expected", expectedUsedCapacity, log.getUsedCapacity());
+    }
+    // try one more write that should fail
+    try {
+      appender.append(log, ByteBuffer.wrap(buf));
+      fail("Should have failed because max capacity has been reached");
+    } catch (IllegalStateException e) {
+      // expected. Nothing to do.
+    }
+  }
+
+  /**
+   * Returns {@code count} number of expected segment file names.
+   * @param count the number of total segment names needed (including the ones in {@code existingNames}).
+   * @param existingNames the names of log segments that are already known.
+   * @return expected segment file names of {@code count} segment files.
+   */
+  private List<String> getSegmentNames(long count, List<String> existingNames) {
+    List<String> segmentNames = new ArrayList<>();
+    if (existingNames != null) {
+      segmentNames.addAll(existingNames);
+    }
+    if (count == segmentNames.size()) {
+      return segmentNames;
+    } else if (segmentNames.size() == 0) {
+      segmentNames.add(LogSegmentNameHelper.generateFirstSegmentName(count));
+    }
+    for (int i = segmentNames.size(); i < count; i++) {
+      String nextSegmentName = LogSegmentNameHelper.getNextPositionName(segmentNames.get(i - 1));
+      segmentNames.add(nextSegmentName);
+    }
+    return segmentNames;
+  }
+
+  /**
+   * Flushes and closes the log and validates that the log has been correctly closed.
+   * @param log the {@link Log} intance to flush and close.
+   * @throws IOException
+   */
+  private void flushCloseAndValidate(Log log)
+      throws IOException {
+    // flush should not throw any exceptions
+    log.flush();
+    // close log and ensure segments are closed
+    log.close();
+    Iterator<Map.Entry<String, LogSegment>> iterator = log.getSegmentIterator();
+    while (iterator.hasNext()) {
+      assertFalse("LogSegment has not been closed", iterator.next().getValue().getView().getSecond().isOpen());
+    }
+  }
+
+  /**
+   * Interface for abstracting append operations.
+   */
+  private interface Appender {
+    /**
+     * Appends the data of {@code buffer} to {@code log}.
+     * @param log the {@link Log} to append {@code buffer} to.
+     * @param buffer the data to append to {@code log}.
+     * @throws IOException
+     */
+    void append(Log log, ByteBuffer buffer)
+        throws IOException;
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/OffsetTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/OffsetTest.java
@@ -14,11 +14,13 @@
 package com.github.ambry.store;
 
 import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
-import com.github.ambry.utils.UtilsTest;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import org.junit.Test;
 
@@ -40,7 +42,9 @@ public class OffsetTest {
   @Test
   public void offsetSerDeTest()
       throws IOException {
-    String name = UtilsTest.getRandomString(10);
+    long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    String name = LogSegmentNameHelper.getName(pos, gen);
     long offset = Utils.getRandomLong(new Random(), Long.MAX_VALUE);
     Offset logOffset = new Offset(name, offset);
     byte[] serialized = logOffset.toBytes();
@@ -64,7 +68,6 @@ public class OffsetTest {
   public void offsetBadInputTest()
       throws IOException {
     doBadOffsetInputTest(null, 10);
-    doBadOffsetInputTest("", 10);
     doBadOffsetInputTest("1_11_log", -1);
 
     Offset offset = new Offset("1_11_log", 10);
@@ -84,13 +87,20 @@ public class OffsetTest {
    */
   @Test
   public void compareToTest() {
-    // TODO (Log Segmentation): Improve and add more cases once compareTo also uses the name.
-    Offset lower = new Offset("lower", 1);
-    Offset match = new Offset("match", 1);
-    Offset higher = new Offset("higher", 2);
-    assertEquals("CompareTo result is inconsistent", -1, lower.compareTo(higher));
-    assertEquals("CompareTo result is inconsistent", 0, lower.compareTo(match));
-    assertEquals("CompareTo result is inconsistent", 1, higher.compareTo(lower));
+    List<Offset> offsets = new ArrayList<>();
+    offsets.add(new Offset("0_0", 0));
+    offsets.add(new Offset("0_0", 1));
+    offsets.add(new Offset("0_1", 0));
+    offsets.add(new Offset("0_1", 1));
+    offsets.add(new Offset("1_0", 0));
+    offsets.add(new Offset("1_0", 1));
+    for (int i = 0; i < offsets.size(); i++) {
+      for (int j = 0; j < offsets.size(); j++) {
+        int expectCompare = i == j ? 0 : i > j ? 1 : -1;
+        assertEquals("Unexpected value on compare", expectCompare, offsets.get(i).compareTo(offsets.get(j)));
+        assertEquals("Unexpected value on compare", -1 * expectCompare, offsets.get(j).compareTo(offsets.get(i)));
+      }
+    }
   }
 
   /**
@@ -98,10 +108,10 @@ public class OffsetTest {
    */
   @Test
   public void equalsAndHashCodeTest() {
-    Offset o1 = new Offset("test", 2);
-    Offset o2 = new Offset("test", 2);
-    Offset o3 = new Offset("test", 3);
-    Offset o4 = new Offset("test_more", 2);
+    Offset o1 = new Offset("1_1", 2);
+    Offset o2 = new Offset("1_1", 2);
+    Offset o3 = new Offset("1_1", 3);
+    Offset o4 = new Offset("1_2", 2);
 
     assertTrue("Offset should be equal to itself", o1.equals(o1));
     assertFalse("Offset should not be equal to null", o1.equals(null));
@@ -111,11 +121,7 @@ public class OffsetTest {
     assertEquals("Hashcode mismatch", o1.hashCode(), o2.hashCode());
 
     assertFalse("Offsets should be declared unequal", o1.equals(o3));
-
-    // TODO (Log Segmentation): Uncomment when compareTo() can handle different offset names.
-    /*
     assertFalse("Offsets should be declared unequal", o1.equals(o4));
-    */
   }
 
   // helpers

--- a/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
@@ -204,7 +204,7 @@ public class PersistentIndexTest {
         c.delete();
       }
       ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
-      Log log = new Log(logFile, 10000, new StoreMetrics(logFile, new MetricRegistry()));
+      Log log = new Log(logFile, 10000, 10000, new StoreMetrics(logFile, new MetricRegistry()));
       StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
@@ -250,7 +250,7 @@ public class PersistentIndexTest {
         c.delete();
       }
       ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
-      Log log = new Log(logFile, 10000, new StoreMetrics(logFile, new MetricRegistry()));
+      Log log = new Log(logFile, 10000, 10000, new StoreMetrics(logFile, new MetricRegistry()));
       StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
@@ -331,7 +331,7 @@ public class PersistentIndexTest {
       Assert.assertEquals(value7.getSize(), 1000);
       Assert.assertEquals(value7.getOffset(), 6000);
       Assert.assertEquals(value7.getTimeToLiveInMs(), 12657);
-      Assert.assertEquals(log.getLogEndOffset(), 7000);
+      Assert.assertEquals(log.getLogEndOffset().getOffset(), 7000);
       indexNew.close();
 
       buffer = ByteBuffer.allocate(1000);
@@ -460,7 +460,7 @@ public class PersistentIndexTest {
         c.delete();
       }
       ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
-      Log log = new Log(logFile, 10000, new StoreMetrics(logFile, new MetricRegistry()));
+      Log log = new Log(logFile, 10000, 10000, new StoreMetrics(logFile, new MetricRegistry()));
       StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
@@ -514,7 +514,7 @@ public class PersistentIndexTest {
         c.delete();
       }
       ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
-      Log log = new Log(logFile, 10000, new StoreMetrics(logFile, new MetricRegistry()));
+      Log log = new Log(logFile, 10000, 10000, new StoreMetrics(logFile, new MetricRegistry()));
       StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
@@ -593,7 +593,7 @@ public class PersistentIndexTest {
         c.delete();
       }
       ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
-      Log log = new Log(logFile, 10000, new StoreMetrics(logFile, new MetricRegistry()));
+      Log log = new Log(logFile, 10000, 10000, new StoreMetrics(logFile, new MetricRegistry()));
       StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
@@ -639,7 +639,7 @@ public class PersistentIndexTest {
         c.delete();
       }
       ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
-      Log log = new Log(logFile, 6900, new StoreMetrics(logFile, new MetricRegistry()));
+      Log log = new Log(logFile, 6900, 6900, new StoreMetrics(logFile, new MetricRegistry()));
       Properties props = new Properties();
       props.setProperty("store.index.memory.size.bytes", "200");
       props.setProperty("store.data.flush.interval.seconds", "1");
@@ -773,7 +773,7 @@ public class PersistentIndexTest {
         c.delete();
       }
       ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
-      Log log = new Log(logFile, 2700, new StoreMetrics(logFile, new MetricRegistry()));
+      Log log = new Log(logFile, 2700, 2700, new StoreMetrics(logFile, new MetricRegistry()));
       Properties props = new Properties();
       props.setProperty("store.index.memory.size.bytes", "200");
       props.setProperty("store.data.flush.interval.seconds", "1");
@@ -919,7 +919,7 @@ public class PersistentIndexTest {
       }
       ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
       StoreMetrics metrics = new StoreMetrics(tempFile().getParent(), new MetricRegistry());
-      Log log = new Log(logFile, 10000, metrics);
+      Log log = new Log(logFile, 10000, 10000, metrics);
       Properties props = new Properties();
       props.put("store.index.max.number.of.inmem.elements", "5");
       props.put("store.max.number.of.entries.to.return.for.find", "12");
@@ -1073,7 +1073,7 @@ public class PersistentIndexTest {
       }
       ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
       StoreMetrics metrics = new StoreMetrics(tempFile().getParent(), new MetricRegistry());
-      Log log = new Log(logFile, 10000, metrics);
+      Log log = new Log(logFile, 10000, 10000, metrics);
       Properties props = new Properties();
       props.put("store.index.max.number.of.inmem.elements", "5");
       props.put("store.max.number.of.entries.to.return.for.find", "12");
@@ -1435,7 +1435,7 @@ public class PersistentIndexTest {
       }
       ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
       StoreMetrics metrics = new StoreMetrics(tempFile().getParent(), new MetricRegistry());
-      Log log = new Log(logFile, 10000, metrics);
+      Log log = new Log(logFile, 10000, 10000, metrics);
       Properties props = new Properties();
       props.put("store.index.max.number.of.inmem.elements", "5");
       props.put("store.max.number.of.entries.to.return.for.find", "12");

--- a/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
@@ -331,7 +331,7 @@ public class PersistentIndexTest {
       Assert.assertEquals(value7.getSize(), 1000);
       Assert.assertEquals(value7.getOffset(), 6000);
       Assert.assertEquals(value7.getTimeToLiveInMs(), 12657);
-      Assert.assertEquals(log.getLogEndOffset().getOffset(), 7000);
+      Assert.assertEquals(log.getEndOffset().getOffset(), 7000);
       indexNew.close();
 
       buffer = ByteBuffer.allocate(1000);

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
@@ -62,7 +62,7 @@ public class StoreMessageReadSetTest {
       int written = logTest.appendFrom(ByteBuffer.wrap(testbuf));
       Assert.assertEquals(written, 3000);
       MessageReadSet readSet =
-          new StoreMessageReadSet(tempFile, randomFile.getChannel(), options, logTest.getLogEndOffset().getOffset());
+          new StoreMessageReadSet(tempFile, randomFile.getChannel(), options, logTest.getEndOffset().getOffset());
       Assert.assertEquals(readSet.count(), 3);
       Assert.assertEquals(readSet.sizeInBytes(0), 15);
       Assert.assertEquals(readSet.sizeInBytes(1), 100);

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
@@ -55,14 +55,14 @@ public class StoreMessageReadSetTest {
       // preallocate file
       randomFile.setLength(5000);
       Log logTest =
-          new Log(tempFile.getParent(), 5000, new StoreMetrics(tempFile.getParent(), new MetricRegistry()));
+          new Log(tempFile.getParent(), 5000, 5000, new StoreMetrics(tempFile.getParent(), new MetricRegistry()));
       byte[] testbuf = new byte[3000];
       new Random().nextBytes(testbuf);
       // append to log from byte buffer
       int written = logTest.appendFrom(ByteBuffer.wrap(testbuf));
       Assert.assertEquals(written, 3000);
       MessageReadSet readSet =
-          new StoreMessageReadSet(tempFile, randomFile.getChannel(), options, logTest.getLogEndOffset());
+          new StoreMessageReadSet(tempFile, randomFile.getChannel(), options, logTest.getLogEndOffset().getOffset());
       Assert.assertEquals(readSet.count(), 3);
       Assert.assertEquals(readSet.sizeInBytes(0), 15);
       Assert.assertEquals(readSet.sizeInBytes(1), 100);

--- a/ambry-tools/src/main/java/com.github.ambry/store/IndexReadPerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/IndexReadPerformance.java
@@ -133,8 +133,8 @@ public class IndexReadPerformance {
       final HashMap<String, IndexPayload> hashes = new HashMap<String, IndexPayload>();
       String line;
       StoreMetrics metrics = new StoreMetrics(System.getProperty("user.dir"), new MetricRegistry());
-      Log log = new Log(System.getProperty("user.dir"), 1000, metrics);
       ScheduledExecutorService s = Utils.newScheduler(numberOfReaders, "index", true);
+      Log log = new Log(System.getProperty("user.dir"), 1000, 1000, metrics);
 
       Properties props = new Properties();
       props.setProperty("store.index.memory.size.bytes", "1048576");

--- a/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
@@ -114,7 +114,7 @@ public class IndexWritePerformance {
       writer = new FileWriter(logFile);
 
       StoreMetrics metrics = new StoreMetrics(System.getProperty("user.dir"), new MetricRegistry());
-      Log log = new Log(System.getProperty("user.dir"), 10, metrics);
+      Log log = new Log(System.getProperty("user.dir"), 10, 10, metrics);
 
       ScheduledExecutorService s = Utils.newScheduler(numberOfWriters, "index", false);
 


### PR DESCRIPTION
This commit introduces the changes required for the log to use `LogSegment` instances. It allows the log to be segmented into multiple segments. However, the index, hard delete and `BlobStore` do not yet completely support segmentation and hence the log cannot yet be segmented. The current configs make sure that segments aren't created

`./gradlew build && ./gradlew test` succeeded.
Code formatted.

**Primary reviewers: @pnarayanan, @nsivabalan**
**Expected time to review: PROD: 60-90 mins TEST: 30-60 mins**

**Unit testing**

| Class | Class, % | Method, % | Line, % |
| --- | --- | --- | --- |
| `LogSegment` | 100% (1/ 1) | 100% (18/ 18) | 100% (93/ 93) |
| `Log` | 100% (1/ 1) | 100% (21/ 21) | 99.1% (110/ 111) |
| `LogSegmentNameHelper` | 100% (3/ 3) | 93.8% (15/ 16) | 95.7% (45/ 47) |
| `Offset` | 100% (1/ 1) | 88.9% (8/ 9) | 97.1% (34/ 35) |

`LogSegmentNameHelper` is a static class so the "method" not covered is its constructor.
Method and line not covered in `Offset` is `toString()`. 
All other classes with new logic have all lines including all if-else branches covered.
