### PR TITLE
Add support for dynamically updating partition sealed state.

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
@@ -27,17 +27,20 @@ class AmbryReplica implements ReplicaId {
   private final AmbryPartition partition;
   private final AmbryDisk disk;
   private final long capacityBytes;
+  private volatile boolean isSealed;
 
   /**
    * Instantiate an AmbryReplica instance.
    * @param partition the {@link AmbryPartition} of which this is a replica.
    * @param disk the {@link AmbryDisk} on which this replica resides.
    * @param capacityBytes the capacity in bytes for this replica.
+   * @param isSealed whether this replica is in sealed state.
    */
-  AmbryReplica(AmbryPartition partition, AmbryDisk disk, long capacityBytes) {
+  AmbryReplica(AmbryPartition partition, AmbryDisk disk, long capacityBytes, boolean isSealed) {
     this.partition = partition;
     this.disk = disk;
     this.capacityBytes = capacityBytes;
+    this.isSealed = isSealed;
     validate();
   }
 
@@ -81,6 +84,21 @@ class AmbryReplica implements ReplicaId {
   @Override
   public long getCapacityInBytes() {
     return capacityBytes;
+  }
+
+  /**
+   * @return true if this replica is in sealed state.
+   */
+  boolean isSealed() {
+    return isSealed;
+  }
+
+  /**
+   * Set the sealed state of this replica.
+   * @param isSealed true if the replica is to be set as sealed; false otherwise.
+   */
+  void setSealedState(boolean isSealed) {
+    this.isSealed = isSealed;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
@@ -28,4 +28,10 @@ interface ClusterManagerCallback {
    * @return the list of {@link AmbryReplica}s associated with the given partition.
    */
   List<AmbryReplica> getReplicaIdsForPartition(AmbryPartition partition);
+
+  /**
+   * Get the counter for the sealed state change for partitions.
+   * @return the counter for the sealed state change for partitions.
+   */
+  long getSealedStateChangeCounter();
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -319,7 +319,7 @@ class HelixClusterManager implements ClusterMap {
             initializationException.compareAndSet(null, e);
           }
         } else {
-          updateInstanceSealedStates(configs);
+          updateSealedStateOfReplicas(configs);
         }
         helixClusterManagerMetrics.instanceConfigChangeTriggerCount.inc();
       }
@@ -345,7 +345,7 @@ class HelixClusterManager implements ClusterMap {
       logger.info("Initialized cluster information from {}", dcName);
     }
 
-    private void updateInstanceSealedStates(List<InstanceConfig> instanceConfigs) {
+    private void updateSealedStateOfReplicas(List<InstanceConfig> instanceConfigs) {
       for (InstanceConfig instanceConfig : instanceConfigs) {
         AmbryDataNode node = instanceNameToAmbryDataNode.get(instanceConfig.getInstanceName());
         List<String> sealedReplicas = getSealedReplicas(instanceConfig);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
@@ -186,6 +186,7 @@ public class DynamicClusterManagerComponentsTest {
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica3);
     AmbryReplica replica4 = new AmbryReplica(partition2, disk2, MIN_REPLICA_CAPACITY_IN_BYTES, true);
     mockClusterManagerCallback.addReplicaToPartition(partition2, replica4);
+    sealedStateChangeCounter.incrementAndGet();
 
     assertEquals(replica1.getDiskId().getMountPath(), replica1.getMountPath());
     List<AmbryReplica> peerReplicas = replica1.getPeerReplicaIds();
@@ -217,7 +218,8 @@ public class DynamicClusterManagerComponentsTest {
     sealedStateChangeCounter.incrementAndGet();
     assertEquals(partition1.getPartitionState(), PartitionState.READ_WRITE);
     replica4.setSealedState(false);
-    assertEquals(partition1.getPartitionState(), PartitionState.READ_WRITE);
+    sealedStateChangeCounter.incrementAndGet();
+    assertEquals(partition2.getPartitionState(), PartitionState.READ_WRITE);
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -281,6 +281,9 @@ public class HelixClusterManagerTest {
     assertStateEquivalency();
   }
 
+  /**
+   * Test that the changes to the sealed states of replicas get reflected correctly in the cluster manager.
+   */
   @Test
   public void sealedReplicaChangeTest() throws Exception {
     if (useComposite) {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
@@ -46,6 +46,11 @@ public class MockHelixAdmin implements HelixAdmin {
   private Map<String, PartitionState> partitionToPartitionStates = new HashMap<>();
   private long totalDiskCapacity;
 
+  /**
+   * Get the instances that have replicas for the given partition.
+   * @param partition the partition name of the partition.
+   * @return the set of instances that have replicas for this partition.
+   */
   Set<String> getInstancesForPartition(String partition) {
     return partitionToInstances.containsKey(partition) ? partitionToInstances.get(partition) : Collections.EMPTY_SET;
   }
@@ -127,7 +132,13 @@ public class MockHelixAdmin implements HelixAdmin {
     return true;
   }
 
-  void  setReplicaSealedState(AmbryPartition partition, String instance, boolean isSealed) {
+  /**
+   * Set or reset the sealed state of the replica for the given partition on the given instance.
+   * @param partition the {@link AmbryPartition}
+   * @param instance the instance name.
+   * @param isSealed if true, the replica will be marked as sealed; otherwise it will be marked as read-write.
+   */
+  void setReplicaSealedState(AmbryPartition partition, String instance, boolean isSealed) {
     InstanceConfig instanceConfig = getInstanceConfig(clusterName, instance);
     List<String> sealedReplicas = ClusterMapUtils.getSealedReplicas(instanceConfig);
     if (isSealed) {
@@ -209,6 +220,9 @@ public class MockHelixAdmin implements HelixAdmin {
     }
   }
 
+  /**
+   * Trigger an instance config change notification.
+   */
   private void triggerInstanceConfigChangeNotification() {
     for (MockHelixManager helixManager : helixManagersForThisAdmin) {
       helixManager.triggerConfigChangeNotification(false);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -13,10 +13,12 @@
  */
 package com.github.ambry.clustermap;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.helix.model.InstanceConfig;
 
 
 /**
@@ -63,6 +65,14 @@ public class MockHelixCluster {
    */
   Set<String> getZkAddrs() {
     return helixAdmins.keySet();
+  }
+
+  void  setReplicaSealedState(AmbryPartition partition, String instance, boolean isSealed) {
+    for (MockHelixAdmin helixAdmin: helixAdmins.values()) {
+      if (helixAdmin.getInstancesInCluster(clusterName).contains(instance)) {
+        helixAdmin.setReplicaSealedState(partition, instance, isSealed);
+      }
+    }
   }
 
   /**
@@ -147,6 +157,25 @@ public class MockHelixCluster {
         helixAdmin.bringInstanceDown(instance);
       }
     }
+  }
+
+  InstanceConfig getInstanceConfig(String instanceName) {
+    InstanceConfig instanceConfig = null;
+    for (MockHelixAdmin helixAdmin: helixAdmins.values()) {
+      if (helixAdmin.getUpInstances().contains(instanceName)) {
+        instanceConfig = helixAdmin.getInstanceConfig(null, instanceName);
+        break;
+      }
+    }
+    return instanceConfig;
+  }
+
+  List<String> getInstancesForPartition(String partition) {
+    List<String> instances = new ArrayList<>();
+    for (MockHelixAdmin helixAdmin: helixAdmins.values()) {
+      instances.addAll(helixAdmin.getInstancesForPartition(partition));
+    }
+    return instances;
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -67,8 +67,8 @@ public class MockHelixCluster {
     return helixAdmins.keySet();
   }
 
-  void  setReplicaSealedState(AmbryPartition partition, String instance, boolean isSealed) {
-    for (MockHelixAdmin helixAdmin: helixAdmins.values()) {
+  void setReplicaSealedState(AmbryPartition partition, String instance, boolean isSealed) {
+    for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
       if (helixAdmin.getInstancesInCluster(clusterName).contains(instance)) {
         helixAdmin.setReplicaSealedState(partition, instance, isSealed);
       }
@@ -161,7 +161,7 @@ public class MockHelixCluster {
 
   InstanceConfig getInstanceConfig(String instanceName) {
     InstanceConfig instanceConfig = null;
-    for (MockHelixAdmin helixAdmin: helixAdmins.values()) {
+    for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
       if (helixAdmin.getUpInstances().contains(instanceName)) {
         instanceConfig = helixAdmin.getInstanceConfig(null, instanceName);
         break;
@@ -170,9 +170,14 @@ public class MockHelixCluster {
     return instanceConfig;
   }
 
+  /**
+   * Get the instances that have replicas for the given partition.
+   * @param partition the partition name of the partition.
+   * @return the list of instances that have replicas for this partition.
+   */
   List<String> getInstancesForPartition(String partition) {
     List<String> instances = new ArrayList<>();
-    for (MockHelixAdmin helixAdmin: helixAdmins.values()) {
+    for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
       instances.addAll(helixAdmin.getInstancesForPartition(partition));
     }
     return instances;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
@@ -106,9 +106,7 @@ class MockHelixManager implements HelixManager {
       throw beBadException;
     }
     instanceConfigChangeListener = listener;
-    NotificationContext notificationContext = new NotificationContext(this);
-    notificationContext.setType(NotificationContext.Type.INIT);
-    instanceConfigChangeListener.onInstanceConfigChange(mockAdmin.getInstanceConfigs(clusterName), notificationContext);
+    triggerConfigChangeNotification(true);
   }
 
   @Override
@@ -155,6 +153,14 @@ class MockHelixManager implements HelixManager {
       notificationContext.setType(NotificationContext.Type.INIT);
     }
     liveInstanceChangeListener.onLiveInstanceChange(liveInstances, notificationContext);
+  }
+
+  void triggerConfigChangeNotification(boolean initial) {
+    NotificationContext notificationContext = new NotificationContext(this);
+    if (initial) {
+      notificationContext.setType(NotificationContext.Type.INIT);
+    }
+    instanceConfigChangeListener.onInstanceConfigChange(mockAdmin.getInstanceConfigs(clusterName), notificationContext);
   }
 
   //****************************


### PR DESCRIPTION
Partition's sealed state is dependent on the sealed states of its
replicas (which is controlled individually by the respective nodes).
A partition is READ_WRITE if *all* its replicas are READ_WRITE. Equivalently,
a partition is READ_ONLY if *any* of its replicas is READ_ONLY. See the
[design document](https://docs.google.com/document/d/1gMweKKzpgcGciXzhNpjI3gf9973QhkZoYA6YkUhaFvU/edit#heading=h.2jxsxqh) for details.

Individual instances (or admin operations) are supposed to update the
InstanceConfig to mark their replicas as READ_ONLY or READ_WRITE (this is not
part of this patch). When this change is made, HelixClusterManager updates the
states of the replicas as part of the InstanceConfig change handling. Changes to
replica sealed state is tracked at the highest level and a `getPartitionState()`
call on a Partition will refresh and cache its state from those of its replicas
if there has been such a change since the last refresh.