### PR TITLE
Removing issuer/creator AccountId from BlobPropertiesV2

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -34,7 +34,6 @@ public class BlobProperties {
   private final long creationTimeInMs;
   private final short accountId;
   private final short containerId;
-  private final short creatorAccountId;
 
   /**
    * @param blobSize The size of the blob in bytes
@@ -50,11 +49,10 @@ public class BlobProperties {
    * @param serviceId The service id that is creating this blob
    * @param accountId accountId of the user who owns the blob
    * @param containerId containerId of the blob
-   * @param creatorAccountId refers to accountId of the creator of the blob
    */
-  public BlobProperties(long blobSize, String serviceId, short accountId, short containerId, short creatorAccountId) {
+  public BlobProperties(long blobSize, String serviceId, short accountId, short containerId) {
     this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, SystemTime.getInstance().milliseconds(),
-        accountId, containerId, creatorAccountId);
+        accountId, containerId);
   }
 
   /**
@@ -81,12 +79,11 @@ public class BlobProperties {
    * @param timeToLiveInSeconds The time to live, in seconds, relative to blob creation time.
    * @param accountId accountId of the user who owns the blob
    * @param containerId containerId of the blob
-   * @param creatorAccountId refers to accountId of the creator of the blob
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
-      long timeToLiveInSeconds, short accountId, short containerId, short creatorAccountId) {
+      long timeToLiveInSeconds, short accountId, short containerId) {
     this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
-        SystemTime.getInstance().milliseconds(), accountId, containerId, creatorAccountId);
+        SystemTime.getInstance().milliseconds(), accountId, containerId);
   }
 
   /**
@@ -102,7 +99,7 @@ public class BlobProperties {
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
       long timeToLiveInSeconds, long creationTimeInMs) {
     this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds, creationTimeInMs,
-        UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID, UNKNOWN_ACCOUNT_ID);
+        UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID);
   }
 
   /**
@@ -115,10 +112,9 @@ public class BlobProperties {
    * @param creationTimeInMs The time at which the blob is created.
    * @param accountId accountId of the user who owns the blob
    * @param containerId containerId of the blob
-   * @param creatorAccountId refers to accountId of the creator of the blob
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
-      long timeToLiveInSeconds, long creationTimeInMs, short accountId, short containerId, short creatorAccountId) {
+      long timeToLiveInSeconds, long creationTimeInMs, short accountId, short containerId) {
     this.blobSize = blobSize;
     this.serviceId = serviceId;
     this.ownerId = ownerId;
@@ -128,7 +124,6 @@ public class BlobProperties {
     this.timeToLiveInSeconds = timeToLiveInSeconds;
     this.accountId = accountId;
     this.containerId = containerId;
-    this.creatorAccountId = creatorAccountId;
   }
 
   public long getTimeToLiveInSeconds() {
@@ -151,6 +146,10 @@ public class BlobProperties {
     return contentType;
   }
 
+  /**
+   * ServiceId of the uploader of the blob
+   * @return the serviceId of the uploader of the blob
+   */
   public String getServiceId() {
     return serviceId;
   }
@@ -165,10 +164,6 @@ public class BlobProperties {
 
   public short getContainerId() {
     return containerId;
-  }
-
-  public short getCreatorAccountId() {
-    return creatorAccountId;
   }
 
   @Override
@@ -200,7 +195,6 @@ public class BlobProperties {
     }
     sb.append(", ").append("AccountId=").append(getAccountId());
     sb.append(", ").append("ContainerId=").append(getContainerId());
-    sb.append(", ").append("CreatorAccountId=").append(getCreatorAccountId());
     sb.append("]");
     return sb.toString();
   }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
