### PR TITLE
Adding more logging to triage HardDelete pause resume test failure

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -48,7 +48,7 @@ public class HardDeleter implements Runnable {
   public static final short Cleanup_Token_Version_V1 = 1;
   private static final String Cleanup_Token_Filename = "cleanuptoken";
   //how long to sleep if token does not advance.
-  static final long HARD_DELETE_SLEEP_TIME_MS_ON_CAUGHT_UP = 10 * Time.MsPerSec;
+  static final long HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP_MS = 10 * Time.MsPerSec;
 
   final AtomicBoolean enabled = new AtomicBoolean(true);
 
@@ -123,8 +123,8 @@ public class HardDeleter implements Runnable {
           if (enabled.get()) {
             if (!hardDelete()) {
               isCaughtUp = true;
-              logger.trace("Waiting for {} ms after caught up for {}", HARD_DELETE_SLEEP_TIME_MS_ON_CAUGHT_UP, dataDir);
-              time.await(pauseCondition, HARD_DELETE_SLEEP_TIME_MS_ON_CAUGHT_UP);
+              logger.trace("Waiting for {} ms after caught up for {}", HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP_MS, dataDir);
+              time.await(pauseCondition, HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP_MS);
             } else if (isCaughtUp) {
               isCaughtUp = false;
               logger.info("Resumed hard deletes for {} after having caught up", dataDir);

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -371,7 +371,7 @@ public class IndexTest {
    * @throws IOException
    * @throws StoreException
    */
-  // @Test
+  @Test
   public void hardDeletePauseResumeTest() throws InterruptedException, IOException, StoreException {
     testHardDeletePauseResume(false);
   }
@@ -383,7 +383,7 @@ public class IndexTest {
    * @throws IOException
    * @throws StoreException
    */
-  // @Test
+  @Test
   public void hardDeletePauseResumeRestartTest() throws InterruptedException, IOException, StoreException {
     testHardDeletePauseResume(true);
   }
@@ -1202,12 +1202,11 @@ public class IndexTest {
     state.reloadIndex(true, false);
     assertTrue("Hard delete is not enabled", state.index.hardDeleter.isRunning());
     // IndexSegment still uses real time so advance time so that it goes 2 days past the real time.
-    state.advanceTime(SystemTime.getInstance().milliseconds() + 2 * Time.MsPerSec * Time.SecsPerDay);
+    state.advanceTime(2 * Time.MsPerSec * Time.SecsPerDay);
     long expectedProgress = state.index.getAbsolutePositionInLogForOffset(state.logOrder.lastKey());
     // give it some time so that hard delete completes one cycle
     waitUntilExpectedProgress(expectedProgress, 5000);
     state.verifyEntriesForHardDeletes(state.deletedKeys);
-
     Set<MockId> idsDeleted = new HashSet<>();
     // delete two entries
     state.addPutEntries(2, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -1222,7 +1221,7 @@ public class IndexTest {
     // pause hard delete
     state.index.hardDeleter.pause();
     assertTrue("Hard deletes should have been paused ", state.index.hardDeleter.isPaused());
-    waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP + 1, 10);
+    waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_MS_ON_CAUGHT_UP + 1, 10);
 
     // delete two entries
     state.addPutEntries(2, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -1237,7 +1236,7 @@ public class IndexTest {
 
     if (reloadIndex) {
       state.reloadIndex(true, true);
-      waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP + 1, 10);
+      waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_MS_ON_CAUGHT_UP + 1, 10);
       idsToDelete.clear();
       state.addPutEntries(2, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
       idsToDelete.add(state.getIdToDeleteFromIndexSegment(state.referenceIndex.lastKey()));
@@ -1250,7 +1249,7 @@ public class IndexTest {
     }
 
     // advance time so that deleted entries becomes eligible to be hard deleted
-    state.advanceTime(SystemTime.getInstance().milliseconds() + 2 * Time.MsPerSec * Time.SecsPerDay);
+    state.advanceTime(2 * Time.MsPerSec * Time.SecsPerDay);
     // resume and verify new entries have been hard deleted
     state.index.hardDeleter.resume();
     assertFalse("Hard deletes should have been resumed ", state.index.hardDeleter.isPaused());
@@ -1981,7 +1980,8 @@ public class IndexTest {
       sleptSoFar += 5;
       Thread.sleep(5);
       if (sleptSoFar >= maxTimeToCheck) {
-        fail("HardDelete failed to catch up in " + maxTimeToCheck);
+        fail("HardDelete failed to catch up in " + maxTimeToCheck + ". Expected " + expectedProgress + ", actual "
+            + state.index.hardDeleter.getProgress());
       }
       state.index.hardDeleter.preLogFlush();
       state.index.hardDeleter.postLogFlush();

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1221,7 +1221,7 @@ public class IndexTest {
     // pause hard delete
     state.index.hardDeleter.pause();
     assertTrue("Hard deletes should have been paused ", state.index.hardDeleter.isPaused());
-    waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_MS_ON_CAUGHT_UP + 1, 10);
+    waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP_MS + 1, 10);
 
     // delete two entries
     state.addPutEntries(2, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -1236,7 +1236,7 @@ public class IndexTest {
 
     if (reloadIndex) {
       state.reloadIndex(true, true);
-      waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_MS_ON_CAUGHT_UP + 1, 10);
+      waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP_MS + 1, 10);
       idsToDelete.clear();
       state.addPutEntries(2, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
       idsToDelete.add(state.getIdToDeleteFromIndexSegment(state.referenceIndex.lastKey()));


### PR DESCRIPTION
HardDeletePauseAndResume tests in IndexTest fails very rarely in automated test environments. Couldn't reproduce in local environments. Hence adding more logging to assist in triaging the issue. 

SLA: 5 mins
Reviewers: @pnarayanan 

built and coding style applied