### PR TITLE
Fixing log-index recovery

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -187,7 +187,7 @@ class LogSegment implements Read, Write {
    * @param buffer The buffer into which the data needs to be written
    * @param position The position to start the read from
    * @throws IOException if data could not be written to the file because of I/O errors
-   * @throws IndexOutOfBoundsException if {@code position} < header size or >= {@link #getEndOffset()} or if
+   * @throws IndexOutOfBoundsException if {@code position} < header size or >= {@link #sizeInBytes()} or if
    * {@code buffer} size is greater than the data available for read.
    */
   @Override

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -192,16 +192,16 @@ class LogSegment implements Read, Write {
    */
   @Override
   public void readInto(ByteBuffer buffer, long position) throws IOException {
-    if (position < startOffset || position >= getEndOffset()) {
+    if (position < startOffset || position >= sizeInBytes()) {
       throw new IndexOutOfBoundsException(
           "Provided position [" + position + "] is out of bounds for the segment [" + file.getAbsolutePath()
-              + "] with end offset [" + getEndOffset() + "]");
+              + "] with size [" + sizeInBytes() + "]");
     }
-    if (position + buffer.remaining() > getEndOffset()) {
+    if (position + buffer.remaining() > sizeInBytes()) {
       metrics.overflowReadError.inc();
       throw new IndexOutOfBoundsException(
           "Cannot read from segment [" + file.getAbsolutePath() + "] from position [" + position + "] for size ["
-              + buffer.remaining() + "] because it exceeds the end offset [" + endOffset + "]");
+              + buffer.remaining() + "] because it exceeds the size [" + sizeInBytes() + "]");
     }
     long bytesRead = 0;
     int size = buffer.remaining();

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -196,7 +196,7 @@ class LogSegment implements Read, Write {
     if (position < startOffset || position >= sizeInBytes) {
       throw new IndexOutOfBoundsException(
           "Provided position [" + position + "] is out of bounds for the segment [" + file.getAbsolutePath()
-              + "] with size [" + sizeInBytes() + "]");
+              + "] with size [" + sizeInBytes + "]");
     }
     if (position + buffer.remaining() > sizeInBytes) {
       metrics.overflowReadError.inc();

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -192,16 +192,17 @@ class LogSegment implements Read, Write {
    */
   @Override
   public void readInto(ByteBuffer buffer, long position) throws IOException {
-    if (position < startOffset || position >= sizeInBytes()) {
+    long sizeInBytes = sizeInBytes();
+    if (position < startOffset || position >= sizeInBytes) {
       throw new IndexOutOfBoundsException(
           "Provided position [" + position + "] is out of bounds for the segment [" + file.getAbsolutePath()
               + "] with size [" + sizeInBytes() + "]");
     }
-    if (position + buffer.remaining() > sizeInBytes()) {
+    if (position + buffer.remaining() > sizeInBytes) {
       metrics.overflowReadError.inc();
       throw new IndexOutOfBoundsException(
           "Cannot read from segment [" + file.getAbsolutePath() + "] from position [" + position + "] for size ["
-              + buffer.remaining() + "] because it exceeds the size [" + sizeInBytes() + "]");
+              + buffer.remaining() + "] because it exceeds the size [" + sizeInBytes + "]");
     }
     long bytesRead = 0;
     int size = buffer.remaining();

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -241,7 +241,7 @@ public class LogSegmentTest {
       readAndEnsureMatch(segment, writeStartOffset + position, Arrays.copyOfRange(data, position, position + size));
 
       // position + buffer.remaining == data size written
-      position = (int) segment.getEndOffset();
+      position = (int) segment.getEndOffset() + random.nextInt(data.length - (int) segment.getEndOffset());
       size = data.length - position;
       readAndEnsureMatch(segment, writeStartOffset + position, Arrays.copyOfRange(data, position, position + size));
 

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -242,12 +242,6 @@ public class LogSegmentTest {
       int size = random.nextInt(data.length - position);
       readAndEnsureMatch(segment, writeStartOffset + position, Arrays.copyOfRange(data, position, position + size));
 
-      // position + buffer.remaining == sizeInBytes
-      segment.setEndOffset(segment.getStartOffset());
-      position = (int) segment.getStartOffset();
-      readAndEnsureMatch(segment, position,
-          Arrays.copyOfRange(data, position - (int) segment.getStartOffset(), data.length));
-
       // error scenarios
       ByteBuffer readBuf = ByteBuffer.wrap(new byte[data.length]);
       // data cannot be read at invalid offsets.

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -247,11 +247,11 @@ public class LogSegmentTest {
         }
       }
 
-      // position + buffer.remaining() > endOffset.
+      // position + buffer.remaining() > sizeInBytes.
       long readOverFlowCount = metrics.overflowReadError.getCount();
       try {
-        segment.readInto(readBuf, writeStartOffset + 1);
-        fail("Should have failed to read because position + buffer.remaining() > endOffset");
+        segment.readInto(readBuf, readBuf.remaining() + 1);
+        fail("Should have failed to read because position + buffer.remaining() > sizeInBytes");
       } catch (IndexOutOfBoundsException e) {
         assertEquals("Read overflow should have been reported", readOverFlowCount + 1,
             metrics.overflowReadError.getCount());


### PR DESCRIPTION
This patch fixes a bug in index and log recovery path.

The issue was LogSegment's end offset is set to index's known last offset to get started. Once index recovery is complete, proper end offsets are set. But recovery code invokes logSegment.readInto() which checks for position < endOffset which fails as any blobs that are in log and not part of index will have position > endOffset, but < sizeInBytes. And hence no blobs are recovered :(

Fix is to check for sizeInBytes within LogSegment.readInto() rather than endOffset. 

Testing done locally:
* Create a store and added new blobs to it. 
* The store was shutdown. Removed all indexes, bloom and other misc file except log files
* Started the service again. 
* Ran ConsistencyCheckerTool to confirm both set of indexes are in consistent with each other

Built and coding style applied
SLA: 5 mins
Reviewers: @vgkholla @pnarayanan 

Fixes linkedin/ambry#594