### PR TITLE
Wake up RequestResponseHandler when the last chunk becomes ready

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -179,12 +179,12 @@ class PutOperation {
       public void onCompletion(Long result, Exception exception) {
         if (exception != null) {
           setOperationExceptionAndComplete(exception);
+          routerCallback.onPollReady();
         } else {
           blobSize = result;
           chunkFillingCompletedSuccessfully = true;
         }
         chunkFillerChannel.close();
-        routerCallback.onPollReady();
       }
     });
   }
@@ -329,7 +329,9 @@ class PutOperation {
         PutChunk lastChunk = getBuildingChunk();
         if (lastChunk != null) {
           lastChunk.onFillComplete(true);
+          updateChunkFillerWaitTimeMetrics();
         }
+        routerCallback.onPollReady();
       }
     } catch (Exception e) {
       RouterException routerException = e instanceof RouterException ? (RouterException) e


### PR DESCRIPTION
For puts, the RequestResponseHandler should be woken up whenever chunks become
ready to be sent out to the server. The wake-up is done by calling onPollReady().
This is missing in a newly added code path (PR #540) for when the last chunk becomes
ready. This considerably increased the Put latency. This patch fixes that.

Built, formatted and tested that this brings the latency down.