@@ -59,10 +59,9 @@ public class BlobPropertiesSerDe {
       case Version2:
         short accountId = stream.readShort();
         short containerId = stream.readShort();
-        short issuerAccountId = stream.readShort();
         toReturn =
             new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, ttl, creationTime, accountId,
-                containerId, issuerAccountId);
+                containerId);
         break;
       default:
         throw new IllegalArgumentException("stream has unknown blob property version " + version);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -59,37 +59,34 @@ public class BlobPropertiesTest {
 
     short accountId = UNKNOWN_ACCOUNT_ID;
     short containerId = UNKNOWN_CONTAINER_ID;
-    short creatorAccountId = UNKNOWN_ACCOUNT_ID;
     if (version == BlobPropertiesSerDe.Version2) {
       accountId = Utils.getRandomShort(TestUtils.RANDOM);
       containerId = Utils.getRandomShort(TestUtils.RANDOM);
-      creatorAccountId = Utils.getRandomShort(TestUtils.RANDOM);
     }
 
-    BlobProperties blobProperties =
-        getBlobProperties(blobSize, serviceId, accountId, containerId, creatorAccountId, version);
+    BlobProperties blobProperties = getBlobProperties(blobSize, serviceId, accountId, containerId, version);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
     verifyBlobProperties(blobProperties, blobSize, serviceId, null, null, false, Utils.Infinite_Time, accountId,
-        containerId, creatorAccountId);
+        containerId);
     assertTrue(blobProperties.getCreationTimeInMs() > 0);
     assertTrue(blobProperties.getCreationTimeInMs() <= System.currentTimeMillis());
 
     blobProperties =
         getBlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds, accountId, containerId,
-            creatorAccountId, version);
+            version);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
     verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds,
-        accountId, containerId, creatorAccountId);
+        accountId, containerId);
     assertTrue(blobProperties.getCreationTimeInMs() > 0);
     assertTrue(blobProperties.getCreationTimeInMs() <= System.currentTimeMillis());
 
     long creationTimeMs = SystemTime.getInstance().milliseconds();
     blobProperties =
         getBlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds, creationTimeMs,
-            accountId, containerId, creatorAccountId, version);
+            accountId, containerId, version);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
     verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds,
-        accountId, containerId, creatorAccountId);
+        accountId, containerId);
     assertEquals(blobProperties.getCreationTimeInMs(), creationTimeMs);
 
     long creationTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(creationTimeMs);
@@ -105,9 +102,9 @@ public class BlobPropertiesTest {
     for (long ttl : validTTLs) {
       blobProperties =
           getBlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs, accountId,
-              containerId, creatorAccountId, version);
-      verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, ttl, accountId, containerId,
-          creatorAccountId);
+              containerId, version);
+      verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, ttl, accountId,
+          containerId);
     }
   }
 
@@ -122,19 +119,18 @@ public class BlobPropertiesTest {
    * @param creationTimeMs creation time of the blob in ms
    * @param accountId accountId of the user who uploaded the blob
    * @param containerId containerId of the blob
-   * @param creatorAccountId Issuer AccountId of the put request
    * @param version the version in which {@link BlobProperties} needs to be created
    * @return the {@link BlobProperties} thus created
    */
   private BlobProperties getBlobProperties(long blobSize, String serviceId, String ownerId, String contentType,
       boolean isPrivate, long timeToLiveInSeconds, long creationTimeMs, short accountId, short containerId,
-      short creatorAccountId, short version) {
+      short version) {
     if (version == BlobPropertiesSerDe.Version1) {
       return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
           creationTimeMs);
     } else {
       return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
-          creationTimeMs, accountId, containerId, creatorAccountId);
+          creationTimeMs, accountId, containerId);
     }
   }
 
@@ -148,18 +144,16 @@ public class BlobPropertiesTest {
    * @param timeToLiveInSeconds the time to live associated with the {@link BlobProperties} in secs
    * @param accountId accountId of the user who uploaded the blob
    * @param containerId containerId of the blob
-   * @param creatorAccountId Issuer AccountId of the put request
    * @param version the version in which {@link BlobProperties} needs to be created
    * @return the {@link BlobProperties} thus created
    */
   private BlobProperties getBlobProperties(long blobSize, String serviceId, String ownerId, String contentType,
-      boolean isPrivate, long timeToLiveInSeconds, short accountId, short containerId, short creatorAccountId,
-      short version) {
+      boolean isPrivate, long timeToLiveInSeconds, short accountId, short containerId, short version) {
     if (version == BlobPropertiesSerDe.Version1) {
       return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds);
     } else {
       return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds, accountId,
-          containerId, creatorAccountId);
+          containerId);
     }
   }
 
