### PR TITLE
Adding a trigger compaction request at the server

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.config;
 
+import com.github.ambry.utils.Time;
+
+
 /**
  * The configs for the store
  */
@@ -155,12 +158,12 @@ public class StoreConfig {
         verifiableProperties.getInt("store.min.used.capacity.to.trigger.compaction.in.percentage", 50);
     storeEnableCompaction = verifiableProperties.getBoolean("store.enable.compaction", false);
     storeCompactionCheckFrequencyInHours =
-        verifiableProperties.getIntInRange("store.compaction.check.frequency.in.hours", 7 * 24, 1, Integer.MAX_VALUE);
+        verifiableProperties.getIntInRange("store.compaction.check.frequency.in.hours", 7 * 24, 1,
+            Integer.MAX_VALUE / (Time.SecsPerHour * Time.MsPerSec));
     storeCompactionPolicyFactory = verifiableProperties.getString("store.compaction.policy.factory",
         "com.github.ambry.store.DefaultCompactionPolicyFactory");
     storeMinLogSegmentCountToReclaimToTriggerCompaction =
         verifiableProperties.getIntInRange("store.min.log.segment.count.to.reclaim.to.trigger.compaction", 1, 1, 1000);
-
   }
 }
 

--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -155,7 +155,7 @@ public class StoreConfig {
         verifiableProperties.getInt("store.min.used.capacity.to.trigger.compaction.in.percentage", 50);
     storeEnableCompaction = verifiableProperties.getBoolean("store.enable.compaction", false);
     storeCompactionCheckFrequencyInHours =
-        verifiableProperties.getIntInRange("store.compaction.check.frequency.in.hours", 7 * 24, 1, 8760);
+        verifiableProperties.getIntInRange("store.compaction.check.frequency.in.hours", 7 * 24, 1, 365 * 24);
     storeCompactionPolicyFactory = verifiableProperties.getString("store.compaction.policy.factory",
         "com.github.ambry.store.DefaultCompactionPolicyFactory");
     storeMinLogSegmentCountToReclaimToTriggerCompaction =

--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -13,9 +13,6 @@
  */
 package com.github.ambry.config;
 
-import com.github.ambry.utils.Time;
-
-
 /**
  * The configs for the store
  */
@@ -158,8 +155,7 @@ public class StoreConfig {
         verifiableProperties.getInt("store.min.used.capacity.to.trigger.compaction.in.percentage", 50);
     storeEnableCompaction = verifiableProperties.getBoolean("store.enable.compaction", false);
     storeCompactionCheckFrequencyInHours =
-        verifiableProperties.getIntInRange("store.compaction.check.frequency.in.hours", 7 * 24, 1,
-            Integer.MAX_VALUE / (Time.SecsPerHour * Time.MsPerSec));
+        verifiableProperties.getIntInRange("store.compaction.check.frequency.in.hours", 7 * 24, 1, 8760);
     storeCompactionPolicyFactory = verifiableProperties.getString("store.compaction.policy.factory",
         "com.github.ambry.store.DefaultCompactionPolicyFactory");
     storeMinLogSegmentCountToReclaimToTriggerCompaction =

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequest.java
@@ -44,6 +44,9 @@ public class AdminRequest extends RequestOrResponse {
    */
   public static AdminRequest readFrom(DataInputStream stream, ClusterMap clusterMap) throws IOException {
     Short versionId = stream.readShort();
+    if (!versionId.equals(ADMIN_REQUEST_VERSION_V1)) {
+      throw new IllegalStateException("Unrecognized version for AdminRequest: " + ADMIN_REQUEST_VERSION_V1);
+    }
     int correlationId = stream.readInt();
     String clientId = Utils.readIntString(stream);
     AdminRequestOrResponseType type = AdminRequestOrResponseType.values()[stream.readShort()];
@@ -56,7 +59,6 @@ public class AdminRequest extends RequestOrResponse {
       default:
         throw new IllegalArgumentException("Unrecognized admin request type: " + type);
     }
-    // ignore version for now
     return request;
   }
 
@@ -71,7 +73,7 @@ public class AdminRequest extends RequestOrResponse {
     super(RequestOrResponseType.AdminRequest, ADMIN_REQUEST_VERSION_V1, correlationId, clientId);
     this.type = type;
     this.partitionId = partitionId;
-    sizeInBytes = computeSizeInBytes();
+    sizeInBytes = computeAndGetSizeInBytes();
   }
 
   @Override
@@ -120,7 +122,7 @@ public class AdminRequest extends RequestOrResponse {
   /**
    * @return the size in bytes of the serialized version of the request
    */
-  private long computeSizeInBytes() {
+  private long computeAndGetSizeInBytes() {
     long size = super.sizeInBytes() + REQUEST_TYPE_SIZE;
     switch (type) {
       case TriggerCompaction:

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+
+/**
+ * Representation of an administration request. Types of requests are represented by {@link AdminRequestOrResponseType}.
+ */
+public class AdminRequest extends RequestOrResponse {
+  private static final int REQUEST_TYPE_SIZE = 2;
+  private static final short ADMIN_REQUEST_VERSION_V1 = 1;
+
+  private final AdminRequestOrResponseType type;
+  private final PartitionId partitionId;
+  private final long sizeInBytes;
+
+  private int sizeSent = 0;
+
+  /**
+   * Reads from a stream and constructs an {@link AdminRequest}.
+   * @param stream the {@link DataInputStream} to read from.
+   * @param clusterMap the {@link ClusterMap} in use.
+   * @return {@link AdminRequest} that is deserialized from the {@code stream}.
+   * @throws IOException if there is an I/O error reading from {@code stream}
+   */
+  public static AdminRequest readFrom(DataInputStream stream, ClusterMap clusterMap) throws IOException {
+    Short versionId = stream.readShort();
+    int correlationId = stream.readInt();
+    String clientId = Utils.readIntString(stream);
+    AdminRequestOrResponseType type = AdminRequestOrResponseType.values()[stream.readShort()];
+    AdminRequest request;
+    switch (type) {
+      case TriggerCompaction:
+        PartitionId id = clusterMap.getPartitionIdFromStream(stream);
+        request = new AdminRequest(type, id, correlationId, clientId);
+        break;
+      default:
+        throw new IllegalArgumentException("Unrecognized admin request type: " + type);
+    }
+    // ignore version for now
+    return request;
+  }
+
+  /**
+   * Constructs an admin request with the given parameters.
+   * @param type the type of the request.
+   * @param partitionId the {@link PartitionId} that the operation should work on. {@link null} if not applicable.
+   * @param correlationId an ID to help match responses to requests.
+   * @param clientId the ID of the client.
+   */
+  public AdminRequest(AdminRequestOrResponseType type, PartitionId partitionId, int correlationId, String clientId) {
+    super(RequestOrResponseType.AdminRequest, ADMIN_REQUEST_VERSION_V1, correlationId, clientId);
+    this.type = type;
+    this.partitionId = partitionId;
+    sizeInBytes = computeSizeInBytes();
+  }
+
+  @Override
+  public long writeTo(WritableByteChannel channel) throws IOException {
+    long written = 0;
+    if (bufferToSend == null) {
+      serializeIntoBuffer();
+    }
+    if (bufferToSend.remaining() > 0) {
+      written = channel.write(bufferToSend);
+      sizeSent += written;
+    }
+    return written;
+  }
+
+  @Override
+  public boolean isSendComplete() {
+    return sizeSent == sizeInBytes();
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return sizeInBytes;
+  }
+
+  /**
+   * @return the type of the request
+   */
+  public AdminRequestOrResponseType getType() {
+    return type;
+  }
+
+  /**
+   * @return the {@link PartitionId} that the operation will work on. {@link null} if not applicable.
+   */
+  public PartitionId getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public String toString() {
+    return "AdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId + ", Type=" + type
+        + ", PartitionId=" + partitionId + "]";
+  }
+
+  /**
+   * @return the size in bytes of the serialized version of the request
+   */
+  private long computeSizeInBytes() {
+    long size = super.sizeInBytes() + REQUEST_TYPE_SIZE;
+    switch (type) {
+      case TriggerCompaction:
+        size += partitionId.getBytes().length;
+        break;
+      default:
+        throw new IllegalArgumentException("Unrecognized admin request type: " + type);
+    }
+    return size;
+  }
+
+  /**
+   * Serializes the request into bytes and loads into the buffer for sending.
+   */
+  private void serializeIntoBuffer() {
+    bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
+    writeHeader();
+    bufferToSend.putShort((short) type.ordinal());
+    switch (type) {
+      case TriggerCompaction:
+        bufferToSend.put(partitionId.getBytes());
+        break;
+    }
+    bufferToSend.flip();
+  }
+}

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2016 LinkedIn Corp. All rights reserved.
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,8 @@
 package com.github.ambry.protocol;
 
 /**
- * Type of request response. Do not change this order. Add
- * new entries to the end of the list.
+ * Enum of types of administration requests/responses.
  */
-public enum RequestOrResponseType {
-  PutRequest, PutResponse, GetRequest, GetResponse, DeleteRequest, DeleteResponse, TTLRequest, // Unsupported
-  TTLResponse, // Unsupported
-  ReplicaMetadataRequest, ReplicaMetadataResponse, AdminRequest, AdminResponse
+public enum AdminRequestOrResponseType {
+  TriggerCompaction
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.commons.ServerErrorCode;
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+/**
+ * Representation of a response to an administration request.
+ */
+public class AdminResponse extends Response {
+  private static final short ADMIN_RESPONSE_VERSION_V1 = 1;
+
+  /**
+   * Constructs a response.
+   * @param correlationId an ID to help match responses to requests.
+   * @param clientId the ID of the client.
+   * @param error the {@link ServerErrorCode} for the request.
+   */
+  public AdminResponse(int correlationId, String clientId, ServerErrorCode error) {
+    super(RequestOrResponseType.AdminResponse, ADMIN_RESPONSE_VERSION_V1, correlationId, clientId, error);
+  }
+
+  /**
+   * Reads from a stream and constructs an {@link AdminResponse}.
+   * @param stream  the {@link DataInputStream} to read from.
+   * @return {@link AdminResponse} that is deserialized from the {@code stream}.
+   * @throws IOException if there is an I/O error reading from {@code stream}
+   */
+  public static AdminResponse readFrom(DataInputStream stream) throws IOException {
+    RequestOrResponseType type = RequestOrResponseType.values()[stream.readShort()];
+    if (type != RequestOrResponseType.AdminResponse) {
+      throw new IllegalArgumentException("The type of request response is not compatible (is " + type + ")");
+    }
+    Short versionId = stream.readShort();
+    int correlationId = stream.readInt();
+    String clientId = Utils.readIntString(stream);
+    ServerErrorCode error = ServerErrorCode.values()[stream.readShort()];
+    // ignore version for now
+    return new AdminResponse(correlationId, clientId, error);
+  }
+
+  @Override
+  public String toString() {
+    return "AdminResponse[ClientId=" + clientId + ", CorrelationId=" + correlationId + ", Type=" + type
+        + ", ServerError=" + getError() + "]";
+  }
+}

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminResponse.java
@@ -47,6 +47,9 @@ public class AdminResponse extends Response {
       throw new IllegalArgumentException("The type of request response is not compatible (is " + type + ")");
     }
     Short versionId = stream.readShort();
+    if (!versionId.equals(ADMIN_RESPONSE_VERSION_V1)) {
+      throw new IllegalStateException("Unrecognized version for AdminResponse: " + ADMIN_RESPONSE_VERSION_V1);
+    }
     int correlationId = stream.readInt();
     String clientId = Utils.readIntString(stream);
     ServerErrorCode error = ServerErrorCode.values()[stream.readShort()];

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -388,13 +388,15 @@ public class RequestResponseTest {
         adminRequest.writeTo(writableByteChannel);
       } while (!adminRequest.isSendComplete());
       DataInputStream requestStream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
-      requestStream.readLong(); // read length
-      requestStream.readShort(); // read short
-      AdminRequest deserializedDeleteRequest = AdminRequest.readFrom(requestStream, clusterMap);
-      Assert.assertEquals(deserializedDeleteRequest.getCorrelationId(), 1234);
-      Assert.assertEquals(deserializedDeleteRequest.getClientId(), "client");
-      Assert.assertEquals(deserializedDeleteRequest.getType(), type);
-      Assert.assertTrue(deserializedDeleteRequest.getPartitionId().isEqual(id.toString()));
+      // read length
+      requestStream.readLong();
+      // read version
+      requestStream.readShort();
+      AdminRequest deserializedAdminRequest = AdminRequest.readFrom(requestStream, clusterMap);
+      Assert.assertEquals(deserializedAdminRequest.getCorrelationId(), 1234);
+      Assert.assertEquals(deserializedAdminRequest.getClientId(), "client");
+      Assert.assertEquals(deserializedAdminRequest.getType(), type);
+      Assert.assertTrue(deserializedAdminRequest.getPartitionId().isEqual(id.toString()));
       AdminResponse response = new AdminResponse(1234, "client", ServerErrorCode.No_Error);
       outputStream.reset();
       do {
@@ -402,9 +404,9 @@ public class RequestResponseTest {
       } while (!response.isSendComplete());
       requestStream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
       requestStream.readLong(); // read size
-      AdminResponse deserializedDeleteResponse = AdminResponse.readFrom(requestStream);
-      Assert.assertEquals(deserializedDeleteResponse.getCorrelationId(), 1234);
-      Assert.assertEquals(deserializedDeleteResponse.getError(), ServerErrorCode.No_Error);
+      AdminResponse deserializedAdminResponse = AdminResponse.readFrom(requestStream);
+      Assert.assertEquals(deserializedAdminResponse.getCorrelationId(), 1234);
+      Assert.assertEquals(deserializedAdminResponse.getError(), ServerErrorCode.No_Error);
     }
   }
 }

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -271,15 +271,15 @@ public class ServerMetrics {
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "ReplicaMetadataTotalTime"));
 
     triggerCompactionRequestQueueTimeInMs =
-        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestQueueTimeMs"));
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestQueueTimeInMs"));
     triggerCompactionRequestProcessingTimeInMs =
-        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestProcessingTimeMs"));
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestProcessingTimeInMs"));
     triggerCompactionResponseQueueTimeInMs =
-        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionResponseQueueTimeMs"));
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionResponseQueueTimeInMs"));
     triggerCompactionResponseSendTimeInMs =
-        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionResponseSendTimeMs"));
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionResponseSendTimeInMs"));
     triggerCompactionRequestTotalTimeInMs =
-        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestTotalTimeMs"));
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestTotalTimeInMs"));
 
     blobSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobSize"));
     blobUserMetadataSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobUserMetadataSize"));

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -106,6 +106,12 @@ public class ServerMetrics {
   public final Histogram replicaMetadataSendTimeInMs;
   public final Histogram replicaMetadataTotalTimeInMs;
 
+  public final Histogram triggerCompactionRequestQueueTimeInMs;
+  public final Histogram triggerCompactionRequestProcessingTimeInMs;
+  public final Histogram triggerCompactionResponseQueueTimeInMs;
+  public final Histogram triggerCompactionResponseSendTimeInMs;
+  public final Histogram triggerCompactionRequestTotalTimeInMs;
+
   public final Histogram blobSizeInBytes;
   public final Histogram blobUserMetadataSizeInBytes;
 
@@ -121,6 +127,7 @@ public class ServerMetrics {
   public final Meter deleteBlobRequestRate;
   public final Meter ttlBlobRequestRate;
   public final Meter replicaMetadataRequestRate;
+  public final Meter triggerCompactionRequestRate;
 
   public final Meter putSmallBlobRequestRate;
   public final Meter getSmallBlobRequestRate;
@@ -139,6 +146,7 @@ public class ServerMetrics {
   public final Counter unExpectedStoreGetError;
   public final Counter unExpectedStoreTTLError;
   public final Counter unExpectedStoreDeleteError;
+  public final Counter unExpectedAdminOperationError;
   public final Counter unExpectedStoreFindEntriesError;
   public final Counter idAlreadyExistError;
   public final Counter dataCorruptError;
@@ -262,6 +270,17 @@ public class ServerMetrics {
     replicaMetadataTotalTimeInMs =
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "ReplicaMetadataTotalTime"));
 
+    triggerCompactionRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestQueueTimeMs"));
+    triggerCompactionRequestProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestProcessingTimeMs"));
+    triggerCompactionResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionResponseQueueTimeMs"));
+    triggerCompactionResponseSendTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionResponseSendTimeMs"));
+    triggerCompactionRequestTotalTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestTotalTimeMs"));
+
     blobSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobSize"));
     blobUserMetadataSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobUserMetadataSize"));
 
@@ -279,6 +298,8 @@ public class ServerMetrics {
     deleteBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "DeleteBlobRequestRate"));
     ttlBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "TTLBlobRequestRate"));
     replicaMetadataRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "ReplicaMetadataRequestRate"));
+    triggerCompactionRequestRate =
+        registry.meter(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestRate"));
 
     putSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "PutSmallBlobRequestRate"));
     getSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "GetSmallBlobRequestRate"));
