### PR TITLE
Fixing TTL value to -1 if expiration value is > Integer.MAX 

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -15,6 +15,7 @@ package com.github.ambry.messageformat;
 
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -69,8 +70,13 @@ public class BlobProperties {
     this.ownerId = ownerId;
     this.contentType = contentType;
     this.isPrivate = isPrivate;
-    this.timeToLiveInSeconds = timeToLiveInSeconds;
     this.creationTimeInMs = creationTimeInMs;
+    long maxAllowedTTLInMs = Utils.getMaxSupportedTimeInMs() - creationTimeInMs;
+    if (TimeUnit.SECONDS.toMillis(timeToLiveInSeconds) > maxAllowedTTLInMs) {
+      this.timeToLiveInSeconds = -1;
+    } else {
+      this.timeToLiveInSeconds = timeToLiveInSeconds;
+    }
   }
 
   public long getTimeToLiveInSeconds() {

--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -71,8 +71,8 @@ public class BlobProperties {
     this.contentType = contentType;
     this.isPrivate = isPrivate;
     this.creationTimeInMs = creationTimeInMs;
-    long maxAllowedTTLInMs = Utils.maxEpochTimeInMs - creationTimeInMs;
-    if (TimeUnit.SECONDS.toMillis(timeToLiveInSeconds) > maxAllowedTTLInMs) {
+    // expiration value in seconds cannot exceed Integer.MAX_VALUE
+    if (timeToLiveInSeconds + TimeUnit.MILLISECONDS.toSeconds(creationTimeInMs) > Integer.MAX_VALUE) {
       this.timeToLiveInSeconds = Utils.Infinite_Time;
     } else {
       this.timeToLiveInSeconds = timeToLiveInSeconds;

--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -71,9 +71,9 @@ public class BlobProperties {
     this.contentType = contentType;
     this.isPrivate = isPrivate;
     this.creationTimeInMs = creationTimeInMs;
-    long maxAllowedTTLInMs = Utils.getMaxSupportedTimeInMs() - creationTimeInMs;
+    long maxAllowedTTLInMs = Utils.maxEpochTimeInMs - creationTimeInMs;
     if (TimeUnit.SECONDS.toMillis(timeToLiveInSeconds) > maxAllowedTTLInMs) {
-      this.timeToLiveInSeconds = -1;
+      this.timeToLiveInSeconds = Utils.Infinite_Time;
     } else {
       this.timeToLiveInSeconds = timeToLiveInSeconds;
     }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -70,7 +70,7 @@ public class BlobPropertiesTest {
         Integer.MAX_VALUE - creationTimeInSecs + 100, Integer.MAX_VALUE - creationTimeInSecs + 10000};
     for (long ttl : invalidTTLs) {
       blobProperties = new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs);
-      verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, -1);
+      verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, Utils.Infinite_Time);
     }
   }
 

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -14,7 +14,6 @@
 package com.github.ambry.messageformat;
 
 import com.github.ambry.utils.SystemTime;
-import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
@@ -53,18 +52,12 @@ public class BlobPropertiesTest {
     verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds);
     assertEquals(blobProperties.getCreationTimeInMs(), creationTimeMs);
 
-    long maxSupportedTimeInMs = Utils.maxEpochTimeInMs;
+    long creationTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(creationTimeMs);
     // valid TTLs
-    long[] validTTLs = new long[]{
-        1 * Time.SecsPerHour,
-        10 * Time.SecsPerHour,
-        100 * Time.SecsPerHour,
-        1 * Time.SecsPerDay,
-        10 * Time.SecsPerDay,
-        100 * Time.SecsPerDay,
-        12 * 30 * Time.SecsPerDay, 10 * 12 * 30 * Time.SecsPerDay, TimeUnit.MILLISECONDS.toSeconds(
-        maxSupportedTimeInMs - creationTimeMs - 1), TimeUnit.MILLISECONDS.toSeconds(
-        maxSupportedTimeInMs - creationTimeMs)};
+    long[] validTTLs = new long[]{TimeUnit.HOURS.toSeconds(1), TimeUnit.HOURS.toSeconds(10), TimeUnit.HOURS.toSeconds(
+        100), TimeUnit.DAYS.toSeconds(1), TimeUnit.DAYS.toSeconds(10), TimeUnit.DAYS.toSeconds(
+        100), TimeUnit.DAYS.toSeconds(30 * 12), TimeUnit.DAYS.toSeconds(30 * 12 * 10),
+        Integer.MAX_VALUE - creationTimeInSecs - 1, Integer.MAX_VALUE - creationTimeInSecs};
 
     for (long ttl : validTTLs) {
       blobProperties = new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs);
@@ -72,11 +65,9 @@ public class BlobPropertiesTest {
     }
 
     // invalid TTLs
-    long[] invalidTTLs = new long[]{TimeUnit.MILLISECONDS.toSeconds(
-        maxSupportedTimeInMs - creationTimeMs + 1 * Time.MsPerSec), TimeUnit.MILLISECONDS.toSeconds(
-        maxSupportedTimeInMs - creationTimeMs + 10 * Time.MsPerSec), TimeUnit.MILLISECONDS.toSeconds(
-        maxSupportedTimeInMs - creationTimeMs + 100 * Time.MsPerSec), TimeUnit.MILLISECONDS.toSeconds(
-        maxSupportedTimeInMs - creationTimeMs + 1000 * Time.MsPerSec)};
+    long[] invalidTTLs = new long[]{
+        Integer.MAX_VALUE - creationTimeInSecs + 1,
+        Integer.MAX_VALUE - creationTimeInSecs + 100, Integer.MAX_VALUE - creationTimeInSecs + 10000};
     for (long ttl : invalidTTLs) {
       blobProperties = new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs);
       verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, -1);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -53,7 +53,7 @@ public class BlobPropertiesTest {
     verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds);
     assertEquals(blobProperties.getCreationTimeInMs(), creationTimeMs);
 
