### PR TITLE
Unsupported HTTP methods should return 405 and the methods allowed

### DIFF
--- a/ambry-admin/src/main/java/com.github.ambry.admin/AdminBlobStorageService.java
+++ b/ambry-admin/src/main/java/com.github.ambry.admin/AdminBlobStorageService.java
@@ -188,7 +188,7 @@ class AdminBlobStorageService implements BlobStorageService {
         restRequest.getSSLSession() != null ? adminMetrics.postBlobSSLMetrics : adminMetrics.postBlobMetrics;
     restRequest.getMetricsTracker().injectMetrics(requestMetrics);
     Exception exception =
-        isUp ? new RestServiceException("POST is not supported", RestServiceErrorCode.UnsupportedHttpMethod)
+        isUp ? new RestServiceException("POST is not supported. Allowed methods are: GET, HEAD, DELETE", RestServiceErrorCode.UnsupportedHttpMethod)
             : new RestServiceException("AdminBlobStorageService unavailable", RestServiceErrorCode.ServiceUnavailable);
     submitResponse(restRequest, restResponseChannel, null, exception);
   }
@@ -204,7 +204,7 @@ class AdminBlobStorageService implements BlobStorageService {
   public void handlePut(RestRequest restRequest, RestResponseChannel restResponseChannel) {
     handlePrechecks(restRequest, restResponseChannel);
     Exception exception =
-        isUp ? new RestServiceException("PUT is not supported", RestServiceErrorCode.UnsupportedHttpMethod)
+        isUp ? new RestServiceException("PUT is not supported. Allowed methods are: GET, HEAD, DELETE", RestServiceErrorCode.UnsupportedHttpMethod)
             : new RestServiceException("AdminBlobStorageService unavailable", RestServiceErrorCode.ServiceUnavailable);
     submitResponse(restRequest, restResponseChannel, null, exception);
   }

--- a/ambry-api/src/main/java/com.github.ambry/rest/ResponseStatus.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/ResponseStatus.java
@@ -50,6 +50,9 @@ public enum ResponseStatus {
    * 404 Not Found - Resource was not found.
    */
   NotFound, /**
+   * 405 Method Not Allowed - The method request was not in the ones allowed for this endpoint.
+   */
+  MethodNotAllowed, /**
    * 407 - Proxy authentication required
    */
   ProxyAuthenticationRequired, /**
@@ -83,7 +86,7 @@ public enum ResponseStatus {
       case MalformedRequest:
       case MissingArgs:
       case UnsupportedHttpMethod:
-        return ResponseStatus.BadRequest;
+        return ResponseStatus.MethodNotAllowed;
       case ResourceDirty:
         return ResponseStatus.Forbidden;
       case Unauthorized:

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageService.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageService.java
@@ -117,7 +117,7 @@ public class MockBlobStorageService implements BlobStorageService {
    */
   @Override
   public void handlePut(RestRequest restRequest, RestResponseChannel restResponseChannel) {
-    Exception exception = new RestServiceException("PUT is not supported", RestServiceErrorCode.UnsupportedHttpMethod);
+    Exception exception = new RestServiceException("PUT is not supported. Allowed methods are: GET, POST, HEAD, DELETE", RestServiceErrorCode.UnsupportedHttpMethod);
     handleResponse(restRequest, restResponseChannel, null, exception);
   }
 

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -211,7 +211,7 @@ class AmbryBlobStorageService implements BlobStorageService {
   public void handlePut(RestRequest restRequest, RestResponseChannel restResponseChannel) {
     handlePrechecks(restRequest, restResponseChannel);
     Exception exception =
-        isUp ? new RestServiceException("PUT is not supported", RestServiceErrorCode.UnsupportedHttpMethod)
+        isUp ? new RestServiceException("PUT is not supported. Allowed methods are: GET, POST, HEAD, DELETE", RestServiceErrorCode.UnsupportedHttpMethod)
             : new RestServiceException("AmbryBlobStorageService unavailable", RestServiceErrorCode.ServiceUnavailable);
     submitResponse(restRequest, restResponseChannel, null, exception);
   }


### PR DESCRIPTION
Added MethodNotAllowed Response Code mapped to the UnsupportedHttpMethod response error code. References to https://github.com/linkedin/ambry/issues/398