### PR TITLE
Adding APIs that the BlobStoreCompactor will eventually use

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +51,7 @@ class BlobStore implements Store {
   private final MessageStoreHardDelete hardDelete;
   private final StoreMetrics metrics;
   private final Time time;
+  private final UUID sessionId = UUID.randomUUID();
 
   private Log log;
   private PersistentIndex index;
@@ -105,8 +107,8 @@ class BlobStore implements Store {
         StoreDescriptor storeDescriptor = new StoreDescriptor(dataDir);
         log = new Log(dataDir, capacityInBytes, config.storeSegmentSizeInBytes, metrics);
         index = new PersistentIndex(dataDir, taskScheduler, log, config, factory, recovery, hardDelete, metrics, time,
-            storeDescriptor.getIncarnationId());
-        metrics.initializeLogGauges(log, capacityInBytes);
+            sessionId, storeDescriptor.getIncarnationId());
+        metrics.initializeIndexGauges(index, capacityInBytes);
         started = true;
       } catch (Exception e) {
         metrics.storeStartFailure.inc();
@@ -300,7 +302,7 @@ class BlobStore implements Store {
 
   @Override
   public long getSizeInBytes() {
-    return log.getUsedCapacity();
+    return index.getUsedCapacity();
   }
 
   @Override

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -302,7 +302,7 @@ class BlobStore implements Store {
 
   @Override
   public long getSizeInBytes() {
-    return index.getUsedCapacity();
+    return index.getLogUsedCapacity();
   }
 
   @Override

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionLog.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionLog.java
@@ -353,7 +353,8 @@ class CompactionLog implements Closeable {
         commitStartTime
         cleanupStartTime
         cycleEndTime
-        safeToken (see StoreFindToken#toBytes())
+        storeTokenPresent flag
+        safeToken if not null (see StoreFindToken#toBytes())
        */
       byte[] compactionDetailsBytes = compactionDetails.toBytes();
       byte[] safeTokenBytes = safeToken != null ? safeToken.toBytes() : ZERO_LENGTH_ARRAY;

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -55,7 +55,6 @@ public class HardDeleter implements Runnable {
   private final StoreMetrics metrics;
   private final String dataDir;
   private final Log log;
-  private final Offset logAbsoluteZeroOffset;
   private final PersistentIndex index;
   private final MessageStoreHardDelete hardDelete;
   private final StoreKeyFactory factory;
@@ -101,7 +100,6 @@ public class HardDeleter implements Runnable {
     this.metrics = metrics;
     this.dataDir = dataDir;
     this.log = log;
-    logAbsoluteZeroOffset = new Offset(log.getFirstSegment().getName(), 0);
     this.index = index;
     this.hardDelete = hardDelete;
     this.factory = factory;
@@ -286,7 +284,7 @@ public class HardDeleter implements Runnable {
    * @return true if the token moved forward, false otherwise.
    */
   boolean hardDelete() throws StoreException {
-    if (index.getCurrentEndOffset().compareTo(log.getStartOffset()) > 0) {
+    if (index.getCurrentEndOffset().compareTo(index.getStartOffset()) > 0) {
       final Timer.Context context = metrics.hardDeleteTime.time();
       try {
         FindInfo info =
@@ -336,7 +334,7 @@ public class HardDeleter implements Runnable {
   long getProgress() {
     StoreFindToken token = (StoreFindToken) startToken;
     return token.getType().equals(StoreFindToken.Type.Uninitialized) ? 0
-        : log.getDifference(token.getOffset(), logAbsoluteZeroOffset);
+        : index.getAbsolutePositionForOffset(token.getOffset());
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -334,7 +334,7 @@ public class HardDeleter implements Runnable {
   long getProgress() {
     StoreFindToken token = (StoreFindToken) startToken;
     return token.getType().equals(StoreFindToken.Type.Uninitialized) ? 0
-        : index.getAbsolutePositionForOffset(token.getOffset());
+        : index.getAbsolutePositionInLogForOffset(token.getOffset());
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -54,6 +54,9 @@ import org.slf4j.LoggerFactory;
  * lookup is performed to find key.
  */
 class IndexSegment {
+  static final String INDEX_SEGMENT_FILE_NAME_SUFFIX = "index";
+  static final String BLOOM_FILE_NAME_SUFFIX = "bloom";
+
   private final static int Key_Size_Invalid_Value = -1;
   private final static int Value_Size_Invalid_Value = -1;
 
@@ -114,8 +117,8 @@ class IndexSegment {
     this.metrics = metrics;
     this.lastModifiedTimeSec = new AtomicLong(0);
     indexSegmentFilenamePrefix = generateIndexSegmentFilenamePrefix();
-    indexFile = new File(dataDir, indexSegmentFilenamePrefix + PersistentIndex.INDEX_SEGMENT_FILE_NAME_SUFFIX);
-    bloomFile = new File(dataDir, indexSegmentFilenamePrefix + PersistentIndex.BLOOM_FILE_NAME_SUFFIX);
+    indexFile = new File(dataDir, indexSegmentFilenamePrefix + INDEX_SEGMENT_FILE_NAME_SUFFIX);
+    bloomFile = new File(dataDir, indexSegmentFilenamePrefix + BLOOM_FILE_NAME_SUFFIX);
   }
 
   /**
@@ -146,8 +149,7 @@ class IndexSegment {
         map(false);
         // Load the bloom filter for this index
         // We need to load the bloom filter only for mapped indexes
-        bloomFile =
-            new File(indexFile.getParent(), indexSegmentFilenamePrefix + PersistentIndex.BLOOM_FILE_NAME_SUFFIX);
+        bloomFile = new File(indexFile.getParent(), indexSegmentFilenamePrefix + BLOOM_FILE_NAME_SUFFIX);
         CrcInputStream crcBloom = new CrcInputStream(new FileInputStream(bloomFile));
         DataInputStream stream = new DataInputStream(crcBloom);
         bloomFilter = FilterFactory.deserialize(stream);
@@ -165,8 +167,7 @@ class IndexSegment {
         index = new ConcurrentSkipListMap<StoreKey, IndexValue>();
         bloomFilter = FilterFactory.getFilter(config.storeIndexMaxNumberOfInmemElements,
             config.storeIndexBloomMaxFalsePositiveProbability);
-        bloomFile =
-            new File(indexFile.getParent(), indexSegmentFilenamePrefix + PersistentIndex.BLOOM_FILE_NAME_SUFFIX);
+        bloomFile = new File(indexFile.getParent(), indexSegmentFilenamePrefix + BLOOM_FILE_NAME_SUFFIX);
         try {
           readFromFile(indexFile, journal);
         } catch (StoreException e) {

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -106,6 +106,10 @@ class IndexValue {
         originalMessageOffset);
   }
 
+  void clearOriginalMessageOffset() {
+    value.putLong(Blob_Size_In_Bytes + Offset_Size_In_Bytes + Flag_Size_In_Bytes + Expires_At_Ms_Size_In_Bytes, -1);
+  }
+
   void setNewSize(long size) {
     value.putLong(0, size);
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -434,11 +434,13 @@ class Log implements Write {
    * @param segment the {@link LogSegment} instance to add.
    * @param increaseUsedSegmentCount {@code true} if the number of segments used has to be incremented, {@code false}
    *                                             otherwise.
-   * @throws IllegalArgumentException if the {@code segment} being added is past the active segment.
+   * @throws IllegalArgumentException if the {@code segment} being added is past the active segment or if the segment
+   *                                  added cannot be counted as "used".
    */
   void addSegment(LogSegment segment, boolean increaseUsedSegmentCount) {
-    if (increaseUsedSegmentCount) {
-      remainingUnallocatedSegments.decrementAndGet();
+    if (increaseUsedSegmentCount && remainingUnallocatedSegments.decrementAndGet() < 0) {
+      remainingUnallocatedSegments.incrementAndGet();
+      throw new IllegalArgumentException("Cannot add any more log segments that contribute to used segment count");
     }
     if (LogSegmentNameHelper.COMPARATOR.compare(segment.getName(), activeSegment.getName()) >= 0) {
       throw new IllegalArgumentException(

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -319,13 +319,9 @@ class Log implements Write {
       segmentsToLoad = Collections.singletonList(checkArgsAndGetFirstSegment(segmentCapacityInBytes));
     }
 
-    long totalSegments = -1;
+    LogSegment firstSegment = segmentsToLoad.get(0);
+    long totalSegments = firstSegment.getName().isEmpty() ? 1 : capacityInBytes / firstSegment.getCapacityInBytes();
     for (LogSegment segment : segmentsToLoad) {
-      if (segment.getName().isEmpty()) {
-        totalSegments = 1;
-      } else {
-        totalSegments = totalSegments == -1 ? capacityInBytes / segment.getCapacityInBytes() : totalSegments;
-      }
       segmentsByName.put(segment.getName(), segment);
     }
     remainingUnallocatedSegments.set(totalSegments - segmentsByName.size());

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -13,15 +13,20 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,13 +39,15 @@ import org.slf4j.LoggerFactory;
 class Log implements Write {
   private final String dataDir;
   private final long capacityInBytes;
+  private final boolean isLogSegmented;
   private final StoreMetrics metrics;
+  private final Iterator<Pair<String, String>> segmentNameAndFileNameIterator;
   private final ConcurrentSkipListMap<String, LogSegment> segmentsByName =
       new ConcurrentSkipListMap<>(LogSegmentNameHelper.COMPARATOR);
   private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final AtomicLong remainingUnallocatedSegments = new AtomicLong(0);
 
-  private long remainingUnallocatedSegments;
-  private LogSegment activeSegment;
+  private LogSegment activeSegment = null;
 
   /**
    * Create a Log instance
@@ -56,20 +63,45 @@ class Log implements Write {
   Log(String dataDir, long totalCapacityInBytes, long segmentCapacityInBytes, StoreMetrics metrics) throws IOException {
     this.dataDir = dataDir;
     this.capacityInBytes = totalCapacityInBytes;
+    this.isLogSegmented = totalCapacityInBytes > segmentCapacityInBytes;
     this.metrics = metrics;
+    this.segmentNameAndFileNameIterator = Collections.EMPTY_LIST.iterator();
 
     File dir = new File(dataDir);
     File[] segmentFiles = dir.listFiles(LogSegmentNameHelper.LOG_FILE_FILTER);
     if (segmentFiles == null) {
       throw new IOException("Could not read from directory: " + dataDir);
-    } else if (segmentFiles.length == 0) {
-      // first startup
-      checkArgsAndAllocateFirstSegment(totalCapacityInBytes, segmentCapacityInBytes);
     } else {
-      // subsequent startup
-      loadSegments(segmentFiles, totalCapacityInBytes);
+      initialize(getSegmentsToLoad(segmentFiles), segmentCapacityInBytes);
     }
-    activeSegment = segmentsByName.lastEntry().getValue();
+  }
+
+  /**
+   * Create a Log instance
+   * @param dataDir the directory where the segments of the log need to be loaded from.
+   * @param totalCapacityInBytes the total capacity of this log.
+   * @param segmentCapacityInBytes the capacity of a single segment in the log.
+   * @param metrics the {@link StoreMetrics} instance to use.
+   * @param isLogSegmented {@code true} if this log is segmented or needs to be segmented.
+   * @param segmentsToLoad the list of pre-created {@link LogSegment} instances to load.
+   * @param segmentNameAndFileNameIterator an {@link Iterator} that provides the name and filename for newly allocated
+   *                                       log segments. Once the iterator ends, the active segment name is used to
+   *                                       generate the names of the subsequent segments.
+   * @throws IOException if there is any I/O error loading the segment files.
+   * @throws IllegalArgumentException if {@code totalCapacityInBytes} or {@code segmentCapacityInBytes} <= 0 or if
+   * {@code totalCapacityInBytes} > {@code segmentCapacityInBytes} and {@code totalCapacityInBytes} is not a perfect
+   * multiple of {@code segmentCapacityInBytes}.
+   */
+  Log(String dataDir, long totalCapacityInBytes, long segmentCapacityInBytes, StoreMetrics metrics,
+      boolean isLogSegmented, List<LogSegment> segmentsToLoad,
+      Iterator<Pair<String, String>> segmentNameAndFileNameIterator) throws IOException {
+    this.dataDir = dataDir;
+    this.capacityInBytes = totalCapacityInBytes;
+    this.isLogSegmented = isLogSegmented;
+    this.metrics = metrics;
+    this.segmentNameAndFileNameIterator = segmentNameAndFileNameIterator;
+
+    initialize(segmentsToLoad, segmentCapacityInBytes);
   }
 
   /**
@@ -125,10 +157,26 @@ class Log implements Write {
       Map.Entry<String, LogSegment> entry = iterator.next();
       logger.info("Freeing extra segment with name [{}] ", entry.getValue().getName());
       free(entry.getValue());
+      remainingUnallocatedSegments.getAndIncrement();
       iterator.remove();
     }
     logger.info("Setting active segment to [{}]", name);
     activeSegment = segmentsByName.get(name);
+  }
+
+  /**
+   * @return the capacity of a single segment.
+   */
+  long getSegmentCapacity() {
+    // all segments same size
+    return getFirstSegment().getCapacityInBytes();
+  }
+
+  /**
+   * @return the total capacity, in bytes, of this log.
+   */
+  long getCapacityInBytes() {
+    return capacityInBytes;
   }
 
   /**
@@ -153,6 +201,20 @@ class Log implements Write {
   }
 
   /**
+   * Returns the {@link LogSegment} that is logically before the given {@code segment}.
+   * @param segment the {@link LogSegment} whose "previous" segment is required.
+   * @return the {@link LogSegment} that is logically before the given {@code segment}.
+   */
+  LogSegment getPrevSegment(LogSegment segment) {
+    String name = segment.getName();
+    if (!segmentsByName.containsKey(name)) {
+      throw new IllegalArgumentException("Invalid log segment name: " + name);
+    }
+    Map.Entry<String, LogSegment> prevEntry = segmentsByName.lowerEntry(name);
+    return prevEntry == null ? null : prevEntry.getValue();
+  }
+
+  /**
    * @param name the name of the segment required.
    * @return a {@link LogSegment} with {@code name} if it exists.
    */
@@ -161,68 +223,11 @@ class Log implements Write {
   }
 
   /**
-   * @return the start offset of the log abstraction.
-   */
-  Offset getStartOffset() {
-    LogSegment segment = getFirstSegment();
-    return new Offset(segment.getName(), segment.getStartOffset());
-  }
-
-  /**
    * @return the end offset of the log abstraction.
    */
   Offset getEndOffset() {
     LogSegment segment = activeSegment;
     return new Offset(segment.getName(), segment.getEndOffset());
-  }
-
-  /**
-   * @return the currently capacity used of the log abstraction. Includes "wasted" space at the end of
-   * {@link LogSegment} instances that are not fully filled.
-   */
-  long getUsedCapacity() {
-    return getDifference(getEndOffset(), new Offset(getFirstSegment().getName(), 0));
-  }
-
-  /**
-   * @return the number of valid segments starting from the first segment.
-   */
-  long getSegmentCount() {
-    return segmentsByName.size();
-  }
-
-  /**
-   * Gets the absolute difference in bytes between {@code o1} and {@code o2}. The difference returned also includes the
-   * sizes of log segment headers if the offsets are across segments.
-   * @param o1 the first {@link Offset}.
-   * @param o2 the second {@link Offset}.
-   * @return the difference between {@code o1} and {@code o2}. If {@code o1} > {@code o2}, the difference returned is
-   * positive, else, unless equal, it is negative
-   */
-  long getDifference(Offset o1, Offset o2) {
-    LogSegment firstSegment = segmentsByName.get(o1.getName());
-    LogSegment secondSegment = segmentsByName.get(o2.getName());
-    if (firstSegment == null || secondSegment == null) {
-      throw new IllegalArgumentException(
-          "One of the log segments provided [" + o1.getName() + ", " + o2.getName() + "] does not belong to this log");
-    }
-    if (o1.getOffset() > firstSegment.getCapacityInBytes() || o2.getOffset() > secondSegment.getCapacityInBytes()) {
-      throw new IllegalArgumentException("One of the offsets provided [" + o1.getOffset() + ", " + o2.getOffset()
-          + "] is out of range of the segment it refers to [" + firstSegment.getCapacityInBytes() + ", " + secondSegment
-          .getCapacityInBytes() + "]");
-    }
-    if (o1.getName().equals(o2.getName())) {
-      return o1.getOffset() - o2.getOffset();
-    }
-    Offset higher = o1.compareTo(o2) > 0 ? o1 : o2;
-    Offset lower = higher == o1 ? o2 : o1;
-    int interveningSegmentsCount = segmentsByName.subMap(lower.getName(), false, higher.getName(), false).size();
-    // segment capacity is the same for every segment.
-    long segmentCapacity = firstSegment.getCapacityInBytes();
-    // adding the left over capacity in lower segment + capacities of all segments inbetween + offset in higher segment
-    long difference =
-        segmentCapacity - lower.getOffset() + segmentCapacity * interveningSegmentsCount + higher.getOffset();
-    return o1.compareTo(o2) * difference;
   }
 
   /**
@@ -250,58 +255,81 @@ class Log implements Write {
   /**
    * Checks the provided arguments for consistency and allocates the first segment file and creates the
    * {@link LogSegment} instance for it.
-   * @param totalCapacity the intended total capacity of the log.
    * @param segmentCapacity the intended capacity of each segment of the log.
+   * @return the {@link LogSegment} instance that is created.
    * @throws IOException if there is an I/O error creating the segment files or creating {@link LogSegment} instances.
    */
-  private void checkArgsAndAllocateFirstSegment(long totalCapacity, long segmentCapacity) throws IOException {
-    if (totalCapacity <= 0 || segmentCapacity <= 0) {
+  private LogSegment checkArgsAndGetFirstSegment(long segmentCapacity) throws IOException {
+    if (capacityInBytes <= 0 || segmentCapacity <= 0) {
       throw new IllegalArgumentException(
-          "One of totalCapacityInBytes [" + totalCapacity + "] or " + "segmentCapacityInBytes [" + segmentCapacity + "]"
-              + " is <=0");
+          "One of totalCapacityInBytes [" + capacityInBytes + "] or " + "segmentCapacityInBytes [" + segmentCapacity
+              + "] is <=0");
     }
-    segmentCapacity = Math.min(totalCapacity, segmentCapacity);
+    segmentCapacity = Math.min(capacityInBytes, segmentCapacity);
     // all segments should be the same size.
-    long numSegments = totalCapacity / segmentCapacity;
-    if (totalCapacity % segmentCapacity != 0) {
+    long numSegments = capacityInBytes / segmentCapacity;
+    if (capacityInBytes % segmentCapacity != 0) {
       throw new IllegalArgumentException(
-          "Capacity of log [" + totalCapacity + "] should be a multiple of segment capacity [" + segmentCapacity + "]");
+          "Capacity of log [" + capacityInBytes + "] should be a multiple of segment capacity [" + segmentCapacity
+              + "]");
     }
-    remainingUnallocatedSegments = numSegments;
-    String firstSegmentName = LogSegmentNameHelper.generateFirstSegmentName(numSegments);
-    logger.info("Allocating first segment with name [{}] and capacity {} bytes. Total number of segments is {}",
-        firstSegmentName, segmentCapacity, numSegments);
-    File segmentFile = allocate(LogSegmentNameHelper.nameToFilename(firstSegmentName), segmentCapacity);
+    Pair<String, String> segmentNameAndFilename = getNextSegmentNameAndFilename();
+    logger.info("Allocating first segment with name [{}], back by file {} and capacity {} bytes. Total number of "
+            + "segments is {}", segmentNameAndFilename.getFirst(), segmentNameAndFilename.getSecond(), segmentCapacity,
+        numSegments);
+    File segmentFile = allocate(segmentNameAndFilename.getSecond(), segmentCapacity);
     // to be backwards compatible, headers are not written for a log segment if it is the only log segment.
-    LogSegment segment = new LogSegment(firstSegmentName, segmentFile, segmentCapacity, metrics, numSegments > 1);
-    segmentsByName.put(segment.getName(), segment);
+    return new LogSegment(segmentNameAndFilename.getFirst(), segmentFile, segmentCapacity, metrics, isLogSegmented);
   }
 
   /**
-   * Loads segment files and creates {@link LogSegment} instances.
+   * Creates {@link LogSegment} instances from {@code segmentFiles}.
    * @param segmentFiles the files that form the segments of the log.
-   * @param totalCapacity the total capacity of the log. This is used only if this is a single segment log.
+   * @return {@code List} of {@link LogSegment} instances corresponding to {@code segmentFiles}.
    * @throws IOException if there is an I/O error loading the segment files or creating {@link LogSegment} instances.
    */
-  private void loadSegments(File[] segmentFiles, long totalCapacity) throws IOException {
-    long totalSegments = -1;
+  private List<LogSegment> getSegmentsToLoad(File[] segmentFiles) throws IOException {
+    List<LogSegment> segments = new ArrayList<>(segmentFiles.length);
     for (File segmentFile : segmentFiles) {
       String name = LogSegmentNameHelper.nameFromFilename(segmentFile.getName());
       logger.info("Loading segment with name [{}]", name);
       LogSegment segment;
       if (name.isEmpty()) {
-        totalSegments = 1;
         // for backwards compatibility, a single segment log is loaded by providing capacity since the old logs have
         // no headers
-        segment = new LogSegment(name, segmentFile, totalCapacity, metrics, false);
+        segment = new LogSegment(name, segmentFile, capacityInBytes, metrics, false);
       } else {
         segment = new LogSegment(name, segmentFile, metrics);
-        totalSegments = totalSegments == -1 ? totalCapacity / segment.getCapacityInBytes() : totalSegments;
       }
       logger.info("Segment [{}] has capacity of {} bytes", name, segment.getCapacityInBytes());
+      segments.add(segment);
+    }
+    return segments;
+  }
+
+  /**
+   * Initializes the log.
+   * @param segmentsToLoad the {@link LogSegment} instances to include as a part of the log.
+   * @param segmentCapacityInBytes the capacity of a single {@link LogSegment}.
+   * @throws IOException if there is any I/O error during initialization.
+   */
+  private void initialize(List<LogSegment> segmentsToLoad, long segmentCapacityInBytes) throws IOException {
+    if (segmentsToLoad.size() == 0) {
+      // bootstrapping log.
+      segmentsToLoad = Collections.singletonList(checkArgsAndGetFirstSegment(segmentCapacityInBytes));
+    }
+
+    long totalSegments = -1;
+    for (LogSegment segment : segmentsToLoad) {
+      if (segment.getName().isEmpty()) {
+        totalSegments = 1;
+      } else {
+        totalSegments = totalSegments == -1 ? capacityInBytes / segment.getCapacityInBytes() : totalSegments;
+      }
       segmentsByName.put(segment.getName(), segment);
     }
-    remainingUnallocatedSegments = totalSegments - segmentsByName.size();
+    remainingUnallocatedSegments.set(totalSegments - segmentsByName.size());
+    activeSegment = segmentsByName.lastEntry().getValue();
   }
 
   /**
@@ -316,7 +344,6 @@ class Log implements Write {
     // TODO (DiskManager changes): a pool of segments.
     File segmentFile = new File(dataDir, filename);
     Utils.preAllocateFileIfNeeded(segmentFile, size);
-    remainingUnallocatedSegments--;
     return segmentFile;
   }
 
@@ -332,7 +359,6 @@ class Log implements Write {
     if (!segmentFile.delete()) {
       throw new IllegalStateException("Could not delete segment file: " + segmentFile.getAbsolutePath());
     }
-    remainingUnallocatedSegments++;
   }
 
   /**
@@ -364,11 +390,6 @@ class Log implements Write {
    * @throws IOException if any I/O error occurred as a part of ensuring capacity.
    */
   private void ensureCapacity(long writeSize) throws IOException {
-    if (remainingUnallocatedSegments == 0) {
-      metrics.overflowWriteError.inc();
-      throw new IllegalStateException(
-          "There is no more capacity left in [" + dataDir + "]. Max capacity is [" + capacityInBytes + "]");
-    }
     // all segments are (should be) the same size.
     long segmentCapacity = activeSegment.getCapacityInBytes();
     if (writeSize > segmentCapacity - LogSegment.HEADER_SIZE) {
@@ -376,11 +397,75 @@ class Log implements Write {
       throw new IllegalArgumentException("Write of size [" + writeSize + "] cannot be serviced because it is greater "
           + "than a single segment's capacity [" + (segmentCapacity - LogSegment.HEADER_SIZE) + "]");
     }
-    String newSegmentName = LogSegmentNameHelper.getNextPositionName(activeSegment.getName());
-    logger.info("Allocating new segment with name: " + newSegmentName);
-    File newSegmentFile = allocate(LogSegmentNameHelper.nameToFilename(newSegmentName), segmentCapacity);
-    LogSegment newSegment = new LogSegment(newSegmentName, newSegmentFile, segmentCapacity, metrics, true);
-    segmentsByName.put(newSegmentName, newSegment);
+    if (remainingUnallocatedSegments.decrementAndGet() < 0) {
+      remainingUnallocatedSegments.incrementAndGet();
+      metrics.overflowWriteError.inc();
+      throw new IllegalStateException(
+          "There is no more capacity left in [" + dataDir + "]. Max capacity is [" + capacityInBytes + "]");
+    }
+    Pair<String, String> segmentNameAndFilename = getNextSegmentNameAndFilename();
+    logger.info("Allocating new segment with name: " + segmentNameAndFilename.getFirst());
+    File newSegmentFile = allocate(segmentNameAndFilename.getSecond(), segmentCapacity);
+    LogSegment newSegment =
+        new LogSegment(segmentNameAndFilename.getFirst(), newSegmentFile, segmentCapacity, metrics, true);
+    segmentsByName.put(segmentNameAndFilename.getFirst(), newSegment);
+  }
+
+  /**
+   * @return the name and filename of the segment that is to be created.
+   */
+  private Pair<String, String> getNextSegmentNameAndFilename() {
+    Pair<String, String> nameAndFilename;
+    if (segmentNameAndFileNameIterator != null && segmentNameAndFileNameIterator.hasNext()) {
+      nameAndFilename = segmentNameAndFileNameIterator.next();
+    } else if (activeSegment == null) {
+      // this code path gets exercised only on first startup
+      String name = LogSegmentNameHelper.generateFirstSegmentName(isLogSegmented);
+      nameAndFilename = new Pair<>(name, LogSegmentNameHelper.nameToFilename(name));
+    } else {
+      String name = LogSegmentNameHelper.getNextPositionName(activeSegment.getName());
+      nameAndFilename = new Pair<>(name, LogSegmentNameHelper.nameToFilename(name));
+    }
+    return nameAndFilename;
+  }
+
+  /**
+   * Adds a {@link LogSegment} instance to the log.
+   * @param segment the {@link LogSegment} instance to add.
+   * @param increaseUsedSegmentCount {@code true} if the number of segments used has to be incremented, {@code false}
+   *                                             otherwise.
+   * @throws IllegalArgumentException if the {@code segment} being added is past the active segment.
+   */
+  void addSegment(LogSegment segment, boolean increaseUsedSegmentCount) {
+    if (increaseUsedSegmentCount) {
+      remainingUnallocatedSegments.decrementAndGet();
+    }
+    if (LogSegmentNameHelper.COMPARATOR.compare(segment.getName(), activeSegment.getName()) >= 0) {
+      throw new IllegalArgumentException(
+          "Cannot add segments past the current active segment. Active segment is [" + activeSegment.getName()
+              + "]. Tried to add [" + segment.getName() + "]");
+    }
+    segmentsByName.put(segment.getName(), segment);
+  }
+
+  /**
+   * Drops an existing {@link LogSegment} instance from the log.
+   * @param segmentName the {@link LogSegment} instance to drop.
+   * @param decreaseUsedSegmentCount {@code true} if the number of segments used has to be decremented, {@code false}
+   *                                             otherwise.
+   * @throws IllegalArgumentException if {@code segmentName} is not a part of the log.
+   * @throws IOException if there is any I/O error cleaning up the log segment.
+   */
+  void dropSegment(String segmentName, boolean decreaseUsedSegmentCount) throws IOException {
+    LogSegment segment = segmentsByName.get(segmentName);
+    if (segment == null || segment == activeSegment) {
+      throw new IllegalArgumentException("Segment does not exist or is the active segment: " + segmentName);
+    }
+    segmentsByName.remove(segmentName);
+    free(segment);
+    if (decreaseUsedSegmentCount) {
+      remainingUnallocatedSegments.incrementAndGet();
+    }
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegmentNameHelper.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegmentNameHelper.java
@@ -106,12 +106,12 @@ class LogSegmentNameHelper {
 
   /**
    * @param name the name of the log segment.
-   * @return what should be the name of the log segment that is exactly one position higher than {@code name}.
+   * @return what should be the name of the log segment that is exactly one position higher than {@code name}. The
+   * generation of the returned name will start from the lowest generation number.
    */
   static String getNextPositionName(String name) {
     long pos = getPosition(name);
-    long gen = getGeneration(name);
-    return getName(pos + 1, gen);
+    return getName(pos + 1, 0);
   }
 
   /**
@@ -125,17 +125,11 @@ class LogSegmentNameHelper {
   }
 
   /**
-   * @param numSegments the total number of segments in the log.
+   * @param isLogSegmented {@code true} if the log is segmented, {@code false} otherwise.
    * @return what should be the name of the first segment.
    */
-  static String generateFirstSegmentName(long numSegments) {
-    if (numSegments <= 0) {
-      throw new IllegalArgumentException("Number of segments <=0");
-    }
-    if (numSegments == 1) {
-      return "";
-    }
-    return getName(0, 0);
+  static String generateFirstSegmentName(boolean isLogSegmented) {
+    return isLogSegmented ? getName(0, 0) : "";
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
@@ -125,7 +125,7 @@ public class StoreFindToken implements FindToken {
     switch (version) {
       case VERSION_0:
         // backwards compatibility
-        String logSegmentName = LogSegmentNameHelper.generateFirstSegmentName(1);
+        String logSegmentName = LogSegmentNameHelper.generateFirstSegmentName(false);
         // read sessionId
         String sessionId = Utils.readIntString(stream);
         UUID sessionIdUUID = null;

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -100,31 +100,31 @@ public class StoreMetrics {
         registry.histogram(MetricRegistry.name(IndexSegment.class, name + "SegmentsAccessedPerBlobCount"));
   }
 
-  void initializeLogGauges(final Log log, final long capacityInBytes) {
+  void initializeIndexGauges(final PersistentIndex index, final long capacityInBytes) {
     Gauge<Long> currentCapacityUsed = new Gauge<Long>() {
       @Override
       public Long getValue() {
-        return log.getUsedCapacity();
+        return index.getUsedCapacity();
       }
     };
     registry.register(MetricRegistry.name(Log.class, name + "CurrentCapacityUsed"), currentCapacityUsed);
     Gauge<Double> percentageUsedCapacity = new Gauge<Double>() {
       @Override
       public Double getValue() {
-        return ((double) log.getUsedCapacity() / capacityInBytes) * 100;
+        return ((double) index.getUsedCapacity() / capacityInBytes) * 100;
       }
     };
     registry.register(MetricRegistry.name(Log.class, name + "PercentageUsedCapacity"), percentageUsedCapacity);
     Gauge<Long> currentSegmentCount = new Gauge<Long>() {
       @Override
       public Long getValue() {
-        return log.getSegmentCount();
+        return index.getLogSegmentCount();
       }
     };
     registry.register(MetricRegistry.name(Log.class, name + "CurrentSegmentCount"), currentSegmentCount);
   }
 
-  void initializeHardDeleteMetric(final HardDeleter hardDeleter, final Log log) {
+  void initializeHardDeleteMetric(final HardDeleter hardDeleter, final PersistentIndex index) {
     Gauge<Long> currentHardDeleteProgress = new Gauge<Long>() {
       @Override
       public Long getValue() {
@@ -137,7 +137,7 @@ public class StoreMetrics {
     Gauge<Double> percentageHardDeleteCompleted = new Gauge<Double>() {
       @Override
       public Double getValue() {
-        return ((double) hardDeleter.getProgress() / log.getUsedCapacity()) * 100;
+        return ((double) hardDeleter.getProgress() / index.getUsedCapacity()) * 100;
       }
     };
     registry.register(MetricRegistry.name(Log.class, name + "PercentageHardDeleteCompleted"),

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -104,14 +104,14 @@ public class StoreMetrics {
     Gauge<Long> currentCapacityUsed = new Gauge<Long>() {
       @Override
       public Long getValue() {
-        return index.getUsedCapacity();
+        return index.getLogUsedCapacity();
       }
     };
     registry.register(MetricRegistry.name(Log.class, name + "CurrentCapacityUsed"), currentCapacityUsed);
     Gauge<Double> percentageUsedCapacity = new Gauge<Double>() {
       @Override
       public Double getValue() {
-        return ((double) index.getUsedCapacity() / capacityInBytes) * 100;
+        return ((double) index.getLogUsedCapacity() / capacityInBytes) * 100;
       }
     };
     registry.register(MetricRegistry.name(Log.class, name + "PercentageUsedCapacity"), percentageUsedCapacity);
@@ -137,7 +137,7 @@ public class StoreMetrics {
     Gauge<Double> percentageHardDeleteCompleted = new Gauge<Double>() {
       @Override
       public Double getValue() {
-        return ((double) hardDeleter.getProgress() / index.getUsedCapacity()) * 100;
+        return ((double) hardDeleter.getProgress() / index.getLogUsedCapacity()) * 100;
       }
     };
     registry.register(MetricRegistry.name(Log.class, name + "PercentageHardDeleteCompleted"),

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionLogTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionLogTest.java
@@ -77,30 +77,30 @@ public class CompactionLogTest {
     String storeName = "store";
     List<CompactionDetails> detailsList = getCompactionDetails(5);
     assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
-    CompactionLog log = new CompactionLog(tempDirStr, storeName, time, detailsList);
+    CompactionLog cLog = new CompactionLog(tempDirStr, storeName, time, detailsList);
     assertTrue("Compaction should be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
     int currentIdx = 0;
     for (CompactionDetails details : detailsList) {
-      assertEquals("CurrentIdx not as expected", currentIdx, log.getCurrentIdx());
-      verifyEquality(details, log.getCompactionDetails());
-      assertEquals("Should be in the PREPARE phase", CompactionLog.Phase.PREPARE, log.getCompactionPhase());
-      log.markCopyStart();
-      assertEquals("Should be in the COPY phase", CompactionLog.Phase.COPY, log.getCompactionPhase());
+      assertEquals("CurrentIdx not as expected", currentIdx, cLog.getCurrentIdx());
+      verifyEquality(details, cLog.getCompactionDetails());
+      assertEquals("Should be in the PREPARE phase", CompactionLog.Phase.PREPARE, cLog.getCompactionPhase());
+      cLog.markCopyStart();
+      assertEquals("Should be in the COPY phase", CompactionLog.Phase.COPY, cLog.getCompactionPhase());
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentNameHelper.generateFirstSegmentName(true), 0),
               new UUID(1, 1), new UUID(1, 1));
-      log.setSafeToken(safeToken);
-      assertEquals("Returned token not the same as the one that was set", safeToken, log.getSafeToken());
-      log.markCommitStart();
-      assertEquals("Should be in the SWITCH phase", CompactionLog.Phase.COMMIT, log.getCompactionPhase());
-      log.markCleanupStart();
-      assertEquals("Should be in the CLEANUP phase", CompactionLog.Phase.CLEANUP, log.getCompactionPhase());
-      log.markCycleComplete();
+      cLog.setSafeToken(safeToken);
+      assertEquals("Returned token not the same as the one that was set", safeToken, cLog.getSafeToken());
+      cLog.markCommitStart();
+      assertEquals("Should be in the SWITCH phase", CompactionLog.Phase.COMMIT, cLog.getCompactionPhase());
+      cLog.markCleanupStart();
+      assertEquals("Should be in the CLEANUP phase", CompactionLog.Phase.CLEANUP, cLog.getCompactionPhase());
+      cLog.markCycleComplete();
       currentIdx++;
     }
-    assertEquals("CurrentIdx not as expected", -1, log.getCurrentIdx());
-    assertEquals("Should be in the DONE phase", CompactionLog.Phase.DONE, log.getCompactionPhase());
-    log.close();
+    assertEquals("CurrentIdx not as expected", -1, cLog.getCurrentIdx());
+    assertEquals("Should be in the DONE phase", CompactionLog.Phase.DONE, cLog.getCompactionPhase());
+    cLog.close();
     assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
   }
 
@@ -113,46 +113,46 @@ public class CompactionLogTest {
     String storeName = "store";
     List<CompactionDetails> detailsList = getCompactionDetails(5);
     assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
-    CompactionLog log = new CompactionLog(tempDirStr, storeName, time, detailsList);
+    CompactionLog cLog = new CompactionLog(tempDirStr, storeName, time, detailsList);
     assertTrue("Compaction should should be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
     int currentIdx = 0;
     for (CompactionDetails details : detailsList) {
-      assertEquals("CurrentIdx not as expected", currentIdx, log.getCurrentIdx());
+      assertEquals("CurrentIdx not as expected", currentIdx, cLog.getCurrentIdx());
 
-      log.close();
-      log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
-      verifyEquality(details, log.getCompactionDetails());
-      assertEquals("Should be in the PREPARE phase", CompactionLog.Phase.PREPARE, log.getCompactionPhase());
-      log.markCopyStart();
+      cLog.close();
+      cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+      verifyEquality(details, cLog.getCompactionDetails());
+      assertEquals("Should be in the PREPARE phase", CompactionLog.Phase.PREPARE, cLog.getCompactionPhase());
+      cLog.markCopyStart();
 
-      log.close();
-      log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
-      assertEquals("Should be in the COPY phase", CompactionLog.Phase.COPY, log.getCompactionPhase());
+      cLog.close();
+      cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+      assertEquals("Should be in the COPY phase", CompactionLog.Phase.COPY, cLog.getCompactionPhase());
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentNameHelper.generateFirstSegmentName(true), 0),
               new UUID(1, 1), new UUID(1, 1));
-      log.setSafeToken(safeToken);
+      cLog.setSafeToken(safeToken);
 
-      log.close();
-      log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
-      assertEquals("Returned token not the same as the one that was set", safeToken, log.getSafeToken());
-      log.markCommitStart();
+      cLog.close();
+      cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+      assertEquals("Returned token not the same as the one that was set", safeToken, cLog.getSafeToken());
+      cLog.markCommitStart();
 
-      log.close();
-      log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
-      assertEquals("Should be in the SWITCH phase", CompactionLog.Phase.COMMIT, log.getCompactionPhase());
-      log.markCleanupStart();
+      cLog.close();
+      cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+      assertEquals("Should be in the SWITCH phase", CompactionLog.Phase.COMMIT, cLog.getCompactionPhase());
+      cLog.markCleanupStart();
 
-      log.close();
-      log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
-      assertEquals("Should be in the CLEANUP phase", CompactionLog.Phase.CLEANUP, log.getCompactionPhase());
-      log.markCycleComplete();
+      cLog.close();
+      cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+      assertEquals("Should be in the CLEANUP phase", CompactionLog.Phase.CLEANUP, cLog.getCompactionPhase());
+      cLog.markCycleComplete();
 
       currentIdx++;
     }
-    assertEquals("CurrentIdx not as expected", -1, log.getCurrentIdx());
-    assertEquals("Should be in the DONE phase", CompactionLog.Phase.DONE, log.getCompactionPhase());
-    log.close();
+    assertEquals("CurrentIdx not as expected", -1, cLog.getCurrentIdx());
+    assertEquals("Should be in the DONE phase", CompactionLog.Phase.DONE, cLog.getCompactionPhase());
+    cLog.close();
     assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
   }
 
@@ -163,28 +163,28 @@ public class CompactionLogTest {
   public void phaseTransitionEnforcementTest() throws IOException {
     String storeName = "store";
     List<CompactionDetails> detailsList = getCompactionDetails(1);
-    CompactionLog log = new CompactionLog(tempDirStr, storeName, time, detailsList);
+    CompactionLog cLog = new CompactionLog(tempDirStr, storeName, time, detailsList);
 
-    assertEquals("Should be in the PREPARE phase", CompactionLog.Phase.PREPARE, log.getCompactionPhase());
-    checkTransitionFailure(log, CompactionLog.Phase.COMMIT, CompactionLog.Phase.CLEANUP, CompactionLog.Phase.DONE);
+    assertEquals("Should be in the PREPARE phase", CompactionLog.Phase.PREPARE, cLog.getCompactionPhase());
+    checkTransitionFailure(cLog, CompactionLog.Phase.COMMIT, CompactionLog.Phase.CLEANUP, CompactionLog.Phase.DONE);
 
-    log.markCopyStart();
-    assertEquals("Should be in the COPY phase", CompactionLog.Phase.COPY, log.getCompactionPhase());
-    checkTransitionFailure(log, CompactionLog.Phase.COPY, CompactionLog.Phase.CLEANUP, CompactionLog.Phase.DONE);
+    cLog.markCopyStart();
+    assertEquals("Should be in the COPY phase", CompactionLog.Phase.COPY, cLog.getCompactionPhase());
+    checkTransitionFailure(cLog, CompactionLog.Phase.COPY, CompactionLog.Phase.CLEANUP, CompactionLog.Phase.DONE);
 
-    log.markCommitStart();
-    assertEquals("Should be in the SWITCH phase", CompactionLog.Phase.COMMIT, log.getCompactionPhase());
-    checkTransitionFailure(log, CompactionLog.Phase.COPY, CompactionLog.Phase.COMMIT, CompactionLog.Phase.DONE);
+    cLog.markCommitStart();
+    assertEquals("Should be in the SWITCH phase", CompactionLog.Phase.COMMIT, cLog.getCompactionPhase());
+    checkTransitionFailure(cLog, CompactionLog.Phase.COPY, CompactionLog.Phase.COMMIT, CompactionLog.Phase.DONE);
 
-    log.markCleanupStart();
-    assertEquals("Should be in the CLEANUP phase", CompactionLog.Phase.CLEANUP, log.getCompactionPhase());
-    checkTransitionFailure(log, CompactionLog.Phase.COPY, CompactionLog.Phase.COMMIT, CompactionLog.Phase.CLEANUP);
+    cLog.markCleanupStart();
+    assertEquals("Should be in the CLEANUP phase", CompactionLog.Phase.CLEANUP, cLog.getCompactionPhase());
+    checkTransitionFailure(cLog, CompactionLog.Phase.COPY, CompactionLog.Phase.COMMIT, CompactionLog.Phase.CLEANUP);
 
-    log.markCycleComplete();
-    assertEquals("Should be in the DONE phase", CompactionLog.Phase.DONE, log.getCompactionPhase());
-    checkTransitionFailure(log, CompactionLog.Phase.COPY, CompactionLog.Phase.COMMIT, CompactionLog.Phase.CLEANUP,
+    cLog.markCycleComplete();
+    assertEquals("Should be in the DONE phase", CompactionLog.Phase.DONE, cLog.getCompactionPhase());
+    checkTransitionFailure(cLog, CompactionLog.Phase.COPY, CompactionLog.Phase.COMMIT, CompactionLog.Phase.CLEANUP,
         CompactionLog.Phase.DONE);
-    log.close();
+    cLog.close();
   }
 
   /**
@@ -194,29 +194,29 @@ public class CompactionLogTest {
   @Test
   public void constructionBadArgsTest() throws IOException {
     String storeName = "store";
-    CompactionLog log = new CompactionLog(tempDirStr, storeName, time, getCompactionDetails(1));
-    log.close();
+    CompactionLog cLog = new CompactionLog(tempDirStr, storeName, time, getCompactionDetails(1));
+    cLog.close();
     // log file already exists
     try {
       new CompactionLog(tempDirStr, storeName, time, getCompactionDetails(1));
-      fail("Construction should have failed because log file already exists");
+      fail("Construction should have failed because compaction log file already exists");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
     }
 
     // make sure file disappears
-    log = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
-    log.markCopyStart();
-    log.markCommitStart();
-    log.markCleanupStart();
-    log.markCycleComplete();
-    log.close();
+    cLog = new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
+    cLog.markCopyStart();
+    cLog.markCommitStart();
+    cLog.markCleanupStart();
+    cLog.markCycleComplete();
+    cLog.close();
     assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, storeName));
 
     // log file does not exist
     try {
       new CompactionLog(tempDirStr, storeName, STORE_KEY_FACTORY, time);
-      fail("Construction should have failed because log file does not exist");
+      fail("Construction should have failed because compaction log file does not exist");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
     }
@@ -263,24 +263,24 @@ public class CompactionLogTest {
 
   /**
    * Checks that transitions to phases in {@code transitionToFailures} fails.
-   * @param log the {@link CompactionLog} being used.
+   * @param cLog the {@link CompactionLog} being used.
    * @param transitionToFailures the list of phases, transition to which should fail.
    */
-  private void checkTransitionFailure(CompactionLog log, CompactionLog.Phase... transitionToFailures) {
+  private void checkTransitionFailure(CompactionLog cLog, CompactionLog.Phase... transitionToFailures) {
     for (CompactionLog.Phase transitionToFailure : transitionToFailures) {
       try {
         switch (transitionToFailure) {
           case COPY:
-            log.markCopyStart();
+            cLog.markCopyStart();
             break;
           case COMMIT:
-            log.markCommitStart();
+            cLog.markCommitStart();
             break;
           case CLEANUP:
-            log.markCleanupStart();
+            cLog.markCleanupStart();
             break;
           case DONE:
-            log.markCycleComplete();
+            cLog.markCycleComplete();
             break;
           default:
             throw new IllegalArgumentException("Unknown Phase: " + transitionToFailure);
@@ -291,12 +291,12 @@ public class CompactionLogTest {
       }
     }
 
-    if (!log.getCompactionPhase().equals(CompactionLog.Phase.COPY)) {
+    if (!cLog.getCompactionPhase().equals(CompactionLog.Phase.COPY)) {
       StoreFindToken safeToken =
           new StoreFindToken(new MockId("dummy"), new Offset(LogSegmentNameHelper.generateFirstSegmentName(true), 0),
               new UUID(1, 1), new UUID(1, 1));
       try {
-        log.setSafeToken(safeToken);
+        cLog.setSafeToken(safeToken);
         fail("Setting safe token should have failed");
       } catch (IllegalStateException e) {
         // expected. Nothing to do.

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -93,7 +93,7 @@ public class IndexSegmentTest {
    */
   @Test
   public void comprehensiveTest() throws IOException, StoreException {
-    String[] logSegmentNames = {LogSegmentNameHelper.generateFirstSegmentName(1), generateRandomLogSegmentName()};
+    String[] logSegmentNames = {LogSegmentNameHelper.generateFirstSegmentName(false), generateRandomLogSegmentName()};
     for (String logSegmentName : logSegmentNames) {
       long writeStartOffset = Utils.getRandomLong(TestUtils.RANDOM, 1000);
       Offset startOffset = new Offset(logSegmentName, writeStartOffset);
@@ -262,7 +262,7 @@ public class IndexSegmentTest {
     }
 
     String expectedFilename =
-        startOffset.getOffset() + BlobStore.SEPARATOR + PersistentIndex.INDEX_SEGMENT_FILE_NAME_SUFFIX;
+        startOffset.getOffset() + BlobStore.SEPARATOR + IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX;
     if (!logSegmentName.isEmpty()) {
       expectedFilename = logSegmentName + BlobStore.SEPARATOR + expectedFilename;
     }

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -129,7 +129,7 @@ public class IndexTest {
   // The index of the log
   private PersistentIndex index;
   // The session ID associated with the index
-  private UUID sessionId;
+  private UUID sessionId = UUID.randomUUID();
   // the incarnationId associated with the store
   private UUID incarnationId = UUID.randomUUID();
 
@@ -271,8 +271,8 @@ public class IndexTest {
       FileSpan fileSpan = new FileSpan(fileSpanForMessage.getStartOffset(), index.getCurrentEndOffset());
       verifyValue(id, index.findKey(id, fileSpan));
 
-      // FileSpan from start offset of log to end offset of message
-      fileSpan = new FileSpan(log.getStartOffset(), fileSpanForMessage.getEndOffset());
+      // FileSpan from start offset of index to end offset of message
+      fileSpan = new FileSpan(index.getStartOffset(), fileSpanForMessage.getEndOffset());
       verifyValue(id, index.findKey(id, fileSpan));
 
       // FileSpan that includes the message
@@ -289,7 +289,7 @@ public class IndexTest {
 
       if (lowerSegmentStartOffset != null) {
         // FileSpan lower than the entry (does not include entry)
-        fileSpan = new FileSpan(log.getStartOffset(), lowerSegmentStartOffset);
+        fileSpan = new FileSpan(index.getStartOffset(), lowerSegmentStartOffset);
         assertNull("There should have been no value returned", index.findKey(id, fileSpan));
       }
     }
@@ -378,8 +378,8 @@ public class IndexTest {
   @Test
   public void addEntryBadInputTest() throws StoreException {
     // FileSpan end offset < currentIndexEndOffset
-    FileSpan fileSpan = log.getFileSpanForMessage(log.getStartOffset(), 1);
-    IndexValue value = new IndexValue(1, log.getStartOffset());
+    FileSpan fileSpan = log.getFileSpanForMessage(index.getStartOffset(), 1);
+    IndexValue value = new IndexValue(1, index.getStartOffset());
     try {
       index.addToIndex(new IndexEntry(getUniqueId(), value), fileSpan);
       fail("Should have failed because filespan provided < currentIndexEndOffset");
@@ -415,7 +415,7 @@ public class IndexTest {
   @Test
   public void markAsDeletedBadInputTest() throws IOException, StoreException {
     // FileSpan end offset < currentIndexEndOffset
-    FileSpan fileSpan = log.getFileSpanForMessage(log.getStartOffset(), 1);
+    FileSpan fileSpan = log.getFileSpanForMessage(index.getStartOffset(), 1);
     try {
       index.markAsDeleted(liveKeys.iterator().next(), fileSpan);
       fail("Should have failed because filespan provided < currentIndexEndOffset");
@@ -484,8 +484,7 @@ public class IndexTest {
     // IndexSegment still uses real time so advance time so that it goes 2 days past the real time.
     advanceTime(SystemTime.getInstance().milliseconds() + 2 * Time.MsPerSec * Time.SecsPerDay);
     assertTrue("Hard delete did not do any work", index.hardDeleter.hardDelete());
-
-    long expectedProgress = log.getDifference(logOrder.lastKey(), new Offset(log.getFirstSegment().getName(), 0));
+    long expectedProgress = index.getAbsolutePositionForOffset(logOrder.lastKey());
     assertEquals("Hard delete did not make expected progress", expectedProgress, index.hardDeleter.getProgress());
     verifyEntriesForHardDeletes(deletedKeys);
   }
@@ -661,7 +660,7 @@ public class IndexTest {
 
     // token with log end offset should not return anything
     StoreFindToken token = new StoreFindToken(log.getEndOffset(), sessionId, incarnationId, false);
-    token.setBytesRead(log.getUsedCapacity());
+    token.setBytesRead(index.getUsedCapacity());
     doFindEntriesSinceTest(token, Long.MAX_VALUE, Collections.EMPTY_SET, token);
 
     findEntriesSinceToIndexBasedTest();
@@ -715,8 +714,7 @@ public class IndexTest {
     // and proceed with session id validation and so on.
     UUID[] incarnationIds = new UUID[]{incarnationId, null};
     for (UUID incarnationIdToTest : incarnationIds) {
-      long bytesRead =
-          log.getDifference(firstRecordFileSpan.getEndOffset(), new Offset(log.getFirstSegment().getName(), 0));
+      long bytesRead = index.getAbsolutePositionForOffset(firstRecordFileSpan.getEndOffset());
       // create a token that will be past the index end offset on startup after recovery.
       startToken = new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, incarnationIdToTest, false);
       // token should get reset internally, no keys should be returned and the returned token should be correct (offset
@@ -755,7 +753,7 @@ public class IndexTest {
         new Offset(log.getEndOffset().getName(), (log.getEndOffset().getOffset() + (2 * PUT_RECORD_SIZE))),
         oldSessionId, incarnationId, false);
     // end token should point to log end offset on startup
-    long bytesRead = log.getDifference(log.getEndOffset(), new Offset(log.getFirstSegment().getName(), 0));
+    long bytesRead = index.getAbsolutePositionForOffset(log.getEndOffset());
     StoreFindToken expectedEndToken = new StoreFindToken(log.getEndOffset(), sessionId, incarnationId, true);
     expectedEndToken.setBytesRead(bytesRead);
     // Fetch the FindToken returned from findEntriesSince
@@ -769,7 +767,7 @@ public class IndexTest {
     expectedEntries.add(logOrder.lastEntry().getValue().getFirst());
     addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);
     expectedEntries.add(logOrder.lastEntry().getValue().getFirst());
-    bytesRead = log.getDifference(index.getCurrentEndOffset(), new Offset(log.getFirstSegment().getName(), 0));
+    bytesRead = index.getAbsolutePositionForOffset(index.getCurrentEndOffset());
     expectedEndToken = new StoreFindToken(index.journal.getLastOffset(), sessionId, incarnationId, false);
     expectedEndToken.setBytesRead(bytesRead);
     doFindEntriesSinceTest((StoreFindToken) findInfo.getFindToken(), Long.MAX_VALUE, expectedEntries, expectedEndToken);
@@ -806,8 +804,7 @@ public class IndexTest {
     incarnationId = UUID.randomUUID();
     reloadIndex(true);
 
-    long bytesRead =
-        log.getDifference(firstRecordFileSpan.getEndOffset(), new Offset(log.getFirstSegment().getName(), 0));
+    long bytesRead = index.getAbsolutePositionForOffset(firstRecordFileSpan.getEndOffset());
     // create a token that will be past the index end offset on startup after recovery with old incarnationId
     StoreFindToken startToken =
         new StoreFindToken(secondRecordFileSpan.getEndOffset(), oldSessionId, oldIncarnationId, false);
@@ -878,9 +875,7 @@ public class IndexTest {
     StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
     index =
         new PersistentIndex(tempDirStr, scheduler, log, config, STORE_KEY_FACTORY, recovery, hardDelete, metrics, time,
-            UUID.randomUUID());
-    sessionId =
-        ((StoreFindToken) index.findEntriesSince(new StoreFindToken(), Long.MAX_VALUE).getFindToken()).getSessionId();
+            UUID.randomUUID(), UUID.randomUUID());
     assertEquals("Index End offset mismatch ",
         new Offset(indexEndOffset.getName(), indexEndOffset.getOffset() + PUT_RECORD_SIZE),
         index.getCurrentEndOffset());
@@ -901,6 +896,130 @@ public class IndexTest {
     }
     // append to log so that log and index are in sync with each other
     appendToLog(PUT_RECORD_SIZE);
+  }
+
+  /**
+   * Tests {@link PersistentIndex#getAbsolutePositionForOffset(Offset)}.
+   */
+  @Test
+  public void getAbsolutePositionForOffsetTest() {
+    List<LogSegment> logSegments = new ArrayList<>();
+    LogSegment segment = log.getFirstSegment();
+    while (segment != null) {
+      logSegments.add(segment);
+      segment = log.getNextSegment(segment);
+    }
+
+    long numLogSegmentsPreceding = 0;
+    for (LogSegment logSegment : logSegments) {
+      verifyAbsolutePosition(new Offset(logSegment.getName(), 0L), numLogSegmentsPreceding);
+      verifyAbsolutePosition(new Offset(logSegment.getName(), logSegment.getStartOffset()), numLogSegmentsPreceding);
+      long randomPosRange = logSegment.getEndOffset() - logSegment.getStartOffset() - 1;
+      long randomPos = Utils.getRandomLong(TestUtils.RANDOM, randomPosRange) + logSegment.getStartOffset() + 1;
+      verifyAbsolutePosition(new Offset(logSegment.getName(), randomPos), numLogSegmentsPreceding);
+      verifyAbsolutePosition(new Offset(logSegment.getName(), logSegment.getEndOffset()), numLogSegmentsPreceding);
+      numLogSegmentsPreceding++;
+    }
+  }
+
+  /**
+   * Tests {@link PersistentIndex#getAbsolutePositionForOffset(Offset)} with bad arguments.
+   */
+  @Test
+  public void getAbsolutePositionForOffsetBadArgsTest() {
+    Offset badSegmentOffset = new Offset(LogSegmentNameHelper.getName(index.getLogSegmentCount() + 1, 0), 0);
+    Offset badOffsetOffset =
+        new Offset(log.getFirstSegment().getName(), log.getFirstSegment().getCapacityInBytes() + 1);
+    List<Offset> offsetsToCheck = new ArrayList<>();
+    offsetsToCheck.add(badSegmentOffset);
+    offsetsToCheck.add(badOffsetOffset);
+
+    for (Offset offset : offsetsToCheck) {
+      try {
+        index.getAbsolutePositionForOffset(offset);
+        fail("Should have failed to get absolute position for invalid offset input: " + offset);
+      } catch (IllegalArgumentException e) {
+        // expected. Nothing to do.
+      }
+    }
+  }
+
+  /**
+   * Test that verifies that everything is ok even if {@link MessageStoreHardDelete} instance provided is null.
+   */
+  @Test
+  public void hardDeleteNullTest() throws IOException, StoreException {
+    hardDelete = null;
+    reloadIndex(false);
+    addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    MockId idToCheck = logOrder.lastEntry().getValue().getFirst();
+    reloadIndex(false);
+    verifyValue(idToCheck, index.findKey(idToCheck));
+  }
+
+  /**
+   * Tests correctness of {@link PersistentIndex#getIndexSegmentFilesForLogSegment(String, String)} and makes sure
+   * it picks up all the files.
+   */
+  @Test
+  public void getIndexSegmentFilesForLogSegmentTest() {
+    LogSegment logSegment = log.getFirstSegment();
+    while (logSegment != null) {
+      LogSegment nextSegment = log.getNextSegment(logSegment);
+      File[] indexSegmentFiles = PersistentIndex.getIndexSegmentFilesForLogSegment(tempDirStr, logSegment.getName());
+      Arrays.sort(indexSegmentFiles, PersistentIndex.INDEX_SEGMENT_FILE_COMPARATOR);
+      Offset from = new Offset(logSegment.getName(), logSegment.getStartOffset());
+      Offset to = new Offset(logSegment.getName(), logSegment.getEndOffset());
+      Set<Offset> offsets = referenceIndex.subMap(from, true, to, true).keySet();
+      assertEquals("Number of index segment files inconsistent", offsets.size(), indexSegmentFiles.length);
+      int i = 0;
+      for (Offset offset : offsets) {
+        assertEquals("Index segment file inconsistent with offset expected", offset,
+            IndexSegment.getIndexSegmentStartOffset(indexSegmentFiles[i].getName()));
+        i++;
+      }
+      logSegment = nextSegment;
+    }
+  }
+
+  /**
+   * Tests {@link PersistentIndex#cleanupIndexSegmentFilesForLogSegment(String, String)} and makes sure it deletes all
+   * the relevant files and no more.
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void cleanupIndexSegmentFilesForLogSegment() throws IOException, StoreException {
+    index.close();
+    LogSegment logSegment = log.getFirstSegment();
+    while (logSegment != null) {
+      LogSegment nextSegment = log.getNextSegment(logSegment);
+      final String logSegmentName = logSegment.getName();
+      int totalFilesInDir = tempDir.listFiles().length;
+      File[] filesToCheck = tempDir.listFiles(new FilenameFilter() {
+        @Override
+        public boolean accept(File dir, String name) {
+          return name.startsWith(logSegmentName) && (name.endsWith(IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX)
+              || name.endsWith(IndexSegment.BLOOM_FILE_NAME_SUFFIX));
+        }
+      });
+      Offset from = new Offset(logSegment.getName(), logSegment.getStartOffset());
+      Offset to = new Offset(logSegment.getName(), logSegment.getEndOffset());
+      int expectedNumFilesToDelete = referenceIndex.subMap(from, true, to, true).size() * 2;
+      if (nextSegment == null) {
+        // latest index segment does not have a bloom file
+        expectedNumFilesToDelete--;
+      }
+      assertEquals("Number of files to check does not match expectation", expectedNumFilesToDelete,
+          filesToCheck.length);
+      PersistentIndex.cleanupIndexSegmentFilesForLogSegment(tempDirStr, logSegmentName);
+      for (File fileToCheck : filesToCheck) {
+        assertFalse(fileToCheck + " should have been deleted", fileToCheck.exists());
+      }
+      assertEquals("More than the expected number of files were deleted", totalFilesInDir - filesToCheck.length,
+          tempDir.listFiles().length);
+      logSegment = nextSegment;
+    }
   }
 
   // helpers
@@ -1093,23 +1212,6 @@ public class IndexTest {
   }
 
   /**
-   * Verifies that the number of log segments is as expected.
-   * @param expectedCount the number of log segments expected.
-   */
-  private void verifyLogSegmentCount(int expectedCount) {
-    // this function works under the assumption that log segments are not allocated until they are required
-    // this is a fair assumption because the PersistentIndex works under the same assumption and would break if it were
-    // not true.
-    LogSegment segment = log.getFirstSegment();
-    int logSegmentCount = 0;
-    while (segment != null) {
-      logSegmentCount++;
-      segment = log.getNextSegment(segment);
-    }
-    assertEquals("Unexpected number of log segments", expectedCount, logSegmentCount);
-  }
-
-  /**
    * Sleeps in intervals of 10ms until expected progress is made or {@code maxTimeToCheck} is reached
    * @param expectedProgress expected progress value
    * @param maxTimeToCheck max time to check if expected progress is reached
@@ -1182,11 +1284,10 @@ public class IndexTest {
     metricRegistry = new MetricRegistry();
     StoreMetrics metrics = new StoreMetrics(tempDirStr, metricRegistry);
     StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+    sessionId = UUID.randomUUID();
     index =
         new PersistentIndex(tempDirStr, scheduler, log, config, STORE_KEY_FACTORY, recovery, hardDelete, metrics, time,
-            incarnationId);
-    sessionId =
-        ((StoreFindToken) index.findEntriesSince(new StoreFindToken(), Long.MAX_VALUE).getFindToken()).getSessionId();
+            sessionId, incarnationId);
   }
 
   /**
@@ -1199,8 +1300,8 @@ public class IndexTest {
     File[] indexSegmentFiles = tempDir.listFiles(new FilenameFilter() {
       @Override
       public boolean accept(File dir, String name) {
-        return name.endsWith(PersistentIndex.INDEX_SEGMENT_FILE_NAME_SUFFIX) || name.endsWith(
-            PersistentIndex.BLOOM_FILE_NAME_SUFFIX);
+        return name.endsWith(IndexSegment.INDEX_SEGMENT_FILE_NAME_SUFFIX) || name.endsWith(
+            IndexSegment.BLOOM_FILE_NAME_SUFFIX);
       }
     });
     assertNotNull("Could not load index segment files", indexSegmentFiles);
@@ -1292,23 +1393,31 @@ public class IndexTest {
     log = new Log(tempDirStr, LOG_CAPACITY, segmentCapacity, metrics);
     index =
         new PersistentIndex(tempDirStr, scheduler, log, config, STORE_KEY_FACTORY, recovery, hardDelete, metrics, time,
-            incarnationId);
-    assertEquals("End Offset of index not as expected", log.getStartOffset(), index.getCurrentEndOffset());
+            sessionId, incarnationId);
+    Offset expectedStartOffset = new Offset(log.getFirstSegment().getName(), log.getFirstSegment().getStartOffset());
+    assertEquals("Start Offset of index not as expected", expectedStartOffset, index.getStartOffset());
+    assertEquals("End Offset of index not as expected", log.getEndOffset(), index.getCurrentEndOffset());
 
     // advance time by a millisecond in order to be able to add expired keys and to avoid keys that are expired from
     // being picked for delete.
     time.sleep(1);
-    verifyLogSegmentCount(1);
+    assertEquals("Incorrect log segment count", 0, index.getLogSegmentCount());
+    long expectedUsedCapacity;
     if (!isLogSegmented) {
       // log is filled about ~50%.
       addCuratedIndexEntriesToLogSegment(segmentCapacity / 2, 1);
+      expectedUsedCapacity = segmentCapacity / 2;
+      assertEquals("Used capacity reported not as expected", expectedUsedCapacity, index.getUsedCapacity());
     } else {
       // first log segment is filled to capacity.
       addCuratedIndexEntriesToLogSegment(segmentCapacity, 1);
+      assertEquals("Used capacity reported not as expected", segmentCapacity, index.getUsedCapacity());
 
       // second log segment is filled but has some space at the end (free space has to be less than the lesser of the
       // standard delete and put record sizes so that the next write causes a roll over of log segments).
       addCuratedIndexEntriesToLogSegment(segmentCapacity - (DELETE_RECORD_SIZE - 1), 2);
+      assertEquals("Used capacity reported not as expected", 2 * segmentCapacity - (DELETE_RECORD_SIZE - 1),
+          index.getUsedCapacity());
 
       // third log segment is partially filled and is left as the "active" segment
       // First Index Segment
@@ -1318,7 +1427,7 @@ public class IndexTest {
       LogSegment segment = log.getFirstSegment();
       MockId idToDelete = getIdToDeleteFromLogSegment(segment);
       addDeleteEntry(idToDelete);
-      verifyLogSegmentCount(3);
+      assertEquals("Incorrect log segment count", 3, index.getLogSegmentCount());
       // DELETE for a key in the second segment
       segment = log.getNextSegment(segment);
       idToDelete = getIdToDeleteFromLogSegment(segment);
@@ -1330,12 +1439,18 @@ public class IndexTest {
       long size = segmentCapacity / 3 - index.getCurrentEndOffset().getOffset();
       addPutEntries(1, size, Utils.Infinite_Time);
 
+      expectedUsedCapacity = 2 * segmentCapacity + segmentCapacity / 3;
+      assertEquals("Used capacity reported not as expected", expectedUsedCapacity, index.getUsedCapacity());
+
       // fourth and fifth log segment are free.
     }
     // make sure all indexes are written to disk and mapped as required (forcing IndexPersistor to run).
     log.flush();
     reloadIndex(false);
     verifyState();
+    assertEquals("Start Offset of index not as expected", expectedStartOffset, index.getStartOffset());
+    assertEquals("End Offset of index not as expected", log.getEndOffset(), index.getCurrentEndOffset());
+    assertEquals("Used capacity reported not as expected", expectedUsedCapacity, index.getUsedCapacity());
   }
 
   /**
@@ -1352,7 +1467,7 @@ public class IndexTest {
     // First Index Segment
     // 1 PUT
     Offset firstJournalEntryAddedNow = addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time).getStartOffset();
-    verifyLogSegmentCount(expectedLogSegmentCount);
+    assertEquals("Incorrect log segment count", expectedLogSegmentCount, index.getLogSegmentCount());
     // 2 more PUT
     addPutEntries(2, PUT_RECORD_SIZE, Utils.Infinite_Time);
     // 2 PUT EXPIRED
@@ -1409,7 +1524,7 @@ public class IndexTest {
     // 1 PUT entry that spans the rest of the data in the segment
     long size = sizeToMakeIndexEntriesFor - index.getCurrentEndOffset().getOffset();
     addPutEntries(1, size, Utils.Infinite_Time);
-    verifyLogSegmentCount(expectedLogSegmentCount);
+    assertEquals("Incorrect log segment count", expectedLogSegmentCount, index.getLogSegmentCount());
   }
 
   /**
@@ -1418,7 +1533,7 @@ public class IndexTest {
    * @throws StoreException
    */
   private void verifyState() throws IOException, StoreException {
-    verifyLogSegmentCount(isLogSegmented ? 3 : 1);
+    assertEquals("Incorrect log segment count", isLogSegmented ? 3 : 1, index.getLogSegmentCount());
     NavigableMap<Offset, IndexSegment> realIndex = index.indexes;
     assertEquals("Number of index segments does not match expected", referenceIndex.size(), realIndex.size());
     Map.Entry<Offset, IndexSegment> realIndexEntry = realIndex.firstEntry();
@@ -1510,7 +1625,7 @@ public class IndexTest {
     assertTrue("Hard delete is not enabled", index.hardDeleter.isRunning());
     // IndexSegment still uses real time so advance time so that it goes 2 days past the real time.
     advanceTime(SystemTime.getInstance().milliseconds() + 2 * Time.MsPerSec * Time.SecsPerDay);
-    long expectedProgress = log.getDifference(logOrder.lastKey(), new Offset(log.getFirstSegment().getName(), 0));
+    long expectedProgress = index.getAbsolutePositionForOffset(logOrder.lastKey());
     // give it some time so that hard delete completes one cycle
     waitUntilExpectedProgress(expectedProgress, 5000);
     verifyEntriesForHardDeletes(deletedKeys);
@@ -1561,7 +1676,7 @@ public class IndexTest {
     // resume and verify new entries have been hard deleted
     index.hardDeleter.resume();
     assertFalse("Hard deletes should have been resumed ", index.hardDeleter.isPaused());
-    expectedProgress = log.getDifference(logOrder.lastKey(), new Offset(log.getFirstSegment().getName(), 0));
+    expectedProgress = index.getAbsolutePositionForOffset(logOrder.lastKey());
     // after resuming. hard deletes should progress. Give it some time to hard delete next range
     waitUntilExpectedProgress(expectedProgress, 5000);
     verifyEntriesForHardDeletes(idsDeleted);
@@ -1726,7 +1841,7 @@ public class IndexTest {
       }
     };
     reloadIndex(false);
-    verifyLogSegmentCount(1);
+    assertEquals("Incorrect log segment count", 1, index.getLogSegmentCount());
     assertEquals("Index should contain exactly one index segment", 1, index.indexes.size());
     LogSegment segment = log.getFirstSegment();
     assertEquals("End offset not as expected",
@@ -1794,7 +1909,7 @@ public class IndexTest {
     StoreFindToken startToken = new StoreFindToken(firstId, firstIndexSegmentStartOffset, sessionId, incarnationId);
     StoreFindToken expectedEndToken =
         new StoreFindToken(secondIndexSegmentEntry.getKey(), secondIndexSegmentStartOffset, sessionId, incarnationId);
-    expectedEndToken.setBytesRead(log.getDifference(secondIndexSegmentStartOffset, logAbsoluteZero));
+    expectedEndToken.setBytesRead(index.getAbsolutePositionForOffset(secondIndexSegmentStartOffset));
     doFindEntriesSinceTest(startToken, maxTotalSizeOfEntries, expectedKeys, expectedEndToken);
 
     // ------------------
@@ -1822,7 +1937,7 @@ public class IndexTest {
    */
   private void findEntriesSinceToJournalBasedTest() throws StoreException {
     StoreFindToken absoluteEndToken = new StoreFindToken(logOrder.lastKey(), sessionId, incarnationId, false);
-    absoluteEndToken.setBytesRead(log.getUsedCapacity());
+    absoluteEndToken.setBytesRead(index.getUsedCapacity());
 
     // ------------------
     // 1. Uninitialized -> Journal
@@ -1887,7 +2002,7 @@ public class IndexTest {
       for (Map.Entry<MockId, IndexValue> indexSegmentEntry : indexEntry.getValue().entrySet()) {
         MockId id = indexSegmentEntry.getKey();
         StoreFindToken expectedEndToken = new StoreFindToken(id, indexSegmentStartOffset, sessionId, incarnationId);
-        expectedEndToken.setBytesRead(log.getDifference(indexSegmentStartOffset, logAbsoluteZero));
+        expectedEndToken.setBytesRead(index.getAbsolutePositionForOffset(indexSegmentStartOffset));
         doFindEntriesSinceTest(startToken, indexSegmentEntry.getValue().getSize(), Collections.singleton(id),
             expectedEndToken);
         startToken = expectedEndToken;
@@ -1903,7 +2018,7 @@ public class IndexTest {
       long size = putDelete.getSecond() != null ? putDelete.getSecond().getSize() : putDelete.getFirst().getSize();
       StoreFindToken expectedEndToken = new StoreFindToken(startOffset, sessionId, incarnationId, false);
       Offset endOffset = log.getFileSpanForMessage(startOffset, size).getEndOffset();
-      expectedEndToken.setBytesRead(log.getDifference(endOffset, logAbsoluteZero));
+      expectedEndToken.setBytesRead(index.getAbsolutePositionForOffset(endOffset));
       doFindEntriesSinceTest(startToken, size, Collections.singleton(id), expectedEndToken);
       startToken = expectedEndToken;
       logEntry = logOrder.higherEntry(logEntry.getKey());
@@ -1937,7 +2052,7 @@ public class IndexTest {
 
     Offset endOffset = log.getFileSpanForMessage(nextIndexSegmentStartOffset, size).getEndOffset();
     StoreFindToken expectedEndToken = new StoreFindToken(nextIndexSegmentStartOffset, sessionId, incarnationId, false);
-    expectedEndToken.setBytesRead(log.getDifference(endOffset, new Offset(log.getFirstSegment().getName(), 0)));
+    expectedEndToken.setBytesRead(index.getAbsolutePositionForOffset(endOffset));
     doFindEntriesSinceTest(startToken, maxSize, expectedKeys, expectedEndToken);
   }
 
@@ -2239,5 +2354,17 @@ public class IndexTest {
       }
     }
     return deletedId;
+  }
+
+  // getAbsolutePositionForOffsetTest() helpers
+
+  /**
+   * Verifies that the absolute position returned for {@code offset} is correct.
+   * @param offset the {@link Offset} whose absolute position needs to be verified.
+   * @param numLogSegmentsPreceding number of log segments that precede the log segment that contains {@code offset}.
+   */
+  private void verifyAbsolutePosition(Offset offset, long numLogSegmentsPreceding) {
+    long expectedPosition = numLogSegmentsPreceding * log.getSegmentCapacity() + offset.getOffset();
+    assertEquals("Position not as expected", expectedPosition, index.getAbsolutePositionForOffset(offset));
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -857,7 +857,6 @@ public class IndexTest {
   }
 
   /**
-<<<<<<< 83ab61e8555ca6ba5170782bb078e1b6b5bbab7b
    * Tests the Index persistor for all cases
    * @throws InterruptedException
    * @throws IOException
@@ -900,10 +899,7 @@ public class IndexTest {
   }
 
   /**
-   * Tests {@link PersistentIndex#getAbsolutePositionForOffset(Offset)}.
-=======
    * Tests {@link PersistentIndex#getAbsolutePositionInLogForOffset(Offset)}.
->>>>>>> Addressing priyesh's comments
    */
   @Test
   public void getAbsolutePositionForOffsetTest() {

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -66,6 +66,10 @@ public class IndexValueTest {
     newValue.setNewSize(newSize);
     verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expiresAtMs, oldOffset);
 
+    // original message offset cleared
+    newValue.clearOriginalMessageOffset();
+    verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expiresAtMs, -1);
+
     newValue = new IndexValue(logSegmentName, value.getBytes());
     String newLogSegmentName = LogSegmentNameHelper.getNextPositionName(logSegmentName);
     // delete not in the same log segment

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentNameHelperTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentNameHelperTest.java
@@ -175,7 +175,7 @@ public class LogSegmentNameHelperTest {
       long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
       long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
       String name = LogSegmentNameHelper.getName(pos, gen);
-      checkPosAndGeneration(LogSegmentNameHelper.getNextPositionName(name), pos + 1, gen);
+      checkPosAndGeneration(LogSegmentNameHelper.getNextPositionName(name), pos + 1, 0);
       checkPosAndGeneration(LogSegmentNameHelper.getNextGenerationName(name), pos, gen + 1);
     }
     try {
@@ -193,27 +193,14 @@ public class LogSegmentNameHelperTest {
   }
 
   /**
-   * Tests correctness of {@link LogSegmentNameHelper#generateFirstSegmentName(long)} for different numbers of log
+   * Tests correctness of {@link LogSegmentNameHelper#generateFirstSegmentName(boolean)} for different numbers of log
    * segments (including invalid ones).
    */
   @Test
   public void generateFirstSegmentNameTest() {
-    assertEquals("Did not get expected name", "", LogSegmentNameHelper.generateFirstSegmentName(1));
+    assertEquals("Did not get expected name", "", LogSegmentNameHelper.generateFirstSegmentName(false));
     String firstSegmentName = LogSegmentNameHelper.getName(0, 0);
-    for (int i = 0; i < 10; i++) {
-      long numSegments = Utils.getRandomLong(TestUtils.RANDOM, 1000) + 2;
-      assertEquals("Did not get expected name", firstSegmentName,
-          LogSegmentNameHelper.generateFirstSegmentName(numSegments));
-    }
-    int[] invalidNumSegments = {0, -1};
-    for (int numSegments : invalidNumSegments) {
-      try {
-        LogSegmentNameHelper.generateFirstSegmentName(numSegments);
-        fail("Should have failed to get the first segment name for [" + numSegments + "] segments");
-      } catch (IllegalArgumentException e) {
-        // expected. Nothing to do.
-      }
-    }
+    assertEquals("Did not get expected name", firstSegmentName, LogSegmentNameHelper.generateFirstSegmentName(true));
   }
 
   /**

--- a/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
@@ -307,6 +307,16 @@ public class LogTest {
       // expected. Nothing to do.
     }
 
+    // cannot add segments that are considered "used"
+    segmentName = LogSegmentNameHelper.getName(activeSegmentPos - 1, 0);
+    segment = getLogSegment(segmentName, SEGMENT_CAPACITY, true);
+    try {
+      log.addSegment(segment, true);
+      fail("Cannot add segment that has to be counted towards used segments");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+
     // drop the uncounted segment
     assertEquals("Segment not as expected", uncountedSegment, log.getSegment(uncountedSegment.getName()));
     File segmentFile = uncountedSegment.getView().getFirst();

--- a/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
@@ -26,6 +26,7 @@ import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import org.junit.After;
 import org.junit.Test;
@@ -126,7 +127,7 @@ public class LogTest {
     }
 
     // file which is not a directory
-    File file = create(LogSegmentNameHelper.nameToFilename(LogSegmentNameHelper.generateFirstSegmentName(1)));
+    File file = create(LogSegmentNameHelper.nameToFilename(LogSegmentNameHelper.generateFirstSegmentName(false)));
     try {
       new Log(file.getAbsolutePath(), 1, 1, metrics);
       fail("Construction should have failed");
@@ -185,32 +186,18 @@ public class LogTest {
   }
 
   /**
-   * Tests cases where bad arguments are provided to {@link Log#getDifference(Offset, Offset)}.
+   * Tests cases where bad arguments are provided to {@link Log#getNextSegment(LogSegment)}.
    * @throws IOException
    */
   @Test
-  public void getDifferenceBadArgsTest() throws IOException {
+  public void getNextSegmentBadArgsTest() throws IOException {
     Log log = new Log(tempDir.getAbsolutePath(), LOG_CAPACITY, SEGMENT_CAPACITY, metrics);
-    long numSegments = LOG_CAPACITY / SEGMENT_CAPACITY;
-    Offset badSegmentOffset = new Offset(LogSegmentNameHelper.getName(numSegments + 1, 0), 0);
-    Offset badOffsetOffset =
-        new Offset(log.getFirstSegment().getName(), log.getFirstSegment().getCapacityInBytes() + 1);
-    List<Pair<Offset, Offset>> pairsToCheck = new ArrayList<>();
-    pairsToCheck.add(new Pair<>(log.getStartOffset(), badSegmentOffset));
-    pairsToCheck.add(new Pair<>(badSegmentOffset, log.getEndOffset()));
-    pairsToCheck.add(new Pair<>(log.getStartOffset(), badOffsetOffset));
-    pairsToCheck.add(new Pair<>(badOffsetOffset, log.getEndOffset()));
-
+    LogSegment segment = getLogSegment(LogSegmentNameHelper.getName(1, 1), SEGMENT_CAPACITY, true);
     try {
-      for (Pair<Offset, Offset> pairToCheck : pairsToCheck) {
-        try {
-          log.getDifference(pairToCheck.getFirst(), pairToCheck.getSecond());
-          fail("Should have failed to get difference with invalid offset input. Input was [" + pairToCheck.getFirst()
-              + ", " + pairToCheck.getSecond() + "]");
-        } catch (IllegalArgumentException e) {
-          // expected. Nothing to do.
-        }
-      }
+      log.getNextSegment(segment);
+      fail("Getting next segment should have failed because provided segment does not exist in the log");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
     } finally {
       log.close();
       cleanDirectory(tempDir);
@@ -218,17 +205,16 @@ public class LogTest {
   }
 
   /**
-   * Tests cases where bad arguments are provided to {@link Log#getNextSegment(LogSegment)}.
+   * Tests cases where bad arguments are provided to {@link Log#getPrevSegment(LogSegment)}.
    * @throws IOException
    */
   @Test
-  public void getNextSegmentBadArgsTest() throws IOException {
+  public void getPrevSegmentBadArgsTest() throws IOException {
     Log log = new Log(tempDir.getAbsolutePath(), LOG_CAPACITY, SEGMENT_CAPACITY, metrics);
-    File file = create(LogSegmentNameHelper.nameToFilename(LogSegmentNameHelper.generateFirstSegmentName(1)));
-    LogSegment segment = new LogSegment(LogSegmentNameHelper.getName(1, 1), file, 1, metrics, false);
+    LogSegment segment = getLogSegment(LogSegmentNameHelper.getName(1, 1), SEGMENT_CAPACITY, true);
     try {
-      log.getNextSegment(segment);
-      fail("Getting next segment should have failed because provided segment does not exist in the log");
+      log.getPrevSegment(segment);
+      fail("Getting prev segment should have failed because provided segment does not exist in the log");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
     } finally {
@@ -255,7 +241,7 @@ public class LogTest {
         // expected. Nothing to do.
       }
       // write a single byte into the log
-      endOffsetOfPrevMessage = log.getStartOffset();
+      endOffsetOfPrevMessage = log.getEndOffset();
       CHANNEL_APPENDER.append(log, ByteBuffer.allocate(1));
       try {
         // provide the wrong size
@@ -268,6 +254,129 @@ public class LogTest {
       log.close();
       cleanDirectory(tempDir);
     }
+  }
+
+  /**
+   * Tests all cases of {@link Log#addSegment(LogSegment, boolean)} and {@link Log#dropSegment(String, boolean)}.
+   * @throws IOException
+   */
+  @Test
+  public void addAndDropSegmentTest() throws IOException {
+    // start with a segment that has a high position to allow for addition of segments
+    long activeSegmentPos = 2 * LOG_CAPACITY / SEGMENT_CAPACITY;
+    LogSegment loadedSegment = getLogSegment(LogSegmentNameHelper.getName(activeSegmentPos, 0), SEGMENT_CAPACITY, true);
+    List<LogSegment> segmentsToLoad = Collections.singletonList(loadedSegment);
+    Log log = new Log(tempDir.getAbsolutePath(), LOG_CAPACITY, SEGMENT_CAPACITY, metrics, true, segmentsToLoad,
+        Collections.EMPTY_LIST.iterator());
+
+    // add a segment
+    String segmentName = LogSegmentNameHelper.getName(0, 0);
+    LogSegment uncountedSegment = getLogSegment(segmentName, SEGMENT_CAPACITY, true);
+    log.addSegment(uncountedSegment, false);
+    assertEquals("Log segment instance not as expected", uncountedSegment, log.getSegment(segmentName));
+
+    // cannot add past the active segment
+    segmentName = LogSegmentNameHelper.getName(activeSegmentPos + 1, 0);
+    LogSegment segment = getLogSegment(segmentName, SEGMENT_CAPACITY, true);
+    try {
+      log.addSegment(segment, false);
+      fail("Should not be able to add past the active segment");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+
+    // since the previous one did not ask for count of segments to be increased, we should be able to add max - 1
+    // more segments. This increments used segment count to the max.
+    int max = (int) (LOG_CAPACITY / SEGMENT_CAPACITY);
+    for (int i = 1; i < max; i++) {
+      segmentName = LogSegmentNameHelper.getName(i, 0);
+      segment = getLogSegment(segmentName, SEGMENT_CAPACITY, true);
+      log.addSegment(segment, true);
+    }
+
+    // fill up the active segment
+    ByteBuffer buffer =
+        ByteBuffer.allocate((int) (loadedSegment.getCapacityInBytes() - loadedSegment.getStartOffset()));
+    CHANNEL_APPENDER.append(log, buffer);
+    // write fails because no more log segments can be allocated
+    buffer = ByteBuffer.allocate(1);
+    try {
+      CHANNEL_APPENDER.append(log, buffer);
+      fail("Write should have failed because no more log segments should be allocated");
+    } catch (IllegalStateException e) {
+      // expected. Nothing to do.
+    }
+
+    // drop the uncounted segment
+    assertEquals("Segment not as expected", uncountedSegment, log.getSegment(uncountedSegment.getName()));
+    File segmentFile = uncountedSegment.getView().getFirst();
+    log.dropSegment(uncountedSegment.getName(), false);
+    assertNull("Segment should not be present", log.getSegment(uncountedSegment.getName()));
+    assertFalse("Segment file should not be present", segmentFile.exists());
+
+    // cannot drop a segment that does not exist
+    // cannot drop the active segment
+    String[] segmentsToDrop = {uncountedSegment.getName(), loadedSegment.getName()};
+    for (String segmentToDrop : segmentsToDrop) {
+      try {
+        log.dropSegment(segmentToDrop, false);
+        fail("Should have failed to drop segment");
+      } catch (IllegalArgumentException e) {
+        // expected. Nothing to do.
+      }
+    }
+
+    // drop a segment and decrement total segment count
+    log.dropSegment(log.getFirstSegment().getName(), true);
+
+    // should be able to write now
+    buffer = ByteBuffer.allocate(1);
+    CHANNEL_APPENDER.append(log, buffer);
+  }
+
+  /**
+   * Checks that the constructor that receives segments and segment names iterator,
+   * {@link Log#Log(String, long, long, StoreMetrics, boolean, List, Iterator)}, loads the segments correctly and uses
+   * the iterator to name new segments and uses the default algorithm once the names run out.
+   * @throws IOException
+   */
+  @Test
+  public void logSegmentCustomNamesTest() throws IOException {
+    int numSegments = (int) (LOG_CAPACITY / SEGMENT_CAPACITY);
+    LogSegment segment = getLogSegment(LogSegmentNameHelper.getName(0, 0), SEGMENT_CAPACITY, true);
+    long startPos = 2 * numSegments;
+    List<Pair<String, String>> expectedSegmentAndFileNames = new ArrayList<>(numSegments);
+    expectedSegmentAndFileNames.add(new Pair<>(segment.getName(), segment.getView().getFirst().getName()));
+    List<Pair<String, String>> segmentNameAndFileNamesDesired = new ArrayList<>();
+    String lastName = null;
+    for (int i = 0; i < 2; i++) {
+      lastName = LogSegmentNameHelper.getName(startPos + i, 0);
+      String fileName = LogSegmentNameHelper.nameToFilename(lastName) + "_modified";
+      segmentNameAndFileNamesDesired.add(new Pair<>(lastName, fileName));
+      expectedSegmentAndFileNames.add(new Pair<>(lastName, fileName));
+    }
+    for (int i = expectedSegmentAndFileNames.size(); i < numSegments; i++) {
+      lastName = LogSegmentNameHelper.getNextPositionName(lastName);
+      String fileName = LogSegmentNameHelper.nameToFilename(lastName);
+      expectedSegmentAndFileNames.add(new Pair<>(lastName, fileName));
+    }
+
+    Log log = new Log(tempDir.getAbsolutePath(), LOG_CAPACITY, SEGMENT_CAPACITY, metrics, true,
+        Collections.singletonList(segment), segmentNameAndFileNamesDesired.iterator());
+    // write enough so that all segments are allocated
+    ByteBuffer buffer = ByteBuffer.allocate((int) (segment.getCapacityInBytes() - segment.getStartOffset()));
+    for (int i = 0; i < numSegments; i++) {
+      buffer.rewind();
+      CHANNEL_APPENDER.append(log, buffer);
+    }
+
+    segment = log.getFirstSegment();
+    for (Pair<String, String> nameAndFilename : expectedSegmentAndFileNames) {
+      assertEquals("Segment name does not match", nameAndFilename.getFirst(), segment.getName());
+      assertEquals("Segment file does not match", nameAndFilename.getSecond(), segment.getView().getFirst().getName());
+      segment = log.getNextSegment(segment);
+    }
+    assertNull("There should be no more segments", segment);
   }
 
   // helpers
@@ -285,6 +394,19 @@ public class LogTest {
         assertTrue("The file [" + file.getAbsolutePath() + "] could not be deleted", file.delete());
       }
     }
+  }
+
+  /**
+   * Returns a {@link LogSegment} instance with name {@code name} and capacity {@code capacityInBytes}.
+   * @param name the name of the {@link LogSegment} instance.
+   * @param capacityInBytes the capacity of the {@link LogSegment} instance.
+   * @param writeHeader {@code true} if headers should be written.
+   * @return a {@link LogSegment} instance with name {@code name} and capacity {@code capacityInBytes}.
+   * @throws IOException
+   */
+  private LogSegment getLogSegment(String name, long capacityInBytes, boolean writeHeader) throws IOException {
+    File file = create(LogSegmentNameHelper.nameToFilename(name));
+    return new LogSegment(name, file, capacityInBytes, metrics, writeHeader);
   }
 
   // comprehensiveTest() helpers
@@ -315,7 +437,7 @@ public class LogTest {
           if (i == 0) {
             // first startup case - segment file is not pre-created but will be created by the Log.
             expectedSegmentNames = new ArrayList<>();
-            expectedSegmentNames.add(LogSegmentNameHelper.generateFirstSegmentName(numSegments));
+            expectedSegmentNames.add(LogSegmentNameHelper.generateFirstSegmentName(numSegments > 1));
           } else if (i == j) {
             // invalid index for anything other than i == 0.
             break;
@@ -344,7 +466,7 @@ public class LogTest {
     }
     List<String> segmentNames = new ArrayList<>(numToCreate);
     if (numFinalSegments == 1) {
-      String name = LogSegmentNameHelper.generateFirstSegmentName(numFinalSegments);
+      String name = LogSegmentNameHelper.generateFirstSegmentName(false);
       File file = create(LogSegmentNameHelper.nameToFilename(name));
       new LogSegment(name, file, segmentCapacity, metrics, false).close();
       segmentNames.add(name);
@@ -398,6 +520,8 @@ public class LogTest {
       List<String> expectedSegmentNames, int segmentIdxToMarkActive, Appender appender) throws IOException {
     long numSegments = (logCapacity - 1) / segmentCapacity + 1;
     Log log = new Log(tempDir.getAbsolutePath(), logCapacity, segmentCapacity, metrics);
+    assertEquals("Total capacity not as expected", logCapacity, log.getCapacityInBytes());
+    assertEquals("Segment capacity not as expected", Math.min(logCapacity, segmentCapacity), log.getSegmentCapacity());
     try {
       // only preloaded segments should be in expectedSegmentNames.
       checkLog(log, Math.min(logCapacity, segmentCapacity), numSegments, expectedSegmentNames);
@@ -412,7 +536,6 @@ public class LogTest {
       // log full - so all segments should be there
       assertEquals("Unexpected number of segments", numSegments, allSegmentNames.size());
       checkLog(log, Math.min(logCapacity, segmentCapacity), numSegments, allSegmentNames);
-      doDifferenceTest(log, allSegmentNames);
       flushCloseAndValidate(log);
       checkLogReload(logCapacity, Math.min(logCapacity, segmentCapacity), allSegmentNames);
     } finally {
@@ -432,6 +555,7 @@ public class LogTest {
   private void checkLog(Log log, long expectedSegmentCapacity, long numFinalSegments, List<String> expectedSegmentNames)
       throws IOException {
     LogSegment nextSegment = log.getFirstSegment();
+    assertNull("Prev segment should be null", log.getPrevSegment(nextSegment));
     for (String segmentName : expectedSegmentNames) {
       assertEquals("Next segment is not as expected", segmentName, nextSegment.getName());
       LogSegment segment = log.getSegment(segmentName);
@@ -439,12 +563,11 @@ public class LogTest {
       assertEquals("Segment capacity not as expected", expectedSegmentCapacity, segment.getCapacityInBytes());
       assertEquals("Segment returned by getSegment() is incorrect", segment, log.getSegment(segment.getName()));
       nextSegment = log.getNextSegment(segment);
+      if (nextSegment != null) {
+        assertEquals("Prev segment not as expected", segment, log.getPrevSegment(nextSegment));
+      }
     }
     assertNull("Next segment should be null", nextSegment);
-    assertEquals("Log segments reported is wrong", expectedSegmentNames.size(), log.getSegmentCount());
-    long startOffsetInSegment = numFinalSegments > 1 ? LogSegment.HEADER_SIZE : 0;
-    Offset expectedStartOffset = new Offset(expectedSegmentNames.get(0), startOffsetInSegment);
-    assertEquals("Start offset is wrong", expectedStartOffset, log.getStartOffset());
   }
 
   /**
@@ -503,13 +626,12 @@ public class LogTest {
           expectedActiveSegment.getEndOffset());
       assertEquals("End offset not as expected", new Offset(expectedActiveSegment.getName(), currentSegmentWriteSize),
           log.getEndOffset());
-      assertEquals("Used capacity not as expected", expectedUsedCapacity, log.getUsedCapacity());
     }
     // try one more write that should fail
     try {
       appender.append(log, ByteBuffer.wrap(buf));
       fail("Should have failed because max capacity has been reached");
-    } catch (IllegalStateException e) {
+    } catch (IllegalArgumentException | IllegalStateException e) {
       // expected. Nothing to do.
     }
   }
@@ -528,82 +650,13 @@ public class LogTest {
     if (count == segmentNames.size()) {
       return segmentNames;
     } else if (segmentNames.size() == 0) {
-      segmentNames.add(LogSegmentNameHelper.generateFirstSegmentName(count));
+      segmentNames.add(LogSegmentNameHelper.generateFirstSegmentName(count > 1));
     }
     for (int i = segmentNames.size(); i < count; i++) {
       String nextSegmentName = LogSegmentNameHelper.getNextPositionName(segmentNames.get(i - 1));
       segmentNames.add(nextSegmentName);
     }
     return segmentNames;
-  }
-
-  /**
-   * Tests {@link Log#getDifference(Offset, Offset)} for all cases.
-   * 1. Same segment and offset
-   * 2. Same segment, different offsets
-   * 3. Boundary offsets (combination of -start of lower, end of lower- and -start of higher, end of higher-
-   * 4. Random offsets that are not boundary offsets.
-   * @param log the {@link Log} instance to use.
-   * @param segmentNames the names of all the segments in the {@code log}.
-   */
-  private void doDifferenceTest(Log log, List<String> segmentNames) {
-    int lowerIdx = 0;
-    int higherIdx = 0;
-    if (segmentNames.size() > 1) {
-      // pick any segment except the last one
-      lowerIdx = TestUtils.RANDOM.nextInt(segmentNames.size() - 1);
-      // pick a segment higher than lowerIdx
-      higherIdx = lowerIdx + 1 + TestUtils.RANDOM.nextInt(segmentNames.size() - lowerIdx - 1);
-    }
-    String lowerSegmentName = segmentNames.get(lowerIdx);
-    String higherSegmentName = segmentNames.get(higherIdx);
-    LogSegment lowerSegment = log.getSegment(lowerSegmentName);
-    LogSegment higherSegment = log.getSegment(higherSegmentName);
-
-    // get boundary offsets
-    Offset lowerLowBound = new Offset(lowerSegmentName, 0);
-    Offset lowerHighBound = new Offset(lowerSegmentName, lowerSegment.getEndOffset());
-    Offset higherLowBound = new Offset(higherSegmentName, 0);
-    Offset higherHighBound = new Offset(higherSegmentName, higherSegment.getEndOffset());
-
-    // get random offsets that are not 0 or the end offset
-    Offset lower =
-        new Offset(lowerSegmentName, Utils.getRandomLong(TestUtils.RANDOM, lowerSegment.getEndOffset() - 1) + 1);
-    Offset higher =
-        new Offset(higherSegmentName, Utils.getRandomLong(TestUtils.RANDOM, higherSegment.getEndOffset() - 1) + 1);
-
-    checkDifference(log, lower, higher, higherIdx - lowerIdx, lowerSegment.getCapacityInBytes());
-    checkDifference(log, lowerLowBound, higherLowBound, higherIdx - lowerIdx, lowerSegment.getCapacityInBytes());
-    checkDifference(log, lowerLowBound, higherHighBound, higherIdx - lowerIdx, lowerSegment.getCapacityInBytes());
-    checkDifference(log, lowerHighBound, higherLowBound, higherIdx - lowerIdx, lowerSegment.getCapacityInBytes());
-    checkDifference(log, lowerHighBound, higherHighBound, higherIdx - lowerIdx, lowerSegment.getCapacityInBytes());
-    checkDifference(log, lower, lower, 0, lowerSegment.getCapacityInBytes());
-    checkDifference(log, lowerLowBound, lower, 0, lowerSegment.getCapacityInBytes());
-  }
-
-  /**
-   * Checks the output of {@link Log#getDifference(Offset, Offset)} for {@code higher} and {@code lower} against the
-   * expected value.
-   * @param log the {@link Log} instance to use.
-   * @param lower the {@link Offset} that is the "lower" offset.
-   * @param higher the {@link Offset} that is the "higher" offset.
-   * @param numSegmentHops the number of segment hops it takes to get from {@code lower} to {@code higher}.
-   * @param segmentCapacity the capacity of each segment.
-   */
-  private void checkDifference(Log log, Offset lower, Offset higher, int numSegmentHops, long segmentCapacity) {
-    long expectedDifference;
-    if (numSegmentHops == 0) {
-      expectedDifference = higher.getOffset() - lower.getOffset();
-    } else {
-      // capacities of full segments b/w higher and lower
-      expectedDifference = (numSegmentHops - 1) * segmentCapacity;
-      // diff b/w lower segment cap and the offset in the lower segment.
-      expectedDifference += segmentCapacity - lower.getOffset();
-      // the offset in the higher segment
-      expectedDifference += higher.getOffset();
-    }
-    assertEquals("Difference returned is not as expected", expectedDifference, log.getDifference(higher, lower));
-    assertEquals("Difference returned is not as expected", -expectedDifference, log.getDifference(lower, higher));
   }
 
   /**

--- a/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
@@ -1951,7 +1951,7 @@ class MockIndex extends PersistentIndex {
       StoreKeyFactory factory, MessageStoreHardDelete messageStoreHardDelete, Time time, UUID incarnationId)
       throws StoreException {
     super(datadir, scheduler, log, config, factory, new DummyMessageStoreRecovery(), messageStoreHardDelete,
-        new StoreMetrics(datadir, new MetricRegistry()), time, incarnationId);
+        new StoreMetrics(datadir, new MetricRegistry()), time, new UUID(1, 1), incarnationId);
   }
 
   public MockIndex(String datadir, ScheduledExecutorService scheduler, Log log, UUID incarnationId, StoreConfig config,
@@ -1963,7 +1963,8 @@ class MockIndex extends PersistentIndex {
   public MockIndex(String datadir, ScheduledExecutorService scheduler, Log log, StoreConfig config,
       StoreKeyFactory factory, Journal journal, UUID incarnationId) throws StoreException {
     super(datadir, scheduler, log, config, factory, new DummyMessageStoreRecovery(), new DummyMessageStoreHardDelete(),
-        new StoreMetrics(datadir, new MetricRegistry()), journal, SystemTime.getInstance(), incarnationId);
+        new StoreMetrics(datadir, new MetricRegistry()), journal, SystemTime.getInstance(), new UUID(1, 1),
+        incarnationId, PersistentIndex.CLEAN_SHUTDOWN_FILENAME);
   }
 
   public void setHardDeleteRunningStatus(boolean status) {
@@ -1991,7 +1992,7 @@ class MockIndex extends PersistentIndex {
   public MockIndex(String datadir, ScheduledExecutorService scheduler, Log log, StoreConfig config,
       StoreKeyFactory factory, MessageStoreRecovery recovery, MessageStoreHardDelete cleanup) throws StoreException {
     super(datadir, scheduler, log, config, factory, recovery, cleanup, new StoreMetrics(datadir, new MetricRegistry()),
-        SystemTime.getInstance(), null);
+        SystemTime.getInstance(), new UUID(1, 1), new UUID(1, 1));
   }
 
   IndexValue getValue(StoreKey key) throws StoreException {

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
@@ -46,7 +46,7 @@ public class StoreFindTokenTest {
     }
   }
 
-  private final long numSegments;
+  private final boolean isLogSegmented;
 
   /**
    * Running for both segmented and non-segmented log.
@@ -54,11 +54,11 @@ public class StoreFindTokenTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{1L}, {2L}});
+    return Arrays.asList(new Object[][]{{false}, {true}});
   }
 
-  public StoreFindTokenTest(long numSegments) {
-    this.numSegments = numSegments;
+  public StoreFindTokenTest(boolean isLogSegmented) {
+    this.isLogSegmented = isLogSegmented;
   }
 
   /**
@@ -68,7 +68,7 @@ public class StoreFindTokenTest {
   public void equalityTest() {
     UUID sessionId = UUID.randomUUID();
     UUID incarnationId = UUID.randomUUID();
-    String logSegmentName = LogSegmentNameHelper.generateFirstSegmentName(numSegments);
+    String logSegmentName = LogSegmentNameHelper.generateFirstSegmentName(isLogSegmented);
     Offset offset = new Offset(logSegmentName, 0);
     Offset otherOffset = new Offset(logSegmentName, 1);
     MockId key = new MockId(UtilsTest.getRandomString(10));
@@ -131,11 +131,11 @@ public class StoreFindTokenTest {
   public void serDeTest() throws IOException {
     UUID sessionId = UUID.randomUUID();
     UUID incarnationId = UUID.randomUUID();
-    String logSegmentName = LogSegmentNameHelper.generateFirstSegmentName(numSegments);
+    String logSegmentName = LogSegmentNameHelper.generateFirstSegmentName(isLogSegmented);
     Offset offset = new Offset(logSegmentName, 0);
     MockId key = new MockId(UtilsTest.getRandomString(10));
 
-    if (numSegments == 1) {
+    if (!isLogSegmented) {
       // UnInitialized
       doSerDeTest(new StoreFindToken(), StoreFindToken.VERSION_0, StoreFindToken.VERSION_1, StoreFindToken.VERSION_2);
 
@@ -180,7 +180,7 @@ public class StoreFindTokenTest {
   public void constructionErrorCasesTest() {
     UUID sessionId = UUID.randomUUID();
     UUID incarnationId = UUID.randomUUID();
-    String logSegmentName = LogSegmentNameHelper.generateFirstSegmentName(numSegments);
+    String logSegmentName = LogSegmentNameHelper.generateFirstSegmentName(isLogSegmented);
     Offset offset = new Offset(logSegmentName, 0);
     MockId key = new MockId(UtilsTest.getRandomString(10));
 

--- a/ambry-tools/src/main/java/com.github.ambry/store/BlobIndexMetrics.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/BlobIndexMetrics.java
@@ -21,6 +21,7 @@ import com.github.ambry.messageformat.BlobStoreRecovery;
 import com.github.ambry.utils.SystemTime;
 import java.io.FileWriter;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -39,7 +40,7 @@ class BlobIndexMetrics extends PersistentIndex {
       AtomicLong totalWrites, AtomicLong totalTimeTaken, AtomicLong totalReads, StoreConfig config, FileWriter writer,
       StoreKeyFactory factory) throws StoreException {
     super(datadir, scheduler, log, config, factory, new BlobStoreRecovery(), new BlobStoreHardDelete(),
-        new StoreMetrics(datadir, new MetricRegistry()), SystemTime.getInstance(), null);
+        new StoreMetrics(datadir, new MetricRegistry()), SystemTime.getInstance(), UUID.randomUUID(), null);
     this.enableVerboseLogging = enableVerboseLogging;
     this.lastOffsetUsed = new AtomicLong(0);
     this.totalWrites = totalWrites;

--- a/ambry-tools/src/main/java/com.github.ambry/store/ConsistencyCheckerTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/ConsistencyCheckerTool.java
@@ -93,9 +93,9 @@ public class ConsistencyCheckerTool {
     IndexStats indexStats = new IndexStats();
     for (File replica : replicas) {
       try {
-        File[] indexFiles = replica.listFiles(PersistentIndex.INDEX_FILE_FILTER);
+        File[] indexFiles = replica.listFiles(PersistentIndex.INDEX_SEGMENT_FILE_FILTER);
         long keysProcessedforReplica = 0;
-        Arrays.sort(indexFiles, PersistentIndex.INDEX_FILE_COMPARATOR);
+        Arrays.sort(indexFiles, PersistentIndex.INDEX_SEGMENT_FILE_COMPARATOR);
         for (File indexFile : indexFiles) {
           keysProcessedforReplica +=
               dumpIndexTool.dumpIndex(indexFile, replica.getName(), replicasList, new ArrayList<String>(),

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpDataTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpDataTool.java
@@ -38,8 +38,6 @@ import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.github.ambry.store.PersistentIndex.*;
-
 
 /**
  * Tool to assist in dumping data from data files in Ambry
@@ -116,11 +114,11 @@ public class DumpDataTool {
    */
   private void compareReplicaIndexEntriestoLogContent(String replicaRootDirectory) throws Exception {
     logger.info("Comparing Index entries to Log ");
-    File[] indexFiles = new File(replicaRootDirectory).listFiles(INDEX_FILE_FILTER);
+    File[] indexFiles = new File(replicaRootDirectory).listFiles(PersistentIndex.INDEX_SEGMENT_FILE_FILTER);
     if (indexFiles == null) {
       throw new IllegalStateException("Could not read index files from " + replicaRootDirectory);
     }
-    Arrays.sort(indexFiles, INDEX_FILE_COMPARATOR);
+    Arrays.sort(indexFiles, PersistentIndex.INDEX_SEGMENT_FILE_COMPARATOR);
     for (int i = 0; i < indexFiles.length; i++) {
       // check end offset if this is the last index segment
       boolean checkEndOffset = i == indexFiles.length - 1;

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpIndexTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpIndexTool.java
@@ -232,8 +232,8 @@ public class DumpIndexTool {
     logger.info("Root directory for replica : " + replicaRootDirectory);
     IndexStats indexStats = new IndexStats();
     Map<String, BlobStatus> blobIdToStatusMap = new HashMap<>();
-    File[] replicas = replicaDirectory.listFiles(PersistentIndex.INDEX_FILE_FILTER);
-    Arrays.sort(replicas, PersistentIndex.INDEX_FILE_COMPARATOR);
+    File[] replicas = replicaDirectory.listFiles(PersistentIndex.INDEX_SEGMENT_FILE_FILTER);
+    Arrays.sort(replicas, PersistentIndex.INDEX_SEGMENT_FILE_COMPARATOR);
     for (File indexFile : replicas) {
       logger.info("Dumping index " + indexFile + " for replica " + replicaDirectory.getName());
       totalKeysProcessed +=
@@ -342,8 +342,8 @@ public class DumpIndexTool {
     File replicaDirectory = new File(replicaRootDirectory);
     Map<String, IndexValue> blobIdToMessageMap = new HashMap<>();
     ActiveBlobStats activeBlobStats = new ActiveBlobStats();
-    File[] replicas = replicaDirectory.listFiles(PersistentIndex.INDEX_FILE_FILTER);
-    Arrays.sort(replicas, PersistentIndex.INDEX_FILE_COMPARATOR);
+    File[] replicas = replicaDirectory.listFiles(PersistentIndex.INDEX_SEGMENT_FILE_FILTER);
+    Arrays.sort(replicas, PersistentIndex.INDEX_SEGMENT_FILE_COMPARATOR);
     for (File indexFile : replicas) {
       logger.info("Dumping index " + indexFile.getName() + " for " + replicaDirectory.getName());
       totalKeysProcessed += dumpActiveBlobsFromIndex(indexFile, blobList, blobIdToMessageMap, activeBlobStats);
@@ -381,8 +381,8 @@ public class DumpIndexTool {
     File replicaDirectory = new File(replicaRootDirectory);
     Map<String, IndexValue> blobIdToBlobMessageMap = new HashMap<>();
     ActiveBlobStats activeBlobStats = new ActiveBlobStats();
-    File[] replicas = replicaDirectory.listFiles(PersistentIndex.INDEX_FILE_FILTER);
-    Arrays.sort(replicas, PersistentIndex.INDEX_FILE_COMPARATOR);
+    File[] replicas = replicaDirectory.listFiles(PersistentIndex.INDEX_SEGMENT_FILE_FILTER);
+    Arrays.sort(replicas, PersistentIndex.INDEX_SEGMENT_FILE_COMPARATOR);
     for (File indexFile : replicas) {
       logger.trace("Dumping index {} for {} ", indexFile.getName(), replicaDirectory.getName());
       totalKeysProcessed += dumpActiveBlobsFromIndex(indexFile, blobList, blobIdToBlobMessageMap, activeBlobStats);

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/BlobValidator.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/BlobValidator.java
@@ -701,8 +701,8 @@ public class BlobValidator {
 
         return false;
       }
-      if (blobProperties.getContentType() != null && that.blobProperties.getContentType() != null &&
-          (!blobProperties.getContentType().equals(that.blobProperties.getContentType()))) {
+      if (blobProperties.getContentType() != null && that.blobProperties.getContentType() != null
+          && (!blobProperties.getContentType().equals(that.blobProperties.getContentType()))) {
         logger.error(
             "Content type Mismatch " + blobProperties.getContentType() + ", " + that.blobProperties.getContentType());
         return false;
@@ -712,8 +712,8 @@ public class BlobValidator {
         return false;
       }
 
-      if (blobProperties.getOwnerId() != null && that.blobProperties.getOwnerId() != null &&
-          (!blobProperties.getOwnerId().equals(that.blobProperties.getOwnerId()))) {
+      if (blobProperties.getOwnerId() != null && that.blobProperties.getOwnerId() != null
+          && (!blobProperties.getOwnerId().equals(that.blobProperties.getOwnerId()))) {
         logger.error("OwnerId Mismatch " + blobProperties.getOwnerId() + ", " + that.blobProperties.getOwnerId());
         return false;
       } else if (blobProperties.getOwnerId() == null || that.blobProperties.getOwnerId() == null) {
@@ -721,8 +721,8 @@ public class BlobValidator {
         return false;
       }
 
-      if (blobProperties.getServiceId() != null && that.blobProperties.getServiceId() != null &&
-          (!blobProperties.getServiceId().equals(that.blobProperties.getServiceId()))) {
+      if (blobProperties.getServiceId() != null && that.blobProperties.getServiceId() != null
+          && (!blobProperties.getServiceId().equals(that.blobProperties.getServiceId()))) {
         logger.error("ServiceId Mismatch " + blobProperties.getServiceId() + ", " + that.blobProperties.getServiceId());
         return false;
       } else if (blobProperties.getServiceId() == null || that.blobProperties.getServiceId() == null) {


### PR DESCRIPTION
1. Moving some APIs from `Log` to `PersistentIndex` because `PersistentIndex` is always expected
to have an atomic view of the store
2. Adding APIs in `PersistentIndex` to fetch/operate on Index segments of a particular Log
segment
3. Adding APIs to log to add and drop segments.
4. Related tests

`./gradlew build && ./gradlew test` on OSx and Linux passed
Formatted

**Primary reviewers: @pnarayanan, @nsivabalan**

**Unit testing**

| Class | Class, % | Method, % | Line, % | Test class |
| --- | --- | --- | --- | --- |
| `Log` | 100% (1/ 1) | 100% (25/ 25) | 99.3% (148/ 149) | `LogTest` |
| `PersistentIndex` | 87.5% (7/ 8) | 92.2% (47/ 51) | 90.7% (470/ 518) | `IndexTest` |
| `CompactionLog` | 100% (3/ 3) | 100% (23/ 23) | 95.5% (126/ 132) | `CompactionLogTest` |

New function in `IndexValue` is also covered.


