### PR TITLE
Adding more trace statements for router operations

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -167,13 +167,13 @@ class DeleteOperation {
     routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId()).deleteRequestLatencyMs.update(requestLatencyMs);
     // Check the error code from NetworkClient.
     if (responseInfo.getError() != null) {
-      logger.trace("DeleteRequest with correlationId {} timed out for replica {} ", deleteRequest.getCorrelationId(),
-          replica.getDataNodeId());
+      logger.trace("DeleteRequest with response correlationId {} timed out for replica {} ",
+          deleteRequest.getCorrelationId(), replica.getDataNodeId());
       updateOperationState(replica, RouterErrorCode.OperationTimedOut);
     } else {
       if (deleteResponse == null) {
         logger.trace(
-            "DeleteRequest with correlationId {} received UnexpectedInternalError on response deserialization for replica {} ",
+            "DeleteRequest with response correlationId {} received UnexpectedInternalError on response deserialization for replica {} ",
             deleteRequest.getCorrelationId(), replica.getDataNodeId());
         updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
       } else {
@@ -266,7 +266,7 @@ class DeleteOperation {
         break;
     }
     if (serverErrorCode != ServerErrorCode.No_Error) {
-      logger.trace("Replica {} returned an error {} for a delete request with correlationId : {} ",
+      logger.trace("Replica {} returned an error {} for a delete request with response correlationId : {} ",
           replica.getDataNodeId(), serverErrorCode, correlationId);
     }
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -175,14 +175,14 @@ class GetBlobInfoOperation extends GetOperation {
     routerMetrics.getDataNodeBasedMetrics(getRequestInfo.replicaId.getDataNodeId()).getBlobInfoRequestLatencyMs.update(
         requestLatencyMs);
     if (responseInfo.getError() != null) {
-      logger.trace("GetBlobInfoRequest with correlationId {} timed out for replica {} ", correlationId,
+      logger.trace("GetBlobInfoRequest with response correlationId {} timed out for replica {} ", correlationId,
           getRequestInfo.replicaId.getDataNodeId());
       setOperationException(new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut));
       onErrorResponse(getRequestInfo.replicaId);
     } else {
       if (getResponse == null) {
         logger.trace(
-            "GetBlobInfoRequest with correlationId {} received an unexpected error on response deserialization from replica {} ",
+            "GetBlobInfoRequest with response correlationId {} received an unexpected error on response deserialization from replica {} ",
             correlationId, getRequestInfo.replicaId.getDataNodeId());
         setOperationException(new RouterException("Response deserialization received an unexpected error",
             RouterErrorCode.UnexpectedInternalError));
@@ -194,7 +194,7 @@ class GetBlobInfoOperation extends GetOperation {
           // sent over it. The check here ensures that is indeed the case. If not, log an error and fail this request.
           // There is no other way to handle it.
           routerMetrics.unknownReplicaResponseError.inc();
-          logger.trace("GetBlobInfoRequest with correlationId {} mismatch from response {} for replica {} ",
+          logger.trace("GetBlobInfoRequest with response correlationId {} mismatch from response {} for replica {} ",
               correlationId, getResponse.getCorrelationId(), getRequestInfo.replicaId.getDataNodeId());
           setOperationException(new RouterException(
               "The correlation id in the GetResponse " + getResponse.getCorrelationId()
@@ -208,7 +208,8 @@ class GetBlobInfoOperation extends GetOperation {
           } catch (IOException | MessageFormatException e) {
             // This should really not happen. Again, we do not notify the ResponseHandler responsible for failure
             // detection.
-            logger.trace("GetBlobInfoRequest with correlationId {} response deserialization failed for replica {} ",
+            logger.trace(
+                "GetBlobInfoRequest with response correlationId {} response deserialization failed for replica {} ",
                 correlationId, getRequestInfo.replicaId.getDataNodeId());
             routerMetrics.responseDeserializationErrorCount.inc();
             setOperationException(new RouterException("Response deserialization received an unexpected error", e,
@@ -253,7 +254,7 @@ class GetBlobInfoOperation extends GetOperation {
         } else {
           // process and set the most relevant exception.
           if (getError != ServerErrorCode.No_Error) {
-            logger.trace("Replica  {} returned error {} with correlationId {} ",
+            logger.trace("Replica  {} returned error {} with response correlationId {} ",
                 getRequestInfo.replicaId.getDataNodeId(), getError, getResponse.getCorrelationId());
           }
           processServerError(getError);
@@ -267,7 +268,7 @@ class GetBlobInfoOperation extends GetOperation {
         }
       }
     } else {
-      logger.trace("Replica {} returned an error {} for a GetBlobInfoRequest with correlationId : {} ",
+      logger.trace("Replica {} returned an error {} for a GetBlobInfoRequest with response correlationId : {} ",
           getRequestInfo.replicaId.getDataNodeId(), getError, getResponse.getCorrelationId());
       onErrorResponse(getRequestInfo.replicaId);
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -644,14 +644,14 @@ class GetBlobOperation extends GetOperation {
       routerMetrics.getDataNodeBasedMetrics(getRequestInfo.replicaId.getDataNodeId()).getRequestLatencyMs.update(
           requestLatencyMs);
       if (responseInfo.getError() != null) {
-        logger.trace("GetBlobRequest with correlationId {} timed out for replica {} ", correlationId,
+        logger.trace("GetBlobRequest with response correlationId {} timed out for replica {} ", correlationId,
             getRequestInfo.replicaId.getDataNodeId());
         chunkException = new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut);
         onErrorResponse(getRequestInfo.replicaId);
       } else {
         if (getResponse == null) {
           logger.trace(
-              "GetBlobRequest with correlationId {} received an unexpected error on response deserialization from replica {} ",
+              "GetBlobRequest with response correlationId {} received an unexpected error on response deserialization from replica {} ",
               correlationId, getRequestInfo.replicaId.getDataNodeId());
           chunkException = new RouterException("Response deserialization received an unexpected error",
               RouterErrorCode.UnexpectedInternalError);
@@ -662,7 +662,7 @@ class GetBlobOperation extends GetOperation {
             // out over a connection id, and the response received on a connection id must be for the latest request
             // sent over it. The check here ensures that is indeed the case. If not, log an error and fail this request.
             // There is no other way to handle it.
-            logger.trace("GetBlobRequest with correlationId {} mismatch from response {} for replica {} ",
+            logger.trace("GetBlobRequest with response correlationId {} mismatch from response {} for replica {} ",
                 correlationId, getResponse.getCorrelationId(), getRequestInfo.replicaId.getDataNodeId());
             routerMetrics.unknownReplicaResponseError.inc();
             chunkException = new RouterException(
@@ -677,7 +677,8 @@ class GetBlobOperation extends GetOperation {
             } catch (IOException | MessageFormatException e) {
               // This should really not happen. Again, we do not notify the ResponseHandler responsible for failure
               // detection.
-              logger.trace("GetBlobRequest with correlationId {} response deserialization failed for replica {} ",
+              logger.trace(
+                  "GetBlobRequest with response correlationId {} response deserialization failed for replica {} ",
                   correlationId, getRequestInfo.replicaId.getDataNodeId());
               routerMetrics.responseDeserializationErrorCount.inc();
               chunkException = new RouterException("Response deserialization received an unexpected error", e,
@@ -730,7 +731,7 @@ class GetBlobOperation extends GetOperation {
           }
         }
       } else {
-        logger.trace("Replica {} returned an error {} for a GetBlobRequest with correlationId : {} ",
+        logger.trace("Replica {} returned an error {} for a GetBlobRequest with response correlationId : {} ",
             getRequestInfo.replicaId.getDataNodeId(), getError, getResponse.getCorrelationId());
         onErrorResponse(getRequestInfo.replicaId);
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -993,14 +993,14 @@ class PutOperation {
           requestLatencyMs);
       boolean isSuccessful;
       if (responseInfo.getError() != null) {
-        logger.trace("PutRequest with correlationId {} timed out for replica {} ", correlationId,
+        logger.trace("PutRequest with response correlationId {} timed out for replica {} ", correlationId,
             chunkPutRequestInfo.replicaId.getDataNodeId());
         setChunkException(new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut));
         isSuccessful = false;
       } else {
         if (putResponse == null) {
           logger.trace(
-              "PutRequest with correlationId {} received an unexpected error on response deserialization from replica {} ",
+              "PutRequest with response correlationId {} received an unexpected error on response deserialization from replica {} ",
               correlationId, chunkPutRequestInfo.replicaId.getDataNodeId());
           setChunkException(new RouterException("Response deserialization received an unexpected error",
               RouterErrorCode.UnexpectedInternalError));
@@ -1025,7 +1025,7 @@ class PutOperation {
               isSuccessful = true;
             } else {
               // chunkException will be set within processServerError.
-              logger.trace("Replica {} returned an error {} for a PutRequest with correlationId : {} ",
+              logger.trace("Replica {} returned an error {} for a PutRequest with response correlationId : {} ",
                   chunkPutRequestInfo.replicaId.getDataNodeId(), putResponse.getError(),
                   putResponse.getCorrelationId());
               processServerError(putResponse.getError());

--- a/ambry-tools/src/main/java/com.github.ambry/store/ConsistencyCheckerTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/ConsistencyCheckerTool.java
@@ -116,7 +116,8 @@ public class ConsistencyCheckerTool {
         realInconsistentBlobs);
     if (realInconsistentBlobs.size() > 0) {
       logger.info("\nDumping Inconsistent blobs ");
-      dumpInconsistentBlobs(rootDir.listFiles(), realInconsistentBlobs);
+      // @TODO: This needs fixes. Doesn't work as some properties in verifiableProperties needs to be fixed
+      // dumpInconsistentBlobs(rootDir.listFiles(), realInconsistentBlobs);
     }
     return realInconsistentBlobs.size() == 0;
   }
@@ -246,7 +247,7 @@ public class ConsistencyCheckerTool {
     DumpIndexTool dumpIndexTool = new DumpIndexTool(verifiableProperties, metrics);
     for (File replica : replicas) {
       try {
-        dumpIndexTool.dumpIndexesForReplica(replica.getAbsolutePath(), blobIdList, 1);
+        dumpIndexTool.dumpIndexesForReplica(replica.getAbsolutePath(), blobIdList, Integer.MAX_VALUE);
       } catch (Exception e) {
         logger.error("Could not complete processing for {}", replica, e);
       }


### PR DESCRIPTION
1. Fixing some trace log statements
2. Adding more trace log statements to track when each request are sent and the response error from every response.

SLA: 10 mins
Reviewers: Priyesh
Built and coding style applied 