### PR TITLE
Upgrading netty version to 4.1.4

### DIFF
--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
@@ -35,7 +35,6 @@ import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestResponseHandler;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
-import com.github.ambry.rest.RestTestUtils;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.rest.SecurityService;
 import com.github.ambry.rest.SecurityServiceFactory;
@@ -49,6 +48,7 @@ import com.github.ambry.router.ReadableStreamChannel;
 import com.github.ambry.router.Router;
 import com.github.ambry.router.RouterErrorCode;
 import com.github.ambry.router.RouterException;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
 import java.io.IOException;
@@ -324,7 +324,7 @@ public class AdminBlobStorageServiceTest {
   @Test
   public void getHeadDeleteTest() throws Exception {
     final int CONTENT_LENGTH = 1024;
-    ByteBuffer content = ByteBuffer.wrap(RestTestUtils.getRandomBytes(CONTENT_LENGTH));
+    ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(CONTENT_LENGTH));
     String serviceId = "getHeadDeleteServiceID";
     String contentType = "application/octet-stream";
     String ownerId = "getHeadDeleteOwnerID";
@@ -352,7 +352,7 @@ public class AdminBlobStorageServiceTest {
   public void oldStyleUserMetadataTest() throws Exception {
     ByteBuffer content = ByteBuffer.allocate(0);
     BlobProperties blobProperties = new BlobProperties(0, "userMetadataTestOldStyleServiceID");
-    byte[] usermetadata = RestTestUtils.getRandomBytes(25);
+    byte[] usermetadata = TestUtils.getRandomBytes(25);
     String blobId = router.putBlob(blobProperties, usermetadata, new ByteBufferReadableStreamChannel(content)).get();
 
     RestUtils.SubResource[] subResources = {RestUtils.SubResource.UserMetadata, RestUtils.SubResource.BlobInfo};

--- a/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
@@ -83,6 +83,10 @@ public class NettyConfig {
   @Default("32 * 1024 * 1024")
   public final int nettyServerRequestBufferWatermark;
 
+  @Config("netty.server.max.bytes.per.read")
+  @Default("1 * 1024 * 1024")
+  public final int nettyServerMaxBytesPerRead;
+
   public NettyConfig(VerifiableProperties verifiableProperties) {
     nettyServerBossThreadCount = verifiableProperties.getInt("netty.server.boss.thread.count", 1);
     nettyServerIdleTimeSeconds = verifiableProperties.getInt("netty.server.idle.time.seconds", 60);
@@ -93,6 +97,9 @@ public class NettyConfig {
     nettyServerMaxHeaderSize = verifiableProperties.getInt("netty.server.max.header.size", 8192);
     nettyServerMaxChunkSize = verifiableProperties.getInt("netty.server.max.chunk.size", 8192);
     nettyServerRequestBufferWatermark =
-        verifiableProperties.getInt("netty.server.request.buffer.watermark", 32 * 1024 * 1024);
+        verifiableProperties.getIntInRange("netty.server.request.buffer.watermark", 32 * 1024 * 1024, 1,
+            Integer.MAX_VALUE);
+    nettyServerMaxBytesPerRead =
+        verifiableProperties.getIntInRange("netty.server.max.bytes.per.read", 1024 * 1024, 1, Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
@@ -83,10 +83,6 @@ public class NettyConfig {
   @Default("32 * 1024 * 1024")
   public final int nettyServerRequestBufferWatermark;
 
-  @Config("netty.server.max.bytes.per.read")
-  @Default("1 * 1024 * 1024")
-  public final int nettyServerMaxBytesPerRead;
-
   public NettyConfig(VerifiableProperties verifiableProperties) {
     nettyServerBossThreadCount = verifiableProperties.getInt("netty.server.boss.thread.count", 1);
     nettyServerIdleTimeSeconds = verifiableProperties.getInt("netty.server.idle.time.seconds", 60);
@@ -99,7 +95,5 @@ public class NettyConfig {
     nettyServerRequestBufferWatermark =
         verifiableProperties.getIntInRange("netty.server.request.buffer.watermark", 32 * 1024 * 1024, 1,
             Integer.MAX_VALUE);
-    nettyServerMaxBytesPerRead =
-        verifiableProperties.getIntInRange("netty.server.max.bytes.per.read", 1024 * 1024, 1, Integer.MAX_VALUE);
   }
 }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -48,6 +48,7 @@ import com.github.ambry.router.Router;
 import com.github.ambry.router.RouterErrorCode;
 import com.github.ambry.router.RouterException;
 import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
 import java.io.IOException;
@@ -327,7 +328,7 @@ public class AmbryBlobStorageServiceTest {
   @Test
   public void postGetHeadDeleteTest() throws Exception {
     final int CONTENT_LENGTH = 1024;
-    ByteBuffer content = ByteBuffer.wrap(RestTestUtils.getRandomBytes(CONTENT_LENGTH));
+    ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(CONTENT_LENGTH));
     String serviceId = "postGetHeadDeleteServiceID";
     String contentType = "application/octet-stream";
     String ownerId = "postGetHeadDeleteOwnerID";
@@ -373,7 +374,7 @@ public class AmbryBlobStorageServiceTest {
   public void oldStyleUserMetadataTest() throws Exception {
     ByteBuffer content = ByteBuffer.allocate(0);
     BlobProperties blobProperties = new BlobProperties(0, "userMetadataTestOldStyleServiceID");
-    byte[] usermetadata = RestTestUtils.getRandomBytes(25);
+    byte[] usermetadata = TestUtils.getRandomBytes(25);
     String blobId = router.putBlob(blobProperties, usermetadata, new ByteBufferReadableStreamChannel(content)).get();
 
     RestUtils.SubResource[] subResources = {RestUtils.SubResource.UserMetadata, RestUtils.SubResource.BlobInfo};

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
@@ -270,10 +270,10 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
       long processingStartTime = System.currentTimeMillis();
       resetState();
       nettyMetrics.requestArrivalRate.mark();
-      if (!httpRequest.getDecoderResult().isSuccess()) {
+      if (!httpRequest.decoderResult().isSuccess()) {
         success = false;
         logger.warn("Decoder failed because of malformed request on channel {}", ctx.channel(),
-            httpRequest.getDecoderResult().cause());
+            httpRequest.decoderResult().cause());
         nettyMetrics.malformedRequestError.inc();
         onRequestAborted(new RestServiceException("Decoder failed because of malformed request",
             RestServiceErrorCode.MalformedRequest));
@@ -281,7 +281,7 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
         try {
           // We need to maintain state about the request itself for the subsequent parts (if any) that come in. We will
           // attach content to the request as the content arrives.
-          if (HttpMethod.POST.equals(httpRequest.getMethod()) && HttpPostRequestDecoder.isMultipart(httpRequest)) {
+          if (HttpMethod.POST.equals(httpRequest.method()) && HttpPostRequestDecoder.isMultipart(httpRequest)) {
             nettyMetrics.multipartPostRequestRate.mark();
             request = new NettyMultipartRequest(httpRequest, ctx.channel(), nettyMetrics);
           } else {
@@ -313,7 +313,7 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
       // because it is in a bad state.
       success = false;
       logger.error("New request received when previous request is yet to be fully received on channel {}. Request under"
-          + " processing: {}. Unexpected request: {}", ctx.channel(), request.getUri(), httpRequest.getUri());
+          + " processing: {}. Unexpected request: {}", ctx.channel(), request.getUri(), httpRequest.uri());
       nettyMetrics.duplicateRequestError.inc();
       onRequestAborted(new RestServiceException("Received request in the middle of another request",
           RestServiceErrorCode.BadRequest));

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * Multipart decoding also creates copies of the data. This affects latency and increases memory pressure.
  */
 class NettyMultipartRequest extends NettyRequest {
-  private final Queue<HttpContent> rawRequestContents = new LinkedBlockingQueue<HttpContent>();
+  private final Queue<HttpContent> rawRequestContents = new LinkedBlockingQueue<>();
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   private boolean readyForRead = false;
@@ -63,10 +63,10 @@ class NettyMultipartRequest extends NettyRequest {
    * @throws RestServiceException if the HTTP method defined in {@code request} is not recognized as a
    *                                {@link RestMethod}.
    */
-  public NettyMultipartRequest(HttpRequest request, Channel channel, NettyMetrics nettyMetrics)
-      throws RestServiceException {
+  NettyMultipartRequest(HttpRequest request, Channel channel, NettyMetrics nettyMetrics) throws RestServiceException {
     super(request, channel, nettyMetrics);
     // reset auto read state.
+    channel.config().setRecvByteBufAllocator(savedAllocator);
     setAutoRead(true);
     if (!getRestMethod().equals(RestMethod.POST)) {
       throw new IllegalArgumentException("NettyMultipartRequest cannot be created for " + getRestMethod());

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -60,8 +60,6 @@ class NettyRequest implements RestRequest {
   // temporarily suspended. It will be resumed when the amount of data unacknowledged drops below this number. If this
   // is <=0, it is assumed that there is no limit on the size of unacknowledged data.
   static int bufferWatermark = -1;
-  // Number of bytes to read on each read loop
-  static int maxBytesPerRead = 1024 * 1024;
   private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
 
   protected final HttpRequest request;
@@ -83,8 +81,7 @@ class NettyRequest implements RestRequest {
   private final AtomicLong bytesReceived = new AtomicLong(0);
   private final AtomicLong bytesBuffered = new AtomicLong(0);
   private final Logger logger = LoggerFactory.getLogger(getClass());
-  private final RecvByteBufAllocator recvByteBufAllocator =
-      new DefaultMaxBytesRecvByteBufAllocator(maxBytesPerRead, maxBytesPerRead);
+  private final RecvByteBufAllocator recvByteBufAllocator = new DefaultMaxBytesRecvByteBufAllocator();
 
   private MessageDigest digest;
   private byte[] digestBytes;

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -17,13 +17,16 @@ import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.FutureResult;
 import io.netty.channel.Channel;
-import io.netty.handler.codec.http.CookieDecoder;
+import io.netty.channel.DefaultMaxBytesRecvByteBufAllocator;
+import io.netty.channel.RecvByteBufAllocator;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.util.ReferenceCountUtil;
 import java.nio.ByteBuffer;
@@ -57,6 +60,8 @@ class NettyRequest implements RestRequest {
   // temporarily suspended. It will be resumed when the amount of data unacknowledged drops below this number. If this
   // is <=0, it is assumed that there is no limit on the size of unacknowledged data.
   static int bufferWatermark = -1;
+  // Number of bytes to read on each read loop
+  static int maxBytesPerRead = 1024 * 1024;
   private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
 
   protected final HttpRequest request;
@@ -68,9 +73,9 @@ class NettyRequest implements RestRequest {
 
   protected volatile ReadIntoCallbackWrapper callbackWrapper = null;
   protected volatile Map<String, Object> allArgsReadOnly = null;
+  protected final RecvByteBufAllocator savedAllocator;
 
   private final long size;
-  private final int savedMaxMessagesPerRead;
   private final QueryStringDecoder query;
   private final RestMethod restMethod;
   private final RestRequestMetricsTracker restRequestMetricsTracker = new RestRequestMetricsTracker();
@@ -78,6 +83,8 @@ class NettyRequest implements RestRequest {
   private final AtomicLong bytesReceived = new AtomicLong(0);
   private final AtomicLong bytesBuffered = new AtomicLong(0);
   private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final RecvByteBufAllocator recvByteBufAllocator =
+      new DefaultMaxBytesRecvByteBufAllocator(maxBytesPerRead, maxBytesPerRead);
 
   private MessageDigest digest;
   private byte[] digestBytes;
@@ -95,7 +102,7 @@ class NettyRequest implements RestRequest {
    * <p/>
    * Note on content size: The content size is deduced in the following order:-
    * 1. From the {@link RestUtils.Headers#BLOB_SIZE} header.
-   * 2. If 1 fails, from the {@link HttpHeaders.Names#CONTENT_LENGTH} header.
+   * 2. If 1 fails, from the {@link HttpHeaderNames#CONTENT_LENGTH} header.
    * 3. If 2 fails, it is set to -1 which means that the content size is unknown.
    * If content size is set in the header (i.e. not -1), the actual content size should match that value. Otherwise, an
    * exception will be thrown.
@@ -112,12 +119,12 @@ class NettyRequest implements RestRequest {
     }
     restRequestMetricsTracker.nioMetricsTracker.markRequestReceived();
     this.request = request;
-    query = new QueryStringDecoder(request.getUri());
+    query = new QueryStringDecoder(request.uri());
     this.channel = channel;
-    savedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
+    savedAllocator = channel.config().getRecvByteBufAllocator();
     this.nettyMetrics = nettyMetrics;
 
-    HttpMethod httpMethod = request.getMethod();
+    HttpMethod httpMethod = request.method();
     if (HttpMethod.GET.equals(httpMethod)) {
       restMethod = RestMethod.GET;
     } else if (HttpMethod.POST.equals(httpMethod)) {
@@ -136,7 +143,7 @@ class NettyRequest implements RestRequest {
           RestServiceErrorCode.UnsupportedHttpMethod);
     }
 
-    String blobSizeStr = HttpHeaders.getHeader(request, RestUtils.Headers.BLOB_SIZE, null);
+    String blobSizeStr = request.headers().get(RestUtils.Headers.BLOB_SIZE, null);
     if (blobSizeStr != null) {
       try {
         size = Long.parseLong(blobSizeStr);
@@ -150,7 +157,7 @@ class NettyRequest implements RestRequest {
             RestServiceErrorCode.InvalidArgs);
       }
     } else {
-      size = HttpHeaders.getContentLength(request, -1);
+      size = HttpUtil.getContentLength(request, -1);
     }
 
     // query params.
@@ -165,14 +172,14 @@ class NettyRequest implements RestRequest {
       allArgs.put(e.getKey(), value);
     }
 
-    Set<io.netty.handler.codec.http.Cookie> nettyCookies = null;
+    Set<io.netty.handler.codec.http.cookie.Cookie> nettyCookies = null;
     // headers.
     for (Map.Entry<String, String> e : request.headers()) {
       StringBuilder sb;
-      if (e.getKey().equals(HttpHeaders.Names.COOKIE)) {
+      if (e.getKey().equalsIgnoreCase(HttpHeaderNames.COOKIE.toString())) {
         String value = e.getValue();
         if (value != null) {
-          nettyCookies = CookieDecoder.decode(value);
+          nettyCookies = ServerCookieDecoder.STRICT.decode(value);
         }
       } else {
         boolean valueNull = request.headers().get(e.getKey()) == null;
@@ -204,7 +211,7 @@ class NettyRequest implements RestRequest {
 
   @Override
   public String getUri() {
-    return request.getUri();
+    return request.uri();
   }
 
   @Override
@@ -392,7 +399,7 @@ class NettyRequest implements RestRequest {
    * @return {@code true} if keep-alive. {@code false} otherwise.
    */
   protected boolean isKeepAlive() {
-    return HttpHeaders.isKeepAlive(request);
+    return HttpUtil.isKeepAlive(request);
   }
 
   /**
@@ -470,24 +477,25 @@ class NettyRequest implements RestRequest {
    */
   protected void setAutoRead(boolean autoRead) {
     channel.config().setAutoRead(autoRead);
-    channel.config().setMaxMessagesPerRead(autoRead ? savedMaxMessagesPerRead : 1);
-    logger.trace("Setting auto-read to {} on channel {} and max messages per read to {}", channel.config().isAutoRead(),
-        channel, channel.config().getMaxMessagesPerRead());
+    channel.config().setRecvByteBufAllocator(autoRead ? savedAllocator : recvByteBufAllocator);
+    logger.trace("Setting auto-read to {} on channel {}", channel.config().isAutoRead(), channel);
   }
 
   /**
-   * Converts the Set of {@link javax.servlet.http.Cookie}s to equivalent {@link javax.servlet.http.Cookie}s
-   * @param httpCookies Set of {@link javax.servlet.http.Cookie}s that needs to be converted
-   * @return Set of {@link javax.servlet.http.Cookie}s equivalent to the passed in {@link javax.servlet.http.Cookie}s
+   * Converts the Set of {@link io.netty.handler.codec.http.cookie.Cookie}s to equivalent
+   * {@link javax.servlet.http.Cookie}s
+   * @param httpCookies Set of {@link io.netty.handler.codec.http.cookie.Cookie}s that needs to be converted
+   * @return Set of {@link javax.servlet.http.Cookie}s equivalent to the passed in
+   * {@link io.netty.handler.codec.http.cookie.Cookie}s
    */
-  private Set<Cookie> convertHttpToJavaCookies(Set<io.netty.handler.codec.http.Cookie> httpCookies) {
+  private Set<Cookie> convertHttpToJavaCookies(Set<io.netty.handler.codec.http.cookie.Cookie> httpCookies) {
     Set<javax.servlet.http.Cookie> cookies = new HashSet<Cookie>();
-    for (io.netty.handler.codec.http.Cookie cookie : httpCookies) {
+    for (io.netty.handler.codec.http.cookie.Cookie cookie : httpCookies) {
       try {
-        javax.servlet.http.Cookie javaCookie = new javax.servlet.http.Cookie(cookie.getName(), cookie.getValue());
+        javax.servlet.http.Cookie javaCookie = new javax.servlet.http.Cookie(cookie.name(), cookie.value());
         cookies.add(javaCookie);
       } catch (IllegalArgumentException e) {
-        logger.debug("Could not create cookie with name [{}]", cookie.getName(), e);
+        logger.debug("Could not create cookie with name [{}]", cookie.name(), e);
       }
     }
     return cookies;

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
@@ -62,7 +62,6 @@ public class NettyServer implements NioServer {
     this.nettyMetrics = nettyMetrics;
     this.channelInitializer = channelInitializer;
     NettyRequest.bufferWatermark = nettyConfig.nettyServerRequestBufferWatermark;
-    NettyRequest.maxBytesPerRead = nettyConfig.nettyServerMaxBytesPerRead;
     logger.trace("Instantiated NettyServer");
   }
 

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyServer.java
@@ -62,6 +62,7 @@ public class NettyServer implements NioServer {
     this.nettyMetrics = nettyMetrics;
     this.channelInitializer = channelInitializer;
     NettyRequest.bufferWatermark = nettyConfig.nettyServerRequestBufferWatermark;
+    NettyRequest.maxBytesPerRead = nettyConfig.nettyServerMaxBytesPerRead;
     logger.trace("Instantiated NettyServer");
   }
 

--- a/ambry-rest/src/main/java/com.github.ambry.rest/PublicAccessLogHandler.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/PublicAccessLogHandler.java
@@ -17,10 +17,10 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,8 +63,8 @@ public class PublicAccessLogHandler extends ChannelDuplexHandler {
       requestArrivalTimeInMs = System.currentTimeMillis();
       request = (HttpRequest) obj;
       logMessage.append(ctx.channel().remoteAddress()).append(" ");
-      logMessage.append(request.getMethod().toString()).append(" ");
-      logMessage.append(request.getUri()).append(", ");
+      logMessage.append(request.method().toString()).append(" ");
+      logMessage.append(request.uri()).append(", ");
       logHeaders("Request", request, publicAccessLogger.getRequestHeaders());
       logMessage.append(", ");
     } else if (obj instanceof LastHttpContent) {
@@ -87,9 +87,9 @@ public class PublicAccessLogHandler extends ChannelDuplexHandler {
         HttpResponse response = (HttpResponse) msg;
         logHeaders("Response", response, publicAccessLogger.getResponseHeaders());
         logMessage.append(", ");
-        logMessage.append("status=").append(response.getStatus().code());
+        logMessage.append("status=").append(response.status().code());
         logMessage.append(", ");
-        if (HttpHeaders.isTransferEncodingChunked(response)) {
+        if (HttpUtil.isTransferEncodingChunked(response)) {
           responseFirstChunkStartTimeInMs = System.currentTimeMillis();
         } else {
           shouldReset = true;
@@ -139,7 +139,7 @@ public class PublicAccessLogHandler extends ChannelDuplexHandler {
         logMessage.append("[").append(header).append("=").append(message.headers().get(header)).append("] ");
       }
     }
-    boolean isChunked = HttpHeaders.isTransferEncodingChunked(message);
+    boolean isChunked = HttpUtil.isTransferEncodingChunked(message);
     logMessage.append("[isChunked=").append(isChunked).append("]");
     logMessage.append(")");
   }
@@ -174,7 +174,7 @@ public class PublicAccessLogHandler extends ChannelDuplexHandler {
 
   /**
    * Logs error message
-   * @param msg
+   * @param msg the message to log
    */
   private void logError(String msg) {
     logDurations();

--- a/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
@@ -23,6 +23,7 @@ import com.github.ambry.router.FutureResult;
 import com.github.ambry.router.InMemoryRouter;
 import com.github.ambry.router.ReadableStreamChannel;
 import com.github.ambry.router.Router;
+import com.github.ambry.utils.TestUtils;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
@@ -351,7 +352,7 @@ public class AsyncRequestResponseHandlerTest {
       MockRestResponseChannel restResponseChannel = null;
       ReadableStreamChannel response = null;
       for (int i = 0; i < EXPECTED_QUEUE_SIZE; i++) {
-        data = RestTestUtils.getRandomBytes(32);
+        data = TestUtils.getRandomBytes(32);
         response = new HaltingRSC(ByteBuffer.wrap(data), releaseRead, executorService);
         restRequest = createRestRequest(RestMethod.GET, "/", null, null);
         restRequest.getMetricsTracker().scalingMetricsTracker.markRequestReceived();
@@ -541,7 +542,7 @@ public class AsyncRequestResponseHandlerTest {
     restRequest = createRestRequest(RestMethod.GET, "/", null, null);
     restRequest.getMetricsTracker().scalingMetricsTracker.markRequestReceived();
     restResponseChannel = new MockRestResponseChannel();
-    ByteBuffer responseBuffer = ByteBuffer.wrap(RestTestUtils.getRandomBytes(1024));
+    ByteBuffer responseBuffer = ByteBuffer.wrap(TestUtils.getRandomBytes(1024));
     ByteBufferRSC response = new ByteBufferRSC(responseBuffer);
     EventMonitor<ByteBufferRSC.Event> responseCloseMonitor =
         new EventMonitor<ByteBufferRSC.Event>(ByteBufferRSC.Event.Close);
@@ -566,7 +567,7 @@ public class AsyncRequestResponseHandlerTest {
     restRequest = createRestRequest(RestMethod.GET, "/", null, null);
     restRequest.getMetricsTracker().scalingMetricsTracker.markRequestReceived();
     restResponseChannel = new MockRestResponseChannel();
-    responseBuffer = ByteBuffer.wrap(RestTestUtils.getRandomBytes(1024));
+    responseBuffer = ByteBuffer.wrap(TestUtils.getRandomBytes(1024));
     response = new ByteBufferRSC(responseBuffer);
     responseCloseMonitor = new EventMonitor<ByteBufferRSC.Event>(ByteBufferRSC.Event.Close);
     response.addListener(responseCloseMonitor);

--- a/ambry-rest/src/test/java/com.github.ambry.rest/HealthCheckHandlerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/HealthCheckHandlerTest.java
@@ -17,10 +17,10 @@ import com.codahale.metrics.MetricRegistry;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import java.io.IOException;
 import junit.framework.Assert;
 import org.junit.Test;
@@ -55,7 +55,7 @@ public class HealthCheckHandlerTest {
 
   /**
    * Tests non health check requests handling
-   * @throws java.io.IOException
+   * @throws IOException
    */
   @Test
   public void requestHandleWithNonHealthCheckRequestTest() throws IOException {
@@ -78,11 +78,11 @@ public class HealthCheckHandlerTest {
         restServerState.markServiceUp();
       }
       HttpRequest request = RestTestUtils.createRequest(httpMethod, healthCheckUri, null);
-      HttpHeaders.setKeepAlive(request, keepAlive);
+      HttpUtil.setKeepAlive(request, keepAlive);
       FullHttpResponse response = sendRequestAndGetResponse(channel, request);
       HttpResponseStatus httpResponseStatus =
           (isServiceUp) ? HttpResponseStatus.OK : HttpResponseStatus.SERVICE_UNAVAILABLE;
-      assertEquals("Unexpected response status", httpResponseStatus, response.getStatus());
+      assertEquals("Unexpected response status", httpResponseStatus, response.status());
       String expectedStr = (isServiceUp) ? goodStr : badStr;
       assertEquals("Unexpected content", expectedStr, RestTestUtils.getContentString(response));
       restServerState.markServiceDown();
@@ -106,7 +106,7 @@ public class HealthCheckHandlerTest {
     EmbeddedChannel channel = createChannel();
     HttpRequest request = RestTestUtils.createRequest(httpMethod, uri, null);
     FullHttpResponse response = sendRequestAndGetResponse(channel, request);
-    assertEquals("Unexpected response status", HttpResponseStatus.OK, response.getStatus());
+    assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
     assertEquals("Unexpected content", httpMethod.toString(), RestTestUtils.getContentString(response));
     channel.close();
   }
@@ -120,8 +120,7 @@ public class HealthCheckHandlerTest {
   private FullHttpResponse sendRequestAndGetResponse(EmbeddedChannel channel, HttpRequest request) {
     channel.writeInbound(request);
     channel.writeInbound(new DefaultLastHttpContent());
-    FullHttpResponse response = (FullHttpResponse) channel.readOutbound();
-    return response;
+    return channel.readOutbound();
   }
 
   // helpers

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyClient.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyClient.java
@@ -27,10 +27,10 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.stream.ChunkedInput;
 import io.netty.handler.stream.ChunkedWriteHandler;
@@ -132,7 +132,7 @@ public class NettyClient implements Closeable {
    * Resets the request tracking state of the client.
    */
   private void resetState() {
-    responseFuture = new FutureResult<Queue<HttpObject>>();
+    responseFuture = new FutureResult<>();
     responseParts.clear();
     exception = null;
     callbackInvoked.set(false);
@@ -221,10 +221,10 @@ public class NettyClient implements Closeable {
       // Make sure that we increase refCnt because we are going to process it async. The other end has to release
       // after processing.
       responseParts.offer(ReferenceCountUtil.retain(in));
-      if (in instanceof HttpResponse && in.getDecoderResult().isSuccess()) {
-        isKeepAlive = HttpHeaders.isKeepAlive((HttpResponse) in);
-      } else if (in.getDecoderResult().isFailure()) {
-        Throwable cause = in.getDecoderResult().cause();
+      if (in instanceof HttpResponse && in.decoderResult().isSuccess()) {
+        isKeepAlive = HttpUtil.isKeepAlive((HttpResponse) in);
+      } else if (in.decoderResult().isFailure()) {
+        Throwable cause = in.decoderResult().cause();
         if (cause instanceof Exception) {
           exception = (Exception) cause;
         } else {

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
@@ -20,6 +20,8 @@ import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.notification.BlobReplicaSourceType;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.router.InMemoryRouter;
+import com.github.ambry.utils.TestUtils;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
@@ -28,11 +30,11 @@ import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory;
@@ -122,11 +124,11 @@ public class NettyMessageProcessorTest {
   public void rawBytesPostTest() throws InterruptedException {
     Random random = new Random();
     // request also contains content.
-    ByteBuffer content = ByteBuffer.wrap(RestTestUtils.getRandomBytes(random.nextInt(128) + 128));
+    ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(random.nextInt(128) + 128));
     HttpRequest postRequest =
         new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/", Unpooled.wrappedBuffer(content));
-    HttpHeaders.setHeader(postRequest, RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
-    HttpHeaders.setHeader(postRequest, RestUtils.Headers.BLOB_SIZE, content.remaining());
+    postRequest.headers().set(RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
+    postRequest.headers().set(RestUtils.Headers.BLOB_SIZE, content.remaining());
     postRequest = ReferenceCountUtil.retain(postRequest);
     ByteBuffer receivedContent = doPostTest(postRequest, null);
     compareContent(receivedContent, Collections.singletonList(content));
@@ -137,12 +139,12 @@ public class NettyMessageProcessorTest {
     List<ByteBuffer> contents = new ArrayList<ByteBuffer>(NUM_CONTENTS);
     int blobSize = 0;
     for (int i = 0; i < NUM_CONTENTS; i++) {
-      ByteBuffer buffer = ByteBuffer.wrap(RestTestUtils.getRandomBytes(random.nextInt(128) + 128));
+      ByteBuffer buffer = ByteBuffer.wrap(TestUtils.getRandomBytes(random.nextInt(128) + 128));
       blobSize += buffer.remaining();
       contents.add(i, buffer);
     }
-    HttpHeaders.setHeader(postRequest, RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
-    HttpHeaders.setHeader(postRequest, RestUtils.Headers.BLOB_SIZE, blobSize);
+    postRequest.headers().set(RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
+    postRequest.headers().set(RestUtils.Headers.BLOB_SIZE, blobSize);
     receivedContent = doPostTest(postRequest, contents);
     compareContent(receivedContent, contents);
   }
@@ -154,16 +156,16 @@ public class NettyMessageProcessorTest {
   @Test
   public void multipartPostTest() throws Exception {
     Random random = new Random();
-    ByteBuffer content = ByteBuffer.wrap(RestTestUtils.getRandomBytes(random.nextInt(128) + 128));
+    ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(random.nextInt(128) + 128));
     HttpRequest httpRequest = RestTestUtils.createRequest(HttpMethod.POST, "/", null);
-    HttpHeaders.setHeader(httpRequest, RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
-    HttpHeaders.setHeader(httpRequest, RestUtils.Headers.BLOB_SIZE, content.remaining());
+    httpRequest.headers().set(RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
+    httpRequest.headers().set(RestUtils.Headers.BLOB_SIZE, content.remaining());
     HttpPostRequestEncoder encoder = createEncoder(httpRequest, content);
     HttpRequest postRequest = encoder.finalizeRequest();
     List<ByteBuffer> contents = new ArrayList<ByteBuffer>();
     while (!encoder.isEndOfInput()) {
       // Sending null for ctx because the encoder is OK with that.
-      contents.add(encoder.readChunk(null).content().nioBuffer());
+      contents.add(encoder.readChunk(PooledByteBufAllocator.DEFAULT).content().nioBuffer());
     }
     ByteBuffer receivedContent = doPostTest(postRequest, contents);
     compareContent(receivedContent, Collections.singletonList(content));
@@ -179,7 +181,7 @@ public class NettyMessageProcessorTest {
     EmbeddedChannel channel = createChannel();
     channel.writeInbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer(content.getBytes())));
     HttpResponse response = (HttpResponse) channel.readOutbound();
-    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
+    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.status());
     assertFalse("Channel is not closed", channel.isOpen());
 
     // content without request on a channel that was kept alive
@@ -188,7 +190,7 @@ public class NettyMessageProcessorTest {
     channel.writeInbound(RestTestUtils.createRequest(HttpMethod.GET, MockBlobStorageService.ECHO_REST_METHOD, null));
     channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
     response = (HttpResponse) channel.readOutbound();
-    assertEquals("Unexpected response status", HttpResponseStatus.OK, response.getStatus());
+    assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
     // drain the content
     while (channel.readOutbound() != null) {
       ;
@@ -197,7 +199,7 @@ public class NettyMessageProcessorTest {
     // send content without request
     channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
     response = (HttpResponse) channel.readOutbound();
-    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
+    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.status());
     assertFalse("Channel is not closed", channel.isOpen());
 
     // content when no content is expected.
@@ -205,14 +207,14 @@ public class NettyMessageProcessorTest {
     channel.writeInbound(RestTestUtils.createRequest(HttpMethod.GET, "/", null));
     channel.writeInbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer(content.getBytes())));
     response = (HttpResponse) channel.readOutbound();
-    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
+    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.status());
     assertFalse("Channel is not closed", channel.isOpen());
 
     // wrong HTTPObject.
     channel = createChannel();
     channel.writeInbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
     response = (HttpResponse) channel.readOutbound();
-    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
+    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.status());
     assertFalse("Channel is not closed", channel.isOpen());
 
     // request while another request is in progress.
@@ -222,7 +224,7 @@ public class NettyMessageProcessorTest {
     // channel should be closed by now
     assertFalse("Channel is not closed", channel.isOpen());
     response = (HttpResponse) channel.readOutbound();
-    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
+    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.status());
 
     // decoding failure
     channel = createChannel();
@@ -232,7 +234,7 @@ public class NettyMessageProcessorTest {
     // channel should be closed by now
     assertFalse("Channel is not closed", channel.isOpen());
     response = (HttpResponse) channel.readOutbound();
-    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
+    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.status());
 
     // unsupported method
     channel = createChannel();
@@ -240,7 +242,7 @@ public class NettyMessageProcessorTest {
     // channel should be closed by now
     assertFalse("Channel is not closed", channel.isOpen());
     response = (HttpResponse) channel.readOutbound();
-    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.getStatus());
+    assertEquals("Unexpected response status", HttpResponseStatus.BAD_REQUEST, response.status());
   }
 
   /**
@@ -292,11 +294,11 @@ public class NettyMessageProcessorTest {
     long requestId = REQUEST_ID_GENERATOR.getAndIncrement();
     String uri = MockBlobStorageService.ECHO_REST_METHOD + requestId;
     HttpRequest httpRequest = RestTestUtils.createRequest(httpMethod, uri, null);
-    HttpHeaders.setKeepAlive(httpRequest, isKeepAlive);
+    HttpUtil.setKeepAlive(httpRequest, isKeepAlive);
     channel.writeInbound(httpRequest);
     channel.writeInbound(new DefaultLastHttpContent());
     HttpResponse response = (HttpResponse) channel.readOutbound();
-    assertEquals("Unexpected response status", HttpResponseStatus.OK, response.getStatus());
+    assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
     // MockBlobStorageService echoes the RestMethod + request id.
     String expectedResponse = restMethod.toString() + requestId;
     assertEquals("Unexpected content", expectedResponse,
@@ -317,8 +319,8 @@ public class NettyMessageProcessorTest {
 
     // POST
     notificationSystem.reset();
-    HttpHeaders.setHeader(postRequest, RestUtils.Headers.AMBRY_CONTENT_TYPE, "application/octet-stream");
-    HttpHeaders.setKeepAlive(postRequest, false);
+    postRequest.headers().set(RestUtils.Headers.AMBRY_CONTENT_TYPE, "application/octet-stream");
+    HttpUtil.setKeepAlive(postRequest, false);
     channel.writeInbound(postRequest);
     if (contentToSend != null) {
       for (ByteBuffer content : contentToSend) {
@@ -416,7 +418,7 @@ public class NettyMessageProcessorTest {
     channel.writeInbound(new DefaultLastHttpContent());
     // first outbound has to be response.
     HttpResponse response = (HttpResponse) channel.readOutbound();
-    assertEquals("Unexpected response status", expectedStatus, response.getStatus());
+    assertEquals("Unexpected response status", expectedStatus, response.status());
   }
 
   /**

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
@@ -20,6 +20,7 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.FutureResult;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -30,19 +31,23 @@ import io.netty.buffer.UnpooledHeapByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.DefaultMaxBytesRecvByteBufAllocator;
+import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.http.Cookie;
-import io.netty.handler.codec.http.DefaultCookie;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
@@ -98,13 +103,11 @@ public class NettyRequestTest {
   public void conversionWithGoodInputTest() throws RestServiceException {
     // headers
     HttpHeaders headers = new DefaultHttpHeaders(false);
-    headers.add(HttpHeaders.Names.CONTENT_LENGTH, new Random().nextInt(Integer.MAX_VALUE));
+    headers.add(HttpHeaderNames.CONTENT_LENGTH, new Random().nextInt(Integer.MAX_VALUE));
     headers.add("headerKey", "headerValue1");
     headers.add("headerKey", "headerValue2");
     headers.add("overLoadedKey", "headerOverloadedValue");
     headers.add("paramNoValueInUriButValueInHeader", "paramValueInHeader");
-    headers.add("headerNoValue", (Object) null);
-    headers.add("headerNoValueButValueInUri", (Object) null);
 
     // params
     Map<String, List<String>> params = new HashMap<String, List<String>>();
@@ -115,9 +118,6 @@ public class NettyRequestTest {
     values = new ArrayList<String>(1);
     values.add("paramOverloadedValue");
     params.put("overLoadedKey", values);
-    values = new ArrayList<String>(1);
-    values.add("headerValueInUri");
-    params.put("headerNoValueButValueInUri", values);
     params.put("paramNoValue", null);
     params.put("paramNoValueInUriButValueInHeader", null);
 
@@ -136,41 +136,53 @@ public class NettyRequestTest {
 
     NettyRequest nettyRequest;
     String uri;
-    Set<Cookie> cookies = new HashSet<Cookie>();
+    Set<Cookie> cookies = new HashSet<>();
     Cookie httpCookie = new DefaultCookie("CookieKey1", "CookieValue1");
     cookies.add(httpCookie);
     httpCookie = new DefaultCookie("CookieKey2", "CookieValue2");
     cookies.add(httpCookie);
     headers.add(RestUtils.Headers.COOKIE, getCookiesHeaderValue(cookies));
     MockChannel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
 
     uri = "/GET" + uriAttachment;
     nettyRequest = createNettyRequest(HttpMethod.GET, uri, headers, channel);
-    validateRequest(nettyRequest, RestMethod.GET, uri, headers, params, cookies, channel, expectedMaxMessagesPerRead);
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    validateRequest(nettyRequest, RestMethod.GET, uri, headers, params, cookies, channel);
+    closeRequestAndValidate(nettyRequest, channel);
 
+    int maxBytesPerRead = 1024 * 1024;
+    NettyRequest.maxBytesPerRead = maxBytesPerRead;
+    RecvByteBufAllocator savedAllocator = channel.config().getRecvByteBufAllocator();
     int[] bufferWatermarks = {-1, 0, 1, DEFAULT_WATERMARK};
     for (int bufferWatermark : bufferWatermarks) {
       NettyRequest.bufferWatermark = bufferWatermark;
       uri = "/POST" + uriAttachment;
       nettyRequest = createNettyRequest(HttpMethod.POST, uri, headers, channel);
-      int maxMessagesPerRead = bufferWatermark > 0 ? 1 : expectedMaxMessagesPerRead;
-      validateRequest(nettyRequest, RestMethod.POST, uri, headers, params, cookies, channel, maxMessagesPerRead);
-      closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+      validateRequest(nettyRequest, RestMethod.POST, uri, headers, params, cookies, channel);
+      if (bufferWatermark > 0) {
+        assertTrue("RecvAllocator should have changed",
+            channel.config().getRecvByteBufAllocator() instanceof DefaultMaxBytesRecvByteBufAllocator);
+        DefaultMaxBytesRecvByteBufAllocator allocator =
+            (DefaultMaxBytesRecvByteBufAllocator) channel.config().getRecvByteBufAllocator();
+        assertEquals("Max bytes per read not as expected", maxBytesPerRead, allocator.maxBytesPerRead());
+        assertEquals("Max bytes per individual read not as expected", maxBytesPerRead,
+            allocator.maxBytesPerIndividualRead());
+      } else {
+        assertEquals("RecvAllocator not as expected", savedAllocator, channel.config().getRecvByteBufAllocator());
+      }
+      closeRequestAndValidate(nettyRequest, channel);
+      assertEquals("Allocator not as expected", savedAllocator, channel.config().getRecvByteBufAllocator());
     }
     NettyRequest.bufferWatermark = DEFAULT_WATERMARK;
 
     uri = "/DELETE" + uriAttachment;
     nettyRequest = createNettyRequest(HttpMethod.DELETE, uri, headers, channel);
-    validateRequest(nettyRequest, RestMethod.DELETE, uri, headers, params, cookies, channel,
-        expectedMaxMessagesPerRead);
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    validateRequest(nettyRequest, RestMethod.DELETE, uri, headers, params, cookies, channel);
+    closeRequestAndValidate(nettyRequest, channel);
 
     uri = "/HEAD" + uriAttachment;
     nettyRequest = createNettyRequest(HttpMethod.HEAD, uri, headers, channel);
-    validateRequest(nettyRequest, RestMethod.HEAD, uri, headers, params, cookies, channel, expectedMaxMessagesPerRead);
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    validateRequest(nettyRequest, RestMethod.HEAD, uri, headers, params, cookies, channel);
+    closeRequestAndValidate(nettyRequest, channel);
   }
 
   /**
@@ -226,9 +238,8 @@ public class NettyRequestTest {
   @Test
   public void operationsAfterCloseTest() throws Exception {
     Channel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
 
     // operations that should be ok to do (does not include all operations).
     nettyRequest.close();
@@ -247,7 +258,7 @@ public class NettyRequestTest {
     }
 
     try {
-      byte[] content = RestTestUtils.getRandomBytes(1024);
+      byte[] content = TestUtils.getRandomBytes(1024);
       nettyRequest.addContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(content)));
       fail("Request channel has been closed, so addContent() should have thrown ClosedChannelException");
     } catch (RestServiceException e) {
@@ -293,7 +304,6 @@ public class NettyRequestTest {
   @Test
   public void readIntoExceptionsTest() throws Exception {
     Channel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     // try to call readInto twice.
     NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     AsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
@@ -305,7 +315,7 @@ public class NettyRequestTest {
     } catch (IllegalStateException e) {
       // expected. Nothing to do.
     }
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
 
     // write into a channel that throws exceptions
     // non RuntimeException
@@ -344,7 +354,7 @@ public class NettyRequestTest {
     } catch (ExecutionException e) {
       assertEquals("Exception message mismatch (future)", expectedMsg, Utils.getRootCause(e).getMessage());
     }
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
 
     // RuntimeException
     // during readInto
@@ -366,7 +376,7 @@ public class NettyRequestTest {
       assertEquals("Exception caught does not match expected exception", expectedMsg, e.getMessage());
     }
     writeChannel.close();
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
     verifyRefCnts(httpContents);
 
     // after readInto
@@ -387,7 +397,7 @@ public class NettyRequestTest {
       assertEquals("Exception caught does not match expected exception", expectedMsg, e.getMessage());
     }
     writeChannel.close();
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
     verifyRefCnts(httpContents);
   }
 
@@ -399,16 +409,15 @@ public class NettyRequestTest {
   @Test
   public void closeTest() throws RestServiceException {
     Channel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     Queue<HttpContent> httpContents = new LinkedBlockingQueue<HttpContent>();
     for (int i = 0; i < 5; i++) {
-      ByteBuffer content = ByteBuffer.wrap(RestTestUtils.getRandomBytes(1024));
+      ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(1024));
       HttpContent httpContent = new DefaultHttpContent(Unpooled.wrappedBuffer(content));
       nettyRequest.addContent(httpContent);
       httpContents.add(httpContent);
     }
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
     while (httpContents.peek() != null) {
       assertEquals("Reference count of http content has changed", 1, httpContents.poll().refCnt());
     }
@@ -421,7 +430,7 @@ public class NettyRequestTest {
    */
   @Test
   public void addContentForGetTest() throws RestServiceException {
-    byte[] content = RestTestUtils.getRandomBytes(16);
+    byte[] content = TestUtils.getRandomBytes(16);
     // adding non LastHttpContent to nettyRequest
     NettyRequest nettyRequest = createNettyRequest(HttpMethod.GET, "/", null, new MockChannel());
     try {
@@ -462,12 +471,12 @@ public class NettyRequestTest {
     assertTrue("Keep-alive not as expected", request.isKeepAlive());
 
     HttpHeaders headers = new DefaultHttpHeaders();
-    headers.set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+    headers.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
     request = createNettyRequest(HttpMethod.GET, "/", headers, new MockChannel());
     assertTrue("Keep-alive not as expected", request.isKeepAlive());
 
     headers = new DefaultHttpHeaders();
-    headers.set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE);
+    headers.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
     request = createNettyRequest(HttpMethod.GET, "/", headers, new MockChannel());
     assertFalse("Keep-alive not as expected", request.isKeepAlive());
   }
@@ -488,7 +497,7 @@ public class NettyRequestTest {
 
     // Content-Length header set
     HttpHeaders headers = new DefaultHttpHeaders();
-    headers.add(HttpHeaders.Names.CONTENT_LENGTH, contentLength);
+    headers.add(HttpHeaderNames.CONTENT_LENGTH, contentLength);
     nettyRequest = createNettyRequest(HttpMethod.GET, "/", headers, new MockChannel());
     assertEquals("Size not as expected", contentLength, nettyRequest.getSize());
 
@@ -501,7 +510,7 @@ public class NettyRequestTest {
     // both set
     headers = new DefaultHttpHeaders();
     headers.add(RestUtils.Headers.BLOB_SIZE, xAmbryBlobSize);
-    headers.add(HttpHeaders.Names.CONTENT_LENGTH, contentLength);
+    headers.add(HttpHeaderNames.CONTENT_LENGTH, contentLength);
     nettyRequest = createNettyRequest(HttpMethod.GET, "/", headers, new MockChannel());
     assertEquals("Size not as expected", xAmbryBlobSize, nettyRequest.getSize());
   }
@@ -513,7 +522,6 @@ public class NettyRequestTest {
   @Test
   public void zeroSizeContentTest() throws Exception {
     Channel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     HttpContent httpContent = new DefaultLastHttpContent();
 
@@ -525,7 +533,7 @@ public class NettyRequestTest {
     Future<Long> future = nettyRequest.readInto(writeChannel, callback);
     assertEquals("There should be no content", 0, writeChannel.getNextChunk().remaining());
     writeChannel.resolveOldestChunk(null);
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
     writeChannel.close();
     assertEquals("Reference count of http content has changed", 1, httpContent.refCnt());
     callback.awaitCallback();
@@ -605,14 +613,11 @@ public class NettyRequestTest {
    * Closes the provided {@code nettyRequest} and validates that it is actually closed.
    * @param nettyRequest the {@link NettyRequest} that needs to be closed and validated.
    * @param channel the {@link Channel} over which the request was received.
-   * @param expectedMaxMessagesPerRead the expected value of {@link ChannelConfig#getMaxMessagesPerRead()}.
    */
-  private void closeRequestAndValidate(NettyRequest nettyRequest, Channel channel, int expectedMaxMessagesPerRead) {
+  private void closeRequestAndValidate(NettyRequest nettyRequest, Channel channel) {
     nettyRequest.close();
     assertFalse("Request channel is not closed", nettyRequest.isOpen());
     assertTrue("Auto-read is not as expected", channel.config().isAutoRead());
-    assertEquals("Max messages per read is in an invalid state", expectedMaxMessagesPerRead,
-        channel.config().getMaxMessagesPerRead());
   }
 
   /**
@@ -626,7 +631,7 @@ public class NettyRequestTest {
       if (cookieStr.length() != 0) {
         cookieStr.append("; ");
       }
-      cookieStr.append(cookie.getName()).append("=").append(cookie.getValue());
+      cookieStr.append(cookie.name()).append("=").append(cookie.value());
     }
     return cookieStr.toString();
   }
@@ -642,12 +647,12 @@ public class NettyRequestTest {
    * @param params the parameters passed with the request that need to be in {@link NettyRequest#getArgs()}.
    * @param httpCookies Set of {@link Cookie} set in the request
    * @param channel the {@link Channel} over which the request was received.
-   * @param expectedMaxMessagesPerRead the expected value of {@link ChannelConfig#getMaxMessagesPerRead()}.
    */
   private void validateRequest(NettyRequest nettyRequest, RestMethod restMethod, String uri, HttpHeaders headers,
-      Map<String, List<String>> params, Set<Cookie> httpCookies, Channel channel, int expectedMaxMessagesPerRead) {
-    long contentLength = headers.contains(HttpHeaders.Names.CONTENT_LENGTH) ? Long.parseLong(
-        headers.get(HttpHeaders.Names.CONTENT_LENGTH)) : 0;
+      Map<String, List<String>> params, Set<Cookie> httpCookies, Channel channel) {
+    long contentLength =
+        headers.contains(HttpHeaderNames.CONTENT_LENGTH) ? Long.parseLong(headers.get(HttpHeaderNames.CONTENT_LENGTH))
+            : 0;
     assertTrue("Request channel is not open", nettyRequest.isOpen());
     assertEquals("Mismatch in content length", contentLength, nettyRequest.getSize());
     assertEquals("Mismatch in rest method", restMethod, nettyRequest.getRestMethod());
@@ -657,12 +662,12 @@ public class NettyRequestTest {
     assertFalse("Should not have been a multipart request", nettyRequest.isMultipart());
 
     Set<javax.servlet.http.Cookie> actualCookies =
-        (Set<javax.servlet.http.Cookie>) nettyRequest.getArgs().get(HttpHeaders.Names.COOKIE);
+        (Set<javax.servlet.http.Cookie>) nettyRequest.getArgs().get(RestUtils.Headers.COOKIE);
     compareCookies(httpCookies, actualCookies);
 
     Map<String, List<String>> receivedArgs = new HashMap<String, List<String>>();
     for (Map.Entry<String, Object> e : nettyRequest.getArgs().entrySet()) {
-      if (!e.getKey().equals(HttpHeaders.Names.COOKIE)) {
+      if (!e.getKey().equalsIgnoreCase(HttpHeaderNames.COOKIE.toString())) {
         if (!receivedArgs.containsKey(e.getKey())) {
           receivedArgs.put(e.getKey(), new LinkedList<String>());
         }
@@ -689,7 +694,7 @@ public class NettyRequestTest {
     }
 
     for (Map.Entry<String, String> e : headers) {
-      if (!e.getKey().equals(HttpHeaders.Names.COOKIE)) {
+      if (!e.getKey().equalsIgnoreCase(HttpHeaderNames.COOKIE.toString())) {
         assertTrue("Did not find key: " + e.getKey(), receivedArgs.containsKey(e.getKey()));
         if (!keyValueCount.containsKey(e.getKey())) {
           keyValueCount.put(e.getKey(), 0);
@@ -710,8 +715,6 @@ public class NettyRequestTest {
 
     assertEquals("Auto-read is in an invalid state",
         !restMethod.equals(RestMethod.POST) || NettyRequest.bufferWatermark <= 0, channel.config().isAutoRead());
-    assertEquals("Max messages per read is in an invalid state", expectedMaxMessagesPerRead,
-        channel.config().getMaxMessagesPerRead());
   }
 
   /**
@@ -724,10 +727,10 @@ public class NettyRequestTest {
     Assert.assertEquals("Size didn't match", expected.size(), actual.size());
     HashMap<String, Cookie> expectedHashMap = new HashMap<String, Cookie>();
     for (Cookie cookie : expected) {
-      expectedHashMap.put(cookie.getName(), cookie);
+      expectedHashMap.put(cookie.name(), cookie);
     }
     for (javax.servlet.http.Cookie cookie : actual) {
-      Assert.assertEquals("Value field didn't match ", expectedHashMap.get(cookie.getName()).getValue(),
+      Assert.assertEquals("Value field didn't match ", expectedHashMap.get(cookie.getName()).value(),
           cookie.getValue());
     }
   }
@@ -787,7 +790,6 @@ public class NettyRequestTest {
     }
 
     Channel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     byte[] wholeDigest = null;
     if (digestAlgorithm != null && !digestAlgorithm.isEmpty()) {
@@ -835,7 +837,7 @@ public class NettyRequestTest {
     for (int i = 0; i < 2; i++) {
       assertArrayEquals("Part by part digest should match digest of whole", wholeDigest, nettyRequest.getDigest());
     }
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
   }
 
   /**
@@ -848,7 +850,7 @@ public class NettyRequestTest {
    */
   private void backPressureTest(String digestAlgorithm, boolean useCopyForcingByteBuf) throws Exception {
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
-    byte[] contentBytes = RestTestUtils.getRandomBytes(GENERATED_CONTENT_SIZE);
+    byte[] contentBytes = TestUtils.getRandomBytes(GENERATED_CONTENT_SIZE);
     ByteBuffer content = ByteBuffer.wrap(contentBytes);
     splitContent(contentBytes, GENERATED_CONTENT_PART_COUNT, httpContents, useCopyForcingByteBuf);
     int chunkSize = httpContents.get(0).content().readableBytes();
@@ -894,7 +896,6 @@ public class NettyRequestTest {
     }
 
     MockChannel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     final NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     byte[] wholeDigest = null;
     if (digestAlgorithm != null && !digestAlgorithm.isEmpty()) {
@@ -966,7 +967,7 @@ public class NettyRequestTest {
     for (int i = 0; i < 2; i++) {
       assertArrayEquals("Part by part digest should match digest of whole", wholeDigest, nettyRequest.getDigest());
     }
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
   }
 
   /**
@@ -986,7 +987,7 @@ public class NettyRequestTest {
    * @return the whole content as a {@link ByteBuffer} - serves as a source of truth.
    */
   private ByteBuffer generateContent(List<HttpContent> httpContents, boolean useCopyForcingByteBuf) {
-    byte[] contentBytes = RestTestUtils.getRandomBytes(GENERATED_CONTENT_SIZE);
+    byte[] contentBytes = TestUtils.getRandomBytes(GENERATED_CONTENT_SIZE);
     splitContent(contentBytes, GENERATED_CONTENT_PART_COUNT, httpContents, useCopyForcingByteBuf);
     return ByteBuffer.wrap(contentBytes);
   }
@@ -1028,7 +1029,7 @@ public class NettyRequestTest {
    */
   private ByteBuffer generateCompositeContent(List<HttpContent> httpContents) {
     int individualPartSize = GENERATED_CONTENT_SIZE / GENERATED_CONTENT_PART_COUNT;
-    byte[] contentBytes = RestTestUtils.getRandomBytes(GENERATED_CONTENT_SIZE);
+    byte[] contentBytes = TestUtils.getRandomBytes(GENERATED_CONTENT_SIZE);
     ArrayList<ByteBuf> byteBufs = new ArrayList<>(GENERATED_CONTENT_PART_COUNT);
     for (int addedContentCount = 0; addedContentCount < GENERATED_CONTENT_PART_COUNT; addedContentCount++) {
       byteBufs.add(Unpooled.wrappedBuffer(contentBytes, addedContentCount * individualPartSize, individualPartSize));
@@ -1082,7 +1083,7 @@ public class NettyRequestTest {
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     ByteBuffer content = generateContent(httpContents);
     HttpHeaders httpHeaders = new DefaultHttpHeaders();
-    httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, content.limit() + 1);
+    httpHeaders.set(HttpHeaderNames.CONTENT_LENGTH, content.limit() + 1);
     doHeaderAndContentSizeMismatchTest(httpHeaders, httpContents);
   }
 
@@ -1095,7 +1096,7 @@ public class NettyRequestTest {
     ByteBuffer content = generateContent(httpContents);
     HttpHeaders httpHeaders = new DefaultHttpHeaders();
     int lastHttpContentSize = httpContents.get(httpContents.size() - 1).content().readableBytes();
-    httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, content.limit() - lastHttpContentSize - 1);
+    httpHeaders.set(HttpHeaderNames.CONTENT_LENGTH, content.limit() - lastHttpContentSize - 1);
     doHeaderAndContentSizeMismatchTest(httpHeaders, httpContents);
   }
 
@@ -1108,7 +1109,6 @@ public class NettyRequestTest {
   private void doHeaderAndContentSizeMismatchTest(HttpHeaders httpHeaders, List<HttpContent> httpContents)
       throws Exception {
     Channel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", httpHeaders, channel);
     AsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
     ReadIntoCallback callback = new ReadIntoCallback();
@@ -1135,7 +1135,7 @@ public class NettyRequestTest {
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.BadRequest, e.getErrorCode());
     }
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
     writeChannel.close();
     verifyRefCnts(httpContents);
     callback.awaitCallback();
@@ -1165,7 +1165,6 @@ public class NettyRequestTest {
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     generateContent(httpContents);
     Channel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     ByteBufferAsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
     ReadIntoCallback callback = new ReadIntoCallback();
@@ -1179,7 +1178,7 @@ public class NettyRequestTest {
     }
 
     writeChannel.close();
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
   }
 
   /**
@@ -1190,7 +1189,6 @@ public class NettyRequestTest {
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     generateContent(httpContents);
     Channel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     try {
       nettyRequest.setDigestAlgorithm("NonExistentAlgorithm");
@@ -1198,7 +1196,7 @@ public class NettyRequestTest {
     } catch (NoSuchAlgorithmException e) {
       // expected. Nothing to do.
     }
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
   }
 
   /**
@@ -1210,7 +1208,6 @@ public class NettyRequestTest {
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     generateContent(httpContents);
     Channel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     ByteBufferAsyncWritableChannel writeChannel = new ByteBufferAsyncWritableChannel();
     ReadIntoCallback callback = new ReadIntoCallback();
@@ -1220,7 +1217,7 @@ public class NettyRequestTest {
       nettyRequest.addContent(httpContent);
     }
     assertNull("Digest should be null because no digest algorithm was set", nettyRequest.getDigest());
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
   }
 
   /**
@@ -1235,7 +1232,6 @@ public class NettyRequestTest {
     List<HttpContent> httpContents = new ArrayList<HttpContent>();
     generateContent(httpContents);
     Channel channel = new MockChannel();
-    int expectedMaxMessagesPerRead = channel.config().getMaxMessagesPerRead();
     NettyRequest nettyRequest = createNettyRequest(HttpMethod.POST, "/", null, channel);
     nettyRequest.setDigestAlgorithm("MD5");
 
@@ -1253,7 +1249,7 @@ public class NettyRequestTest {
     } catch (IllegalStateException e) {
       // expected. Nothing to do.
     }
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
 
     // content not processed test.
     httpContents.clear();
@@ -1270,7 +1266,7 @@ public class NettyRequestTest {
     } catch (IllegalStateException e) {
       // expected. Nothing to do.
     }
-    closeRequestAndValidate(nettyRequest, channel, expectedMaxMessagesPerRead);
+    closeRequestAndValidate(nettyRequest, channel);
   }
 }
 
@@ -1380,8 +1376,6 @@ class MockChannel extends EmbeddedChannel {
     // sending a placeholder handler to avoid NPE. This is of no consequence and saves us from having to implement
     // needless functions.
     super(new ConnectionStatsHandler(new NettyMetrics(new MetricRegistry())));
-    // setting max messages per read to something other than 1
-    config().setMaxMessagesPerRead(16);
   }
 
   /**

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
@@ -149,8 +149,6 @@ public class NettyRequestTest {
     validateRequest(nettyRequest, RestMethod.GET, uri, headers, params, cookies, channel);
     closeRequestAndValidate(nettyRequest, channel);
 
-    int maxBytesPerRead = 1024 * 1024;
-    NettyRequest.maxBytesPerRead = maxBytesPerRead;
     RecvByteBufAllocator savedAllocator = channel.config().getRecvByteBufAllocator();
     int[] bufferWatermarks = {-1, 0, 1, DEFAULT_WATERMARK};
     for (int bufferWatermark : bufferWatermarks) {
@@ -161,11 +159,6 @@ public class NettyRequestTest {
       if (bufferWatermark > 0) {
         assertTrue("RecvAllocator should have changed",
             channel.config().getRecvByteBufAllocator() instanceof DefaultMaxBytesRecvByteBufAllocator);
-        DefaultMaxBytesRecvByteBufAllocator allocator =
-            (DefaultMaxBytesRecvByteBufAllocator) channel.config().getRecvByteBufAllocator();
-        assertEquals("Max bytes per read not as expected", maxBytesPerRead, allocator.maxBytesPerRead());
-        assertEquals("Max bytes per individual read not as expected", maxBytesPerRead,
-            allocator.maxBytesPerIndividualRead());
       } else {
         assertEquals("RecvAllocator not as expected", savedAllocator, channel.config().getRecvByteBufAllocator());
       }

--- a/ambry-rest/src/test/java/com.github.ambry.rest/RestTestUtils.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/RestTestUtils.java
@@ -23,7 +23,6 @@ import io.netty.handler.codec.http.HttpVersion;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Random;
 
 
 /**
@@ -55,19 +54,6 @@ public class RestTestUtils {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     httpContent.content().readBytes(out, httpContent.content().readableBytes());
     return out.toString(StandardCharsets.UTF_8.name());
-  }
-
-  /**
-   * Gets a byte array of length {@code size} with random bytes.
-   * @param size the required length of the random byte array.
-   * @return a byte array of length {@code size} with random bytes.
-   * @deprecated use {@link com.github.ambry.utils.TestUtils#getRandomBytes(int)} instead.
-   */
-  @Deprecated
-  public static byte[] getRandomBytes(int size) {
-    byte[] bytes = new byte[size];
-    new Random().nextBytes(bytes);
-    return bytes;
   }
 
   /**

--- a/build.gradle
+++ b/build.gradle
@@ -209,7 +209,7 @@ project(':ambry-rest') {
                 project(':ambry-commons')
         compile "com.codahale.metrics:metrics-core:$metricsVersion"
         compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
-        compile "io.netty:netty-all:4.0.25.Final"
+        compile "io.netty:netty-all:$nettyVersion"
         compile "javax.servlet:javax.servlet-api:$javaxVersion"
         testCompile project(':ambry-api').sourceSets.test.output
         testCompile project(':ambry-clustermap').sourceSets.test.output

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -18,4 +18,5 @@ ext {
     bouncycastleVersion = "1.52"
     javaxVersion = "3.0.1"
     helixVersion = "0.6.6"
+    nettyVersion = "4.1.4.Final"
 }


### PR DESCRIPTION
This change upgrades netty to 4.1.4, removes use of deprecated APIs and adds
any new functions required by netty interfaces

Built (on OSx and Linux) and formatted.
Also made a few requests and checked headers and public access log

**Primary reviewers: @fhlawaczek, @saravindpsg, @xiahome**

Please refer to netty 4.1.4 docs when reviewing the changes in `NettyResponseChannel`. The summary of changes from 4.0 to 4.1 is [here](http://netty.io/wiki/new-and-noteworthy-in-4.1.html).  