### PR TITLE
Fixing expiration values in IndexValue for overflow cases

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -15,7 +15,6 @@ package com.github.ambry.messageformat;
 
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
-import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -71,12 +70,7 @@ public class BlobProperties {
     this.contentType = contentType;
     this.isPrivate = isPrivate;
     this.creationTimeInMs = creationTimeInMs;
-    // expiration value in seconds cannot exceed Integer.MAX_VALUE
-    if (timeToLiveInSeconds + TimeUnit.MILLISECONDS.toSeconds(creationTimeInMs) > Integer.MAX_VALUE) {
-      this.timeToLiveInSeconds = Utils.Infinite_Time;
-    } else {
-      this.timeToLiveInSeconds = timeToLiveInSeconds;
-    }
+    this.timeToLiveInSeconds = timeToLiveInSeconds;
   }
 
   public long getTimeToLiveInSeconds() {

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -187,7 +187,7 @@ class AmbryBlobStorageService implements BlobStorageService {
       BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
       if (blobProperties.getTimeToLiveInSeconds() + TimeUnit.MILLISECONDS.toSeconds(
           blobProperties.getCreationTimeInMs()) > Integer.MAX_VALUE) {
-        logger.warn("TTL set to very large value in POST request with BlobProperties {}", blobProperties);
+        logger.debug("TTL set to very large value in POST request with BlobProperties {}", blobProperties);
         frontendMetrics.ttlTooLargeError.inc();
       }
       byte[] usermetadata = RestUtils.buildUsermetadata(restRequest.getArgs());

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
@@ -107,6 +107,7 @@ class FrontendMetrics {
   public final Counter responseSubmissionError;
   public final Counter resourceReleaseError;
   public final Counter routerCallbackError;
+  public final Counter ttlTooLargeError;
   // DeleteCallback
   public final Counter deleteCallbackProcessingError;
   // HeadCallback
@@ -117,8 +118,6 @@ class FrontendMetrics {
   // PostCallback
   public final Counter postCallbackProcessingError;
   public final Counter outboundIdConversionCallbackProcessingError;
-  // TTL too large error
-  public final Counter ttlTooLargeError;
   // Other
   // AmbryBlobStorageService
   public final Histogram blobStorageServiceStartupTimeInMs;

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
@@ -117,7 +117,8 @@ class FrontendMetrics {
   // PostCallback
   public final Counter postCallbackProcessingError;
   public final Counter outboundIdConversionCallbackProcessingError;
-
+  // TTL too large error
+  public final Counter ttlTooLargeError;
   // Other
   // AmbryBlobStorageService
   public final Histogram blobStorageServiceStartupTimeInMs;
@@ -265,6 +266,7 @@ class FrontendMetrics {
         metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "PostCallbackProcessingError"));
     outboundIdConversionCallbackProcessingError = metricRegistry.counter(
         MetricRegistry.name(AmbryBlobStorageService.class, "OutboundIdConversionCallbackProcessingError"));
+    ttlTooLargeError = metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "TtlTooLargeError"));
 
     // Other
     blobStorageServiceStartupTimeInMs =

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -57,20 +57,14 @@ public class BlobPropertiesTest {
     long[] validTTLs = new long[]{TimeUnit.HOURS.toSeconds(1), TimeUnit.HOURS.toSeconds(10), TimeUnit.HOURS.toSeconds(
         100), TimeUnit.DAYS.toSeconds(1), TimeUnit.DAYS.toSeconds(10), TimeUnit.DAYS.toSeconds(
         100), TimeUnit.DAYS.toSeconds(30 * 12), TimeUnit.DAYS.toSeconds(30 * 12 * 10),
-        Integer.MAX_VALUE - creationTimeInSecs - 1, Integer.MAX_VALUE - creationTimeInSecs};
+        Integer.MAX_VALUE - creationTimeInSecs - 1,
+        Integer.MAX_VALUE - creationTimeInSecs,
+        Integer.MAX_VALUE - creationTimeInSecs + 1,
+        Integer.MAX_VALUE - creationTimeInSecs + 100, Integer.MAX_VALUE - creationTimeInSecs + 10000};
 
     for (long ttl : validTTLs) {
       blobProperties = new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs);
       verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, ttl);
-    }
-
-    // invalid TTLs
-    long[] invalidTTLs = new long[]{
-        Integer.MAX_VALUE - creationTimeInSecs + 1,
-        Integer.MAX_VALUE - creationTimeInSecs + 100, Integer.MAX_VALUE - creationTimeInSecs + 10000};
-    for (long ttl : invalidTTLs) {
-      blobProperties = new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs);
-      verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, Utils.Infinite_Time);
     }
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -16,6 +16,7 @@ package com.github.ambry.store;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -105,11 +106,11 @@ class IndexValue {
         offset = new Offset(logSegmentName, value.getLong());
         flags = value.get();
         long expiresAt = value.getInt();
-        expiresAtMs = expiresAt != Utils.Infinite_Time ? (expiresAt * Time.MsPerSec) : Utils.Infinite_Time;
+        expiresAtMs = expiresAt > Utils.Infinite_Time ? (expiresAt * Time.MsPerSec) : Utils.Infinite_Time;
         originalMessageOffset = value.getLong();
         long operationTimeInSecs = value.getInt();
-        operationTimeInMs = operationTimeInSecs != Utils.Infinite_Time ? (operationTimeInSecs * Time.MsPerSec)
-            : Utils.Infinite_Time;
+        operationTimeInMs =
+            operationTimeInSecs != Utils.Infinite_Time ? (operationTimeInSecs * Time.MsPerSec) : Utils.Infinite_Time;
         serviceId = value.getShort();
         containerId = value.getShort();
         break;
@@ -187,7 +188,12 @@ class IndexValue {
     this.size = size;
     this.offset = offset;
     this.flags = flags;
-    this.expiresAtMs = Utils.getTimeInMsToTheNearestSec(expiresAtMs);
+    // if expiry in secs > Integer.MAX_VALUE, treat it as permanent blob
+    if (TimeUnit.MILLISECONDS.toSeconds(expiresAtMs) > Integer.MAX_VALUE) {
+      this.expiresAtMs = Utils.Infinite_Time;
+    } else {
+      this.expiresAtMs = Utils.getTimeInMsToTheNearestSec(expiresAtMs);
+    }
     this.originalMessageOffset = originalMessageOffset;
     this.operationTimeInMs = Utils.getTimeInMsToTheNearestSec(operationTimeInMs);
     this.serviceId = serviceId;

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -106,11 +106,11 @@ class IndexValue {
         offset = new Offset(logSegmentName, value.getLong());
         flags = value.get();
         long expiresAt = value.getInt();
-        expiresAtMs = expiresAt >= 0 ? (expiresAt * Time.MsPerSec) : Utils.Infinite_Time;
+        expiresAtMs = expiresAt >= 0 ? TimeUnit.SECONDS.toMillis(expiresAt) : Utils.Infinite_Time;
         originalMessageOffset = value.getLong();
         long operationTimeInSecs = value.getInt();
-        operationTimeInMs =
-            operationTimeInSecs != Utils.Infinite_Time ? (operationTimeInSecs * Time.MsPerSec) : Utils.Infinite_Time;
+        operationTimeInMs = operationTimeInSecs != Utils.Infinite_Time ? TimeUnit.SECONDS.toMillis(operationTimeInSecs)
+            : Utils.Infinite_Time;
         serviceId = value.getShort();
         containerId = value.getShort();
         break;

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -106,7 +106,7 @@ class IndexValue {
         offset = new Offset(logSegmentName, value.getLong());
         flags = value.get();
         long expiresAt = value.getInt();
-        expiresAtMs = expiresAt > Utils.Infinite_Time ? (expiresAt * Time.MsPerSec) : Utils.Infinite_Time;
+        expiresAtMs = expiresAt >= 0 ? (expiresAt * Time.MsPerSec) : Utils.Infinite_Time;
         originalMessageOffset = value.getLong();
         long operationTimeInSecs = value.getInt();
         operationTimeInMs =
@@ -191,6 +191,8 @@ class IndexValue {
     // if expiry in secs > Integer.MAX_VALUE, treat it as permanent blob
     if (TimeUnit.MILLISECONDS.toSeconds(expiresAtMs) > Integer.MAX_VALUE) {
       this.expiresAtMs = Utils.Infinite_Time;
+    } else if (expiresAtMs != Utils.Infinite_Time && expiresAtMs < 0) {
+      this.expiresAtMs = 0;
     } else {
       this.expiresAtMs = Utils.getTimeInMsToTheNearestSec(expiresAtMs);
     }

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -191,8 +191,6 @@ class IndexValue {
     // if expiry in secs > Integer.MAX_VALUE, treat it as permanent blob
     if (TimeUnit.MILLISECONDS.toSeconds(expiresAtMs) > Integer.MAX_VALUE) {
       this.expiresAtMs = Utils.Infinite_Time;
-    } else if (expiresAtMs != Utils.Infinite_Time && expiresAtMs < 0) {
-      this.expiresAtMs = 0;
     } else {
       this.expiresAtMs = Utils.getTimeInMsToTheNearestSec(expiresAtMs);
     }

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -87,10 +87,10 @@ public class IndexValueTest {
     // expiry > Integer.MAX_VALUE, expected to be -1
     expirationTimeAtMs = TimeUnit.SECONDS.toMillis(2 * (long) Integer.MAX_VALUE);
     expirationTimes.put(expirationTimeAtMs, Utils.Infinite_Time);
-    // expiry < 0
+    // expiry < 0. This is to test how negative expiration values are treated in deser path.
     expirationTimeAtMs = -1 * TimeUnit.DAYS.toMillis(1);
     expirationTimes.put(expirationTimeAtMs, Utils.getTimeInMsToTheNearestSec(expirationTimeAtMs));
-    // expiry < 0
+    // expiry < 0. This is to test how negative expiration values are treated in deser path.
     expirationTimeAtMs = (long) Integer.MIN_VALUE;
     expirationTimes.put(expirationTimeAtMs, Utils.getTimeInMsToTheNearestSec(expirationTimeAtMs));
 

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -84,9 +84,6 @@ public class IndexValueTest {
     // expiry > Integer.MAX_VALUE, expected to be -1
     expirationTimeAtMs = TimeUnit.SECONDS.toMillis((long) Integer.MAX_VALUE + 1);
     expirationTimes.put(expirationTimeAtMs, Utils.Infinite_Time);
-    // expiry > Integer.MAX_VALUE, expected to be -1
-    expirationTimeAtMs = TimeUnit.SECONDS.toMillis(2 * (long) Integer.MAX_VALUE);
-    expirationTimes.put(expirationTimeAtMs, Utils.Infinite_Time);
     // expiry < 0. This is to test how negative expiration values are treated in deser path.
     expirationTimeAtMs = -1 * TimeUnit.DAYS.toMillis(1);
     expirationTimes.put(expirationTimeAtMs, Utils.getTimeInMsToTheNearestSec(expirationTimeAtMs));
@@ -210,7 +207,7 @@ public class IndexValueTest {
         expectedExpiryValue = expiresAtMs;
         break;
       case PersistentIndex.VERSION_1:
-        expectedExpiryValue = expiresAtMs < Utils.Infinite_Time ? Utils.Infinite_Time : expiresAtMs;
+        expectedExpiryValue = expiresAtMs >= 0 ? expiresAtMs : Utils.Infinite_Time;
         break;
     }
     verifyGetters(new IndexValue(logSegmentName, value.getBytes(), version), logSegmentName, size, offset, isDeleted,

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.store;
 
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -87,12 +88,6 @@ public class IndexValueTest {
     // expiry > Integer.MAX_VALUE, expected to be -1
     expirationTimeAtMs = TimeUnit.SECONDS.toMillis(2 * (long) Integer.MAX_VALUE);
     expirationTimes.put(expirationTimeAtMs, Utils.Infinite_Time);
-    // expiry < 0
-    expirationTimeAtMs = -1 * TimeUnit.DAYS.toMillis(1);
-    expirationTimes.put(expirationTimeAtMs, Utils.getTimeInMsToTheNearestSec(expirationTimeAtMs));
-    // expiry < 0
-    expirationTimeAtMs = -1 * (long) Integer.MAX_VALUE;
-    expirationTimes.put(expirationTimeAtMs, Utils.getTimeInMsToTheNearestSec(expirationTimeAtMs));
 
     for (Map.Entry<Long, Long> expirationTime : expirationTimes.entrySet()) {
       long expiresAtMs = expirationTime.getKey();
@@ -110,6 +105,14 @@ public class IndexValueTest {
           break;
       }
     }
+
+    // verify negative expiration value in serialized IndexValue
+    expirationTimeAtMs = -1 * (long) Integer.MAX_VALUE;
+    IndexValue value =
+        getIndexValue(size, new Offset(logSegmentName, offset), (byte) 0, expirationTimeAtMs, offset, version);
+    verifyIndexValue(value, logSegmentName, size, offset, false,
+        version == PersistentIndex.VERSION_0 ? expirationTimeAtMs : Utils.Infinite_Time, offset, Utils.Infinite_Time,
+        IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE, IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE);
   }
 
   /**
@@ -274,7 +277,8 @@ public class IndexValueTest {
   static IndexValue getIndexValue(long size, Offset offset, long expirationTimeInMs, long operationTimeInMs,
       short serviceId, short containerId, short version) {
     if (version == PersistentIndex.VERSION_0) {
-      return getIndexValue(size, offset, IndexValue.FLAGS_DEFAULT_VALUE, expirationTimeInMs, offset.getOffset());
+      return getIndexValue(size, offset, IndexValue.FLAGS_DEFAULT_VALUE, expirationTimeInMs, offset.getOffset(),
+          version);
     } else {
       return new IndexValue(size, offset, IndexValue.FLAGS_DEFAULT_VALUE, expirationTimeInMs, operationTimeInMs,
           serviceId, containerId);
@@ -291,7 +295,8 @@ public class IndexValueTest {
    */
   static IndexValue getIndexValue(long size, Offset offset, long operationTimeInMs, short version) {
     if (version == PersistentIndex.VERSION_0) {
-      return getIndexValue(size, offset, IndexValue.FLAGS_DEFAULT_VALUE, Utils.Infinite_Time, offset.getOffset());
+      return getIndexValue(size, offset, IndexValue.FLAGS_DEFAULT_VALUE, Utils.Infinite_Time, offset.getOffset(),
+          version);
     } else {
       return new IndexValue(size, offset, IndexValue.FLAGS_DEFAULT_VALUE, Utils.Infinite_Time, operationTimeInMs);
     }
@@ -306,7 +311,7 @@ public class IndexValueTest {
   static IndexValue getIndexValue(IndexValue value, short version) {
     if (version == PersistentIndex.VERSION_0) {
       return getIndexValue(value.getSize(), value.getOffset(), value.getFlags(), value.getExpiresAtMs(),
-          value.getOffset().getOffset());
+          value.getOffset().getOffset(), version);
     } else {
       return new IndexValue(value.getSize(), value.getOffset(), value.getFlags(), value.getExpiresAtMs(),
           value.getOperationTimeInMs(), value.getServiceId(), value.getContainerId());
@@ -316,24 +321,44 @@ public class IndexValueTest {
   // Instantiation of {@link IndexValue} in version {@link PersistentIndex#VERSION_0}
 
   /**
-   * Constructs IndexValue based on the args passed in version {@link PersistentIndex#VERSION_0}
+   * Constructs IndexValue based on the args passed in, in the version specified
    * @param size the size of the blob that this index value refers to
    * @param offset the {@link Offset} in the {@link Log} where the blob that this index value refers to resides
    * @param expiresAtMs the expiration time in ms at which the blob expires
    * @param originalMessageOffset the original message offset where the Put record pertaining to a delete record exists
    *                              in the same log segment. Set to -1 otherwise.
+   * @param version the version of IndexValue which is to be constructed
    * @return the {@link IndexValue} thus constructed
    */
   private static IndexValue getIndexValue(long size, Offset offset, byte flags, long expiresAtMs,
-      long originalMessageOffset) {
-    ByteBuffer value = ByteBuffer.allocate(IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0);
-    value.putLong(size);
-    value.putLong(offset.getOffset());
-    value.put(flags);
-    value.putLong(expiresAtMs);
-    value.putLong(originalMessageOffset);
-    value.position(0);
-    return new IndexValue(offset.getName(), value, PersistentIndex.VERSION_0);
+      long originalMessageOffset, short version) {
+    IndexValue indexValue = null;
+    switch (version) {
+      case PersistentIndex.VERSION_0:
+        ByteBuffer value = ByteBuffer.allocate(IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0);
+        value.putLong(size);
+        value.putLong(offset.getOffset());
+        value.put(flags);
+        value.putLong(expiresAtMs);
+        value.putLong(originalMessageOffset);
+        value.position(0);
+        indexValue = new IndexValue(offset.getName(), value, PersistentIndex.VERSION_0);
+        break;
+      case PersistentIndex.VERSION_1:
+        value = ByteBuffer.allocate(IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1);
+        value.putLong(size);
+        value.putLong(offset.getOffset());
+        value.put(flags);
+        value.putInt(expiresAtMs != Utils.Infinite_Time ? (int) (expiresAtMs / Time.MsPerSec) : (int) expiresAtMs);
+        value.putLong(originalMessageOffset);
+        value.putInt((int) Utils.Infinite_Time);
+        value.putShort(IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE);
+        value.putShort(IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE);
+        value.position(0);
+        indexValue = new IndexValue(offset.getName(), value, PersistentIndex.VERSION_1);
+        break;
+    }
+    return indexValue;
   }
 }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -91,7 +91,7 @@ public class IndexValueTest {
     expirationTimeAtMs = -1 * TimeUnit.DAYS.toMillis(1);
     expirationTimes.put(expirationTimeAtMs, Utils.getTimeInMsToTheNearestSec(expirationTimeAtMs));
     // expiry < 0
-    expirationTimeAtMs = -1 * (long) Integer.MAX_VALUE;
+    expirationTimeAtMs = (long) Integer.MIN_VALUE;
     expirationTimes.put(expirationTimeAtMs, Utils.getTimeInMsToTheNearestSec(expirationTimeAtMs));
 
     for (Map.Entry<Long, Long> expirationTime : expirationTimes.entrySet()) {


### PR DESCRIPTION
This is a follow up on PR: https://github.com/linkedin/ambry/pull/599

* Removed any validation wrt TTL in BlobProperties.
* Added validation in IndexValue initialization wrt expiration value. Any expiry value in secs > Integer.MAX will be set to -1 (never expire)
* Sometime back there was a bug in deserialization path of expiry values and the fix is [here](https://github.com/linkedin/ambry/pull/599). Before the fix, some expiration values are written as negative values to the store. Fixing them in this patch. Treating any negative expiry values as -1 in read path. 
* Added metric in frontend to track very large TTLs. 

Built and coding style applied
SLA: 15 mins
Reviewers: @cgtz @vgkholla 