### PR TITLE
Making the index friendly to a switch of active index segments

### DIFF
--- a/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
@@ -602,7 +602,7 @@ class CuratedLogIndexState {
    */
   private void verifyState(boolean isLogSegmented) throws IOException, StoreException {
     assertEquals("Incorrect log segment count", isLogSegmented ? 3 : 1, index.getLogSegmentCount());
-    NavigableMap<Offset, IndexSegment> realIndex = index.indexes;
+    NavigableMap<Offset, IndexSegment> realIndex = index.getIndexSegments();
     assertEquals("Number of index segments does not match expected", referenceIndex.size(), realIndex.size());
     Map.Entry<Offset, IndexSegment> realIndexEntry = realIndex.firstEntry();
     for (Map.Entry<Offset, TreeMap<MockId, IndexValue>> referenceIndexEntry : referenceIndex.entrySet()) {

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1878,7 +1878,8 @@ public class IndexTest {
   private void partitionIndexSegments(Map<Offset, IndexSegment> toRemove, Set<Offset> toRetain) {
     int i = 0;
     for (Map.Entry<Offset, IndexSegment> indexSegmentEntry : state.index.getIndexSegments().entrySet()) {
-      if (indexSegmentEntry.equals(state.index.getIndexSegments().lastEntry()) || i % 3 != 0) {
+      if (indexSegmentEntry.getValue().getEndOffset().compareTo(state.index.journal.getFirstOffset()) >= 0
+          || i % 3 != 0) {
         toRetain.add(indexSegmentEntry.getKey());
       } else {
         toRemove.put(indexSegmentEntry.getKey(), indexSegmentEntry.getValue());

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -502,6 +502,14 @@ public class IndexTest {
     state.index.persistIndex();
 
     // error case
+    // try to remove the last segment (its offset is in the journal)
+    try {
+      state.index.changeIndexSegments(Collections.EMPTY_LIST, Collections.singleton(state.referenceIndex.lastKey()));
+      fail("Should have failed to remove index segment because start offset is past the first offset in the journal");
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
+    }
+
     // add an entry into the journal for the very first offset in the index
     state.index.journal.addEntry(state.logOrder.firstKey(), state.logOrder.firstEntry().getValue().getFirst());
     // remove the first index segment

--- a/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
@@ -2000,7 +2000,7 @@ class MockIndex extends PersistentIndex {
   }
 
   public void deleteAll() {
-    indexes.clear();
+    getIndexSegments().clear();
   }
 
   public void stopScheduler() throws InterruptedException {
@@ -2013,7 +2013,7 @@ class MockIndex extends PersistentIndex {
   }
 
   public IndexSegment getLastSegment() {
-    return super.indexes.lastEntry().getValue();
+    return getIndexSegments().lastEntry().getValue();
   }
 }
 

--- a/ambry-tools/src/main/java/com.github.ambry/store/BlobIndexMetrics.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/BlobIndexMetrics.java
@@ -78,7 +78,7 @@ class BlobIndexMetrics extends PersistentIndex {
     }
     totalWrites.incrementAndGet();
     if (totalWrites.get() % 1000 == 0) {
-      System.out.println("number of indexes created " + indexes.size());
+      System.out.println("number of indexes created " + getIndexSegments().size());
     }
   }
 }


### PR DESCRIPTION
Compaction needs to atomically change the valid index segments after the completion of a cycle. `PersistentIndex` was built with the assumption that the reference to the valid index segments will not change. This commit removes that assumption and makes all functions in the index work with a view of the valid index segments at a certain point in time.

Built on OSx and Linux. Formatted.

**Reviewers: @pnarayanan, @nsivabalan**

| Class | Class, % | Method, % | Line, % | Test class |
| --- | --- | --- | --- | --- |
| `PersistentIndex` | 100% (7/ 7) | 98.2% (54/ 55) | 91.9% (513/ 558) | `IndexTest` |

  