### PR TITLE
Generates meaningful blob ids in InMemory router

### DIFF
--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
@@ -45,7 +45,7 @@ public class AmbryBlobStorageServiceFactoryTest {
 
     AmbryBlobStorageServiceFactory ambryBlobStorageServiceFactory =
         new AmbryBlobStorageServiceFactory(verifiableProperties, new MockClusterMap(),
-            new MockRestRequestResponseHandler(), new InMemoryRouter(verifiableProperties));
+            new MockRestRequestResponseHandler(), new InMemoryRouter(verifiableProperties, new MockClusterMap()));
     BlobStorageService ambryBlobStorageService = ambryBlobStorageServiceFactory.getBlobStorageService();
     assertNotNull("No BlobStorageService returned", ambryBlobStorageService);
     assertEquals("Did not receive an AmbryBlobStorageService instance",
@@ -63,7 +63,7 @@ public class AmbryBlobStorageServiceFactoryTest {
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     ClusterMap clusterMap = new MockClusterMap();
     RestResponseHandler restResponseHandler = new MockRestRequestResponseHandler();
-    Router router = new InMemoryRouter(verifiableProperties);
+    Router router = new InMemoryRouter(verifiableProperties, clusterMap);
 
     // VerifiableProperties null.
     try {

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -118,9 +118,9 @@ public class AmbryBlobStorageServiceTest {
     frontendConfig = new FrontendConfig(verifiableProperties);
     idConverterFactory = new AmbryIdConverterFactory(verifiableProperties, metricRegistry);
     securityServiceFactory = new AmbrySecurityServiceFactory(verifiableProperties, metricRegistry);
-    router = new InMemoryRouter(verifiableProperties);
-    responseHandler = new FrontendTestResponseHandler();
     clusterMap = new MockClusterMap();
+    router = new InMemoryRouter(verifiableProperties, clusterMap);
+    responseHandler = new FrontendTestResponseHandler();
     ambryBlobStorageService = getAmbryBlobStorageService();
     responseHandler.start();
     ambryBlobStorageService.start();

--- a/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerFactoryTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerFactoryTest.java
@@ -14,9 +14,11 @@
 package com.github.ambry.rest;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.router.InMemoryRouter;
 import com.github.ambry.router.Router;
+import java.io.IOException;
 import java.util.Properties;
 import org.junit.Test;
 
@@ -35,10 +37,10 @@ public class AsyncRequestResponseHandlerFactoryTest {
    * @throws InstantiationException
    */
   @Test
-  public void getAsyncRequestResponseHandlerTest() throws InstantiationException {
+  public void getAsyncRequestResponseHandlerTest() throws InstantiationException, IOException {
     Properties properties = new Properties();
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
-    Router router = new InMemoryRouter(verifiableProperties);
+    Router router = new InMemoryRouter(verifiableProperties, new MockClusterMap());
 
     // Get response handler.
     AsyncRequestResponseHandlerFactory responseHandlerFactory =
@@ -70,9 +72,9 @@ public class AsyncRequestResponseHandlerFactoryTest {
    * Tests instantiation of {@link AsyncRequestResponseHandlerFactory} with bad input.
    */
   @Test
-  public void getFactoryTestWithBadInputTest() {
+  public void getFactoryTestWithBadInputTest() throws IOException {
     VerifiableProperties verifiableProperties = new VerifiableProperties(new Properties());
-    Router router = new InMemoryRouter(verifiableProperties);
+    Router router = new InMemoryRouter(verifiableProperties, new MockClusterMap());
     MockRestRequestResponseHandler restRequestResponseHandler = new MockRestRequestResponseHandler();
     BlobStorageService blobStorageService =
         new MockBlobStorageService(verifiableProperties, restRequestResponseHandler, router);

--- a/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/AsyncRequestResponseHandlerTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.rest;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.router.AsyncWritableChannel;
@@ -67,7 +68,7 @@ public class AsyncRequestResponseHandlerTest {
   @BeforeClass
   public static void startRequestResponseHandler() throws InstantiationException, IOException {
     verifiableProperties = new VerifiableProperties(new Properties());
-    router = new InMemoryRouter(verifiableProperties);
+    router = new InMemoryRouter(verifiableProperties, new MockClusterMap());
     asyncRequestResponseHandler = getAsyncRequestResponseHandler(5);
     blobStorageService.start();
     asyncRequestResponseHandler.start();

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.rest;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.config.NettyConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
@@ -83,7 +84,7 @@ public class NettyMessageProcessorTest {
   public NettyMessageProcessorTest() throws InstantiationException, IOException {
     VerifiableProperties verifiableProperties = new VerifiableProperties(new Properties());
     RestRequestMetricsTracker.setDefaults(new MetricRegistry());
-    router = new InMemoryRouter(verifiableProperties, notificationSystem);
+    router = new InMemoryRouter(verifiableProperties, notificationSystem, new MockClusterMap());
     requestHandler = new MockRestRequestResponseHandler();
     blobStorageService = new MockBlobStorageService(verifiableProperties, requestHandler, router);
     requestHandler.setBlobStorageService(blobStorageService);

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
@@ -226,6 +226,8 @@ public class InMemoryRouter implements Router {
       } else if (!deletedBlobs.contains(blobId)) {
         exception = new RouterException("Blob not found", RouterErrorCode.BlobDoesNotExist);
       }
+    } catch (RouterException e) {
+      exception = e;
     } catch (Exception e) {
       exception = new RouterException(e, RouterErrorCode.UnexpectedInternalError);
     } finally {
@@ -350,12 +352,10 @@ class InMemoryBlobPoster implements Runnable {
             NotificationBlobType.Simple);
       }
       operationResult = blobId;
+    } catch (RouterException e) {
+      exception = e;
     } catch (Exception e) {
-      if (e instanceof RouterException) {
-        exception = e;
-      } else {
-        exception = new RouterException(e, RouterErrorCode.UnexpectedInternalError);
-      }
+      exception = new RouterException(e, RouterErrorCode.UnexpectedInternalError);
     } finally {
       InMemoryRouter.completeOperation(postData.getFuture(), postData.getCallback(), operationResult, exception);
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouterFactory.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouterFactory.java
@@ -29,16 +29,18 @@ public class InMemoryRouterFactory implements RouterFactory {
 
   private final VerifiableProperties verifiableProperties;
   private final NotificationSystem notificationSystem;
+  private final ClusterMap clusterMap;
 
   public InMemoryRouterFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
       NotificationSystem notificationSystem, Object sslFactory) {
     this.verifiableProperties = verifiableProperties;
     this.notificationSystem = notificationSystem;
+    this.clusterMap = clusterMap;
   }
 
   @Override
   public Router getRouter() throws InstantiationException {
-    latestInstance = new InMemoryRouter(verifiableProperties, notificationSystem);
+    latestInstance = new InMemoryRouter(verifiableProperties, notificationSystem, clusterMap);
     return latestInstance;
   }
 


### PR DESCRIPTION
The InMemory router previously generates uuid as blob ids, which could
not be parsed for flag, dc id, account/container id, etc. This patch
makes the InMemory router to generate real blob ids.

This change is used for testing purpose so that ids can be
get/head/delete later.

Test:
./gradlew clean && ./gradlew build