### PR TITLE
Fixing a bug when Log::close() is called more than once

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +41,6 @@ class Log implements Write {
   private final ConcurrentSkipListMap<String, LogSegment> segmentsByName =
       new ConcurrentSkipListMap<>(LogSegmentNameHelper.COMPARATOR);
   private final Logger logger = LoggerFactory.getLogger(getClass());
-  private final AtomicBoolean open = new AtomicBoolean(true);
 
   private long remainingUnallocatedSegments;
   private LogSegment activeSegment;
@@ -247,11 +245,8 @@ class Log implements Write {
    * @throws IOException if the flush encountered an I/O error.
    */
   void close() throws IOException {
-    if (open.compareAndSet(true, false)) {
-      for (LogSegment segment : segmentsByName.values()) {
-        segment.flush();
-        segment.close();
-      }
+    for (LogSegment segment : segmentsByName.values()) {
+      segment.close();
     }
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +42,7 @@ class Log implements Write {
   private final ConcurrentSkipListMap<String, LogSegment> segmentsByName =
       new ConcurrentSkipListMap<>(LogSegmentNameHelper.COMPARATOR);
   private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final AtomicBoolean open = new AtomicBoolean(true);
 
   private long remainingUnallocatedSegments;
   private LogSegment activeSegment;
@@ -245,9 +247,11 @@ class Log implements Write {
    * @throws IOException if the flush encountered an I/O error.
    */
   void close() throws IOException {
-    for (LogSegment segment : segmentsByName.values()) {
-      segment.flush();
-      segment.close();
+    if (open.compareAndSet(true, false)) {
+      for (LogSegment segment : segmentsByName.values()) {
+        segment.flush();
+        segment.close();
+      }
     }
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 
@@ -51,6 +52,7 @@ class LogSegment implements Read, Write {
   private final long startOffset;
   private final AtomicLong endOffset;
   private final AtomicLong refCount = new AtomicLong(0);
+  private final AtomicBoolean open = new AtomicBoolean(true);
 
   /**
    * Creates a LogSegment abstraction with the given capacity.
@@ -337,7 +339,9 @@ class LogSegment implements Read, Write {
    */
   void close()
       throws IOException {
-    fileChannel.close();
+    if (open.compareAndSet(true, false)) {
+      fileChannel.close();
+    }
   }
 
   /**


### PR DESCRIPTION
`./gradlew build && ./gradlew test` succeeded