### PR TITLE
Shutting down all stores in a disk in parallel

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManagerMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManagerMetrics.java
@@ -26,8 +26,12 @@ import java.util.concurrent.atomic.AtomicLong;
 public class StorageManagerMetrics {
   private final MetricRegistry registry;
 
+  public final Timer storageManagerStartTime;
+  public final Timer storageManagerShutdownTime;
   public final Timer diskStartTime;
+  public final Timer diskShutdownTime;
   public final Counter totalStoreStartFailures;
+  public final Counter totalStoreShutdownFailures;
   public final Counter diskMountPathFailures;
 
   // CompactionManager related metrics
@@ -44,9 +48,14 @@ public class StorageManagerMetrics {
    */
   public StorageManagerMetrics(MetricRegistry registry) {
     this.registry = registry;
-    diskStartTime = registry.timer(MetricRegistry.name(StorageManager.class, "DiskStartTime"));
-    totalStoreStartFailures = registry.counter(MetricRegistry.name(StorageManager.class, "TotalStoreStartFailures"));
-    diskMountPathFailures = registry.counter(MetricRegistry.name(StorageManager.class, "DiskMountPathFailures"));
+    storageManagerStartTime = registry.timer(MetricRegistry.name(StorageManager.class, "StorageManagerStartTime"));
+    storageManagerShutdownTime =
+        registry.timer(MetricRegistry.name(StorageManager.class, "StorageManagerShutdownTime"));
+    diskStartTime = registry.timer(MetricRegistry.name(DiskManager.class, "DiskStartTime"));
+    diskShutdownTime = registry.timer(MetricRegistry.name(DiskManager.class, "DiskShutdownTime"));
+    totalStoreStartFailures = registry.counter(MetricRegistry.name(DiskManager.class, "TotalStoreStartFailures"));
+    totalStoreShutdownFailures = registry.counter(MetricRegistry.name(DiskManager.class, "TotalStoreShutdownFailures"));
+    diskMountPathFailures = registry.counter(MetricRegistry.name(DiskManager.class, "DiskMountPathFailures"));
 
     compactionCount = registry.counter(MetricRegistry.name(CompactionManager.class, "CompactionCount"));
     compactionManagerTerminateErrorCount =

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManagerMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManagerMetrics.java
@@ -15,8 +15,8 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
 import java.util.concurrent.atomic.AtomicLong;
 
 
@@ -26,10 +26,10 @@ import java.util.concurrent.atomic.AtomicLong;
 public class StorageManagerMetrics {
   private final MetricRegistry registry;
 
-  public final Timer storageManagerStartTime;
-  public final Timer storageManagerShutdownTime;
-  public final Timer diskStartTime;
-  public final Timer diskShutdownTime;
+  public final Histogram storageManagerStartTimeMs;
+  public final Histogram storageManagerShutdownTimeMs;
+  public final Histogram diskStartTimeMs;
+  public final Histogram diskShutdownTimeMs;
   public final Counter totalStoreStartFailures;
   public final Counter totalStoreShutdownFailures;
   public final Counter diskMountPathFailures;
@@ -48,11 +48,12 @@ public class StorageManagerMetrics {
    */
   public StorageManagerMetrics(MetricRegistry registry) {
     this.registry = registry;
-    storageManagerStartTime = registry.timer(MetricRegistry.name(StorageManager.class, "StorageManagerStartTime"));
-    storageManagerShutdownTime =
-        registry.timer(MetricRegistry.name(StorageManager.class, "StorageManagerShutdownTime"));
-    diskStartTime = registry.timer(MetricRegistry.name(DiskManager.class, "DiskStartTime"));
-    diskShutdownTime = registry.timer(MetricRegistry.name(DiskManager.class, "DiskShutdownTime"));
+    storageManagerStartTimeMs =
+        registry.histogram(MetricRegistry.name(StorageManager.class, "StorageManagerStartTimeMs"));
+    storageManagerShutdownTimeMs =
+        registry.histogram(MetricRegistry.name(StorageManager.class, "StorageManagerShutdownTimeMs"));
+    diskStartTimeMs = registry.histogram(MetricRegistry.name(DiskManager.class, "DiskStartTimeMs"));
+    diskShutdownTimeMs = registry.histogram(MetricRegistry.name(DiskManager.class, "DiskShutdownTimeMs"));
     totalStoreStartFailures = registry.counter(MetricRegistry.name(DiskManager.class, "TotalStoreStartFailures"));
     totalStoreShutdownFailures = registry.counter(MetricRegistry.name(DiskManager.class, "TotalStoreShutdownFailures"));
     diskMountPathFailures = registry.counter(MetricRegistry.name(DiskManager.class, "DiskMountPathFailures"));

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -164,11 +164,11 @@ public class StorageManagerTest {
 
   /**
    * Test that stores for all partitions on a node have been started and partitions not present on this node are
-   * inaccessible.
+   * inaccessible. Also tests all stores are shutdown on shutting down the storage manager
    * @throws Exception
    */
   @Test
-  public void successfulStartTest() throws Exception {
+  public void successfulStartupShutdownTest() throws Exception {
     MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     StorageManager storageManager = createAndStartStoreManager(replicas);
@@ -209,9 +209,10 @@ public class StorageManagerTest {
    * @param storageManager the {@link StorageManager} to shutdown.
    * @param replicas the {@link ReplicaId}s to check for store inaccessibility.
    * @throws StoreException
+   * @throws InterruptedException
    */
   private static void shutdownAndAssertStoresInaccessible(StorageManager storageManager, List<ReplicaId> replicas)
-      throws StoreException {
+      throws StoreException, InterruptedException {
     storageManager.shutdown();
     for (ReplicaId replica : replicas) {
       assertNull(storageManager.getStore(replica.getPartitionId()));

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -124,7 +124,8 @@ public class StorageManagerTest {
     }
     StorageManager storageManager = createAndStartStoreManager(replicas, metricRegistry);
     Map<String, Counter> counters = metricRegistry.getCounters();
-    assertEquals(2, getCounterValue(counters, DiskManager.class.getName(), "TotalStoreStartFailures"));
+    assertEquals(badReplicaIndexes.size(),
+        getCounterValue(counters, DiskManager.class.getName(), "TotalStoreStartFailures"));
     assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "DiskMountPathFailures"));
     for (int i = 0; i < replicas.size(); i++) {
       ReplicaId replica = replicas.get(i);
@@ -143,7 +144,8 @@ public class StorageManagerTest {
     verifyCompactionThreadCount(storageManager, dataNode.getMountPaths().size());
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
     assertEquals("Compaction thread count is incorrect", 0, storageManager.getCompactionThreadCount());
-    assertEquals(2, getCounterValue(counters, DiskManager.class.getName(), "TotalStoreShutdownFailures"));
+    assertEquals(badReplicaIndexes.size(),
+        getCounterValue(counters, DiskManager.class.getName(), "TotalStoreShutdownFailures"));
   }
 
   /**

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -14,6 +14,7 @@
 
 package com.github.ambry.store;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
@@ -31,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
@@ -44,6 +46,7 @@ import static org.junit.Assert.*;
 public class StorageManagerTest {
   private static final Random RANDOM = new Random();
   private MockClusterMap clusterMap;
+  private MetricRegistry metricRegistry;
 
   /**
    * Startup the {@link MockClusterMap} for a test.
@@ -52,6 +55,7 @@ public class StorageManagerTest {
   @Before
   public void initializeCluster() throws IOException {
     clusterMap = new MockClusterMap(false, 1, 3, 3);
+    this.metricRegistry = clusterMap.getMetricRegistry();
   }
 
   /**
@@ -73,8 +77,17 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<String> mountPaths = dataNode.getMountPaths();
     String mountPathToDelete = mountPaths.get(RANDOM.nextInt(mountPaths.size()));
+    int downReplicaCount = 0;
+    for (ReplicaId replica : replicas) {
+      if (replica.getMountPath().equals(mountPathToDelete)) {
+        downReplicaCount++;
+      }
+    }
     deleteDirectory(new File(mountPathToDelete));
-    StorageManager storageManager = createAndStartStoreManager(replicas);
+    StorageManager storageManager = createAndStartStoreManager(replicas, metricRegistry);
+    Map<String, Counter> counters = metricRegistry.getCounters();
+    assertEquals(downReplicaCount, getCounterValue(counters, DiskManager.class.getName(), "TotalStoreStartFailures"));
+    assertEquals(1, getCounterValue(counters, DiskManager.class.getName(), "DiskMountPathFailures"));
     for (ReplicaId replica : replicas) {
       PartitionId id = replica.getPartitionId();
       if (replica.getMountPath().equals(mountPathToDelete)) {
@@ -92,6 +105,8 @@ public class StorageManagerTest {
     verifyCompactionThreadCount(storageManager, mountPaths.size() - 1);
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
     assertEquals("Compaction thread count is incorrect", 0, storageManager.getCompactionThreadCount());
+    assertEquals(downReplicaCount,
+        getCounterValue(counters, DiskManager.class.getName(), "TotalStoreShutdownFailures"));
   }
 
   /**
@@ -107,7 +122,10 @@ public class StorageManagerTest {
     for (Integer badReplicaIndex : badReplicaIndexes) {
       new File(replicas.get(badReplicaIndex).getReplicaPath()).setReadable(false);
     }
-    StorageManager storageManager = createAndStartStoreManager(replicas);
+    StorageManager storageManager = createAndStartStoreManager(replicas, metricRegistry);
+    Map<String, Counter> counters = metricRegistry.getCounters();
+    assertEquals(2, getCounterValue(counters, DiskManager.class.getName(), "TotalStoreStartFailures"));
+    assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "DiskMountPathFailures"));
     for (int i = 0; i < replicas.size(); i++) {
       ReplicaId replica = replicas.get(i);
       PartitionId id = replica.getPartitionId();
@@ -125,6 +143,7 @@ public class StorageManagerTest {
     verifyCompactionThreadCount(storageManager, dataNode.getMountPaths().size());
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
     assertEquals("Compaction thread count is incorrect", 0, storageManager.getCompactionThreadCount());
+    assertEquals(2, getCounterValue(counters, DiskManager.class.getName(), "TotalStoreShutdownFailures"));
   }
 
   /**
@@ -138,12 +157,17 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<String> mountPaths = dataNode.getMountPaths();
     String badDiskMountPath = mountPaths.get(RANDOM.nextInt(mountPaths.size()));
+    int downReplicaCount = 0;
     for (ReplicaId replica : replicas) {
       if (replica.getMountPath().equals(badDiskMountPath)) {
         new File(replica.getReplicaPath()).setReadable(false);
+        downReplicaCount++;
       }
     }
-    StorageManager storageManager = createAndStartStoreManager(replicas);
+    StorageManager storageManager = createAndStartStoreManager(replicas, metricRegistry);
+    Map<String, Counter> counters = metricRegistry.getCounters();
+    assertEquals(downReplicaCount, getCounterValue(counters, DiskManager.class.getName(), "TotalStoreStartFailures"));
+    assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "DiskMountPathFailures"));
     for (ReplicaId replica : replicas) {
       PartitionId id = replica.getPartitionId();
       if (replica.getMountPath().equals(badDiskMountPath)) {
@@ -160,6 +184,8 @@ public class StorageManagerTest {
     verifyCompactionThreadCount(storageManager, mountPaths.size());
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
     assertEquals("Compaction thread count is incorrect", 0, storageManager.getCompactionThreadCount());
+    assertEquals(downReplicaCount,
+        getCounterValue(counters, DiskManager.class.getName(), "TotalStoreShutdownFailures"));
   }
 
   /**
@@ -171,12 +197,15 @@ public class StorageManagerTest {
   public void successfulStartupShutdownTest() throws Exception {
     MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
-    StorageManager storageManager = createAndStartStoreManager(replicas);
+    StorageManager storageManager = createAndStartStoreManager(replicas, metricRegistry);
     for (ReplicaId replica : replicas) {
       Store store = storageManager.getStore(replica.getPartitionId());
       assertTrue("Store should be started", ((BlobStore) store).isStarted());
       assertTrue("Compaction should be scheduled", storageManager.scheduleNextForCompaction(replica.getPartitionId()));
     }
+    Map<String, Counter> counters = metricRegistry.getCounters();
+    assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "TotalStoreStartFailures"));
+    assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "DiskMountPathFailures"));
     MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, Collections.<MockDataNodeId>emptyList(), 0);
     assertNull("Should not have found a store for an invalid partition.", storageManager.getStore(invalidPartition));
     assertEquals("Compaction thread count is incorrect", dataNode.getMountPaths().size(),
@@ -184,21 +213,23 @@ public class StorageManagerTest {
     verifyCompactionThreadCount(storageManager, dataNode.getMountPaths().size());
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
     assertEquals("Compaction thread count is incorrect", 0, storageManager.getCompactionThreadCount());
+    assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "TotalStoreShutdownFailures"));
   }
 
   /**
    * Create a {@link StorageManager} and start stores for the passed in set of replicas.
    * @param replicas the list of replicas for the {@link StorageManager} to use.
+   * @param metricRegistry the {@link MetricRegistry} instance to use to instantiate {@link StorageManager}
    * @return a started {@link StorageManager}
    * @throws StoreException
    */
-  private static StorageManager createAndStartStoreManager(List<ReplicaId> replicas)
+  private StorageManager createAndStartStoreManager(List<ReplicaId> replicas, MetricRegistry metricRegistry)
       throws StoreException, InterruptedException {
     Properties properties = new Properties();
     properties.put("store.enable.compaction", "true");
     StorageManager storageManager =
         new StorageManager(new StoreConfig(new VerifiableProperties(properties)), Utils.newScheduler(1, false),
-            new MetricRegistry(), replicas, new MockIdFactory(), new DummyMessageStoreRecovery(),
+            metricRegistry, replicas, new MockIdFactory(), new DummyMessageStoreRecovery(),
             new DummyMessageStoreHardDelete(), SystemTime.getInstance());
     storageManager.start();
     return storageManager;
@@ -217,6 +248,17 @@ public class StorageManagerTest {
     for (ReplicaId replica : replicas) {
       assertNull(storageManager.getStore(replica.getPartitionId()));
     }
+  }
+
+  /**
+   * Get the counter value for the metric in {@link StorageManagerMetrics} for the given class and suffix.
+   * @param counters Map of counter metrics to use
+   * @param className the class to which the metric belongs to
+   * @param suffix the suffix of the metric that distinguishes it from other metrics in the class.
+   * @return the value of the counter.
+   */
+  private long getCounterValue(Map<String, Counter> counters, String className, String suffix) {
+    return counters.get(className + "." + suffix).getCount();
   }
 
   /**


### PR DESCRIPTION
As of now, all stores in a disk and all disks in a storage node is shutdown sequentially. We don't see a reason why not to shutdown all in parallel. No data is shared among different disks. Only shared data among different stores in the same disk is replicaToken file which is handled by the ReplicationManager. And during shutdown of an Ambry Server, ReplicationManager is shutdown before we shutdown StorageManager. So, there is no dependency or anything else that holds us back not to shutdown all stores in parallel. So, with this change, the net effect will be seen only wrt shutdown times of an ambry server. We don't see any correctness issues with this change. 

SLA: 15 mins
Reviewers: @cgtz @vgkholla 

Built and coding style applied

Coverage:
By running StorageManagerTest
ClassName              Class, %	        Method, %	  Line, %
DiskManager	        100% (3/ 3)	100% (14/ 14)	  100% (79/ 79)
StorageManager	100% (3/ 3)	92.3% (12/ 13)	  89.9% (71/ 79)
(InterruptedException catch block is not covered in StorageManager)
