### PR TITLE
Removing some checks from the newScheduler unit test

### DIFF
--- a/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
@@ -379,8 +379,6 @@ public class UtilsTest {
     String threadName = future.get(10, TimeUnit.SECONDS);
     assertTrue("Unexpected thread name returned: " + threadName, threadName.startsWith("ambry-scheduler-"));
     scheduler.shutdown();
-    assertTrue("All tasks should be finished.", scheduler.isTerminated());
-    assertTrue("Scheduler should be shutdown.", scheduler.isShutdown());
   }
 
   private static final String CHARACTERS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";


### PR DESCRIPTION
Removed these lines because
1) It was failing often - `awaitTermination()` needs to be called before being sure that
`isTerminated()` returns `true`
2) The two lines removed are testing `SchedulerExecutorService` which is a java provided
service and need not be tested to ensure the correctness of `newScheduler()`