### PR TITLE
Log segmentation tests

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
@@ -41,8 +41,8 @@ class BlobReadOptions implements Comparable<BlobReadOptions>, Closeable {
   private final AtomicBoolean open = new AtomicBoolean(true);
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
-  private static final short VERSION_0 = 0;
-  private static final short VERSION_1 = 1;
+  static final short VERSION_0 = 0;
+  static final short VERSION_1 = 1;
 
   private static final short VERSION_LENGTH = 2;
   private static final short SIZE_LENGTH = 8;

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -14,520 +14,1062 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.clustermap.DataNodeId;
-import com.github.ambry.clustermap.MockClusterMap;
-import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.ByteBufferOutputStream;
 import com.github.ambry.utils.MockTime;
-import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import org.junit.Assert;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
 
 
+/**
+ * Tests for {@link BlobStore}. Tests both segmented and non segmented log use cases.
+ */
+@RunWith(Parameterized.class)
 public class BlobStoreTest {
+  private static final StoreKeyFactory STORE_KEY_FACTORY;
 
-  /**
-   * Create a temporary file
-   */
-  File tempFile() throws IOException {
-    File f = File.createTempFile("ambry", ".tmp");
-    f.deleteOnExit();
-    return f;
+  static {
+    try {
+      STORE_KEY_FACTORY = Utils.getObj("com.github.ambry.store.MockIdFactory");
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
   }
 
-  class MockMessageWriteSet implements MessageWriteSet {
+  // setupTestState() is coupled to these numbers. Changing them *will* cause setting test state or tests to fail.
+  private static final long LOG_CAPACITY = 10000;
+  private static final long SEGMENT_CAPACITY = 2000;
+  private static final int MAX_IN_MEM_ELEMENTS = 5;
+  // deliberately do not divide the capacities perfectly.
+  private static final long PUT_RECORD_SIZE = 53;
+  private static final long DELETE_RECORD_SIZE = 29;
 
-    public ByteBuffer bufToWrite;
-    public List<MessageInfo> info;
+  /**
+   * A mock implementation of {@link MessageWriteSet} to help write to the {@link BlobStore}
+   */
+  private static class MockMessageWriteSet implements MessageWriteSet {
+    final List<ByteBuffer> buffers;
+    final List<MessageInfo> infos;
 
-    public MockMessageWriteSet(ByteBuffer bufToWrite, List<MessageInfo> info) {
-      this.bufToWrite = bufToWrite;
-      this.info = info;
+    MockMessageWriteSet(List<MessageInfo> infos, List<ByteBuffer> buffers) {
+      this.infos = infos;
+      this.buffers = buffers;
     }
 
     @Override
     public long writeTo(Write writeChannel) throws IOException {
-      return writeChannel.appendFrom(bufToWrite);
+      long sizeWritten = 0;
+      for (ByteBuffer buffer : buffers) {
+        sizeWritten += buffer.remaining();
+        writeChannel.appendFrom(Channels.newChannel(new ByteBufferInputStream(buffer)), buffer.remaining());
+      }
+      return sizeWritten;
     }
 
     @Override
     public List<MessageInfo> getMessageSetInfo() {
-      return info;
+      return infos;
     }
   }
 
-  @Test
-  public void storePutTest() throws Exception {
-    MockClusterMap map = null;
-    try {
-      ScheduledExecutorService scheduler = Utils.newScheduler(4, "thread", false);
-      Properties props = new Properties();
-      VerifiableProperties verifyProperty = new VerifiableProperties(props);
-      verifyProperty.verify();
-      StoreConfig config = new StoreConfig(verifyProperty);
-      map = new MockClusterMap();
-      DataNodeId dataNodeId1 = map.getDataNodeIds().get(0);
-      StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      List<ReplicaId> replicaIds = map.getReplicaIds(map.getDataNodeId("localhost", dataNodeId1.getPort()));
-      String storeId = replicaIds.get(0).getPartitionId().toString();
-      StorageManagerMetrics metrics = new StorageManagerMetrics(new MetricRegistry());
-      Store store = new BlobStore(storeId, config, scheduler, new DiskIOScheduler(null), metrics,
-          replicaIds.get(0).getReplicaPath(), replicaIds.get(0).getCapacityInBytes(), factory,
-          new DummyMessageStoreRecovery(), new DummyMessageStoreHardDelete(), SystemTime.getInstance());
-      store.start();
-      byte[] bufToWrite = new byte[2000];
-      new Random().nextBytes(bufToWrite);
-      MockId blobId1 = new MockId("id1");
-      MockId blobId2 = new MockId("id2");
-      MessageInfo info1 = new MessageInfo(blobId1, 1000);
-      MessageInfo info2 = new MessageInfo(blobId2, 1000);
-      ArrayList<MessageInfo> listInfo = new ArrayList<MessageInfo>(2);
-      listInfo.add(info1);
-      listInfo.add(info2);
+  /**
+   * A mock implementation of {@link MessageStoreHardDelete} that can be set to return {@link MessageInfo} for a
+   * particular {@link MockId}.
+   */
+  private static class MockMessageStoreHardDelete implements MessageStoreHardDelete {
+    private MessageInfo messageInfo = null;
 
-      MessageWriteSet set = new MockMessageWriteSet(ByteBuffer.wrap(bufToWrite), listInfo);
-      store.put(set);
+    @Override
+    public Iterator<HardDeleteInfo> getHardDeleteMessages(MessageReadSet readSet, StoreKeyFactory factory,
+        List<byte[]> recoveryInfoList) throws IOException {
+      throw new UnsupportedOperationException();
+    }
 
-      // verify existance
-      ArrayList<StoreKey> keys = new ArrayList<StoreKey>();
-      keys.add(blobId1);
-      keys.add(blobId2);
-      StoreInfo info = store.get(keys, EnumSet.noneOf(StoreGetOptions.class));
-      MessageReadSet readSet = info.getMessageReadSet();
-      Assert.assertEquals(readSet.count(), 2);
-      Assert.assertEquals(readSet.sizeInBytes(0), 1000);
-      Assert.assertEquals(readSet.sizeInBytes(1), 1000);
-      byte[] output = new byte[1000];
-      readSet.writeTo(0, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 0; i < 1000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i]);
-      }
-      readSet.writeTo(1, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 1000; i < 2000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i - 1000]);
-      }
+    @Override
+    public MessageInfo getMessageInfo(Read read, long offset, StoreKeyFactory factory) throws IOException {
+      return messageInfo;
+    }
 
-      // put a blob that already exist
-      new Random().nextBytes(bufToWrite);
-      info1 = new MessageInfo(blobId1, 1000);
-      listInfo = new ArrayList<MessageInfo>(1);
-      listInfo.add(info1);
-
-      set = new MockMessageWriteSet(ByteBuffer.wrap(bufToWrite), listInfo);
-      try {
-        store.put(set);
-        Assert.assertTrue(false);
-      } catch (StoreException e) {
-        Assert.assertTrue(e.getErrorCode() == StoreErrorCodes.Already_Exist);
-      }
-    } finally {
-      if (map != null) {
-        map.cleanup();
-      }
+    void setMessageInfo(MessageInfo messageInfo) {
+      this.messageInfo = messageInfo;
     }
   }
 
-  @Test
-  public void storeGetTest() throws Exception {
-    MockClusterMap map = null;
-    try {
-      ScheduledExecutorService scheduler = Utils.newScheduler(4, "thread", false);
-      File tempFile = tempFile();
-      Properties props = new Properties();
-      VerifiableProperties verifyProperty = new VerifiableProperties(props);
-      verifyProperty.verify();
-      StoreConfig config = new StoreConfig(verifyProperty);
-      map = new MockClusterMap();
-      DataNodeId dataNodeId1 = map.getDataNodeIds().get(0);
-      StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      List<ReplicaId> replicaIds = map.getReplicaIds(map.getDataNodeId("localhost", dataNodeId1.getPort()));
-      String storeId = replicaIds.get(0).getPartitionId().toString();
-      StorageManagerMetrics metrics = new StorageManagerMetrics(new MetricRegistry());
-      Store store = new BlobStore(storeId, config, scheduler, new DiskIOScheduler(null), metrics,
-          replicaIds.get(0).getReplicaPath(), replicaIds.get(0).getCapacityInBytes(), factory,
-          new DummyMessageStoreRecovery(), new DummyMessageStoreHardDelete(), SystemTime.getInstance());
-      store.start();
-      byte[] bufToWrite = new byte[2000];
-      new Random().nextBytes(bufToWrite);
-      MockId blobId1 = new MockId("id1");
-      MockId blobId2 = new MockId("id2");
-      MessageInfo info1 = new MessageInfo(blobId1, 1000);
-      MessageInfo info2 = new MessageInfo(blobId2, 1000);
-      ArrayList<MessageInfo> listInfo = new ArrayList<MessageInfo>(2);
-      listInfo.add(info1);
-      listInfo.add(info2);
-      MessageWriteSet set = new MockMessageWriteSet(ByteBuffer.wrap(bufToWrite), listInfo);
-      store.put(set);
+  /**
+   * An abstraction to unify and contains the results from the {@link Putter}, {@link Getter} and {@link Deleter}
+   */
+  private static class CallableResult {
+    // Will be non-null only for PUT.
+    final MockId id;
+    // Will be non-null only for GET.
+    final StoreInfo storeInfo;
 
-      // verify existence
-      ArrayList<StoreKey> keys = new ArrayList<StoreKey>();
-      keys.add(blobId1);
-      keys.add(blobId2);
-      StoreInfo info = store.get(keys, EnumSet.noneOf(StoreGetOptions.class));
-      MessageReadSet readSet = info.getMessageReadSet();
-      Assert.assertEquals(readSet.count(), 2);
-      Assert.assertEquals(readSet.sizeInBytes(0), 1000);
-      Assert.assertEquals(readSet.sizeInBytes(1), 1000);
-      byte[] output = new byte[1000];
-      readSet.writeTo(0, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 0; i < 1000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i]);
-      }
-      readSet.writeTo(1, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 1000; i < 2000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i - 1000]);
-      }
-    } finally {
-      if (map != null) {
-        map.cleanup();
-      }
+    CallableResult(MockId id, StoreInfo storeInfo) {
+      this.id = id;
+      this.storeInfo = storeInfo;
     }
   }
 
-  @Test
-  public void storeDeleteTest() throws Exception {
-    MockClusterMap map = null;
-    try {
-      ScheduledExecutorService scheduler = Utils.newScheduler(4, "thread", false);
-      File tempFile = tempFile();
-      Properties props = new Properties();
-      VerifiableProperties verifyProperty = new VerifiableProperties(props);
-      verifyProperty.verify();
-      StoreConfig config = new StoreConfig(verifyProperty);
-      map = new MockClusterMap();
-      DataNodeId dataNodeId1 = map.getDataNodeIds().get(0);
-      StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      List<ReplicaId> replicaIds = map.getReplicaIds(map.getDataNodeId("localhost", dataNodeId1.getPort()));
-      String storeId = replicaIds.get(0).getPartitionId().toString();
-      StorageManagerMetrics metrics = new StorageManagerMetrics(new MetricRegistry());
-      Store store = new BlobStore(storeId, config, scheduler, new DiskIOScheduler(null), metrics,
-          replicaIds.get(0).getReplicaPath(), replicaIds.get(0).getCapacityInBytes(), factory,
-          new DummyMessageStoreRecovery(), new DummyMessageStoreHardDelete(), SystemTime.getInstance());
-      store.start();
-      byte[] bufToWrite = new byte[2000];
-      new Random().nextBytes(bufToWrite);
-      MockId blobId1 = new MockId("id1");
-      MockId blobId2 = new MockId("id2");
-      MessageInfo info1 = new MessageInfo(blobId1, 1000);
-      MessageInfo info2 = new MessageInfo(blobId2, 1000);
-      ArrayList<MessageInfo> listInfo = new ArrayList<MessageInfo>(2);
-      listInfo.add(info1);
-      listInfo.add(info2);
+  // a static instance to return for Deleter::call().
+  private static final CallableResult EMPTY_RESULT = new CallableResult(null, null);
 
-      MessageWriteSet set = new MockMessageWriteSet(ByteBuffer.wrap(bufToWrite), listInfo);
-      store.put(set);
+  /**
+   * Puts a blob and returns the {@link MockId} associated with it.
+   */
+  private class Putter implements Callable<CallableResult> {
 
-      // verify existence
-      ArrayList<StoreKey> keys = new ArrayList<StoreKey>();
-      keys.add(blobId1);
-      keys.add(blobId2);
-      StoreInfo info = store.get(keys, EnumSet.noneOf(StoreGetOptions.class));
-      MessageReadSet readSet = info.getMessageReadSet();
-      Assert.assertEquals(readSet.count(), 2);
-      Assert.assertEquals(readSet.sizeInBytes(0), 1000);
-      Assert.assertEquals(readSet.sizeInBytes(1), 1000);
-      byte[] output = new byte[1000];
-      readSet.writeTo(0, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 0; i < 1000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i]);
-      }
-      readSet.writeTo(1, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 1000; i < 2000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i - 1000]);
-      }
-
-      // delete an id
-      byte[] bufToDelete = new byte[1000];
-      new Random().nextBytes(bufToDelete);
-
-      MessageInfo info3 = new MessageInfo(blobId1, 1000, 1234);
-      ArrayList<MessageInfo> listInfo1 = new ArrayList<MessageInfo>(1);
-      listInfo1.add(info3);
-      MessageWriteSet setToDelete = new MockMessageWriteSet(ByteBuffer.wrap(bufToDelete), listInfo1);
-      store.delete(setToDelete);
-      ArrayList<StoreKey> keysDeleted = new ArrayList<StoreKey>();
-      keysDeleted.add(blobId1);
-      try {
-        store.get(keysDeleted, EnumSet.noneOf(StoreGetOptions.class));
-        Assert.assertEquals(false, true);
-      } catch (StoreException e) {
-        Assert.assertEquals(e.getErrorCode(), StoreErrorCodes.ID_Deleted);
-      }
-      keys.clear();
-      keys.add(blobId2);
-      store.get(keys, EnumSet.noneOf(StoreGetOptions.class));
-    } finally {
-      if (map != null) {
-        map.cleanup();
-      }
+    @Override
+    public CallableResult call() throws Exception {
+      return new CallableResult(put(1, PUT_RECORD_SIZE, Utils.Infinite_Time).get(0), null);
     }
   }
 
-  @Test
-  public void storeGetDeletedTest() throws Exception {
-    MockClusterMap map = null;
-    try {
-      ScheduledExecutorService scheduler = Utils.newScheduler(4, "thread", false);
-      File tempFile = tempFile();
-      Properties props = new Properties();
-      VerifiableProperties verifyProperty = new VerifiableProperties(props);
-      verifyProperty.verify();
-      StoreConfig config = new StoreConfig(verifyProperty);
-      map = new MockClusterMap();
-      DataNodeId dataNodeId1 = map.getDataNodeIds().get(0);
-      StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      List<ReplicaId> replicaIds = map.getReplicaIds(map.getDataNodeId("localhost", dataNodeId1.getPort()));
-      byte[] bufToWrite = new byte[5000];
-      new Random().nextBytes(bufToWrite);
-      MockId blobId1 = new MockId("id1");
-      MockId blobId2 = new MockId("id2");
-      MockId blobId3 = new MockId("id3");
-      MockId blobId4 = new MockId("id4");
-      MockId blobId5 = new MockId("id5");
-      MessageInfo info1 = new MessageInfo(blobId1, 1000);
-      MessageInfo info2 = new MessageInfo(blobId2, 1000);
-      MessageInfo info3 = new MessageInfo(blobId3, 1000);
-      MessageInfo info4 = new MessageInfo(blobId4, 1000);
-      MessageInfo info5 = new MessageInfo(blobId5, 1000);
-      ArrayList<MessageInfo> listInfo = new ArrayList<MessageInfo>(5);
-      listInfo.add(info1);
-      listInfo.add(info2);
-      listInfo.add(info3);
-      listInfo.add(info4);
-      listInfo.add(info5);
+  /**
+   * Gets a blob by returning the {@link StoreInfo} associated with it.
+   */
+  private class Getter implements Callable<CallableResult> {
+    final MockId id;
+    final EnumSet<StoreGetOptions> storeGetOptions;
 
-      HashMap<Long, MessageInfo> dummyMap = new HashMap<Long, MessageInfo>();
-      dummyMap.put(new Long(0), info1);
-      dummyMap.put(new Long(1000), info2);
-      dummyMap.put(new Long(2000), info3);
-      dummyMap.put(new Long(3000), info4);
-      dummyMap.put(new Long(4000), info5);
+    /**
+     * @param id the {@link MockId} of the blob to GET
+     * @param storeGetOptions options for the GET.
+     */
+    Getter(MockId id, EnumSet<StoreGetOptions> storeGetOptions) {
+      this.id = id;
+      this.storeGetOptions = storeGetOptions;
+    }
 
-      String storeId = replicaIds.get(0).getPartitionId().toString();
-      StorageManagerMetrics metrics = new StorageManagerMetrics(new MetricRegistry());
-      Store store = new BlobStore("storeId", config, scheduler, new DiskIOScheduler(null), metrics,
-          replicaIds.get(0).getReplicaPath(), replicaIds.get(0).getCapacityInBytes(), factory,
-          new DummyMessageStoreRecovery(), new DummyMessageStoreHardDelete(dummyMap), SystemTime.getInstance());
-      store.start();
-
-      // put blobs
-      MessageWriteSet set = new MockMessageWriteSet(ByteBuffer.wrap(bufToWrite), listInfo);
-      store.put(set);
-
-      // get them
-      ArrayList<StoreKey> keys = new ArrayList<StoreKey>(5);
-      keys.add(blobId1);
-      keys.add(blobId2);
-      keys.add(blobId3);
-      keys.add(blobId4);
-      keys.add(blobId5);
-      StoreInfo info = store.get(keys, EnumSet.noneOf(StoreGetOptions.class));
-      MessageReadSet readSet = info.getMessageReadSet();
-      Assert.assertEquals(readSet.count(), 5);
-      byte[] output = new byte[1000];
-      readSet.writeTo(0, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 0; i < 1000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i]);
-      }
-      readSet.writeTo(1, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 1000; i < 2000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i - 1000]);
-      }
-      readSet.writeTo(2, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 2000; i < 3000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i - 2000]);
-      }
-      readSet.writeTo(3, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 3000; i < 4000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i - 3000]);
-      }
-      readSet.writeTo(4, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 4000; i < 5000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i - 4000]);
-      }
-
-      // delete a few ids
-      byte[] bufToDelete = new byte[3000];
-      new Random().nextBytes(bufToDelete);
-
-      MessageInfo info1d = new MessageInfo(blobId1, 1000, 1234);
-      MessageInfo info4d = new MessageInfo(blobId4, 1000, 1234);
-      MessageInfo info3d = new MessageInfo(blobId3, 1000, 1234);
-      ArrayList<MessageInfo> listInfo1 = new ArrayList<MessageInfo>(3);
-      listInfo1.add(info1d);
-      listInfo1.add(info4d);
-      listInfo1.add(info3d);
-      MessageWriteSet setToDelete = new MockMessageWriteSet(ByteBuffer.wrap(bufToDelete), listInfo1);
-      store.delete(setToDelete);
-
-      info = store.get(keys, EnumSet.of(StoreGetOptions.Store_Include_Deleted));
-      readSet = info.getMessageReadSet();
-      Assert.assertEquals(readSet.count(), 5);
-      Assert.assertEquals(readSet.sizeInBytes(0), 1000);
-      Assert.assertEquals(readSet.sizeInBytes(1), 1000);
-      Assert.assertEquals(readSet.sizeInBytes(2), 1000);
-      Assert.assertEquals(readSet.sizeInBytes(3), 1000);
-      Assert.assertEquals(readSet.sizeInBytes(4), 1000);
-
-      output = new byte[1000];
-      readSet.writeTo(0, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 0; i < 1000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i]);
-      }
-      readSet.writeTo(1, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 1000; i < 2000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i - 1000]);
-      }
-      readSet.writeTo(2, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 2000; i < 3000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i - 2000]);
-      }
-      readSet.writeTo(3, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 3000; i < 4000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i - 3000]);
-      }
-      readSet.writeTo(4, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 4000; i < 5000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i - 4000]);
-      }
-    } finally {
-      if (map != null) {
-        map.cleanup();
-      }
+    @Override
+    public CallableResult call() throws Exception {
+      return new CallableResult(null, store.get(Collections.singletonList(id), storeGetOptions));
     }
   }
 
