### PR TITLE
Enable CRCs in the protocol

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -72,7 +72,6 @@ import org.json.JSONObject;
  *    "datacenter" : "dc1",                                # [datacenterName]
  *    "rackId" : "1611",                                   # [rackId]
  *    "sslPort": "27088"                                   # [sslPort]
- *                                                         #  @todo: version.
  *  }
  *}
  */

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
@@ -40,8 +40,7 @@ public class GetResponse extends Response {
   static final short Get_Response_Version_V1 = 1;
   static final short Get_Response_Version_V2 = 2;
 
-  // @todo change this to V2 once all cluster nodes understand V2.
-  private static final short currentVersion = Get_Response_Version_V1;
+  private static final short currentVersion = Get_Response_Version_V2;
 
   public GetResponse(int correlationId, String clientId, List<PartitionResponseInfo> partitionResponseInfoList,
       Send send, ServerErrorCode error) {

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
@@ -57,8 +57,7 @@ public class PutRequest extends RequestOrResponse {
   private static final short Put_Request_Version_V2 = 2;
   private static final short Put_Request_Version_V3 = 3;
 
-  // @todo change this to V3 once all cluster nodes understand V3.
-  private static final short currentVersion = Put_Request_Version_V2;
+  private static final short currentVersion = Put_Request_Version_V3;
 
   /**
    * Construct a PutRequest
@@ -99,9 +98,7 @@ public class PutRequest extends RequestOrResponse {
   @Override
   public long sizeInBytes() {
     long sizeInBytes = sizeExcludingBlobAndCrcSize() + blobSize;
-    if (currentVersion == Put_Request_Version_V3) {
-      sizeInBytes += Crc_Field_Size_InBytes;
-    }
+    sizeInBytes += Crc_Field_Size_InBytes;
     return sizeInBytes;
   }
 

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
@@ -140,7 +140,7 @@ public class PutRequest extends RequestOrResponse {
       // try and write out as much of the blob now.
       if (!bufferToSend.hasRemaining()) {
         written += channel.write(blob);
-        okayToWriteCrc = !blob.hasRemaining() && currentVersion == Put_Request_Version_V3;
+        okayToWriteCrc = !blob.hasRemaining();
       }
 
       if (okayToWriteCrc && crcBuf.hasRemaining()) {

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
@@ -39,8 +39,7 @@ public class ReplicaMetadataResponse extends Response {
   static final short Replica_Metadata_Response_Version_V1 = 1;
   static final short Replica_Metadata_Response_Version_V2 = 2;
 
-  // @todo change this to V2 once all cluster nodes understand V2.
-  private static final short currentVersion = Replica_Metadata_Response_Version_V1;
+  private static final short currentVersion = Replica_Metadata_Response_Version_V2;
 
   public ReplicaMetadataResponse(int correlationId, String clientId, ServerErrorCode error,
       List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList) {

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -383,10 +383,8 @@ public final class ServerTestUtil {
 
       // Now that the blob is created and replicated, test the cases where a put request arrives for the same blob id
       // later than replication.
-      // @todo Once PutRequest starts going out in V3, ReplicaMetadataResponse goes out in V2 and GetResponse goes
-      // @todo out in V2, the expected error is No_Error for the first case here, where the blob is exactly the same.
       testLatePutRequest(blobIds.get(0), properties, usermetadata, data, channel1, channel2, channel3,
-          ServerErrorCode.Blob_Already_Exists);
+          ServerErrorCode.No_Error);
       // Test the case where a put arrives with the same id as one in the server, but the blob is not identical.
       BlobProperties differentProperties = new BlobProperties(properties.getBlobSize(), properties.getServiceId());
       testLatePutRequest(blobIds.get(0), differentProperties, usermetadata, data, channel1, channel2, channel3,


### PR DESCRIPTION
This is a follow-up of #549 which introduced new versions with CRCs
and the capability to read them correctly. This patch enables these
new versions.

Fixes linkedin/ambry#454