### PR TITLE
Adding CompactionManagerV0

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -96,6 +96,14 @@ public class StoreConfig {
   @Default("9223372036854775807")
   public final long storeSegmentSizeInBytes;
 
+  /**
+   * The minimum capacity that has to be used (as a percentage of the total capacity) for the store to trigger
+   * compaction
+   */
+  @Config("store.min.used.capacity.to.trigger.compaction.in.percentage")
+  @Default("50")
+  public final int storeMinUsedCapacityToTriggerCompactionInPercentage;
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -112,6 +120,8 @@ public class StoreConfig {
     storeEnableHardDelete = verifiableProperties.getBoolean("store.enable.hard.delete", false);
     storeSegmentSizeInBytes =
         verifiableProperties.getLongInRange("store.segment.size.in.bytes", Long.MAX_VALUE, 1, Long.MAX_VALUE);
+    storeMinUsedCapacityToTriggerCompactionInPercentage =
+        verifiableProperties.getInt("store.min.used.capacity.to.trigger.compaction.in.percentage", 50);
   }
 }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -360,6 +360,25 @@ class BlobStore implements Store {
     return index.getLogUsedCapacity();
   }
 
+  /**
+   * Return total capacity of the {@link BlobStore} in bytes
+   * @return the total capacity of the {@link BlobStore} in bytes
+   */
+  long getCapacityInBytes() {
+    return capacityInBytes;
+  }
+
+  /**
+   * Fetches a list of {@link LogSegment} names whose entries don't over lap with {@link Journal}. Returns {@code null}
+   * if there aren't any
+   * @return list of {@link LogSegment} names whose entries don't over lap with {@link Journal}. {@code null}
+   * if there aren't any
+   */
+  List<String> getLogSegmentsNotInJournal() throws StoreException {
+    checkStarted();
+    return index.getLogSegmentsNotInJournal();
+  }
+
   @Override
   public void shutdown() throws StoreException {
     synchronized (lock) {

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -44,11 +44,10 @@ class CompactionManager {
     long usedCapacity = blobStore.getSizeInBytes();
     long totalCapacity = blobStore.getCapacityInBytes();
     CompactionDetails details = null;
-    if (usedCapacity > (storeConfig.storeMinUsedCapacityToTriggerCompactionInPercentage * totalCapacity / 100)) {
+    if (usedCapacity >= (storeConfig.storeMinUsedCapacityToTriggerCompactionInPercentage / 100.0) * totalCapacity) {
       List<String> potentialLogSegments = blobStore.getLogSegmentsNotInJournal();
       if (potentialLogSegments != null) {
-        details =
-            new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs, potentialLogSegments);
+        details = new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs, potentialLogSegments);
       }
     }
     return details;

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.utils.Time;
+import java.util.List;
+
+
+/**
+ * Responsible for managing compaction of a {@link BlobStore}. V0 implementation returns entire log segment range
+ * ignoring those overlapping with {@link Journal} as part of CompactionDetails.
+ */
+class CompactionManager {
+  private final StoreConfig storeConfig;
+  private final Time time;
+  private final long messageRetentionTimeInMs;
+
+  CompactionManager(StoreConfig storeConfig, Time time) {
+    this.storeConfig = storeConfig;
+    this.time = time;
+    this.messageRetentionTimeInMs = storeConfig.storeDeletedMessageRetentionDays * Time.SecsPerDay * Time.MsPerSec;
+  }
+
+  /**
+   * Get compaction details for a given {@link BlobStore} if any
+   * @param blobStore the {@link BlobStore} for which compation details are requested
+   * @return the {@link CompactionDetails} containing the details about log segments that needs to be compacted.
+   * {@code null} if compaction is not required
+   * @throws StoreException when {@link BlobStore} is not started
+   */
+  CompactionDetails getCompactionDetails(BlobStore blobStore) throws StoreException {
+    long usedCapacity = blobStore.getSizeInBytes();
+    long totalCapacity = blobStore.getCapacityInBytes();
+    CompactionDetails details = null;
+    if (usedCapacity > (storeConfig.storeMinUsedCapacityToTriggerCompactionInPercentage * totalCapacity / 100)) {
+      List<String> potentialLogSegments = blobStore.getLogSegmentsNotInJournal();
+      if (potentialLogSegments != null) {
+        details =
+            new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs, potentialLogSegments);
+      }
+    }
+    return details;
+  }
+}

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -912,6 +912,27 @@ class PersistentIndex {
   }
 
   /**
+   * Fetches {@link LogSegment} names whose entries don't over lap with {@link Journal}. Returns {@code null}
+   * if there aren't any
+   * @return a {@link List<String>} of {@link LogSegment} names whose entries don't overlap with {@link Journal}.
+   * {@code null} if there aren't any
+   */
+  List<String> getLogSegmentsNotInJournal() {
+    LogSegment logSegment = log.getFirstSegment();
+    Offset firstOffsetInJournal = journal.getFirstOffset();
+    List<String> logSegmentNamesToReturn = new ArrayList<>();
+    while (logSegment != null) {
+      if (!logSegment.getName().equals(firstOffsetInJournal.getName())) {
+        logSegmentNamesToReturn.add(logSegment.getName());
+      } else {
+        break;
+      }
+      logSegment = log.getNextSegment(logSegment);
+    }
+    return logSegmentNamesToReturn.size() > 0 ? logSegmentNamesToReturn : null;
+  }
+
+  /**
    * @param indexSegments the map of index segment start {@link Offset} to {@link IndexSegment} instances
    * @return mapping from log segment names to {@link IndexSegment} instances that refer to them.
    */

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -1157,6 +1157,13 @@ public class BlobStoreTest {
     }
 
     try {
+      blobStore.getLogSegmentsNotInJournal();
+      fail("Operation should have failed because store is inactive");
+    } catch (StoreException e) {
+      assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.Store_Not_Started, e.getErrorCode());
+    }
+
+    try {
       blobStore.shutdown();
     } catch (StoreException e) {
       assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.Store_Not_Started, e.getErrorCode());

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.UtilsTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Unit tests {@link CompactionManager}.
+ */
+public class CompactionManagerTest {
+
+  private static long CAPACITY_IN_BYTES = 10 * 1024 * 1024;
+  private static long DEFAULT_USED_CAPACITY_IN_BYTES = CAPACITY_IN_BYTES * 6 / 10;
+  // the properties that will used to generate a StoreConfig. Clear before use if required.
+  private final Properties properties = new Properties();
+  private final Time time = new MockTime();
+  private StoreConfig config;
+  private MockBlobStore blobStore;
+  private CompactionManager compactionManager;
+  private long messageRetentionTimeInMs;
+
+  /**
+   * Instantiates {@link CompactionManagerTest} with the required cast
+   * @throws InterruptedException
+   */
+  public CompactionManagerTest() throws InterruptedException {
+    config = new StoreConfig(new VerifiableProperties(properties));
+    messageRetentionTimeInMs = config.storeDeletedMessageRetentionDays * Time.SecsPerDay * Time.MsPerSec;
+    time.sleep(2 * messageRetentionTimeInMs);
+    MetricRegistry metricRegistry = new MetricRegistry();
+    StorageManagerMetrics metrics = new StorageManagerMetrics(metricRegistry);
+    blobStore = new MockBlobStore(config, metrics, time, CAPACITY_IN_BYTES, DEFAULT_USED_CAPACITY_IN_BYTES);
+    compactionManager = new CompactionManager(config, time);
+  }
+
+  /**
+   * Basic tests for {@link CompactionManager#getCompactionDetails(BlobStore)} for different values of
+   * log segment count
+   * @throws StoreException
+   * @throws InterruptedException
+   */
+  @Test
+  public void testGetCompactionDetailsBasicTest() throws StoreException, InterruptedException {
+    // null validLogSegments
+    blobStore.validLogSegments = null;
+    verifyCompactionDetails(null);
+
+    // 0 valid LogSegment
+    blobStore.validLogSegments = new ArrayList<>();
+    verifyCompactionDetails(null);
+
+    // 1 valid LogSegment
+    blobStore.validLogSegments = generateRandomStrings(1);
+    verifyCompactionDetails(new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs,
+        blobStore.validLogSegments));
+
+    // random no of valid logSegments
+    for (int i = 0; i < 3; i++) {
+      int logSegmentCount = TestUtils.RANDOM.nextInt(10) + 1;
+      blobStore.validLogSegments = generateRandomStrings(logSegmentCount);
+      verifyCompactionDetails(new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs,
+          blobStore.validLogSegments));
+    }
+  }
+
+  /**
+   * Tests {@link CompactionManager#getCompactionDetails(BlobStore)} for different values for {@link BlobStore}'s
+   * used capacity
+   * @throws StoreException
+   */
+  @Test
+  public void testDifferentUsedCapacities() throws StoreException {
+    blobStore.validLogSegments = generateRandomStrings(2);
+    // if used capacity is <= 60%, compaction details will be null. If not, validLogSegments needs to be returned.
+    Long[] usedCapacities =
+        new Long[]{CAPACITY_IN_BYTES * 2 / 10, (CAPACITY_IN_BYTES * 4 / 10), CAPACITY_IN_BYTES * 5 / 10,
+            CAPACITY_IN_BYTES * 51 / 100, (CAPACITY_IN_BYTES * 6 / 10),
+            CAPACITY_IN_BYTES * 7 / 10, CAPACITY_IN_BYTES * 9 / 10};
+    for (Long usedCapacity : usedCapacities) {
+      blobStore.usedCapacity = usedCapacity;
+      if(blobStore.usedCapacity <= (config.storeMinUsedCapacityToTriggerCompactionInPercentage * blobStore.capacityInBytes / 100))
+      {
+        verifyCompactionDetails(null);
+      } else{
+        verifyCompactionDetails(new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs,
+            blobStore.validLogSegments));
+      }
+    }
+  }
+
+  /**
+   * Tests {@link CompactionManager#getCompactionDetails(BlobStore)} for different values for
+   * {@link StoreConfig#storeMinUsedCapacityToTriggerCompactionInPercentage}
+   */
+  @Test
+  public void testDifferentThresholdsForMinLogSizeToCompact() throws StoreException {
+    int[] minLogSizeToTriggerCompactionInPercentages = new int[]{10, 20, 35, 40, 50, 59, 60, 61, 65, 70, 80, 95};
+    // when used capacity(60%) is <= (minLogSize) % of total capacity, compactionDetails is expected to be null.
+    // If not, validLogSegments needs to be returned
+    for (int minLogSize : minLogSizeToTriggerCompactionInPercentages) {
+      properties.setProperty("store.min.log.size.to.trigger.compaction.in.percent", String.valueOf(minLogSize));
+      config = new StoreConfig(new VerifiableProperties(properties));
+      MetricRegistry metricRegistry = new MetricRegistry();
+      StorageManagerMetrics metrics = new StorageManagerMetrics(metricRegistry);
+      blobStore = new MockBlobStore(config, metrics, time, CAPACITY_IN_BYTES, DEFAULT_USED_CAPACITY_IN_BYTES);
+      compactionManager = new CompactionManager(config, time);
+      blobStore.validLogSegments = generateRandomStrings(2);
+      if(blobStore.usedCapacity > (config.storeMinUsedCapacityToTriggerCompactionInPercentage * blobStore.capacityInBytes / 100)) {
+        verifyCompactionDetails(null);
+      } else{
+        verifyCompactionDetails(new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs,
+          blobStore.validLogSegments));
+      }
+    }
+  }
+
+  /**
+   * Tests {@link CompactionManager#getCompactionDetails(BlobStore)} for different values for
+   * {@link StoreConfig#storeDeletedMessageRetentionDays}
+   */
+  @Test
+  public void testDifferentMessageRetentionDays() throws StoreException, InterruptedException {
+    int[] messageRetentionDayValues = new int[]{1, 2, 3, 6, 9};
+    time.sleep(10 * messageRetentionTimeInMs);
+    for (int messageRetentionDays : messageRetentionDayValues) {
+      properties.setProperty("store.deleted.message.retention.days", String.valueOf(messageRetentionDays));
+      config = new StoreConfig(new VerifiableProperties(properties));
+      MetricRegistry metricRegistry = new MetricRegistry();
+      StorageManagerMetrics metrics = new StorageManagerMetrics(metricRegistry);
+      blobStore = new MockBlobStore(config, metrics, time, CAPACITY_IN_BYTES, DEFAULT_USED_CAPACITY_IN_BYTES);
+      compactionManager = new CompactionManager(config, time);
+      blobStore.validLogSegments = generateRandomStrings(2);
+      verifyCompactionDetails(new CompactionDetails(
+          time.milliseconds() - messageRetentionDays * Time.SecsPerDay * Time.MsPerSec,
+          blobStore.validLogSegments));
+    }
+  }
+
+  // helper methods
+
+  /**
+   * Generates random strings
+   * @param count the total number of random strings that needs to be generated
+   * @return a {@link List} of random strings of size {@code count}
+   */
+  private List<String> generateRandomStrings(int count) {
+    List<String> randomStrings = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      randomStrings.add(UtilsTest.getRandomString(5));
+    }
+    return randomStrings;
+  }
+
+  // verification helper methods
+
+  /**
+   * Verifies {@link CompactionManager#getCompactionDetails(BlobStore)} returns expected values i.e. {@code expectedCompactionDetails}
+   * @param expectedCompactionDetails expected {@link CompactionDetails}
+   * @throws StoreException
+   */
+  private void verifyCompactionDetails(CompactionDetails expectedCompactionDetails) throws StoreException {
+    CompactionDetails compactionDetails = compactionManager.getCompactionDetails(blobStore);
+    if (expectedCompactionDetails == null) {
+      assertNull("CompactionDetails expected to be null ", compactionDetails);
+    } else {
+      assertEquals("Returned invalid time ", expectedCompactionDetails.getReferenceTimeMs(),
+          compactionDetails.getReferenceTimeMs());
+      assertEquals("Compaction range mismatch ", expectedCompactionDetails.getLogSegmentsUnderCompaction(),
+          compactionDetails.getLogSegmentsUnderCompaction());
+    }
+  }
+
+  /**
+   * MockBlobStore to assist in testing {@link CompactionManager}
+   */
+  private class MockBlobStore extends BlobStore {
+    private long usedCapacity;
+    private long capacityInBytes;
+    List<String> validLogSegments = null;
+
+    MockBlobStore(StoreConfig config, StorageManagerMetrics metrics, Time time, long capacityInBytes, long usedCapacity) {
+      super("", config, null, null, metrics, null, 0, null, null, null, time);
+      this.capacityInBytes = capacityInBytes;
+      this.usedCapacity = usedCapacity;
+    }
+
+    @Override
+    public long getSizeInBytes() {
+      return usedCapacity;
+    }
+
+    /**
+     * Return total capacity of the {@link BlobStore} in bytes
+     * @return the total capacity of the {@link BlobStore} in bytes
+     */
+    @Override
+    long getCapacityInBytes() {
+      return capacityInBytes;
+    }
+
+    /**
+     * Fetches a list of valid {@link LogSegment} names that are considered valid for the purpose of compaction
+     * @return list of valid {@link LogSegment} names that are considered valid for the purpose of compaction
+     */
+    @Override
+    List<String> getLogSegmentsNotInJournal() throws StoreException {
+      return validLogSegments;
+    }
+
+  }
+}

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
@@ -21,7 +21,6 @@ import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.UtilsTest;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import org.junit.Test;
@@ -100,8 +99,8 @@ public class CompactionManagerTest {
         CAPACITY_IN_BYTES * 7 / 10, CAPACITY_IN_BYTES * 9 / 10};
     for (Long usedCapacity : usedCapacities) {
       blobStore.usedCapacity = usedCapacity;
-      if (blobStore.usedCapacity <= (
-          config.storeMinUsedCapacityToTriggerCompactionInPercentage * blobStore.capacityInBytes / 100)) {
+      if (blobStore.usedCapacity < (config.storeMinUsedCapacityToTriggerCompactionInPercentage / 100.0
+          * blobStore.capacityInBytes)) {
         verifyCompactionDetails(null);
       } else {
         verifyCompactionDetails(
@@ -127,8 +126,8 @@ public class CompactionManagerTest {
       blobStore = new MockBlobStore(config, metrics, time, CAPACITY_IN_BYTES, DEFAULT_USED_CAPACITY_IN_BYTES);
       compactionManager = new CompactionManager(config, time);
       blobStore.validLogSegments = generateRandomStrings(2);
-      if (blobStore.usedCapacity <= (
-          config.storeMinUsedCapacityToTriggerCompactionInPercentage * blobStore.capacityInBytes / 100)) {
+      if (blobStore.usedCapacity < (config.storeMinUsedCapacityToTriggerCompactionInPercentage / 100.0
+          * blobStore.capacityInBytes)) {
         verifyCompactionDetails(null);
       } else {
         verifyCompactionDetails(
@@ -156,20 +155,6 @@ public class CompactionManagerTest {
       verifyCompactionDetails(
           new CompactionDetails(time.milliseconds() - messageRetentionDays * Time.SecsPerDay * Time.MsPerSec,
               blobStore.validLogSegments));
-    }
-  }
-
-  /**
-   * Test {@link CompactionManager#getCompactionDetails(BlobStore)} for failure cases
-   * @throws StoreException
-   */
-  @Test
-  public void testConstructionFailureTest() throws StoreException {
-    blobStore.validLogSegments = Collections.EMPTY_LIST;
-    try {
-      compactionManager.getCompactionDetails(blobStore);
-      fail("Empty list for log segments to compact should have IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
     }
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -790,24 +790,10 @@ public class IndexTest {
   @Test
   public void getLogSegmentsNotInJournalTest() throws InterruptedException, IOException, StoreException {
     if (isLogSegmented) {
-      testGetLogSegmentsNotInJournal(2, 2 * MAX_IN_MEM_ELEMENTS, false);
-      testGetLogSegmentsNotInJournal(3, 2 * MAX_IN_MEM_ELEMENTS, false);
+      testGetLogSegmentsNotInJournal(2, 2 * MAX_IN_MEM_ELEMENTS);
+      testGetLogSegmentsNotInJournal(3, 2 * MAX_IN_MEM_ELEMENTS);
     } else {
       assertEquals("LogSegments mismatch for non segmented log ", null, state.index.getLogSegmentsNotInJournal());
-    }
-  }
-
-  /**
-   * Tests {@link PersistentIndex#getLogSegmentsNotInJournal()} with reloading of {@link PersistentIndex}
-   * @throws InterruptedException
-   * @throws StoreException
-   * @throws IOException
-   */
-  @Test
-  public void getLogSegmentsNotInJournalTestWithReload() throws InterruptedException, IOException, StoreException {
-    if (isLogSegmented) {
-      testGetLogSegmentsNotInJournal(2, 2 * MAX_IN_MEM_ELEMENTS, true);
-      testGetLogSegmentsNotInJournal(3, 2 * MAX_IN_MEM_ELEMENTS, true);
     }
   }
 
@@ -1295,14 +1281,12 @@ public class IndexTest {
    * Tests {@link PersistentIndex#getLogSegmentsNotInJournal()}
    * @param maxLogSegmentsToBeIgnored number of log segments not to be returned via {@link PersistentIndex#getLogSegmentsNotInJournal()}
    * @param maxEntriesInJournal max number of entries in {@link Journal}
-   * @param reloadIndex {@code true} if index needs to be reloaded and tested for {@link PersistentIndex#getLogSegmentsNotInJournal()}
-   *                    @@code false} otherwise
    * @throws InterruptedException
    * @throws StoreException
    * @throws IOException
    */
-  private void testGetLogSegmentsNotInJournal(int maxLogSegmentsToBeIgnored, int maxEntriesInJournal,
-      boolean reloadIndex) throws InterruptedException, StoreException, IOException {
+  private void testGetLogSegmentsNotInJournal(int maxLogSegmentsToBeIgnored, int maxEntriesInJournal)
+      throws InterruptedException, StoreException, IOException {
     // fill current log segment to its capacity
     fillLastLogSegmentToCapacity(1, false);
 
@@ -1326,11 +1310,9 @@ public class IndexTest {
     assertEquals("LogSegments mismatch ", getExpectedLogSegmentNames(maxLogSegmentsToBeIgnored),
         state.index.getLogSegmentsNotInJournal());
 
-    if (reloadIndex) {
-      state.reloadIndex(true, false);
-      // every log segment except the last one should be returned
-      assertEquals("LogSegments mismatch ", getExpectedLogSegmentNames(1), state.index.getLogSegmentsNotInJournal());
-    }
+    // reload and verify every log segment except the last one should be returned
+    state.reloadIndex(true, false);
+    assertEquals("LogSegments mismatch ", getExpectedLogSegmentNames(1), state.index.getLogSegmentsNotInJournal());
   }
 
   /**
@@ -1350,7 +1332,7 @@ public class IndexTest {
   }
 
   /**
-   * Fill the current log segment to it capacity
+   * Fill the current log segment to its capacity
    * @param numberOfEntries number of entries to be added to fill the log segment to its capacity
    * @param newLogSegment {@code true} if this is a new log segment. {@code false} otherwise
    * @throws InterruptedException
@@ -1364,7 +1346,7 @@ public class IndexTest {
       state.addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);
       numberOfEntries--;
     }
-    // 1 PUT entry that spans the rest of the data in the last segment
+    // add PUT entries that spans the rest of the data in the last segment
     long remainingSize = state.log.getSegmentCapacity() - state.index.getCurrentEndOffset().getOffset();
     long sizePerPutRecord = remainingSize / numberOfEntries;
     for (int i = 0; i < numberOfEntries; i++) {


### PR DESCRIPTION
CompactionManager assists in fetching the log segments that needs to be compacted for any given store. V0 implementation is added in this patch. 

V0 implemenatation returns all logSegments as a range as part of CompactionDetails. Those log segments which doesn't overlap with journal are considered to be valid.

More details are covered [here](https://github.com/linkedin/ambry/issues/570)

Reviewers: @vgkholla @cgtz 
SLA: 15 mins

Built and coding style applied 

Coverage:
Package       	    Class, %	     Method, %	      Line, %
By running IndexTest
PersistentIndex	    100% (8/ 8)	     94.9% (56/ 59)	  91% (575/ 632)
By running CompactionManagerTest
CompactionManager	100% (1/ 1)	     100% (2/ 2)	  100% (10/ 10)
