### PR TITLE
Adding travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+script: 
+- ./gradlew build
+sudo: required
+jdk:
+  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,14 @@ script:
 sudo: required
 jdk:
   - oraclejdk8
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer


### PR DESCRIPTION
Adding a config to allow us to use travis-ci. `sudo: required` is set to allow us to use machines with a higher memory limit (7.5 vs 4 GB). Only enabling running unit tests for now to avoid timeouts when running integration tests.

**Reviewer:** @vgkholla 
**Time:** 2 min.