### PR TITLE
Use CRCs to distinguish real id collisions from those due to fast replication

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
@@ -20,11 +20,11 @@ import com.github.ambry.utils.Utils;
  * A message info class that contains basic info about a message
  */
 public class MessageInfo {
-  private StoreKey key;
-  private long size;
-  private long expirationTimeInMs;
-  private boolean isDeleted;
-  private Long crc;
+  private final StoreKey key;
+  private final long size;
+  private final long expirationTimeInMs;
+  private final boolean isDeleted;
+  private final Long crc;
 
   public MessageInfo(StoreKey key, long size, long expirationTimeInMs) {
     this(key, size, false, expirationTimeInMs);
@@ -100,6 +100,9 @@ public class MessageInfo {
         .append(",")
         .append("IsDeleted-")
         .append(isDeleted)
+        .append(",")
+        .append("Crc-")
+        .append(crc)
         .append("]");
     return stringBuilder.toString();
   }

--- a/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
@@ -24,6 +24,7 @@ public class MessageInfo {
   private long size;
   private long expirationTimeInMs;
   private boolean isDeleted;
+  private Long crc;
 
   public MessageInfo(StoreKey key, long size, long expirationTimeInMs) {
     this(key, size, false, expirationTimeInMs);
@@ -34,14 +35,27 @@ public class MessageInfo {
   }
 
   public MessageInfo(StoreKey key, long size, boolean deleted, long expirationTimeInMs) {
-    this.key = key;
-    this.size = size;
-    this.isDeleted = deleted;
-    this.expirationTimeInMs = expirationTimeInMs;
+    this(key, size, deleted, expirationTimeInMs, null);
   }
 
   public MessageInfo(StoreKey key, long size) {
     this(key, size, Utils.Infinite_Time);
+  }
+
+  /**
+   * Construct an instance of MessageInfo.
+   * @param key the {@link StoreKey} associated with this message.
+   * @param size the size of this message.
+   * @param deleted whethe the message is deleted.
+   * @param expirationTimeInMs the time at which the message will expire. A value of -1 means no expiration.
+   * @param crc the crc associated with this message. If unavailable, pass in null.
+   */
+  public MessageInfo(StoreKey key, long size, boolean deleted, long expirationTimeInMs, Long crc) {
+    this.key = key;
+    this.size = size;
+    this.isDeleted = deleted;
+    this.expirationTimeInMs = expirationTimeInMs;
+    this.crc = crc;
   }
 
   public StoreKey getStoreKey() {
@@ -62,6 +76,13 @@ public class MessageInfo {
 
   public boolean isExpired() {
     return getExpirationTimeInMs() != Utils.Infinite_Time && System.currentTimeMillis() > getExpirationTimeInMs();
+  }
+
+  /**
+   * @return the crc associated with this message, if there is one; null otherwise.
+   */
+  public Long getCrc() {
+    return crc;
   }
 
   @Override

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
@@ -37,11 +37,15 @@ public class GetResponse extends Response {
   private int partitionResponseInfoSize;
 
   private static int Partition_Response_Info_List_Size = 4;
-  private static final short Get_Response_Version_V1 = 1;
+  static final short Get_Response_Version_V1 = 1;
+  static final short Get_Response_Version_V2 = 2;
+
+  // @todo change this to V2 once all cluster nodes understand V2.
+  private static final short currentVersion = Get_Response_Version_V1;
 
   public GetResponse(int correlationId, String clientId, List<PartitionResponseInfo> partitionResponseInfoList,
       Send send, ServerErrorCode error) {
-    super(RequestOrResponseType.GetResponse, Get_Response_Version_V1, correlationId, clientId, error);
+    super(RequestOrResponseType.GetResponse, currentVersion, correlationId, clientId, error);
     this.partitionResponseInfoList = partitionResponseInfoList;
     this.partitionResponseInfoSize = 0;
     for (PartitionResponseInfo partitionResponseInfo : partitionResponseInfoList) {
@@ -52,7 +56,7 @@ public class GetResponse extends Response {
 
   public GetResponse(int correlationId, String clientId, List<PartitionResponseInfo> partitionResponseInfoList,
       InputStream stream, ServerErrorCode error) {
-    super(RequestOrResponseType.GetResponse, Get_Response_Version_V1, correlationId, clientId, error);
+    super(RequestOrResponseType.GetResponse, currentVersion, correlationId, clientId, error);
     this.partitionResponseInfoList = partitionResponseInfoList;
     this.partitionResponseInfoSize = 0;
     for (PartitionResponseInfo partitionResponseInfo : partitionResponseInfoList) {
@@ -62,7 +66,7 @@ public class GetResponse extends Response {
   }
 
   public GetResponse(int correlationId, String clientId, ServerErrorCode error) {
-    super(RequestOrResponseType.GetResponse, Get_Response_Version_V1, correlationId, clientId, error);
+    super(RequestOrResponseType.GetResponse, currentVersion, correlationId, clientId, error);
     this.partitionResponseInfoList = null;
     this.partitionResponseInfoSize = 0;
   }
@@ -94,7 +98,7 @@ public class GetResponse extends Response {
       ArrayList<PartitionResponseInfo> partitionResponseInfoList =
           new ArrayList<PartitionResponseInfo>(partitionResponseInfoCount);
       for (int i = 0; i < partitionResponseInfoCount; i++) {
-        PartitionResponseInfo partitionResponseInfo = PartitionResponseInfo.readFrom(stream, map);
+        PartitionResponseInfo partitionResponseInfo = PartitionResponseInfo.readFrom(stream, map, versionId);
         partitionResponseInfoList.add(partitionResponseInfo);
       }
       return new GetResponse(correlationId, clientId, partitionResponseInfoList, stream, error);
@@ -149,5 +153,12 @@ public class GetResponse extends Response {
     }
     sb.append("]");
     return sb.toString();
+  }
+
+  /**
+   * @return the current version in which new GetResponse objects are created.
+   */
+  static short getCurrentVersion() {
+    return currentVersion;
   }
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
@@ -143,11 +143,7 @@ public class PutRequest extends RequestOrResponse {
       // try and write out as much of the blob now.
       if (!bufferToSend.hasRemaining()) {
         written += channel.write(blob);
-        if (!blob.hasRemaining()) {
-          if (currentVersion == Put_Request_Version_V3) {
-            okayToWriteCrc = true;
-          }
-        }
+        okayToWriteCrc = !blob.hasRemaining() && currentVersion == Put_Request_Version_V3;
       }
 
       if (okayToWriteCrc && crcBuf.hasRemaining()) {

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
@@ -18,6 +18,9 @@ import com.github.ambry.commons.BlobId;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.BlobPropertiesSerDe;
 import com.github.ambry.messageformat.BlobType;
+import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.Crc32;
+import com.github.ambry.utils.CrcInputStream;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -37,11 +40,25 @@ public class PutRequest extends RequestOrResponse {
   protected final BlobProperties properties;
   protected final BlobType blobType;
   protected final ByteBuffer blob;
+  // crc will cover all the fields associated with the blob, namely:
+  // blob type
+  // BlobId
+  // BlobProperties
+  // UserMetadata
+  // BlobData
+  private final Crc32 crc;
+  private final ByteBuffer crcBuf;
+  private boolean blobWriteComplete = false;
 
   private static final int UserMetadata_Size_InBytes = 4;
-  protected static final int Blob_Size_InBytes = 8;
-  protected static final int BlobType_Size_InBytes = 2;
-  protected static final short Put_Request_Version_V2 = 2;
+  private static final int Blob_Size_InBytes = 8;
+  private static final int BlobType_Size_InBytes = 2;
+  private static final int Crc_Field_Size_InBytes = 8;
+  private static final short Put_Request_Version_V2 = 2;
+  private static final short Put_Request_Version_V3 = 3;
+
+  // @todo change this to V3 once all cluster nodes understand V3.
+  private static final short currentVersion = Put_Request_Version_V2;
 
   /**
    * Construct a PutRequest
@@ -56,13 +73,15 @@ public class PutRequest extends RequestOrResponse {
    */
   public PutRequest(int correlationId, String clientId, BlobId blobId, BlobProperties properties,
       ByteBuffer usermetadata, ByteBuffer materializedBlob, long blobSize, BlobType blobType) {
-    super(RequestOrResponseType.PutRequest, Put_Request_Version_V2, correlationId, clientId);
+    super(RequestOrResponseType.PutRequest, currentVersion, correlationId, clientId);
     this.blobId = blobId;
     this.properties = properties;
     this.usermetadata = usermetadata;
     this.blobSize = blobSize;
     this.blobType = blobType;
     this.blob = materializedBlob;
+    this.crc = new Crc32();
+    this.crcBuf = ByteBuffer.allocate(Crc_Field_Size_InBytes);
   }
 
   public static ReceivedPutRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
@@ -70,6 +89,8 @@ public class PutRequest extends RequestOrResponse {
     switch (versionId) {
       case Put_Request_Version_V2:
         return PutRequest_V2.readFrom(stream, map);
+      case Put_Request_Version_V3:
+        return PutRequest_V3.readFrom(stream, map);
       default:
         throw new IllegalStateException("Unknown Request response version" + versionId);
     }
@@ -77,10 +98,14 @@ public class PutRequest extends RequestOrResponse {
 
   @Override
   public long sizeInBytes() {
-    return sizeExcludingBlobSize() + blobSize;
+    long sizeInBytes = sizeExcludingBlobAndCrcSize() + blobSize;
+    if (currentVersion == Put_Request_Version_V3) {
+      sizeInBytes += Crc_Field_Size_InBytes;
+    }
+    return sizeInBytes;
   }
 
-  protected int sizeExcludingBlobSize() {
+  private int sizeExcludingBlobAndCrcSize() {
     // size of (header + blobId + blob properties + metadata size + metadata + blob size + blob type)
     return (int) super.sizeInBytes() + blobId.sizeInBytes() + BlobPropertiesSerDe.getBlobPropertiesSize(properties)
         + UserMetadata_Size_InBytes + usermetadata.capacity() + Blob_Size_InBytes + BlobType_Size_InBytes;
@@ -93,14 +118,19 @@ public class PutRequest extends RequestOrResponse {
       if (bufferToSend == null) {
         // this is the first time this method was called, prepare the buffer to send the header and other metadata
         // (everything except the blob content).
-        bufferToSend = ByteBuffer.allocate(sizeExcludingBlobSize());
+        bufferToSend = ByteBuffer.allocate(sizeExcludingBlobAndCrcSize());
         writeHeader();
+        int crcStart = bufferToSend.position();
         bufferToSend.put(blobId.toBytes());
         BlobPropertiesSerDe.putBlobPropertiesToBuffer(bufferToSend, properties);
         bufferToSend.putInt(usermetadata.capacity());
         bufferToSend.put(usermetadata);
         bufferToSend.putShort((short) blobType.ordinal());
         bufferToSend.putLong(blobSize);
+        crc.update(bufferToSend.array(), bufferToSend.arrayOffset() + crcStart, bufferToSend.position() - crcStart);
+        crc.update(blob.array(), blob.arrayOffset(), blob.remaining());
+        crcBuf.putLong(crc.getValue());
+        crcBuf.flip();
         bufferToSend.flip();
       }
 
@@ -113,7 +143,15 @@ public class PutRequest extends RequestOrResponse {
       // try and write out as much of the blob now.
       if (!bufferToSend.hasRemaining()) {
         written += channel.write(blob);
+        if (!blob.hasRemaining()) {
+          blobWriteComplete = true;
+        }
       }
+
+      if (currentVersion == Put_Request_Version_V3 && blobWriteComplete && crcBuf.hasRemaining()) {
+        written += channel.write(crcBuf);
+      }
+
       sentBytes += written;
     }
     return written;
@@ -147,7 +185,9 @@ public class PutRequest extends RequestOrResponse {
     return sb.toString();
   }
 
-  // Class to read protocol version 2 Put Request from the stream.
+  /**
+   * Class to read protocol version 2 PutRequest from the stream.
+   */
   private static class PutRequest_V2 {
     static ReceivedPutRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
       int correlationId = stream.readInt();
@@ -157,7 +197,33 @@ public class PutRequest extends RequestOrResponse {
       ByteBuffer metadata = Utils.readIntBuffer(stream);
       BlobType blobType = BlobType.values()[stream.readShort()];
       long blobSize = stream.readLong();
-      return new ReceivedPutRequest(correlationId, clientId, id, properties, metadata, blobSize, blobType, stream);
+      return new ReceivedPutRequest(correlationId, clientId, id, properties, metadata, blobSize, blobType, stream,
+          null);
+    }
+  }
+
+  /**
+   * Class to read protocol version 3 PutRequest from the stream.
+   */
+  private static class PutRequest_V3 {
+    static ReceivedPutRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+      int correlationId = stream.readInt();
+      String clientId = Utils.readIntString(stream);
+      CrcInputStream crcInputStream = new CrcInputStream(stream);
+      stream = new DataInputStream(crcInputStream);
+      BlobId id = new BlobId(stream, map);
+      BlobProperties properties = BlobPropertiesSerDe.getBlobPropertiesFromStream(stream);
+      ByteBuffer metadata = Utils.readIntBuffer(stream);
+      BlobType blobType = BlobType.values()[stream.readShort()];
+      long blobSize = stream.readLong();
+      ByteBufferInputStream blobStream = new ByteBufferInputStream(stream, (int) blobSize);
+      long computedCrc = crcInputStream.getValue();
+      long receivedCrc = stream.readLong();
+      if (computedCrc != receivedCrc) {
+        throw new IOException("CRC mismatch, data in PutRequest is unreliable");
+      }
+      return new ReceivedPutRequest(correlationId, clientId, id, properties, metadata, blobSize, blobType, blobStream,
+          receivedCrc);
     }
   }
 
@@ -173,6 +239,7 @@ public class PutRequest extends RequestOrResponse {
     private final long blobSize;
     private final BlobType blobType;
     private final InputStream blobStream;
+    private final Long receivedCrc;
 
     /**
      * Construct a ReceivedPutRequest with the given parameters.
@@ -184,9 +251,11 @@ public class PutRequest extends RequestOrResponse {
      * @param blobSize the size of the blob data.
      * @param blobType the type of the blob being put.
      * @param blobStream the {@link InputStream} containing the data associated with the blob.
+     * @param crc the crc associated with this request.
      */
     ReceivedPutRequest(int correlationId, String clientId, BlobId blobId, BlobProperties blobProperties,
-        ByteBuffer userMetadata, long blobSize, BlobType blobType, InputStream blobStream) {
+        ByteBuffer userMetadata, long blobSize, BlobType blobType, InputStream blobStream, Long crc)
+        throws IOException {
       this.correlationId = correlationId;
       this.clientId = clientId;
       this.blobId = blobId;
@@ -195,6 +264,7 @@ public class PutRequest extends RequestOrResponse {
       this.blobSize = blobSize;
       this.blobType = blobType;
       this.blobStream = blobStream;
+      this.receivedCrc = crc;
     }
 
     /**
@@ -251,6 +321,13 @@ public class PutRequest extends RequestOrResponse {
      */
     public InputStream getBlobStream() {
       return blobStream;
+    }
+
+    /**
+     * @return the crc associated with the request.
+     */
+    public Long getCrc() {
+      return receivedCrc;
     }
   }
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
@@ -35,11 +35,16 @@ public class ReplicaMetadataResponse extends Response {
   private int replicaMetadataResponseInfoListSizeInBytes;
 
   private static int Replica_Metadata_Response_Info_List_Size_In_Bytes = 4;
-  private static final short Replica_Metadata_Response_Version_V1 = 1;
+
+  static final short Replica_Metadata_Response_Version_V1 = 1;
+  static final short Replica_Metadata_Response_Version_V2 = 2;
+
+  // @todo change this to V2 once all cluster nodes understand V2.
+  private static final short currentVersion = Replica_Metadata_Response_Version_V1;
 
   public ReplicaMetadataResponse(int correlationId, String clientId, ServerErrorCode error,
       List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList) {
-    super(RequestOrResponseType.ReplicaMetadataResponse, Replica_Metadata_Response_Version_V1, correlationId, clientId,
+    super(RequestOrResponseType.ReplicaMetadataResponse, currentVersion, correlationId, clientId,
         error);
     this.replicaMetadataResponseInfoList = replicaMetadataResponseInfoList;
     this.replicaMetadataResponseInfoListSizeInBytes = 0;
@@ -49,7 +54,7 @@ public class ReplicaMetadataResponse extends Response {
   }
 
   public ReplicaMetadataResponse(int correlationId, String clientId, ServerErrorCode error) {
-    super(RequestOrResponseType.ReplicaMetadataResponse, Replica_Metadata_Response_Version_V1, correlationId, clientId,
+    super(RequestOrResponseType.ReplicaMetadataResponse, currentVersion, correlationId, clientId,
         error);
     replicaMetadataResponseInfoList = null;
     replicaMetadataResponseInfoListSizeInBytes = 0;
@@ -74,7 +79,7 @@ public class ReplicaMetadataResponse extends Response {
         new ArrayList<ReplicaMetadataResponseInfo>(replicaMetadataResponseInfoListCount);
     for (int i = 0; i < replicaMetadataResponseInfoListCount; i++) {
       ReplicaMetadataResponseInfo replicaMetadataResponseInfo =
-          ReplicaMetadataResponseInfo.readFrom(stream, factory, clusterMap);
+          ReplicaMetadataResponseInfo.readFrom(stream, factory, clusterMap, versionId);
       replicaMetadataResponseInfoList.add(replicaMetadataResponseInfo);
     }
     if (error != ServerErrorCode.No_Error) {
@@ -127,5 +132,12 @@ public class ReplicaMetadataResponse extends Response {
     }
     sb.append("]");
     return sb.toString();
+  }
+
+  /**
+   * @return the current version in which new ReplicaMetadataResponse objects are created.
+   */
+  public static short getCurrentVersion() {
+    return currentVersion;
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
@@ -313,11 +313,11 @@ class MockServer {
     ServerErrorCode retCode = ServerErrorCode.No_Error;
     if (blob == null) {
       retCode = ServerErrorCode.Blob_Not_Found;
-    } else if (blob.isDeleted() && !getRequest.getGetOption().equals(GetOption.Include_All) && !getRequest
-        .getGetOption().equals(GetOption.Include_Deleted_Blobs)) {
+    } else if (blob.isDeleted() && !getRequest.getGetOption().equals(GetOption.Include_All)
+        && !getRequest.getGetOption().equals(GetOption.Include_Deleted_Blobs)) {
       retCode = ServerErrorCode.Blob_Deleted;
-    } else if (blob.hasExpired() && !getRequest.getGetOption().equals(GetOption.Include_All) && !getRequest
-        .getGetOption().equals(GetOption.Include_Expired_Blobs)) {
+    } else if (blob.hasExpired() && !getRequest.getGetOption().equals(GetOption.Include_All)
+        && !getRequest.getGetOption().equals(GetOption.Include_Expired_Blobs)) {
       retCode = ServerErrorCode.Blob_Expired;
     }
     return retCode;

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -67,6 +67,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -279,6 +280,48 @@ public final class ServerTestUtil {
     }
   }
 
+  /**
+   * Tests the case where a late PutRequest is sent to each server when it already has a record for the given BlobId.
+   * The expected error from each server should be the given error.
+   * @param blobId the {@link BlobId} of the blob to be put.
+   * @param properties the {@link BlobProperties} of the blob to be put.
+   * @param usermetadata the usermetadata of the blob to be put.
+   * @param data the blob data of the blob to be put.
+   * @param channelToDatanode1 the {@link BlockingChannel} to the Datanode1.
+   * @param channelToDatanode2 the {@link BlockingChannel} to the Datanode2.
+   * @param channelToDatanode3 the {@link BlockingChannel} to the Datanode3.
+   * @param expectedErrorCode the {@link ServerErrorCode} that is expected from every Datanode.
+   * @throws IOException
+   */
+  private static void testLatePutRequest(BlobId blobId, BlobProperties properties, byte[] usermetadata, byte[] data,
+      BlockingChannel channelToDatanode1, BlockingChannel channelToDatanode2, BlockingChannel channelToDatanode3,
+      ServerErrorCode expectedErrorCode) throws IOException {
+    // Send put requests for an existing blobId for the exact blob to simulate a request arriving late.
+    PutRequest latePutRequest1 =
+        new PutRequest(1, "client1", blobId, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
+            properties.getBlobSize(), BlobType.DataBlob);
+    PutRequest latePutRequest2 =
+        new PutRequest(1, "client2", blobId, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
+            properties.getBlobSize(), BlobType.DataBlob);
+    PutRequest latePutRequest3 =
+        new PutRequest(1, "client3", blobId, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
+            properties.getBlobSize(), BlobType.DataBlob);
+    channelToDatanode1.send(latePutRequest1);
+    InputStream putResponseStream = channelToDatanode1.receive().getInputStream();
+    PutResponse response = PutResponse.readFrom(new DataInputStream(putResponseStream));
+    assertEquals(expectedErrorCode, response.getError());
+
+    channelToDatanode2.send(latePutRequest2);
+    putResponseStream = channelToDatanode2.receive().getInputStream();
+    response = PutResponse.readFrom(new DataInputStream(putResponseStream));
+    assertEquals(expectedErrorCode, response.getError());
+
+    channelToDatanode3.send(latePutRequest3);
+    putResponseStream = channelToDatanode3.receive().getInputStream();
+    response = PutResponse.readFrom(new DataInputStream(putResponseStream));
+    assertEquals(expectedErrorCode, response.getError());
+  }
+
   protected static void endToEndReplicationWithMultiNodeMultiPartitionTest(int interestedDataNodePortNumber,
       Port dataNode1Port, Port dataNode2Port, Port dataNode3Port, MockCluster cluster, SSLConfig clientSSLConfig1,
       SSLConfig clientSSLConfig2, SSLConfig clientSSLConfig3, SSLSocketFactory clientSSLSocketFactory1,
@@ -334,6 +377,25 @@ public final class ServerTestUtil {
       for (BlobId blobId : blobIds) {
         notificationSystem.awaitBlobCreations(blobId.getID());
       }
+
+      // Now that the blob is created and replicated, test the cases where a put request arrives for the same blob id
+      // later than replication.
+      // @todo Once PutRequest starts going out in V3, ReplicaMetadataResponse goes out in V2 and GetResponse goes
+      // @todo out in V2, the expected error is No_Error for the first case here, where the blob is exactly the same.
+      testLatePutRequest(blobIds.get(0), properties, usermetadata, data, channel1, channel2, channel3,
+          ServerErrorCode.Blob_Already_Exists);
+      // Test the case where a put arrives with the same id as one in the server, but the blob is not identical.
+      BlobProperties differentProperties = new BlobProperties(properties.getBlobSize(), properties.getServiceId());
+      testLatePutRequest(blobIds.get(0), differentProperties, usermetadata, data, channel1, channel2, channel3,
+          ServerErrorCode.Blob_Already_Exists);
+      byte[] differentUsermetadata = Arrays.copyOf(usermetadata, usermetadata.length);
+      differentUsermetadata[0] = (byte) ~differentUsermetadata[0];
+      testLatePutRequest(blobIds.get(0), properties, differentUsermetadata, data, channel1, channel2, channel3,
+          ServerErrorCode.Blob_Already_Exists);
+      byte[] differentData = Arrays.copyOf(data, data.length);
+      differentData[0] = (byte) ~differentData[0];
+      testLatePutRequest(blobIds.get(0), properties, usermetadata, differentData, channel1, channel2, channel3,
+          ServerErrorCode.Blob_Already_Exists);
 
       // verify blob properties, metadata and blob across all nodes
       for (int i = 0; i < 3; i++) {
@@ -716,8 +778,8 @@ public final class ServerTestUtil {
     List<Future<String>> putFutures = new ArrayList<>(numberOfRequestsToSend);
     for (int i = 0; i < numberOfRequestsToSend; i++) {
       int size = new Random().nextInt(5000);
-      final BlobProperties properties = new BlobProperties(size, "service1", "owner id check", "image/jpeg", false,
-          Utils.Infinite_Time);
+      final BlobProperties properties =
+          new BlobProperties(size, "service1", "owner id check", "image/jpeg", false, Utils.Infinite_Time);
       final byte[] metadata = new byte[new Random().nextInt(1000)];
       final byte[] blob = new byte[size];
       new Random().nextBytes(metadata);

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -156,9 +156,9 @@ public class AmbryRequests implements RequestAPI {
             new PutMessageFormatInputStream(receivedRequest.getBlobId(), receivedRequest.getBlobProperties(),
                 receivedRequest.getUsermetadata(), receivedRequest.getBlobStream(), receivedRequest.getBlobSize(),
                 receivedRequest.getBlobType());
-        MessageInfo info = new MessageInfo(receivedRequest.getBlobId(), stream.getSize(),
+        MessageInfo info = new MessageInfo(receivedRequest.getBlobId(), stream.getSize(), false,
             Utils.addSecondsToEpochTime(receivedRequest.getBlobProperties().getCreationTimeInMs(),
-                receivedRequest.getBlobProperties().getTimeToLiveInSeconds()));
+                receivedRequest.getBlobProperties().getTimeToLiveInSeconds()), receivedRequest.getCrc());
         ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
         infoList.add(info);
         MessageFormatWriteSet writeset = new MessageFormatWriteSet(stream, infoList, false);

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -58,6 +58,20 @@ class BlobStore implements Store {
   private boolean started;
   private FileLock fileLock;
 
+  /**
+   * States representing the different scenarios that can occur when a set of messages are to be written to the store.
+   * Nomenclature:
+   * Absent: a key that is non-existent in the store.
+   * Duplicate: a key that exists in the store and has the same CRC (meaning the message is the same).
+   * Colliding: a key that exists in the store but has a different CRC (meaning the message is different).
+   */
+  private enum MessageWriteSetStateInStore {
+    ALL_ABSENT, // The messages are all absent in the store.
+    COLLIDING, // At least one message in the write set has the same key as another, different message in the store.
+    ALL_DUPLICATE, // The messages are all duplicates - every one of them already exist in the store.
+    SOME_NOT_ALL_DUPLICATE, // At least one of the message is a duplicate, but not all.
+  }
+
   BlobStore(String storeId, StoreConfig config, ScheduledExecutorService taskScheduler, DiskIOScheduler diskIOScheduler,
       StorageManagerMetrics storageManagerMetrics, String dataDir, long capacityInBytes, StoreKeyFactory factory,
       MessageStoreRecovery recovery, MessageStoreHardDelete hardDelete, Time time) {
@@ -152,6 +166,43 @@ class BlobStore implements Store {
     }
   }
 
+  /**
+   * Checks the state of the messages in the given {@link MessageWriteSet} in the given {@link FileSpan}.
+   * @param messageSetToWrite Non-empty set of messages to write to the store.
+   * @param fileSpan The fileSpan on which the check for existence of the messages have to be made.
+   * @return {@link MessageWriteSetStateInStore} representing the outcome of the state check.
+   * @throws StoreException relays those encountered from {@link PersistentIndex#findKey(StoreKey, FileSpan)}.
+   */
+  private MessageWriteSetStateInStore checkWriteSetStateInStore(MessageWriteSet messageSetToWrite, FileSpan fileSpan)
+      throws StoreException {
+    int totalEntries = messageSetToWrite.getMessageSetInfo().size();
+    if (totalEntries == 0) {
+      throw new IllegalArgumentException("Message write set cannot be empty");
+    }
+    // if any existing entry is found and is identical, then return if all entries are already present.
+    int existingIdenticalEntries = 0;
+    for (MessageInfo info : messageSetToWrite.getMessageSetInfo()) {
+      if (index.findKey(info.getStoreKey(), fileSpan) != null) {
+        if (index.wasRecentlySeen(info)) {
+          existingIdenticalEntries++;
+          metrics.identicalPutAttemptCount.inc();
+        } else {
+          return MessageWriteSetStateInStore.COLLIDING;
+        }
+      }
+    }
+    if (existingIdenticalEntries == totalEntries) {
+      logger.trace("All entries to put already exist in the store");
+      return MessageWriteSetStateInStore.ALL_DUPLICATE;
+    } else if (existingIdenticalEntries > 0) {
+      // At least one entry in the given write set is already present, and at least one of them is not. The
+      // operation cannot succeed.
+      return MessageWriteSetStateInStore.SOME_NOT_ALL_DUPLICATE;
+    } else {
+      return MessageWriteSetStateInStore.ALL_ABSENT;
+    }
+  }
+
   @Override
   public void put(MessageWriteSet messageSetToWrite) throws StoreException {
     checkStarted();
@@ -162,50 +213,18 @@ class BlobStore implements Store {
         throw new IllegalArgumentException("Message write set cannot be empty");
       }
       Offset indexEndOffsetBeforeCheck = index.getCurrentEndOffset();
-      // if any existing entry is found and is identical, then return if all entries are already present.
-      int existingIdenticalEntries = 0;
-      for (MessageInfo info : messageSetToWrite.getMessageSetInfo()) {
-        if (index.findKey(info.getStoreKey()) != null) {
-          if (index.recentlySeen(info)) {
-            existingIdenticalEntries++;
-            metrics.identicalPutAttemptCount.inc();
-          } else {
-            throw new StoreException("Another blob with same key exists in store", StoreErrorCodes.Already_Exist);
-          }
-        }
-      }
-      if (existingIdenticalEntries == totalEntries) {
-        logger.trace("All entries to put already exist in the store");
-      } else if (existingIdenticalEntries > 0) {
-        // At least one entry in the given write set is already present, and at least one of them is not. The
-        // operation cannot succeed.
-        throw new StoreException("An identical blob exists in store", StoreErrorCodes.Already_Exist);
-      } else {
+      MessageWriteSetStateInStore state = checkWriteSetStateInStore(messageSetToWrite, null);
+      if (state == MessageWriteSetStateInStore.ALL_ABSENT) {
         synchronized (lock) {
           // Validate that log end offset was not changed. If changed, check once again for existing
           // keys in store
           Offset currentIndexEndOffset = index.getCurrentEndOffset();
           if (!currentIndexEndOffset.equals(indexEndOffsetBeforeCheck)) {
             FileSpan fileSpan = new FileSpan(indexEndOffsetBeforeCheck, currentIndexEndOffset);
-            for (MessageInfo info : messageSetToWrite.getMessageSetInfo()) {
-              if (index.findKey(info.getStoreKey(), fileSpan) != null) {
-                if (index.recentlySeen(info)) {
-                  existingIdenticalEntries++;
-                  metrics.identicalPutAttemptCount.inc();
-                } else {
-                  throw new StoreException("Key already exists on filespan check", StoreErrorCodes.Already_Exist);
-                }
-              }
-            }
+            state = checkWriteSetStateInStore(messageSetToWrite, fileSpan);
           }
 
-          if (existingIdenticalEntries == totalEntries) {
-            logger.trace("All entries to put already exist in the store");
-          } else if (existingIdenticalEntries > 0) {
-            // At least one entry in the given write set is already present, and at least one of them is not. The
-            // operation cannot succeed.
-            throw new StoreException("An identical blob exists in store", StoreErrorCodes.Already_Exist);
-          } else {
+          if (state == MessageWriteSetStateInStore.ALL_ABSENT) {
             Offset endOffsetOfLastMessage = log.getEndOffset();
             messageSetToWrite.writeTo(log);
             logger.trace("Store : {} message set written to log", dataDir);
@@ -224,6 +243,22 @@ class BlobStore implements Store {
             logger.trace("Store : {} message set written to index ", dataDir);
           }
         }
+      }
+      switch (state) {
+        case COLLIDING:
+          throw new StoreException(
+              "For at least one message in the write set, another blob with same key exists in store",
+              StoreErrorCodes.Already_Exist);
+        case SOME_NOT_ALL_DUPLICATE:
+          throw new StoreException(
+              "At least one message but not all in the write set is identical to an existing entry",
+              StoreErrorCodes.Already_Exist);
+        case ALL_DUPLICATE:
+          logger.trace("All entries to put already exist in the store, marking operation as successful");
+          break;
+        case ALL_ABSENT:
+          logger.trace("All entries were absent, and were written to the store successfully");
+          break;
       }
     } catch (StoreException e) {
       throw e;

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexEntry.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexEntry.java
@@ -19,10 +19,16 @@ package com.github.ambry.store;
 class IndexEntry {
   private final StoreKey key;
   private final IndexValue value;
+  private final Long crc;
 
-  IndexEntry(StoreKey key, IndexValue value) {
+  IndexEntry(StoreKey key, IndexValue value, Long crc) {
     this.key = key;
     this.value = value;
+    this.crc = crc;
+  }
+
+  IndexEntry(StoreKey key, IndexValue value) {
+    this(key, value, null);
   }
 
   StoreKey getKey() {
@@ -31,5 +37,9 @@ class IndexEntry {
 
   IndexValue getValue() {
     return this.value;
+  }
+
+  Long getCrc() {
+    return this.crc;
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/Journal.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Journal.java
@@ -14,9 +14,9 @@
 package com.github.ambry.store;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -48,7 +48,7 @@ class JournalEntry {
 class Journal {
 
   private final ConcurrentSkipListMap<Offset, StoreKey> journal;
-  private final HashMap<StoreKey, Long> recentCrcs;
+  private final ConcurrentHashMap<StoreKey, Long> recentCrcs;
   private final int maxEntriesToJournal;
   private final int maxEntriesToReturn;
   private final AtomicInteger currentNumberOfEntries;
@@ -63,7 +63,7 @@ class Journal {
    */
   Journal(String dataDir, int maxEntriesToJournal, int maxEntriesToReturn) {
     journal = new ConcurrentSkipListMap<>();
-    recentCrcs = new HashMap<>();
+    recentCrcs = new ConcurrentHashMap<>();
     this.maxEntriesToJournal = maxEntriesToJournal;
     this.maxEntriesToReturn = maxEntriesToReturn;
     this.currentNumberOfEntries = new AtomicInteger(0);

--- a/ambry-store/src/main/java/com.github.ambry.store/Journal.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Journal.java
@@ -14,9 +14,9 @@
 package com.github.ambry.store;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -48,7 +48,7 @@ class JournalEntry {
 class Journal {
 
   private final ConcurrentSkipListMap<Offset, StoreKey> journal;
-  private final ConcurrentHashMap<StoreKey, Long> recentCrcs;
+  private final HashMap<StoreKey, Long> recentCrcs;
   private final int maxEntriesToJournal;
   private final int maxEntriesToReturn;
   private final AtomicInteger currentNumberOfEntries;
@@ -63,7 +63,7 @@ class Journal {
    */
   Journal(String dataDir, int maxEntriesToJournal, int maxEntriesToReturn) {
     journal = new ConcurrentSkipListMap<>();
-    recentCrcs = new ConcurrentHashMap<>();
+    recentCrcs = new HashMap<>();
     this.maxEntriesToJournal = maxEntriesToJournal;
     this.maxEntriesToReturn = maxEntriesToReturn;
     this.currentNumberOfEntries = new AtomicInteger(0);
@@ -174,7 +174,7 @@ class Journal {
    * @param key the key for which the crc is to be obtained.
    * @return the crc associated with this key in the journal if there is one; else returns null.
    */
-  Long getCrcIfExists(StoreKey key) {
+  Long getCrcOfKey(StoreKey key) {
     return recentCrcs.get(key);
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/Journal.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Journal.java
@@ -16,6 +16,7 @@ package com.github.ambry.store;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -47,6 +48,7 @@ class JournalEntry {
 class Journal {
 
   private final ConcurrentSkipListMap<Offset, StoreKey> journal;
+  private final ConcurrentHashMap<StoreKey, Long> recentCrcs;
   private final int maxEntriesToJournal;
   private final int maxEntriesToReturn;
   private final AtomicInteger currentNumberOfEntries;
@@ -61,6 +63,7 @@ class Journal {
    */
   Journal(String dataDir, int maxEntriesToJournal, int maxEntriesToReturn) {
     journal = new ConcurrentSkipListMap<>();
+    recentCrcs = new ConcurrentHashMap<>();
     this.maxEntriesToJournal = maxEntriesToJournal;
     this.maxEntriesToReturn = maxEntriesToReturn;
     this.currentNumberOfEntries = new AtomicInteger(0);
@@ -68,24 +71,39 @@ class Journal {
   }
 
   /**
-   * The entry that needs to be added to the journal.
+   * Adds an entry into the journal with the given {@link Offset}, {@link StoreKey}, and crc.
    * @param offset The {@link Offset} that the key pertains to.
    * @param key The key that the entry in the journal refers to.
+   * @param crc The crc of the object. This may be null if crc is not available.
    */
-  void addEntry(Offset offset, StoreKey key) {
+  void addEntry(Offset offset, StoreKey key, Long crc) {
     if (key == null || offset == null) {
       throw new IllegalArgumentException("Invalid arguments passed to add to the journal");
     }
     if (maxEntriesToJournal > 0) {
       if (currentNumberOfEntries.get() == maxEntriesToJournal) {
-        journal.remove(journal.firstKey());
+        Map.Entry<Offset, StoreKey> earliestEntry = journal.firstEntry();
+        journal.remove(earliestEntry.getKey());
+        recentCrcs.remove(earliestEntry.getValue());
         currentNumberOfEntries.decrementAndGet();
       }
       journal.put(offset, key);
+      if (crc != null) {
+        recentCrcs.put(key, crc);
+      }
       logger.trace("Journal : " + dataDir + " offset " + offset + " key " + key);
       currentNumberOfEntries.incrementAndGet();
       logger.trace("Journal : " + dataDir + " number of entries " + currentNumberOfEntries.get());
     }
+  }
+
+  /**
+   * Adds an entry into the journal with the given {@link Offset}, {@link StoreKey}, and a null crc.
+   * @param offset The {@link Offset} that the key pertains to.
+   * @param key The key that the entry in the journal refers to.
+   */
+  void addEntry(Offset offset, StoreKey key) {
+    addEntry(offset, key, null);
   }
 
   /**
@@ -149,5 +167,14 @@ class Journal {
   Offset getLastOffset() {
     Map.Entry<Offset, StoreKey> last = journal.lastEntry();
     return last == null ? null : last.getKey();
+  }
+
+  /**
+   * Returns the crc associated with this key in the journal if there is one; else returns null.
+   * @param key the key for which the crc is to be obtained.
+   * @return the crc associated with this key in the journal if there is one; else returns null.
+   */
+  Long getCrcIfExists(StoreKey key) {
+    return recentCrcs.get(key);
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -287,7 +287,7 @@ class PersistentIndex {
         } else {
           // create a new entry in the index
           IndexValue newValue = new IndexValue(info.getSize(), runningOffset, info.getExpirationTimeInMs());
-          addToIndex(new IndexEntry(info.getStoreKey(), newValue), new FileSpan(runningOffset, infoEndOffset));
+          addToIndex(new IndexEntry(info.getStoreKey(), newValue, null), new FileSpan(runningOffset, infoEndOffset));
           logger.info("Index : {} adding new message to index with key {} size {} ttl {} deleted {}", dataDir,
               info.getStoreKey(), info.getSize(), info.getExpirationTimeInMs(), info.isDeleted());
         }
@@ -337,7 +337,7 @@ class PersistentIndex {
     } else {
       indexes.lastEntry().getValue().addEntry(entry, fileSpan.getEndOffset());
     }
-    journal.addEntry(entry.getValue().getOffset(), entry.getKey());
+    journal.addEntry(entry.getValue().getOffset(), entry.getKey(), entry.getCrc());
   }
 
   /**
@@ -472,6 +472,16 @@ class PersistentIndex {
   }
 
   /**
+   * Returns true if the given message was recently seen by this Index.
+   * @param info the {@link MessageInfo} to check.
+   * @return true if the exact message was recently added to this index; false otherwise.
+   */
+  boolean recentlySeen(MessageInfo info) {
+    Long crcInJournal = journal.getCrcIfExists(info.getStoreKey());
+    return info.getCrc() != null && info.getCrc().equals(crcInJournal);
+  }
+
+  /**
    * Marks the index entry represented by the key for delete
    * @param id The id of the entry that needs to be deleted
    * @param fileSpan The file span represented by this entry in the log
@@ -490,7 +500,7 @@ class PersistentIndex {
     newValue.setFlag(IndexValue.Flags.Delete_Index);
     newValue.setNewOffset(fileSpan.getStartOffset());
     newValue.setNewSize(fileSpan.getEndOffset().getOffset() - fileSpan.getStartOffset().getOffset());
-    addToIndex(new IndexEntry(id, newValue), fileSpan);
+    addToIndex(new IndexEntry(id, newValue, null), fileSpan);
   }
 
   /**
@@ -514,7 +524,8 @@ class PersistentIndex {
     } else if (isExpired(value) && !getOptions.contains(StoreGetOptions.Store_Include_Expired)) {
       throw new StoreException("Id " + id + " has expired ttl in index " + dataDir, StoreErrorCodes.TTL_Expired);
     } else {
-      readOptions = new BlobReadOptions(log, value.getOffset(), value.getSize(), value.getExpiresAtMs(), id);
+      readOptions = new BlobReadOptions(log, value.getOffset(), value.getSize(), value.getExpiresAtMs(), id,
+          value.isFlagSet(IndexValue.Flags.Delete_Index), journal.getCrcIfExists(id));
     }
     return readOptions;
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -476,8 +476,8 @@ class PersistentIndex {
    * @param info the {@link MessageInfo} to check.
    * @return true if the exact message was recently added to this index; false otherwise.
    */
-  boolean recentlySeen(MessageInfo info) {
-    Long crcInJournal = journal.getCrcIfExists(info.getStoreKey());
+  boolean wasRecentlySeen(MessageInfo info) {
+    Long crcInJournal = journal.getCrcOfKey(info.getStoreKey());
     return info.getCrc() != null && info.getCrc().equals(crcInJournal);
   }
 
@@ -525,7 +525,7 @@ class PersistentIndex {
       throw new StoreException("Id " + id + " has expired ttl in index " + dataDir, StoreErrorCodes.TTL_Expired);
     } else {
       readOptions = new BlobReadOptions(log, value.getOffset(), value.getSize(), value.getExpiresAtMs(), id,
-          value.isFlagSet(IndexValue.Flags.Delete_Index), journal.getCrcIfExists(id));
+          value.isFlagSet(IndexValue.Flags.Delete_Index), journal.getCrcOfKey(id));
     }
     return readOptions;
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
@@ -88,14 +88,6 @@ class BlobReadOptions implements Comparable<BlobReadOptions>, Closeable {
     return expiresAtMs;
   }
 
-  boolean getIsDeleted() {
-    return isDeleted;
-  }
-
-  Long getCrc() {
-    return crc;
-  }
-
   StoreKey getStoreKey() {
     return storeKey;
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
@@ -36,7 +36,9 @@ class BlobReadOptions implements Comparable<BlobReadOptions>, Closeable {
   private final Pair<File, FileChannel> segmentView;
   private final Offset offset;
   private final Long size;
+  private final boolean isDeleted;
   private final Long expiresAtMs;
+  private final Long crc;
   private final StoreKey storeKey;
   private final AtomicBoolean open = new AtomicBoolean(true);
   private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -49,6 +51,10 @@ class BlobReadOptions implements Comparable<BlobReadOptions>, Closeable {
   private static final short EXPIRES_AT_MS_LENGTH = 8;
 
   BlobReadOptions(Log log, Offset offset, long size, long expiresAtMs, StoreKey storeKey) {
+    this(log, offset, size, expiresAtMs, storeKey, false, null);
+  }
+
+  BlobReadOptions(Log log, Offset offset, long size, long expiresAtMs, StoreKey storeKey, boolean isDeleted, Long crc) {
     segment = log.getSegment(offset.getName());
     if (offset.getOffset() + size > segment.getEndOffset()) {
       throw new IllegalArgumentException(
@@ -60,7 +66,10 @@ class BlobReadOptions implements Comparable<BlobReadOptions>, Closeable {
     this.size = size;
     this.expiresAtMs = expiresAtMs;
     this.storeKey = storeKey;
-    logger.trace("BlobReadOption offset {} size {} expiresAtMs {} storeKey {}", offset, size, expiresAtMs, storeKey);
+    this.isDeleted = isDeleted;
+    this.crc = crc;
+    logger.trace("BlobReadOption offset {} size {} expiresAtMs {} storeKey {}", offset, size, expiresAtMs, storeKey,
+        isDeleted, crc);
   }
 
   String getLogSegmentName() {
@@ -79,12 +88,20 @@ class BlobReadOptions implements Comparable<BlobReadOptions>, Closeable {
     return expiresAtMs;
   }
 
+  boolean getIsDeleted() {
+    return isDeleted;
+  }
+
+  Long getCrc() {
+    return crc;
+  }
+
   StoreKey getStoreKey() {
     return storeKey;
   }
 
   MessageInfo getMessageInfo() {
-    return new MessageInfo(storeKey, size, expiresAtMs);
+    return new MessageInfo(storeKey, size, isDeleted, expiresAtMs, crc);
   }
 
   File getFile() {

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -53,6 +53,7 @@ public class StoreMetrics {
   public final Counter hardDeleteExceptionsCount;
   public final Histogram segmentSizeForExists;
   public final Histogram segmentsAccessedPerBlobCount;
+  public final Counter identicalPutAttemptCount;
 
   private final MetricRegistry registry;
   private final String name;
@@ -98,6 +99,8 @@ public class StoreMetrics {
     segmentSizeForExists = registry.histogram(MetricRegistry.name(IndexSegment.class, name + "SegmentSizeForExists"));
     segmentsAccessedPerBlobCount =
         registry.histogram(MetricRegistry.name(IndexSegment.class, name + "SegmentsAccessedPerBlobCount"));
+    identicalPutAttemptCount =
+        registry.counter(MetricRegistry.name(PersistentIndex.class, name + "IdenticalPutAttemptCount"));
   }
 
   void initializeIndexGauges(final PersistentIndex index, final long capacityInBytes) {

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -77,7 +77,7 @@ public class BlobStoreTest {
   private static final int MAX_IN_MEM_ELEMENTS = 5;
   // deliberately do not divide the capacities perfectly.
   private static final int PUT_RECORD_SIZE = 53;
-  private static final long DELETE_RECORD_SIZE = 29;
+  private static final int DELETE_RECORD_SIZE = 29;
 
   private final Random random = new Random();
 
@@ -415,8 +415,8 @@ public class BlobStoreTest {
    */
   @Test
   public void concurrentPutTest() throws Exception {
-    long blobCount = 4000 / PUT_RECORD_SIZE + 1;
-    List<Putter> putters = new ArrayList<>((int) blobCount);
+    int blobCount = 4000 / PUT_RECORD_SIZE + 1;
+    List<Putter> putters = new ArrayList<>(blobCount);
     for (int i = 0; i < blobCount; i++) {
       putters.add(new Putter());
     }
@@ -431,8 +431,8 @@ public class BlobStoreTest {
    */
   @Test
   public void concurrentGetTest() throws Exception {
-    long extraBlobCount = 4000 / PUT_RECORD_SIZE + 1;
-    put((int) extraBlobCount, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    int extraBlobCount = 4000 / PUT_RECORD_SIZE + 1;
+    put(extraBlobCount, PUT_RECORD_SIZE, Utils.Infinite_Time);
     List<Getter> getters = new ArrayList<>(allKeys.size());
     for (MockId id : allKeys.keySet()) {
       getters.add(new Getter(id, EnumSet.noneOf(StoreGetOptions.class)));
@@ -448,8 +448,8 @@ public class BlobStoreTest {
    */
   @Test
   public void concurrentDeleteTest() throws Exception {
-    long extraBlobCount = 2000 / PUT_RECORD_SIZE + 1;
-    put((int) extraBlobCount, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    int extraBlobCount = 2000 / PUT_RECORD_SIZE + 1;
+    put(extraBlobCount, PUT_RECORD_SIZE, Utils.Infinite_Time);
     List<Deleter> deleters = new ArrayList<>(liveKeys.size());
     for (MockId id : liveKeys) {
       deleters.add(new Deleter(id));
@@ -465,8 +465,8 @@ public class BlobStoreTest {
    */
   @Test
   public void concurrentAllTest() throws Exception {
-    long putBlobCount = 1500 / PUT_RECORD_SIZE + 1;
-    List<Putter> putters = new ArrayList<>((int) putBlobCount);
+    int putBlobCount = 1500 / PUT_RECORD_SIZE + 1;
+    List<Putter> putters = new ArrayList<>(putBlobCount);
     for (int i = 0; i < putBlobCount; i++) {
       putters.add(new Putter());
     }
@@ -476,9 +476,9 @@ public class BlobStoreTest {
       getters.add(new Getter(id, EnumSet.allOf(StoreGetOptions.class)));
     }
 
-    long deleteBlobCount = 1500 / PUT_RECORD_SIZE;
-    List<MockId> idsToDelete = put((int) deleteBlobCount, PUT_RECORD_SIZE, Utils.Infinite_Time);
-    List<Deleter> deleters = new ArrayList<>((int) deleteBlobCount);
+    int deleteBlobCount = 1500 / PUT_RECORD_SIZE;
+    List<MockId> idsToDelete = put(deleteBlobCount, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    List<Deleter> deleters = new ArrayList<>(deleteBlobCount);
     for (MockId id : idsToDelete) {
       deleters.add(new Deleter(id));
     }
@@ -537,7 +537,7 @@ public class BlobStoreTest {
     List<StoreKey> mockIdList = Arrays.asList(allMockIdList.get(0), allMockIdList.get(1));
     List<Long> crcList = Arrays.asList(allCrcList.get(0), allCrcList.get(1));
     Set<StoreKey> missingKeysAfter = new HashSet<>(Arrays.asList(allMockIdList.get(2), allMockIdList.get(3)));
-    attemptPut(mockIdList, crcList);
+    putWithKeysAndCrcs(mockIdList, crcList);
     assertEquals(missingKeysAfter, store.findMissingKeys(allMockIdList));
 
     // 1. SOME_NOT_ALL_DUPLICATE - should fail.
@@ -545,7 +545,7 @@ public class BlobStoreTest {
     mockIdList = Arrays.asList(allMockIdList.get(0), allMockIdList.get(2));
     crcList = Arrays.asList(allCrcList.get(0), allCrcList.get(2));
     try {
-      attemptPut(mockIdList, crcList);
+      putWithKeysAndCrcs(mockIdList, crcList);
       fail("Put should fail if some keys exist, but some do not");
     } catch (StoreException e) {
       assertEquals(StoreErrorCodes.Already_Exist, e.getErrorCode());
@@ -556,7 +556,7 @@ public class BlobStoreTest {
     mockIdList = Arrays.asList(allMockIdList.get(2), allMockIdList.get(0));
     crcList = Arrays.asList(allCrcList.get(2), allCrcList.get(0));
     try {
-      attemptPut(mockIdList, crcList);
+      putWithKeysAndCrcs(mockIdList, crcList);
       fail("Put should fail if some keys exist, but some do not");
     } catch (StoreException e) {
       assertEquals(StoreErrorCodes.Already_Exist, e.getErrorCode());
@@ -568,7 +568,7 @@ public class BlobStoreTest {
     mockIdList = Arrays.asList(allMockIdList.get(0), allMockIdList.get(1));
     crcList = Arrays.asList(allCrcList.get(0), allCrcList.get(2));
     try {
-      attemptPut(mockIdList, crcList);
+      putWithKeysAndCrcs(mockIdList, crcList);
       fail("Put should fail if some keys exist, but some do not");
     } catch (StoreException e) {
       assertEquals(StoreErrorCodes.Already_Exist, e.getErrorCode());
@@ -579,7 +579,7 @@ public class BlobStoreTest {
     mockIdList = Arrays.asList(allMockIdList.get(3), allMockIdList.get(1));
     crcList = Arrays.asList(allCrcList.get(3), allCrcList.get(2));
     try {
-      attemptPut(mockIdList, crcList);
+      putWithKeysAndCrcs(mockIdList, crcList);
       fail("Put should fail if some keys exist, but some do not");
     } catch (StoreException e) {
       assertEquals(StoreErrorCodes.Already_Exist, e.getErrorCode());
@@ -589,13 +589,13 @@ public class BlobStoreTest {
     // 3. ALL_DUPLICATE - should succeed.
     mockIdList = Arrays.asList(allMockIdList.get(0), allMockIdList.get(1));
     crcList = Arrays.asList(allCrcList.get(0), allCrcList.get(1));
-    attemptPut(mockIdList, crcList);
+    putWithKeysAndCrcs(mockIdList, crcList);
     assertEquals(missingKeysAfter, store.findMissingKeys(allMockIdList));
 
     // 4. ALL_ABSENT
     mockIdList = Arrays.asList(allMockIdList.get(2), allMockIdList.get(3));
     crcList = Arrays.asList(allCrcList.get(2), allCrcList.get(3));
-    attemptPut(mockIdList, crcList);
+    putWithKeysAndCrcs(mockIdList, crcList);
     // Ensure that all new entries were added.
     missingKeysAfter.clear();
     assertEquals(missingKeysAfter, store.findMissingKeys(allMockIdList));
@@ -729,7 +729,7 @@ public class BlobStoreTest {
    */
   private MessageInfo delete(MockId idToDelete) throws StoreException {
     MessageInfo info = new MessageInfo(idToDelete, DELETE_RECORD_SIZE);
-    ByteBuffer buffer = ByteBuffer.allocate((int) DELETE_RECORD_SIZE);
+    ByteBuffer buffer = ByteBuffer.allocate(DELETE_RECORD_SIZE);
     store.delete(new MockMessageWriteSet(Collections.singletonList(info), Collections.singletonList(buffer)));
     deletedKeys.add(idToDelete);
     return info;
@@ -1167,7 +1167,7 @@ public class BlobStoreTest {
    * @param crcList the list of crcs of the messages.
    * @throws StoreException
    */
-  private void attemptPut(List<StoreKey> mockIdList, List<Long> crcList) throws StoreException {
+  private void putWithKeysAndCrcs(List<StoreKey> mockIdList, List<Long> crcList) throws StoreException {
     List<ByteBuffer> bufferList = new ArrayList<>();
     List<MessageInfo> messageInfoList = new ArrayList<>();
     for (int i = 0; i < mockIdList.size(); i++) {

--- a/ambry-store/src/test/java/com.github.ambry.store/MockJournal.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/MockJournal.java
@@ -25,12 +25,14 @@ import java.util.List;
 class MockJournal extends Journal {
   private List<Offset> savedOffsets;
   private List<StoreKey> savedKeys;
+  private List<Long> savedCrcs;
   boolean paused;
 
   public MockJournal(String dataDir, int maxEntriesToJournal, int maxEntriesToReturn) {
     super(dataDir, maxEntriesToJournal, maxEntriesToReturn);
     savedOffsets = new ArrayList<>();
     savedKeys = new ArrayList<>();
+    savedCrcs = new ArrayList<>();
     paused = false;
   }
 
@@ -40,18 +42,24 @@ class MockJournal extends Journal {
 
   public void resume() {
     for (int i = 0; i < savedOffsets.size(); i++) {
-      super.addEntry(savedOffsets.get(i), savedKeys.get(i));
+      super.addEntry(savedOffsets.get(i), savedKeys.get(i), savedCrcs.get(i));
     }
     paused = false;
   }
 
   @Override
   public void addEntry(Offset offset, StoreKey key) {
+    addEntry(offset, key, null);
+  }
+
+  @Override
+  public void addEntry(Offset offset, StoreKey key, Long crc) {
     if (paused) {
       savedOffsets.add(offset);
       savedKeys.add(key);
+      savedCrcs.add(crc);
     } else {
-      super.addEntry(offset, key);
+      super.addEntry(offset, key, crc);
     }
   }
 }


### PR DESCRIPTION
Add CRCs to PutRequests to serve two purposes:

1. Validate the request within handlePutRequest() at the server. This detects any
   corruptions in the router->datanode Put path, which, unlike Gets, does not get
   covered by CRCs today.

2. During a put, distinguish between real id collisions and those due to fast
   replication as follows:
   - Make the store save these CRCs in the journal against the blob id. This
     mapping will remain in the journal only as long as the associated entry
     remains in the journal.
   - During a put, if the attempted blob id is found to exist already, the store
     checks to see if the content of the message is identical to the existing entry
     via the CRC in the journal. If so, the put will be marked successful. This
     only takes care of cases where the identical entry was recently put in the store,
     but that should be good enough for handling the target case where the blob
     arrives faster via async replication than the synchronous put (for which
     currently we use a 1 second replication delay hack). When the journal is
     constructed during recovery and such, it will not contain any crcs, which should
     be okay as far as the target scenario we are fixing is concerned. To achieve the
     above, we also need to pass in the CRC as part of replication so that the store
     saves it. To do this, the CRC has to be part of the GetResponse (used by
     replication). Since MessageInfo is where this information will go in the
     GetResponse, and since MessageInfoList SerDe does not have a version today, its
     instantiators, GetResponse and ReplicaMetadataResponse, will now have new versions
     and the MessageInfoList "version" will be interpreted via those versions.

The new versions for PutRequest, GetResponse and ReplicaMetadataResponse are not yet
enabled, as they have to be done in phases, so this PR only Fixes linkedin/ambry#455
Once the new versions are enabled, this will also take care of #454.

--

Test coverage:
- Added unit tests for validating that the store returns success for identical puts (and failure for non-identical ones).
- Added integration tests for testing that with the new versions enabled, a late PutRequest will indeed succeed. This patch however, does not enable the new versions, so the added tests were manually verified and in this patch still expects (and gets) Already_Exists error. I think this is fine as adding more code that deals with both versions is unnecessary as the old versions of the protocol can be phased out eventually.

Built and tested both with the new versions and without them.