### PR TITLE
Changing log level for certain external packages to reduce verbosity

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -28,3 +28,8 @@ log4j.appender.PublicAccessLog.layout.conversionPattern=%m%n
 
 log4j.logger.PublicAccessLogger = WARN, PublicAccessLog
 log4j.additivity.PublicAccessLogger = false
+
+# Package specific levels:
+log4j.logger.org.apache.helix=WARN
+log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.org.I0Itec.zkclient=WARN


### PR DESCRIPTION
Setting log4j package specific log levels to reduce verbosity of external
packages that log a lot of INFO messages.

(Manually tested that these settings work as expected).