### PR TITLE
Fix a race condition in the ChunkFiller

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -346,7 +346,7 @@ class PutManager {
           }
           if (chunkFillerThreadMaySleep) {
             synchronized (chunkFillerSynchronizer) {
-              while (chunkFillerThreadMaySleep) {
+              while (chunkFillerThreadMaySleep && isOpen.get()) {
                 isChunkFillerThreadAsleep = true;
                 chunkFillerSynchronizer.wait();
               }

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentNameHelperTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentNameHelperTest.java
@@ -201,7 +201,7 @@ public class LogSegmentNameHelperTest {
     assertEquals("Did not get expected name", "", LogSegmentNameHelper.generateFirstSegmentName(1));
     String firstSegmentName = LogSegmentNameHelper.getName(0, 0);
     for (int i = 0; i < 10; i++) {
-      long numSegments = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+      long numSegments = Utils.getRandomLong(TestUtils.RANDOM, 1000) + 2;
       assertEquals("Did not get expected name", firstSegmentName,
           LogSegmentNameHelper.generateFirstSegmentName(numSegments));
     }


### PR DESCRIPTION
Fix a race condition that makes the ChunkFiller thread from going to
wait indefinitely. This causes the thread to never exit.

Built and verified on Linux and OS X.