### PR TITLE
Removing auto-persistence for compactor created index

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -125,8 +125,8 @@ class BlobStore implements Store {
         StoreDescriptor storeDescriptor = new StoreDescriptor(dataDir);
         log = new Log(dataDir, capacityInBytes, config.storeSegmentSizeInBytes, metrics);
         compactor =
-            new BlobStoreCompactor(dataDir, storeId, factory, config, metrics, diskIOScheduler, log, taskScheduler,
-                recovery, time, sessionId, storeDescriptor.getIncarnationId());
+            new BlobStoreCompactor(dataDir, storeId, factory, config, metrics, diskIOScheduler, log, recovery, time,
+                sessionId, storeDescriptor.getIncarnationId());
         index = new PersistentIndex(dataDir, taskScheduler, log, config, factory, recovery, hardDelete, metrics, time,
             sessionId, storeDescriptor.getIncarnationId());
         compactor.initialize(index);

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
@@ -718,8 +718,8 @@ public class BlobStoreCompactorTest {
     closeOrExceptionInduced = false;
     StoreConfig config = new StoreConfig(new VerifiableProperties(state.properties));
     return new BlobStoreCompactor(tempDirStr, STORE_ID, CuratedLogIndexState.STORE_KEY_FACTORY, config,
-        new StoreMetrics(STORE_ID, new MetricRegistry()), ioScheduler, log, state.scheduler, state.recovery, state.time,
-        state.sessionId, state.incarnationId);
+        new StoreMetrics(STORE_ID, new MetricRegistry()), ioScheduler, log, state.recovery, state.time, state.sessionId,
+        state.incarnationId);
   }
 
   /**


### PR DESCRIPTION
The auto persistence is not required for compactor indices since we persist synchronously. Moreover, the auto persistence jobs cannot be cancelled when an index is closed and keep throwing errors.