### PR TITLE
Ensure network client is woken up when put channel is closed

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -184,6 +184,7 @@ class PutOperation {
           chunkFillingCompletedSuccessfully = true;
         }
         chunkFillerChannel.close();
+        routerCallback.onPollReady();
       }
     });
   }


### PR DESCRIPTION
This is to ensure that the last chunk that has to wait for
the channel to get closed (with the recent change to avoid
upfront size specification) gets sent as soon as the
channel is closed.