### PR TITLE
Fixing a couple of issues with startup disk failure handling

### DIFF
--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -178,16 +178,16 @@ class ReplicaThread implements Runnable {
           if (activeReplicasPerNode.size() > 0) {
             try {
               connectedChannel = connectionPool.checkOutConnection(remoteNode.getHostname(),
-                  replicasToReplicatePerNode.get(0).getPort(),
+                  activeReplicasPerNode.get(0).getPort(),
                   replicationConfig.replicationConnectionPoolCheckoutTimeoutMs);
               checkoutConnectionTimeInMs = SystemTime.getInstance().milliseconds() - startTimeInMs;
               startTimeInMs = SystemTime.getInstance().milliseconds();
               List<ExchangeMetadataResponse> exchangeMetadataResponseList =
-                  exchangeMetadata(connectedChannel, replicasToReplicatePerNode);
+                  exchangeMetadata(connectedChannel, activeReplicasPerNode);
               exchangeMetadataTimeInMs = SystemTime.getInstance().milliseconds() - startTimeInMs;
 
               startTimeInMs = SystemTime.getInstance().milliseconds();
-              fixMissingStoreKeys(connectedChannel, replicasToReplicatePerNode, exchangeMetadataResponseList);
+              fixMissingStoreKeys(connectedChannel, activeReplicasPerNode, exchangeMetadataResponseList);
               fixMissingStoreKeysTimeInMs = SystemTime.getInstance().milliseconds() - startTimeInMs;
             } catch (Exception e) {
               if (checkoutConnectionTimeInMs == -1) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -625,9 +625,6 @@ public final class ReplicationManager {
                   logger.warn("Persisted remote replica host {} and port {} not present in new cluster ", hostname,
                       port);
                 }
-              } else {
-                logger.warn("The local store corresponding to partition {} in the replica token file was not started",
-                    partitionId);
               }
             }
             long crc = crcStream.getValue();

--- a/config/HardwareLayoutMultiPartition.json
+++ b/config/HardwareLayoutMultiPartition.json
@@ -1,0 +1,77 @@
+{
+    "clusterName": "LocalSetUp_MultiPartition_MultiNode",
+    "version": 1,
+    "datacenters": [
+        {
+            "dataNodes": [
+                {
+                    "disks": [
+                        {
+                            "capacityInBytes": 21474836480,
+                            "hardwareState": "AVAILABLE",
+                            "mountPath": "/tmp/node-a/1"
+                        },
+                        {
+                            "capacityInBytes": 21474836480,
+                            "hardwareState": "AVAILABLE",
+                            "mountPath": "/tmp/node-a/2"
+                        },
+                        {
+                            "capacityInBytes": 21474836480,
+                            "hardwareState": "AVAILABLE",
+                            "mountPath": "/tmp/node-a/3"
+                        }
+                    ],
+                    "hardwareState": "AVAILABLE",
+                    "hostname": "localhost",
+                    "port": 6670
+                },
+                {
+                    "disks": [
+                        {
+                            "capacityInBytes": 21474836480,
+                            "hardwareState": "AVAILABLE",
+                            "mountPath": "/tmp/node-b/1"
+                        },
+                        {
+                            "capacityInBytes": 21474836480,
+                            "hardwareState": "AVAILABLE",
+                            "mountPath": "/tmp/node-b/2"
+                        },
+                        {
+                            "capacityInBytes": 21474836480,
+                            "hardwareState": "AVAILABLE",
+                            "mountPath": "/tmp/node-b/3"
+                        }
+                    ],
+                    "hardwareState": "AVAILABLE",
+                    "hostname": "localhost",
+                    "port": 6671
+                },
+                {
+                    "disks": [
+                        {
+                            "capacityInBytes": 21474836480,
+                            "hardwareState": "AVAILABLE",
+                            "mountPath": "/tmp/node-c/1"
+                        },
+                        {
+                            "capacityInBytes": 21474836480,
+                            "hardwareState": "AVAILABLE",
+                            "mountPath": "/tmp/node-c/2"
+                        },
+                        {
+                            "capacityInBytes": 21474836480,
+                            "hardwareState": "AVAILABLE",
+                            "mountPath": "/tmp/node-c/3"
+                        }
+                    ],
+                    "hardwareState": "AVAILABLE",
+                    "hostname": "localhost",
+                    "port": 6672
+                }
+            ],
+            "name": "Datacenter"
+        }
+    ]
+}

--- a/config/PartitionLayoutMultiPartition.json
+++ b/config/PartitionLayoutMultiPartition.json
@@ -1,0 +1,138 @@
+{
+    "clusterName": "LocalSetUp_MultiPartition_MultiNode",
+    "version": 1,
+    "partitions": [
+        {
+            "id": 0,
+            "partitionState": "READ_WRITE",
+            "replicaCapacityInBytes": 10737418240,
+            "replicas": [
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-a/1",
+                    "port": 6670
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-b/1",
+                    "port": 6671
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-c/1",
+                    "port": 6672
+                }
+            ]
+        },
+        {
+            "id": 1,
+            "partitionState": "READ_WRITE",
+            "replicaCapacityInBytes": 10737418240,
+            "replicas": [
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-a/1",
+                    "port": 6670
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-b/1",
+                    "port": 6671
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-c/1",
+                    "port": 6672
+                }
+            ]
+        },
+        {
+            "id": 2,
+            "partitionState": "READ_WRITE",
+            "replicaCapacityInBytes": 10737418240,
+            "replicas": [
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-a/2",
+                    "port": 6670
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-b/2",
+                    "port": 6671
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-c/2",
+                    "port": 6672
+                }
+            ]
+        },
+        {
+            "id": 3,
+            "partitionState": "READ_WRITE",
+            "replicaCapacityInBytes": 10737418240,
+            "replicas": [
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-a/2",
+                    "port": 6670
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-b/2",
+                    "port": 6671
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-c/2",
+                    "port": 6672
+                }
+            ]
+        },
+        {
+            "id": 4,
+            "partitionState": "READ_WRITE",
+            "replicaCapacityInBytes": 10737418240,
+            "replicas": [
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-a/3",
+                    "port": 6670
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-b/3",
+                    "port": 6671
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-c/3",
+                    "port": 6672
+                }
+            ]
+        },
+        {
+            "id": 5,
+            "partitionState": "READ_WRITE",
+            "replicaCapacityInBytes": 10737418240,
+            "replicas": [
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-a/3",
+                    "port": 6670
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-b/3",
+                    "port": 6671
+                },
+                {
+                    "hostname": "localhost",
+                    "mountPath": "/tmp/node-c/3",
+                    "port": 6672
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This commit:
- Fixes a null pointer exception that occurs during replication startup
  when only some of the stores on a disk are offline
- Prevent nodes from making replication requests to replicas with individual
  disks offline. Previously, replication requests would be made unless
  an entire node was marked as down.

Reviewers: @pnarayanan, @nsivabalan 
Time to review: 10 min.
Testing: I tested various startup scenarios locally with the layouts in this PR. I verified that startup suceeds in the scenario with a single store offline, and that individual disks on remote nodes are marked offline (so that replication requests will not be made).