### PR TITLE
Storing the offset for delete check in compaction log

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
@@ -491,14 +491,15 @@ class BlobStoreCompactor {
    */
   private boolean copyDataByLogSegment(LogSegment logSegmentToCopy, FileSpan duplicateSearchSpan)
       throws IOException, StoreException {
-    logger.debug("Copying data from {}", logSegmentToCopy);
+    logger.info("Copying data from {}", logSegmentToCopy);
     for (Offset indexSegmentStartOffset : getIndexSegmentDetails(logSegmentToCopy.getName()).keySet()) {
       IndexSegment indexSegmentToCopy = srcIndex.getIndexSegments().get(indexSegmentStartOffset);
-      logger.debug("Processing index segment {}", indexSegmentToCopy.getFile());
+      logger.info("Processing index segment {}", indexSegmentToCopy.getFile());
       if (needsCopying(indexSegmentToCopy.getEndOffset()) && !copyDataByIndexSegment(logSegmentToCopy,
           indexSegmentToCopy, duplicateSearchSpan)) {
         // there is a shutdown in progress or there was no space to copy all entries.
-        logger.debug("Did not copy all entries in {}", indexSegmentToCopy.getFile());
+        logger.info("Did not copy all entries in {} (either because there is no space or there is a shutdown)",
+            indexSegmentToCopy.getFile());
         return false;
       }
     }

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -191,13 +191,15 @@ class CompactionManager {
               boolean compactionStarted = false;
               try {
                 if (store.isStarted() && !storesToSkip.contains(store)) {
-                  logger.trace("{} is started and eligible for compaction check", store);
+                  logger.info("{} is started and is being checked for compaction eligibility", store);
                   CompactionDetails details = getCompactionDetails(store);
                   if (details != null) {
                     logger.trace("Generated {} as details for {}", details, store);
                     metrics.markCompactionStart(true);
                     compactionStarted = true;
                     store.compact(details);
+                  } else {
+                    logger.info("{} is not eligible for compaction", store);
                   }
                 }
               } catch (Exception e) {

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1715,7 +1715,6 @@ public class IndexTest {
    * @throws StoreException
    */
   private void findEntriesSinceOneByOneTest() throws StoreException {
-    Offset logAbsoluteZero = new Offset(state.log.getFirstSegment().getName(), 0);
     Offset journalStartOffset = state.index.journal.getFirstOffset();
     StoreFindToken startToken = new StoreFindToken();
     Offset stoppedAt = null;

--- a/ambry-tools/src/main/java/com.github.ambry/store/CompactionVerifier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/CompactionVerifier.java
@@ -583,8 +583,8 @@ public class CompactionVerifier implements Closeable {
     assert
         srcValue.getSize() == tgtValue.getSize() :
         errMsgId + ": Size mismatch: old - " + srcValue.getSize() + ", new - " + tgtValue.getSize();
-    assert
-        Utils.getTimeInMsToTheNearestSec(srcValue.getExpiresAtMs()) == tgtValue.getExpiresAtMs() :
+    assert Utils.getTimeInMsToTheNearestSec(srcValue.getExpiresAtMs()) == Utils.getTimeInMsToTheNearestSec(
+        tgtValue.getExpiresAtMs()) :
         errMsgId + ": ExpiresAt mismatch: old - " + srcValue.getExpiresAtMs() + ", new - " + tgtValue.getExpiresAtMs();
     assert
         srcValue.getServiceId() == tgtValue.getServiceId() :


### PR DESCRIPTION
To avoid recalculating the offset based on the ref time and last modified time of index segments, the offset is calculated once and stored and reused as long as it is valid.

Built and formatted.
All new lines covered.