### PR TITLE
Enhancements to HardDeletes and IndexPersistor

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -96,13 +96,6 @@ public class StoreConfig {
   @Default("9223372036854775807")
   public final long storeSegmentSizeInBytes;
 
-  /**
-   * Hard deleter sleep time when caught up in ms
-   */
-  @Config("store.hard.deleter.sleep.time.when.caught.up.in.ms")
-  @Default("10000")
-  public final long storeHardDeleterSleepTimeWhenCaughtUpInMs;
-
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -119,8 +112,6 @@ public class StoreConfig {
     storeEnableHardDelete = verifiableProperties.getBoolean("store.enable.hard.delete", false);
     storeSegmentSizeInBytes =
         verifiableProperties.getLongInRange("store.segment.size.in.bytes", Long.MAX_VALUE, 1, Long.MAX_VALUE);
-    storeHardDeleterSleepTimeWhenCaughtUpInMs =
-        verifiableProperties.getLong("store.hard.deleter.sleep.time.when.caught.up.in.ms", 10000);
   }
 }
 

--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -96,6 +96,13 @@ public class StoreConfig {
   @Default("9223372036854775807")
   public final long storeSegmentSizeInBytes;
 
+  /**
+   * Hard deleter sleep time when caught up in ms
+   */
+  @Config("store.hard.deleter.sleep.time.when.caught.up.in.ms")
+  @Default("10000")
+  public final long storeHardDeleterSleepTimeWhenCaughtUpInMs;
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -112,6 +119,8 @@ public class StoreConfig {
     storeEnableHardDelete = verifiableProperties.getBoolean("store.enable.hard.delete", false);
     storeSegmentSizeInBytes =
         verifiableProperties.getLongInRange("store.segment.size.in.bytes", Long.MAX_VALUE, 1, Long.MAX_VALUE);
+    storeHardDeleterSleepTimeWhenCaughtUpInMs =
+        verifiableProperties.getLong("store.hard.deleter.sleep.time.when.caught.up.in.ms", 10000);
   }
 }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -15,7 +15,6 @@ package com.github.ambry.server;
 
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
-import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ServerErrorCode;
@@ -23,7 +22,6 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobData;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.BlobType;
-import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatFlags;
 import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.network.BlockingChannel;