-    long maxSupportedTimeInMs = Utils.getMaxSupportedTimeInMs();
+    long maxSupportedTimeInMs = Utils.maxEpochTimeInMs;
     // valid TTLs
     long[] validTTLs = new long[]{
         1 * Time.SecsPerHour,

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -14,7 +14,9 @@
 package com.github.ambry.messageformat;
 
 import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -32,27 +34,15 @@ public class BlobPropertiesTest {
     final String contentType = "ContentType";
     final int timeToLiveInSeconds = 144;
 
-    BlobProperties blobProperties;
-
-    blobProperties = new BlobProperties(blobSize, serviceId);
+    BlobProperties blobProperties = new BlobProperties(blobSize, serviceId);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
-    assertEquals(blobProperties.getBlobSize(), blobSize);
-    assertEquals(blobProperties.getServiceId(), serviceId);
-    assertEquals(blobProperties.getOwnerId(), null);
-    assertEquals(blobProperties.getContentType(), null);
-    assertFalse(blobProperties.isPrivate());
-    assertTrue(blobProperties.getTimeToLiveInSeconds() == Utils.Infinite_Time);
+    verifyBlobProperties(blobProperties, blobSize, serviceId, null, null, false, Utils.Infinite_Time);
     assertTrue(blobProperties.getCreationTimeInMs() > 0);
     assertTrue(blobProperties.getCreationTimeInMs() <= System.currentTimeMillis());
 
     blobProperties = new BlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
-    assertEquals(blobProperties.getBlobSize(), blobSize);
-    assertEquals(blobProperties.getServiceId(), serviceId);
-    assertEquals(blobProperties.getOwnerId(), ownerId);
-    assertEquals(blobProperties.getContentType(), contentType);
-    assertTrue(blobProperties.isPrivate());
-    assertTrue(blobProperties.getTimeToLiveInSeconds() == timeToLiveInSeconds);
+    verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds);
     assertTrue(blobProperties.getCreationTimeInMs() > 0);
     assertTrue(blobProperties.getCreationTimeInMs() <= System.currentTimeMillis());
 
@@ -60,12 +50,56 @@ public class BlobPropertiesTest {
     blobProperties =
         new BlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds, creationTimeMs);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
+    verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds);
+    assertEquals(blobProperties.getCreationTimeInMs(), creationTimeMs);
+
+    long maxSupportedTimeInMs = Utils.getMaxSupportedTimeInMs();
+    // valid TTLs
+    long[] validTTLs = new long[]{
+        1 * Time.SecsPerHour,
+        10 * Time.SecsPerHour,
+        100 * Time.SecsPerHour,
+        1 * Time.SecsPerDay,
+        10 * Time.SecsPerDay,
+        100 * Time.SecsPerDay,
+        12 * 30 * Time.SecsPerDay, 10 * 12 * 30 * Time.SecsPerDay, TimeUnit.MILLISECONDS.toSeconds(
+        maxSupportedTimeInMs - creationTimeMs - 1), TimeUnit.MILLISECONDS.toSeconds(
+        maxSupportedTimeInMs - creationTimeMs)};
+
+    for (long ttl : validTTLs) {
+      blobProperties = new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs);
+      verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, ttl);
+    }
+
+    // invalid TTLs
+    long[] invalidTTLs = new long[]{TimeUnit.MILLISECONDS.toSeconds(
+        maxSupportedTimeInMs - creationTimeMs + 1 * Time.MsPerSec), TimeUnit.MILLISECONDS.toSeconds(
+        maxSupportedTimeInMs - creationTimeMs + 10 * Time.MsPerSec), TimeUnit.MILLISECONDS.toSeconds(
+        maxSupportedTimeInMs - creationTimeMs + 100 * Time.MsPerSec), TimeUnit.MILLISECONDS.toSeconds(
+        maxSupportedTimeInMs - creationTimeMs + 1000 * Time.MsPerSec)};
+    for (long ttl : invalidTTLs) {
+      blobProperties = new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs);
+      verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, -1);
+    }
+  }
+
+  /**
+   * Verify {@link BlobProperties} for its constituent values
+   * @param blobProperties the {@link BlobProperties} that needs to be compared against
+   * @param blobSize the size of the blob
+   * @param serviceId the serviceId associated with the {@link BlobProperties}
+   * @param ownerId the ownerId associated with the {@link BlobProperties}
+   * @param contentType the contentType associated with the {@link BlobProperties}
+   * @param isPrivate refers to whether the blob is private or not
+   * @param ttlInSecs the time to live associated with the {@link BlobProperties} in secs
+   */
+  private void verifyBlobProperties(BlobProperties blobProperties, long blobSize, String serviceId, String ownerId,
+      String contentType, boolean isPrivate, long ttlInSecs) {
     assertEquals(blobProperties.getBlobSize(), blobSize);
     assertEquals(blobProperties.getServiceId(), serviceId);
     assertEquals(blobProperties.getOwnerId(), ownerId);
     assertEquals(blobProperties.getContentType(), contentType);
-    assertTrue(blobProperties.isPrivate());
-    assertEquals(blobProperties.getTimeToLiveInSeconds(), timeToLiveInSeconds);
-    assertEquals(blobProperties.getCreationTimeInMs(), creationTimeMs);
+    assertEquals(blobProperties.isPrivate(), isPrivate);
+    assertEquals(blobProperties.getTimeToLiveInSeconds(), ttlInSecs);
   }
 }

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -46,19 +46,6 @@ import org.json.JSONObject;
  */
 public class Utils {
 
-  // epoch time beyond this date(time) will have issues
-  static String maxAllowableDateForEpochTime = "19-01-2038";
-  static String maxAllowableDateForEpochTimeFormat = "dd-MM-yyyy";
-  public static long maxEpochTimeInMs;
-
-  static {
-    try {
-      maxEpochTimeInMs =
-          new SimpleDateFormat(maxAllowableDateForEpochTimeFormat).parse(maxAllowableDateForEpochTime).getTime();
-    } catch (ParseException e) {
-    }
-  }
-
   /**
    * Constant to define "infinite" time.
    * <p/>

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -31,7 +31,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
@@ -50,6 +49,15 @@ public class Utils {
   // epoch time beyond this date(time) will have issues
   static String maxAllowableDateForEpochTime = "19-01-2038";
   static String maxAllowableDateForEpochTimeFormat = "dd-MM-yyyy";
+  public static long maxEpochTimeInMs;
+
+  static {
+    try {
+      maxEpochTimeInMs =
+          new SimpleDateFormat(maxAllowableDateForEpochTimeFormat).parse(maxAllowableDateForEpochTime).getTime();
+    } catch (ParseException e) {
+    }
+  }
 
   /**
    * Constant to define "infinite" time.
@@ -58,20 +66,6 @@ public class Utils {
    * time).
    */
   public static final long Infinite_Time = -1;
-
-  /**
-   * Maximum supported time in millis
-   * @return the max supported time in millis
-   */
-  public static long getMaxSupportedTimeInMs() {
-    Date date = null;
-    try {
-      SimpleDateFormat sdf = new SimpleDateFormat(maxAllowableDateForEpochTimeFormat);
-      date = sdf.parse(maxAllowableDateForEpochTime);
-    } catch (ParseException e) {
-    }
-    return date.getTime();
-  }
 
   // The read*String methods assume that the underlying stream is blocking
 

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -27,8 +27,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Properties;

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -27,8 +27,11 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
@@ -43,6 +46,11 @@ import org.json.JSONObject;
  * A set of utility methods
  */
 public class Utils {
+
+  // epoch time beyond this date(time) will have issues
+  static String maxAllowableDateForEpochTime = "19-01-2038";
+  static String maxAllowableDateForEpochTimeFormat = "dd-MM-yyyy";
+
   /**
    * Constant to define "infinite" time.
    * <p/>
@@ -50,6 +58,20 @@ public class Utils {
    * time).
    */
   public static final long Infinite_Time = -1;
+
+  /**
+   * Maximum supported time in millis
+   * @return the max supported time in millis
+   */
+  public static long getMaxSupportedTimeInMs() {
+    Date date = null;
+    try {
+      SimpleDateFormat sdf = new SimpleDateFormat(maxAllowableDateForEpochTimeFormat);
+      date = sdf.parse(maxAllowableDateForEpochTime);
+    } catch (ParseException e) {
+    }
+    return date.getTime();
+  }
 
   // The read*String methods assume that the underlying stream is blocking
 
@@ -747,7 +769,7 @@ public class Utils {
    * @return the time in ms to the nearest second(floored) for the given time in ms
    */
   public static long getTimeInMsToTheNearestSec(long timeInMs) {
-    long timeInSecs =  timeInMs / Time.MsPerSec;
+    long timeInSecs = timeInMs / Time.MsPerSec;
     return timeInMs != Utils.Infinite_Time ? (timeInSecs * Time.MsPerSec) : Utils.Infinite_Time;
   }
 

--- a/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
@@ -18,9 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -29,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static com.github.ambry.utils.Utils.*;
 import static org.junit.Assert.*;
 
 
@@ -41,13 +37,6 @@ public class UtilsTest {
   @Test(expected = IllegalArgumentException.class)
   public void testGetRandomLongException() {
     Utils.getRandomLong(new Random(), 0);
-  }
-
-  @Test
-  public void testGetMaxSupportedTimeInMs() throws ParseException {
-    SimpleDateFormat sdf = new SimpleDateFormat(maxAllowableDateForEpochTimeFormat);
-    Date date = sdf.parse(maxAllowableDateForEpochTime);
-    assertEquals("Time mismatch ", date.getTime(), Utils.getMaxSupportedTimeInMs());
   }
 
   public void whpGetRandomLongRangeTest(int range, int draws) {

--- a/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
@@ -18,6 +18,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -26,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static com.github.ambry.utils.Utils.*;
 import static org.junit.Assert.*;
 
 
@@ -37,6 +41,13 @@ public class UtilsTest {
   @Test(expected = IllegalArgumentException.class)
   public void testGetRandomLongException() {
     Utils.getRandomLong(new Random(), 0);
+  }
+
+  @Test
+  public void testGetMaxSupportedTimeInMs() throws ParseException {
+    SimpleDateFormat sdf = new SimpleDateFormat(maxAllowableDateForEpochTimeFormat);
+    Date date = sdf.parse(maxAllowableDateForEpochTime);
+    assertEquals("Time mismatch ", date.getTime(), Utils.getMaxSupportedTimeInMs());
   }
 
   public void whpGetRandomLongRangeTest(int range, int draws) {


### PR DESCRIPTION
Ambry doesn't support expiration values > Integer.MAX value. Hence, setting TTLs going beyond such values to -1. 

Build and tested. 
Coding format applied.
SLA: 5 mins