### PR TITLE
Fixing config files

### DIFF
--- a/config/admin.properties
+++ b/config/admin.properties
@@ -19,3 +19,8 @@ router.datacenter.name=Datacenter
 
 # netty
 netty.server.port=16503
+
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost

--- a/config/admin.test.properties
+++ b/config/admin.test.properties
@@ -18,3 +18,8 @@ rest.server.router.factory=com.github.ambry.router.InMemoryRouterFactory
 router.hostname=localhost
 router.datacenter.name=Datacenter
 router.put.success.target=1
+
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost

--- a/config/concurrencyTool.router.properties
+++ b/config/concurrencyTool.router.properties
@@ -21,3 +21,8 @@ router.datacenter.name=Datacenter
 router.put.success.target=1
 router.delete.success.target=1
 router.scaling.unit.max.connections.per.port.plain.text=20
+
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost

--- a/config/frontend.properties
+++ b/config/frontend.properties
@@ -18,3 +18,9 @@ router.hostname=localhost
 router.datacenter.name=Datacenter
 router.put.success.target=1
 router.delete.success.target=1
+# router.max.put.chunk.size.bytes=1048576
+
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost

--- a/config/frontend.ssl.properties
+++ b/config/frontend.ssl.properties
@@ -20,6 +20,11 @@ router.datacenter.name=Datacenter
 router.put.success.target=1
 router.delete.success.target=1
 
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost
+
 # ssl
 clustermap.ssl.enabled.datacenters=Datacenter
 ssl.context.protocol=TLS

--- a/config/frontend.test.properties
+++ b/config/frontend.test.properties
@@ -18,3 +18,8 @@ rest.server.router.factory=com.github.ambry.router.InMemoryRouterFactory
 router.hostname=localhost
 router.datacenter.name=Datacenter
 router.put.success.target=1
+
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost

--- a/config/server.properties
+++ b/config/server.properties
@@ -11,4 +11,8 @@
 #
 
 host.name=localhost
+
+# cluster map
 clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost

--- a/config/server.ssl.properties
+++ b/config/server.ssl.properties
@@ -12,6 +12,11 @@
 
 host.name=localhost
 
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost
+
 # ssl
 ssl.context.protocol=TLS
 ssl.context.provider=SunJSSE
@@ -19,7 +24,7 @@ ssl.enabled.protocols=TLSv1.2
 ssl.endpoint.identification.algorithm=HTTPS
 ssl.client.authentication=required
 ssl.keystore.type=PKCS12
-#the path to the store. this location must exist 
+#the path to the store. this location must exist
 ssl.keystore.path=/tmp/keystore
 # set key store password. this cannot be blank
 ssl.keystore.password=password

--- a/config/server1.properties
+++ b/config/server1.properties
@@ -12,3 +12,8 @@
 
 host.name=localhost
 port=6670
+
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost

--- a/config/server1.ssl.properties
+++ b/config/server1.ssl.properties
@@ -13,6 +13,11 @@
 host.name=localhost
 port=6670
 
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost
+
 # ssl
 ssl.context.protocol=TLS
 ssl.context.provider=SunJSSE
@@ -20,7 +25,7 @@ ssl.enabled.protocols=TLSv1.2
 ssl.endpoint.identification.algorithm=HTTPS
 ssl.client.authentication=required
 ssl.keystore.type=PKCS12
-#the path to the store. this location must exist 
+#the path to the store. this location must exist
 ssl.keystore.path=/tmp/keystore1
 # set key store password. this cannot be blank
 ssl.keystore.password=password

--- a/config/server2.properties
+++ b/config/server2.properties
@@ -12,3 +12,8 @@
 
 host.name=localhost
 port=6671
+
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost

--- a/config/server2.ssl.properties
+++ b/config/server2.ssl.properties
@@ -13,6 +13,11 @@
 host.name=localhost
 port=6671
 
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost
+
 # ssl
 ssl.context.protocol=TLS
 ssl.context.provider=SunJSSE
@@ -20,7 +25,7 @@ ssl.enabled.protocols=TLSv1.2
 ssl.endpoint.identification.algorithm=HTTPS
 ssl.client.authentication=required
 ssl.keystore.type=PKCS12
-#the path to the store. this location must exist 
+#the path to the store. this location must exist
 ssl.keystore.path=/tmp/keystore2
 # set key store password. this cannot be blank
 ssl.keystore.password=password

--- a/config/server3.properties
+++ b/config/server3.properties
@@ -12,3 +12,8 @@
 
 host.name=localhost
 port=6672
+
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost

--- a/config/server3.ssl.properties
+++ b/config/server3.ssl.properties
@@ -13,6 +13,11 @@
 host.name=localhost
 port=6672
 
+# cluster map
+clustermap.cluster.name=Ambry_Dev
+clustermap.datacenter.name=Datacenter
+clustermap.host.name=localhost
+
 # ssl
 ssl.context.protocol=TLS
 ssl.context.provider=SunJSSE
@@ -20,7 +25,7 @@ ssl.enabled.protocols=TLSv1.2
 ssl.endpoint.identification.algorithm=HTTPS
 ssl.client.authentication=required
 ssl.keystore.type=PKCS12
-#the path to the store. this location must exist 
+#the path to the store. this location must exist
 ssl.keystore.path=/tmp/keystore3
 # set key store password. this cannot be blank
 ssl.keystore.password=password


### PR DESCRIPTION
Config files for the quick start don't work anymore because cluster map config requires some config keys with the recent change to introduce dynamic cluster manager. This commit fixes those files by including those necessary keys.