### PR TITLE
Increase netty version to 4.1.6

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -17,6 +17,6 @@ ext {
     commonsVersion = "1.5"
     bouncycastleVersion = "1.52"
     javaxVersion = "3.0.1"
-    nettyVersion = "4.1.4.Final"
+    nettyVersion = "4.1.6.Final"
     helixVersion = "0.6.7"
 }


### PR DESCRIPTION
This is to bring in Netty's fix to the ipv6 issue. Netty has some issue with ipv6 (its dnsnameresolver could not parse if the underlying jvm only prefers ipv4). The issue got fixed in 4.1.5.

Link to more details of the issue
https://github.com/eclipse/vert.x/issues/1570

built and tested successfully in both mac and linux