### PR TITLE
Introducing support for getting peers of a given data node

### DIFF
--- a/ambry-admin/src/main/java/com.github.ambry.admin/GetReplicasHandler.java
+++ b/ambry-admin/src/main/java/com.github.ambry.admin/GetReplicasHandler.java
@@ -60,16 +60,16 @@ class GetReplicasHandler {
    * @return a {@link ReadableStreamChannel} that contains the getReplicas response.
    * @throws RestServiceException if there was any problem constructing the response.
    */
-  public ReadableStreamChannel getReplicas(String blobId, RestResponseChannel restResponseChannel)
+  ReadableStreamChannel getReplicas(String blobId, RestResponseChannel restResponseChannel)
       throws RestServiceException {
     logger.trace("Getting replicas of blob ID - {}", blobId);
     long startTime = System.currentTimeMillis();
     ReadableStreamChannel channel = null;
     try {
-      String replicaStr = getReplicas(blobId).toString();
+      byte[] replicasResponseBytes = getReplicas(blobId).toString().getBytes();
       restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, "application/json");
-      restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, replicaStr.length());
-      channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(replicaStr.getBytes()));
+      restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, replicasResponseBytes.length);
+      channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(replicasResponseBytes));
     } finally {
       adminMetrics.getReplicasProcessingTimeInMs.update(System.currentTimeMillis() - startTime);
     }

--- a/ambry-admin/src/test/java/com.github.ambry.admin/AdminTestUtils.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/AdminTestUtils.java
@@ -16,8 +16,6 @@ package com.github.ambry.admin;
 import com.github.ambry.rest.MockRestRequest;
 import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
-import com.github.ambry.router.CopyingAsyncWritableChannel;
-import com.github.ambry.router.ReadableStreamChannel;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
@@ -29,7 +27,7 @@ import org.json.JSONObject;
 /**
  * Utility functions for Admin tests.
  */
