### PR TITLE
Avoid upfront size limitation for router puts

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -36,18 +36,7 @@ public class BlobProperties {
    * @param serviceId The service id that is creating this blob
    */
   public BlobProperties(long blobSize, String serviceId) {
-    this(blobSize, serviceId, null, null, false, Utils.Infinite_Time);
-  }
-
-  /**
-   * @param blobSize The size of the blob in bytes
-   * @param serviceId The service id that is creating this blob
-   * @param ownerId The owner of the blob (For example , memberId or groupId)
-   * @param contentType The content type of the blob (eg: mime). Can be Null
-   * @param isPrivate Is the blob secure
-   */
-  public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate) {
-    this(blobSize, serviceId, ownerId, contentType, isPrivate, Utils.Infinite_Time);
+    this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, SystemTime.getInstance().milliseconds());
   }
 
   /**
@@ -60,13 +49,8 @@ public class BlobProperties {
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
       long timeToLiveInSeconds) {
-    this.blobSize = blobSize;
-    this.serviceId = serviceId;
-    this.ownerId = ownerId;
-    this.contentType = contentType;
-    this.isPrivate = isPrivate;
-    this.timeToLiveInSeconds = timeToLiveInSeconds;
-    this.creationTimeInMs = SystemTime.getInstance().milliseconds();
+    this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
+        SystemTime.getInstance().milliseconds());
   }
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -32,7 +32,7 @@ public class BlobProperties {
   protected long creationTimeInMs;
 
   /**
-   * @param blobSize The size of the blob in bytes.
+   * @param blobSize The size of the blob in bytes
    * @param serviceId The service id that is creating this blob
    */
   public BlobProperties(long blobSize, String serviceId) {
@@ -40,7 +40,7 @@ public class BlobProperties {
   }
 
   /**
-   * @param blobSize The size of the blob in bytes.
+   * @param blobSize The size of the blob in bytes
    * @param serviceId The service id that is creating this blob
    * @param ownerId The owner of the blob (For example , memberId or groupId)
    * @param contentType The content type of the blob (eg: mime). Can be Null
@@ -51,7 +51,7 @@ public class BlobProperties {
   }
 
   /**
-   * @param blobSize The size of the blob in bytes.
+   * @param blobSize The size of the blob in bytes
    * @param serviceId The service id that is creating this blob
    * @param ownerId The owner of the blob (For example , memberId or groupId)
    * @param contentType The content type of the blob (eg: mime). Can be Null
@@ -70,7 +70,7 @@ public class BlobProperties {
   }
 
   /**
-   * @param blobSize The size of the blob in bytes.
+   * @param blobSize The size of the blob in bytes
    * @param serviceId The service id that is creating this blob
    * @param ownerId The owner of the blob (For example , memberId or groupId)
    * @param contentType The content type of the blob (eg: mime). Can be Null

--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -32,7 +32,7 @@ public class BlobProperties {
   protected long creationTimeInMs;
 
   /**
-   * @param blobSize The size of the blob in bytes
+   * @param blobSize The size of the blob in bytes.
    * @param serviceId The service id that is creating this blob
    */
   public BlobProperties(long blobSize, String serviceId) {
@@ -40,7 +40,7 @@ public class BlobProperties {
   }
 
   /**
-   * @param blobSize The size of the blob in bytes
+   * @param blobSize The size of the blob in bytes.
    * @param serviceId The service id that is creating this blob
    * @param ownerId The owner of the blob (For example , memberId or groupId)
    * @param contentType The content type of the blob (eg: mime). Can be Null
@@ -51,7 +51,7 @@ public class BlobProperties {
   }
 
   /**
-   * @param blobSize The size of the blob in bytes
+   * @param blobSize The size of the blob in bytes.
    * @param serviceId The service id that is creating this blob
    * @param ownerId The owner of the blob (For example , memberId or groupId)
    * @param contentType The content type of the blob (eg: mime). Can be Null
@@ -67,6 +67,26 @@ public class BlobProperties {
     this.isPrivate = isPrivate;
     this.timeToLiveInSeconds = timeToLiveInSeconds;
     this.creationTimeInMs = SystemTime.getInstance().milliseconds();
+  }
+
+  /**
+   * @param blobSize The size of the blob in bytes.
+   * @param serviceId The service id that is creating this blob
+   * @param ownerId The owner of the blob (For example , memberId or groupId)
+   * @param contentType The content type of the blob (eg: mime). Can be Null
+   * @param isPrivate Is the blob secure
+   * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
+   * @param creationTimeInMs The time at which the blob is created.
+   */
+  public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
+      long timeToLiveInSeconds, long creationTimeInMs) {
+    this.blobSize = blobSize;
+    this.serviceId = serviceId;
+    this.ownerId = ownerId;
+    this.contentType = contentType;
+    this.isPrivate = isPrivate;
+    this.timeToLiveInSeconds = timeToLiveInSeconds;
+    this.creationTimeInMs = creationTimeInMs;
   }
 
   public long getTimeToLiveInSeconds() {

--- a/ambry-api/src/main/java/com.github.ambry/router/Router.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/Router.java
@@ -49,7 +49,8 @@ public interface Router extends Closeable {
   /**
    * Requests for a new blob to be put asynchronously and returns a future that will eventually contain the BlobId of
    * the new blob on a successful response.
-   * @param blobProperties The properties of the blob.
+   * @param blobProperties The properties of the blob. Note that the size specified in the properties is ignored. The
+   *                       channel is consumed fully, and the size of the blob is the number of bytes read from it.
    * @param usermetadata Optional user metadata about the blob. This can be null.
    * @param channel The {@link ReadableStreamChannel} that contains the content of the blob.
    * @return A future that would contain the BlobId eventually.
@@ -58,7 +59,8 @@ public interface Router extends Closeable {
 
   /**
    * Requests for a new blob to be put asynchronously and invokes the {@link Callback} when the request completes.
-   * @param blobProperties The properties of the blob.
+   * @param blobProperties The properties of the blob. Note that the size specified in the properties is ignored. The
+   *                       channel is consumed fully, and the size of the blob is the number of bytes read from it.
    * @param usermetadata Optional user metadata about the blob. This can be null.
    * @param channel The {@link ReadableStreamChannel} that contains the content of the blob.
    * @param callback The {@link Callback} which will be invoked on the completion of the request .

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.messageformat;
 
+import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
 import org.junit.Test;
 
@@ -44,17 +45,6 @@ public class BlobPropertiesTest {
     assertTrue(blobProperties.getCreationTimeInMs() > 0);
     assertTrue(blobProperties.getCreationTimeInMs() <= System.currentTimeMillis());
 
-    blobProperties = new BlobProperties(blobSize, serviceId, ownerId, contentType, true);
-    System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
-    assertEquals(blobProperties.getBlobSize(), blobSize);
-    assertEquals(blobProperties.getServiceId(), serviceId);
-    assertEquals(blobProperties.getOwnerId(), ownerId);
-    assertEquals(blobProperties.getContentType(), contentType);
-    assertTrue(blobProperties.isPrivate());
-    assertTrue(blobProperties.getTimeToLiveInSeconds() == Utils.Infinite_Time);
-    assertTrue(blobProperties.getCreationTimeInMs() > 0);
-    assertTrue(blobProperties.getCreationTimeInMs() <= System.currentTimeMillis());
-
     blobProperties = new BlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
     assertEquals(blobProperties.getBlobSize(), blobSize);
@@ -65,5 +55,17 @@ public class BlobPropertiesTest {
     assertTrue(blobProperties.getTimeToLiveInSeconds() == timeToLiveInSeconds);
     assertTrue(blobProperties.getCreationTimeInMs() > 0);
     assertTrue(blobProperties.getCreationTimeInMs() <= System.currentTimeMillis());
+
+    long creationTimeMs = SystemTime.getInstance().milliseconds();
+    blobProperties =
+        new BlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds, creationTimeMs);
+    System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
+    assertEquals(blobProperties.getBlobSize(), blobSize);
+    assertEquals(blobProperties.getServiceId(), serviceId);
+    assertEquals(blobProperties.getOwnerId(), ownerId);
+    assertEquals(blobProperties.getContentType(), contentType);
+    assertTrue(blobProperties.isPrivate());
+    assertEquals(blobProperties.getTimeToLiveInSeconds(), timeToLiveInSeconds);
+    assertEquals(blobProperties.getCreationTimeInMs(), creationTimeMs);
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -169,7 +169,8 @@ class NonBlockingRouter implements Router {
   /**
    * Requests for a new blob to be put asynchronously and returns a future that will eventually contain the BlobId of
    * the new blob on a successful response.
-   * @param blobProperties The properties of the blob.
+   * @param blobProperties The properties of the blob. Note that the size specified in the properties is ignored. The
+   *                       channel is consumed fully, and the size of the blob is the number of bytes read from it.
    * @param userMetadata Optional user metadata about the blob. This can be null.
    * @param channel The {@link ReadableStreamChannel} that contains the content of the blob.
    * @return A future that would contain the BlobId eventually.
@@ -181,7 +182,8 @@ class NonBlockingRouter implements Router {
 
   /**
    * Requests for a new blob to be put asynchronously and invokes the {@link Callback} when the request completes.
-   * @param blobProperties The properties of the blob.
+   * @param blobProperties The properties of the blob. Note that the size specified in the properties is ignored. The
+   *                       channel is consumed fully, and the size of the blob is the number of bytes read from it.
    * @param userMetadata Optional user metadata about the blob. This can be null.
    * @param channel The {@link ReadableStreamChannel} that contains the content of the blob.
    * @param callback The {@link Callback} which will be invoked on the completion of the request .

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -245,7 +245,7 @@ class PutManager {
     if (e != null) {
       blobId = null;
       routerMetrics.onPutBlobError(e);
-      routerCallback.scheduleDeletes(op.getSuccessfullyPutChunkIds());
+      routerCallback.scheduleDeletes(op.getSuccessfullyPutChunkIdsIfComposite());
     } else {
       notificationSystem.onBlobCreated(op.getBlobIdString(), op.getBlobProperties(), op.getUserMetadata());
       updateChunkingAndSizeMetricsOnSuccessfulPut(op);
@@ -331,7 +331,7 @@ class PutManager {
           chunkFillerThreadMaySleep = true;
           for (PutOperation op : putOperations) {
             op.fillChunks();
-            if (!op.isChunkFillComplete()) {
+            if (!op.isChunkFillingDone()) {
               chunkFillerThreadMaySleep = false;
             }
           }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -330,8 +330,8 @@ class PutManager {
         while (isOpen.get()) {
           chunkFillerThreadMaySleep = true;
           for (PutOperation op : putOperations) {
+            op.fillChunks();
             if (!op.isChunkFillComplete()) {
-              op.fillChunks();
               chunkFillerThreadMaySleep = false;
             }
           }

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterCallback.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterCallback.java
@@ -55,9 +55,7 @@ class RouterCallback {
    * @param idsToDelete the list of ids that need to be deleted.
    */
   void scheduleDeletes(List<StoreKey> idsToDelete) {
-    if (idsToDelete != null) {
-      this.idsToDelete.addAll(idsToDelete);
-    }
+    this.idsToDelete.addAll(idsToDelete);
   }
 }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -84,4 +84,8 @@ class RouterUtils {
     }
     return isSystemHealthError;
   }
+
+  static int getNumChunksForBlobAndChunkSize(long blobSize, int chunkSize) {
+    return (int) (blobSize == 0 ? 1 : (blobSize - 1) / chunkSize + 1);
+  }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -85,6 +85,12 @@ class RouterUtils {
     return isSystemHealthError;
   }
 
+  /**
+   * Return the number of data chunks for the given blob and chunk sizes.
+   * @param blobSize the size of the overall blob.
+   * @param chunkSize the size of each data chunk (except, possibly the last one).
+   * @return the number of data chunks for the given blob and chunk sizes.
+   */
   static int getNumChunksForBlobAndChunkSize(long blobSize, int chunkSize) {
     return (int) (blobSize == 0 ? 1 : (blobSize - 1) / chunkSize + 1);
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -159,7 +159,7 @@ public class ChunkFillTest {
               || putChunk.getState() == PutOperation.ChunkState.Building);
           if (putChunk.getState() == PutOperation.ChunkState.Ready) {
             Assert.assertEquals("Chunk size should be the last chunk size", lastChunkSize, putChunk.buf.remaining());
-            Assert.assertTrue("Chunk Filling should be complete at this time", op.isChunkFillComplete());
+            Assert.assertTrue("Chunk Filling should be complete at this time", op.isChunkFillingDone());
             fillingComplete = true;
           }
         } else {
@@ -230,7 +230,7 @@ public class ChunkFillTest {
         compositeBuffers[putChunk.getChunkIndex()] = ByteBuffer.allocate(buf.remaining()).put(buf);
         putChunk.clear();
       }
-    } while (!op.isChunkFillComplete());
+    } while (!op.isChunkFillingDone());
 
     Assert.assertEquals("total size written out should match the blob size", blobSize, totalSizeWritten);
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -29,7 +29,6 @@ import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.RequestOrResponse;
-import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Utils;
@@ -43,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Assert;
@@ -106,7 +104,7 @@ public class GetBlobInfoOperationTest {
         CHECKOUT_TIMEOUT_MS, mockServerLayout, time);
     router = new NonBlockingRouter(new RouterConfig(vprops), new NonBlockingRouterMetrics(mockClusterMap),
         networkClientFactory, new LoggingNotificationSystem(), mockClusterMap, time);
