### PR TITLE
Adhering to RFC7232 

### DIFF
--- a/ambry-admin/src/main/java/com.github.ambry.admin/AdminSecurityService.java
+++ b/ambry-admin/src/main/java/com.github.ambry.admin/AdminSecurityService.java
@@ -98,14 +98,14 @@ class AdminSecurityService implements SecurityService {
             RestUtils.SubResource subResource = RestUtils.getBlobSubResource(restRequest);
             if (subResource == null) {
               Long ifModifiedSinceMs = getIfModifiedSinceMs(restRequest);
+              responseChannel.setHeader(RestUtils.Headers.LAST_MODIFIED,
+                  new Date(blobInfo.getBlobProperties().getCreationTimeInMs()));
               if (ifModifiedSinceMs != null
                   && RestUtils.toSecondsPrecisionInMs(blobInfo.getBlobProperties().getCreationTimeInMs())
                   <= ifModifiedSinceMs) {
                 responseChannel.setStatus(ResponseStatus.NotModified);
-                responseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
+                setCacheHeaders(blobInfo.getBlobProperties().isPrivate(), responseChannel);
               } else {
-                responseChannel.setHeader(RestUtils.Headers.LAST_MODIFIED,
-                    new Date(blobInfo.getBlobProperties().getCreationTimeInMs()));
                 setGetBlobResponseHeaders(responseChannel, blobInfo);
               }
             } else {
@@ -187,7 +187,17 @@ class AdminSecurityService implements SecurityService {
         restResponseChannel.setHeader("Content-Disposition", "attachment");
       }
     }
-    if (blobProperties.isPrivate()) {
+    setCacheHeaders(blobProperties.isPrivate(), restResponseChannel);
+  }
+
+  /**
+   * Sets headers that provide directions to proxies and caches.
+   * @param isPrivate whether the blob is private.
+   * @param restResponseChannel the channel that the response will be sent over
+   * @throws RestServiceException if there is any problem setting the headers
+   */
+  private void setCacheHeaders(boolean isPrivate, RestResponseChannel restResponseChannel) throws RestServiceException {
+    if (isPrivate) {
       restResponseChannel.setHeader(RestUtils.Headers.EXPIRES, new Date(0));
       restResponseChannel.setHeader(RestUtils.Headers.CACHE_CONTROL, "private, no-cache, no-store, proxy-revalidate");
       restResponseChannel.setHeader(RestUtils.Headers.PRAGMA, "no-cache");

--- a/ambry-admin/src/main/java/com.github.ambry.admin/AdminSecurityService.java
+++ b/ambry-admin/src/main/java/com.github.ambry.admin/AdminSecurityService.java
@@ -198,7 +198,7 @@ class AdminSecurityService implements SecurityService {
    */
   private void setCacheHeaders(boolean isPrivate, RestResponseChannel restResponseChannel) throws RestServiceException {
     if (isPrivate) {
-      restResponseChannel.setHeader(RestUtils.Headers.EXPIRES, new Date(0));
+      restResponseChannel.setHeader(RestUtils.Headers.EXPIRES, restResponseChannel.getHeader(RestUtils.Headers.DATE));
       restResponseChannel.setHeader(RestUtils.Headers.CACHE_CONTROL, "private, no-cache, no-store, proxy-revalidate");
       restResponseChannel.setHeader(RestUtils.Headers.PRAGMA, "no-cache");
     } else {

--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
@@ -707,7 +707,7 @@ public class AdminBlobStorageServiceTest {
    * @param getOption the options to use while getting the blob.
    * @throws Exception
    */
-  public void getNotModifiedBlobAndVerify(String blobId, GetOption getOption) throws Exception {
+  private void getNotModifiedBlobAndVerify(String blobId, GetOption getOption) throws Exception {
     JSONObject headers = new JSONObject();
     if (getOption != null) {
       headers.put(RestUtils.Headers.GET_OPTION, getOption.toString());
@@ -721,11 +721,12 @@ public class AdminBlobStorageServiceTest {
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(restRequest, restResponseChannel);
     assertEquals("Unexpected response status", ResponseStatus.NotModified, restResponseChannel.getStatus());
-    assertTrue("No Date header", restResponseChannel.getHeader(RestUtils.Headers.DATE) != null);
-    assertNull("No Last-Modified header expected", restResponseChannel.getHeader("Last-Modified"));
+    assertNotNull("Date header expected", restResponseChannel.getHeader(RestUtils.Headers.DATE));
+    assertNotNull("Last-Modified header expected", restResponseChannel.getHeader(RestUtils.Headers.LAST_MODIFIED));
     assertNull(RestUtils.Headers.BLOB_SIZE + " should have been null ",
         restResponseChannel.getHeader(RestUtils.Headers.BLOB_SIZE));
     assertNull("Content-Type should have been null", restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
+    assertNull("Content-Length should have been null", restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
     assertEquals("No content expected as blob is not modified", 0, restResponseChannel.getResponseBody().length);
   }
 

--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminIntegrationTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminIntegrationTest.java
@@ -129,14 +129,14 @@ public class AdminIntegrationTest {
     doGetHeadDeleteTest(0, false);
     doGetHeadDeleteTest(0, true);
 
-    doGetHeadDeleteTest(1024, false);
-    doGetHeadDeleteTest(1024, true);
+    doGetHeadDeleteTest(ADMIN_CONFIG.adminChunkedGetResponseThresholdInBytes - 1, false);
+    doGetHeadDeleteTest(ADMIN_CONFIG.adminChunkedGetResponseThresholdInBytes - 1, true);
 
-    doGetHeadDeleteTest(8192, false);
-    doGetHeadDeleteTest(8192, true);
+    doGetHeadDeleteTest(ADMIN_CONFIG.adminChunkedGetResponseThresholdInBytes, false);
+    doGetHeadDeleteTest(ADMIN_CONFIG.adminChunkedGetResponseThresholdInBytes, true);
 
-    doGetHeadDeleteTest(10000, false);
-    doGetHeadDeleteTest(10000, true);
+    doGetHeadDeleteTest(ADMIN_CONFIG.adminChunkedGetResponseThresholdInBytes * 3, false);
+    doGetHeadDeleteTest(ADMIN_CONFIG.adminChunkedGetResponseThresholdInBytes * 3, true);
   }
 
   /*

--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminSecurityServiceTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminSecurityServiceTest.java
@@ -199,6 +199,14 @@ public class AdminSecurityServiceTest {
     blobInfo =
         new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, Utils.Infinite_Time), null);
     testGetBlob(blobInfo);
+    // not modified response
+    // > creation time (in secs).
+    testGetNotModifiedBlob(blobInfo, blobInfo.getBlobProperties().getCreationTimeInMs() + 1000);
+    // == creation time
+    testGetNotModifiedBlob(blobInfo, blobInfo.getBlobProperties().getCreationTimeInMs());
+    // < creation time (in secs)
+    testGetNotModifiedBlob(blobInfo, blobInfo.getBlobProperties().getCreationTimeInMs() - 1000);
+
     // Get blob for a public blob with content type as "text/html"
     blobInfo = new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, "text/html", true, 10000), null);
     testGetBlob(blobInfo);
@@ -277,7 +285,7 @@ public class AdminSecurityServiceTest {
     if (ifModifiedSinceMs >= blobInfo.getBlobProperties().getCreationTimeInMs()) {
       Assert.assertEquals("Not modified response expected", ResponseStatus.NotModified,
           restResponseChannel.getStatus());
-      verifyHeadersForGetBlobNotModified(restResponseChannel);
+      verifyHeadersForGetBlobNotModified(restResponseChannel, blobInfo.getBlobProperties().isPrivate());
     } else {
       Assert.assertEquals("Not modified response should not be returned", ResponseStatus.Ok,
           restResponseChannel.getStatus());
@@ -410,7 +418,33 @@ public class AdminSecurityServiceTest {
           restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
     }
 
-    if (blobProperties.isPrivate()) {
+    verifyCacheHeaders(blobProperties.isPrivate(), restResponseChannel);
+  }
+
+  /**
+   * Verify the headers from the response for a Not modified blob are as expected
+   * @param restResponseChannel {@link MockRestResponseChannel} from which headers are to be verified
+   * @param isPrivate {@code true} if blob is private, {@code false} otherwise.
+   * @throws RestServiceException if there was any problem getting the headers.
+   */
+  private void verifyHeadersForGetBlobNotModified(MockRestResponseChannel restResponseChannel, boolean isPrivate)
+      throws RestServiceException {
+    Assert.assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
+    Assert.assertNotNull("Last-Modified has not been set",
+        restResponseChannel.getHeader(RestUtils.Headers.LAST_MODIFIED));
+    Assert.assertNull("Content length should not have been set",
+        restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
+    verifyCacheHeaders(isPrivate, restResponseChannel);
+    verifyAbsenceOfHeaders(restResponseChannel, RestUtils.Headers.BLOB_SIZE, RestUtils.Headers.CONTENT_TYPE);
+  }
+
+  /**
+   * Verifies that the right cache headers are returned.
+   * @param isPrivate {@code true} if the blob is private, {@code false} if not.
+   * @param restResponseChannel the {@link RestResponseChannel} over which the response is sent.
+   */
+  private void verifyCacheHeaders(boolean isPrivate, MockRestResponseChannel restResponseChannel) {
+    if (isPrivate) {
       Assert.assertEquals("Expires value is incorrect for private blob", 0,
           RestUtils.getTimeFromDateString(restResponseChannel.getHeader(RestUtils.Headers.EXPIRES)).longValue());
       Assert.assertEquals("Cache-Control value not as expected", "private, no-cache, no-store, proxy-revalidate",
@@ -419,28 +453,13 @@ public class AdminSecurityServiceTest {
           restResponseChannel.getHeader(RestUtils.Headers.PRAGMA));
     } else {
       Assert.assertTrue("Expires value should be in the future",
-          RestUtils.getTimeFromDateString(restResponseChannel.getHeader(RestUtils.Headers.EXPIRES)).longValue() > System
-              .currentTimeMillis());
+          RestUtils.getTimeFromDateString(restResponseChannel.getHeader(RestUtils.Headers.EXPIRES))
+              > System.currentTimeMillis());
       Assert.assertEquals("Cache-Control value not as expected", "max-age=" + ADMIN_CONFIG.adminCacheValiditySeconds,
           restResponseChannel.getHeader(RestUtils.Headers.CACHE_CONTROL));
       Assert.assertNull("Pragma value should not have been set",
           restResponseChannel.getHeader(RestUtils.Headers.PRAGMA));
     }
-  }
-
-  /**
-   * Verify the headers from the response for a Not modified blob are as expected
-   * @param restResponseChannel {@link MockRestResponseChannel} from which headers are to be verified
-   * @throws RestServiceException if there was any problem getting the headers.
-   */
-  private void verifyHeadersForGetBlobNotModified(MockRestResponseChannel restResponseChannel)
-      throws RestServiceException {
-    Assert.assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
-    Assert.assertEquals("Content length should have been 0", "0",
-        restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
-    verifyAbsenceOfHeaders(restResponseChannel, RestUtils.Headers.LAST_MODIFIED, RestUtils.Headers.BLOB_SIZE,
-        RestUtils.Headers.CONTENT_TYPE, RestUtils.Headers.EXPIRES, RestUtils.Headers.CACHE_CONTROL,
-        RestUtils.Headers.PRAGMA);
   }
 
   /**

--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminSecurityServiceTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminSecurityServiceTest.java
@@ -445,8 +445,9 @@ public class AdminSecurityServiceTest {
    */
   private void verifyCacheHeaders(boolean isPrivate, MockRestResponseChannel restResponseChannel) {
     if (isPrivate) {
-      Assert.assertEquals("Expires value is incorrect for private blob", 0,
-          RestUtils.getTimeFromDateString(restResponseChannel.getHeader(RestUtils.Headers.EXPIRES)).longValue());
+      Assert.assertEquals("Expires value is incorrect for private blob",
+          restResponseChannel.getHeader(RestUtils.Headers.DATE),
+          restResponseChannel.getHeader(RestUtils.Headers.EXPIRES));
       Assert.assertEquals("Cache-Control value not as expected", "private, no-cache, no-store, proxy-revalidate",
           restResponseChannel.getHeader(RestUtils.Headers.CACHE_CONTROL));
       Assert.assertEquals("Pragma value not as expected", "no-cache",

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -241,7 +241,7 @@ class AmbrySecurityService implements SecurityService {
    */
   private void setCacheHeaders(boolean isPrivate, RestResponseChannel restResponseChannel) throws RestServiceException {
     if (isPrivate) {
-      restResponseChannel.setHeader(RestUtils.Headers.EXPIRES, new Date(0));
+      restResponseChannel.setHeader(RestUtils.Headers.EXPIRES, restResponseChannel.getHeader(RestUtils.Headers.DATE));
       restResponseChannel.setHeader(RestUtils.Headers.CACHE_CONTROL, "private, no-cache, no-store, proxy-revalidate");
       restResponseChannel.setHeader(RestUtils.Headers.PRAGMA, "no-cache");
     } else {

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -117,9 +117,9 @@ class AmbrySecurityService implements SecurityService {
           case GET:
             responseChannel.setStatus(ResponseStatus.Ok);
             RestUtils.SubResource subResource = RestUtils.getBlobSubResource(restRequest);
+            responseChannel.setHeader(RestUtils.Headers.LAST_MODIFIED,
+                new Date(blobInfo.getBlobProperties().getCreationTimeInMs()));
             if (subResource == null) {
-              responseChannel.setHeader(RestUtils.Headers.LAST_MODIFIED,
-                  new Date(blobInfo.getBlobProperties().getCreationTimeInMs()));
               Long ifModifiedSinceMs = getIfModifiedSinceMs(restRequest);
               if (ifModifiedSinceMs != null
                   && RestUtils.toSecondsPrecisionInMs(blobInfo.getBlobProperties().getCreationTimeInMs())
@@ -134,8 +134,6 @@ class AmbrySecurityService implements SecurityService {
                 setGetBlobResponseHeaders(blobInfo, options, responseChannel);
               }
             } else {
-              responseChannel.setHeader(RestUtils.Headers.LAST_MODIFIED,
-                  new Date(blobInfo.getBlobProperties().getCreationTimeInMs()));
               if (subResource.equals(RestUtils.SubResource.BlobInfo)) {
                 setBlobPropertiesHeaders(blobInfo.getBlobProperties(), responseChannel);
               }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -735,11 +735,12 @@ public class AmbryBlobStorageServiceTest {
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(restRequest, restResponseChannel);
     assertEquals("Unexpected response status", ResponseStatus.NotModified, restResponseChannel.getStatus());
-    assertTrue("No Date header", restResponseChannel.getHeader(RestUtils.Headers.DATE) != null);
-    assertNull("No Last-Modified header expected", restResponseChannel.getHeader("Last-Modified"));
+    assertNotNull("Date header expected", restResponseChannel.getHeader(RestUtils.Headers.DATE));
+    assertNotNull("Last-Modified header expected", restResponseChannel.getHeader(RestUtils.Headers.LAST_MODIFIED));
     assertNull(RestUtils.Headers.BLOB_SIZE + " should have been null ",
         restResponseChannel.getHeader(RestUtils.Headers.BLOB_SIZE));
     assertNull("Content-Type should have been null", restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
+    assertNull("Content-Length should have been null", restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
     assertEquals("No content expected as blob is not modified", 0, restResponseChannel.getResponseBody().length);
     assertNull("Accept-Ranges should not be set", restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
     assertNull("Content-Range header should not be set",

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -622,8 +622,9 @@ public class AmbrySecurityServiceTest {
    */
   private void verifyCacheHeaders(boolean isPrivate, MockRestResponseChannel restResponseChannel) {
     if (isPrivate) {
-      Assert.assertEquals("Expires value is incorrect for private blob", 0,
-          RestUtils.getTimeFromDateString(restResponseChannel.getHeader(RestUtils.Headers.EXPIRES)).longValue());
+      Assert.assertEquals("Expires value is incorrect for private blob",
+          restResponseChannel.getHeader(RestUtils.Headers.DATE),
+          restResponseChannel.getHeader(RestUtils.Headers.EXPIRES));
       Assert.assertEquals("Cache-Control value not as expected", "private, no-cache, no-store, proxy-revalidate",
           restResponseChannel.getHeader(RestUtils.Headers.CACHE_CONTROL));
       Assert.assertEquals("Pragma value not as expected", "no-cache",

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -215,6 +215,14 @@ public class AmbrySecurityServiceTest {
     blobInfo =
         new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, Utils.Infinite_Time), null);
     testGetBlobWithVariousRanges(blobInfo);
+    // not modified response
+    // > creation time (in secs).
+    testGetNotModifiedBlob(blobInfo, blobInfo.getBlobProperties().getCreationTimeInMs() + 1000);
+    // == creation time
+    testGetNotModifiedBlob(blobInfo, blobInfo.getBlobProperties().getCreationTimeInMs());
+    // < creation time (in secs)
+    testGetNotModifiedBlob(blobInfo, blobInfo.getBlobProperties().getCreationTimeInMs() - 1000);
+
     // Get blob for a public blob with content type as "text/html"
     blobInfo = new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, "text/html", true, 10000), null);
     testGetBlobWithVariousRanges(blobInfo);
@@ -370,7 +378,7 @@ public class AmbrySecurityServiceTest {
     if (ifModifiedSinceMs >= blobInfo.getBlobProperties().getCreationTimeInMs()) {
       Assert.assertEquals("Not modified response expected", ResponseStatus.NotModified,
           restResponseChannel.getStatus());
-      verifyHeadersForGetBlobNotModified(restResponseChannel);
+      verifyHeadersForGetBlobNotModified(restResponseChannel, blobInfo.getBlobProperties().isPrivate());
     } else {
       Assert.assertEquals("Not modified response should not be returned", ResponseStatus.Ok,
           restResponseChannel.getStatus());
@@ -583,8 +591,37 @@ public class AmbrySecurityServiceTest {
       Assert.assertNull("Content length value should not be set",
           restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
     }
+    verifyCacheHeaders(blobProperties.isPrivate(), restResponseChannel);
+  }
 
-    if (blobProperties.isPrivate()) {
+  /**
+   * Verify the headers from the response for a Not modified blob are as expected
+   * @param restResponseChannel {@link MockRestResponseChannel} from which headers are to be verified
+   * @param isPrivate {@code true} if blob is private, {@code false} otherwise.
+   * @throws RestServiceException if there was any problem getting the headers.
+   */
+  private void verifyHeadersForGetBlobNotModified(MockRestResponseChannel restResponseChannel, boolean isPrivate)
+      throws RestServiceException {
+    Assert.assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
+    Assert.assertNotNull("Last-Modified has not been set",
+        restResponseChannel.getHeader(RestUtils.Headers.LAST_MODIFIED));
+    Assert.assertNull("Content length should not be set",
+        restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
+    Assert.assertNull("Accept-Ranges should not be set",
+        restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
+    Assert.assertNull("Content-Range header should not be set",
+        restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
+    verifyCacheHeaders(isPrivate, restResponseChannel);
+    verifyAbsenceOfHeaders(restResponseChannel, RestUtils.Headers.BLOB_SIZE, RestUtils.Headers.CONTENT_TYPE);
+  }
+
+  /**
+   * Verifies that the right cache headers are returned.
+   * @param isPrivate {@code true} if the blob is private, {@code false} if not.
+   * @param restResponseChannel the {@link RestResponseChannel} over which the response is sent.
+   */
+  private void verifyCacheHeaders(boolean isPrivate, MockRestResponseChannel restResponseChannel) {
+    if (isPrivate) {
       Assert.assertEquals("Expires value is incorrect for private blob", 0,
           RestUtils.getTimeFromDateString(restResponseChannel.getHeader(RestUtils.Headers.EXPIRES)).longValue());
       Assert.assertEquals("Cache-Control value not as expected", "private, no-cache, no-store, proxy-revalidate",
@@ -593,33 +630,14 @@ public class AmbrySecurityServiceTest {
           restResponseChannel.getHeader(RestUtils.Headers.PRAGMA));
     } else {
       Assert.assertTrue("Expires value should be in the future",
-          RestUtils.getTimeFromDateString(restResponseChannel.getHeader(RestUtils.Headers.EXPIRES)).longValue() > System
-              .currentTimeMillis());
+          RestUtils.getTimeFromDateString(restResponseChannel.getHeader(RestUtils.Headers.EXPIRES))
+              > System.currentTimeMillis());
       Assert.assertEquals("Cache-Control value not as expected",
           "max-age=" + FRONTEND_CONFIG.frontendCacheValiditySeconds,
           restResponseChannel.getHeader(RestUtils.Headers.CACHE_CONTROL));
       Assert.assertNull("Pragma value should not have been set",
           restResponseChannel.getHeader(RestUtils.Headers.PRAGMA));
     }
-  }
-
-  /**
-   * Verify the headers from the response for a Not modified blob are as expected
-   * @param restResponseChannel {@link MockRestResponseChannel} from which headers are to be verified
-   * @throws RestServiceException if there was any problem getting the headers.
-   */
-  private void verifyHeadersForGetBlobNotModified(MockRestResponseChannel restResponseChannel)
-      throws RestServiceException {
-    Assert.assertNotNull("Date has not been set", restResponseChannel.getHeader(RestUtils.Headers.DATE));
-    Assert.assertEquals("Content length should have been 0", "0",
-        restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
-    Assert.assertNull("Accept-Ranges should not be set",
-        restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
-    Assert.assertNull("Content-Range header should not be set",
-        restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
-    verifyAbsenceOfHeaders(restResponseChannel, RestUtils.Headers.LAST_MODIFIED, RestUtils.Headers.BLOB_SIZE,
-        RestUtils.Headers.CONTENT_TYPE, RestUtils.Headers.EXPIRES, RestUtils.Headers.CACHE_CONTROL,
-        RestUtils.Headers.PRAGMA);
   }
 
   /**

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -60,6 +60,7 @@ import java.util.Queue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -299,7 +300,7 @@ public class FrontendIntegrationTest {
       getBlobAndVerify(blobId, range, headers, content);
       getHeadAndVerify(blobId, range, headers);
     }
-    getNotModifiedBlobAndVerify(blobId);
+    getNotModifiedBlobAndVerify(blobId, false);
     getUserMetadataAndVerify(blobId, headers, usermetadata);
     getBlobInfoAndVerify(blobId, headers, usermetadata);
     deleteBlobAndVerify(blobId);
@@ -409,6 +410,7 @@ public class FrontendIntegrationTest {
       assertEquals("Content-length not as expected", expectedContentArray.length,
           HttpHeaders.getContentLength(response));
     }
+    verifyCacheHeaders(Boolean.parseBoolean(expectedHeaders.get(RestUtils.Headers.PRIVATE)), response);
     byte[] responseContentArray = getContent(responseParts, expectedContentArray.length).array();
     assertArrayEquals("GET content does not match original content", expectedContentArray, responseContentArray);
     assertTrue("Channel should be active", HttpHeaders.isKeepAlive(response));
@@ -417,22 +419,25 @@ public class FrontendIntegrationTest {
   /**
    * Gets the blob with blob ID {@code blobId} and verifies that the blob is not returned as blob is not modified
    * @param blobId the blob ID of the blob to GET.
+   * @param isPrivate {@code true} if the blob is private, {@code false} if not.
    * @throws Exception
    */
-  private void getNotModifiedBlobAndVerify(String blobId) throws Exception {
+  private void getNotModifiedBlobAndVerify(String blobId, boolean isPrivate) throws Exception {
     HttpHeaders headers = new DefaultHttpHeaders();
     headers.add(RestUtils.Headers.IF_MODIFIED_SINCE, new Date());
     FullHttpRequest httpRequest = buildRequest(HttpMethod.GET, blobId, headers, null);
     Queue<HttpObject> responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
     HttpResponse response = (HttpResponse) responseParts.poll();
     assertEquals("Unexpected response status", HttpResponseStatus.NOT_MODIFIED, response.getStatus());
-    assertTrue("No Date header", response.headers().get(RestUtils.Headers.DATE) != null);
-    assertNull("No Last-Modified header expected", response.headers().get("Last-Modified"));
+    assertNotNull("Date header should be set", response.headers().get(RestUtils.Headers.DATE));
+    assertNotNull("Last-Modified header should be set", response.headers().get("Last-Modified"));
+    assertNull("Content-Length should not be set", response.headers().get(RestUtils.Headers.CONTENT_LENGTH));
     assertNull("Accept-Ranges should not be set", response.headers().get(RestUtils.Headers.ACCEPT_RANGES));
     assertNull("Content-Range header should not be set", response.headers().get(RestUtils.Headers.CONTENT_RANGE));
     assertNull(RestUtils.Headers.BLOB_SIZE + " should have been null ",
         response.headers().get(RestUtils.Headers.BLOB_SIZE));
     assertNull("Content-Type should have been null", response.headers().get(RestUtils.Headers.CONTENT_TYPE));
+    verifyCacheHeaders(isPrivate, response);
     assertNoContent(responseParts);
   }
 
@@ -628,6 +633,28 @@ public class FrontendIntegrationTest {
   private void checkCommonGetHeadHeaders(HttpHeaders receivedHeaders) {
     assertTrue("No Date header", receivedHeaders.get(HttpHeaders.Names.DATE) != null);
     assertTrue("No Last-Modified header", receivedHeaders.get(HttpHeaders.Names.LAST_MODIFIED) != null);
+  }
+
+  /**
+   * Verifies that the right cache headers are returned.
+   * @param isPrivate {@code true} if the blob is private, {@code false} if not.
+   * @param response the {@link HttpResponse}.
+   */
+  private void verifyCacheHeaders(boolean isPrivate, HttpResponse response) {
+    if (isPrivate) {
+      Assert.assertEquals("Cache-Control value not as expected", "private, no-cache, no-store, proxy-revalidate",
+          response.headers().get(RestUtils.Headers.CACHE_CONTROL));
+      Assert.assertEquals("Pragma value not as expected", "no-cache", response.headers().get(RestUtils.Headers.PRAGMA));
+    } else {
+      String expiresValue = response.headers().get(RestUtils.Headers.EXPIRES);
+      assertNotNull("Expires value should be non null", expiresValue);
+      assertTrue("Expires value should be in future",
+          RestUtils.getTimeFromDateString(expiresValue) > System.currentTimeMillis());
+      Assert.assertEquals("Cache-Control value not as expected",
+          "max-age=" + FRONTEND_CONFIG.frontendCacheValiditySeconds,
+          response.headers().get(RestUtils.Headers.CACHE_CONTROL));
+      Assert.assertNull("Pragma value should not have been set", response.headers().get(RestUtils.Headers.PRAGMA));
+    }
   }
 
   /**

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -130,9 +130,9 @@ public class FrontendIntegrationTest {
   @Test
   public void postGetHeadDeleteTest() throws Exception {
     doPostGetHeadDeleteTest(0, false);
-    doPostGetHeadDeleteTest(1024, false);
-    doPostGetHeadDeleteTest(8192, false);
-    doPostGetHeadDeleteTest(10000, false);
+    doPostGetHeadDeleteTest(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes - 1, false);
+    doPostGetHeadDeleteTest(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes, false);
+    doPostGetHeadDeleteTest(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes * 3, false);
   }
 
   /**

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -305,12 +305,13 @@ class NettyResponseChannel implements RestResponseChannel {
     if (responseMetadataWriteInitiated.compareAndSet(false, true) && ctx.channel().isActive()) {
       // we do some manipulation here for chunking. According to the HTTP spec, we can have either a Content-Length
       // or Transfer-Encoding:chunked, never both. So we check for Content-Length - if it is not there, we add
-      // Transfer-Encoding:chunked. Note that sending HttpContent chunks data anyway - we are just explicitly specifying
-      // this in the header.
-      if (!HttpHeaders.isContentLengthSet(responseMetadata)) {
+      // Transfer-Encoding:chunked on 200 response. Note that sending HttpContent chunks data anyway - we are just
+      // explicitly specifying this in the header.
+      if (!HttpHeaders.isContentLengthSet(responseMetadata) && (responseMetadata.getStatus()
+          .equals(HttpResponseStatus.OK) || responseMetadata.getStatus().equals(HttpResponseStatus.PARTIAL_CONTENT))) {
         // This makes sure that we don't stomp on any existing transfer-encoding.
         HttpHeaders.setTransferEncodingChunked(responseMetadata);
-      } else if (HttpHeaders.getContentLength(responseMetadata) == 0
+      } else if (HttpHeaders.isContentLengthSet(responseMetadata) && HttpHeaders.getContentLength(responseMetadata) == 0
           && !(responseMetadata instanceof FullHttpResponse)) {
         // if the Content-Length is 0, we can send a FullHttpResponse since there is no content expected.
         FullHttpResponse fullHttpResponse =

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -307,8 +307,9 @@ class NettyResponseChannel implements RestResponseChannel {
       // or Transfer-Encoding:chunked, never both. So we check for Content-Length - if it is not there, we add
       // Transfer-Encoding:chunked on 200 response. Note that sending HttpContent chunks data anyway - we are just
       // explicitly specifying this in the header.
-      if (!HttpHeaders.isContentLengthSet(responseMetadata) && (responseMetadata.getStatus()
-          .equals(HttpResponseStatus.OK) || responseMetadata.getStatus().equals(HttpResponseStatus.PARTIAL_CONTENT))) {
+      if (!HttpHeaders.isContentLengthSet(responseMetadata) && (
+          responseMetadata.getStatus().equals(HttpResponseStatus.OK) || responseMetadata.getStatus()
+              .equals(HttpResponseStatus.PARTIAL_CONTENT))) {
         // This makes sure that we don't stomp on any existing transfer-encoding.
         HttpHeaders.setTransferEncodingChunked(responseMetadata);
       } else if (HttpHeaders.isContentLengthSet(responseMetadata) && HttpHeaders.getContentLength(responseMetadata) == 0


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7232#section-4.1
Need to send Expires and Cache-Control messages during revalidation (304)

`./gradlew build && ./gradlew test`passed.
Formatted.

Tests cover all new lines. 

Reviewers: @cgtz 
Expected time to review: 15-20 mins