### PR TITLE
Add a tool to map static cluster map information into Helix

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Partition extends PartitionId {
 
-  private static final long Min_Replica_Capacity_In_Bytes = 1 * 1024 * 1024 * 1024L;
+  private static final long Min_Replica_Capacity_In_Bytes = 1024 * 1024 * 1024L;
   private static final long Max_Replica_Capacity_In_Bytes = 10995116277760L; // 10 TB
   private static final short Version_Field_Size_In_Bytes = 2;
   private static final int Partition_Size_In_Bytes = Version_Field_Size_In_Bytes + 8;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/PartitionTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/PartitionTest.java
@@ -30,17 +30,18 @@ public class PartitionTest {
 
   @Test
   public void basics() throws JSONException {
-    int replicaCount = 6;
+    int replicaCount = 3;
     long replicaCapacityInBytes = 100 * 1024 * 1024 * 1024L;
 
     TestUtils.TestHardwareLayout thl = new TestUtils.TestHardwareLayout("Alpha");
+    int dcCount = thl.getDatacenterCount();
     JSONArray jsonReplicas = TestUtils.getJsonArrayReplicas(thl.getIndependentDisks(replicaCount));
     JSONObject jsonObject =
         TestUtils.getJsonPartition(99, PartitionState.READ_WRITE, replicaCapacityInBytes, jsonReplicas);
 
     Partition partition = new Partition(thl.getHardwareLayout(), jsonObject);
 
-    assertEquals(partition.getReplicaIds().size(), replicaCount);
+    assertEquals(partition.getReplicaIds().size(), replicaCount * dcCount);
     assertEquals(partition.getReplicaCapacityInBytes(), replicaCapacityInBytes);
     assertEquals(partition.getPartitionState(), PartitionState.READ_WRITE);
   }
@@ -56,10 +57,11 @@ public class PartitionTest {
 
   @Test
   public void validation() throws JSONException {
-    int replicaCount = 6;
+    int replicaCount = 3;
     long replicaCapacityInBytes = 100 * 1024 * 1024 * 1024L;
 
     TestUtils.TestHardwareLayout thl = new TestUtils.TestHardwareLayout("Alpha");
+    int dcCount = thl.getDatacenterCount();
     JSONArray jsonReplicas = TestUtils.getJsonArrayReplicas(thl.getIndependentDisks(replicaCount));
     JSONObject jsonObject;
 
@@ -68,8 +70,8 @@ public class PartitionTest {
     failValidation(thl.getHardwareLayout(), jsonObject);
 
     // Bad replica capacity in bytes (too big)
-    jsonObject = TestUtils.getJsonPartition(99, PartitionState.READ_WRITE, 1024 * 1024 * 1024 * 1024 * 1024 * 1024L,
-        jsonReplicas);
+    jsonObject =
+        TestUtils.getJsonPartition(99, PartitionState.READ_WRITE, 11L * 1024 * 1024 * 1024 * 1024, jsonReplicas);
     failValidation(thl.getHardwareLayout(), jsonObject);
 
     // Multiple Replica on same Disk.

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -537,7 +537,7 @@ public class TestUtils {
      * @param dataNodeCountPerDc number of datanodes to get from each datacenter.
      * @return a list of datanodes.
      */
-    public List<DataNode> getIndependentDataNodes(int dataNodeCountPerDc) {
+    List<DataNode> getIndependentDataNodes(int dataNodeCountPerDc) {
       List<DataNode> dataNodesToReturn = new ArrayList<DataNode>();
       for (Datacenter datacenter : hardwareLayout.getDatacenters()) {
         List<DataNode> dataNodesInThisDc = new ArrayList<>();

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -1,0 +1,466 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.tools.util.ToolUtils;
+import com.github.ambry.utils.Utils;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import joptsimple.ArgumentAcceptingOptionSpec;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.builder.AutoModeISBuilder;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+
+/**
+ * This tool takes the hardware layout, partition layout and the Zk hosts information json files as input,
+ * and updates the ZK hosts with the contents of the layout files. It adds all partitions and hosts that have not
+ * previously been added (so, initially this will bootstrap the cluster information and on an ongoing basis, this can
+ * add new nodes and partitions).
+ *
+ * The existing hardware and partition layout json files will be read in as is.
+ *
+ * The ZkLayoutPath argument containing the Zk hosts information in each datacenter should be a json of the
+ * following example form:
+ *
+ * {
+ *   "zkHosts" : [
+ *     {
+ *       "datacenter":"dc1",
+ *       "hostname":"abc.example.com",
+ *       "port":"2199",
+ *     },
+ *     {
+ *       "datacenter":"dc2",
+ *       "hostname":"def.example.com",
+ *       "port":"2300",
+ *     }
+ *   ]
+ * }
+ *
+ * This tool should be run from an admin node that has access to the nodes in the hardware layout. The access is
+ * required because the static {@link ClusterMapManager} that we use to parse the static layout files validates
+ * these nodes.
+ *
+ * The tool does the following:
+ * 1. bootstraps a static cluster map, adding nodes and partitions to Helix.
+ * 2. upgrades that involve new nodes and new partitions. To avoid over-complicating things, it assumes that the
+ *    existing partition assignment do not change during an upgrade. Newly added partitions can be distributed in any
+ *    way (new partitions can have replicas even in previously added nodes).
+ * 3. Upgrades will also update the partition states if required (READ_WRITE to SEALED or vice versa) for existing
+ *    partitions.
+ *
+ */
+public class HelixBootstrapUpgradeTool {
+  private final ClusterMapManager staticClusterMap;
+  private final Map<String, String> dataCenterToZkAddress = new HashMap<>();
+  private final Map<String, HelixAdmin> adminForDc = new HashMap<>();
+  private final TreeMap<Long, Long> existingPartitions = new TreeMap<>();
+  private final TreeSet<Long> existingResources = new TreeSet<>();
+  private final String localDc;
+  private String clusterName;
+
+  static final int MAX_PARTITIONS_PER_RESOURCE = 100;
+  static final String CAPACITY_STR = "capacityInBytes";
+  static final String REPLICAS_STR = "Replicas";
+  static final String REPLICAS_DELIM_STR = ",";
+  static final String SSLPORT_STR = "sslPort";
+  static final String DATACENTER_STR = "dataCenter";
+  static final String RACKID_STR = "rackId";
+  static final String SEALED_STR = "SEALED";
+
+  /**
+   * @param args takes in three mandatory arguments: the hardware layout path, the partition layout path and the zk
+   *             layout path.
+   *             The Zk layout has to be of the following form:
+   *             {
+   *               "zkHosts" : [
+   *                 {
+   *                   "datacenter":"dc1",
+   *                   "hostname":"abc.example.com",
+   *                   "port":"2199",
+   *                 },
+   *                 {
+   *                   "datacenter":"dc2",
+   *                   "hostname":"def.example.com",
+   *                   "port":"2300",
+   *                 }
+   *               ]
+   *             }
+   *
+   *             Also takes in an optional argument that specifies the local datacenter name, so that can be used as
+   *             the "reference" datacenter. If none provided, the tool simply chooses one of the datacenters in the
+   *             layout as the reference datacenter.
+   */
+  public static void main(String args[]) {
+    try {
+      OptionParser parser = new OptionParser();
+
+      ArgumentAcceptingOptionSpec<String> hardwareLayoutPathOpt =
+          parser.accepts("hardwareLayoutPath", "The path to the hardware layout json file")
+              .withRequiredArg()
+              .describedAs("hardware_layout_path")
+              .ofType(String.class);
+
+      ArgumentAcceptingOptionSpec<String> partitionLayoutPathOpt =
+          parser.accepts("partitionLayoutPath", "The path to the partition layout json file")
+              .withRequiredArg()
+              .describedAs("partition_layout_path")
+              .ofType(String.class);
+
+      ArgumentAcceptingOptionSpec<String> zkLayoutPathOpt = parser.accepts("zkLayoutPath",
+          "The path to the json file containing zookeeper connect info. This should"
+              + " be of the following form: \n{\n" + "  \"zkHosts\" : [\n" + "     {\n"
+              + "       \"datacenter\":\"dc1\",\n" + "       \"hostname\":\"abc.example.com\",\n"
+              + "       \"port\":\"2199\",\n" + "     },\n" + "     {\n" + "       \"datacenter\":\"dc2\",\n"
+              + "       \"hostname\":\"def.example.com\",\n" + "       \"port\":\"2300\",\n" + "     }\n" + "  ]\n"
+              + "}").
+          withRequiredArg().
+          describedAs("zk_connect_info_path").
+          ofType(String.class);
+
+      ArgumentAcceptingOptionSpec<String> localDcOpt = parser.accepts("localDc", "The local datacenter name")
+          .withRequiredArg()
+          .describedAs("local_dc")
+          .ofType(String.class);
+
+      OptionSet options = parser.parse(args);
+      String hardwareLayoutPath = options.valueOf(hardwareLayoutPathOpt);
+      String partitionLayoutPath = options.valueOf(partitionLayoutPathOpt);
+      String zkLayoutPath = options.valueOf(zkLayoutPathOpt);
+      ArrayList<OptionSpec> listOpt = new ArrayList<>();
+      listOpt.add(hardwareLayoutPathOpt);
+      listOpt.add(partitionLayoutPathOpt);
+      listOpt.add(zkLayoutPathOpt);
+      ToolUtils.ensureOrExit(listOpt, options, parser);
+      bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, options.valueOf(localDcOpt));
+    } catch (Exception e) {
+      System.out.println("Exception while executing partition command: " + e);
+    }
+  }
+
+  /**
+   * Takes in the path to the files that make up the static cluster map and adds or updates the cluster map information
+   * in Helix to make the two consistent.
+   * @param hardwareLayoutPath the path to the hardware layout file.
+   * @param partitionLayoutPath the path to the partition layout file.
+   * @param zkLayoutPath the path to the zookeeper layout file.
+   * @param localDc the name of the local datacenter. This can be null.
+   * @throws IOException if there is an error reading a file.
+   * @throws JSONException if there is an error parsing the JSON content in any of the files.
+   */
+  static void bootstrapOrUpgrade(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
+      String localDc) throws IOException, JSONException {
+    HelixBootstrapUpgradeTool clusterMapToHelixMapper =
+        new HelixBootstrapUpgradeTool(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, localDc);
+    clusterMapToHelixMapper.updateHelix();
+  }
+
+  /**
+   * Instantiates this class with the given information.
+   * @param hardwareLayoutPath the path to the hardware layout file.
+   * @param partitionLayoutPath the path to the partition layout file.
+   * @param zkLayoutPath the path to the zookeeper layout file.
+   * @param localDc the name of the local datacenter. This can be null.
+   * @throws IOException if there is an error reading a file.
+   * @throws JSONException if there is an error parsing the JSON content in any of the files.
+   */
+  private HelixBootstrapUpgradeTool(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
+      String localDc) throws IOException, JSONException {
+    this.localDc = localDc;
+    parseZkJsonAndPopulateZkInfo(zkLayoutPath);
+
+    String partitionLayoutString = null;
+    try {
+      partitionLayoutString = Utils.readStringFromFile(partitionLayoutPath);
+    } catch (FileNotFoundException e) {
+      System.out.println("Partition layout path not found. Creating new file");
+    }
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
+    if (partitionLayoutString == null) {
+      staticClusterMap = new ClusterMapManager(new PartitionLayout(
+          new HardwareLayout(new JSONObject(Utils.readStringFromFile(hardwareLayoutPath)), clusterMapConfig)));
+    } else {
+      staticClusterMap = new ClusterMapManager(hardwareLayoutPath, partitionLayoutPath, clusterMapConfig);
+    }
+  }
+
+  /**
+   * Parses the zk layout JSON file and populates an internal map of datacenter name to Zk connect strings.
+   * @param zkLayoutPath the path to the Zookeeper layout file.
+   * @throws IOException if there is an error reading the file.
+   * @throws JSONException if there is an error parsing the JSON.
+   */
+  private void parseZkJsonAndPopulateZkInfo(String zkLayoutPath) throws IOException, JSONException {
+    JSONObject root = new JSONObject(Utils.readStringFromFile(zkLayoutPath));
+    JSONArray all = (root).getJSONArray("zkHosts");
+    for (int i = 0; i < all.length(); i++) {
+      JSONObject entry = all.getJSONObject(i);
+      dataCenterToZkAddress.put(entry.getString("datacenter"),
+          entry.getString("hostname") + ":" + entry.getString("port"));
+    }
+  }
+
+  /**
+   * Map the information in the layout files to Helix. Calling this method multiple times has no effect if the
+   * information in the static files do not change. This tool is therefore safe to use for upgrades.
+   *
+   * Instead of defining the entire cluster under a single resource, or defining a resource for every partition, the
+   * tool groups together partitions under resources, with a limit to the number of partitions that will be grouped
+   * under a single resource.
+   */
+  private void updateHelix() {
+    initializeAdminsAndAddCluster();
+    HelixAdmin refAdmin = localDc != null ? adminForDc.get(localDc) : adminForDc.values().iterator().next();
+    populateResourcesAndPartitionsSet(refAdmin);
+    addNewDataNodes();
+    long nextResource = existingResources.isEmpty() ? 1 : existingResources.last() + 1;
+    List<Partition> partitionsUnderNextResource = new ArrayList<>();
+    for (PartitionId partitionId : staticClusterMap.partitionLayout.getPartitions()) {
+      Partition partition = (Partition) partitionId;
+      if (existingPartitions.containsKey(partition.getId())) {
+        updatePartitionStateIfChanged(partition);
+      } else {
+        partitionsUnderNextResource.add(partition);
+        if (partitionsUnderNextResource.size() == MAX_PARTITIONS_PER_RESOURCE) {
+          addNewAmbryPartitions(partitionsUnderNextResource, Long.toString(nextResource));
+          partitionsUnderNextResource.clear();
+          nextResource++;
+        }
+      }
+    }
+    if (!partitionsUnderNextResource.isEmpty()) {
+      addNewAmbryPartitions(partitionsUnderNextResource, Long.toString(nextResource));
+    }
+  }
+
+  /**
+   * Initialize a map of dataCenter to HelixAdmin based on the given zk Connect Strings.
+   */
+  private void initializeAdminsAndAddCluster() {
+    clusterName = staticClusterMap.partitionLayout.getClusterName();
+    for (Map.Entry<String, String> entry : dataCenterToZkAddress.entrySet()) {
+      ZKHelixAdmin admin = new ZKHelixAdmin(entry.getValue());
+      adminForDc.put(entry.getKey(), admin);
+      // Add a cluster entry in every DC
+      if (!admin.getClusters().contains(clusterName)) {
+        admin.addCluster(clusterName);
+        admin.addStateModelDef(clusterName, "LeaderStandby",
+            BuiltInStateModelDefinitions.LeaderStandby.getStateModelDefinition());
+      }
+    }
+  }
+
+  /**
+   * Populate the set of existing resources and existing partitions in the cluster. This assumes that all partitions
+   * and resources exist in all datacenters (This assumption helps simplify the logic. This can be gotten rid of in
+   * the future if need be).
+   * @param dcAdmin the reference admin (preferably the admin to the zookeeper server in the local datacenter).
+   */
+  private void populateResourcesAndPartitionsSet(HelixAdmin dcAdmin) {
+    for (String resource : dcAdmin.getResourcesInCluster(clusterName)) {
+      existingResources.add(Long.valueOf(resource));
+      for (String partition : dcAdmin.getResourceIdealState(clusterName, resource).getPartitionSet()) {
+        existingPartitions.put(Long.valueOf(partition), Long.valueOf(resource));
+      }
+    }
+  }
+
+  /**
+   * Add nodes in the static cluster map that is not already present in Helix.
+   * Ignores those that are already present. This is to make upgrades smooth.
+   *
+   * Replica/Partition information is not updated by this method. That is updated when
+   * replicas and partitions are added.
+   *
+   * At this time, node removals are not dealt with.
+   */
+  private void addNewDataNodes() {
+    for (Datacenter dc : staticClusterMap.hardwareLayout.getDatacenters()) {
+      HelixAdmin dcAdmin = adminForDc.get(dc.getName());
+      for (DataNode node : dc.getDataNodes()) {
+        String instanceName = node.getHostname() + "_" + node.getPort();
+        if (!dcAdmin.getInstancesInCluster(clusterName).contains(instanceName)) {
+          InstanceConfig instanceConfig = new InstanceConfig(instanceName);
+          instanceConfig.setHostName(node.getHostname());
+          instanceConfig.setPort(Integer.toString(node.getPort()));
+
+          // populate mountPath -> Disk information.
+          Map<String, Map<String, String>> diskInfos = new HashMap<>();
+          for (Disk disk : node.getDisks()) {
+            Map<String, String> diskInfo = new HashMap<>();
+            diskInfo.put(CAPACITY_STR, Long.toString(disk.getRawCapacityInBytes()));
+            // Note: An instance config has to contain the information for each disk about the replicas it hosts.
+            // This information will be initialized to the empty string - but will be updated whenever the partition
+            // is added to the cluster.
+            diskInfo.put(REPLICAS_STR, "");
+            diskInfos.put(disk.getMountPath(), diskInfo);
+          }
+
+          // Add all instance configuration.
+          instanceConfig.getRecord().setMapFields(diskInfos);
+          instanceConfig.getRecord().setSimpleField(SSLPORT_STR, Integer.toString(node.getSSLPort()));
+          instanceConfig.getRecord().setSimpleField(DATACENTER_STR, node.getDatacenterName());
+          instanceConfig.getRecord().setSimpleField(RACKID_STR, Long.toString(node.getRackId()));
+          instanceConfig.getRecord().setListField(SEALED_STR, new ArrayList<String>());
+
+          // Finally, add this node to the DC.
+          dcAdmin.addInstance(clusterName, instanceConfig);
+        }
+      }
+    }
+  }
+
+  /**
+   * Goes through each existing partition and changes the {@link PartitionState} for the replicas in each of the
+   * instances that hosts a replica for this partition, if it has changed and is different from the current state
+   * in Helix.
+   * @param partition the partition whose {@link PartitionState} may have to be updated.
+   */
+  private void updatePartitionStateIfChanged(Partition partition) {
+    for (Map.Entry<String, HelixAdmin> entry : adminForDc.entrySet()) {
+      String dcName = entry.getKey();
+      HelixAdmin dcAdmin = entry.getValue();
+      String partitionName = Long.toString(partition.getId());
+      boolean isSealed = partition.getPartitionState().equals(PartitionState.READ_ONLY);
+      List<ReplicaId> replicaList = getReplicasInDc(partition, dcName);
+      for (ReplicaId replicaId : replicaList) {
+        DataNodeId node = replicaId.getDataNodeId();
+        String instanceName = node.getHostname() + "_" + node.getPort();
+        InstanceConfig instanceConfig = dcAdmin.getInstanceConfig(clusterName, instanceName);
+        List<String> currentSealedPartitions = instanceConfig.getRecord().getListField("SEALED");
+        if (isSealed && !currentSealedPartitions.contains(partitionName)) {
+          List<String> newSealedPartitionsList = new ArrayList<>(currentSealedPartitions);
+          newSealedPartitionsList.add(partitionName);
+          instanceConfig.getRecord().setListField("SEALED", newSealedPartitionsList);
+          dcAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
+        } else if (!isSealed && currentSealedPartitions.contains(partitionName)) {
+          List<String> newSealedPartitionsList = new ArrayList<>(currentSealedPartitions);
+          newSealedPartitionsList.remove(partitionName);
+          instanceConfig.getRecord().setListField("SEALED", newSealedPartitionsList);
+          dcAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
+        }
+      }
+    }
+  }
+
+  /**
+   * Adds all partitions to every datacenter with replicas in nodes as specified in the static clustermap (unless it
+   * was already added).
+   *
+   * The assumption is that in the static layout, every partition is contained in every colo. We make this assumption
+   * to ensure that partitions are grouped under the same resource in all colos (since the resource id is not
+   * something that is present today in the static cluster map). This is not a strict requirement though, but helps
+   * ease the logic.
+   *
+   * Note: We ensure that the partition names are unique in the Ambry cluster even across resources.
+   */
+  private void addNewAmbryPartitions(List<Partition> partitions, String resourceName) {
+    // In the future, a resource may be used to group together partitions of a container. For now, multiple
+    // resources are created and partitions are grouped under these resources upto a maximum threshold.
+    if (partitions.isEmpty()) {
+      throw new IllegalArgumentException("Cannot add resource with zero partitions");
+    }
+    for (Map.Entry<String, HelixAdmin> entry : adminForDc.entrySet()) {
+      String dcName = entry.getKey();
+      HelixAdmin dcAdmin = entry.getValue();
+      AutoModeISBuilder resourceISBuilder = new AutoModeISBuilder(resourceName);
+      int numReplicas = 0;
+      resourceISBuilder.setStateModel("LeaderStandby");
+      for (Partition partition : partitions) {
+        String partitionName = Long.toString(partition.getId());
+        boolean sealed = partition.getPartitionState().equals(PartitionState.READ_ONLY);
+        List<ReplicaId> replicaList = getReplicasInDc(partition, dcName);
+        numReplicas = replicaList.size();
+        String[] instances = updateInstancesAndGetInstanceNames(dcAdmin, partitionName, replicaList, sealed);
+        resourceISBuilder.assignPreferenceList(partitionName, instances);
+      }
+      resourceISBuilder.setNumReplica(numReplicas);
+      IdealState idealState = resourceISBuilder.build();
+      dcAdmin.addResource(clusterName, resourceName, idealState);
+    }
+  }
+
+  /**
+   * Updates instances that hosts replicas of this partition with the replica information (including the mount points
+   * on which these replicas should reside, which will be purely an instance level information).
+   * @param dcAdmin the admin to the Zk server on which this operatin is to be done.
+   * @param partitionName the partition name.
+   * @param replicaList the list of replicas of this partition.
+   * @param sealed whether the given partition state is sealed.
+   * @return an array of Strings containing the names of the instances on which the replicas of this partition reside.
+   */
+  private String[] updateInstancesAndGetInstanceNames(HelixAdmin dcAdmin, String partitionName,
+      List<ReplicaId> replicaList, boolean sealed) {
+    String[] instances = new String[replicaList.size()];
+    for (int i = 0; i < replicaList.size(); i++) {
+      Replica replica = (Replica) replicaList.get(i);
+      DataNodeId node = replica.getDataNodeId();
+      String instanceName = node.getHostname() + "_" + node.getPort();
+      instances[i] = instanceName;
+      InstanceConfig instanceConfig = dcAdmin.getInstanceConfig(clusterName, instanceName);
+      Map<String, String> diskInfo = instanceConfig.getRecord().getMapField(replica.getMountPath());
+      String replicasStr = diskInfo.get(REPLICAS_STR);
+      replicasStr += replica.getPartition().getId() + REPLICAS_DELIM_STR;
+      diskInfo.put(REPLICAS_STR, replicasStr);
+      instanceConfig.getRecord().setMapField(replica.getMountPath(), diskInfo);
+      if (sealed) {
+        List<String> currentSealedPartitions = instanceConfig.getRecord().getListField(SEALED_STR);
+        List<String> newSealedPartitionsList = new ArrayList<>(currentSealedPartitions);
+        newSealedPartitionsList.add(partitionName);
+        instanceConfig.getRecord().setListField(SEALED_STR, newSealedPartitionsList);
+      }
+      dcAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
+    }
+    return instances;
+  }
+
+  /**
+   * Helper method to get the list of {@link ReplicaId} of all replicas of a partition in the given datacenter.
+   * @param partition the partition of interest.
+   * @param dcName the datacenter to which the returned replicas should belong.
+   * @return a list of {@link ReplicaId} of all replicas of the given partition in the given datacenter.
+   */
+  private List<ReplicaId> getReplicasInDc(Partition partition, String dcName) {
+    // returns a copy unlike getReplicas()
+    List<ReplicaId> replicaList = partition.getReplicaIds();
+    ListIterator<ReplicaId> iter = replicaList.listIterator();
+    while (iter.hasNext()) {
+      if (!iter.next().getDataNodeId().getDatacenterName().equals(dcName)) {
+        iter.remove();
+      }
+    }
+    return replicaList;
+  }
+}
+

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -20,6 +20,8 @@ import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
@@ -400,6 +402,7 @@ public class HelixBootstrapUpgradeTool {
         List<ReplicaId> replicaList = getReplicasInDc(partition, dcName);
         numReplicas = replicaList.size();
         String[] instances = updateInstancesAndGetInstanceNames(dcAdmin, partitionName, replicaList, sealed);
+        Collections.shuffle(Arrays.asList(instances));
         resourceISBuilder.assignPreferenceList(partitionName, instances);
       }
       resourceISBuilder.setNumReplica(numReplicas);

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -493,7 +493,7 @@ public class HelixBootstrapUpgradeTool {
    */
   private void validateAndClose() {
     try {
-      verifyEquivalencyWithStatic(staticClusterMap.hardwareLayout, staticClusterMap.partitionLayout);
+      verifyEquivalencyWithStaticClusterMap(staticClusterMap.hardwareLayout, staticClusterMap.partitionLayout);
     } finally {
       for (HelixAdmin admin : adminForDc.values()) {
         admin.close();
@@ -506,7 +506,7 @@ public class HelixBootstrapUpgradeTool {
    * @param hardwareLayout the {@link HardwareLayout} of the static clustermap.
    * @param partitionLayout the {@link PartitionLayout} of the static clustermap.
    */
-  private void verifyEquivalencyWithStatic(HardwareLayout hardwareLayout, PartitionLayout partitionLayout) {
+  private void verifyEquivalencyWithStaticClusterMap(HardwareLayout hardwareLayout, PartitionLayout partitionLayout) {
     String clusterName = hardwareLayout.getClusterName();
     for (Datacenter dc : hardwareLayout.getDatacenters()) {
       HelixAdmin admin = adminForDc.get(dc.getName());
@@ -627,7 +627,7 @@ public class HelixBootstrapUpgradeTool {
               + replicaHostsInHelix);
     }
     ensureOrThrow(allPartitionsToInstancesInHelix.isEmpty(),
-        "More partitions in Helix than in clustermap, additional" + " partitions: "
+        "More partitions in Helix than in clustermap, additional partitions: "
             + allPartitionsToInstancesInHelix.keySet());
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry/store/HardDeleteVerifier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/HardDeleteVerifier.java
@@ -22,6 +22,7 @@ import com.github.ambry.messageformat.BlobData;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatRecord;
+import com.github.ambry.tools.util.ToolUtils;
 import com.github.ambry.utils.CrcInputStream;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
@@ -137,19 +138,13 @@ public class HardDeleteVerifier {
 
       OptionSet options = parser.parse(args);
 
-      ArrayList<OptionSpec<?>> requiredOpts = new ArrayList<OptionSpec<?>>();
+      ArrayList<OptionSpec> requiredOpts = new ArrayList<>();
       requiredOpts.add(hardwareLayoutOpt);
       requiredOpts.add(partitionLayoutOpt);
       requiredOpts.add(dataDirOpt);
       requiredOpts.add(outFileOpt);
 
-      for (OptionSpec opt : requiredOpts) {
-        if (!options.has(opt)) {
-          System.err.println("Missing required argument \"" + opt + "\"");
-          parser.printHelpOn(System.err);
-          System.exit(1);
-        }
-      }
+      ToolUtils.ensureOrExit(requiredOpts, options, parser);
 
       String hardwareLayoutPath = options.valueOf(hardwareLayoutOpt);
       String partitionLayoutPath = options.valueOf(partitionLayoutOpt);

--- a/ambry-tools/src/main/java/com.github.ambry/store/IndexReadPerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/IndexReadPerformance.java
@@ -21,6 +21,7 @@ import com.github.ambry.commons.BlobIdFactory;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.tools.util.ToolUtils;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Throttler;
 import com.github.ambry.utils.Utils;
@@ -113,23 +114,17 @@ public class IndexReadPerformance {
 
       OptionSet options = parser.parse(args);
 
-      ArrayList<OptionSpec<?>> listOpt = new ArrayList<OptionSpec<?>>();
+      ArrayList<OptionSpec> listOpt = new ArrayList<>();
       listOpt.add(logToReadOpt);
       listOpt.add(hardwareLayoutOpt);
       listOpt.add(partitionLayoutOpt);
 
-      for (OptionSpec opt : listOpt) {
-        if (!options.has(opt)) {
-          System.err.println("Missing required argument \"" + opt + "\"");
-          parser.printHelpOn(System.err);
-          System.exit(1);
-        }
-      }
+      ToolUtils.ensureOrExit(listOpt, options, parser);
 
       String logToRead = options.valueOf(logToReadOpt);
       int numberOfReaders = options.valueOf(numberOfReadersOpt);
       int readsPerSecond = options.valueOf(readsPerSecondOpt);
-      boolean enableVerboseLogging = options.has(verboseLoggingOpt) ? true : false;
+      boolean enableVerboseLogging = options.has(verboseLoggingOpt);
       if (enableVerboseLogging) {
         System.out.println("Enabled verbose logging");
       }

--- a/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
@@ -22,6 +22,7 @@ import com.github.ambry.commons.BlobIdFactory;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.tools.util.ToolUtils;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Throttler;
 import com.github.ambry.utils.Utils;
@@ -91,23 +92,17 @@ public class IndexWritePerformance {
 
       OptionSet options = parser.parse(args);
 
-      ArrayList<OptionSpec<?>> listOpt = new ArrayList<OptionSpec<?>>();
+      ArrayList<OptionSpec> listOpt = new ArrayList<>();
       listOpt.add(numberOfIndexesOpt);
       listOpt.add(hardwareLayoutOpt);
       listOpt.add(partitionLayoutOpt);
 
-      for (OptionSpec opt : listOpt) {
-        if (!options.has(opt)) {
-          System.err.println("Missing required argument \"" + opt + "\"");
-          parser.printHelpOn(System.err);
-          System.exit(1);
-        }
-      }
+      ToolUtils.ensureOrExit(listOpt, options, parser);
 
       int numberOfIndexes = options.valueOf(numberOfIndexesOpt);
       int numberOfWriters = options.valueOf(numberOfWritersOpt);
       int writesPerSecond = options.valueOf(writesPerSecondOpt);
-      boolean enableVerboseLogging = options.has(verboseLoggingOpt) ? true : false;
+      boolean enableVerboseLogging = options.has(verboseLoggingOpt);
       if (enableVerboseLogging) {
         System.out.println("Enabled verbose logging");
       }

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/AdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/AdminTool.java
@@ -154,18 +154,12 @@ public class AdminTool {
 
       OptionSet options = parser.parse(args);
 
-      ArrayList<OptionSpec<?>> listOpt = new ArrayList<OptionSpec<?>>();
+      ArrayList<OptionSpec> listOpt = new ArrayList<>();
       listOpt.add(hardwareLayoutOpt);
       listOpt.add(partitionLayoutOpt);
       listOpt.add(typeOfOperationOpt);
       listOpt.add(ambryBlobIdOpt);
-      for (OptionSpec opt : listOpt) {
-        if (!options.has(opt)) {
-          System.err.println("Missing required argument \"" + opt + "\"");
-          parser.printHelpOn(System.err);
-          System.exit(1);
-        }
-      }
+      ToolUtils.ensureOrExit(listOpt, options, parser);
 
       ToolUtils.validateSSLOptions(options, parser, sslEnabledDatacentersOpt, sslKeystorePathOpt, sslKeystoreTypeOpt,
           sslTruststorePathOpt, sslKeystorePasswordOpt, sslKeyPasswordOpt, sslTruststorePasswordOpt);

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/PartitionManager.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/PartitionManager.java
@@ -19,6 +19,7 @@ import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.PartitionLayout;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.tools.util.ToolUtils;
 import com.github.ambry.utils.Utils;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
@@ -96,17 +97,12 @@ public class PartitionManager {
 
       OptionSet options = parser.parse(args);
 
-      ArrayList<OptionSpec<?>> listOpt = new ArrayList<OptionSpec<?>>();
+      ArrayList<OptionSpec> listOpt = new ArrayList<OptionSpec>();
       listOpt.add(hardwareLayoutPathOpt);
       listOpt.add(operationTypeOpt);
 
-      for (OptionSpec opt : listOpt) {
-        if (!options.has(opt)) {
-          System.err.println("Missing required argument \"" + opt + "\"");
-          parser.printHelpOn(System.err);
-          System.exit(1);
-        }
-      }
+      ToolUtils.ensureOrExit(listOpt, options, parser);
+
       String hardwareLayoutPath = options.valueOf(hardwareLayoutPathOpt);
       String partitionLayoutPath = options.valueOf(partitionLayoutPathOpt);
       String outputPartitionLayoutPath =
@@ -133,13 +129,7 @@ public class PartitionManager {
         listOpt.add(numberOfPartitionsOpt);
         listOpt.add(numberOfReplicasPerDatacenterOpt);
         listOpt.add(replicaCapacityInBytesOpt);
-        for (OptionSpec opt : listOpt) {
-          if (!options.has(opt)) {
-            System.err.println("Missing required argument \"" + opt + "\"");
-            parser.printHelpOn(System.err);
-            System.exit(1);
-          }
-        }
+        ToolUtils.ensureOrExit(listOpt, options, parser);
         int numberOfPartitions = options.valueOf(numberOfPartitionsOpt);
         int numberOfReplicas = options.valueOf(numberOfReplicasPerDatacenterOpt);
         long replicaCapacityInBytes = options.valueOf(replicaCapacityInBytesOpt);
@@ -149,13 +139,7 @@ public class PartitionManager {
         listOpt.add(partitionIdsToAddReplicasToOpt);
         listOpt.add(datacenterToAddReplicasToOpt);
         listOpt.add(partitionLayoutPathOpt);
-        for (OptionSpec opt : listOpt) {
-          if (!options.has(opt)) {
-            System.err.println("Missing required argument \"" + opt + "\"");
-            parser.printHelpOn(System.err);
-            System.exit(1);
-          }
-        }
+        ToolUtils.ensureOrExit(listOpt, options, parser);
         String partitionIdsToAddReplicas = options.valueOf(partitionIdsToAddReplicasToOpt);
         String datacenterToAddReplicasTo = options.valueOf(datacenterToAddReplicasToOpt);
         if (partitionIdsToAddReplicas.compareToIgnoreCase(".") == 0) {

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerTool.java
@@ -34,6 +34,7 @@ import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.protocol.PutRequest;
 import com.github.ambry.protocol.PutResponse;
+import com.github.ambry.tools.util.ToolUtils;
 import com.github.ambry.utils.ByteBufferInputStream;
 import java.io.DataInputStream;
 import java.io.File;
@@ -336,7 +337,7 @@ public class ServerTool {
 
       OptionSet options = parser.parse(args);
 
-      ArrayList<OptionSpec<?>> listOpt = new ArrayList<OptionSpec<?>>();
+      ArrayList<OptionSpec> listOpt = new ArrayList<>();
       listOpt.add(rootDirectoryOpt);
       listOpt.add(hardwareLayoutOpt);
       listOpt.add(partitionLayoutOpt);
@@ -344,16 +345,10 @@ public class ServerTool {
       listOpt.add(datacenterOpt);
       listOpt.add(outFileOpt);
 
-      for (OptionSpec opt : listOpt) {
-        if (!options.has(opt)) {
-          System.err.println("Missing required argument \"" + opt + "\"");
-          parser.printHelpOn(System.err);
-          System.exit(1);
-        }
-      }
+      ToolUtils.ensureOrExit(listOpt, options, parser);
 
       System.out.println("Starting to parse arguments");
-      boolean enableVerboseLogging = options.has(verboseLoggingOpt) ? true : false;
+      boolean enableVerboseLogging = options.has(verboseLoggingOpt);
       if (enableVerboseLogging) {
         System.out.println("Enabled verbose logging");
       }

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerReadPerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerReadPerformance.java
@@ -163,18 +163,12 @@ public class ServerReadPerformance {
 
       OptionSet options = parser.parse(args);
 
-      ArrayList<OptionSpec<?>> listOpt = new ArrayList<OptionSpec<?>>();
+      ArrayList<OptionSpec> listOpt = new ArrayList<>();
       listOpt.add(logToReadOpt);
       listOpt.add(hardwareLayoutOpt);
       listOpt.add(partitionLayoutOpt);
 
-      for (OptionSpec opt : listOpt) {
-        if (!options.has(opt)) {
-          System.err.println("Missing required argument \"" + opt + "\"");
-          parser.printHelpOn(System.err);
-          System.exit(1);
-        }
-      }
+      ToolUtils.ensureOrExit(listOpt, options, parser);
 
       long measurementIntervalNs = options.valueOf(measurementIntervalOpt) * SystemTime.NsPerSec;
       ToolUtils.validateSSLOptions(options, parser, sslEnabledDatacentersOpt, sslKeystorePathOpt, sslKeystoreTypeOpt,
@@ -194,7 +188,7 @@ public class ServerReadPerformance {
       String logToRead = options.valueOf(logToReadOpt);
 
       int readsPerSecond = options.valueOf(readsPerSecondOpt);
-      boolean enableVerboseLogging = options.has(verboseLoggingOpt) ? true : false;
+      boolean enableVerboseLogging = options.has(verboseLoggingOpt);
       if (enableVerboseLogging) {
         System.out.println("Enabled verbose logging");
       }

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
@@ -176,17 +176,11 @@ public class ServerWritePerformance {
 
       OptionSet options = parser.parse(args);
 
-      ArrayList<OptionSpec<?>> listOpt = new ArrayList<OptionSpec<?>>();
+      ArrayList<OptionSpec> listOpt = new ArrayList<>();
       listOpt.add(hardwareLayoutOpt);
       listOpt.add(partitionLayoutOpt);
 
-      for (OptionSpec opt : listOpt) {
-        if (!options.has(opt)) {
-          System.err.println("Missing required argument \"" + opt + "\"");
-          parser.printHelpOn(System.err);
-          System.exit(1);
-        }
-      }
+      ToolUtils.ensureOrExit(listOpt, options, parser);
 
       long measurementIntervalNs = options.valueOf(measurementIntervalOpt) * SystemTime.NsPerSec;
       ToolUtils.validateSSLOptions(options, parser, sslEnabledDatacentersOpt, sslKeystorePathOpt, sslKeystoreTypeOpt,

--- a/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
@@ -13,7 +13,9 @@
  */
 package com.github.ambry.tools.util;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
@@ -80,5 +82,16 @@ public final class ToolUtils {
     props.put("connectionpool.read.timeout.ms", "10000");
     props.put("connectionpool.connect.timeout.ms", "2000");
     return props;
+  }
+
+  public static void ensureOrExit(List<OptionSpec> requiredArgs, OptionSet actualArgs, OptionParser parser)
+      throws IOException {
+    for (OptionSpec opt : requiredArgs) {
+      if (!actualArgs.has(opt)) {
+        System.err.println("Missing required argument \"" + opt + "\"");
+        parser.printHelpOn(System.err);
+        System.exit(1);
+      }
+    }
   }
 }

--- a/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
@@ -84,6 +84,13 @@ public final class ToolUtils {
     return props;
   }
 
+  /**
+   * Ensure that the given argument list has all the required arguments. If not, exit.
+   * @param requiredArgs the list of required arguments.
+   * @param actualArgs the set of actual arguments.
+   * @param parser the {@link OptionParser} used to parse arguments.
+   * @throws IOException if there is a problem writing out usage information.
+   */
   public static void ensureOrExit(List<OptionSpec> requiredArgs, OptionSet actualArgs, OptionParser parser)
       throws IOException {
     for (OptionSpec opt : requiredArgs) {

--- a/ambry-tools/src/test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -181,7 +181,8 @@ public class HelixBootstrapUpgradeToolTest {
   /**
    * A single test (for convenience) that tests bootstrap and upgrades.
    */
-  @Test
+  // @todo: uncomment when we move to Helix 0.6.7.
+  // @Test
   public void testEverything() throws Exception {
     /* Test bootstrap */
     long expectedResourceCount =

--- a/ambry-tools/src/test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -1,0 +1,372 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.clustermap;
+
+import com.github.ambry.clustermap.TestUtils.TestHardwareLayout;
+import com.github.ambry.clustermap.TestUtils.TestPartitionLayout;
+import com.github.ambry.utils.Utils;
+import com.google.common.collect.Sets;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.I0Itec.zkclient.IDefaultNameSpace;
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.ZkServer;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.github.ambry.clustermap.HelixBootstrapUpgradeTool.*;
+
+
+public class HelixBootstrapUpgradeToolTest {
+  /**
+   * A class to initialize and hold information about each Zk Server.
+   */
+  private static class ZkInfo {
+    String dcName;
+    int port;
+    String dataDir;
+    String logDir;
+    ZkServer zkServer;
+
+    /**
+     * Instantiate by starting a Zk server.
+     * @param dcName the name of the datacenter.
+     * @param port the port at which this Zk server should run on localhost.
+     */
+    ZkInfo(String dcName, int port) throws Exception {
+      this.dcName = dcName;
+      this.port = port;
+      File tempDir = Files.createTempDirectory(dcName).toFile();
+      tempDirPath = tempDir.getAbsolutePath();
+      tempDir.deleteOnExit();
+      this.dataDir = tempDirPath + "/dataDir";
+      this.logDir = tempDirPath + "/logDir";
+      startZkServer(port, dataDir, logDir);
+    }
+
+    private void startZkServer(int port, String dataDir, String logDir) throws Exception {
+      IDefaultNameSpace defaultNameSpace = new IDefaultNameSpace() {
+        @Override
+        public void createDefaultNameSpace(ZkClient zkClient) {
+        }
+      };
+      // start zookeeper
+      zkServer = new ZkServer(dataDir, logDir, defaultNameSpace, port);
+      zkServer.start();
+    }
+
+    void shutdown() {
+      zkServer.shutdown();
+    }
+  }
+
+  private static String tempDirPath;
+  private static final HashMap<String, ZkInfo> dcsToZkInfo = new HashMap<>();
+  private final String dcs[] = new String[]{"DC0", "DC1"};
+  private final String hardwareLayoutPath;
+  private final String partitionLayoutPath;
+  private final String zkLayoutPath;
+  private final JSONObject zkJson;
+  private TestHardwareLayout testHardwareLayout;
+  private TestPartitionLayout testPartitionLayout;
+
+  /**
+   * Shutdown all Zk servers before exit.
+   */
+  @AfterClass
+  public static void destroy() {
+    for (ZkInfo zkInfo : dcsToZkInfo.values()) {
+      zkInfo.shutdown();
+    }
+  }
+
+  /**
+   * Initialize ZKInfos for all dcs and start the ZK server.
+   */
+  public HelixBootstrapUpgradeToolTest() throws Exception {
+    int port = 2200;
+    for (String dcName : dcs) {
+      dcsToZkInfo.put(dcName, new ZkInfo(dcName, port++));
+    }
+    hardwareLayoutPath = tempDirPath + "/hardwareLayoutTest.json";
+    partitionLayoutPath = tempDirPath + "/partitionLayoutTest.json";
+    zkLayoutPath = tempDirPath + "/zkLayoutPath.json";
+    zkJson = constructZkLayoutJSON();
+    testHardwareLayout = constructInitialHardwareLayoutJSON();
+    testPartitionLayout = constructInitialPartitionLayoutJSON(testHardwareLayout);
+  }
+
+  /**
+   * Construct a ZK layout JSON using predetermined information.
+   * @return the constructed JSON.
+   */
+  private JSONObject constructZkLayoutJSON() throws JSONException {
+    JSONArray zkInfosJson = new JSONArray();
+    for (ZkInfo zkInfo : dcsToZkInfo.values()) {
+      JSONObject zkInfoJson = new JSONObject();
+      zkInfoJson.put("datacenter", zkInfo.dcName);
+      zkInfoJson.put("hostname", "localhost");
+      zkInfoJson.put("port", zkInfo.port);
+      zkInfosJson.put(zkInfoJson);
+    }
+    return new JSONObject().put("zkHosts", zkInfosJson);
+  }
+
+  /**
+   * Construct a {@link TestHardwareLayout}
+   * @return return the constructed layout.
+   */
+  private TestHardwareLayout constructInitialHardwareLayoutJSON() throws JSONException {
+    return new TestHardwareLayout("Proto", 6, 100L * 1024 * 1024 * 1024, 6, 2, 18088, 20, false);
+  }
+
+  /**
+   * Construct a {@link TestPartitionLayout}
+   * @return return the constructed layout.
+   */
+  private TestPartitionLayout constructInitialPartitionLayoutJSON(TestHardwareLayout testHardwareLayout)
+      throws JSONException {
+    return new TestPartitionLayout(testHardwareLayout, HelixBootstrapUpgradeTool.MAX_PARTITIONS_PER_RESOURCE * 3 + 20,
+        PartitionState.READ_WRITE, 1024L * 1024 * 1024, 3);
+  }
+
+  /**
+   * A single test (for convenience) that tests bootstrap and upgrades.
+   */
+  @Test
+  public void testEverything() throws Exception {
+    /* Test bootstrap */
+    long expectedResourceCount =
+        (testPartitionLayout.getPartitionLayout().getPartitionCount() - 1) / MAX_PARTITIONS_PER_RESOURCE + 1;
+    Utils.writeJsonToFile(zkJson, zkLayoutPath);
+    Utils.writeJsonToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
+    Utils.writeJsonToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
+    HelixBootstrapUpgradeTool.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, "DC1");
+    verifyEquivalencyWithStatic(testHardwareLayout.getHardwareLayout(), testPartitionLayout.getPartitionLayout(),
+        expectedResourceCount);
+
+    /* Test Simple Upgrade */
+    int numNewNodes = 4;
+    int numNewPartitions = 220;
+    testHardwareLayout.addNewDataNodes(numNewNodes);
+    testPartitionLayout.addNewPartitions(numNewPartitions);
+    expectedResourceCount += (numNewPartitions - 1) / MAX_PARTITIONS_PER_RESOURCE + 1;
+    writeBootstrapOrUpgradeAndVerify(expectedResourceCount);
+
+    /* Test sealed state update. */
+    Set<Long> partitionIdsBeforeAddition = new HashSet<>();
+    for (PartitionId partitionId : testPartitionLayout.getPartitionLayout().getPartitions()) {
+      partitionIdsBeforeAddition.add(((Partition) partitionId).getId());
+    }
+
+    // First, add new nodes and partitions (which are default READ_WRITE)
+    numNewNodes = 2;
+    numNewPartitions = 50;
+    testHardwareLayout.addNewDataNodes(numNewNodes);
+    testPartitionLayout.addNewPartitions(numNewPartitions);
+
+    // Next, mark all previous partitions as READ_ONLY
+    for (PartitionId partitionId : testPartitionLayout.getPartitionLayout().getPartitions()) {
+      if (partitionIdsBeforeAddition.contains(((Partition) partitionId).getId())) {
+        Partition partition = (Partition) partitionId;
+        partition.partitionState = PartitionState.READ_ONLY;
+      }
+    }
+
+    expectedResourceCount += (numNewPartitions - 1) / MAX_PARTITIONS_PER_RESOURCE + 1;
+    writeBootstrapOrUpgradeAndVerify(expectedResourceCount);
+
+    // Now, mark the ones that were READ_ONLY as READ_WRITE and vice versa
+    for (PartitionId partitionId : testPartitionLayout.getPartitionLayout().getPartitions()) {
+      Partition partition = (Partition) partitionId;
+      if (partitionIdsBeforeAddition.contains(((Partition) partitionId).getId())) {
+        partition.partitionState = PartitionState.READ_WRITE;
+      } else {
+        partition.partitionState = PartitionState.READ_ONLY;
+      }
+    }
+    writeBootstrapOrUpgradeAndVerify(expectedResourceCount);
+  }
+
+  /**
+   * Write the layout files out from the constructed in-memory hardware and partition layouts; use the bootstrap tool
+   * to update the contents in Helix; verify that the information is consistent between the two.
+   * @param expectedResourceCount number of resources expected in Helix for this cluster in each datacenter.
+   * @throws IOException if a file read error is encountered.
+   * @throws JSONException if a JSON parse error is encountered.
+   */
+  private void writeBootstrapOrUpgradeAndVerify(long expectedResourceCount) throws IOException, JSONException {
+    Utils.writeJsonToFile(zkJson, zkLayoutPath);
+    Utils.writeJsonToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
+    Utils.writeJsonToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
+    HelixBootstrapUpgradeTool.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, "DC1");
+    verifyEquivalencyWithStatic(testHardwareLayout.getHardwareLayout(), testPartitionLayout.getPartitionLayout(),
+        expectedResourceCount);
+  }
+
+  /**
+   * Verify that the information in Helix and the information in the static clustermap are equivalent.
+   * @param hardwareLayout the {@link HardwareLayout} of the static clustermap.
+   * @param partitionLayout the {@link PartitionLayout} of the static clustermap.
+   * @param expectedResourceCount the expected number of resources in Helix.
+   */
+  private void verifyEquivalencyWithStatic(HardwareLayout hardwareLayout, PartitionLayout partitionLayout,
+      long expectedResourceCount) {
+    String clusterName = hardwareLayout.getClusterName();
+    for (Datacenter dc : hardwareLayout.getDatacenters()) {
+      ZkInfo zkInfo = dcsToZkInfo.get(dc.getName());
+      Assert.assertNotNull(zkInfo);
+      ZKHelixAdmin admin = new ZKHelixAdmin("localhost:" + zkInfo.port);
+      Assert.assertTrue(admin.getClusters().contains(clusterName));
+      verifyResourcesAndPartitionEquivalencyInDc(dc, clusterName, partitionLayout, expectedResourceCount);
+      verifyDataNodeAndDiskEquivalencyInDc(dc, clusterName, hardwareLayout, partitionLayout);
+    }
+  }
+
+  /**
+   * Verify that the hardware layout information is in sync - which includes the node and disk information. Also verify
+   * that the replicas belonging to disks are in sync between the static cluster map and Helix.
+   * @param dc the datacenter whose information is to be verified.
+   * @param clusterName the cluster to be verified.
+   * @param hardwareLayout the {@link HardwareLayout} of the static clustermap.
+   * @param partitionLayout the {@link PartitionLayout} of the static clustermap.
+   */
+  private void verifyDataNodeAndDiskEquivalencyInDc(Datacenter dc, String clusterName, HardwareLayout hardwareLayout,
+      PartitionLayout partitionLayout) {
+    ClusterMapManager staticClusterMap = new ClusterMapManager(partitionLayout);
+    String dcName = dc.getName();
+    ZKHelixAdmin admin = new ZKHelixAdmin("localhost:" + dcsToZkInfo.get(dcName).port);
+    List<String> allInstancesInHelix = admin.getInstancesInCluster(clusterName);
+    for (DataNodeId dataNodeId : dc.getDataNodes()) {
+      Map<String, List<String>> mountPathToReplicas = getMountPathToReplicas(staticClusterMap, dataNodeId);
+      DataNode dataNode = (DataNode) dataNodeId;
+      String instanceName = dataNode.getHostname() + "_" + dataNode.getPort();
+      Assert.assertTrue(allInstancesInHelix.remove(instanceName));
+      InstanceConfig instanceConfig = admin.getInstanceConfig(clusterName, instanceName);
+
+      Map<String, Map<String, String>> diskInfos = instanceConfig.getRecord().getMapFields();
+      for (Disk disk : dataNode.getDisks()) {
+        Map<String, String> diskInfoInHelix = diskInfos.remove(disk.getMountPath());
+        Assert.assertNotNull(diskInfoInHelix);
+        Assert.assertEquals(disk.getRawCapacityInBytes(), Long.valueOf(diskInfoInHelix.get(CAPACITY_STR)).longValue());
+        Set<String> replicasInHelix;
+        String replicasStr = diskInfoInHelix.get(REPLICAS_STR);
+        if (replicasStr.isEmpty()) {
+          replicasInHelix = new HashSet<>();
+        } else {
+          replicasInHelix = Sets.newHashSet(replicasStr.split(REPLICAS_DELIM_STR));
+        }
+        Set<String> replicasInClusterMap;
+        List<String> replicaList = mountPathToReplicas.get(disk.getMountPath());
+        if (replicaList == null) {
+          replicasInClusterMap = new HashSet<>();
+        } else {
+          replicasInClusterMap = Sets.newHashSet(replicaList);
+        }
+        Assert.assertTrue(replicasInClusterMap.equals(replicasInHelix));
+      }
+
+      Assert.assertEquals(dataNode.getSSLPort(),
+          Integer.valueOf(instanceConfig.getRecord().getSimpleField(SSLPORT_STR)).intValue());
+      Assert.assertEquals(dataNode.getDatacenterName(), instanceConfig.getRecord().getSimpleField(DATACENTER_STR));
+      Assert.assertEquals(dataNode.getRackId(),
+          Long.valueOf(instanceConfig.getRecord().getSimpleField(RACKID_STR)).longValue());
+      Assert.assertEquals(dataNode.getDatacenterName(), instanceConfig.getRecord().getSimpleField(DATACENTER_STR));
+      Set<String> sealedReplicasInHelix = Sets.newHashSet(instanceConfig.getRecord().getListField(SEALED_STR));
+      Set<String> sealedReplicasInClusterMap = new HashSet<>();
+      for (Replica replica : staticClusterMap.getReplicas(dataNodeId)) {
+        if (replica.getPartition().partitionState.equals(PartitionState.READ_ONLY)) {
+          sealedReplicasInClusterMap.add(Long.toString(replica.getPartition().getId()));
+        }
+      }
+      Assert.assertTrue(sealedReplicasInClusterMap.equals(sealedReplicasInHelix));
+    }
+    Assert.assertTrue(allInstancesInHelix.isEmpty());
+  }
+
+  /**
+   * Verify that the partition layout information is in sync.
+   * @param dc the datacenter whose information is to be verified.
+   * @param clusterName the cluster to be verified.
+   * @param partitionLayout the {@link PartitionLayout} of the static clustermap.
+   * @param expectedResourceCount the expected number of resources in Helix.
+   */
+  private void verifyResourcesAndPartitionEquivalencyInDc(Datacenter dc, String clusterName,
+      PartitionLayout partitionLayout, long expectedResourceCount) {
+    String dcName = dc.getName();
+    ZKHelixAdmin admin = new ZKHelixAdmin("localhost:" + dcsToZkInfo.get(dcName).port);
+    Map<String, Set<String>> allPartitionsToInstancesInHelix = new HashMap<>();
+    long numResources = 0;
+    for (String resourceName : admin.getResourcesInCluster(clusterName)) {
+      IdealState resourceIS = admin.getResourceIdealState(clusterName, resourceName);
+      Set<String> resourcePartitions = resourceIS.getPartitionSet();
+      for (String resourcePartition : resourcePartitions) {
+        Assert.assertNull(
+            allPartitionsToInstancesInHelix.put(resourcePartition, resourceIS.getInstanceSet(resourcePartition)));
+      }
+      numResources++;
+    }
+    Assert.assertEquals(expectedResourceCount, numResources);
+    for (PartitionId partitionId : partitionLayout.getPartitions()) {
+      Partition partition = (Partition) partitionId;
+      String partitionName = Long.toString(partition.getId());
+      Set<String> replicaHostsInHelix = allPartitionsToInstancesInHelix.remove(partitionName);
+      Assert.assertNotNull(replicaHostsInHelix);
+      for (Replica replica : partition.getReplicas()) {
+        if (replica.getDataNodeId().getDatacenterName().equals(dcName)) {
+          String instanceName = replica.getDataNodeId().getHostname() + "_" + replica.getDataNodeId().getPort();
+          Assert.assertTrue(replicaHostsInHelix.remove(instanceName));
+        }
+      }
+      Assert.assertTrue(replicaHostsInHelix.isEmpty());
+    }
+    Assert.assertTrue(allPartitionsToInstancesInHelix.isEmpty());
+  }
+
+  /**
+   * A helper method that returns a map of mountPaths to a list of replicas for a given {@link DataNodeId}
+   * @param staticClusterMap the static {@link ClusterMapManager}
+   * @param dataNodeId the {@link DataNodeId} of interest.
+   * @return the constructed map.
+   */
+  static Map<String, List<String>> getMountPathToReplicas(ClusterMapManager staticClusterMap, DataNodeId dataNodeId) {
+    Map<String, List<String>> mountPathToReplicas = new HashMap<>();
+    for (Replica replica : staticClusterMap.getReplicas(dataNodeId)) {
+      List<String> replicaStrs = mountPathToReplicas.get(replica.getMountPath());
+      if (replicaStrs != null) {
+        replicaStrs.add(Long.toString(replica.getPartition().getId()));
+      } else {
+        replicaStrs = new ArrayList<>();
+        replicaStrs.add(Long.toString(replica.getPartition().getId()));
+        mountPathToReplicas.put(replica.getMountPath(), replicaStrs);
+      }
+    }
+    return mountPathToReplicas;
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ project(':ambry-clustermap') {
     dependencies {
         compile project(':ambry-api'),
                 project(':ambry-utils')
+        compile "org.apache.helix:helix-core:$helixVersion"
         compile "com.codahale.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"
     }
@@ -186,6 +187,7 @@ project(':ambry-tools') {
                 project(':ambry-admin'),
                 project(':ambry-frontend')
         compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
+        testCompile project(':ambry-clustermap').sourceSets.test.output
     }
 }
 
@@ -269,6 +271,7 @@ task allJar(type: Jar, dependsOn: subprojects.assemble) {
         attributes 'Implementation-Title': 'Ambry',
                    'Main-Class': 'com.github.ambry.server.AmbryMain'
     }
+    zip64 true
     destinationDir = file('target')
     baseName = 'ambry'
     subprojects.each { subproject ->

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -17,5 +17,5 @@ ext {
     commonsVersion = "1.5"
     bouncycastleVersion = "1.52"
     javaxVersion = "3.0.1"
-    helixVersion = "0.6.7"
+    helixVersion = "0.6.6"
 }

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -17,5 +17,5 @@ ext {
     commonsVersion = "1.5"
     bouncycastleVersion = "1.52"
     javaxVersion = "3.0.1"
-    helixVersion = "0.6.7-SNAPSHOT"
+    helixVersion = "0.6.7"
 }

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -17,4 +17,5 @@ ext {
     commonsVersion = "1.5"
     bouncycastleVersion = "1.52"
     javaxVersion = "3.0.1"
+    helixVersion = "0.6.7-SNAPSHOT"
 }


### PR DESCRIPTION
- Add a tool to bootstrap and, from time to time, upgrade
  cluster map information in Helix from the static clustermap files.
- Adds tests to verify the tool's claims.
- Adds certain functionalities in the test classes of the static
  cluster map to help test the tool.

Part of #524 

--
Notes:
* Main changes to be reviewed are in `HelixBootstrapUpgradeTool.java` and `HelixBootstrapUpgradeToolTest.java`.
* Tests cover all of the core functionalities.
* We make use of a recently added [method](https://github.com/apache/helix/commit/0737d7accbf70c78bab72be02a39ad8300266fe1) in Helix. This is available in Helix 0.6.7, which has not yet been published. For now, have commented out the applicable lines and marked TODOs that will be taken care of once 0.6.7 is out.