-public class AdminTestUtils {
+class AdminTestUtils {
 
   /**
    * Method to easily create {@link RestRequest} objects containing a specific request.
@@ -51,17 +49,5 @@ public class AdminTestUtils {
       request.put(MockRestRequest.HEADERS_KEY, headers);
     }
     return new MockRestRequest(request, contents);
-  }
-
-  /**
-   * Reads the response received from the {@code channel} and decodes it into a {@link JSONObject}.
-   * @param channel the {@link ReadableStreamChannel} that contains the response
-   * @return the response decoded into a {@link JSONObject}.
-   * @throws Exception
-   */
-  static JSONObject getJsonizedResponseBody(ReadableStreamChannel channel) throws Exception {
-    CopyingAsyncWritableChannel asyncWritableChannel = new CopyingAsyncWritableChannel((int) channel.getSize());
-    channel.readInto(asyncWritableChannel, null).get();
-    return new JSONObject(new String(asyncWritableChannel.getData()));
   }
 }

--- a/ambry-admin/src/test/java/com.github.ambry.admin/GetReplicasHandlerTest.java
+++ b/ambry-admin/src/test/java/com.github.ambry.admin/GetReplicasHandlerTest.java
@@ -23,6 +23,7 @@ import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestResponseChannel;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.rest.RestTestUtils;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.ReadableStreamChannel;
 import java.io.IOException;
@@ -68,7 +69,7 @@ public class GetReplicasHandlerTest {
       assertEquals("Unexpected Content-Type", "application/json",
           restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
       String returnedReplicasStr =
-          AdminTestUtils.getJsonizedResponseBody(channel).getString(GetReplicasHandler.REPLICAS_KEY).replace("\"", "");
+          RestTestUtils.getJsonizedResponseBody(channel).getString(GetReplicasHandler.REPLICAS_KEY).replace("\"", "");
       assertEquals("Replica IDs returned for the BlobId do no match with the replicas IDs of partition",
           originalReplicaStr, returnedReplicasStr);
     }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequest.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequest.java
@@ -58,8 +58,8 @@ public interface RestRequest extends ReadableStreamChannel {
   /**
    * Gets all the arguments passed as a part of the request.
    * <p/>
-   * The implementation can decide what constitute as arguments. It can be specific parts of the URI, query parameters,
-   * header values etc. or a combination of any of these.
+   * The query parameters and headers (including cookies) should necessarily be a part of the args. In addition to
+   * these, the implementation can decide what constitute as arguments.
    * @return the arguments and their values (if any) as a map.
    */
   public Map<String, Object> getArgs();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
@@ -29,11 +29,16 @@ public class MockDataNodeId extends DataNodeId {
   String datacenter;
   List<String> sslEnabledDataCenters = new ArrayList<String>();
 
-  public MockDataNodeId(List<Port> ports, List<String> mountPaths, String dataCenter) {
+  public MockDataNodeId(String hostname, List<Port> ports, List<String> mountPaths, String dataCenter) {
+    this.hostname = hostname;
     this.mountPaths = mountPaths;
     this.datacenter = dataCenter;
     this.ports = new HashMap<PortType, Port>();
     populatePorts(ports);
+  }
+
+  public MockDataNodeId(List<Port> ports, List<String> mountPaths, String dataCenter) {
+    this("localhost", ports, mountPaths, dataCenter);
   }
 
   private void populatePorts(List<Port> ports) {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
@@ -22,18 +22,18 @@ import java.util.Map;
 
 
 public class MockDataNodeId extends DataNodeId {
-  int portNum;
-  Map<PortType, Port> ports;
-  List<String> mountPaths;
-  String hostname = "localhost";
-  String datacenter;
-  List<String> sslEnabledDataCenters = new ArrayList<String>();
+  private final Map<PortType, Port> ports;
+  private final List<String> mountPaths;
+  private final String hostname;
+  private final String datacenter;
+  private List<String> sslEnabledDataCenters = new ArrayList<String>();
+  private int portNum;
 
   public MockDataNodeId(String hostname, List<Port> ports, List<String> mountPaths, String dataCenter) {
     this.hostname = hostname;
     this.mountPaths = mountPaths;
     this.datacenter = dataCenter;
-    this.ports = new HashMap<PortType, Port>();
+    this.ports = new HashMap<>();
     populatePorts(ports);
   }
 

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -155,12 +155,8 @@ class AmbryBlobStorageService implements BlobStorageService {
         operationOrBlobId = operationOrBlobId.substring(1);
       }
       if (operationOrBlobId.equalsIgnoreCase(OPERATION_GET_PEERS)) {
-        getPeersHandler.handle(restRequest, restResponseChannel, new Callback<ReadableStreamChannel>() {
-          @Override
-          public void onCompletion(ReadableStreamChannel result, Exception exception) {
-            submitResponse(restRequest, restResponseChannel, result, exception);
-          }
-        });
+        getPeersHandler.handle(restRequest, restResponseChannel,
+            (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
       } else {
         RestRequestMetrics requestMetrics =
             restRequest.getSSLSession() != null ? frontendMetrics.getBlobSSLMetrics : frontendMetrics.getBlobMetrics;

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
@@ -77,6 +77,6 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
   @Override
   public BlobStorageService getBlobStorageService() {
     return new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, idConverterFactory,
-        securityServiceFactory);
+        securityServiceFactory, clusterMap);
   }
 }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
@@ -42,6 +42,8 @@ class FrontendMetrics {
   public final RestRequestMetrics getBlobSSLMetrics;
   public final RestRequestMetrics getUserMetadataMetrics;
   public final RestRequestMetrics getUserMetadataSSLMetrics;
+  public final RestRequestMetrics getPeersMetrics;
+  public final RestRequestMetrics getPeersSSLMetrics;
   // POST
   public final RestRequestMetrics postBlobMetrics;
   public final RestRequestMetrics postBlobSSLMetrics;
@@ -101,6 +103,9 @@ class FrontendMetrics {
   public final Histogram securityServiceProcessResponseTimeInMs;
   // AmbryIdConverter
   public final Histogram idConverterProcessingTimeInMs;
+  // GetPeersHandler
+  public final Histogram getPeersSecurityProcessingTimeInMs;
+  public final Histogram getPeersProcessingTimeInMs;
 
   // Errors
   // AmbryBlobStorageService
@@ -118,6 +123,8 @@ class FrontendMetrics {
   // PostCallback
   public final Counter postCallbackProcessingError;
   public final Counter outboundIdConversionCallbackProcessingError;
+  // GetPeersHandler
+  public final Counter unknownDatanodeError;
   // Other
   // AmbryBlobStorageService
   public final Histogram blobStorageServiceStartupTimeInMs;
@@ -145,6 +152,8 @@ class FrontendMetrics {
     getUserMetadataMetrics = new RestRequestMetrics(AmbryBlobStorageService.class, "GetUserMetadata", metricRegistry);
     getUserMetadataSSLMetrics =
         new RestRequestMetrics(AmbryBlobStorageService.class, "GetUserMetadata" + SSL_SUFFIX, metricRegistry);
+    getPeersMetrics = new RestRequestMetrics(GetPeersHandler.class, "GetPeers", metricRegistry);
+    getPeersSSLMetrics = new RestRequestMetrics(GetPeersHandler.class, "GetPeers" + SSL_SUFFIX, metricRegistry);
     // POST
     postBlobMetrics = new RestRequestMetrics(AmbryBlobStorageService.class, "PostBlob", metricRegistry);
     postBlobSSLMetrics = new RestRequestMetrics(AmbryBlobStorageService.class, "PostBlob" + SSL_SUFFIX, metricRegistry);
@@ -240,6 +249,11 @@ class FrontendMetrics {
     // AmbryIdConverter
     idConverterProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(AmbryIdConverterFactory.class, "ProcessingTimeInMs"));
+    // GetPeersHandler
+    getPeersSecurityProcessingTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(GetPeersHandler.class, "SecurityProcessingTimeInMs"));
+    getPeersProcessingTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(GetPeersHandler.class, "ProcessingTimeInMs"));
 
     // Errors
     // AmbryBlobStorageService
@@ -266,6 +280,8 @@ class FrontendMetrics {
     outboundIdConversionCallbackProcessingError = metricRegistry.counter(
         MetricRegistry.name(AmbryBlobStorageService.class, "OutboundIdConversionCallbackProcessingError"));
     ttlTooLargeError = metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "TtlTooLargeError"));
+    // GetPeersHandler
+    unknownDatanodeError = metricRegistry.counter(MetricRegistry.name(GetPeersHandler.class, "UnknownDatanodeError"));
 
     // Other
     blobStorageServiceStartupTimeInMs =

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
@@ -98,13 +98,13 @@ class FrontendMetrics {
   public final Histogram getSecurityRequestTimeInMs;
   public final Histogram headSecurityRequestTimeInMs;
   public final Histogram postSecurityRequestTimeInMs;
+  public final Histogram getPeersSecurityRequestTimeInMs;
   // AmbrySecurityService
   public final Histogram securityServiceProcessRequestTimeInMs;
   public final Histogram securityServiceProcessResponseTimeInMs;
   // AmbryIdConverter
   public final Histogram idConverterProcessingTimeInMs;
   // GetPeersHandler
-  public final Histogram getPeersSecurityProcessingTimeInMs;
   public final Histogram getPeersProcessingTimeInMs;
 
   // Errors
@@ -241,6 +241,8 @@ class FrontendMetrics {
         MetricRegistry.name(AmbryBlobStorageService.class, "PostSecurityRequestCallbackProcessingTimeInMs"));
     postSecurityRequestTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "PostSecurityRequestTimeInMs"));
+    getPeersSecurityRequestTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(GetPeersHandler.class, "SecurityRequestTimeInMs"));
     // AmbrySecurityService
     securityServiceProcessRequestTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(AmbrySecurityService.class, "RequestProcessingTimeInMs"));
@@ -250,8 +252,6 @@ class FrontendMetrics {
     idConverterProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(AmbryIdConverterFactory.class, "ProcessingTimeInMs"));
     // GetPeersHandler
-    getPeersSecurityProcessingTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(GetPeersHandler.class, "SecurityProcessingTimeInMs"));
     getPeersProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(GetPeersHandler.class, "ProcessingTimeInMs"));
 

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/GetPeersHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/GetPeersHandler.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.frontend;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.commons.ByteBufferReadableStreamChannel;
+import com.github.ambry.rest.RestRequest;
+import com.github.ambry.rest.RestRequestMetrics;
+import com.github.ambry.rest.RestResponseChannel;
+import com.github.ambry.rest.RestServiceErrorCode;
+import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.rest.RestUtils;
+import com.github.ambry.rest.SecurityService;
+import com.github.ambry.router.Callback;
+import com.github.ambry.router.ReadableStreamChannel;
+import com.github.ambry.utils.SystemTime;
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Handler for requests that require the peer datanodes of a given datanode.
+ */
+class GetPeersHandler {
+  static final String NAME_QUERY_PARAM = "name";
+  static final String PORT_QUERY_PARAM = "port";
+  private static final Logger LOGGER = LoggerFactory.getLogger(GetPeersHandler.class);
+
+  private final ClusterMap clusterMap;
+  private final SecurityService securityService;
+  private final FrontendMetrics metrics;
+
+  /**
+   * Constructs a handler for handling requests for peers.
+   * @param clusterMap the {@link ClusterMap} to use.
+   * @param securityService the {@link SecurityService} to use.
+   * @param metrics {@link FrontendMetrics} instance where metrics should be recorded.
+   */
+  GetPeersHandler(ClusterMap clusterMap, SecurityService securityService, FrontendMetrics metrics) {
+    this.clusterMap = clusterMap;
+    this.securityService = securityService;
+    this.metrics = metrics;
+  }
+
+  /**
+   * Handles a request for peers of a given datanode. Expects the arguments to have {@link #NAME_QUERY_PARAM} and
+   * {@link #PORT_QUERY_PARAM}. Returns the peers as comma separated list of host:port pairs in the response body.
+   * @param restRequest the {@link RestRequest} that contains the request parameters.
+   * @param restResponseChannel the {@link RestResponseChannel} where headers should be set.
+   * @param callback the {@link Callback} to invoke when the response {@link ReadableStreamChannel} is ready (or if
+   *                 there is an exception).
+   */
+  void handle(RestRequest restRequest, RestResponseChannel restResponseChannel,
+      Callback<ReadableStreamChannel> callback) {
+    RestRequestMetrics requestMetrics =
+        restRequest.getSSLSession() != null ? metrics.getPeersMetrics : metrics.getPeersSSLMetrics;
+    restRequest.getMetricsTracker().injectMetrics(requestMetrics);
+    securityService.processRequest(restRequest,
+        new SecurityProcessRequestCallback(restRequest, restResponseChannel, callback));
+  }
+
+  /**
+   * Callback for the {@link SecurityService} that handles generating the replica list if the security checks
+   * succeeded.
+   */
+  private class SecurityProcessRequestCallback implements Callback<Void> {
+    private final RestRequest restRequest;
+    private final RestResponseChannel restResponseChannel;
+    private final Callback<ReadableStreamChannel> callback;
+    private final long operationStartTimeMs;
+
+    SecurityProcessRequestCallback(RestRequest restRequest, RestResponseChannel restResponseChannel,
+        Callback<ReadableStreamChannel> callback) {
+      this.restRequest = restRequest;
+      this.restResponseChannel = restResponseChannel;
+      this.callback = callback;
+      operationStartTimeMs = SystemTime.getInstance().milliseconds();
+    }
+
+    /**
+     * If {@code exception} is null, gathers all the peers of the datanode that corresponds to the params in the request
+     * and returns them as a part of the response body.
+     * @param result The result of the request. This would be non null when the request executed successfully
+     * @param exception The exception that was reported on execution of the request
+     */
+    @Override
+    public void onCompletion(Void result, Exception exception) {
+      long processingStartTimeMs = SystemTime.getInstance().milliseconds();
+      metrics.getPeersSecurityProcessingTimeInMs.update(processingStartTimeMs - operationStartTimeMs);
+      try {
+        if (exception == null) {
+          DataNodeId dataNodeId = getDataNodeId(restRequest);
+          LOGGER.trace("Getting peer hosts for {}:{}", dataNodeId.getHostname(), dataNodeId.getPort());
+          Set<DataNodeId> peerDataNodeIds = new HashSet<>();
+          List<? extends ReplicaId> replicaIdList = clusterMap.getReplicaIds(dataNodeId);
+          for (ReplicaId replicaId : replicaIdList) {
+            List<? extends ReplicaId> peerReplicaIds = replicaId.getPeerReplicaIds();
+            for (ReplicaId peerReplicaId : peerReplicaIds) {
+              peerDataNodeIds.add(peerReplicaId.getDataNodeId());
+            }
+          }
+          StringBuilder peerSb = new StringBuilder();
+          for (DataNodeId peerDataNodeId : peerDataNodeIds) {
+            peerSb.append(peerDataNodeId.getHostname()).append(":").append(peerDataNodeId.getPort()).append(",");
+          }
+          if (peerSb.length() > 0) {
+            peerSb.deleteCharAt(peerSb.length() - 1);
+          }
+          String peerStr = peerSb.toString();
+          ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(peerStr.getBytes()));
+          restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, "text/plain");
+          restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, channel.getSize());
+          callback.onCompletion(channel, null);
+        } else {
+          callback.onCompletion(null, exception);
+        }
+      } catch (Exception e) {
+        callback.onCompletion(null, e);
+      } finally {
+        metrics.getPeersProcessingTimeInMs.update(SystemTime.getInstance().milliseconds() - processingStartTimeMs);
+      }
+    }
+
+    /**
+     * Gets the {@link DataNodeId} based on query parameters in the {@code restRequest}. Return is always non-null.
+     * @param restRequest the {@link RestRequest} containing the parameters of the request.
+     * @return the {@link DataNodeId} based on query parameters in the {@code restRequest}. Return is always non-null.
+     * @throws RestServiceException if either {@link #NAME_QUERY_PARAM} or {@link #PORT_QUERY_PARAM} is missing, if
+     * {@link #PORT_QUERY_PARAM} is not an {@link Integer} or if there is no datanode that corresponds to the given
+     * parameters.
+     */
+    private DataNodeId getDataNodeId(RestRequest restRequest) throws RestServiceException {
+      String name = (String) restRequest.getArgs().get(NAME_QUERY_PARAM);
+      String portStr = (String) restRequest.getArgs().get(PORT_QUERY_PARAM);
+      if (name == null || portStr == null) {
+        throw new RestServiceException("Missing name and/or port of data node", RestServiceErrorCode.MissingArgs);
+      }
+      int port;
+      try {
+        port = Integer.parseInt(portStr);
+      } catch (NumberFormatException e) {
+        throw new RestServiceException("Port " + "[" + portStr + "] could not parsed into a number",
+            RestServiceErrorCode.InvalidArgs);
+      }
+      DataNodeId dataNodeId = clusterMap.getDataNodeId(name, port);
+      if (dataNodeId == null) {
+        metrics.unknownDatanodeError.inc();
+        throw new RestServiceException("No datanode found for parameters " + name + ":" + port,
+            RestServiceErrorCode.NotFound);
+      }
+      return dataNodeId;
+    }
+  }
+}

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/GetPeersHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/GetPeersHandler.java
@@ -109,7 +109,7 @@ class GetPeersHandler {
     @Override
     public void onCompletion(Void result, Exception exception) {
       long processingStartTimeMs = SystemTime.getInstance().milliseconds();
-      metrics.getPeersSecurityProcessingTimeInMs.update(processingStartTimeMs - operationStartTimeMs);
+      metrics.getPeersSecurityRequestTimeInMs.update(processingStartTimeMs - operationStartTimeMs);
       ReadableStreamChannel channel = null;
       try {
         if (exception == null) {
@@ -131,7 +131,7 @@ class GetPeersHandler {
         exception = e;
       } finally {
         metrics.getPeersProcessingTimeInMs.update(SystemTime.getInstance().milliseconds() - processingStartTimeMs);
-        callback.onCompletion(channel, exception);
+        callback.onCompletion(exception == null ? channel : null, exception);
       }
     }
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -552,14 +552,10 @@ public class AmbryBlobStorageServiceTest {
         MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
         doOperation(createRestRequest(RestMethod.GET, uri, null, null), restResponseChannel);
         byte[] peerStrBytes = restResponseChannel.getResponseBody();
-        String peersStr = new String(peerStrBytes);
-        List<String> peers = peersStr.length() > 0 ? Arrays.asList(peersStr.split(",")) : new ArrayList<String>();
+        Set<String> peersFromResponse =
+            GetPeersHandlerTest.getPeersFromResponse(new JSONObject(new String(peerStrBytes)));
         Set<String> expectedPeers = clusterMap.getPeers(datanode);
-        assertTrue("Peer list returned does not match expected for " + datanode, expectedPeers.containsAll(peers));
-        assertEquals("Content-type is not as expected", "text/plain",
-            restResponseChannel.getHeader(RestUtils.Headers.CONTENT_TYPE));
-        assertEquals("Content-length is not as expected", peerStrBytes.length,
-            Integer.parseInt((String) restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH)));
+        assertEquals("Peer list returned does not match expected for " + datanode, expectedPeers, peersFromResponse);
       }
     }
     // test one bad request

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -542,7 +542,7 @@ public class AmbryBlobStorageServiceTest {
             securityServiceFactory, clusterMap);
     ambryBlobStorageService.start();
     // test good requests
-    for (String datanode : TailoredPeersClusterMap.datanodeNames) {
+    for (String datanode : TailoredPeersClusterMap.DATANODE_NAMES) {
       String[] parts = datanode.split(":");
       String baseUri =
           AmbryBlobStorageService.OPERATION_GET_PEERS + "?" + GetPeersHandler.NAME_QUERY_PARAM + "=" + parts[0] + "&"

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -367,8 +367,8 @@ public class FrontendIntegrationTest {
    * @throws IllegalArgumentException if any of {@code headers}, {@code serviceId}, {@code contentType} is null or if
    *                                  {@code contentLength} < 0 or if {@code ttlInSecs} < -1.
    */
-  private void setAmbryHeadersForPut(HttpHeaders httpHeaders, long ttlInSecs, boolean isPrivate,
-      String serviceId, String contentType, String ownerId) {
+  private void setAmbryHeadersForPut(HttpHeaders httpHeaders, long ttlInSecs, boolean isPrivate, String serviceId,
+      String contentType, String ownerId) {
     if (httpHeaders != null && ttlInSecs >= -1 && serviceId != null && contentType != null) {
       httpHeaders.add(RestUtils.Headers.TTL, ttlInSecs);
       httpHeaders.add(RestUtils.Headers.PRIVATE, isPrivate);

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
@@ -80,7 +80,7 @@ public class GetPeersHandlerTest {
    */
   @Test
   public void handleGoodCaseTest() throws Exception {
-    for (String datanode : TailoredPeersClusterMap.datanodeNames) {
+    for (String datanode : TailoredPeersClusterMap.DATANODE_NAMES) {
       RestRequest restRequest = getRestRequest(datanode);
       RestResponseChannel restResponseChannel = new MockRestResponseChannel();
       ReadableStreamChannel channel = sendRequestGetResponse(restRequest, restResponseChannel);
@@ -127,7 +127,7 @@ public class GetPeersHandlerTest {
     doBadArgsTest("host", null, RestServiceErrorCode.MissingArgs);
     doBadArgsTest("host", "abc", RestServiceErrorCode.InvalidArgs);
     doBadArgsTest("non-existent-host", "100", RestServiceErrorCode.NotFound);
-    String host = TailoredPeersClusterMap.datanodeNames[0].split(":")[0];
+    String host = TailoredPeersClusterMap.DATANODE_NAMES[0].split(":")[0];
     doBadArgsTest(host, "-1", RestServiceErrorCode.NotFound);
   }
 
@@ -201,7 +201,7 @@ public class GetPeersHandlerTest {
    * @throws Exception
    */
   private void verifyFailureWithMsg(String msg) throws Exception {
-    RestRequest restRequest = getRestRequest(TailoredPeersClusterMap.datanodeNames[0]);
+    RestRequest restRequest = getRestRequest(TailoredPeersClusterMap.DATANODE_NAMES[0]);
     try {
       sendRequestGetResponse(restRequest, new MockRestResponseChannel());
       fail("Request should have failed");
@@ -276,10 +276,9 @@ public class GetPeersHandlerTest {
  * Can also throw exceptions on demand.
  */
 class TailoredPeersClusterMap implements ClusterMap {
-  static final String[] datanodeNames = {"host1:100", "host1:200", "host2:100", "host3:100"};
+  static final String[] DATANODE_NAMES = {"host1:100", "host1:200", "host2:100", "host3:100"};
 
   private static final String DC_NAME = "Datacenter";
-  private static final String[] mountPathsArr = {"/tmp1", "/tmp2", "/tmp3", "/tmp4"};
 
   private final Map<String, MockDataNodeId> datanodes = new HashMap<>();
   private final Map<String, Set<String>> peerMap = new HashMap<>();
@@ -288,7 +287,7 @@ class TailoredPeersClusterMap implements ClusterMap {
   RuntimeException exceptionToThrow = null;
 
   TailoredPeersClusterMap() {
-    for (String datanodeName : datanodeNames) {
+    for (String datanodeName : DATANODE_NAMES) {
       String[] parts = datanodeName.split(":");
       Port port = new Port(Integer.parseInt(parts[1]), PortType.PLAINTEXT);
       List<String> mountPaths = Collections.singletonList("/" + datanodeName);
@@ -297,28 +296,28 @@ class TailoredPeersClusterMap implements ClusterMap {
     }
 
     List<MockDataNodeId> partNodes = new ArrayList<>();
-    partNodes.add(datanodes.get(datanodeNames[0]));
-    partNodes.add(datanodes.get(datanodeNames[1]));
+    partNodes.add(datanodes.get(DATANODE_NAMES[0]));
+    partNodes.add(datanodes.get(DATANODE_NAMES[1]));
     partitions.add(new MockPartitionId(0, partNodes, 0));
     partNodes.clear();
-    partNodes.add(datanodes.get(datanodeNames[0]));
-    partNodes.add(datanodes.get(datanodeNames[1]));
+    partNodes.add(datanodes.get(DATANODE_NAMES[0]));
+    partNodes.add(datanodes.get(DATANODE_NAMES[1]));
     partitions.add(new MockPartitionId(1, partNodes, 0));
     partNodes.clear();
-    partNodes.add(datanodes.get(datanodeNames[0]));
-    partNodes.add(datanodes.get(datanodeNames[2]));
+    partNodes.add(datanodes.get(DATANODE_NAMES[0]));
+    partNodes.add(datanodes.get(DATANODE_NAMES[2]));
     partitions.add(new MockPartitionId(2, partNodes, 0));
     partNodes.clear();
-    partNodes.add(datanodes.get(datanodeNames[0]));
+    partNodes.add(datanodes.get(DATANODE_NAMES[0]));
     partitions.add(new MockPartitionId(3, partNodes, 0));
     partNodes.clear();
-    partNodes.add(datanodes.get(datanodeNames[3]));
+    partNodes.add(datanodes.get(DATANODE_NAMES[3]));
     partitions.add(new MockPartitionId(4, partNodes, 0));
 
-    peerMap.put(datanodeNames[0], new HashSet(Arrays.asList(datanodeNames[1], datanodeNames[2])));
-    peerMap.put(datanodeNames[1], new HashSet(Arrays.asList(datanodeNames[0])));
-    peerMap.put(datanodeNames[2], Collections.singleton(datanodeNames[0]));
-    peerMap.put(datanodeNames[3], Collections.EMPTY_SET);
+    peerMap.put(DATANODE_NAMES[0], new HashSet(Arrays.asList(DATANODE_NAMES[1], DATANODE_NAMES[2])));
+    peerMap.put(DATANODE_NAMES[1], new HashSet(Arrays.asList(DATANODE_NAMES[0])));
+    peerMap.put(DATANODE_NAMES[2], Collections.singleton(DATANODE_NAMES[0]));
+    peerMap.put(DATANODE_NAMES[3], Collections.EMPTY_SET);
   }
 
   @Override

--- a/ambry-rest/src/test/java/com.github.ambry.rest/RestTestUtils.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/RestTestUtils.java
@@ -17,6 +17,8 @@ import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.commons.TestSSLUtils;
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.router.ByteRange;
+import com.github.ambry.router.CopyingAsyncWritableChannel;
+import com.github.ambry.router.ReadableStreamChannel;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -28,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import org.json.JSONObject;
 
 
 /**
@@ -89,5 +92,17 @@ public class RestTestUtils {
     } catch (IOException | GeneralSecurityException e) {
       throw new IllegalStateException(e);
     }
+  }
+
+  /**
+   * Reads the response received from the {@code channel} and decodes it into a {@link JSONObject}.
+   * @param channel the {@link ReadableStreamChannel} that contains the response
+   * @return the response decoded into a {@link JSONObject}.
+   * @throws Exception
+   */
+  public static JSONObject getJsonizedResponseBody(ReadableStreamChannel channel) throws Exception {
+    CopyingAsyncWritableChannel asyncWritableChannel = new CopyingAsyncWritableChannel((int) channel.getSize());
+    channel.readInto(asyncWritableChannel, null).get();
+    return new JSONObject(new String(asyncWritableChannel.getData()));
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
@@ -173,6 +173,9 @@ public class CompactionManagerTest {
     assertTrue("Should schedule compaction", compactionManager.scheduleNextForCompaction(lastStore));
     assertTrue("Compaction call did not come within the expected time",
         lastStore.compactCallsCountdown.await(1, TimeUnit.HOURS));
+    if (lastStore.callOrderException != null) {
+      throw lastStore.callOrderException;
+    }
     assertTrue("compact() should have been called", lastStore.compactCalled);
     compactionManager.disable();
     compactionManager.awaitTermination();


### PR DESCRIPTION
With dynamic cluster management, static files will no longer serve as source of truth for cluster details. This commit introduces a method to fetch some details about the cluster from the frontend.

Built and formatted.

Unit tests

| Class | Class, % | Method, % | Line, % | Test class |
| --- | --- | --- | --- | --- |
| `GetPeersHandler` | 100% (2/ 2) | 100% (7/ 7) | 100% (57/ 57) | `GetPeersHandlerTest` |
| `AmbryBlobStorageService` | 100% (14/ 14) | 100% (55/ 55) | 95.7% (357/ 373) | `AmbryBlobStorageServiceTest` |