### PR TITLE
Adding an API to disable requests selectively at storage server

### DIFF
--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDiskId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDiskId.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 public class MockDiskId implements DiskId {
   String mountPath;
   MockDataNodeId dataNode;
+  HardwareState state = HardwareState.AVAILABLE;
 
   public MockDiskId(MockDataNodeId dataNode, String mountPath) {
     this.mountPath = mountPath;
@@ -29,7 +30,7 @@ public class MockDiskId implements DiskId {
 
   @Override
   public HardwareState getState() {
-    return HardwareState.AVAILABLE;
+    return state;
   }
 
   @Override
@@ -38,11 +39,11 @@ public class MockDiskId implements DiskId {
   }
 
   public void onDiskError() {
-    /* no-op for now */
+    state = HardwareState.UNAVAILABLE;
   }
 
   public void onDiskOk() {
-    /* no-op for now */
+    state = HardwareState.AVAILABLE;
   }
 
   @Override

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
@@ -31,6 +31,6 @@ public enum ServerErrorCode {
   Disk_Unavailable,
   Partition_ReadOnly,
   Unknown_Error,
-  Temporarily_Unavailable,
+  Temporarily_Disabled,
   Bad_Request
 }

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
@@ -27,5 +27,7 @@ public enum ServerErrorCode {
   Partition_Unknown,
   Disk_Unavailable,
   Partition_ReadOnly,
-  Unknown_Error
+  Unknown_Error,
+  Temporarily_Unavailable,
+  Bad_Request
 }

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
@@ -15,6 +15,9 @@ package com.github.ambry.commons;
 
 /**
  * The error codes that the server returns on a failed request
+ * </p>
+ * The order of these enums should not be changed since their relative position goes into the serialized form of
+ * requests/responses
  */
 public enum ServerErrorCode {
   No_Error,

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequest.java
@@ -46,13 +46,13 @@ public class AdminRequest extends RequestOrResponse {
   public static AdminRequest readFrom(DataInputStream stream, ClusterMap clusterMap) throws IOException {
     Short versionId = stream.readShort();
     if (!versionId.equals(ADMIN_REQUEST_VERSION_V2)) {
-      throw new IllegalStateException("Unrecognized version for AdminRequest: " + ADMIN_REQUEST_VERSION_V2);
+      throw new IllegalStateException("Unrecognized versionId for AdminRequest: " + ADMIN_REQUEST_VERSION_V2);
     }
     int correlationId = stream.readInt();
     String clientId = Utils.readIntString(stream);
     AdminRequestOrResponseType type = AdminRequestOrResponseType.values()[stream.readShort()];
     PartitionId id = null;
-    if (stream.readByte() == 1){
+    if (stream.readByte() == 1) {
       id = clusterMap.getPartitionIdFromStream(stream);
     }
     return new AdminRequest(type, id, correlationId, clientId);
@@ -124,7 +124,7 @@ public class AdminRequest extends RequestOrResponse {
     writeHeader();
     bufferToSend.putShort((short) type.ordinal());
     bufferToSend.put(partitionId == null ? (byte) 0 : 1);
-    if (partitionId != null){
+    if (partitionId != null) {
       bufferToSend.put(partitionId.getBytes());
     }
   }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequest.java
@@ -46,7 +46,7 @@ public class AdminRequest extends RequestOrResponse {
   public static AdminRequest readFrom(DataInputStream stream, ClusterMap clusterMap) throws IOException {
     Short versionId = stream.readShort();
     if (!versionId.equals(ADMIN_REQUEST_VERSION_V2)) {
-      throw new IllegalStateException("Unrecognized versionId for AdminRequest: " + ADMIN_REQUEST_VERSION_V2);
+      throw new IllegalStateException("Unrecognized version for AdminRequest: " + versionId);
     }
     int correlationId = stream.readInt();
     String clientId = Utils.readIntString(stream);

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
@@ -15,8 +15,10 @@ package com.github.ambry.protocol;
 
 /**
  * Enum of types of administration requests/responses.
+ * </p>
+ * The order of these enums should not be changed since their relative position goes into the serialized form of
+ * requests/responses
  */
 public enum AdminRequestOrResponseType {
-  TriggerCompaction,
-  RequestControl
+  TriggerCompaction, RequestControl
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
@@ -17,5 +17,6 @@ package com.github.ambry.protocol;
  * Enum of types of administration requests/responses.
  */
 public enum AdminRequestOrResponseType {
-  TriggerCompaction
+  TriggerCompaction,
+  RequestControl
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestControlAdminRequest.java
@@ -38,7 +38,7 @@ public class RequestControlAdminRequest extends AdminRequest {
       throws IOException {
     Short versionId = stream.readShort();
     if (!versionId.equals(VERSION_V1)) {
-      throw new IllegalStateException("Unrecognized version for RequestControlAdminRequest: " + VERSION_V1);
+      throw new IllegalStateException("Unrecognized version for RequestControlAdminRequest: " + versionId);
     }
     RequestOrResponseType requestType = RequestOrResponseType.values()[stream.readShort()];
     boolean enable = stream.readByte() == 1;

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestControlAdminRequest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+/**
+ * An admin request used to control request behavior (enable/disable)
+ */
+public class RequestControlAdminRequest extends AdminRequest {
+  private static final short VERSION_V1 = 1;
+
+  private final RequestOrResponseType requestTypeToControl;
+  private final boolean enable;
+  private final long sizeInBytes;
+
+  /**
+   * Reads from a stream and constructs a {@link RequestControlAdminRequest}.
+   * @param stream the stream to read from
+   * @param adminRequest the {@link AdminRequest} that contains some necessary headers.
+   * @return
+   * @throws IOException
+   */
+  public static RequestControlAdminRequest readFrom(DataInputStream stream, AdminRequest adminRequest)
+      throws IOException {
+    Short versionId = stream.readShort();
+    if (!versionId.equals(VERSION_V1)) {
+      throw new IllegalStateException("Unrecognized version for RequestControlAdminRequest: " + VERSION_V1);
+    }
+    RequestOrResponseType requestType = RequestOrResponseType.values()[stream.readShort()];
+    boolean enable = stream.readByte() == 1;
+    return new RequestControlAdminRequest(requestType, enable, adminRequest);
+  }
+
+  /**
+   * Construct a RequestControlAdminRequest
+   * @param requestTypeToControl the {@link RequestOrResponseType} to control.
+   * @param enable enable/disable flag ({@code true} to enable).
+   * @param adminRequest the {@link AdminRequest} that contains common admin request releated information.
+   */
+  public RequestControlAdminRequest(RequestOrResponseType requestTypeToControl, boolean enable,
+      AdminRequest adminRequest) {
+    super(AdminRequestOrResponseType.RequestControl, adminRequest.getPartitionId(), adminRequest.getCorrelationId(),
+        adminRequest.getClientId());
+    this.requestTypeToControl = requestTypeToControl;
+    this.enable = enable;
+    // parent size + version size + request type size + enable flag size
+    sizeInBytes = super.sizeInBytes() + Short.BYTES + Short.BYTES + Byte.BYTES;
+  }
+
+  /**
+   * @return the {@link RequestOrResponseType} to control.
+   */
+  public RequestOrResponseType getRequestTypeToControl() {
+    return requestTypeToControl;
+  }
+
+  /**
+   * @return if {@link #getRequestTypeToControl()} needs to enabled ({@code true}) or disabled ({@code false}).
+   */
+  public boolean shouldEnable() {
+    return enable;
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return sizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    return "RequestControlAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId
+        + ", RequestTypeToControl=" + requestTypeToControl + ", PartitionId=" + getPartitionId() + "]";
+  }
+
+  @Override
+  protected void serializeIntoBuffer() {
+    super.serializeIntoBuffer();
+    bufferToSend.putShort(VERSION_V1);
+    bufferToSend.putShort((short) requestTypeToControl.ordinal());
+    bufferToSend.put(enable ? (byte) 1 : 0);
+  }
+}

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestControlAdminRequest.java
@@ -31,7 +31,7 @@ public class RequestControlAdminRequest extends AdminRequest {
    * Reads from a stream and constructs a {@link RequestControlAdminRequest}.
    * @param stream the stream to read from
    * @param adminRequest the {@link AdminRequest} that contains some necessary headers.
-   * @return
+   * @return the {@link RequestControlAdminRequest} constructed from the {@code stream}.
    * @throws IOException
    */
   public static RequestControlAdminRequest readFrom(DataInputStream stream, AdminRequest adminRequest)

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -589,18 +589,21 @@ public class AmbryRequests implements RequestAPI {
             metrics.badRequestError.inc();
             error = ServerErrorCode.Bad_Request;
           } else {
+            error = ServerErrorCode.No_Error;
             List<? extends PartitionId> partitionIds;
             if (controlRequest.getPartitionId() != null) {
+              error = validateRequest(controlRequest.getPartitionId(), RequestOrResponseType.AdminRequest);
               partitionIds = Collections.singletonList(controlRequest.getPartitionId());
             } else {
               partitionIds = clusterMap.getAllPartitionIds();
             }
-            controlRequestForPartitions(toControl, partitionIds, controlRequest.shouldEnable());
-            for (PartitionId partitionId : partitionIds) {
-              logger.info("Enable state for {} on {} is {}", toControl, partitionId,
-                  isRequestEnabled(toControl, partitionId));
+            if (!error.equals(ServerErrorCode.Partition_Unknown)) {
+              controlRequestForPartitions(toControl, partitionIds, controlRequest.shouldEnable());
+              for (PartitionId partitionId : partitionIds) {
+                logger.info("Enable state for {} on {} is {}", toControl, partitionId,
+                    isRequestEnabled(toControl, partitionId));
+              }
             }
-            error = ServerErrorCode.No_Error;
           }
           break;
       }

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -529,6 +529,7 @@ public class AmbryRequests implements RequestAPI {
    * Enables/disables {@code requestOrResponseType} on the given {@code id}.
    * @param requestType the {@link RequestOrResponseType} to enable/disable.
    * @param id the {@link PartitionId} to enable/disable it on.
+   * @param enable whether to enable ({@code true}) or disable
    */
   private void controlRequestForPartition(RequestOrResponseType requestType, PartitionId id, boolean enable) {
     if (enable) {

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -555,7 +555,7 @@ public class AmbryRequests implements RequestAPI {
     Histogram processingTimeHistogram = null;
     Histogram responseQueueTimeHistogram = null;
     Histogram responseSendTimeHistogram = null;
-    Histogram responseTotalTimeHistogram = null;
+    Histogram requestTotalTimeHistogram = null;
     AdminResponse response = null;
     ServerErrorCode error = ServerErrorCode.Unknown_Error;
     try {
@@ -566,7 +566,7 @@ public class AmbryRequests implements RequestAPI {
           processingTimeHistogram = metrics.triggerCompactionResponseQueueTimeInMs;
           responseQueueTimeHistogram = metrics.triggerCompactionResponseQueueTimeInMs;
           responseSendTimeHistogram = metrics.triggerCompactionResponseSendTimeInMs;
-          responseTotalTimeHistogram = metrics.triggerCompactionRequestTotalTimeInMs;
+          requestTotalTimeHistogram = metrics.triggerCompactionRequestTotalTimeInMs;
           error = validateRequest(adminRequest.getPartitionId(), RequestOrResponseType.AdminRequest);
           if (error != ServerErrorCode.No_Error) {
             logger.error("Validating trigger compaction request failed with error {} for {}", error, adminRequest);
@@ -582,7 +582,7 @@ public class AmbryRequests implements RequestAPI {
           processingTimeHistogram = metrics.requestControlResponseQueueTimeInMs;
           responseQueueTimeHistogram = metrics.requestControlResponseQueueTimeInMs;
           responseSendTimeHistogram = metrics.requestControlResponseSendTimeInMs;
-          responseTotalTimeHistogram = metrics.requestControlRequestTotalTimeInMs;
+          requestTotalTimeHistogram = metrics.requestControlRequestTotalTimeInMs;
           RequestControlAdminRequest controlRequest = RequestControlAdminRequest.readFrom(requestStream, adminRequest);
           RequestOrResponseType toControl = controlRequest.getRequestTypeToControl();
           if (!requestsDisableInfo.containsKey(toControl)) {
@@ -618,7 +618,7 @@ public class AmbryRequests implements RequestAPI {
     }
     requestResponseChannel.sendResponse(response, request,
         new ServerNetworkResponseMetrics(responseQueueTimeHistogram, responseSendTimeHistogram,
-            responseTotalTimeHistogram, null, null, totalTimeSpent));
+            requestTotalTimeHistogram, null, null, totalTimeSpent));
   }
 
   private void sendPutResponse(RequestResponseChannel requestResponseChannel, PutResponse response, Request request,

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -74,11 +74,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +100,8 @@ public class AmbryRequests implements RequestAPI {
   private final NotificationSystem notification;
   private final ReplicationManager replicationManager;
   private final StoreKeyFactory storeKeyFactory;
-  private final Map<RequestOrResponseType, Set<PartitionId>> requestsDisableInfo = new HashMap<>();
+  private final ConcurrentHashMap<RequestOrResponseType, Set<PartitionId>> requestsDisableInfo =
+      new ConcurrentHashMap<>();
 
   public AmbryRequests(StorageManager storageManager, RequestResponseChannel requestResponseChannel,
       ClusterMap clusterMap, DataNodeId nodeId, MetricRegistry registry, FindTokenFactory findTokenFactory,
@@ -119,10 +118,11 @@ public class AmbryRequests implements RequestAPI {
     this.replicationManager = replicationManager;
     this.storeKeyFactory = storeKeyFactory;
 
-    requestsDisableInfo.put(RequestOrResponseType.PutRequest, new HashSet<>());
-    requestsDisableInfo.put(RequestOrResponseType.GetRequest, new HashSet<>());
-    requestsDisableInfo.put(RequestOrResponseType.DeleteRequest, new HashSet<>());
-    requestsDisableInfo.put(RequestOrResponseType.ReplicaMetadataRequest, new HashSet<>());
+    requestsDisableInfo.put(RequestOrResponseType.PutRequest, Collections.newSetFromMap(new ConcurrentHashMap<>()));
+    requestsDisableInfo.put(RequestOrResponseType.GetRequest, Collections.newSetFromMap(new ConcurrentHashMap<>()));
+    requestsDisableInfo.put(RequestOrResponseType.DeleteRequest, Collections.newSetFromMap(new ConcurrentHashMap<>()));
+    requestsDisableInfo.put(RequestOrResponseType.ReplicaMetadataRequest,
+        Collections.newSetFromMap(new ConcurrentHashMap<>()));
   }
 
   public void handleRequests(Request request) throws InterruptedException {

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -757,7 +757,7 @@ public class AmbryRequests implements RequestAPI {
     // 5. Ensure that the request is enabled.
     if (!isRequestEnabled(requestType, partition)) {
       metrics.temporarilyUnavailableError.inc();
-      return ServerErrorCode.Temporarily_Unavailable;
+      return ServerErrorCode.Temporarily_Disabled;
     }
     return ServerErrorCode.No_Error;
   }

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -526,16 +526,17 @@ public class AmbryRequests implements RequestAPI {
   }
 
   /**
-   * Enables/disables {@code requestOrResponseType} on the given {@code id}.
+   * Enables/disables {@code requestOrResponseType} on the given {@code ids}.
    * @param requestType the {@link RequestOrResponseType} to enable/disable.
-   * @param id the {@link PartitionId} to enable/disable it on.
+   * @param ids the {@link PartitionId}s to enable/disable it on.
    * @param enable whether to enable ({@code true}) or disable
    */
-  private void controlRequestForPartition(RequestOrResponseType requestType, PartitionId id, boolean enable) {
+  private void controlRequestForPartitions(RequestOrResponseType requestType, List<? extends PartitionId> ids,
+      boolean enable) {
     if (enable) {
-      requestsDisableInfo.get(requestType).remove(id);
+      requestsDisableInfo.get(requestType).removeAll(ids);
     } else {
-      requestsDisableInfo.get(requestType).add(id);
+      requestsDisableInfo.get(requestType).addAll(ids);
     }
   }
 
@@ -594,8 +595,8 @@ public class AmbryRequests implements RequestAPI {
             } else {
               partitionIds = clusterMap.getAllPartitionIds();
             }
+            controlRequestForPartitions(toControl, partitionIds, controlRequest.shouldEnable());
             for (PartitionId partitionId : partitionIds) {
-              controlRequestForPartition(toControl, partitionId, controlRequest.shouldEnable());
               logger.info("Enable state for {} on {} is {}", toControl, partitionId,
                   isRequestEnabled(toControl, partitionId));
             }

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -112,6 +112,12 @@ public class ServerMetrics {
   public final Histogram triggerCompactionResponseSendTimeInMs;
   public final Histogram triggerCompactionRequestTotalTimeInMs;
 
+  public final Histogram requestControlRequestQueueTimeInMs;
+  public final Histogram requestControlRequestProcessingTimeInMs;
+  public final Histogram requestControlResponseQueueTimeInMs;
+  public final Histogram requestControlResponseSendTimeInMs;
+  public final Histogram requestControlRequestTotalTimeInMs;
+
   public final Histogram blobSizeInBytes;
   public final Histogram blobUserMetadataSizeInBytes;
 
@@ -128,6 +134,7 @@ public class ServerMetrics {
   public final Meter ttlBlobRequestRate;
   public final Meter replicaMetadataRequestRate;
   public final Meter triggerCompactionRequestRate;
+  public final Meter requestControlRequestRate;
 
   public final Meter putSmallBlobRequestRate;
   public final Meter getSmallBlobRequestRate;
@@ -154,6 +161,8 @@ public class ServerMetrics {
   public final Counter idNotFoundError;
   public final Counter idDeletedError;
   public final Counter ttlExpiredError;
+  public final Counter badRequestError;
+  public final Counter temporarilyUnavailableError;
 
   public ServerMetrics(MetricRegistry registry) {
     putBlobRequestQueueTimeInMs =
@@ -281,6 +290,17 @@ public class ServerMetrics {
     triggerCompactionRequestTotalTimeInMs =
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestTotalTimeInMs"));
 
+    requestControlRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "RequestControlRequestQueueTimeInMs"));
+    requestControlRequestProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "RequestControlRequestProcessingTimeInMs"));
+    requestControlResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "RequestControlResponseQueueTimeInMs"));
+    requestControlResponseSendTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "RequestControlResponseSendTimeInMs"));
+    requestControlRequestTotalTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "RequestControlRequestTotalTimeInMs"));
+
     blobSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobSize"));
     blobUserMetadataSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobUserMetadataSize"));
 
@@ -300,6 +320,7 @@ public class ServerMetrics {
     replicaMetadataRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "ReplicaMetadataRequestRate"));
     triggerCompactionRequestRate =
         registry.meter(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestRate"));
+    requestControlRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "RequestControlRequestRate"));
 
     putSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "PutSmallBlobRequestRate"));
     getSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "GetSmallBlobRequestRate"));
@@ -320,6 +341,8 @@ public class ServerMetrics {
     idNotFoundError = registry.counter(MetricRegistry.name(AmbryRequests.class, "IDNotFoundError"));
     idDeletedError = registry.counter(MetricRegistry.name(AmbryRequests.class, "IDDeletedError"));
     ttlExpiredError = registry.counter(MetricRegistry.name(AmbryRequests.class, "TTLExpiredError"));
+    temporarilyUnavailableError = registry.counter(MetricRegistry.name(AmbryRequests.class, "TemporarilyUnavailableError"));
+    badRequestError = registry.counter(MetricRegistry.name(AmbryRequests.class, "BadRequestError"));
     unExpectedStorePutError = registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStorePutError"));
     unExpectedStoreGetError = registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStoreGetError"));
     unExpectedStoreDeleteError =

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -341,7 +341,8 @@ public class ServerMetrics {
     idNotFoundError = registry.counter(MetricRegistry.name(AmbryRequests.class, "IDNotFoundError"));
     idDeletedError = registry.counter(MetricRegistry.name(AmbryRequests.class, "IDDeletedError"));
     ttlExpiredError = registry.counter(MetricRegistry.name(AmbryRequests.class, "TTLExpiredError"));
-    temporarilyUnavailableError = registry.counter(MetricRegistry.name(AmbryRequests.class, "TemporarilyUnavailableError"));
+    temporarilyUnavailableError =
+        registry.counter(MetricRegistry.name(AmbryRequests.class, "TemporarilyUnavailableError"));
     badRequestError = registry.counter(MetricRegistry.name(AmbryRequests.class, "BadRequestError"));
     unExpectedStorePutError = registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStorePutError"));
     unExpectedStoreGetError = registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStoreGetError"));

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -14,11 +14,21 @@
 package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
+import com.github.ambry.clustermap.ClusterMapUtils;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ServerErrorCode;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.messageformat.BlobType;
+import com.github.ambry.messageformat.MessageFormatFlags;
 import com.github.ambry.network.Request;
 import com.github.ambry.network.Send;
 import com.github.ambry.network.ServerNetworkResponseMetrics;
@@ -26,8 +36,28 @@ import com.github.ambry.network.SocketRequestResponseChannel;
 import com.github.ambry.protocol.AdminRequest;
 import com.github.ambry.protocol.AdminRequestOrResponseType;
 import com.github.ambry.protocol.AdminResponse;
+import com.github.ambry.protocol.DeleteRequest;
+import com.github.ambry.protocol.GetOption;
+import com.github.ambry.protocol.GetRequest;
+import com.github.ambry.protocol.GetResponse;
+import com.github.ambry.protocol.PartitionRequestInfo;
+import com.github.ambry.protocol.PartitionResponseInfo;
+import com.github.ambry.protocol.PutRequest;
+import com.github.ambry.protocol.ReplicaMetadataRequest;
+import com.github.ambry.protocol.ReplicaMetadataRequestInfo;
+import com.github.ambry.protocol.ReplicaMetadataResponse;
+import com.github.ambry.protocol.ReplicaMetadataResponseInfo;
+import com.github.ambry.protocol.RequestControlAdminRequest;
+import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.protocol.RequestOrResponseType;
+import com.github.ambry.protocol.Response;
+import com.github.ambry.replication.MockFindTokenFactory;
+import com.github.ambry.replication.ReplicationException;
+import com.github.ambry.replication.ReplicationManager;
 import com.github.ambry.store.FindInfo;
 import com.github.ambry.store.FindToken;
+import com.github.ambry.store.FindTokenFactory;
+import com.github.ambry.store.MessageReadSet;
 import com.github.ambry.store.MessageWriteSet;
 import com.github.ambry.store.StorageManager;
 import com.github.ambry.store.Store;
@@ -35,16 +65,20 @@ import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreGetOptions;
 import com.github.ambry.store.StoreInfo;
 import com.github.ambry.store.StoreKey;
+import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.store.StoreStats;
 import com.github.ambry.utils.ByteBufferChannel;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -59,18 +93,38 @@ import static org.junit.Assert.*;
  * Tests for {@link AmbryRequests}.
  */
 public class AmbryRequestsTest {
+  private static final FindTokenFactory FIND_TOKEN_FACTORY = new MockFindTokenFactory();
 
   private final MockClusterMap clusterMap;
   private final MockStorageManager storageManager;
   private final MockRequestResponseChannel requestResponseChannel = new MockRequestResponseChannel();
   private final AmbryRequests ambryRequests;
 
-  public AmbryRequestsTest() throws IOException, StoreException {
+  public AmbryRequestsTest() throws IOException, ReplicationException, StoreException {
     clusterMap = new MockClusterMap();
     storageManager = new MockStorageManager();
+    Properties properties = new Properties();
+    properties.setProperty("clustermap.cluster.name", "test");
+    properties.setProperty("clustermap.datacenter.name", "DC1");
+    properties.setProperty("clustermap.host.name", "localhost");
+    properties.setProperty("replication.token.factory", "com.github.ambry.store.StoreFindTokenFactory");
+    properties.setProperty("replication.no.of.intra.dc.replica.threads", "0");
+    properties.setProperty("replication.no.of.inter.dc.replica.threads", "0");
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+    ReplicationConfig replicationConfig = new ReplicationConfig(verifiableProperties);
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    StoreConfig storeConfig = new StoreConfig(verifiableProperties);
+    DataNodeId dataNodeId = clusterMap.getDataNodeIds().get(0);
+    ReplicationManager replicationManager =
+        new ReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, new StoreKeyFactory() {
+          @Override
+          public StoreKey getStoreKey(DataInputStream stream) throws IOException {
+            return null;
+          }
+        }, clusterMap, null, dataNodeId, null, clusterMap.getMetricRegistry(), null);
     ambryRequests =
         new AmbryRequests(storageManager, requestResponseChannel, clusterMap, clusterMap.getDataNodeIds().get(0),
-            clusterMap.getMetricRegistry(), null, null, null, null);
+            clusterMap.getMetricRegistry(), FIND_TOKEN_FACTORY, null, replicationManager, null);
   }
 
   /**
@@ -114,7 +168,63 @@ public class AmbryRequestsTest {
     storageManager.exceptionToThrowOnSchedulingCompaction = null;
   }
 
+  /**
+   * Tests that {@link AdminRequestOrResponseType#RequestControl} works correctly.
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  @Test
+  public void controlRequestSuccessTest() throws InterruptedException, IOException {
+    RequestOrResponseType[] requestOrResponseTypes =
+        {RequestOrResponseType.PutRequest, RequestOrResponseType.DeleteRequest, RequestOrResponseType.GetRequest, RequestOrResponseType.ReplicaMetadataRequest};
+    for (RequestOrResponseType requestType : requestOrResponseTypes) {
+      List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+      for (PartitionId id : partitionIds) {
+        doControlRequestTest(requestType, id);
+      }
+      doControlRequestTest(requestType, null);
+    }
+  }
+
+  /**
+   * Tests that {@link AdminRequestOrResponseType#RequestControl} fails when bad input is provided (or when there is
+   * bad internal state).
+   */
+  @Test
+  public void controlRequestFailureTest() throws InterruptedException, IOException {
+    // cannot disable admin request
+    sendAndVerifyControlRequest(RequestOrResponseType.AdminRequest, false, null, ServerErrorCode.Bad_Request);
+  }
+
   // helpers
+
+  // general
+
+  /**
+   * Calls {@link AmbryRequests#handleRequests(Request)} with {@code request} and returns the {@link Response} received.
+   * @param request the {@link Request} to process
+   * @param expectedServerErrorCode the expected {@link ServerErrorCode} in the server response.
+   * @return the {@link Response} received.
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  private Response sendRequestGetResponse(RequestOrResponse request, ServerErrorCode expectedServerErrorCode)
+      throws InterruptedException, IOException {
+    Request mockRequest = MockRequest.fromRequest(request);
+    ambryRequests.handleRequests(mockRequest);
+    assertEquals("Request accompanying response does not match original request", mockRequest,
+        requestResponseChannel.lastOriginalRequest);
+    assertNotNull("Response not sent", requestResponseChannel.lastResponse);
+    Response response = (Response) requestResponseChannel.lastResponse;
+    assertNotNull("Response is not of type Response", response);
+    assertEquals("Correlation id in response does match the one in the request", request.getCorrelationId(),
+        response.getCorrelationId());
+    assertEquals("Client id in response does match the one in the request", request.getClientId(),
+        response.getClientId());
+    assertEquals("Error code does not match expected", expectedServerErrorCode, response.getError());
+    return response;
+  }
+
   // scheduleCompactionSuccessTest() and scheduleCompactionFailuresTest() helpers
 
   /**
@@ -131,17 +241,133 @@ public class AmbryRequestsTest {
     String clientId = UtilsTest.getRandomString(10);
     AdminRequest adminRequest =
         new AdminRequest(AdminRequestOrResponseType.TriggerCompaction, id, correlationId, clientId);
-    Request request = MockRequest.fromAdminRequest(adminRequest, true);
-    ambryRequests.handleRequests(request);
-    assertEquals("Request accompanying response does not match original request", request,
-        requestResponseChannel.lastOriginalRequest);
-    assertNotNull("Response not sent", requestResponseChannel.lastResponse);
-    assertTrue("Response is not of type AdminResponse", requestResponseChannel.lastResponse instanceof AdminResponse);
-    AdminResponse response = (AdminResponse) requestResponseChannel.lastResponse;
-    assertEquals("Correlation id in response does match the one in the request", correlationId,
-        response.getCorrelationId());
-    assertEquals("Client id in response does match the one in the request", clientId, response.getClientId());
-    assertEquals("Error code does not match expected", expectedServerErrorCode, response.getError());
+    Response response = sendRequestGetResponse(adminRequest, expectedServerErrorCode);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+  }
+
+  // controlRequestSuccessTest() and controlRequestFailureTest() helpers
+
+  /**
+   * Does the test for {@link AdminRequestOrResponseType#RequestControl} by checking that
+   * 1. The request that is being disabled works
+   * 2. The disabling of the request works
+   * 3. The request disabling has taken effect
+   * 4. The enabling of the request works
+   * 5. The re-enabled request works correctly
+   * @param toControl the {@link RequestOrResponseType} to control.
+   * @param id the {@link PartitionId} to disable {@code toControl} on. Can be {@code null}.
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  private void doControlRequestTest(RequestOrResponseType toControl, PartitionId id)
+      throws InterruptedException, IOException {
+    List<? extends PartitionId> idsToTest;
+    if (id == null) {
+      idsToTest = clusterMap.getAllPartitionIds();
+    } else {
+      idsToTest = Collections.singletonList(id);
+    }
+    // check that everything works
+    sendAndVerifyOperationRequest(toControl, idsToTest, ServerErrorCode.No_Error);
+    // disable the request
+    sendAndVerifyControlRequest(toControl, false, id, ServerErrorCode.No_Error);
+    // check that it is disabled
+    sendAndVerifyOperationRequest(toControl, idsToTest, ServerErrorCode.Temporarily_Unavailable);
+    // ok to call disable again
+    sendAndVerifyControlRequest(toControl, false, id, ServerErrorCode.No_Error);
+    // enable
+    sendAndVerifyControlRequest(toControl, true, id, ServerErrorCode.No_Error);
+    // check that everything works
+    sendAndVerifyOperationRequest(toControl, idsToTest, ServerErrorCode.No_Error);
+    // ok to call enable again
+    sendAndVerifyControlRequest(toControl, true, id, ServerErrorCode.No_Error);
+    // check that everything works
+    sendAndVerifyOperationRequest(toControl, idsToTest, ServerErrorCode.No_Error);
+  }
+
+  /**
+   * Sends and verifies that an operation specific request works correctly.
+   * @param requestType the type of the request to send.
+   * @param ids the partitionIds to send requests for.
+   * @param expectedErrorCode the {@link ServerErrorCode} expected in the response. For some requests this is the
+   *                          response in the constituents rather than the actual response ({@link GetResponse} and
+   *                          {@link ReplicaMetadataResponse}).
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  private void sendAndVerifyOperationRequest(RequestOrResponseType requestType, List<? extends PartitionId> ids,
+      ServerErrorCode expectedErrorCode) throws InterruptedException, IOException {
+    for (PartitionId id : ids) {
+      int correlationId = TestUtils.RANDOM.nextInt();
+      String clientId = UtilsTest.getRandomString(10);
+      BlobId blobId = new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID,
+          Container.UNKNOWN_CONTAINER_ID, id);
+      RequestOrResponse request;
+      switch (requestType) {
+        case PutRequest:
+          BlobProperties properties = new BlobProperties(0, "serviceId", blobId.getAccountId(), blobId.getAccountId());
+          request = new PutRequest(correlationId, clientId, blobId, properties, ByteBuffer.allocate(0),
+              ByteBuffer.allocate(0), 0, BlobType.DataBlob);
+          break;
+        case DeleteRequest:
+          request = new DeleteRequest(correlationId, clientId, blobId, SystemTime.getInstance().milliseconds());
+          break;
+        case GetRequest:
+          PartitionRequestInfo pRequestInfo = new PartitionRequestInfo(id, Collections.singletonList(blobId));
+          request =
+              new GetRequest(correlationId, clientId, MessageFormatFlags.All, Collections.singletonList(pRequestInfo),
+                  GetOption.Include_All);
+          break;
+        case ReplicaMetadataRequest:
+          ReplicaMetadataRequestInfo rRequestInfo =
+              new ReplicaMetadataRequestInfo(id, FIND_TOKEN_FACTORY.getNewFindToken(), "localhost", "/tmp");
+          request = new ReplicaMetadataRequest(correlationId, clientId, Collections.singletonList(rRequestInfo),
+              Long.MAX_VALUE);
+          break;
+        default:
+          throw new IllegalArgumentException(requestType + " not supported by this function");
+      }
+      storageManager.resetStore();
+      Response response = sendRequestGetResponse(request,
+          requestType == RequestOrResponseType.GetRequest || requestType == RequestOrResponseType.ReplicaMetadataRequest
+              ? ServerErrorCode.No_Error : expectedErrorCode);
+      if (expectedErrorCode.equals(ServerErrorCode.No_Error)) {
+        assertEquals("Operation received at the store not as expected", requestType,
+            MockStorageManager.operationReceived);
+      }
+      if (requestType == RequestOrResponseType.GetRequest) {
+        GetResponse getResponse = (GetResponse) response;
+        for (PartitionResponseInfo info : getResponse.getPartitionResponseInfoList()) {
+          assertEquals("Error code does not match expected", expectedErrorCode, info.getErrorCode());
+        }
+      } else if (requestType == RequestOrResponseType.ReplicaMetadataRequest) {
+        ReplicaMetadataResponse replicaMetadataResponse = (ReplicaMetadataResponse) response;
+        for (ReplicaMetadataResponseInfo info : replicaMetadataResponse.getReplicaMetadataResponseInfoList()) {
+          assertEquals("Error code does not match expected", expectedErrorCode, info.getError());
+        }
+      }
+    }
+  }
+
+  /**
+   * Sends and verifies that a {@link AdminRequestOrResponseType#RequestControl} request received the error code
+   * expected.
+   * @param toControl the {@link AdminRequestOrResponseType#RequestControl} to control.
+   * @param enable {@code true} if {@code toControl} needs to be enabled. {@code false} otherwise.
+   * @param id the {@link PartitionId} to send the request for. Can be {@code null}.
+   * @param expectedServerErrorCode the {@link ServerErrorCode} expected in the
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  private void sendAndVerifyControlRequest(RequestOrResponseType toControl, boolean enable, PartitionId id,
+      ServerErrorCode expectedServerErrorCode) throws InterruptedException, IOException {
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = UtilsTest.getRandomString(10);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.RequestControl, id, correlationId, clientId);
+    RequestControlAdminRequest controlRequest = new RequestControlAdminRequest(toControl, enable, adminRequest);
+    Response response = sendRequestGetResponse(controlRequest, expectedServerErrorCode);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
   }
 
   /**
@@ -152,21 +378,17 @@ public class AmbryRequestsTest {
     private final InputStream stream;
 
     /**
-     * Constructs a {@link MockRequest} from {@code adminRequest}.
-     * @param adminRequest the {@link AdminRequest} to construct the {@link MockRequest} for.
-     * @param prepareForHandling prepares for handling by {@link AmbryRequests#handleRequests(Request)} by reading
-     *                           some initial field(s).
-     * @return an instance of {@link MockRequest} that represents {@code adminRequest}.
+     * Constructs a {@link MockRequest} from {@code request}.
+     * @param request the {@link RequestOrResponse} to construct the {@link MockRequest} for.
+     * @return an instance of {@link MockRequest} that represents {@code request}.
      * @throws IOException
      */
-    static MockRequest fromAdminRequest(AdminRequest adminRequest, boolean prepareForHandling) throws IOException {
-      ByteBuffer buffer = ByteBuffer.allocate((int) adminRequest.sizeInBytes());
-      adminRequest.writeTo(new ByteBufferChannel(buffer));
+    static MockRequest fromRequest(RequestOrResponse request) throws IOException {
+      ByteBuffer buffer = ByteBuffer.allocate((int) request.sizeInBytes());
+      request.writeTo(new ByteBufferChannel(buffer));
       buffer.flip();
-      if (prepareForHandling) {
-        // read length
-        buffer.getLong();
-      }
+      // read length (to bring it to a state where AmbryRequests can handle it).
+      buffer.getLong();
       return new MockRequest(new ByteBufferInputStream(buffer));
     }
 
@@ -220,9 +442,15 @@ public class AmbryRequestsTest {
   private static class MockStorageManager extends StorageManager {
 
     /**
+     * The operation received at the store.
+     */
+    static RequestOrResponseType operationReceived = null;
+
+    /**
      * An empty {@link Store} implementation.
      */
     private static Store store = new Store() {
+
       @Override
       public void start() throws StoreException {
 
@@ -231,22 +459,45 @@ public class AmbryRequestsTest {
       @Override
       public StoreInfo get(List<? extends StoreKey> ids, EnumSet<StoreGetOptions> storeGetOptions)
           throws StoreException {
-        return null;
+        operationReceived = RequestOrResponseType.GetRequest;
+        return new StoreInfo(new MessageReadSet() {
+          @Override
+          public long writeTo(int index, WritableByteChannel channel, long relativeOffset, long maxSize)
+              throws IOException {
+            return 0;
+          }
+
+          @Override
+          public int count() {
+            return 0;
+          }
+
+          @Override
+          public long sizeInBytes(int index) {
+            return 0;
+          }
+
+          @Override
+          public StoreKey getKeyAt(int index) {
+            return null;
+          }
+        }, Collections.EMPTY_LIST);
       }
 
       @Override
       public void put(MessageWriteSet messageSetToWrite) throws StoreException {
-
+        operationReceived = RequestOrResponseType.PutRequest;
       }
 
       @Override
       public void delete(MessageWriteSet messageSetToDelete) throws StoreException {
-
+        operationReceived = RequestOrResponseType.DeleteRequest;
       }
 
       @Override
       public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries) throws StoreException {
-        return null;
+        operationReceived = RequestOrResponseType.ReplicaMetadataRequest;
+        return new FindInfo(Collections.EMPTY_LIST, FIND_TOKEN_FACTORY.getNewFindToken());
       }
 
       @Override
@@ -310,6 +561,10 @@ public class AmbryRequestsTest {
       }
       compactionScheduledPartitionId = id;
       return returnValueOfSchedulingCompaction;
+    }
+
+    void resetStore() {
+      operationReceived = null;
     }
   }
 }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -291,7 +291,7 @@ public class AmbryRequestsTest {
     // disable the request
     sendAndVerifyRequestControlRequest(toControl, false, id, ServerErrorCode.No_Error);
     // check that it is disabled
-    sendAndVerifyOperationRequest(toControl, idsToTest, ServerErrorCode.Temporarily_Unavailable);
+    sendAndVerifyOperationRequest(toControl, idsToTest, ServerErrorCode.Temporarily_Disabled);
     // ok to call disable again
     sendAndVerifyRequestControlRequest(toControl, false, id, ServerErrorCode.No_Error);
     // enable

--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,7 @@ project(':ambry-server') {
         testCompile project(':ambry-network').sourceSets.test.output
         testCompile project(':ambry-api').sourceSets.test.output
         testCompile project(':ambry-commons').sourceSets.test.output
+        testCompile project(':ambry-replication').sourceSets.test.output
         testCompile "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
     }
 }


### PR DESCRIPTION
This commit adds the support to disable a particular type of request on a specific partition. For example, `PutRequest` can be disabled on partition 0 while all other requests continue to function and `PutRequest`s to other partitions work as usual.

Built and formatted.