### PR TITLE
Remove blob size requirement in the frontend

### DIFF
--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
@@ -330,10 +330,11 @@ public class AdminBlobStorageServiceTest {
     String contentType = "application/octet-stream";
     String ownerId = "getHeadDeleteOwnerID";
     Map<String, Object> headers = new HashMap<>();
-    setAmbryHeaders(headers, CONTENT_LENGTH, 7200, false, serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, 7200, false, serviceId, contentType, ownerId);
     headers.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key1", "value1");
     headers.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key2", "value2");
     String blobId = putBlobInRouter(headers, content);
+    headers.put(RestUtils.Headers.BLOB_SIZE, (long) CONTENT_LENGTH);
     getBlobAndVerify(blobId, null, headers, content);
     getNotModifiedBlobAndVerify(blobId, null);
     getUserMetadataAndVerify(blobId, null, headers);
@@ -546,7 +547,6 @@ public class AdminBlobStorageServiceTest {
    * Sets headers that helps build {@link BlobProperties} on the server. See argument list for the headers that are set.
    * Any other headers have to be set explicitly.
    * @param headers the {@link Map} where the headers should be set.
-   * @param contentLength sets the {@link RestUtils.Headers#BLOB_SIZE} header. Required.
    * @param ttlInSecs sets the {@link RestUtils.Headers#TTL} header. Set to {@link Utils#Infinite_Time} if no
    *                  expiry.
    * @param isPrivate sets the {@link RestUtils.Headers#PRIVATE} header. Allowed values: true, false.
@@ -557,10 +557,9 @@ public class AdminBlobStorageServiceTest {
    * @throws IllegalArgumentException if any of {@code headers}, {@code serviceId}, {@code contentType} is null or if
    *                                  {@code contentLength} < 0 or if {@code ttlInSecs} < -1.
    */
-  private static void setAmbryHeaders(Map<String, Object> headers, long contentLength, long ttlInSecs,
-      boolean isPrivate, String serviceId, String contentType, String ownerId) {
-    if (headers != null && contentLength >= 0 && ttlInSecs >= -1 && serviceId != null && contentType != null) {
-      headers.put(RestUtils.Headers.BLOB_SIZE, contentLength);
+  private static void setAmbryHeadersForPut(Map<String, Object> headers, long ttlInSecs, boolean isPrivate,
+      String serviceId, String contentType, String ownerId) {
+    if (headers != null && ttlInSecs >= -1 && serviceId != null && contentType != null) {
       headers.put(RestUtils.Headers.TTL, ttlInSecs);
       headers.put(RestUtils.Headers.PRIVATE, isPrivate);
       headers.put(RestUtils.Headers.SERVICE_ID, serviceId);
@@ -702,7 +701,7 @@ public class AdminBlobStorageServiceTest {
    * @param expectedContent the expected content of the blob.
    * @throws Exception
    */
-  public void getBlobAndVerify(String blobId, GetOption getOption, Map<String, Object> expectedHeaders,
+  private void getBlobAndVerify(String blobId, GetOption getOption, Map<String, Object> expectedHeaders,
       ByteBuffer expectedContent) throws Exception {
     JSONObject headers = new JSONObject();
     if (getOption != null) {

--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminBlobStorageServiceTest.java
@@ -334,6 +334,8 @@ public class AdminBlobStorageServiceTest {
     headers.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key1", "value1");
     headers.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key2", "value2");
     String blobId = putBlobInRouter(headers, content);
+    // Adding the BLOB_SIZE header after doing the put, in order to verify that the get calls return the expected
+    // value.
     headers.put(RestUtils.Headers.BLOB_SIZE, (long) CONTENT_LENGTH);
     getBlobAndVerify(blobId, null, headers, content);
     getNotModifiedBlobAndVerify(blobId, null);

--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminIntegrationTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminIntegrationTest.java
@@ -308,7 +308,6 @@ public class AdminIntegrationTest {
     String ownerId = "getHeadDeleteOwnerID";
     HttpHeaders headers = new DefaultHttpHeaders();
     setAmbryHeadersForPut(headers, 7200, false, serviceId, contentType, ownerId);
-    headers.set(HttpHeaderNames.CONTENT_LENGTH, content.capacity());
     String blobId;
     byte[] usermetadata = null;
     if (multipartPost) {

--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminIntegrationTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminIntegrationTest.java
@@ -307,7 +307,7 @@ public class AdminIntegrationTest {
     String contentType = "application/octet-stream";
     String ownerId = "getHeadDeleteOwnerID";
     HttpHeaders headers = new DefaultHttpHeaders();
-    setAmbryHeaders(headers, content.capacity(), 7200, false, serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, 7200, false, serviceId, contentType, ownerId);
     headers.set(HttpHeaderNames.CONTENT_LENGTH, content.capacity());
     String blobId;
     byte[] usermetadata = null;
@@ -318,6 +318,7 @@ public class AdminIntegrationTest {
       headers.add(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key2", "value2");
     }
     blobId = putBlob(headers, content, usermetadata);
+    headers.add(RestUtils.Headers.BLOB_SIZE, (long) content.capacity());
     getBlobAndVerify(blobId, null, headers, content);
     getNotModifiedBlobAndVerify(blobId, null, false);
     getUserMetadataAndVerify(blobId, null, headers, usermetadata);
@@ -333,7 +334,6 @@ public class AdminIntegrationTest {
    * Sets headers that helps build {@link BlobProperties} on the server. See argument list for the headers that are set.
    * Any other headers have to be set explicitly.
    * @param httpHeaders the {@link HttpHeaders} where the headers should be set.
-   * @param contentLength sets the {@link RestUtils.Headers#BLOB_SIZE} header. Required.
    * @param ttlInSecs sets the {@link RestUtils.Headers#TTL} header. Set to {@link Utils#Infinite_Time} if no
    *                  expiry.
    * @param isPrivate sets the {@link RestUtils.Headers#PRIVATE} header. Allowed values: true, false.
@@ -345,10 +345,9 @@ public class AdminIntegrationTest {
    *                                  {@code contentLength} < 0 or if {@code ttlInSecs} < -1.
    * @throws org.json.JSONException
    */
-  private void setAmbryHeaders(HttpHeaders httpHeaders, long contentLength, long ttlInSecs, boolean isPrivate,
-      String serviceId, String contentType, String ownerId) throws JSONException {
-    if (httpHeaders != null && contentLength >= 0 && ttlInSecs >= -1 && serviceId != null && contentType != null) {
-      httpHeaders.add(RestUtils.Headers.BLOB_SIZE, contentLength);
+  private void setAmbryHeadersForPut(HttpHeaders httpHeaders, long ttlInSecs, boolean isPrivate, String serviceId,
+      String contentType, String ownerId) throws JSONException {
+    if (httpHeaders != null && ttlInSecs >= -1 && serviceId != null && contentType != null) {
       httpHeaders.add(RestUtils.Headers.TTL, ttlInSecs);
       httpHeaders.add(RestUtils.Headers.PRIVATE, isPrivate);
       httpHeaders.add(RestUtils.Headers.SERVICE_ID, serviceId);

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -183,19 +183,6 @@ public class RestUtils {
    *                                    expected.
    */
   public static BlobProperties buildBlobProperties(Map<String, Object> args) throws RestServiceException {
-    String blobSizeStr = getHeader(args, Headers.BLOB_SIZE, true);
-    long blobSize;
-    try {
-      blobSize = Long.parseLong(blobSizeStr);
-      if (blobSize < 0) {
-        throw new RestServiceException(Headers.BLOB_SIZE + "[" + blobSize + "] is less than 0",
-            RestServiceErrorCode.InvalidArgs);
-      }
-    } catch (NumberFormatException e) {
-      throw new RestServiceException(Headers.BLOB_SIZE + "[" + blobSizeStr + "] could not parsed into a number",
-          RestServiceErrorCode.InvalidArgs);
-    }
-
     long ttl = Utils.Infinite_Time;
     String ttlStr = getHeader(args, Headers.TTL, false);
     if (ttlStr != null) {
@@ -227,7 +214,7 @@ public class RestUtils {
     String contentType = getHeader(args, Headers.AMBRY_CONTENT_TYPE, true);
     String ownerId = getHeader(args, Headers.OWNER_ID, false);
 
-    return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, ttl);
+    return new BlobProperties(-1, serviceId, ownerId, contentType, isPrivate, ttl);
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -54,8 +54,8 @@ public class RestUtilsTest {
   @Test
   public void getBlobPropertiesGoodInputTest() throws Exception {
     JSONObject headers = new JSONObject();
-    setAmbryHeaders(headers, Long.toString(RANDOM.nextInt(10000)), Long.toString(RANDOM.nextInt(10000)),
-        Boolean.toString(RANDOM.nextBoolean()), generateRandomString(10), "image/gif", generateRandomString(10));
+    setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), Boolean.toString(RANDOM.nextBoolean()),
+        generateRandomString(10), "image/gif", generateRandomString(10));
     verifyBlobPropertiesConstructionSuccess(headers);
   }
 
@@ -66,7 +66,6 @@ public class RestUtilsTest {
    */
   @Test
   public void getBlobPropertiesVariedInputTest() throws Exception {
-    String contentLength = Long.toString(RANDOM.nextInt(10000));
     String ttl = Long.toString(RANDOM.nextInt(10000));
     String isPrivate = Boolean.toString(RANDOM.nextBoolean());
     String serviceId = generateRandomString(10);
@@ -75,57 +74,39 @@ public class RestUtilsTest {
 
     JSONObject headers;
     // failure required.
-    // content length missing.
-    headers = new JSONObject();
-    setAmbryHeaders(headers, null, ttl, isPrivate, serviceId, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.MissingArgs);
-    // content length null.
-    headers = new JSONObject();
-    setAmbryHeaders(headers, null, ttl, isPrivate, serviceId, contentType, ownerId);
-    headers.put(RestUtils.Headers.BLOB_SIZE, JSONObject.NULL);
-    verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
-    // content length not a number.
-    headers = new JSONObject();
-    setAmbryHeaders(headers, "NaN", ttl, isPrivate, serviceId, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
-    // content length < 0.
-    headers = new JSONObject();
-    setAmbryHeaders(headers, "-1", ttl, isPrivate, serviceId, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
     // ttl not a number.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, "NaN", isPrivate, serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, "NaN", isPrivate, serviceId, contentType, ownerId);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
     // ttl < -1.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, "-2", isPrivate, serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, "-2", isPrivate, serviceId, contentType, ownerId);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
     // isPrivate not true or false.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, ttl, "!(true||false)", serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, ttl, "!(true||false)", serviceId, contentType, ownerId);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
     // serviceId missing.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, ttl, isPrivate, null, contentType, ownerId);
+    setAmbryHeadersForPut(headers, ttl, isPrivate, null, contentType, ownerId);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.MissingArgs);
     // serviceId null.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, ttl, isPrivate, null, contentType, ownerId);
+    setAmbryHeadersForPut(headers, ttl, isPrivate, null, contentType, ownerId);
     headers.put(RestUtils.Headers.SERVICE_ID, JSONObject.NULL);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
     // contentType missing.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, ttl, isPrivate, serviceId, null, ownerId);
+    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, null, ownerId);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.MissingArgs);
     // contentType null.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, ttl, isPrivate, serviceId, null, ownerId);
+    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, null, ownerId);
     headers.put(RestUtils.Headers.AMBRY_CONTENT_TYPE, JSONObject.NULL);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
     // too many values for some headers.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, ttl, isPrivate, serviceId, contentType, ownerId);
-    tooManyValuesTest(headers, RestUtils.Headers.BLOB_SIZE);
+    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, ownerId);
     tooManyValuesTest(headers, RestUtils.Headers.TTL);
     tooManyValuesTest(headers, RestUtils.Headers.PRIVATE);
 
@@ -134,25 +115,31 @@ public class RestUtilsTest {
     // isPrivate missing. Should be false by default.
     // ownerId missing.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, null, null, serviceId, contentType, null);
+    setAmbryHeadersForPut(headers, null, null, serviceId, contentType, null);
     verifyBlobPropertiesConstructionSuccess(headers);
 
     // ttl null.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, null, isPrivate, serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, null, isPrivate, serviceId, contentType, ownerId);
     headers.put(RestUtils.Headers.TTL, JSONObject.NULL);
     verifyBlobPropertiesConstructionSuccess(headers);
 
     // isPrivate null.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, ttl, isPrivate, serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, ownerId);
     headers.put(RestUtils.Headers.PRIVATE, JSONObject.NULL);
     verifyBlobPropertiesConstructionSuccess(headers);
 
     // ownerId null.
     headers = new JSONObject();
-    setAmbryHeaders(headers, contentLength, ttl, isPrivate, serviceId, contentType, null);
+    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, null);
     headers.put(RestUtils.Headers.OWNER_ID, JSONObject.NULL);
+    verifyBlobPropertiesConstructionSuccess(headers);
+
+    // blobSize null (should be ignored)
+    headers = new JSONObject();
+    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, null);
+    headers.put(RestUtils.Headers.BLOB_SIZE, JSONObject.NULL);
     verifyBlobPropertiesConstructionSuccess(headers);
   }
 
@@ -173,8 +160,8 @@ public class RestUtilsTest {
   @Test
   public void getUserMetadataGoodInputTest() throws Exception {
     JSONObject headers = new JSONObject();
-    setAmbryHeaders(headers, Long.toString(RANDOM.nextInt(10000)), Long.toString(RANDOM.nextInt(10000)),
-        Boolean.toString(RANDOM.nextBoolean()), generateRandomString(10), "image/gif", generateRandomString(10));
+    setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), Boolean.toString(RANDOM.nextBoolean()),
+        generateRandomString(10), "image/gif", generateRandomString(10));
     Map<String, String> userMetadata = new HashMap<String, String>();
     userMetadata.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key1", "value1");
     userMetadata.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key2", "value2");
@@ -205,8 +192,8 @@ public class RestUtilsTest {
   @Test
   public void getUserMetadataUnusualInputTest() throws Exception {
     JSONObject headers = new JSONObject();
-    setAmbryHeaders(headers, Long.toString(RANDOM.nextInt(10000)), Long.toString(RANDOM.nextInt(10000)),
-        Boolean.toString(RANDOM.nextBoolean()), generateRandomString(10), "image/gif", generateRandomString(10));
+    setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), Boolean.toString(RANDOM.nextBoolean()),
+        generateRandomString(10), "image/gif", generateRandomString(10));
     Map<String, String> userMetadata = new HashMap<String, String>();
     String key1 = RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key1";
     userMetadata.put(key1, "value1");
@@ -242,8 +229,8 @@ public class RestUtilsTest {
   @Test
   public void getEmptyUserMetadataInputTest() throws Exception {
     JSONObject headers = new JSONObject();
-    setAmbryHeaders(headers, Long.toString(RANDOM.nextInt(10000)), Long.toString(RANDOM.nextInt(10000)),
-        Boolean.toString(RANDOM.nextBoolean()), generateRandomString(10), "image/gif", generateRandomString(10));
+    setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), Boolean.toString(RANDOM.nextBoolean()),
+        generateRandomString(10), "image/gif", generateRandomString(10));
     Map<String, String> userMetadata = new HashMap<String, String>();
     setUserMetadataHeaders(headers, userMetadata);
 
@@ -657,7 +644,6 @@ public class RestUtilsTest {
    * Sets headers that helps build {@link BlobProperties} on the server. See argument list for the headers that are set.
    * Any other headers have to be set explicitly.
    * @param headers the {@link JSONObject} where the headers should be set.
-   * @param contentLength sets the {@link RestUtils.Headers#BLOB_SIZE} header.
    * @param ttlInSecs sets the {@link RestUtils.Headers#TTL} header.
    * @param isPrivate sets the {@link RestUtils.Headers#PRIVATE} header. Allowed values: true, false.
    * @param serviceId sets the {@link RestUtils.Headers#SERVICE_ID} header.
@@ -665,9 +651,8 @@ public class RestUtilsTest {
    * @param ownerId sets the {@link RestUtils.Headers#OWNER_ID} header. Optional - if not required, send null.
    * @throws JSONException
    */
-  private void setAmbryHeaders(JSONObject headers, String contentLength, String ttlInSecs, String isPrivate,
-      String serviceId, String contentType, String ownerId) throws JSONException {
-    headers.putOpt(RestUtils.Headers.BLOB_SIZE, contentLength);
+  private void setAmbryHeadersForPut(JSONObject headers, String ttlInSecs, String isPrivate, String serviceId,
+      String contentType, String ownerId) throws JSONException {
     headers.putOpt(RestUtils.Headers.TTL, ttlInSecs);
     headers.putOpt(RestUtils.Headers.PRIVATE, isPrivate);
     headers.putOpt(RestUtils.Headers.SERVICE_ID, serviceId);
@@ -684,8 +669,6 @@ public class RestUtilsTest {
   private void verifyBlobPropertiesConstructionSuccess(JSONObject headers) throws Exception {
     RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
     BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
-    assertEquals("Blob size does not match", headers.getLong(RestUtils.Headers.BLOB_SIZE),
-        blobProperties.getBlobSize());
     long expectedTTL = Utils.Infinite_Time;
     if (headers.has(RestUtils.Headers.TTL) && !JSONObject.NULL.equals(headers.get(RestUtils.Headers.TTL))) {
       expectedTTL = headers.getLong(RestUtils.Headers.TTL);

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -141,6 +141,12 @@ public class RestUtilsTest {
     setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, null);
     headers.put(RestUtils.Headers.BLOB_SIZE, JSONObject.NULL);
     verifyBlobPropertiesConstructionSuccess(headers);
+
+    // blobSize negative (should succeed)
+    headers = new JSONObject();
+    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, null);
+    headers.put(RestUtils.Headers.BLOB_SIZE, -1);
+    verifyBlobPropertiesConstructionSuccess(headers);
   }
 
   /**

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
@@ -200,7 +200,7 @@ class NettyMultipartRequest extends NettyRequest {
               RestServiceErrorCode.BadRequest);
         } else {
           hasBlob = true;
-          if (fileUpload.length() != getSize()) {
+          if (getSize() != -1 && fileUpload.length() != getSize()) {
             nettyMetrics.multipartRequestSizeMismatchError.inc();
             throw new RestServiceException(
                 "Request size [" + fileUpload.length() + "] does not match Content-Length [" + getSize() + "]",

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -291,7 +291,7 @@ class NettyRequest implements RestRequest {
   /**
    * Returns the value of the ambry specific content length header ({@link RestUtils.Headers#BLOB_SIZE}. If there is
    * no such header, returns length in the "Content-Length" header. If there is no such header, tries to infer content
-   * size. If that cannot be done, returns 0.
+   * size. If that cannot be done, returns -1.
    * <p/>
    * This function does not individually count the bytes in the content (it is not possible) so the bytes received may
    * actually be different if the stream is buggy or the client made a mistake. Do *not* treat this as fully accurate.

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
@@ -129,7 +129,6 @@ public class NettyMessageProcessorTest {
     HttpRequest postRequest =
         new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/", Unpooled.wrappedBuffer(content));
     postRequest.headers().set(RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
-    postRequest.headers().set(RestUtils.Headers.BLOB_SIZE, content.remaining());
     postRequest = ReferenceCountUtil.retain(postRequest);
     ByteBuffer receivedContent = doPostTest(postRequest, null);
     compareContent(receivedContent, Collections.singletonList(content));
@@ -145,7 +144,6 @@ public class NettyMessageProcessorTest {
       contents.add(i, buffer);
     }
     postRequest.headers().set(RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
-    postRequest.headers().set(RestUtils.Headers.BLOB_SIZE, blobSize);
     receivedContent = doPostTest(postRequest, contents);
     compareContent(receivedContent, contents);
   }
@@ -160,7 +158,6 @@ public class NettyMessageProcessorTest {
     ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(random.nextInt(128) + 128));
     HttpRequest httpRequest = RestTestUtils.createRequest(HttpMethod.POST, "/", null);
     httpRequest.headers().set(RestUtils.Headers.SERVICE_ID, "rawBytesPostTest");
-    httpRequest.headers().set(RestUtils.Headers.BLOB_SIZE, content.remaining());
     HttpPostRequestEncoder encoder = createEncoder(httpRequest, content);
     HttpRequest postRequest = encoder.finalizeRequest();
     List<ByteBuffer> contents = new ArrayList<ByteBuffer>();

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
@@ -298,7 +298,7 @@ public class NettyMultipartRequestTest {
     request = createRequest(httpHeaders, files);
     try {
       request.prepare();
-      fail("Prepare should have failed because there was more than one " + RestUtils.MultipartPost.BLOB_PART);
+      fail("Prepare should have failed because the size advertised does not match the actual size");
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.BadRequest, e.getErrorCode());
     } finally {
@@ -323,6 +323,17 @@ public class NettyMultipartRequestTest {
       fail("Prepare should have failed because there was non fileupload");
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.BadRequest, e.getErrorCode());
+    } finally {
+      closeRequestAndValidate(request);
+    }
+
+    // size of blob is not set. Prepare should succeed.
+    httpHeaders = new DefaultHttpHeaders();
+    files = new InMemoryFile[1];
+    files[0] = new InMemoryFile(RestUtils.MultipartPost.BLOB_PART, ByteBuffer.wrap(TestUtils.getRandomBytes(128)));
+    request = createRequest(httpHeaders, files);
+    try {
+      request.prepare();
     } finally {
       closeRequestAndValidate(request);
     }


### PR DESCRIPTION
Frontend should not look for x-ambry-blob-size header in PUT requests,
as the router putBlob() no longer uses the size field in BlobProperties.