### PR TITLE
Add postProcessRequest to SecurityService

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/account/ContainerBlobsResource.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/ContainerBlobsResource.java
@@ -22,14 +22,14 @@ public class ContainerBlobsResource implements AclService.Resource {
   private static final String RESOURCE_TYPE = "ContainerBlobs";
   private static final String SEPARATOR = "_";
 
-  private final Container container;
+  private final String resourceId;
 
   /**
    * Construct the resource from a container.
    * @param container the {@link Container}
    */
   public ContainerBlobsResource(Container container) {
-    this.container = container;
+    resourceId = container.getParentAccountId() + SEPARATOR + container.getId();
   }
 
   /**
@@ -47,6 +47,25 @@ public class ContainerBlobsResource implements AclService.Resource {
    */
   @Override
   public String getResourceId() {
-    return container.getParentAccountId() + SEPARATOR + container.getId();
+    return resourceId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ContainerBlobsResource that = (ContainerBlobsResource) o;
+
+    return resourceId.equals(that.resourceId);
+  }
+
+  @Override
+  public int hashCode() {
+    return resourceId.hashCode();
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/rest/SecurityService.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/SecurityService.java
@@ -15,6 +15,7 @@ package com.github.ambry.rest;
 
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.router.Callback;
+import com.github.ambry.router.FutureResult;
 import java.io.Closeable;
 import java.util.concurrent.Future;
 
@@ -35,7 +36,16 @@ public interface SecurityService extends Closeable {
    * @return A future that would contain information about whether processing of request succeeded or not,
    * eventually.
    */
-  public Future<Void> processRequest(RestRequest restRequest, Callback<Void> callback);
+  Future<Void> processRequest(RestRequest restRequest, Callback<Void> callback);
+
+  /**
+   * Perform security validations (if any) on the {@link RestRequest} when it has been fully parsed. That is, when the
+   * {@link RestRequest} has been annotated with any additional arguments (like account and container ID).
+   * Invokes the {@link Callback} when the validation is complete.
+   * @param restRequest {@link RestRequest} upon which validations has to be performed
+   * @param callback The {@link Callback} which will be invoked on the completion of the request. Cannot be null.
+   */
+  void postProcessRequest(RestRequest restRequest, Callback<Void> callback);
 
   /**
    * Perform security validations (if any) on the response for {@link RestRequest} asynchronously, sets headers if need
@@ -49,6 +59,18 @@ public interface SecurityService extends Closeable {
    * @return A future that would contain information about whether processing of request succeeded or not,
    * eventually.
    */
-  public Future<Void> processResponse(RestRequest restRequest, RestResponseChannel responseChannel, BlobInfo blobInfo,
+  Future<Void> processResponse(RestRequest restRequest, RestResponseChannel responseChannel, BlobInfo blobInfo,
       Callback<Void> callback);
+
+  /**
+   * Similar to {@link #postProcessRequest(RestRequest, Callback)} but returns a {@link Future} instead of requiring
+   * a callback.
+   * @param restRequest {@link RestRequest} upon which validations has to be performed
+   * @return a {@link Future} that is completed when the post-processing is done.
+   */
+  default Future<Void> postProcessRequest(RestRequest restRequest) {
+    FutureResult<Void> futureResult = new FutureResult<>();
+    postProcessRequest(restRequest, futureResult::done);
+    return futureResult;
+  }
 }

--- a/ambry-api/src/main/java/com.github.ambry/rest/SecurityService.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/SecurityService.java
@@ -38,7 +38,7 @@ public interface SecurityService extends Closeable {
 
   /**
    * Perform security validations (if any) on the {@link RestRequest} when it has been fully parsed. That is, when the
-   * {@link RestRequest} has been annotated with any additional arguments (like account and container ID).
+   * {@link RestRequest} has been annotated with any additional arguments (like account and container).
    * Invokes the {@link Callback} when the validation is complete.
    * @param restRequest {@link RestRequest} upon which validations has to be performed
    * @param callback The {@link Callback} which will be invoked on the completion of the request. Cannot be null.

--- a/ambry-api/src/main/java/com.github.ambry/rest/SecurityService.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/SecurityService.java
@@ -32,11 +32,9 @@ public interface SecurityService extends Closeable {
    * Perform security validations (if any) on the {@link RestRequest} asynchronously and invokes the
    * {@link Callback} when the validation completes.
    * @param restRequest {@link RestRequest} upon which validations has to be performed
-   * @param callback The {@link Callback} which will be invoked on the completion of the request.
-   * @return A future that would contain information about whether processing of request succeeded or not,
-   * eventually.
+   * @param callback The {@link Callback} which will be invoked on the completion of the request. Cannot be null.
    */
-  Future<Void> processRequest(RestRequest restRequest, Callback<Void> callback);
+  void processRequest(RestRequest restRequest, Callback<Void> callback);
 
   /**
    * Perform security validations (if any) on the {@link RestRequest} when it has been fully parsed. That is, when the
@@ -55,12 +53,22 @@ public interface SecurityService extends Closeable {
    * @param restRequest {@link RestRequest} whose response have to be validated
    * @param responseChannel the {@link RestResponseChannel} over which the response is sent
    * @param blobInfo the {@link BlobInfo} pertaining to the rest request made
-   * @param callback The {@link Callback} which will be invoked on the completion of the request.
-   * @return A future that would contain information about whether processing of request succeeded or not,
-   * eventually.
+   * @param callback The {@link Callback} which will be invoked on the completion of the request. Cannot be null.
    */
-  Future<Void> processResponse(RestRequest restRequest, RestResponseChannel responseChannel, BlobInfo blobInfo,
+  void processResponse(RestRequest restRequest, RestResponseChannel responseChannel, BlobInfo blobInfo,
       Callback<Void> callback);
+
+  /**
+   * Similar to {@link #processRequest(RestRequest, Callback)} but returns a {@link Future} instead of requiring
+   * a callback.
+   * @param restRequest {@link RestRequest} upon which validations has to be performed
+   * @return a {@link Future} that is completed when the post-processing is done.
+   */
+  default Future<Void> processRequest(RestRequest restRequest) {
+    FutureResult<Void> futureResult = new FutureResult<>();
+    processRequest(restRequest, futureResult::done);
+    return futureResult;
+  }
 
   /**
    * Similar to {@link #postProcessRequest(RestRequest, Callback)} but returns a {@link Future} instead of requiring
@@ -71,6 +79,21 @@ public interface SecurityService extends Closeable {
   default Future<Void> postProcessRequest(RestRequest restRequest) {
     FutureResult<Void> futureResult = new FutureResult<>();
     postProcessRequest(restRequest, futureResult::done);
+    return futureResult;
+  }
+
+  /**
+   * Similar to {@link #processResponse(RestRequest, RestResponseChannel, BlobInfo, Callback)} but returns a
+   * {@link Future} instead of requiring a callback.
+   * @param restRequest {@link RestRequest} whose response have to be validated
+   * @param responseChannel the {@link RestResponseChannel} over which the response is sent
+   * @param blobInfo the {@link BlobInfo} pertaining to the rest request made
+   * @return a {@link Future} that is completed when the post-processing is done.
+   */
+  default Future<Void> processResponse(RestRequest restRequest, RestResponseChannel responseChannel,
+      BlobInfo blobInfo) {
+    FutureResult<Void> futureResult = new FutureResult<>();
+    processResponse(restRequest, responseChannel, blobInfo, futureResult::done);
     return futureResult;
   }
 }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -354,6 +354,20 @@ class AmbryBlobStorageService implements BlobStorageService {
   }
 
   /**
+   * Extracts the cause of an {@link ExecutionException}. This is used to ensure that the correct
+   * {@link RestServiceErrorCode} is set when using a {@link java.util.concurrent.Future} to wait for a task to
+   * complete.
+   * @param e the {@link ExecutionException}
+   * @return if the cause is {@code null}, return {@code e} itself. If the cause is not an instance
+   *         of exception, return the {@link Throwable} wrapped in an exception. Otherwise, return the cause
+   *         {@link Exception}.
+   */
+  public static Exception extractCause(ExecutionException e) {
+    Throwable cause = e.getCause();
+    return cause == null ? e : (cause instanceof Exception ? (Exception) cause : new Exception(cause));
+  }
+
+  /**
    * Callback for {@link IdConverter} that is used when inbound IDs are converted.
    */
   private class InboundIdConverterCallback implements Callback<String> {
@@ -449,7 +463,7 @@ class AmbryBlobStorageService implements BlobStorageService {
               exception = new IllegalStateException("Unrecognized RestMethod: " + restMethod);
           }
         } catch (ExecutionException e) {
-          exception = Utils.extractCause(e);
+          exception = extractCause(e);
         } catch (Exception e) {
           exception = e;
         }
@@ -588,7 +602,7 @@ class AmbryBlobStorageService implements BlobStorageService {
               exception = new IllegalStateException("Unrecognized RestMethod: " + restMethod);
           }
         } catch (ExecutionException e) {
-          exception = Utils.extractCause(e);
+          exception = extractCause(e);
         } catch (Exception e) {
           exception = e;
         }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -62,12 +62,12 @@ class AmbrySecurityService implements SecurityService {
     } else if (restRequest == null) {
       throw new IllegalArgumentException("RestRequest is null");
     }
+    frontendMetrics.securityServiceProcessRequestTimeInMs.update(System.currentTimeMillis() - startTimeMs);
     FutureResult<Void> futureResult = new FutureResult<Void>();
     if (callback != null) {
       callback.onCompletion(null, exception);
     }
     futureResult.done(null, exception);
-    frontendMetrics.securityServiceProcessRequestTimeInMs.update(System.currentTimeMillis() - startTimeMs);
     return futureResult;
   }
 
@@ -81,8 +81,8 @@ class AmbrySecurityService implements SecurityService {
     } else if (restRequest == null || callback == null) {
       throw new IllegalArgumentException("RestRequest or Callback is null");
     }
-    callback.onCompletion(null, exception);
     frontendMetrics.securityServicePostProcessRequestTimeInMs.update(System.currentTimeMillis() - startTimeMs);
+    callback.onCompletion(null, exception);
   }
 
   @Override
@@ -149,11 +149,11 @@ class AmbrySecurityService implements SecurityService {
         exception = e;
       }
     }
