### PR TITLE
Speed up cluster manager initialization

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -96,6 +96,15 @@ public class ClusterMapUtils {
   }
 
   /**
+   * Get the datacenter name associated with the given instance.
+   * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
+   * @return the datacenter name associated with the given instance.
+   */
+  static String getDcName(InstanceConfig instanceConfig) {
+    return instanceConfig.getRecord().getSimpleField(DATACENTER_STR);
+  }
+
+  /**
    * Get the ssl port associated with the given instance (if any).
    * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
    * @return the ssl port associated with the given instance.

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -108,6 +108,9 @@ class HelixClusterManager implements ClusterMap {
           @Override
           public void run() {
             try {
+              // Helix provides the initial notification for a change from within the same thread that adds the
+              // listener, in the context of the add call. Therefore, when the call to add a listener returns, the
+              // initial notification will have been received and handled.
               dcZkInfo.helixManager.addInstanceConfigChangeListener(dcZkInfo.clusterChangeHandler);
               logger.info("Registered instance config change listeners for Helix manager at {}", dcZkInfo.zkConnectStr);
               // Now register listeners to get notified on live instance change in every datacenter.

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -291,7 +291,6 @@ public class HelixClusterManagerTest {
     // trigger for live instance change event should have come in twice per dc - the initial one, and the one due to a
     // node brought up in each DC.
     assertEquals(instanceTriggerCount, getCounterValue("liveInstanceChangeTriggerCount"));
-    assertEquals(dcs.length, getCounterValue("externalViewChangeTriggerCount"));
     assertEquals(dcs.length, getCounterValue("instanceConfigChangeTriggerCount"));
     assertEquals(helixCluster.getDataCenterCount(), getGaugeValue("datacenterCount"));
     assertEquals(helixCluster.getDownInstances().size() + helixCluster.getUpInstances().size(),

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
@@ -15,6 +15,7 @@ package com.github.ambry.clustermap;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -108,6 +109,10 @@ public class MockHelixAdmin implements HelixAdmin {
     return instances;
   }
 
+  List<InstanceConfig> getInstanceConfigs(String clusterName) {
+    return new ArrayList<>(instanceNameToinstanceConfigs.values());
+  }
+
   @Override
   public InstanceConfig getInstanceConfig(String clusterName, String instanceName) {
     return instanceNameToinstanceConfigs.get(instanceName);
@@ -185,7 +190,7 @@ public class MockHelixAdmin implements HelixAdmin {
    */
   private void triggerLiveInstanceChangeNotification() {
     for (MockHelixManager helixManager : helixManagersForThisAdmin) {
-      helixManager.triggerLiveInstanceNotification();
+      helixManager.triggerLiveInstanceNotification(false);
     }
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
@@ -90,19 +90,23 @@ class MockHelixManager implements HelixManager {
   @Override
   public void addLiveInstanceChangeListener(LiveInstanceChangeListener listener) throws Exception {
     liveInstanceChangeListener = listener;
-    triggerLiveInstanceNotification();
+    triggerLiveInstanceNotification(true);
   }
 
   @Override
   public void addInstanceConfigChangeListener(InstanceConfigChangeListener listener) throws Exception {
     instanceConfigChangeListener = listener;
-    instanceConfigChangeListener.onInstanceConfigChange(Collections.EMPTY_LIST, new NotificationContext(this));
+    NotificationContext notificationContext = new NotificationContext(this);
+    notificationContext.setType(NotificationContext.Type.INIT);
+    instanceConfigChangeListener.onInstanceConfigChange(mockAdmin.getInstanceConfigs(clusterName), notificationContext);
   }
 
   @Override
   public void addExternalViewChangeListener(ExternalViewChangeListener listener) throws Exception {
     externalViewChangeListener = listener;
-    externalViewChangeListener.onExternalViewChange(Collections.EMPTY_LIST, new NotificationContext(this));
+    NotificationContext notificationContext = new NotificationContext(this);
+    notificationContext.setType(NotificationContext.Type.INIT);
+    externalViewChangeListener.onExternalViewChange(Collections.EMPTY_LIST, notificationContext);
   }
 
   @Override
@@ -128,12 +132,16 @@ class MockHelixManager implements HelixManager {
   /**
    * Trigger a live instance change notification.
    */
-  void triggerLiveInstanceNotification() {
+  void triggerLiveInstanceNotification(boolean initial) {
     List<LiveInstance> liveInstances = new ArrayList<>();
     for (String instance : mockAdmin.getUpInstances()) {
       liveInstances.add(new LiveInstance(instance));
     }
-    liveInstanceChangeListener.onLiveInstanceChange(liveInstances, new NotificationContext(this));
+    NotificationContext notificationContext = new NotificationContext(this);
+    if (initial) {
+      notificationContext.setType(NotificationContext.Type.INIT);
+    }
+    liveInstanceChangeListener.onLiveInstanceChange(liveInstances, notificationContext);
   }
 
   //****************************

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
@@ -55,7 +55,8 @@ class MockHelixManager implements HelixManager {
   private LiveInstanceChangeListener liveInstanceChangeListener;
   private ExternalViewChangeListener externalViewChangeListener;
   private InstanceConfigChangeListener instanceConfigChangeListener;
-  private MockHelixAdmin mockAdmin;
+  private final MockHelixAdmin mockAdmin;
+  private final Exception beBadException;
 
   /**
    * Instantiate a MockHelixManager.
@@ -63,13 +64,16 @@ class MockHelixManager implements HelixManager {
    * @param instanceType the {@link InstanceType} of the requester.
    * @param zkAddr the address identifying the zk service to which this request is to be made.
    * @param helixCluster the {@link MockHelixCluster} associated with this manager.
+   * @param beBadException the {@link Exception} that this manager will throw on listener registrations.
    */
-  MockHelixManager(String instanceName, InstanceType instanceType, String zkAddr, MockHelixCluster helixCluster) {
+  MockHelixManager(String instanceName, InstanceType instanceType, String zkAddr, MockHelixCluster helixCluster,
+      Exception beBadException) {
     this.instanceName = instanceName;
     this.instanceType = instanceType;
     mockAdmin = helixCluster.getHelixAdminFactory().getHelixAdmin(zkAddr);
     mockAdmin.addHelixManager(this);
     clusterName = helixCluster.getClusterName();
+    this.beBadException = beBadException;
   }
 
   @Override
@@ -89,12 +93,18 @@ class MockHelixManager implements HelixManager {
 
   @Override
   public void addLiveInstanceChangeListener(LiveInstanceChangeListener listener) throws Exception {
+    if (beBadException != null) {
+      throw beBadException;
+    }
     liveInstanceChangeListener = listener;
     triggerLiveInstanceNotification(true);
   }
 
   @Override
   public void addInstanceConfigChangeListener(InstanceConfigChangeListener listener) throws Exception {
+    if (beBadException != null) {
+      throw beBadException;
+    }
     instanceConfigChangeListener = listener;
     NotificationContext notificationContext = new NotificationContext(this);
     notificationContext.setType(NotificationContext.Type.INIT);
@@ -103,6 +113,9 @@ class MockHelixManager implements HelixManager {
 
   @Override
   public void addExternalViewChangeListener(ExternalViewChangeListener listener) throws Exception {
+    if (beBadException != null) {
+      throw beBadException;
+    }
     externalViewChangeListener = listener;
     NotificationContext notificationContext = new NotificationContext(this);
     notificationContext.setType(NotificationContext.Type.INIT);


### PR DESCRIPTION
In order to speed up cluster manager initialization, optimize a few things:
- Initialize via the first InstanceConfig change event and avoid
  unnecessary extra work.
- Avoiding inter-colo initialization barriers.
- Avoid listening on external view changes (this can be re-added later
  if necessary).