### PR TITLE
Using store abstractions in tools + supporting segmented logs in tools

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -116,9 +116,7 @@ class IndexValue {
 
   @Override
   public String toString() {
-    return "Offset: " + offset + ", Size: " + getSize() + ", Flags: " + getFlags() + ", ExpiresAtMs: "
-        + getExpiresAtMs() + ", Original Message Offset: " + getOriginalMessageOffset();
+    return "Offset: " + offset + ", Size: " + getSize() + ", Deleted: " + isFlagSet(Flags.Delete_Index)
+        + ", ExpiresAtMs: " + getExpiresAtMs() + ", Original Message Offset: " + getOriginalMessageOffset();
   }
 }
-
-

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -113,6 +113,12 @@ class IndexValue {
   ByteBuffer getBytes() {
     return value;
   }
+
+  @Override
+  public String toString() {
+    return "Offset: " + offset + ", Size: " + getSize() + ", Flags: " + getFlags() + ", ExpiresAtMs: "
+        + getExpiresAtMs() + ", Original Message Offset: " + getOriginalMessageOffset();
+  }
 }
 
 

--- a/ambry-store/src/main/java/com.github.ambry.store/Journal.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Journal.java
@@ -76,14 +76,16 @@ class Journal {
     if (key == null || offset == null) {
       throw new IllegalArgumentException("Invalid arguments passed to add to the journal");
     }
-    if (currentNumberOfEntries.get() == maxEntriesToJournal) {
-      journal.remove(journal.firstKey());
-      currentNumberOfEntries.decrementAndGet();
+    if (maxEntriesToJournal > 0) {
+      if (currentNumberOfEntries.get() == maxEntriesToJournal) {
+        journal.remove(journal.firstKey());
+        currentNumberOfEntries.decrementAndGet();
+      }
+      journal.put(offset, key);
+      logger.trace("Journal : " + dataDir + " offset " + offset + " key " + key);
+      currentNumberOfEntries.incrementAndGet();
+      logger.trace("Journal : " + dataDir + " number of entries " + currentNumberOfEntries.get());
     }
-    journal.put(offset, key);
-    logger.trace("Journal : " + dataDir + " offset " + offset + " key " + key);
-    currentNumberOfEntries.incrementAndGet();
-    logger.trace("Journal : " + dataDir + " number of entries " + currentNumberOfEntries.get());
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -61,7 +61,7 @@ class PersistentIndex {
   static final String BLOOM_FILE_NAME_SUFFIX = "bloom";
   static final String CLEAN_SHUTDOWN_FILENAME = "cleanshutdown";
 
-  private static final Comparator<File> INDEX_FILE_COMPARATOR = new Comparator<File>() {
+  static final Comparator<File> INDEX_FILE_COMPARATOR = new Comparator<File>() {
     @Override
     public int compare(File o1, File o2) {
       if (o1 == null || o2 == null) {
@@ -71,7 +71,7 @@ class PersistentIndex {
       return o1Offset.compareTo(IndexSegment.getIndexSegmentStartOffset(o2.getName()));
     }
   };
-  private static final FilenameFilter INDEX_FILE_FILTER = new FilenameFilter() {
+  static final FilenameFilter INDEX_FILE_FILTER = new FilenameFilter() {
     @Override
     public boolean accept(File dir, String name) {
       return name.endsWith(INDEX_SEGMENT_FILE_NAME_SUFFIX);

--- a/ambry-tools/scripts/layout-analyzer.py
+++ b/ambry-tools/scripts/layout-analyzer.py
@@ -1,13 +1,12 @@
 #!/usr/bin/python2.7
 
-import json
 import argparse
+import json
 import sys
 from collections import defaultdict
 
 
 class Node(object):
-
     def __init__(self, node, datacenter):
         self.node = node
         self.datacenter = datacenter
@@ -42,7 +41,6 @@ class Node(object):
 
 
 class Partition(object):
-
     def __init__(self, partition):
         self.partition = partition
         self.nodes_by_datacenter = defaultdict(set)
@@ -120,7 +118,7 @@ class Layout(object):
             print("Max partitions sharing a node combo: {} on the following nodes:".format(max_per_combo))
             for node in max_combo:
                 print(node)
-            if (float(max_per_combo)/avg_per_combo) > self.BALANCE_THRESHOLD:
+            if (float(max_per_combo) / avg_per_combo) > self.BALANCE_THRESHOLD:
                 print("The ratio of max to average number of partitions sharing a node combo "
                       + "exceeds the threshold: {} on this datacenter".format(self.BALANCE_THRESHOLD))
 
@@ -154,7 +152,7 @@ class Layout(object):
                     print("Partition {} in datacenter {} uses the following racks: {}".format(
                         cmd[1], cmd[2], self.racks_used(int(cmd[1]), cmd[2])))
                 elif cmd[0] == "shared_partitions":
-                    args = [(cmd[i+1], int(cmd[i+2])) for i in range(0, len(cmd)-1, 2)]
+                    args = [(cmd[i + 1], int(cmd[i + 2])) for i in range(0, len(cmd) - 1, 2)]
                     print("The following nodes:")
                     for hostname, port in args:
                         print("  {}:{}".format(hostname, port))
@@ -182,6 +180,7 @@ def main():
         layout.interactive()
     else:
         layout.print_report()
+
 
 if __name__ == "__main__":
     main()

--- a/ambry-tools/src/main/java/com.github.ambry/store/ConsistencyCheckerTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/ConsistencyCheckerTool.java
@@ -144,21 +144,21 @@ public class ConsistencyCheckerTool {
         for (File indexFile : indexFiles) {
           keysProcessedforReplica +=
               dumpData.dumpIndex(indexFile, replica.getName(), replicasList, new ArrayList<String>(), blobIdToStatusMap,
-                  indexStats, true);
+                  indexStats, false);
         }
-        logger.info("Total keys processed for " + replica.getName() + " " + keysProcessedforReplica);
+        logger.debug("Total keys processed for {} is {}", replica.getName(), keysProcessedforReplica);
         totalKeysProcessed.addAndGet(keysProcessedforReplica);
       } catch (Exception e) {
         logger.error("Could not complete processing for {}", replica, e);
       }
     }
-    logger.info("Total Keys Processed " + totalKeysProcessed.get());
-    logger.info("Total Put Records " + indexStats.getTotalPutRecords().get());
-    logger.info("Total Delete Records " + indexStats.getTotalDeleteRecords().get());
-    logger.info("Total Duplicate Put Records " + indexStats.getTotalDuplicatePutRecords().get());
-    logger.info("Total Delete before Put Records " + indexStats.getTotalDeleteBeforePutRecords().get());
-    logger.info("Total Put after Delete Records " + indexStats.getTotalPutAfterDeleteRecords().get());
-    logger.info("Total Duplicate Delete Records " + indexStats.getTotalDuplicateDeleteRecords().get());
+    logger.debug("Total Keys Processed {}", totalKeysProcessed.get());
+    logger.debug("Total Put Records {}", indexStats.getTotalPutRecords().get());
+    logger.debug("Total Delete Records {}", indexStats.getTotalDeleteRecords().get());
+    logger.debug("Total Duplicate Put Records {}", indexStats.getTotalDuplicatePutRecords().get());
+    logger.debug("Total Delete before Put Records {}", indexStats.getTotalDeleteBeforePutRecords().get());
+    logger.debug("Total Put after Delete Records {}", indexStats.getTotalPutAfterDeleteRecords().get());
+    logger.debug("Total Duplicate Delete Records {}", indexStats.getTotalDuplicateDeleteRecords().get());
   }
 
   private boolean populateOutput(AtomicLong totalKeysProcessed, Map<String, BlobStatus> blobIdToStatusMap,

--- a/ambry-tools/src/main/java/com.github.ambry/store/ConsistencyCheckerTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/ConsistencyCheckerTool.java
@@ -17,13 +17,10 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapManager;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -43,17 +40,13 @@ import org.slf4j.LoggerFactory;
  */
 public class ConsistencyCheckerTool {
 
-  public static String SUBJECT_BLOBS = "blobs";
-  public static String SUBJECT_INDEX = "index";
-
-  //For additional checks
-  public static int DELETE_RECORD_SIZE = 97;
-
-  private static ClusterMap map = null;
   private static final Logger logger = LoggerFactory.getLogger(ConsistencyCheckerTool.class);
+  private final ClusterMap map;
+  private boolean includeAcceptableInconsistentBlobs;
 
-  public ConsistencyCheckerTool(ClusterMap map) {
+  public ConsistencyCheckerTool(ClusterMap map, boolean includeAcceptableInconsistentBlobs) {
     this.map = map;
+    this.includeAcceptableInconsistentBlobs = includeAcceptableInconsistentBlobs;
   }
 
   public static void main(String args[]) {
@@ -86,13 +79,6 @@ public class ConsistencyCheckerTool {
               .defaultsTo("false")
               .ofType(String.class);
 
-      ArgumentAcceptingOptionSpec<String> subjectOpt =
-          parser.accepts("subject", "The subject of the check (" + SUBJECT_BLOBS + ", " + SUBJECT_INDEX + " etc)")
-              .withRequiredArg()
-              .describedAs("To select the subject of the check (" + SUBJECT_BLOBS + ", " + SUBJECT_INDEX + " etc)")
-              .defaultsTo(SUBJECT_BLOBS)
-              .ofType(String.class);
-
       OptionSet options = parser.parse(args);
 
       ArrayList<OptionSpec<?>> listOpt = new ArrayList<OptionSpec<?>>();
@@ -115,150 +101,127 @@ public class ConsistencyCheckerTool {
       String rootDirectoryForPartition = options.valueOf(rootDirectoryForPartitionOpt);
       boolean includeAcceptableInconsistentBlobs =
           Boolean.parseBoolean(options.valueOf(includeAcceptableInconsistentBlobsOpt));
-      String subject = options.valueOf(subjectOpt);
 
-      ConsistencyCheckerTool consistencyCheckerTool = null;
-      if (subject.equals(SUBJECT_INDEX)) {
-        consistencyCheckerTool = new IndexConsistencyCheckerTool(map);
-      } else {
-        consistencyCheckerTool = new BlobConsistencyCheckerTool(map, includeAcceptableInconsistentBlobs);
-      }
-
+      ConsistencyCheckerTool consistencyCheckerTool =
+          new ConsistencyCheckerTool(map, includeAcceptableInconsistentBlobs);
       consistencyCheckerTool.checkConsistency(rootDirectoryForPartition);
     } catch (Exception e) {
       System.err.println("Consistency checker exited with Exception: " + e);
     }
   }
 
-  public boolean checkConsistency(String directoryForConsistencyCheck) throws Exception {
-    return false;
+  private boolean checkConsistency(String directoryForConsistencyCheck) throws Exception {
+    File rootDir = new File(directoryForConsistencyCheck);
+    logger.info("Root directory for Partition" + rootDir);
+    ArrayList<String> replicaList = populateReplicaList(rootDir);
+    logger.trace("Replica List " + replicaList);
+    ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap = new ConcurrentHashMap<String, BlobStatus>();
+    AtomicLong totalKeysProcessed = new AtomicLong(0);
+    int replicaCount = replicaList.size();
+
+    doCheck(rootDir.listFiles(), replicaList, blobIdToStatusMap, totalKeysProcessed);
+    return populateOutput(totalKeysProcessed, blobIdToStatusMap, replicaCount, includeAcceptableInconsistentBlobs);
   }
 
-  static class BlobConsistencyCheckerTool extends ConsistencyCheckerTool {
+  private ArrayList<String> populateReplicaList(File rootDir) {
+    ArrayList<String> replicaList = new ArrayList<String>();
+    File[] replicas = rootDir.listFiles();
+    for (File replicaFile : replicas) {
+      replicaList.add(replicaFile.getName());
+    }
+    return replicaList;
+  }
 
-    private boolean includeAcceptableInconsistentBlobs;
+  private void doCheck(File[] replicas, ArrayList<String> replicasList,
+      ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap, AtomicLong totalKeysProcessed)
+      throws IOException, InterruptedException {
+    DumpData dumpData = new DumpData(map);
+    CountDownLatch countDownLatch = new CountDownLatch(replicas.length);
+    IndexStats indexStats = new IndexStats();
+    for (File replica : replicas) {
+      Thread thread = new Thread(
+          new ReplicaProcessorForBlobs(replica, replicasList, blobIdToStatusMap, totalKeysProcessed, dumpData,
+              countDownLatch, indexStats));
+      thread.start();
+      thread.join();
+    }
+    countDownLatch.await();
+    logger.info("Total Keys Processed " + totalKeysProcessed.get());
+    logger.info("Total Put Records " + indexStats.getTotalPutRecords().get());
+    logger.info("Total Delete Records " + indexStats.getTotalDeleteRecords().get());
+    logger.info("Total Duplicate Put Records " + indexStats.getTotalDuplicatePutRecords().get());
+    logger.info("Total Delete before Put Records " + indexStats.getTotalDeleteBeforePutRecords().get());
+    logger.info("Total Put after Delete Records " + indexStats.getTotalPutAfterDeleteRecords().get());
+    logger.info("Total Duplicate Delete Records " + indexStats.getTotalDuplicateDeleteRecords().get());
+  }
 
-    public BlobConsistencyCheckerTool(ClusterMap map, boolean includeAcceptableInconsistentBlobs) {
-      super(map);
-      this.includeAcceptableInconsistentBlobs = includeAcceptableInconsistentBlobs;
+  private boolean populateOutput(AtomicLong totalKeysProcessed, ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap,
+      int replicaCount, boolean includeAcceptableInconsistentBlobs) {
+    logger.info("Total keys processed " + totalKeysProcessed.get());
+    logger.info("\nTotal Blobs Found " + blobIdToStatusMap.size());
+    long inconsistentBlobs = 0;
+    long realInconsistentBlobs = 0;
+    long acceptableInconsistentBlobs = 0;
+    for (String blobId : blobIdToStatusMap.keySet()) {
+      BlobStatus consistencyBlobResult = blobIdToStatusMap.get(blobId);
+      // valid blobs : count of available replicas = total replica count or count of deleted replicas = total replica count
+      // acceptable inconsistent blobs : count of deleted + count of unavailable = total replica count
+      // rest are all inconsistent blobs
+      boolean isValid = consistencyBlobResult.getAvailable().size() == replicaCount
+          || consistencyBlobResult.getDeletedOrExpired().size() == replicaCount;
+      if (!isValid) {
+        inconsistentBlobs++;
+        if ((consistencyBlobResult.getDeletedOrExpired().size() + consistencyBlobResult.getUnavailableList().size()
+            == replicaCount)) {
+          if (includeAcceptableInconsistentBlobs) {
+            logger.info("Partially deleted (acceptable inconsistency) blob " + blobId + " isDeletedOrExpired "
+                + consistencyBlobResult.getIsDeletedOrExpired() + "\n" + consistencyBlobResult);
+          }
+          acceptableInconsistentBlobs++;
+        } else {
+          realInconsistentBlobs++;
+          logger.info(
+              "Inconsistent Blob : " + blobId + " isDeletedOrExpired " + consistencyBlobResult.getIsDeletedOrExpired()
+                  + "\n" + consistencyBlobResult);
+        }
+      }
+    }
+    logger.info("Total Inconsistent blobs count : " + inconsistentBlobs);
+    if (includeAcceptableInconsistentBlobs) {
+      logger.info("Acceptable Inconsistent blobs count : " + acceptableInconsistentBlobs);
+    }
+    logger.info("Real Inconsistent blobs count :" + realInconsistentBlobs);
+    return realInconsistentBlobs == 0;
+  }
+
+  private static class ReplicaProcessorForBlobs implements Runnable {
+
+    File rootDirectory;
+    ArrayList<String> replicaList;
+    ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap;
+    AtomicLong totalKeysProcessed;
+    DumpData dumpData;
+    CountDownLatch countDownLatch;
+    IndexStats indexStats;
+
+    ReplicaProcessorForBlobs(File rootDirectory, ArrayList<String> replicaList,
+        ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap, AtomicLong totalKeysProcessed, DumpData dumpData,
+        CountDownLatch countDownLatch, IndexStats indexStats) {
+      this.rootDirectory = rootDirectory;
+      this.replicaList = replicaList;
+      this.blobIdToStatusMap = blobIdToStatusMap;
+      this.totalKeysProcessed = totalKeysProcessed;
+      this.dumpData = dumpData;
+      this.countDownLatch = countDownLatch;
+      this.indexStats = indexStats;
     }
 
     @Override
-    public boolean checkConsistency(String directoryForConsistencyCheck) throws Exception {
-      File rootDir = new File(directoryForConsistencyCheck);
-      logger.info("Root directory for Partition" + rootDir);
-      ArrayList<String> replicaList = populateReplicaList(rootDir);
-      logger.trace("Replica List " + replicaList);
-      ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap = new ConcurrentHashMap<String, BlobStatus>();
-      AtomicLong totalKeysProcessed = new AtomicLong(0);
-      int replicaCount = replicaList.size();
-
-      doCheck(rootDir.listFiles(), replicaList, blobIdToStatusMap, totalKeysProcessed);
-      return populateOutput(totalKeysProcessed, blobIdToStatusMap, replicaCount, includeAcceptableInconsistentBlobs);
-    }
-
-    private ArrayList<String> populateReplicaList(File rootDir) {
-      ArrayList<String> replicaList = new ArrayList<String>();
-      File[] replicas = rootDir.listFiles();
-      for (File replicaFile : replicas) {
-        replicaList.add(replicaFile.getName());
-      }
-      return replicaList;
-    }
-
-    private void doCheck(File[] replicas, ArrayList<String> replicasList,
-        ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap, AtomicLong totalKeysProcessed)
-        throws IOException, InterruptedException {
-      DumpData dumpData = new DumpData(map);
-      CountDownLatch countDownLatch = new CountDownLatch(replicas.length);
-      IndexStats indexStats = new IndexStats();
-      for (File replica : replicas) {
-        Thread thread = new Thread(
-            new ReplicaProcessorForBlobs(replica, replicasList, blobIdToStatusMap, totalKeysProcessed, dumpData,
-                countDownLatch, indexStats));
-        thread.start();
-        thread.join();
-      }
-      countDownLatch.await();
-      logger.info("Total Keys Processed " + totalKeysProcessed.get());
-      logger.info("Total Put Records " + indexStats.getTotalPutRecords().get());
-      logger.info("Total Delete Records " + indexStats.getTotalDeleteRecords().get());
-      logger.info("Total Duplicate Put Records " + indexStats.getTotalDuplicatePutRecords().get());
-      logger.info("Total Delete before Put Records " + indexStats.getTotalDeleteBeforePutRecords().get());
-      logger.info("Total Put after Delete Records " + indexStats.getTotalPutAfterDeleteRecords().get());
-      logger.info("Total Duplicate Delete Records " + indexStats.getTotalDuplicateDeleteRecords().get());
-    }
-
-    private boolean populateOutput(AtomicLong totalKeysProcessed,
-        ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap, int replicaCount,
-        boolean includeAcceptableInconsistentBlobs) {
-      logger.info("Total keys processed " + totalKeysProcessed.get());
-      logger.info("\nTotal Blobs Found " + blobIdToStatusMap.size());
-      long inconsistentBlobs = 0;
-      long realInconsistentBlobs = 0;
-      long acceptableInconsistentBlobs = 0;
-      for (String blobId : blobIdToStatusMap.keySet()) {
-        BlobStatus consistencyBlobResult = blobIdToStatusMap.get(blobId);
-        // valid blobs : count of available replicas = total replica count or count of deleted replicas = total replica count
-        // acceptable inconsistent blobs : count of deleted + count of unavailable = total replica count
-        // rest are all inconsistent blobs
-        boolean isValid = consistencyBlobResult.getAvailable().size() == replicaCount
-            || consistencyBlobResult.getDeletedOrExpired().size() == replicaCount;
-        if (!isValid) {
-          inconsistentBlobs++;
-          if ((consistencyBlobResult.getDeletedOrExpired().size() + consistencyBlobResult.getUnavailableList().size()
-              == replicaCount)) {
-            if (includeAcceptableInconsistentBlobs) {
-              logger.info("Partially deleted (acceptable inconsistency) blob " + blobId + " isDeletedOrExpired "
-                  + consistencyBlobResult.getIsDeletedOrExpired() + "\n" + consistencyBlobResult);
-            }
-            acceptableInconsistentBlobs++;
-          } else {
-            realInconsistentBlobs++;
-            logger.info(
-                "Inconsistent Blob : " + blobId + " isDeletedOrExpired " + consistencyBlobResult.getIsDeletedOrExpired()
-                    + "\n" + consistencyBlobResult);
-          }
-        }
-      }
-      logger.info("Total Inconsistent blobs count : " + inconsistentBlobs);
-      if (includeAcceptableInconsistentBlobs) {
-        logger.info("Acceptable Inconsistent blobs count : " + acceptableInconsistentBlobs);
-      }
-      logger.info("Real Inconsistent blobs count :" + realInconsistentBlobs);
-
-      if (realInconsistentBlobs > 0) {
-        return false;
-      }
-      return true;
-    }
-
-    class ReplicaProcessorForBlobs implements Runnable {
-
-      File rootDirectory;
-      ArrayList<String> replicaList;
-      ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap;
-      AtomicLong totalKeysProcessed;
-      DumpData dumpData;
-      CountDownLatch countDownLatch;
-      IndexStats indexStats;
-
-      public ReplicaProcessorForBlobs(File rootDirectory, ArrayList<String> replicaList,
-          ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap, AtomicLong totalKeysProcessed, DumpData dumpData,
-          CountDownLatch countDownLatch, IndexStats indexStats) {
-        this.rootDirectory = rootDirectory;
-        this.replicaList = replicaList;
-        this.blobIdToStatusMap = blobIdToStatusMap;
-        this.totalKeysProcessed = totalKeysProcessed;
-        this.dumpData = dumpData;
-        this.countDownLatch = countDownLatch;
-        this.indexStats = indexStats;
-      }
-
-      public void run() {
-        File[] indexFiles = rootDirectory.listFiles(new DumpData.IndexFileNameFilter());
+    public void run() {
+      try {
+        File[] indexFiles = rootDirectory.listFiles(PersistentIndex.INDEX_FILE_FILTER);
         long keysProcessedforReplica = 0;
-        Arrays.sort(indexFiles, new IndexFileNameComparator());
+        Arrays.sort(indexFiles, PersistentIndex.INDEX_FILE_COMPARATOR);
         for (File indexFile : indexFiles) {
           keysProcessedforReplica +=
               dumpData.dumpIndex(indexFile, rootDirectory.getName(), replicaList, new ArrayList<String>(),
@@ -267,93 +230,9 @@ public class ConsistencyCheckerTool {
         logger.info("Total keys processed for " + rootDirectory.getName() + " " + keysProcessedforReplica);
         totalKeysProcessed.addAndGet(keysProcessedforReplica);
         countDownLatch.countDown();
+      } catch (Exception e) {
+        logger.error("Could not complete processing", e);
       }
-    }
-  }
-
-  static class IndexConsistencyCheckerTool extends ConsistencyCheckerTool {
-
-    public IndexConsistencyCheckerTool(ClusterMap map) {
-      super(map);
-    }
-
-    @Override
-    public boolean checkConsistency(String directoryForConsistencyCheck) throws Exception {
-      boolean isConsistent = true;
-      File rootDir = new File(directoryForConsistencyCheck);
-      logger.info("Root directory for Partition is " + rootDir);
-      for (File replicaFolder : rootDir.listFiles()) {
-        try {
-          isConsistent = checkSingleReplica(replicaFolder) && isConsistent;
-        } catch (Exception e) {
-          logger.error("Exception while performing operation: " + e.getStackTrace());
-        }
-      }
-      return isConsistent;
-    }
-
-    public boolean checkSingleReplica(File replicaFolder) throws Exception {
-      boolean isConsistent = true;
-      File[] indexFiles = replicaFolder.listFiles();
-      Arrays.sort(indexFiles, new IndexFileNameComparator());
-
-      logger.info("------- Processing " + replicaFolder.getName() + " -------");
-      String lastProcessedIndexFileName = null;
-      long lastLogOffsetEnd = 0;
-      for (File indexFile : indexFiles) {
-        long logOffsetStart = getLogOffsetStart(indexFile);
-        isConsistent =
-            validateValues(logOffsetStart, lastLogOffsetEnd, indexFile.getName(), lastProcessedIndexFileName);
-        lastLogOffsetEnd = getLogOffsetEnd(indexFile);
-        lastProcessedIndexFileName = indexFile.getName();
-      }
-
-      return isConsistent;
-    }
-
-    private boolean validateValues(long logOffsetStart, long lastLogOffsetEnd, String currentIndexFileName,
-        String lastProcessedIndexFileName) {
-      long difference = logOffsetStart - lastLogOffsetEnd;
-      if (difference > 0) {
-        logger.error(
-            "Difference of " + difference + " between " + lastProcessedIndexFileName + " and " + currentIndexFileName
-                + ". (" + lastLogOffsetEnd + ", " + logOffsetStart + ")");
-        if (difference % DELETE_RECORD_SIZE != 0) {
-          logger.error("The difference " + difference + " is not a multiple of delete record size");
-        }
-        return false;
-      }
-      return true;
-    }
-
-    private long getLogOffsetStart(File indexFile) {
-      String name = indexFile.getName();
-      return Long.parseLong(name.substring(0, name.indexOf("_")));
-    }
-
-    private long getLogOffsetEnd(File indexFile) throws Exception {
-      long fileEndPointer;
-      DataInputStream stream = new DataInputStream(new FileInputStream(indexFile));
-      short version = stream.readShort();
-      if (version == 0) {
-        stream.skipBytes((2 * Integer.SIZE) / Byte.SIZE);
-        fileEndPointer = stream.readLong();
-      } else {
-        throw new Exception("Version read from " + indexFile.getName() + " is " + version + " (not 0)");
-      }
-      return fileEndPointer;
-    }
-  }
-
-  static class IndexFileNameComparator implements Comparator {
-    public int compare(Object o1, Object o2) {
-      String s1 = ((File) o1).getName();
-      String s2 = ((File) o2).getName();
-
-      long n1 = Long.parseLong(s1.substring(0, s1.indexOf("_")));
-      long n2 = Long.parseLong(s2.substring(0, s2.indexOf("_")));
-
-      return Long.compare(n1, n2);
     }
   }
 }

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpData.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpData.java
@@ -26,12 +26,12 @@ import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
@@ -236,12 +236,12 @@ public class DumpData {
   }
 
   /**
-   * Dumps all records in an index file and updates the {@link ConcurrentHashMap} for the blob status
+   * Dumps all records in an index file and updates the {@link Map} for the blob status
    * @param indexFileToDump the index file that needs to be parsed for
    * @param replica the replica from which the index files are being parsed for
    * @param replicaList total list of all replicas for the partition which this replica is part of
    * @param blobList List of blobIds to be filtered for. Can be {@code null}
-   * @param blobIdToStatusMap {@link ConcurrentHashMap} of BlobId to {@link BlobStatus} that needs to be updated with the
+   * @param blobIdToStatusMap {@link Map} of BlobId to {@link BlobStatus} that needs to be updated with the
    *                                         status of every blob in the index
    * @param indexStats the {@link IndexStats} to be updated with some stats info
    * @param logBlobStats {@code true} if blobs stats needs to be logged, {@code false} otherwise
@@ -249,9 +249,8 @@ public class DumpData {
    * @throws Exception
    */
   long dumpIndex(File indexFileToDump, String replica, ArrayList<String> replicaList, ArrayList<String> blobList,
-      ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap, IndexStats indexStats, boolean logBlobStats)
-      throws Exception {
-    ConcurrentHashMap<String, DumpDataHelper.IndexRecord> blobIdToMessageMapPerIndexFile = new ConcurrentHashMap<>();
+      Map<String, BlobStatus> blobIdToStatusMap, IndexStats indexStats, boolean logBlobStats) throws Exception {
+    Map<String, DumpDataHelper.IndexRecord> blobIdToMessageMapPerIndexFile = new HashMap<>();
     logger.trace("Dumping index {} for {}", indexFileToDump.getName(), replica);
     long blobsProcessed = dumpDataHelper.dumpBlobsFromIndex(indexFileToDump, blobList, blobIdToMessageMapPerIndexFile);
 
@@ -320,17 +319,17 @@ public class DumpData {
    * @param replicaRootDirectory the root directory for a replica
    * @param blobList list of blobIds to be filtered for. Can be {@code null}
    * @param logBlobStats {@code true} if blobs stats needs to be logged, {@code false} otherwise
-   * @return a {@link ConcurrentHashMap} of BlobId to {@link BlobStatus} containing the information about every blob in
+   * @return a {@link Map} of BlobId to {@link BlobStatus} containing the information about every blob in
    * this replica
    * @throws Exception
    */
-  private ConcurrentHashMap<String, BlobStatus> dumpIndexesForReplica(String replicaRootDirectory,
-      ArrayList<String> blobList, boolean logBlobStats) throws Exception {
+  private Map<String, BlobStatus> dumpIndexesForReplica(String replicaRootDirectory, ArrayList<String> blobList,
+      boolean logBlobStats) throws Exception {
     long totalKeysProcessed = 0;
     File replicaDirectory = new File(replicaRootDirectory);
     logger.info("Root directory for replica : " + replicaRootDirectory);
     IndexStats indexStats = new IndexStats();
-    ConcurrentHashMap<String, BlobStatus> blobIdToStatusMap = new ConcurrentHashMap<>();
+    Map<String, BlobStatus> blobIdToStatusMap = new HashMap<>();
     File[] replicas = replicaDirectory.listFiles(PersistentIndex.INDEX_FILE_FILTER);
     Arrays.sort(replicas, PersistentIndex.INDEX_FILE_COMPARATOR);
     for (File indexFile : replicas) {
@@ -363,15 +362,15 @@ public class DumpData {
    * Dumps active blobs for a given index file
    * @param indexFileToDump the index file that needs to be parsed for
    * @param blobList List of BlobIds that needs to be filtered for. Can be {@code null}
-   * @param blobIdToBlobMessageMap a {@link ConcurrentHashMap} of BlobId to Message that needs to be updated with the
-   *                               information about the blobs in the index
+   * @param blobIdToBlobMessageMap a {@link Map} of BlobId to Message that needs to be updated with the information
+   *                               about the blobs in the index
    * @param activeBlobStats {@link ActiveBlobStats} to be updated with necessary stats
    * @return the total number of blobs parsed from the given index file
    * @throws Exception
    */
   private long dumpActiveBlobsFromIndex(File indexFileToDump, ArrayList<String> blobList,
-      ConcurrentHashMap<String, String> blobIdToBlobMessageMap, ActiveBlobStats activeBlobStats) throws Exception {
-    ConcurrentHashMap<String, DumpDataHelper.IndexRecord> blobIdToMessageMapPerIndexFile = new ConcurrentHashMap<>();
+      Map<String, String> blobIdToBlobMessageMap, ActiveBlobStats activeBlobStats) throws Exception {
+    Map<String, DumpDataHelper.IndexRecord> blobIdToMessageMapPerIndexFile = new HashMap<>();
 
     long blobsProcessed = dumpDataHelper.dumpBlobsFromIndex(indexFileToDump, blobList, blobIdToMessageMapPerIndexFile);
     for (String key : blobIdToMessageMapPerIndexFile.keySet()) {
@@ -410,7 +409,7 @@ public class DumpData {
    * @throws Exception
    */
   private void dumpActiveBlobsFromIndex(File indexFileToDump, ArrayList<String> blobList) throws Exception {
-    ConcurrentHashMap<String, String> blobIdToBlobMessageMap = new ConcurrentHashMap<>();
+    Map<String, String> blobIdToBlobMessageMap = new HashMap<>();
     logger.trace("Dumping index {} ", indexFileToDump);
     ActiveBlobStats activeBlobStats = new ActiveBlobStats();
     long totalKeysProcessed =
@@ -439,7 +438,7 @@ public class DumpData {
   private void dumpActiveBlobsForReplica(String replicaRootDirectory, ArrayList<String> blobList) throws Exception {
     long totalKeysProcessed = 0;
     File replicaDirectory = new File(replicaRootDirectory);
-    ConcurrentHashMap<String, String> blobIdToMessageMap = new ConcurrentHashMap<>();
+    Map<String, String> blobIdToMessageMap = new HashMap<>();
     ActiveBlobStats activeBlobStats = new ActiveBlobStats();
     File[] replicas = replicaDirectory.listFiles(PersistentIndex.INDEX_FILE_FILTER);
     Arrays.sort(replicas, PersistentIndex.INDEX_FILE_COMPARATOR);
@@ -478,7 +477,7 @@ public class DumpData {
       long randomBlobsCount) throws Exception {
     long totalKeysProcessed = 0;
     File replicaDirectory = new File(replicaRootDirectory);
-    ConcurrentHashMap<String, String> blobIdToBlobMessageMap = new ConcurrentHashMap<>();
+    Map<String, String> blobIdToBlobMessageMap = new HashMap<>();
     ActiveBlobStats activeBlobStats = new ActiveBlobStats();
     File[] replicas = replicaDirectory.listFiles(PersistentIndex.INDEX_FILE_FILTER);
     Arrays.sort(replicas, PersistentIndex.INDEX_FILE_COMPARATOR);
@@ -517,7 +516,7 @@ public class DumpData {
   private void dumpLog(File logFile, long startOffset, long endOffset, ArrayList<String> blobs, boolean filter)
       throws IOException {
 
-    ConcurrentHashMap<String, DumpDataHelper.LogBlobRecord> blobIdToLogRecord = new ConcurrentHashMap<>();
+    Map<String, DumpDataHelper.LogBlobRecord> blobIdToLogRecord = new HashMap<>();
     dumpDataHelper.dumpLog(logFile, startOffset, endOffset, blobs, filter, blobIdToLogRecord, true);
 
     long totalInConsistentBlobs = 0;

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpData.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpData.java
@@ -618,7 +618,6 @@ public class DumpData {
                 logger.trace("Put Record at {} with delete msg offset {} ignored because it is prior to startOffset {}",
                     originalOffset, value.getOffset(), startOffset);
               } else {
-                randomAccessFile.seek(originalOffset);
                 LogBlobRecordInfo logBlobRecordInfo =
                     dumpDataHelper.readSingleRecordFromLog(randomAccessFile, originalOffset);
                 coveredRanges.put(originalOffset, originalOffset + logBlobRecordInfo.totalRecordSize);

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
@@ -63,13 +62,13 @@ class DumpDataHelper {
    * Dumps all blobs in an index file
    * @param indexFileToDump the index file that needs to be parsed
    * @param blobList List of blobIds to be filtered for
-   * @param blobIdToMessageMap {@link HashMap} of BlobId to {@link IndexRecord} to hold the information
+   * @param blobIdToMessageMap {@link Map} of BlobId to {@link IndexRecord} to hold the information
    *                                          about blobs in the index after parsing
    * @return the total number of keys/records processed
    * @throws Exception
    */
-  long dumpBlobsFromIndex(File indexFileToDump, ArrayList<String> blobList,
-      ConcurrentHashMap<String, IndexRecord> blobIdToMessageMap) throws Exception {
+  long dumpBlobsFromIndex(File indexFileToDump, ArrayList<String> blobList, Map<String, IndexRecord> blobIdToMessageMap)
+      throws Exception {
     StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", _clusterMap);
     StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
     StoreMetrics metrics = new StoreMetrics(indexFileToDump.getParent(), new MetricRegistry());
@@ -109,7 +108,7 @@ class DumpDataHelper {
    * @throws IOException
    */
   void dumpLog(File file, long startOffset, long endOffset, ArrayList<String> blobs, boolean filter,
-      ConcurrentHashMap<String, LogBlobRecord> blobIdToLogRecord, boolean logRecord) throws IOException {
+      Map<String, LogBlobRecord> blobIdToLogRecord, boolean logRecord) throws IOException {
     logger.info("Dumping log file " + file.getAbsolutePath());
     long currentOffset = 0;
     RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r");
@@ -377,17 +376,17 @@ class DumpDataHelper {
   }
 
   /**
-   * Updates the {@link ConcurrentHashMap} of blobIds to {@link LogBlobRecord} with the information about the passed in
+   * Updates the {@link Map} of blobIds to {@link LogBlobRecord} with the information about the passed in
    * <code>blobId</code>
    * @param blobIdToLogRecord {@link HashMap} of blobId to {@link LogBlobRecord} that needs to be updated with the
    *                                         information about the blob
-   * @param blobId the blobId of the blob that needs to be updated in the {@link ConcurrentHashMap}
+   * @param blobId the blobId of the blob that needs to be updated in the {@link Map}
    * @param offset the offset at which the blob record was parsed from in the log file
    * @param putRecord {@code true} if the record is a Put record, {@code false} otherwise (incase of a Delete record)
    * @param isExpired {@code true} if the blob has expired, {@code false} otherwise
    */
-  private void updateBlobIdToLogRecordMap(ConcurrentHashMap<String, LogBlobRecord> blobIdToLogRecord, String blobId,
-      Long offset, boolean putRecord, boolean isExpired) {
+  private void updateBlobIdToLogRecordMap(Map<String, LogBlobRecord> blobIdToLogRecord, String blobId, Long offset,
+      boolean putRecord, boolean isExpired) {
     if (blobIdToLogRecord != null) {
       if (blobIdToLogRecord.containsKey(blobId)) {
         if (putRecord) {

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ConcurrencyTestTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ConcurrencyTestTool.java
@@ -85,13 +85,6 @@ import org.slf4j.LoggerFactory;
  *  --totalPutBlobCount 1000 --maxBlobSizeInBytes 1000 --minBlobSizeInBytes 100 --routerPropsFilePath [Path to router props
  *  file] --deleteAndValidate true
  *
- * Server
- *  java -cp ambry.jar com.github.ambry.tools.admin.ConcurrencyTestTool --hardwareLayout [HardwareLayoutFile]
- *  --partitionLayout [PartitionLayoutFile] --putGetHelperFactory com.github.ambry.tools.admin.RouterPutGetHelperFactory
- *  --maxParallelPutCount 2 --parallelGetCount 4 --burstCountForGet 4 --maxGetCountPerBlob 10
- *  --totalPutBlobCount 1000 --maxBlobSizeInBytes 1000 --minBlobSizeInBytes 100 --hostName [HostName] --port [PortNo]
- *  --deleteAndValidate true
- *
  *  Few other options that might be useful:
  * --sleepTimeBetweenBatchGetsInMs long : Time to sleep in ms between batch Gets
  * --sleepTimeBetweenBatchPutsInMs long : Time to sleep in ms between batch Puts

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ConcurrencyTestTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ConcurrencyTestTool.java
@@ -430,14 +430,13 @@ public class ConcurrencyTestTool {
             deleteHelper.deleteBlobAndValidate(blobIdStr, deleteHelper.getErrorCodeForNoError(), callback);
           }
         } catch (InterruptedException e) {
-          logger.error(" Interrupted Exception thrown in , exception ",  e);
+          logger.error("Delete operation interrupted", e);
         }
       }
       try {
         countDownLatch.await();
       } catch (InterruptedException e) {
-        logger.error(
-            " Interrupted Exception thrown while waiting for deletion to complete , exception ", e);
+        logger.error("Waiting for delete operations to complete interrupted", e);
       }
     }
   }

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/PutGetHelperFactory.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/PutGetHelperFactory.java
@@ -23,6 +23,5 @@ interface PutGetHelperFactory {
    * @returns a new instance of {@link ConcurrencyTestTool.PutGetHelper}
    * @throws Exception
    */
-  ConcurrencyTestTool.PutGetHelper getPutGetHelper()
-      throws Exception;
+  ConcurrencyTestTool.PutGetHelper getPutGetHelper() throws Exception;
 }

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/RouterPutGetHelperFactory.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/RouterPutGetHelperFactory.java
@@ -43,8 +43,7 @@ public class RouterPutGetHelperFactory implements PutGetHelperFactory {
    * @return an instance of {@link ConcurrencyTestTool.RouterPutGetHelper}
    * throws Exception if instantiation of the {@link ConcurrencyTestTool.RouterPutGetHelper} fails
    */
-  public ConcurrencyTestTool.RouterPutGetHelper getPutGetHelper()
-      throws Exception {
+  public ConcurrencyTestTool.RouterPutGetHelper getPutGetHelper() throws Exception {
     return new ConcurrencyTestTool.RouterPutGetHelper(properties, clusterMap, routerFactoryClass, maxBlobSize,
         minBlobSize);
   }


### PR DESCRIPTION
ambry-tools had some repeated code for reading index segments. This commit makes use of the `IndexSegment` class to read the index file and thus unifies the code that enables interpretation of index segment formats

This commit also enables support for segmented logs in ambry tools and enables them to work with segmented or non segmented logs

This commit also removed the option to verify consistency of log entries with index. This functionality is (almost) fully covered in the code that verifies the consistency of index entries with the log and thus is no longer required.

This commit also removes the `IndexConsistencyChecker` tool which is no longer relevant and has been replaced by better tools (compareIndexEntriesWithLog).

**Primary reviewer : @nsivabalan**
Formatted and `./gradlew build` succeeded. 
Tested by verifying some segmented logs.