+    frontendMetrics.securityServiceProcessResponseTimeInMs.update(System.currentTimeMillis() - startTimeMs);
     futureResult.done(null, exception);
     if (callback != null) {
       callback.onCompletion(null, exception);
     }
-    frontendMetrics.securityServiceProcessResponseTimeInMs.update(System.currentTimeMillis() - startTimeMs);
     return futureResult;
   }
 

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -33,7 +33,6 @@ import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.concurrent.Future;
 
 
 /**
@@ -53,7 +52,7 @@ class AmbrySecurityService implements SecurityService {
   }
 
   @Override
-  public Future<Void> processRequest(RestRequest restRequest, Callback<Void> callback) {
+  public void processRequest(RestRequest restRequest, Callback<Void> callback) {
     Exception exception = null;
     frontendMetrics.securityServiceProcessRequestRate.mark();
     long startTimeMs = System.currentTimeMillis();
@@ -63,12 +62,7 @@ class AmbrySecurityService implements SecurityService {
       throw new IllegalArgumentException("RestRequest is null");
     }
     frontendMetrics.securityServiceProcessRequestTimeInMs.update(System.currentTimeMillis() - startTimeMs);
-    FutureResult<Void> futureResult = new FutureResult<Void>();
-    if (callback != null) {
-      callback.onCompletion(null, exception);
-    }
-    futureResult.done(null, exception);
-    return futureResult;
+    callback.onCompletion(null, exception);
   }
 
   @Override
@@ -86,7 +80,7 @@ class AmbrySecurityService implements SecurityService {
   }
 
   @Override
-  public Future<Void> processResponse(RestRequest restRequest, RestResponseChannel responseChannel, BlobInfo blobInfo,
+  public void processResponse(RestRequest restRequest, RestResponseChannel responseChannel, BlobInfo blobInfo,
       Callback<Void> callback) {
     Exception exception = null;
     frontendMetrics.securityServiceProcessResponseRate.mark();
@@ -150,11 +144,7 @@ class AmbrySecurityService implements SecurityService {
       }
     }
     frontendMetrics.securityServiceProcessResponseTimeInMs.update(System.currentTimeMillis() - startTimeMs);
-    futureResult.done(null, exception);
-    if (callback != null) {
-      callback.onCompletion(null, exception);
-    }
-    return futureResult;
+    callback.onCompletion(null, exception);
   }
 
   @Override

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -72,6 +72,22 @@ class AmbrySecurityService implements SecurityService {
   }
 
   @Override
+  public void postProcessRequest(RestRequest restRequest, Callback<Void> callback) {
+    Exception exception = null;
+    frontendMetrics.securityServicePostProcessRequestRate.mark();
+    long startTimeMs = System.currentTimeMillis();
+    if (!isOpen) {
+      exception = new RestServiceException("SecurityService is closed", RestServiceErrorCode.ServiceUnavailable);
+    } else if (restRequest == null) {
+      throw new IllegalArgumentException("RestRequest is null");
+    }
+    if (callback != null) {
+      callback.onCompletion(null, exception);
+    }
+    frontendMetrics.securityServicePostProcessRequestTimeInMs.update(System.currentTimeMillis() - startTimeMs);
+  }
+
+  @Override
   public Future<Void> processResponse(RestRequest restRequest, RestResponseChannel responseChannel, BlobInfo blobInfo,
       Callback<Void> callback) {
     Exception exception = null;

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -78,12 +78,10 @@ class AmbrySecurityService implements SecurityService {
     long startTimeMs = System.currentTimeMillis();
     if (!isOpen) {
       exception = new RestServiceException("SecurityService is closed", RestServiceErrorCode.ServiceUnavailable);
-    } else if (restRequest == null) {
-      throw new IllegalArgumentException("RestRequest is null");
+    } else if (restRequest == null || callback == null) {
+      throw new IllegalArgumentException("RestRequest or Callback is null");
     }
-    if (callback != null) {
-      callback.onCompletion(null, exception);
-    }
+    callback.onCompletion(null, exception);
     frontendMetrics.securityServicePostProcessRequestTimeInMs.update(System.currentTimeMillis() - startTimeMs);
   }
 

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
@@ -53,6 +53,7 @@ class FrontendMetrics {
   // Rates
   // AmbrySecurityService
   public final Meter securityServiceProcessRequestRate;
+  public final Meter securityServicePostProcessRequestRate;
   public final Meter securityServiceProcessResponseRate;
   // AmbryIdConverter
   public final Meter idConverterRequestRate;
@@ -94,6 +95,7 @@ class FrontendMetrics {
   // SecurityProcessRequestCallback
   public final Histogram deleteSecurityRequestCallbackProcessingTimeInMs;
   public final Histogram getSecurityRequestCallbackProcessingTimeInMs;
+  public final Histogram getPeersSecurityRequestCallbackProcessingTimeInMs;
   public final Histogram headSecurityRequestCallbackProcessingTimeInMs;
   public final Histogram postSecurityRequestCallbackProcessingTimeInMs;
   public final Histogram deleteSecurityRequestTimeInMs;
@@ -101,8 +103,11 @@ class FrontendMetrics {
   public final Histogram headSecurityRequestTimeInMs;
   public final Histogram postSecurityRequestTimeInMs;
   public final Histogram getPeersSecurityRequestTimeInMs;
+  // SecurityPostProcessRequestCallback
+  public final Histogram getPeersSecurityPostProcessRequestTimeInMs;
   // AmbrySecurityService
   public final Histogram securityServiceProcessRequestTimeInMs;
+  public final Histogram securityServicePostProcessRequestTimeInMs;
   public final Histogram securityServiceProcessResponseTimeInMs;
   // AmbryIdConverter
   public final Histogram idConverterProcessingTimeInMs;
@@ -172,6 +177,8 @@ class FrontendMetrics {
     // AmbrySecurityService
     securityServiceProcessRequestRate =
         metricRegistry.meter(MetricRegistry.name(AmbrySecurityService.class, "ProcessRequestRate"));
+    securityServicePostProcessRequestRate =
+        metricRegistry.meter(MetricRegistry.name(AmbrySecurityService.class, "PostProcessRequestRate"));
     securityServiceProcessResponseRate =
         metricRegistry.meter(MetricRegistry.name(AmbrySecurityService.class, "ProcessResponseRate"));
     // AmbryIdConverter
@@ -245,6 +252,8 @@ class FrontendMetrics {
         metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "HeadSecurityRequestTimeInMs"));
     getSecurityRequestCallbackProcessingTimeInMs = metricRegistry.histogram(
         MetricRegistry.name(AmbryBlobStorageService.class, "GetSecurityRequestCallbackProcessingTimeInMs"));
+    getPeersSecurityRequestCallbackProcessingTimeInMs = metricRegistry.histogram(
+        MetricRegistry.name(AmbryBlobStorageService.class, "GetPeersSecurityRequestCallbackProcessingTimeInMs"));
     getSecurityRequestTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "GetSecurityRequestTimeInMs"));
     postSecurityRequestCallbackProcessingTimeInMs = metricRegistry.histogram(
@@ -253,9 +262,14 @@ class FrontendMetrics {
         metricRegistry.histogram(MetricRegistry.name(AmbryBlobStorageService.class, "PostSecurityRequestTimeInMs"));
     getPeersSecurityRequestTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(GetPeersHandler.class, "SecurityRequestTimeInMs"));
+    // SecurityPostProcessRequestCallback
+    getPeersSecurityPostProcessRequestTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(GetPeersHandler.class, "SecurityPostProcessRequestTimeInMs"));
     // AmbrySecurityService
     securityServiceProcessRequestTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(AmbrySecurityService.class, "RequestProcessingTimeInMs"));
+    securityServicePostProcessRequestTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbrySecurityService.class, "RequestPostProcessingTimeInMs"));
     securityServiceProcessResponseTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(AmbrySecurityService.class, "ResponseProcessingTimeInMs"));
     // AmbryIdConverter

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/GetPeersHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/GetPeersHandler.java
@@ -157,7 +157,6 @@ class GetPeersHandler {
     public void onCompletion(Void result, Exception exception) {
       long processingStartTimeMs = SystemTime.getInstance().milliseconds();
       metrics.getPeersSecurityRequestTimeInMs.update(processingStartTimeMs - operationStartTimeMs);
-      ReadableStreamChannel channel = null;
       try {
         if (exception == null) {
           securityService.postProcessRequest(restRequest,

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -1394,11 +1394,11 @@ class FrontendTestSecurityServiceFactory implements SecurityServiceFactory {
     private boolean isOpen = true;
 
     @Override
-    public Future<Void> processRequest(RestRequest restRequest, Callback<Void> callback) {
+    public void processRequest(RestRequest restRequest, Callback<Void> callback) {
       if (!isOpen) {
         throw new IllegalStateException("SecurityService closed");
       }
-      return completeOperation(callback, mode == null || mode == Mode.ProcessRequest);
+      completeOperation(callback, mode == null || mode == Mode.ProcessRequest);
     }
 
     @Override
@@ -1410,12 +1410,12 @@ class FrontendTestSecurityServiceFactory implements SecurityServiceFactory {
     }
 
     @Override
-    public Future<Void> processResponse(RestRequest restRequest, RestResponseChannel responseChannel, BlobInfo blobInfo,
+    public void processResponse(RestRequest restRequest, RestResponseChannel responseChannel, BlobInfo blobInfo,
         Callback<Void> callback) {
       if (!isOpen) {
         throw new IllegalStateException("SecurityService closed");
       }
-      return completeOperation(callback, mode == Mode.ProcessResponse);
+      completeOperation(callback, mode == Mode.ProcessResponse);
     }
 
     @Override
@@ -1424,21 +1424,15 @@ class FrontendTestSecurityServiceFactory implements SecurityServiceFactory {
     }
 
     /**
-     * Completes the operation by creating and invoking a {@link Future} and invoking the {@code callback} if non-null.
-     * @param callback the {@link Callback} to invoke. Can be null.
+     * Completes the operation by  invoking the {@code callback}.
+     * @param callback the {@link Callback} to invoke.
      * @param misbehaveIfRequired whether to exhibit misbehavior or not.
-     * @return the created {@link Future}.
      */
