### PR TITLE
Introduces InMemoryUnknownAccountService

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
@@ -24,7 +24,8 @@ import java.util.Objects;
  * is in memory, and does not talk to any persistent storage service.
  */
 class InMemoryUnknownAccountService implements AccountService {
-  private static final Collection<Account> accounts = Collections.singletonList(Account.UNKNOWN_ACCOUNT);
+  private static final Collection<Account> accounts =
+      Collections.unmodifiableCollection(Collections.singletonList(Account.UNKNOWN_ACCOUNT));
   private volatile boolean isOpen = true;
 
   @Override
@@ -49,7 +50,7 @@ class InMemoryUnknownAccountService implements AccountService {
 
   @Override
   public Collection<Account> getAllAccounts() {
-    return Collections.unmodifiableCollection(accounts);
+    return accounts;
   }
 
   @Override

--- a/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
@@ -24,28 +24,20 @@ import java.util.Objects;
  * is in memory, and does not talk to any persistent storage service.
  */
 class InMemoryUnknownAccountService implements AccountService {
-  private static final Account unknownAccount = Account.UNKNOWN_ACCOUNT;
-  private static final Collection<Account> accounts = Collections.singletonList(unknownAccount);
-  private volatile boolean isOpen = false;
-
-  /**
-   * Constructor.
-   */
-  InMemoryUnknownAccountService() {
-    isOpen = true;
-  }
+  private static final Collection<Account> accounts = Collections.singletonList(Account.UNKNOWN_ACCOUNT);
+  private volatile boolean isOpen = true;
 
   @Override
   public Account getAccountById(short accountId) {
     checkOpen();
-    return unknownAccount;
+    return Account.UNKNOWN_ACCOUNT;
   }
 
   @Override
   public Account getAccountByName(String accountName) {
     checkOpen();
     Objects.requireNonNull(accountName, "accountName cannot be null.");
-    return unknownAccount;
+    return Account.UNKNOWN_ACCOUNT;
   }
 
   @Override
@@ -57,7 +49,7 @@ class InMemoryUnknownAccountService implements AccountService {
 
   @Override
   public Collection<Account> getAllAccounts() {
-    return accounts;
+    return Collections.unmodifiableCollection(accounts);
   }
 
   @Override

--- a/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.account;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+
+
+/**
+ * An implementation of {@link AccountService} that always has a single entry {@link Account#UNKNOWN_ACCOUNT}. Any
+ * queries to this account service will unconditionally return {@link Account#UNKNOWN_ACCOUNT}. This account service
+ * is in memory, and does not talk to any persistent storage service.
+ */
+class InMemoryUnknownAccountService implements AccountService {
+  private static final Account unknownAccount = Account.UNKNOWN_ACCOUNT;
+  private static final Collection<Account> accounts = Collections.singletonList(unknownAccount);
+  private volatile boolean isOpen = false;
+
+  /**
+   * Constructor.
+   */
+  InMemoryUnknownAccountService() {
+    isOpen = true;
+  }
+
+  @Override
+  public Account getAccountById(short accountId) {
+    checkOpen();
+    return unknownAccount;
+  }
+
+  @Override
+  public Account getAccountByName(String accountName) {
+    checkOpen();
+    Objects.requireNonNull(accountName, "accountName cannot be null.");
+    return unknownAccount;
+  }
+
+  @Override
+  public boolean updateAccounts(Collection<Account> accounts) {
+    checkOpen();
+    Objects.requireNonNull(accounts, "accounts cannot be null");
+    return false;
+  }
+
+  @Override
+  public Collection<Account> getAllAccounts() {
+    return accounts;
+  }
+
+  @Override
+  public void close() {
+    isOpen = false;
+  }
+
+  /**
+   * Checks if the service is open.
+   */
+  private void checkOpen() {
+    if (!isOpen) {
+      throw new IllegalStateException("AccountService is closed.");
+    }
+  }
+}

--- a/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountServiceFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.account;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.commons.Notifier;
+import com.github.ambry.config.VerifiableProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An {@link AccountServiceFactory} that returns an {@link InMemoryUnknownAccountService}.
+ */
+public class InMemoryUnknownAccountServiceFactory implements AccountServiceFactory {
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  /**
+   * Constructor.
+   * @param verifiableProperties The properties to get a {@link HelixAccountService} instance. Cannot be {@code null}.
+   * @param metricRegistry The {@link MetricRegistry} for metrics tracking. Cannot be {@code null}.
+   * @param notifier The {@link Notifier} used to get a {@link HelixAccountService}.
+   */
+  public InMemoryUnknownAccountServiceFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
+      Notifier<String> notifier) {
+  }
+
+  @Override
+  public AccountService getAccountService() {
+    logger.info("Starting an InMemoryUnknownAccountService.");
+    long startTime = System.currentTimeMillis();
+    AccountService res = new InMemoryUnknownAccountService();
+    logger.info("InMemoryUnknownAccountService started, took {} ms", System.currentTimeMillis() - startTime);
+    return res;
+  }
+}

--- a/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountServiceFactory.java
@@ -39,9 +39,6 @@ public class InMemoryUnknownAccountServiceFactory implements AccountServiceFacto
   @Override
   public AccountService getAccountService() {
     logger.info("Starting an InMemoryUnknownAccountService.");
-    long startTime = System.currentTimeMillis();
-    AccountService res = new InMemoryUnknownAccountService();
-    logger.info("InMemoryUnknownAccountService started, took {} ms", System.currentTimeMillis() - startTime);
-    return res;
+    return new InMemoryUnknownAccountService();
   }
 }

--- a/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.account;
+
+import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
+import java.util.Collections;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Unit tests for {@link InMemoryUnknownAccountService} and {@link InMemoryUnknownAccountServiceFactory}.
+ */
+public class InMemoryUnknownAccountServiceTest {
+  private static final Random random = new Random();
+  private AccountService accountService;
+
+  @After
+  public void close() throws Exception {
+    accountService.close();
+  }
+
+  @Test
+  public void testAllMethods() throws Exception {
+    accountService = new InMemoryUnknownAccountServiceFactory(null, null, null).getAccountService();
+    Account refAccount = new AccountBuilder((short) 1, "a", Account.AccountStatus.INACTIVE, null).build();
+    assertEquals("Wrong account", Account.UNKNOWN_ACCOUNT, accountService.getAccountById(Utils.getRandomShort(random)));
+    assertEquals("Wrong account", Account.UNKNOWN_ACCOUNT, accountService.getAccountById((short) -1));
+    assertEquals("Wrong account", Account.UNKNOWN_ACCOUNT,
+        accountService.getAccountByName(UtilsTest.getRandomString(10)));
+    assertEquals("Wrong size of account collection", 1, accountService.getAllAccounts().size());
+    assertFalse("Wrong return value from an unsuccessful update operation",
+        accountService.updateAccounts(Collections.singletonList(refAccount)));
+    assertEquals("Wrong size of account collection", 1, accountService.getAllAccounts().size());
+    accountService.close();
+  }
+
+  /**
+   * Tests {@code null} inputs.
+   */
+  @Test
+  public void testNullInputs() {
+    accountService = new InMemoryUnknownAccountServiceFactory(null, null, null).getAccountService();
+    try {
+      accountService.updateAccounts(null);
+      fail("should have thrown");
+    } catch (NullPointerException e) {
+      // expected
+    }
+    try {
+      accountService.getAccountByName(null);
+      fail("should have thrown");
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+}

--- a/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
@@ -38,14 +38,15 @@ public class InMemoryUnknownAccountServiceTest {
   @Test
   public void testAllMethods() throws Exception {
     accountService = new InMemoryUnknownAccountServiceFactory(null, null, null).getAccountService();
-    Account refAccount = new AccountBuilder((short) 1, "a", Account.AccountStatus.INACTIVE, null).build();
     assertEquals("Wrong account", Account.UNKNOWN_ACCOUNT, accountService.getAccountById(Utils.getRandomShort(random)));
     assertEquals("Wrong account", Account.UNKNOWN_ACCOUNT, accountService.getAccountById((short) -1));
     assertEquals("Wrong account", Account.UNKNOWN_ACCOUNT,
         accountService.getAccountByName(UtilsTest.getRandomString(10)));
     assertEquals("Wrong size of account collection", 1, accountService.getAllAccounts().size());
+    // updating the InMemoryUnknownAccountService should fail.
+    Account account = new AccountBuilder((short) 1, "a", Account.AccountStatus.INACTIVE, null).build();
     assertFalse("Wrong return value from an unsuccessful update operation",
-        accountService.updateAccounts(Collections.singletonList(refAccount)));
+        accountService.updateAccounts(Collections.singletonList(account)));
     assertEquals("Wrong size of account collection", 1, accountService.getAllAccounts().size());
     accountService.close();
   }

--- a/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
@@ -48,6 +48,12 @@ public class InMemoryUnknownAccountServiceTest {
     assertFalse("Wrong return value from an unsuccessful update operation",
         accountService.updateAccounts(Collections.singletonList(account)));
     assertEquals("Wrong size of account collection", 1, accountService.getAllAccounts().size());
+    try {
+      accountService.getAllAccounts().add(account);
+      fail("Should have thrown.");
+    } catch (UnsupportedOperationException e) {
+      // expected
+    }
     accountService.close();
   }
 


### PR DESCRIPTION
This `AccountService` implementation will be used temporarily before
actual accounts are created and before `HelixAccountService` is turned on.
It simply responds to all the queries with `UNKNOWN_ACCOUNT`.