@@ -69,6 +67,10 @@ public class ServerHardDeleteTest {
   private MockTime time;
   private AmbryServer server;
   private MockClusterMap mockClusterMap;
+  private ArrayList<BlobProperties> properties;
+  private ArrayList<byte[]> usermetadata;
+  private ArrayList<byte[]> data;
+  private ArrayList<BlobId> blobIdList;
 
   @Before
   public void initialize() throws Exception {
@@ -139,7 +141,7 @@ public class ServerHardDeleteTest {
         DataInputStream stream = new DataInputStream(crcStream);
         try {
           short version = stream.readShort();
-          Assert.assertEquals(version, HardDeleter.Cleanup_Token_Version_V1);
+          Assert.assertEquals(version, HardDeleter.Cleanup_Token_Version_V0);
           StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", mockClusterMap);
           FindTokenFactory factory = Utils.getObj("com.github.ambry.store.StoreFindTokenFactory", storeKeyFactory);
 
@@ -209,8 +211,8 @@ public class ServerHardDeleteTest {
   @Test
   public void endToEndTestHardDeletes() throws Exception {
     DataNodeId dataNodeId = mockClusterMap.getDataNodeIds().get(0);
-    ArrayList<byte[]> usermetadata = new ArrayList<byte[]>(9);
-    ArrayList<byte[]> data = new ArrayList<byte[]>(9);
+    usermetadata = new ArrayList<byte[]>(9);
+    data = new ArrayList<byte[]>(9);
     Random random = new Random();
     for (int i = 0; i < 9; i++) {
       usermetadata.add(new byte[1000 + i]);
@@ -219,7 +221,7 @@ public class ServerHardDeleteTest {
       random.nextBytes(data.get(i));
     }
 
-    ArrayList<BlobProperties> properties = new ArrayList<BlobProperties>(9);
+    properties = new ArrayList<BlobProperties>(9);
     properties.add(new BlobProperties(31870, "serviceid1"));
     properties.add(new BlobProperties(31871, "serviceid1"));
     properties.add(new BlobProperties(31872, "serviceid1"));
@@ -231,74 +233,20 @@ public class ServerHardDeleteTest {
     properties.add(new BlobProperties(31878, "serviceid1"));
 
     List<PartitionId> partitionIds = mockClusterMap.getWritablePartitionIds();
-    ArrayList<BlobId> blobIdList = new ArrayList<BlobId>(9);
-    blobIdList.add(new BlobId(partitionIds.get(0)));
-    blobIdList.add(new BlobId(partitionIds.get(0)));
-    blobIdList.add(new BlobId(partitionIds.get(0)));
-    blobIdList.add(new BlobId(partitionIds.get(0)));
-    blobIdList.add(new BlobId(partitionIds.get(0)));
-    blobIdList.add(new BlobId(partitionIds.get(0)));
-    blobIdList.add(new BlobId(partitionIds.get(0)));
-    blobIdList.add(new BlobId(partitionIds.get(0)));
-    blobIdList.add(new BlobId(partitionIds.get(0)));
+    PartitionId chosenPartition = partitionIds.get(0);
+    blobIdList = new ArrayList<BlobId>(9);
+    for (int i = 0; i < 9; i++) {
+      blobIdList.add(new BlobId(chosenPartition));
+    }
 
-    // put blob 0
-    PutRequest putRequest0 =
-        new PutRequest(1, "client1", blobIdList.get(0), properties.get(0), ByteBuffer.wrap(usermetadata.get(0)),
-            ByteBuffer.wrap(data.get(0)), properties.get(0).getBlobSize(), BlobType.DataBlob);
     BlockingChannel channel =
         ServerTestUtil.getBlockingChannelBasedOnPortType(new Port(dataNodeId.getPort(), PortType.PLAINTEXT),
             "localhost", null, null);
     channel.connect();
-    channel.send(putRequest0);
-    InputStream putResponseStream = channel.receive().getInputStream();
-    PutResponse response0 = PutResponse.readFrom(new DataInputStream(putResponseStream));
-    Assert.assertEquals(response0.getError(), ServerErrorCode.No_Error);
-
-    // put blob 1
-    PutRequest putRequest1 =
-        new PutRequest(1, "client1", blobIdList.get(1), properties.get(1), ByteBuffer.wrap(usermetadata.get(1)),
-            ByteBuffer.wrap(data.get(1)), properties.get(1).getBlobSize(), BlobType.DataBlob);
-    channel.send(putRequest1);
-    putResponseStream = channel.receive().getInputStream();
-    PutResponse response1 = PutResponse.readFrom(new DataInputStream(putResponseStream));
-    Assert.assertEquals(response1.getError(), ServerErrorCode.No_Error);
-
-    // put blob 2
-    PutRequest putRequest2 =
-        new PutRequest(1, "client1", blobIdList.get(2), properties.get(2), ByteBuffer.wrap(usermetadata.get(2)),
-            ByteBuffer.wrap(data.get(2)), properties.get(2).getBlobSize(), BlobType.DataBlob);
-    channel.send(putRequest2);
-    putResponseStream = channel.receive().getInputStream();
-    PutResponse response2 = PutResponse.readFrom(new DataInputStream(putResponseStream));
-    Assert.assertEquals(response2.getError(), ServerErrorCode.No_Error);
-
-    // put blob 3 that is expired
-    PutRequest putRequest3 =
-        new PutRequest(1, "client1", blobIdList.get(3), properties.get(3), ByteBuffer.wrap(usermetadata.get(3)),
-            ByteBuffer.wrap(data.get(3)), properties.get(3).getBlobSize(), BlobType.DataBlob);
-    channel.send(putRequest3);
-    putResponseStream = channel.receive().getInputStream();
-    PutResponse response3 = PutResponse.readFrom(new DataInputStream(putResponseStream));
-    Assert.assertEquals(response3.getError(), ServerErrorCode.No_Error);
-
-    // put blob 4
-    PutRequest putRequest4 =
-        new PutRequest(1, "client1", blobIdList.get(4), properties.get(4), ByteBuffer.wrap(usermetadata.get(4)),
-            ByteBuffer.wrap(data.get(4)), properties.get(4).getBlobSize(), BlobType.DataBlob);
-    channel.send(putRequest4);
-    putResponseStream = channel.receive().getInputStream();
-    PutResponse response4 = PutResponse.readFrom(new DataInputStream(putResponseStream));
-    Assert.assertEquals(response4.getError(), ServerErrorCode.No_Error);
-
-    // put blob 5 that is expired
-    PutRequest putRequest5 =
-        new PutRequest(1, "client1", blobIdList.get(5), properties.get(5), ByteBuffer.wrap(usermetadata.get(5)),
-            ByteBuffer.wrap(data.get(5)), properties.get(5).getBlobSize(), BlobType.DataBlob);
-    channel.send(putRequest5);
-    putResponseStream = channel.receive().getInputStream();
-    PutResponse response5 = PutResponse.readFrom(new DataInputStream(putResponseStream));
-    Assert.assertEquals(response5.getError(), ServerErrorCode.No_Error);
+    for (int i = 0; i < 6; i++) {
+      // blob 3 and 5 are expired among these
+      putBlob(blobIdList.get(i), properties.get(i), usermetadata.get(i), data.get(i), channel);
+    }
 
     notificationSystem.awaitBlobCreations(blobIdList.get(0).getID());
     notificationSystem.awaitBlobCreations(blobIdList.get(1).getID());
@@ -306,114 +254,26 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobCreations(blobIdList.get(4).getID());
 
     // delete blob 1
-    DeleteRequest deleteRequest = new DeleteRequest(1, "client1", blobIdList.get(1));
-    channel.send(deleteRequest);
-    InputStream deleteResponseStream = channel.receive().getInputStream();
-    DeleteResponse deleteResponse = DeleteResponse.readFrom(new DataInputStream(deleteResponseStream));
-    Assert.assertEquals(deleteResponse.getError(), ServerErrorCode.No_Error);
-
-    byte[] zeroedMetadata = new byte[usermetadata.get(1).length];
-    usermetadata.set(1, zeroedMetadata);
-    byte[] zeroedData = new byte[data.get(1).length];
-    data.set(1, zeroedData);
-
+    deleteBlob(blobIdList.get(1), channel);
+    zeroOutBlobContent(1);
     // delete blob 4
-    deleteRequest = new DeleteRequest(1, "client1", blobIdList.get(4));
-    channel.send(deleteRequest);
-    deleteResponseStream = channel.receive().getInputStream();
-    deleteResponse = DeleteResponse.readFrom(new DataInputStream(deleteResponseStream));
-    Assert.assertEquals(deleteResponse.getError(), ServerErrorCode.No_Error);
-
-    zeroedMetadata = new byte[usermetadata.get(4).length];
-    usermetadata.set(4, zeroedMetadata);
-    zeroedData = new byte[data.get(4).length];
-    data.set(4, zeroedData);
+    deleteBlob(blobIdList.get(4), channel);
+    zeroOutBlobContent(4);
 
     notificationSystem.awaitBlobDeletions(blobIdList.get(1).getID());
     notificationSystem.awaitBlobDeletions(blobIdList.get(4).getID());
 
     time.currentMilliseconds = time.currentMilliseconds + Time.SecsPerDay * Time.MsPerSec;
-    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198443);
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198443);
 
-    MockPartitionId partition = (MockPartitionId) mockClusterMap.getWritablePartitionIds().get(0);
-
-    ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
-    ArrayList<BlobId> ids = new ArrayList<BlobId>();
-    for (int i = 0; i < 6; i++) {
-      ids.add(blobIdList.get(i));
-    }
-
-    PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(partition, ids);
-    partitionRequestInfoList.add(partitionRequestInfo);
-
-    try {
-      GetRequest getRequest =
-          new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partitionRequestInfoList,
-              GetOption.Include_All);
-      channel.send(getRequest);
-      InputStream stream = channel.receive().getInputStream();
-      GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
-
-      for (int i = 0; i < 6; i++) {
-        BlobProperties propertyOutput = MessageFormatRecord.deserializeBlobProperties(resp.getInputStream());
-        Assert.assertEquals(propertyOutput.getBlobSize(), properties.get(i).getBlobSize());
-        Assert.assertEquals(propertyOutput.getServiceId(), "serviceid1");
-      }
-
-      getRequest = new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, partitionRequestInfoList,
-          GetOption.Include_All);
-      channel.send(getRequest);
-      stream = channel.receive().getInputStream();
-      resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
-
-      for (int i = 0; i < 6; i++) {
-        ByteBuffer userMetadataOutput = MessageFormatRecord.deserializeUserMetadata(resp.getInputStream());
-        Assert.assertArrayEquals(userMetadataOutput.array(), usermetadata.get(i));
-      }
-
-      getRequest =
-          new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList, GetOption.Include_All);
-      channel.send(getRequest);
-      stream = channel.receive().getInputStream();
-      resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
-
-      for (int i = 0; i < 6; i++) {
-        BlobData blobData = MessageFormatRecord.deserializeBlob(resp.getInputStream());
-        Assert.assertEquals(properties.get(i).getBlobSize(), blobData.getSize());
-        byte[] dataOutput = new byte[(int) blobData.getSize()];
-        blobData.getStream().read(dataOutput);
-        Assert.assertArrayEquals(dataOutput, data.get(i));
-      }
-    } catch (Exception e) {
-      Assert.assertEquals(false, true);
-    }
+    getAndVerify(channel, 6);
 
     // put blob 6
-    PutRequest putRequest6 =
-        new PutRequest(1, "client1", blobIdList.get(6), properties.get(6), ByteBuffer.wrap(usermetadata.get(6)),
-            ByteBuffer.wrap(data.get(6)), properties.get(6).getBlobSize(), BlobType.DataBlob);
-    channel.send(putRequest6);
-    putResponseStream = channel.receive().getInputStream();
-    PutResponse response6 = PutResponse.readFrom(new DataInputStream(putResponseStream));
-    Assert.assertEquals(response6.getError(), ServerErrorCode.No_Error);
-
+    putBlob(blobIdList.get(6), properties.get(6), usermetadata.get(6), data.get(6), channel);
     // put blob 7
-    PutRequest putRequest7 =
-        new PutRequest(1, "client1", blobIdList.get(7), properties.get(7), ByteBuffer.wrap(usermetadata.get(7)),
-            ByteBuffer.wrap(data.get(7)), properties.get(7).getBlobSize(), BlobType.DataBlob);
-    channel.send(putRequest7);
-    putResponseStream = channel.receive().getInputStream();
-    PutResponse response7 = PutResponse.readFrom(new DataInputStream(putResponseStream));
-    Assert.assertEquals(response7.getError(), ServerErrorCode.No_Error);
-
+    putBlob(blobIdList.get(7), properties.get(7), usermetadata.get(7), data.get(7), channel);
     // put blob 8
-    PutRequest putRequest8 =
-        new PutRequest(1, "client1", blobIdList.get(8), properties.get(8), ByteBuffer.wrap(usermetadata.get(8)),
-            ByteBuffer.wrap(data.get(8)), properties.get(8).getBlobSize(), BlobType.DataBlob);
-    channel.send(putRequest8);
-    putResponseStream = channel.receive().getInputStream();
-    PutResponse response9 = PutResponse.readFrom(new DataInputStream(putResponseStream));
-    Assert.assertEquals(response9.getError(), ServerErrorCode.No_Error);
+    putBlob(blobIdList.get(8), properties.get(8), usermetadata.get(8), data.get(8), channel);
 
     notificationSystem.awaitBlobCreations(blobIdList.get(6).getID());
     notificationSystem.awaitBlobCreations(blobIdList.get(7).getID());
@@ -421,92 +281,117 @@ public class ServerHardDeleteTest {
     // Do more deletes
 
     // delete blob 3 that is expired.
-    deleteRequest = new DeleteRequest(1, "client1", blobIdList.get(3));
-    channel.send(deleteRequest);
-    deleteResponseStream = channel.receive().getInputStream();
-    deleteResponse = DeleteResponse.readFrom(new DataInputStream(deleteResponseStream));
-    Assert.assertEquals(deleteResponse.getError(), ServerErrorCode.No_Error);
-
-    zeroedMetadata = new byte[usermetadata.get(3).length];
-    usermetadata.set(3, zeroedMetadata);
-    zeroedData = new byte[data.get(3).length];
-    data.set(3, zeroedData);
-
+    deleteBlob(blobIdList.get(3), channel);
+    zeroOutBlobContent(3);
     // delete blob 0
-    deleteRequest = new DeleteRequest(1, "client1", blobIdList.get(0));
-    channel.send(deleteRequest);
-    deleteResponseStream = channel.receive().getInputStream();
-    deleteResponse = DeleteResponse.readFrom(new DataInputStream(deleteResponseStream));
-    Assert.assertEquals(deleteResponse.getError(), ServerErrorCode.No_Error);
-
-    zeroedMetadata = new byte[usermetadata.get(0).length];
-    usermetadata.set(0, zeroedMetadata);
-    zeroedData = new byte[data.get(0).length];
-    data.set(0, zeroedData);
-
+    deleteBlob(blobIdList.get(0), channel);
+    zeroOutBlobContent(0);
     // delete blob 6.
-    deleteRequest = new DeleteRequest(1, "client1", blobIdList.get(6));
-    channel.send(deleteRequest);
-    deleteResponseStream = channel.receive().getInputStream();
-    deleteResponse = DeleteResponse.readFrom(new DataInputStream(deleteResponseStream));
-    Assert.assertEquals(deleteResponse.getError(), ServerErrorCode.No_Error);
-
-    zeroedMetadata = new byte[usermetadata.get(6).length];
-    usermetadata.set(6, zeroedMetadata);
-    zeroedData = new byte[data.get(6).length];
-    data.set(6, zeroedData);
+    deleteBlob(blobIdList.get(6), channel);
+    zeroOutBlobContent(6);
 
     notificationSystem.awaitBlobDeletions(blobIdList.get(0).getID());
     notificationSystem.awaitBlobDeletions(blobIdList.get(6).getID());
 
     time.currentMilliseconds = time.currentMilliseconds + Time.SecsPerDay * Time.MsPerSec;
-    ensureCleanupTokenCatchesUp(partitionIds.get(0).getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 297923);
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 297923);
 
-    partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
-    partitionRequestInfo = new PartitionRequestInfo(partition, blobIdList);
+    getAndVerify(channel, 9);
+  }
+
+  /**
+   * Uploads a single blob to ambry server node
+   * @param blobId the {@link BlobId} that needs to be put
+   * @param properties the {@link BlobProperties} of the blob being uploaded
+   * @param usermetadata the user metadata of the blob being uploaded
+   * @param data the blob content of the blob being uploaded
+   * @param channel the {@link BlockingChannel} to use to send and receive data
+   * @throws IOException
+   */
+  void putBlob(BlobId blobId, BlobProperties properties, byte[] usermetadata, byte[] data, BlockingChannel channel)
+      throws IOException {
+    PutRequest putRequest0 =
+        new PutRequest(1, "client1", blobId, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
+            properties.getBlobSize(), BlobType.DataBlob);
+    channel.send(putRequest0);
+    InputStream putResponseStream = channel.receive().getInputStream();
+    PutResponse response0 = PutResponse.readFrom(new DataInputStream(putResponseStream));
+    Assert.assertEquals(response0.getError(), ServerErrorCode.No_Error);
+  }
+
+  /**
+   * Deletes a single blob from ambry server node
+   * @param blobId the {@link BlobId} that needs to be deleted
+   * @param channel the {@link BlockingChannel} to use to send and receive data
+   * @throws IOException
+   */
+  void deleteBlob(BlobId blobId, BlockingChannel channel) throws IOException {
+    DeleteRequest deleteRequest = new DeleteRequest(1, "client1", blobId);
+    channel.send(deleteRequest);
+    InputStream deleteResponseStream = channel.receive().getInputStream();
+    DeleteResponse deleteResponse = DeleteResponse.readFrom(new DataInputStream(deleteResponseStream));
+    Assert.assertEquals(deleteResponse.getError(), ServerErrorCode.No_Error);
+  }
+
+  /**
+   * Zeros out user metadata and blob content for the blob indexed at the given {@code index}
+   * @param index the index of the blob that needs to be zeroed out
+   */
+  void zeroOutBlobContent(int index) {
+    byte[] zeroedMetadata = new byte[usermetadata.get(index).length];
+    usermetadata.set(index, zeroedMetadata);
+    byte[] zeroedData = new byte[data.get(index).length];
+    data.set(index, zeroedData);
+  }
+
+  /**
+   * Fetches the Blob(for all MessageFormatFlags) and verifies the content
+   * @param channel the {@link BlockingChannel} to use to send and receive data
+   * @param blobsCount the total number of blobs that needs to be verified against
+   * @throws Exception
+   */
+  void getAndVerify(BlockingChannel channel, int blobsCount) throws Exception {
+    ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
+    ArrayList<BlobId> ids = new ArrayList<BlobId>();
+    for (int i = 0; i < blobsCount; i++) {
+      ids.add(blobIdList.get(i));
+    }
+
+    PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(blobIdList.get(0).getPartition(), ids);
     partitionRequestInfoList.add(partitionRequestInfo);
 
-    try {
-      GetRequest getRequest =
-          new GetRequest(1, "clientid2", MessageFormatFlags.BlobProperties, partitionRequestInfoList,
-              GetOption.Include_All);
+    ArrayList<MessageFormatFlags> flags = new ArrayList<>();
+    flags.add(MessageFormatFlags.BlobProperties);
+    flags.add(MessageFormatFlags.BlobUserMetadata);
+    flags.add(MessageFormatFlags.Blob);
+    for (MessageFormatFlags flag : flags) {
+      GetRequest getRequest = new GetRequest(1, "clientid2", flag, partitionRequestInfoList, GetOption.Include_All);
       channel.send(getRequest);
       InputStream stream = channel.receive().getInputStream();
       GetResponse resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
-
-      for (int i = 0; i < 9; i++) {
-        BlobProperties propertyOutput = MessageFormatRecord.deserializeBlobProperties(resp.getInputStream());
-        Assert.assertEquals(propertyOutput.getBlobSize(), properties.get(i).getBlobSize());
-        Assert.assertEquals(propertyOutput.getServiceId(), "serviceid1");
+      if (flag == MessageFormatFlags.BlobProperties) {
+        for (int i = 0; i < blobsCount; i++) {
+          BlobProperties propertyOutput = MessageFormatRecord.deserializeBlobProperties(resp.getInputStream());
+          Assert.assertEquals(propertyOutput.getBlobSize(), properties.get(i).getBlobSize());
+          Assert.assertEquals(propertyOutput.getServiceId(), "serviceid1");
+        }
+      } else if (flag == MessageFormatFlags.BlobUserMetadata) {
+        for (int i = 0; i < blobsCount; i++) {
+          ByteBuffer userMetadataOutput = MessageFormatRecord.deserializeUserMetadata(resp.getInputStream());
+          Assert.assertArrayEquals(userMetadataOutput.array(), usermetadata.get(i));
+        }
+      } else if (flag == MessageFormatFlags.Blob) {
+        for (int i = 0; i < blobsCount; i++) {
+          BlobData blobData = MessageFormatRecord.deserializeBlob(resp.getInputStream());
+          Assert.assertEquals(properties.get(i).getBlobSize(), blobData.getSize());
+          byte[] dataOutput = new byte[(int) blobData.getSize()];
+          blobData.getStream().read(dataOutput);
+          Assert.assertArrayEquals(dataOutput, data.get(i));
+        }
+      } else {
+        throw new IllegalArgumentException("Unrecognized message format flags " + flags);
       }
-
-      getRequest = new GetRequest(1, "clientid2", MessageFormatFlags.BlobUserMetadata, partitionRequestInfoList,
-          GetOption.Include_All);
-      channel.send(getRequest);
-      stream = channel.receive().getInputStream();
-      resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
-
-      for (int i = 0; i < 9; i++) {
-        ByteBuffer userMetadataOutput = MessageFormatRecord.deserializeUserMetadata(resp.getInputStream());
-        Assert.assertArrayEquals(userMetadataOutput.array(), usermetadata.get(i));
-      }
-
-      getRequest =
-          new GetRequest(1, "clientid2", MessageFormatFlags.Blob, partitionRequestInfoList, GetOption.Include_All);
-      channel.send(getRequest);
-      stream = channel.receive().getInputStream();
-      resp = GetResponse.readFrom(new DataInputStream(stream), mockClusterMap);
-
-      for (int i = 0; i < 9; i++) {
-        BlobData blobData = MessageFormatRecord.deserializeBlob(resp.getInputStream());
-        Assert.assertEquals(blobData.getSize(), properties.get(i).getBlobSize());
-        byte[] dataOutput = new byte[(int) blobData.getSize()];
-        blobData.getStream().read(dataOutput);
-        Assert.assertArrayEquals(dataOutput, data.get(i));
-      }
-    } catch (MessageFormatException e) {
-      e.printStackTrace();
-      Assert.assertEquals(false, true);
     }
   }
 }
+

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -119,6 +119,7 @@ public class ServerHardDeleteTest {
            startTokenForRecovery
            endTokenForRecovery
            numBlobsInRange
+           pause flag
            --
            blob1_blobReadOptions {version, offset, sz, ttl, key}
            blob2_blobReadOptions
@@ -141,7 +142,7 @@ public class ServerHardDeleteTest {
         DataInputStream stream = new DataInputStream(crcStream);
         try {
           short version = stream.readShort();
-          Assert.assertEquals(version, HardDeleter.Cleanup_Token_Version_V0);
+          Assert.assertEquals(version, HardDeleter.Cleanup_Token_Version_V1);
           StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", mockClusterMap);
           FindTokenFactory factory = Utils.getObj("com.github.ambry.store.StoreFindTokenFactory", storeKeyFactory);
 
@@ -149,7 +150,7 @@ public class ServerHardDeleteTest {
           endToken = (StoreFindToken) factory.getFindToken(stream);
           Offset endTokenOffset = endToken.getOffset();
           parsedTokenValue = endTokenOffset == null ? -1 : endTokenOffset.getOffset();
-
+          boolean pauseFlag = stream.readByte() == (byte) 1;
           int num = stream.readInt();
           List<StoreKey> storeKeyList = new ArrayList<StoreKey>(num);
           for (int i = 0; i < num; i++) {

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -118,6 +118,7 @@ public class HardDeleter implements Runnable {
       while (running.get()) {
         reentrantLock.lock();
         try {
+          // if paused
           while (running.get() && isPaused()) {
             try {
               pauseCondition.await();
@@ -125,6 +126,7 @@ public class HardDeleter implements Runnable {
               logger.warn("InterruptedException thrown while hard delete thread is paused ", e);
             }
           }
+          // if not paused
           if (running.get()) {
             if (!hardDelete()) {
               isCaughtUp = true;

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -418,8 +418,7 @@ public class HardDeleter implements Runnable {
           case Cleanup_Token_Version_V1:
             recoveryStartToken = StoreFindToken.fromBytes(stream, factory);
             recoveryEndToken = StoreFindToken.fromBytes(stream, factory);
-            byte pauseByte = stream.readByte();
-            paused.set(pauseByte == (byte) 1);
+            paused.set(stream.readByte() == (byte) 1);
             hardDeleteRecoveryRange = new HardDeletePersistInfo(stream, factory);
             break;
           default:

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -117,11 +117,9 @@ public class HardDeleter implements Runnable {
       while (enabled.get()) {
         hardDeleteLock.lock();
         try {
-          // if paused
           while (enabled.get() && isPaused()) {
             pauseCondition.await();
           }
-          // if not paused
           if (enabled.get()) {
             if (!hardDelete()) {
               isCaughtUp = true;

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -61,7 +61,7 @@ public class HardDeleter implements Runnable {
   private final int scanSizeInBytes;
   private final int messageRetentionSeconds;
   //how long to sleep if token does not advance.
-  private final long hardDeleterSleepTimeWhenCaughtUpMs;
+  private final long hardDeleterSleepTimeWhenCaughtUpMs = 10 * Time.MsPerSec;
   private final CountDownLatch shutdownLatch = new CountDownLatch(1);
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -109,7 +109,6 @@ public class HardDeleter implements Runnable {
     throttler = new Throttler(config.storeHardDeleteBytesPerSec, 10, true, time);
     scanSizeInBytes = config.storeHardDeleteBytesPerSec * 10;
     messageRetentionSeconds = config.storeDeletedMessageRetentionDays * Time.SecsPerDay;
-    hardDeleterSleepTimeWhenCaughtUpMs = config.storeHardDeleterSleepTimeWhenCaughtUpInMs;
   }
 
   @Override
@@ -166,7 +165,6 @@ public class HardDeleter implements Runnable {
     try {
       if (paused.compareAndSet(false, true)) {
         logger.info("HardDelete thread has been paused ");
-        pauseCondition.signal();
         index.persistIndex();
         pruneHardDeleteRecoveryRange();
         persistCleanupToken();

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -47,6 +47,8 @@ public class HardDeleter implements Runnable {
   public static final short Cleanup_Token_Version_V0 = 0;
   public static final short Cleanup_Token_Version_V1 = 1;
   private static final String Cleanup_Token_Filename = "cleanuptoken";
+  //how long to sleep if token does not advance.
+  static final long HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP = 10 * Time.MsPerSec;
 
   final AtomicBoolean running = new AtomicBoolean(true);
 
@@ -60,8 +62,6 @@ public class HardDeleter implements Runnable {
   private final Time time;
   private final int scanSizeInBytes;
   private final int messageRetentionSeconds;
-  //how long to sleep if token does not advance.
-  private final long hardDeleterSleepTimeWhenCaughtUpMs = 10 * Time.MsPerSec;
   private final CountDownLatch shutdownLatch = new CountDownLatch(1);
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -132,7 +132,7 @@ public class HardDeleter implements Runnable {
               if (!running.get()) {
                 break;
               }
-              time.await(pauseCondition, hardDeleterSleepTimeWhenCaughtUpMs);
+              time.await(pauseCondition, HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP);
             } else if (isCaughtUp) {
               isCaughtUp = false;
               logger.info("Resumed hard deletes for {} after having caught up", dataDir);

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -80,7 +80,7 @@ class PersistentIndex {
   final ConcurrentSkipListMap<Offset, IndexSegment> indexes = new ConcurrentSkipListMap<>();
   final Journal journal;
   final HardDeleter hardDeleter;
-  volatile Thread hardDeleteThread = null;
+  final Thread hardDeleteThread;
 
   private final Log log;
   private final Offset logAbsoluteZeroOffset;
@@ -208,6 +208,7 @@ class PersistentIndex {
         hardDeleteThread = Utils.newThread("hard delete thread " + datadir, hardDeleter, true);
         hardDeleteThread.start();
       } else {
+        hardDeleteThread = null;
         hardDeleter.close();
       }
       metrics.initializeHardDeleteMetric(hardDeleter, log);

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -87,6 +87,7 @@ class PersistentIndex {
   private final int maxInMemoryNumElements;
   private final String dataDir;
   private final MessageStoreHardDelete hardDelete;
+  private Thread hardDeleteThread = null;
   private final StoreKeyFactory factory;
   private final StoreConfig config;
   private final boolean cleanShutdown;
@@ -204,7 +205,7 @@ class PersistentIndex {
           config.storeDataFlushIntervalSeconds, TimeUnit.SECONDS);
       if (config.storeEnableHardDelete) {
         logger.info("Index : " + datadir + " Starting hard delete thread ");
-        Thread hardDeleteThread = Utils.newThread("hard delete thread " + datadir, hardDeleter, true);
+        hardDeleteThread = Utils.newThread("hard delete thread " + datadir, hardDeleter, true);
         hardDeleteThread.start();
       } else {
         hardDeleter.close();
@@ -722,6 +723,14 @@ class PersistentIndex {
       }
     }
     return storeToken;
+  }
+
+  /**
+   * Returns the state of hard delete thread
+   * @return the state of hard delete thread
+   */
+  Thread.State getHardDeleteThreadStatus() {
+    return hardDeleteThread.getState();
   }
 
   private long getTotalBytesRead(StoreFindToken newToken, List<MessageInfo> messageEntries,

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -1043,6 +1043,14 @@ class PersistentIndex {
     }
   }
 
+  /**
+   * Persists index files to disk.
+   * @throws StoreException
+   */
+  void persistIndex() throws StoreException {
+    persistor.write();
+  }
+
   private class IndexPersistor implements Runnable {
 
     /**
@@ -1051,7 +1059,7 @@ class PersistentIndex {
      * The last index segment is flushed whenever write is invoked.
      * @throws StoreException
      */
-    public void write() throws StoreException {
+    public synchronized void write() throws StoreException {
       final Timer.Context context = metrics.indexFlushTime.time();
       try {
         if (indexes.size() > 0) {

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -80,6 +80,7 @@ class PersistentIndex {
   final ConcurrentSkipListMap<Offset, IndexSegment> indexes = new ConcurrentSkipListMap<>();
   final Journal journal;
   final HardDeleter hardDeleter;
+  volatile Thread hardDeleteThread = null;
 
   private final Log log;
   private final Offset logAbsoluteZeroOffset;
@@ -87,7 +88,6 @@ class PersistentIndex {
   private final int maxInMemoryNumElements;
   private final String dataDir;
   private final MessageStoreHardDelete hardDelete;
-  private Thread hardDeleteThread = null;
   private final StoreKeyFactory factory;
   private final StoreConfig config;
   private final boolean cleanShutdown;
@@ -723,14 +723,6 @@ class PersistentIndex {
       }
     }
     return storeToken;
-  }
-
-  /**
-   * Returns the state of hard delete thread
-   * @return the state of hard delete thread
-   */
-  Thread.State getHardDeleteThreadStatus() {
-    return hardDeleteThread.getState();
   }
 
   private long getTotalBytesRead(StoreFindToken newToken, List<MessageInfo> messageEntries,

--- a/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
@@ -163,7 +163,7 @@ public class HardDeleterTest {
         UUID.randomUUID());
     helper.setIndex(index, log);
     // Setting this below will not enable the hard delete thread. This being a unit test, the methods
-    // are going to be called directly. We simply want to set the running flag to avoid those methods
+    // are going to be called directly. We simply want to set the enabled flag to avoid those methods
     // from bailing out prematurely.
     index.setHardDeleteRunningStatus(true);
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1544,7 +1544,7 @@ public class IndexTest {
 
     if (reloadIndex) {
       reloadIndex(true);
-      assertEquals("Hard deletes should have been paused ", Thread.State.WAITING, index.hardDeleteThread.getState());
+      waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP + 1, 10);
       idsToDelete.clear();
       addPutEntries(2, PUT_RECORD_SIZE, Utils.Infinite_Time);
       idsToDelete.add(getIdToDeleteFromIndexSegment(referenceIndex.lastKey()));

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1534,8 +1534,7 @@ public class IndexTest {
 
     if (reloadIndex) {
       reloadIndex(true);
-      assertTrue("Hard deletes should have been paused ", index.hardDeleter.isPaused());
-      assertEquals("Hard delete should not have progressed ", expectedProgress, index.hardDeleter.getProgress());
+      assertEquals("Hard deletes should have been paused ", Thread.State.WAITING, index.hardDeleteThread.getState());
 
       Set<MockId> newIdsToDelete = new HashSet<>();
       addPutEntries(2, PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -1548,7 +1547,6 @@ public class IndexTest {
       idsToDelete.addAll(newIdsToDelete);
       // advance time so that deleted entries becomes eligible to be hard deleted
       advanceTime(SystemTime.getInstance().milliseconds() + 2 * Time.MsPerSec * Time.SecsPerDay);
-      waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP + 1, 10);
     }
 
     // resume and verify new entries have been hard deleted

--- a/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
@@ -1967,7 +1967,7 @@ class MockIndex extends PersistentIndex {
   }
 
   public void setHardDeleteRunningStatus(boolean status) {
-    super.hardDeleter.running.set(status);
+    super.hardDeleter.enabled.set(status);
   }
 
   public boolean hardDelete() throws StoreException {

--- a/ambry-utils/src/main/java/com.github.ambry.utils/SystemTime.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/SystemTime.java
@@ -13,6 +13,10 @@
  */
 package com.github.ambry.utils;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+
+
 /**
  * The normal system implementation of time functions
  */
@@ -50,5 +54,10 @@ public class SystemTime extends Time {
   @Override
   public void wait(Object o, long ms) throws InterruptedException {
     o.wait(ms);
+  }
+
+  @Override
+  public void await(Condition c, long ms) throws InterruptedException {
+    c.await(ms, TimeUnit.MILLISECONDS);
   }
 }

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Time.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Time.java
@@ -45,11 +45,17 @@ public abstract class Time {
 
   public abstract void sleep(long ms) throws InterruptedException;
 
+  /**
+   * Waits on the {@code o} for {@code ms}
+   * @param o the {@link Object} over which wait has been called
+   * @param ms time in millisecs for which the wait should be called
+   * @throws InterruptedException
+   */
   public abstract void wait(Object o, long ms) throws InterruptedException;
 
   /**
    * Awaits on the {@code c} for {@code ms}
-   * @param c the {@link Condition} over which await has to be called
+   * @param c the {@link Condition} over which await has been called
    * @param ms time in millisecs for which the await should be called
    * @throws InterruptedException
    */

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Time.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Time.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.utils;
 
+import java.util.concurrent.locks.Condition;
+
+
 /**
  * A mockable interface for time functions
  */
@@ -43,5 +46,13 @@ public abstract class Time {
   public abstract void sleep(long ms) throws InterruptedException;
 
   public abstract void wait(Object o, long ms) throws InterruptedException;
+
+  /**
+   * Awaits on the {@code c} for {@code ms}
+   * @param c the {@link Condition} over which await has to be called
+   * @param ms time in millisecs for which the await should be called
+   * @throws InterruptedException
+   */
+  public abstract void await(Condition c, long ms) throws InterruptedException;
 }
 

--- a/ambry-utils/src/test/java/com.github.ambry.utils/MockTime.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/MockTime.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.utils;
 
+import java.util.concurrent.locks.Condition;
+
+
 /**
  * A mock time class
  */
@@ -51,6 +54,11 @@ public class MockTime extends Time {
 
   @Override
   public void wait(Object o, long ms) throws InterruptedException {
+    sleep(ms);
+  }
+
+  @Override
+  public void await(Condition c, long ms) throws InterruptedException {
     sleep(ms);
   }
 }


### PR DESCRIPTION
Addresing https://github.com/linkedin/ambry/issues/529 

1. Adding pause and resume support to hard deletes
2. Making write() in IndexPersistor synchronized so that the index can call it on demand. Index exposes an api to persist the index with this change.

Details on what happens in pause() within hard deleter
  Complete any on-going hard delete cycle if any
  Persist the index(which will update the startTokenSafeToPersist within hard deletes)
  Prune hard delete recovery range
  Persist clean up token(tokens and hard delete recovery range)

SLA: 20 mins
Reviewers: Gopal, Priyesh

Coverage(on running entire IndexTest):
PersistentIndex	100% (5/ 5)	100% (38/ 38)	91.1% (479/ 526)
HardDeleter	100% (3/ 3)	80% (24/ 30)	68.4% (188/ 275)
(Uncovered lines among new lines added: InterruptedException while waiting in pause state)

Built and coding style applied