### PR TITLE
Fix 3 lgtm.com alerts: do not test reference equality, fix int overflow

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
@@ -192,12 +192,6 @@ class Partition extends PartitionId {
     }
 
     Partition partition = (Partition) o;
-
-    if (id == null ^ partition.id == null){
-      // one of them is null (XOR, so not both)
-      return false;
-    }
-    
     return id.equals(partition.id);
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
@@ -193,7 +193,12 @@ class Partition extends PartitionId {
 
     Partition partition = (Partition) o;
 
-    return id == partition.id;
+    if (id == null ^ partition.id == null){
+      // one of them is null (XOR, so not both)
+      return false;
+    }
+    
+    return id.equals(partition.id);
   }
 
   @Override


### PR DESCRIPTION
I hope this is the right way to contribute.

This PR fixes 3 alerts flagged up by lgtm.com (@lgtmhq): https://lgtm.com/projects/g/linkedin/ambry/alerts. There are about 100 other alerts there - most of them are well worth fixing, but require more experience with the ambry code base to know what the right way to fix is.

Partition.java: using the '==' operator on boxed Integers only tests for reference equality, not value equality. More details: https://lgtm.com/projects/g/linkedin/ambry/snapshot/24055194cb62260545c73e6e1282df079c97cc32/files/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java#V196

CompactAllPolicyFactory.java and DefaultCompactionPolicy.java: the multiplication of integers will have result of type ```int``` which can overflow before being stored as a ```long```.

Tip: enable automatic code reviews of pull requests! https://lgtm.com/projects/g/linkedin/ambry/ci/