### PR TITLE
Exposing tests as separate jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,14 +76,14 @@ subprojects {
     check.dependsOn -= test
     check.dependsOn += unitTest
     
-     task testJar(type: Jar) {
+    task testJar(type: Jar) {
         from sourceSets.test.output
         classifier = 'test'
     }
     
     artifacts {
-         archives testJar
-     }
+        archives testJar
+    }
 }
 
 project(':ambry-utils') {

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,15 @@ subprojects {
     // but run integration tests too when running the test target
     check.dependsOn -= test
     check.dependsOn += unitTest
+    
+     task testJar(type: Jar) {
+        from sourceSets.test.output
+        classifier = 'test'
+    }
+    
+    artifacts {
+         archives testJar
+     }
 }
 
 project(':ambry-utils') {


### PR DESCRIPTION
Some (mock) test classes are useful to those dependent on "Ambry". So this patch exposes tests as separate jars.

SLA: 5 mins
Reviewers: Priyesh, Casey

Build succeeded