### PR TITLE
Adding new BlobProperties V2 with accountId and containerId

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -23,18 +23,19 @@ import com.github.ambry.utils.Utils;
  */
 public class BlobProperties {
 
-  public static final short ACCOUNTID_CONTAINERID_DEFAULT_VALUE = -1;
+  public static final short ACCOUNTID_DEFAULT_VALUE = -1;
+  public static final short CONTAINERID_DEFAULT_VALUE = -1;
 
-  protected long blobSize;
-  protected String serviceId;
-  protected String ownerId;
-  protected String contentType;
-  protected boolean isPrivate;
-  protected long timeToLiveInSeconds;
-  protected long creationTimeInMs;
-  private short accountId;
-  private short containerId;
-  private short issuerAccountId;
+  private final long blobSize;
+  private final String serviceId;
+  private final String ownerId;
+  private final String contentType;
+  private final boolean isPrivate;
+  private final long timeToLiveInSeconds;
+  private final long creationTimeInMs;
+  private final short accountId;
+  private final short containerId;
+  private final short creatorAccountId;
 
   /**
    * @param blobSize The size of the blob in bytes
@@ -48,13 +49,13 @@ public class BlobProperties {
   /**
    * @param blobSize The size of the blob in bytes
    * @param serviceId The service id that is creating this blob
-   * @param accountId accountId of the user who uploaded the blob
+   * @param accountId accountId of the user who owns the blob
    * @param containerId containerId of the blob
-   * @param issuerAccountId Issuer AccountId of the put request
+   * @param creatorAccountId refers to accountId of the creator of the blob
    */
-  public BlobProperties(long blobSize, String serviceId, short accountId, short containerId, short issuerAccountId) {
+  public BlobProperties(long blobSize, String serviceId, short accountId, short containerId, short creatorAccountId) {
     this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, SystemTime.getInstance().milliseconds(),
-        accountId, containerId, issuerAccountId);
+        accountId, containerId, creatorAccountId);
   }
 
   /**
@@ -79,14 +80,14 @@ public class BlobProperties {
    * @param contentType The content type of the blob (eg: mime). Can be Null
    * @param isPrivate Is the blob secure
    * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
-   * @param accountId accountId of the user who uploaded the blob
+   * @param accountId accountId of the user who owns the blob
    * @param containerId containerId of the blob
-   * @param issuerAccountId Issuer AccountId of the put request
+   * @param creatorAccountId refers to accountId of the creator of the blob
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
-      long timeToLiveInSeconds, short accountId, short containerId, short issuerAccountId) {
+      long timeToLiveInSeconds, short accountId, short containerId, short creatorAccountId) {
     this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
-        SystemTime.getInstance().milliseconds(), accountId, containerId, issuerAccountId);
+        SystemTime.getInstance().milliseconds(), accountId, containerId, creatorAccountId);
   }
 
   /**
@@ -102,7 +103,7 @@ public class BlobProperties {
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
       long timeToLiveInSeconds, long creationTimeInMs) {
     this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds, creationTimeInMs,
-        ACCOUNTID_CONTAINERID_DEFAULT_VALUE, ACCOUNTID_CONTAINERID_DEFAULT_VALUE, ACCOUNTID_CONTAINERID_DEFAULT_VALUE);
+        ACCOUNTID_DEFAULT_VALUE, CONTAINERID_DEFAULT_VALUE, ACCOUNTID_DEFAULT_VALUE);
   }
 
   /**
@@ -113,10 +114,12 @@ public class BlobProperties {
    * @param isPrivate Is the blob secure
    * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
    * @param creationTimeInMs The time at which the blob is created.
-   * @param issuerAccountId Issuer AccountId of the put request
+   * @param accountId accountId of the user who owns the blob
+   * @param containerId containerId of the blob
+   * @param creatorAccountId refers to accountId of the creator of the blob
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
-      long timeToLiveInSeconds, long creationTimeInMs, short accountId, short containerId, short issuerAccountId) {
+      long timeToLiveInSeconds, long creationTimeInMs, short accountId, short containerId, short creatorAccountId) {
     this.blobSize = blobSize;
     this.serviceId = serviceId;
     this.ownerId = ownerId;
@@ -126,7 +129,7 @@ public class BlobProperties {
     this.timeToLiveInSeconds = timeToLiveInSeconds;
     this.accountId = accountId;
     this.containerId = containerId;
-    this.issuerAccountId = issuerAccountId;
+    this.creatorAccountId = creatorAccountId;
   }
 
   public long getTimeToLiveInSeconds() {
@@ -153,10 +156,6 @@ public class BlobProperties {
     return serviceId;
   }
 
-  public void setServiceId(String serviceId) {
-    this.serviceId = serviceId;
-  }
-
   public long getCreationTimeInMs() {
     return creationTimeInMs;
   }
@@ -169,8 +168,8 @@ public class BlobProperties {
     return containerId;
   }
 
-  public short getIssuerAccountId() {
-    return issuerAccountId;
+  public short getCreatorAccountId() {
+    return creatorAccountId;
   }
 
   @Override
@@ -202,7 +201,7 @@ public class BlobProperties {
     }
     sb.append(", ").append("AccountId=").append(getAccountId());
     sb.append(", ").append("ContainerId=").append(getContainerId());
-    sb.append(", ").append("IssuerAccountId=").append(getIssuerAccountId());
+    sb.append(", ").append("CreatorAccountId=").append(getCreatorAccountId());
     sb.append("]");
     return sb.toString();
   }

--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -23,8 +23,8 @@ import com.github.ambry.utils.Utils;
  */
 public class BlobProperties {
 
-  public static final short ACCOUNTID_DEFAULT_VALUE = -1;
-  public static final short CONTAINERID_DEFAULT_VALUE = -1;
+  public static final short LEGACY_ACCOUNT_ID = -1;
+  public static final short LEGACY_CONTAINER_ID = -1;
 
   private final long blobSize;
   private final String serviceId;
@@ -102,8 +102,8 @@ public class BlobProperties {
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
       long timeToLiveInSeconds, long creationTimeInMs) {
-    this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds, creationTimeInMs,
-        ACCOUNTID_DEFAULT_VALUE, CONTAINERID_DEFAULT_VALUE, ACCOUNTID_DEFAULT_VALUE);
+    this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds, creationTimeInMs, LEGACY_ACCOUNT_ID,
+        LEGACY_CONTAINER_ID, LEGACY_ACCOUNT_ID);
   }
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -23,6 +23,8 @@ import com.github.ambry.utils.Utils;
  */
 public class BlobProperties {
 
+  public static final short ACCOUNTID_CONTAINERID_DEFAULT_VALUE = -1;
+
   protected long blobSize;
   protected String serviceId;
   protected String ownerId;
@@ -30,13 +32,29 @@ public class BlobProperties {
   protected boolean isPrivate;
   protected long timeToLiveInSeconds;
   protected long creationTimeInMs;
+  private short accountId;
+  private short containerId;
+  private short issuerAccountId;
 
   /**
    * @param blobSize The size of the blob in bytes
    * @param serviceId The service id that is creating this blob
+   * @TODO: Remove this constructor once BlobProperty V2 is enabled
    */
   public BlobProperties(long blobSize, String serviceId) {
     this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, SystemTime.getInstance().milliseconds());
+  }
+
+  /**
+   * @param blobSize The size of the blob in bytes
+   * @param serviceId The service id that is creating this blob
+   * @param accountId accountId of the user who uploaded the blob
+   * @param containerId containerId of the blob
+   * @param issuerAccountId Issuer AccountId of the put request
+   */
+  public BlobProperties(long blobSize, String serviceId, short accountId, short containerId, short issuerAccountId) {
+    this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, SystemTime.getInstance().milliseconds(),
+        accountId, containerId, issuerAccountId);
   }
 
   /**
@@ -46,6 +64,7 @@ public class BlobProperties {
    * @param contentType The content type of the blob (eg: mime). Can be Null
    * @param isPrivate Is the blob secure
    * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
+   * @TODO: Remove this constructor once BlobProperty V2 is enabled
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
       long timeToLiveInSeconds) {
@@ -60,10 +79,44 @@ public class BlobProperties {
    * @param contentType The content type of the blob (eg: mime). Can be Null
    * @param isPrivate Is the blob secure
    * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
+   * @param accountId accountId of the user who uploaded the blob
+   * @param containerId containerId of the blob
+   * @param issuerAccountId Issuer AccountId of the put request
+   */
+  public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
+      long timeToLiveInSeconds, short accountId, short containerId, short issuerAccountId) {
+    this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
+        SystemTime.getInstance().milliseconds(), accountId, containerId, issuerAccountId);
+  }
+
+  /**
+   * @param blobSize The size of the blob in bytes
+   * @param serviceId The service id that is creating this blob
+   * @param ownerId The owner of the blob (For example , memberId or groupId)
+   * @param contentType The content type of the blob (eg: mime). Can be Null
+   * @param isPrivate Is the blob secure
+   * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
    * @param creationTimeInMs The time at which the blob is created.
+   * @TODO: Remove this constructor once BlobProperty V2 is enabled
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
       long timeToLiveInSeconds, long creationTimeInMs) {
+    this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds, creationTimeInMs,
+        ACCOUNTID_CONTAINERID_DEFAULT_VALUE, ACCOUNTID_CONTAINERID_DEFAULT_VALUE, ACCOUNTID_CONTAINERID_DEFAULT_VALUE);
+  }
+
+  /**
+   * @param blobSize The size of the blob in bytes
+   * @param serviceId The service id that is creating this blob
+   * @param ownerId The owner of the blob (For example , memberId or groupId)
+   * @param contentType The content type of the blob (eg: mime). Can be Null
+   * @param isPrivate Is the blob secure
+   * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
+   * @param creationTimeInMs The time at which the blob is created.
+   * @param issuerAccountId Issuer AccountId of the put request
+   */
+  public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
+      long timeToLiveInSeconds, long creationTimeInMs, short accountId, short containerId, short issuerAccountId) {
     this.blobSize = blobSize;
     this.serviceId = serviceId;
     this.ownerId = ownerId;
@@ -71,6 +124,9 @@ public class BlobProperties {
     this.isPrivate = isPrivate;
     this.creationTimeInMs = creationTimeInMs;
     this.timeToLiveInSeconds = timeToLiveInSeconds;
+    this.accountId = accountId;
+    this.containerId = containerId;
+    this.issuerAccountId = issuerAccountId;
   }
 
   public long getTimeToLiveInSeconds() {
@@ -105,6 +161,18 @@ public class BlobProperties {
     return creationTimeInMs;
   }
 
+  public short getAccountId() {
+    return accountId;
+  }
+
+  public short getContainerId() {
+    return containerId;
+  }
+
+  public short getIssuerAccountId() {
+    return issuerAccountId;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -132,6 +200,9 @@ public class BlobProperties {
     } else {
       sb.append(", ").append("TimeToLiveInSeconds=Infinite");
     }
+    sb.append(", ").append("AccountId=").append(getAccountId());
+    sb.append(", ").append("ContainerId=").append(getContainerId());
+    sb.append(", ").append("IssuerAccountId=").append(getIssuerAccountId());
     sb.append("]");
     return sb.toString();
   }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
@@ -19,23 +19,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 
-// A class that derives from blob properties. It is mainly used to set
-// properties in BlobProperties that are not user editable
-class SystemMetadata extends BlobProperties {
-  public SystemMetadata(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
-      long timeToLiveInSeconds, long creationTime) {
-    super(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds);
-    this.creationTimeInMs = creationTime;
-  }
-
-  public SystemMetadata(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
-      long timeToLiveInSeconds, long creationTime, short accountId, short containerId, short issuerAccountId) {
-    super(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds, accountId, containerId,
-        issuerAccountId);
-    this.creationTimeInMs = creationTime;
-  }
-}
-
 /**
  * Serializes and deserializes BlobProperties
  */
@@ -89,14 +72,14 @@ public class BlobPropertiesSerDe {
     String serviceId = Utils.readIntString(stream);
     switch (version) {
       case Version1:
-        toReturn = new SystemMetadata(blobSize, serviceId, ownerId, contentType, isPrivate, ttl, creationTime);
+        toReturn = new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, ttl, creationTime);
         break;
       case Version2:
         short accountId = stream.readShort();
         short containerId = stream.readShort();
         short issuerAccountId = stream.readShort();
         toReturn =
-            new SystemMetadata(blobSize, serviceId, ownerId, contentType, isPrivate, ttl, creationTime, accountId,
+            new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, ttl, creationTime, accountId,
                 containerId, issuerAccountId);
         break;
       default:
@@ -132,6 +115,6 @@ public class BlobPropertiesSerDe {
     Utils.serializeNullableString(outputBuffer, properties.getServiceId());
     outputBuffer.putShort(properties.getAccountId());
     outputBuffer.putShort(properties.getContainerId());
-    outputBuffer.putShort(properties.getIssuerAccountId());
+    outputBuffer.putShort(properties.getCreatorAccountId());
   }
 }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
@@ -26,6 +26,7 @@ public class BlobPropertiesSerDe {
 
   static final short Version1 = 1;
   static final short Version2 = 2;
+  static final short currentVersion = Version1;
   private static final int Version_Field_Size_In_Bytes = 2;
   private static final int TTL_Field_Size_In_Bytes = 8;
   private static final int Private_Field_Size_In_Bytes = 1;
@@ -36,7 +37,7 @@ public class BlobPropertiesSerDe {
   private static final int ContainerId_Field_Size_In_Bytes = 2;
   private static final int IssuerAccountId_Field_Size_In_Bytes = 2;
 
-  // @TODO: remove this to add accountId and containerId once putBlobPropertiesToBuffer is changed to version2
+  // @TODO: remove this to add accountId and containerId once serializeBlobProperties is changed to version2
   public static int getBlobPropertiesSerDeSize(BlobProperties properties) {
     return Version_Field_Size_In_Bytes + TTL_Field_Size_In_Bytes + Private_Field_Size_In_Bytes
         + CreationTime_Field_Size_In_Bytes + BlobSize_Field_Size_In_Bytes + Variable_Field_Size_In_Bytes
@@ -49,7 +50,7 @@ public class BlobPropertiesSerDe {
    * Returns the size of {@link BlobProperties} to serialize in Version 2
    * @param properties {@link BlobProperties} for which size is requested
    * @return the size of the {@link BlobProperties} to serialize in Version 2
-   * @TODO: will be used once putBlobPropertiesToBuffer is changed to version2
+   * @TODO: will be used once serializeBlobProperties is changed to version2
    */
   public static int getBlobPropertiesV2SerDeSize(BlobProperties properties) {
     return Version_Field_Size_In_Bytes + TTL_Field_Size_In_Bytes + Private_Field_Size_In_Bytes
@@ -64,7 +65,7 @@ public class BlobPropertiesSerDe {
     short version = stream.readShort();
     BlobProperties toReturn;
     long ttl = stream.readLong();
-    boolean isPrivate = stream.readByte() == 1 ? true : false;
+    boolean isPrivate = stream.readByte() == 1;
     long creationTime = stream.readLong();
     long blobSize = stream.readLong();
     String contentType = Utils.readIntString(stream);
@@ -88,24 +89,13 @@ public class BlobPropertiesSerDe {
     return toReturn;
   }
 
-  public static void putBlobPropertiesToBuffer(ByteBuffer outputBuffer, BlobProperties properties) {
-    outputBuffer.putShort(Version1);
-    outputBuffer.putLong(properties.getTimeToLiveInSeconds());
-    outputBuffer.put(properties.isPrivate() ? (byte) 1 : (byte) 0);
-    outputBuffer.putLong(properties.getCreationTimeInMs());
-    outputBuffer.putLong(properties.getBlobSize());
-    Utils.serializeNullableString(outputBuffer, properties.getContentType());
-    Utils.serializeNullableString(outputBuffer, properties.getOwnerId());
-    Utils.serializeNullableString(outputBuffer, properties.getServiceId());
-  }
-
   /**
-   * Serialized {@link BlobProperties} to buffer in version {@link #Version2}
-   * @param outputBuffer the {@link ByteBuffer} to write the {@link BlobProperties}
-   * @param properties the {@link BlobProperties} to be serialized
+   * Serialize {@link BlobProperties} to buffer in the {@link #currentVersion}
+   * @param outputBuffer the {@link ByteBuffer} to which {@link BlobProperties} needs to be serialized
+   * @param properties the {@link BlobProperties} that needs to be serialized
    */
-  public static void putBlobPropertiesToBufferV2(ByteBuffer outputBuffer, BlobProperties properties) {
-    outputBuffer.putShort(Version2);
+  public static void serializeBlobProperties(ByteBuffer outputBuffer, BlobProperties properties) {
+    outputBuffer.putShort(currentVersion);
     outputBuffer.putLong(properties.getTimeToLiveInSeconds());
     outputBuffer.put(properties.isPrivate() ? (byte) 1 : (byte) 0);
     outputBuffer.putLong(properties.getCreationTimeInMs());
@@ -113,8 +103,5 @@ public class BlobPropertiesSerDe {
     Utils.serializeNullableString(outputBuffer, properties.getContentType());
     Utils.serializeNullableString(outputBuffer, properties.getOwnerId());
     Utils.serializeNullableString(outputBuffer, properties.getServiceId());
-    outputBuffer.putShort(properties.getAccountId());
-    outputBuffer.putShort(properties.getContainerId());
-    outputBuffer.putShort(properties.getCreatorAccountId());
   }
 }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
@@ -26,39 +26,20 @@ public class BlobPropertiesSerDe {
 
   static final short Version1 = 1;
   static final short Version2 = 2;
-  static final short currentVersion = Version1;
+  private static final short currentVersion = Version1;
   private static final int Version_Field_Size_In_Bytes = 2;
   private static final int TTL_Field_Size_In_Bytes = 8;
   private static final int Private_Field_Size_In_Bytes = 1;
   private static final int CreationTime_Field_Size_In_Bytes = 8;
   private static final int Variable_Field_Size_In_Bytes = 4;
   private static final int BlobSize_Field_Size_In_Bytes = 8;
-  private static final int AccountId_Field_Size_In_Bytes = 2;
-  private static final int ContainerId_Field_Size_In_Bytes = 2;
-  private static final int IssuerAccountId_Field_Size_In_Bytes = 2;
 
-  // @TODO: remove this to add accountId and containerId once serializeBlobProperties is changed to version2
   public static int getBlobPropertiesSerDeSize(BlobProperties properties) {
     return Version_Field_Size_In_Bytes + TTL_Field_Size_In_Bytes + Private_Field_Size_In_Bytes
         + CreationTime_Field_Size_In_Bytes + BlobSize_Field_Size_In_Bytes + Variable_Field_Size_In_Bytes
         + Utils.getNullableStringLength(properties.getContentType()) + Variable_Field_Size_In_Bytes
         + Utils.getNullableStringLength(properties.getOwnerId()) + Variable_Field_Size_In_Bytes
         + Utils.getNullableStringLength(properties.getServiceId());
-  }
-
-  /**
-   * Returns the size of {@link BlobProperties} to serialize in Version 2
-   * @param properties {@link BlobProperties} for which size is requested
-   * @return the size of the {@link BlobProperties} to serialize in Version 2
-   * @TODO: will be used once serializeBlobProperties is changed to version2
-   */
-  public static int getBlobPropertiesV2SerDeSize(BlobProperties properties) {
-    return Version_Field_Size_In_Bytes + TTL_Field_Size_In_Bytes + Private_Field_Size_In_Bytes
-        + CreationTime_Field_Size_In_Bytes + BlobSize_Field_Size_In_Bytes + Variable_Field_Size_In_Bytes
-        + Utils.getNullableStringLength(properties.getContentType()) + Variable_Field_Size_In_Bytes
-        + Utils.getNullableStringLength(properties.getOwnerId()) + Variable_Field_Size_In_Bytes
-        + Utils.getNullableStringLength(properties.getServiceId()) + AccountId_Field_Size_In_Bytes
-        + ContainerId_Field_Size_In_Bytes + IssuerAccountId_Field_Size_In_Bytes;
   }
 
   public static BlobProperties getBlobPropertiesFromStream(DataInputStream stream) throws IOException {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -398,7 +398,7 @@ public class MessageFormatRecord {
     public static void serializeBlobPropertiesRecord(ByteBuffer outputBuffer, BlobProperties properties) {
       int startOffset = outputBuffer.position();
       outputBuffer.putShort(BlobProperties_Version_V1);
-      BlobPropertiesSerDe.putBlobPropertiesToBuffer(outputBuffer, properties);
+      BlobPropertiesSerDe.serializeBlobProperties(outputBuffer, properties);
       Crc32 crc = new Crc32();
       crc.update(outputBuffer.array(), startOffset, getBlobPropertiesRecordSize(properties) - Crc_Size);
       outputBuffer.putLong(crc.getValue());

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -78,15 +78,6 @@ public class MessageFormatRecord {
     }
   }
 
-  static boolean isValidBlobPropertiesVersion(short blobPropertiesVersion) {
-    switch (blobPropertiesVersion) {
-      case BlobProperties_Version_V1:
-        return true;
-      default:
-        return false;
-    }
-  }
-
   public static boolean deserializeDeleteRecord(InputStream stream) throws IOException, MessageFormatException {
     CrcInputStream crcStream = new CrcInputStream(stream);
     DataInputStream inputStream = new DataInputStream(crcStream);
@@ -97,15 +88,6 @@ public class MessageFormatRecord {
       default:
         throw new MessageFormatException("delete record version not supported",
             MessageFormatErrorCodes.Unknown_Format_Version);
-    }
-  }
-
-  static boolean isValidDeleteRecordVersion(short deleteRecordVersion) {
-    switch (deleteRecordVersion) {
-      case Delete_Version_V1:
-        return true;
-      default:
-        return false;
     }
   }
 

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -392,7 +392,7 @@ public class MessageFormatRecord {
     private static Logger logger = LoggerFactory.getLogger(BlobProperties_Format_V1.class);
 
     public static int getBlobPropertiesRecordSize(BlobProperties properties) {
-      return Version_Field_Size_In_Bytes + BlobPropertiesSerDe.getBlobPropertiesSize(properties) + Crc_Size;
+      return Version_Field_Size_In_Bytes + BlobPropertiesSerDe.getBlobPropertiesSerDeSize(properties) + Crc_Size;
     }
 
     public static void serializeBlobPropertiesRecord(ByteBuffer outputBuffer, BlobProperties properties) {

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -55,9 +55,9 @@ public class BlobPropertiesTest {
     final String contentType = "ContentType";
     final int timeToLiveInSeconds = 144;
 
-    short accountId = BlobProperties.ACCOUNTID_DEFAULT_VALUE;
-    short containerId = BlobProperties.CONTAINERID_DEFAULT_VALUE;
-    short creatorAccountId = BlobProperties.ACCOUNTID_DEFAULT_VALUE;
+    short accountId = BlobProperties.LEGACY_ACCOUNT_ID;
+    short containerId = BlobProperties.LEGACY_CONTAINER_ID;
+    short creatorAccountId = BlobProperties.LEGACY_ACCOUNT_ID;
     if (version == BlobPropertiesSerDe.Version2) {
       accountId = Utils.getRandomShort(TestUtils.RANDOM);
       containerId = Utils.getRandomShort(TestUtils.RANDOM);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -131,6 +131,11 @@ public class MessageFormatRecordTest {
     }
   }
 
+  /**
+   * Tests {@link MessageFormatRecord#BlobProperties_Version_V1} for different versions of {@link BlobPropertiesSerDe}
+   * @throws IOException
+   * @throws MessageFormatException
+   */
   @Test
   public void testBlobPropertyV1() throws IOException, MessageFormatException {
     // Test Blob property Format V1 for both versions of BlobPropertiesMsgFormat

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -129,6 +129,11 @@ public class MessageFormatRecordTest {
     }
   }
 
+  /**
+   * Tests BlobProperty format V1 serialize and deserialize. Tests for different versions of BlobProperties msg format.
+   * @throws IOException
+   * @throws MessageFormatException
+   */
   @Test
   public void testBlobPropertyV1() throws IOException, MessageFormatException {
     // Test Blob property Format V1 for both versions of BlobPropertiesMsgFormat
@@ -161,15 +166,9 @@ public class MessageFormatRecordTest {
       Assert.assertEquals(properties.getCreationTimeInMs(), result.getCreationTimeInMs());
       Assert.assertEquals(properties.getOwnerId(), result.getOwnerId());
       Assert.assertEquals(properties.getServiceId(), result.getServiceId());
-      if (version == BlobPropertiesSerDe.Version1) {
-        Assert.assertEquals(BlobProperties.ACCOUNTID_CONTAINERID_DEFAULT_VALUE, result.getAccountId());
-        Assert.assertEquals(BlobProperties.ACCOUNTID_CONTAINERID_DEFAULT_VALUE, result.getContainerId());
-        Assert.assertEquals(BlobProperties.ACCOUNTID_CONTAINERID_DEFAULT_VALUE, result.getIssuerAccountId());
-      } else {
-        Assert.assertEquals(properties.getAccountId(), result.getAccountId());
-        Assert.assertEquals(properties.getContainerId(), result.getContainerId());
-        Assert.assertEquals(properties.getIssuerAccountId(), result.getIssuerAccountId());
-      }
+      Assert.assertEquals(properties.getAccountId(), result.getAccountId());
+      Assert.assertEquals(properties.getContainerId(), result.getContainerId());
+      Assert.assertEquals(properties.getCreatorAccountId(), result.getCreatorAccountId());
 
       // corrupt blob property V1 record
       stream.flip();
@@ -184,7 +183,7 @@ public class MessageFormatRecordTest {
   }
 
   // TODO: remove this once BlobProperties V2 is enabled
-  public static void serializeBlobPropertiesV2Record(ByteBuffer outputBuffer, BlobProperties properties) {
+  private static void serializeBlobPropertiesV2Record(ByteBuffer outputBuffer, BlobProperties properties) {
     int startOffset = outputBuffer.position();
     outputBuffer.putShort(BlobProperties_Version_V1);
     BlobPropertiesSerDe.putBlobPropertiesToBufferV2(outputBuffer, properties);
@@ -194,7 +193,7 @@ public class MessageFormatRecordTest {
   }
 
   //  TODO: remove this once BlobProperties V2 is enabled
-  public static int getBlobPropertiesV2RecordSize(BlobProperties properties) {
+  private static int getBlobPropertiesV2RecordSize(BlobProperties properties) {
     int size = BlobPropertiesSerDe.getBlobPropertiesV2SerDeSize(properties);
     return Version_Field_Size_In_Bytes + size + Crc_Size;
   }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -131,7 +131,7 @@ public class MessageFormatRecordTest {
 
   @Test
   public void testBlobPropertyV1() throws IOException, MessageFormatException {
-    // Test Blob property V1 Record
+    // Test Blob property Format V1 for both versions of BlobPropertiesMsgFormat
     short[] versions = new short[]{BlobPropertiesSerDe.Version1, BlobPropertiesSerDe.Version2};
     for (short version : versions) {
       BlobProperties properties;
@@ -161,7 +161,6 @@ public class MessageFormatRecordTest {
       Assert.assertEquals(properties.getCreationTimeInMs(), result.getCreationTimeInMs());
       Assert.assertEquals(properties.getOwnerId(), result.getOwnerId());
       Assert.assertEquals(properties.getServiceId(), result.getServiceId());
-      // @TODO: fix this once BlobProperty V2 is enabled
       if (version == BlobPropertiesSerDe.Version1) {
         Assert.assertEquals(BlobProperties.ACCOUNTID_CONTAINERID_DEFAULT_VALUE, result.getAccountId());
         Assert.assertEquals(BlobProperties.ACCOUNTID_CONTAINERID_DEFAULT_VALUE, result.getContainerId());
@@ -196,7 +195,7 @@ public class MessageFormatRecordTest {
 
   //  TODO: remove this once BlobProperties V2 is enabled
   public static int getBlobPropertiesV2RecordSize(BlobProperties properties) {
-    int size = BlobPropertiesSerDe.getBlobPropertiesV2Size(properties);
+    int size = BlobPropertiesSerDe.getBlobPropertiesV2SerDeSize(properties);
     return Version_Field_Size_In_Bytes + size + Crc_Size;
   }
 

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -138,12 +138,12 @@ public class MessageFormatRecordTest {
   @Test
   public void testBlobPropertyV1() throws IOException, MessageFormatException {
     // Test Blob property Format V1 for both versions of BlobPropertiesMsgFormat
-    short[] versions = new short[]{BlobPropertiesSerDe.Version1, Version2};
+    short[] versions = new short[]{Version1, Version2};
     for (short version : versions) {
       BlobProperties properties;
       long blobSize = TestUtils.RANDOM.nextLong();
       long ttl = TestUtils.RANDOM.nextInt();
-      if (version == BlobPropertiesSerDe.Version1) {
+      if (version == Version1) {
         properties = new BlobProperties(blobSize, "id", "member", "test", true, ttl);
       } else {
         short accountId = Utils.getRandomShort(TestUtils.RANDOM);
@@ -153,7 +153,7 @@ public class MessageFormatRecordTest {
             new BlobProperties(blobSize, "id", "member", "test", true, ttl, accountId, containerId, issuerAccountId);
       }
       ByteBuffer stream;
-      if (version == BlobPropertiesSerDe.Version1) {
+      if (version == Version1) {
         stream = ByteBuffer.allocate(getBlobPropertiesRecordSize(properties));
         MessageFormatRecord.BlobProperties_Format_V1.serializeBlobPropertiesRecord(stream, properties);
       } else {
@@ -199,7 +199,7 @@ public class MessageFormatRecordTest {
    * @param properties the {@link BlobProperties} to be serialized
    * @todo: move this method to {@link BlobPropertiesSerDe} when enabling write path in V2
    */
-  public static void serializeBlobPropertiesV2(ByteBuffer outputBuffer, BlobProperties properties) {
+  private static void serializeBlobPropertiesV2(ByteBuffer outputBuffer, BlobProperties properties) {
     outputBuffer.putShort(Version2);
     outputBuffer.putLong(properties.getTimeToLiveInSeconds());
     outputBuffer.put(properties.isPrivate() ? (byte) 1 : (byte) 0);
@@ -215,7 +215,7 @@ public class MessageFormatRecordTest {
 
   //  TODO: remove this once BlobProperties V2 is enabled
   private static int getBlobPropertiesV2RecordSize(BlobProperties properties) {
-    int size = BlobPropertiesSerDe.getBlobPropertiesV2SerDeSize(properties);
+    int size = getBlobPropertiesV2SerDeSize(properties);
     return Version_Field_Size_In_Bytes + size + Crc_Size;
   }
 

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
@@ -104,7 +104,7 @@ public class PutRequest extends RequestOrResponse {
 
   private int sizeExcludingBlobAndCrcSize() {
     // size of (header + blobId + blob properties + metadata size + metadata + blob size + blob type)
-    return (int) super.sizeInBytes() + blobId.sizeInBytes() + BlobPropertiesSerDe.getBlobPropertiesSize(properties)
+    return (int) super.sizeInBytes() + blobId.sizeInBytes() + BlobPropertiesSerDe.getBlobPropertiesSerDeSize(properties)
         + UserMetadata_Size_InBytes + usermetadata.capacity() + Blob_Size_InBytes + BlobType_Size_InBytes;
   }
 

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
@@ -119,7 +119,7 @@ public class PutRequest extends RequestOrResponse {
         writeHeader();
         int crcStart = bufferToSend.position();
         bufferToSend.put(blobId.toBytes());
-        BlobPropertiesSerDe.putBlobPropertiesToBuffer(bufferToSend, properties);
+        BlobPropertiesSerDe.serializeBlobProperties(bufferToSend, properties);
         bufferToSend.putInt(usermetadata.capacity());
         bufferToSend.put(usermetadata);
         bufferToSend.putShort((short) blobType.ordinal());


### PR DESCRIPTION
Adding new version of BlobProperty V2 with accountId and containerId. This patch supports reading new format, but still serialization happens in old format (v1).

SLA: 20 mins
Reviewers: Gopal and Priyesh

Built and coding style applied

Coverage:
Class	                        Class, %	        Method, %	  Line, %
BlobProperties	        100% (1/ 1)	94.1% (16/ 17)	  95.8% (46/ 48)
BlobPropertiesSerDe	100% (1/ 1)	83.3% (5/ 6)	  98.2% (56/ 57)
