### PR TITLE
Adding getAllPartitions() to ClusterMap

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -37,6 +37,12 @@ public interface ClusterMap extends AutoCloseable {
   List<? extends PartitionId> getWritablePartitionIds();
 
   /**
+   * Gets a list of all partitions in the cluster
+   * @return a list of all partitions in the cluster
+   */
+  List<? extends PartitionId> getAllPartitions();
+
+  /**
    * Checks if datacenter name corresponds to some datacenter in this cluster map's hardware layout.
    *
    * @param datacenterName name of datacenter

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -40,7 +40,7 @@ public interface ClusterMap extends AutoCloseable {
    * Gets a list of all partitions in the cluster
    * @return a list of all partitions in the cluster
    */
-  List<? extends PartitionId> getAllPartitions();
+  List<? extends PartitionId> getAllPartitionIds();
 
   /**
    * Checks if datacenter name corresponds to some datacenter in this cluster map's hardware layout.

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -64,7 +64,7 @@ class CompositeClusterManager implements ClusterMap {
   /**
    * Get writable partition ids from both the underlying {@link StaticClusterManager} and the underlying
    * {@link HelixClusterManager}. Compare the two and if there is a mismatch, update a metric.
-   * @return a list of partition ids from the underlying {@link StaticClusterManager}.
+   * @return a list of writable partition ids from the underlying {@link StaticClusterManager}.
    */
   @Override
   public List<PartitionId> getWritablePartitionIds() {
@@ -85,6 +85,32 @@ class CompositeClusterManager implements ClusterMap {
       }
     }
     return staticWritablePartitionIds;
+  }
+
+  /**
+   * Get all partition ids from both the underlying {@link StaticClusterManager} and the underlying
+   * {@link HelixClusterManager}. Compare the two and if there is a mismatch, update a metric.
+   * @return a list of partition ids from the underlying {@link StaticClusterManager}.
+   */
+  @Override
+  public List<PartitionId> getAllPartitions() {
+    List<PartitionId> staticPartitionIds = staticClusterManager.getAllPartitions();
+    if (helixClusterManager != null) {
+      Set<String> staticPartitionIdStrings = new HashSet<>();
+      for (PartitionId partitionId : staticPartitionIds) {
+        staticPartitionIdStrings.add(partitionId.toString());
+      }
+
+      Set<String> helixPartitionIdStrings = new HashSet<>();
+      for (PartitionId partitionId : helixClusterManager.getAllPartitions()) {
+        helixPartitionIdStrings.add(partitionId.toString());
+      }
+
+      if (!staticPartitionIdStrings.equals(helixPartitionIdStrings)) {
+        helixClusterManagerMetrics.getAllPartitionsMismatchCount.inc();
+      }
+    }
+    return staticPartitionIds;
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -70,8 +70,8 @@ class CompositeClusterManager implements ClusterMap {
   public List<PartitionId> getWritablePartitionIds() {
     List<PartitionId> staticWritablePartitionIds = staticClusterManager.getWritablePartitionIds();
     if (helixClusterManager != null) {
-      if (!checkPartitionListEquivalency(staticWritablePartitionIds, helixClusterManager.getWritablePartitionIds())) {
-        helixClusterManagerMetrics.getAllPartitionsMismatchCount.inc();
+      if (!areEqual(staticWritablePartitionIds, helixClusterManager.getWritablePartitionIds())) {
+        helixClusterManagerMetrics.getAllPartitionIdsMismatchCount.inc();
       }
     }
     return staticWritablePartitionIds;
@@ -86,8 +86,8 @@ class CompositeClusterManager implements ClusterMap {
   public List<PartitionId> getAllPartitionIds() {
     List<PartitionId> staticPartitionIds = staticClusterManager.getAllPartitionIds();
     if (helixClusterManager != null) {
-      if (!checkPartitionListEquivalency(staticPartitionIds, helixClusterManager.getAllPartitionIds())) {
-        helixClusterManagerMetrics.getAllPartitionsMismatchCount.inc();
+      if (!areEqual(staticPartitionIds, helixClusterManager.getAllPartitionIds())) {
+        helixClusterManagerMetrics.getAllPartitionIdsMismatchCount.inc();
       }
     }
     return staticPartitionIds;
@@ -221,13 +221,12 @@ class CompositeClusterManager implements ClusterMap {
   }
 
   /**
-   * Check for partition list equivalency
+   * Check if two lists of partitions are equivalent
    * @param partitionListOne {@link List} of {@link PartitionId}s to compare
    * @param partitionListTwo {@link List} of {@link AmbryPartition}s to compare
    * @return {@code true} if both list are equal, {@code false} otherwise
    */
-  private boolean checkPartitionListEquivalency(List<PartitionId> partitionListOne,
-      List<AmbryPartition> partitionListTwo) {
+  private boolean areEqual(List<PartitionId> partitionListOne, List<AmbryPartition> partitionListTwo) {
     Set<String> partitionStringsOne = new HashSet<>();
     for (PartitionId partitionId : partitionListOne) {
       partitionStringsOne.add(partitionId.toString());

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -70,18 +70,8 @@ class CompositeClusterManager implements ClusterMap {
   public List<PartitionId> getWritablePartitionIds() {
     List<PartitionId> staticWritablePartitionIds = staticClusterManager.getWritablePartitionIds();
     if (helixClusterManager != null) {
-      Set<String> staticPartitionIdStrings = new HashSet<>();
-      for (PartitionId partitionId : staticWritablePartitionIds) {
-        staticPartitionIdStrings.add(partitionId.toString());
-      }
-
-      Set<String> helixPartitionIdStrings = new HashSet<>();
-      for (PartitionId partitionId : helixClusterManager.getWritablePartitionIds()) {
-        helixPartitionIdStrings.add(partitionId.toString());
-      }
-
-      if (!staticPartitionIdStrings.equals(helixPartitionIdStrings)) {
-        helixClusterManagerMetrics.getWritablePartitionIdsMismatchCount.inc();
+      if (!checkPartitionListEquivalency(staticWritablePartitionIds, helixClusterManager.getWritablePartitionIds())) {
+        helixClusterManagerMetrics.getAllPartitionsMismatchCount.inc();
       }
     }
     return staticWritablePartitionIds;
@@ -93,20 +83,10 @@ class CompositeClusterManager implements ClusterMap {
    * @return a list of partition ids from the underlying {@link StaticClusterManager}.
    */
   @Override
-  public List<PartitionId> getAllPartitions() {
-    List<PartitionId> staticPartitionIds = staticClusterManager.getAllPartitions();
+  public List<PartitionId> getAllPartitionIds() {
+    List<PartitionId> staticPartitionIds = staticClusterManager.getAllPartitionIds();
     if (helixClusterManager != null) {
-      Set<String> staticPartitionIdStrings = new HashSet<>();
-      for (PartitionId partitionId : staticPartitionIds) {
-        staticPartitionIdStrings.add(partitionId.toString());
-      }
-
-      Set<String> helixPartitionIdStrings = new HashSet<>();
-      for (PartitionId partitionId : helixClusterManager.getAllPartitions()) {
-        helixPartitionIdStrings.add(partitionId.toString());
-      }
-
-      if (!staticPartitionIdStrings.equals(helixPartitionIdStrings)) {
+      if (!checkPartitionListEquivalency(staticPartitionIds, helixClusterManager.getAllPartitionIds())) {
         helixClusterManagerMetrics.getAllPartitionsMismatchCount.inc();
       }
     }
@@ -238,6 +218,25 @@ class CompositeClusterManager implements ClusterMap {
     if (helixClusterManager != null) {
       helixClusterManager.close();
     }
+  }
+
+  /**
+   * Check for partition list equivalency
+   * @param partitionListOne {@link List} of {@link PartitionId}s to compare
+   * @param partitionListTwo {@link List} of {@link AmbryPartition}s to compare
+   * @return {@code true} if both list are equal, {@code false} otherwise
+   */
+  private boolean checkPartitionListEquivalency(List<PartitionId> partitionListOne,
+      List<AmbryPartition> partitionListTwo) {
+    Set<String> partitionStringsOne = new HashSet<>();
+    for (PartitionId partitionId : partitionListOne) {
+      partitionStringsOne.add(partitionId.toString());
+    }
+    Set<String> partitionStringsTwo = new HashSet<>();
+    for (PartitionId partitionId : partitionListTwo) {
+      partitionStringsTwo.add(partitionId.toString());
+    }
+    return partitionStringsOne.equals(partitionStringsTwo);
   }
 }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixAdminFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixAdminFactory.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 
+
 /**
  * A factory class to construct and get a reference to a {@link HelixAdmin}
  */
@@ -25,7 +26,7 @@ public class HelixAdminFactory {
    * @param zkAddr the address identifying the zk service to which this request is to be made.
    * @return the reference to the {@link HelixAdmin}.
    */
-  HelixAdmin getHelixAdmin(String zkAddr) {
+  public HelixAdmin getHelixAdmin(String zkAddr) {
     return new ZKHelixAdmin(zkAddr);
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -309,7 +309,7 @@ class HelixClusterManager implements ClusterMap {
    * @return list of all partition ids in the cluster
    */
   @Override
-  public List<AmbryPartition> getAllPartitions() {
+  public List<AmbryPartition> getAllPartitionIds() {
     return new ArrayList<>(partitionNameToAmbryPartition.values());
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -306,6 +306,14 @@ class HelixClusterManager implements ClusterMap {
   }
 
   /**
+   * @return list of all partition ids in the cluster
+   */
+  @Override
+  public List<AmbryPartition> getAllPartitions() {
+    return new ArrayList<>(partitionNameToAmbryPartition.values());
+  }
+
+  /**
    * Disconnect from the HelixManagers associated with each and every datacenter.
    */
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
@@ -31,6 +31,7 @@ class HelixClusterManagerMetrics {
   public final Counter instanceConfigChangeTriggerCount;
   public final Counter getPartitionIdFromStreamMismatchCount;
   public final Counter getWritablePartitionIdsMismatchCount;
+  public final Counter getAllPartitionsMismatchCount;
   public final Counter hasDatacenterMismatchCount;
   public final Counter getDataNodeIdMismatchCount;
   public final Counter getReplicaIdsMismatchCount;
@@ -58,6 +59,8 @@ class HelixClusterManagerMetrics {
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getPartitionIdFromStreamMismatchCount"));
     getWritablePartitionIdsMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getWritablePartitionIdsMismatchCount"));
+    getAllPartitionsMismatchCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "getAllPartitionsMismatchCount"));
     hasDatacenterMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "hasDatacenterMismatchCount"));
     getDataNodeIdMismatchCount =

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
@@ -31,7 +31,7 @@ class HelixClusterManagerMetrics {
   public final Counter instanceConfigChangeTriggerCount;
   public final Counter getPartitionIdFromStreamMismatchCount;
   public final Counter getWritablePartitionIdsMismatchCount;
-  public final Counter getAllPartitionsMismatchCount;
+  public final Counter getAllPartitionIdsMismatchCount;
   public final Counter hasDatacenterMismatchCount;
   public final Counter getDataNodeIdMismatchCount;
   public final Counter getReplicaIdsMismatchCount;
@@ -59,8 +59,8 @@ class HelixClusterManagerMetrics {
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getPartitionIdFromStreamMismatchCount"));
     getWritablePartitionIdsMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getWritablePartitionIdsMismatchCount"));
-    getAllPartitionsMismatchCount =
-        registry.counter(MetricRegistry.name(HelixClusterManager.class, "getAllPartitionsMismatchCount"));
+    getAllPartitionIdsMismatchCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "getAllPartitionIdsMismatchCount"));
     hasDatacenterMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "hasDatacenterMismatchCount"));
     getDataNodeIdMismatchCount =

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -75,7 +75,7 @@ class StaticClusterManager implements ClusterMap {
   }
 
   @Override
-  public List<PartitionId> getAllPartitions() {
+  public List<PartitionId> getAllPartitionIds() {
     return partitionLayout.getPartitions();
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -66,16 +66,17 @@ class StaticClusterManager implements ClusterMap {
     writeJsonToFile(partitionLayout.toJSONObject(), partitionLayoutPath);
   }
 
-  List<PartitionId> getAllPartitions() {
-    return partitionLayout.getPartitions();
-  }
-
   // Implementation of ClusterMap interface
   // --------------------------------------
 
   @Override
   public List<PartitionId> getWritablePartitionIds() {
     return partitionLayout.getWritablePartitions();
+  }
+
+  @Override
+  public List<PartitionId> getAllPartitions() {
+    return partitionLayout.getPartitions();
   }
 
   @Override

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -385,7 +385,7 @@ public class HelixClusterManagerTest {
    */
   private void testAllPartitions() {
     Set<String> partitionsInClusterManager = new HashSet<>();
-    for (PartitionId partition : clusterManager.getAllPartitions()) {
+    for (PartitionId partition : clusterManager.getAllPartitionIds()) {
       String partitionStr =
           useComposite ? ((Partition) partition).toPathString() : ((AmbryPartition) partition).toPathString();
       partitionsInClusterManager.add(partitionStr);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -301,7 +301,8 @@ public class HelixClusterManagerTest {
     assertEquals(helixCluster.getDiskDownCount(), getGaugeValue("diskDownCount"));
     assertEquals(helixCluster.getAllPartitions().size(), getGaugeValue("partitionCount"));
     assertEquals(helixCluster.getAllWritablePartitions().size(), getGaugeValue("partitionReadWriteCount"));
-    assertEquals(3L, getGaugeValue("partitionSealedCount"));
+    assertEquals(helixCluster.getAllPartitions().size() - helixCluster.getAllWritablePartitions().size(),
+        getGaugeValue("partitionSealedCount"));
     assertEquals(helixCluster.getDiskCapacity(), getGaugeValue("rawTotalCapacityBytes"));
     assertEquals(0L, getGaugeValue("isMajorityReplicasDownForAnyPartition"));
     assertEquals(0L,

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -172,7 +172,7 @@ public class MockClusterMap implements ClusterMap {
   }
 
   @Override
-  public List<PartitionId> getAllPartitions() {
+  public List<PartitionId> getAllPartitionIds() {
     return new ArrayList<>(partitions.values());
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -172,6 +172,11 @@ public class MockClusterMap implements ClusterMap {
   }
 
   @Override
+  public List<PartitionId> getAllPartitions() {
+    return new ArrayList<>(partitions.values());
+  }
+
+  @Override
   public boolean hasDatacenter(String datacenterName) {
     return dataCentersInClusterMap.contains(datacenterName);
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
@@ -200,7 +200,7 @@ class MockHelixAdmin implements HelixAdmin {
    * @return all writable partitions registered via this Helix admin.
    */
   Set<String> getWritablePartitions() {
-    Set<String> healthWritablePartitions = new HashSet<>();
+    Set<String> healthyWritablePartitions = new HashSet<>();
     for (Map.Entry<String, Set<String>> entry : partitionToInstances.entrySet()) {
       if (partitionStates.get(entry.getKey()).equals(PartitionState.READ_WRITE)) {
         boolean up = true;
@@ -211,11 +211,11 @@ class MockHelixAdmin implements HelixAdmin {
           }
         }
         if (up) {
-          healthWritablePartitions.add(entry.getKey());
+          healthyWritablePartitions.add(entry.getKey());
         }
       }
     }
-    return healthWritablePartitions;
+    return healthyWritablePartitions;
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
@@ -200,11 +200,9 @@ class MockHelixAdmin implements HelixAdmin {
    * @return all writable partitions registered via this Helix admin.
    */
   Set<String> getWritablePartitions() {
-    Set<String> writablePartitions = new HashSet<>();
     Set<String> healthWritablePartitions = new HashSet<>();
     for (Map.Entry<String, Set<String>> entry : partitionToInstances.entrySet()) {
       if (partitionStates.get(entry.getKey()).equals(PartitionState.READ_WRITE)) {
-        writablePartitions.add(entry.getKey());
         boolean up = true;
         for (String instance : entry.getValue()) {
           if (!getUpInstances().contains(instance)) {
@@ -217,7 +215,7 @@ class MockHelixAdmin implements HelixAdmin {
         }
       }
     }
-    return healthWritablePartitions.isEmpty() ? writablePartitions : healthWritablePartitions;
+    return healthWritablePartitions;
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
@@ -43,7 +43,7 @@ class MockHelixAdmin implements HelixAdmin {
   private long totalDiskCount = 0;
   private final List<MockHelixManager> helixManagersForThisAdmin = new ArrayList<>();
   private Map<String, Set<String>> partitionToInstances = new HashMap<>();
-  private Map<String, PartitionState> partitionStates = new HashMap<>();
+  private Map<String, PartitionState> partitionToPartitionStates = new HashMap<>();
   private long totalDiskCapacity;
 
   @Override
@@ -83,7 +83,7 @@ class MockHelixAdmin implements HelixAdmin {
       if (partitionToInstances.get(partition) == null) {
         Set<String> instanceSet = new HashSet<>();
         partitionToInstances.put(partition, instanceSet);
-        partitionStates.put(partition, PartitionState.READ_WRITE);
+        partitionToPartitionStates.put(partition, PartitionState.READ_WRITE);
       }
       partitionToInstances.get(partition).addAll(idealstate.getInstanceSet(partition));
     }
@@ -172,9 +172,9 @@ class MockHelixAdmin implements HelixAdmin {
    */
   void setPartitionState(String partition, PartitionState partitionState) {
     for (IdealState entry : resourcesToIdealStates.values()) {
-      for (String partitionStr : entry.getPartitionSet()) {
-        if (partitionStr.equals(partition) && partitionStates.containsKey(partition)) {
-          partitionStates.put(partition, partitionState);
+      for (String partitionInIdealState : entry.getPartitionSet()) {
+        if (partitionInIdealState.equals(partition)) {
+          partitionToPartitionStates.put(partition, partitionState);
         }
       }
     }
@@ -202,7 +202,7 @@ class MockHelixAdmin implements HelixAdmin {
   Set<String> getWritablePartitions() {
     Set<String> healthyWritablePartitions = new HashSet<>();
     for (Map.Entry<String, Set<String>> entry : partitionToInstances.entrySet()) {
-      if (partitionStates.get(entry.getKey()).equals(PartitionState.READ_WRITE)) {
+      if (partitionToPartitionStates.get(entry.getKey()).equals(PartitionState.READ_WRITE)) {
         boolean up = true;
         for (String instance : entry.getValue()) {
           if (!getUpInstances().contains(instance)) {
@@ -224,7 +224,7 @@ class MockHelixAdmin implements HelixAdmin {
   Set<String> getAllWritablePartitions() {
     Set<String> writablePartitions = new HashSet<>();
     for (Map.Entry<String, Set<String>> entry : partitionToInstances.entrySet()) {
-      if (partitionStates.get(entry.getKey()).equals(PartitionState.READ_WRITE)) {
+      if (partitionToPartitionStates.get(entry.getKey()).equals(PartitionState.READ_WRITE)) {
         writablePartitions.add(entry.getKey());
       }
     }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -131,9 +131,9 @@ public class MockHelixCluster {
    * @param instanceName the instance to be brought down.
    */
   void bringInstanceDown(String instanceName) {
-    for (Map.Entry<String, MockHelixAdmin> helixAdmin : helixAdmins.entrySet()) {
-      if (helixAdmin.getValue().getInstancesInCluster(clusterName).contains(instanceName)) {
-        helixAdmin.getValue().bringInstanceDown(instanceName);
+    for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
+      if (helixAdmin.getInstancesInCluster(clusterName).contains(instanceName)) {
+        helixAdmin.bringInstanceDown(instanceName);
       }
     }
   }
@@ -163,7 +163,7 @@ public class MockHelixCluster {
   /**
    * @return the set of all partitions in this cluster.
    */
-  Set<String> getPartitions() {
+  Set<String> getAllPartitions() {
     Set<String> partitions = null;
     for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
       if (partitions == null) {
@@ -187,7 +187,7 @@ public class MockHelixCluster {
         writablePartitions.retainAll(helixAdmin.getWritablePartitions());
       }
     }
-    return writablePartitions;
+    return writablePartitions.isEmpty() ? getAllWritablePartitions() : writablePartitions;
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -131,9 +131,9 @@ public class MockHelixCluster {
    * @param instanceName the instance to be brought down.
    */
   void bringInstanceDown(String instanceName) {
-    for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
-      if (helixAdmin.getInstancesInCluster(clusterName).contains(instanceName)) {
-        helixAdmin.bringInstanceDown(instanceName);
+    for (Map.Entry<String, MockHelixAdmin> helixAdmin : helixAdmins.entrySet()) {
+      if (helixAdmin.getValue().getInstancesInCluster(clusterName).contains(instanceName)) {
+        helixAdmin.getValue().bringInstanceDown(instanceName);
       }
     }
   }
@@ -150,12 +150,27 @@ public class MockHelixCluster {
   }
 
   /**
+   * Set the state of a partition
+   * @param partition partition for which state needs to be updated
+   * @param partitionState {@link PartitionState} that needs to be set
+   */
+  void setPartitionState(String partition, PartitionState partitionState) {
+    for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
+      helixAdmin.setPartitionState(partition, partitionState);
+    }
+  }
+
+  /**
    * @return the set of all partitions in this cluster.
    */
   Set<String> getPartitions() {
-    Set<String> partitions = new HashSet<>();
+    Set<String> partitions = null;
     for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
-      partitions.addAll(helixAdmin.getPartitions());
+      if (partitions == null) {
+        partitions = new HashSet<>(helixAdmin.getPartitions());
+      } else {
+        partitions.retainAll(helixAdmin.getPartitions());
+      }
     }
     return partitions;
   }
@@ -163,16 +178,31 @@ public class MockHelixCluster {
   /**
    * @return the set of all partitions in this cluster that are up.
    */
-  Set<String> getUpPartitions() {
-    Set<String> upPartitions = null;
+  Set<String> getWritablePartitions() {
+    Set<String> writablePartitions = null;
     for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
-      if (upPartitions == null) {
-        upPartitions = new HashSet<>(helixAdmin.getUpPartitions());
+      if (writablePartitions == null) {
+        writablePartitions = new HashSet<>(helixAdmin.getWritablePartitions());
       } else {
-        upPartitions.retainAll(helixAdmin.getUpPartitions());
+        writablePartitions.retainAll(helixAdmin.getWritablePartitions());
       }
     }
-    return upPartitions;
+    return writablePartitions;
+  }
+
+  /**
+   * @return the set of all partitions in this cluster that are up.
+   */
+  Set<String> getAllWritablePartitions() {
+    Set<String> writablePartitions = null;
+    for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
+      if (writablePartitions == null) {
+        writablePartitions = new HashSet<>(helixAdmin.getAllWritablePartitions());
+      } else {
+        writablePartitions.retainAll(helixAdmin.getAllWritablePartitions());
+      }
+    }
+    return writablePartitions;
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
@@ -78,10 +78,9 @@ public class StaticClusterManagerTest {
 
     TestUtils.TestHardwareLayout testHardwareLayout = new TestUtils.TestHardwareLayout("Alpha");
     TestUtils.TestPartitionLayout testPartitionLayout = new TestUtils.TestPartitionLayout(testHardwareLayout);
-    // add one partition with read_only state. This doesnt exactly mimic real behavior as a new partition added will
-    // always be in read_write state. This is just to test getWritablePartitions() and getAllPartitions()
+    // add 3 partitions with read_only state.
     testPartitionLayout.partitionState = PartitionState.READ_ONLY;
-    testPartitionLayout.addNewPartitions(1);
+    testPartitionLayout.addNewPartitions(3);
     testPartitionLayout.partitionState = PartitionState.READ_WRITE;
 
     ClusterMap clusterMapManager =
@@ -92,7 +91,7 @@ public class StaticClusterManagerTest {
 
     List<? extends PartitionId> writablePartitionIds = clusterMapManager.getWritablePartitionIds();
     List<? extends PartitionId> partitionIds = clusterMapManager.getAllPartitions();
-    assertEquals(writablePartitionIds.size(), testPartitionLayout.getPartitionCount() - 1);
+    assertEquals(writablePartitionIds.size(), testPartitionLayout.getPartitionCount() - 3);
     assertEquals(partitionIds.size(), testPartitionLayout.getPartitionCount());
     for (PartitionId partitionId : partitionIds) {
       if (partitionId.getPartitionState().equals(PartitionState.READ_WRITE)) {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
@@ -90,7 +90,7 @@ public class StaticClusterManagerTest {
     }
 
     List<? extends PartitionId> writablePartitionIds = clusterMapManager.getWritablePartitionIds();
-    List<? extends PartitionId> partitionIds = clusterMapManager.getAllPartitions();
+    List<? extends PartitionId> partitionIds = clusterMapManager.getAllPartitionIds();
     assertEquals(writablePartitionIds.size(), testPartitionLayout.getPartitionCount() - 3);
     assertEquals(partitionIds.size(), testPartitionLayout.getPartitionCount());
     for (PartitionId partitionId : partitionIds) {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
@@ -78,6 +78,11 @@ public class StaticClusterManagerTest {
 
     TestUtils.TestHardwareLayout testHardwareLayout = new TestUtils.TestHardwareLayout("Alpha");
     TestUtils.TestPartitionLayout testPartitionLayout = new TestUtils.TestPartitionLayout(testHardwareLayout);
+    // add one partition with read_only state. This doesnt exactly mimic real behavior as a new partition added will
+    // always be in read_write state. This is just to test getWritablePartitions() and getAllPartitions()
+    testPartitionLayout.partitionState = PartitionState.READ_ONLY;
+    testPartitionLayout.addNewPartitions(1);
+    testPartitionLayout.partitionState = PartitionState.READ_WRITE;
 
     ClusterMap clusterMapManager =
         (new StaticClusterAgentsFactory(null, testPartitionLayout.getPartitionLayout())).getClusterMap();
@@ -85,8 +90,17 @@ public class StaticClusterManagerTest {
       System.out.println(metricName);
     }
 
-    List<? extends PartitionId> partitionIds = clusterMapManager.getWritablePartitionIds();
+    List<? extends PartitionId> writablePartitionIds = clusterMapManager.getWritablePartitionIds();
+    List<? extends PartitionId> partitionIds = clusterMapManager.getAllPartitions();
+    assertEquals(writablePartitionIds.size(), testPartitionLayout.getPartitionCount() - 1);
     assertEquals(partitionIds.size(), testPartitionLayout.getPartitionCount());
+    for (PartitionId partitionId : partitionIds) {
+      if (partitionId.getPartitionState().equals(PartitionState.READ_WRITE)) {
+        assertTrue("Partition not found in writable set ", writablePartitionIds.contains(partitionId));
+      } else {
+        assertFalse("READ_ONLY Partition found in writable set ", writablePartitionIds.contains(partitionId));
+      }
+    }
     for (int i = 0; i < partitionIds.size(); i++) {
       PartitionId partitionId = partitionIds.get(i);
       assertEquals(partitionId.getReplicaIds().size(), testPartitionLayout.getTotalReplicaCount());

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -62,7 +62,7 @@ public class ResponseHandlerTest {
     }
 
     @Override
-    public List<PartitionId> getAllPartitions() {
+    public List<PartitionId> getAllPartitionIds() {
       return null;
     }
 

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -62,6 +62,11 @@ public class ResponseHandlerTest {
     }
 
     @Override
+    public List<PartitionId> getAllPartitions() {
+      return null;
+    }
+
+    @Override
     public boolean hasDatacenter(String datacenterName) {
       return false;
     }

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/PartitionManager.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/PartitionManager.java
@@ -141,13 +141,13 @@ public class PartitionManager {
         String partitionIdsToAddReplicas = options.valueOf(partitionIdsToAddReplicasToOpt);
         String datacenterToAddReplicasTo = options.valueOf(datacenterToAddReplicasToOpt);
         if (partitionIdsToAddReplicas.compareToIgnoreCase(".") == 0) {
-          for (PartitionId partitionId : manager.getAllPartitions()) {
+          for (PartitionId partitionId : manager.getAllPartitionIds()) {
             manager.addReplicas(partitionId, datacenterToAddReplicasTo, attemptNonRackAwareOnFailure);
           }
         } else {
           String[] partitionIds = partitionIdsToAddReplicas.split(",");
           for (String partitionId : partitionIds) {
-            for (PartitionId partitionInCluster : manager.getAllPartitions()) {
+            for (PartitionId partitionInCluster : manager.getAllPartitionIds()) {
               if (partitionInCluster.isEqual(partitionId)) {
                 manager.addReplicas(partitionInCluster, datacenterToAddReplicasTo, attemptNonRackAwareOnFailure);
               }

--- a/ambry-tools/src/main/java/com.github.ambry/store/StoreToolsMetrics.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/StoreToolsMetrics.java
@@ -42,7 +42,7 @@ public class StoreToolsMetrics {
   final Counter logRangeNotFoundInIndexError;
   final Counter indexLogEndOffsetMisMatchError;
 
-  public StoreToolsMetrics(MetricRegistry registry) {
+  StoreToolsMetrics(MetricRegistry registry) {
     dumpIndexTimeMs = registry.timer(MetricRegistry.name(DumpIndexTool.class, "DumpIndexTimeMs"));
     dumpReplicaIndexesTimeMs = registry.timer(MetricRegistry.name(DumpIndexTool.class, "DumpReplicaIndexesTimeMs"));
     dumpLogTimeMs = registry.timer(MetricRegistry.name(DumpLogTool.class, "DumpLogTimeMs"));


### PR DESCRIPTION
For building tooling around Ambry, clustermap interface is expanded to add support for getAllPartitions()

SLA: 20 mins
Reviewer: Priyesh, Casey

built and coding style applied