### PR TITLE
Fix a test failure

### DIFF
--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -57,7 +57,6 @@ import org.junit.Test;
  * Class to test the {@link NonBlockingRouter}
  */
 public class NonBlockingRouterTest {
-
   private static final int MAX_PORTS_PLAIN_TEXT = 3;
   private static final int MAX_PORTS_SSL = 3;
   private static final int CHECKOUT_TIMEOUT_MS = 1000;


### PR DESCRIPTION
Account for the `BackgroundDeleter`'s `RequestResponseHandler` to exit in a test.
Fixes linkedin/ambry#663