### PR TITLE
Introduce notion of participant and a Helix based implementation

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipant.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.clustermap;
+
+/**
+ * A ClusterParticipant is a component that makes up the Ambry cluster.
+ */
+public interface ClusterParticipant {
+  /**
+   * Initialize the participant.
+   */
+  void initialize(String hostname, int port) throws Exception;
+
+  /**
+   * Terminate the participant.
+   */
+  void terminate();
+}

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipantFactory.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipantFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.clustermap;
+
+/**
+ * A factory interface to get a {@link ClusterParticipant}
+ */
+public interface ClusterParticipantFactory {
+  /**
+   * Get a reference to a {@link ClusterParticipant}
+   */
+  ClusterParticipant getClusterParticipant();
+}

--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -25,11 +25,8 @@ public class ClusterMapConfig {
   @Default("com.github.ambry.clustermap.FixedBackoffResourceStatePolicyFactory")
   public final String clusterMapResourceStatePolicyFactory;
 
-  /**
-   * The fixed timeout based resource state handling checks if we have had a 'threshold'
-   * number of consecutive errors, and if so, considers the resource as down for
-   * 'retry backoff' milliseconds.
-   */
+  // The fixed timeout based resource state handling checks if we have had a 'threshold' number of consecutive errors,
+  // and if so, considers the resource as down for 'retry backoff' milliseconds.
 
   /**
    * The threshold for the number of consecutive errors to tolerate for a datanode.
@@ -66,6 +63,26 @@ public class ClusterMapConfig {
   @Default("")
   public final String clusterMapSslEnabledDatacenters;
 
+  /**
+   * The zk connect string cluster participants should use in the Helix based dynamic cluster manager.
+   */
+  @Config("clustermap.participant.zk.connect.string")
+  @Default("")
+  public final String clusterMapParticipantZkConnectString;
+
+  /**
+   * The clustermap participant factory to use.
+   */
+  @Config("clustermap.participant.factory")
+  @Default("com.github.ambry.clustermap.StaticParticipantFactory")
+  public final String clusterMapParticipantFactory;
+
+  /**
+   * The name of the associated cluster for this node.
+   */
+  @Config("clustermap.cluster.name")
+  public final String clusterMapClusterName;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapResourceStatePolicyFactory = verifiableProperties.getString("clustermap.resourcestatepolicy.factory",
         "com.github.ambry.clustermap.FixedBackoffResourceStatePolicyFactory");
@@ -80,5 +97,10 @@ public class ClusterMapConfig {
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.disk.retry.backoff.ms", 10 * 60 * 1000, 1,
             30 * 60 * 1000);
     clusterMapSslEnabledDatacenters = verifiableProperties.getString("clustermap.ssl.enabled.datacenters", "");
+    clusterMapClusterName = verifiableProperties.getString("clustermap.cluster.name");
+    clusterMapParticipantFactory = verifiableProperties.getString("clustermap.participant.factory",
+        "com.github.ambry.clustermap.StaticParticipantFactory");
+    clusterMapParticipantZkConnectString =
+        verifiableProperties.getString("clustermap.participant.zk.connect.string", "");
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModel.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import org.apache.helix.NotificationContext;
+import org.apache.helix.model.Message;
+import org.apache.helix.participant.statemachine.StateModel;
+import org.apache.helix.participant.statemachine.StateModelInfo;
+import org.apache.helix.participant.statemachine.StateModelParser;
+import org.apache.helix.participant.statemachine.Transition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * {@link StateModel} to use when the Ambry participants (datanodes) register to Helix. The methods are callbacks
+ * that get called within a participant whenever its state changes in Helix. For now these are no-ops.
+ *
+ * In the criticial path of puts and gets, there are no leader replicas in Ambry. Every replica can serve reads and
+ * writes. However, going forward, it is useful to have one of the replicas chosen as a LEADER for purposes such as
+ * replication.
+ */
+@StateModelInfo(initialState = "OFFLINE", states = {"LEADER", "STANDBY"})
+public class AmbryStateModel extends StateModel {
+  private Logger logger = LoggerFactory.getLogger(getClass());
+  private final String zkAddr;
+
+  AmbryStateModel(String zkAddr) {
+    StateModelParser parser = new StateModelParser();
+    _currentState = parser.getInitialState(AmbryStateModel.class);
+    this.zkAddr = zkAddr;
+  }
+
+  @Transition(to = "STANDBY", from = "OFFLINE")
+  public void onBecomeStandbyFromOffline(Message message, NotificationContext context) {
+    logger.info("Becoming STANDBY from OFFLINE");
+  }
+
+  @Transition(to = "LEADER", from = "STANDBY")
+  public void onBecomeLeaderFromStandby(Message message, NotificationContext context) {
+    logger.info("Becoming LEADER from STANDBY");
+  }
+
+  @Transition(to = "STANDBY", from = "LEADER")
+  public void onBecomeStandbyFromLeader(Message message, NotificationContext context) {
+    logger.info("Becoming STANDBY from LEADER");
+  }
+
+  @Transition(to = "OFFLINE", from = "STANDBY")
+  public void onBecomeOfflineFromStandby(Message message, NotificationContext context) {
+    logger.info("Becoming OFFLINE from STANDBY");
+  }
+
+  @Transition(to = "OFFLINE", from = "LEADER")
+  public void onBecomeOfflineFromLeader(Message message, NotificationContext context) {
+    logger.info("Becoming OFFLINE from LEADER");
+  }
+}
+

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import org.apache.helix.participant.statemachine.StateModel;
+import org.apache.helix.participant.statemachine.StateModelFactory;
+
+
+class AmbryStateModelFactory extends StateModelFactory<StateModel> {
+  private final String zkAddr;
+
+  AmbryStateModelFactory(String zkAddr) {
+    this.zkAddr = zkAddr;
+  }
+
+  @Override
+  public StateModel createNewStateModel(String resourceName, String partitionName) {
+    return new AmbryStateModel(zkAddr);
+  }
+}
+

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.model.LeaderStandbySMD;
+import org.apache.helix.participant.StateMachineEngine;
+
+
+public class HelixParticipant implements ClusterParticipant {
+  private HelixManager manager;
+  private final String clusterName;
+  private final String zkConnectStr;
+
+  HelixParticipant(ClusterMapConfig clusterMapConfig) {
+    clusterName = clusterMapConfig.clusterMapClusterName;
+    if (clusterName.isEmpty()) {
+      throw new IllegalStateException("Clustername is empty in clusterMapConfig");
+    }
+    zkConnectStr = clusterMapConfig.clusterMapParticipantZkConnectString;
+  }
+
+  @Override
+  public void initialize(String hostName, int port) throws Exception {
+    String instanceName = hostName + "_" + port;
+    manager = HelixManagerFactory.getZKHelixManager(clusterName, instanceName, InstanceType.PARTICIPANT, zkConnectStr);
+    StateMachineEngine stateMachineEngine = manager.getStateMachineEngine();
+    stateMachineEngine.registerStateModelFactory(LeaderStandbySMD.name, new AmbryStateModelFactory(zkConnectStr));
+    manager.connect();
+  }
+
+  @Override
+  public void terminate() {
+    manager.disconnect();
+  }
+}
+

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipantFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipantFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.VerifiableProperties;
+
+
+public class HelixParticipantFactory implements ClusterParticipantFactory {
+  private VerifiableProperties properties;
+  private ClusterMapConfig clusterMapConfig;
+
+  public HelixParticipantFactory(VerifiableProperties properties, ClusterMapConfig clusterMapConfig) {
+    this.properties = properties;
+    this.clusterMapConfig = clusterMapConfig;
+  }
+
+  @Override
+  public ClusterParticipant getClusterParticipant() {
+    return new HelixParticipant(clusterMapConfig);
+  }
+}
+

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticParticipantFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticParticipantFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.VerifiableProperties;
+
+
+/**
+ * A no-op {@link ClusterParticipant} associated with static cluster management.
+ */
+public class StaticParticipantFactory implements ClusterParticipantFactory {
+
+  public StaticParticipantFactory(VerifiableProperties properties, ClusterMapConfig clusterMapConfig) {
+  }
+
+  @Override
+  public ClusterParticipant getClusterParticipant() {
+    // Static participant methods are no-op.
+    return new ClusterParticipant() {
+      @Override
+      public void initialize(String hostname, int port) throws Exception {
+      }
+
+      @Override
+      public void terminate() {
+      }
+    };
+  }
+}
+

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapManagerTest.java
@@ -293,6 +293,8 @@ public class ClusterMapManagerTest {
   @Test
   public void persistAndReadBack() throws JSONException, IOException {
     String tmpDir = folder.getRoot().getPath();
+    Properties props = new Properties();
+    props.setProperty("clustermap.cluster.name", "test");
 
     String hardwareLayoutSer = tmpDir + "/hardwareLayoutSer.json";
     String partitionLayoutSer = tmpDir + "/partitionLayoutSer.json";
@@ -302,7 +304,7 @@ public class ClusterMapManagerTest {
     ClusterMapManager clusterMapManagerSer = TestUtils.getTestClusterMap();
     clusterMapManagerSer.persist(hardwareLayoutSer, partitionLayoutSer);
 
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
 
     ClusterMapManager clusterMapManagerDe =
         new ClusterMapManager(hardwareLayoutSer, partitionLayoutSer, clusterMapConfig);
@@ -316,6 +318,8 @@ public class ClusterMapManagerTest {
 
   @Test
   public void validateSimpleConfig() throws JSONException, IOException {
+    Properties props = new Properties();
+    props.setProperty("clustermap.cluster.name", "test");
     String configDir = System.getProperty("user.dir");
     // intelliJ and gradle return different values for user.dir: gradle includes the sub-project directory. To handle
     // this, we check the string suffix for the sub-project directory and append ".." to correctly set configDir.
@@ -326,7 +330,7 @@ public class ClusterMapManagerTest {
     String hardwareLayoutSer = configDir + "/HardwareLayout.json";
     String partitionLayoutSer = configDir + "/PartitionLayout.json";
     ClusterMapManager clusterMapManager = new ClusterMapManager(hardwareLayoutSer, partitionLayoutSer,
-        new ClusterMapConfig(new VerifiableProperties(new Properties())));
+        new ClusterMapConfig(new VerifiableProperties(props)));
     assertEquals(clusterMapManager.getWritablePartitionIds().size(), 1);
     assertEquals(clusterMapManager.getUnallocatedRawCapacityInBytes(), 10737418240L);
     assertNotNull(clusterMapManager.getDataNodeId("localhost", 6667));

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DataNodeTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DataNodeTest.java
@@ -71,6 +71,12 @@ class TestDataNode extends DataNode {
 public class DataNodeTest {
   private static final int diskCount = 10;
   private static final long diskCapacityInBytes = 1000 * 1024 * 1024 * 1024L;
+  private Properties props;
+
+  public DataNodeTest() {
+    props = new Properties();
+    props.setProperty("clustermap.cluster.name", "test");
+  }
 
   JSONArray getDisks() throws JSONException {
     return TestUtils.getJsonArrayDisks(diskCount, "/mnt", HardwareState.AVAILABLE, diskCapacityInBytes);
@@ -81,7 +87,7 @@ public class DataNodeTest {
 
     JSONObject jsonObject =
         TestUtils.getJsonDataNode(TestUtils.getLocalHost(), 6666, 7666, HardwareState.AVAILABLE, getDisks());
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
 
     DataNode dataNode = new TestDataNode("datacenter", jsonObject, clusterMapConfig);
 
@@ -119,7 +125,7 @@ public class DataNodeTest {
   @Test
   public void validation() throws JSONException {
     JSONObject jsonObject;
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
 
     try {
       // Null DataNode
@@ -172,6 +178,7 @@ public class DataNodeTest {
         TestUtils.getJsonDataNode(TestUtils.getLocalHost(), 6666, 7666, HardwareState.AVAILABLE, getDisks());
     Properties props = new Properties();
     props.setProperty("clustermap.fixedtimeout.datanode.retry.backoff.ms", Integer.toString(2000));
+    props.setProperty("clustermap.cluster.name", "test");
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     int threshold = clusterMapConfig.clusterMapFixedTimeoutDatanodeErrorThreshold;
     long retryBackoffMs = clusterMapConfig.clusterMapFixedTimeoutDataNodeRetryBackoffMs;
@@ -207,6 +214,7 @@ public class DataNodeTest {
     ClusterMapConfig clusterMapConfig;
     Properties props = new Properties();
     props.setProperty("clustermap.ssl.enabled.datacenters", "datacenter1,datacenter2,datacenter3");
+    props.setProperty("clustermap.cluster.name", "test");
     clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     System.out.println(clusterMapConfig.clusterMapSslEnabledDatacenters);
     JSONObject jsonObject =

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DatacenterTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DatacenterTest.java
@@ -61,6 +61,12 @@ public class DatacenterTest {
   private static final long diskCapacityInBytes = 1000 * 1024 * 1024 * 1024L;
 
   private static final int dataNodeCount = 6;
+  private Properties props;
+
+  public DatacenterTest() {
+    props = new Properties();
+    props.setProperty("clustermap.cluster.name", "test");
+  }
 
   JSONArray getDisks() throws JSONException {
     return TestUtils.getJsonArrayDisks(diskCount, "/mnt", HardwareState.AVAILABLE, diskCapacityInBytes);
@@ -84,7 +90,7 @@ public class DatacenterTest {
   @Test
   public void basics() throws JSONException {
     JSONObject jsonObject = TestUtils.getJsonDatacenter("XYZ1", getDataNodes());
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
 
     Datacenter datacenter = new TestDatacenter(jsonObject, clusterMapConfig);
 
@@ -114,7 +120,7 @@ public class DatacenterTest {
   @Test
   public void validation() throws JSONException {
     JSONObject jsonObject;
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
 
     try {
       // Null HardwareLayout

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DiskTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DiskTest.java
@@ -64,10 +64,17 @@ class TestDisk extends Disk {
  * Tests {@link Disk} class.
  */
 public class DiskTest {
+  private Properties props;
+
+  public DiskTest() {
+    props = new Properties();
+    props.setProperty("clustermap.cluster.name", "test");
+  }
+
   @Test
   public void basics() throws JSONException {
     JSONObject jsonObject = TestUtils.getJsonDisk("/mnt1", HardwareState.AVAILABLE, 100 * 1024 * 1024 * 1024L);
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
 
     Disk testDisk = new TestDisk(jsonObject, clusterMapConfig);
 
@@ -89,7 +96,7 @@ public class DiskTest {
 
   @Test
   public void validation() throws JSONException {
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     try {
       // Null DataNode
       new Disk(null, TestUtils.getJsonDisk("/mnt1", HardwareState.AVAILABLE, 100 * 1024 * 1024 * 1024L),
@@ -118,6 +125,7 @@ public class DiskTest {
     JSONObject jsonObject = TestUtils.getJsonDisk("/mnt1", HardwareState.AVAILABLE, 100 * 1024 * 1024 * 1024L);
     Properties props = new Properties();
     props.setProperty("clustermap.fixedtimeout.disk.retry.backoff.ms", Integer.toString(2000));
+    props.setProperty("clustermap.cluster.name", "test");
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
 
     int threshold = clusterMapConfig.clusterMapFixedTimeoutDiskErrorThreshold;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HardwareLayoutTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HardwareLayoutTest.java
@@ -36,6 +36,12 @@ public class HardwareLayoutTest {
   private static final int datacenterCount = 3;
   private static final int basePort = 6666;
   private static final int baseSslPort = 7666;
+  private Properties props;
+
+  public HardwareLayoutTest() {
+    props = new Properties();
+    props.setProperty("clustermap.cluster.name", "test");
+  }
 
   private JSONArray getDisks() throws JSONException {
     return TestUtils.getJsonArrayDisks(diskCount, "/mnt", HardwareState.AVAILABLE, diskCapacityInBytes);
@@ -125,7 +131,7 @@ public class HardwareLayoutTest {
     JSONObject jsonObject = TestUtils.getJsonHardwareLayout("Alpha", getDatacenters());
 
     HardwareLayout hardwareLayout =
-        new HardwareLayout(jsonObject, new ClusterMapConfig(new VerifiableProperties(new Properties())));
+        new HardwareLayout(jsonObject, new ClusterMapConfig(new VerifiableProperties(props)));
 
     assertEquals(hardwareLayout.getVersion(), TestUtils.defaultHardwareLayoutVersion);
     assertEquals(hardwareLayout.getClusterName(), "Alpha");
@@ -145,7 +151,7 @@ public class HardwareLayoutTest {
 
   public void failValidation(JSONObject jsonObject) throws JSONException {
     try {
-      new HardwareLayout(jsonObject, new ClusterMapConfig(new VerifiableProperties(new Properties())));
+      new HardwareLayout(jsonObject, new ClusterMapConfig(new VerifiableProperties(props)));
       fail("Should have failed validation: " + jsonObject.toString(2));
     } catch (IllegalStateException e) {
       // Expected.

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -403,6 +403,7 @@ public class TestUtils {
     private boolean rackAware;
     private String clusterName;
     private List<JSONArray> datanodeJSONArrays;
+    private Properties properties;
 
     private HardwareLayout hardwareLayout;
 
@@ -461,15 +462,16 @@ public class TestUtils {
       this.numRacks = numRacks;
       this.rackAware = rackAware;
       this.clusterName = clusterName;
-
+      this.properties = new Properties();
+      properties.setProperty("clustermap.cluster.name", "test");
       this.hardwareLayout = new HardwareLayout(getJsonHardwareLayout(clusterName, getDatacenters(true)),
-          new ClusterMapConfig(new VerifiableProperties(new Properties())));
+          new ClusterMapConfig(new VerifiableProperties(properties)));
     }
 
     void addNewDataNodes(int i) throws JSONException {
       this.dataNodeCount += i;
       this.hardwareLayout = new HardwareLayout(getJsonHardwareLayout(clusterName, getDatacenters(false)),
-          new ClusterMapConfig(new VerifiableProperties(new Properties())));
+          new ClusterMapConfig(new VerifiableProperties(properties)));
     }
 
     /**

--- a/ambry-commons/src/test/java/com.github.ambry.commons/TestSSLUtils.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/TestSSLUtils.java
@@ -216,6 +216,7 @@ public class TestSSLUtils {
       File trustStoreFile, String certAlias) throws IOException, GeneralSecurityException {
     Properties props = new Properties();
     addSSLProperties(props, sslEnabledDatacenters, mode, trustStoreFile, certAlias);
+    props.setProperty("clustermap.cluster.name", "test");
     return new VerifiableProperties(props);
   }
 

--- a/ambry-network/src/test/java/com.github.ambry.network/BlockingChannelConnectionPoolTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/BlockingChannelConnectionPoolTest.java
@@ -72,7 +72,9 @@ public class BlockingChannelConnectionPoolTest {
         TestSSLUtils.createSslProps("DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client");
     sslConfig = new SSLConfig(sslClientProps);
     sslEnabledClusterMapConfig = new ClusterMapConfig(sslClientProps);
-    plainTextClusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
+    Properties props = new Properties();
+    props.setProperty("clustermap.cluster.name", "test");
+    plainTextClusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     sslFactory = new SSLFactory(sslConfig);
     SSLContext sslContext = sslFactory.getSSLContext();
     sslSocketFactory = sslContext.getSocketFactory();
@@ -81,6 +83,7 @@ public class BlockingChannelConnectionPoolTest {
   public BlockingChannelConnectionPoolTest() throws Exception {
     Properties props = new Properties();
     props.setProperty("port", "6667");
+    props.setProperty("clustermap.cluster.name", "test");
     VerifiableProperties propverify = new VerifiableProperties(props);
     NetworkConfig config = new NetworkConfig(propverify);
     ArrayList<Port> ports = new ArrayList<Port>();
@@ -172,8 +175,10 @@ public class BlockingChannelConnectionPoolTest {
     int port = 6680;
     String host = "127.0.0.1";
     SocketServer server = startServer(port);
+    Properties props = new Properties();
+    props.setProperty("clustermap.cluster.name", "test");
     BlockingChannelInfo channelInfo =
-        new BlockingChannelInfo(new ConnectionPoolConfig(new VerifiableProperties(new Properties())), host,
+        new BlockingChannelInfo(new ConnectionPoolConfig(new VerifiableProperties(props)), host,
             new Port(port, PortType.PLAINTEXT), new MetricRegistry(), sslSocketFactory, sslConfig);
     // ask for N no of connections
     Assert.assertEquals(channelInfo.getNumberOfConnections(), 0);
@@ -216,6 +221,7 @@ public class BlockingChannelConnectionPoolTest {
     Properties props = new Properties();
     props.put("connectionpool.max.connections.per.port.plain.text", "" + maxConnectionsPerPortPlainText);
     props.put("connectionpool.max.connections.per.port.ssl", "" + maxConnectionsPerPortSSL);
+    props.put("clustermap.cluster.name", "test");
     int maxConnectionsPerHost =
         (port.getPortType() == PortType.PLAINTEXT) ? maxConnectionsPerPortPlainText : maxConnectionsPerPortSSL;
     createAndReleaseSingleChannelTest(props, host, port);
@@ -311,6 +317,7 @@ public class BlockingChannelConnectionPoolTest {
   private SocketServer startServer(int port) throws IOException, InterruptedException {
     Properties props = new Properties();
     props.setProperty("port", "" + port);
+    props.setProperty("clustermap.cluster.name", "test");
     VerifiableProperties propverify = new VerifiableProperties(props);
     NetworkConfig config = new NetworkConfig(propverify);
     ArrayList<Port> ports = new ArrayList<Port>();
@@ -378,6 +385,7 @@ public class BlockingChannelConnectionPoolTest {
     Properties props = new Properties();
     props.put("connectionpool.max.connections.per.port.plain.text", "5");
     props.put("connectionpool.max.connections.per.port.ssl", "5");
+    props.put("clustermap.cluster.name", "test");
     ConnectionPool connectionPool =
         new BlockingChannelConnectionPool(new ConnectionPoolConfig(new VerifiableProperties(props)), sslConfig,
             plainTextClusterMapConfig, new MetricRegistry());
@@ -422,6 +430,7 @@ public class BlockingChannelConnectionPoolTest {
     Properties props = new Properties();
     props.put("connectionpool.max.connections.per.port.plain.text", "5");
     props.put("connectionpool.max.connections.per.port.ssl", "5");
+    props.put("clustermap.cluster.name", "test");
     ConnectionPool connectionPool =
         new BlockingChannelConnectionPool(new ConnectionPoolConfig(new VerifiableProperties(props)), sslConfig,
             sslEnabledClusterMapConfig, new MetricRegistry());

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -117,6 +117,7 @@ public class NonBlockingRouterTest {
     properties.setProperty("router.delete.success.target", Integer.toString(DELETE_SUCCESS_TARGET));
     properties.setProperty("router.connection.checkout.timeout.ms", Integer.toString(CHECKOUT_TIMEOUT_MS));
     properties.setProperty("router.request.timeout.ms", Integer.toString(REQUEST_TIMEOUT_MS));
+    properties.setProperty("clustermap.cluster.name", "test");
     return properties;
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterFactoryTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterFactoryTest.java
@@ -48,6 +48,7 @@ public class RouterFactoryTest {
     Properties properties = new Properties();
     properties.setProperty("router.hostname", "localhost");
     properties.setProperty("router.datacenter.name", "DC1");
+    properties.setProperty("clustermap.cluster.name", "test");
     return new VerifiableProperties(properties);
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -99,6 +99,7 @@ public class MockCluster {
     props.setProperty("replication.token.flush.interval.seconds", "5");
     props.setProperty("replication.wait.time.between.replicas.ms", "50");
     props.setProperty("replication.validate.message.stream", "true");
+    props.setProperty("clustermap.cluster.name", "test");
     props.putAll(sslProperties);
     VerifiableProperties propverify = new VerifiableProperties(props);
     AmbryServer server = new AmbryServer(propverify, clusterMap, notificationSystem, time);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -168,6 +168,7 @@ class RouterServerTestFramework {
     properties.setProperty("router.request.timeout.ms", "10000");
     properties.setProperty("router.max.put.chunk.size.bytes", Integer.toString(CHUNK_SIZE));
     properties.setProperty("router.put.success.target", "1");
+    properties.setProperty("clustermap.cluster.name", "test");
     return properties;
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -83,6 +83,7 @@ public class ServerHardDeleteTest {
     props.setProperty("store.data.flush.interval.seconds", "1");
     props.setProperty("store.enable.hard.delete", "true");
     props.setProperty("store.deleted.message.retention.days", "1");
+    props.setProperty("clustermap.cluster.name", "test");
     VerifiableProperties propverify = new VerifiableProperties(props);
     server = new AmbryServer(propverify, mockClusterMap, notificationSystem, time);
     server.startup();

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -769,6 +769,7 @@ public final class ServerTestUtil {
     props.setProperty("router.datacenter.name", sourceDatacenter);
     props.setProperty("router.put.request.parallelism", "1");
     props.setProperty("router.put.success.target", "1");
+    props.setProperty("clustermap.cluster.name", "test");
     props.putAll(routerProps);
     VerifiableProperties verifiableProperties = new VerifiableProperties(props);
     Router router = new NonBlockingRouterFactory(verifiableProperties, cluster.getClusterMap(), notificationSystem,
@@ -813,6 +814,7 @@ public final class ServerTestUtil {
     Properties sslProps = new Properties();
     sslProps.putAll(routerProps);
     sslProps.setProperty("clustermap.ssl.enabled.datacenters", sslEnabledDatacenters);
+    sslProps.setProperty("clustermap.cluster.name", "test");
     VerifiableProperties vProps = new VerifiableProperties(sslProps);
     ConnectionPool connectionPool =
         new BlockingChannelConnectionPool(new ConnectionPoolConfig(new VerifiableProperties(new Properties())),
@@ -1323,6 +1325,7 @@ public final class ServerTestUtil {
     Properties properties = new Properties();
     properties.setProperty("router.hostname", "localhost");
     properties.setProperty("router.datacenter.name", routerDatacenter);
+    properties.setProperty("clustermap.cluster.name", "test");
     return properties;
   }
 

--- a/config/server_helix.properties
+++ b/config/server_helix.properties
@@ -11,4 +11,6 @@
 #
 
 host.name=localhost
-clustermap.cluster.name=Ambry_Dev
+clustermap.cluster.name=Ambry_Proto
+clustermap.participant.zk.connect.string=localhost:2199
+clustermap.participant.factory=com.github.ambry.clustermap.HelixParticipantFactory

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -17,6 +17,6 @@ ext {
     commonsVersion = "1.5"
     bouncycastleVersion = "1.52"
     javaxVersion = "3.0.1"
-    helixVersion = "0.6.6"
     nettyVersion = "4.1.4.Final"
+    helixVersion = "0.6.7"
 }


### PR DESCRIPTION
- Introduce the notion of a "participant": a component that constitutes a cluster.
  In Ambry, all datanodes are participants.
- Introduce ClusterParticipant interface and a factory for it.
- Add implementations for static and Helix-based cluster participants, that will be
  called by AmbryServer at startup and shutdown.
- Introduce a "cluster name" config and make it mandatory.
- Add additional clusterName mandatory parameter for HelixBootstrapUgpradeTool.
- Enable Helix 0.6.7 and re-add the todos dependent on this version.

--
AmbryServer does not have unit tests, so most of the testing was done manually. Will figure a way to add unit tests for newly introduced classes before the patch gets merged.