### PR TITLE
Adding CompactionDetails and CompactionLog

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionDetails.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionDetails.java
@@ -44,8 +44,8 @@ class CompactionDetails {
    * @param referenceTime the epoch time to use to get the same results from the {@link BlobStore} as when these details
    *                      were created.
    * @param logSegmentsUnderCompaction the names of the {@link LogSegment} under compaction.
-   * @param extraSegmentName the name of the segment which will provide the "extra" data. Can be {@code null} or empty
-   *                         if no extra data is required.
+   * @param extraSegmentName the name of the segment which will provide the "extra" data. Should be {@code null} if no
+   *                         extra data is required.
    * @param swapSpaceCount the number of swap spaces that will be required for compaction.
    */
   CompactionDetails(long referenceTime, List<String> logSegmentsUnderCompaction, String extraSegmentName,
@@ -74,7 +74,7 @@ class CompactionDetails {
           logSegmentsUnderCompaction.add(Utils.readIntString(stream));
         }
         String extraLogSegmentName = Utils.readIntString(stream);
-        if (extraLogSegmentName != null && extraLogSegmentName.isEmpty()) {
+        if (extraLogSegmentName.isEmpty()) {
           extraLogSegmentName = null;
         }
         int swapSpaceCount = stream.readInt();

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionDetails.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionDetails.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Contains all the details required for a compaction cycle.
+ */
+class CompactionDetails {
+  private static final byte[] ZERO_LENGTH_ARRAY = new byte[0];
+
+  private static final short VERSION_0 = 0;
+  private static final int VERSION_SIZE = 2;
+  private static final int REFERENCE_TIME_SIZE = 8;
+  private static final int SEGMENT_COUNT_SIZE = 4;
+  private static final int SEGMENT_NAME_LENGTH_SIZE = 4;
+  private static final int SWAP_SPACE_COUNT_SIZE = 4;
+
+  private final long referenceTime;
+  private final List<String> logSegmentsUnderCompaction;
+  private final String extraSegmentName;
+  private final int swapSpaceCount;
+
+  /**
+   * Construct a representation of all the details required for a compaction cycle.
+   * @param referenceTime the epoch time to use to get the same results from the {@link BlobStore} as when these details
+   *                      were created.
+   * @param logSegmentsUnderCompaction the names of the {@link LogSegment} under compaction.
+   * @param extraSegmentName the name of the segment which will provide the "extra" data. Can be {@code null} or empty
+   *                         if no extra data is required.
+   * @param swapSpaceCount the number of swap spaces that will be required for compaction.
+   */
+  CompactionDetails(long referenceTime, List<String> logSegmentsUnderCompaction, String extraSegmentName,
+      int swapSpaceCount) {
+    this.referenceTime = referenceTime;
+    this.logSegmentsUnderCompaction = logSegmentsUnderCompaction;
+    this.extraSegmentName = extraSegmentName;
+    this.swapSpaceCount = swapSpaceCount;
+  }
+
+  /**
+   * @param stream the serialized version of the {@link CompactionDetails} that has to be loaded.
+   * @return a representation of all the details required for compaction from the given {@code stream}.
+   * @throws IllegalArgumentException if the version is not recognized
+   * @throws IOException if there is an I/O error reading from the stream
+   */
+  static CompactionDetails fromBytes(DataInputStream stream) throws IOException {
+    CompactionDetails details;
+    short version = stream.readShort();
+    switch (version) {
+      case VERSION_0:
+        long referenceTime = stream.readLong();
+        int segmentCount = stream.readInt();
+        List<String> logSegmentsUnderCompaction = new ArrayList<>();
+        for (int i = 0; i < segmentCount; i++) {
+          logSegmentsUnderCompaction.add(Utils.readIntString(stream));
+        }
+        String extraLogSegmentName = Utils.readIntString(stream);
+        if (extraLogSegmentName != null && extraLogSegmentName.isEmpty()) {
+          extraLogSegmentName = null;
+        }
+        int swapSpaceCount = stream.readInt();
+        details = new CompactionDetails(referenceTime, logSegmentsUnderCompaction, extraLogSegmentName, swapSpaceCount);
+        break;
+      default:
+        throw new IllegalArgumentException("Unrecognized version: " + version);
+    }
+    return details;
+  }
+
+  /**
+   * @return the epoch time to use to get the same results from the {@link BlobStore} as when the details were created
+   */
+  long getReferenceTime() {
+    return referenceTime;
+  }
+
+  /**
+   * @return the names of the segments under compaction.
+   */
+  List<String> getLogSegmentsUnderCompaction() {
+    return logSegmentsUnderCompaction;
+  }
+
+  /**
+   * @return the name of the segment which will provide the "extra" data. Can be {@code null} or empty if no extra data
+   * is required.
+   */
+  String getExtraSegmentName() {
+    return extraSegmentName;
+  }
+
+  /**
+   * @return the number of swap spaces that will be required for compaction.
+   */
+  int getSwapSpaceCount() {
+    return swapSpaceCount;
+  }
+
+  /**
+   * @return serialized representation of this object.
+   */
+  byte[] toBytes() {
+    List<byte[]> segmentNamesBytes = new ArrayList<>();
+    int size = VERSION_SIZE + REFERENCE_TIME_SIZE + SEGMENT_COUNT_SIZE
+        + logSegmentsUnderCompaction.size() * SEGMENT_NAME_LENGTH_SIZE;
+    for (String segmentName : logSegmentsUnderCompaction) {
+      byte[] segmentNameBytes = segmentName.getBytes();
+      segmentNamesBytes.add(segmentNameBytes);
+      size += segmentNameBytes.length;
+    }
+    byte[] extraSegmentNameBytes = extraSegmentName == null ? ZERO_LENGTH_ARRAY : extraSegmentName.getBytes();
+    size += SEGMENT_NAME_LENGTH_SIZE + extraSegmentNameBytes.length + SWAP_SPACE_COUNT_SIZE;
+
+    byte[] buf = new byte[size];
+    ByteBuffer bufWrap = ByteBuffer.wrap(buf);
+    // version
+    bufWrap.putShort(VERSION_0);
+    // reference time
+    bufWrap.putLong(referenceTime);
+    // size of logSegmentsUnderCompaction
+    bufWrap.putInt(logSegmentsUnderCompaction.size());
+    // log segments under compaction
+    for (byte[] segmentNameBytes : segmentNamesBytes) {
+      bufWrap.putInt(segmentNameBytes.length);
+      bufWrap.put(segmentNameBytes);
+    }
+    // extra log segment name
+    bufWrap.putInt(extraSegmentNameBytes.length);
+    bufWrap.put(extraSegmentNameBytes);
+    // swap space count
+    bufWrap.putInt(swapSpaceCount);
+    return buf;
+  }
+}

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionLog.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionLog.java
@@ -1,0 +1,314 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.utils.CrcInputStream;
+import com.github.ambry.utils.CrcOutputStream;
+import com.github.ambry.utils.Time;
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Represents a record of the compaction process and helps in recovery in case of crashes.
+ */
+class CompactionLog implements Closeable {
+  private static final String COMPACTION_LOG_SUFFIX = "_compaction_log";
+  private static final short VERSION_0 = 0;
+
+  /**
+   * The {@link State} of the current compaction cycle.
+   */
+  enum State {
+    PREPARE, COPY, SWITCH, CLEANUP, DONE
+  }
+
+  private final File file;
+  private final Time time;
+  private final Long startTime;
+  private final List<CycleLog> cycleLogs;
+
+  private int currentIdx = 0;
+
+  /**
+   * Used to determine whether compaction is in progress.
+   * @param dir the directory where the compaction log is expected to exist (if any).
+   * @param name the unique name for the store under compaction.
+   * @return whether compaction is in progress for the store.
+   */
+  static boolean isCompactionInProgress(String dir, String name) {
+    return new File(dir, name + COMPACTION_LOG_SUFFIX).exists();
+  }
+
+  /**
+   * Creates a new compaction log.
+   * @param dir the directory at which the compaction log must be created.
+   * @param name unique name of the store.
+   * @param time the {@link Time} instance to use.
+   * @param compactionDetailsList the details about the compaction.
+   */
+  CompactionLog(String dir, String name, Time time, List<CompactionDetails> compactionDetailsList) throws IOException {
+    this.time = time;
+    file = new File(dir, name + COMPACTION_LOG_SUFFIX);
+    if (file.exists() || !file.createNewFile()) {
+      throw new IllegalArgumentException(file.getAbsolutePath() + " already exists or could not be created");
+    }
+    startTime = time.milliseconds();
+    cycleLogs = new ArrayList<>(compactionDetailsList.size());
+    for (CompactionDetails details : compactionDetailsList) {
+      cycleLogs.add(new CycleLog(details));
+    }
+    flush();
+  }
+
+  /**
+   * Loads an existing compaction log.
+   * @param dir the directory at which the log exists.
+   * @param name unique name of the store.
+   * @param storeKeyFactory the {@link StoreKeyFactory} that is used for keys in the {@link BlobStore} being compacted.
+   * @param time the {@link Time} instance to use.
+   */
+  CompactionLog(String dir, String name, StoreKeyFactory storeKeyFactory, Time time) throws IOException {
+    this.time = time;
+    file = new File(dir, name + COMPACTION_LOG_SUFFIX);
+    if (!file.exists()) {
+      throw new IllegalArgumentException(file.getAbsolutePath() + " does not exist");
+    }
+    try (FileInputStream fileInputStream = new FileInputStream(file)) {
+      CrcInputStream crcInputStream = new CrcInputStream(fileInputStream);
+      DataInputStream stream = new DataInputStream(crcInputStream);
+      short version = stream.readShort();
+      switch (version) {
+        case VERSION_0:
+          startTime = stream.readLong();
+          currentIdx = stream.readInt();
+          int cycleLogsSize = stream.readInt();
+          cycleLogs = new ArrayList<>(cycleLogsSize);
+          while (cycleLogs.size() < cycleLogsSize) {
+            cycleLogs.add(CycleLog.fromBytes(stream, storeKeyFactory));
+          }
+          long crc = crcInputStream.getValue();
+          if (crc != stream.readLong()) {
+            throw new IllegalStateException("CRC of data read does not match CRC in file");
+          }
+          break;
+        default:
+          throw new IllegalArgumentException("Unrecognized version");
+      }
+    }
+  }
+
+  /**
+   * @return the current state of compaction.
+   */
+  State getCompactionState() {
+    return currentIdx >= cycleLogs.size() ? State.DONE : getCurrentCycleLog().getState();
+  }
+
+  /**
+   * @return the {@link CompactionDetails} for the compaction cycle in progress.
+   */
+  CompactionDetails getCompactionDetails() {
+    return getCurrentCycleLog().compactionDetails;
+  }
+
+  /**
+   * @return the {@link StoreFindToken} until which data has been copied and flushed.
+   */
+  StoreFindToken getSafeToken() {
+    return getCurrentCycleLog().safeToken;
+  }
+
+  /**
+   * Sets the {@link StoreFindToken} until which data is copied and flushed.
+   * @param safeToken the {@link StoreFindToken} until which data is copied and flushed.
+   */
+  void setSafeToken(StoreFindToken safeToken) {
+    CycleLog cycleLog = getCurrentCycleLog();
+    if (!cycleLog.getState().equals(State.COPY)) {
+      throw new IllegalStateException("Cannot set a safe token - not in COPY phase");
+    }
+    cycleLog.safeToken = safeToken;
+    flush();
+  }
+
+  /**
+   * Marks the start of the copy phase.
+   */
+  void markCopyStart() {
+    getCurrentCycleLog().copyStartTime = time.milliseconds();
+    flush();
+  }
+
+  /**
+   * Marks the start of the switch phase.
+   */
+  void markSwitchStart() {
+    getCurrentCycleLog().switchStartTime = time.milliseconds();
+    flush();
+  }
+
+  /**
+   * Marks the start of the cleanup phase.
+   */
+  void markCleanupStart() {
+    getCurrentCycleLog().cleanupStartTime = time.milliseconds();
+    flush();
+  }
+
+  /**
+   * Marks the current compaction cycle as complete.
+   */
+  void markCycleComplete() {
+    getCurrentCycleLog().cycleEndTime = time.milliseconds();
+    currentIdx++;
+    flush();
+  }
+
+  /**
+   * Closes the compaction log. If compaction is complete, renames the log to keep a permanent record.
+   */
+  @Override
+  public void close() {
+    if (file.exists() && getCompactionState().equals(State.DONE)) {
+      File savedLog = new File(file.getAbsolutePath() + "_" + startTime);
+      if (!file.renameTo(savedLog)) {
+        throw new IllegalStateException("Compaction log could not be renamed after completion of compaction");
+      }
+    }
+  }
+
+  /**
+   * @return the {@link CycleLog} for the current compaction cycle.
+   */
+  private CycleLog getCurrentCycleLog() {
+    return cycleLogs.get(currentIdx);
+  }
+
+  /**
+   * Flushes all changes to the file backing this compaction log.
+   */
+  private void flush() {
+    File tempFile = new File(file.getAbsolutePath() + ".tmp");
+    try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile)) {
+      CrcOutputStream crcOutputStream = new CrcOutputStream(fileOutputStream);
+      DataOutputStream stream = new DataOutputStream(crcOutputStream);
+      stream.writeShort(VERSION_0);
+      stream.writeLong(startTime);
+      stream.writeInt(currentIdx);
+      stream.writeInt(cycleLogs.size());
+      for (CycleLog cycleLog : cycleLogs) {
+        stream.write(cycleLog.toBytes());
+      }
+      stream.writeLong(crcOutputStream.getValue());
+      fileOutputStream.getChannel().force(true);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+    if (!tempFile.renameTo(file)) {
+      throw new IllegalStateException("Newly written compaction log could not be saved");
+    }
+  }
+
+  /**
+   * Details and log for a single compaction cycle.
+   */
+  private static class CycleLog {
+    private static final int TIMESTAMP_SIZE = 8;
+
+    // details about the cycle
+    final CompactionDetails compactionDetails;
+    // start time of the copy phase
+    long copyStartTime = -1;
+    // start time of the switch phase
+    long switchStartTime = -1;
+    // start time of the cleanup phase
+    long cleanupStartTime = -1;
+    // end time of the current cycle
+    long cycleEndTime = -1;
+    // point until which copying is complete
+    StoreFindToken safeToken = new StoreFindToken();
+
+    /**
+     * Create a log for a single cycle of compaction.
+     * @param compactionDetails the details for the compaction cycle.
+     */
+    CycleLog(CompactionDetails compactionDetails) {
+      this.compactionDetails = compactionDetails;
+    }
+
+    /**
+     * Create a log for a cycle from a {@code stream}.
+     * @param stream the {@link DataInputStream} that represents the serialized object.
+     * @param storeKeyFactory the {@link StoreKeyFactory} used to generate the {@link StoreFindToken}.
+     * @return a {@link CycleLog} that represents a cycle.
+     * @throws IOException if there is an I/O error while reading the stream.
+     */
+    static CycleLog fromBytes(DataInputStream stream, StoreKeyFactory storeKeyFactory) throws IOException {
+      CompactionDetails compactionDetails = CompactionDetails.fromBytes(stream);
+      CycleLog cycleLog = new CycleLog(compactionDetails);
+      cycleLog.copyStartTime = stream.readLong();
+      cycleLog.switchStartTime = stream.readLong();
+      cycleLog.cleanupStartTime = stream.readLong();
+      cycleLog.cycleEndTime = stream.readLong();
+      cycleLog.safeToken = StoreFindToken.fromBytes(stream, storeKeyFactory);
+      return cycleLog;
+    }
+
+    /**
+     * @return the current state of this cycle of compaction.
+     */
+    State getState() {
+      State state;
+      if (copyStartTime == -1) {
+        state = State.PREPARE;
+      } else if (switchStartTime == -1) {
+        state = State.COPY;
+      } else if (cleanupStartTime == -1) {
+        state = State.SWITCH;
+      } else if (cycleEndTime == -1) {
+        state = State.CLEANUP;
+      } else {
+        state = State.DONE;
+      }
+      return state;
+    }
+
+    /**
+     * @return serialized version of the {@link CycleLog}.
+     */
+    byte[] toBytes() {
+      byte[] compactionDetailsBytes = compactionDetails.toBytes();
+      byte[] safeTokenBytes = safeToken.toBytes();
+      int size = compactionDetailsBytes.length + 4 * TIMESTAMP_SIZE + safeTokenBytes.length;
+      byte[] buf = new byte[size];
+      ByteBuffer bufWrap = ByteBuffer.wrap(buf);
+      bufWrap.put(compactionDetailsBytes);
+      bufWrap.putLong(copyStartTime);
+      bufWrap.putLong(switchStartTime);
+      bufWrap.putLong(cleanupStartTime);
+      bufWrap.putLong(cycleEndTime);
+      bufWrap.put(safeTokenBytes);
+      return buf;
+    }
+  }
+}

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionLog.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionLog.java
@@ -208,6 +208,18 @@ class CompactionLog implements Closeable {
    * Flushes all changes to the file backing this compaction log.
    */
   private void flush() {
+    /*
+        Description of serialized format
+
+        version
+        startTime
+        index of current cycle's log
+        size of cycle log list
+        cycleLog1 (see CycleLog#toBytes())
+        cycleLog2
+        ...
+        crc
+       */
     File tempFile = new File(file.getAbsolutePath() + ".tmp");
     try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile)) {
       CrcOutputStream crcOutputStream = new CrcOutputStream(fileOutputStream);
@@ -297,6 +309,16 @@ class CompactionLog implements Closeable {
      * @return serialized version of the {@link CycleLog}.
      */
     byte[] toBytes() {
+      /*
+        Description of serialized format
+
+        compactionDetails (see CompactionDetails#toBytes())
+        copyStartTime
+        switchStartTime
+        cleanupStartTime
+        cycleEndTime
+        safeToken (see StoreFindToken#toBytes())
+       */
       byte[] compactionDetailsBytes = compactionDetails.toBytes();
       byte[] safeTokenBytes = safeToken.toBytes();
       int size = compactionDetailsBytes.length + 4 * TIMESTAMP_SIZE + safeTokenBytes.length;

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionLog.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionLog.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 
@@ -190,7 +191,9 @@ class CompactionLog implements Closeable {
   @Override
   public void close() {
     if (file.exists() && getCompactionState().equals(State.DONE)) {
-      File savedLog = new File(file.getAbsolutePath() + "_" + startTime);
+      String dateString = new Date(startTime).toString();
+      File savedLog =
+          new File(file.getAbsolutePath() + BlobStore.SEPARATOR + startTime + BlobStore.SEPARATOR + dateString);
       if (!file.renameTo(savedLog)) {
         throw new IllegalStateException("Compaction log could not be renamed after completion of compaction");
       }
@@ -269,7 +272,7 @@ class CompactionLog implements Closeable {
     }
 
     /**
-     * Create a log for a cycle from a {@code stream}.
+     * Create a log for a compaction cycle from a {@code stream}.
      * @param stream the {@link DataInputStream} that represents the serialized object.
      * @param storeKeyFactory the {@link StoreKeyFactory} used to generate the {@link StoreFindToken}.
      * @return a {@link CycleLog} that represents a cycle.

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -248,7 +248,9 @@ public class BlobStoreTest {
 
   /**
    * Creates a temporary directory and sets up some test state.
+   * @throws InterruptedException
    * @throws IOException
+   * @throws StoreException
    */
   public BlobStoreTest(boolean isLogSegmented) throws InterruptedException, IOException, StoreException {
     this.isLogSegmented = isLogSegmented;
@@ -261,6 +263,7 @@ public class BlobStoreTest {
    * Releases all resources and deletes the temporary directory.
    * @throws InterruptedException
    * @throws IOException
+   * @throws StoreException
    */
   @After
   public void cleanup() throws InterruptedException, IOException, StoreException {

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionDetailsTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionDetailsTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.UtilsTest;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Tests for {@link CompactionDetails}.
+ */
+public class CompactionDetailsTest {
+
+  /**
+   * Tests the serialization and deserialization of {@link CompactionDetails} and verifies eqaulity of the original and
+   * deserialized forms.
+   * @throws IOException
+   */
+  @Test
+  public void serDeTest() throws IOException {
+    int segmentCount = TestUtils.RANDOM.nextInt(10) + 1;
+    List<String> segmentsUnderCompaction = new ArrayList<>();
+    for (int i = 0; i < segmentCount; i++) {
+      int stringSize = TestUtils.RANDOM.nextInt(10) + 1;
+      segmentsUnderCompaction.add(UtilsTest.getRandomString(stringSize));
+    }
+    long referenceTime = SystemTime.getInstance().milliseconds();
+    int swapSpaceCount = TestUtils.RANDOM.nextInt(10) + 1;
+
+    // without extra segment
+    CompactionDetails details = new CompactionDetails(referenceTime, segmentsUnderCompaction, null, swapSpaceCount);
+    DataInputStream stream = new DataInputStream(new ByteArrayInputStream(details.toBytes()));
+    verifyEquality(details, CompactionDetails.fromBytes(stream));
+
+    // with extra segment
+    String extraSegmentName = UtilsTest.getRandomString(5);
+    details = new CompactionDetails(referenceTime, segmentsUnderCompaction, extraSegmentName, swapSpaceCount);
+    stream = new DataInputStream(new ByteArrayInputStream(details.toBytes()));
+    verifyEquality(details, CompactionDetails.fromBytes(stream));
+  }
+
+  /**
+   * Verifies that two {@link CompactionDetails} instances are equal.
+   * @param original the expected {@link CompactionDetails}.
+   * @param toCheck the {@link CompactionDetails} that needs to be checked.
+   */
+  private void verifyEquality(CompactionDetails original, CompactionDetails toCheck) {
+    assertEquals("Reference time does not match", original.getReferenceTime(), toCheck.getReferenceTime());
+    assertEquals("Segments under compaction don't match", original.getLogSegmentsUnderCompaction(),
+        toCheck.getLogSegmentsUnderCompaction());
+    assertEquals("Extra segment name does not match", original.getExtraSegmentName(), toCheck.getExtraSegmentName());
+    assertEquals("Swap space count does not match", original.getSwapSpaceCount(), toCheck.getSwapSpaceCount());
+  }
+}

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionLogTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionLogTest.java
@@ -78,7 +78,7 @@ public class CompactionLogTest {
     List<CompactionDetails> detailsList = getCompactionDetails(5);
     assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
     CompactionLog log = new CompactionLog(tempDirStr, storeName, time, detailsList);
-    assertTrue("Compaction should should be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
+    assertTrue("Compaction should be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
     for (CompactionDetails details : detailsList) {
       verifyEquality(details, log.getCompactionDetails());
       assertEquals("Should be in the PREPARE phase", CompactionLog.Phase.PREPARE, log.getCompactionPhase());

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionLogTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionLogTest.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Tests for {@link CompactionLog}.
+ */
+public class CompactionLogTest {
+  private static final StoreKeyFactory STORE_KEY_FACTORY;
+
+  static {
+    try {
+      STORE_KEY_FACTORY = Utils.getObj("com.github.ambry.store.MockIdFactory");
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  // Variables that represent the folder where the data resides
+  private final File tempDir;
+  private final String tempDirStr;
+  // the time instance that will be used in the index
+  private final Time time = new MockTime();
+
+  /**
+   * Creates a temporary directory for the compaction log file.
+   * @throws IOException
+   */
+  public CompactionLogTest() throws IOException {
+    tempDir = StoreTestUtils.createTempDirectory("storeDir-" + UtilsTest.getRandomString(10));
+    tempDirStr = tempDir.getAbsolutePath();
+  }
+
+  /**
+   * Deletes the temporary directory.
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  @After
+  public void cleanup() throws InterruptedException, IOException, StoreException {
+    assertTrue(tempDir.getAbsolutePath() + " could not be deleted", StoreTestUtils.cleanDirectory(tempDir, true));
+  }
+
+  /**
+   * Tests the behavior of {@link CompactionLog#isCompactionInProgress(String, String)}.
+   * @throws IOException
+   */
+  @Test
+  public void isCompactionInProgressTest() throws IOException {
+    String storeName = "store";
+    assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
+    CompactionLog log = new CompactionLog(tempDirStr, storeName, time, getCompactionDetails(1));
+    assertTrue("Compaction should should be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
+    log.markCycleComplete();
+    log.close();
+    assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
+  }
+
+  /**
+   * Tests the use of {@link CompactionLog} when it is used without closing b/w operations and compaction cycles.
+   * @throws IOException
+   */
+  @Test
+  public void iterationWithoutReloadTest() throws IOException {
+    String storeName = "store";
+    List<CompactionDetails> detailsList = getCompactionDetails(5);
+    CompactionLog log = new CompactionLog(tempDirStr, storeName, time, detailsList);
+    assertTrue("Compaction should should be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
+    for (CompactionDetails details : detailsList) {
+      verifyEquality(details, log.getCompactionDetails());
+      assertEquals("Should be in the PREPARE state", CompactionLog.State.PREPARE, log.getCompactionState());
+      log.markCopyStart();
+      assertEquals("Should be in the COPY state", CompactionLog.State.COPY, log.getCompactionState());
+      StoreFindToken safeToken =
+          new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentNameHelper.generateFirstSegmentName(5), 0),
+              new UUID(1, 1));
+      log.setSafeToken(safeToken);
+      assertEquals("Returned token not the same as the one that was set", safeToken, log.getSafeToken());
+      log.markSwitchStart();
+      assertEquals("Should be in the SWITCH state", CompactionLog.State.SWITCH, log.getCompactionState());
+      log.markCleanupStart();
+      assertEquals("Should be in the CLEANUP state", CompactionLog.State.CLEANUP, log.getCompactionState());
+      log.markCycleComplete();
+    }
+    assertEquals("Should be in the DONE state", CompactionLog.State.DONE, log.getCompactionState());
+    log.close();
+    assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
+  }
+
+  /**
+   * Tests the use of {@link CompactionLog} when it is closed and reloaded b/w operations and compaction cycles.
+   * @throws IOException
+   */
+  @Test
+  public void iterationWithReloadTest() throws IOException {
+    String storeName = "store";
+    List<CompactionDetails> detailsList = getCompactionDetails(5);
+    CompactionLog log = new CompactionLog(tempDirStr, storeName, time, detailsList);
+    assertTrue("Compaction should should be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
+    for (CompactionDetails details : detailsList) {
+      log.close();
+      log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+      verifyEquality(details, log.getCompactionDetails());
+      assertEquals("Should be in the PREPARE state", CompactionLog.State.PREPARE, log.getCompactionState());
+      log.markCopyStart();
+
+      log.close();
+      log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+      assertEquals("Should be in the COPY state", CompactionLog.State.COPY, log.getCompactionState());
+      StoreFindToken safeToken =
+          new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentNameHelper.generateFirstSegmentName(5), 0),
+              new UUID(1, 1));
+      log.setSafeToken(safeToken);
+
+      log.close();
+      log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+      assertEquals("Returned token not the same as the one that was set", safeToken, log.getSafeToken());
+      log.markSwitchStart();
+
+      log.close();
+      log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+      assertEquals("Should be in the SWITCH state", CompactionLog.State.SWITCH, log.getCompactionState());
+      log.markCleanupStart();
+
+      log.close();
+      log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+      assertEquals("Should be in the CLEANUP state", CompactionLog.State.CLEANUP, log.getCompactionState());
+      log.markCycleComplete();
+    }
+    assertEquals("Should be in the DONE state", CompactionLog.State.DONE, log.getCompactionState());
+    log.close();
+    assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
+  }
+
+  /**
+   * Tests for construction of {@link CompactionLog} with bad arguments/state.
+   * @throws IOException
+   */
+  @Test
+  public void constructionBadArgsTest() throws IOException {
+    String storeName = "store";
+    CompactionLog log = new CompactionLog(tempDirStr, storeName, time, getCompactionDetails(1));
+    log.close();
+    // log file already exists
+    try {
+      new CompactionLog(tempDirStr, storeName, time, getCompactionDetails(1));
+      fail("Construction should have failed because log file already exists");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+
+    // make sure file disappears
+    log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+    log.markCycleComplete();
+    log.close();
+    assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
+
+    // log file does not exist
+    try {
+      new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+      fail("Construction should have failed because log file does not exist");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+  }
+
+  // helpers
+  // general
+
+  /**
+   * Gets a {@link List<CompactionDetails>} of size {@code size} with random {@link CompactionDetails}.
+   * @param size the number of {@link CompactionDetails} required.
+   * @return a {@link List<CompactionDetails>} of size {@code size} with random {@link CompactionDetails}.
+   */
+  private List<CompactionDetails> getCompactionDetails(int size) {
+    List<CompactionDetails> details = new ArrayList<>(size);
+    for (int i = 0; i < size; i++) {
+      long referenceTime = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+      int segmentCount = TestUtils.RANDOM.nextInt(10) + 1;
+      List<String> segmentsUnderCompaction = new ArrayList<>();
+      for (int j = 0; j < segmentCount; j++) {
+        segmentsUnderCompaction.add(UtilsTest.getRandomString(10));
+      }
+      String extraSegmentName = i % 2 == 0 ? null : UtilsTest.getRandomString(10);
+      int swapSpaceCount = TestUtils.RANDOM.nextInt(10) + 1;
+      details.add(new CompactionDetails(referenceTime, segmentsUnderCompaction, extraSegmentName, swapSpaceCount));
+    }
+    return details;
+  }
+
+  /**
+   * Verifies that two {@link CompactionDetails} instances are equal.
+   * @param original the expected {@link CompactionDetails}.
+   * @param toCheck the {@link CompactionDetails} that needs to be checked.
+   */
+  private void verifyEquality(CompactionDetails original, CompactionDetails toCheck) {
+    assertEquals("Reference time does not match", original.getReferenceTime(), toCheck.getReferenceTime());
+    assertEquals("Segments under compaction don't match", original.getLogSegmentsUnderCompaction(),
+        toCheck.getLogSegmentsUnderCompaction());
+    assertEquals("Extra segment name does not match", original.getExtraSegmentName(), toCheck.getExtraSegmentName());
+    assertEquals("Swap space count does not match", original.getSwapSpaceCount(), toCheck.getSwapSpaceCount());
+  }
+}


### PR DESCRIPTION
`CompactionDetails` - serves as a job spec that will define the segments under compaction. Medium of exchange of info b/w the component that determines what needs to be done and the component that does the work.
`CompactionLog` - a recovery log that checkpoints the different stages of compaction and helps in recovery in cases of restarts and crashes

This is the initial version of both of these constructs to kick start the compaction implementation. The fields added are based on the design (#441). If more details/fields are required, they will be added as required.

Formatted. `./gradlew build && ./gradlew test` passed.

**Primary reviewers: @cgtz, @nsivabalan**
**Expected time to review: 30-45 mins**

**Unit testing**

| Class | Class, % | Method, % | Line, % |
| --- | --- | --- | --- |
| `CompactionDetails` | 100% (1/ 1) | 100% (9/ 9) | 97.6% (40/ 41) |
| `CompactionLog` | 100% (3/ 3) | 100% (22/ 22) | 93.5% (116/ 124) |