### PR TITLE
Adding a config to selectively enable different compaction triggers

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -97,11 +97,13 @@ public class StoreConfig {
   public final long storeSegmentSizeInBytes;
 
   /**
-   * Whether compaction is to be enabled or not
+   * Comma separated list of the compaction triggers that should be enabled. If this config is an empty string,
+   * compaction will not be enabled.
+   * The valid triggers are: Periodic,Admin
    */
-  @Config("store.enable.compaction")
-  @Default("false")
-  public final boolean storeEnableCompaction;
+  @Config("store.compaction.triggers")
+  @Default("")
+  public final String[] storeCompactionTriggers;
 
   /**
    * The frequency (in hours) at which a store is checked to see whether it is ready for compaction.
@@ -133,14 +135,6 @@ public class StoreConfig {
   @Default("1")
   public final int storeMinLogSegmentCountToReclaimToTriggerCompaction;
 
-  /**
-   * Comma separated list of the compaction triggers that should be enabled. The valid triggers are:
-   * Time, Admin
-   */
-  @Config("store.compaction.triggers")
-  @Default("Time,Admin")
-  public final String[] storeCompactionTriggers;
-
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -161,14 +155,13 @@ public class StoreConfig {
         verifiableProperties.getLongInRange("store.segment.size.in.bytes", Long.MAX_VALUE, 1, Long.MAX_VALUE);
     storeMinUsedCapacityToTriggerCompactionInPercentage =
         verifiableProperties.getInt("store.min.used.capacity.to.trigger.compaction.in.percentage", 50);
-    storeEnableCompaction = verifiableProperties.getBoolean("store.enable.compaction", false);
+    storeCompactionTriggers = verifiableProperties.getString("store.compaction.triggers", "").split(",");
     storeCompactionCheckFrequencyInHours =
         verifiableProperties.getIntInRange("store.compaction.check.frequency.in.hours", 7 * 24, 1, 365 * 24);
     storeCompactionPolicyFactory = verifiableProperties.getString("store.compaction.policy.factory",
         "com.github.ambry.store.DefaultCompactionPolicyFactory");
     storeMinLogSegmentCountToReclaimToTriggerCompaction =
         verifiableProperties.getIntInRange("store.min.log.segment.count.to.reclaim.to.trigger.compaction", 1, 1, 1000);
-    storeCompactionTriggers = verifiableProperties.getString("store.compaction.triggers", "Time,Admin").split(",");
   }
 }
 

--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -133,6 +133,14 @@ public class StoreConfig {
   @Default("1")
   public final int storeMinLogSegmentCountToReclaimToTriggerCompaction;
 
+  /**
+   * Comma separated list of the compaction triggers that should be enabled. The valid triggers are:
+   * Time, Admin
+   */
+  @Config("store.compaction.triggers")
+  @Default("Time,Admin")
+  public final String[] storeCompactionTriggers;
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -160,6 +168,7 @@ public class StoreConfig {
         "com.github.ambry.store.DefaultCompactionPolicyFactory");
     storeMinLogSegmentCountToReclaimToTriggerCompaction =
         verifiableProperties.getIntInRange("store.min.log.segment.count.to.reclaim.to.trigger.compaction", 1, 1, 1000);
+    storeCompactionTriggers = verifiableProperties.getString("store.compaction.triggers", "Time,Admin").split(",");
   }
 }
 

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -529,7 +529,8 @@ public class AmbryRequests implements RequestAPI {
             logger.error("Validating trigger compaction request failed with error {} for {}", error, adminRequest);
           } else if (!storageManager.scheduleNextForCompaction(adminRequest.getPartitionId())) {
             error = ServerErrorCode.Unknown_Error;
-            logger.error("Triggering compaction failed for {}", adminRequest);
+            logger.error("Triggering compaction failed for {}. Check if admin trigger is enabled for compaction",
+                adminRequest);
           }
           response = new AdminResponse(adminRequest.getCorrelationId(), adminRequest.getClientId(), error);
       }

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -33,8 +33,8 @@ import org.slf4j.LoggerFactory;
 class CompactionManager {
   static final String THREAD_NAME_PREFIX = "StoreCompactionThread-";
 
-  private static final String TIME_BASED_TRIGGER_NAME = "time";
-  private static final String ADMIN_BASED_TRIGGER_NAME = "admin";
+  private static final String PERIODIC_TRIGGER_NAME = "periodic";
+  private static final String ADMIN_TRIGGER_NAME = "admin";
 
   private final String mountPath;
   private final StoreConfig storeConfig;
@@ -62,19 +62,19 @@ class CompactionManager {
     this.stores = stores;
     this.time = time;
     this.metrics = metrics;
-    if (storeConfig.storeEnableCompaction) {
+    if (!storeConfig.storeCompactionTriggers[0].isEmpty()) {
       boolean enableTimeBasedTrigger = false;
       boolean enableAdminBasedTrigger = false;
       for (String trigger : storeConfig.storeCompactionTriggers) {
         switch (trigger.toLowerCase()) {
-          case TIME_BASED_TRIGGER_NAME:
+          case PERIODIC_TRIGGER_NAME:
             enableTimeBasedTrigger = true;
             break;
-          case ADMIN_BASED_TRIGGER_NAME:
+          case ADMIN_TRIGGER_NAME:
             enableAdminBasedTrigger = true;
             break;
           default:
-            throw new IllegalArgumentException("Unrecognized trigger name: " + trigger);
+            throw new IllegalArgumentException("Unrecognized trigger name: [" + trigger + "]");
         }
       }
       compactionExecutor = new CompactionExecutor(enableTimeBasedTrigger, enableAdminBasedTrigger);

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -228,7 +228,7 @@ public class StorageManagerTest {
   private StorageManager createAndStartStoreManager(List<ReplicaId> replicas, MetricRegistry metricRegistry)
       throws StoreException, InterruptedException {
     Properties properties = new Properties();
-    properties.put("store.enable.compaction", "true");
+    properties.put("store.compaction.triggers", "Periodic,Admin");
     StorageManager storageManager =
         new StorageManager(new StoreConfig(new VerifiableProperties(properties)), Utils.newScheduler(1, false),
             metricRegistry, replicas, new MockIdFactory(), new DummyMessageStoreRecovery(),


### PR DESCRIPTION
It might be desirable to enable/disable certain compaction triggers to get a better handle on the pathways through which compaction can be triggered.

| Class | Class, % | Method, % | Line, % | Test class |
| --- | --- | --- | --- | --- |
| `CompactionManager` | 100% (3/ 3) | 92.9% (13/ 14) | 93.2% (124/ 133) | `CompactionManagerTest` |