### PR TITLE
Assigns id to each datacenter.

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -51,6 +51,20 @@ public interface ClusterMap extends AutoCloseable {
   boolean hasDatacenter(String datacenterName);
 
   /**
+   * Gets the id for the given datacenter name, which is unique across the entire cluster.
+   * @param datacenterName The name of the datacenter to get the id.
+   * @return The id of the datacenter.
+   */
+  Short getDatacenterIdByName(String datacenterName);
+
+  /**
+   * Gets the name for the given datacenter id, which is unique across the entire cluster.
+   * @param datacenterId The id of the datacenter to get the name.
+   * @return The name of the datacenter.
+   */
+  String getDatacenterNameById(short datacenterId);
+
+  /**
    * Gets a specific DataNodeId by its hostname and port.
    *
    * @param hostname of the DataNodeId

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -37,6 +37,8 @@ import org.apache.helix.model.builder.AutoModeISBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+
 
 /**
  * A class to bootstrap static cluster map information into Helix.
@@ -500,7 +502,11 @@ class HelixBootstrapUpgradeUtil {
     String clusterNameInStaticClusterMap = hardwareLayout.getClusterName();
     System.out.println("Verifying equivalency of static cluster: " + clusterNameInStaticClusterMap + " with the "
         + "corresponding cluster in Helix: " + clusterName);
+    Set<Short> dcIdSet = new HashSet<>();
     for (Datacenter dc : hardwareLayout.getDatacenters()) {
+      if (!dcIdSet.add(hashDcNameToNonNegativeId(dc.getName()))) {
+        throw new IllegalStateException("Two datacenters are hashed to the same id. DC name: " + dc.getName());
+      }
       HelixAdmin admin = adminForDc.get(dc.getName());
       ensureOrThrow(admin != null, "No ZkInfo for datacenter " + dc.getName());
       ensureOrThrow(admin.getClusters().contains(clusterName),

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
@@ -33,6 +33,8 @@ class HelixClusterManagerMetrics {
   public final Counter getWritablePartitionIdsMismatchCount;
   public final Counter getAllPartitionIdsMismatchCount;
   public final Counter hasDatacenterMismatchCount;
+  public final Counter datacenterIdMismatchCount;
+  public final Counter datacenterNameMismatchCount;
   public final Counter getDataNodeIdMismatchCount;
   public final Counter getReplicaIdsMismatchCount;
   public final Counter getDataNodeIdsMismatchCount;
@@ -63,6 +65,10 @@ class HelixClusterManagerMetrics {
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getAllPartitionIdsMismatchCount"));
     hasDatacenterMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "hasDatacenterMismatchCount"));
+    datacenterIdMismatchCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "datacenterIdMismatchCount"));
+    datacenterNameMismatchCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "datacenterNameMismatchCount"));
     getDataNodeIdMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getDataNodeIdMismatchCount"));
     getReplicaIdsMismatchCount =

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+import static org.junit.Assert.*;
+
+
+/**
+ * Unit tests for {@link ClusterMapUtils}.
+ */
+public class ClusterMapUtilsTest {
+  private final String dc1Name = "dc1";
+  private final String dc2Name = "dc2";
+  private final String dc3Name = "dc3";
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  /**
+   * Tests the {@link ClusterMapUtils#getDcNameToIdMap(Set)} method with a list of different datacenter names.
+   */
+  @Test
+  public void testGoodDcNamesForGetDcNameToIdMap() {
+    Set<String> goodDcNames = new HashSet<>(Arrays.asList(new String[]{dc1Name, dc2Name, dc3Name}));
+    Map<String, Short> dcNameToIdMap = getDcNameToIdMap(goodDcNames);
+    assertEquals("Wrong map size", goodDcNames.size(), dcNameToIdMap.entrySet().size());
+    Set<Short> idSet = new HashSet<>();
+    for (Short id : dcNameToIdMap.values()) {
+      if (!idSet.add(id)) {
+        fail("Datacenter ids collide.");
+      }
+    }
+  }
+
+  /**
+   * Tests the case when ids collide when calling {@link ClusterMapUtils#getDcNameToIdMap(Set)}.
+   */
+  @Test
+  public void testDcIdCollision() {
+    Set<String> stringSet = new HashSet<>();
+    try {
+      for (int i = 0; i <= Short.MAX_VALUE; i++) {
+        String str = generateRandomString();
+        assertTrue("Datacenter id cannot be negative.", hashDcNameToNonNegativeId(str) >= 0);
+        if (stringSet.add(str)) {
+          System.out.println(
+              "Random string: " + str + " - Hash code: " + hashDcNameToNonNegativeId(str) + " - round: " + i);
+          getDcNameToIdMap(stringSet);
+        }
+      }
+      fail("should have thrown");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+  }
+
+  /**
+   * Generates a random string.
+   * @return A randomly generated string.
+   */
+  private String generateRandomString() {
+    return new BigInteger(100, RANDOM).toString(32);
+  }
+}

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
 
@@ -182,6 +183,7 @@ public class HelixClusterManagerTest {
       System.out.println(metricName);
     }
     testPartitionReplicaConsistency();
+    testDcNameIdMapping();
     testInvalidPartitionId();
     testDatacenterDatanodeReplicas();
     assertStateEquivalency();
@@ -406,6 +408,22 @@ public class HelixClusterManagerTest {
       PartitionId fetchedPartition = clusterManager.getPartitionIdFromStream(partitionStream);
       assertEquals(partition, fetchedPartition);
     }
+  }
+
+  /**
+   * Tests the ids of datacenters get from the {@code ClusterMap}.
+   */
+  private void testDcNameIdMapping() {
+    for (Map.Entry<String, ZkInfo> entry : dcsToZkInfo.entrySet()) {
+      String dcName = entry.getKey();
+      assertEquals("Wrong datacenter id.", (short) hashDcNameToNonNegativeId(dcName),
+          (short) clusterManager.getDatacenterIdByName(dcName));
+      assertEquals("Wrong datacenter name.", dcName,
+          clusterManager.getDatacenterNameById(clusterManager.getDatacenterIdByName(dcName)));
+    }
+    assertNull("Wrong id for non existent datacenter name", clusterManager.getDatacenterIdByName("NonExistentDcName"));
+    assertNull("Wrong id for null datacenter name", clusterManager.getDatacenterIdByName("null"));
+    assertNull("Wrong name for non existent datacenter id", clusterManager.getDatacenterNameById((short) 10));
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
@@ -30,6 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static org.junit.Assert.*;
 
 
@@ -114,8 +115,13 @@ public class StaticClusterManagerTest {
         assertEquals(true, false);
       }
     }
-
     for (Datacenter datacenter : testHardwareLayout.getHardwareLayout().getDatacenters()) {
+      String dcName = datacenter.getName();
+      assertEquals("Wrong datacenter id.", (short) hashDcNameToNonNegativeId(dcName),
+          (short) clusterMapManager.getDatacenterIdByName(dcName));
+      short id = clusterMapManager.getDatacenterIdByName(dcName);
+      String newName = clusterMapManager.getDatacenterNameById(id);
+      assertEquals("Wrong datacenter name.", dcName, newName);
       for (DataNode dataNode : datacenter.getDataNodes()) {
         DataNodeId dataNodeId = clusterMapManager.getDataNodeId(dataNode.getHostname(), dataNode.getPort());
         assertEquals(dataNodeId, dataNode);
@@ -124,6 +130,10 @@ public class StaticClusterManagerTest {
         }
       }
     }
+    assertNull("Wrong id for non existent datacenter name",
+        clusterMapManager.getDatacenterIdByName("NonExistentDcName"));
+    assertNull("Wrong id for null datacenter name", clusterMapManager.getDatacenterIdByName("null"));
+    assertNull("Wrong name for non existent datacenter id", clusterMapManager.getDatacenterNameById((short) 10));
   }
 
   @Test

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -47,7 +47,7 @@ public class ResponseHandlerTest {
     Set<ReplicaEventType> lastReplicaEvents;
 
     public DummyMap() {
-      lastReplicaEvents = new HashSet<ReplicaEventType>();
+      lastReplicaEvents = new HashSet<>();
       lastReplicaID = null;
     }
 
@@ -69,6 +69,16 @@ public class ResponseHandlerTest {
     @Override
     public boolean hasDatacenter(String datacenterName) {
       return false;
+    }
+
+    @Override
+    public Short getDatacenterIdByName(String datacenterName) {
+      return null;
+    }
+
+    @Override
+    public String getDatacenterNameById(short datacenterId) {
+      return null;
     }
 
     @Override

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -29,6 +29,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
@@ -752,6 +754,27 @@ public class Utils {
   public static long getTimeInMsToTheNearestSec(long timeInMs) {
     long timeInSecs = timeInMs / Time.MsPerSec;
     return timeInMs != Utils.Infinite_Time ? (timeInSecs * Time.MsPerSec) : Utils.Infinite_Time;
+  }
+
+  /**
+   * Reverse a {@link Map}, such that the key in the original map becomes the value, and the value
+   * in the original map becomes the key. If in the original map there are more than one key are
+   * mapped to the same value, the reversed map would have the value to be mapped to one of the keys.
+   * @param originMap The map to be reversed.
+   * @param <K> The type of key in the original map.
+   * @param <V> The type of value in the original map.
+   * @return A map that has key as the value in the original map, and value as the key in the original
+   * map.
+   */
+  public static <K, V> Map<V, K> reverseMap(Map<K, V> originMap) {
+    if (originMap == null) {
+      throw new IllegalArgumentException("originMap cannot be null");
+    }
+    Map<V, K> reversedMap = new HashMap<>();
+    for (Map.Entry<K, V> entry : originMap.entrySet()) {
+      reversedMap.put(entry.getValue(), entry.getKey());
+    }
+    return reversedMap;
   }
 
   /**

--- a/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
@@ -18,6 +18,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -408,6 +410,23 @@ public class UtilsTest {
       assertEquals("epoch epochTimeInMs mismatch ", Utils.Infinite_Time,
           Utils.addSecondsToEpochTime(epochTimeInMs, Utils.Infinite_Time));
     }
+  }
+
+  /**
+   * Tests {@link Utils#reverseMap(Map)}.
+   */
+  @Test
+  public void reverseMapTest() {
+    Map<String, Short> originalMap = new HashMap<>();
+    originalMap.put("first", (short) 1);
+    originalMap.put("second", (short) 2);
+    Map<Short, String> reversedMap = Utils.reverseMap(originalMap);
+    assertEquals("Wrong size of reversedMap", originalMap.size(), reversedMap.size());
+    assertEquals("Wrong value get from the reversed map.", "first", reversedMap.get((short) 1));
+    assertEquals("Wrong value get from the reversed map.", "second", reversedMap.get((short) 2));
+    originalMap.put("third", (short) 2);
+    reversedMap = Utils.reverseMap(originalMap);
+    assertEquals("Wrong size of reversedMap", 2, reversedMap.size());
   }
 
   private static final String CHARACTERS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";


### PR DESCRIPTION
This patch brings in an internal concept of datacenter id, and generates
an id in short for each datacenter. Querying the id of a datacenter is
supported by the ClusterMap interface.

The datacenter id will be needed when it is embeded into blob id, to
indicate the originating datacenter of the blob.

This patch also introduces a util method to check if a datacenter name
is valid to add to a cluster.

Test done: ./gradlew clean && ./gradlew build

Test coverage:
Class Class, %  Method, % Line, %
ClusterMapUtils 100% (1/ 1) 92.3% (12/ 13)  90.4% (47/ 52)
CompositeClusterManager 100% (1/ 1) 100% (14/ 14) 88.9% (88/ 99)
Datacenter  100% (1/ 1) 93.3% (14/ 15)  92.5% (49/ 53)
HelixClusterManager 100% (5/ 5) 95.2% (40/ 42)  96.6% (255/ 264)
HelixClusterManagerMetrics  100% (16/ 16) 92.1% (35/ 38)  97.2% (103/
106)
StaticClusterManager  100% (2/ 2) 91.4% (32/ 35)  80.9% (178/ 220)