### PR TITLE
Fixing two bugs with revalidation

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -501,7 +501,7 @@ public class HardDeleter implements Runnable {
            crc
            ---
          */
-    if (endToken == null || ((StoreFindToken) endToken).getType().equals(StoreFindToken.Type.Uninitialized)) {
+    if (endToken == null) {
       return;
     }
     final Timer.Context context = metrics.cleanupTokenFlushTime.time();

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -1340,7 +1340,7 @@ class PersistentIndex {
    * Re-validates the {@code token} to ensure that it is consistent with the given view of {@code indexSegments}. If it
    * is not, a {@link StoreFindToken.Type#Uninitialized} token is returned.
    * @param token the {@link StoreFindToken} to revalidate.
-   * @param indexSegments the view of the index segment to revalidate against.
+   * @param indexSegments the view of the index segments to revalidate against.
    * @return {@code token} if is consistent with {@code indexSegments}, a new {@link StoreFindToken.Type#Uninitialized}
    * token otherwise.
    */
@@ -1354,15 +1354,15 @@ class PersistentIndex {
         break;
       case JournalBased:
         Offset floorOffset = indexSegments.floorKey(offset);
-        if (!floorOffset.getName().equals(offset.getName())) {
+        if (floorOffset == null || !floorOffset.getName().equals(offset.getName())) {
           revalidatedToken = new StoreFindToken();
-          logger.info("Reset token {} because it is invalid for the index segment map", token);
+          logger.info("Revalidated token {} because it is invalid for the index segment map", token);
         }
         break;
       case IndexBased:
         if (!indexSegments.containsKey(offset)) {
           revalidatedToken = new StoreFindToken();
-          logger.info("Reset token {} because it is invalid for the index segment map", token);
+          logger.info("Revalidated token {} because it is invalid for the index segment map", token);
         }
         break;
       default:

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -825,7 +825,7 @@ public class IndexTest {
       long offsetBeforeStart = firstIndexSegmentStartOffset.getOffset() - 1;
 
       Offset[] invalidOffsets =
-          {new Offset(newName, newOffset + 1), new Offset(firstIndexSegmentStartOffset.getName(), offsetBeforeStart)};
+          {new Offset(newName, newOffset), new Offset(firstIndexSegmentStartOffset.getName(), offsetBeforeStart)};
       MockId firstIdInFirstIndexSegment = state.referenceIndex.firstEntry().getValue().firstKey();
 
       for (Offset invalidOffset : invalidOffsets) {

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -814,21 +814,30 @@ public class IndexTest {
           new StoreFindToken(state.logOrder.lastKey(), state.sessionId, state.incarnationId, false);
       absoluteEndToken.setBytesRead(state.index.getLogUsedCapacity());
 
-      // generate an offset that does not exist.
       Offset firstIndexSegmentStartOffset = state.referenceIndex.firstKey();
-      MockId firstIdInFirstIndexSegment = state.referenceIndex.firstEntry().getValue().firstKey();
+      assertTrue("The first index segment must have an offset > 0", firstIndexSegmentStartOffset.getOffset() > 0);
+
+      // generate an offset that does not exist.
       String newName = LogSegmentNameHelper.getNextGenerationName(firstIndexSegmentStartOffset.getName());
       long newOffset = firstIndexSegmentStartOffset.getOffset() + 1;
-      Offset invalidOffset = new Offset(newName, newOffset + 1);
 
-      // Generate an index based token from invalidOffset
-      StoreFindToken startToken =
-          new StoreFindToken(firstIdInFirstIndexSegment, invalidOffset, state.sessionId, state.incarnationId);
-      doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), absoluteEndToken);
+      // Generate an offset that is below the index start offset
+      long offsetBeforeStart = firstIndexSegmentStartOffset.getOffset() - 1;
 
-      // Generate a journal based token from invalidOffset (not in journal and is invalid)
-      startToken = new StoreFindToken(invalidOffset, state.sessionId, state.incarnationId, false);
-      doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), absoluteEndToken);
+      Offset[] invalidOffsets =
+          {new Offset(newName, newOffset + 1), new Offset(firstIndexSegmentStartOffset.getName(), offsetBeforeStart)};
+      MockId firstIdInFirstIndexSegment = state.referenceIndex.firstEntry().getValue().firstKey();
+
+      for (Offset invalidOffset : invalidOffsets) {
+        // Generate an index based token from invalidOffset
+        StoreFindToken startToken =
+            new StoreFindToken(firstIdInFirstIndexSegment, invalidOffset, state.sessionId, state.incarnationId);
+        doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), absoluteEndToken);
+
+        // Generate a journal based token from invalidOffset (not in journal and is invalid)
+        startToken = new StoreFindToken(invalidOffset, state.sessionId, state.incarnationId, false);
+        doFindEntriesSinceTest(startToken, Long.MAX_VALUE, state.allKeys.keySet(), absoluteEndToken);
+      }
     }
   }
 


### PR DESCRIPTION
1. floorOffset can be null when examining validity
2. Making hard delete persist cleanup tokens even if the endToken is uninitialized