-    blobProperties = new BlobProperties(BLOB_SIZE, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
+    blobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
     userMetadata = new byte[BLOB_USER_METADATA_SIZE];
     random.nextBytes(userMetadata);
     putContent = new byte[BLOB_SIZE];
@@ -449,6 +447,8 @@ public class GetBlobInfoOperationTest {
         op.getOperationResult().getBlobResult.getBlobDataChannel());
     Assert.assertTrue("Blob properties must be the same",
         RouterTestHelpers.haveEquivalentFields(blobProperties, blobInfo.getBlobProperties()));
+    Assert.assertEquals("Blob size should in received blobProperties should be the same as actual", BLOB_SIZE,
+        blobInfo.getBlobProperties().getBlobSize());
     Assert.assertArrayEquals("User metadata must be the same", userMetadata, blobInfo.getUserMetadata());
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -33,7 +33,6 @@ import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.router.RouterTestHelpers.*;
-import com.github.ambry.store.Store;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
@@ -53,7 +52,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
@@ -174,7 +172,7 @@ public class GetBlobOperationTest {
    * @throws Exception
    */
   private void doPut() throws Exception {
-    blobProperties = new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
+    blobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
     userMetadata = new byte[10];
     random.nextBytes(userMetadata);
     putContent = new byte[blobSize];
@@ -786,6 +784,8 @@ public class GetBlobOperationTest {
                 BlobInfo blobInfo = result.getBlobResult.getBlobInfo();
                 Assert.assertTrue("Blob properties must be the same",
                     RouterTestHelpers.haveEquivalentFields(blobProperties, blobInfo.getBlobProperties()));
+                Assert.assertEquals("Blob size should in received blobProperties should be the same as actual",
+                    blobSize, blobInfo.getBlobProperties().getBlobSize());
                 Assert.assertArrayEquals("User metadata must be the same", userMetadata, blobInfo.getUserMetadata());
                 break;
               case Data:

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -52,6 +52,7 @@ public class GetManagerTest {
   private int requestParallelism;
   private int successTarget;
   // Request params;
+  private long blobSize;
   private BlobProperties putBlobProperties;
   private byte[] putUserMetadata;
   private byte[] putContent;
@@ -309,6 +310,8 @@ public class GetManagerTest {
   private void compareBlobInfo(BlobInfo blobInfo) {
     Assert.assertTrue("Blob properties should match",
         RouterTestHelpers.haveEquivalentFields(putBlobProperties, blobInfo.getBlobProperties()));
+    Assert.assertEquals("Blob size in received blobProperties should be the same as actual", blobSize,
+        blobInfo.getBlobProperties().getBlobSize());
     Assert.assertArrayEquals("User metadata should match", putUserMetadata, blobInfo.getUserMetadata());
   }
 
@@ -369,8 +372,8 @@ public class GetManagerTest {
    * @param options the options for the get request
    */
   private void setOperationParams(int blobSize, GetBlobOptions options) {
-    putBlobProperties =
-        new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
+    this.blobSize = blobSize;
+    putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
     putUserMetadata = new byte[10];
     random.nextBytes(putUserMetadata);
     putContent = new byte[blobSize];

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -422,15 +422,15 @@ public class PutManagerTest {
   }
 
   /**
-   * A bad arguments test, where the channel size is different from the size in BlobProperties. This should succeed
-   * as the size in the passed in BlobProperties is ignored by the router.
+   * Test that the size in BlobProperties is ignored for puts, by attempting puts with varying values for size in
+   * BlobProperties.
    */
   @Test
   public void testChannelSizeNotSizeInPropertiesPutSuccess() throws Exception {
     int actualBlobSizes[] = {0, chunkSize - 1, chunkSize, chunkSize + 1, chunkSize * 2, chunkSize * 2 + 1};
     for (int actualBlobSize : actualBlobSizes) {
       requestAndResultsList.clear();
-      int sizeInBlobProperties = actualBlobSize == 0 ? 1 : random.nextInt(actualBlobSize);
+      int sizeInBlobProperties = random.nextInt(actualBlobSize * 2 + 1);
       RequestAndResult requestAndResult = new RequestAndResult(sizeInBlobProperties);
       // Change the actual content size.
       requestAndResult.putContent = new byte[actualBlobSize];

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -387,15 +387,7 @@ public class PutManagerTest {
         (FutureResult<String>) router.putBlob(requestAndResult.putBlobProperties, requestAndResult.putUserMetadata,
             putChannel, null);
     ByteBuffer src = ByteBuffer.wrap(requestAndResult.putContent);
-    int pushedSoFar = 0;
-    while (pushedSoFar < blobSize && !future.isDone()) {
-      int toPush = random.nextInt(blobSize - pushedSoFar + 1);
-      ByteBuffer buf = ByteBuffer.allocate(toPush);
-      src.get(buf.array());
-      putChannel.write(buf);
-      Thread.yield();
-      pushedSoFar += toPush;
-    }
+    pushwithDelay(src, putChannel, blobSize, future);
     future.await();
     requestAndResult.result = future;
     assertSuccess();
@@ -417,19 +409,11 @@ public class PutManagerTest {
         (FutureResult<String>) router.putBlob(requestAndResult.putBlobProperties, requestAndResult.putUserMetadata,
             putChannel, null);
     ByteBuffer src = ByteBuffer.wrap(requestAndResult.putContent);
-    int pushedSoFar = 0;
 
     //Make the channel act bad.
     putChannel.beBad();
 
-    while (pushedSoFar < blobSize && !future.isDone()) {
-      int toPush = random.nextInt(blobSize - pushedSoFar + 1);
-      ByteBuffer buf = ByteBuffer.allocate(toPush);
-      src.get(buf.array());
-      putChannel.write(buf);
-      Thread.yield();
-      pushedSoFar += toPush;
-    }
+    pushwithDelay(src, putChannel, blobSize, future);
     future.await();
     requestAndResult.result = future;
     Exception expectedException = new Exception("Channel encountered an error");
@@ -438,46 +422,22 @@ public class PutManagerTest {
   }
 
   /**
-   * A bad arguments test, where the channel size is different from the size in BlobProperties.
+   * A bad arguments test, where the channel size is different from the size in BlobProperties. This should succeed
+   * as the size in the passed in BlobProperties is ignored by the router.
    */
   @Test
-  public void testChannelSizeNotSizeInPropertiesPutFailure() throws Exception {
-    requestAndResultsList.clear();
-    int blobSize = chunkSize;
-    RequestAndResult requestAndResult = new RequestAndResult(blobSize);
-    // Change the actual content size.
-    requestAndResult.putContent = new byte[blobSize + 1];
-    requestAndResultsList.add(requestAndResult);
-    Exception expectedException = new RouterException("", RouterErrorCode.BadInputChannel);
-    submitPutsAndAssertFailure(expectedException, true, false);
-  }
-
-  /**
-   * A bad arguments test, where the blob size is very large.
-   */
-  @Test
-  public void testBlobTooLargePutFailure() throws Exception {
-    // A blob size of 4G.
-    // A chunkSize of 1 byte.
-    // The max blob size that can be supported is a function of the chunk size. With the given parameters,
-    // the operation will require more than Integer.MAX_VALUE number of data chunks which is too large.
-    long blobSize = 4 * 1024 * 1024 * 1024L;
-    chunkSize = 1;
-
-    router = getNonBlockingRouter();
-    RequestAndResult requestAndResult = new RequestAndResult(0);
-    requestAndResultsList.add(requestAndResult);
-    requestAndResult.putBlobProperties =
-        new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
-    MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize);
-    FutureResult<String> future =
-        (FutureResult<String>) router.putBlob(requestAndResult.putBlobProperties, requestAndResult.putUserMetadata,
-            putChannel, null);
-    future.await();
-    requestAndResult.result = future;
-    Exception expectedException = new RouterException("", RouterErrorCode.BlobTooLarge);
-    assertFailure(expectedException);
-    assertCloseCleanup();
+  public void testChannelSizeNotSizeInPropertiesPutSuccess() throws Exception {
+    int actualBlobSizes[] = {0, chunkSize - 1, chunkSize, chunkSize + 1, chunkSize * 2, chunkSize * 2 + 1};
+    for (int actualBlobSize : actualBlobSizes) {
+      requestAndResultsList.clear();
+      int sizeInBlobProperties = actualBlobSize == 0 ? 1 : random.nextInt(actualBlobSize);
+      RequestAndResult requestAndResult = new RequestAndResult(sizeInBlobProperties);
+      // Change the actual content size.
+      requestAndResult.putContent = new byte[actualBlobSize];
+      random.nextBytes(requestAndResult.putContent);
+      requestAndResultsList.add(requestAndResult);
+      submitPutsAndAssertSuccess(true);
+    }
   }
 
   /**
@@ -524,6 +484,27 @@ public class PutManagerTest {
     requestAndResult.result = future;
     assertSuccess();
     assertCloseCleanup();
+  }
+
+  /**
+   * Push from the src to the putChannel in random sized writes, with possible delays.
+   * @param src the input {@link ByteBuffer}
+   * @param putChannel the destination {@link MockReadableStreamChannel}
+   * @param blobSize the total length of bytes to push.
+   * @param future the future associated with the overall operation.
+   * @throws Exception if the write to the channel throws an exception.
+   */
+  private void pushwithDelay(ByteBuffer src, MockReadableStreamChannel putChannel, int blobSize, Future future)
+      throws Exception {
+    int pushedSoFar = 0;
+    while (pushedSoFar < blobSize && !future.isDone()) {
+      int toPush = random.nextInt(blobSize - pushedSoFar + 1);
+      ByteBuffer buf = ByteBuffer.allocate(toPush);
+      src.get(buf.array());
+      putChannel.write(buf);
+      Thread.yield();
+      pushedSoFar += toPush;
+    }
   }
 
   /**
@@ -784,8 +765,7 @@ public class PutManagerTest {
     FutureResult<String> result;
 
     RequestAndResult(int blobSize) {
-      putBlobProperties =
-          new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
+      putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
       putUserMetadata = new byte[10];
       random.nextBytes(putUserMetadata);
       putContent = new byte[blobSize];
@@ -796,7 +776,8 @@ public class PutManagerTest {
 }
 
 /**
- * A {@link ReadableStreamChannel} implementation whose {@link #readInto(AsyncWritableChannel, * Callback)} method reads into the {@link AsyncWritableChannel} passed into it as and when data is written to it and
+ * A {@link ReadableStreamChannel} implementation whose {@link #readInto(AsyncWritableChannel, Callback)} method
+ * reads into the {@link AsyncWritableChannel} passed into it as and when data is written to it and
  * not at once. Also if the beBad state is set, the callback is called with an exception.
  */
 class MockReadableStreamChannel implements ReadableStreamChannel {

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -429,14 +429,18 @@ public class PutManagerTest {
   public void testChannelSizeNotSizeInPropertiesPutSuccess() throws Exception {
     int actualBlobSizes[] = {0, chunkSize - 1, chunkSize, chunkSize + 1, chunkSize * 2, chunkSize * 2 + 1};
     for (int actualBlobSize : actualBlobSizes) {
-      requestAndResultsList.clear();
-      int sizeInBlobProperties = random.nextInt(actualBlobSize * 2 + 1);
-      RequestAndResult requestAndResult = new RequestAndResult(sizeInBlobProperties);
-      // Change the actual content size.
-      requestAndResult.putContent = new byte[actualBlobSize];
-      random.nextBytes(requestAndResult.putContent);
-      requestAndResultsList.add(requestAndResult);
-      submitPutsAndAssertSuccess(true);
+      int sizesInProperties[] = {actualBlobSize - 1, actualBlobSize + 1};
+      for (int sizeInProperties : sizesInProperties) {
+        requestAndResultsList.clear();
+        RequestAndResult requestAndResult = new RequestAndResult(0);
+        // Change the actual content size.
+        requestAndResult.putContent = new byte[actualBlobSize];
+        requestAndResult.putBlobProperties =
+            new BlobProperties(sizeInProperties, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
+        random.nextBytes(requestAndResult.putContent);
+        requestAndResultsList.add(requestAndResult);
+        submitPutsAndAssertSuccess(true);
+      }
     }
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -92,7 +92,7 @@ public class PutOperationTest {
   public void testSendIncomplete() throws Exception {
     int numChunks = NonBlockingRouter.MAX_IN_MEM_CHUNKS + 1;
     BlobProperties blobProperties =
-        new BlobProperties(chunkSize * numChunks, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
+        new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time);
     byte[] userMetadata = new byte[10];
     byte[] content = new byte[chunkSize * numChunks];
     random.nextBytes(content);

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
@@ -34,8 +34,8 @@ class RouterTestHelpers {
    * @return true if the fields are equivalent in the two {@link BlobProperties}
    */
   static boolean haveEquivalentFields(BlobProperties a, BlobProperties b) {
-    return a.getBlobSize() == b.getBlobSize() && a.getServiceId().equals(b.getServiceId()) && a.getOwnerId()
-        .equals(b.getOwnerId()) && a.getContentType().equals(b.getContentType()) && a.isPrivate() == b.isPrivate()
+    return a.getServiceId().equals(b.getServiceId()) && a.getOwnerId().equals(b.getOwnerId()) && a.getContentType()
+        .equals(b.getContentType()) && a.isPrivate() == b.isPrivate()
         && a.getTimeToLiveInSeconds() == b.getTimeToLiveInSeconds()
         && a.getCreationTimeInMs() == b.getCreationTimeInMs();
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -716,7 +716,8 @@ public final class ServerTestUtil {
     List<Future<String>> putFutures = new ArrayList<>(numberOfRequestsToSend);
     for (int i = 0; i < numberOfRequestsToSend; i++) {
       int size = new Random().nextInt(5000);
-      final BlobProperties properties = new BlobProperties(size, "service1", "owner id check", "image/jpeg", false);
+      final BlobProperties properties = new BlobProperties(size, "service1", "owner id check", "image/jpeg", false,
+          Utils.Infinite_Time);
       final byte[] metadata = new byte[new Random().nextInt(1000)];
       final byte[] blob = new byte[size];
       new Random().nextBytes(metadata);


### PR DESCRIPTION
Relaxing the requirement to provide the size in advance allows for truly
streaming puts, where a caller may not know the size of the stream in advance.
- The router depended heavily on the size, so this change is a little extensive.
Unlike before, when the router could determine that a stream has ended the moment
the last byte arrives, now it will know that only when the channel gets closed.
- The MetadataChunk object is always created now and will track all data chunks,
even for non-composite blobs. When it gets finalized, it will result in an actual
metadata blob only if there are more than one data chunks.
- For puts, the router will ignore the size in the passed in BlobProperties. The
BlobProperties that is sent to the server during a PUT and returned during GETs will
always have the correct size.

Fixes #479 

--

Test coverage:
Production changes are mostly isolated to PutOperation.java for which coverage is as follows:
```
Class: 100%, Method: 100%, Line: 90%
```
Overall router package coverage:
```
Class: 95%, Method: 97%, Line: 91%
```