### PR TITLE
Storing the lag of local from remote as part of the RemoteReplicaInfo

### DIFF
--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -722,7 +722,7 @@ class ReplicaThread implements Runnable {
         replicatingFromRemoteColo, replicatingOverSsl, datacenterName);
   }
 
-  class ExchangeMetadataResponse {
+  static class ExchangeMetadataResponse {
     final Set<StoreKey> missingStoreKeys;
     final FindToken remoteToken;
     final long lagFromRemoteInBytes;

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -90,7 +90,7 @@ class ReplicaThread implements Runnable {
   private final boolean replicatingOverSsl;
   private final String datacenterName;
 
-  public ReplicaThread(String threadName, Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicateGroupedByNode,
+  ReplicaThread(String threadName, Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicateGroupedByNode,
       FindTokenFactory findTokenFactory, ClusterMap clusterMap, AtomicInteger correlationIdGenerator,
       DataNodeId dataNodeId, ConnectionPool connectionPool, ReplicationConfig replicationConfig,
       ReplicationMetrics replicationMetrics, NotificationSystem notification, StoreKeyFactory storeKeyFactory,
@@ -117,7 +117,7 @@ class ReplicaThread implements Runnable {
     this.datacenterName = datacenterName;
   }
 
-  public String getName() {
+  String getName() {
     return threadName;
   }
 
@@ -264,7 +264,7 @@ class ReplicaThread implements Runnable {
    * @throws ReplicationException
    * @throws InterruptedException
    */
-  protected List<ExchangeMetadataResponse> exchangeMetadata(ConnectedChannel connectedChannel,
+  List<ExchangeMetadataResponse> exchangeMetadata(ConnectedChannel connectedChannel,
       List<RemoteReplicaInfo> replicasToReplicatePerNode)
       throws IOException, ReplicationException, InterruptedException {
 
@@ -295,7 +295,8 @@ class ReplicaThread implements Runnable {
               processReplicaMetadataResponse(missingStoreKeys, replicaMetadataResponseInfo, remoteReplicaInfo,
                   remoteNode);
               ExchangeMetadataResponse exchangeMetadataResponse =
-                  new ExchangeMetadataResponse(missingStoreKeys, replicaMetadataResponseInfo.getFindToken());
+                  new ExchangeMetadataResponse(missingStoreKeys, replicaMetadataResponseInfo.getFindToken(),
+                      replicaMetadataResponseInfo.getRemoteReplicaLagInBytes());
               exchangeMetadataResponseList.add(exchangeMetadataResponse);
             } catch (Exception e) {
               replicationMetrics.updateLocalStoreError(remoteReplicaInfo.getReplicaId());
@@ -339,8 +340,8 @@ class ReplicaThread implements Runnable {
    * @throws MessageFormatException
    * @throws ReplicationException
    */
-  protected void fixMissingStoreKeys(ConnectedChannel connectedChannel,
-      List<RemoteReplicaInfo> replicasToReplicatePerNode, List<ExchangeMetadataResponse> exchangeMetadataResponseList)
+  void fixMissingStoreKeys(ConnectedChannel connectedChannel, List<RemoteReplicaInfo> replicasToReplicatePerNode,
+      List<ExchangeMetadataResponse> exchangeMetadataResponseList)
       throws IOException, StoreException, MessageFormatException, ReplicationException {
     long fixMissingStoreKeysStartTimeInMs = SystemTime.getInstance().milliseconds();
     try {
@@ -692,6 +693,7 @@ class ReplicaThread implements Runnable {
               }
               totalBlobsFixed += messageInfoList.size();
               remoteReplicaInfo.setToken(exchangeMetadataResponse.remoteToken);
+              remoteReplicaInfo.setLocalLagFromRemoteInBytes(exchangeMetadataResponse.lagFromRemoteInBytes);
               logger.trace("Remote node: {} Thread name: {} Remote replica: {} Token after speaking to remote node: {}",
                   remoteNode, threadName, remoteReplicaInfo.getReplicaId(), exchangeMetadataResponse.remoteToken);
             } catch (StoreException e) {
@@ -709,6 +711,7 @@ class ReplicaThread implements Runnable {
         } else {
           // There are no missing keys. We just advance the token
           remoteReplicaInfo.setToken(exchangeMetadataResponse.remoteToken);
+          remoteReplicaInfo.setLocalLagFromRemoteInBytes(exchangeMetadataResponse.lagFromRemoteInBytes);
           logger.trace("Remote node: {} Thread name: {} Remote replica: {} Token after speaking to remote node: {}",
               remoteNode, threadName, remoteReplicaInfo.getReplicaId(), exchangeMetadataResponse.remoteToken);
         }
@@ -720,28 +723,31 @@ class ReplicaThread implements Runnable {
   }
 
   class ExchangeMetadataResponse {
-    public final Set<StoreKey> missingStoreKeys;
-    public final FindToken remoteToken;
-    public final ServerErrorCode serverErrorCode;
+    final Set<StoreKey> missingStoreKeys;
+    final FindToken remoteToken;
+    final long lagFromRemoteInBytes;
+    final ServerErrorCode serverErrorCode;
 
-    public ExchangeMetadataResponse(Set<StoreKey> missingStoreKeys, FindToken remoteToken) {
+    ExchangeMetadataResponse(Set<StoreKey> missingStoreKeys, FindToken remoteToken, long lagFromRemoteInBytes) {
       this.missingStoreKeys = missingStoreKeys;
       this.remoteToken = remoteToken;
+      this.lagFromRemoteInBytes = lagFromRemoteInBytes;
       this.serverErrorCode = ServerErrorCode.No_Error;
     }
 
-    public ExchangeMetadataResponse(ServerErrorCode errorCode) {
+    ExchangeMetadataResponse(ServerErrorCode errorCode) {
       missingStoreKeys = null;
       remoteToken = null;
+      lagFromRemoteInBytes = -1;
       this.serverErrorCode = errorCode;
     }
   }
 
-  public boolean isThreadUp() {
+  boolean isThreadUp() {
     return running;
   }
 
-  public void shutdown() throws InterruptedException {
+  void shutdown() throws InterruptedException {
     running = false;
     shutdownLatch.await();
   }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -693,7 +693,7 @@ class ReplicaThread implements Runnable {
               }
               totalBlobsFixed += messageInfoList.size();
               remoteReplicaInfo.setToken(exchangeMetadataResponse.remoteToken);
-              remoteReplicaInfo.setLocalLagFromRemoteInBytes(exchangeMetadataResponse.lagFromRemoteInBytes);
+              remoteReplicaInfo.setLocalLagFromRemoteInBytes(exchangeMetadataResponse.localLagFromRemoteInBytes);
               logger.trace("Remote node: {} Thread name: {} Remote replica: {} Token after speaking to remote node: {}",
                   remoteNode, threadName, remoteReplicaInfo.getReplicaId(), exchangeMetadataResponse.remoteToken);
             } catch (StoreException e) {
@@ -711,7 +711,7 @@ class ReplicaThread implements Runnable {
         } else {
           // There are no missing keys. We just advance the token
           remoteReplicaInfo.setToken(exchangeMetadataResponse.remoteToken);
-          remoteReplicaInfo.setLocalLagFromRemoteInBytes(exchangeMetadataResponse.lagFromRemoteInBytes);
+          remoteReplicaInfo.setLocalLagFromRemoteInBytes(exchangeMetadataResponse.localLagFromRemoteInBytes);
           logger.trace("Remote node: {} Thread name: {} Remote replica: {} Token after speaking to remote node: {}",
               remoteNode, threadName, remoteReplicaInfo.getReplicaId(), exchangeMetadataResponse.remoteToken);
         }
@@ -725,20 +725,20 @@ class ReplicaThread implements Runnable {
   static class ExchangeMetadataResponse {
     final Set<StoreKey> missingStoreKeys;
     final FindToken remoteToken;
-    final long lagFromRemoteInBytes;
+    final long localLagFromRemoteInBytes;
     final ServerErrorCode serverErrorCode;
 
-    ExchangeMetadataResponse(Set<StoreKey> missingStoreKeys, FindToken remoteToken, long lagFromRemoteInBytes) {
+    ExchangeMetadataResponse(Set<StoreKey> missingStoreKeys, FindToken remoteToken, long localLagFromRemoteInBytes) {
       this.missingStoreKeys = missingStoreKeys;
       this.remoteToken = remoteToken;
-      this.lagFromRemoteInBytes = lagFromRemoteInBytes;
+      this.localLagFromRemoteInBytes = localLagFromRemoteInBytes;
       this.serverErrorCode = ServerErrorCode.No_Error;
     }
 
     ExchangeMetadataResponse(ServerErrorCode errorCode) {
       missingStoreKeys = null;
       remoteToken = null;
-      lagFromRemoteInBytes = -1;
+      localLagFromRemoteInBytes = -1;
       this.serverErrorCode = errorCode;
     }
   }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -398,7 +398,7 @@ public final class ReplicationManager {
    * @param replicaPath The path of the remote replica on the host
    * @return The lag in bytes that the remote replica is behind the local store
    */
-  public long getRemoteReplicaLagInBytes(PartitionId partitionId, String hostName, String replicaPath) {
+  public long getRemoteReplicaLagFromLocalInBytes(PartitionId partitionId, String hostName, String replicaPath) {
     RemoteReplicaInfo remoteReplicaInfo = getRemoteReplicaInfo(partitionId, hostName, replicaPath);
     if (remoteReplicaInfo != null) {
       return remoteReplicaInfo.getRemoteLagFromLocalInBytes();

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -59,10 +59,13 @@ final class RemoteReplicaInfo {
   private final ReplicaId replicaId;
   private final ReplicaId localReplicaId;
   private final Object lock = new Object();
-
+  private final Store localStore;
+  private final Port port;
+  private final Time time;
   // tracks the point up to which a node is in sync with a remote replica
   private final long tokenPersistIntervalInMs;
-  // The latest know token
+
+  // The latest known token
   private FindToken currentToken = null;
   // The token that will be safe to persist eventually
   private FindToken candidateTokenToPersist = null;
@@ -70,12 +73,10 @@ final class RemoteReplicaInfo {
   private long timeCandidateSetInMs;
   // The token that is known to be safe to persist.
   private FindToken tokenSafeToPersist = null;
-  private final Store localStore;
   private long totalBytesReadFromLocalStore;
-  private Time time;
-  private final Port port;
+  private long localLagFromRemoteStore = -1;
 
-  public RemoteReplicaInfo(ReplicaId replicaId, ReplicaId localReplicaId, Store localStore, FindToken token,
+  RemoteReplicaInfo(ReplicaId replicaId, ReplicaId localReplicaId, Store localStore, FindToken token,
       long tokenPersistIntervalInMs, Time time, Port port) {
     this.replicaId = replicaId;
     this.localReplicaId = localReplicaId;
@@ -87,23 +88,23 @@ final class RemoteReplicaInfo {
     initializeTokens(token);
   }
 
-  public ReplicaId getReplicaId() {
+  ReplicaId getReplicaId() {
     return replicaId;
   }
 
-  public ReplicaId getLocalReplicaId() {
+  ReplicaId getLocalReplicaId() {
     return localReplicaId;
   }
 
-  public Store getLocalStore() {
+  Store getLocalStore() {
     return localStore;
   }
 
-  public Port getPort() {
+  Port getPort() {
     return this.port;
   }
 
-  public long getReplicaLagInBytes() {
+  long getRemoteLagFromLocalInBytes() {
     if (localStore != null) {
       return this.localStore.getSizeInBytes() - this.totalBytesReadFromLocalStore;
     } else {
@@ -111,21 +112,29 @@ final class RemoteReplicaInfo {
     }
   }
 
-  public FindToken getToken() {
+  long getLocalLagFromRemoteInBytes() {
+    return localLagFromRemoteStore;
+  }
+
+  FindToken getToken() {
     synchronized (lock) {
       return currentToken;
     }
   }
 
-  public void setTotalBytesReadFromLocalStore(long totalBytesReadFromLocalStore) {
+  void setTotalBytesReadFromLocalStore(long totalBytesReadFromLocalStore) {
     this.totalBytesReadFromLocalStore = totalBytesReadFromLocalStore;
   }
 
-  public long getTotalBytesReadFromLocalStore() {
+  void setLocalLagFromRemoteInBytes(long localLagFromRemoteStore) {
+    this.localLagFromRemoteStore = localLagFromRemoteStore;
+  }
+
+  long getTotalBytesReadFromLocalStore() {
     return this.totalBytesReadFromLocalStore;
   }
 
-  public void setToken(FindToken token) {
+  void setToken(FindToken token) {
     // reference assignment is atomic in java but we want to be completely safe. performance is
     // not important here
     synchronized (lock) {
@@ -142,7 +151,7 @@ final class RemoteReplicaInfo {
     }
   }
 
-  /**
+  /*
    * The token persist logic ensures that a token corresponding to an entry in the store is never persisted in the
    * replicaTokens file before the entry itself is persisted in the store. This is done as follows. Objects of this
    * class maintain 3 tokens: tokenSafeToPersist, candidateTokenToPersist and currentToken:
@@ -166,7 +175,7 @@ final class RemoteReplicaInfo {
    * get the token to persist. Returns either the candidate token if enough time has passed since it was
    * set, or the last token again.
    */
-  public FindToken getTokenToPersist() {
+  FindToken getTokenToPersist() {
     synchronized (lock) {
       if (time.milliseconds() - timeCandidateSetInMs > tokenPersistIntervalInMs) {
         // candidateTokenToPersist is now safe to be persisted.
@@ -176,7 +185,7 @@ final class RemoteReplicaInfo {
     }
   }
 
-  public void onTokenPersisted() {
+  void onTokenPersisted() {
     synchronized (lock) {
       /* Only update the candidate token if it qualified as the token safe to be persisted in the previous get call.
        * If not, keep it as it is.
@@ -392,7 +401,7 @@ public final class ReplicationManager {
   public long getRemoteReplicaLagInBytes(PartitionId partitionId, String hostName, String replicaPath) {
     RemoteReplicaInfo remoteReplicaInfo = getRemoteReplicaInfo(partitionId, hostName, replicaPath);
     if (remoteReplicaInfo != null) {
-      return remoteReplicaInfo.getReplicaLagInBytes();
+      return remoteReplicaInfo.getRemoteLagFromLocalInBytes();
     }
     return 0;
   }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -354,7 +354,7 @@ public class ReplicationMetrics {
     Gauge<Long> replicaLag = new Gauge<Long>() {
       @Override
       public Long getValue() {
-        return remoteReplicaInfo.getReplicaLagInBytes();
+        return remoteReplicaInfo.getRemoteLagFromLocalInBytes();
       }
     };
     registry.register(MetricRegistry.name(ReplicationMetrics.class, metricName), replicaLag);

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -450,7 +450,7 @@ public class AmbryRequests implements RequestAPI {
 
             partitionStartTimeInMs = SystemTime.getInstance().milliseconds();
             long remoteReplicaLagInBytes =
-                replicationManager.getRemoteReplicaLagInBytes(partitionId, hostName, replicaPath);
+                replicationManager.getRemoteReplicaLagFromLocalInBytes(partitionId, hostName, replicaPath);
             logger.trace("{} Time used to get remote replica lag in bytes: {}", partitionId,
                 (SystemTime.getInstance().milliseconds() - partitionStartTimeInMs));
 


### PR DESCRIPTION
This commit does not yet store this information in the replication token but is the first step towards doing that.

This the first step towards addressing #493.

Formatted
`./gradlew build && ./gradlew test` succeeded.

**Primary reviewers: @cgtz, @xiahome**
**Expected time to review: 15 mins**   