### PR TITLE
Adding latency per 100Kb metric

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/network/ServerNetworkResponseMetrics.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/ServerNetworkResponseMetrics.java
@@ -26,16 +26,20 @@ public class ServerNetworkResponseMetrics extends NetworkSendMetrics {
   private final Histogram responseSendTimeBySize;
   private final Histogram responseTotalTimeBySize;
   private long timeSpentTillNow;
+  private final long blobSize;
+  private final Histogram responseTotalTimePer100Kb;
 
   public ServerNetworkResponseMetrics(Histogram responseQueueTime, Histogram responseSendTime,
       Histogram responseTotalTime, Histogram responseSendTimeBySize, Histogram responseTotalTimeBySize,
-      long timeSpentTillNow) {
+      long timeSpentTillNow, long blobSize, Histogram responseTotalTimePer100Kb) {
     super(responseSendTime);
     this.responseQueueTime = responseQueueTime;
     this.responseTotalTime = responseTotalTime;
     this.responseSendTimeBySize = responseSendTimeBySize;
     this.responseTotalTimeBySize = responseTotalTimeBySize;
     this.timeSpentTillNow = timeSpentTillNow;
+    this.blobSize = blobSize;
+    this.responseTotalTimePer100Kb = responseTotalTimePer100Kb;
   }
 
   /**
@@ -61,6 +65,9 @@ public class ServerNetworkResponseMetrics extends NetworkSendMetrics {
     responseTotalTime.update(timeSpentTillNow);
     if (responseTotalTimeBySize != null) {
       responseTotalTimeBySize.update(timeSpentTillNow);
+    }
+    if (responseTotalTimePer100Kb != null && blobSize > 100 * 1024) {
+      responseTotalTimePer100Kb.update(timeSpentTillNow / (100 * 1024));
     }
   }
 }

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -399,7 +399,7 @@ public class AmbryRequests implements RequestAPI {
     }
     requestResponseChannel.sendResponse(response, request,
         new ServerNetworkResponseMetrics(metrics.deleteBlobResponseQueueTimeInMs, metrics.deleteBlobSendTimeInMs,
-            metrics.deleteBlobTotalTimeInMs, null, null, totalTimeSpent));
+            metrics.deleteBlobTotalTimeInMs, null, null, totalTimeSpent, -1, null));
   }
 
   public void handleReplicaMetadataRequest(Request request) throws IOException, InterruptedException {
@@ -491,7 +491,8 @@ public class AmbryRequests implements RequestAPI {
 
     requestResponseChannel.sendResponse(response, request,
         new ServerNetworkResponseMetrics(metrics.replicaMetadataResponseQueueTimeInMs,
-            metrics.replicaMetadataSendTimeInMs, metrics.replicaMetadataTotalTimeInMs, null, null, totalTimeSpent));
+            metrics.replicaMetadataSendTimeInMs, metrics.replicaMetadataTotalTimeInMs, null, null, totalTimeSpent, -1,
+            null));
   }
 
   private void sendPutResponse(RequestResponseChannel requestResponseChannel, PutResponse response, Request request,
@@ -502,20 +503,23 @@ public class AmbryRequests implements RequestAPI {
       if (blobSize <= ServerMetrics.smallBlob) {
         requestResponseChannel.sendResponse(response, request,
             new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime,
-                metrics.putSmallBlobProcessingTimeInMs, metrics.putSmallBlobTotalTimeInMs, totalTimeSpent));
+                metrics.putSmallBlobProcessingTimeInMs, metrics.putSmallBlobTotalTimeInMs, totalTimeSpent, blobSize,
+                metrics.putBlobTotalTimePer100kbInMs));
       } else if (blobSize <= ServerMetrics.mediumBlob) {
         requestResponseChannel.sendResponse(response, request,
             new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime,
-                metrics.putMediumBlobProcessingTimeInMs, metrics.putMediumBlobTotalTimeInMs, totalTimeSpent));
+                metrics.putMediumBlobProcessingTimeInMs, metrics.putMediumBlobTotalTimeInMs, totalTimeSpent, blobSize,
+                metrics.putBlobTotalTimePer100kbInMs));
       } else {
         requestResponseChannel.sendResponse(response, request,
             new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime,
-                metrics.putLargeBlobProcessingTimeInMs, metrics.putLargeBlobTotalTimeInMs, totalTimeSpent));
+                metrics.putLargeBlobProcessingTimeInMs, metrics.putLargeBlobTotalTimeInMs, totalTimeSpent, blobSize,
+                metrics.putBlobTotalTimePer100kbInMs));
       }
     } else {
       requestResponseChannel.sendResponse(response, request,
           new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime, null, null,
-              totalTimeSpent));
+              totalTimeSpent, -1, null));
     }
   }
 
@@ -529,16 +533,17 @@ public class AmbryRequests implements RequestAPI {
           metrics.markGetBlobRequestRateBySize(blobSize);
           requestResponseChannel.sendResponse(response, request,
               new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime,
-                  metrics.getSmallBlobProcessingTimeInMs, metrics.getSmallBlobTotalTimeInMs, totalTimeSpent));
+                  metrics.getSmallBlobProcessingTimeInMs, metrics.getSmallBlobTotalTimeInMs, totalTimeSpent, blobSize,
+                  metrics.getBlobTotalTimePer100kbInMs));
         } else {
           requestResponseChannel.sendResponse(response, request,
               new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime, null, null,
-                  totalTimeSpent));
+                  totalTimeSpent, -1, null));
         }
       } else {
         requestResponseChannel.sendResponse(response, request,
             new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime, null, null,
-                totalTimeSpent));
+                totalTimeSpent, -1, null));
       }
     } else if (blobSize <= ServerMetrics.mediumBlob) {
       if (flags == MessageFormatFlags.Blob) {
@@ -546,16 +551,17 @@ public class AmbryRequests implements RequestAPI {
           metrics.markGetBlobRequestRateBySize(blobSize);
           requestResponseChannel.sendResponse(response, request,
               new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime,
-                  metrics.getMediumBlobProcessingTimeInMs, metrics.getMediumBlobTotalTimeInMs, totalTimeSpent));
+                  metrics.getMediumBlobProcessingTimeInMs, metrics.getMediumBlobTotalTimeInMs, totalTimeSpent, blobSize,
+                  metrics.getBlobTotalTimePer100kbInMs));
         } else {
           requestResponseChannel.sendResponse(response, request,
               new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime, null, null,
-                  totalTimeSpent));
+                  totalTimeSpent, -1, null));
         }
       } else {
         requestResponseChannel.sendResponse(response, request,
             new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime, null, null,
-                totalTimeSpent));
+                totalTimeSpent, -1, null));
       }
     } else {
       if (flags == MessageFormatFlags.Blob) {
@@ -563,16 +569,17 @@ public class AmbryRequests implements RequestAPI {
           metrics.markGetBlobRequestRateBySize(blobSize);
           requestResponseChannel.sendResponse(response, request,
               new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime,
-                  metrics.getLargeBlobProcessingTimeInMs, metrics.getLargeBlobTotalTimeInMs, totalTimeSpent));
+                  metrics.getLargeBlobProcessingTimeInMs, metrics.getLargeBlobTotalTimeInMs, totalTimeSpent, blobSize,
+                  metrics.getBlobTotalTimePer100kbInMs));
         } else {
           requestResponseChannel.sendResponse(response, request,
               new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime, null, null,
-                  totalTimeSpent));
+                  totalTimeSpent, -1, null));
         }
       } else {
         requestResponseChannel.sendResponse(response, request,
             new ServerNetworkResponseMetrics(responseQueueTime, responseSendTime, requestTotalTime, null, null,
-                totalTimeSpent));
+                totalTimeSpent, -1, null));
       }
     }
   }

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -33,6 +33,7 @@ public class ServerMetrics {
   public final Histogram putBlobResponseQueueTimeInMs;
   public final Histogram putBlobSendTimeInMs;
   public final Histogram putBlobTotalTimeInMs;
+  public final Histogram putBlobTotalTimePer100kbInMs;
 
   public final Histogram putSmallBlobProcessingTimeInMs;
   public final Histogram putSmallBlobSendTimeInMs;
@@ -51,6 +52,7 @@ public class ServerMetrics {
   public final Histogram getBlobResponseQueueTimeInMs;
   public final Histogram getBlobSendTimeInMs;
   public final Histogram getBlobTotalTimeInMs;
+  public final Histogram getBlobTotalTimePer100kbInMs;
 
   public final Histogram getSmallBlobProcessingTimeInMs;
   public final Histogram getSmallBlobSendTimeInMs;
@@ -155,6 +157,8 @@ public class ServerMetrics {
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "PutBlobResponseQueueTime"));
     putBlobSendTimeInMs = registry.histogram(MetricRegistry.name(AmbryRequests.class, "PutBlobSendTime"));
     putBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(AmbryRequests.class, "PutBlobTotalTime"));
+    putBlobTotalTimePer100kbInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "putBlobTotalTimePer100kb"));
 
     putSmallBlobProcessingTimeInMs =
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "PutSmallBlobProcessingTime"));
@@ -178,6 +182,8 @@ public class ServerMetrics {
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "GetBlobResponseQueueTime"));
     getBlobSendTimeInMs = registry.histogram(MetricRegistry.name(AmbryRequests.class, "GetBlobSendTime"));
     getBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(AmbryRequests.class, "GetBlobTotalTime"));
+    getBlobTotalTimePer100kbInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "getBlobTotalTimePer100kb"));
 
     getSmallBlobProcessingTimeInMs =
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "GetSmallBlobProcessingTime"));


### PR DESCRIPTION
For a blob store, latency in isolation may not make much sense, as blob sizes may vary and hence the latency. So, introducing latency per 100Kb metric

Reviewers: Gopal, Casey
SLA: 5 mins