-    private Future<Void> completeOperation(Callback<Void> callback, boolean misbehaveIfRequired) {
+    private void completeOperation(Callback<Void> callback, boolean misbehaveIfRequired) {
       if (misbehaveIfRequired && exceptionToThrow != null) {
         throw exceptionToThrow;
       }
-      FutureResult<Void> futureResult = new FutureResult<Void>();
-      futureResult.done(null, misbehaveIfRequired ? exceptionToReturn : null);
-      if (callback != null) {
-        callback.onCompletion(null, misbehaveIfRequired ? exceptionToReturn : null);
-      }
-      return futureResult;
+      callback.onCompletion(null, misbehaveIfRequired ? exceptionToReturn : null);
     }
   }
 }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -299,11 +299,11 @@ public class AmbryBlobStorageServiceTest {
       assertTrue("RestRequest channel is not open", restRequest.isOpen());
       restResponseChannel = new MockRestResponseChannel();
       ReadableStreamChannel response = new ByteBufferReadableStreamChannel(ByteBuffer.allocate(0));
-      assertTrue("ProcessResponse channel is not open", response.isOpen());
+      assertTrue("Response channel is not open", response.isOpen());
       ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, response, null);
       assertNotNull("There is no cause of failure", restResponseChannel.getException());
       // resources should have been cleaned up.
