### PR TITLE
Replaced Partition with MockPartitionId in StatsManagerTest

### DIFF
--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
@@ -27,8 +27,12 @@ public class MockPartitionId extends PartitionId {
   public List<ReplicaId> replicaIds;
 
   public MockPartitionId() {
-    partition = 0L;
-    replicaIds = new ArrayList<ReplicaId>(0);
+    this(0L);
+  }
+
+  public MockPartitionId(long partition) {
+    this.partition = partition;
+    replicaIds = new ArrayList<>(0);
   }
 
   public MockPartitionId(long partition, List<MockDataNodeId> dataNodes, int mountPathIndexToUse) {

--- a/ambry-store/src/test/java/com.github.ambry.store/StatsManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StatsManagerTest.java
@@ -15,9 +15,8 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.clustermap.Partition;
+import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
-import com.github.ambry.clustermap.PartitionState;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.StatsManagerConfig;
 import com.github.ambry.config.StoreConfig;
@@ -77,10 +76,10 @@ public class StatsManagerTest {
     Pair<StatsSnapshot, StatsSnapshot> baseSliceAndNewSlice = new Pair<>(preAggregatedSnapshot, null);
     for (int i = 0; i < 2; i++) {
       baseSliceAndNewSlice = decomposeSnapshot(baseSliceAndNewSlice.getFirst());
-      storeMap.put(new Partition(i, PartitionState.READ_WRITE, CAPACITY),
+      storeMap.put(new MockPartitionId(i),
           new MockBlobStore(new MockBlobStoreStats(baseSliceAndNewSlice.getSecond(), false)));
     }
-    storeMap.put(new Partition(2, PartitionState.READ_WRITE, CAPACITY),
+    storeMap.put(new MockPartitionId(2),
         new MockBlobStore(new MockBlobStoreStats(baseSliceAndNewSlice.getFirst(), false)));
     StorageManager storageManager = new MockStorageManager(storeMap);
     Properties properties = new Properties();
@@ -126,9 +125,9 @@ public class StatsManagerTest {
   @Test
   public void testStatsManagerWithProblematicStores() throws StoreException, IOException {
     Map<PartitionId, Store> problematicStoreMap = new HashMap<>();
-    problematicStoreMap.put(new Partition(1, PartitionState.READ_WRITE, CAPACITY), null);
+    problematicStoreMap.put(new MockPartitionId(1), null);
     Store exceptionStore = new MockBlobStore(new MockBlobStoreStats(null, true));
-    problematicStoreMap.put(new Partition(2, PartitionState.READ_WRITE, CAPACITY), exceptionStore);
+    problematicStoreMap.put(new MockPartitionId(2), exceptionStore);
     StatsManager testStatsManager =
         new StatsManager(new MockStorageManager(problematicStoreMap), new ArrayList<>(problematicStoreMap.keySet()),
             new MetricRegistry(), config, new MockTime());
@@ -142,8 +141,8 @@ public class StatsManagerTest {
     // test for the scenario where some stores are healthy and some are bad
     Map<PartitionId, Store> mixedStoreMap = new HashMap<>(storeMap);
     unreachableStores.clear();
-    mixedStoreMap.put(new Partition(3, PartitionState.READ_WRITE, CAPACITY), null);
-    mixedStoreMap.put(new Partition(4, PartitionState.READ_WRITE, CAPACITY), exceptionStore);
+    mixedStoreMap.put(new MockPartitionId(3), null);
+    mixedStoreMap.put(new MockPartitionId(4), exceptionStore);
     testStatsManager = new StatsManager(new MockStorageManager(mixedStoreMap), new ArrayList<>(mixedStoreMap.keySet()),
         new MetricRegistry(), config, new MockTime());
     actualSnapshot = new StatsSnapshot(0L, null);


### PR DESCRIPTION
This PR is a minor fix for #574. The fix is to use MockPartitionId instead of Partition in StatsManagerTest. The reason is that Partition will no longer be public in the future and StatsManager does not require any specific implementation of PartitionId to verify its behavior.

`./gradlew build && ./gradlew test` success.

Reviewers: @pnarayanan 