@@ -169,16 +163,15 @@ public class BlobPropertiesTest {
    * @param serviceId the serviceId associated with the {@link BlobProperties}
    * @param accountId accountId of the user who uploaded the blob
    * @param containerId containerId of the blob
-   * @param creatorAccountId Issuer AccountId of the put request
    * @param version the version in which {@link BlobProperties} needs to be created
    * @return the {@link BlobProperties} thus created
    */
   private BlobProperties getBlobProperties(long blobSize, String serviceId, short accountId, short containerId,
-      short creatorAccountId, short version) {
+      short version) {
     if (version == BlobPropertiesSerDe.Version1) {
       return new BlobProperties(blobSize, serviceId);
     } else {
-      return new BlobProperties(blobSize, serviceId, accountId, containerId, creatorAccountId);
+      return new BlobProperties(blobSize, serviceId, accountId, containerId);
     }
   }
 
@@ -193,11 +186,9 @@ public class BlobPropertiesTest {
    * @param ttlInSecs the time to live associated with the {@link BlobProperties} in secs
    * @param accountId accountId of the user who uploaded the blob
    * @param containerId containerId of the blob
-   * @param issuerAccountId Issuer AccountId of the put request
    */
   private void verifyBlobProperties(BlobProperties blobProperties, long blobSize, String serviceId, String ownerId,
-      String contentType, boolean isPrivate, long ttlInSecs, short accountId, short containerId,
-      short issuerAccountId) {
+      String contentType, boolean isPrivate, long ttlInSecs, short accountId, short containerId) {
     assertEquals(blobProperties.getBlobSize(), blobSize);
     assertEquals(blobProperties.getServiceId(), serviceId);
     assertEquals(blobProperties.getOwnerId(), ownerId);
@@ -206,6 +197,5 @@ public class BlobPropertiesTest {
     assertEquals(blobProperties.getTimeToLiveInSeconds(), ttlInSecs);
     assertEquals("AccountId mismatch ", accountId, blobProperties.getAccountId());
     assertEquals("ContainerId mismatch ", containerId, blobProperties.getContainerId());
-    assertEquals("IssuerAccountId mismatch ", issuerAccountId, blobProperties.getCreatorAccountId());
   }
 }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -135,9 +135,7 @@ public class MessageFormatRecordTest {
       } else {
         short accountId = Utils.getRandomShort(TestUtils.RANDOM);
         short containerId = Utils.getRandomShort(TestUtils.RANDOM);
-        short issuerAccountId = Utils.getRandomShort(TestUtils.RANDOM);
-        properties =
-            new BlobProperties(blobSize, "id", "member", "test", true, ttl, accountId, containerId, issuerAccountId);
+        properties = new BlobProperties(blobSize, "id", "member", "test", true, ttl, accountId, containerId);
       }
       ByteBuffer stream;
       if (version == Version1) {
@@ -156,7 +154,6 @@ public class MessageFormatRecordTest {
       Assert.assertEquals(properties.getServiceId(), result.getServiceId());
       Assert.assertEquals(properties.getAccountId(), result.getAccountId());
       Assert.assertEquals(properties.getContainerId(), result.getContainerId());
-      Assert.assertEquals(properties.getCreatorAccountId(), result.getCreatorAccountId());
 
       // corrupt blob property V1 record
       stream.flip();
@@ -193,7 +190,7 @@ public class MessageFormatRecordTest {
     int size = Version_Field_Size_In_Bytes + Long.BYTES + Byte.BYTES + Long.BYTES + Long.BYTES + Integer.BYTES
         + Utils.getNullableStringLength(properties.getContentType()) + Integer.BYTES + Utils.getNullableStringLength(
         properties.getOwnerId()) + Integer.BYTES + Utils.getNullableStringLength(properties.getServiceId())
-        + Short.BYTES + Short.BYTES + Short.BYTES;
+        + Short.BYTES + Short.BYTES;
     return Version_Field_Size_In_Bytes + size + Crc_Size;
   }
 
@@ -213,7 +210,6 @@ public class MessageFormatRecordTest {
     Utils.serializeNullableString(outputBuffer, properties.getServiceId());
     outputBuffer.putShort(properties.getAccountId());
     outputBuffer.putShort(properties.getContainerId());
-    outputBuffer.putShort(properties.getCreatorAccountId());
   }
 
   /**


### PR DESCRIPTION
An issuer of upload request need to necessarily belong to an account. So, an issuer is identified via serviceId of the request for any new uploads. Hence, removing the "creatorAccountId" field in latest BlobProperties version. 

SLA: 10 mins
Coding style applied