-      assertFalse("ProcessResponse channel is not cleaned up", response.isOpen());
+      assertFalse("Response channel is not cleaned up", response.isOpen());
     } finally {
       responseHandler.start();
     }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -1424,7 +1424,7 @@ class FrontendTestSecurityServiceFactory implements SecurityServiceFactory {
     }
 
     /**
-     * Completes the operation by  invoking the {@code callback}.
+     * Completes the operation by invoking the {@code callback}.
      * @param callback the {@link Callback} to invoke.
      * @param misbehaveIfRequired whether to exhibit misbehavior or not.
      */

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
@@ -108,6 +108,9 @@ public class GetPeersHandlerTest {
     verifyFailureWithMsg(msg);
     securityServiceFactory.mode = FrontendTestSecurityServiceFactory.Mode.PostProcessRequest;
     verifyFailureWithMsg(msg);
+    securityServiceFactory.exceptionToThrow = new IllegalStateException(msg);
+    securityServiceFactory.exceptionToReturn = null;
+    verifyFailureWithMsg(msg);
   }
 
   /**

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -756,6 +756,18 @@ public class Utils {
   }
 
   /**
+   * Extracts the cause of an {@link Exception}.
+   * @param e the {@link Exception}
+   * @return if the cause is {@code null}, return {@code e} itself. If the cause is not an instance
+   *         of exception, return the {@link Throwable} wrapped in an exception. Otherwise, return the cause
+   *         {@link Exception}.
+   */
+  public static Exception extractCause(Exception e) {
+    Throwable cause = e.getCause();
+    return cause == null ? e : (cause instanceof Exception ? (Exception) cause : new Exception(cause));
+  }
+
+  /**
    * A thread factory to use for {@link ScheduledExecutorService}s instantiated using
    * {@link #newScheduler(int, String, boolean)}.
    */

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -756,18 +756,6 @@ public class Utils {
   }
 
   /**
-   * Extracts the cause of an {@link Exception}.
-   * @param e the {@link Exception}
-   * @return if the cause is {@code null}, return {@code e} itself. If the cause is not an instance
-   *         of exception, return the {@link Throwable} wrapped in an exception. Otherwise, return the cause
-   *         {@link Exception}.
-   */
-  public static Exception extractCause(Exception e) {
-    Throwable cause = e.getCause();
-    return cause == null ? e : (cause instanceof Exception ? (Exception) cause : new Exception(cause));
-  }
-
-  /**
    * A thread factory to use for {@link ScheduledExecutorService}s instantiated using
    * {@link #newScheduler(int, String, boolean)}.
    */

--- a/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
@@ -14,7 +14,6 @@
 package com.github.ambry.utils;
 
 import java.util.Random;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -90,6 +89,7 @@ public class TestUtils {
    * @param exceptionClass the type of exception that should occur.
    * @param body the body to execute. This should throw an exception of type {@code exceptionClass}
    * @param errorAction if non-null and the exception class matches, execute this action.
+   * @throws Exception when an unexpected exception occurs.
    */
   public static <E extends Exception> void assertException(Class<E> exceptionClass, ThrowingRunnable body,
       ThrowingConsumer<E> errorAction) throws Exception {
@@ -106,7 +106,6 @@ public class TestUtils {
       }
     }
   }
-
 
   /**
    * Similar to {@link Runnable}, but able to throw checked exceptions.


### PR DESCRIPTION
This adds a new method to the SecurityService interface that is used to
run additional request security validations after the request has been
fully parsed (i.e. inbound id conversion has finished). This is a useful
place to implement AclService calls.

*Reviewers:* @xiahome @vgkholla 