### PR TITLE
Fixing a couple of intermittent router tests

### DIFF
--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -368,6 +368,7 @@ public class DeleteManagerTest {
    */
   @Test
   public void testRouterClosedDuringOperation() throws Exception {
+    setServerResponse(false);
     testWithErrorCodes(Collections.singletonMap(ServerErrorCode.No_Error, 9), serverLayout,
         RouterErrorCode.RouterClosed, new ErrorCodeChecker() {
           @Override

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -319,8 +319,11 @@ public class NonBlockingRouterTest {
     mockSelectorState.set(MockSelectorState.ThrowThrowableOnSend);
     future = router.putBlob(putBlobProperties, putUserMetadata, putChannel);
 
-    // Now wait till the thread dies
-    TestUtils.getThreadByThisName("RequestResponseHandlerThread").join();
+    Thread requestResponseHandlerThread = TestUtils.getThreadByThisName("RequestResponseHandlerThread");
+    // If the thread is still running, wait until it dies
+    if (requestResponseHandlerThread != null) {
+      requestResponseHandlerThread.join();
+    }
 
     try {
       future.get();


### PR DESCRIPTION
In DeleteManagerTest.testRouterClosedDuringOperation(), I'm adding back
a line that ensured that the servers did not respond before the router
is closed. I mistakenly removed this when refactoring these test cases.

In NonBlockingRouterTest.testRequestResponseHandlerThreadExitFlow(), the
thread could die before we call getThreadByThisName(), which resulted in
a NPE.

*Testing:* Running router unit tests 50 times.
*Reviewer:* @pnarayanan 