### PR TITLE
1. Adding new DeleteRecord V2 and DeleteRequest protocol V2

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
@@ -13,8 +13,10 @@
  */
 package com.github.ambry.store;
 
-import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.Utils;
+
+import static com.github.ambry.account.Account.*;
+import static com.github.ambry.account.Container.*;
 
 
 /**
@@ -84,8 +86,7 @@ public class MessageInfo {
    * @param crc the crc associated with this message. If unavailable, pass in null.
    */
   public MessageInfo(StoreKey key, long size, boolean deleted, long expirationTimeInMs, Long crc) {
-    this(key, size, deleted, expirationTimeInMs, crc, BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID,
-        Utils.Infinite_Time);
+    this(key, size, deleted, expirationTimeInMs, crc, UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID, Utils.Infinite_Time);
   }
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
@@ -21,8 +21,8 @@ import com.github.ambry.utils.Utils;
  */
 public class MessageInfo {
 
-  public static final short ACCOUNT_ID_DEFAULT_VALUE = -1;
-  public static final short CONTAINER_ID_DEFAULT_VALUE = -1;
+  public static final short ACCOUNT_ID_LEGACY_VALUE = -1;
+  public static final short CONTAINER_ID_LEGACY_VALUE = -1;
 
   private final StoreKey key;
   private final long size;
@@ -86,7 +86,7 @@ public class MessageInfo {
    * @param crc the crc associated with this message. If unavailable, pass in null.
    */
   public MessageInfo(StoreKey key, long size, boolean deleted, long expirationTimeInMs, Long crc) {
-    this(key, size, deleted, expirationTimeInMs, crc, ACCOUNT_ID_DEFAULT_VALUE, CONTAINER_ID_DEFAULT_VALUE,
+    this(key, size, deleted, expirationTimeInMs, crc, ACCOUNT_ID_LEGACY_VALUE, CONTAINER_ID_LEGACY_VALUE,
         Utils.Infinite_Time);
   }
 

--- a/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.Utils;
 
 
@@ -20,9 +21,6 @@ import com.github.ambry.utils.Utils;
  * A message info class that contains basic info about a message
  */
 public class MessageInfo {
-
-  public static final short ACCOUNT_ID_LEGACY_VALUE = -1;
-  public static final short CONTAINER_ID_LEGACY_VALUE = -1;
 
   private final StoreKey key;
   private final long size;
@@ -86,7 +84,7 @@ public class MessageInfo {
    * @param crc the crc associated with this message. If unavailable, pass in null.
    */
   public MessageInfo(StoreKey key, long size, boolean deleted, long expirationTimeInMs, Long crc) {
-    this(key, size, deleted, expirationTimeInMs, crc, ACCOUNT_ID_LEGACY_VALUE, CONTAINER_ID_LEGACY_VALUE,
+    this(key, size, deleted, expirationTimeInMs, crc, BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID,
         Utils.Infinite_Time);
   }
 

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
@@ -92,7 +92,7 @@ public class BlobStoreHardDelete implements MessageStoreHardDelete {
       }
     } catch (MessageFormatException e) {
       // log in case where we were not able to parse a message.
-      throw new IOException("Message format exception while parsing messages {} ", e);
+      throw new IOException("Message format exception while parsing messages ", e);
     } catch (IndexOutOfBoundsException e) {
       // log in case where were not able to read a complete message.
       throw new IOException("Trying to read more than the available bytes");

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
@@ -82,9 +82,13 @@ public class BlobStoreHardDelete implements MessageStoreHardDelete {
             return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
                 Utils.addSecondsToEpochTime(properties.getCreationTimeInMs(), properties.getTimeToLiveInSeconds()));
           } else {
-            boolean deleteFlag = MessageFormatRecord.deserializeDeleteRecord(stream);
-            return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
-                deleteFlag);
+            DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(stream);
+            if (deleteRecord.getVersion() == MessageFormatRecord.Delete_Version_V1) {
+              return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
+                  deleteRecord.isDeleted());
+            } else {
+              // TODO: construct new MessageInfo with accountId, containerId, operationTime
+            }
           }
         default:
           throw new MessageFormatException("Version not known while reading message - " + version,

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
@@ -86,7 +86,8 @@ public class BlobStoreHardDelete implements MessageStoreHardDelete {
             if (deleteRecord.getVersion() == MessageFormatRecord.Delete_Version_V1) {
               return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true);
             } else {
-              // TODO: construct new MessageInfo with accountId, containerId, operationTime
+              return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
+                  deleteRecord.getAccountId(), deleteRecord.getContainerId(), deleteRecord.getDeletionTimeInMs());
             }
           }
         default:

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
@@ -84,8 +84,7 @@ public class BlobStoreHardDelete implements MessageStoreHardDelete {
           } else {
             DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(stream);
             if (deleteRecord.getVersion() == MessageFormatRecord.Delete_Version_V1) {
-              return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
-                  deleteRecord.isDeleted());
+              return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true);
             } else {
               // TODO: construct new MessageInfo with accountId, containerId, operationTime
             }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
@@ -96,7 +96,7 @@ public class BlobStoreHardDelete implements MessageStoreHardDelete {
       }
     } catch (MessageFormatException e) {
       // log in case where we were not able to parse a message.
-      throw new IOException("Message format exception while parsing messages");
+      throw new IOException("Message format exception while parsing messages {} ", e);
     } catch (IndexOutOfBoundsException e) {
       // log in case where were not able to read a complete message.
       throw new IOException("Trying to read more than the available bytes");

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
@@ -83,12 +83,8 @@ public class BlobStoreHardDelete implements MessageStoreHardDelete {
                 Utils.addSecondsToEpochTime(properties.getCreationTimeInMs(), properties.getTimeToLiveInSeconds()));
           } else {
             DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(stream);
-            if (deleteRecord.getVersion() == MessageFormatRecord.Delete_Version_V1) {
-              return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true);
-            } else {
-              return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
-                  deleteRecord.getAccountId(), deleteRecord.getContainerId(), deleteRecord.getDeletionTimeInMs());
-            }
+            return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true,
+                deleteRecord.getAccountId(), deleteRecord.getContainerId(), deleteRecord.getDeletionTimeInMs());
           }
         default:
           throw new MessageFormatException("Version not known while reading message - " + version,

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
@@ -82,11 +82,15 @@ public class BlobStoreRecovery implements MessageStoreRecovery {
                           properties.getTimeToLiveInSeconds()));
               messageRecovered.add(info);
             } else {
-              boolean deleteFlag = MessageFormatRecord.deserializeDeleteRecord(stream);
-              MessageInfo info =
-                  new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
-                      deleteFlag);
-              messageRecovered.add(info);
+              DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(stream);
+              if (deleteRecord.getVersion() == MessageFormatRecord.Delete_Version_V1) {
+                MessageInfo info =
+                    new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
+                        deleteRecord.isDeleted());
+                messageRecovered.add(info);
+              } else {
+                // TODO: construct new MessageInfo with accountId, containerId, operationTime
+              }
             }
             startOffset = stream.getCurrentPosition();
             break;

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
@@ -83,16 +83,10 @@ public class BlobStoreRecovery implements MessageStoreRecovery {
               messageRecovered.add(info);
             } else {
               DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(stream);
-              if (deleteRecord.getVersion() == MessageFormatRecord.Delete_Version_V1) {
-                MessageInfo info =
-                    new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true);
-                messageRecovered.add(info);
-              } else {
-                MessageInfo info =
-                    new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
-                        deleteRecord.getAccountId(), deleteRecord.getContainerId(), deleteRecord.getDeletionTimeInMs());
-                messageRecovered.add(info);
-              }
+              MessageInfo info =
+                  new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true,
+                      deleteRecord.getAccountId(), deleteRecord.getContainerId(), deleteRecord.getDeletionTimeInMs());
+              messageRecovered.add(info);
             }
             startOffset = stream.getCurrentPosition();
             break;

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
@@ -88,7 +88,10 @@ public class BlobStoreRecovery implements MessageStoreRecovery {
                     new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true);
                 messageRecovered.add(info);
               } else {
-                // TODO: construct new MessageInfo with accountId, containerId, operationTime
+                MessageInfo info =
+                    new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
+                        deleteRecord.getAccountId(), deleteRecord.getContainerId(), deleteRecord.getDeletionTimeInMs());
+                messageRecovered.add(info);
               }
             }
             startOffset = stream.getCurrentPosition();

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
@@ -85,8 +85,7 @@ public class BlobStoreRecovery implements MessageStoreRecovery {
               DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(stream);
               if (deleteRecord.getVersion() == MessageFormatRecord.Delete_Version_V1) {
                 MessageInfo info =
-                    new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
-                        deleteRecord.isDeleted());
+                    new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true);
                 messageRecovered.add(info);
               } else {
                 // TODO: construct new MessageInfo with accountId, containerId, operationTime
@@ -102,7 +101,7 @@ public class BlobStoreRecovery implements MessageStoreRecovery {
     } catch (MessageFormatException e) {
       // log in case where we were not able to parse a message. we stop recovery at that point and return the
       // messages that have been recovered so far.
-      logger.error("Message format exception while recovering messages {} ", e);
+      logger.error("Message format exception while recovering messages", e);
     } catch (IndexOutOfBoundsException e) {
       // log in case where were not able to read a complete message. we stop recovery at that point and return
       // the message that have been recovered so far.

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
@@ -102,7 +102,7 @@ public class BlobStoreRecovery implements MessageStoreRecovery {
     } catch (MessageFormatException e) {
       // log in case where we were not able to parse a message. we stop recovery at that point and return the
       // messages that have been recovered so far.
-      logger.error("Message format exception while recovering messages");
+      logger.error("Message format exception while recovering messages {} ", e);
     } catch (IndexOutOfBoundsException e) {
       // log in case where were not able to read a complete message. we stop recovery at that point and return
       // the message that have been recovered so far.

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteMessageFormatInputStream.java
@@ -31,7 +31,9 @@ import java.nio.ByteBuffer;
  *
  */
 public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
-  public DeleteMessageFormatInputStream(StoreKey key) throws MessageFormatException {
+  public DeleteMessageFormatInputStream(StoreKey key, short accountId, short containerId, long deletionTimeMs)
+      throws MessageFormatException {
+    // @TODO: fix this once we start to write DeleteFormat in V2
     int headerSize = MessageFormatRecord.MessageHeader_Format_V1.getHeaderSize();
     int deleteRecordSize = MessageFormatRecord.Delete_Format_V1.getDeleteRecordSize();
     buffer = ByteBuffer.allocate(headerSize + key.sizeInBytes() + deleteRecordSize);
@@ -41,7 +43,8 @@ public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
         MessageFormatRecord.Message_Header_Invalid_Relative_Offset);
     buffer.put(key.toBytes());
     // set the message as deleted
-    MessageFormatRecord.Delete_Format_V1.serializeDeleteRecord(buffer, true);
+    MessageFormatRecord.Delete_Format_V1.serializeDeleteRecord(buffer,
+        new DeleteRecord(accountId, containerId, deletionTimeMs));
     messageLength = buffer.capacity();
     buffer.flip();
   }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
@@ -21,27 +21,29 @@ import com.github.ambry.utils.Utils;
  */
 public class DeleteRecord {
 
-  public static final short ACCOUNTID_CONTAINERID_DEFAULT_VALUE = -1;
-  private short version;
-  private boolean isDeleted;
-  private short accountId = ACCOUNTID_CONTAINERID_DEFAULT_VALUE;
-  private short containerId = ACCOUNTID_CONTAINERID_DEFAULT_VALUE;
-  private int deletionTimeInSecs = (int) Utils.Infinite_Time;
+  public static final short ACCOUNTID_DEFAULT_VALUE = -1;
+  public static final short CONTAINERID_DEFAULT_VALUE = -1;
+  private final short version;
+  private final short accountId;
+  private final short containerId;
+  private final long deletionTimeInMs;
 
-  DeleteRecord(boolean isDeleted) {
-    this.isDeleted = isDeleted;
+  DeleteRecord() {
+    accountId = ACCOUNTID_DEFAULT_VALUE;
+    containerId = CONTAINERID_DEFAULT_VALUE;
+    deletionTimeInMs = Utils.Infinite_Time;
     this.version = MessageFormatRecord.Delete_Version_V1;
   }
 
-  DeleteRecord(short accountId, short containerId, int deletionTimeInSecs) {
+  DeleteRecord(short accountId, short containerId, long deletionTimeInMs) {
     this.accountId = accountId;
     this.containerId = containerId;
-    this.deletionTimeInSecs = deletionTimeInSecs;
+    this.deletionTimeInMs = deletionTimeInMs;
     this.version = MessageFormatRecord.Delete_Version_V2;
   }
 
   public boolean isDeleted() {
-    return isDeleted;
+    return true;
   }
 
   public short getAccountId() {
@@ -52,8 +54,8 @@ public class DeleteRecord {
     return containerId;
   }
 
-  public int getDeletionTimeInSecs() {
-    return deletionTimeInSecs;
+  public long getDeletionTimeInMs() {
+    return deletionTimeInMs;
   }
 
   public short getVersion() {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.messageformat;
+
+import com.github.ambry.utils.Utils;
+
+
+/**
+ * Contains the delete record info
+ */
+public class DeleteRecord {
+
+  public static final short ACCOUNTID_CONTAINERID_DEFAULT_VALUE = -1;
+  private short version;
+  private boolean isDeleted;
+  private short accountId = ACCOUNTID_CONTAINERID_DEFAULT_VALUE;
+  private short containerId = ACCOUNTID_CONTAINERID_DEFAULT_VALUE;
+  private int deletionTimeInSecs = (int) Utils.Infinite_Time;
+
+  DeleteRecord(boolean isDeleted) {
+    this.isDeleted = isDeleted;
+    this.version = MessageFormatRecord.Delete_Version_V1;
+  }
+
+  DeleteRecord(short accountId, short containerId, int deletionTimeInSecs) {
+    this.accountId = accountId;
+    this.containerId = containerId;
+    this.deletionTimeInSecs = deletionTimeInSecs;
+    this.version = MessageFormatRecord.Delete_Version_V2;
+  }
+
+  public boolean isDeleted() {
+    return isDeleted;
+  }
+
+  public short getAccountId() {
+    return accountId;
+  }
+
+  public short getContainerId() {
+    return containerId;
+  }
+
+  public int getDeletionTimeInSecs() {
+    return deletionTimeInSecs;
+  }
+
+  public short getVersion() {
+    return version;
+  }
+}

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
@@ -28,6 +28,9 @@ public class DeleteRecord {
   private final short containerId;
   private final long deletionTimeInMs;
 
+  /**
+   * Constructs Delete Record in {@link MessageFormatRecord#Delete_Version_V1}
+   */
   DeleteRecord() {
     accountId = ACCOUNT_ID_DEFAULT_VALUE;
     containerId = CONTAINER_ID_DEFAULT_VALUE;
@@ -35,6 +38,9 @@ public class DeleteRecord {
     this.version = MessageFormatRecord.Delete_Version_V1;
   }
 
+  /**
+   * Constructs Delete Record in {@link MessageFormatRecord#Delete_Version_V2}
+   */
   DeleteRecord(short accountId, short containerId, long deletionTimeInMs) {
     this.accountId = accountId;
     this.containerId = containerId;

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
@@ -13,10 +13,6 @@
  */
 package com.github.ambry.messageformat;
 
-import com.github.ambry.store.MessageInfo;
-import com.github.ambry.utils.Utils;
-
-
 /**
  * Contains the delete record info
  */
@@ -27,17 +23,7 @@ public class DeleteRecord {
   private final long deletionTimeInMs;
 
   /**
-   * Constructs Delete Record in {@link MessageFormatRecord#Delete_Version_V1}
-   */
-  DeleteRecord() {
-    accountId = MessageInfo.ACCOUNT_ID_LEGACY_VALUE;
-    containerId = MessageInfo.CONTAINER_ID_LEGACY_VALUE;
-    deletionTimeInMs = Utils.Infinite_Time;
-    this.version = MessageFormatRecord.Delete_Version_V1;
-  }
-
-  /**
-   * Constructs Delete Record in {@link MessageFormatRecord#Delete_Version_V2}
+   * Constructs Delete Record
    */
   DeleteRecord(short accountId, short containerId, long deletionTimeInMs) {
     this.accountId = accountId;

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.messageformat;
 
+import com.github.ambry.store.MessageInfo;
 import com.github.ambry.utils.Utils;
 
 
@@ -20,9 +21,6 @@ import com.github.ambry.utils.Utils;
  * Contains the delete record info
  */
 public class DeleteRecord {
-
-  public static final short ACCOUNT_ID_DEFAULT_VALUE = -1;
-  public static final short CONTAINER_ID_DEFAULT_VALUE = -1;
   private final short version;
   private final short accountId;
   private final short containerId;
@@ -32,8 +30,8 @@ public class DeleteRecord {
    * Constructs Delete Record in {@link MessageFormatRecord#Delete_Version_V1}
    */
   DeleteRecord() {
-    accountId = ACCOUNT_ID_DEFAULT_VALUE;
-    containerId = CONTAINER_ID_DEFAULT_VALUE;
+    accountId = MessageInfo.ACCOUNT_ID_LEGACY_VALUE;
+    containerId = MessageInfo.CONTAINER_ID_LEGACY_VALUE;
     deletionTimeInMs = Utils.Infinite_Time;
     this.version = MessageFormatRecord.Delete_Version_V1;
   }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
@@ -17,7 +17,6 @@ package com.github.ambry.messageformat;
  * Contains the delete record info
  */
 public class DeleteRecord {
-  private final short version;
   private final short accountId;
   private final short containerId;
   private final long deletionTimeInMs;
@@ -29,7 +28,6 @@ public class DeleteRecord {
     this.accountId = accountId;
     this.containerId = containerId;
     this.deletionTimeInMs = deletionTimeInMs;
-    this.version = MessageFormatRecord.Delete_Version_V2;
   }
 
   public short getAccountId() {
@@ -42,9 +40,5 @@ public class DeleteRecord {
 
   public long getDeletionTimeInMs() {
     return deletionTimeInMs;
-  }
-
-  public short getVersion() {
-    return version;
   }
 }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
@@ -21,16 +21,16 @@ import com.github.ambry.utils.Utils;
  */
 public class DeleteRecord {
 
-  public static final short ACCOUNTID_DEFAULT_VALUE = -1;
-  public static final short CONTAINERID_DEFAULT_VALUE = -1;
+  public static final short ACCOUNT_ID_DEFAULT_VALUE = -1;
+  public static final short CONTAINER_ID_DEFAULT_VALUE = -1;
   private final short version;
   private final short accountId;
   private final short containerId;
   private final long deletionTimeInMs;
 
   DeleteRecord() {
-    accountId = ACCOUNTID_DEFAULT_VALUE;
-    containerId = CONTAINERID_DEFAULT_VALUE;
+    accountId = ACCOUNT_ID_DEFAULT_VALUE;
+    containerId = CONTAINER_ID_DEFAULT_VALUE;
     deletionTimeInMs = Utils.Infinite_Time;
     this.version = MessageFormatRecord.Delete_Version_V1;
   }
@@ -40,10 +40,6 @@ public class DeleteRecord {
     this.containerId = containerId;
     this.deletionTimeInMs = deletionTimeInMs;
     this.version = MessageFormatRecord.Delete_Version_V2;
-  }
-
-  public boolean isDeleted() {
-    return true;
   }
 
   public short getAccountId() {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -478,14 +478,14 @@ public class MessageFormatRecord {
    */
   public static class Delete_Format_V2 {
 
-    public static final int AccountId_Field_Size_In_Bytes = 2;
-    public static final int ContainerId_Field_Size_In_Bytes = 2;
+    public static final int Account_Id_Field_Size_In_Bytes = 2;
+    public static final int Container_Id_Field_Size_In_Bytes = 2;
     public static final int Deletion_Time_Field_Size_In_Bytes = 8;
 
     private static Logger logger = LoggerFactory.getLogger(Delete_Format_V2.class);
 
     public static int getDeleteRecordSize() {
-      return Version_Field_Size_In_Bytes + AccountId_Field_Size_In_Bytes + ContainerId_Field_Size_In_Bytes
+      return Version_Field_Size_In_Bytes + Account_Id_Field_Size_In_Bytes + Container_Id_Field_Size_In_Bytes
           + Deletion_Time_Field_Size_In_Bytes + Crc_Size;
     }
 

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -462,7 +462,7 @@ public class MessageFormatRecord {
    *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    * |         |               |               |               |             |
    * | version |   AccountId   |  ContainerId  |  DeletionTime |     Crc     |
-   * |(2 bytes)|    (2 byte2)  |   (2 bytes)   |   (4 bytes)   |  (8 bytes)  |
+   * |(2 bytes)|    (2 byte2)  |   (2 bytes)   |   (8 bytes)   |  (8 bytes)  |
    * |         |               |               |               |             |
    *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    *  version         - The version of the delete record
@@ -471,9 +471,9 @@ public class MessageFormatRecord {
    *
    *  ContainerId   - ContainerId that the blob belongs to
    *
-   *  Deletion Time - Time of deletion in secs
+   *  Deletion Time - Time of deletion in Ms
    *
-   *  Crc             - The crc of the delete record
+   *  Crc           - The crc of the delete record
    *
    */
   public static class Delete_Format_V2 {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -454,7 +454,8 @@ public class MessageFormatRecord {
             "corrupt data while parsing delete record Expected CRC " + expectedCRC + " Actual CRC " + actualCRC);
         throw new MessageFormatException("delete record data is corrupt", MessageFormatErrorCodes.Data_Corrupt);
       }
-      return new DeleteRecord();
+      return new DeleteRecord(BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID,
+          Utils.Infinite_Time);
     }
   }
 
@@ -478,22 +479,21 @@ public class MessageFormatRecord {
    */
   public static class Delete_Format_V2 {
 
-    public static final int Account_Id_Field_Size_In_Bytes = 2;
-    public static final int Container_Id_Field_Size_In_Bytes = 2;
-    public static final int Deletion_Time_Field_Size_In_Bytes = 8;
+    public static final int ACCOUNT_ID_FIELD_SIZE_IN_BYTES = Short.BYTES;
+    public static final int CONTAINER_ID_FIELD_SIZE_IN_BYTES = Short.BYTES;
+    public static final int DELETION_TIME_FIELD_SIZE_IN_BYTES = Long.BYTES;
 
     public static int getDeleteRecordSize() {
-      return Version_Field_Size_In_Bytes + Account_Id_Field_Size_In_Bytes + Container_Id_Field_Size_In_Bytes
-          + Deletion_Time_Field_Size_In_Bytes + Crc_Size;
+      return Version_Field_Size_In_Bytes + ACCOUNT_ID_FIELD_SIZE_IN_BYTES + CONTAINER_ID_FIELD_SIZE_IN_BYTES
+          + DELETION_TIME_FIELD_SIZE_IN_BYTES + Crc_Size;
     }
 
-    public static void serializeDeleteRecord(ByteBuffer outputBuffer, short accountId, short containerId,
-        long deletionTimeInMs) {
+    public static void serializeDeleteRecord(ByteBuffer outputBuffer, DeleteRecord deleteRecord) {
       int startOffset = outputBuffer.position();
       outputBuffer.putShort(Delete_Version_V2);
-      outputBuffer.putShort(accountId);
-      outputBuffer.putShort(containerId);
-      outputBuffer.putLong(deletionTimeInMs);
+      outputBuffer.putShort(deleteRecord.getAccountId());
+      outputBuffer.putShort(deleteRecord.getContainerId());
+      outputBuffer.putLong(deleteRecord.getDeletionTimeInMs());
       Crc32 crc = new Crc32();
       crc.update(outputBuffer.array(), startOffset, getDeleteRecordSize() - Crc_Size);
       outputBuffer.putLong(crc.getValue());

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -446,7 +446,7 @@ public class MessageFormatRecord {
     public static DeleteRecord deserializeDeleteRecord(CrcInputStream crcStream)
         throws IOException, MessageFormatException {
       DataInputStream dataStream = new DataInputStream(crcStream);
-      boolean isDeleted = dataStream.readByte() == 1 ? true : false;
+      boolean isDeleted = dataStream.readByte() == 1;
       long actualCRC = crcStream.getValue();
       long expectedCRC = dataStream.readLong();
       if (actualCRC != expectedCRC) {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -482,8 +482,6 @@ public class MessageFormatRecord {
     public static final int Container_Id_Field_Size_In_Bytes = 2;
     public static final int Deletion_Time_Field_Size_In_Bytes = 8;
 
-    private static Logger logger = LoggerFactory.getLogger(Delete_Format_V2.class);
-
     public static int getDeleteRecordSize() {
       return Version_Field_Size_In_Bytes + Account_Id_Field_Size_In_Bytes + Container_Id_Field_Size_In_Bytes
           + Deletion_Time_Field_Size_In_Bytes + Crc_Size;

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -434,10 +434,10 @@ public class MessageFormatRecord {
       return Version_Field_Size_In_Bytes + Delete_Field_Size_In_Bytes + Crc_Size;
     }
 
-    public static void serializeDeleteRecord(ByteBuffer outputBuffer, boolean deleteFlag) {
+    public static void serializeDeleteRecord(ByteBuffer outputBuffer, DeleteRecord deleteRecord) {
       int startOffset = outputBuffer.position();
       outputBuffer.putShort(Delete_Version_V1);
-      outputBuffer.put(deleteFlag ? (byte) 1 : (byte) 0);
+      outputBuffer.put((byte) 1);
       Crc32 crc = new Crc32();
       crc.update(outputBuffer.array(), startOffset, getDeleteRecordSize() - Crc_Size);
       outputBuffer.putLong(crc.getValue());

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -28,6 +28,9 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.account.Account.*;
+import static com.github.ambry.account.Container.*;
+
 
 /**
  * Represents the message format of the individual records that are used to write a message to the store.
@@ -454,8 +457,7 @@ public class MessageFormatRecord {
             "corrupt data while parsing delete record Expected CRC " + expectedCRC + " Actual CRC " + actualCRC);
         throw new MessageFormatException("delete record data is corrupt", MessageFormatErrorCodes.Data_Corrupt);
       }
-      return new DeleteRecord(BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID,
-          Utils.Infinite_Time);
+      return new DeleteRecord(UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID, Utils.Infinite_Time);
     }
   }
 

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
@@ -21,6 +21,7 @@ import com.github.ambry.store.Read;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -35,8 +36,9 @@ import org.junit.Test;
 
 public class BlobStoreHardDeleteTest {
 
-  public class ReadImp implements Read {
+  static Random random = new Random();
 
+  public class ReadImp implements Read {
     MockReadSet readSet = new MockReadSet();
     List<byte[]> recoveryInfoList = new ArrayList<byte[]>();
     ByteBuffer buffer;
@@ -52,8 +54,11 @@ public class BlobStoreHardDeleteTest {
       final int BLOB_SIZE = 4000;
       byte[] usermetadata = new byte[USERMETADATA_SIZE];
       byte[] blob = new byte[BLOB_SIZE];
-      new Random().nextBytes(usermetadata);
-      new Random().nextBytes(blob);
+      random.nextBytes(usermetadata);
+      random.nextBytes(blob);
+      short accountId = Utils.getRandomShort(random);
+      short containerId = Utils.getRandomShort(random);
+      long deletionTimeMs = SystemTime.getInstance().milliseconds() + random.nextInt();
 
       BlobProperties blobProperties = new BlobProperties(BLOB_SIZE, "test", "mem1", "img", false, 9999);
       expectedExpirationTimeMs =
@@ -68,7 +73,8 @@ public class BlobStoreHardDeleteTest {
       MessageFormatInputStream msg2 =
           getPutMessage(keys[2], blobProperties, usermetadata, blob, BLOB_SIZE, blobVersions[2], blobTypes[2]);
 
-      DeleteMessageFormatInputStream msg3d = new DeleteMessageFormatInputStream(keys[1]);
+      DeleteMessageFormatInputStream msg3d =
+          new DeleteMessageFormatInputStream(keys[1], accountId, containerId, deletionTimeMs);
 
       MessageFormatInputStream msg4 =
           getPutMessage(keys[3], blobProperties, usermetadata, blob, BLOB_SIZE, blobVersions[3], blobTypes[3]);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
@@ -22,6 +22,7 @@ import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -29,14 +30,11 @@ import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import org.junit.Assert;
 import org.junit.Test;
 
 
 public class BlobStoreHardDeleteTest {
-
-  static Random random = new Random();
 
   public class ReadImp implements Read {
     MockReadSet readSet = new MockReadSet();
@@ -54,11 +52,11 @@ public class BlobStoreHardDeleteTest {
       final int BLOB_SIZE = 4000;
       byte[] usermetadata = new byte[USERMETADATA_SIZE];
       byte[] blob = new byte[BLOB_SIZE];
-      random.nextBytes(usermetadata);
-      random.nextBytes(blob);
-      short accountId = Utils.getRandomShort(random);
-      short containerId = Utils.getRandomShort(random);
-      long deletionTimeMs = SystemTime.getInstance().milliseconds() + random.nextInt();
+      TestUtils.RANDOM.nextBytes(usermetadata);
+      TestUtils.RANDOM.nextBytes(blob);
+      short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+      long deletionTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
 
       BlobProperties blobProperties = new BlobProperties(BLOB_SIZE, "test", "mem1", "img", false, 9999);
       expectedExpirationTimeMs =

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
@@ -20,12 +20,12 @@ import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.Random;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -114,8 +114,6 @@ class MockIdFactory implements StoreKeyFactory {
 
 public class BlobStoreRecoveryTest {
 
-  static Random random = new Random();
-
   public class ReadImp implements Read {
 
     ByteBuffer buffer;
@@ -127,11 +125,11 @@ public class BlobStoreRecoveryTest {
       // message that is partial
       byte[] usermetadata = new byte[2000];
       byte[] blob = new byte[4000];
-      random.nextBytes(usermetadata);
-      random.nextBytes(blob);
-      short accountId = Utils.getRandomShort(random);
-      short containerId = Utils.getRandomShort(random);
-      long deletionTimeMs = SystemTime.getInstance().milliseconds() + random.nextInt();
+      TestUtils.RANDOM.nextBytes(usermetadata);
+      TestUtils.RANDOM.nextBytes(blob);
+      short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+      long deletionTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
 
       // 1st message
       BlobProperties blobProperties = new BlobProperties(4000, "test", "mem1", "img", false, 9999);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.store.Read;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -113,6 +114,8 @@ class MockIdFactory implements StoreKeyFactory {
 
 public class BlobStoreRecoveryTest {
 
+  static Random random = new Random();
+
   public class ReadImp implements Read {
 
     ByteBuffer buffer;
@@ -124,8 +127,11 @@ public class BlobStoreRecoveryTest {
       // message that is partial
       byte[] usermetadata = new byte[2000];
       byte[] blob = new byte[4000];
-      new Random().nextBytes(usermetadata);
-      new Random().nextBytes(blob);
+      random.nextBytes(usermetadata);
+      random.nextBytes(blob);
+      short accountId = Utils.getRandomShort(random);
+      short containerId = Utils.getRandomShort(random);
+      long deletionTimeMs = SystemTime.getInstance().milliseconds() + random.nextInt();
 
       // 1st message
       BlobProperties blobProperties = new BlobProperties(4000, "test", "mem1", "img", false, 9999);
@@ -146,7 +152,8 @@ public class BlobStoreRecoveryTest {
               new ByteBufferInputStream(ByteBuffer.wrap(blob)), 4000);
 
       // 4th message
-      DeleteMessageFormatInputStream msg4 = new DeleteMessageFormatInputStream(keys[1]);
+      DeleteMessageFormatInputStream msg4 =
+          new DeleteMessageFormatInputStream(keys[1], accountId, containerId, deletionTimeMs);
 
       // 5th message
       PutMessageFormatInputStream msg5 =

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
@@ -17,6 +17,8 @@ import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Crc32;
 import com.github.ambry.utils.CrcInputStream;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -26,6 +28,8 @@ import org.junit.Test;
 
 
 public class MessageFormatInputStreamTest {
+
+  static Random random = new Random();
 
   @Test
   public void messageFormatBlobPropertiesTest() throws IOException, MessageFormatException {
@@ -139,11 +143,16 @@ public class MessageFormatInputStreamTest {
   @Test
   public void messageFormatDeleteRecordTest() throws IOException, MessageFormatException {
     StoreKey key = new MockId("id1");
-    MessageFormatInputStream messageFormatStream = new DeleteMessageFormatInputStream(key);
+    short accountId = Utils.getRandomShort(random);
+    short containerId = Utils.getRandomShort(random);
+    long deletionTimeMs = SystemTime.getInstance().milliseconds() + random.nextInt();
+    MessageFormatInputStream messageFormatStream =
+        new DeleteMessageFormatInputStream(key, accountId, containerId, deletionTimeMs);
     int headerSize = MessageFormatRecord.MessageHeader_Format_V1.getHeaderSize();
     int deleteRecordSize = MessageFormatRecord.Delete_Format_V1.getDeleteRecordSize();
     Assert.assertEquals(headerSize + deleteRecordSize + key.sizeInBytes(), messageFormatStream.getSize());
 
+    // @TODO: fix verifier once we start to serialize in DeleteMsgFormat V2
     // check header
     byte[] headerOutput = new byte[headerSize];
     messageFormatStream.read(headerOutput);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
@@ -18,6 +18,7 @@ import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Crc32;
 import com.github.ambry.utils.CrcInputStream;
 import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -28,8 +29,6 @@ import org.junit.Test;
 
 
 public class MessageFormatInputStreamTest {
-
-  static Random random = new Random();
 
   @Test
   public void messageFormatBlobPropertiesTest() throws IOException, MessageFormatException {
@@ -143,9 +142,9 @@ public class MessageFormatInputStreamTest {
   @Test
   public void messageFormatDeleteRecordTest() throws IOException, MessageFormatException {
     StoreKey key = new MockId("id1");
-    short accountId = Utils.getRandomShort(random);
-    short containerId = Utils.getRandomShort(random);
-    long deletionTimeMs = SystemTime.getInstance().milliseconds() + random.nextInt();
+    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+    short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+    long deletionTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
     MessageFormatInputStream messageFormatStream =
         new DeleteMessageFormatInputStream(key, accountId, containerId, deletionTimeMs);
     int headerSize = MessageFormatRecord.MessageHeader_Format_V1.getHeaderSize();

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -42,29 +42,6 @@ public class MessageFormatRecordTest {
   @Test
   public void deserializeTest() {
     try {
-      // Test Blob property V1 Record
-      BlobProperties properties = new BlobProperties(1234, "id", "member", "test", true, 1234);
-      ByteBuffer stream =
-          ByteBuffer.allocate(MessageFormatRecord.BlobProperties_Format_V1.getBlobPropertiesRecordSize(properties));
-      MessageFormatRecord.BlobProperties_Format_V1.serializeBlobPropertiesRecord(stream, properties);
-      stream.flip();
-      BlobProperties result = MessageFormatRecord.deserializeBlobProperties(new ByteBufferInputStream(stream));
-      Assert.assertEquals(properties.getBlobSize(), result.getBlobSize());
-      Assert.assertEquals(properties.getContentType(), result.getContentType());
-      Assert.assertEquals(properties.getCreationTimeInMs(), result.getCreationTimeInMs());
-      Assert.assertEquals(properties.getOwnerId(), result.getOwnerId());
-      Assert.assertEquals(properties.getServiceId(), result.getServiceId());
-
-      // corrupt blob property V1 record
-      stream.flip();
-      stream.put(10, (byte) 10);
-      try {
-        BlobProperties resultCorrupt = MessageFormatRecord.deserializeBlobProperties(new ByteBufferInputStream(stream));
-        Assert.assertEquals(true, false);
-      } catch (MessageFormatException e) {
-        Assert.assertEquals(e.getErrorCode(), MessageFormatErrorCodes.Data_Corrupt);
-      }
-
       // Test message header V1
       ByteBuffer header = ByteBuffer.allocate(MessageFormatRecord.MessageHeader_Format_V1.getHeaderSize());
       MessageFormatRecord.MessageHeader_Format_V1.serializeHeader(header, 1000, 10, -1, 20, 30);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -139,7 +139,6 @@ public class MessageFormatRecordTest {
   }
 
   /**
-   <<<<<<< HEAD
    * Tests {@link MessageFormatRecord#BlobProperties_Version_V1} for different versions of {@link BlobPropertiesSerDe}
    * @throws IOException
    * @throws MessageFormatException

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -31,6 +31,8 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static com.github.ambry.account.Account.*;
+import static com.github.ambry.account.Container.*;
 import static com.github.ambry.messageformat.BlobPropertiesSerDe.*;
 import static com.github.ambry.messageformat.MessageFormatRecord.BlobProperties_Format_V1.*;
 import static com.github.ambry.messageformat.MessageFormatRecord.*;
@@ -158,7 +160,7 @@ public class MessageFormatRecordTest {
 
       // corrupt blob property V1 record
       stream.flip();
-      stream.put(10, (byte)(stream.get(10) + 1));
+      stream.put(10, (byte) (stream.get(10) + 1));
       try {
         MessageFormatRecord.deserializeBlobProperties(new ByteBufferInputStream(stream));
         fail("Deserialization of BlobProperties should have failed ");
@@ -233,10 +235,8 @@ public class MessageFormatRecordTest {
     deleteRecord.flip();
     DeleteRecord deserializeDeleteRecord =
         MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));
-    Assert.assertEquals("AccountId mismatch ", BlobProperties.LEGACY_ACCOUNT_ID,
-        deserializeDeleteRecord.getAccountId());
-    Assert.assertEquals("ContainerId mismatch ", BlobProperties.LEGACY_CONTAINER_ID,
-        deserializeDeleteRecord.getContainerId());
+    Assert.assertEquals("AccountId mismatch ", UNKNOWN_ACCOUNT_ID, deserializeDeleteRecord.getAccountId());
+    Assert.assertEquals("ContainerId mismatch ", UNKNOWN_CONTAINER_ID, deserializeDeleteRecord.getContainerId());
     Assert.assertEquals("DeletionTime mismatch ", Utils.Infinite_Time, deserializeDeleteRecord.getDeletionTimeInMs());
 
     // corrupt delete V1 record

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -241,7 +241,8 @@ public class MessageFormatRecordTest {
 
     // corrupt delete V1 record
     deleteRecord.flip();
-    deleteRecord.put(10, (byte) 4);
+    byte toCorrupt = deleteRecord.get(10);
+    deleteRecord.put(10, (byte) (toCorrupt + 1));
     try {
       MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));
       fail("Deserialization of a corrupt delete record V1 should have failed ");
@@ -273,7 +274,8 @@ public class MessageFormatRecordTest {
 
     // corrupt delete V2 record
     deleteRecord.flip();
-    deleteRecord.put(10, (byte) 4);
+    byte toCorrupt = deleteRecord.get(10);
+    deleteRecord.put(10, (byte) (toCorrupt + 1));
     try {
       MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));
       fail("Deserialization of a corrupt delete record V2 should have failed ");

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -17,6 +17,7 @@ import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Crc32;
+import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
@@ -138,6 +139,7 @@ public class MessageFormatRecordTest {
   }
 
   /**
+   <<<<<<< HEAD
    * Tests {@link MessageFormatRecord#BlobProperties_Version_V1} for different versions of {@link BlobPropertiesSerDe}
    * @throws IOException
    * @throws MessageFormatException
@@ -236,6 +238,11 @@ public class MessageFormatRecordTest {
     outputBuffer.putShort(properties.getCreatorAccountId());
   }
 
+  /**
+   * Tests DeleteRecord V1 for serialization and deserialization
+   * @throws IOException
+   * @throws MessageFormatException
+   */
   @Test
   public void testDeleteRecordV1() throws IOException, MessageFormatException {
     // Test delete V1 record
@@ -253,20 +260,25 @@ public class MessageFormatRecordTest {
     deleteRecord.put(10, (byte) 4);
     try {
       MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));
-      Assert.assertEquals(true, false);
+      fail("Deserialization of a corrupt delete record V1 should have failed ");
     } catch (MessageFormatException e) {
       Assert.assertEquals(e.getErrorCode(), MessageFormatErrorCodes.Data_Corrupt);
     }
   }
 
+  /**
+   * Tests DeleteRecord V2 for serialization and deserialization
+   * @throws IOException
+   * @throws MessageFormatException
+   */
   @Test
   public void testDeleteRecordV2() throws IOException, MessageFormatException {
     // Test delete V2 record
     ByteBuffer deleteRecord = ByteBuffer.allocate(MessageFormatRecord.Delete_Format_V2.getDeleteRecordSize());
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
-    int deletionTimeSecs = TestUtils.RANDOM.nextInt();
-    MessageFormatRecord.Delete_Format_V2.serializeDeleteRecord(deleteRecord, accountId, containerId, deletionTimeSecs);
+    long deletionTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
+    MessageFormatRecord.Delete_Format_V2.serializeDeleteRecord(deleteRecord, accountId, containerId, deletionTimeMs);
     deleteRecord.flip();
     DeleteRecord deserializeDeleteRecord =
         MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));
@@ -274,14 +286,14 @@ public class MessageFormatRecordTest {
         MessageFormatRecord.Delete_Version_V2);
     Assert.assertEquals("AccountId mismatch ", accountId, deserializeDeleteRecord.getAccountId());
     Assert.assertEquals("ContainerId mismatch ", containerId, deserializeDeleteRecord.getContainerId());
-    Assert.assertEquals("DeletionTime mismatch ", deletionTimeSecs, deserializeDeleteRecord.getDeletionTimeInSecs());
+    Assert.assertEquals("DeletionTime mismatch ", deletionTimeMs, deserializeDeleteRecord.getDeletionTimeInMs());
 
     // corrupt delete V2 record
     deleteRecord.flip();
     deleteRecord.put(10, (byte) 4);
     try {
       MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));
-      Assert.assertEquals(true, false);
+      fail("Deserialization of a corrupt delete record V2 should have failed ");
     } catch (MessageFormatException e) {
       Assert.assertEquals(e.getErrorCode(), MessageFormatErrorCodes.Data_Corrupt);
     }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -247,7 +247,7 @@ public class MessageFormatRecordTest {
   public void testDeleteRecordV1() throws IOException, MessageFormatException {
     // Test delete V1 record
     ByteBuffer deleteRecord = ByteBuffer.allocate(MessageFormatRecord.Delete_Format_V1.getDeleteRecordSize());
-    MessageFormatRecord.Delete_Format_V1.serializeDeleteRecord(deleteRecord, true);
+    MessageFormatRecord.Delete_Format_V1.serializeDeleteRecord(deleteRecord, new DeleteRecord());
     deleteRecord.flip();
     DeleteRecord deserializeDeleteRecord =
         MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -253,7 +253,6 @@ public class MessageFormatRecordTest {
         MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));
     Assert.assertEquals("Delete record version mismatch ", deserializeDeleteRecord.getVersion(),
         MessageFormatRecord.Delete_Version_V1);
-    Assert.assertEquals(deserializeDeleteRecord.isDeleted(), true);
 
     // corrupt delete V1 record
     deleteRecord.flip();

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
@@ -20,6 +20,7 @@ import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Crc32;
 import com.github.ambry.utils.CrcInputStream;
 import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -33,8 +34,6 @@ import org.junit.Test;
 
 
 public class MessageSievingInputStreamTest {
-
-  static Random random = new Random();
 
   @Test
   public void testValidBlobsAgainstCorruption() throws IOException, MessageFormatException {
@@ -355,9 +354,9 @@ public class MessageSievingInputStreamTest {
 
       // create message stream for blob 2 and mark it as deleted
       StoreKey key2 = new MockId("id2");
-      short accountId = Utils.getRandomShort(random);
-      short containerId = Utils.getRandomShort(random);
-      long deletionTimeMs = SystemTime.getInstance().milliseconds() + random.nextInt();
+      short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+      long deletionTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
       MessageFormatInputStream messageFormatStream2 =
           new DeleteMessageFormatInputStream(key2, accountId, containerId, deletionTimeMs);
 

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
@@ -19,6 +19,8 @@ import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Crc32;
 import com.github.ambry.utils.CrcInputStream;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +33,8 @@ import org.junit.Test;
 
 
 public class MessageSievingInputStreamTest {
+
+  static Random random = new Random();
 
   @Test
   public void testValidBlobsAgainstCorruption() throws IOException, MessageFormatException {
@@ -351,9 +355,14 @@ public class MessageSievingInputStreamTest {
 
       // create message stream for blob 2 and mark it as deleted
       StoreKey key2 = new MockId("id2");
-      MessageFormatInputStream messageFormatStream2 = new DeleteMessageFormatInputStream(key2);
+      short accountId = Utils.getRandomShort(random);
+      short containerId = Utils.getRandomShort(random);
+      long deletionTimeMs = SystemTime.getInstance().milliseconds() + random.nextInt();
+      MessageFormatInputStream messageFormatStream2 =
+          new DeleteMessageFormatInputStream(key2, accountId, containerId, deletionTimeMs);
 
-      MessageInfo msgInfo2 = new MessageInfo(key2, messageFormatStream2.getSize(), true);
+      MessageInfo msgInfo2 =
+          new MessageInfo(key2, messageFormatStream2.getSize(), accountId, containerId, deletionTimeMs);
 
       // create message stream for blob 3
       StoreKey key3 = new MockId("id3");

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -27,11 +27,12 @@ import java.nio.channels.WritableByteChannel;
  * Delete request to delete blob
  */
 public class DeleteRequest extends RequestOrResponse {
-  private BlobId blobId;
-  private short accountId;
-  private short containerId;
-  private int deletionTimeInSecs;
+  private final BlobId blobId;
+  private final short accountId;
+  private final short containerId;
+  private final int deletionTimeInSecs;
   private int sizeSent;
+  private final short version;
   static final short Delete_Request_Version_V1 = 1;
   static final short Delete_Request_Version_V2 = 2;
   private static short currentVersion = Delete_Request_Version_V1;
@@ -41,15 +42,19 @@ public class DeleteRequest extends RequestOrResponse {
 
   // @TODO: remove this constructor once DeleteRequest V2 is enabled
   public DeleteRequest(int correlationId, String clientId, BlobId blobId) {
-    super(RequestOrResponseType.DeleteRequest, currentVersion, correlationId, clientId);
-    this.blobId = blobId;
-    sizeSent = 0;
+    this(correlationId, clientId, blobId, DeleteRecord.ACCOUNTID_DEFAULT_VALUE, DeleteRecord.CONTAINERID_DEFAULT_VALUE,
+        (int) Utils.Infinite_Time, currentVersion);
   }
 
   public DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
       int deletionTimeInSecs) {
-    super(RequestOrResponseType.DeleteRequest, Delete_Request_Version_V2, correlationId, clientId);
-    this.currentVersion = Delete_Request_Version_V2;
+    this(correlationId, clientId, blobId, accountId, containerId, deletionTimeInSecs, Delete_Request_Version_V2);
+  }
+
+  private DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
+      int deletionTimeInSecs, short version) {
+    super(RequestOrResponseType.DeleteRequest, version, correlationId, clientId);
+    this.version = version;
     this.blobId = blobId;
     this.accountId = accountId;
     this.containerId = containerId;
@@ -57,7 +62,7 @@ public class DeleteRequest extends RequestOrResponse {
     sizeSent = 0;
   }
 
-  public static ReceivedDeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+  public static DeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
     Short version = stream.readShort();
     switch (version) {
       case Delete_Request_Version_V1:
@@ -76,7 +81,7 @@ public class DeleteRequest extends RequestOrResponse {
       bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
       writeHeader();
       bufferToSend.put(blobId.toBytes());
-      if (currentVersion == Delete_Request_Version_V2) {
+      if (version == Delete_Request_Version_V2) {
         bufferToSend.putShort(accountId);
         bufferToSend.putShort(containerId);
         bufferToSend.putInt(deletionTimeInSecs);
@@ -99,11 +104,31 @@ public class DeleteRequest extends RequestOrResponse {
     return blobId;
   }
 
+  public int getCorrelationId() {
+    return correlationId;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public short getAccountId() {
+    return accountId;
+  }
+
+  public short getContainerId() {
+    return containerId;
+  }
+
+  public int getDeletionTimeInSecs() {
+    return deletionTimeInSecs;
+  }
+
   @Override
   public long sizeInBytes() {
     // header + blobId
     long sizeInBytes = super.sizeInBytes() + blobId.sizeInBytes();
-    if (currentVersion == Delete_Request_Version_V2) {
+    if (version == Delete_Request_Version_V2) {
       // accountId
       sizeInBytes += AccountId_ContainerId_Field_Size_InBytes;
       // containerId
@@ -132,11 +157,11 @@ public class DeleteRequest extends RequestOrResponse {
    * Class to read protocol version 1 DeleteRequest from the stream.
    */
   private static class DeleteRequest_V1 {
-    static ReceivedDeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+    static DeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
       int correlationId = stream.readInt();
       String clientId = Utils.readIntString(stream);
       BlobId id = new BlobId(stream, map);
-      return new ReceivedDeleteRequest(correlationId, clientId, id);
+      return new DeleteRequest(correlationId, clientId, id);
     }
   }
 
@@ -144,80 +169,14 @@ public class DeleteRequest extends RequestOrResponse {
    * Class to read protocol version 2 DeleteRequest from the stream.
    */
   private static class DeleteRequest_V2 {
-    static ReceivedDeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+    static DeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
       int correlationId = stream.readInt();
       String clientId = Utils.readIntString(stream);
       BlobId id = new BlobId(stream, map);
       short accountId = stream.readShort();
       short containerId = stream.readShort();
       int deletionTimeInSecs = stream.readInt();
-      return new ReceivedDeleteRequest(correlationId, clientId, id, accountId, containerId, deletionTimeInSecs);
-    }
-  }
-
-  /**
-   * Class that represents a DeleteRequest that was received and cannot be sent out.
-   */
-  public static class ReceivedDeleteRequest {
-    private int correlationId;
-    private String clientId;
-    private BlobId blobId;
-    private short accountId = DeleteRecord.ACCOUNTID_CONTAINERID_DEFAULT_VALUE;
-    private short containerId = DeleteRecord.ACCOUNTID_CONTAINERID_DEFAULT_VALUE;
-    private int deletionTimeInSecs = (int) Utils.Infinite_Time;
-
-    ReceivedDeleteRequest(int correlationId, String clientId, BlobId blobId) {
-      this.correlationId = correlationId;
-      this.clientId = clientId;
-      this.blobId = blobId;
-    }
-
-    ReceivedDeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
-        int deletionTimeInSecs) {
-      this.correlationId = correlationId;
-      this.clientId = clientId;
-      this.blobId = blobId;
-      this.accountId = accountId;
-      this.containerId = containerId;
-      this.deletionTimeInSecs = deletionTimeInSecs;
-    }
-
-    public int getCorrelationId() {
-      return correlationId;
-    }
-
-    public String getClientId() {
-      return clientId;
-    }
-
-    public BlobId getBlobId() {
-      return blobId;
-    }
-
-    public short getAccountId() {
-      return accountId;
-    }
-
-    public short getContainerId() {
-      return containerId;
-    }
-
-    public int getDeletionTimeInSecs() {
-      return deletionTimeInSecs;
-    }
-
-    @Override
-    public String toString() {
-      StringBuilder sb = new StringBuilder();
-      sb.append("DeleteRequest[");
-      sb.append("BlobID=").append(blobId);
-      sb.append(", ").append("ClientId=").append(clientId);
-      sb.append(", ").append("CorrelationId=").append(correlationId);
-      sb.append(", ").append("AccountId=").append(accountId);
-      sb.append(", ").append("ContainerId=").append(containerId);
-      sb.append(", ").append("DeletionTimeInSecs=").append(deletionTimeInSecs);
-      sb.append("]");
-      return sb.toString();
+      return new DeleteRequest(correlationId, clientId, id, accountId, containerId, deletionTimeInSecs);
     }
   }
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -15,6 +15,7 @@ package com.github.ambry.protocol;
 
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
+import com.github.ambry.messageformat.DeleteRecord;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -27,27 +28,45 @@ import java.nio.channels.WritableByteChannel;
  */
 public class DeleteRequest extends RequestOrResponse {
   private BlobId blobId;
+  private short accountId;
+  private short containerId;
+  private int deletionTimeInSecs;
   private int sizeSent;
-  private static final short Delete_Request_Version_V1 = 1;
+  static final short Delete_Request_Version_V1 = 1;
+  static final short Delete_Request_Version_V2 = 2;
+  private static short currentVersion = Delete_Request_Version_V1;
 
+  private static final int AccountId_ContainerId_Field_Size_InBytes = 2;
+  private static final int DeletionTime_Field_Size_InBytes = 4;
+
+  // @TODO: remove this constructor once DeleteRequest V2 is enabled
   public DeleteRequest(int correlationId, String clientId, BlobId blobId) {
-    super(RequestOrResponseType.DeleteRequest, Delete_Request_Version_V1, correlationId, clientId);
+    super(RequestOrResponseType.DeleteRequest, currentVersion, correlationId, clientId);
     this.blobId = blobId;
     sizeSent = 0;
   }
 
-  public static DeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
-    RequestOrResponseType type = RequestOrResponseType.DeleteRequest;
-    Short versionId = stream.readShort();
-    int correlationId = stream.readInt();
-    String clientId = Utils.readIntString(stream);
-    BlobId blobId = new BlobId(stream, map);
-    // ignore version for now
-    return new DeleteRequest(correlationId, clientId, blobId);
+  public DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
+      int deletionTimeInSecs) {
+    super(RequestOrResponseType.DeleteRequest, Delete_Request_Version_V2, correlationId, clientId);
+    this.currentVersion = Delete_Request_Version_V2;
+    this.blobId = blobId;
+    this.accountId = accountId;
+    this.containerId = containerId;
+    this.deletionTimeInSecs = deletionTimeInSecs;
+    sizeSent = 0;
   }
 
-  public BlobId getBlobId() {
-    return blobId;
+  public static ReceivedDeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+    Short version = stream.readShort();
+    switch (version) {
+      case Delete_Request_Version_V1:
+        return DeleteRequest_V1.readFrom(stream, map);
+      case Delete_Request_Version_V2:
+        return DeleteRequest_V2.readFrom(stream, map);
+      default:
+        throw new IllegalStateException("Unknown Delete Request version " + version);
+    }
   }
 
   @Override
@@ -57,6 +76,11 @@ public class DeleteRequest extends RequestOrResponse {
       bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
       writeHeader();
       bufferToSend.put(blobId.toBytes());
+      if (currentVersion == Delete_Request_Version_V2) {
+        bufferToSend.putShort(accountId);
+        bufferToSend.putShort(containerId);
+        bufferToSend.putInt(deletionTimeInSecs);
+      }
       bufferToSend.flip();
     }
     if (bufferToSend.remaining() > 0) {
@@ -71,10 +95,23 @@ public class DeleteRequest extends RequestOrResponse {
     return sizeSent == sizeInBytes();
   }
 
+  public BlobId getBlobId() {
+    return blobId;
+  }
+
   @Override
   public long sizeInBytes() {
     // header + blobId
-    return super.sizeInBytes() + blobId.sizeInBytes();
+    long sizeInBytes = super.sizeInBytes() + blobId.sizeInBytes();
+    if (currentVersion == Delete_Request_Version_V2) {
+      // accountId
+      sizeInBytes += AccountId_ContainerId_Field_Size_InBytes;
+      // containerId
+      sizeInBytes += AccountId_ContainerId_Field_Size_InBytes;
+      // deletion time
+      sizeInBytes += DeletionTime_Field_Size_InBytes;
+    }
+    return sizeInBytes;
   }
 
   @Override
@@ -84,7 +121,103 @@ public class DeleteRequest extends RequestOrResponse {
     sb.append("BlobID=").append(blobId);
     sb.append(", ").append("ClientId=").append(clientId);
     sb.append(", ").append("CorrelationId=").append(correlationId);
+    sb.append(", ").append("AccountId=").append(accountId);
+    sb.append(", ").append("ContainerId=").append(containerId);
+    sb.append(", ").append("DeletionTimeInSecs=").append(deletionTimeInSecs);
     sb.append("]");
     return sb.toString();
+  }
+
+  /**
+   * Class to read protocol version 1 DeleteRequest from the stream.
+   */
+  private static class DeleteRequest_V1 {
+    static ReceivedDeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+      int correlationId = stream.readInt();
+      String clientId = Utils.readIntString(stream);
+      BlobId id = new BlobId(stream, map);
+      return new ReceivedDeleteRequest(correlationId, clientId, id);
+    }
+  }
+
+  /**
+   * Class to read protocol version 2 DeleteRequest from the stream.
+   */
+  private static class DeleteRequest_V2 {
+    static ReceivedDeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
+      int correlationId = stream.readInt();
+      String clientId = Utils.readIntString(stream);
+      BlobId id = new BlobId(stream, map);
+      short accountId = stream.readShort();
+      short containerId = stream.readShort();
+      int deletionTimeInSecs = stream.readInt();
+      return new ReceivedDeleteRequest(correlationId, clientId, id, accountId, containerId, deletionTimeInSecs);
+    }
+  }
+
+  /**
+   * Class that represents a DeleteRequest that was received and cannot be sent out.
+   */
+  public static class ReceivedDeleteRequest {
+    private int correlationId;
+    private String clientId;
+    private BlobId blobId;
+    private short accountId = DeleteRecord.ACCOUNTID_CONTAINERID_DEFAULT_VALUE;
+    private short containerId = DeleteRecord.ACCOUNTID_CONTAINERID_DEFAULT_VALUE;
+    private int deletionTimeInSecs = (int) Utils.Infinite_Time;
+
+    ReceivedDeleteRequest(int correlationId, String clientId, BlobId blobId) {
+      this.correlationId = correlationId;
+      this.clientId = clientId;
+      this.blobId = blobId;
+    }
+
+    ReceivedDeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
+        int deletionTimeInSecs) {
+      this.correlationId = correlationId;
+      this.clientId = clientId;
+      this.blobId = blobId;
+      this.accountId = accountId;
+      this.containerId = containerId;
+      this.deletionTimeInSecs = deletionTimeInSecs;
+    }
+
+    public int getCorrelationId() {
+      return correlationId;
+    }
+
+    public String getClientId() {
+      return clientId;
+    }
+
+    public BlobId getBlobId() {
+      return blobId;
+    }
+
+    public short getAccountId() {
+      return accountId;
+    }
+
+    public short getContainerId() {
+      return containerId;
+    }
+
+    public int getDeletionTimeInSecs() {
+      return deletionTimeInSecs;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append("DeleteRequest[");
+      sb.append("BlobID=").append(blobId);
+      sb.append(", ").append("ClientId=").append(clientId);
+      sb.append(", ").append("CorrelationId=").append(correlationId);
+      sb.append(", ").append("AccountId=").append(accountId);
+      sb.append(", ").append("ContainerId=").append(containerId);
+      sb.append(", ").append("DeletionTimeInSecs=").append(deletionTimeInSecs);
+      sb.append("]");
+      return sb.toString();
+    }
   }
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -15,7 +15,7 @@ package com.github.ambry.protocol;
 
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
-import com.github.ambry.messageformat.DeleteRecord;
+import com.github.ambry.store.MessageInfo;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -48,8 +48,8 @@ public class DeleteRequest extends RequestOrResponse {
    */
   // @TODO: remove this constructor once DeleteRequest V2 is enabled
   public DeleteRequest(int correlationId, String clientId, BlobId blobId) {
-    this(correlationId, clientId, blobId, DeleteRecord.ACCOUNT_ID_DEFAULT_VALUE,
-        DeleteRecord.CONTAINER_ID_DEFAULT_VALUE, (int) Utils.Infinite_Time, currentVersion);
+    this(correlationId, clientId, blobId, MessageInfo.ACCOUNT_ID_LEGACY_VALUE, MessageInfo.CONTAINER_ID_LEGACY_VALUE,
+        (int) Utils.Infinite_Time, currentVersion);
   }
 
   /**

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -77,7 +77,7 @@ public class DeleteRequest extends RequestOrResponse {
    * @param deletionTimeInMs deletion time of the blob in ms
    * @param version version of the {@link DeleteRequest}
    */
-  private DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
+  protected DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
       long deletionTimeInMs, short version) {
     super(RequestOrResponseType.DeleteRequest, version, correlationId, clientId);
     this.version = version;

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -28,38 +28,38 @@ import java.nio.channels.WritableByteChannel;
 public class DeleteRequest extends RequestOrResponse {
   private final BlobId blobId;
   private final long deletionTimeInMs;
-  private int sizeSent;
   private final short version;
-  static final short Delete_Request_Version_1 = 1;
-  static final short Delete_Request_Version_2 = 2;
-  private final static short currentVersion = Delete_Request_Version_1;
-
+  static final short DELETE_REQUEST_VERSION_1 = 1;
+  static final short DELETE_REQUEST_VERSION_2 = 2;
+  private final static short CURRENT_VERSION = DELETE_REQUEST_VERSION_1;
   protected static final int DELETION_TIME_FIELD_SIZE_IN_BYTES = Long.BYTES;
 
+  private int sizeSent;
+
   /**
-   * Constructs {@link DeleteRequest} in {@link #Delete_Request_Version_1}
+   * Constructs {@link DeleteRequest} in {@link #DELETE_REQUEST_VERSION_1}
    * @param correlationId correlationId of the delete request
    * @param clientId clientId of the delete request
    * @param blobId blobId of the delete request
    */
   // @TODO: remove this constructor once DeleteRequest V2 is enabled
   public DeleteRequest(int correlationId, String clientId, BlobId blobId) {
-    this(correlationId, clientId, blobId, Utils.Infinite_Time, currentVersion);
+    this(correlationId, clientId, blobId, Utils.Infinite_Time, CURRENT_VERSION);
   }
 
   /**
-   * Constructs {@link DeleteRequest} in {@link #Delete_Request_Version_2}
+   * Constructs {@link DeleteRequest} in {@link #DELETE_REQUEST_VERSION_2}
    * @param correlationId correlationId of the delete request
    * @param clientId clientId of the delete request
    * @param blobId blobId of the delete request
    * @param deletionTimeInMs deletion time of the blob in ms
    */
   public DeleteRequest(int correlationId, String clientId, BlobId blobId, long deletionTimeInMs) {
-    this(correlationId, clientId, blobId, deletionTimeInMs, currentVersion);
+    this(correlationId, clientId, blobId, deletionTimeInMs, CURRENT_VERSION);
   }
 
   /**
-   * Constructs {@link DeleteRequest} in {@link #Delete_Request_Version_2}
+   * Constructs {@link DeleteRequest} in {@link #DELETE_REQUEST_VERSION_2}
    * @param correlationId correlationId of the delete request
    * @param clientId clientId of the delete request
    * @param blobId blobId of the delete request
@@ -77,9 +77,9 @@ public class DeleteRequest extends RequestOrResponse {
   public static DeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
     Short version = stream.readShort();
     switch (version) {
-      case Delete_Request_Version_1:
+      case DELETE_REQUEST_VERSION_1:
         return DeleteRequest_V1.readFrom(stream, map);
-      case Delete_Request_Version_2:
+      case DELETE_REQUEST_VERSION_2:
         return DeleteRequest_V2.readFrom(stream, map);
       default:
         throw new IllegalStateException("Unknown Delete Request version " + version);
@@ -93,7 +93,7 @@ public class DeleteRequest extends RequestOrResponse {
       bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
       writeHeader();
       bufferToSend.put(blobId.toBytes());
-      if (version == Delete_Request_Version_2) {
+      if (version == DELETE_REQUEST_VERSION_2) {
         bufferToSend.putLong(deletionTimeInMs);
       }
       bufferToSend.flip();
@@ -130,7 +130,7 @@ public class DeleteRequest extends RequestOrResponse {
   public long sizeInBytes() {
     // header + blobId
     long sizeInBytes = super.sizeInBytes() + blobId.sizeInBytes();
-    if (version == Delete_Request_Version_2) {
+    if (version == DELETE_REQUEST_VERSION_2) {
       // deletion time
       sizeInBytes += DELETION_TIME_FIELD_SIZE_IN_BYTES;
     }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -30,7 +30,7 @@ public class DeleteRequest extends RequestOrResponse {
   private final BlobId blobId;
   private final short accountId;
   private final short containerId;
-  private final int deletionTimeInSecs;
+  private final long deletionTimeInMs;
   private int sizeSent;
   private final short version;
   static final short Delete_Request_Version_1 = 1;
@@ -38,7 +38,7 @@ public class DeleteRequest extends RequestOrResponse {
   private final static short currentVersion = Delete_Request_Version_1;
 
   private static final int AccountId_ContainerId_Field_Size_InBytes = 2;
-  private static final int DeletionTime_Field_Size_InBytes = 4;
+  private static final int DeletionTime_Field_Size_InBytes = 8;
 
   /**
    * Constructs {@link DeleteRequest} in {@link #Delete_Request_Version_1}
@@ -59,11 +59,11 @@ public class DeleteRequest extends RequestOrResponse {
    * @param blobId blobId of the delete request
    * @param accountId accountId of the blobId being requested
    * @param containerId containerId of the blobId being requested
-   * @param deletionTimeInSecs deletion time of the blob in ms
+   * @param deletionTimeInMs deletion time of the blob in ms
    */
   public DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
-      int deletionTimeInSecs) {
-    this(correlationId, clientId, blobId, accountId, containerId, deletionTimeInSecs, Delete_Request_Version_2);
+      long deletionTimeInMs) {
+    this(correlationId, clientId, blobId, accountId, containerId, deletionTimeInMs, Delete_Request_Version_2);
   }
 
   /**
@@ -73,17 +73,17 @@ public class DeleteRequest extends RequestOrResponse {
    * @param blobId blobId of the delete request
    * @param accountId accountId of the blobId being requested
    * @param containerId containerId of the blobId being requested
-   * @param deletionTimeInSecs deletion time of the blob in ms
+   * @param deletionTimeInMs deletion time of the blob in ms
    * @param version version of the {@link DeleteRequest}
    */
   private DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
-      int deletionTimeInSecs, short version) {
+      long deletionTimeInMs, short version) {
     super(RequestOrResponseType.DeleteRequest, version, correlationId, clientId);
     this.version = version;
     this.blobId = blobId;
     this.accountId = accountId;
     this.containerId = containerId;
-    this.deletionTimeInSecs = deletionTimeInSecs;
+    this.deletionTimeInMs = deletionTimeInMs;
     sizeSent = 0;
   }
 
@@ -109,7 +109,7 @@ public class DeleteRequest extends RequestOrResponse {
       if (version == Delete_Request_Version_2) {
         bufferToSend.putShort(accountId);
         bufferToSend.putShort(containerId);
-        bufferToSend.putInt(deletionTimeInSecs);
+        bufferToSend.putLong(deletionTimeInMs);
       }
       bufferToSend.flip();
     }
@@ -145,8 +145,8 @@ public class DeleteRequest extends RequestOrResponse {
     return containerId;
   }
 
-  public int getDeletionTimeInSecs() {
-    return deletionTimeInSecs;
+  public long getDeletionTimeInMs() {
+    return deletionTimeInMs;
   }
 
   @Override
@@ -173,7 +173,7 @@ public class DeleteRequest extends RequestOrResponse {
     sb.append(", ").append("CorrelationId=").append(correlationId);
     sb.append(", ").append("AccountId=").append(accountId);
     sb.append(", ").append("ContainerId=").append(containerId);
-    sb.append(", ").append("DeletionTimeInSecs=").append(deletionTimeInSecs);
+    sb.append(", ").append("DeletionTimeInMs=").append(deletionTimeInMs);
     sb.append("]");
     return sb.toString();
   }
@@ -200,8 +200,8 @@ public class DeleteRequest extends RequestOrResponse {
       BlobId id = new BlobId(stream, map);
       short accountId = stream.readShort();
       short containerId = stream.readShort();
-      int deletionTimeInSecs = stream.readInt();
-      return new DeleteRequest(correlationId, clientId, id, accountId, containerId, deletionTimeInSecs);
+      long deletionTimeInMs = stream.readLong();
+      return new DeleteRequest(correlationId, clientId, id, accountId, containerId, deletionTimeInMs);
     }
   }
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -50,7 +50,7 @@ public class DeleteRequest extends RequestOrResponse {
   // @TODO: remove this constructor once DeleteRequest V2 is enabled
   public DeleteRequest(int correlationId, String clientId, BlobId blobId) {
     this(correlationId, clientId, blobId, BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID,
-        (int) Utils.Infinite_Time, currentVersion);
+        Utils.Infinite_Time, currentVersion);
   }
 
   /**

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -129,14 +129,6 @@ public class DeleteRequest extends RequestOrResponse {
     return blobId;
   }
 
-  public int getCorrelationId() {
-    return correlationId;
-  }
-
-  public String getClientId() {
-    return clientId;
-  }
-
   public short getAccountId() {
     return accountId;
   }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -33,22 +33,22 @@ public class DeleteRequest extends RequestOrResponse {
   private final int deletionTimeInSecs;
   private int sizeSent;
   private final short version;
-  static final short Delete_Request_Version_V1 = 1;
-  static final short Delete_Request_Version_V2 = 2;
-  private static short currentVersion = Delete_Request_Version_V1;
+  static final short Delete_Request_Version_1 = 1;
+  static final short Delete_Request_Version_2 = 2;
+  private static short currentVersion = Delete_Request_Version_1;
 
   private static final int AccountId_ContainerId_Field_Size_InBytes = 2;
   private static final int DeletionTime_Field_Size_InBytes = 4;
 
   // @TODO: remove this constructor once DeleteRequest V2 is enabled
   public DeleteRequest(int correlationId, String clientId, BlobId blobId) {
-    this(correlationId, clientId, blobId, DeleteRecord.ACCOUNTID_DEFAULT_VALUE, DeleteRecord.CONTAINERID_DEFAULT_VALUE,
-        (int) Utils.Infinite_Time, currentVersion);
+    this(correlationId, clientId, blobId, DeleteRecord.ACCOUNT_ID_DEFAULT_VALUE,
+        DeleteRecord.CONTAINER_ID_DEFAULT_VALUE, (int) Utils.Infinite_Time, currentVersion);
   }
 
   public DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
       int deletionTimeInSecs) {
-    this(correlationId, clientId, blobId, accountId, containerId, deletionTimeInSecs, Delete_Request_Version_V2);
+    this(correlationId, clientId, blobId, accountId, containerId, deletionTimeInSecs, Delete_Request_Version_2);
   }
 
   private DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
@@ -65,9 +65,9 @@ public class DeleteRequest extends RequestOrResponse {
   public static DeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
     Short version = stream.readShort();
     switch (version) {
-      case Delete_Request_Version_V1:
+      case Delete_Request_Version_1:
         return DeleteRequest_V1.readFrom(stream, map);
-      case Delete_Request_Version_V2:
+      case Delete_Request_Version_2:
         return DeleteRequest_V2.readFrom(stream, map);
       default:
         throw new IllegalStateException("Unknown Delete Request version " + version);
@@ -81,7 +81,7 @@ public class DeleteRequest extends RequestOrResponse {
       bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
       writeHeader();
       bufferToSend.put(blobId.toBytes());
-      if (version == Delete_Request_Version_V2) {
+      if (version == Delete_Request_Version_2) {
         bufferToSend.putShort(accountId);
         bufferToSend.putShort(containerId);
         bufferToSend.putInt(deletionTimeInSecs);
@@ -128,7 +128,7 @@ public class DeleteRequest extends RequestOrResponse {
   public long sizeInBytes() {
     // header + blobId
     long sizeInBytes = super.sizeInBytes() + blobId.sizeInBytes();
-    if (version == Delete_Request_Version_V2) {
+    if (version == Delete_Request_Version_2) {
       // accountId
       sizeInBytes += AccountId_ContainerId_Field_Size_InBytes;
       // containerId

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -15,7 +15,7 @@ package com.github.ambry.protocol;
 
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
-import com.github.ambry.store.MessageInfo;
+import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -37,8 +37,9 @@ public class DeleteRequest extends RequestOrResponse {
   static final short Delete_Request_Version_2 = 2;
   private final static short currentVersion = Delete_Request_Version_1;
 
-  private static final int AccountId_ContainerId_Field_Size_InBytes = 2;
-  private static final int DeletionTime_Field_Size_InBytes = 8;
+  protected static final int ACCOUNT_ID_FIELD_SIZE_IN_BYTES = Short.BYTES;
+  protected static final int CONTAINER_ID_FIELD_SIZE_IN_BYTES = Short.BYTES;
+  protected static final int DELETION_TIME_FIELD_SIZE_IN_BYTES = Long.BYTES;
 
   /**
    * Constructs {@link DeleteRequest} in {@link #Delete_Request_Version_1}
@@ -48,7 +49,7 @@ public class DeleteRequest extends RequestOrResponse {
    */
   // @TODO: remove this constructor once DeleteRequest V2 is enabled
   public DeleteRequest(int correlationId, String clientId, BlobId blobId) {
-    this(correlationId, clientId, blobId, MessageInfo.ACCOUNT_ID_LEGACY_VALUE, MessageInfo.CONTAINER_ID_LEGACY_VALUE,
+    this(correlationId, clientId, blobId, BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID,
         (int) Utils.Infinite_Time, currentVersion);
   }
 
@@ -63,7 +64,7 @@ public class DeleteRequest extends RequestOrResponse {
    */
   public DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
       long deletionTimeInMs) {
-    this(correlationId, clientId, blobId, accountId, containerId, deletionTimeInMs, Delete_Request_Version_2);
+    this(correlationId, clientId, blobId, accountId, containerId, deletionTimeInMs, currentVersion);
   }
 
   /**
@@ -147,11 +148,11 @@ public class DeleteRequest extends RequestOrResponse {
     long sizeInBytes = super.sizeInBytes() + blobId.sizeInBytes();
     if (version == Delete_Request_Version_2) {
       // accountId
-      sizeInBytes += AccountId_ContainerId_Field_Size_InBytes;
+      sizeInBytes += ACCOUNT_ID_FIELD_SIZE_IN_BYTES;
       // containerId
-      sizeInBytes += AccountId_ContainerId_Field_Size_InBytes;
+      sizeInBytes += CONTAINER_ID_FIELD_SIZE_IN_BYTES;
       // deletion time
-      sizeInBytes += DeletionTime_Field_Size_InBytes;
+      sizeInBytes += DELETION_TIME_FIELD_SIZE_IN_BYTES;
     }
     return sizeInBytes;
   }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -35,22 +35,47 @@ public class DeleteRequest extends RequestOrResponse {
   private final short version;
   static final short Delete_Request_Version_1 = 1;
   static final short Delete_Request_Version_2 = 2;
-  private static short currentVersion = Delete_Request_Version_1;
+  private final static short currentVersion = Delete_Request_Version_1;
 
   private static final int AccountId_ContainerId_Field_Size_InBytes = 2;
   private static final int DeletionTime_Field_Size_InBytes = 4;
 
+  /**
+   * Constructs {@link DeleteRequest} in {@link #Delete_Request_Version_1}
+   * @param correlationId correlationId of the delete request
+   * @param clientId clientId of the delete request
+   * @param blobId blobId of the delete request
+   */
   // @TODO: remove this constructor once DeleteRequest V2 is enabled
   public DeleteRequest(int correlationId, String clientId, BlobId blobId) {
     this(correlationId, clientId, blobId, DeleteRecord.ACCOUNT_ID_DEFAULT_VALUE,
         DeleteRecord.CONTAINER_ID_DEFAULT_VALUE, (int) Utils.Infinite_Time, currentVersion);
   }
 
+  /**
+   * Constructs {@link DeleteRequest} in {@link #Delete_Request_Version_2}
+   * @param correlationId correlationId of the delete request
+   * @param clientId clientId of the delete request
+   * @param blobId blobId of the delete request
+   * @param accountId accountId of the blobId being requested
+   * @param containerId containerId of the blobId being requested
+   * @param deletionTimeInSecs deletion time of the blob in ms
+   */
   public DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
       int deletionTimeInSecs) {
     this(correlationId, clientId, blobId, accountId, containerId, deletionTimeInSecs, Delete_Request_Version_2);
   }
 
+  /**
+   * Constructs {@link DeleteRequest} in {@link #Delete_Request_Version_2}
+   * @param correlationId correlationId of the delete request
+   * @param clientId clientId of the delete request
+   * @param blobId blobId of the delete request
+   * @param accountId accountId of the blobId being requested
+   * @param containerId containerId of the blobId being requested
+   * @param deletionTimeInSecs deletion time of the blob in ms
+   * @param version version of the {@link DeleteRequest}
+   */
   private DeleteRequest(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
       int deletionTimeInSecs, short version) {
     super(RequestOrResponseType.DeleteRequest, version, correlationId, clientId);

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/DeleteRequest.java
@@ -15,12 +15,14 @@ package com.github.ambry.protocol;
 
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
-import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
+
+import static com.github.ambry.account.Account.*;
+import static com.github.ambry.account.Container.*;
 
 
 /**
@@ -49,8 +51,8 @@ public class DeleteRequest extends RequestOrResponse {
    */
   // @TODO: remove this constructor once DeleteRequest V2 is enabled
   public DeleteRequest(int correlationId, String clientId, BlobId blobId) {
-    this(correlationId, clientId, blobId, BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID,
-        Utils.Infinite_Time, currentVersion);
+    this(correlationId, clientId, blobId, UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID, Utils.Infinite_Time,
+        currentVersion);
   }
 
   /**

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -46,6 +46,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static com.github.ambry.account.Account.*;
+import static com.github.ambry.account.Container.*;
+
 
 class MockFindTokenFactory implements FindTokenFactory {
 
@@ -287,8 +290,8 @@ public class RequestResponseTest {
       Assert.assertEquals("ConatinerId mismatch ", containerId, msgInfo.getContainerId());
       Assert.assertEquals("OperationTime mismatch ", operationTimeMs, msgInfo.getOperationTimeMs());
     } else {
-      Assert.assertEquals("AccountId mismatch ", BlobProperties.LEGACY_ACCOUNT_ID, msgInfo.getAccountId());
-      Assert.assertEquals("ConatinerId mismatch ", BlobProperties.LEGACY_CONTAINER_ID, msgInfo.getContainerId());
+      Assert.assertEquals("AccountId mismatch ", UNKNOWN_ACCOUNT_ID, msgInfo.getAccountId());
+      Assert.assertEquals("ConatinerId mismatch ", UNKNOWN_CONTAINER_ID, msgInfo.getContainerId());
       Assert.assertEquals("OperationTime mismatch ", Utils.Infinite_Time, msgInfo.getOperationTimeMs());
     }
   }
@@ -421,8 +424,8 @@ public class RequestResponseTest {
       Assert.assertEquals("ConatinerId mismatch ", containerId, msgInfo.getContainerId());
       Assert.assertEquals("OperationTime mismatch ", operationTimeMs, msgInfo.getOperationTimeMs());
     } else {
-      Assert.assertEquals("AccountId mismatch ", BlobProperties.LEGACY_ACCOUNT_ID, msgInfo.getAccountId());
-      Assert.assertEquals("ConatinerId mismatch ", BlobProperties.LEGACY_CONTAINER_ID, msgInfo.getContainerId());
+      Assert.assertEquals("AccountId mismatch ", UNKNOWN_ACCOUNT_ID, msgInfo.getAccountId());
+      Assert.assertEquals("ConatinerId mismatch ", UNKNOWN_CONTAINER_ID, msgInfo.getContainerId());
       Assert.assertEquals("OperationTime mismatch ", Utils.Infinite_Time, msgInfo.getOperationTimeMs());
     }
   }

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -289,8 +289,8 @@ public class RequestResponseTest {
       Assert.assertEquals("ConatinerId mismatch ", containerId, msgInfo.getContainerId());
       Assert.assertEquals("OperationTime mismatch ", operationTimeMs, msgInfo.getOperationTimeMs());
     } else {
-      Assert.assertEquals("AccountId mismatch ", ACCOUNT_ID_DEFAULT_VALUE, msgInfo.getAccountId());
-      Assert.assertEquals("ConatinerId mismatch ", CONTAINER_ID_DEFAULT_VALUE, msgInfo.getContainerId());
+      Assert.assertEquals("AccountId mismatch ", ACCOUNT_ID_LEGACY_VALUE, msgInfo.getAccountId());
+      Assert.assertEquals("ConatinerId mismatch ", CONTAINER_ID_LEGACY_VALUE, msgInfo.getContainerId());
       Assert.assertEquals("OperationTime mismatch ", Utils.Infinite_Time, msgInfo.getOperationTimeMs());
     }
   }
@@ -423,8 +423,8 @@ public class RequestResponseTest {
       Assert.assertEquals("ConatinerId mismatch ", containerId, msgInfo.getContainerId());
       Assert.assertEquals("OperationTime mismatch ", operationTimeMs, msgInfo.getOperationTimeMs());
     } else {
-      Assert.assertEquals("AccountId mismatch ", ACCOUNT_ID_DEFAULT_VALUE, msgInfo.getAccountId());
-      Assert.assertEquals("ConatinerId mismatch ", CONTAINER_ID_DEFAULT_VALUE, msgInfo.getContainerId());
+      Assert.assertEquals("AccountId mismatch ", ACCOUNT_ID_LEGACY_VALUE, msgInfo.getAccountId());
+      Assert.assertEquals("ConatinerId mismatch ", CONTAINER_ID_LEGACY_VALUE, msgInfo.getContainerId());
       Assert.assertEquals("OperationTime mismatch ", Utils.Infinite_Time, msgInfo.getOperationTimeMs());
     }
   }

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -303,7 +303,7 @@ public class RequestResponseTest {
     for (short version : versions) {
       short accountId = Utils.getRandomShort(random);
       short containerId = Utils.getRandomShort(random);
-      int deletionTimeSecs = random.nextInt();
+      int deletionTimeSecs = (int) (SystemTime.getInstance().seconds() + random.nextInt(60 * 60 * 24 * 365));
       int correlationId = random.nextInt();
       DeleteRequest deleteRequest;
       if (version == DeleteRequest.Delete_Request_Version_V1) {
@@ -319,7 +319,7 @@ public class RequestResponseTest {
       DataInputStream requestStream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
       requestStream.readLong(); // read length
       requestStream.readShort(); // read short
-      DeleteRequest.ReceivedDeleteRequest deserializedDeleteRequest = DeleteRequest.readFrom(requestStream, clusterMap);
+      DeleteRequest deserializedDeleteRequest = DeleteRequest.readFrom(requestStream, clusterMap);
       Assert.assertEquals(deserializedDeleteRequest.getClientId(), "client");
       Assert.assertEquals(deserializedDeleteRequest.getBlobId(), id1);
       if (version == DeleteRequest.Delete_Request_Version_V2) {

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -302,8 +302,8 @@ public class RequestResponseTest {
     for (short version : versions) {
       short accountId = Utils.getRandomShort(random);
       short containerId = Utils.getRandomShort(random);
-      int deletionTimeMs =
-          (int) (SystemTime.getInstance().milliseconds() + random.nextInt((int) TimeUnit.DAYS.toMillis(100)));
+      long deletionTimeMs =
+          (SystemTime.getInstance().milliseconds() + random.nextInt((int) TimeUnit.DAYS.toMillis(100)));
       int correlationId = random.nextInt();
       DeleteRequest deleteRequest;
       if (version == DeleteRequest.Delete_Request_Version_1) {

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -467,15 +467,9 @@ public class RequestResponseTest {
   }
 
   /**
-   * Class representing {@link DeleteRequest} in verison {@link DeleteRequest#Delete_Request_Version_2}
+   * Class representing {@link DeleteRequest} in version {@link DeleteRequest#Delete_Request_Version_2}
    */
-  class DeleteRequestV2 extends DeleteRequest {
-    BlobId blobId;
-    short accountId;
-    short containerId;
-    long deletionTimeInMs;
-    int sizeSent = 0;
-
+  private class DeleteRequestV2 extends DeleteRequest {
     /**
      * Constructs {@link DeleteRequest} in {@link #Delete_Request_Version_2}
      * @param correlationId correlationId of the delete request
@@ -485,63 +479,10 @@ public class RequestResponseTest {
      * @param containerId containerId of the blobId being requested
      * @param deletionTimeInMs deletion time of the blob in ms
      */
-    public DeleteRequestV2(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
+    private DeleteRequestV2(int correlationId, String clientId, BlobId blobId, short accountId, short containerId,
         long deletionTimeInMs) {
-      super(correlationId, clientId, blobId, accountId, containerId, deletionTimeInMs);
-      this.blobId = blobId;
-      this.accountId = accountId;
-      this.containerId = containerId;
-      this.deletionTimeInMs = deletionTimeInMs;
-    }
-
-    @Override
-    public long sizeInBytes() {
-      // header + blobId
-      long sizeInBytes = super.sizeInBytes();
-      // accountId
-      sizeInBytes += ACCOUNT_ID_FIELD_SIZE_IN_BYTES;
-      // containerId
-      sizeInBytes += CONTAINER_ID_FIELD_SIZE_IN_BYTES;
-      // deletion time
-      sizeInBytes += DELETION_TIME_FIELD_SIZE_IN_BYTES;
-      return sizeInBytes;
-    }
-
-    @Override
-    public long writeTo(WritableByteChannel channel) throws IOException {
-      long written = 0;
-      if (bufferToSend == null) {
-        bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
-        writeHeader();
-        bufferToSend.put(blobId.toBytes());
-        bufferToSend.putShort(accountId);
-        bufferToSend.putShort(containerId);
-        bufferToSend.putLong(deletionTimeInMs);
-        bufferToSend.flip();
-      }
-      if (bufferToSend.remaining() > 0) {
-        written = channel.write(bufferToSend);
-        sizeSent += written;
-      }
-      return written;
-    }
-
-    @Override
-    protected void writeHeader() {
-      if (bufferToSend == null) {
-        throw new IllegalStateException("Buffer to send should not be null");
-      }
-      bufferToSend.putLong(sizeInBytes());
-      bufferToSend.putShort((short) type.ordinal());
-      bufferToSend.putShort(DeleteRequest.Delete_Request_Version_2);
-      bufferToSend.putInt(correlationId);
-      bufferToSend.putInt(clientId.length());
-      bufferToSend.put(clientId.getBytes());
-    }
-
-    @Override
-    public boolean isSendComplete() {
-      return sizeSent == sizeInBytes();
+      super(correlationId, clientId, blobId, accountId, containerId, deletionTimeInMs,
+          DeleteRequest.Delete_Request_Version_2);
     }
   }
 }

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -299,14 +299,14 @@ public class RequestResponseTest {
     MockClusterMap clusterMap = new MockClusterMap();
     BlobId id1 = new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID,
         Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0));
-    short[] versions = new short[]{DeleteRequest.Delete_Request_Version_V1, DeleteRequest.Delete_Request_Version_V2};
+    short[] versions = new short[]{DeleteRequest.Delete_Request_Version_1, DeleteRequest.Delete_Request_Version_2};
     for (short version : versions) {
       short accountId = Utils.getRandomShort(random);
       short containerId = Utils.getRandomShort(random);
       int deletionTimeSecs = (int) (SystemTime.getInstance().seconds() + random.nextInt(60 * 60 * 24 * 365));
       int correlationId = random.nextInt();
       DeleteRequest deleteRequest;
-      if (version == DeleteRequest.Delete_Request_Version_V1) {
+      if (version == DeleteRequest.Delete_Request_Version_1) {
         deleteRequest = new DeleteRequest(correlationId, "client", id1);
       } else {
         deleteRequest = new DeleteRequest(correlationId, "client", id1, accountId, containerId, deletionTimeSecs);
@@ -322,7 +322,7 @@ public class RequestResponseTest {
       DeleteRequest deserializedDeleteRequest = DeleteRequest.readFrom(requestStream, clusterMap);
       Assert.assertEquals(deserializedDeleteRequest.getClientId(), "client");
       Assert.assertEquals(deserializedDeleteRequest.getBlobId(), id1);
-      if (version == DeleteRequest.Delete_Request_Version_V2) {
+      if (version == DeleteRequest.Delete_Request_Version_2) {
         Assert.assertEquals("AccountId mismatch ", accountId, deserializedDeleteRequest.getAccountId());
         Assert.assertEquals("ContainerId mismatch ", containerId, deserializedDeleteRequest.getContainerId());
         Assert.assertEquals("DeletionTime mismatch ", deletionTimeSecs,

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -476,7 +476,9 @@ class ReplicaThread implements Runnable {
         // the key is present in the local store. Mark it for deletion if it is deleted in the remote store and not
         // deleted yet locally
         if (messageInfo.isDeleted() && !remoteReplicaInfo.getLocalStore().isKeyDeleted(messageInfo.getStoreKey())) {
-          MessageFormatInputStream deleteStream = new DeleteMessageFormatInputStream(messageInfo.getStoreKey());
+          MessageFormatInputStream deleteStream =
+              new DeleteMessageFormatInputStream(messageInfo.getStoreKey(), messageInfo.getAccountId(),
+                  messageInfo.getContainerId(), messageInfo.getOperationTimeMs());
           MessageInfo info = new MessageInfo(messageInfo.getStoreKey(), deleteStream.getSize(), true);
           ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
           infoList.add(info);

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -357,7 +357,9 @@ public class AmbryRequests implements RequestAPI {
         logger.error("Validating delete request failed with error {} for request {}", error, deleteRequest);
         response = new DeleteResponse(deleteRequest.getCorrelationId(), deleteRequest.getClientId(), error);
       } else {
-        MessageFormatInputStream stream = new DeleteMessageFormatInputStream(deleteRequest.getBlobId());
+        MessageFormatInputStream stream =
+            new DeleteMessageFormatInputStream(deleteRequest.getBlobId(), deleteRequest.getAccountId(),
+                deleteRequest.getContainerId(), deleteRequest.getDeletionTimeInMs());
         MessageInfo info = new MessageInfo(deleteRequest.getBlobId(), stream.getSize());
         ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
         infoList.add(info);

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -344,7 +344,8 @@ public class AmbryRequests implements RequestAPI {
   }
 
   public void handleDeleteRequest(Request request) throws IOException, InterruptedException {
-    DeleteRequest deleteRequest = DeleteRequest.readFrom(new DataInputStream(request.getInputStream()), clusterMap);
+    DeleteRequest.ReceivedDeleteRequest deleteRequest =
+        DeleteRequest.readFrom(new DataInputStream(request.getInputStream()), clusterMap);
     long requestQueueTime = SystemTime.getInstance().milliseconds() - request.getStartTimeInMs();
     long totalTimeSpent = requestQueueTime;
     metrics.deleteBlobRequestQueueTimeInMs.update(requestQueueTime);

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -344,8 +344,7 @@ public class AmbryRequests implements RequestAPI {
   }
 
   public void handleDeleteRequest(Request request) throws IOException, InterruptedException {
-    DeleteRequest.ReceivedDeleteRequest deleteRequest =
-        DeleteRequest.readFrom(new DataInputStream(request.getInputStream()), clusterMap);
+    DeleteRequest deleteRequest = DeleteRequest.readFrom(new DataInputStream(request.getInputStream()), clusterMap);
     long requestQueueTime = SystemTime.getInstance().milliseconds() - request.getStartTimeInMs();
     long totalTimeSpent = requestQueueTime;
     metrics.deleteBlobRequestQueueTimeInMs.update(requestQueueTime);

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -13,11 +13,13 @@
  */
 package com.github.ambry.store;
 
-import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
+
+import static com.github.ambry.account.Account.*;
+import static com.github.ambry.account.Container.*;
 
 
 /**
@@ -95,8 +97,8 @@ class IndexValue {
         expiresAtMs = value.getLong();
         originalMessageOffset = value.getLong();
         operationTimeInMs = (int) Utils.Infinite_Time;
-        serviceId = BlobProperties.LEGACY_ACCOUNT_ID;
-        containerId = BlobProperties.LEGACY_CONTAINER_ID;
+        serviceId = UNKNOWN_ACCOUNT_ID;
+        containerId = UNKNOWN_CONTAINER_ID;
         break;
       case PersistentIndex.VERSION_1:
         if (value.capacity() != INDEX_VALUE_SIZE_IN_BYTES_V1) {
@@ -127,7 +129,7 @@ class IndexValue {
    */
   IndexValue(long size, Offset offset, long expiresAtMs) {
     this(size, offset, FLAGS_DEFAULT_VALUE, expiresAtMs, offset.getOffset(), (int) Utils.Infinite_Time,
-        BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID);
+        UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID);
   }
 
   /**
@@ -139,8 +141,8 @@ class IndexValue {
    * @param operationTimeInMs operation time ins ms of the entry in secs
    */
   IndexValue(long size, Offset offset, byte flags, long expiresAtMs, long operationTimeInMs) {
-    this(size, offset, flags, expiresAtMs, offset.getOffset(), operationTimeInMs, BlobProperties.LEGACY_ACCOUNT_ID,
-        BlobProperties.LEGACY_CONTAINER_ID);
+    this(size, offset, flags, expiresAtMs, offset.getOffset(), operationTimeInMs, UNKNOWN_ACCOUNT_ID,
+        UNKNOWN_CONTAINER_ID);
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.nio.ByteBuffer;
@@ -43,7 +44,6 @@ class IndexValue {
   }
 
   final static byte FLAGS_DEFAULT_VALUE = (byte) 0;
-  final static short SERVICE_CONTAINER_ID_DEFAULT_VALUE = -1;
   final static long UNKNOWN_ORIGINAL_MESSAGE_OFFSET = -1;
 
   private final static int BLOB_SIZE_IN_BYTES = 8;
@@ -95,8 +95,8 @@ class IndexValue {
         expiresAtMs = value.getLong();
         originalMessageOffset = value.getLong();
         operationTimeInMs = (int) Utils.Infinite_Time;
-        serviceId = SERVICE_CONTAINER_ID_DEFAULT_VALUE;
-        containerId = SERVICE_CONTAINER_ID_DEFAULT_VALUE;
+        serviceId = BlobProperties.LEGACY_ACCOUNT_ID;
+        containerId = BlobProperties.LEGACY_CONTAINER_ID;
         break;
       case PersistentIndex.VERSION_1:
         if (value.capacity() != INDEX_VALUE_SIZE_IN_BYTES_V1) {
@@ -127,7 +127,7 @@ class IndexValue {
    */
   IndexValue(long size, Offset offset, long expiresAtMs) {
     this(size, offset, FLAGS_DEFAULT_VALUE, expiresAtMs, offset.getOffset(), (int) Utils.Infinite_Time,
-        SERVICE_CONTAINER_ID_DEFAULT_VALUE, SERVICE_CONTAINER_ID_DEFAULT_VALUE);
+        BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID);
   }
 
   /**
@@ -139,8 +139,8 @@ class IndexValue {
    * @param operationTimeInMs operation time ins ms of the entry in secs
    */
   IndexValue(long size, Offset offset, byte flags, long expiresAtMs, long operationTimeInMs) {
-    this(size, offset, flags, expiresAtMs, offset.getOffset(), operationTimeInMs, SERVICE_CONTAINER_ID_DEFAULT_VALUE,
-        SERVICE_CONTAINER_ID_DEFAULT_VALUE);
+    this(size, offset, flags, expiresAtMs, offset.getOffset(), operationTimeInMs, BlobProperties.LEGACY_ACCOUNT_ID,
+        BlobProperties.LEGACY_CONTAINER_ID);
   }
 
   /**

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.store;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
@@ -2265,8 +2266,7 @@ public class IndexTest {
       if (indexSegment != null) {
         entry = new IndexEntry(state.getUniqueId(),
             IndexValueTest.getIndexValue(size, prevEntryEndOffset, expiresAtMs, state.time.milliseconds(),
-                IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE, IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE,
-                indexSegment.getVersion()));
+                BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID, indexSegment.getVersion()));
         indexSegment.addEntry(entry, fileSpan.getEndOffset());
       } else {
         entry = new IndexEntry(state.getUniqueId(),

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -16,7 +16,6 @@ package com.github.ambry.store;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
@@ -51,6 +50,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static com.github.ambry.account.Account.*;
+import static com.github.ambry.account.Container.*;
 import static com.github.ambry.store.CuratedLogIndexState.*;
 import static org.junit.Assert.*;
 
@@ -2266,7 +2267,7 @@ public class IndexTest {
       if (indexSegment != null) {
         entry = new IndexEntry(state.getUniqueId(),
             IndexValueTest.getIndexValue(size, prevEntryEndOffset, expiresAtMs, state.time.milliseconds(),
-                BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID, indexSegment.getVersion()));
+                UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID, indexSegment.getVersion()));
         indexSegment.addEntry(entry, fileSpan.getEndOffset());
       } else {
         entry = new IndexEntry(state.getUniqueId(),

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.store;
 
-import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
@@ -28,6 +27,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static com.github.ambry.account.Account.*;
+import static com.github.ambry.account.Container.*;
 import static org.junit.Assert.*;
 
 
@@ -100,7 +101,7 @@ public class IndexValueTest {
       switch (version) {
         case PersistentIndex.VERSION_0:
           verifyIndexValue(value, logSegmentName, size, offset, false, expiresAtMs, offset, Utils.Infinite_Time,
-              BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID);
+              UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID);
           break;
         case PersistentIndex.VERSION_1:
           verifyIndexValue(value, logSegmentName, size, offset, false, expirationTime.getValue(), offset,
@@ -140,7 +141,7 @@ public class IndexValueTest {
     switch (version) {
       case PersistentIndex.VERSION_0:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expiresAtMs, oldOffset,
-            Utils.Infinite_Time, BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID);
+            Utils.Infinite_Time, UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID);
         break;
       case PersistentIndex.VERSION_1:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, oldOffset,
@@ -153,7 +154,7 @@ public class IndexValueTest {
     switch (version) {
       case PersistentIndex.VERSION_0:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expiresAtMs, -1, Utils.Infinite_Time,
-            BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID);
+            UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID);
         break;
       case PersistentIndex.VERSION_1:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, -1,
@@ -171,7 +172,7 @@ public class IndexValueTest {
     switch (version) {
       case PersistentIndex.VERSION_0:
         verifyIndexValue(newValue, newLogSegmentName, newSize, newOffset, true, expiresAtMs, -1, Utils.Infinite_Time,
-            BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID);
+            UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID);
         break;
       case PersistentIndex.VERSION_1:
         verifyIndexValue(newValue, newLogSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, -1,

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
@@ -99,7 +100,7 @@ public class IndexValueTest {
       switch (version) {
         case PersistentIndex.VERSION_0:
           verifyIndexValue(value, logSegmentName, size, offset, false, expiresAtMs, offset, Utils.Infinite_Time,
-              IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE, IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE);
+              BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID);
           break;
         case PersistentIndex.VERSION_1:
           verifyIndexValue(value, logSegmentName, size, offset, false, expirationTime.getValue(), offset,
@@ -139,8 +140,7 @@ public class IndexValueTest {
     switch (version) {
       case PersistentIndex.VERSION_0:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expiresAtMs, oldOffset,
-            Utils.Infinite_Time, IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE,
-            IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE);
+            Utils.Infinite_Time, BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID);
         break;
       case PersistentIndex.VERSION_1:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, oldOffset,
@@ -153,7 +153,7 @@ public class IndexValueTest {
     switch (version) {
       case PersistentIndex.VERSION_0:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expiresAtMs, -1, Utils.Infinite_Time,
-            IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE, IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE);
+            BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID);
         break;
       case PersistentIndex.VERSION_1:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, -1,
@@ -171,7 +171,7 @@ public class IndexValueTest {
     switch (version) {
       case PersistentIndex.VERSION_0:
         verifyIndexValue(newValue, newLogSegmentName, newSize, newOffset, true, expiresAtMs, -1, Utils.Infinite_Time,
-            IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE, IndexValue.SERVICE_CONTAINER_ID_DEFAULT_VALUE);
+            BlobProperties.LEGACY_ACCOUNT_ID, BlobProperties.LEGACY_CONTAINER_ID);
         break;
       case PersistentIndex.VERSION_1:
         verifyIndexValue(newValue, newLogSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, -1,

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
@@ -94,12 +94,8 @@ class DumpDataHelper {
         } else {
           DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(streamlog);
           isDeleted = true;
-          if (deleteRecord.getVersion() == MessageFormatRecord.Delete_Version_V1) {
-            deleteMsg = "delete change : true";
-          } else {
-            deleteMsg = "delete change : AccountId:" + deleteRecord.getAccountId() + ", ContainerId:"
-                + deleteRecord.getContainerId() + ", DeletionTimeInSecs:" + deleteRecord.getDeletionTimeInMs();
-          }
+          deleteMsg = "delete change : AccountId:" + deleteRecord.getAccountId() + ", ContainerId:"
+              + deleteRecord.getContainerId() + ", DeletionTimeInSecs:" + deleteRecord.getDeletionTimeInMs();
         }
       } else {
         throw new MessageFormatException("Header version not supported " + version, MessageFormatErrorCodes.IO_Error);

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
@@ -18,6 +18,7 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.messageformat.BlobData;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.messageformat.DeleteRecord;
 import com.github.ambry.messageformat.MessageFormatErrorCodes;
 import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatRecord;
@@ -91,9 +92,14 @@ class DumpDataHelper {
           BlobData blobData = MessageFormatRecord.deserializeBlob(streamlog);
           blobDataOutput = "Blob - size " + blobData.getSize();
         } else {
-          boolean deleteFlag = MessageFormatRecord.deserializeDeleteRecord(streamlog);
+          DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(streamlog);
           isDeleted = true;
-          deleteMsg = "delete change " + deleteFlag;
+          if (deleteRecord.getVersion() == MessageFormatRecord.Delete_Version_V1) {
+            deleteMsg = "delete change " + deleteRecord.isDeleted();
+          } else {
+            deleteMsg = "delete change : AccountId:" + deleteRecord.getAccountId() + ", ContainerId:"
+                + deleteRecord.getContainerId() + ", DeletionTimeInSecs:" + deleteRecord.getDeletionTimeInSecs();
+          }
         }
       } else {
         throw new MessageFormatException("Header version not supported " + version, MessageFormatErrorCodes.IO_Error);

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
@@ -98,7 +98,7 @@ class DumpDataHelper {
             deleteMsg = "delete change " + deleteRecord.isDeleted();
           } else {
             deleteMsg = "delete change : AccountId:" + deleteRecord.getAccountId() + ", ContainerId:"
-                + deleteRecord.getContainerId() + ", DeletionTimeInSecs:" + deleteRecord.getDeletionTimeInSecs();
+                + deleteRecord.getContainerId() + ", DeletionTimeInSecs:" + deleteRecord.getDeletionTimeInMs();
           }
         }
       } else {

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
@@ -95,7 +95,7 @@ class DumpDataHelper {
           DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(streamlog);
           isDeleted = true;
           if (deleteRecord.getVersion() == MessageFormatRecord.Delete_Version_V1) {
-            deleteMsg = "delete change " + deleteRecord.isDeleted();
+            deleteMsg = "delete change : true";
           } else {
             deleteMsg = "delete change : AccountId:" + deleteRecord.getAccountId() + ", ContainerId:"
                 + deleteRecord.getContainerId() + ", DeletionTimeInSecs:" + deleteRecord.getDeletionTimeInMs();


### PR DESCRIPTION
1. Adding new DeleteRecord V2 with accountId, containerId, deletionTime and deleteIssuerAccountId. 
2. Adding new DeleteRequest protocol V2 to carry accountId, containerId, deletionTime and deleteIssuerAccountId.

Supports reading both new formats. Write still happens in old versions. 

SLA: 30 mins
Reviewers: Gopal and Casey

Built and coding style applied
Coverage:
Class	                        Class, %	        Method, %	  Line, %
DeleteRecord	                100% (1/ 1)	100% (8/ 8)	  100% (19/ 19)
MessageFormatRecord	100% (9/ 9)	79% (49/ 62)	  81.7% (197/ 241)
All new lines are covered
DeleteRequest	        100% (4/ 4)	73.9% (17/ 23)	  73% (73/ 100)
 toString() is not covered