### PR TITLE
Ensure router handles zero length buffers properly

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -353,8 +353,12 @@ class PutOperation {
       if (chunkFillingCompletedSuccessfully) {
         PutChunk lastChunk = getBuildingChunk();
         if (lastChunk != null) {
-          lastChunk.onFillComplete(true);
-          updateChunkFillerWaitTimeMetrics();
+          if (chunkCounter != 0 && lastChunk.buf.position() == 0) {
+            logger.trace("The last chunk received from ReadableStreamChannel has no data, discarding");
+          } else {
+            lastChunk.onFillComplete(true);
+            updateChunkFillerWaitTimeMetrics();
+          }
         }
         routerCallback.onPollReady();
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -354,7 +354,7 @@ class PutOperation {
         PutChunk lastChunk = getBuildingChunk();
         if (lastChunk != null) {
           if (chunkCounter != 0 && lastChunk.buf.position() == 0) {
-            logger.trace("The last chunk received from ReadableStreamChannel has no data, discarding");
+            logger.trace("The last buffer(s) received from chunkFillerChannel have no data, discarding them.");
           } else {
             lastChunk.onFillComplete(true);
             updateChunkFillerWaitTimeMetrics();

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -107,7 +107,7 @@ public class ChunkFillTest {
     Random random = new Random();
     byte[] putUserMetadata = new byte[10];
     random.nextBytes(putUserMetadata);
-    final MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize);
+    final MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize, false);
     FutureResult<String> futureResult = new FutureResult<String>();
     MockTime time = new MockTime();
     MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -907,16 +907,16 @@ class MockReadableStreamChannel implements ReadableStreamChannel {
   private final long size;
   private long readSoFar;
   private boolean beBad = false;
-  private final boolean sendZeroSizedLastChunk;
+  private final boolean sendZeroSizedBuffers;
   private final Random random = new Random();
 
   /**
    * Constructs a MockReadableStreamChannel.
    * @param size the number of bytes that will eventually be written into this channel.
    */
-  MockReadableStreamChannel(long size, boolean sendZeroSizedLastChunk) {
+  MockReadableStreamChannel(long size, boolean sendZeroSizedBuffers) {
     this.size = size;
-    this.sendZeroSizedLastChunk = sendZeroSizedLastChunk;
+    this.sendZeroSizedBuffers = sendZeroSizedBuffers;
     readSoFar = 0;
   }
 
@@ -950,18 +950,16 @@ class MockReadableStreamChannel implements ReadableStreamChannel {
     writableChannel.write(buf, null).get();
     readSoFar += toRead;
     if (readSoFar == size) {
-      if (sendZeroSizedLastChunk) {
+      if (sendZeroSizedBuffers) {
         // Send a final zero sized buffer.
         sendZeroAndWait();
       }
       returnedFuture.done(size, null);
       callback.onCompletion(size, null);
     } else {
-      if (sendZeroSizedLastChunk) {
+      if (sendZeroSizedBuffers && random.nextInt(2) % 2 == 0) {
         // Send a zero-sized blob with 50% probability.
-        if (random.nextInt(2) % 2 == 0) {
-          sendZeroAndWait();
-        }
+        sendZeroAndWait();
       }
     }
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -35,6 +35,7 @@ import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -379,24 +380,39 @@ public class PutManagerTest {
   }
 
   /**
-   * Tests put of a blob with a channel that does not have all the data at once.
+   * Tests put of blobs with various sizes with channels that do not have all the data at once.
    */
   @Test
   public void testDelayedChannelPutSuccess() throws Exception {
     router = getNonBlockingRouter();
-    int blobSize = chunkSize * random.nextInt(10) + 1;
+    int[] blobSizes = {0, // zero sized blob.
+        chunkSize, // blob size is the same as chunk size.
+        chunkSize + random.nextInt(chunkSize - 1) + 1, // over a chunk but less than 2 chunks.
+        chunkSize * (2 + random.nextInt(10)), // blob size is a multiple of chunk size.
+        chunkSize + (2 + random.nextInt(10)) + random.nextInt(chunkSize - 1) + 1 // multiple of a chunk and over.
+    };
+    for (int blobSize : blobSizes) {
+      testDelayed(blobSize, false);
+      testDelayed(blobSize, true);
+    }
+    assertSuccess();
+    assertCloseCleanup();
+  }
+
+  /**
+   * Helper method to put a blob with a channel that does not have all the data at once.
+   */
+  private void testDelayed(int blobSize, boolean sendZeroSizedBuffers) throws Exception {
     RequestAndResult requestAndResult = new RequestAndResult(blobSize);
     requestAndResultsList.add(requestAndResult);
-    MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize);
+    MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize, sendZeroSizedBuffers);
     FutureResult<String> future =
         (FutureResult<String>) router.putBlob(requestAndResult.putBlobProperties, requestAndResult.putUserMetadata,
             putChannel, null);
     ByteBuffer src = ByteBuffer.wrap(requestAndResult.putContent);
-    pushwithDelay(src, putChannel, blobSize, future);
+    pushWithDelay(src, putChannel, blobSize, future);
     future.await();
     requestAndResult.result = future;
-    assertSuccess();
-    assertCloseCleanup();
   }
 
   /**
@@ -409,7 +425,7 @@ public class PutManagerTest {
     int blobSize = chunkSize * random.nextInt(10) + 1;
     RequestAndResult requestAndResult = new RequestAndResult(blobSize);
     requestAndResultsList.add(requestAndResult);
-    MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize);
+    MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize, false);
     FutureResult<String> future =
         (FutureResult<String>) router.putBlob(requestAndResult.putBlobProperties, requestAndResult.putUserMetadata,
             putChannel, null);
@@ -418,7 +434,7 @@ public class PutManagerTest {
     //Make the channel act bad.
     putChannel.beBad();
 
-    pushwithDelay(src, putChannel, blobSize, future);
+    pushWithDelay(src, putChannel, blobSize, future);
     future.await();
     requestAndResult.result = future;
     Exception expectedException = new Exception("Channel encountered an error");
@@ -464,7 +480,7 @@ public class PutManagerTest {
     int blobSize = chunkSize * 2;
     RequestAndResult requestAndResult = new RequestAndResult(blobSize);
     requestAndResultsList.add(requestAndResult);
-    MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize);
+    MockReadableStreamChannel putChannel = new MockReadableStreamChannel(blobSize, false);
     FutureResult<String> future =
         (FutureResult<String>) router.putBlob(requestAndResult.putBlobProperties, requestAndResult.putUserMetadata,
             putChannel, null);
@@ -503,17 +519,17 @@ public class PutManagerTest {
    * @param future the future associated with the overall operation.
    * @throws Exception if the write to the channel throws an exception.
    */
-  private void pushwithDelay(ByteBuffer src, MockReadableStreamChannel putChannel, int blobSize, Future future)
+  private void pushWithDelay(ByteBuffer src, MockReadableStreamChannel putChannel, int blobSize, Future future)
       throws Exception {
     int pushedSoFar = 0;
-    while (pushedSoFar < blobSize && !future.isDone()) {
+    do {
       int toPush = random.nextInt(blobSize - pushedSoFar + 1);
       ByteBuffer buf = ByteBuffer.allocate(toPush);
       src.get(buf.array());
       putChannel.write(buf);
       Thread.yield();
       pushedSoFar += toPush;
-    }
+    } while (pushedSoFar < blobSize && !future.isDone());
   }
 
   /**
@@ -676,13 +692,25 @@ public class PutManagerTest {
       Assert.assertEquals("Wrong max chunk size in metadata", chunkSize, compositeBlobInfo.getChunkSize());
       Assert.assertEquals("Wrong total size in metadata", originalPutContent.length, compositeBlobInfo.getTotalSize());
       List<StoreKey> dataBlobIds = compositeBlobInfo.getKeys();
+      Assert.assertEquals("Number of chunks is not as expected",
+          RouterUtils.getNumChunksForBlobAndChunkSize(originalPutContent.length, chunkSize), dataBlobIds.size());
+      StoreKey lastKey = dataBlobIds.get(dataBlobIds.size() - 1);
       byte[] content = new byte[(int) request.getBlobProperties().getBlobSize()];
       int offset = 0;
       for (StoreKey key : dataBlobIds) {
         PutRequest.ReceivedPutRequest dataBlobPutRequest = deserializePutRequest(serializedRequests.get(key.getID()));
-        Utils.readBytesFromStream(dataBlobPutRequest.getBlobStream(), content, offset,
-            (int) dataBlobPutRequest.getBlobSize());
-        offset += (int) dataBlobPutRequest.getBlobSize();
+        int dataBlobLength = (int) dataBlobPutRequest.getBlobSize();
+        InputStream dataBlobStream = dataBlobPutRequest.getBlobStream();
+        Utils.readBytesFromStream(dataBlobStream, content, offset, dataBlobLength);
+        Assert.assertEquals("dataBlobStream should have no more data", -1, dataBlobStream.read());
+        if (key != lastKey) {
+          Assert.assertEquals("all chunks except last should be fully filled", chunkSize, dataBlobLength);
+        } else {
+          // If we are here (composite blob), we know that the blob size is non-zero.
+          Assert.assertEquals("Last chunk should be of non-zero length and equal to the length of the remaining bytes",
+              (originalPutContent.length - 1) % chunkSize + 1, dataBlobLength);
+        }
+        offset += dataBlobLength;
         notificationSystem.verifyNotification(key.getID(), NotificationBlobType.DataChunk,
             dataBlobPutRequest.getBlobProperties(), dataBlobPutRequest.getUsermetadata().array());
       }
@@ -879,13 +907,16 @@ class MockReadableStreamChannel implements ReadableStreamChannel {
   private final long size;
   private long readSoFar;
   private boolean beBad = false;
+  private final boolean sendZeroSizedLastChunk;
+  private final Random random = new Random();
 
   /**
    * Constructs a MockReadableStreamChannel.
    * @param size the number of bytes that will eventually be written into this channel.
    */
-  MockReadableStreamChannel(long size) {
+  MockReadableStreamChannel(long size, boolean sendZeroSizedLastChunk) {
     this.size = size;
+    this.sendZeroSizedLastChunk = sendZeroSizedLastChunk;
     readSoFar = 0;
   }
 
@@ -916,13 +947,31 @@ class MockReadableStreamChannel implements ReadableStreamChannel {
       callback.onCompletion(null, exception);
       return;
     }
-    Future<Long> future = writableChannel.write(buf, null);
-    future.get();
+    writableChannel.write(buf, null).get();
     readSoFar += toRead;
     if (readSoFar == size) {
+      if (sendZeroSizedLastChunk) {
+        // Send a final zero sized buffer.
+        sendZeroAndWait();
+      }
       returnedFuture.done(size, null);
       callback.onCompletion(size, null);
+    } else {
+      if (sendZeroSizedLastChunk) {
+        // Send a zero-sized blob with 50% probability.
+        if (random.nextInt(2) % 2 == 0) {
+          sendZeroAndWait();
+        }
+      }
     }
+  }
+
+  /**
+   * Send a zero sized buffer to the associated {@link AsyncWritableChannel}
+   */
+  private void sendZeroAndWait() throws Exception {
+    ByteBuffer buf = ByteBuffer.allocate(0);
+    writableChannel.write(buf, null).get();
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -380,7 +380,8 @@ public class PutManagerTest {
   }
 
   /**
-   * Tests put of blobs with various sizes with channels that do not have all the data at once.
+   * Tests put of blobs with various sizes with channels that do not have all the data at once. This also tests cases
+   * where zero-length buffers are given out by the channel.
    */
   @Test
   public void testDelayedChannelPutSuccess() throws Exception {
@@ -401,6 +402,9 @@ public class PutManagerTest {
 
   /**
    * Helper method to put a blob with a channel that does not have all the data at once.
+   * @param blobSize the size of the blob to put.
+   * @param sendZeroSizedBuffers whether this test should involve making the channel send zero-sized buffers between
+   *                             sending data buffers.
    */
   private void testDelayed(int blobSize, boolean sendZeroSizedBuffers) throws Exception {
     RequestAndResult requestAndResult = new RequestAndResult(blobSize);
@@ -913,6 +917,8 @@ class MockReadableStreamChannel implements ReadableStreamChannel {
   /**
    * Constructs a MockReadableStreamChannel.
    * @param size the number of bytes that will eventually be written into this channel.
+   * @param sendZeroSizedBuffers if true, this channel will write out a zero-sized buffer at the end, and with
+   *                             50% probability, send out zero-sized buffers after every data buffer.
    */
   MockReadableStreamChannel(long size, boolean sendZeroSizedBuffers) {
     this.size = size;


### PR DESCRIPTION
Ensure proper handling of zero length buffers in the input
channel within router put operations.

Fixes linkedin/ambry#592

--

Added test cases to handle zero sized buffers at the end and every now and then from the channel.