### PR TITLE
Fix an incorrect assumption made by Helix Cluster Manager

### DIFF
--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -283,7 +283,8 @@ public class HelixClusterManagerTest {
 
   /**
    * Test that the changes to the sealed states of replicas get reflected correctly in the cluster manager.
-   * This also tests multiple InstanceConfig change callbacks and that they are dealt with correctly.
+   * This also tests multiple InstanceConfig change callbacks (including multiple such callbacks tagged with
+   * {@link NotficationContext.INIT} and that they are dealt with correctly.
    */
   @Test
   public void sealedReplicaChangeTest() throws Exception {
@@ -296,22 +297,22 @@ public class HelixClusterManagerTest {
 
     AmbryPartition partition = (AmbryPartition) clusterManager.getWritablePartitionIds().get(0);
     List<String> instances = helixCluster.getInstancesForPartition((partition.toPathString()));
-    helixCluster.setReplicaSealedState(partition, instances.get(0), true);
+    helixCluster.setReplicaSealedState(partition, instances.get(0), true, false);
     assertFalse("If any one replica is SEALED, the whole partition should be SEALED",
         clusterManager.getWritablePartitionIds().contains(partition));
     assertEquals("If any one replica is SEALED, the whole partition should be SEALED", PartitionState.READ_ONLY,
         partition.getPartitionState());
-    helixCluster.setReplicaSealedState(partition, instances.get(1), true);
+    helixCluster.setReplicaSealedState(partition, instances.get(1), true, true);
     assertFalse("If any one replica is SEALED, the whole partition should be SEALED",
         clusterManager.getWritablePartitionIds().contains(partition));
     assertEquals("If any one replica is SEALED, the whole partition should be SEALED", PartitionState.READ_ONLY,
         partition.getPartitionState());
-    helixCluster.setReplicaSealedState(partition, instances.get(1), false);
+    helixCluster.setReplicaSealedState(partition, instances.get(1), false, true);
     assertFalse("If any one replica is SEALED, the whole partition should be SEALED",
         clusterManager.getWritablePartitionIds().contains(partition));
     assertEquals("If any one replica is SEALED, the whole partition should be SEALED", PartitionState.READ_ONLY,
         partition.getPartitionState());
-    helixCluster.setReplicaSealedState(partition, instances.get(0), false);
+    helixCluster.setReplicaSealedState(partition, instances.get(0), false, false);
     // At this point all replicas have been marked READ_WRITE. Now, the entire partition should be READ_WRITE.
     assertTrue("If no replica is SEALED, the whole partition should be Writable",
         clusterManager.getWritablePartitionIds().contains(partition));

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -283,8 +283,8 @@ public class HelixClusterManagerTest {
 
   /**
    * Test that the changes to the sealed states of replicas get reflected correctly in the cluster manager.
-   * This also tests multiple InstanceConfig change callbacks (including multiple such callbacks tagged with
-   * {@link NotficationContext.INIT} and that they are dealt with correctly.
+   * This also tests multiple InstanceConfig change callbacks (including multiple such callbacks tagged as
+   * {@link org.apache.helix.NotificationContext.Type#INIT} and that they are dealt with correctly.
    */
   @Test
   public void sealedReplicaChangeTest() throws Exception {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -283,6 +283,7 @@ public class HelixClusterManagerTest {
 
   /**
    * Test that the changes to the sealed states of replicas get reflected correctly in the cluster manager.
+   * This also tests multiple InstanceConfig change callbacks and that they are dealt with correctly.
    */
   @Test
   public void sealedReplicaChangeTest() throws Exception {
@@ -316,6 +317,7 @@ public class HelixClusterManagerTest {
         clusterManager.getWritablePartitionIds().contains(partition));
     assertEquals("If no replica is SEALED, the whole partition should be Writable", PartitionState.READ_WRITE,
         partition.getPartitionState());
+    assertStateEquivalency();
   }
 
   /**
@@ -511,9 +513,11 @@ public class HelixClusterManagerTest {
     Set<String> downInstancesInClusterManager = new HashSet<>();
     for (DataNodeId dataNode : clusterManager.getDataNodeIds()) {
       if (dataNode.getState() == HardwareState.UNAVAILABLE) {
-        downInstancesInClusterManager.add(ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort()));
+        assertTrue("Datanode should not be a duplicate", downInstancesInClusterManager.add(
+            ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort())));
       } else {
-        upInstancesInClusterManager.add(ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort()));
+        assertTrue("Datanode should not be a duplicate", upInstancesInClusterManager.add(
+            ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort())));
       }
     }
     assertEquals(downInstancesInCluster, downInstancesInClusterManager);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
@@ -137,8 +137,10 @@ public class MockHelixAdmin implements HelixAdmin {
    * @param partition the {@link AmbryPartition}
    * @param instance the instance name.
    * @param isSealed if true, the replica will be marked as sealed; otherwise it will be marked as read-write.
+   * @param tagAsInit whether the InstanceConfig notification should be tagged with
+   *                  {@link org.apache.helix.NotificationContext.Type#INIT}
    */
-  void setReplicaSealedState(AmbryPartition partition, String instance, boolean isSealed) {
+  void setReplicaSealedState(AmbryPartition partition, String instance, boolean isSealed, boolean tagAsInit) {
     InstanceConfig instanceConfig = getInstanceConfig(clusterName, instance);
     List<String> sealedReplicas = ClusterMapUtils.getSealedReplicas(instanceConfig);
     if (isSealed) {
@@ -147,7 +149,7 @@ public class MockHelixAdmin implements HelixAdmin {
       sealedReplicas.remove(partition.toPathString());
     }
     instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, sealedReplicas);
-    triggerInstanceConfigChangeNotification();
+    triggerInstanceConfigChangeNotification(tagAsInit);
   }
 
   /**
@@ -222,10 +224,12 @@ public class MockHelixAdmin implements HelixAdmin {
 
   /**
    * Trigger an instance config change notification.
+   * @param tagAsInit whether the InstanceConfig notification should be tagged with
+   *                  {@link org.apache.helix.NotificationContext.Type#INIT}
    */
-  private void triggerInstanceConfigChangeNotification() {
+  private void triggerInstanceConfigChangeNotification(boolean tagAsInit) {
     for (MockHelixManager helixManager : helixManagersForThisAdmin) {
-      helixManager.triggerConfigChangeNotification(false);
+      helixManager.triggerConfigChangeNotification(tagAsInit);
     }
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -67,10 +67,18 @@ public class MockHelixCluster {
     return helixAdmins.keySet();
   }
 
-  void setReplicaSealedState(AmbryPartition partition, String instance, boolean isSealed) {
+  /**
+   * Set or reset the replica state for the given partition on the given instance.
+   * @param partition the partition whose replica needs the state change.
+   * @param instance the instance hosting the replica.
+   * @param isSealed whether to set or reset the state.
+   * @param tagAsInit whether the InstanceConfig notification should be tagged with
+   *                  {@link org.apache.helix.NotificationContext.Type#INIT}
+   */
+  void setReplicaSealedState(AmbryPartition partition, String instance, boolean isSealed, boolean tagAsInit) {
     for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
       if (helixAdmin.getInstancesInCluster(clusterName).contains(instance)) {
-        helixAdmin.setReplicaSealedState(partition, instance, isSealed);
+        helixAdmin.setReplicaSealedState(partition, instance, isSealed, tagAsInit);
       }
     }
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
@@ -143,21 +143,21 @@ class MockHelixManager implements HelixManager {
   /**
    * Trigger a live instance change notification.
    */
-  void triggerLiveInstanceNotification(boolean initial) {
+  void triggerLiveInstanceNotification(boolean init) {
     List<LiveInstance> liveInstances = new ArrayList<>();
     for (String instance : mockAdmin.getUpInstances()) {
       liveInstances.add(new LiveInstance(instance));
     }
     NotificationContext notificationContext = new NotificationContext(this);
-    if (initial) {
+    if (init) {
       notificationContext.setType(NotificationContext.Type.INIT);
     }
     liveInstanceChangeListener.onLiveInstanceChange(liveInstances, notificationContext);
   }
 
-  void triggerConfigChangeNotification(boolean initial) {
+  void triggerConfigChangeNotification(boolean init) {
     NotificationContext notificationContext = new NotificationContext(this);
-    if (initial) {
+    if (init) {
       notificationContext.setType(NotificationContext.Type.INIT);
     }
     instanceConfigChangeListener.onInstanceConfigChange(mockAdmin.getInstanceConfigs(clusterName), notificationContext);

--- a/config/frontend_helix.properties
+++ b/config/frontend_helix.properties
@@ -21,7 +21,7 @@ router.delete.success.target=1
 
 #clustermap
 clustermap.host.name=localhost
-clustermap.cluster.name=Ambry_Proto
+clustermap.cluster.name=Ambry-Proto
 clustermap.datacenter.name=dc1
 clustermap.clusteragents.factory=com.github.ambry.clustermap.HelixClusterAgentsFactory
 clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", "zkConnectStr":"localhost:2300", } ] }

--- a/config/zkLayout.json
+++ b/config/zkLayout.json
@@ -2,11 +2,11 @@
   "zkInfo" : [
      {
        "datacenter":"dc1",
-       "zkConnectStr":"localhost:2199",
+       "zkConnectStr":"localhost:2199"
      },
      {
        "datacenter":"dc2",
-       "zkConnectStr":"localhost:2300",
+       "zkConnectStr":"localhost:2300"
      }
   ]
 }


### PR DESCRIPTION
Helix Cluster Manager makes an assumption that callbacks
from ZK that are tagged as INIT by Helix client are received only
once - at the time of the initial registration. This turned
out to be false, as INIT callbacks get triggered on reconnections
when connections with ZK get dropped.