-  @Test
-  public void storeShutdownTest() throws Exception {
-    MockClusterMap map = null;
-    try {
-      ScheduledExecutorService scheduler = Utils.newScheduler(4, "thread", false);
-      Properties props = new Properties();
-      VerifiableProperties verifyProperty = new VerifiableProperties(props);
-      verifyProperty.verify();
-      StoreConfig config = new StoreConfig(verifyProperty);
-      map = new MockClusterMap();
-      DataNodeId dataNodeId1 = map.getDataNodeIds().get(0);
-      StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      List<ReplicaId> replicaIds = map.getReplicaIds(map.getDataNodeId("localhost", dataNodeId1.getPort()));
-      String storeId = replicaIds.get(0).getPartitionId().toString();
-      StorageManagerMetrics metrics = new StorageManagerMetrics(new MetricRegistry());
-      Store store = new BlobStore(storeId, config, scheduler, new DiskIOScheduler(null), metrics,
-          replicaIds.get(0).getReplicaPath(), replicaIds.get(0).getCapacityInBytes(), factory,
-          new DummyMessageStoreRecovery(), new DummyMessageStoreHardDelete(), SystemTime.getInstance());
-      store.start();
-      byte[] bufToWrite = new byte[2000];
-      new Random().nextBytes(bufToWrite);
-      MockId blobId1 = new MockId("id1");
-      MockId blobId2 = new MockId("id2");
-      MessageInfo info1 = new MessageInfo(blobId1, 1000);
-      MessageInfo info2 = new MessageInfo(blobId2, 1000);
-      ArrayList<MessageInfo> listInfo = new ArrayList<MessageInfo>(2);
-      listInfo.add(info1);
-      listInfo.add(info2);
+  /**
+   * Deletes a blob.
+   */
+  private class Deleter implements Callable<CallableResult> {
 
-      MessageWriteSet set = new MockMessageWriteSet(ByteBuffer.wrap(bufToWrite), listInfo);
-      store.put(set);
+    final MockId id;
 
-      // verify existance
-      ArrayList<StoreKey> keys = new ArrayList<StoreKey>();
-      keys.add(blobId1);
-      keys.add(blobId2);
-      StoreInfo info = store.get(keys, EnumSet.noneOf(StoreGetOptions.class));
-      MessageReadSet readSet = info.getMessageReadSet();
-      Assert.assertEquals(readSet.count(), 2);
+    /**
+     * @param id the {@link MockId} to delete.
+     */
+    Deleter(MockId id) {
+      this.id = id;
+    }
 
-      // close store
+    @Override
+    public CallableResult call() throws Exception {
+      delete(id);
+      return EMPTY_RESULT;
+    }
+  }
+
+  // used by getUniqueId() to make sure keys are never regenerated in a single test run.
+  private final Set<MockId> generatedKeys = new HashSet<>();
+  // A map of all the keys. The key is the MockId and the value is a Pair that contains the metadata and data of the
+  // message.
+  private final Map<MockId, Pair<MessageInfo, ByteBuffer>> allKeys = new HashMap<>();
+  // A list of keys grouped by the log segment that they belong to
+  private final List<Set<MockId>> idsByLogSegment = new ArrayList<>();
+  // Set of all deleted keys
+  private final Set<MockId> deletedKeys = new HashSet<>();
+  // Set of all expired keys
+  private final Set<MockId> expiredKeys = new HashSet<>();
+  // Set of all keys that are not deleted/expired
+  private final Set<MockId> liveKeys = new HashSet<>();
+
+  // Indicates whether the log is segmented
+  private final boolean isLogSegmented;
+  // Variables that represent the folder where the data resides
+  private final File tempDir;
+  private final String tempDirStr;
+  // the time instance that will be used in the index
+  private final Time time = new MockTime();
+
+  private final String storeId = UtilsTest.getRandomString(10);
+  private final DiskIOScheduler diskIOScheduler = new DiskIOScheduler(null);
+  private final ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
+  private final Properties properties = new Properties();
+
+  // The BlobStore instance
+  private BlobStore store;
+  // The MessageStoreRecovery that is used with the BlobStore
+  private MessageStoreRecovery recovery = new DummyMessageStoreRecovery();
+  // The MessageStoreHardDelete that is used with the BlobStore
+  private MessageStoreHardDelete hardDelete = new MockMessageStoreHardDelete();
+  // The MetricRegistry that is used with the index
+  private MetricRegistry metricRegistry;
+
+  /**
+   * Running for both segmented and non-segmented log.
+   * @return an array with both {@code false} and {@code true}.
+   */
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][]{{false}, {true}});
+  }
+
+  /**
+   * Creates a temporary directory and sets up some test state.
+   * @throws IOException
+   */
+  public BlobStoreTest(boolean isLogSegmented) throws InterruptedException, IOException, StoreException {
+    this.isLogSegmented = isLogSegmented;
+    tempDir = StoreTestUtils.createTempDirectory("storeDir-" + UtilsTest.getRandomString(10));
+    tempDirStr = tempDir.getAbsolutePath();
+    setupTestState();
+  }
+
+  /**
+   * Releases all resources and deletes the temporary directory.
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  @After
+  public void cleanup() throws InterruptedException, IOException, StoreException {
+    if (store.isStarted()) {
       store.shutdown();
+    }
+    scheduler.shutdown();
+    assertTrue(scheduler.awaitTermination(1, TimeUnit.SECONDS));
+    assertTrue(tempDir.getAbsolutePath() + " could not be deleted", StoreTestUtils.cleanDirectory(tempDir, true));
+  }
 
-      try {
-        store.get(keys, EnumSet.noneOf(StoreGetOptions.class));
-        Assert.assertTrue(false);
-      } catch (StoreException e) {
-        Assert.assertTrue(e.getErrorCode() == StoreErrorCodes.Store_Not_Started);
+  /**
+   * Tests {@link BlobStore#start()} for corner cases and error cases.
+   * Corner cases
+   * 1. Creating a directory on first startup
+   * Error cases
+   * 1. Start an already started store.
+   * 2. Unable to create store directory on first startup.
+   * 3. Starting two stores at the same path.
+   * 4. Directory not readable.
+   * 5. Path is not a directory.
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void storeStartupTests() throws IOException, StoreException {
+    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+
+    // attempt to start when store is already started fails
+    verifyStartupFailure(store, StoreErrorCodes.Store_Already_Started);
+
+    String nonExistentDir = new File(tempDir, UtilsTest.getRandomString(10)).getAbsolutePath();
+
+    // fail if attempt to create directory fails
+    String badPath = new File(nonExistentDir, UtilsTest.getRandomString(10)).getAbsolutePath();
+    MetricRegistry registry = new MetricRegistry();
+    StorageManagerMetrics metrics = new StorageManagerMetrics(registry);
+    BlobStore blobStore =
+        new BlobStore(storeId, config, scheduler, diskIOScheduler, metrics, badPath, LOG_CAPACITY, STORE_KEY_FACTORY,
+            recovery, hardDelete, time);
+    verifyStartupFailure(blobStore, StoreErrorCodes.Initialization_Error);
+
+    // create directory if it does not exist
+    registry = new MetricRegistry();
+    metrics = new StorageManagerMetrics(registry);
+    blobStore = new BlobStore(storeId, config, scheduler, diskIOScheduler, metrics, nonExistentDir, LOG_CAPACITY,
+        STORE_KEY_FACTORY, recovery, hardDelete, time);
+    verifyStartupSuccess(blobStore);
+    File createdDir = new File(nonExistentDir);
+    assertTrue("Directory should now exist", createdDir.exists() && createdDir.isDirectory());
+
+    // should not be able to start two stores at the same path
+    registry = new MetricRegistry();
+    metrics = new StorageManagerMetrics(registry);
+    blobStore = new BlobStore(storeId, config, scheduler, diskIOScheduler, metrics, nonExistentDir, LOG_CAPACITY,
+        STORE_KEY_FACTORY, recovery, hardDelete, time);
+    blobStore.start();
+    registry = new MetricRegistry();
+    metrics = new StorageManagerMetrics(registry);
+    BlobStore secondStore =
+        new BlobStore(storeId, config, scheduler, diskIOScheduler, metrics, nonExistentDir, LOG_CAPACITY,
+            STORE_KEY_FACTORY, recovery, hardDelete, time);
+    verifyStartupFailure(secondStore, StoreErrorCodes.Initialization_Error);
+    blobStore.shutdown();
+
+    // fail if directory is not readable
+    assertTrue("Could not set readable state to false", createdDir.setReadable(false));
+    verifyStartupFailure(blobStore, StoreErrorCodes.Initialization_Error);
+
+    assertTrue("Could not set readable state to true", createdDir.setReadable(true));
+    assertTrue("Directory could not be deleted", StoreTestUtils.cleanDirectory(createdDir, true));
+
+    // fail if provided path is not a directory
+    File file = new File(tempDir, UtilsTest.getRandomString(10));
+    assertTrue("Test file could not be created", file.createNewFile());
+    file.deleteOnExit();
+    registry = new MetricRegistry();
+    metrics = new StorageManagerMetrics(registry);
+    blobStore =
+        new BlobStore(storeId, config, scheduler, diskIOScheduler, metrics, file.getAbsolutePath(), LOG_CAPACITY,
+            STORE_KEY_FACTORY, recovery, hardDelete, time);
+    verifyStartupFailure(blobStore, StoreErrorCodes.Initialization_Error);
+  }
+
+  /**
+   * Does a basic test by getting all the blobs that were put (and deleted) during the test setup. This implicitly tests
+   * all three of PUT, GET and DELETE.
+   * </p>
+   * Also tests GET with different combinations of {@link StoreGetOptions}.
+   * @throws InterruptedException
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void basicTest() throws InterruptedException, IOException, StoreException {
+    // PUT a key that is slated to expire when time advances by 2ms
+    MockId addedId = put(1, PUT_RECORD_SIZE, time.milliseconds() + 1).get(0);
+    time.sleep(2);
+    liveKeys.remove(addedId);
+    expiredKeys.add(addedId);
+
+    // GET of all the keys implicitly tests the PUT and DELETE.
+    // live keys
+    StoreInfo storeInfo = store.get(new ArrayList<>(liveKeys), EnumSet.noneOf(StoreGetOptions.class));
+    checkStoreInfo(storeInfo, liveKeys);
+
+    MockMessageStoreHardDelete hd = (MockMessageStoreHardDelete) hardDelete;
+    for (MockId id : deletedKeys) {
+      hd.setMessageInfo(allKeys.get(id).getFirst());
+
+      // cannot get without StoreGetOptions
+      verifyGetFailure(id, StoreErrorCodes.ID_Deleted);
+
+      // with StoreGetOptions.Store_Include_Deleted
+      storeInfo = store.get(Collections.singletonList(id), EnumSet.of(StoreGetOptions.Store_Include_Deleted));
+      checkStoreInfo(storeInfo, Collections.singleton(id));
+
+      // with all StoreGetOptions
+      storeInfo = store.get(Collections.singletonList(id), EnumSet.allOf(StoreGetOptions.class));
+      checkStoreInfo(storeInfo, Collections.singleton(id));
+    }
+
+    for (MockId id : expiredKeys) {
+      // cannot get without StoreGetOptions
+      verifyGetFailure(id, StoreErrorCodes.TTL_Expired);
+
+      // with StoreGetOptions.Store_Include_Expired
+      storeInfo = store.get(Collections.singletonList(id), EnumSet.of(StoreGetOptions.Store_Include_Expired));
+      checkStoreInfo(storeInfo, Collections.singleton(id));
+
+      // with all StoreGetOptions
+      storeInfo = store.get(Collections.singletonList(id), EnumSet.allOf(StoreGetOptions.class));
+      checkStoreInfo(storeInfo, Collections.singleton(id));
+    }
+
+    // should be able to delete expired blobs
+    delete(addedId);
+
+    // non existent ID has to fail
+    verifyGetFailure(getUniqueId(), StoreErrorCodes.ID_Not_Found);
+  }
+
+  /**
+   * Tests the case where there are many concurrent PUTs.
+   * @throws Exception
+   */
+  @Test
+  public void concurrentPutTest() throws Exception {
+    long blobCount = 4000 / PUT_RECORD_SIZE + 1;
+    List<Putter> putters = new ArrayList<>((int) blobCount);
+    for (int i = 0; i < blobCount; i++) {
+      putters.add(new Putter());
+    }
+    ExecutorService executorService = Executors.newFixedThreadPool(putters.size());
+    List<Future<CallableResult>> futures = executorService.invokeAll(putters);
+    verifyPutFutures(putters, futures);
+  }
+
+  /**
+   * Tests the case where there are many concurrent GETs.
+   * @throws Exception
+   */
+  @Test
+  public void concurrentGetTest() throws Exception {
+    long extraBlobCount = 4000 / PUT_RECORD_SIZE + 1;
+    put((int) extraBlobCount, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    List<Getter> getters = new ArrayList<>(allKeys.size());
+    for (MockId id : allKeys.keySet()) {
+      getters.add(new Getter(id, EnumSet.noneOf(StoreGetOptions.class)));
+    }
+    ExecutorService executorService = Executors.newFixedThreadPool(getters.size());
+    List<Future<CallableResult>> futures = executorService.invokeAll(getters);
+    verifyGetFutures(getters, futures);
+  }
+
+  /**
+   * Tests the case where there are many concurrent DELETEs.
+   * @throws Exception
+   */
+  @Test
+  public void concurrentDeleteTest() throws Exception {
+    long extraBlobCount = 2000 / PUT_RECORD_SIZE + 1;
+    put((int) extraBlobCount, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    List<Deleter> deleters = new ArrayList<>(liveKeys.size());
+    for (MockId id : liveKeys) {
+      deleters.add(new Deleter(id));
+    }
+    ExecutorService executorService = Executors.newFixedThreadPool(deleters.size());
+    List<Future<CallableResult>> futures = executorService.invokeAll(deleters);
+    verifyDeleteFutures(deleters, futures);
+  }
+
+  /**
+   * Tests the case where there are concurrent PUTs, GETs and DELETEs.
+   * @throws Exception
+   */
+  @Test
+  public void concurrentAllTest() throws Exception {
+    long putBlobCount = 1500 / PUT_RECORD_SIZE + 1;
+    List<Putter> putters = new ArrayList<>((int) putBlobCount);
+    for (int i = 0; i < putBlobCount; i++) {
+      putters.add(new Putter());
+    }
+
+    List<Getter> getters = new ArrayList<>(liveKeys.size());
+    for (MockId id : liveKeys) {
+      getters.add(new Getter(id, EnumSet.allOf(StoreGetOptions.class)));
+    }
+
+    long deleteBlobCount = 1500 / PUT_RECORD_SIZE;
+    List<MockId> idsToDelete = put((int) deleteBlobCount, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    List<Deleter> deleters = new ArrayList<>((int) deleteBlobCount);
+    for (MockId id : idsToDelete) {
+      deleters.add(new Deleter(id));
+    }
+
+    List<Callable<CallableResult>> callables = new ArrayList<Callable<CallableResult>>(putters);
+    callables.addAll(getters);
+    callables.addAll(deleters);
+
+    ExecutorService executorService = Executors.newFixedThreadPool(callables.size());
+    List<Future<CallableResult>> futures = executorService.invokeAll(callables);
+    verifyPutFutures(putters, futures.subList(0, putters.size()));
+    verifyGetFutures(getters, futures.subList(putters.size(), putters.size() + getters.size()));
+    verifyDeleteFutures(deleters, futures.subList(putters.size() + getters.size(), callables.size()));
+  }
+
+  /**
+   * Tests error cases for {@link BlobStore#put(MessageWriteSet)}.
+   */
+  @Test
+  public void putErrorCasesTest() {
+    // ID that exists
+    // live
+    verifyPutFailure(liveKeys.iterator().next(), StoreErrorCodes.Already_Exist);
+    // expired
+    verifyPutFailure(expiredKeys.iterator().next(), StoreErrorCodes.Already_Exist);
+    // deleted
+    verifyPutFailure(deletedKeys.iterator().next(), StoreErrorCodes.Already_Exist);
+  }
+
+  /**
+   * Tests error cases for {@link BlobStore#delete(MessageWriteSet)}.
+   */
+  @Test
+  public void deleteErrorCasesTest() {
+    // ID that is already deleted
+    verifyDeleteFailure(deletedKeys.iterator().next(), StoreErrorCodes.ID_Deleted);
+    // ID that does not exist
+    verifyDeleteFailure(getUniqueId(), StoreErrorCodes.ID_Not_Found);
+  }
+
+  /**
+   * Tests {@link BlobStore#findEntriesSince(FindToken, long)}.
+   * <p/>
+   * This test is minimal for two reasons
+   * 1. The BlobStore simply calls into the index for this function and the index has extensive tests for this.
+   * 2. It is almost impossible to validate the StoreFindToken here.
+   * If the first condition changes, then more tests will be required here
+   * @throws StoreException
+   */
+  @Test
+  public void findEntriesSinceTest() throws StoreException {
+    FindInfo findInfo = store.findEntriesSince(new StoreFindToken(), Long.MAX_VALUE);
+    Set<StoreKey> keysPresent = new HashSet<>();
+    for (MessageInfo info : findInfo.getMessageEntries()) {
+      keysPresent.add(info.getStoreKey());
+    }
+    assertEquals("All keys were not present in the return from findEntriesSince()", allKeys.keySet(), keysPresent);
+  }
+
+  /**
+   * Tests {@link BlobStore#findMissingKeys(List)}.
+   * @throws StoreException
+   */
+  @Test
+  public void findMissingKeysTest() throws StoreException {
+    List<StoreKey> idsToProvide = new ArrayList<StoreKey>(allKeys.keySet());
+    Set<StoreKey> nonExistentIds = new HashSet<>();
+    for (int i = 0; i < 10; i++) {
+      nonExistentIds.add(getUniqueId());
+    }
+    idsToProvide.addAll(nonExistentIds);
+    Collections.shuffle(idsToProvide);
+    Set<StoreKey> missingKeys = store.findMissingKeys(idsToProvide);
+    assertEquals("Set of missing keys not as expected", nonExistentIds, missingKeys);
+  }
+
+  /**
+   * Tests {@link BlobStore#isKeyDeleted(StoreKey)} including error cases.
+   * @throws StoreException
+   */
+  @Test
+  public void isKeyDeletedTest() throws StoreException {
+    for (MockId id : allKeys.keySet()) {
+      assertEquals("Returned state is not as expected", deletedKeys.contains(id), store.isKeyDeleted(id));
+    }
+    // non existent id
+    try {
+      store.isKeyDeleted(getUniqueId());
+      fail("Getting the deleted state of a non existent key should have failed");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.ID_Not_Found, e.getErrorCode());
+    }
+  }
+
+  /**
+   * Tests store shutdown and the ability to do operations when a store is shutdown or has not been started yet.
+   * @throws StoreException
+   */
+  @Test
+  public void shutdownTest() throws StoreException {
+    store.shutdown();
+    // no operations should be possible if store is not up or has been shutdown
+    verifyOperationFailuresOnInactiveStore(store);
+    StorageManagerMetrics metrics = new StorageManagerMetrics(new MetricRegistry());
+    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+    store =
+        new BlobStore(storeId, config, scheduler, diskIOScheduler, metrics, tempDirStr, LOG_CAPACITY, STORE_KEY_FACTORY,
+            recovery, hardDelete, time);
+    verifyOperationFailuresOnInactiveStore(store);
+  }
+
+  // helpers
+  // general
+
+  /**
+   * @return a {@link MockId} that is unique and has not been generated before in this run.
+   */
+  private MockId getUniqueId() {
+    MockId id;
+    do {
+      id = new MockId(UtilsTest.getRandomString(10));
+    } while (generatedKeys.contains(id));
+    generatedKeys.add(id);
+    return id;
+  }
+
+  /**
+   * Puts some blobs into the {@link BlobStore}.
+   * @param count the number of blobs to PUT.
+   * @param size the size of each blob.
+   * @param expiresAtMs the expiry time (in ms) of each blob.
+   * @return the {@link MockId}s of the blobs created.
+   * @throws StoreException
+   */
+  private List<MockId> put(int count, long size, long expiresAtMs) throws StoreException {
+    if (count <= 0) {
+      throw new IllegalArgumentException("Number of put entries to add cannot be <= 0");
+    }
+    List<MockId> ids = new ArrayList<>(count);
+    List<MessageInfo> infos = new ArrayList<>(count);
+    List<ByteBuffer> buffers = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      MockId id = getUniqueId();
+      MessageInfo info = new MessageInfo(id, size, expiresAtMs);
+      ByteBuffer buffer = ByteBuffer.wrap(TestUtils.getRandomBytes((int) size));
+      ids.add(id);
+      infos.add(info);
+      buffers.add(buffer);
+      allKeys.put(id, new Pair<>(info, buffer));
+      if (expiresAtMs != Utils.Infinite_Time && expiresAtMs < time.milliseconds()) {
+        expiredKeys.add(id);
+      } else {
+        liveKeys.add(id);
       }
-    } finally {
-      if (map != null) {
-        map.cleanup();
+    }
+    store.put(new MockMessageWriteSet(infos, buffers));
+    return ids;
+  }
+
+  /**
+   * Deletes a blob
+   * @param idToDelete the {@link MockId} of the blob to DELETE.
+   * @return the {@link MessageInfo} associated with the DELETE.
+   * @throws StoreException
+   */
+  private MessageInfo delete(MockId idToDelete) throws StoreException {
+    MessageInfo info = new MessageInfo(idToDelete, DELETE_RECORD_SIZE);
+    ByteBuffer buffer = ByteBuffer.allocate((int) DELETE_RECORD_SIZE);
+    store.delete(new MockMessageWriteSet(Collections.singletonList(info), Collections.singletonList(buffer)));
+    deletedKeys.add(idToDelete);
+    return info;
+  }
+
+  /**
+   * Verifies the provided {@code storeInfo} for correctness of the {@link MessageInfo}. Also reads the blob as
+   * described by the {@link MessageReadSet} inside {@code storeInfo} to verify that it matches the reference.
+   * @param storeInfo the {@link StoreInfo} to verify.
+   * @param expectedKeys all the {@link MockId}s that are expected to be found in {@code storeInfo}.
+   * @throws IOException
+   */
+  private void checkStoreInfo(StoreInfo storeInfo, Set<MockId> expectedKeys) throws IOException {
+    List<MessageInfo> messageInfos = storeInfo.getMessageReadSetInfo();
+    MessageReadSet readSet = storeInfo.getMessageReadSet();
+    assertEquals("ReadSet contains an unexpected number of messages", expectedKeys.size(), readSet.count());
+    Set<MockId> examinedKeys = new HashSet<>();
+    for (int i = 0; i < messageInfos.size(); i++) {
+      MessageInfo messageInfo = messageInfos.get(i);
+      MockId id = (MockId) messageInfo.getStoreKey();
+      MessageInfo expectedInfo = allKeys.get(id).getFirst();
+      assertEquals("Unexpected size in MessageInfo", expectedInfo.getSize(), messageInfo.getSize());
+      assertEquals("Unexpected expiresAtMs in MessageInfo", expectedInfo.getExpirationTimeInMs(),
+          messageInfo.getExpirationTimeInMs());
+
+      assertEquals("Unexpected key in readSet", id, readSet.getKeyAt(i));
+      assertEquals("Unexpected size in ReadSet", expectedInfo.getSize(), readSet.sizeInBytes(i));
+      ByteBuffer readBuf = ByteBuffer.allocate((int) expectedInfo.getSize());
+      ByteBufferOutputStream stream = new ByteBufferOutputStream(readBuf);
+      WritableByteChannel channel = Channels.newChannel(stream);
+      readSet.writeTo(i, channel, 0, expectedInfo.getSize());
+      ByteBuffer expectedData = allKeys.get(id).getSecond();
+      assertArrayEquals("Data obtained from reset does not match original", expectedData.array(), readBuf.array());
+      examinedKeys.add(id);
+    }
+    assertEquals("Expected and examined keys do not match", expectedKeys, examinedKeys);
+  }
+
+  /**
+   * Verifies that a GET of {@code id} fails.
+   * @param id the {@link MockId} to GET.
+   * @param expectedErrorCode the {@link StoreErrorCodes} for the failure.
+   */
+  private void verifyGetFailure(MockId id, StoreErrorCodes expectedErrorCode) {
+    try {
+      store.get(Collections.singletonList(id), EnumSet.noneOf(StoreGetOptions.class));
+      fail("Should not be able to GET " + id);
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", expectedErrorCode, e.getErrorCode());
+    }
+  }
+
+  // test setup helpers
+
+  /**
+   * Sets up some state in order to make sure all cases are represented and the tests don't need to do any setup
+   * individually. For understanding the created store, please read the source code which is annotated with comments.
+   * @throws InterruptedException
+   * @throws StoreException
+   */
+  private void setupTestState() throws InterruptedException, StoreException {
+    long segmentCapacity = isLogSegmented ? SEGMENT_CAPACITY : LOG_CAPACITY;
+    metricRegistry = new MetricRegistry();
+    StorageManagerMetrics metrics = new StorageManagerMetrics(metricRegistry);
+    properties.put("store.index.max.number.of.inmem.elements", Integer.toString(MAX_IN_MEM_ELEMENTS));
+    properties.put("store.segment.size.in.bytes", Long.toString(segmentCapacity));
+    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+    store =
+        new BlobStore(storeId, config, scheduler, diskIOScheduler, metrics, tempDirStr, LOG_CAPACITY, STORE_KEY_FACTORY,
+            recovery, hardDelete, time);
+    store.start();
+    // advance time by a millisecond in order to be able to add expired keys and to avoid keys that are expired from
+    // being picked for delete.
+    time.sleep(1);
+    long expectedStoreSize;
+    if (!isLogSegmented) {
+      // log is filled about ~50%.
+      expectedStoreSize = segmentCapacity / 2;
+      addCuratedData(expectedStoreSize, 0);
+    } else {
+      expectedStoreSize = segmentCapacity;
+      // first log segment is filled to capacity.
+      addCuratedData(segmentCapacity, 0);
+      assertEquals("Store size not as expected", expectedStoreSize, store.getSizeInBytes());
+
+      // second log segment is filled but has some space at the end (free space has to be less than the lesser of the
+      // standard delete and put record sizes so that the next write causes a roll over of log segments).
+      long sizeToWrite = segmentCapacity - (DELETE_RECORD_SIZE - 1);
+      expectedStoreSize += sizeToWrite;
+      addCuratedData(sizeToWrite, 1);
+      assertEquals("Store size not as expected", expectedStoreSize, store.getSizeInBytes());
+
+      // third log segment is partially filled and is left as the "active" segment
+      sizeToWrite = segmentCapacity / 3;
+      // First Index Segment
+      // 1 PUT entry
+      MockId addedId = put(1, PUT_RECORD_SIZE, Utils.Infinite_Time).get(0);
+      idsByLogSegment.add(new HashSet<MockId>());
+      idsByLogSegment.get(2).add(addedId);
+      // 1 DELETE for a key in the first log segment
+      MockId idToDelete = getIdToDelete(idsByLogSegment.get(0));
+      delete(idToDelete);
+      idsByLogSegment.get(2).add(idToDelete);
+      // 1 DELETE for a key in the second log segment
+      idToDelete = getIdToDelete(idsByLogSegment.get(1));
+      delete(idToDelete);
+      idsByLogSegment.get(2).add(idToDelete);
+      // 1 DELETE for the PUT in the same log segment
+      deletedKeys.add(addedId);
+      liveKeys.remove(addedId);
+      delete(addedId);
+      // 1 PUT entry that spans the rest of the data in the segment (upto a third of the segment size)
+      long size = sizeToWrite - (LogSegment.HEADER_SIZE + PUT_RECORD_SIZE + 3 * DELETE_RECORD_SIZE);
+      addedId = put(1, size, Utils.Infinite_Time).get(0);
+      idsByLogSegment.get(2).add(addedId);
+      // the store counts the wasted space at the end of the second segment as "used capacity".
+      expectedStoreSize = 2 * segmentCapacity + sizeToWrite;
+      assertEquals("Store size not as expected", expectedStoreSize, store.getSizeInBytes());
+      // fourth and fifth log segment are free.
+    }
+    // make sure all indexes are written to disk and mapped as required (forcing IndexPersistor to run).
+    reloadStore();
+    assertEquals("Store size not as expected", expectedStoreSize, store.getSizeInBytes());
+  }
+
+  /**
+   * Adds some curated data into the store in order to ensure a good mix for testing. For understanding the created
+   * store, please read the source code which is annotated with comments.
+   * @param sizeToWrite the size to add for.
+   * @param logSegmentIndex the index of the log segment being written to (0 being the first one).
+   * @throws StoreException
+   */
+  private void addCuratedData(long sizeToWrite, int logSegmentIndex) throws StoreException {
+    Set<MockId> idsInLogSegment = new HashSet<>();
+    idsByLogSegment.add(idsInLogSegment);
+    List<Set<MockId>> idsGroupedByIndexSegment = new ArrayList<>();
+    int deletedKeyCount = 0;
+
+    Set<MockId> idsInIndexSegment = new HashSet<>();
+    // First Index Segment
+    // 1 PUT
+    idsInIndexSegment.addAll(put(1, PUT_RECORD_SIZE, Utils.Infinite_Time));
+    // 2 more PUT
+    idsInIndexSegment.addAll(put(2, PUT_RECORD_SIZE, Utils.Infinite_Time));
+    // 2 PUT EXPIRED
+    idsInIndexSegment.addAll(put(2, PUT_RECORD_SIZE, 0));
+    idsGroupedByIndexSegment.add(idsInIndexSegment);
+    idsInLogSegment.addAll(idsInIndexSegment);
+
+    idsInIndexSegment = new HashSet<>();
+    // Second Index Segment
+    // 4 PUT
+    idsInIndexSegment.addAll(put(4, PUT_RECORD_SIZE, Utils.Infinite_Time));
+    // 1 DELETE for a PUT in the same index segment
+    delete(getIdToDelete(idsInIndexSegment));
+    deletedKeyCount++;
+    // 1 DELETE for a PUT in the first index segment
+    delete(getIdToDelete(idsGroupedByIndexSegment.get(0)));
+    deletedKeyCount++;
+    idsGroupedByIndexSegment.add(idsInIndexSegment);
+    idsInLogSegment.addAll(idsInIndexSegment);
+
+    // Third and Fourth Index Segment
+    for (int seg = 0; seg < 2; seg++) {
+      idsInIndexSegment = new HashSet<>();
+      // 3 PUT
+      idsInIndexSegment.addAll(put(3, PUT_RECORD_SIZE, Utils.Infinite_Time));
+      // 1 PUT for an expired blob
+      MockId expiredId = put(1, PUT_RECORD_SIZE, 0).get(0);
+      idsInIndexSegment.add(expiredId);
+      // 1 DELETE for the expired PUT
+      delete(expiredId);
+      deletedKeys.add(expiredId);
+      expiredKeys.remove(expiredId);
+      deletedKeyCount++;
+      // 1 PUT
+      idsInIndexSegment.addAll(put(1, PUT_RECORD_SIZE, Utils.Infinite_Time));
+      idsGroupedByIndexSegment.add(idsInIndexSegment);
+      idsInLogSegment.addAll(idsInIndexSegment);
+    }
+
+    idsInIndexSegment = new HashSet<>();
+    // Fifth Index Segment
+    // 1 PUT entry
+    idsInIndexSegment.addAll(put(1, PUT_RECORD_SIZE, Utils.Infinite_Time));
+    // 1 DELETE for a PUT in each of the third and fourth segments
+    delete(getIdToDelete(idsGroupedByIndexSegment.get(2)));
+    deletedKeyCount++;
+    delete(getIdToDelete(idsGroupedByIndexSegment.get(3)));
+    deletedKeyCount++;
+    // 1 DELETE for the PUT in the same segment
+    delete(getIdToDelete(idsInIndexSegment));
+    deletedKeyCount++;
+    // 1 PUT entry that spans the rest of the data in the segment
+    idsInLogSegment.addAll(idsInIndexSegment);
+
+    long sizeWritten = isLogSegmented ? LogSegment.HEADER_SIZE : 0;
+    sizeWritten += idsInLogSegment.size() * PUT_RECORD_SIZE + deletedKeyCount * DELETE_RECORD_SIZE;
+    MockId id = put(1, sizeToWrite - sizeWritten, Utils.Infinite_Time).get(0);
+    idsInIndexSegment.add(id);
+    idsGroupedByIndexSegment.add(idsInIndexSegment);
+    idsInLogSegment.add(id);
+  }
+
+  /**
+   * Gets an id to delete from {@code ids} by picking the first live key encountered.
+   * @param ids the {@link MockId}s to choose from
+   * @return an id to delete from {@code ids}
+   */
+  private MockId getIdToDelete(Set<MockId> ids) {
+    MockId deleteCandidate = null;
+    for (MockId id : ids) {
+      if (liveKeys.contains(id)) {
+        deleteCandidate = id;
+        break;
+      }
+    }
+    if (deleteCandidate == null) {
+      throw new IllegalStateException("Could not find a key to delete in set: " + ids);
+    }
+    deletedKeys.add(deleteCandidate);
+    liveKeys.remove(deleteCandidate);
+    return deleteCandidate;
+  }
+
+  /**
+   * Shuts down and restarts the store. All further tests will implcitly test persistence.
+   * @throws StoreException
+   */
+  private void reloadStore() throws StoreException {
+    if (store.isStarted()) {
+      store.shutdown();
+    }
+    assertFalse("Store should be shutdown", store.isStarted());
+    metricRegistry = new MetricRegistry();
+    StorageManagerMetrics metrics = new StorageManagerMetrics(metricRegistry);
+    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+    store =
+        new BlobStore(storeId, config, scheduler, diskIOScheduler, metrics, tempDirStr, LOG_CAPACITY, STORE_KEY_FACTORY,
+            recovery, hardDelete, time);
+    assertFalse("Store should not be started", store.isStarted());
+    store.start();
+    assertTrue("Store should be started", store.isStarted());
+  }
+
+  // storeStartupTests() helpers
+
+  /**
+   * Verifies that {@link BlobStore#start()} executes successfully and shuts down the store.
+   * @param blobStore the {@link BlobStore} to start.
+   * @throws StoreException
+   */
+  private void verifyStartupSuccess(BlobStore blobStore) throws StoreException {
+    blobStore.start();
+    assertTrue("Store has not been started", blobStore.isStarted());
+    blobStore.shutdown();
+  }
+
+  /**
+   * Verifies that {@link BlobStore#start()} fails.
+   * @param blobStore the {@link BlobStore} to start.
+   * @param expectedErrorCode the expected {@link StoreErrorCodes} for the failure.
+   */
+  private void verifyStartupFailure(BlobStore blobStore, StoreErrorCodes expectedErrorCode) {
+    try {
+      blobStore.start();
+      fail("Store start should have failed");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", expectedErrorCode, e.getErrorCode());
+    }
+  }
+
+  // concurrent tests helpers
+
+  /**
+   * Verifies that the blobs have been successfully put and the GETs them to make sure the metadata and data match the
+   * reference.
+   * @param putters list of {@link Putter} instances.
+   * @param futures list of {@link Future}s returned from submitting the {@code putters} to an {@link ExecutorService}
+   * @throws Exception
+   */
+  private void verifyPutFutures(List<Putter> putters, List<Future<CallableResult>> futures) throws Exception {
+    for (int i = 0; i < putters.size(); i++) {
+      Future<CallableResult> future = futures.get(i);
+      MockId id = future.get(1, TimeUnit.SECONDS).id;
+      StoreInfo storeInfo = store.get(Collections.singletonList(id), EnumSet.noneOf(StoreGetOptions.class));
+      checkStoreInfo(storeInfo, Collections.singleton(id));
+    }
+  }
+
+  /**
+   * Verifies that the GETs initiated by the {@code getters} are successful and consistent with the state expected i.e.
+   * live, expired or deleted. If live, return value is also verified for correctness.
+   * @param getters list of {@link Getter} instances.
+   * @param futures  list of {@link Future}s returned from submitting the {@code getters} to an {@link ExecutorService}
+   * @throws Exception
+   */
+  private void verifyGetFutures(List<Getter> getters, List<Future<CallableResult>> futures) throws Exception {
+    for (int i = 0; i < getters.size(); i++) {
+      MockId id = getters.get(i).id;
+      Future<CallableResult> future = futures.get(i);
+      if (liveKeys.contains(id)) {
+        StoreInfo storeInfo = future.get(1, TimeUnit.SECONDS).storeInfo;
+        checkStoreInfo(storeInfo, Collections.singleton(getters.get(i).id));
+      } else {
+        try {
+          future.get(1, TimeUnit.SECONDS);
+          fail("Operation should have failed");
+        } catch (ExecutionException e) {
+          StoreException storeException = (StoreException) e.getCause();
+          StoreErrorCodes expectedCode = StoreErrorCodes.ID_Not_Found;
+          if (deletedKeys.contains(id)) {
+            expectedCode = StoreErrorCodes.ID_Deleted;
+          } else if (expiredKeys.contains(id)) {
+            expectedCode = StoreErrorCodes.TTL_Expired;
+          }
+          assertEquals("Unexpected StoreErrorCode", expectedCode, storeException.getErrorCode());
+        }
       }
     }
   }
 
-  @Test
-  public void storeRecoverTest() {
-
+  /**
+   * Verifies that the deletes are successful. Also ensures that a GET for the {@link MockId} fails with
+   * {@link StoreErrorCodes#ID_Deleted}.
+   * @param deleters list of {@link Deleter} instances.
+   * @param futures list of {@link Future}s returned from submitting the {@code deleters} to an {@link ExecutorService}
+   * @throws Exception
+   */
+  private void verifyDeleteFutures(List<Deleter> deleters, List<Future<CallableResult>> futures) throws Exception {
+    for (int i = 0; i < deleters.size(); i++) {
+      MockId id = deleters.get(i).id;
+      Future<CallableResult> future = futures.get(i);
+      future.get(1, TimeUnit.SECONDS);
+      verifyGetFailure(id, StoreErrorCodes.ID_Deleted);
+    }
   }
 
-  @Test
-  public void storeTTLTest() throws Exception {
-    MockClusterMap map = null;
-    try {
-      ScheduledExecutorService scheduler = Utils.newScheduler(4, "thread", false);
-      Properties props = new Properties();
-      VerifiableProperties verifyProperty = new VerifiableProperties(props);
-      verifyProperty.verify();
-      StoreConfig config = new StoreConfig(verifyProperty);
-      map = new MockClusterMap();
-      DataNodeId dataNodeId1 = map.getDataNodeIds().get(0);
-      MockTime mockTime = new MockTime();
-      StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      List<ReplicaId> replicaIds = map.getReplicaIds(dataNodeId1);
-      String storeId = replicaIds.get(0).getPartitionId().toString();
-      StorageManagerMetrics metrics = new StorageManagerMetrics(new MetricRegistry());
-      Store store = new BlobStore(storeId, config, scheduler, new DiskIOScheduler(null), metrics,
-          replicaIds.get(0).getReplicaPath(), replicaIds.get(0).getCapacityInBytes(), factory,
-          new DummyMessageStoreRecovery(), new DummyMessageStoreHardDelete(), mockTime);
-      store.start();
-      byte[] bufToWrite = new byte[1000];
-      new Random().nextBytes(bufToWrite);
-      MockId blobId = new MockId("id1");
-      Long ttl = 60L * Time.MsPerSec;
-      MessageInfo messageInfo = new MessageInfo(blobId, 1000, mockTime.currentMilliseconds + ttl);
-      ArrayList<MessageInfo> listInfo = new ArrayList<MessageInfo>();
-      listInfo.add(messageInfo);
-      MessageWriteSet set = new MockMessageWriteSet(ByteBuffer.wrap(bufToWrite), listInfo);
-      store.put(set);
-      mockTime.sleep(30L * Time.MsPerSec);
+  // putErrorCasesTest() helpers
 
-      // verify existence
-      ArrayList<StoreKey> keyList = new ArrayList<StoreKey>();
-      keyList.add(blobId);
-      EnumSet<StoreGetOptions> storeGetOptions = EnumSet.noneOf(StoreGetOptions.class);
-      StoreInfo storeInfo = store.get(keyList, storeGetOptions);
-      MessageReadSet readSet = storeInfo.getMessageReadSet();
-      Assert.assertEquals(readSet.count(), 1);
-      Assert.assertEquals(readSet.sizeInBytes(0), 1000);
-      byte[] output = new byte[1000];
-      readSet.writeTo(0, Channels.newChannel(new ByteBufferOutputStream(ByteBuffer.wrap(output))), 0, 1000);
-      for (int i = 0; i < 1000; i++) {
-        Assert.assertEquals(bufToWrite[i], output[i]);
-      }
-      mockTime.sleep(60L * Time.MsPerSec);
-      try {
-        storeInfo = store.get(keyList, storeGetOptions);
-        Assert.fail("Blob already expired. Should throw exception here.");
-      } catch (StoreException e) {
-        Assert.assertEquals(e.getErrorCode(), StoreErrorCodes.TTL_Expired);
-      }
-    } finally {
-      if (map != null) {
-        map.cleanup();
-      }
+  /**
+   * Verifies that PUT fails.
+   * @param idToPut the {@link MockId} to PUT.
+   * @param expectedErrorCode the expected {@link StoreErrorCodes} for the failure.
+   */
+  private void verifyPutFailure(MockId idToPut, StoreErrorCodes expectedErrorCode) {
+    MessageInfo info = new MessageInfo(idToPut, PUT_RECORD_SIZE);
+    MessageWriteSet writeSet =
+        new MockMessageWriteSet(Collections.singletonList(info), Collections.singletonList(ByteBuffer.allocate(1)));
+    try {
+      store.put(writeSet);
+      fail("Store PUT should have failed");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", expectedErrorCode, e.getErrorCode());
+    }
+  }
+
+  // deleteErrorCasesTest() helpers
+
+  /**
+   * Verifies that DELETE fails.
+   * @param idToDelete the {@link MockId} to DELETE.
+   * @param expectedErrorCode the expected {@link StoreErrorCodes} for the failure.
+   */
+  private void verifyDeleteFailure(MockId idToDelete, StoreErrorCodes expectedErrorCode) {
+    MessageInfo info = new MessageInfo(idToDelete, DELETE_RECORD_SIZE);
+    MessageWriteSet writeSet =
+        new MockMessageWriteSet(Collections.singletonList(info), Collections.singletonList(ByteBuffer.allocate(1)));
+    try {
+      store.delete(writeSet);
+      fail("Store DELETE should have failed");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", expectedErrorCode, e.getErrorCode());
+    }
+  }
+
+  // shutdownTest() helpers
+
+  /**
+   * Verifies that operations on {@link BlobStore} fail because it is inactive.
+   * @param blobStore the inactive {@link BlobStore} on which the operations are performed.
+   */
+  private void verifyOperationFailuresOnInactiveStore(BlobStore blobStore) {
+    try {
+      blobStore.get(Collections.EMPTY_LIST, EnumSet.noneOf(StoreGetOptions.class));
+      fail("Operation should have failed because store is inactive");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.Store_Not_Started, e.getErrorCode());
+    }
+
+    try {
+      blobStore.put(new MockMessageWriteSet(Collections.EMPTY_LIST, Collections.EMPTY_LIST));
+      fail("Operation should have failed because store is inactive");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.Store_Not_Started, e.getErrorCode());
+    }
+
+    try {
+      blobStore.delete(new MockMessageWriteSet(Collections.EMPTY_LIST, Collections.EMPTY_LIST));
+      fail("Operation should have failed because store is inactive");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.Store_Not_Started, e.getErrorCode());
+    }
+
+    try {
+      blobStore.findEntriesSince(new StoreFindToken(), Long.MAX_VALUE);
+      fail("Operation should have failed because store is inactive");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.Store_Not_Started, e.getErrorCode());
+    }
+
+    try {
+      blobStore.findMissingKeys(Collections.EMPTY_LIST);
+      fail("Operation should have failed because store is inactive");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.Store_Not_Started, e.getErrorCode());
+    }
+
+    try {
+      blobStore.isKeyDeleted(getUniqueId());
+      fail("Operation should have failed because store is inactive");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.Store_Not_Started, e.getErrorCode());
+    }
+
+    try {
+      blobStore.shutdown();
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.Store_Not_Started, e.getErrorCode());
     }
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -1,0 +1,518 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Tests for {@link IndexSegment}.s
+ */
+public class IndexSegmentTest {
+  private static final int CUSTOM_ID_SIZE = 10;
+  private static final int KEY_SIZE = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE)).sizeInBytes();
+  private static final int VALUE_SIZE = new IndexValue(0, new Offset("", 0)).getBytes().capacity();
+  private static final StoreConfig STORE_CONFIG = new StoreConfig(new VerifiableProperties(new Properties()));
+  private static final long DELETE_FILE_SPAN_SIZE = 10;
+  private static final StoreKeyFactory STORE_KEY_FACTORY;
+
+  static {
+    try {
+      STORE_KEY_FACTORY = Utils.getObj("com.github.ambry.store.MockIdFactory");
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private final File tempDir;
+  private final StoreMetrics metrics;
+
+  /**
+   * Creates a temporary directory and sets up metrics.
+   * @throws IOException
+   */
+  public IndexSegmentTest() throws IOException {
+    tempDir = StoreTestUtils.createTempDirectory("indexSegmentDir-" + UtilsTest.getRandomString(10));
+    metrics = new StoreMetrics(tempDir.getAbsolutePath(), new MetricRegistry());
+  }
+
+  /**
+   * Deletes the temporary directory.
+   * @throws IOException
+   */
+  @After
+  public void cleanup() throws IOException {
+    assertTrue(tempDir.getAbsolutePath() + " could not be deleted", StoreTestUtils.cleanDirectory(tempDir, true));
+  }
+
+  /**
+   * Comprehensive tests for {@link IndexSegment}.
+   * 1. Creates a segment and checks the getters to make sure they return the right values
+   * 2. Adds some put entries with random sizes, checks getters again and exercises {@link IndexSegment#find(StoreKey)}
+   * and {@link IndexSegment#getEntriesSince(StoreKey, FindEntriesCondition, List, AtomicLong)}.
+   * 3. Adds some delete entries (deletes some existing put entries and creates deletes for puts not in this segment)
+   * and does the same checks as #2.
+   * 4. Writes index to a file and loads it mapped and unmapped and does all the checks in #2 once again along with
+   * checking that journal entries are populated correctly.
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void comprehensiveTest() throws IOException, StoreException {
+    String[] logSegmentNames = {LogSegmentNameHelper.generateFirstSegmentName(1), generateRandomLogSegmentName()};
+    for (String logSegmentName : logSegmentNames) {
+      long writeStartOffset = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+      Offset startOffset = new Offset(logSegmentName, writeStartOffset);
+      NavigableMap<MockId, IndexValue> referenceIndex = new TreeMap<>();
+      IndexSegment indexSegment = generateIndexSegment(startOffset);
+      verifyIndexSegmentDetails(indexSegment, startOffset, 0, false, startOffset.getOffset());
+      int numItems = 10;
+      List<Long> offsets = new ArrayList<>();
+      offsets.add(writeStartOffset);
+      for (int i = 0; i < numItems - 1; i++) {
+        // size has to be > 0 (no record is 0 sized)
+        long size = Utils.getRandomLong(TestUtils.RANDOM, 1000) + 1;
+        offsets.add(writeStartOffset + size);
+        writeStartOffset += size;
+      }
+      long lastEntrySize = Utils.getRandomLong(TestUtils.RANDOM, 1000) + 1;
+      long endOffset = offsets.get(offsets.size() - 1) + lastEntrySize;
+      addPutEntries(offsets, lastEntrySize, indexSegment, referenceIndex);
+      verifyIndexSegmentDetails(indexSegment, startOffset, offsets.size(), false, endOffset);
+      verifyFind(referenceIndex, indexSegment);
+      verifyGetEntriesSince(referenceIndex, indexSegment);
+
+      int extraIdsToDelete = 10;
+      Set<MockId> idsToDelete = getIdsToDelete(referenceIndex, extraIdsToDelete);
+      Map<Offset, MockId> extraOffsetsToCheck = addDeleteEntries(idsToDelete, indexSegment, referenceIndex);
+      endOffset += idsToDelete.size() * DELETE_FILE_SPAN_SIZE;
+      numItems += extraIdsToDelete;
+      verifyIndexSegmentDetails(indexSegment, startOffset, numItems, false, endOffset);
+      verifyFind(referenceIndex, indexSegment);
+      verifyGetEntriesSince(referenceIndex, indexSegment);
+
+      // write to file
+      indexSegment.writeIndexSegmentToFile(indexSegment.getEndOffset());
+      verifyReadFromFile(referenceIndex, indexSegment.getFile(), startOffset, numItems, endOffset, extraOffsetsToCheck);
+    }
+  }
+
+  /**
+   * Tests the case when {@link IndexSegment#writeIndexSegmentToFile(Offset)} is provided with different offsets <=
+   * {@link IndexSegment#getEndOffset()} and makes sure that only the relevant parts of the segment are written to disk.
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void partialWriteTest() throws IOException, StoreException {
+    String prevLogSegmentName = LogSegmentNameHelper.getName(0, 0);
+    String logSegmentName = LogSegmentNameHelper.getNextPositionName(prevLogSegmentName);
+    Offset startOffset = new Offset(logSegmentName, 0);
+    MockId id1 = new MockId("id1");
+    MockId id2 = new MockId("id2");
+    MockId id3 = new MockId("id3");
+    IndexValue value1 = new IndexValue(1000, new Offset(logSegmentName, 0), (byte) 0, Utils.Infinite_Time);
+    IndexValue value2 = new IndexValue(1000, new Offset(logSegmentName, 1000), (byte) 0, Utils.Infinite_Time);
+    IndexValue value3 = new IndexValue(1000, new Offset(logSegmentName, 2000), (byte) 0, Utils.Infinite_Time);
+    IndexSegment indexSegment = generateIndexSegment(startOffset);
+    // inserting in the opposite order by design to ensure that writes are based on offset ordering and not key ordering
+    indexSegment.addEntry(new IndexEntry(id3, value1), new Offset(logSegmentName, 1000));
+    indexSegment.addEntry(new IndexEntry(id2, value2), new Offset(logSegmentName, 2000));
+    indexSegment.addEntry(new IndexEntry(id1, value3), new Offset(logSegmentName, 3000));
+
+    // provide end offset such that nothing is written
+    indexSegment.writeIndexSegmentToFile(new Offset(prevLogSegmentName, 0));
+    assertFalse("Index file should not have been created", indexSegment.getFile().exists());
+    List<MockId> shouldBeFound = new ArrayList<>();
+    List<MockId> shouldNotBeFound = new ArrayList<>(Arrays.asList(id3, id2, id1));
+    for (int safeEndPoint = 1000; safeEndPoint <= 3000; safeEndPoint += 1000) {
+      shouldBeFound.add(shouldNotBeFound.remove(0));
+      // repeat twice
+      for (int i = 0; i < 2; i++) {
+        indexSegment.writeIndexSegmentToFile(new Offset(logSegmentName, safeEndPoint));
+        Journal journal = new Journal(tempDir.getAbsolutePath(), 3, 3);
+        IndexSegment fromDisk =
+            new IndexSegment(indexSegment.getFile(), false, STORE_KEY_FACTORY, STORE_CONFIG, metrics, journal);
+        for (MockId id : shouldBeFound) {
+          assertNotNull("Value for key should have been found", fromDisk.find(id));
+        }
+        for (MockId id : shouldNotBeFound) {
+          assertNull("Value for key should not have been found", fromDisk.find(id));
+        }
+      }
+    }
+  }
+
+  // helpers
+  // comprehensiveTest() helpers
+
+  /**
+   * @return a random log segment name.
+   */
+  private String generateRandomLogSegmentName() {
+    long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    return LogSegmentNameHelper.getName(pos, gen);
+  }
+
+  /**
+   * Generates an {@link IndexSegment} for entries from {@code startOffset}.
+   * @param startOffset the start {@link Offset} of the {@link IndexSegment}.
+   * @returnn an {@link IndexSegment} for entries from {@code startOffset}.
+   */
+  private IndexSegment generateIndexSegment(Offset startOffset) {
+    return new IndexSegment(tempDir.getAbsolutePath(), startOffset, STORE_KEY_FACTORY, KEY_SIZE, VALUE_SIZE,
+        STORE_CONFIG, metrics);
+  }
+
+  /**
+   * Creates an {@link IndexSegment} from the given {@code file}.
+   * @param file the {@link File} to use to build the {@link IndexSegment}.
+   * @param isMapped {@code true} if the segment needs to be mmapped, {@code false} for holding entries in memory.
+   * @param journal the {@link Journal} to use.
+   * @return an {@link IndexSegment} from the given {@code file}.
+   * @throws StoreException
+   */
+  private IndexSegment createIndexSegmentFromFile(File file, boolean isMapped, Journal journal) throws StoreException {
+    return new IndexSegment(file, isMapped, STORE_KEY_FACTORY, STORE_CONFIG, metrics, journal);
+  }
+
+  /**
+   * Adds put entries at offsets {@code offsets} into {@code segment}. The {@code offsets} are assumed to be contiguous
+   * with no breaks.
+   * @param offsets the offsets to add the entries at. Difference b/w two entries will be used to compute size.
+   * @param lastEntrySize the size of the last entry in {@code offsets}.
+   * @param segment the {@link IndexSegment} to add the entries to.
+   * @param referenceIndex the {@link NavigableMap} to add all the entries to. This repreents the source of truth for
+   *                       all checks.
+   * @throws StoreException
+   */
+  private void addPutEntries(List<Long> offsets, long lastEntrySize, IndexSegment segment,
+      NavigableMap<MockId, IndexValue> referenceIndex) throws StoreException {
+    for (int i = 0; i < offsets.size(); i++) {
+      MockId id;
+      do {
+        id = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE));
+      } while (referenceIndex.containsKey(id));
+      long offset = offsets.get(i);
+      long size = i == offsets.size() - 1 ? lastEntrySize : offsets.get(i + 1) - offset;
+      IndexValue value =
+          new IndexValue(size, new Offset(segment.getLogSegmentName(), offset), (byte) 0, Utils.Infinite_Time);
+      segment.addEntry(new IndexEntry(id, value), new Offset(segment.getLogSegmentName(), offset + size));
+      referenceIndex.put(id, value);
+    }
+  }
+
+  /**
+   * Verifies the getters of the {@link IndexSegment} and makes sure the values returned by them match the reference
+   * values.
+   * @param indexSegment the {@link IndexSegment} to test.
+   * @param startOffset the expected start {@link Offset} of the {@code indexSegment}
+   * @param numItems the expected numner of items the {@code indexSegment}
+   * @param isMapped the expected mapped state of the {@code indexSegment}
+   * @param endOffset the expected end offset of the {@code indexSegment}
+   */
+  private void verifyIndexSegmentDetails(IndexSegment indexSegment, Offset startOffset, int numItems, boolean isMapped,
+      long endOffset) {
+    String logSegmentName = startOffset.getName();
+    long indexEntrySize = KEY_SIZE + VALUE_SIZE;
+    assertEquals("LogSegment name not as expected", logSegmentName, indexSegment.getLogSegmentName());
+    assertEquals("Start offset not as expected", startOffset, indexSegment.getStartOffset());
+    assertEquals("End offset not as expected", new Offset(logSegmentName, endOffset), indexSegment.getEndOffset());
+    assertEquals("Mapped state is incorrect", isMapped, indexSegment.isMapped());
+    assertEquals("Key size is incorrect", KEY_SIZE, indexSegment.getKeySize());
+    assertEquals("Value size is incorrect", VALUE_SIZE, indexSegment.getValueSize());
+    if (!isMapped) {
+      assertEquals("Size written not as expected", indexEntrySize * numItems, indexSegment.getSizeWritten());
+      assertEquals("Number of items not as expected", numItems, indexSegment.getNumberOfItems());
+    }
+
+    String expectedFilename =
+        startOffset.getOffset() + BlobStore.SEPARATOR + PersistentIndex.INDEX_SEGMENT_FILE_NAME_SUFFIX;
+    if (!logSegmentName.isEmpty()) {
+      expectedFilename = logSegmentName + BlobStore.SEPARATOR + expectedFilename;
+    }
+    String path = tempDir.getAbsolutePath() + File.separator + expectedFilename;
+    assertEquals("File path not as expected", path, indexSegment.getFile().getAbsolutePath());
+    assertEquals("Segment start offset from filename not as expected", startOffset,
+        IndexSegment.getIndexSegmentStartOffset(indexSegment.getFile().getName()));
+  }
+
+  /**
+   * Verifies {@link IndexSegment#find(StoreKey)} to make sure that it returns/does not return values.
+   * @param referenceIndex the index entries to be used as reference.
+   * @param segment the {@link IndexSegment} to test
+   * @throws StoreException
+   */
+  private void verifyFind(NavigableMap<MockId, IndexValue> referenceIndex, IndexSegment segment) throws StoreException {
+    for (Map.Entry<MockId, IndexValue> entry : referenceIndex.entrySet()) {
+      IndexValue referenceValue = entry.getValue();
+      IndexValue valueFromSegment = segment.find(entry.getKey());
+      assertNotNull("Value obtained from segment is null", valueFromSegment);
+      assertEquals("Offset is not equal", referenceValue.getOffset(), valueFromSegment.getOffset());
+      assertEquals("Value is not equal", referenceValue.getBytes(), valueFromSegment.getBytes());
+    }
+    // try to find a key that does not exist.
+    MockId id = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE));
+    assertNull("Should have failed to find non existent key", segment.find(id));
+  }
+
+  /**
+   * Verifies {@link IndexSegment#getEntriesSince(StoreKey, FindEntriesCondition, List, AtomicLong)} to make sure that
+   * it returns the right values for all keys in {@code referenceIndex} and for all conditions.
+   * @param referenceIndex the index entries to be used as reference.
+   * @param segment the {@link IndexSegment} to test
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void verifyGetEntriesSince(NavigableMap<MockId, IndexValue> referenceIndex, IndexSegment segment)
+      throws IOException, StoreException {
+    // index segment is "too" recent
+    FindEntriesCondition condition = new FindEntriesCondition(Long.MAX_VALUE, segment.getLastModifiedTime() - 1);
+    List<MessageInfo> entries = new ArrayList<>();
+    assertFalse("Should not have fetched entries since segment is too recent",
+        segment.getEntriesSince(null, condition, entries, new AtomicLong(0)));
+    assertEquals("Should not have fetched entries since segment is too recent", 0, entries.size());
+
+    long sizeLeftInSegment = segment.getEndOffset().getOffset() - segment.getStartOffset().getOffset();
+    getEntriesSinceTest(referenceIndex, segment, null, sizeLeftInSegment);
+    for (Map.Entry<MockId, IndexValue> entry : referenceIndex.entrySet()) {
+      sizeLeftInSegment -= entry.getValue().getSize();
+      getEntriesSinceTest(referenceIndex, segment, entry.getKey(), sizeLeftInSegment);
+    }
+  }
+
+  /**
+   * Verifies {@link IndexSegment#getEntriesSince(StoreKey, FindEntriesCondition, List, AtomicLong)} to make sure that
+   * it returns the right values for {@code idToCheck} for all size conditions.
+   * @param referenceIndex the index entries to be used as reference.
+   * @param segment the {@link IndexSegment} to test
+   * @param idToCheck the {@link MockId} to use as input for getEntriesSince().
+   * @param sizeLeftInSegment the total size of values in the segment beyond {@code idToCheck}.
+   * @throws IOException
+   */
+  private void getEntriesSinceTest(NavigableMap<MockId, IndexValue> referenceIndex, IndexSegment segment,
+      MockId idToCheck, long sizeLeftInSegment) throws IOException {
+    long maxSize = 0;
+    MockId idHigherThanIdToCheck = idToCheck == null ? referenceIndex.firstKey() : referenceIndex.higherKey(idToCheck);
+    MockId highestIdIncluded = null;
+    while (maxSize <= sizeLeftInSegment) {
+      MockId nextHighestIdIncluded =
+          highestIdIncluded == null ? idHigherThanIdToCheck : referenceIndex.higherKey(highestIdIncluded);
+      long existingSize = 0;
+      while (existingSize < maxSize) {
+        doGetEntriesSinceTest(referenceIndex, segment, idToCheck, maxSize, existingSize, highestIdIncluded);
+        existingSize += referenceIndex.get(highestIdIncluded).getSize();
+        highestIdIncluded = referenceIndex.lowerKey(highestIdIncluded);
+      }
+      doGetEntriesSinceTest(referenceIndex, segment, idToCheck, maxSize, maxSize, null);
+      if (nextHighestIdIncluded != null) {
+        highestIdIncluded = nextHighestIdIncluded;
+        maxSize += referenceIndex.get(highestIdIncluded).getSize();
+      } else {
+        break;
+      }
+    }
+    highestIdIncluded = referenceIndex.lastKey().equals(idToCheck) ? null : referenceIndex.lastKey();
+    // check the case where maxSize is more than the number of entries in the segment
+    doGetEntriesSinceTest(referenceIndex, segment, idToCheck, maxSize + 1, 0, highestIdIncluded);
+    // try to getEntriesSince a key that does not exist.
+    MockId id = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE));
+    doGetEntriesSinceTest(referenceIndex, segment, id, Long.MAX_VALUE, 0, null);
+  }
+
+  /**
+   * Does the {@link IndexSegment#getEntriesSince(StoreKey, FindEntriesCondition, List, AtomicLong)} and checks that
+   * all the returned entries are as expected and that all the entries expected have been returned.
+   * @param referenceIndex the index entries to be used as reference.
+   * @param segment the {@link IndexSegment} to test
+   * @param idToCheck the {@link MockId} to check.
+   * @param maxSize the parameter for {@link FindEntriesCondition#FindEntriesCondition(long)}.
+   * @param existingSize the third parameter for getEntriesSince().
+   * @param highestExpectedId the highest expected Id in the returned entries.
+   * @throws IOException
+   */
+  private void doGetEntriesSinceTest(NavigableMap<MockId, IndexValue> referenceIndex, IndexSegment segment,
+      MockId idToCheck, long maxSize, long existingSize, MockId highestExpectedId) throws IOException {
+    FindEntriesCondition condition = new FindEntriesCondition(maxSize);
+    List<MessageInfo> entries = new ArrayList<>();
+    assertEquals("Unexpected return value from getEntriesSince()", highestExpectedId != null,
+        segment.getEntriesSince(idToCheck, condition, entries, new AtomicLong(existingSize)));
+    if (highestExpectedId != null) {
+      assertEquals("Highest ID not as expected", highestExpectedId, entries.get(entries.size() - 1).getStoreKey());
+      MockId nextExpectedId = idToCheck == null ? referenceIndex.firstKey() : referenceIndex.higherKey(idToCheck);
+      for (MessageInfo info : entries) {
+        assertEquals("Entry is unexpected", nextExpectedId, info.getStoreKey());
+        nextExpectedId = referenceIndex.higherKey(nextExpectedId);
+      }
+    } else {
+      assertEquals("Entries list is not empty", 0, entries.size());
+    }
+  }
+
+  /**
+   * Gets some IDs for deleting. Picks alternate IDs from {@code referenceIndex} and randomly generates
+   * {@code outOfSegmentIdCount} ids.
+   * @param referenceIndex the index entries to pick for delete from.
+   * @param outOfSegmentIdCount the number of ids to be generated that are not in {@code referenceIndex}.
+   * @return a {@link Set} of IDs to create delete entries for.
+   */
+  private Set<MockId> getIdsToDelete(NavigableMap<MockId, IndexValue> referenceIndex, int outOfSegmentIdCount) {
+    Set<MockId> idsToDelete = new HashSet<>();
+    // return every alternate id in the map
+    boolean include = true;
+    for (MockId id : referenceIndex.keySet()) {
+      if (include) {
+        idsToDelete.add(id);
+      }
+      include = !include;
+    }
+    // generate some ids for delete
+    for (int i = 0; i < outOfSegmentIdCount; i++) {
+      MockId id;
+      do {
+        id = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE));
+      } while (idsToDelete.contains(id));
+      idsToDelete.add(id);
+    }
+    return idsToDelete;
+  }
+
+  /**
+   * Adds delete entries to {@code segment.}
+   * @param idsToDelete the {@link Set} of IDs to create delete entries for.
+   * @param segment the {@link IndexSegment} to add the entries to.
+   * @param referenceIndex the {@link NavigableMap} to add all the entries to. This repreents the source of truth for
+   *                       all checks.
+   * @return a {@link Map} that defines the put record offsets of keys whose index entries have been replaced by delete
+   * entries owing to the fact that the put and delete both occurred in the same index segment.
+   * @throws StoreException
+   */
+  private Map<Offset, MockId> addDeleteEntries(Set<MockId> idsToDelete, IndexSegment segment,
+      NavigableMap<MockId, IndexValue> referenceIndex) throws StoreException {
+    Map<Offset, MockId> putRecordOffsets = new HashMap<>();
+    for (MockId id : idsToDelete) {
+      Offset offset = segment.getEndOffset();
+      IndexValue value = segment.find(id);
+      if (value == null) {
+        // create an index value with a random log segment name
+        value = new IndexValue(1, new Offset(UtilsTest.getRandomString(1), 0), (byte) 0, Utils.Infinite_Time);
+      } else {
+        // if in this segment, add to putRecordOffsets so that journal can verify these later
+        putRecordOffsets.put(value.getOffset(), id);
+      }
+      IndexValue newValue =
+          new IndexValue(value.getSize(), value.getOffset(), value.getFlags(), value.getExpiresAtMs());
+      newValue.setFlag(IndexValue.Flags.Delete_Index);
+      newValue.setNewOffset(offset);
+      newValue.setNewSize(DELETE_FILE_SPAN_SIZE);
+      segment.addEntry(new IndexEntry(id, newValue),
+          new Offset(offset.getName(), offset.getOffset() + DELETE_FILE_SPAN_SIZE));
+      referenceIndex.put(id, newValue);
+    }
+    return putRecordOffsets;
+  }
+
+  /**
+   * Creates an {@link IndexSegment} from the given {@code file} and checks for both sanity and find operations.
+   * @param referenceIndex the index entries to be used as reference.
+   * @param file the {@link File} to be used to load the index.
+   * @param startOffset the expected start {@link Offset} of the {@link IndexSegment}
+   * @param numItems the expected numner of items the {@code indexSegment}
+   * @param endOffset the expected end offset of the {@code indexSegment}
+   * @param extraOffsetsToCheck a {@link Map} that defines the put record offsets of keys whose presence needs to be
+   *                            verified in the {@link Journal}.
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void verifyReadFromFile(NavigableMap<MockId, IndexValue> referenceIndex, File file, Offset startOffset,
+      int numItems, long endOffset, Map<Offset, MockId> extraOffsetsToCheck) throws IOException, StoreException {
+    // read from file (unmapped) and verify that everything is ok
+    Journal journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
+    IndexSegment fromDisk = createIndexSegmentFromFile(file, false, journal);
+    verifyIndexSegmentDetails(fromDisk, startOffset, numItems, false, endOffset);
+    verifyFind(referenceIndex, fromDisk);
+    verifyGetEntriesSince(referenceIndex, fromDisk);
+    // journal should contain all the entries
+    verifyJournal(referenceIndex, startOffset, journal, extraOffsetsToCheck);
+    fromDisk.map(true);
+
+    // read from file (mapped) and verify that everything is ok
+    journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
+    fromDisk = createIndexSegmentFromFile(file, true, journal);
+    verifyIndexSegmentDetails(fromDisk, startOffset, numItems, true, endOffset);
+    verifyFind(referenceIndex, fromDisk);
+    verifyGetEntriesSince(referenceIndex, fromDisk);
+    // journal should not contain any entries
+    assertNull("Journal should not have any entries", journal.getFirstOffset());
+  }
+
+  /**
+   * Verfies that the journal has all and only expected entries.
+   * @param referenceIndex the index entries to be used as reference.
+   * @param indexSegmentStartOffset the start offset of the {@link IndexSegment} that filled the journal.
+   * @param journal the {@link Journal} to check.
+   * @param extraOffsetsToCheck a {@link Map} that defines the put record offsets of keys whose presence needs to be
+   *                            verified in the {@link Journal}.
+   */
+  private void verifyJournal(NavigableMap<MockId, IndexValue> referenceIndex, Offset indexSegmentStartOffset,
+      Journal journal, Map<Offset, MockId> extraOffsetsToCheck) {
+    Set<StoreKey> seenKeys = new TreeSet<>();
+    Map<Offset, Boolean> extraEntriesCheckState = null;
+    if (extraOffsetsToCheck != null) {
+      extraEntriesCheckState = new HashMap<>();
+      for (Map.Entry<Offset, MockId> extra : extraOffsetsToCheck.entrySet()) {
+        extraEntriesCheckState.put(extra.getKey(), false);
+      }
+    }
+    List<JournalEntry> entries = journal.getEntriesSince(indexSegmentStartOffset, true);
+    for (JournalEntry entry : entries) {
+      StoreKey key = entry.getKey();
+      Offset offset = entry.getOffset();
+      seenKeys.add(key);
+      if (extraOffsetsToCheck != null && extraOffsetsToCheck.containsKey(offset) && extraOffsetsToCheck.get(offset)
+          .equals(key)) {
+        extraEntriesCheckState.put(offset, true);
+      }
+    }
+    assertEquals("Keys seen does not match keys in reference index", seenKeys.size(), referenceIndex.size());
+    seenKeys.containsAll(referenceIndex.keySet());
+    if (extraEntriesCheckState != null) {
+      assertFalse("One of the extraOffsetsToCheck was not found", extraEntriesCheckState.values().contains(false));
+    }
+  }
+}

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1,0 +1,1930 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NoSuchElementException;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Tests for {@link PersistentIndex}. Tests both segmented and non segmented log use cases.
+ */
+@RunWith(Parameterized.class)
+public class IndexTest {
+  private static final StoreKeyFactory STORE_KEY_FACTORY;
+  private static final byte[] RECOVERY_INFO = new byte[100];
+
+  static {
+    try {
+      STORE_KEY_FACTORY = Utils.getObj("com.github.ambry.store.MockIdFactory");
+      Arrays.fill(RECOVERY_INFO, (byte) 0);
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  // setupTestState() is coupled to these numbers. Changing them *will* cause setting test state or tests to fail.
+  private static final long LOG_CAPACITY = 10000;
+  private static final long SEGMENT_CAPACITY = 2000;
+  private static final int MAX_IN_MEM_ELEMENTS = 5;
+  // deliberately do not divide the capacities perfectly.
+  private static final long PUT_RECORD_SIZE = 53;
+  private static final long DELETE_RECORD_SIZE = 29;
+  private static final long HARD_DELETE_START_OFFSET = 11;
+  private static final long HARD_DELETE_LAST_PART_SIZE = 13;
+
+  // used by getUniqueId() to make sure keys are never regenerated in a single test run.
+  private final Set<MockId> generatedKeys = new HashSet<>();
+  // The reference index to compare against. Key is index segment start Offset, Value is the reference index segment.
+  // This reflects exactly how PersistentIndex is supposed to look.
+  private final TreeMap<Offset, TreeMap<MockId, IndexValue>> referenceIndex = new TreeMap<>();
+  // A map of all the keys. The key is the MockId and the value is a pair of index segment start Offsets.
+  // first Offset represents the index segment start offset of the PUT entry.
+  // second Offset represents the index segment start offset of the DELETE entry (null if the key has not been deleted).
+  private final Map<MockId, Pair<Offset, Offset>> indexSegmentStartOffsets = new HashMap<>();
+  // A map of all the keys. The key is the MockId and the value is a pair of IndexValues.
+  // The first IndexValue represents the value of the PUT entry.
+  // The second IndexValue represents the value of the DELETE entry (null if the key has not been deleted).
+  private final Map<MockId, Pair<IndexValue, IndexValue>> allKeys = new HashMap<>();
+  // Set of all deleted keys
+  private final Set<MockId> deletedKeys = new HashSet<>();
+  // Set of all expired keys
+  private final Set<MockId> expiredKeys = new HashSet<>();
+  // Set of all keys that are not deleted/expired
+  private final Set<MockId> liveKeys = new HashSet<>();
+  // The keys in offset order as they appear in the log.
+  private final TreeMap<Offset, Pair<MockId, IndexValue>> logOrder = new TreeMap<>();
+
+  // Indicates whether the log is segmented
+  private final boolean isLogSegmented;
+  // Variables that represent the folder where the data resides
+  private final File tempDir;
+  private final String tempDirStr;
+  // the time instance that will be used in the index
+  private final Time time = new MockTime();
+
+  private final ScheduledExecutorService scheduler = Utils.newScheduler(1, false);
+  private final Properties properties = new Properties();
+
+  // The Log which has the data
+  private Log log;
+  // The MessageStoreRecovery that is used with the index
+  private MessageStoreRecovery recovery = new DummyMessageStoreRecovery();
+  // The MessageStoreHardDelete that is used with the index
+  private MessageStoreHardDelete hardDelete = new MockMessageStoreHardDelete();
+  // The MetricRegistry that is used with the index
+  private MetricRegistry metricRegistry;
+  // The index of the log
+  private PersistentIndex index;
+  // The session ID associated with the index
+  private UUID sessionId;
+
+  /**
+   * Mock implementation of {@link MessageStoreHardDelete} that returns {@link MessageInfo} appropriately and
+   * zeroes out a well defined section of any offered blobs.
+   */
+  private class MockMessageStoreHardDelete implements MessageStoreHardDelete {
+
+    @Override
+    public Iterator<HardDeleteInfo> getHardDeleteMessages(MessageReadSet readSet, StoreKeyFactory factory,
+        List<byte[]> recoveryInfoList) {
+      /*
+       * Returns hard delete messages that zero out well known parts of the offered blobs.
+       */
+      class MockMessageStoreHardDeleteIterator implements Iterator<HardDeleteInfo> {
+        private final MessageReadSet readSet;
+        private int count = 0;
+
+        private MockMessageStoreHardDeleteIterator(MessageReadSet readSet) {
+          this.readSet = readSet;
+        }
+
+        @Override
+        public boolean hasNext() {
+          return count < readSet.count();
+        }
+
+        @Override
+        public HardDeleteInfo next() {
+          if (!hasNext()) {
+            throw new NoSuchElementException();
+          }
+          count++;
+          long size = readSet.sizeInBytes(count - 1) - HARD_DELETE_START_OFFSET - HARD_DELETE_LAST_PART_SIZE;
+          ByteBuffer buf = ByteBuffer.allocate((int) size);
+          Arrays.fill(buf.array(), (byte) 0);
+          ByteBufferInputStream stream = new ByteBufferInputStream(buf);
+          ReadableByteChannel channel = Channels.newChannel(stream);
+          return new HardDeleteInfo(channel, buf.capacity(), 100, RECOVERY_INFO);
+        }
+
+        @Override
+        public void remove() {
+          throw new UnsupportedOperationException();
+        }
+      }
+
+      return new MockMessageStoreHardDeleteIterator(readSet);
+    }
+
+    @Override
+    public MessageInfo getMessageInfo(Read read, long offset, StoreKeyFactory factory) {
+      String segmentName = ((LogSegment) read).getName();
+      Pair<MockId, IndexValue> idAndValue = logOrder.get(new Offset(segmentName, offset));
+      IndexValue value = idAndValue.getSecond();
+      return new MessageInfo(idAndValue.getFirst(), value.getSize(), value.getExpiresAtMs());
+    }
+  }
+
+  /**
+   * Running for both segmented and non-segmented log.
+   * @return an array with both {@code false} and {@code true}.
+   */
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][]{{false}, {true}});
+  }
+
+  /**
+   * Creates a temporary directory and sets up some test state.
+   * @throws IOException
+   */
+  public IndexTest(boolean isLogSegmented) throws InterruptedException, IOException, StoreException {
+    this.isLogSegmented = isLogSegmented;
+    tempDir = StoreTestUtils.createTempDirectory("indexDir-" + UtilsTest.getRandomString(10));
+    tempDirStr = tempDir.getAbsolutePath();
+    setupTestState();
+  }
+
+  /**
+   * Releases all resources and deletes the temporary directory.
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  @After
+  public void cleanup() throws InterruptedException, IOException, StoreException {
+    index.close();
+    log.close();
+    scheduler.shutdown();
+    assertTrue(scheduler.awaitTermination(1, TimeUnit.SECONDS));
+    assertTrue(tempDir.getAbsolutePath() + " could not be deleted", StoreTestUtils.cleanDirectory(tempDir, true));
+  }
+
+  /**
+   * Tests for {@link PersistentIndex#findKey(StoreKey)}.
+   * Cases:
+   * 1. Live keys
+   * 2. Expired keys
+   * 3. Deleted keys
+   * 4. Non existent keys
+   * @throws StoreException
+   */
+  @Test
+  public void findKeyTest() throws StoreException {
+    for (MockId id : allKeys.keySet()) {
+      IndexValue value = index.findKey(id);
+      verifyValue(id, value);
+    }
+    // search for a non existent key
+    MockId nonExistentId = getUniqueId();
+    verifyValue(nonExistentId, index.findKey(nonExistentId));
+  }
+
+  /**
+   * Tests for {@link PersistentIndex#findKey(StoreKey, FileSpan)}.
+   * Cases:
+   * 1. FileSpan exactly that of the message
+   * 2. FileSpan before and after message including it on the boundary
+   * 3. FileSpan that includes the message.
+   * 4. FileSpan before and after message not including it
+   * @throws StoreException
+   */
+  @Test
+  public void findKeyWithFileSpanTest() throws StoreException {
+    // using only liveKeys to simplify the test - behavior does not differ based on the type of entry.
+    for (MockId id : liveKeys) {
+      IndexValue expectedValue = getExpectedValue(id, true);
+      FileSpan fileSpanForMessage = log.getFileSpanForMessage(expectedValue.getOffset(), expectedValue.getSize());
+
+      // FileSpan that is exactly that of the message
+      verifyValue(id, index.findKey(id, fileSpanForMessage));
+
+      Offset indexSegmentStartOffset = indexSegmentStartOffsets.get(id).getFirst();
+      Offset lowerSegmentStartOffset = referenceIndex.lowerKey(indexSegmentStartOffset);
+      Offset higherSegmentStartOffset = referenceIndex.higherKey(indexSegmentStartOffset);
+
+      // FileSpan from start offset of message to index end offset
+      FileSpan fileSpan = new FileSpan(fileSpanForMessage.getStartOffset(), index.getCurrentEndOffset());
+      verifyValue(id, index.findKey(id, fileSpan));
+
+      // FileSpan from start offset of log to end offset of message
+      fileSpan = new FileSpan(log.getStartOffset(), fileSpanForMessage.getEndOffset());
+      verifyValue(id, index.findKey(id, fileSpan));
+
+      // FileSpan that includes the message
+      Offset startOffset = lowerSegmentStartOffset == null ? indexSegmentStartOffset : lowerSegmentStartOffset;
+      Offset endOffset = higherSegmentStartOffset == null ? index.getCurrentEndOffset() : higherSegmentStartOffset;
+      fileSpan = new FileSpan(startOffset, endOffset);
+      verifyValue(id, index.findKey(id, fileSpan));
+
+      if (higherSegmentStartOffset != null) {
+        // FileSpan higher than the entry (does not include entry)
+        fileSpan = new FileSpan(higherSegmentStartOffset, log.getEndOffset());
+        assertNull("There should have been no value returned", index.findKey(id, fileSpan));
+      }
+
+      if (lowerSegmentStartOffset != null) {
+        // FileSpan lower than the entry (does not include entry)
+        fileSpan = new FileSpan(log.getStartOffset(), lowerSegmentStartOffset);
+        assertNull("There should have been no value returned", index.findKey(id, fileSpan));
+      }
+    }
+  }
+
+  /**
+   * Tests {@link PersistentIndex#getBlobReadInfo(StoreKey, EnumSet)}.
+   * Cases (all cases on all types of keys - live, expired, deleted):
+   * 1. With no options
+   * 2. With combinations of parameters in {@link StoreGetOptions}.
+   * </p>
+   * Also tests non existent keys.
+   * @throws StoreException
+   */
+  @Test
+  public void getBlobReadInfoTest() throws StoreException {
+    final AtomicReference<MockId> idRequested = new AtomicReference<>();
+    hardDelete = new MessageStoreHardDelete() {
+      @Override
+      public Iterator<HardDeleteInfo> getHardDeleteMessages(MessageReadSet readSet, StoreKeyFactory factory,
+          List<byte[]> recoveryInfoList) throws IOException {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public MessageInfo getMessageInfo(Read read, long offset, StoreKeyFactory factory) throws IOException {
+        MockId id = idRequested.get();
+        if (id == null) {
+          throw new IllegalStateException("No ID was set before making a call to getBlobReadInfo()");
+        }
+        IndexValue value = getExpectedValue(id, true);
+        return new MessageInfo(id, value.getSize(), value.getExpiresAtMs());
+      }
+    };
+    reloadIndex(false);
+    List<EnumSet<StoreGetOptions>> allCombos = new ArrayList<>();
+    allCombos.add(EnumSet.noneOf(StoreGetOptions.class));
+    allCombos.add(EnumSet.of(StoreGetOptions.Store_Include_Expired));
+    allCombos.add(EnumSet.of(StoreGetOptions.Store_Include_Deleted));
+    allCombos.add(EnumSet.allOf(StoreGetOptions.class));
+    for (MockId id : allKeys.keySet()) {
+      idRequested.set(id);
+      for (EnumSet<StoreGetOptions> getOptions : allCombos) {
+        if (liveKeys.contains(id)) {
+          verifyBlobReadOptions(id, getOptions, null);
+        } else if (expiredKeys.contains(id)) {
+          StoreErrorCodes expectedErrorCode =
+              getOptions.contains(StoreGetOptions.Store_Include_Expired) ? null : StoreErrorCodes.TTL_Expired;
+          verifyBlobReadOptions(id, getOptions, expectedErrorCode);
+        } else if (deletedKeys.contains(id)) {
+          StoreErrorCodes expectedErrorCode =
+              getOptions.contains(StoreGetOptions.Store_Include_Deleted) ? null : StoreErrorCodes.ID_Deleted;
+          verifyBlobReadOptions(id, getOptions, expectedErrorCode);
+        }
+      }
+    }
+    // try to get BlobReadOption for a non existent key
+    MockId nonExistentId = getUniqueId();
+    verifyBlobReadOptions(nonExistentId, EnumSet.allOf(StoreGetOptions.class), StoreErrorCodes.ID_Not_Found);
+  }
+
+  /**
+   * Tests {@link PersistentIndex#findMissingKeys(List)}.
+   * @throws StoreException
+   */
+  @Test
+  public void findMissingKeysTest() throws StoreException {
+    List<StoreKey> idsToProvide = new ArrayList<StoreKey>(allKeys.keySet());
+    Set<StoreKey> nonExistentIds = new HashSet<>();
+    for (int i = 0; i < 10; i++) {
+      nonExistentIds.add(getUniqueId());
+    }
+    idsToProvide.addAll(nonExistentIds);
+    Collections.shuffle(idsToProvide);
+    Set<StoreKey> missingKeys = index.findMissingKeys(idsToProvide);
+    assertEquals("Set of missing keys not as expected", nonExistentIds, missingKeys);
+  }
+
+  /**
+   * Tests error cases for {@link PersistentIndex#addToIndex(IndexEntry, FileSpan)}.
+   * Cases:
+   * 1. FileSpan end offset < currentIndexEndOffset
+   * 2. FileSpan is across segments
+   * @throws StoreException
+   */
+  @Test
+  public void addEntryBadInputTest() throws StoreException {
+    // FileSpan end offset < currentIndexEndOffset
+    FileSpan fileSpan = log.getFileSpanForMessage(log.getStartOffset(), 1);
+    IndexValue value = new IndexValue(1, log.getStartOffset());
+    try {
+      index.addToIndex(new IndexEntry(getUniqueId(), value), fileSpan);
+      fail("Should have failed because filespan provided < currentIndexEndOffset");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+
+    if (isLogSegmented) {
+      // FileSpan spans across segments
+      Offset startOffset = index.getCurrentEndOffset();
+      String nextLogSegmentName = LogSegmentNameHelper.getNextPositionName(startOffset.getName());
+      Offset endOffset = new Offset(nextLogSegmentName, 0);
+      fileSpan = new FileSpan(startOffset, endOffset);
+      try {
+        index.addToIndex(new IndexEntry(getUniqueId(), value), fileSpan);
+        fail("Should have failed because fileSpan provided spanned across segments");
+      } catch (IllegalArgumentException e) {
+        // expected. Nothing to do.
+      }
+    }
+  }
+
+  /**
+   * Tests error cases for {@link PersistentIndex#markAsDeleted(StoreKey, FileSpan)}.
+   * Cases
+   * 1. FileSpan end offset < currentIndexEndOffset
+   * 2. FileSpan is across segments
+   * 3. ID does not exist
+   * 4. ID already deleted
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void markAsDeletedBadInputTest() throws IOException, StoreException {
+    // FileSpan end offset < currentIndexEndOffset
+    FileSpan fileSpan = log.getFileSpanForMessage(log.getStartOffset(), 1);
+    try {
+      index.markAsDeleted(liveKeys.iterator().next(), fileSpan);
+      fail("Should have failed because filespan provided < currentIndexEndOffset");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+
+    if (isLogSegmented) {
+      // FileSpan spans across segments
+      Offset startOffset = index.getCurrentEndOffset();
+      String nextLogSegmentName = LogSegmentNameHelper.getNextPositionName(startOffset.getName());
+      Offset endOffset = new Offset(nextLogSegmentName, 0);
+      fileSpan = new FileSpan(startOffset, endOffset);
+      try {
+        index.markAsDeleted(liveKeys.iterator().next(), fileSpan);
+        fail("Should have failed because fileSpan provided spanned across segments");
+      } catch (IllegalArgumentException e) {
+        // expected. Nothing to do.
+      }
+    }
+
+    appendToLog(5);
+    fileSpan = log.getFileSpanForMessage(index.getCurrentEndOffset(), 5);
+    // ID does not exist
+    try {
+      index.markAsDeleted(getUniqueId(), fileSpan);
+      fail("Should have failed because ID provided for delete does not exist");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.ID_Not_Found, e.getErrorCode());
+    }
+
+    // ID already deleted
+    try {
+      index.markAsDeleted(deletedKeys.iterator().next(), fileSpan);
+      fail("Should have failed because ID provided for delete is already deleted");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.ID_Deleted, e.getErrorCode());
+    }
+  }
+
+  /**
+   * Tests that hard delete is kicked off by the index.
+   * @throws StoreException
+   */
+  @Test
+  public void hardDeleteKickOffTest() throws StoreException {
+    assertFalse("HardDelete should not be running", index.hardDeleter.isRunning());
+    properties.put("store.enable.hard.delete", "true");
+    reloadIndex(false);
+    assertTrue("HardDelete is not running", index.hardDeleter.isRunning());
+  }
+
+  /**
+   * Tests that hard delete zeros out blobs correctly and makes progress as expected.
+   * @throws InterruptedException
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void hardDeleteTest() throws InterruptedException, IOException, StoreException {
+    properties.put("store.deleted.message.retention.days", Integer.toString(1));
+    properties.put("store.hard.delete.bytes.per.sec", Integer.toString(Integer.MAX_VALUE / 10));
+    reloadIndex(false);
+    index.hardDeleter.running.set(true);
+    assertFalse("Hard delete did work even though no message is past retention time", index.hardDeleter.hardDelete());
+    // IndexSegment still uses real time so advance time so that it goes 2 days past the real time.
+    advanceTime(SystemTime.getInstance().milliseconds() + 2 * Time.MsPerSec * Time.SecsPerDay);
+    assertTrue("Hard delete did not do any work", index.hardDeleter.hardDelete());
+    for (MockId id : deletedKeys) {
+      IndexValue putValue = allKeys.get(id).getFirst();
+      Offset offset = putValue.getOffset();
+      LogSegment segment = log.getSegment(offset.getName());
+      long size = putValue.getSize() - HARD_DELETE_START_OFFSET - HARD_DELETE_LAST_PART_SIZE;
+      ByteBuffer readBuf = ByteBuffer.allocate((int) size);
+      segment.readInto(readBuf, offset.getOffset() + HARD_DELETE_START_OFFSET);
+      readBuf.flip();
+      while (readBuf.hasRemaining()) {
+        assertEquals("Hard delete has not zeroed out the data", (byte) 0, readBuf.get());
+      }
+    }
+    index.hardDeleter.preLogFlush();
+    index.hardDeleter.postLogFlush();
+    long expectedProgress = log.getDifference(logOrder.lastKey(), new Offset(log.getFirstSegment().getName(), 0));
+    assertEquals("Hard delete has not processed all keys", expectedProgress, index.hardDeleter.getProgress());
+  }
+
+  /**
+   * Tests that expired values are correctly handled.
+   * @throws InterruptedException
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void expirationTest() throws InterruptedException, IOException, StoreException {
+    // add a PUT entry that will expire if time advances by a millisecond
+    addPutEntries(1, 1, time.milliseconds());
+    MockId id = logOrder.lastEntry().getValue().getFirst();
+    verifyBlobReadOptions(id, EnumSet.noneOf(StoreGetOptions.class), null);
+    advanceTime(1);
+    verifyBlobReadOptions(id, EnumSet.noneOf(StoreGetOptions.class), StoreErrorCodes.TTL_Expired);
+  }
+
+  /**
+   * Tests that end offsets are set correctly in log segments when the index is created.
+   * Cases
+   * 1. Current end offsets have been set correctly
+   * 2. Add data to log but not index, restart and check that end offsets have been reset.
+   * 3. Add data to log such that a new log segment is created but not to index, restart and check that the new log
+   * segment is gone.
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void setEndOffsetsTest() throws IOException, StoreException {
+    // check that current end offsets set are correct
+    LogSegment segment = log.getFirstSegment();
+    while (segment != null) {
+      Offset lastRecordStartOffset = getLastRecordOffset(segment);
+      long size = logOrder.get(lastRecordStartOffset).getSecond().getSize();
+      Offset expectedEndOffset = log.getFileSpanForMessage(lastRecordStartOffset, size).getEndOffset();
+      assertEquals("End offset of segment not as expected", expectedEndOffset.getOffset(), segment.getEndOffset());
+      segment = log.getNextSegment(segment);
+    }
+
+    // write some data to the log but not the index, check that end offset of the segment has changed
+    // reload the index and check the end offset has been reset
+    LogSegment activeSegment = log.getSegment(index.getCurrentEndOffset().getName());
+    long offsetBeforeAppend = activeSegment.getEndOffset();
+    appendToLog(PUT_RECORD_SIZE);
+    assertEquals("End offset of active segment did not change", offsetBeforeAppend + PUT_RECORD_SIZE,
+        activeSegment.getEndOffset());
+    reloadIndex(false);
+    assertEquals("End offset of active segment should have been reset", offsetBeforeAppend,
+        activeSegment.getEndOffset());
+
+    if (isLogSegmented) {
+      // this test works under the assumption that log segments are not allocated until they are required
+      // this is a fair assumption because the PersistentIndex works under the same assumption and would break if it
+      // were not true (which this test failing would indicate).
+
+      // write some data to the log but not the index such that new segment is created, check that end offset of the
+      // segment has changed and a new segment created, reload the index and check the end offset has been reset and
+      // the new segment does not exist.
+      activeSegment = log.getSegment(index.getCurrentEndOffset().getName());
+      offsetBeforeAppend = activeSegment.getEndOffset();
+      // fill up this segment
+      appendToLog(activeSegment.getCapacityInBytes() - activeSegment.getEndOffset());
+      assertEquals("End offset of active segment did not change", activeSegment.getCapacityInBytes(),
+          activeSegment.getEndOffset());
+      // write a little more so that a new segment is created
+      appendToLog(PUT_RECORD_SIZE);
+      LogSegment nextActiveSegment = log.getNextSegment(activeSegment);
+      assertNotNull("New segment has not been created", nextActiveSegment);
+      assertEquals("Unexpected end offset for new segment", PUT_RECORD_SIZE,
+          nextActiveSegment.getEndOffset() - nextActiveSegment.getStartOffset());
+      reloadIndex(false);
+      // there should no longer be a "next" segment to the old active segment
+      assertNull("There should have been no more segments", log.getNextSegment(activeSegment));
+      assertEquals("End offset of active segment should have been reset", offsetBeforeAppend,
+          activeSegment.getEndOffset());
+    }
+  }
+
+  /**
+   * Tests success cases for recovery.
+   * Cases
+   * 1. Single segment recovery
+   * 2. Multiple segment recovery
+   * 3. Recovery after index is completely lost
+   * In all cases, the tests also verify that end offsets are set correctly.
+   * @throws InterruptedException
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void recoverySuccessTest() throws InterruptedException, IOException, StoreException {
+    advanceTime(1);
+    singleSegmentRecoveryTest();
+    if (isLogSegmented) {
+      multipleSegmentRecoveryTest();
+    }
+    totalIndexLossRecoveryTest();
+  }
+
+  /**
+   * Tests recovery failure cases.
+   * Cases
+   * 1. Recovery info contains a PUT for a key that already exists
+   * 2. Recovery info contains a PUT for a key that has been deleted
+   * 3. Recovery info contains a DELETE for a key that has been deleted
+   * 4. Recovery info that contains a DELETE for a key that has no PUT record
+   * 5. Recovery info that contains a PUT beyond the end offset of the log segment
+   */
+  @Test
+  public void recoveryFailureTest() {
+    // recovery info contains a PUT for a key that already exists
+    MessageInfo info = new MessageInfo(liveKeys.iterator().next(), PUT_RECORD_SIZE);
+    doRecoveryFailureTest(info, StoreErrorCodes.Initialization_Error);
+    // recovery info contains a PUT for a key that has been deleted
+    info = new MessageInfo(deletedKeys.iterator().next(), PUT_RECORD_SIZE);
+    doRecoveryFailureTest(info, StoreErrorCodes.Initialization_Error);
+    // recovery info contains a DELETE for a key that has been deleted
+    info = new MessageInfo(deletedKeys.iterator().next(), DELETE_RECORD_SIZE, true);
+    doRecoveryFailureTest(info, StoreErrorCodes.ID_Deleted);
+    // recovery info that contains a DELETE for a key that has no PUT record
+    info = new MessageInfo(getUniqueId(), DELETE_RECORD_SIZE, true);
+    doRecoveryFailureTest(info, StoreErrorCodes.ID_Not_Found);
+    // recovery info that contains a PUT beyond the end offset of the log segment
+    info = new MessageInfo(getUniqueId(), PUT_RECORD_SIZE);
+    doRecoveryFailureTest(info, StoreErrorCodes.Index_Creation_Failure);
+  }
+
+  /**
+   * Tests {@link PersistentIndex#findEntriesSince(FindToken, long)} for various cases
+   * 1. All cases that result in getting an index based token
+   * 2. All cases that result in getting a journal based token
+   * 3. Getting entries one by one
+   * 4. Getting entries using an index based token for an offset in the journal
+   * 5. Error case - trying to findEntriesSince() using an index based token that contains the last index segment
+   * 6. Using findEntriesSince() in an empty index
+   * 7. Token that has the log end offset
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void findEntriesSinceTest() throws IOException, StoreException {
+    // add some more entries so that the journal gets entries across segments and doesn't start at the beginning
+    // of an index segment.
+    addPutEntries(7, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    addDeleteEntry(getIdToDeleteFromIndexSegment(referenceIndex.lastKey()));
+
+    // token with log end offset should not return anything
+    StoreFindToken token = new StoreFindToken(log.getEndOffset(), sessionId);
+    token.setBytesRead(log.getUsedCapacity());
+    doFindEntriesSinceTest(token, Long.MAX_VALUE, Collections.EMPTY_SET, token);
+
+    findEntriesSinceToIndexBasedTest();
+    findEntriesSinceToJournalBasedTest();
+    findEntriesSinceOneByOneTest();
+    findEntriesSinceIndexBasedTokenForOffsetInJournalTest();
+
+    // error case - can never have provided an index based token that is contains the offset of the last segment
+    token = new StoreFindToken(referenceIndex.lastEntry().getValue().firstKey(), referenceIndex.lastKey(), sessionId);
+    doFindEntriesSinceFailureTest(token, StoreErrorCodes.Unknown_Error);
+
+    findEntriesSinceInEmptyIndexTest(false);
+  }
+
+  /**
+   * Tests behaviour of {@link PersistentIndex#findEntriesSince(FindToken, long)} on crash-restart of index and some
+   * recovery. Specifically tests cases where tokens have been handed out before the "crash" failure.
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void findEntriesSinceOnRestartTest() throws IOException, StoreException {
+    Offset lastRecordOffset = index.journal.getLastOffset();
+    appendToLog(2 * PUT_RECORD_SIZE);
+    // this record will be recovered.
+    FileSpan firstRecordFileSpan = log.getFileSpanForMessage(index.getCurrentEndOffset(), PUT_RECORD_SIZE);
+    // this record will not be recovered.
+    FileSpan secondRecordFileSpan = log.getFileSpanForMessage(firstRecordFileSpan.getEndOffset(), PUT_RECORD_SIZE);
+
+    // if there is no bad shutdown but the store token is past the index end offset, it is an error state
+    StoreFindToken startToken = new StoreFindToken(secondRecordFileSpan.getStartOffset(), new UUID(1, 1));
+    doFindEntriesSinceFailureTest(startToken, StoreErrorCodes.Unknown_Error);
+
+    UUID oldSessionId = sessionId;
+    final MockId newId = getUniqueId();
+    // add to allKeys() so that doFindEntriesSinceTest() works correctly.
+    allKeys.put(newId,
+        new Pair<IndexValue, IndexValue>(new IndexValue(PUT_RECORD_SIZE, firstRecordFileSpan.getStartOffset()), null));
+    recovery = new MessageStoreRecovery() {
+      @Override
+      public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
+          throws IOException {
+        return Collections.singletonList(new MessageInfo(newId, PUT_RECORD_SIZE));
+      }
+    };
+    reloadIndex(true);
+
+    long bytesRead =
+        log.getDifference(firstRecordFileSpan.getEndOffset(), new Offset(log.getFirstSegment().getName(), 0));
+    // create a token that will be past the index end offset on startup after recovery.
+    startToken = new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId);
+    // token should get reset internally, no keys should be returned and the returned token should be correct (offset in
+    // it will be the current log end offset = firstRecordFileSpan.getEndOffset()).
+    StoreFindToken expectedEndToken = new StoreFindToken(firstRecordFileSpan.getEndOffset(), sessionId);
+    expectedEndToken.setBytesRead(bytesRead);
+    doFindEntriesSinceTest(startToken, Long.MAX_VALUE, Collections.EMPTY_SET, expectedEndToken);
+
+    // create a token that is not past the index end offset on startup after recovery. Should work as expected
+    startToken = new StoreFindToken(lastRecordOffset, oldSessionId);
+    expectedEndToken = new StoreFindToken(firstRecordFileSpan.getStartOffset(), sessionId);
+    expectedEndToken.setBytesRead(bytesRead);
+    doFindEntriesSinceTest(startToken, Long.MAX_VALUE, Collections.singleton(newId), expectedEndToken);
+  }
+
+  /**
+   * Tests {@link PersistentIndex#findDeletedEntriesSince(FindToken, long, long)} for various cases
+   * 1. All cases that result in getting an index based token
+   * 2. All cases that result in getting a journal based token
+   * 3. Getting entries one by one
+   * 4. Getting entries using an index based token for an offset in the journal
+   * 5. Using findDeletedEntriesSince() in an empty index
+   * 6. Token that has the log end offset
+   * @throws InterruptedException
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void findDeletedEntriesSinceTest() throws InterruptedException, IOException, StoreException {
+    // add some more entries so that the journal gets entries across segments and doesn't start at the beginning
+    // of an index segment.
+    addPutEntries(7, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    MockId idToDelete = getIdToDeleteFromIndexSegment(referenceIndex.lastKey());
+    addDeleteEntry(idToDelete);
+
+    // token with log end offset should not return anything
+    StoreFindToken token = new StoreFindToken(log.getEndOffset(), sessionId);
+    doFindDeletedEntriesSinceTest(token, Long.MAX_VALUE, Collections.EMPTY_SET, token);
+
+    findDeletedEntriesSinceToIndexBasedTest();
+    findDeletedEntriesSinceToJournalBasedTest();
+    findDeletedEntriesSinceOneByOneTest();
+    findDeletedEntriesSinceIndexBasedTokenForOffsetInJournalTest();
+
+    findEntriesSinceInEmptyIndexTest(true);
+  }
+
+  // helpers
+
+  // general
+
+  /**
+   * @return a {@link MockId} that is unique and has not been generated before in this run.
+   */
+  private MockId getUniqueId() {
+    MockId id;
+    do {
+      id = new MockId(UtilsTest.getRandomString(10));
+    } while (generatedKeys.contains(id));
+    generatedKeys.add(id);
+    return id;
+  }
+
+  /**
+   * Appends random data of size {@code size} to the {@link #log}.
+   * @param size the size of data that needs to be appeneded.
+   * @throws IOException
+   */
+  private void appendToLog(long size) throws IOException {
+    ByteBuffer buffer = ByteBuffer.allocate((int) size);
+    ReadableByteChannel channel = Channels.newChannel(new ByteBufferInputStream(buffer));
+    log.appendFrom(channel, buffer.capacity());
+  }
+
+  /**
+   * Given an offset, generates the start offset of the index segment that the record at that offset has to go to.
+   * <p/>
+   * Use only for the latest record - does not work for offsets that are below the current index end offset.
+   * @param recordOffset the offset of the record being added to the index.
+   * @return the index segment start offset of the index segment that the record belongs to.
+   */
+  private Offset generateReferenceIndexSegmentStartOffset(Offset recordOffset) {
+    if (referenceIndex.size() == 0) {
+      return recordOffset;
+    }
+
+    Map.Entry<Offset, TreeMap<MockId, IndexValue>> lastEntry = referenceIndex.lastEntry();
+    Offset indexSegmentStartOffset = lastEntry.getKey();
+    if (!indexSegmentStartOffset.getName().equals(recordOffset.getName())
+        || lastEntry.getValue().size() == MAX_IN_MEM_ELEMENTS) {
+      indexSegmentStartOffset = recordOffset;
+    }
+    return indexSegmentStartOffset;
+  }
+
+  /**
+   * Gets an ID to delete from the index segment with start offset {@code indexSegmentStartOffset}. The returned ID will
+   * have been removed from {@link #liveKeys} and added to {@link #deletedKeys}.
+   * @param indexSegmentStartOffset the start offset of the index segment from which an ID is required.
+   * @return an ID to delete from the index segment with start offset {@code indexSegmentStartOffset}.
+   */
+  private MockId getIdToDeleteFromIndexSegment(Offset indexSegmentStartOffset) {
+    MockId deleteCandidate = null;
+    TreeMap<MockId, IndexValue> indexSegment = referenceIndex.get(indexSegmentStartOffset);
+    for (Map.Entry<MockId, IndexValue> entry : indexSegment.entrySet()) {
+      MockId id = entry.getKey();
+      if (liveKeys.contains(id)) {
+        deleteCandidate = id;
+        break;
+      }
+    }
+    if (deleteCandidate != null) {
+      deletedKeys.add(deleteCandidate);
+      liveKeys.remove(deleteCandidate);
+    }
+    return deleteCandidate;
+  }
+
+  /**
+   * Gets an ID to delete from the given log segment. The returned ID will have been removed from {@link #liveKeys} and
+   * added to {@link #deletedKeys}.
+   * @param segment the {@link LogSegment} from which an ID is required.
+   * @return the ID to delete.
+   */
+  private MockId getIdToDeleteFromLogSegment(LogSegment segment) {
+    MockId deleteCandidate;
+    Offset indexSegmentStartOffset = new Offset(segment.getName(), segment.getStartOffset());
+    do {
+      deleteCandidate = getIdToDeleteFromIndexSegment(indexSegmentStartOffset);
+      indexSegmentStartOffset = referenceIndex.higherKey(indexSegmentStartOffset);
+      if (indexSegmentStartOffset == null || !indexSegmentStartOffset.getName().equals(segment.getName())) {
+        break;
+      }
+    } while (deleteCandidate == null);
+    return deleteCandidate;
+  }
+
+  /**
+   * Gets the value that is expected to obtained from the {@link PersistentIndex}.
+   * @param id the {@link MockId} whose value is required.
+   * @param wantPut {@code true} if the {@link IndexValue} of the PUT entry is required.
+   * @return the value that is expected to obtained from the {@link PersistentIndex}
+   */
+  private IndexValue getExpectedValue(MockId id, boolean wantPut) {
+    Pair<IndexValue, IndexValue> indexValues = allKeys.get(id);
+    return wantPut ? indexValues.getFirst() : indexValues.getSecond();
+  }
+
+  /**
+   * Adds {@code count} number of put entries each of size {@code size} and that expire at {@code expiresAtMs} to the
+   * index (both real and reference).
+   * @param count the number of PUT entries to add.
+   * @param size the size of each PUT entry.
+   * @param expiresAtMs the time at which each of the PUT entries expires.
+   * @return the {@link FileSpan} of the added entries.
+   * @throws IOException
+   * @throws StoreException
+   */
+  private FileSpan addPutEntries(int count, long size, long expiresAtMs) throws IOException, StoreException {
+    if (count <= 0) {
+      throw new IllegalArgumentException("Number of put entries to add cannot be <= 0");
+    }
+    ArrayList<IndexEntry> indexEntries = new ArrayList<>(count);
+    Offset expectedJournalLastOffset = null;
+    Offset endOffsetOfPrevMsg = index.getCurrentEndOffset();
+    for (int i = 0; i < count; i++) {
+      appendToLog(size);
+      FileSpan fileSpan = log.getFileSpanForMessage(endOffsetOfPrevMsg, size);
+      IndexValue value = new IndexValue(size, fileSpan.getStartOffset(), expiresAtMs);
+      MockId id = getUniqueId();
+      logOrder.put(fileSpan.getStartOffset(), new Pair<>(id, value));
+      indexEntries.add(new IndexEntry(id, value));
+      Offset indexSegmentStartOffset = generateReferenceIndexSegmentStartOffset(fileSpan.getStartOffset());
+      indexSegmentStartOffsets.put(id, new Pair<Offset, Offset>(indexSegmentStartOffset, null));
+      allKeys.put(id, new Pair<IndexValue, IndexValue>(value, null));
+      if (!referenceIndex.containsKey(indexSegmentStartOffset)) {
+        referenceIndex.put(indexSegmentStartOffset, new TreeMap<MockId, IndexValue>());
+      }
+      referenceIndex.get(indexSegmentStartOffset).put(id, value);
+      if (expiresAtMs != Utils.Infinite_Time && expiresAtMs < time.milliseconds()) {
+        expiredKeys.add(id);
+      } else {
+        liveKeys.add(id);
+      }
+      expectedJournalLastOffset = fileSpan.getStartOffset();
+      endOffsetOfPrevMsg = fileSpan.getEndOffset();
+    }
+    FileSpan fileSpan = new FileSpan(indexEntries.get(0).getValue().getOffset(), endOffsetOfPrevMsg);
+    index.addToIndex(indexEntries, fileSpan);
+    assertEquals("End Offset of index not as expected", endOffsetOfPrevMsg, index.getCurrentEndOffset());
+    assertEquals("Journal's last offset not as expected", expectedJournalLastOffset, index.journal.getLastOffset());
+    return fileSpan;
+  }
+
+  /**
+   * Adds a delete entry in the index (real and reference) for {@code idToDelete}.
+   * @param idToDelete the id to be deleted.
+   * @return the {@link FileSpan} of the added entries.
+   * @throws IOException
+   * @throws StoreException
+   */
+  private FileSpan addDeleteEntry(MockId idToDelete) throws IOException, StoreException {
+    appendToLog(DELETE_RECORD_SIZE);
+    Offset endOffsetOfPrevMsg = index.getCurrentEndOffset();
+    FileSpan fileSpan = log.getFileSpanForMessage(endOffsetOfPrevMsg, DELETE_RECORD_SIZE);
+    index.markAsDeleted(idToDelete, fileSpan);
+
+    IndexValue value = getExpectedValue(idToDelete, true);
+    IndexValue newValue = new IndexValue(value.getSize(), value.getOffset(), value.getFlags(), value.getExpiresAtMs());
+    newValue.setFlag(IndexValue.Flags.Delete_Index);
+    newValue.setNewOffset(fileSpan.getStartOffset());
+    newValue.setNewSize(DELETE_RECORD_SIZE);
+
+    logOrder.put(fileSpan.getStartOffset(), new Pair<>(idToDelete, newValue));
+    Offset indexSegmentStartOffset = generateReferenceIndexSegmentStartOffset(fileSpan.getStartOffset());
+    Pair<Offset, Offset> keyLocations = indexSegmentStartOffsets.get(idToDelete);
+    indexSegmentStartOffsets.put(idToDelete, new Pair<>(keyLocations.getFirst(), indexSegmentStartOffset));
+    Pair<IndexValue, IndexValue> keyValues = allKeys.get(idToDelete);
+    allKeys.put(idToDelete, new Pair<>(keyValues.getFirst(), newValue));
+    if (!referenceIndex.containsKey(indexSegmentStartOffset)) {
+      referenceIndex.put(indexSegmentStartOffset, new TreeMap<MockId, IndexValue>());
+    }
+    referenceIndex.get(indexSegmentStartOffset).put(idToDelete, newValue);
+    endOffsetOfPrevMsg = fileSpan.getEndOffset();
+    assertEquals("End Offset of index not as expected", endOffsetOfPrevMsg, index.getCurrentEndOffset());
+    assertEquals("Journal's last offset not as expected", fileSpan.getStartOffset(), index.journal.getLastOffset());
+    return fileSpan;
+  }
+
+  /**
+   * Verifies that the number of log segments is as expected.
+   * @param expectedCount the number of log segments expected.
+   */
+  private void verifyLogSegmentCount(int expectedCount) {
+    // this function works under the assumption that log segments are not allocated until they are required
+    // this is a fair assumption because the PersistentIndex works under the same assumption and would break if it were
+    // not true.
+    LogSegment segment = log.getFirstSegment();
+    int logSegmentCount = 0;
+    while (segment != null) {
+      logSegmentCount++;
+      segment = log.getNextSegment(segment);
+    }
+    assertEquals("Unexpected number of log segments", expectedCount, logSegmentCount);
+  }
+
+  /**
+   * Reloads the index. Uses the class variables as parameters. For e.g, if a particular implementation of
+   * {@link MessageStoreRecovery} is desired, it can be set to {@link #recovery} and this function called. The newly
+   * created index will use that implementation of {@link MessageStoreRecovery}.
+   * @param deleteCleanShutdownFile {@code true} if the clean shutdown file should be deleted to mimic unclean shutdown
+   * @throws StoreException
+   */
+  private void reloadIndex(boolean deleteCleanShutdownFile) throws StoreException {
+    index.close();
+    if (deleteCleanShutdownFile) {
+      assertTrue("The clean shutdown file could not be deleted",
+          new File(tempDir, PersistentIndex.CLEAN_SHUTDOWN_FILENAME).delete());
+    }
+    metricRegistry = new MetricRegistry();
+    StoreMetrics metrics = new StoreMetrics(tempDirStr, metricRegistry);
+    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+    index =
+        new PersistentIndex(tempDirStr, scheduler, log, config, STORE_KEY_FACTORY, recovery, hardDelete, metrics, time);
+    sessionId =
+        ((StoreFindToken) index.findEntriesSince(new StoreFindToken(), Long.MAX_VALUE).getFindToken()).getSessionId();
+  }
+
+  /**
+   * Closes the index and clears all the index files essentially creating a new index.
+   * @throws StoreException
+   */
+  private void closeAndClearIndex() throws StoreException {
+    index.close();
+    // delete all index files
+    File[] indexSegmentFiles = tempDir.listFiles(new FilenameFilter() {
+      @Override
+      public boolean accept(File dir, String name) {
+        return name.endsWith(PersistentIndex.INDEX_SEGMENT_FILE_NAME_SUFFIX) || name.endsWith(
+            PersistentIndex.BLOOM_FILE_NAME_SUFFIX);
+      }
+    });
+    assertNotNull("Could not load index segment files", indexSegmentFiles);
+    for (File indexSegmentFile : indexSegmentFiles) {
+      assertTrue("Could not deleted index segment file", indexSegmentFile.delete());
+    }
+  }
+
+  /**
+   * Advances time by {@code ms} and adjusts {@link #liveKeys} if any of the keys in it expire.
+   * @param ms the amount in ms to advance.
+   * @throws InterruptedException
+   */
+  private void advanceTime(long ms) throws InterruptedException {
+    time.sleep(ms);
+    Iterator<MockId> liveKeysIterator = liveKeys.iterator();
+    while (liveKeysIterator.hasNext()) {
+      MockId id = liveKeysIterator.next();
+      IndexValue value = allKeys.get(id).getFirst();
+      if (value.getExpiresAtMs() != Utils.Infinite_Time && value.getExpiresAtMs() < time.milliseconds()) {
+        expiredKeys.add(id);
+        liveKeysIterator.remove();
+      }
+    }
+  }
+
+  /**
+   * Verifies that the {@link BlobReadOptions} returned from {@link PersistentIndex#getBlobReadInfo(StoreKey, EnumSet)}
+   * matches the expected value.
+   * @param id the {@link MockId} to use
+   * @param storeGetOptions the {@link StoreGetOptions} to use.
+   * @param expectedErrorCode if this operation is expected to fail, the {@link StoreErrorCodes} expected.
+   * @throws StoreException
+   */
+  private void verifyBlobReadOptions(MockId id, EnumSet<StoreGetOptions> storeGetOptions,
+      StoreErrorCodes expectedErrorCode) throws StoreException {
+    try {
+      BlobReadOptions options = index.getBlobReadInfo(id, storeGetOptions);
+      if (expectedErrorCode != null) {
+        fail("Should have failed because a StoreException is expected");
+      }
+      IndexValue putEntryValue = getExpectedValue(id, true);
+      assertEquals("StoreKey not as expected", id, options.getStoreKey());
+      assertEquals("Log Segment Name not as expected", putEntryValue.getOffset().getName(),
+          options.getLogSegmentName());
+      assertEquals("Offset not as expected", putEntryValue.getOffset().getOffset(), options.getOffset());
+      assertEquals("Size not as expected", putEntryValue.getSize(), options.getSize());
+      assertEquals("ExpiresAtMs not as expected", putEntryValue.getExpiresAtMs(), options.getExpiresAtMs());
+    } catch (StoreException e) {
+      if (expectedErrorCode == null) {
+        throw e;
+      } else {
+        assertEquals("Unexpected StoreErrorCode", expectedErrorCode, e.getErrorCode());
+      }
+    }
+  }
+
+  /**
+   * Compares two tokens to ensure their equality test passes and that they have the same session ID.
+   * @param reference the reference {@link StoreFindToken}
+   * @param toCheck the {@link StoreFindToken} to check
+   */
+  private void compareTokens(StoreFindToken reference, StoreFindToken toCheck) {
+    assertEquals("Tokens do not match", reference, toCheck);
+    assertEquals("SessionId does not match", reference.getSessionId(), toCheck.getSessionId());
+  }
+
+  // test setup
+
+  /**
+   * Sets up some state in order to make sure all cases are represented and the tests don't need to do any setup
+   * individually. For understanding the created index, please read the source code which is annotated with comments.
+   * <p/>
+   * Also tests critical functionality of {@link PersistentIndex} and behaviour of the {@link Journal} in the index.
+   * Also verifies that the state in {@link #referenceIndex} matches the state in the real index.
+   * @throws InterruptedException
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void setupTestState() throws InterruptedException, IOException, StoreException {
+    long segmentCapacity = isLogSegmented ? SEGMENT_CAPACITY : LOG_CAPACITY;
+    metricRegistry = new MetricRegistry();
+    StoreMetrics metrics = new StoreMetrics(tempDirStr, metricRegistry);
+    properties.put("store.index.max.number.of.inmem.elements", Integer.toString(MAX_IN_MEM_ELEMENTS));
+    // the segment capacity property is never used, so it is not set.
+    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+    log = new Log(tempDirStr, LOG_CAPACITY, segmentCapacity, metrics);
+    index =
+        new PersistentIndex(tempDirStr, scheduler, log, config, STORE_KEY_FACTORY, recovery, hardDelete, metrics, time);
+    assertEquals("End Offset of index not as expected", log.getStartOffset(), index.getCurrentEndOffset());
+
+    // advance time by a millisecond in order to be able to add expired keys and to avoid keys that are expired from
+    // being picked for delete.
+    time.sleep(1);
+    verifyLogSegmentCount(1);
+    if (!isLogSegmented) {
+      // log is filled about ~50%.
+      addCuratedIndexEntriesToLogSegment(segmentCapacity / 2, 1);
+    } else {
+      // first log segment is filled to capacity.
+      addCuratedIndexEntriesToLogSegment(segmentCapacity, 1);
+
+      // second log segment is filled but has some space at the end (free space has to be less than the lesser of the
+      // standard delete and put record sizes so that the next write causes a roll over of log segments).
+      addCuratedIndexEntriesToLogSegment(segmentCapacity - (DELETE_RECORD_SIZE - 1), 2);
+
+      // third log segment is partially filled and is left as the "active" segment
+      // First Index Segment
+      // 1 PUT entry
+      addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);
+      // DELETE for a key in the first log segment
+      LogSegment segment = log.getFirstSegment();
+      MockId idToDelete = getIdToDeleteFromLogSegment(segment);
+      addDeleteEntry(idToDelete);
+      verifyLogSegmentCount(3);
+      // DELETE for a key in the second segment
+      segment = log.getNextSegment(segment);
+      idToDelete = getIdToDeleteFromLogSegment(segment);
+      addDeleteEntry(idToDelete);
+      // 1 DELETE for the PUT in the same segment
+      idToDelete = getIdToDeleteFromIndexSegment(referenceIndex.lastKey());
+      addDeleteEntry(idToDelete);
+      // 1 PUT entry that spans the rest of the data in the segment (upto a third of the segment size)
+      long size = segmentCapacity / 3 - index.getCurrentEndOffset().getOffset();
+      addPutEntries(1, size, Utils.Infinite_Time);
+
+      // fourth and fifth log segment are free.
+    }
+    // make sure all indexes are written to disk and mapped as required (forcing IndexPersistor to run).
+    log.flush();
+    reloadIndex(false);
+    verifyState();
+  }
+
+  /**
+   * Adds some curated entries into the index in order to ensure a good mix for testing. For understanding the created
+   * index, please read the source code which is annotated with comments.
+   * @param sizeToMakeIndexEntriesFor the size to make index entries for.
+   * @param expectedLogSegmentCount the number of log segments that are expected to assist after the addition of the
+   *                                first entry and at the end of the addition of all entries.
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void addCuratedIndexEntriesToLogSegment(long sizeToMakeIndexEntriesFor, int expectedLogSegmentCount)
+      throws IOException, StoreException {
+    // First Index Segment
+    // 1 PUT
+    Offset firstJournalEntryAddedNow = addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time).getStartOffset();
+    verifyLogSegmentCount(expectedLogSegmentCount);
+    // 2 more PUT
+    addPutEntries(2, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    // 2 PUT EXPIRED
+    addPutEntries(2, PUT_RECORD_SIZE, 0);
+    // 5 entries were added - firstJournalEntryAddedNow should still be a part of the journal
+    List<JournalEntry> entries = index.journal.getEntriesSince(firstJournalEntryAddedNow, true);
+    assertEquals("There should have been exactly 5 entries returned from the journal", 5, entries.size());
+
+    // Second Index Segment
+    // 4 PUT
+    addPutEntries(4, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    // 1 DELETE for a PUT in the same index segment
+    MockId idToDelete = getIdToDeleteFromIndexSegment(referenceIndex.lastKey());
+    addDeleteEntry(idToDelete);
+    // 5 more entries (for a total of 10) were added - firstJournalEntryAddedNow should still be a part of the journal
+    entries = index.journal.getEntriesSince(firstJournalEntryAddedNow, true);
+    assertEquals("There should have been exactly 10 entries returned from the journal", 10, entries.size());
+    // 1 DELETE for a PUT in the first index segment
+    Offset firstIndexSegmentStartOffset = referenceIndex.lowerKey(referenceIndex.lastKey());
+    idToDelete = getIdToDeleteFromIndexSegment(firstIndexSegmentStartOffset);
+    addDeleteEntry(idToDelete);
+    // 1 more entry (for a total of 11) was added - firstJournalEntryAddedNow should no longer be a part of the journal
+    assertNull("There should no entries returned from the journal",
+        index.journal.getEntriesSince(firstJournalEntryAddedNow, true));
+
+    // Third and Fourth Index Segment
+    for (int seg = 0; seg < 2; seg++) {
+      // 3 PUT
+      addPutEntries(3, PUT_RECORD_SIZE, Utils.Infinite_Time);
+      // 1 PUT for an expired blob
+      addPutEntries(1, PUT_RECORD_SIZE, 0);
+      // 1 DELETE for the expired PUT
+      MockId expiredId = logOrder.lastEntry().getValue().getFirst();
+      addDeleteEntry(expiredId);
+      deletedKeys.add(expiredId);
+      expiredKeys.remove(expiredId);
+      // 1 PUT
+      addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    }
+
+    Offset fourthIndexSegmentStartOffset = referenceIndex.lastKey();
+    Offset thirdIndexSegmentStartOffset = referenceIndex.lowerKey(fourthIndexSegmentStartOffset);
+    // Fifth Index Segment
+    // 1 PUT entry
+    addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    // 1 DELETE for a PUT in each of the third and fourth segments
+    idToDelete = getIdToDeleteFromIndexSegment(thirdIndexSegmentStartOffset);
+    addDeleteEntry(idToDelete);
+    idToDelete = getIdToDeleteFromIndexSegment(fourthIndexSegmentStartOffset);
+    addDeleteEntry(idToDelete);
+    // 1 DELETE for the PUT in the same segment
+    idToDelete = getIdToDeleteFromIndexSegment(referenceIndex.lastKey());
+    addDeleteEntry(idToDelete);
+    // 1 PUT entry that spans the rest of the data in the segment
+    long size = sizeToMakeIndexEntriesFor - index.getCurrentEndOffset().getOffset();
+    addPutEntries(1, size, Utils.Infinite_Time);
+    verifyLogSegmentCount(expectedLogSegmentCount);
+  }
+
+  /**
+   * Verifies that the state in {@link PersistentIndex} is the same as the one in {@link #referenceIndex}.
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void verifyState() throws IOException, StoreException {
+    verifyLogSegmentCount(isLogSegmented ? 3 : 1);
+    NavigableMap<Offset, IndexSegment> realIndex = index.indexes;
+    assertEquals("Number of index segments does not match expected", referenceIndex.size(), realIndex.size());
+    Map.Entry<Offset, IndexSegment> realIndexEntry = realIndex.firstEntry();
+    for (Map.Entry<Offset, TreeMap<MockId, IndexValue>> referenceIndexEntry : referenceIndex.entrySet()) {
+      assertEquals("Offset of index segment does not match expected", referenceIndexEntry.getKey(),
+          realIndexEntry.getKey());
+      TreeMap<MockId, IndexValue> referenceIndexSegment = referenceIndexEntry.getValue();
+      IndexSegment realIndexSegment = realIndexEntry.getValue();
+      List<MessageInfo> messageInfos = new ArrayList<>();
+      FindEntriesCondition condition = new FindEntriesCondition(Long.MAX_VALUE);
+      assertTrue("There should have been entries returned from the index segment",
+          realIndexSegment.getEntriesSince(null, condition, messageInfos, new AtomicLong(0)));
+      assertEquals("Size of index segment differs from expected", referenceIndexSegment.size(), messageInfos.size());
+      for (Map.Entry<MockId, IndexValue> referenceIndexSegmentEntry : referenceIndexSegment.entrySet()) {
+        IndexValue value = realIndexSegment.find(referenceIndexSegmentEntry.getKey());
+        IndexValue referenceValue = referenceIndexSegmentEntry.getValue();
+        assertEquals("Value from IndexSegment does not match expected", referenceValue.getBytes(), value.getBytes());
+      }
+      realIndexEntry = realIndex.higherEntry(realIndexEntry.getKey());
+    }
+    assertNull("There should no more index segments left", realIndexEntry);
+    // all the elements in the last segment should be in the journal
+    assertNotNull("There is no offset in the log that corresponds to the last index segment start offset",
+        logOrder.floorEntry(referenceIndex.lastKey()));
+    Map.Entry<Offset, Pair<MockId, IndexValue>> logEntry = logOrder.floorEntry(referenceIndex.lastKey());
+    List<JournalEntry> entries = index.journal.getEntriesSince(referenceIndex.lastKey(), true);
+    for (JournalEntry entry : entries) {
+      assertNotNull("There are no more entries in the reference log but there are entries in the journal", logEntry);
+      assertEquals("Offset in journal not as expected", logEntry.getKey(), entry.getOffset());
+      assertEquals("Key in journal not as expected", logEntry.getValue().getFirst(), entry.getKey());
+      logEntry = logOrder.higherEntry(logEntry.getKey());
+    }
+    assertNull("There should be no more entries in the reference log", logEntry);
+  }
+
+  // findKey test helpers
+
+  /**
+   * Verifies that {@code valueFromFind} matches the expected value from {@link #referenceIndex}.
+   * @param id the {@link MockId} whose value is required.
+   * @param valueFromFind the {@link IndexValue} that needs to be verified.
+   */
+  private void verifyValue(MockId id, IndexValue valueFromFind) {
+    if (allKeys.containsKey(id)) {
+      assertNotNull("Value should be successfully fetched", valueFromFind);
+      IndexValue expectedValue = getExpectedValue(id, !deletedKeys.contains(id));
+      assertEquals("Offset in value from index not as expected", expectedValue.getOffset(), valueFromFind.getOffset());
+      assertEquals("Bytes from value from index not as expected", expectedValue.getBytes(), valueFromFind.getBytes());
+    } else {
+      assertNull("There should have been no value returned", valueFromFind);
+    }
+  }
+
+  // setEndOffsetsTest() helpers
+
+  /**
+   * Gets the offset of the last record in the given log {@code segment}.
+   * @param segment the {@link LogSegment} whose last record offset is required.
+   * @return the offset of the last record in the given log {@code segment}.
+   */
+  private Offset getLastRecordOffset(LogSegment segment) {
+    Offset lastOffset;
+    LogSegment nextSegment = log.getNextSegment(segment);
+    if (nextSegment == null) {
+      lastOffset = logOrder.lastKey();
+    } else {
+      Offset nextSegmentStartOffset = new Offset(nextSegment.getName(), nextSegment.getStartOffset());
+      lastOffset = logOrder.lowerKey(nextSegmentStartOffset);
+    }
+    return lastOffset;
+  }
+
+  // recoverySuccessTest() helpers
+
+  /**
+   * Test recovery of a single segment.
+   * @throws InterruptedException
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void singleSegmentRecoveryTest() throws InterruptedException, IOException, StoreException {
+    Offset indexEndOffsetBeforeRecovery = index.getCurrentEndOffset();
+    MockId idToCreateAndDelete = getUniqueId();
+    // recover a few messages in a single segment
+    final List<MessageInfo> infos = getCuratedSingleSegmentRecoveryInfos(idToCreateAndDelete);
+    final AtomicInteger returnTracker = new AtomicInteger(0);
+    recovery = new MessageStoreRecovery() {
+      @Override
+      public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
+          throws IOException {
+        switch (returnTracker.getAndIncrement()) {
+          case 0:
+            return infos;
+          default:
+            throw new IllegalStateException("This function should not have been called more than once");
+        }
+      }
+    };
+    // This test relies on log segment not spilling over. If that happens, this test will fail.
+    LogSegment activeSegment = log.getSegment(indexEndOffsetBeforeRecovery.getName());
+    long expectedSegmentEndOffset = activeSegment.getEndOffset();
+    // write a little "extra" data
+    appendToLog(2 * PUT_RECORD_SIZE);
+
+    reloadIndex(false);
+    assertEquals("End offset not as expected", expectedSegmentEndOffset, activeSegment.getEndOffset());
+    checkInfos(infos, idToCreateAndDelete, indexEndOffsetBeforeRecovery);
+  }
+
+  /**
+   * Tests recovery of more than one segment.
+   * @throws InterruptedException
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void multipleSegmentRecoveryTest() throws InterruptedException, IOException, StoreException {
+    Offset indexEndOffsetBeforeRecovery = index.getCurrentEndOffset();
+    LogSegment activeSegment = log.getSegment(indexEndOffsetBeforeRecovery.getName());
+    // recover a few messages across segments
+    final List<MessageInfo> activeSegmentInfos = new ArrayList<>();
+    // 1 PUT record that will be deleted in the next segment
+    MockId idToCreateAndDeleteAcrossSegments = getUniqueId();
+    appendToLog(PUT_RECORD_SIZE);
+    activeSegmentInfos.add(new MessageInfo(idToCreateAndDeleteAcrossSegments, PUT_RECORD_SIZE));
+    // 1 PUT record that will remain and covers almost the rest of the active segment.
+    long size = activeSegment.getCapacityInBytes() - activeSegment.getEndOffset() - (DELETE_RECORD_SIZE - 1);
+    appendToLog(size);
+    activeSegmentInfos.add(new MessageInfo(getUniqueId(), size));
+    MockId idToCreateAndDeleteInSameSegment = getUniqueId();
+    final List<MessageInfo> nextSegmentInfos = getCuratedSingleSegmentRecoveryInfos(idToCreateAndDeleteInSameSegment);
+    // 1 DELETE record for the PUT in the previous segment
+    appendToLog(DELETE_RECORD_SIZE);
+    nextSegmentInfos.add(new MessageInfo(idToCreateAndDeleteAcrossSegments, DELETE_RECORD_SIZE, true));
+    final AtomicInteger returnTracker = new AtomicInteger(0);
+    recovery = new MessageStoreRecovery() {
+      @Override
+      public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
+          throws IOException {
+        switch (returnTracker.getAndIncrement()) {
+          case 0:
+            return activeSegmentInfos;
+          case 1:
+            return nextSegmentInfos;
+          default:
+            throw new IllegalStateException("This function should not have been called more than two times");
+        }
+      }
+    };
+    long activeSegmentExpectedEndOffset = activeSegment.getEndOffset();
+    long nextSegmentExpectedEndOffset = log.getNextSegment(activeSegment).getEndOffset();
+    // write a little "extra" data
+    appendToLog(2 * PUT_RECORD_SIZE);
+
+    reloadIndex(false);
+    assertEquals("End offset of former active segment not as expected", activeSegmentExpectedEndOffset,
+        activeSegment.getEndOffset());
+    activeSegment = log.getNextSegment(activeSegment);
+    assertNotNull("A new segment has not been created", activeSegment);
+    assertEquals("End offset active segment not as expected", nextSegmentExpectedEndOffset,
+        activeSegment.getEndOffset());
+    checkInfos(activeSegmentInfos, idToCreateAndDeleteAcrossSegments, indexEndOffsetBeforeRecovery);
+    checkInfos(nextSegmentInfos, idToCreateAndDeleteInSameSegment,
+        new Offset(activeSegment.getName(), activeSegment.getStartOffset()));
+  }
+
+  /**
+   * Creates a few curated recovery entries. For understanding the created entries, please read the source code which is
+   * annotated with comments.
+   * @param idToCreateAndDelete the {@link MockId} that will have both a PUT and DELETE entry.
+   * @return curated revovery entries.
+   * @throws IOException
+   */
+  private List<MessageInfo> getCuratedSingleSegmentRecoveryInfos(MockId idToCreateAndDelete) throws IOException {
+    List<MessageInfo> infos = new ArrayList<>();
+    appendToLog(2 * DELETE_RECORD_SIZE + 4 * PUT_RECORD_SIZE);
+    // 1 DELETE for a PUT not in the infos
+    infos.add(new MessageInfo(getIdToDeleteFromLogSegment(log.getFirstSegment()), DELETE_RECORD_SIZE, true));
+    // 3 PUT
+    infos.add(new MessageInfo(idToCreateAndDelete, PUT_RECORD_SIZE));
+    infos.add(new MessageInfo(getUniqueId(), PUT_RECORD_SIZE));
+    infos.add(new MessageInfo(getUniqueId(), PUT_RECORD_SIZE));
+    // 1 DELETE for a PUT in the infos
+    infos.add(new MessageInfo(idToCreateAndDelete, DELETE_RECORD_SIZE, true));
+    // 1 expired PUT
+    infos.add(new MessageInfo(getUniqueId(), PUT_RECORD_SIZE, 0));
+    return infos;
+  }
+
+  /**
+   * Checks that the provided {@code infos} is present in the index.
+   * @param infos the {@link List} of {@link MessageInfo} whose presence needs to be checked in the index.
+   * @param putRecordIdToIgnore the {@link MockId} whose PUT {@link MessageInfo} has to be ignored.
+   * @param indexEndOffsetBeforeRecovery the end offset of the {@link PersistentIndex} before recovery.
+   * @throws StoreException
+   */
+  private void checkInfos(List<MessageInfo> infos, MockId putRecordIdToIgnore, Offset indexEndOffsetBeforeRecovery)
+      throws StoreException {
+    Offset currCheckOffset = indexEndOffsetBeforeRecovery;
+    for (MessageInfo info : infos) {
+      FileSpan expectedFileSpan = log.getFileSpanForMessage(currCheckOffset, info.getSize());
+      if (!info.getStoreKey().equals(putRecordIdToIgnore) || info.isDeleted()) {
+        IndexValue value = index.findKey(info.getStoreKey());
+        assertEquals("Incorrect value for start offset", currCheckOffset, value.getOffset());
+        assertEquals("Inconsistent size", info.getSize(), value.getSize());
+        assertEquals("Inconsistent delete state ", info.isDeleted(), value.isFlagSet(IndexValue.Flags.Delete_Index));
+        assertEquals("Inconsistent expiresAtMs", info.getExpirationTimeInMs(), value.getExpiresAtMs());
+      }
+      currCheckOffset = expectedFileSpan.getEndOffset();
+    }
+  }
+
+  /**
+   * Tests the case where the index is lost completely and needs to be recovered from scratch.
+   * @throws StoreException
+   */
+  private void totalIndexLossRecoveryTest() throws StoreException {
+    closeAndClearIndex();
+    final AtomicInteger returnTracker = new AtomicInteger(0);
+    recovery = new MessageStoreRecovery() {
+      @Override
+      public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
+          throws IOException {
+        switch (returnTracker.getAndIncrement()) {
+          case 0:
+            return Collections.singletonList(new MessageInfo(getUniqueId(), PUT_RECORD_SIZE));
+          default:
+            return Collections.emptyList();
+        }
+      }
+    };
+    reloadIndex(false);
+    verifyLogSegmentCount(1);
+    assertEquals("Index should contain exactly one index segment", 1, index.indexes.size());
+    LogSegment segment = log.getFirstSegment();
+    assertEquals("End offset not as expected",
+        new Offset(segment.getName(), segment.getStartOffset() + PUT_RECORD_SIZE), index.getCurrentEndOffset());
+  }
+
+  // recoveryFailureTest() helpers
+
+  /**
+   * Tests that recovery fails for {@code info}.
+   * @param info the {@link MessageInfo} which will cause recovery to fail.
+   * @param expectedErrorCode the {@link StoreErrorCodes} expected for the failure.
+   */
+  private void doRecoveryFailureTest(final MessageInfo info, StoreErrorCodes expectedErrorCode) {
+    recovery = new MessageStoreRecovery() {
+      @Override
+      public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
+          throws IOException {
+        return Collections.singletonList(info);
+      }
+    };
+    try {
+      reloadIndex(false);
+      fail("Loading index should have failed because recovery contains invalid info");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", expectedErrorCode, e.getErrorCode());
+    }
+  }
+
+  // findEntriesSinceTest() helpers
+
+  /**
+   * Tests all cases of {@link PersistentIndex#findEntriesSince(FindToken, long)} that result in an index based
+   * {@link StoreFindToken} being returned.
+   * 1. Uninited -> Index
+   * 2. Index -> Index
+   * 3. Journal -> Index
+   * @throws StoreException
+   */
+  private void findEntriesSinceToIndexBasedTest() throws StoreException {
+    Offset logAbsoluteZero = new Offset(log.getFirstSegment().getName(), 0);
+
+    // ------------------
+    // 1. Index -> Index
+    Offset firstIndexSegmentStartOffset = referenceIndex.firstKey();
+    Offset secondIndexSegmentStartOffset = referenceIndex.higherKey(firstIndexSegmentStartOffset);
+    MockId firstId = referenceIndex.get(firstIndexSegmentStartOffset).firstKey();
+    // All elements from first index segment and two from the second to be returned (because of size restrictions)
+    Set<MockId> expectedKeys = new HashSet<>();
+    long maxTotalSizeOfEntries = 0;
+    for (Map.Entry<MockId, IndexValue> segmentEntry : referenceIndex.get(firstIndexSegmentStartOffset).entrySet()) {
+      if (!segmentEntry.getKey().equals(firstId)) {
+        expectedKeys.add(segmentEntry.getKey());
+        maxTotalSizeOfEntries += segmentEntry.getValue().getSize();
+      }
+    }
+    TreeMap<MockId, IndexValue> secondIndexSegment = referenceIndex.get(secondIndexSegmentStartOffset);
+    Map.Entry<MockId, IndexValue> secondIndexSegmentEntry = secondIndexSegment.firstEntry();
+    expectedKeys.add(secondIndexSegmentEntry.getKey());
+    maxTotalSizeOfEntries += secondIndexSegmentEntry.getValue().getSize();
+    secondIndexSegmentEntry = secondIndexSegment.higherEntry(secondIndexSegmentEntry.getKey());
+    expectedKeys.add(secondIndexSegmentEntry.getKey());
+    maxTotalSizeOfEntries += secondIndexSegmentEntry.getValue().getSize();
+
+    StoreFindToken startToken = new StoreFindToken(firstId, firstIndexSegmentStartOffset, sessionId);
+    StoreFindToken expectedEndToken =
+        new StoreFindToken(secondIndexSegmentEntry.getKey(), secondIndexSegmentStartOffset, sessionId);
+    expectedEndToken.setBytesRead(log.getDifference(secondIndexSegmentStartOffset, logAbsoluteZero));
+    doFindEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
+
+    // ------------------
+    // 2. Uninitialized -> Index
+    // add firstStoreKey and its size
+    expectedKeys.add(firstId);
+    maxTotalSizeOfEntries += allKeys.get(firstId).getFirst().getSize();
+    doFindEntriesSinceTest(new StoreFindToken(), maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
+
+    // ------------------
+    // 3. Journal -> Index
+    // create a journal based token for an offset that isn't in the journal
+    startToken = new StoreFindToken(logOrder.firstKey(), sessionId);
+    doFindEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
+  }
+
+  /**
+   * Tests all cases of {@link PersistentIndex#findEntriesSince(FindToken, long)} that result in an journal based
+   * {@link StoreFindToken} being returned.
+   * 1. Uninited -> Journal
+   * 2. Index -> Journal
+   * 3. Journal -> Journal
+   * 4. No movement.
+   * @throws StoreException
+   */
+  private void findEntriesSinceToJournalBasedTest() throws StoreException {
+    StoreFindToken absoluteEndToken = new StoreFindToken(logOrder.lastKey(), sessionId);
+    absoluteEndToken.setBytesRead(log.getUsedCapacity());
+
+    // ------------------
+    // 1. Uninitialized -> Journal
+    doFindEntriesSinceTest(new StoreFindToken(), Long.MAX_VALUE, allKeys.keySet(), absoluteEndToken);
+
+    // ------------------
+    // 2. Index -> Journal
+    Offset firstIndexSegmentStartOffset = referenceIndex.firstKey();
+    StoreKey firstStoreKey = referenceIndex.get(firstIndexSegmentStartOffset).firstKey();
+    StoreFindToken startToken = new StoreFindToken(firstStoreKey, firstIndexSegmentStartOffset, sessionId);
+    Set<MockId> expectedKeys = new HashSet<>(allKeys.keySet());
+    if (!deletedKeys.contains(firstStoreKey)) {
+      // if firstStoreKey has not been deleted, it will not show up in findEntries since its PUT record is ignored
+      expectedKeys.remove(firstStoreKey);
+    }
+    doFindEntriesSinceTest(startToken, Long.MAX_VALUE, expectedKeys, absoluteEndToken);
+
+    // ------------------
+    // 3. Journal -> Journal
+    // a. Token no longer in journal
+    startToken = new StoreFindToken(logOrder.firstKey(), sessionId);
+    doFindEntriesSinceTest(startToken, Long.MAX_VALUE, allKeys.keySet(), absoluteEndToken);
+
+    // b. Token still in journal
+    startToken = new StoreFindToken(index.journal.getFirstOffset(), sessionId);
+    expectedKeys = new HashSet<>();
+    for (Map.Entry<Offset, Pair<MockId, IndexValue>> entry : logOrder.tailMap(startToken.getOffset(), false)
+        .entrySet()) {
+      expectedKeys.add(entry.getValue().getFirst());
+    }
+    doFindEntriesSinceTest(startToken, Long.MAX_VALUE, expectedKeys, absoluteEndToken);
+
+    // ------------------
+    // 4. Journal no change
+    doFindEntriesSinceTest(absoluteEndToken, Long.MAX_VALUE, Collections.EMPTY_SET, absoluteEndToken);
+  }
+
+  /**
+   * Uses {@link PersistentIndex#findEntriesSince(FindToken, long)} to get entries one by one.
+   * @throws StoreException
+   */
+  private void findEntriesSinceOneByOneTest() throws StoreException {
+    Offset logAbsoluteZero = new Offset(log.getFirstSegment().getName(), 0);
+    Offset journalStartOffset = index.journal.getFirstOffset();
+    StoreFindToken startToken = new StoreFindToken();
+    Offset stoppedAt = null;
+    for (Map.Entry<Offset, TreeMap<MockId, IndexValue>> indexEntry : referenceIndex.entrySet()) {
+      Offset indexSegmentStartOffset = indexEntry.getKey();
+      // We get index based tokens as long as
+      // 1. The original token is index based
+      // 2. The size of entries being obtained is <= the size of records in the current index segment
+      if (indexSegmentStartOffset.compareTo(journalStartOffset) >= 0) {
+        stoppedAt = indexSegmentStartOffset;
+        break;
+      }
+      for (Map.Entry<MockId, IndexValue> indexSegmentEntry : indexEntry.getValue().entrySet()) {
+        MockId id = indexSegmentEntry.getKey();
+        StoreFindToken expectedEndToken = new StoreFindToken(id, indexSegmentStartOffset, sessionId);
+        expectedEndToken.setBytesRead(log.getDifference(indexSegmentStartOffset, logAbsoluteZero));
+        doFindEntriesSinceTest(startToken, indexSegmentEntry.getValue().getSize(), Collections.singleton(id),
+            expectedEndToken);
+        startToken = expectedEndToken;
+      }
+    }
+
+    Map.Entry<Offset, Pair<MockId, IndexValue>> logEntry = logOrder.floorEntry(stoppedAt);
+    while (logEntry != null) {
+      Offset startOffset = logEntry.getKey();
+      MockId id = logEntry.getValue().getFirst();
+      Pair<IndexValue, IndexValue> putDelete = allKeys.get(id);
+      // size returned is the size of the delete if the key has been deleted.
+      long size = putDelete.getSecond() != null ? putDelete.getSecond().getSize() : putDelete.getFirst().getSize();
+      StoreFindToken expectedEndToken = new StoreFindToken(startOffset, sessionId);
+      Offset endOffset = log.getFileSpanForMessage(startOffset, size).getEndOffset();
+      expectedEndToken.setBytesRead(log.getDifference(endOffset, logAbsoluteZero));
+      doFindEntriesSinceTest(startToken, size, Collections.singleton(id), expectedEndToken);
+      startToken = expectedEndToken;
+      logEntry = logOrder.higherEntry(logEntry.getKey());
+    }
+  }
+
+  /**
+   * Tests {@link PersistentIndex#findEntriesSince(FindToken, long)} when an index based {@link StoreFindToken} has been
+   * given out for an offset in the {@link Journal}.
+   * @throws StoreException
+   */
+  private void findEntriesSinceIndexBasedTokenForOffsetInJournalTest() throws StoreException {
+    Map.Entry<Offset, TreeMap<MockId, IndexValue>> indexEntry =
+        referenceIndex.floorEntry(index.journal.getFirstOffset());
+    Offset nextIndexSegmentStartOffset = referenceIndex.higherKey(indexEntry.getKey());
+    MockId firstIdInSegment = indexEntry.getValue().firstKey();
+    StoreFindToken startToken = new StoreFindToken(firstIdInSegment, indexEntry.getKey(), sessionId);
+    long maxSize = 0;
+    Set<MockId> expectedKeys = new HashSet<>();
+    for (Map.Entry<MockId, IndexValue> indexSegmentEntry : indexEntry.getValue().entrySet()) {
+      if (!firstIdInSegment.equals(indexSegmentEntry.getKey())) {
+        expectedKeys.add(indexSegmentEntry.getKey());
+        maxSize += indexSegmentEntry.getValue().getSize();
+      }
+    }
+    MockId logId = logOrder.get(nextIndexSegmentStartOffset).getFirst();
+    expectedKeys.add(logId);
+    long size = deletedKeys.contains(logId) ? DELETE_RECORD_SIZE
+        : logOrder.get(nextIndexSegmentStartOffset).getSecond().getSize();
+    maxSize += size;
+
+    Offset endOffset = log.getFileSpanForMessage(nextIndexSegmentStartOffset, size).getEndOffset();
+    StoreFindToken expectedEndToken = new StoreFindToken(nextIndexSegmentStartOffset, sessionId);
+    expectedEndToken.setBytesRead(log.getDifference(endOffset, new Offset(log.getFirstSegment().getName(), 0)));
+    doFindEntriesSinceTest(startToken, maxSize, expectedKeys, expectedEndToken);
+  }
+
+  /**
+   * Does the test for {@link PersistentIndex#findEntriesSince(FindToken, long)} and compares the token received to
+   * the expected token. It also verifies that the index entries obtained are as expected.
+   * @param startToken the {@link StoreFindToken} to provide to the function.
+   * @param maxTotalSizeOfEntries the total size of entries to fetch
+   * @param expectedKeys the keys expected in the returned entries.
+   * @param expectedEndToken the {@link StoreFindToken} expected to be returned.
+   * @throws StoreException
+   */
+  private void doFindEntriesSinceTest(StoreFindToken startToken, long maxTotalSizeOfEntries, Set<MockId> expectedKeys,
+      StoreFindToken expectedEndToken) throws StoreException {
+    FindInfo findInfo = index.findEntriesSince(startToken, maxTotalSizeOfEntries);
+    StoreFindToken token = (StoreFindToken) findInfo.getFindToken();
+    compareTokens(expectedEndToken, token);
+    assertEquals("Returned token should have the right number of bytes read", expectedEndToken.getBytesRead(),
+        token.getBytesRead());
+    List<MessageInfo> infos = findInfo.getMessageEntries();
+    Set<StoreKey> keysExamined = new HashSet<>();
+    for (MessageInfo info : infos) {
+      Pair<IndexValue, IndexValue> putDelete = allKeys.get(info.getStoreKey());
+      IndexValue value = putDelete.getFirst();
+      // size returned is hard to predict if the key has been deleted - it depends on the locations of the PUT and
+      // DELETE entries and whether both or one of them is present in the return list. It is not useful to recompute the
+      // situations here and check since there isn't currently a reason to depend on the size if the record has been
+      // deleted.
+      if (putDelete.getSecond() == null) {
+        assertEquals("Inconsistent size", value.getSize(), info.getSize());
+      }
+      // if a key is deleted, it doesn't matter if we reached the delete record or not, the delete state will be
+      // the one that is returned.
+      assertEquals("Inconsistent delete state ", putDelete.getSecond() != null, info.isDeleted());
+      assertEquals("Inconsistent expiresAtMs", value.getExpiresAtMs(), info.getExpirationTimeInMs());
+      keysExamined.add(info.getStoreKey());
+    }
+    assertEquals("All keys should be present", expectedKeys, keysExamined);
+  }
+
+  // findEntriesSinceTest() and findEntriesSinceOnRestartTest() helpers
+
+  /**
+   * Tests for failure of {@link PersistentIndex#findEntriesSince(FindToken, long)}.
+   * @param token the {@link StoreFindToken} to provide to the function.
+   * @param expectedCode the expected {@link StoreErrorCodes}.
+   */
+  private void doFindEntriesSinceFailureTest(StoreFindToken token, StoreErrorCodes expectedCode) {
+    try {
+      index.findEntriesSince(token, Long.MAX_VALUE);
+      fail("Should have failed because token is beyond the end offset in the index");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", expectedCode, e.getErrorCode());
+    }
+  }
+
+  // findEntriesSinceTest(), findDeletedEntriesSinceTest() and findEntriesSinceOnRestartTest() helpers
+
+  /**
+   * Tests the case where {@link PersistentIndex#findEntriesSince(FindToken, long)} or
+   * {@link PersistentIndex#findDeletedEntriesSince(FindToken, long, long)} is run on an empty index.
+   * @param deletedEntries if {@code true}, the test is on
+   * {@link PersistentIndex#findDeletedEntriesSince(FindToken, long, long)}.
+   * @throws StoreException
+   */
+  private void findEntriesSinceInEmptyIndexTest(boolean deletedEntries) throws StoreException {
+    closeAndClearIndex();
+    reloadIndex(false);
+    StoreFindToken token = new StoreFindToken();
+    token.setBytesRead(0);
+    if (deletedEntries) {
+      doFindDeletedEntriesSinceTest(token, Long.MAX_VALUE, Collections.EMPTY_SET, token);
+    } else {
+      doFindEntriesSinceTest(token, Long.MAX_VALUE, Collections.EMPTY_SET, token);
+    }
+  }
+
+  // findDeletedEntriesSinceTest() helpers
+
+  /**
+   * Tests all cases of {@link PersistentIndex#findDeletedEntriesSince(FindToken, long, long)} that result in an index
+   * based {@link StoreFindToken} being returned.
+   * 1. Uninited -> Index
+   * 2. Index -> Index
+   * 3. Journal -> Index
+   * @throws StoreException
+   */
+  private void findDeletedEntriesSinceToIndexBasedTest() throws StoreException {
+    // ------------------
+    // 1. Index -> Index
+    Offset secondIndexSegmentStartOffset = referenceIndex.higherKey(referenceIndex.firstKey());
+    Map.Entry<MockId, IndexValue> firstSegmentEntry = referenceIndex.get(secondIndexSegmentStartOffset).firstEntry();
+    // Most elements from the second to be returned (because of size restrictions)
+    Set<MockId> expectedKeys = new HashSet<>();
+    long maxTotalSizeOfEntries = 0;
+    MockId lastKey = null;
+    for (Map.Entry<MockId, IndexValue> segmentEntry : referenceIndex.get(secondIndexSegmentStartOffset).entrySet()) {
+      if (!segmentEntry.equals(firstSegmentEntry)) {
+        if (segmentEntry.getValue().isFlagSet(IndexValue.Flags.Delete_Index)) {
+          expectedKeys.add(segmentEntry.getKey());
+        }
+        maxTotalSizeOfEntries += segmentEntry.getValue().getSize();
+      }
+      lastKey = segmentEntry.getKey();
+    }
+    StoreFindToken startToken =
+        new StoreFindToken(firstSegmentEntry.getKey(), secondIndexSegmentStartOffset, sessionId);
+    StoreFindToken expectedEndToken = new StoreFindToken(lastKey, secondIndexSegmentStartOffset, sessionId);
+    doFindDeletedEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
+
+    // ------------------
+    // 2. Uninitialized -> Index
+    // add size of values and any keys that are supposed to be returned from the first index segment
+    for (Map.Entry<MockId, IndexValue> segmentEntry : referenceIndex.firstEntry().getValue().entrySet()) {
+      if (segmentEntry.getValue().isFlagSet(IndexValue.Flags.Delete_Index)) {
+        expectedKeys.add(segmentEntry.getKey());
+      }
+      maxTotalSizeOfEntries += segmentEntry.getValue().getSize();
+    }
+    // add size of value of firstIdInSegment
+    maxTotalSizeOfEntries += firstSegmentEntry.getValue().getSize();
+    if (firstSegmentEntry.getValue().isFlagSet(IndexValue.Flags.Delete_Index)) {
+      expectedKeys.add(firstSegmentEntry.getKey());
+    }
+    doFindDeletedEntriesSinceTest(new StoreFindToken(), maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
+
+    // ------------------
+    // 3. Journal -> Index
+    // create a journal based token for an offset that isn't in the journal
+    startToken = new StoreFindToken(logOrder.firstKey(), sessionId);
+    doFindDeletedEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
+  }
+
+  /**
+   * Tests all cases of {@link PersistentIndex#findDeletedEntriesSince(FindToken, long, long)} that result in an journal
+   * based {@link StoreFindToken} being returned.
+   * 1. Uninited -> Journal
+   * 2. Index -> Journal
+   * 3. Journal -> Journal
+   * 4. No movement.
+   * @throws StoreException
+   */
+  private void findDeletedEntriesSinceToJournalBasedTest() throws StoreException {
+    StoreFindToken absoluteEndToken = new StoreFindToken(logOrder.lastKey(), sessionId);
+
+    // ------------------
+    // 1. Uninitialized -> Journal
+    doFindDeletedEntriesSinceTest(new StoreFindToken(), Long.MAX_VALUE, deletedKeys, absoluteEndToken);
+
+    // ------------------
+    // 2. Index -> Journal
+    Offset secondIndexSegmentStartOffset = referenceIndex.higherKey(referenceIndex.firstKey());
+    // second index segment contains the first delete entry
+    StoreKey firstDeletedKey = getDeletedKeyFromIndexSegment(secondIndexSegmentStartOffset);
+    StoreFindToken startToken = new StoreFindToken(firstDeletedKey, secondIndexSegmentStartOffset, sessionId);
+    Set<MockId> expectedKeys = new HashSet<>(deletedKeys);
+    expectedKeys.remove(firstDeletedKey);
+    doFindDeletedEntriesSinceTest(startToken, Long.MAX_VALUE, expectedKeys, absoluteEndToken);
+
+    // ------------------
+    // 3. Journal -> Journal
+    // a. Token no longer in journal
+    startToken = new StoreFindToken(allKeys.get(firstDeletedKey).getSecond().getOffset(), sessionId);
+    doFindDeletedEntriesSinceTest(startToken, Long.MAX_VALUE, deletedKeys, absoluteEndToken);
+
+    // b. Token still in journal
+    startToken = new StoreFindToken(index.journal.getFirstOffset(), sessionId);
+    expectedKeys.clear();
+    for (Map.Entry<Offset, Pair<MockId, IndexValue>> entry : logOrder.tailMap(startToken.getOffset(), false)
+        .entrySet()) {
+      if (entry.getValue().getSecond().isFlagSet(IndexValue.Flags.Delete_Index)) {
+        expectedKeys.add(entry.getValue().getFirst());
+      }
+    }
+    doFindDeletedEntriesSinceTest(startToken, Long.MAX_VALUE, expectedKeys, absoluteEndToken);
+
+    // ------------------
+    // 4. Journal no change
+    doFindDeletedEntriesSinceTest(absoluteEndToken, Long.MAX_VALUE, Collections.EMPTY_SET, absoluteEndToken);
+  }
+
+  /**
+   * Uses {@link PersistentIndex#findDeletedEntriesSince(FindToken, long, long)} to get entries one by one.
+   * @throws StoreException
+   */
+  private void findDeletedEntriesSinceOneByOneTest() throws StoreException {
+    Offset journalStartOffset = index.journal.getFirstOffset();
+    StoreFindToken startToken = new StoreFindToken();
+    Offset stoppedAt = null;
+    for (Map.Entry<Offset, TreeMap<MockId, IndexValue>> indexEntry : referenceIndex.entrySet()) {
+      Offset indexSegmentStartOffset = indexEntry.getKey();
+      // We get index based tokens as long as
+      // 1. The original token is index based
+      // 2. The size of entries being obtained is <= the size of records in the current index segment
+      if (indexSegmentStartOffset.compareTo(journalStartOffset) >= 0) {
+        stoppedAt = indexSegmentStartOffset;
+        break;
+      }
+      for (Map.Entry<MockId, IndexValue> indexSegmentEntry : indexEntry.getValue().entrySet()) {
+        MockId id = indexSegmentEntry.getKey();
+        boolean isDeleted = indexSegmentEntry.getValue().isFlagSet(IndexValue.Flags.Delete_Index);
+        StoreFindToken expectedEndToken = new StoreFindToken(id, indexSegmentStartOffset, sessionId);
+        long size = indexSegmentEntry.getValue().getSize();
+        doFindDeletedEntriesSinceTest(startToken, size, isDeleted ? Collections.singleton(id) : Collections.EMPTY_SET,
+            expectedEndToken);
+        startToken = expectedEndToken;
+      }
+    }
+
+    Map.Entry<Offset, Pair<MockId, IndexValue>> logEntry = logOrder.floorEntry(stoppedAt);
+    while (logEntry != null) {
+      Offset startOffset = logEntry.getKey();
+      MockId id = logEntry.getValue().getFirst();
+      Pair<IndexValue, IndexValue> putDelete = allKeys.get(id);
+      boolean isDeleted = putDelete.getSecond() != null;
+      // size returned is the size of the delete if the key has been deleted.
+      long size = isDeleted ? putDelete.getSecond().getSize() : putDelete.getFirst().getSize();
+      StoreFindToken expectedEndToken = new StoreFindToken(startOffset, sessionId);
+      doFindDeletedEntriesSinceTest(startToken, size, isDeleted ? Collections.singleton(id) : Collections.EMPTY_SET,
+          expectedEndToken);
+      startToken = expectedEndToken;
+      logEntry = logOrder.higherEntry(logEntry.getKey());
+    }
+  }
+
+  /**
+   * Tests {@link PersistentIndex#findDeletedEntriesSince(FindToken, long, long)} when an index based
+   * {@link StoreFindToken} has been given out for an offset in the {@link Journal}.
+   * @throws StoreException
+   */
+  private void findDeletedEntriesSinceIndexBasedTokenForOffsetInJournalTest() throws StoreException {
+    Map.Entry<Offset, TreeMap<MockId, IndexValue>> indexEntry =
+        referenceIndex.floorEntry(index.journal.getFirstOffset());
+    Offset nextIndexSegmentStartOffset = referenceIndex.higherKey(indexEntry.getKey());
+    MockId firstIdInSegment = indexEntry.getValue().firstKey();
+    StoreFindToken startToken = new StoreFindToken(firstIdInSegment, indexEntry.getKey(), sessionId);
+    long maxSize = 0;
+    Set<MockId> expectedKeys = new HashSet<>();
+    for (Map.Entry<MockId, IndexValue> indexSegmentEntry : indexEntry.getValue().entrySet()) {
+      if (!firstIdInSegment.equals(indexSegmentEntry.getKey())) {
+        if (indexSegmentEntry.getValue().isFlagSet(IndexValue.Flags.Delete_Index)) {
+          expectedKeys.add(indexSegmentEntry.getKey());
+        }
+        maxSize += indexSegmentEntry.getValue().getSize();
+      }
+    }
+    MockId logId = logOrder.get(nextIndexSegmentStartOffset).getFirst();
+    long size = logOrder.get(nextIndexSegmentStartOffset).getSecond().getSize();
+    if (deletedKeys.contains(logId)) {
+      expectedKeys.add(logId);
+      size = DELETE_RECORD_SIZE;
+    }
+    maxSize += size;
+
+    StoreFindToken expectedEndToken = new StoreFindToken(nextIndexSegmentStartOffset, sessionId);
+    doFindDeletedEntriesSinceTest(startToken, maxSize, expectedKeys, expectedEndToken);
+  }
+
+  /**
+   * Does the test for {@link PersistentIndex#findDeletedEntriesSince(FindToken, long, long)}  and compares the token
+   * received to the expected token. It also verifies that the index entries obtained are as expected.
+   * @param startToken the {@link StoreFindToken} to provide to the function.
+   * @param maxTotalSizeOfEntries the total size of entries to fetch
+   * @param expectedKeys the keys expected in the returned entries.
+   * @param expectedEndToken the {@link StoreFindToken} expected to be returned.
+   * @throws StoreException
+   */
+  private void doFindDeletedEntriesSinceTest(StoreFindToken startToken, long maxTotalSizeOfEntries,
+      Set<MockId> expectedKeys, StoreFindToken expectedEndToken) throws StoreException {
+    FindInfo findInfo = index.findDeletedEntriesSince(startToken, maxTotalSizeOfEntries, Long.MAX_VALUE);
+    StoreFindToken token = (StoreFindToken) findInfo.getFindToken();
+    compareTokens(expectedEndToken, token);
+    List<MessageInfo> infos = findInfo.getMessageEntries();
+    Set<StoreKey> keysExamined = new HashSet<>();
+    for (MessageInfo info : infos) {
+      IndexValue value = allKeys.get(info.getStoreKey()).getSecond();
+      assertEquals("Inconsistent size", value.getSize(), info.getSize());
+      assertTrue("Not deleted", info.isDeleted());
+      assertEquals("Inconsistent expiresAtMs", value.getExpiresAtMs(), info.getExpirationTimeInMs());
+      keysExamined.add(info.getStoreKey());
+    }
+    assertEquals("All keys should be present", expectedKeys, keysExamined);
+  }
+
+  /**
+   * Gets a deleted key from the index segment with start offset {@code indexSegmentStartOffset}.
+   * @param indexSegmentStartOffset the start {@link Offset} of the index segment from which a deleted key is required
+   * @return a deleted key from the index segment with start offset {@code indexSegmentStartOffset}.
+   */
+  private MockId getDeletedKeyFromIndexSegment(Offset indexSegmentStartOffset) {
+    MockId deletedId = null;
+    for (Map.Entry<MockId, IndexValue> indexSegmentEntry : referenceIndex.get(indexSegmentStartOffset).entrySet()) {
+      if (indexSegmentEntry.getValue().isFlagSet(IndexValue.Flags.Delete_Index)) {
+        deletedId = indexSegmentEntry.getKey();
+        break;
+      }
+    }
+    return deletedId;
+  }
+}

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Tests for {@link IndexValue}.
+ */
+public class IndexValueTest {
+
+  /**
+   * Tests an {@link IndexValue} that is representative of a PUT index entry value.
+   */
+  @Test
+  public void putValueTest() {
+    long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    String logSegmentName = LogSegmentNameHelper.getName(pos, gen);
+    long size = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    long offset = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    long expiresAtMs = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    IndexValue value = new IndexValue(size, new Offset(logSegmentName, offset), expiresAtMs);
+    verifyIndexValue(value, logSegmentName, size, offset, false, expiresAtMs, offset);
+    value = new IndexValue(size, new Offset(logSegmentName, offset));
+    verifyIndexValue(value, logSegmentName, size, offset, false, Utils.Infinite_Time, offset);
+  }
+
+  /**
+   * Tests an {@link IndexValue} that is representative of a DELETE index entry value. Tests both when the DELETE
+   * value is in the same log segment and a different one.
+   */
+  @Test
+  public void deleteRecordTest() {
+    long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    String logSegmentName = LogSegmentNameHelper.getName(pos, gen);
+    long oldSize = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    long oldOffset = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    long expiresAtMs = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    IndexValue value = new IndexValue(oldSize, new Offset(logSegmentName, oldOffset), expiresAtMs);
+
+    long newOffset = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    long newSize = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+
+    IndexValue newValue = new IndexValue(logSegmentName, value.getBytes());
+    // delete in the same log segment
+    newValue.setFlag(IndexValue.Flags.Delete_Index);
+    newValue.setNewOffset(new Offset(logSegmentName, newOffset));
+    newValue.setNewSize(newSize);
+    verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expiresAtMs, oldOffset);
+
+    newValue = new IndexValue(logSegmentName, value.getBytes());
+    String newLogSegmentName = LogSegmentNameHelper.getNextPositionName(logSegmentName);
+    // delete not in the same log segment
+    newValue.setFlag(IndexValue.Flags.Delete_Index);
+    newValue.setNewOffset(new Offset(newLogSegmentName, newOffset));
+    newValue.setNewSize(newSize);
+    verifyIndexValue(newValue, newLogSegmentName, newSize, newOffset, true, expiresAtMs, -1);
+  }
+
+  /**
+   * Verifies the given {@code value} for the returns of the getters. Also verifies that an {@link IndexValue} created
+   * with {@link IndexValue#getBytes()} from {@code value} exports the same data.
+   * @param value the {@link IndexValue} that needs to be checked.
+   * @param logSegmentName the name of the log segment containing the record for which {@code value} is the
+   * {@link IndexValue}.
+   * @param size the size expected in {@code value}.
+   * @param offset the offset expected in {@code value}.
+   * @param isDeleted the expected record type referred to by {@code value}.
+   * @param expiresAtMs the expected expiration time in {@code value}.
+   * @param originalMessageOffset the original message offset expected in {@code value}.
+   */
+  private void verifyIndexValue(IndexValue value, String logSegmentName, long size, long offset, boolean isDeleted,
+      long expiresAtMs, long originalMessageOffset) {
+    verifyGetters(value, logSegmentName, size, offset, isDeleted, expiresAtMs, originalMessageOffset);
+    verifyGetters(new IndexValue(logSegmentName, value.getBytes()), logSegmentName, size, offset, isDeleted,
+        expiresAtMs, originalMessageOffset);
+  }
+
+  /**
+   * Verifies the given {@code value} for the returns of the getters.
+   * @param value the {@link IndexValue} that needs to be checked.
+   * @param logSegmentName the name of the log segment containing the record for which {@code value} is the
+   * {@link IndexValue}.
+   * @param size the size expected in {@code value}.
+   * @param offset the offset expected in {@code value}.
+   * @param isDeleted the expected record type referred to by {@code value}.
+   * @param expiresAtMs the expected expiration time in {@code value}.
+   * @param originalMessageOffset the original message offset expected in {@code value}.
+   */
+  private void verifyGetters(IndexValue value, String logSegmentName, long size, long offset, boolean isDeleted,
+      long expiresAtMs, long originalMessageOffset) {
+    assertEquals("Size is not as expected", size, value.getSize());
+    assertEquals("Offset is not as expected", new Offset(logSegmentName, offset), value.getOffset());
+    assertEquals("Delete status not as expected", isDeleted, value.isFlagSet(IndexValue.Flags.Delete_Index));
+    assertEquals("ExpiresAtMs not as expected", expiresAtMs, value.getExpiresAtMs());
+    assertEquals("Original message offset not as expected", originalMessageOffset, value.getOriginalMessageOffset());
+  }
+}
+

--- a/ambry-store/src/test/java/com.github.ambry.store/JournalTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/JournalTest.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
@@ -22,43 +24,64 @@ public class JournalTest {
 
   @Test
   public void testJournalOperation() {
+    long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+    String firstLogSegmentName = LogSegmentNameHelper.getName(pos, gen);
+    String secondLogSegmentName = LogSegmentNameHelper.getNextPositionName(firstLogSegmentName);
     Journal journal = new Journal("test", 10, 5);
-    journal.addEntry(new Offset("", 0), new MockId("id1"));
-    journal.addEntry(new Offset("", 1000), new MockId("id2"));
-    journal.addEntry(new Offset("", 2000), new MockId("id3"));
-    journal.addEntry(new Offset("", 3000), new MockId("id4"));
-    journal.addEntry(new Offset("", 4000), new MockId("id5"));
-    journal.addEntry(new Offset("", 5000), new MockId("id6"));
-    journal.addEntry(new Offset("", 6000), new MockId("id7"));
-    journal.addEntry(new Offset("", 7000), new MockId("id8"));
-    journal.addEntry(new Offset("", 8000), new MockId("id9"));
-    journal.addEntry(new Offset("", 9000), new MockId("id10"));
-    List<JournalEntry> entries = journal.getEntriesSince(new Offset("", 0), true);
-    Assert.assertEquals(entries.get(0).getOffset(), new Offset("", 0));
+    Assert.assertNull("First offset should be null", journal.getFirstOffset());
+    Assert.assertNull("Last offset should be null", journal.getLastOffset());
+    Assert.assertNull("Should not be able to get entries because there are none",
+        journal.getEntriesSince(new Offset(firstLogSegmentName, 0), true));
+    journal.addEntry(new Offset(firstLogSegmentName, 0), new MockId("id1"));
+    journal.addEntry(new Offset(firstLogSegmentName, 1000), new MockId("id2"));
+    journal.addEntry(new Offset(firstLogSegmentName, 2000), new MockId("id3"));
+    journal.addEntry(new Offset(firstLogSegmentName, 3000), new MockId("id4"));
+    journal.addEntry(new Offset(firstLogSegmentName, 4000), new MockId("id5"));
+    journal.addEntry(new Offset(secondLogSegmentName, 0), new MockId("id6"));
+    journal.addEntry(new Offset(secondLogSegmentName, 1000), new MockId("id7"));
+    journal.addEntry(new Offset(secondLogSegmentName, 2000), new MockId("id8"));
+    journal.addEntry(new Offset(secondLogSegmentName, 3000), new MockId("id9"));
+    journal.addEntry(new Offset(secondLogSegmentName, 4000), new MockId("id10"));
+    Assert.assertEquals("First offset not as expected", new Offset(firstLogSegmentName, 0), journal.getFirstOffset());
+    Assert.assertEquals("Last offset not as expected", new Offset(secondLogSegmentName, 4000), journal.getLastOffset());
+    List<JournalEntry> entries = journal.getEntriesSince(new Offset(firstLogSegmentName, 0), true);
+    Assert.assertEquals(entries.get(0).getOffset(), new Offset(firstLogSegmentName, 0));
     Assert.assertEquals(entries.get(0).getKey(), new MockId("id1"));
     Assert.assertEquals(entries.size(), 5);
-    Assert.assertEquals(entries.get(4).getOffset(), new Offset("", 4000));
+    Assert.assertEquals(entries.get(4).getOffset(), new Offset(firstLogSegmentName, 4000));
     Assert.assertEquals(entries.get(4).getKey(), new MockId("id5"));
-    entries = journal.getEntriesSince(new Offset("", 5000), false);
-    Assert.assertEquals(entries.get(0).getOffset(), new Offset("", 6000));
+    entries = journal.getEntriesSince(new Offset(secondLogSegmentName, 0), false);
+    Assert.assertEquals(entries.get(0).getOffset(), new Offset(secondLogSegmentName, 1000));
     Assert.assertEquals(entries.get(0).getKey(), new MockId("id7"));
-    Assert.assertEquals(entries.get(3).getOffset(), new Offset("", 9000));
+    Assert.assertEquals(entries.get(3).getOffset(), new Offset(secondLogSegmentName, 4000));
     Assert.assertEquals(entries.get(3).getKey(), new MockId("id10"));
     Assert.assertEquals(entries.size(), 4);
-    entries = journal.getEntriesSince(new Offset("", 7000), false);
-    Assert.assertEquals(entries.get(0).getOffset(), new Offset("", 8000));
+    entries = journal.getEntriesSince(new Offset(secondLogSegmentName, 2000), false);
+    Assert.assertEquals(entries.get(0).getOffset(), new Offset(secondLogSegmentName, 3000));
     Assert.assertEquals(entries.get(0).getKey(), new MockId("id9"));
-    Assert.assertEquals(entries.get(1).getOffset(), new Offset("", 9000));
+    Assert.assertEquals(entries.get(1).getOffset(), new Offset(secondLogSegmentName, 4000));
     Assert.assertEquals(entries.get(1).getKey(), new MockId("id10"));
     Assert.assertEquals(entries.size(), 2);
-    journal.addEntry(new Offset("", 10000), new MockId("id11"));
-    entries = journal.getEntriesSince(new Offset("", 0), true);
+    entries = journal.getEntriesSince(new Offset(firstLogSegmentName, 2000), false);
+    Assert.assertEquals(entries.get(0).getOffset(), new Offset(firstLogSegmentName, 3000));
+    Assert.assertEquals(entries.get(0).getKey(), new MockId("id4"));
+    Assert.assertEquals(entries.get(4).getOffset(), new Offset(secondLogSegmentName, 2000));
+    Assert.assertEquals(entries.get(4).getKey(), new MockId("id8"));
+    Assert.assertEquals(entries.size(), 5);
+    Assert.assertNull("Should not be able to get entries because offset does not exist",
+        journal.getEntriesSince(new Offset(firstLogSegmentName, 1), true));
+    journal.addEntry(new Offset(secondLogSegmentName, 5000), new MockId("id11"));
+    Assert.assertEquals("First offset not as expected", new Offset(firstLogSegmentName, 1000),
+        journal.getFirstOffset());
+    Assert.assertEquals("Last offset not as expected", new Offset(secondLogSegmentName, 5000), journal.getLastOffset());
+    entries = journal.getEntriesSince(new Offset(firstLogSegmentName, 0), true);
     Assert.assertNull(entries);
-    entries = journal.getEntriesSince(new Offset("", 1000), false);
-    Assert.assertEquals(entries.get(0).getOffset(), new Offset("", 2000));
+    entries = journal.getEntriesSince(new Offset(firstLogSegmentName, 1000), false);
+    Assert.assertEquals(entries.get(0).getOffset(), new Offset(firstLogSegmentName, 2000));
     Assert.assertEquals(entries.get(0).getKey(), new MockId("id3"));
     Assert.assertEquals(entries.size(), 5);
-    Assert.assertEquals(entries.get(4).getOffset(), new Offset("", 6000));
+    Assert.assertEquals(entries.get(4).getOffset(), new Offset(secondLogSegmentName, 1000));
     Assert.assertEquals(entries.get(4).getKey(), new MockId("id7"));
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/MockId.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/MockId.java
@@ -42,7 +42,7 @@ public class MockId extends StoreKey {
 
   @Override
   public String getID() {
-    return toString();
+    return id;
   }
 
   @Override
@@ -90,5 +90,10 @@ public class MockId extends StoreKey {
       return false;
     }
     return true;
+  }
+
+  @Override
+  public String toString() {
+    return getID();
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
@@ -14,116 +14,310 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.ByteBufferOutputStream;
+import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
+import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
-import org.junit.Assert;
+import org.junit.After;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 
+/**
+ * Tests for {@link StoreMessageReadSet} and {@link BlobReadOptions}.
+ */
 public class StoreMessageReadSetTest {
+  private static final StoreKeyFactory STORE_KEY_FACTORY;
 
-  /**
-   * Create a temporary file
-   */
-  File tempFile() throws IOException {
-    File f = File.createTempFile("ambry", ".tmp");
-    f.deleteOnExit();
-    return f;
+  static {
+    try {
+      STORE_KEY_FACTORY = Utils.getObj("com.github.ambry.store.MockIdFactory");
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
   }
 
+  private final File tempDir;
+  private final StoreMetrics metrics;
+
+  /**
+   * Creates a temporary directory.
+   * @throws IOException
+   */
+  public StoreMessageReadSetTest() throws IOException {
+    tempDir = StoreTestUtils.createTempDirectory("storeMessageReadSetDir-" + UtilsTest.getRandomString(10));
+    metrics = new StoreMetrics(tempDir.getAbsolutePath(), new MetricRegistry());
+  }
+
+  /**
+   * Deletes the temporary directory.
+   * @throws IOException
+   */
+  @After
+  public void cleanup() throws IOException {
+    assertTrue(tempDir.getAbsolutePath() + " could not be deleted", StoreTestUtils.cleanDirectory(tempDir, true));
+  }
+
+  /**
+   * Primarily tests {@link StoreMessageReadSet} and its APIs but also checks the the {@link Comparable} APIs of
+   * {@link BlobReadOptions}.
+   * @throws IOException
+   */
   @Test
-  public void testMessageRead() throws IOException {
-    File tempFile = tempFile();
+  public void storeMessageReadSetTest() throws IOException {
+    int logCapacity = 2000;
+    int segCapacity = 1000;
+    Log log = new Log(tempDir.getAbsolutePath(), logCapacity, segCapacity, metrics);
     try {
-      RandomAccessFile randomFile = new RandomAccessFile(tempFile.getParent() + File.separator + "log_current", "rw");
-      // preallocate file
-      randomFile.setLength(5000);
-      Log logTest =
-          new Log(tempFile.getParent(), 5000, 5000, new StoreMetrics(tempFile.getParent(), new MetricRegistry()));
-      String logSegmentName = logTest.getFirstSegment().getName();
-      byte[] testbuf = new byte[3000];
-      new Random().nextBytes(testbuf);
-      // append to log from byte buffer
-      int written = logTest.appendFrom(ByteBuffer.wrap(testbuf));
-      Assert.assertEquals(written, 3000);
-      BlobReadOptions readOptions1 = new BlobReadOptions(logTest, new Offset(logSegmentName, 500), 30, 1, null);
-      BlobReadOptions readOptions2 = new BlobReadOptions(logTest, new Offset(logSegmentName, 100), 15, 1, null);
-      BlobReadOptions readOptions3 = new BlobReadOptions(logTest, new Offset(logSegmentName, 200), 100, 1, null);
-      List<BlobReadOptions> options = new ArrayList<>(3);
-      options.add(0, readOptions1);
-      options.add(1, readOptions2);
-      options.add(2, readOptions3);
+      LogSegment firstSegment = log.getFirstSegment();
+      int availableSegCapacity = (int) (segCapacity - firstSegment.getStartOffset());
+      byte[] srcOfTruth = TestUtils.getRandomBytes(2 * availableSegCapacity);
+      ReadableByteChannel dataChannel = Channels.newChannel(new ByteBufferInputStream(ByteBuffer.wrap(srcOfTruth)));
+      log.appendFrom(dataChannel, availableSegCapacity);
+      log.appendFrom(dataChannel, availableSegCapacity);
+      LogSegment secondSegment = log.getNextSegment(firstSegment);
+
+      Offset firstSegOffset1 = new Offset(firstSegment.getName(), firstSegment.getStartOffset());
+      Offset firstSegOffset2 =
+          new Offset(firstSegment.getName(), firstSegment.getStartOffset() + availableSegCapacity / 2);
+      Offset secondSegOffset1 = new Offset(secondSegment.getName(), secondSegment.getStartOffset());
+      Offset secondSegOffset2 =
+          new Offset(secondSegment.getName(), secondSegment.getStartOffset() + availableSegCapacity / 2);
+      BlobReadOptions ro1 = new BlobReadOptions(log, firstSegOffset2, availableSegCapacity / 3, 1, new MockId("id1"));
+      BlobReadOptions ro2 = new BlobReadOptions(log, secondSegOffset1, availableSegCapacity / 4, 1, new MockId("id2"));
+      BlobReadOptions ro3 = new BlobReadOptions(log, secondSegOffset2, availableSegCapacity / 2, 1, new MockId("id3"));
+      BlobReadOptions ro4 = new BlobReadOptions(log, firstSegOffset1, availableSegCapacity / 5, 1, new MockId("id4"));
+      // to test equality in the compareTo() of BlobReadOptions
+      BlobReadOptions ro5 = new BlobReadOptions(log, firstSegOffset2, availableSegCapacity / 6, 1, new MockId("id5"));
+      List<BlobReadOptions> options = new ArrayList<>(Arrays.asList(ro1, ro2, ro3, ro4, ro5));
       MessageReadSet readSet = new StoreMessageReadSet(options);
-      Assert.assertEquals(readSet.count(), 3);
-      Assert.assertEquals(readSet.sizeInBytes(0), 15);
-      Assert.assertEquals(readSet.sizeInBytes(1), 100);
-      Assert.assertEquals(readSet.sizeInBytes(2), 30);
-      ByteBuffer buf = ByteBuffer.allocate(3000);
-      ByteBufferOutputStream stream = new ByteBufferOutputStream(buf);
-      readSet.writeTo(0, Channels.newChannel(stream), 0, 15);
-      Assert.assertEquals(buf.position(), 15);
-      buf.flip();
-      for (int i = 100; i < 115; i++) {
-        Assert.assertEquals(buf.get(), testbuf[i]);
-      }
 
-      buf.flip();
-      readSet.writeTo(0, Channels.newChannel(stream), 5, 1000);
-      Assert.assertEquals(buf.position(), 10);
-      buf.flip();
-      for (int i = 105; i < 115; i++) {
-        Assert.assertEquals(buf.get(), testbuf[i]);
-      }
+      assertEquals(readSet.count(), options.size());
+      // options should get sorted by offsets in the constructor
+      assertEquals(readSet.getKeyAt(0), new MockId("id4"));
+      assertEquals(readSet.sizeInBytes(0), availableSegCapacity / 5);
+      assertEquals(readSet.getKeyAt(1), new MockId("id1"));
+      assertEquals(readSet.sizeInBytes(1), availableSegCapacity / 3);
+      assertEquals(readSet.getKeyAt(2), new MockId("id5"));
+      assertEquals(readSet.sizeInBytes(2), availableSegCapacity / 6);
+      assertEquals(readSet.getKeyAt(3), new MockId("id2"));
+      assertEquals(readSet.sizeInBytes(3), availableSegCapacity / 4);
+      assertEquals(readSet.getKeyAt(4), new MockId("id3"));
+      assertEquals(readSet.sizeInBytes(4), availableSegCapacity / 2);
 
-      // do similarly for index 2
-      buf.clear();
-      readSet.writeTo(1, Channels.newChannel(stream), 0, 100);
-      Assert.assertEquals(buf.position(), 100);
-      buf.flip();
-      for (int i = 200; i < 300; i++) {
-        Assert.assertEquals(buf.get(), testbuf[i]);
-      }
+      ByteBuffer readBuf = ByteBuffer.allocate(availableSegCapacity / 5);
+      ByteBufferOutputStream stream = new ByteBufferOutputStream(readBuf);
 
-      // verify args
-      readOptions1 = new BlobReadOptions(logTest, new Offset(logSegmentName, 500), 30, 1, null);
-      readOptions2 = new BlobReadOptions(logTest, new Offset(logSegmentName, 100), 15, 1, null);
-      readOptions3 = new BlobReadOptions(logTest, new Offset(logSegmentName, 200), 100, 1, null);
-      options = new ArrayList<>(3);
-      options.add(0, readOptions1);
-      options.add(1, readOptions2);
-      options.add(2, readOptions3);
+      // read the first one all at once
+      long written = readSet.writeTo(0, Channels.newChannel(stream), 0, Long.MAX_VALUE);
+      assertEquals("Return value from writeTo() is incorrect", availableSegCapacity / 5, written);
+      assertArrayEquals(readBuf.array(), Arrays.copyOfRange(srcOfTruth, 0, availableSegCapacity / 5));
+
+      // read the second one byte by byte
+      readBuf = ByteBuffer.allocate(availableSegCapacity / 3);
+      stream = new ByteBufferOutputStream(readBuf);
+      WritableByteChannel channel = Channels.newChannel(stream);
+      long currentReadOffset = 0;
+      while (currentReadOffset < availableSegCapacity / 3) {
+        written = readSet.writeTo(1, channel, currentReadOffset, 1);
+        assertEquals("Return value from writeTo() is incorrect", 1, written);
+        currentReadOffset++;
+      }
+      long startOffset = availableSegCapacity / 2;
+      long endOffset = availableSegCapacity / 2 + availableSegCapacity / 3;
+      assertArrayEquals(readBuf.array(), Arrays.copyOfRange(srcOfTruth, (int) startOffset, (int) endOffset));
+
+      // read the last one in multiple stages
+      readBuf = ByteBuffer.allocate(availableSegCapacity / 2);
+      stream = new ByteBufferOutputStream(readBuf);
+      channel = Channels.newChannel(stream);
+      currentReadOffset = 0;
+      while (currentReadOffset < availableSegCapacity / 2) {
+        written = readSet.writeTo(4, channel, currentReadOffset, availableSegCapacity / 6);
+        long expectedWritten = Math.min(availableSegCapacity / 2 - currentReadOffset, availableSegCapacity / 6);
+        assertEquals("Return value from writeTo() is incorrect", expectedWritten, written);
+        currentReadOffset += availableSegCapacity / 6;
+      }
+      startOffset = availableSegCapacity + availableSegCapacity / 2;
+      endOffset = startOffset + availableSegCapacity / 2;
+      assertArrayEquals(readBuf.array(), Arrays.copyOfRange(srcOfTruth, (int) startOffset, (int) endOffset));
+
+      // should not write anything if relative offset is at the size
+      readBuf = ByteBuffer.allocate(1);
+      stream = new ByteBufferOutputStream(readBuf);
+      channel = Channels.newChannel(stream);
+      written = readSet.writeTo(0, channel, readSet.sizeInBytes(0), 1);
+      assertEquals("No data should have been written", 0, written);
+
       try {
-        new BlobReadOptions(logTest, new Offset(logSegmentName, logTest.getFirstSegment().getEndOffset()), 1, 1, null);
-        fail("Construction should have failed because offset + size > endOffset");
-      } catch (IllegalArgumentException e) {
-        // expected. Nothing to do.
-      }
-      readSet = new StoreMessageReadSet(options);
-      try {
-        readSet.sizeInBytes(4);
+        readSet.sizeInBytes(options.size());
         fail("Reading should have failed because index is out of bounds");
       } catch (IndexOutOfBoundsException e) {
         // expected. Nothing to do.
       }
+
       try {
-        readSet.writeTo(4, randomFile.getChannel(), 100, 100);
+        readSet.writeTo(options.size(), channel, 100, 100);
         fail("Reading should have failed because index is out of bounds");
+      } catch (IndexOutOfBoundsException e) {
+        // expected. Nothing to do.
+      }
+
+      try {
+        readSet.getKeyAt(options.size());
+        fail("Getting key should have failed because index is out of bounds");
       } catch (IndexOutOfBoundsException e) {
         // expected. Nothing to do.
       }
     } finally {
-      tempFile.delete();
-      File logFile = new File(tempFile.getParent(), "log_current");
-      logFile.delete();
+      log.close();
     }
+  }
+
+  /**
+   * Tests {@link BlobReadOptions} for getter correctness, serialization/deserialization and bad input.
+   * @throws IOException
+   */
+  @Test
+  public void blobReadOptionsTest() throws IOException {
+    int logCapacity = 2000;
+    int[] segCapacities = {2000, 1000};
+    for (int segCapacity : segCapacities) {
+      Log log = new Log(tempDir.getAbsolutePath(), logCapacity, segCapacity, metrics);
+      try {
+        LogSegment firstSegment = log.getFirstSegment();
+        int availableSegCapacity = (int) (segCapacity - firstSegment.getStartOffset());
+        int count = logCapacity / segCapacity;
+        for (int i = 0; i < count; i++) {
+          ByteBuffer buffer = ByteBuffer.allocate(availableSegCapacity);
+          log.appendFrom(Channels.newChannel(new ByteBufferInputStream(buffer)), availableSegCapacity);
+        }
+        long offset = Utils.getRandomLong(TestUtils.RANDOM, availableSegCapacity) + firstSegment.getStartOffset();
+        long size = Utils.getRandomLong(TestUtils.RANDOM, firstSegment.getEndOffset() - offset);
+        long expiresAtMs = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+        MockId id = new MockId("id1");
+
+        // basic test
+        BlobReadOptions options =
+            new BlobReadOptions(log, new Offset(firstSegment.getName(), offset), size, expiresAtMs, id);
+        assertEquals("Ref count of log segment should have increased", 1, firstSegment.refCount());
+        verifyGetters(options, firstSegment, offset, size, expiresAtMs, id);
+        options.close();
+        assertEquals("Ref count of log segment should have decreased", 0, firstSegment.refCount());
+
+        // toBytes() and back test
+        doSerDeTest(options, firstSegment, log);
+
+        if (count > 1) {
+          // toBytes() and back test for the second segment
+          LogSegment secondSegment = log.getNextSegment(firstSegment);
+          options = new BlobReadOptions(log, new Offset(secondSegment.getName(), offset), size, expiresAtMs, id);
+          assertEquals("Ref count of log segment should have increased", 1, secondSegment.refCount());
+          options.close();
+          assertEquals("Ref count of log segment should have decreased", 0, secondSegment.refCount());
+          doSerDeTest(options, secondSegment, log);
+        }
+
+        try {
+          new BlobReadOptions(log, new Offset(firstSegment.getName(), firstSegment.getEndOffset()), 1, 1, null);
+          fail("Construction should have failed because offset + size > endOffset");
+        } catch (IllegalArgumentException e) {
+          // expected. Nothing to do.
+        }
+      } finally {
+        log.close();
+        StoreTestUtils.cleanDirectory(tempDir, false);
+      }
+    }
+  }
+
+  // helpers
+  // blobReadOptionsTest() helpers
+
+  /**
+   * Verifies getters of {@link BlobReadOptions} for correctness.
+   * @param options the {@link BlobReadOptions} to check.
+   * @param logSegment the expected {@link LogSegment} which {@code options} should refer to.
+   * @param offset the expected offset inside {@code logSegment} which {@code options} should refer to.
+   * @param size the expected size in {@code options}.
+   * @param expiresAtMs the expected expiration time in {@code options}.
+   * @param id the expected {@link MockId} in {@code options}.
+   */
+  private void verifyGetters(BlobReadOptions options, LogSegment logSegment, long offset, long size, long expiresAtMs,
+      MockId id) {
+    assertEquals("LogSegment name not as expected", logSegment.getName(), options.getLogSegmentName());
+    assertEquals("Offset not as expected", offset, options.getOffset());
+    assertEquals("Size not as expected", size, options.getSize());
+    assertEquals("ExpiresAtMs not as expected", expiresAtMs, options.getExpiresAtMs());
+    assertEquals("StoreKey not as expected", id, options.getStoreKey());
+    MessageInfo messageInfo = options.getMessageInfo();
+    assertEquals("Size not as expected", size, messageInfo.getSize());
+    assertEquals("ExpiresAtMs not as expected", expiresAtMs, messageInfo.getExpirationTimeInMs());
+    assertEquals("StoreKey not as expected", id, messageInfo.getStoreKey());
+    Pair<File, FileChannel> fileAndFileChannel = logSegment.getView();
+    assertEquals("File instance not as expected", fileAndFileChannel.getFirst(), options.getFile());
+    assertEquals("FileChannel instance not as expected", fileAndFileChannel.getSecond(), options.getChannel());
+    logSegment.closeView();
+  }
+
+  /**
+   * Serializes {@code readOptions} in all formats and ensures that the {@link BlobReadOptions} obtained from the
+   * deserialization matches the original.
+   * @param readOptions the {@link BlobReadOptions} that has to be serialized/deserialized.
+   * @param segment the {@link LogSegment} referred to by {@code readOptions}.
+   * @param log the {@link Log} that {@code segment} is a part of.
+   * @throws IOException
+   */
+  private void doSerDeTest(BlobReadOptions readOptions, LogSegment segment, Log log) throws IOException {
+    for (short i = 0; i <= 1; i++) {
+      DataInputStream stream = getSerializedStream(readOptions, i);
+      BlobReadOptions deSerReadOptions = BlobReadOptions.fromBytes(stream, STORE_KEY_FACTORY, log);
+      assertEquals("Ref count of log segment should have increased", 1, segment.refCount());
+      verifyGetters(deSerReadOptions, segment, readOptions.getOffset(), readOptions.getSize(),
+          readOptions.getExpiresAtMs(), (MockId) readOptions.getStoreKey());
+      deSerReadOptions.close();
+      assertEquals("Ref count of log segment should have decreased", 0, segment.refCount());
+    }
+  }
+
+  /**
+   * Gets a serialized format of {@code readOptions} in the version {@code version}.
+   * @param readOptions the {@link BlobReadOptions} to serialize.
+   * @param version the version to serialize it in.
+   * @return a serialized format of {@code readOptions} in the version {@code version}.
+   */
+  private DataInputStream getSerializedStream(BlobReadOptions readOptions, short version) {
+    byte[] bytes;
+    switch (version) {
+      case BlobReadOptions.VERSION_0:
+        // version length + offset length + size length + expires at length + key size
+        bytes = new byte[2 + 8 + 8 + 8 + readOptions.getStoreKey().sizeInBytes()];
+        ByteBuffer bufWrap = ByteBuffer.wrap(bytes);
+        bufWrap.putShort(BlobReadOptions.VERSION_0);
+        bufWrap.putLong(readOptions.getOffset());
+        bufWrap.putLong(readOptions.getSize());
+        bufWrap.putLong(readOptions.getExpiresAtMs());
+        bufWrap.put(readOptions.getStoreKey().toBytes());
+      case BlobReadOptions.VERSION_1:
+        bytes = readOptions.toBytes();
+        break;
+      default:
+        throw new IllegalArgumentException("Version " + version + " of BlobReadOptions does not exist");
+    }
+    return new DataInputStream(new ByteBufferInputStream(ByteBuffer.wrap(bytes)));
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+
+/**
+ * Utility class for common functions used in tests of store classes.
+ */
+class StoreTestUtils {
+
+  /**
+   * Creates a temporary directory whose name starts with the given {@code prefix}.
+   * @param prefix the prefix of the directory name.
+   * @return the directory created as a {@link File} instance.
+   * @throws IOException
+   */
+  static File createTempDirectory(String prefix) throws IOException {
+    File tempDir = Files.createTempDirectory(prefix).toFile();
+    tempDir.deleteOnExit();
+    return tempDir;
+  }
+
+  /**
+   * Cleans up the {@code dir} and deletes it.
+   * @param dir the directory to be cleaned up and deleted.
+   * @param deleteDirectory if {@code true}, the directory is deleted too.
+   * @throws IOException
+   */
+  static boolean cleanDirectory(File dir, boolean deleteDirectory) throws IOException {
+    if (!dir.exists()) {
+      return true;
+    }
+    if (!dir.isDirectory()) {
+      throw new IllegalArgumentException(dir.getAbsolutePath() + " is not a directory");
+    }
+    File[] files = dir.listFiles();
+    if (files == null) {
+      throw new IOException("Could not list files in directory: " + dir.getAbsolutePath());
+    }
+    boolean success = true;
+    for (File file : files) {
+      success = file.delete() && success;
+    }
+    return deleteDirectory ? dir.delete() && success : success;
+  }
+}


### PR DESCRIPTION
This commit introduces comprehensive tests for ambry-store particularly the Index, BlobStore and other supporting components. The tests verify the behaviour of the store for both segmented and non segmented logs in a curated setting that mixes all possible cases and configurations.

Most test classes set up a curated test state for each test (the same setup) which covers a lot of use cases, combinations and configurations. The tests then operate on the state or add to the state to verify behavior. 

I'm currently verifying that `IndexTest` covers all cases of `PersistentIndexTest` in order to delete the latter. This is not a blocker however and this PR can be merged and I can make a different PR to add any missing coverage and delete `PersistentIndexTest`.

`./gradlew build && ./gradlew test` passed successfully on both OSx and Linux.

No production logic has changed in this PR.

**Primary reviewer : @pnarayanan**

| Class | Type | Class, % | Method, % | Line, % |
| --- | --- | --- | --- | --- |
`BlobReadOptions` | Old | 100% (1/ 1) | 92.3% (12/ 13) | 82.2% (37/ 45)
`BlobReadOptions` | New | 100% (1/ 1) | 100% (13/ 13) | 87.2% (41/ 47)
`BlobStore` | Old | 100% (1/ 1) | 66.7% (8/ 12) | 68.2% (116/ 170)
`BlobStore` | New | 100% (1/ 1) | 100% (12/ 12) | 88.4% (152/ 172)
`FileSpan` | Old | 100% (1/ 1) | 75% (3/ 4) | 75% (6/ 8)
`FileSpan` | New | 100% (1/ 1) | 100% (4/ 4) | 87.5% (7/ 8)
`FindEntriesCondition` | Old | 100% (1/ 1) | 60% (3/ 5) | 58.3% (7/ 12)
`FindEntriesCondition` | New | 100% (1/ 1) | 80% (4/ 5) | 66.7% (8/ 12)
`HardDeleter` | Old | 100% (3/ 3) | 85.2% (23/ 27) | 74.2% (178/ 240)
`HardDeleter` | New | 100% (3/ 3) | 92.6% (25/ 27) | 79% (196/ 248)
`IndexSegment` | Old | 100% (1/ 1) | 100% (23/ 23) | 88.2% (255/ 289)
`IndexSegment` | New | 100% (1/ 1) | 100% (23/ 23) | 86.3% (270/ 313)
`IndexValue` | Old | 100% (2/ 2) | 100% (18/ 18) | 97.4% (37/ 38)
`IndexValue` | New | 100% (2/ 2) | 100% (18/ 18) | 97.4% (37/ 38)
`Journal` | Old | 100% (1/ 1) | 100% (5/ 5) | 95% (38/ 40)
`Journal` | New | 100% (1/ 1) | 100% (5/ 5) | 95.1% (39/ 41)
`MessageInfo` | Old | 100% (1/ 1) | 80% (8/ 10) | 75% (12/ 16)
`MessageInfo` | New | 100% (1/ 1) | 80% (8/ 10) | 42.9% (12/ 28)
`PersistentIndex` | Old | 83.3% (5/ 6) | 94.7% (36/ 38) | 88.8% (419/ 472)
`PersistentIndex` | New | 100% (5/ 5) | 97.2% (35/ 36) | 91% (475/ 522)
`StoreFindToken` | Old | 100% (3/ 3) | 84.2% (16/ 19) | 60.8% (59/ 97)
`StoreFindToken` | New | 100% (3/ 3) | 89.5% (17/ 19) | 67% (65/ 97)
`StoreInfo` | Old | 100% (1/ 1) | 66.7% (2/ 3) | 80% (4/ 5)
`StoreInfo` | New | 100% (1/ 1) | 100% (3/ 3) | 100% (5/ 5)
`StoreMessageReadSet` | Old | 100% (1/ 1) | 100% (5/ 5) | 95% (19/ 20)
`StoreMessageReadSet` | New | 100% (1/ 1) | 100% (5/ 5) | 100% (20/ 20)