### PR TITLE
Support reading of empty incarnationId and sessionsId in V2 of StoreFindToken

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
@@ -182,10 +182,16 @@ public class StoreFindToken implements FindToken {
           case JournalBased:
             // read incarnationId
             String incarnationId = Utils.readIntString(stream);
-            UUID incarnationIdUUID = UUID.fromString(incarnationId);
+            UUID incarnationIdUUID = null;
+            if (!incarnationId.isEmpty()) {
+              incarnationIdUUID = UUID.fromString(incarnationId);
+            }
             // read sessionId
             sessionId = Utils.readIntString(stream);
-            sessionIdUUID = UUID.fromString(sessionId);
+            sessionIdUUID = null;
+            if (!sessionId.isEmpty()) {
+              sessionIdUUID = UUID.fromString(sessionId);
+            }
             Offset logOffset = Offset.fromBytes(stream);
             byte inclusive = stream.readByte();
             storeFindToken = new StoreFindToken(logOffset, sessionIdUUID, incarnationIdUUID, inclusive == (byte) 1);
@@ -193,10 +199,16 @@ public class StoreFindToken implements FindToken {
           case IndexBased:
             // read incarnationId
             incarnationId = Utils.readIntString(stream);
-            incarnationIdUUID = UUID.fromString(incarnationId);
+            incarnationIdUUID = null;
+            if (!incarnationId.isEmpty()) {
+              incarnationIdUUID = UUID.fromString(incarnationId);
+            }
             // read sessionId
             sessionId = Utils.readIntString(stream);
-            sessionIdUUID = UUID.fromString(sessionId);
+            sessionIdUUID = null;
+            if (!sessionId.isEmpty()) {
+              sessionIdUUID = UUID.fromString(sessionId);
+            }
             Offset indexSegmentStartOffset = Offset.fromBytes(stream);
             StoreKey storeKey = factory.getStoreKey(stream);
             storeFindToken = new StoreFindToken(storeKey, indexSegmentStartOffset, sessionIdUUID, incarnationIdUUID);


### PR DESCRIPTION
StoreFindToken in V1 will not have incarnationId. With latest patch(StoreFindToken V2), reading the old token will result in V2 token with null incarnationId. But deserialization of V2 token assumes that incarnationId and sessionsId cannot be null. So, any further deserialization with the same token will fail. This patch makes the fix to remove that assumption. 

SLA: 5 mins
Reviewers: @vgkholla 

Built and coding style applied.