### PR TITLE
Maintaining version in StoreFindToken during ser and deser

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
@@ -118,7 +118,7 @@ public class StoreFindToken implements FindToken {
       } else if (type.equals(Type.IndexBased) && key == null) {
         throw new IllegalArgumentException("StoreKey cannot be null for an index based token");
       }
-      if (version >= VERSION_2 && incarnationId == null) {
+      if (version == VERSION_2 && incarnationId == null) {
         throw new IllegalArgumentException("IncarnationId cannot be null for StoreFindToken of version 2");
       }
     }

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
@@ -351,6 +351,9 @@ public class StoreFindToken implements FindToken {
       case VERSION_2:
         offsetBytes = offset != null ? offset.toBytes() : ZERO_LENGTH_ARRAY;
         sessionIdBytes = sessionId != null ? sessionId.toString().getBytes() : ZERO_LENGTH_ARRAY;
+        if (type != Type.Uninitialized && incarnationId == null) {
+          throw new IllegalStateException("IncarnationId cannot be null for Journal or Index based token ");
+        }
         byte[] incarnationIdBytes = incarnationId != null ? incarnationId.toString().getBytes() : ZERO_LENGTH_ARRAY;
         storeKeyBytes = storeKey != null ? storeKey.toBytes() : ZERO_LENGTH_ARRAY;
         size = VERSION_SIZE + TYPE_SIZE;

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
@@ -66,7 +66,7 @@ public class StoreFindToken implements FindToken {
   // refers to the bytes read so far (from the beginning of the log)
   private long bytesRead;
   // refers to the version of the StoreFindToken
-  private short version;
+  private final short version;
 
   /**
    * Uninitialized token. Refers to the starting of the log.
@@ -146,9 +146,6 @@ public class StoreFindToken implements FindToken {
    */
   private StoreFindToken(Type type, Offset offset, StoreKey key, UUID sessionId, UUID incarnationId, boolean inclusive,
       short version) {
-    if (version != VERSION_0 && version != VERSION_1 && version != VERSION_2) {
-      throw new IllegalArgumentException("Unsupported version " + version + " for StoreFindToken ");
-    }
     if (!type.equals(Type.Uninitialized)) {
       if (offset == null || sessionId == null) {
         throw new IllegalArgumentException("Offset [" + offset + "] or SessionId [" + sessionId + "] cannot be null");
@@ -289,6 +286,10 @@ public class StoreFindToken implements FindToken {
     return inclusive == (byte) 1;
   }
 
+  /**
+   * Returns the version of the {@link StoreFindToken}
+   * @return the version of the {}@link {@link StoreFindToken}
+   */
   short getVersion() {
     return version;
   }
@@ -306,12 +307,12 @@ public class StoreFindToken implements FindToken {
     byte[] buf = null;
     switch (version) {
       case VERSION_0:
-        int OFFSET_SIZE = 8;
-        int START_OFFSET_SIZE = 8;
+        int offsetSize = 8;
+        int startOffsetSize = 8;
         byte[] sessionIdBytes = sessionId != null ? sessionId.toString().getBytes() : ZERO_LENGTH_ARRAY;
         byte[] storeKeyBytes = storeKey != null ? storeKey.toBytes() : ZERO_LENGTH_ARRAY;
         int size = VERSION_SIZE + SESSION_ID_LENGTH_SIZE + sessionIdBytes.length +
-            OFFSET_SIZE + START_OFFSET_SIZE + storeKeyBytes.length;
+            offsetSize + startOffsetSize + storeKeyBytes.length;
         buf = new byte[size];
         ByteBuffer bufWrap = ByteBuffer.wrap(buf);
         // add version

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreFindToken.java
@@ -41,6 +41,7 @@ public class StoreFindToken implements FindToken {
   static final short VERSION_0 = 0;
   static final short VERSION_1 = 1;
   static final short VERSION_2 = 2;
+  static final short CURRENT_VERSION = VERSION_2;
 
   private static final int VERSION_SIZE = 2;
   private static final int TYPE_SIZE = 2;
@@ -72,7 +73,7 @@ public class StoreFindToken implements FindToken {
    * Uninitialized token. Refers to the starting of the log.
    */
   StoreFindToken() {
-    this(Type.Uninitialized, null, null, null, null, true, VERSION_2);
+    this(Type.Uninitialized, null, null, null, null, true, CURRENT_VERSION);
   }
 
   /**
@@ -83,7 +84,7 @@ public class StoreFindToken implements FindToken {
    * @param incarnationId the incarnationId of the store
    */
   StoreFindToken(StoreKey key, Offset indexSegmentStartOffset, UUID sessionId, UUID incarnationId) {
-    this(Type.IndexBased, indexSegmentStartOffset, key, sessionId, incarnationId, false, VERSION_2);
+    this(Type.IndexBased, indexSegmentStartOffset, key, sessionId, incarnationId, false, CURRENT_VERSION);
   }
 
   /**
@@ -95,15 +96,15 @@ public class StoreFindToken implements FindToken {
    *                  {@code false} otherwise
    */
   StoreFindToken(Offset offset, UUID sessionId, UUID incarnationId, boolean inclusive) {
-    this(Type.JournalBased, offset, null, sessionId, incarnationId, inclusive, VERSION_2);
+    this(Type.JournalBased, offset, null, sessionId, incarnationId, inclusive, CURRENT_VERSION);
   }
 
   /**
    * Instantiating {@link StoreFindToken}
    * @param type the {@link Type} of the token
    * @param offset the offset that this token refers to
-   * @param key The {@link StoreKey} which the token refers to. Index segments are keyed on store keys and hence
-   * @param sessionId the sessionId of the store that this token referes to
+   * @param key The {@link StoreKey} that the token refers to
+   * @param sessionId the sessionId of the store that this token refers to
    * @param incarnationId the incarnationId of the store that this token refers to
    * @param inclusive {@code true} if the offset is inclusive or in other words the blob at the given offset is inclusive.
    *                  {@code false} otherwise
@@ -117,7 +118,7 @@ public class StoreFindToken implements FindToken {
       } else if (type.equals(Type.IndexBased) && key == null) {
         throw new IllegalArgumentException("StoreKey cannot be null for an index based token");
       }
-      if(version == StoreFindToken.VERSION_2 && incarnationId == null){
+      if (version >= VERSION_2 && incarnationId == null) {
         throw new IllegalArgumentException("IncarnationId cannot be null for StoreFindToken of version 2");
       }
     }
@@ -291,11 +292,9 @@ public class StoreFindToken implements FindToken {
         bufWrap.putInt(sessionIdBytes.length);
         bufWrap.put(sessionIdBytes);
         // add offset for journal based token
-        bufWrap.putLong((type == Type.JournalBased) ? (offset != null ? offset.getOffset() : UNINITIALIZED_OFFSET)
-            : UNINITIALIZED_OFFSET);
+        bufWrap.putLong((type == Type.JournalBased) ? offset.getOffset() : UNINITIALIZED_OFFSET);
         // add index start offset for Index based token
-        bufWrap.putLong((type == Type.IndexBased) ? (offset != null ? offset.getOffset() : UNINITIALIZED_OFFSET)
-            : UNINITIALIZED_OFFSET);
+        bufWrap.putLong((type == Type.IndexBased) ? offset.getOffset() : UNINITIALIZED_OFFSET);
         // add storekey
         bufWrap.put(storeKeyBytes);
         break;

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static com.github.ambry.store.CuratedLogIndexState.*;
 import static org.junit.Assert.*;
 
 
@@ -52,15 +53,6 @@ public class IndexTest {
   private final boolean isLogSegmented;
   private final File tempDir;
   private final CuratedLogIndexState state;
-  private static final StoreKeyFactory STORE_KEY_FACTORY;
-
-  static {
-    try {
-      STORE_KEY_FACTORY = Utils.getObj("com.github.ambry.store.MockIdFactory");
-    } catch (Exception e) {
-      throw new IllegalStateException(e);
-    }
-  }
 
   /**
    * Running for both segmented and non-segmented log.

--- a/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/PersistentIndexTest.java
@@ -47,6 +47,7 @@ import static org.junit.Assert.*;
 public class PersistentIndexTest {
   private final File tempDir;
   private final String tempDirStr;
+  private final UUID incarnationId = UUID.randomUUID();
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
@@ -227,7 +228,7 @@ public class PersistentIndexTest {
       StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      MockIndex index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      MockIndex index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       MockId blobId1 = new MockId("id1");
       MockId blobId2 = new MockId("id2");
       MockId blobId3 = new MockId("id3");
@@ -268,7 +269,7 @@ public class PersistentIndexTest {
       StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      MockIndex index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      MockIndex index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       final MockId blobId1 = new MockId("id1");
       final MockId blobId2 = new MockId("id2");
       final MockId blobId3 = new MockId("id3");
@@ -287,7 +288,7 @@ public class PersistentIndexTest {
       index.close();
 
       // create a new index and ensure the index is restored
-      MockIndex indexNew = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      MockIndex indexNew = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
 
       IndexValue value1 = indexNew.getValue(blobId1);
       IndexValue value2 = indexNew.getValue(blobId2);
@@ -302,7 +303,7 @@ public class PersistentIndexTest {
       Properties props = new Properties();
       props.put("store.data.flush.delay.seconds", "999999");
       config = new StoreConfig(new VerifiableProperties(props));
-      indexNew = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      indexNew = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       indexNew.addToIndex(new IndexEntry(blobId4, new IndexValue(1000, toOffset(5000), 12657)),
           new FileSpan(toOffset(5000), toOffset(6000)));
       indexNew.addToIndex(new IndexEntry(blobId5, new IndexValue(1000, toOffset(6000), 12657)),
@@ -313,7 +314,7 @@ public class PersistentIndexTest {
       } catch (StoreException e) {
         Assert.assertTrue("StoreException thrown as expected ", true);
       }
-      indexNew = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      indexNew = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       value1 = indexNew.getValue(blobId1);
       value2 = indexNew.getValue(blobId2);
       value3 = indexNew.getValue(blobId3);
@@ -379,7 +380,7 @@ public class PersistentIndexTest {
       scheduler = Utils.newScheduler(1, false);
 
       try {
-        MockIndex indexFail = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+        MockIndex indexFail = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
         Assert.assertFalse(true);
       } catch (StoreException e) {
         Assert.assertTrue(true);
@@ -390,7 +391,7 @@ public class PersistentIndexTest {
       channelToModify.write(ByteBuffer.wrap(salt));  // write version 1
 
       try {
-        MockIndex indexReadFail = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+        MockIndex indexReadFail = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
         Assert.assertFalse(true);
       } catch (StoreException e) {
         Assert.assertTrue(true);
@@ -402,7 +403,7 @@ public class PersistentIndexTest {
       channelToModify.write(ByteBuffer.wrap(addOnlyVersion));
 
       try {
-        MockIndex indexEmptyLine = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+        MockIndex indexEmptyLine = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
         Assert.assertTrue(false);
       } catch (StoreException e) {
         Assert.assertTrue(true);
@@ -471,7 +472,7 @@ public class PersistentIndexTest {
       StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      MockIndex index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      MockIndex index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       MockId blobId1 = new MockId("id1");
       MockId blobId2 = new MockId("id2");
       MockId blobId3 = new MockId("id3");
@@ -521,7 +522,7 @@ public class PersistentIndexTest {
       StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      MockIndex index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      MockIndex index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       MockId blobId1 = new MockId("id1");
       MockId blobId2 = new MockId("id2");
       MockId blobId3 = new MockId("id3");
@@ -595,7 +596,7 @@ public class PersistentIndexTest {
       StoreConfig config = new StoreConfig(new VerifiableProperties(new Properties()));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      MockIndex index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      MockIndex index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       MockId blobId1 = new MockId("id1");
       MockId blobId2 = new MockId("id2");
       MockId blobId3 = new MockId("id3");
@@ -640,7 +641,7 @@ public class PersistentIndexTest {
       StoreConfig config = new StoreConfig(new VerifiableProperties(props));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      MockIndex index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      MockIndex index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       ByteBuffer buffer = ByteBuffer.allocate(6900);
       log.appendFrom(buffer);
       MockId blobId1 = new MockId("id01");
@@ -742,7 +743,7 @@ public class PersistentIndexTest {
       Assert.assertEquals(index.findKey(blobId2).getOffset(), toOffset(100));
 
       index.close();
-      MockIndex indexNew = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      MockIndex indexNew = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       Assert.assertEquals(indexNew.findKey(blobId1).getOffset(), toOffset(0));
       Assert.assertEquals(indexNew.findKey(blobId2).getOffset(), toOffset(100));
     } catch (Exception e) {
@@ -772,7 +773,7 @@ public class PersistentIndexTest {
       StoreConfig config = new StoreConfig(new VerifiableProperties(props));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      MockIndex index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      MockIndex index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       ByteBuffer buffer = ByteBuffer.allocate(2700);
       log.appendFrom(buffer);
       MockId blobId1 = new MockId("id01");
@@ -923,7 +924,7 @@ public class PersistentIndexTest {
       StoreConfig config = new StoreConfig(new VerifiableProperties(props));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      MockIndex index = new MockIndex(tempDirStr, scheduler, log, tokenToTest.getIncarnationId(), config, factory);
+      MockIndex index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       FindInfo infoempty = index.findEntriesSince(tokenToTest, 1000);
       Assert.assertEquals(infoempty.getMessageEntries().size(), 0);
       MockId blobId1 = new MockId("id1");
@@ -983,7 +984,7 @@ public class PersistentIndexTest {
 
       index.markAsDeleted(blobId1, new FileSpan(toOffset(1500), toOffset(1600)));
       index.close();
-      index = new MockIndex(tempDirStr, scheduler, log, tokenToTest.getIncarnationId(), config, factory);
+      index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       FindInfo info = index.findEntriesSince(tokenToTest, 1200);
       List<MessageInfo> messageEntries = info.getMessageEntries();
       Assert.assertEquals(messageEntries.get(0).getStoreKey(), blobId1);
@@ -1003,7 +1004,7 @@ public class PersistentIndexTest {
       index.close();
       props = new Properties();
       config = new StoreConfig(new VerifiableProperties(props));
-      index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
 
       StoreFindToken token2 = new StoreFindToken();
       FindInfo info2 = index.findEntriesSince(token2, 300);
@@ -1242,7 +1243,7 @@ public class PersistentIndexTest {
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
       MockIndex index = new MockIndex(tempDirStr, scheduler, log, config, factory,
           new MockJournal(tempDirStr, 2 * config.storeIndexMaxNumberOfInmemElements,
-              config.storeMaxNumberOfEntriesToReturnFromJournal), tokenToTest.getIncarnationId());
+              config.storeMaxNumberOfEntriesToReturnFromJournal), incarnationId);
       MockJournal journal = (MockJournal) index.getJournal();
 
       MockId blobId1 = new MockId("id01");
@@ -1312,8 +1313,7 @@ public class PersistentIndexTest {
       /* Ensure older tokens are reset, and no entries are returned when the store just started.
        * (when the index is created for the first time, it is similar to an unclean shutdown, so
        * this tests token getting reset in the wake of an unclean shutdown case) */
-      StoreFindToken token =
-          new StoreFindToken(blobId1, toOffset(1000), new UUID(0, 0), tokenToTest.getIncarnationId());
+      StoreFindToken token = new StoreFindToken(blobId1, toOffset(1000), new UUID(0, 0), incarnationId);
       FindInfo info = index.findEntriesSince(token, 500);
       List<MessageInfo> mEntries = info.getMessageEntries();
       Assert.assertEquals(mEntries.size(), 0);
@@ -1357,7 +1357,7 @@ public class PersistentIndexTest {
       // token before:                    i  // i means index based token
       // token after :          j            // j means offset (journal) based token
 
-      token = new StoreFindToken(blobId1, toOffset(1000), new UUID(0, 0), tokenToTest.getIncarnationId());
+      token = new StoreFindToken(blobId1, toOffset(1000), new UUID(0, 0), incarnationId);
       info = index.findEntriesSince(token, 5 * entrySize);
       mEntries = info.getMessageEntries();
       // Ensure that we got all the keys from the beginning and ordered by offset
@@ -1710,7 +1710,7 @@ public class PersistentIndexTest {
       StoreConfig config = new StoreConfig(new VerifiableProperties(props));
       map = new MockClusterMap();
       StoreKeyFactory factory = Utils.getObj("com.github.ambry.store.MockIdFactory");
-      MockIndex index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      MockIndex index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       FindInfo infoempty = index.findDeletedEntriesSince(token, 1000, SystemTime.getInstance().milliseconds() / 1000);
       Assert.assertEquals(infoempty.getMessageEntries().size(), 0);
       MockId blobId1 = new MockId("id01");
@@ -1809,7 +1809,7 @@ public class PersistentIndexTest {
       Assert.assertEquals(value3.getOriginalMessageOffset(), 200);
 
       index.close();
-      index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
 
       //Segment 1: [*1* 2d 3 4 5]
       //Segment 2: [1d 6 7 8 9]
@@ -1898,7 +1898,7 @@ public class PersistentIndexTest {
       //Test end time
 
       index.close();
-      index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
 
       AtomicLong beforeSegment5LastModification = new AtomicLong(index.getLastSegment().getLastModifiedTime());
       // Wait long enough for the current time in seconds to be greater than the above time. In the future we
@@ -1909,7 +1909,7 @@ public class PersistentIndexTest {
       index.markAsDeleted(blobId16, new FileSpan(toOffset(2900), toOffset(3000)));
       index.markAsDeleted(blobId5, new FileSpan(toOffset(3000), toOffset(3100)));
       index.close();
-      index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
       //Segment 1: [1 2d 3 4 5]
       //Segment 2: [1d 6 7 8 9]
       //Segment 3: [6d 10d 11 12 13]
@@ -1930,7 +1930,7 @@ public class PersistentIndexTest {
 
       // just close and open again to execute the shutdown logic once again.
       index.close();
-      index = new MockIndex(tempDirStr, scheduler, log, null, config, factory);
+      index = new MockIndex(tempDirStr, scheduler, log, incarnationId, config, factory);
 
       // close and cleanup for good.
       index.close();

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
@@ -171,6 +171,18 @@ public class StoreFindTokenTest {
       doSerDeTest(new StoreFindToken(key, offset, sessionId, incarnationId), StoreFindToken.VERSION_1,
           StoreFindToken.VERSION_2);
     }
+
+    // Journal based token toBytes() will fail if incarnationId is null
+    try {
+      new StoreFindToken(offset, sessionId, null, false).toBytes();
+    } catch (IllegalStateException e) {
+    }
+
+    // Index based token toBytes() will fail if incarnationId is null
+    try {
+      new StoreFindToken(key, offset, sessionId, null).toBytes();
+    } catch (IllegalStateException e) {
+    }
   }
 
   /**

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
@@ -226,9 +226,22 @@ public class StoreFindTokenTest {
     for (Short version : versions) {
       DataInputStream stream = getSerializedStream(token, version);
       StoreFindToken deSerToken = StoreFindToken.fromBytes(stream, STORE_KEY_FACTORY);
+      assertEquals("Stream should have ended ", 0, stream.available());
+      assertEquals("Version mismatch for token ", version.shortValue(), deSerToken.getVersion());
       compareTokens(token, deSerToken);
       assertEquals("SessionId does not match", token.getSessionId(), deSerToken.getSessionId());
+      if (version == StoreFindToken.VERSION_2) {
+        assertEquals("IncarnationId mismatch ", token.getIncarnationId(), deSerToken.getIncarnationId());
+      }
+      stream = new DataInputStream(new ByteBufferInputStream(ByteBuffer.wrap(deSerToken.toBytes())));
+      deSerToken = StoreFindToken.fromBytes(stream, STORE_KEY_FACTORY);
       assertEquals("Stream should have ended ", 0, stream.available());
+      assertEquals("Version mismatch for token ", version.shortValue(), deSerToken.getVersion());
+      compareTokens(token, deSerToken);
+      assertEquals("SessionId does not match", token.getSessionId(), deSerToken.getSessionId());
+      if (version == StoreFindToken.VERSION_2) {
+        assertEquals("IncarnationId mismatch ", token.getIncarnationId(), deSerToken.getIncarnationId());
+      }
     }
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
@@ -224,6 +224,8 @@ public class StoreFindTokenTest {
       if (version == StoreFindToken.VERSION_2) {
         assertEquals("IncarnationId mismatch ", token.getIncarnationId(), deSerToken.getIncarnationId());
       }
+      // use StoreFindToken's actual serialize method to verify that token is serialized in the expected
+      // version
       stream = new DataInputStream(new ByteBufferInputStream(ByteBuffer.wrap(deSerToken.toBytes())));
       deSerToken = StoreFindToken.fromBytes(stream, STORE_KEY_FACTORY);
       assertEquals("Stream should have ended ", 0, stream.available());
@@ -305,7 +307,7 @@ public class StoreFindTokenTest {
           bufWrap.put(key.toBytes());
         }
         break;
-      case StoreFindToken.VERSION_2:
+      case StoreFindToken.CURRENT_VERSION:
         bytes = token.toBytes();
         break;
       default:

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
@@ -175,12 +175,14 @@ public class StoreFindTokenTest {
     // Journal based token toBytes() will fail if incarnationId is null
     try {
       new StoreFindToken(offset, sessionId, null, false).toBytes();
+      fail("Serialization should have failed");
     } catch (IllegalStateException e) {
     }
 
     // Index based token toBytes() will fail if incarnationId is null
     try {
       new StoreFindToken(key, offset, sessionId, null).toBytes();
+      fail("Serialization should have failed");
     } catch (IllegalStateException e) {
     }
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
@@ -140,17 +140,12 @@ public class StoreFindTokenTest {
       doSerDeTest(new StoreFindToken(), StoreFindToken.VERSION_0, StoreFindToken.VERSION_1, StoreFindToken.VERSION_2);
 
       // Journal based token
-      // incarnationId cannot be null for VERSION_2
-      doSerDeTest(new StoreFindToken(offset, sessionId, null, false), StoreFindToken.VERSION_0,
-          StoreFindToken.VERSION_1);
       doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, false), StoreFindToken.VERSION_0,
           StoreFindToken.VERSION_1, StoreFindToken.VERSION_2);
       // inclusiveness is present only in VERSION_2
       doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, true), StoreFindToken.VERSION_2);
 
       // Index based
-      // incarnationId cannot be null for VERSION_2
-      doSerDeTest(new StoreFindToken(key, offset, sessionId, null), StoreFindToken.VERSION_0, StoreFindToken.VERSION_1);
       doSerDeTest(new StoreFindToken(key, offset, sessionId, incarnationId), StoreFindToken.VERSION_0,
           StoreFindToken.VERSION_1, StoreFindToken.VERSION_2);
     } else {
@@ -158,32 +153,14 @@ public class StoreFindTokenTest {
       doSerDeTest(new StoreFindToken(), StoreFindToken.VERSION_1, StoreFindToken.VERSION_2);
 
       // Journal based token
-      // incarnationId cannot be null for VERSION_2
-      doSerDeTest(new StoreFindToken(offset, sessionId, null, false), StoreFindToken.VERSION_1);
       doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, false), StoreFindToken.VERSION_1,
           StoreFindToken.VERSION_2);
       // inclusiveness is present only in VERSION_2
       doSerDeTest(new StoreFindToken(offset, sessionId, incarnationId, true), StoreFindToken.VERSION_2);
 
       // Index based
-      // incarnationId cannot be null for VERSION_2
-      doSerDeTest(new StoreFindToken(key, offset, sessionId, null), StoreFindToken.VERSION_1);
       doSerDeTest(new StoreFindToken(key, offset, sessionId, incarnationId), StoreFindToken.VERSION_1,
           StoreFindToken.VERSION_2);
-    }
-
-    // Journal based token toBytes() will fail if incarnationId is null
-    try {
-      new StoreFindToken(offset, sessionId, null, false).toBytes();
-      fail("Serialization should have failed");
-    } catch (IllegalStateException e) {
-    }
-
-    // Index based token toBytes() will fail if incarnationId is null
-    try {
-      new StoreFindToken(key, offset, sessionId, null).toBytes();
-      fail("Serialization should have failed");
-    } catch (IllegalStateException e) {
     }
   }
 
@@ -202,8 +179,8 @@ public class StoreFindTokenTest {
     testConstructionFailure(key, sessionId, incarnationId, null);
     // no session id
     testConstructionFailure(key, null, incarnationId, offset);
-    // no incarnation Id. TODO: Uncomment this once incarnationId validation for not null is enabled in StoreFindToken
-    // testConstructionFailure(key, sessionId, null, offset);
+    // no incarnation Id
+    testConstructionFailure(key, sessionId, null, offset);
 
     // no key in IndexBased
     try {
@@ -265,7 +242,7 @@ public class StoreFindTokenTest {
    * @param version the version to serialize it in.
    * @return a serialized format of {@code token} in the version {@code version}.
    */
-  private DataInputStream getSerializedStream(StoreFindToken token, short version) {
+  static DataInputStream getSerializedStream(StoreFindToken token, short version) {
     byte[] bytes;
     switch (version) {
       case StoreFindToken.VERSION_0:


### PR DESCRIPTION
Currently, StoreFindToken doesn't have a version strictly associated with it and hence there are chances that a token that was serialized in V1, while reading it back will take up version 2 implicitly.

This patch adds version field to StoreFindtoken so that serialization is based on the version of the token and de-serialization maintains the same version. Any new StoreFindToken created (using public constructors) will take up the latest version(i.e. Version 2). This will ensure that any token read in version X will be written in a version <=X and never in a version > X.
Added unit tests to verify that version is maintained during serialization and deserialization as expected. 

More details: https://github.com/linkedin/ambry/issues/551

SLA: 10 mins
Reviewers: @pnarayanan @vgkholla 
Coverage: (running StoreFindTokenTest)
StoreFindToken	100% (3/ 3)	90.9% (20/ 22)	95.5% (169/ 177)
Verified that all new lines are covered except for few error cases (unknown store find token version and type) 

Built and coding style applied