### PR TITLE
Adding a thread to run compactions on stores

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -97,6 +97,20 @@ public class StoreConfig {
   public final long storeSegmentSizeInBytes;
 
   /**
+   * Whether compaction is to be enabled or not
+   */
+  @Config("store.enable.compaction")
+  @Default("false")
+  public final boolean storeEnableCompaction;
+
+  /**
+   * The frequency (in hours) at which a store is checked to see whether it is ready for compaction.
+   */
+  @Config("store.compaction.check.frequency.in.hours")
+  @Default("7*24")
+  public final int storeCompactionCheckFrequencyInHours;
+
+  /**
    * The minimum capacity that has to be used (as a percentage of the total capacity) for the store to trigger
    * compaction
    */
@@ -122,6 +136,9 @@ public class StoreConfig {
         verifiableProperties.getLongInRange("store.segment.size.in.bytes", Long.MAX_VALUE, 1, Long.MAX_VALUE);
     storeMinUsedCapacityToTriggerCompactionInPercentage =
         verifiableProperties.getInt("store.min.used.capacity.to.trigger.compaction.in.percentage", 50);
+    storeEnableCompaction = verifiableProperties.getBoolean("store.enable.compaction", false);
+    storeCompactionCheckFrequencyInHours =
+        verifiableProperties.getIntInRange("store.compaction.check.frequency.in.hours", 7 * 24, 1, Integer.MAX_VALUE);
   }
 }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -38,6 +38,7 @@ class BlobStore implements Store {
   static final String SEPARATOR = "_";
   private final static String LockFile = ".lock";
 
+  private final String storeId;
   private final String dataDir;
   private final ScheduledExecutorService taskScheduler;
   private final DiskIOScheduler diskIOScheduler;
@@ -76,6 +77,7 @@ class BlobStore implements Store {
       StorageManagerMetrics storageManagerMetrics, String dataDir, long capacityInBytes, StoreKeyFactory factory,
       MessageStoreRecovery recovery, MessageStoreHardDelete hardDelete, Time time) {
     this.metrics = storageManagerMetrics.createStoreMetrics(storeId);
+    this.storeId = storeId;
     this.dataDir = dataDir;
     this.taskScheduler = taskScheduler;
     this.diskIOScheduler = diskIOScheduler;
@@ -407,9 +409,38 @@ class BlobStore implements Store {
     return started;
   }
 
+  /**
+   * Compacts the store data based on {@code details}.
+   * @param details the {@link CompactionDetails} describing what needs to be compacted.
+   * @throws IllegalArgumentException if any of the provided segments doesn't exist in the log or if one or more offsets
+   * in the segments to compact are in the journal.
+   * @throws IOException if there is any error creating the {@link CompactionLog}.
+   * @throws StoreException if there are any errors during the compaction.
+   */
+  void compact(CompactionDetails details) throws IOException, StoreException {
+    checkStarted();
+    // TODO: compactor.compact(details);
+  }
+
+  /**
+   * Resumes a compaction if one is in progress.
+   * @throws StoreException if there are any errors during the compaction.
+   */
+  void maybeResumeCompaction() throws StoreException {
+    checkStarted();
+    if (CompactionLog.isCompactionInProgress(dataDir, storeId)) {
+      // TODO: compactor.resumeCompaction();
+    }
+  }
+
   private void checkStarted() throws StoreException {
     if (!started) {
       throw new StoreException("Store not started", StoreErrorCodes.Store_Not_Started);
     }
+  }
+
+  @Override
+  public String toString() {
+    return "StoreId: " + storeId + ". DataDir: " + dataDir + ". Capacity: " + capacityInBytes;
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -419,7 +419,9 @@ class BlobStore implements Store {
    */
   void compact(CompactionDetails details) throws IOException, StoreException {
     checkStarted();
+    logger.info("Compaction of {} started", this);
     // TODO: compactor.compact(details);
+    logger.info("Compaction of {} finished", this);
   }
 
   /**
@@ -429,7 +431,9 @@ class BlobStore implements Store {
   void maybeResumeCompaction() throws StoreException {
     checkStarted();
     if (CompactionLog.isCompactionInProgress(dataDir, storeId)) {
+      logger.info("Resuming compaction of {}", this);
       // TODO: compactor.resumeCompaction();
+      logger.info("Compaction of {} finished", this);
     }
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -15,7 +15,16 @@ package com.github.ambry.store;
 
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -23,14 +32,63 @@ import java.util.List;
  * ignoring those overlapping with {@link Journal} as part of CompactionDetails.
  */
 class CompactionManager {
+  private final String mountPath;
   private final StoreConfig storeConfig;
   private final Time time;
   private final long messageRetentionTimeInMs;
+  private final Collection<BlobStore> stores;
+  private final CompactionExecutor compactionExecutor;
+  private final Logger logger = LoggerFactory.getLogger(getClass());
 
-  CompactionManager(StoreConfig storeConfig, Time time) {
+  private Thread compactionThread;
+
+  /**
+   * Creates a CompactionManager that handles scheduling and executing compaction.
+   * @param mountPath the mount path of all the stores for which compaction may be executed.
+   * @param storeConfig the {@link StoreConfig} that contains configurationd details.
+   * @param stores the {@link Collection} of {@link BlobStore} that compaction needs to be executed for.
+   * @param time the {@link Time} instance to use.
+   */
+  CompactionManager(String mountPath, StoreConfig storeConfig, Collection<BlobStore> stores, Time time) {
+    this.mountPath = mountPath;
     this.storeConfig = storeConfig;
+    this.stores = stores;
     this.time = time;
     this.messageRetentionTimeInMs = storeConfig.storeDeletedMessageRetentionDays * Time.SecsPerDay * Time.MsPerSec;
+    compactionExecutor = storeConfig.storeEnableCompaction ? new CompactionExecutor() : null;
+  }
+
+  /**
+   * Enables the compaction manager allowing it execute compactions if required.
+   */
+  void enable() {
+    if (compactionExecutor != null) {
+      logger.info("Compaction thread started for {}", mountPath);
+      compactionThread = Utils.newThread("CompactionThread-" + mountPath, compactionExecutor, true);
+      compactionThread.start();
+    }
+  }
+
+  /**
+   * Disables the compaction manager which disallows any new compactions.
+   */
+  void disable() {
+    if (compactionExecutor != null) {
+      compactionExecutor.disable();
+    }
+  }
+
+  /**
+   * Awaits the termination of all pending jobs of the compaction manager.
+   */
+  void awaitTermination() {
+    if (compactionExecutor != null) {
+      try {
+        compactionThread.join(2000);
+      } catch (InterruptedException e) {
+        logger.error("Compaction thread join wait was interrupted");
+      }
+    }
   }
 
   /**
@@ -51,5 +109,81 @@ class CompactionManager {
       }
     }
     return details;
+  }
+
+  /**
+   * A {@link Runnable} that cycles through the stores and executes compaction if required.
+   */
+  private class CompactionExecutor implements Runnable {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final AtomicBoolean enabled = new AtomicBoolean(true);
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition waitCondition = lock.newCondition();
+    private final Set<BlobStore> storesToSkip = new HashSet<>();
+    private final long waitTimeMs =
+        storeConfig.storeCompactionCheckFrequencyInHours * Time.MinsPerHour * Time.SecsPerMin * Time.MsPerSec;
+
+    /**
+     * Starts by resuming any compactions that were left halfway. In steady state, it cycles through the stores at a
+     * configurable frequency and runs compaction as required.
+     */
+    @Override
+    public void run() {
+      // complete any compactions in progress
+      for (BlobStore store : stores) {
+        if (store.isStarted()) {
+          try {
+            store.maybeResumeCompaction();
+          } catch (Exception e) {
+            logger.error("Compaction of store {} failed on resume. Continuing with the next store", store, e);
+            storesToSkip.add(store);
+          }
+        }
+      }
+      // continue to do compactions as required.
+      while (enabled.get()) {
+        try {
+          long startTimeMs = time.milliseconds();
+          for (BlobStore store : stores) {
+            try {
+              if (!enabled.get()) {
+                break;
+              }
+              if (store.isStarted() && !storesToSkip.contains(store)) {
+                CompactionDetails details = getCompactionDetails(store);
+                if (details != null) {
+                  store.compact(details);
+                }
+              }
+            } catch (Exception e) {
+              logger.error("Compaction of store {} failed. Continuing with the next store", store, e);
+              storesToSkip.add(store);
+            }
+          }
+          long timeElapsed = time.milliseconds() - startTimeMs;
+          lock.lock();
+          try {
+            time.await(waitCondition, waitTimeMs - timeElapsed);
+          } finally {
+            lock.unlock();
+          }
+        } catch (Exception e) {
+          logger.error("Compaction execution encountered an error either during wait. Continuing", e);
+        }
+      }
+    }
+
+    /**
+     * Disables the executor by disallowing scheduling of any new compaction jobs.
+     */
+    void disable() {
+      enabled.set(false);
+      lock.lock();
+      try {
+        waitCondition.signal();
+      } finally {
+        lock.unlock();
+      }
+    }
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -118,8 +118,7 @@ class CompactionManager {
     private final ReentrantLock lock = new ReentrantLock();
     private final Condition waitCondition = lock.newCondition();
     private final Set<BlobStore> storesToSkip = new HashSet<>();
-    private final long waitTimeMs =
-        storeConfig.storeCompactionCheckFrequencyInHours * Time.MinsPerHour * Time.SecsPerMin * Time.MsPerSec;
+    private final long waitTimeMs = storeConfig.storeCompactionCheckFrequencyInHours * Time.SecsPerHour * Time.MsPerSec;
 
     private volatile boolean enabled = true;
 

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -160,12 +160,14 @@ class CompactionManager {
               storesToSkip.add(store);
             }
           }
-          long timeElapsed = time.milliseconds() - startTimeMs;
-          lock.lock();
-          try {
-            time.await(waitCondition, waitTimeMs - timeElapsed);
-          } finally {
-            lock.unlock();
+          if (enabled.get()) {
+            long timeElapsed = time.milliseconds() - startTimeMs;
+            lock.lock();
+            try {
+              time.await(waitCondition, waitTimeMs - timeElapsed);
+            } finally {
+              lock.unlock();
+            }
           }
         } catch (Exception e) {
           logger.error("Compaction execution encountered an error either during wait. Continuing", e);

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -921,7 +921,7 @@ class PersistentIndex {
     LogSegment logSegment = log.getFirstSegment();
     Offset firstOffsetInJournal = journal.getFirstOffset();
     List<String> logSegmentNamesToReturn = new ArrayList<>();
-    while (logSegment != null) {
+    while (firstOffsetInJournal != null && logSegment != null) {
       if (!logSegment.getName().equals(firstOffsetInJournal.getName())) {
         logSegmentNamesToReturn.add(logSegment.getName());
       } else {

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -795,6 +795,10 @@ public class IndexTest {
     } else {
       assertEquals("LogSegments mismatch for non segmented log ", null, state.index.getLogSegmentsNotInJournal());
     }
+    state.closeAndClearIndex();
+    state.reloadIndex(false, false);
+    assertNull("There should be no offsets in the journal", state.index.journal.getFirstOffset());
+    assertNull("There should be no log segments returned", state.index.getLogSegmentsNotInJournal());
   }
 
   /**


### PR DESCRIPTION
Adding a thread in `CompactionManger` that runs compactions serially for all the stores inside a single instance of a `DiskManager`. The compactions are run at a configurable frequency

Reviewers: @nsivabalan 

Built on OSx and Linux and formatted.

**Unit testing**

| Class | Class, % | Method, % | Line, % | Test class |
| --- | --- | --- | --- | --- |
| `CompactionManager` | 100% (2/ 2) | 100% (9/ 9) | 94% (63/ 67) | `CompactionManagerTest` |
