### PR TITLE
Move cleanup of failed composite blobs to the background

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -110,7 +110,7 @@ class DeleteManager {
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
       routerMetrics.onDeleteBlobError(e);
-      OperationCallback.completeOperation(futureResult, callback, null, e);
+      NonBlockingRouter.completeOperation(futureResult, callback, null, e);
     }
   }
 
@@ -213,7 +213,7 @@ class DeleteManager {
     }
     routerMetrics.operationDequeuingRate.mark();
     routerMetrics.deleteBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmissionTimeMs());
-    OperationCallback.completeOperation(op.getFutureResult(), op.getCallback(), op.getOperationResult(),
+    NonBlockingRouter.completeOperation(op.getFutureResult(), op.getCallback(), op.getOperationResult(),
         op.getOperationException());
   }
 
@@ -231,7 +231,7 @@ class DeleteManager {
         routerMetrics.operationDequeuingRate.mark();
         routerMetrics.operationAbortCount.inc();
         routerMetrics.onDeleteBlobError(e);
-        OperationCallback.completeOperation(op.getFutureResult(), op.getCallback(), null, e);
+        NonBlockingRouter.completeOperation(op.getFutureResult(), op.getCallback(), null, e);
       }
     }
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -50,7 +50,7 @@ class DeleteManager {
   private final NonBlockingRouterMetrics routerMetrics;
   private final ClusterMap clusterMap;
   private final RouterConfig routerConfig;
-  private final OperationCompleteCallback operationCompleteCallback;
+  private final OperationCallback operationCallback;
 
   private static final Logger logger = LoggerFactory.getLogger(DeleteManager.class);
 
@@ -78,18 +78,18 @@ class DeleteManager {
    * @param notificationSystem The {@link NotificationSystem} used for notifying blob deletions.
    * @param routerConfig The {@link RouterConfig} containing the configs for the DeleteManager.
    * @param routerMetrics The {@link NonBlockingRouterMetrics} to be used for reporting metrics.
-   * @param operationCompleteCallback The {@link OperationCompleteCallback} to use to complete operations.
+   * @param operationCallback The {@link OperationCallback} to use for callbacks to the router.
    * @param time The {@link Time} instance to use.
    */
   DeleteManager(ClusterMap clusterMap, ResponseHandler responseHandler, NotificationSystem notificationSystem,
-      RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
-      OperationCompleteCallback operationCompleteCallback, Time time) {
+      RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, OperationCallback operationCallback,
+      Time time) {
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.notificationSystem = notificationSystem;
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
-    this.operationCompleteCallback = operationCompleteCallback;
+    this.operationCallback = operationCallback;
     this.time = time;
     deleteOperations = Collections.newSetFromMap(new ConcurrentHashMap<DeleteOperation, Boolean>());
     correlationIdToDeleteOperation = new HashMap<Integer, DeleteOperation>();
@@ -110,7 +110,7 @@ class DeleteManager {
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
       routerMetrics.onDeleteBlobError(e);
-      operationCompleteCallback.completeOperation(futureResult, callback, null, e);
+      OperationCallback.completeOperation(futureResult, callback, null, e);
     }
   }
 
@@ -213,7 +213,7 @@ class DeleteManager {
     }
     routerMetrics.operationDequeuingRate.mark();
     routerMetrics.deleteBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmissionTimeMs());
-    operationCompleteCallback.completeOperation(op.getFutureResult(), op.getCallback(), op.getOperationResult(),
+    OperationCallback.completeOperation(op.getFutureResult(), op.getCallback(), op.getOperationResult(),
         op.getOperationException());
   }
 
@@ -231,7 +231,7 @@ class DeleteManager {
         routerMetrics.operationDequeuingRate.mark();
         routerMetrics.operationAbortCount.inc();
         routerMetrics.onDeleteBlobError(e);
-        operationCompleteCallback.completeOperation(op.getFutureResult(), op.getCallback(), null, e);
+        OperationCallback.completeOperation(op.getFutureResult(), op.getCallback(), null, e);
       }
     }
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -50,7 +50,7 @@ class DeleteManager {
   private final NonBlockingRouterMetrics routerMetrics;
   private final ClusterMap clusterMap;
   private final RouterConfig routerConfig;
-  private final OperationCallback operationCallback;
+  private final RouterCallback routerCallback;
 
   private static final Logger logger = LoggerFactory.getLogger(DeleteManager.class);
 
@@ -78,18 +78,17 @@ class DeleteManager {
    * @param notificationSystem The {@link NotificationSystem} used for notifying blob deletions.
    * @param routerConfig The {@link RouterConfig} containing the configs for the DeleteManager.
    * @param routerMetrics The {@link NonBlockingRouterMetrics} to be used for reporting metrics.
-   * @param operationCallback The {@link OperationCallback} to use for callbacks to the router.
+   * @param routerCallback The {@link RouterCallback} to use for callbacks to the router.
    * @param time The {@link Time} instance to use.
    */
   DeleteManager(ClusterMap clusterMap, ResponseHandler responseHandler, NotificationSystem notificationSystem,
-      RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, OperationCallback operationCallback,
-      Time time) {
+      RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, RouterCallback routerCallback, Time time) {
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.notificationSystem = notificationSystem;
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
-    this.operationCallback = operationCallback;
+    this.routerCallback = routerCallback;
     this.time = time;
     deleteOperations = Collections.newSetFromMap(new ConcurrentHashMap<DeleteOperation, Boolean>());
     correlationIdToDeleteOperation = new HashMap<Integer, DeleteOperation>();

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
  * which is either the only chunk in the case of a simple blob, or the metadata chunk in the case of composite blobs.
  */
 class GetBlobInfoOperation extends GetOperation {
-  private final OperationCallback operationCallback;
   private final SimpleOperationTracker operationTracker;
   // map of correlation id to the request metadata for every request issued for this operation.
   private final Map<Integer, GetRequestInfo> correlationIdToGetRequestInfo = new TreeMap<Integer, GetRequestInfo>();
@@ -59,15 +58,13 @@ class GetBlobInfoOperation extends GetOperation {
    * @param blobIdStr the blob id associated with the operation in string form.
    * @param options the {@link GetBlobOptionsInternal} containing the options associated with this operation.
    * @param callback the callback that is to be called when the operation completes.
-   * @param operationCallback the {@link OperationCallback} to use to complete operations.
    * @param time the Time instance to use.
    * @throws RouterException if there is an error with any of the parameters, such as an invalid blob id.
    */
   GetBlobInfoOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
       ResponseHandler responseHandler, String blobIdStr, GetBlobOptionsInternal options,
-      Callback<GetBlobResultInternal> callback, OperationCallback operationCallback, Time time) throws RouterException {
+      Callback<GetBlobResultInternal> callback, Time time) throws RouterException {
     super(routerConfig, routerMetrics, clusterMap, responseHandler, blobIdStr, options, callback, time);
-    this.operationCallback = operationCallback;
     operationTracker = new SimpleOperationTracker(routerConfig.routerDatacenterName, blobId.getPartition(),
         routerConfig.routerGetCrossDcEnabled, routerConfig.routerGetSuccessTarget,
         routerConfig.routerGetRequestParallelism);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * which is either the only chunk in the case of a simple blob, or the metadata chunk in the case of composite blobs.
  */
 class GetBlobInfoOperation extends GetOperation {
-  private final OperationCompleteCallback operationCompleteCallback;
+  private final OperationCallback operationCallback;
   private final SimpleOperationTracker operationTracker;
   // map of correlation id to the request metadata for every request issued for this operation.
   private final Map<Integer, GetRequestInfo> correlationIdToGetRequestInfo = new TreeMap<Integer, GetRequestInfo>();
@@ -59,16 +59,15 @@ class GetBlobInfoOperation extends GetOperation {
    * @param blobIdStr the blob id associated with the operation in string form.
    * @param options the {@link GetBlobOptionsInternal} containing the options associated with this operation.
    * @param callback the callback that is to be called when the operation completes.
-   * @param operationCompleteCallback the {@link OperationCompleteCallback} to use to complete operations.
+   * @param operationCallback the {@link OperationCallback} to use to complete operations.
    * @param time the Time instance to use.
    * @throws RouterException if there is an error with any of the parameters, such as an invalid blob id.
    */
   GetBlobInfoOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
       ResponseHandler responseHandler, String blobIdStr, GetBlobOptionsInternal options,
-      Callback<GetBlobResultInternal> callback,
-      OperationCompleteCallback operationCompleteCallback, Time time) throws RouterException {
+      Callback<GetBlobResultInternal> callback, OperationCallback operationCallback, Time time) throws RouterException {
     super(routerConfig, routerMetrics, clusterMap, responseHandler, blobIdStr, options, callback, time);
-    this.operationCompleteCallback = operationCompleteCallback;
+    this.operationCallback = operationCallback;
     operationTracker = new SimpleOperationTracker(routerConfig.routerDatacenterName, blobId.getPartition(),
         routerConfig.routerGetCrossDcEnabled, routerConfig.routerGetSuccessTarget,
         routerConfig.routerGetRequestParallelism);
@@ -76,7 +75,7 @@ class GetBlobInfoOperation extends GetOperation {
 
   @Override
   void abort(Exception abortCause) {
-    operationCompleteCallback.completeOperation(null, operationCallback, null, abortCause);
+    OperationCallback.completeOperation(null, getOperationCallback, null, abortCause);
     operationCompleted = true;
   }
 
@@ -332,7 +331,7 @@ class GetBlobInfoOperation extends GetOperation {
         routerMetrics.onGetBlobError(e, options);
       }
       routerMetrics.getBlobInfoOperationLatencyMs.update(time.milliseconds() - submissionTimeMs);
-      operationCompleteCallback.completeOperation(null, operationCallback, operationResult, e);
+      OperationCallback.completeOperation(null, getOperationCallback, operationResult, e);
     }
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -75,7 +75,7 @@ class GetBlobInfoOperation extends GetOperation {
 
   @Override
   void abort(Exception abortCause) {
-    OperationCallback.completeOperation(null, getOperationCallback, null, abortCause);
+    NonBlockingRouter.completeOperation(null, getOperationCallback, null, abortCause);
     operationCompleted = true;
   }
 
@@ -331,7 +331,7 @@ class GetBlobInfoOperation extends GetOperation {
         routerMetrics.onGetBlobError(e, options);
       }
       routerMetrics.getBlobInfoOperationLatencyMs.update(time.milliseconds() - submissionTimeMs);
-      OperationCallback.completeOperation(null, getOperationCallback, operationResult, e);
+      NonBlockingRouter.completeOperation(null, getOperationCallback, operationResult, e);
     }
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -141,7 +141,7 @@ class GetBlobOperation extends GetOperation {
   @Override
   void abort(Exception abortCause) {
     if (operationCallbackInvoked.compareAndSet(false, true)) {
-      OperationCallback.completeOperation(null, getOperationCallback, null, abortCause);
+      NonBlockingRouter.completeOperation(null, getOperationCallback, null, abortCause);
     } else {
       setOperationException(abortCause);
       if (blobDataChannel != null && blobDataChannel.isReadCalled()) {
@@ -189,7 +189,7 @@ class GetBlobOperation extends GetOperation {
             routerMetrics.onGetBlobError(e, options);
           }
         }
-        OperationCallback.completeOperation(null, getOperationCallback, operationResult, e);
+        NonBlockingRouter.completeOperation(null, getOperationCallback, operationResult, e);
       }
     }
     chunk.postCompletionCleanup();

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -70,7 +70,7 @@ import org.slf4j.LoggerFactory;
  */
 class GetBlobOperation extends GetOperation {
   // the callback to use to complete the operation.
-  private final OperationCallback operationCallback;
+  private final RouterCallback routerCallback;
   // whether the operationCallback has been called already.
   private final AtomicBoolean operationCallbackInvoked = new AtomicBoolean(false);
   // The first chunk may be a metadata chunk if the blob is composite, or the only data chunk if the blob is simple.
@@ -116,17 +116,17 @@ class GetBlobOperation extends GetOperation {
    * @param blobIdStr the blob id associated with the operation in string form.
    * @param options the {@link GetBlobOptionsInternal} associated with the operation.
    * @param callback the callback that is to be called when the operation completes.
-   * @param operationCallback the {@link OperationCallback} to use to complete operations.
+   * @param routerCallback the {@link RouterCallback} to use to complete operations.
    * @param blobIdFactory the factory to use to deserialize keys in a metadata chunk.
    * @param time the Time instance to use.
    * @throws RouterException if there is an error with any of the parameters, such as an invalid blob id.
    */
   GetBlobOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
       ResponseHandler responseHandler, String blobIdStr, GetBlobOptionsInternal options,
-      Callback<GetBlobResultInternal> callback, OperationCallback operationCallback, BlobIdFactory blobIdFactory,
-      Time time) throws RouterException {
+      Callback<GetBlobResultInternal> callback, RouterCallback routerCallback, BlobIdFactory blobIdFactory, Time time)
+      throws RouterException {
     super(routerConfig, routerMetrics, clusterMap, responseHandler, blobIdStr, options, callback, time);
-    this.operationCallback = operationCallback;
+    this.routerCallback = routerCallback;
     this.blobIdFactory = blobIdFactory;
     firstChunk = new FirstGetChunk();
   }
@@ -296,7 +296,7 @@ class GetBlobOperation extends GetOperation {
           setOperationException(exception);
         }
         numChunksWrittenOut++;
-        operationCallback.onPollReady();
+        routerCallback.onPollReady();
       }
     };
 
@@ -324,7 +324,7 @@ class GetBlobOperation extends GetOperation {
       if (operationException.get() != null) {
         completeRead();
       }
-      operationCallback.onPollReady();
+      routerCallback.onPollReady();
       return readIntoFuture;
     }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -122,7 +122,7 @@ class GetManager {
     } catch (RouterException e) {
       routerMetrics.onGetBlobError(e, options);
       routerMetrics.operationDequeuingRate.mark();
-      OperationCallback.completeOperation(null, callback, null, e);
+      NonBlockingRouter.completeOperation(null, callback, null, e);
     }
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -62,8 +62,7 @@ class GetManager {
   private final RouterConfig routerConfig;
   private final ResponseHandler responseHandler;
   private final NonBlockingRouterMetrics routerMetrics;
-  private final OperationCompleteCallback operationCompleteCallback;
-  private final ReadyForPollCallback readyForPollCallback;
+  private final OperationCallback operationCallback;
 
   private class GetRequestRegistrationCallbackImpl implements RequestRegistrationCallback<GetOperation> {
     private List<RequestInfo> requestListToFill;
@@ -86,21 +85,17 @@ class GetManager {
    * @param responseHandler The {@link ResponseHandler} used to notify failures for failure detection.
    * @param routerConfig  The {@link RouterConfig} containing the configs for the PutManager.
    * @param routerMetrics The {@link NonBlockingRouterMetrics} to be used for reporting metrics.
-   * @param operationCompleteCallback The {@link OperationCompleteCallback} to use to complete operations.
-   * @param readyForPollCallback The callback to be used to notify the router of any state changes within the
-   *                             operations.
+   * @param operationCallback The {@link OperationCallback} to use for callbacks to the router.
    * @param time The {@link Time} instance to use.
    */
   GetManager(ClusterMap clusterMap, ResponseHandler responseHandler, RouterConfig routerConfig,
-      NonBlockingRouterMetrics routerMetrics, OperationCompleteCallback operationCompleteCallback,
-      ReadyForPollCallback readyForPollCallback, Time time) {
+      NonBlockingRouterMetrics routerMetrics, OperationCallback operationCallback, Time time) {
     this.clusterMap = clusterMap;
     blobIdFactory = new BlobIdFactory(clusterMap);
     this.responseHandler = responseHandler;
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
-    this.operationCompleteCallback = operationCompleteCallback;
-    this.readyForPollCallback = readyForPollCallback;
+    this.operationCallback = operationCallback;
     this.time = time;
     getOperations = Collections.newSetFromMap(new ConcurrentHashMap<GetOperation, Boolean>());
   }
@@ -117,17 +112,17 @@ class GetManager {
       if (options.getBlobOptions.getOperationType() == GetBlobOptions.OperationType.BlobInfo) {
         getOperation =
             new GetBlobInfoOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options,
-                callback, operationCompleteCallback, time);
+                callback, operationCallback, time);
       } else {
         getOperation =
             new GetBlobOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback,
-                operationCompleteCallback, readyForPollCallback, blobIdFactory, time);
+                operationCallback, blobIdFactory, time);
       }
       getOperations.add(getOperation);
     } catch (RouterException e) {
       routerMetrics.onGetBlobError(e, options);
       routerMetrics.operationDequeuingRate.mark();
-      operationCompleteCallback.completeOperation(null, callback, null, e);
+      OperationCallback.completeOperation(null, callback, null, e);
     }
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -41,7 +41,7 @@ abstract class GetOperation {
   protected final NonBlockingRouterMetrics routerMetrics;
   protected final ClusterMap clusterMap;
   protected final ResponseHandler responseHandler;
-  protected final Callback<GetBlobResultInternal> operationCallback;
+  protected final Callback<GetBlobResultInternal> getOperationCallback;
   protected final BlobId blobId;
   protected final GetBlobOptionsInternal options;
   protected final Time time;
@@ -60,19 +60,19 @@ abstract class GetOperation {
    * @param responseHandler the {@link ResponseHandler} responsible for failure detection.
    * @param blobIdStr the blobId of the associated blob in string form.
    * @param options the {@link GetBlobOptionsInternal} associated with this operation.
-   * @param operationCallback the callback that is to be called when the operation completes.
+   * @param getOperationCallback the callback that is to be called when the operation completes.
    * @param time the {@link Time} instance to use.
    * @throws RouterException if there is an error with any of the parameters, such as an invalid blob id.
    */
   GetOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
       ResponseHandler responseHandler, String blobIdStr, GetBlobOptionsInternal options,
-      Callback<GetBlobResultInternal> operationCallback, Time time) throws RouterException {
+      Callback<GetBlobResultInternal> getOperationCallback, Time time) throws RouterException {
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.options = options;
-    this.operationCallback = operationCallback;
+    this.getOperationCallback = getOperationCallback;
     this.time = time;
     submissionTimeMs = time.milliseconds();
     blobId = RouterUtils.getBlobIdFromString(blobIdStr, clusterMap);
@@ -83,7 +83,7 @@ abstract class GetOperation {
    * @return the {@link Callback} associated with this operation.
    */
   Callback<GetBlobResultInternal> getCallback() {
-    return operationCallback;
+    return getOperationCallback;
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -23,7 +23,6 @@ import com.github.ambry.clustermap.DataNodeId;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 
 /**

--- a/ambry-router/src/main/java/com.github.ambry.router/OperationCallback.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/OperationCallback.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import com.github.ambry.network.NetworkClient;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An object of this class is passed by the router to the operation managers for the latter to use to notify about
+ * events.
+ */
+class OperationCallback {
+  private final NetworkClient networkClient;
+  private final List<String> idsToDelete;
+
+  /**
+   * Construct an OperationCompleteCallback object
+   * @param networkClient the {@link NetworkClient} associated with this callback.
+   */
+  OperationCallback(NetworkClient networkClient, List<String> idsToDelete) {
+    this.networkClient = networkClient;
+    this.idsToDelete = idsToDelete;
+  }
+
+  /**
+   * Wake up the associated {@link NetworkClient}.
+   *
+   * Called by the operation managers when a poll-eligible event occurs for any operation. A poll-eligible event is any
+   * event that occurs asynchronously to the RequestResponseHandler thread such that there is a high chance of
+   * meaningful work getting done when the operation is subsequently polled. When the callback is invoked, the
+   * RequestResponseHandler thread which could be sleeping in a {@link NetworkClient#sendAndPoll(List, int)} is woken up
+   * so that the operations can be polled without additional delays. For example, when a chunk gets filled by the
+   * ChunkFillerThread within the {@link PutManager}, this callback is invoked so that the RequestResponseHandler
+   * immediately polls the operation to send out the request for the chunk.
+   */
+  void onPollReady() {
+    networkClient.wakeup();
+  }
+
+  /**
+   * Schedule the deletes of ids in the given list.
+   * @param idsToDelete the list of ids that need to be deleted.
+   */
+  void scheduleDeletes(List<String> idsToDelete) {
+    if (idsToDelete != null) {
+      this.idsToDelete.addAll(idsToDelete);
+    }
+  }
+}
+

--- a/ambry-router/src/main/java/com.github.ambry.router/OperationCallback.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/OperationCallback.java
@@ -14,6 +14,8 @@
 package com.github.ambry.router;
 
 import com.github.ambry.network.NetworkClient;
+import com.github.ambry.store.Store;
+import com.github.ambry.store.StoreKey;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,13 +27,13 @@ import org.slf4j.LoggerFactory;
  */
 class OperationCallback {
   private final NetworkClient networkClient;
-  private final List<String> idsToDelete;
+  private final List<StoreKey> idsToDelete;
 
   /**
    * Construct an OperationCompleteCallback object
    * @param networkClient the {@link NetworkClient} associated with this callback.
    */
-  OperationCallback(NetworkClient networkClient, List<String> idsToDelete) {
+  OperationCallback(NetworkClient networkClient, List<StoreKey> idsToDelete) {
     this.networkClient = networkClient;
     this.idsToDelete = idsToDelete;
   }
@@ -55,7 +57,7 @@ class OperationCallback {
    * Schedule the deletes of ids in the given list.
    * @param idsToDelete the list of ids that need to be deleted.
    */
-  void scheduleDeletes(List<String> idsToDelete) {
+  void scheduleDeletes(List<StoreKey> idsToDelete) {
     if (idsToDelete != null) {
       this.idsToDelete.addAll(idsToDelete);
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -145,7 +145,7 @@ class PutManager {
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
       routerMetrics.onPutBlobError(e);
-      OperationCallback.completeOperation(futureResult, callback, null, e);
+      NonBlockingRouter.completeOperation(futureResult, callback, null, e);
     }
   }
 
@@ -252,7 +252,7 @@ class PutManager {
     }
     routerMetrics.operationDequeuingRate.mark();
     routerMetrics.putBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmissionTimeMs());
-    OperationCallback.completeOperation(op.getFuture(), op.getCallback(), blobId, e);
+    NonBlockingRouter.completeOperation(op.getFuture(), op.getCallback(), blobId, e);
   }
 
   /**
@@ -314,7 +314,7 @@ class PutManager {
         routerMetrics.operationDequeuingRate.mark();
         routerMetrics.operationAbortCount.inc();
         routerMetrics.onPutBlobError(e);
-        OperationCallback.completeOperation(op.getFuture(), op.getCallback(), null, e);
+        NonBlockingRouter.completeOperation(op.getFuture(), op.getCallback(), null, e);
       }
     }
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -61,9 +61,7 @@ class PutManager {
   // get cleaned up periodically.
   private final Map<Integer, PutOperation> correlationIdToPutOperation;
   private final AtomicBoolean isOpen = new AtomicBoolean(true);
-  private final OperationCompleteCallback operationCompleteCallback;
-  private final ReadyForPollCallback readyForPollCallback;
-  private final List<String> idsToDeleteList;
+  private final OperationCallback operationCallback;
   private final ByteBufferAsyncWritableChannel.ChannelEventListener chunkArrivalListener;
 
   // shared by all PutOperations
@@ -94,26 +92,19 @@ class PutManager {
    * @param notificationSystem The {@link NotificationSystem} used for notifying blob creations.
    * @param routerConfig  The {@link RouterConfig} containing the configs for the PutManager.
    * @param routerMetrics The {@link NonBlockingRouterMetrics} to be used for reporting metrics.
-   * @param operationCompleteCallback The {@link OperationCompleteCallback} to use to complete operations.
-   * @param readyForPollCallback The callback to be used to notify the router of any state changes within the
-   *                             operations.
-   * @param idsToDeleteList The list to fill with ids of successfully put data chunks of an unsuccessful
-   *                        overall put operation.
+   * @param operationCallback The {@link OperationCallback} to use for callbacks to the router.
    * @param suffix the suffix to associate with the names of the threads created by this PutManager
    * @param time The {@link Time} instance to use.
    */
   PutManager(ClusterMap clusterMap, ResponseHandler responseHandler, NotificationSystem notificationSystem,
-      RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
-      OperationCompleteCallback operationCompleteCallback, ReadyForPollCallback readyForPollCallback,
-      List<String> idsToDeleteList, String suffix, Time time) {
+      RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, OperationCallback operationCallback,
+      String suffix, Time time) {
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.notificationSystem = notificationSystem;
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
-    this.operationCompleteCallback = operationCompleteCallback;
-    this.readyForPollCallback = readyForPollCallback;
-    this.idsToDeleteList = idsToDeleteList;
+    this.operationCallback = operationCallback;
     this.chunkArrivalListener = new ByteBufferAsyncWritableChannel.ChannelEventListener() {
       @Override
       public void onEvent(ByteBufferAsyncWritableChannel.EventType e) {
@@ -148,13 +139,13 @@ class PutManager {
     try {
       PutOperation putOperation =
           new PutOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobProperties, userMetaData,
-              channel, futureResult, callback, readyForPollCallback, chunkArrivalListener, time);
+              channel, futureResult, callback, operationCallback, chunkArrivalListener, time);
       putOperations.add(putOperation);
       putOperation.startReadingFromChannel();
     } catch (RouterException e) {
       routerMetrics.operationDequeuingRate.mark();
       routerMetrics.onPutBlobError(e);
-      operationCompleteCallback.completeOperation(futureResult, callback, null, e);
+      OperationCallback.completeOperation(futureResult, callback, null, e);
     }
   }
 
@@ -254,14 +245,14 @@ class PutManager {
     if (e != null) {
       blobId = null;
       routerMetrics.onPutBlobError(e);
-      op.addSuccessfullyPutChunkIds(idsToDeleteList);
+      operationCallback.scheduleDeletes(op.getSuccessfullyPutChunkIds());
     } else {
       notificationSystem.onBlobCreated(op.getBlobIdString(), op.getBlobProperties(), op.getUserMetadata());
       updateChunkingAndSizeMetricsOnSuccessfulPut(op);
     }
     routerMetrics.operationDequeuingRate.mark();
     routerMetrics.putBlobOperationLatencyMs.update(time.milliseconds() - op.getSubmissionTimeMs());
-    operationCompleteCallback.completeOperation(op.getFuture(), op.getCallback(), blobId, e);
+    OperationCallback.completeOperation(op.getFuture(), op.getCallback(), blobId, e);
   }
 
   /**
@@ -323,7 +314,7 @@ class PutManager {
         routerMetrics.operationDequeuingRate.mark();
         routerMetrics.operationAbortCount.inc();
         routerMetrics.onPutBlobError(e);
-        operationCompleteCallback.completeOperation(op.getFuture(), op.getCallback(), null, e);
+        OperationCallback.completeOperation(op.getFuture(), op.getCallback(), null, e);
       }
     }
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -526,7 +526,7 @@ class PutOperation {
    * if this is a composite object, fill the list with successfully put chunk ids.
    * @return the list of successfully put chunk ids, if any; else null.
    */
-  List<String> getSuccessfullyPutChunkIds() {
+  List<StoreKey> getSuccessfullyPutChunkIds() {
     return numDataChunks > 1 ? metadataPutChunk.getChunkIds() : null;
   }
 
@@ -1088,11 +1088,11 @@ class PutOperation {
      * Add all the successfully put chunk ids of the overall blob to the passed in list.
      * @return list of chunk ids associated with this composite blob.
      */
-    List<String> getChunkIds() {
-      List<String> chunkIdList = new ArrayList<>();
+    List<StoreKey> getChunkIds() {
+      List<StoreKey> chunkIdList = new ArrayList<>();
       for (int i = 0; i <= maxFilledChunkIndex; i++) {
         if (chunkIds[i] != null) {
-          chunkIdList.add(chunkIds[i].getID());
+          chunkIdList.add(chunkIds[i]);
         }
       }
       return chunkIdList;

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -78,7 +78,7 @@ class PutOperation {
   private final ByteBufferAsyncWritableChannel chunkFillerChannel;
   private final FutureResult<String> futureResult;
   private final Callback<String> callback;
-  private final ReadyForPollCallback readyForPollCallback;
+  private final OperationCallback operationCallback;
   private final Time time;
 
   // Parameters associated with the state.
@@ -141,15 +141,14 @@ class PutOperation {
    * @param channel the {@link ReadableStreamChannel} containing the blob data.
    * @param futureResult the future that will contain the result of the operation.
    * @param callback the callback that is to be called when the operation completes.
-   * @param readyForPollCallback The callback to be used to notify the router of any state changes within this
-   *                             operation.
+   * @param operationCallback The {@link OperationCallback} to use for callbacks to the router.
    * @param time the Time instance to use.
    * @throws RouterException if there is an error in constructing the PutOperation with the given parameters.
    */
   PutOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
       ResponseHandler responseHandler, BlobProperties blobProperties, byte[] userMetadata,
       ReadableStreamChannel channel, FutureResult<String> futureResult, Callback<String> callback,
-      ReadyForPollCallback readyForPollCallback,
+      OperationCallback operationCallback,
       ByteBufferAsyncWritableChannel.ChannelEventListener writableChannelEventListener, Time time)
       throws RouterException {
     submissionTimeMs = time.milliseconds();
@@ -175,7 +174,7 @@ class PutOperation {
     this.channel = channel;
     this.futureResult = futureResult;
     this.callback = callback;
-    this.readyForPollCallback = readyForPollCallback;
+    this.operationCallback = operationCallback;
     this.time = time;
     bytesFilledSoFar = 0;
     chunkCounter = -1;
@@ -331,7 +330,7 @@ class PutOperation {
               maybeStopTrackingWaitForChunkTime();
               bytesFilledSoFar += chunkToFill.fillFrom(channelReadBuffer);
               if (chunkToFill.isReady()) {
-                readyForPollCallback.onPollReady();
+                operationCallback.onPollReady();
                 updateChunkFillerWaitTimeMetrics();
               }
               if (!channelReadBuffer.hasRemaining()) {
@@ -354,7 +353,7 @@ class PutOperation {
       }
     } catch (Exception e) {
       routerMetrics.chunkFillerUnexpectedErrorCount.inc();
-      readyForPollCallback.onPollReady();
+      operationCallback.onPollReady();
       setOperationExceptionAndComplete(new RouterException("PutOperation fillChunks encountered unexpected error", e,
           RouterErrorCode.UnexpectedInternalError));
     }
@@ -525,12 +524,10 @@ class PutOperation {
 
   /**
    * if this is a composite object, fill the list with successfully put chunk ids.
-   * @param chunkIdList the list to fill with chunk ids.
+   * @return the list of successfully put chunk ids, if any; else null.
    */
-  void addSuccessfullyPutChunkIds(List<String> chunkIdList) {
-    if (numDataChunks > 1) {
-      metadataPutChunk.addChunkIds(chunkIdList);
-    }
+  List<String> getSuccessfullyPutChunkIds() {
+    return numDataChunks > 1 ? metadataPutChunk.getChunkIds() : null;
   }
 
   /**
@@ -1089,14 +1086,16 @@ class PutOperation {
 
     /**
      * Add all the successfully put chunk ids of the overall blob to the passed in list.
-     * @param chunkIdList list to fill with chunk ids.
+     * @return list of chunk ids associated with this composite blob.
      */
-    void addChunkIds(List<String> chunkIdList) {
+    List<String> getChunkIds() {
+      List<String> chunkIdList = new ArrayList<>();
       for (int i = 0; i <= maxFilledChunkIndex; i++) {
         if (chunkIds[i] != null) {
           chunkIdList.add(chunkIds[i].getID());
         }
       }
+      return chunkIdList;
     }
 
     /**

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterCallback.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterCallback.java
@@ -14,26 +14,23 @@
 package com.github.ambry.router;
 
 import com.github.ambry.network.NetworkClient;
-import com.github.ambry.store.Store;
 import com.github.ambry.store.StoreKey;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
- * An object of this class is passed by the router to the operation managers for the latter to use to notify about
- * events.
+ * An object of this class is passed by the router to the operation managers for the latter to use to notify the
+ * router about events and state changes that need attention.
  */
-class OperationCallback {
+class RouterCallback {
   private final NetworkClient networkClient;
   private final List<StoreKey> idsToDelete;
 
   /**
-   * Construct an OperationCompleteCallback object
+   * Construct a RouterCallback object
    * @param networkClient the {@link NetworkClient} associated with this callback.
    */
-  OperationCallback(NetworkClient networkClient, List<StoreKey> idsToDelete) {
+  RouterCallback(NetworkClient networkClient, List<StoreKey> idsToDelete) {
     this.networkClient = networkClient;
     this.idsToDelete = idsToDelete;
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -113,8 +113,7 @@ public class ChunkFillTest {
     MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
         putUserMetadata, putChannel, futureResult, null,
-        new OperationCallback(networkClientFactory.getNetworkClient(), new ArrayList<StoreKey>()), null,
-        new MockTime());
+        new RouterCallback(networkClientFactory.getNetworkClient(), new ArrayList<StoreKey>()), null, new MockTime());
     op.startReadingFromChannel();
     numChunks = op.getNumDataChunks();
     // largeBlobSize is not a multiple of chunkSize
@@ -199,7 +198,7 @@ public class ChunkFillTest {
     MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
         putUserMetadata, putChannel, futureResult, null,
-        new OperationCallback(networkClientFactory.getNetworkClient(), new ArrayList<StoreKey>()), null, time);
+        new RouterCallback(networkClientFactory.getNetworkClient(), new ArrayList<StoreKey>()), null, time);
     op.startReadingFromChannel();
     numChunks = op.getNumDataChunks();
     compositeBuffers = new ByteBuffer[numChunks];

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -22,6 +22,7 @@ import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Utils;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.Random;
@@ -111,7 +112,7 @@ public class ChunkFillTest {
     MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
         putUserMetadata, putChannel, futureResult, null,
-        new ReadyForPollCallback(networkClientFactory.getNetworkClient()), null, new MockTime());
+        new OperationCallback(networkClientFactory.getNetworkClient(), new ArrayList<String>()), null, new MockTime());
     op.startReadingFromChannel();
     numChunks = op.getNumDataChunks();
     // largeBlobSize is not a multiple of chunkSize
@@ -196,7 +197,7 @@ public class ChunkFillTest {
     MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
         putUserMetadata, putChannel, futureResult, null,
-        new ReadyForPollCallback(networkClientFactory.getNetworkClient()), null, time);
+        new OperationCallback(networkClientFactory.getNetworkClient(), new ArrayList<String>()), null, time);
     op.startReadingFromChannel();
     numChunks = op.getNumDataChunks();
     compositeBuffers = new ByteBuffer[numChunks];

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Utils;
 import java.nio.ByteBuffer;
@@ -112,7 +113,8 @@ public class ChunkFillTest {
     MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
         putUserMetadata, putChannel, futureResult, null,
-        new OperationCallback(networkClientFactory.getNetworkClient(), new ArrayList<String>()), null, new MockTime());
+        new OperationCallback(networkClientFactory.getNetworkClient(), new ArrayList<StoreKey>()), null,
+        new MockTime());
     op.startReadingFromChannel();
     numChunks = op.getNumDataChunks();
     // largeBlobSize is not a multiple of chunkSize
@@ -197,7 +199,7 @@ public class ChunkFillTest {
     MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);
     PutOperation op = new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, putBlobProperties,
         putUserMetadata, putChannel, futureResult, null,
-        new OperationCallback(networkClientFactory.getNetworkClient(), new ArrayList<String>()), null, time);
+        new OperationCallback(networkClientFactory.getNetworkClient(), new ArrayList<StoreKey>()), null, time);
     op.startReadingFromChannel();
     numChunks = op.getNumDataChunks();
     compositeBuffers = new ByteBuffer[numChunks];

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -29,6 +29,7 @@ import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Utils;
@@ -93,7 +94,7 @@ public class GetBlobInfoOperationTest {
     }
   }
 
-  private final OperationCallback operationCallback = new OperationCallback(null, new ArrayList<String>());
+  private final OperationCallback operationCallback = new OperationCallback(null, new ArrayList<StoreKey>());
 
   public GetBlobInfoOperationTest() throws Exception {
     VerifiableProperties vprops = new VerifiableProperties(getNonBlockingRouterProperties());

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -93,8 +93,7 @@ public class GetBlobInfoOperationTest {
     }
   }
 
-  private final AtomicInteger operationsCount = new AtomicInteger(0);
-  private final OperationCompleteCallback operationCompleteCallback = new OperationCompleteCallback(operationsCount);
+  private final OperationCallback operationCallback = new OperationCallback(null, new ArrayList<String>());
 
   public GetBlobInfoOperationTest() throws Exception {
     VerifiableProperties vprops = new VerifiableProperties(getNonBlockingRouterProperties());
@@ -124,7 +123,7 @@ public class GetBlobInfoOperationTest {
     if (networkClient != null) {
       networkClient.close();
     }
-    Assert.assertEquals("All operations should have completed", 0, operationsCount.get());
+    Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
   }
 
   /**
@@ -134,7 +133,7 @@ public class GetBlobInfoOperationTest {
   @Test
   public void testInstantiation() throws Exception {
     String blobIdStr = (new BlobId(mockClusterMap.getWritablePartitionIds().get(0))).getID();
-    Callback<GetBlobResultInternal> operationCallback = new Callback<GetBlobResultInternal>() {
+    Callback<GetBlobResultInternal> getOperationCallback = new Callback<GetBlobResultInternal>() {
       @Override
       public void onCompletion(GetBlobResultInternal result, Exception exception) {
         // no op.
@@ -144,7 +143,7 @@ public class GetBlobInfoOperationTest {
     // test a bad case
     try {
       new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, "invalid_id", options,
-          operationCallback, operationCompleteCallback, time);
+          getOperationCallback, operationCallback, time);
       Assert.fail("Instantiation of GetBlobInfo operation with an invalid blob id must fail");
     } catch (RouterException e) {
       Assert.assertEquals("Unexpected exception received on creating GetBlobInfoOperation",
@@ -154,9 +153,9 @@ public class GetBlobInfoOperationTest {
     // test a good case
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options,
-            operationCallback, operationCompleteCallback, time);
+            getOperationCallback, operationCallback, time);
 
-    Assert.assertEquals("Callback must match", operationCallback, op.getCallback());
+    Assert.assertEquals("Callback must match", getOperationCallback, op.getCallback());
     Assert.assertEquals("Blob ids must match", blobIdStr, op.getBlobIdStr());
   }
 
@@ -166,10 +165,10 @@ public class GetBlobInfoOperationTest {
    */
   @Test
   public void testPollAndResponseHandling() throws Exception {
-    operationsCount.incrementAndGet();
+    NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCompleteCallback, time);
+            operationCallback, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
     op.poll(requestRegistrationCallback);
@@ -195,10 +194,10 @@ public class GetBlobInfoOperationTest {
    */
   @Test
   public void testRouterRequestTimeoutAllFailure() throws Exception {
-    operationsCount.incrementAndGet();
+    NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCompleteCallback, time);
+            operationCallback, time);
     requestRegistrationCallback.requestListToFill = new ArrayList<>();
     op.poll(requestRegistrationCallback);
     while (!op.isOperationComplete()) {
@@ -220,10 +219,10 @@ public class GetBlobInfoOperationTest {
    */
   @Test
   public void testNetworkClientTimeoutAllFailure() throws Exception {
-    operationsCount.incrementAndGet();
+    NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCompleteCallback, time);
+            operationCallback, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -255,10 +254,10 @@ public class GetBlobInfoOperationTest {
    */
   @Test
   public void testBlobNotFoundCase() throws Exception {
-    operationsCount.incrementAndGet();
+    NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCompleteCallback, time);
+            operationCallback, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -317,10 +316,10 @@ public class GetBlobInfoOperationTest {
    */
   private void testErrorPrecedence(ServerErrorCode[] serverErrorCodesInOrder, RouterErrorCode expectedErrorCode)
       throws Exception {
-    operationsCount.incrementAndGet();
+    NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCompleteCallback, time);
+            operationCallback, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -374,10 +373,10 @@ public class GetBlobInfoOperationTest {
   }
 
   private void testVariousErrors(String dcWherePutHappened) throws Exception {
-    operationsCount.incrementAndGet();
+    NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCompleteCallback, time);
+            operationCallback, time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -94,8 +94,6 @@ public class GetBlobInfoOperationTest {
     }
   }
 
-  private final OperationCallback operationCallback = new OperationCallback(null, new ArrayList<StoreKey>());
-
   public GetBlobInfoOperationTest() throws Exception {
     VerifiableProperties vprops = new VerifiableProperties(getNonBlockingRouterProperties());
     routerConfig = new RouterConfig(vprops);
@@ -144,7 +142,7 @@ public class GetBlobInfoOperationTest {
     // test a bad case
     try {
       new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, "invalid_id", options,
-          getOperationCallback, operationCallback, time);
+          getOperationCallback, time);
       Assert.fail("Instantiation of GetBlobInfo operation with an invalid blob id must fail");
     } catch (RouterException e) {
       Assert.assertEquals("Unexpected exception received on creating GetBlobInfoOperation",
@@ -154,7 +152,7 @@ public class GetBlobInfoOperationTest {
     // test a good case
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options,
-            getOperationCallback, operationCallback, time);
+            getOperationCallback, time);
 
     Assert.assertEquals("Callback must match", getOperationCallback, op.getCallback());
     Assert.assertEquals("Blob ids must match", blobIdStr, op.getBlobIdStr());
@@ -169,7 +167,7 @@ public class GetBlobInfoOperationTest {
     NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCallback, time);
+            time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
     op.poll(requestRegistrationCallback);
@@ -198,7 +196,7 @@ public class GetBlobInfoOperationTest {
     NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCallback, time);
+            time);
     requestRegistrationCallback.requestListToFill = new ArrayList<>();
     op.poll(requestRegistrationCallback);
     while (!op.isOperationComplete()) {
@@ -223,7 +221,7 @@ public class GetBlobInfoOperationTest {
     NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCallback, time);
+            time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -258,7 +256,7 @@ public class GetBlobInfoOperationTest {
     NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCallback, time);
+            time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -320,7 +318,7 @@ public class GetBlobInfoOperationTest {
     NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCallback, time);
+            time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 
@@ -377,7 +375,7 @@ public class GetBlobInfoOperationTest {
     NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, null,
-            operationCallback, time);
+            time);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestListToFill;
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -91,7 +91,7 @@ public class GetBlobOperationTest {
   private final ResponseHandler responseHandler;
   private final NonBlockingRouter router;
   private final MockNetworkClient mockNetworkClient;
-  private final OperationCallback operationCallback;
+  private final RouterCallback routerCallback;
 
   // Certain tests recreate the routerConfig with different properties.
   private RouterConfig routerConfig;
@@ -164,7 +164,7 @@ public class GetBlobOperationTest {
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap), networkClientFactory,
         new LoggingNotificationSystem(), mockClusterMap, time);
     mockNetworkClient = networkClientFactory.getMockNetworkClient();
-    operationCallback = new OperationCallback(mockNetworkClient, new ArrayList<StoreKey>());
+    routerCallback = new RouterCallback(mockNetworkClient, new ArrayList<StoreKey>());
   }
 
   /**
@@ -189,7 +189,7 @@ public class GetBlobOperationTest {
    */
   @Test
   public void testInstantiation() throws Exception {
-    Callback<GetBlobResultInternal> getOperationCallback = new Callback<GetBlobResultInternal>() {
+    Callback<GetBlobResultInternal> getRouterCallback = new Callback<GetBlobResultInternal>() {
       @Override
       public void onCompletion(GetBlobResultInternal result, Exception exception) {
         // no op.
@@ -199,7 +199,7 @@ public class GetBlobOperationTest {
     // test a bad case
     try {
       new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, "invalid_id", null,
-          getOperationCallback, operationCallback, blobIdFactory, time);
+          getRouterCallback, routerCallback, blobIdFactory, time);
       Assert.fail("Instantiation of GetBlobOperation with an invalid blob id must fail");
     } catch (RouterException e) {
       Assert.assertEquals("Unexpected exception received on creating GetBlobOperation", RouterErrorCode.InvalidBlobId,
@@ -210,10 +210,10 @@ public class GetBlobOperationTest {
     // test a good case
     // operationCount is not incremented here as this operation is not taken to completion.
     GetBlobOperation op = new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,
-        new GetBlobOptionsInternal(new GetBlobOptionsBuilder().build(), false), getOperationCallback, operationCallback,
+        new GetBlobOptionsInternal(new GetBlobOptionsBuilder().build(), false), getRouterCallback, routerCallback,
         blobIdFactory, time);
 
-    Assert.assertEquals("Callbacks must match", getOperationCallback, op.getCallback());
+    Assert.assertEquals("Callbacks must match", getRouterCallback, op.getCallback());
     Assert.assertEquals("Blob ids must match", blobIdStr, op.getBlobIdStr());
   }
 
@@ -873,7 +873,7 @@ public class GetBlobOperationTest {
     NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobOperation op =
         new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr, options, callback,
-            operationCallback, blobIdFactory, time);
+            routerCallback, blobIdFactory, time);
     requestRegistrationCallback.requestListToFill = new ArrayList<>();
     return op;
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -33,6 +33,8 @@ import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.router.RouterTestHelpers.*;
+import com.github.ambry.store.Store;
+import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Utils;
@@ -162,7 +164,7 @@ public class GetBlobOperationTest {
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap), networkClientFactory,
         new LoggingNotificationSystem(), mockClusterMap, time);
     mockNetworkClient = networkClientFactory.getMockNetworkClient();
-    operationCallback = new OperationCallback(mockNetworkClient, new ArrayList<String>());
+    operationCallback = new OperationCallback(mockNetworkClient, new ArrayList<StoreKey>());
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -27,6 +27,7 @@ import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
@@ -584,7 +585,7 @@ public class NonBlockingRouterTest {
 
     putManager = new PutManager(mockClusterMap, mockResponseHandler, new LoggingNotificationSystem(),
         new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
-        new OperationCallback(networkClient, new ArrayList<String>()), "0", mockTime);
+        new OperationCallback(networkClient, new ArrayList<StoreKey>()), "0", mockTime);
     OperationHelper opHelper = new OperationHelper(OperationType.PUT);
     testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, null, successfulResponseCount,
         invalidResponse, -1);
@@ -599,7 +600,7 @@ public class NonBlockingRouterTest {
 
     opHelper = new OperationHelper(OperationType.GET);
     getManager = new GetManager(mockClusterMap, mockResponseHandler, new RouterConfig(verifiableProperties),
-        new NonBlockingRouterMetrics(mockClusterMap), new OperationCallback(networkClient, new ArrayList<String>()),
+        new NonBlockingRouterMetrics(mockClusterMap), new OperationCallback(networkClient, new ArrayList<StoreKey>()),
         mockTime);
     testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
         invalidResponse, -1);
@@ -615,7 +616,7 @@ public class NonBlockingRouterTest {
     opHelper = new OperationHelper(OperationType.DELETE);
     deleteManager = new DeleteManager(mockClusterMap, mockResponseHandler, new LoggingNotificationSystem(),
         new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
-        new OperationCallback(null, new ArrayList<String>()), mockTime);
+        new OperationCallback(null, new ArrayList<StoreKey>()), mockTime);
     testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
         invalidResponse, -1);
     // Test that if a failed response comes before the operation is completed, failure detector is notified.

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -585,7 +585,7 @@ public class NonBlockingRouterTest {
 
     putManager = new PutManager(mockClusterMap, mockResponseHandler, new LoggingNotificationSystem(),
         new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
-        new OperationCallback(networkClient, new ArrayList<StoreKey>()), "0", mockTime);
+        new RouterCallback(networkClient, new ArrayList<StoreKey>()), "0", mockTime);
     OperationHelper opHelper = new OperationHelper(OperationType.PUT);
     testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, null, successfulResponseCount,
         invalidResponse, -1);
@@ -600,7 +600,7 @@ public class NonBlockingRouterTest {
 
     opHelper = new OperationHelper(OperationType.GET);
     getManager = new GetManager(mockClusterMap, mockResponseHandler, new RouterConfig(verifiableProperties),
-        new NonBlockingRouterMetrics(mockClusterMap), new OperationCallback(networkClient, new ArrayList<StoreKey>()),
+        new NonBlockingRouterMetrics(mockClusterMap), new RouterCallback(networkClient, new ArrayList<StoreKey>()),
         mockTime);
     testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
         invalidResponse, -1);
@@ -616,7 +616,7 @@ public class NonBlockingRouterTest {
     opHelper = new OperationHelper(OperationType.DELETE);
     deleteManager = new DeleteManager(mockClusterMap, mockResponseHandler, new LoggingNotificationSystem(),
         new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
-        new OperationCallback(null, new ArrayList<StoreKey>()), mockTime);
+        new RouterCallback(null, new ArrayList<StoreKey>()), mockTime);
     testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
         invalidResponse, -1);
     // Test that if a failed response comes before the operation is completed, failure detector is notified.

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -101,7 +101,7 @@ public class PutOperationTest {
     MockNetworkClient mockNetworkClient = new MockNetworkClient();
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobProperties, userMetadata,
-            channel, future, null, new OperationCallback(mockNetworkClient, new ArrayList<StoreKey>()), null, time);
+            channel, future, null, new RouterCallback(mockNetworkClient, new ArrayList<StoreKey>()), null, time);
     op.startReadingFromChannel();
     List<RequestInfo> requestInfos = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestInfos;

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -25,6 +25,7 @@ import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.PutRequest;
 import com.github.ambry.protocol.PutResponse;
 import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferChannel;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
@@ -100,7 +101,7 @@ public class PutOperationTest {
     MockNetworkClient mockNetworkClient = new MockNetworkClient();
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobProperties, userMetadata,
-            channel, future, null, new OperationCallback(mockNetworkClient, new ArrayList<String>()), null, time);
+            channel, future, null, new OperationCallback(mockNetworkClient, new ArrayList<StoreKey>()), null, time);
     op.startReadingFromChannel();
     List<RequestInfo> requestInfos = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestInfos;

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -100,7 +100,7 @@ public class PutOperationTest {
     MockNetworkClient mockNetworkClient = new MockNetworkClient();
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobProperties, userMetadata,
-            channel, future, null, new ReadyForPollCallback(mockNetworkClient), null, time);
+            channel, future, null, new OperationCallback(mockNetworkClient, new ArrayList<String>()), null, time);
     op.startReadingFromChannel();
     List<RequestInfo> requestInfos = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestInfos;


### PR DESCRIPTION
Move the deletes of successfully put chunks of a failed composite
blob put operation to the background deleter. Also refactor router
code to move all operation related callbacks to a single class.

--

No new tests added, existing tests cover the changes.