@@ -303,6 +324,8 @@ public class ServerMetrics {
     unExpectedStoreGetError = registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStoreGetError"));
     unExpectedStoreDeleteError =
         registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStoreDeleteError"));
+    unExpectedAdminOperationError =
+        registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedAdminOperationError"));
     unExpectedStoreTTLError = registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStoreTTLError"));
     unExpectedStoreFindEntriesError =
         registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStoreFindEntriesError"));

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.server;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.commons.ServerErrorCode;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.network.Request;
+import com.github.ambry.network.Send;
+import com.github.ambry.network.ServerNetworkResponseMetrics;
+import com.github.ambry.network.SocketRequestResponseChannel;
+import com.github.ambry.protocol.AdminRequest;
+import com.github.ambry.protocol.AdminRequestOrResponseType;
+import com.github.ambry.protocol.AdminResponse;
+import com.github.ambry.store.FindInfo;
+import com.github.ambry.store.FindToken;
+import com.github.ambry.store.MessageWriteSet;
+import com.github.ambry.store.StorageManager;
+import com.github.ambry.store.Store;
+import com.github.ambry.store.StoreException;
+import com.github.ambry.store.StoreGetOptions;
+import com.github.ambry.store.StoreInfo;
+import com.github.ambry.store.StoreKey;
+import com.github.ambry.store.StoreStats;
+import com.github.ambry.utils.ByteBufferChannel;
+import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Tests for {@link AmbryRequests}.
+ */
+public class AmbryRequestsTest {
+
+  private final MockClusterMap clusterMap;
+  private final MockStorageManager storageManager;
+  private final MockRequestResponseChannel requestResponseChannel = new MockRequestResponseChannel();
+  private final AmbryRequests ambryRequests;
+
+  public AmbryRequestsTest() throws IOException, StoreException {
+    clusterMap = new MockClusterMap();
+    storageManager = new MockStorageManager();
+    ambryRequests =
+        new AmbryRequests(storageManager, requestResponseChannel, clusterMap, clusterMap.getDataNodeIds().get(0),
+            clusterMap.getMetricRegistry(), null, null, null, null);
+  }
+
+  /**
+   * Tests that compactions are scheduled correctly.
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  @Test
+  public void scheduleCompactionSuccessTest() throws InterruptedException, IOException {
+    List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+    for (PartitionId id : partitionIds) {
+      doScheduleCompactionTest(id, ServerErrorCode.No_Error);
+      assertEquals("Partition scheduled for compaction not as expected", id,
+          storageManager.compactionScheduledPartitionId);
+    }
+  }
+
+  /**
+   * Tests failure scenarios for compaction - disk down, store not scheduled for compaction, exception while scheduling.
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  @Test
+  public void scheduleCompactionFailureTest() throws InterruptedException, IOException {
+    PartitionId id = clusterMap.getWritablePartitionIds().get(0);
+
+    // store is not started - Disk_Unavailable
+    storageManager.returnNullStore = true;
+    doScheduleCompactionTest(id, ServerErrorCode.Disk_Unavailable);
+    storageManager.returnNullStore = false;
+    // PartitionUnknown is hard to simulate without betraying knowledge of the internals of MockClusterMap.
+
+    // store cannot be scheduled for compaction - Unknown_Error
+    storageManager.returnValueOfSchedulingCompaction = false;
+    doScheduleCompactionTest(id, ServerErrorCode.Unknown_Error);
+    storageManager.returnValueOfSchedulingCompaction = true;
+
+    // exception while attempting to schedule - InternalServerError
+    storageManager.exceptionToThrowOnSchedulingCompaction = new IllegalStateException();
+    doScheduleCompactionTest(id, ServerErrorCode.Unknown_Error);
+    storageManager.exceptionToThrowOnSchedulingCompaction = null;
+  }
+
+  // helpers
+  // scheduleCompactionSuccessTest() and scheduleCompactionFailuresTest() helpers
+
+  /**
+   * Schedules a compaction for {@code id} and checks that the {@link ServerErrorCode} returned matches
+   * {@code expectedServerErrorCode}.
+   * @param id the {@link PartitionId} to schedule compaction for.
+   * @param expectedServerErrorCode the {@link ServerErrorCode} expected when the request is processed.
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  private void doScheduleCompactionTest(PartitionId id, ServerErrorCode expectedServerErrorCode)
+      throws InterruptedException, IOException {
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = UtilsTest.getRandomString(10);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.TriggerCompaction, id, correlationId, clientId);
+    Request request = MockRequest.fromAdminRequest(adminRequest, true);
+    ambryRequests.handleRequests(request);
+    assertEquals("Request accompanying response does not match original request", request,
+        requestResponseChannel.lastOriginalRequest);
+    assertNotNull("Response not sent", requestResponseChannel.lastResponse);
+    assertTrue("Response is not of type AdminResponse", requestResponseChannel.lastResponse instanceof AdminResponse);
+    AdminResponse response = (AdminResponse) requestResponseChannel.lastResponse;
+    assertEquals("Correlation id in response does match the one in the request", correlationId,
+        response.getCorrelationId());
+    assertEquals("Client id in response does match the one in the request", clientId, response.getClientId());
+    assertEquals("Error code does not match expected", expectedServerErrorCode, response.getError());
+  }
+
+  /**
+   * Implementation of {@link Request} to help with tests.
+   */
+  private static class MockRequest implements Request {
+
+    private final InputStream stream;
+
+    /**
+     * Constructs a {@link MockRequest} from {@code adminRequest}.
+     * @param adminRequest the {@link AdminRequest} to construct the {@link MockRequest} for.
+     * @param prepareForHandling prepares for handling by {@link AmbryRequests#handleRequests(Request)} by reading
+     *                           some initial field(s).
+     * @return an instance of {@link MockRequest} that represents {@code adminRequest}.
+     * @throws IOException
+     */
+    static MockRequest fromAdminRequest(AdminRequest adminRequest, boolean prepareForHandling) throws IOException {
+      ByteBuffer buffer = ByteBuffer.allocate((int) adminRequest.sizeInBytes());
+      adminRequest.writeTo(new ByteBufferChannel(buffer));
+      buffer.flip();
+      if (prepareForHandling) {
+        // read length
+        buffer.getLong();
+      }
+      return new MockRequest(new ByteBufferInputStream(buffer));
+    }
+
+    /**
+     * Constructs a {@link MockRequest}.
+     * @param stream the {@link InputStream} that will be returned on a call to {@link #getInputStream()}.
+     */
+    private MockRequest(InputStream stream) {
+      this.stream = stream;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return stream;
+    }
+
+    @Override
+    public long getStartTimeInMs() {
+      return 0;
+    }
+  }
+
+  /**
+   * An extension of {@link SocketRequestResponseChannel} to help with tests.
+   */
+  private static class MockRequestResponseChannel extends SocketRequestResponseChannel {
+    /**
+     * {@link Request} provided in the last call to {@link #sendResponse(Send, Request, ServerNetworkResponseMetrics).
+     */
+    Request lastOriginalRequest = null;
+
+    /**
+     * The {@link Send} provided in the last call to {@link #sendResponse(Send, Request, ServerNetworkResponseMetrics).
+     */
+    Send lastResponse = null;
+
+    MockRequestResponseChannel() {
+      super(1, 1);
+    }
+
+    @Override
+    public void sendResponse(Send payloadToSend, Request originalRequest, ServerNetworkResponseMetrics metrics) {
+      lastResponse = payloadToSend;
+      lastOriginalRequest = originalRequest;
+    }
+  }
+
+  /**
+   * An extension of {@link StorageManager} to help with tests.
+   */
+  private static class MockStorageManager extends StorageManager {
+
+    /**
+     * An empty {@link Store} implementation.
+     */
+    private static Store store = new Store() {
+      @Override
+      public void start() throws StoreException {
+
+      }
+
+      @Override
+      public StoreInfo get(List<? extends StoreKey> ids, EnumSet<StoreGetOptions> storeGetOptions)
+          throws StoreException {
+        return null;
+      }
+
+      @Override
+      public void put(MessageWriteSet messageSetToWrite) throws StoreException {
+
+      }
+
+      @Override
+      public void delete(MessageWriteSet messageSetToDelete) throws StoreException {
+
+      }
+
+      @Override
+      public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries) throws StoreException {
+        return null;
+      }
+
+      @Override
+      public Set<StoreKey> findMissingKeys(List<StoreKey> keys) throws StoreException {
+        return null;
+      }
+
+      @Override
+      public StoreStats getStoreStats() {
+        return null;
+      }
+
+      @Override
+      public boolean isKeyDeleted(StoreKey key) throws StoreException {
+        return false;
+      }
+
+      @Override
+      public long getSizeInBytes() {
+        return 0;
+      }
+
+      @Override
+      public void shutdown() throws StoreException {
+
+      }
+    };
+
+    /**
+     * if {@code true}, a {@code null} {@link Store} is returned on a call to {@link #getStore(PartitionId)}. Otherwise
+     * {@link #store} is returned.
+     */
+    boolean returnNullStore = false;
+    /**
+     * If non-null, the given exception is thrown when {@link #scheduleNextForCompaction(PartitionId)} is called.
+     */
+    RuntimeException exceptionToThrowOnSchedulingCompaction = null;
+    /**
+     * The return value for a call to {@link #scheduleNextForCompaction(PartitionId)}.
+     */
+    boolean returnValueOfSchedulingCompaction = true;
+    /**
+     * The {@link PartitionId} that was provided in the call to {@link #scheduleNextForCompaction(PartitionId)}
+     */
+    PartitionId compactionScheduledPartitionId = null;
+
+    MockStorageManager() throws StoreException {
+      super(new StoreConfig(new VerifiableProperties(new Properties())), Utils.newScheduler(1, true),
+          new MetricRegistry(), Collections.EMPTY_LIST, null, null, null, new MockTime());
+    }
+
+    @Override
+    public Store getStore(PartitionId id) {
+      return returnNullStore ? null : store;
+    }
+
+    @Override
+    public boolean scheduleNextForCompaction(PartitionId id) {
+      if (exceptionToThrowOnSchedulingCompaction != null) {
+        throw exceptionToThrowOnSchedulingCompaction;
+      }
+      compactionScheduledPartitionId = id;
+      return returnValueOfSchedulingCompaction;
+    }
+  }
+}

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
@@ -141,7 +142,7 @@ class CompactionManager {
     private final Condition waitCondition = lock.newCondition();
     private final Set<BlobStore> storesToSkip = new HashSet<>();
     private final LinkedBlockingDeque<BlobStore> storesToCheck = new LinkedBlockingDeque<>();
-    private final long waitTimeMs = storeConfig.storeCompactionCheckFrequencyInHours * Time.SecsPerHour * Time.MsPerSec;
+    private final long waitTimeMs = TimeUnit.HOURS.toMillis(storeConfig.storeCompactionCheckFrequencyInHours);
 
     private volatile boolean enabled = true;
 

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
@@ -160,6 +160,16 @@ class DiskManager {
   }
 
   /**
+   * Schedules the {@link PartitionId} {@code id} for compaction next.
+   * @param id the {@link PartitionId} of the {@link BlobStore} to compact.
+   * @return {@code true} if the scheduling was successful. {@code false} if not.
+   */
+  boolean scheduleNextForCompaction(PartitionId id) {
+    BlobStore store = (BlobStore) getStore(id);
+    return store != null && compactionManager.scheduleNextForCompaction(store);
+  }
+
+  /**
    * Gets all the throttlers that the {@link DiskIOScheduler} will be constructed with.
    * @param config the {@link StoreConfig} with configuration values.
    * @param time the {@link Time} instance to use in the throttlers

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -133,6 +133,16 @@ public class StorageManager {
   }
 
   /**
+   * Schedules the {@link PartitionId} {@code id} for compaction next.
+   * @param id the {@link PartitionId} of the {@link Store} to compact.
+   * @return {@code true} if the scheduling was successful. {@code false} if not.
+   */
+  public boolean scheduleNextForCompaction(PartitionId id) {
+    DiskManager diskManager = partitionToDiskManager.get(id);
+    return diskManager != null && diskManager.scheduleNextForCompaction(id);
+  }
+
+  /**
    * Shutdown the {@link DiskManager}s for the disks on this node.
    * @throws StoreException
    */

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionPolicyTest.java
@@ -208,8 +208,8 @@ public class CompactionPolicyTest {
    */
   private List<String> setUpStateForDefaultCompactionPolicy(MockBlobStore blobStore,
       MockBlobStoreStats mockBlobStoreStats) {
-    long maxLogSegmentCapacity = blobStore.segmentCapacity - blobStore.segmentHeaderSize -
-        mockBlobStoreStats.getMaxBlobSize();
+    long maxLogSegmentCapacity =
+        blobStore.segmentCapacity - blobStore.segmentHeaderSize - mockBlobStoreStats.getMaxBlobSize();
     long logSegmentCount = blobStore.capacityInBytes / blobStore.segmentCapacity;
     blobStore.logSegmentsNotInJournal = generateRandomStrings((int) logSegmentCount);
 


### PR DESCRIPTION
This commit introduces an admin command to trigger compaction at will on a particular partition/store on a storage server.

Reviewers: @nsivabalan, @cgtz  

`./gradlew build && ./gradlew test` succeeded.
Formatted

All new lines in `AmbryRequests`, `DiskManager` and `StorageManager` are covered by unit tests.

| Class | Class, % | Method, % | Line, % | Test class |
| --- | --- | --- | --- | --- |
| `AdminRequest` | 100% (2/ 2) | 90.9% (10/ 11) | 92.5% (37/ 40)| `RequestResponseTest` |
| `AdminResponse` | 100% (1/ 1) | 66.7% (2/ 3) | 80% (8/ 10) | `RequestResponseTest` |
| `CompactionManager` | 100% (2/ 2) | 100% (12/ 12) | 92.6% (100/ 108) | `CompactionManagerTest` |

(the functions not covered in `AdminRequest` and `AdminResponse` is the `toString()` method)