### PR TITLE
Ensure data chunks of a deleted composite blob get deleted

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -57,6 +57,7 @@ class GetBlobInfoOperation extends GetOperation {
    * @param clusterMap the {@link ClusterMap} of the cluster
    * @param responseHandler the {@link ResponseHandler} responsible for failure detection.
    * @param blobIdStr the blob id associated with the operation in string form.
+   * @param options the {@link ExtendedGetBlobOptions} containing the options associated with this operation.
    * @param futureResult the future that will contain the result of the operation.
    * @param callback the callback that is to be called when the operation completes.
    * @param operationCompleteCallback the {@link OperationCompleteCallback} to use to complete operations.
@@ -64,7 +65,7 @@ class GetBlobInfoOperation extends GetOperation {
    * @throws RouterException if there is an error with any of the parameters, such as an invalid blob id.
    */
   GetBlobInfoOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
-      ResponseHandler responseHandler, String blobIdStr, GetBlobOptions options,
+      ResponseHandler responseHandler, String blobIdStr, ExtendedGetBlobOptions options,
       FutureResult<GetBlobResult> futureResult, Callback<GetBlobResult> callback,
       OperationCompleteCallback operationCompleteCallback, Time time) throws RouterException {
     super(routerConfig, routerMetrics, clusterMap, responseHandler, blobIdStr, options, futureResult, callback, time);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -57,18 +57,17 @@ class GetBlobInfoOperation extends GetOperation {
    * @param clusterMap the {@link ClusterMap} of the cluster
    * @param responseHandler the {@link ResponseHandler} responsible for failure detection.
    * @param blobIdStr the blob id associated with the operation in string form.
-   * @param options the {@link ExtendedGetBlobOptions} containing the options associated with this operation.
-   * @param futureResult the future that will contain the result of the operation.
+   * @param options the {@link GetBlobOptionsInternal} containing the options associated with this operation.
    * @param callback the callback that is to be called when the operation completes.
    * @param operationCompleteCallback the {@link OperationCompleteCallback} to use to complete operations.
    * @param time the Time instance to use.
    * @throws RouterException if there is an error with any of the parameters, such as an invalid blob id.
    */
   GetBlobInfoOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
-      ResponseHandler responseHandler, String blobIdStr, ExtendedGetBlobOptions options,
-      FutureResult<GetBlobResult> futureResult, Callback<GetBlobResult> callback,
+      ResponseHandler responseHandler, String blobIdStr, GetBlobOptionsInternal options,
+      Callback<GetBlobResultInternal> callback,
       OperationCompleteCallback operationCompleteCallback, Time time) throws RouterException {
-    super(routerConfig, routerMetrics, clusterMap, responseHandler, blobIdStr, options, futureResult, callback, time);
+    super(routerConfig, routerMetrics, clusterMap, responseHandler, blobIdStr, options, callback, time);
     this.operationCompleteCallback = operationCompleteCallback;
     operationTracker = new SimpleOperationTracker(routerConfig.routerDatacenterName, blobId.getPartition(),
         routerConfig.routerGetCrossDcEnabled, routerConfig.routerGetSuccessTarget,
@@ -77,7 +76,7 @@ class GetBlobInfoOperation extends GetOperation {
 
   @Override
   void abort(Exception abortCause) {
-    operationCompleteCallback.completeOperation(operationFuture, operationCallback, null, abortCause);
+    operationCompleteCallback.completeOperation(null, operationCallback, null, abortCause);
     operationCompleted = true;
   }
 
@@ -136,7 +135,7 @@ class GetBlobInfoOperation extends GetOperation {
       ReplicaId replicaId = replicaIterator.next();
       String hostname = replicaId.getDataNodeId().getHostname();
       Port port = replicaId.getDataNodeId().getPortToConnectTo();
-      GetRequest getRequest = createGetRequest(blobId, getOperationFlag(), options.getGetOption());
+      GetRequest getRequest = createGetRequest(blobId, getOperationFlag(), options.getBlobOptions.getGetOption());
       RouterRequestInfo request = new RouterRequestInfo(hostname, port, getRequest, replicaId);
       int correlationId = getRequest.getCorrelationId();
       correlationIdToGetRequestInfo.put(correlationId, new GetRequestInfo(replicaId, time.milliseconds()));
@@ -275,8 +274,9 @@ class GetBlobInfoOperation extends GetOperation {
    */
   private void handleBody(InputStream payload) throws IOException, MessageFormatException {
     if (operationResult == null) {
-      operationResult = new GetBlobResult(new BlobInfo(MessageFormatRecord.deserializeBlobProperties(payload),
-          MessageFormatRecord.deserializeUserMetadata(payload).array()), null);
+      operationResult = new GetBlobResultInternal(new GetBlobResult(
+          new BlobInfo(MessageFormatRecord.deserializeBlobProperties(payload),
+              MessageFormatRecord.deserializeUserMetadata(payload).array()), null), null);
     } else {
       // If the successTarget is 1, this case will never get executed.
       // If it is more than 1, then, different responses will have to be reconciled in some way. Here is where that
@@ -332,7 +332,7 @@ class GetBlobInfoOperation extends GetOperation {
         routerMetrics.onGetBlobError(e, options);
       }
       routerMetrics.getBlobInfoOperationLatencyMs.update(time.milliseconds() - submissionTimeMs);
-      operationCompleteCallback.completeOperation(operationFuture, operationCallback, operationResult, e);
+      operationCompleteCallback.completeOperation(null, operationCallback, operationResult, e);
     }
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -102,6 +102,8 @@ class GetBlobOperation extends GetOperation {
   private BlobInfo blobInfo;
   // the ReadableStreamChannel that is populated on OperationType.Blob or OperationType.All requests.
   private BlobDataReadableStreamChannel blobDataChannel;
+  // the CompositeBlobInfo that will be set if (and when) this blob turns out to be a composite blob.
+  private CompositeBlobInfo compositeBlobInfo;
   private final ReadyForPollCallback readyForPollCallback;
 
   private static final Logger logger = LoggerFactory.getLogger(GetBlobOperation.class);
@@ -113,7 +115,7 @@ class GetBlobOperation extends GetOperation {
    * @param clusterMap the {@link ClusterMap} of the cluster
    * @param responseHandler the {@link ResponseHandler} responsible for failure detection.
    * @param blobIdStr the blob id associated with the operation in string form.
-   * @param options the {@link GetBlobOptions} associated with the operation.
+   * @param options the {@link ExtendedGetBlobOptions} associated with the operation.
    * @param futureResult the future that will contain the result of the operation.
    * @param callback the callback that is to be called when the operation completes.
    * @param operationCompleteCallback the {@link OperationCompleteCallback} to use to complete operations.
@@ -124,9 +126,8 @@ class GetBlobOperation extends GetOperation {
    * @throws RouterException if there is an error with any of the parameters, such as an invalid blob id.
    */
   GetBlobOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
-      ResponseHandler responseHandler, String blobIdStr, GetBlobOptions options,
-      FutureResult<GetBlobResult> futureResult, Callback<GetBlobResult> callback,
-      OperationCompleteCallback operationCompleteCallback, ReadyForPollCallback readyForPollCallback,
+      ResponseHandler responseHandler, String blobIdStr, ExtendedGetBlobOptions options, FutureResult futureResult,
+      Callback callback, OperationCompleteCallback operationCompleteCallback, ReadyForPollCallback readyForPollCallback,
       BlobIdFactory blobIdFactory, Time time) throws RouterException {
     super(routerConfig, routerMetrics, clusterMap, responseHandler, blobIdStr, options, futureResult, callback, time);
     this.operationCompleteCallback = operationCompleteCallback;
@@ -168,23 +169,32 @@ class GetBlobOperation extends GetOperation {
     }
     if (chunk == firstChunk) {
       if (operationCallbackInvoked.compareAndSet(false, true)) {
-        // Complete the operation from the caller's perspective, so that the caller can start reading from the
-        // channel if there is no exception. The operation will not be marked as complete internally as subsequent
-        // chunk retrievals and channel writes will need to happen and for that, this operation needs the GetManager to
-        // poll it periodically. If any exception is encountered while processing subsequent chunks, those will be
-        // notified during the channel read.
-        long timeElapsed = time.milliseconds() - submissionTimeMs;
-        routerMetrics.getBlobOperationLatencyMs.update(timeElapsed);
         Exception e = getOperationException();
-        if (e == null) {
-          blobDataChannel = new BlobDataReadableStreamChannel();
-          operationResult = new GetBlobResult(blobInfo, blobDataChannel);
+        if (options.getChunkIdsOnly) {
+          // If this is an operation just to get the chunk ids, then these ids will be returned as part of the
+          // result callback and no more chunks will be fetched, so mark the operation as complete to let the
+          // GetManager remove this operation.
+          operationCompleted = true;
+          List<StoreKey> result = e == null && compositeBlobInfo != null ? compositeBlobInfo.getKeys() : null;
+          operationCompleteCallback.completeOperation(operationFuture, operationCallback, result, e);
         } else {
-          blobDataChannel = null;
-          operationResult = null;
-          routerMetrics.onGetBlobError(e, options);
+          // Complete the operation from the caller's perspective, so that the caller can start reading from the
+          // channel if there is no exception. The operation will not be marked as complete internally as subsequent
+          // chunk retrievals and channel writes will need to happen and for that, this operation needs the GetManager to
+          // poll it periodically. If any exception is encountered while processing subsequent chunks, those will be
+          // notified during the channel read.
+          long timeElapsed = time.milliseconds() - submissionTimeMs;
+          routerMetrics.getBlobOperationLatencyMs.update(timeElapsed);
+          if (e == null) {
+            blobDataChannel = new BlobDataReadableStreamChannel();
+            operationResult = new GetBlobResult(blobInfo, blobDataChannel);
+          } else {
+            blobDataChannel = null;
+            operationResult = null;
+            routerMetrics.onGetBlobError(e, options);
+          }
+          operationCompleteCallback.completeOperation(operationFuture, operationCallback, operationResult, e);
         }
-        operationCompleteCallback.completeOperation(operationFuture, operationCallback, operationResult, e);
       }
     }
     chunk.postCompletionCleanup();
@@ -908,7 +918,7 @@ class GetBlobOperation extends GetOperation {
      */
     private void handleMetadataBlob(BlobData blobData) throws IOException, MessageFormatException {
       ByteBuffer serializedMetadataContent = blobData.getStream().getByteBuffer();
-      CompositeBlobInfo compositeBlobInfo =
+      compositeBlobInfo =
           MetadataContentSerDe.deserializeMetadataContentRecord(serializedMetadataContent, blobIdFactory);
       chunkSize = compositeBlobInfo.getChunkSize();
       totalSize = compositeBlobInfo.getTotalSize();
@@ -927,11 +937,17 @@ class GetBlobOperation extends GetOperation {
         rangeResolutionFailure = true;
       }
       if (!rangeResolutionFailure) {
-        chunkIdIterator = keys.listIterator();
-        numChunksTotal = keys.size();
-        dataChunks = new GetChunk[Math.min(keys.size(), NonBlockingRouter.MAX_IN_MEM_CHUNKS)];
-        for (int i = 0; i < dataChunks.length; i++) {
-          dataChunks[i] = new GetChunk(chunkIdIterator.nextIndex(), (BlobId) chunkIdIterator.next());
+        if (options.getChunkIdsOnly) {
+          chunkIdIterator = null;
+          numChunksTotal = 0;
+          dataChunks = null;
+        } else {
+          chunkIdIterator = keys.listIterator();
+          numChunksTotal = keys.size();
+          dataChunks = new GetChunk[Math.min(keys.size(), NonBlockingRouter.MAX_IN_MEM_CHUNKS)];
+          for (int i = 0; i < dataChunks.length; i++) {
+            dataChunks[i] = new GetChunk(chunkIdIterator.nextIndex(), (BlobId) chunkIdIterator.next());
+          }
         }
       }
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -41,14 +41,13 @@ abstract class GetOperation {
   protected final NonBlockingRouterMetrics routerMetrics;
   protected final ClusterMap clusterMap;
   protected final ResponseHandler responseHandler;
-  protected final FutureResult operationFuture;
-  protected final Callback operationCallback;
+  protected final Callback<GetBlobResultInternal> operationCallback;
   protected final BlobId blobId;
-  protected final ExtendedGetBlobOptions options;
+  protected final GetBlobOptionsInternal options;
   protected final Time time;
   protected volatile boolean operationCompleted = false;
   protected final AtomicReference<Exception> operationException = new AtomicReference<>();
-  protected GetBlobResult operationResult;
+  protected GetBlobResultInternal operationResult;
   protected final long submissionTimeMs;
 
   private static final Logger logger = LoggerFactory.getLogger(GetOperation.class);
@@ -60,22 +59,19 @@ abstract class GetOperation {
    * @param clusterMap the {@link ClusterMap} of the cluster
    * @param responseHandler the {@link ResponseHandler} responsible for failure detection.
    * @param blobIdStr the blobId of the associated blob in string form.
-   * @param options the {@link ExtendedGetBlobOptions} associated with this operation.
-   * @param futureResult the future that will contain the result of the operation.
+   * @param options the {@link GetBlobOptionsInternal} associated with this operation.
    * @param operationCallback the callback that is to be called when the operation completes.
    * @param time the {@link Time} instance to use.
    * @throws RouterException if there is an error with any of the parameters, such as an invalid blob id.
    */
   GetOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
-      ResponseHandler responseHandler, String blobIdStr, ExtendedGetBlobOptions options,
-      FutureResult futureResult, Callback operationCallback, Time time)
-      throws RouterException {
+      ResponseHandler responseHandler, String blobIdStr, GetBlobOptionsInternal options,
+      Callback<GetBlobResultInternal> operationCallback, Time time) throws RouterException {
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.options = options;
-    this.operationFuture = futureResult;
     this.operationCallback = operationCallback;
     this.time = time;
     submissionTimeMs = time.milliseconds();
@@ -83,18 +79,10 @@ abstract class GetOperation {
   }
 
   /**
-   * Return the {@link FutureResult} associated with this operation.
-   * @return the {@link FutureResult} associated with this operation.
-   */
-  FutureResult<GetBlobResult> getFuture() {
-    return operationFuture;
-  }
-
-  /**
    * Return the {@link Callback} associated with this operation.
    * @return the {@link Callback} associated with this operation.
    */
-  Callback<GetBlobResult> getCallback() {
+  Callback<GetBlobResultInternal> getCallback() {
     return operationCallback;
   }
 
@@ -110,7 +98,7 @@ abstract class GetOperation {
    * Return the result of the operation.
    * @return the operation result.
    */
-  GetBlobResult getOperationResult() {
+  GetBlobResultInternal getOperationResult() {
     return operationResult;
   }
 
@@ -125,7 +113,7 @@ abstract class GetOperation {
   /**
    * @return The {@link GetBlobOptions} associated with this operation.
    */
-  GetBlobOptions getOptions() {
+  GetBlobOptionsInternal getOptions() {
     return options;
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -41,10 +41,10 @@ abstract class GetOperation {
   protected final NonBlockingRouterMetrics routerMetrics;
   protected final ClusterMap clusterMap;
   protected final ResponseHandler responseHandler;
-  protected final FutureResult<GetBlobResult> operationFuture;
-  protected final Callback<GetBlobResult> operationCallback;
+  protected final FutureResult operationFuture;
+  protected final Callback operationCallback;
   protected final BlobId blobId;
-  protected final GetBlobOptions options;
+  protected final ExtendedGetBlobOptions options;
   protected final Time time;
   protected volatile boolean operationCompleted = false;
   protected final AtomicReference<Exception> operationException = new AtomicReference<>();
@@ -60,14 +60,15 @@ abstract class GetOperation {
    * @param clusterMap the {@link ClusterMap} of the cluster
    * @param responseHandler the {@link ResponseHandler} responsible for failure detection.
    * @param blobIdStr the blobId of the associated blob in string form.
+   * @param options the {@link ExtendedGetBlobOptions} associated with this operation.
    * @param futureResult the future that will contain the result of the operation.
    * @param operationCallback the callback that is to be called when the operation completes.
    * @param time the {@link Time} instance to use.
    * @throws RouterException if there is an error with any of the parameters, such as an invalid blob id.
    */
   GetOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
-      ResponseHandler responseHandler, String blobIdStr, GetBlobOptions options,
-      FutureResult<GetBlobResult> futureResult, Callback<GetBlobResult> operationCallback, Time time)
+      ResponseHandler responseHandler, String blobIdStr, ExtendedGetBlobOptions options,
+      FutureResult futureResult, Callback operationCallback, Time time)
       throws RouterException {
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -99,13 +99,13 @@ class PutManager {
    *                             operations.
    * @param idsToDeleteList The list to fill with ids of successfully put data chunks of an unsuccessful
    *                        overall put operation.
-   * @param index the index of the {@link NonBlockingRouter.OperationController} in the {@link NonBlockingRouter}
+   * @param suffix the suffix to associate with the names of the threads created by this PutManager
    * @param time The {@link Time} instance to use.
    */
   PutManager(ClusterMap clusterMap, ResponseHandler responseHandler, NotificationSystem notificationSystem,
       RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
       OperationCompleteCallback operationCompleteCallback, ReadyForPollCallback readyForPollCallback,
-      List<String> idsToDeleteList, int index, Time time) {
+      List<String> idsToDeleteList, String suffix, Time time) {
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.notificationSystem = notificationSystem;
@@ -130,7 +130,7 @@ class PutManager {
     this.time = time;
     putOperations = Collections.newSetFromMap(new ConcurrentHashMap<PutOperation, Boolean>());
     correlationIdToPutOperation = new HashMap<Integer, PutOperation>();
-    chunkFillerThread = Utils.newThread("ChunkFillerThread-" + index, new ChunkFiller(), true);
+    chunkFillerThread = Utils.newThread("ChunkFillerThread-" + suffix, new ChunkFiller(), true);
     chunkFillerThread.start();
     routerMetrics.initializePutManagerMetrics(chunkFillerThread);
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -23,6 +23,7 @@ import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.router.RouterTestHelpers.*;
 import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
 import java.util.ArrayList;
@@ -51,7 +52,7 @@ import static org.junit.Assert.*;
  */
 
 public class DeleteManagerTest {
-  private static final int AWAIT_TIMEOUT_SECONDS = 200;
+  private static final int AWAIT_TIMEOUT_SECONDS = 10;
   private Time mockTime;
   private AtomicReference<MockSelectorState> mockSelectorState;
   private MockClusterMap clusterMap;
@@ -147,6 +148,11 @@ public class DeleteManagerTest {
             }
             for (Future future : futures) {
               future.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            }
+            long waitStart = SystemTime.getInstance().milliseconds();
+            while (router.getBackgroundOperationsCount() != 0
+                && SystemTime.getInstance().milliseconds() < waitStart + AWAIT_TIMEOUT_SECONDS * 1000) {
+              Thread.sleep(1000);
             }
             Assert.assertTrue("Callback not called.", callbackCalled.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
             Assert.assertEquals("All operations should be finished.", 0, router.getOperationsCount());

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -81,9 +81,9 @@ public class GetBlobInfoOperationTest {
   private final byte[] putContent;
   private final GetTestRequestRegistrationCallbackImpl requestRegistrationCallback =
       new GetTestRequestRegistrationCallbackImpl();
-  private final FutureResult<GetBlobResult> operationFuture = new FutureResult<>();
-  private final ExtendedGetBlobOptions options =
-      new ExtendedGetBlobOptions(GetBlobOptions.OperationType.BlobInfo, GetOption.None, null, false);
+  private final GetBlobOptionsInternal options =
+      new GetBlobOptionsInternal(new GetBlobOptions(GetBlobOptions.OperationType.BlobInfo, GetOption.None, null),
+          false);
 
   private class GetTestRequestRegistrationCallbackImpl implements RequestRegistrationCallback<GetOperation> {
     private List<RequestInfo> requestListToFill;
@@ -136,9 +136,9 @@ public class GetBlobInfoOperationTest {
   @Test
   public void testInstantiation() throws Exception {
     String blobIdStr = (new BlobId(mockClusterMap.getWritablePartitionIds().get(0))).getID();
-    Callback<GetBlobResult> operationCallback = new Callback<GetBlobResult>() {
+    Callback<GetBlobResultInternal> operationCallback = new Callback<GetBlobResultInternal>() {
       @Override
-      public void onCompletion(GetBlobResult result, Exception exception) {
+      public void onCompletion(GetBlobResultInternal result, Exception exception) {
         // no op.
       }
     };
@@ -146,7 +146,7 @@ public class GetBlobInfoOperationTest {
     // test a bad case
     try {
       new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, "invalid_id", options,
-          operationFuture, operationCallback, operationCompleteCallback, time);
+          operationCallback, operationCompleteCallback, time);
       Assert.fail("Instantiation of GetBlobInfo operation with an invalid blob id must fail");
     } catch (RouterException e) {
       Assert.assertEquals("Unexpected exception received on creating GetBlobInfoOperation",
@@ -156,10 +156,9 @@ public class GetBlobInfoOperationTest {
     // test a good case
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options,
-            operationFuture, operationCallback, operationCompleteCallback, time);
+            operationCallback, operationCompleteCallback, time);
 
     Assert.assertEquals("Callback must match", operationCallback, op.getCallback());
-    Assert.assertEquals("Futures must match", operationFuture, op.getFuture());
     Assert.assertEquals("Blob ids must match", blobIdStr, op.getBlobIdStr());
   }
 
@@ -171,8 +170,8 @@ public class GetBlobInfoOperationTest {
   public void testPollAndResponseHandling() throws Exception {
     operationsCount.incrementAndGet();
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options,
-            operationFuture, null, operationCompleteCallback, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
+            operationCompleteCallback, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
     op.poll(requestRegistrationCallback);
@@ -200,8 +199,8 @@ public class GetBlobInfoOperationTest {
   public void testRouterRequestTimeoutAllFailure() throws Exception {
     operationsCount.incrementAndGet();
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options,
-            operationFuture, null, operationCompleteCallback, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
+            operationCompleteCallback, time);
     requestRegistrationCallback.requestListToFill = new ArrayList<>();
     op.poll(requestRegistrationCallback);
     while (!op.isOperationComplete()) {
@@ -225,8 +224,8 @@ public class GetBlobInfoOperationTest {
   public void testNetworkClientTimeoutAllFailure() throws Exception {
     operationsCount.incrementAndGet();
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options,
-            operationFuture, null, operationCompleteCallback, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
+            operationCompleteCallback, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -260,8 +259,8 @@ public class GetBlobInfoOperationTest {
   public void testBlobNotFoundCase() throws Exception {
     operationsCount.incrementAndGet();
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options,
-            operationFuture, null, operationCompleteCallback, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
+            operationCompleteCallback, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -322,8 +321,8 @@ public class GetBlobInfoOperationTest {
       throws Exception {
     operationsCount.incrementAndGet();
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options,
-            operationFuture, null, operationCompleteCallback, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
+            operationCompleteCallback, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -379,8 +378,8 @@ public class GetBlobInfoOperationTest {
   private void testVariousErrors(String dcWherePutHappened) throws Exception {
     operationsCount.incrementAndGet();
     GetBlobInfoOperation op =
-        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options,
-            operationFuture, null, operationCompleteCallback, time);
+        new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
+            operationCompleteCallback, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -449,8 +448,9 @@ public class GetBlobInfoOperationTest {
    */
   private void assertSuccess(GetBlobInfoOperation op) {
     Assert.assertEquals("Null expected", null, op.getOperationException());
-    BlobInfo blobInfo = op.getOperationResult().getBlobInfo();
-    Assert.assertNull("Unexpected blob data channel in operation result", op.getOperationResult().getBlobDataChannel());
+    BlobInfo blobInfo = op.getOperationResult().getBlobResult.getBlobInfo();
+    Assert.assertNull("Unexpected blob data channel in operation result",
+        op.getOperationResult().getBlobResult.getBlobDataChannel());
     Assert.assertTrue("Blob properties must be the same",
         RouterTestHelpers.haveEquivalentFields(blobProperties, blobInfo.getBlobProperties()));
     Assert.assertArrayEquals("User metadata must be the same", userMetadata, blobInfo.getUserMetadata());

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -82,8 +82,8 @@ public class GetBlobInfoOperationTest {
   private final GetTestRequestRegistrationCallbackImpl requestRegistrationCallback =
       new GetTestRequestRegistrationCallbackImpl();
   private final FutureResult<GetBlobResult> operationFuture = new FutureResult<>();
-  private final GetBlobOptions options =
-      new GetBlobOptions(GetBlobOptions.OperationType.BlobInfo, GetOption.None, null);
+  private final ExtendedGetBlobOptions options =
+      new ExtendedGetBlobOptions(GetBlobOptions.OperationType.BlobInfo, GetOption.None, null, false);
 
   private class GetTestRequestRegistrationCallbackImpl implements RequestRegistrationCallback<GetOperation> {
     private List<RequestInfo> requestListToFill;

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -104,7 +104,7 @@ public class GetBlobOperationTest {
   private byte[] putContent;
 
   // Options which are passed into GetBlobOperations
-  private GetBlobOptions options = new GetBlobOptions();
+  private ExtendedGetBlobOptions options = new ExtendedGetBlobOptions(new GetBlobOptions());
 
   private final GetTestRequestRegistrationCallbackImpl requestRegistrationCallback =
       new GetTestRequestRegistrationCallbackImpl();
@@ -213,8 +213,8 @@ public class GetBlobOperationTest {
     // test a good case
     // operationCount is not incremented here as this operation is not taken to completion.
     GetBlobOperation op = new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,
-        new GetBlobOptions(), operationFuture, operationCallback, operationCompleteCallback, readyForPollCallback,
-        blobIdFactory, time);
+        new ExtendedGetBlobOptions(new GetBlobOptions()), operationFuture, operationCallback, operationCompleteCallback,
+        readyForPollCallback, blobIdFactory, time);
 
     Assert.assertEquals("Callbacks must match", operationCallback, op.getCallback());
     Assert.assertEquals("Futures must match", operationFuture, op.getFuture());
@@ -232,10 +232,10 @@ public class GetBlobOperationTest {
       doPut();
       switch (i % 2) {
         case 0:
-          options = new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, null);
+          options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, null, false);
           break;
         case 1:
-          options = new GetBlobOptions(GetBlobOptions.OperationType.Data, GetOption.None, null);
+          options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.Data, GetOption.None, null, false);
           break;
       }
       getAndAssertSuccess();
@@ -275,10 +275,10 @@ public class GetBlobOperationTest {
       doPut();
       switch (i % 2) {
         case 0:
-          options = new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, null);
+          options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, null, false);
           break;
         case 1:
-          options = new GetBlobOptions(GetBlobOptions.OperationType.Data, GetOption.None, null);
+          options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.Data, GetOption.None, null, false);
           break;
       }
       getAndAssertSuccess();
@@ -654,8 +654,8 @@ public class GetBlobOperationTest {
   private void testRangeRequestOffsetRange(long startOffset, long endOffset, boolean rangeSatisfiable)
       throws Exception {
     doPut();
-    options = new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None,
-        ByteRange.fromOffsetRange(startOffset, endOffset));
+    options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None,
+        ByteRange.fromOffsetRange(startOffset, endOffset), false);
     getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
   }
 
@@ -668,8 +668,8 @@ public class GetBlobOperationTest {
    */
   private void testRangeRequestFromStartOffset(long startOffset, boolean rangeSatisfiable) throws Exception {
     doPut();
-    options =
-        new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, ByteRange.fromStartOffset(startOffset));
+    options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None,
+        ByteRange.fromStartOffset(startOffset), false);
     getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
   }
 
@@ -682,8 +682,8 @@ public class GetBlobOperationTest {
    */
   private void testRangeRequestLastNBytes(long lastNBytes, boolean rangeSatisfiable) throws Exception {
     doPut();
-    options =
-        new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, ByteRange.fromLastNBytes(lastNBytes));
+    options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None,
+        ByteRange.fromLastNBytes(lastNBytes), false);
     getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -82,7 +82,6 @@ public class GetBlobOperationTest {
   private final MockTime time = new MockTime();
   private final Map<Integer, GetOperation> correlationIdToGetOperation = new HashMap<>();
   private final Random random = new Random();
-  private final FutureResult<GetBlobResult> operationFuture = new FutureResult<>();
   private final MockClusterMap mockClusterMap;
   private final BlobIdFactory blobIdFactory;
   private final NonBlockingRouterMetrics routerMetrics;
@@ -104,7 +103,7 @@ public class GetBlobOperationTest {
   private byte[] putContent;
 
   // Options which are passed into GetBlobOperations
-  private ExtendedGetBlobOptions options = new ExtendedGetBlobOptions(new GetBlobOptions());
+  private GetBlobOptionsInternal options = new GetBlobOptionsInternal(new GetBlobOptions(), false);
 
   private final GetTestRequestRegistrationCallbackImpl requestRegistrationCallback =
       new GetTestRequestRegistrationCallbackImpl();
@@ -192,9 +191,9 @@ public class GetBlobOperationTest {
    */
   @Test
   public void testInstantiation() throws Exception {
-    Callback<GetBlobResult> operationCallback = new Callback<GetBlobResult>() {
+    Callback<GetBlobResultInternal> operationCallback = new Callback<GetBlobResultInternal>() {
       @Override
-      public void onCompletion(GetBlobResult result, Exception exception) {
+      public void onCompletion(GetBlobResultInternal result, Exception exception) {
         // no op.
       }
     };
@@ -202,7 +201,7 @@ public class GetBlobOperationTest {
     // test a bad case
     try {
       new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, "invalid_id", null,
-          operationFuture, operationCallback, operationCompleteCallback, readyForPollCallback, blobIdFactory, time);
+          operationCallback, operationCompleteCallback, readyForPollCallback, blobIdFactory, time);
       Assert.fail("Instantiation of GetBlobOperation with an invalid blob id must fail");
     } catch (RouterException e) {
       Assert.assertEquals("Unexpected exception received on creating GetBlobOperation", RouterErrorCode.InvalidBlobId,
@@ -213,11 +212,10 @@ public class GetBlobOperationTest {
     // test a good case
     // operationCount is not incremented here as this operation is not taken to completion.
     GetBlobOperation op = new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,
-        new ExtendedGetBlobOptions(new GetBlobOptions()), operationFuture, operationCallback, operationCompleteCallback,
+        new GetBlobOptionsInternal(new GetBlobOptions(), false), operationCallback, operationCompleteCallback,
         readyForPollCallback, blobIdFactory, time);
 
     Assert.assertEquals("Callbacks must match", operationCallback, op.getCallback());
-    Assert.assertEquals("Futures must match", operationFuture, op.getFuture());
     Assert.assertEquals("Blob ids must match", blobIdStr, op.getBlobIdStr());
   }
 
@@ -232,10 +230,14 @@ public class GetBlobOperationTest {
       doPut();
       switch (i % 2) {
         case 0:
-          options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, null, false);
+          options =
+              new GetBlobOptionsInternal(new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, null),
+                  false);
           break;
         case 1:
-          options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.Data, GetOption.None, null, false);
+          options =
+              new GetBlobOptionsInternal(new GetBlobOptions(GetBlobOptions.OperationType.Data, GetOption.None, null),
+                  false);
           break;
       }
       getAndAssertSuccess();
@@ -275,10 +277,14 @@ public class GetBlobOperationTest {
       doPut();
       switch (i % 2) {
         case 0:
-          options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, null, false);
+          options =
+              new GetBlobOptionsInternal(new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, null),
+                  false);
           break;
         case 1:
-          options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.Data, GetOption.None, null, false);
+          options =
+              new GetBlobOptionsInternal(new GetBlobOptions(GetBlobOptions.OperationType.Data, GetOption.None, null),
+                  false);
           break;
       }
       getAndAssertSuccess();
@@ -589,15 +595,15 @@ public class GetBlobOperationTest {
     final AtomicReference<Exception> callbackException = new AtomicReference<>();
     final AtomicReference<Future<Long>> readIntoFuture = new AtomicReference<>();
     final CountDownLatch readCompleteLatch = new CountDownLatch(1);
-    Callback<GetBlobResult> callback = new Callback<GetBlobResult>() {
+    Callback<GetBlobResultInternal> callback = new Callback<GetBlobResultInternal>() {
       @Override
-      public void onCompletion(final GetBlobResult result, Exception exception) {
+      public void onCompletion(final GetBlobResultInternal result, Exception exception) {
         if (exception != null) {
           callbackException.set(exception);
           readCompleteLatch.countDown();
         } else {
           final ByteBufferAsyncWritableChannel writableChannel = new ByteBufferAsyncWritableChannel();
-          readIntoFuture.set(result.getBlobDataChannel().readInto(writableChannel, null));
+          readIntoFuture.set(result.getBlobResult.getBlobDataChannel().readInto(writableChannel, null));
           Utils.newThread(new Runnable() {
             @Override
             public void run() {
@@ -608,7 +614,7 @@ public class GetBlobOperationTest {
                   writableChannel.resolveOldestChunk(null);
                   chunksLeftToRead--;
                 }
-                result.getBlobDataChannel().close();
+                result.getBlobResult.getBlobDataChannel().close();
               } catch (Exception e) {
                 callbackException.set(e);
               } finally {
@@ -654,8 +660,8 @@ public class GetBlobOperationTest {
   private void testRangeRequestOffsetRange(long startOffset, long endOffset, boolean rangeSatisfiable)
       throws Exception {
     doPut();
-    options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None,
-        ByteRange.fromOffsetRange(startOffset, endOffset), false);
+    options = new GetBlobOptionsInternal(new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None,
+        ByteRange.fromOffsetRange(startOffset, endOffset)), false);
     getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
   }
 
@@ -668,8 +674,9 @@ public class GetBlobOperationTest {
    */
   private void testRangeRequestFromStartOffset(long startOffset, boolean rangeSatisfiable) throws Exception {
     doPut();
-    options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None,
-        ByteRange.fromStartOffset(startOffset), false);
+    options = new GetBlobOptionsInternal(
+        new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, ByteRange.fromStartOffset(startOffset)),
+        false);
     getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
   }
 
@@ -682,8 +689,9 @@ public class GetBlobOperationTest {
    */
   private void testRangeRequestLastNBytes(long lastNBytes, boolean rangeSatisfiable) throws Exception {
     doPut();
-    options = new ExtendedGetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None,
-        ByteRange.fromLastNBytes(lastNBytes), false);
+    options = new GetBlobOptionsInternal(
+        new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, ByteRange.fromLastNBytes(lastNBytes)),
+        false);
     getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
   }
 
@@ -706,9 +714,9 @@ public class GetBlobOperationTest {
         expectedErrorCode, new ErrorCodeChecker() {
           @Override
           public void testAndAssert(RouterErrorCode expectedError) throws Exception {
-            Callback<GetBlobResult> callback = new Callback<GetBlobResult>() {
+            Callback<GetBlobResultInternal> callback = new Callback<GetBlobResultInternal>() {
               @Override
-              public void onCompletion(final GetBlobResult result, final Exception exception) {
+              public void onCompletion(final GetBlobResultInternal result, final Exception exception) {
                 if (exception != null) {
                   asyncWritableChannel.close();
                   readCompleteLatch.countDown();
@@ -717,7 +725,7 @@ public class GetBlobOperationTest {
                     @Override
                     public void run() {
                       try {
-                        result.getBlobDataChannel().readInto(asyncWritableChannel, new Callback<Long>() {
+                        result.getBlobResult.getBlobDataChannel().readInto(asyncWritableChannel, new Callback<Long>() {
                           @Override
                           public void onCompletion(Long result, Exception exception) {
                             asyncWritableChannel.close();
@@ -770,23 +778,23 @@ public class GetBlobOperationTest {
     final AtomicReference<Exception> operationException = new AtomicReference<>(null);
     final int numChunks = ((blobSize + maxChunkSize - 1) / maxChunkSize) + (blobSize > maxChunkSize ? 1 : 0);
     mockNetworkClient.resetProcessedResponseCount();
-    Callback<GetBlobResult> callback = new Callback<GetBlobResult>() {
+    Callback<GetBlobResultInternal> callback = new Callback<GetBlobResultInternal>() {
       @Override
-      public void onCompletion(final GetBlobResult result, final Exception exception) {
+      public void onCompletion(final GetBlobResultInternal result, final Exception exception) {
         if (exception != null) {
           operationException.set(exception);
           readCompleteLatch.countDown();
         } else {
           try {
-            switch (options.getOperationType()) {
+            switch (options.getBlobOptions.getOperationType()) {
               case All:
-                BlobInfo blobInfo = result.getBlobInfo();
+                BlobInfo blobInfo = result.getBlobResult.getBlobInfo();
                 Assert.assertTrue("Blob properties must be the same",
                     RouterTestHelpers.haveEquivalentFields(blobProperties, blobInfo.getBlobProperties()));
                 Assert.assertArrayEquals("User metadata must be the same", userMetadata, blobInfo.getUserMetadata());
                 break;
               case Data:
-                Assert.assertNull("Unexpected blob info in operation result", result.getBlobInfo());
+                Assert.assertNull("Unexpected blob info in operation result", result.getBlobResult.getBlobInfo());
                 break;
             }
           } catch (Exception e) {
@@ -795,7 +803,8 @@ public class GetBlobOperationTest {
 
           final ByteBufferAsyncWritableChannel asyncWritableChannel = new ByteBufferAsyncWritableChannel();
           final Future<Long> preSetReadIntoFuture =
-              initiateReadBeforeChunkGet ? result.getBlobDataChannel().readInto(asyncWritableChannel, null) : null;
+              initiateReadBeforeChunkGet ? result.getBlobResult.getBlobDataChannel()
+                  .readInto(asyncWritableChannel, null) : null;
           Utils.newThread(new Runnable() {
             @Override
             public void run() {
@@ -807,9 +816,10 @@ public class GetBlobOperationTest {
                 }
               }
               Future<Long> readIntoFuture = initiateReadBeforeChunkGet ? preSetReadIntoFuture
-                  : result.getBlobDataChannel().readInto(asyncWritableChannel, null);
-              assertBlobReadSuccess(options, readIntoFuture, asyncWritableChannel, result.getBlobDataChannel(),
-                  readCompleteLatch, readCompleteResult, readCompleteException);
+                  : result.getBlobResult.getBlobDataChannel().readInto(asyncWritableChannel, null);
+              assertBlobReadSuccess(options.getBlobOptions, readIntoFuture, asyncWritableChannel,
+                  result.getBlobResult.getBlobDataChannel(), readCompleteLatch, readCompleteResult,
+                  readCompleteException);
             }
           }, false).start();
         }
@@ -828,10 +838,10 @@ public class GetBlobOperationTest {
     }
     // Ensure that a ChannelClosed exception is not set when the ReadableStreamChannel is closed correctly.
     Assert.assertNull("Callback operation exception should be null", op.getOperationException());
-    if (options.getOperationType() != GetBlobOptions.OperationType.BlobInfo) {
+    if (options.getBlobOptions.getOperationType() != GetBlobOptions.OperationType.BlobInfo) {
       int sizeWritten = blobSize;
-      if (options.getRange() != null) {
-        ByteRange range = options.getRange().toResolvedByteRange(blobSize);
+      if (options.getBlobOptions.getRange() != null) {
+        ByteRange range = options.getBlobOptions.getRange().toResolvedByteRange(blobSize);
         sizeWritten = (int) (range.getEndOffset() - range.getStartOffset() + 1);
       }
       Assert.assertEquals("Size read must equal size written", sizeWritten, readCompleteResult.get());
@@ -844,7 +854,7 @@ public class GetBlobOperationTest {
    * @return the operation
    * @throws Exception
    */
-  private GetBlobOperation createOperationAndComplete(Callback<GetBlobResult> callback) throws Exception {
+  private GetBlobOperation createOperationAndComplete(Callback<GetBlobResultInternal> callback) throws Exception {
     GetBlobOperation op = createOperation(callback);
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
@@ -864,11 +874,11 @@ public class GetBlobOperationTest {
    * @return the operation
    * @throws Exception
    */
-  private GetBlobOperation createOperation(Callback<GetBlobResult> callback) throws Exception {
+  private GetBlobOperation createOperation(Callback<GetBlobResultInternal> callback) throws Exception {
     operationsCount.incrementAndGet();
     GetBlobOperation op =
-        new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options,
-            operationFuture, callback, operationCompleteCallback, readyForPollCallback, blobIdFactory, time);
+        new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, callback,
+            operationCompleteCallback, readyForPollCallback, blobIdFactory, time);
     requestRegistrationCallback.requestListToFill = new ArrayList<>();
     return op;
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -427,12 +427,11 @@ public class NonBlockingRouterTest {
     Set<String> blobsToBeDeleted = getBlobsInServers(mockServerLayout);
     // The second iteration is to test the case where the blob was already deleted.
     // The third iteration is to test the case where the blob has expired.
-    for (int i=0; i<3; i++) {
+    for (int i = 0; i < 3; i++) {
       if (i == 2) {
         // Create a clean cluster and put another blob that immediate expires.
         setOperationParams();
-        putBlobProperties =
-            new BlobProperties(PUT_CONTENT_SIZE, "serviceId", "memberId", "contentType", false, 0);
+        putBlobProperties = new BlobProperties(PUT_CONTENT_SIZE, "serviceId", "memberId", "contentType", false, 0);
         blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel).get();
         Set<String> allBlobsInServer = getBlobsInServers(mockServerLayout);
         allBlobsInServer.removeAll(blobsToBeDeleted);

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -457,6 +457,11 @@ public class NonBlockingRouterTest {
     Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
   }
 
+  /**
+   * Return the blob ids of all the blobs in the servers in the cluster.
+   * @param mockServerLayout the {@link MockServerLayout} representing the cluster.
+   * @return a Set of blob id strings of the blobs in the servers in the cluster.
+   */
   private Set<String> getBlobsInServers(MockServerLayout mockServerLayout) {
     Set<String> blobsInServers = new HashSet<>();
     for (MockServer mockServer : mockServerLayout.getMockServers()) {

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -767,7 +767,7 @@ public class PutManagerTest {
   private void assertCloseCleanup() {
     Assert.assertEquals("Exactly one chunkFiller thread should be running before the router is closed", 1,
         TestUtils.numThreadsByThisName("ChunkFillerThread"));
-    Assert.assertEquals("Exactly one RequestResponseHandler thread should be running before the router is closed", 1,
+    Assert.assertEquals("Exactly two RequestResponseHandler thread should be running before the router is closed", 2,
         TestUtils.numThreadsByThisName("RequestResponseHandlerThread"));
     router.close();
     Assert.assertEquals("No ChunkFiller Thread should be running after the router is closed", 0,


### PR DESCRIPTION
Create a special OperationController that is responsible for
handling background delete operations in the router. Background
deletes are not latency sensitive and are best-effort. This
OperationController will use its own resources so as to not
interfere with regular operations.

Fixes #298 (approach described in [this](https://github.com/linkedin/ambry/issues/298#issuecomment-262604991) comment)

Coverage information (relevant newly added code is getting covered):

```
DeleteManager                   100% (2/ 2)     100% (11/ 11)   92.8% (77/ 83)
DeleteOperation                 100% (3/ 3)     100% (21/ 21)   95.4% (103/ 108)
FutureResult                    100% (1/ 1)     84.6% (11/ 13)  86.4% (19/ 22)
GetBlobInfoOperation            100% (2/ 2)     92.9% (13/ 14)  89.2% (99/ 111)
GetBlobOperation                100% (7/ 7)     98.1% (52/ 53)  94.2% (307/ 326)
GetBlobOptionsInternal          100% (1/ 1)     100% (1/ 1)     100% (3/ 3)
GetBlobResult                   100% (1/ 1)     100% (3/ 3)     100% (5/ 5)
GetBlobResultInternal           100% (1/ 1)     100% (1/ 1)     100% (3/ 3)
GetManager                      100% (2/ 2)     100% (12/ 12)   87% (67/ 77)
GetOperation                    100% (1/ 1)     100% (10/ 10)   100% (29/ 29)
GetRequestInfo                  100% (1/ 1)     100% (1/ 1)     100% (3/ 3)
NonBlockingRouter               100% (8/ 8)     97.4% (38/ 39)  83.2% (178/ 214)
NonBlockingRouterFactory        100% (1/ 1)     100% (3/ 3)     87% (20/ 23)
NonBlockingRouterMetrics        100% (7/ 7)     81% (17/ 21)    93.7% (149/ 159)
OperationCompleteCallback       100% (1/ 1)     100% (3/ 3)     100% (11/ 11)
```