### PR TITLE
Use padding to support different key sizes in the same segment

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -171,6 +171,17 @@ public class StoreConfig {
   @Default("240000")
   public final int storeStatsIndexEntriesPerSecond;
 
+  /**
+   * Specifies the minimum size that index entries should occupy when they get persisted. If the number of bytes for
+   * constituting keys and values fall short of this size, the entries will be padded with dummy bytes to amount to this
+   * number.
+   * Setting this value to N bytes ensures that even if the size of keys put to the store changes at runtime, as long as
+   * the total entry size is still N bytes, the key size change will not cause the active index segment to roll over.
+   */
+  @Config("store.index.persisted.entry.min.bytes")
+  @Default("")
+  public final int storeIndexPersistedEntryMinBytes;
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -207,6 +218,7 @@ public class StoreConfig {
         verifiableProperties.getLongInRange("store.stats.wait.timeout.in.secs", 2 * 60, 0, 30 * 60);
     storeStatsIndexEntriesPerSecond =
         verifiableProperties.getIntInRange("store.stats.index.entries.per.second", 240000, 1, Integer.MAX_VALUE);
+    storeIndexPersistedEntryMinBytes = verifiableProperties.getInt("store.index.persisted.entry.min.bytes", 115);
   }
 }
 

--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -179,7 +179,7 @@ public class StoreConfig {
    * the total entry size is still N bytes, the key size change will not cause the active index segment to roll over.
    */
   @Config("store.index.persisted.entry.min.bytes")
-  @Default("")
+  @Default("115")
   public final int storeIndexPersistedEntryMinBytes;
 
   public StoreConfig(VerifiableProperties verifiableProperties) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -66,7 +66,7 @@ class HelixClusterManager implements ClusterMap {
   private final ConcurrentHashMap<ByteBuffer, AmbryPartition> partitionMap = new ConcurrentHashMap<>();
   private long clusterWideRawCapacityBytes;
   private long clusterWideAllocatedRawCapacityBytes;
-  private long clusterWiseAllocatedUsableCapacityBytes;
+  private long clusterWideAllocatedUsableCapacityBytes;
   private final HelixClusterManagerCallback helixClusterManagerCallback;
   private final AtomicReference<Exception> initializationException = new AtomicReference<>();
   private final AtomicLong sealedStateChangeCounter = new AtomicLong(0);
@@ -158,7 +158,7 @@ class HelixClusterManager implements ClusterMap {
     for (Set<AmbryReplica> partitionReplicas : ambryPartitionToAmbryReplicas.values()) {
       long replicaCapacity = partitionReplicas.iterator().next().getCapacityInBytes();
       clusterWideAllocatedRawCapacityBytes += replicaCapacity * partitionReplicas.size();
-      clusterWiseAllocatedUsableCapacityBytes += replicaCapacity;
+      clusterWideAllocatedUsableCapacityBytes += replicaCapacity;
     }
   }
 
@@ -659,7 +659,7 @@ class HelixClusterManager implements ClusterMap {
      * @return the cluster wide allocated usable capacity in bytes.
      */
     long getAllocatedUsableCapacity() {
-      return clusterWiseAllocatedUsableCapacityBytes;
+      return clusterWideAllocatedUsableCapacityBytes;
     }
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -61,11 +61,11 @@ class IndexSegment {
   static final String INDEX_SEGMENT_FILE_NAME_SUFFIX = "index";
   static final String BLOOM_FILE_NAME_SUFFIX = "bloom";
 
-  private final static int KEY_SIZE_INVALID_VALUE = -1;
+  private final static int ENTRY_SIZE_INVALID_VALUE = -1;
   private final static int VALUE_SIZE_INVALID_VALUE = -1;
 
   private final int VERSION_FIELD_LENGTH = 2;
-  private final int KEY_SIZE_FIELD_LENGTH = 4;
+  private final int KEY_OR_ENTRY_SIZE_FIELD_LENGTH = 4;
   private final int VALUE_SIZE_FIELD_LENGTH = 4;
   private final int CRC_FIELD_LENGTH = 8;
   private final int LOG_END_OFFSET_FIELD_LENGTH = 8;
@@ -74,6 +74,7 @@ class IndexSegment {
 
   private int indexSizeExcludingEntries;
   private int firstKeyRelativeOffset;
+  private final StoreConfig config;
   private final String indexSegmentFilenamePrefix;
   private final Offset startOffset;
   private final AtomicReference<Offset> endOffset;
@@ -92,8 +93,8 @@ class IndexSegment {
   private final AtomicLong lastModifiedTimeSec;
   private MappedByteBuffer mmap = null;
   private IFilter bloomFilter;
-  private int keySize;
   private int valueSize;
+  private int persistedEntrySize;
   private short version;
   private Offset prevSafeEndPoint = null;
   // reset key refers to the first StoreKey that is added to the index segment
@@ -105,23 +106,26 @@ class IndexSegment {
    * @param dataDir The data directory to use for this segment
    * @param startOffset The start {@link Offset} in the {@link Log} that this segment represents.
    * @param factory The store key factory used to create new store keys
-   * @param keySize The key size that this segment supports
-   * @param valueSize The value size that this segment supports
+   * @param entrySize The size of entries that this segment needs to support. The actual supported entry size for the
+   *                  constructed segment is the max of this value and {@link StoreConfig#storeIndexPersistedEntryMinBytes}.
+   *                  The constructed index segment guarantees to support entries that are of this size or smaller.
+   * @param valueSize The value size that this segment supports. All entries in a segment must have the same value sizes.
    * @param config The store config used to initialize the index segment
    * @param time the {@link Time} instance to use
    */
-  IndexSegment(String dataDir, Offset startOffset, StoreKeyFactory factory, int keySize, int valueSize,
+  IndexSegment(String dataDir, Offset startOffset, StoreKeyFactory factory, int entrySize, int valueSize,
       StoreConfig config, StoreMetrics metrics, Time time) {
     this.rwLock = new ReentrantReadWriteLock();
+    this.config = config;
     this.startOffset = startOffset;
     this.endOffset = new AtomicReference<>(startOffset);
     index = new ConcurrentSkipListMap<>();
     mapped = new AtomicBoolean(false);
     sizeWritten = new AtomicLong(0);
     this.factory = factory;
-    this.keySize = keySize;
-    this.valueSize = valueSize;
     this.version = PersistentIndex.CURRENT_VERSION;
+    this.valueSize = valueSize;
+    this.persistedEntrySize = Math.max(config.storeIndexPersistedEntryMinBytes, entrySize);
     bloomFilter = FilterFactory.getFilter(config.storeIndexMaxNumberOfInmemElements,
         config.storeIndexBloomMaxFalsePositiveProbability);
     numberOfItems = new AtomicInteger(0);
@@ -148,6 +152,7 @@ class IndexSegment {
   IndexSegment(File indexFile, boolean shouldMap, StoreKeyFactory factory, StoreConfig config, StoreMetrics metrics,
       Journal journal, Time time) throws StoreException {
     try {
+      this.config = config;
       startOffset = getIndexSegmentStartOffset(indexFile.getName());
       endOffset = new AtomicReference<>(startOffset);
       indexSegmentFilenamePrefix = generateIndexSegmentFilenamePrefix();
@@ -244,11 +249,11 @@ class IndexSegment {
   }
 
   /**
-   * The key size in this segment
-   * @return The key size in this segment
+   * The persisted entry size of this segment
+   * @return The persisted entry size of this segment
    */
-  int getKeySize() {
-    return keySize;
+  int getPersistedEntrySize() {
+    return persistedEntrySize;
   }
 
   /**
@@ -367,11 +372,11 @@ class IndexSegment {
   }
 
   private int numberOfEntries(ByteBuffer mmap) {
-    return (mmap.capacity() - indexSizeExcludingEntries) / (keySize + valueSize);
+    return (mmap.capacity() - indexSizeExcludingEntries) / (persistedEntrySize);
   }
 
   private StoreKey getKeyAt(ByteBuffer mmap, int index) throws IOException {
-    mmap.position(firstKeyRelativeOffset + (index * (keySize + valueSize)));
+    mmap.position(firstKeyRelativeOffset + (index * (persistedEntrySize)));
     return factory.getStoreKey(new DataInputStream(new ByteBufferInputStream(mmap)));
   }
 
@@ -430,16 +435,18 @@ class IndexSegment {
       } else if ((operationTimeInMs / Time.MsPerSec) > lastModifiedTimeSec.get()) {
         lastModifiedTimeSec.set(operationTimeInMs / Time.MsPerSec);
       }
-      if (keySize == KEY_SIZE_INVALID_VALUE) {
-        StoreKey key = entry.getKey();
-        keySize = key.sizeInBytes();
-        logger.info("IndexSegment : {} setting key size to {} of key {} for index with start offset {}",
-            indexFile.getAbsolutePath(), key.sizeInBytes(), key.getLongForm(), startOffset);
-      }
       if (valueSize == VALUE_SIZE_INVALID_VALUE) {
         valueSize = entry.getValue().getBytes().capacity();
         logger.info("IndexSegment : {} setting value size to {} for index with start offset {}",
             indexFile.getAbsolutePath(), valueSize, startOffset);
+      }
+      if (persistedEntrySize == ENTRY_SIZE_INVALID_VALUE) {
+        StoreKey key = entry.getKey();
+        persistedEntrySize =
+            getVersion() == PersistentIndex.VERSION_2 ? Math.max(config.storeIndexPersistedEntryMinBytes,
+                key.sizeInBytes() + valueSize) : key.sizeInBytes() + valueSize;
+        logger.info("IndexSegment : {} setting persisted entry size to {} of key {} for index with start offset {}",
+            indexFile.getAbsolutePath(), persistedEntrySize, key.getLongForm(), startOffset);
       }
     } finally {
       rwLock.readLock().unlock();
@@ -479,15 +486,40 @@ class IndexSegment {
   }
 
   /**
-   * Writes the index to a persistent file. Writes the data in the following format in version 1
+   * Writes the index to a persistent file.
+   *
+   * Those that are written in version 2 have the following format:
+   *
+   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   * | version | entrysize | valuesize | fileendpointer |  last modified time(in secs) | Reset key | Reset key type  ...
+   * |(2 bytes)|(4 bytes)  | (4 bytes) |    (8 bytes)   |     (4 bytes)                | (m bytes) |   ( 2 bytes)    ...
+   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   *         - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   *     ...   key 1    | value 1          | Padding    | ...  | key n     | value n           | Padding    | crc      |
+   *     ...   (m bytes)| (valuesize bytes)| (var size) |      | (p bytes) | (valuesize bytes) | (var size) | (8 bytes)|
+   *         - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   *          |<- - - - - (entrysize bytes) - - - - - ->|      |<- - - - - - (entrysize bytes)- - - - - - ->|
+   *
+   *  version            - the index format version
+   *  entrysize          - the total size of an entry (key + value + padding) in this index segment
+   *  valuesize          - the size of the value in this index segment
+   *  fileendpointer     - the log end pointer that pertains to the index being persisted
+   *  last modified time - the last modified time of the index segment in secs
+   *  reset key          - the reset key(StoreKey) of the index segment
+   *  reset key type     - the reset key index entry type(PUT/DELETE)
+   *  key n / value n    - the key and value entries contained in this index segment
+   *  crc                - the crc of the index segment content
+   *
+   *
+   * Those that were written in version 1 have the following format
    *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    * | version | keysize | valuesize | fileendpointer |  last modified time(in secs) | Reset key | Reset key type
-   * |(2 bytes)|(4 bytes)| (4 bytes) |    (8 bytes)   |     (4 bytes)                | (n bytes) |   ( 2 bytes)
+   * |(2 bytes)|(4 bytes)| (4 bytes) |    (8 bytes)   |     (4 bytes)                | (m bytes) |   ( 2 bytes)
    *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   *                                                   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   *                                                     key 1  | value 1  |  ...  |   key n   | value n   | crc      |
-   *                                                   (n bytes)| (n bytes)|       | (n bytes) | (n bytes) | (8 bytes)|
-   *                                                   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   *                      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   *                  ...  key 1          | value 1          |  ...  |   key n         | value n           | crc       |
+   *                  ...  (keysize bytes)| (valuesize bytes)|       | (keysize bytes) | (valuesize bytes) | (8 bytes) |
+   *                      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    *  version            - the index format version
    *  keysize            - the size of the key in this index segment
    *  valuesize          - the size of the value in this index segment
@@ -498,11 +530,16 @@ class IndexSegment {
    *  key n / value n    - the key and value entries contained in this index segment
    *  crc                - the crc of the index segment content
    *
-   * Those that were written in version 0 has the following format
-   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   * | version | keysize | valuesize | fileendpointer |   key 1  | value 1  |  ...  |   key n   | value n   | crc      |
-   * |(2 bytes)|(4 bytes)| (4 bytes) |    (8 bytes)   | (n bytes)| (n bytes)|       | (n bytes) | (n bytes) | (8 bytes)|
-   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   * Those that were written in version 0 have the following format
+   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   * | version | keysize | valuesize | fileendpointer |   key 1        | value 1          |  ...  |   key n          ...
+   * |(2 bytes)|(4 bytes)| (4 bytes) |    (8 bytes)   | (keysize bytes)| (valuesize bytes)|       | (keysize bytes)  ...
+   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   *                                                          - - - - - - - - - - - - - - - -
+   *                                                      ...  value n            | crc      |
+   *                                                      ...  (valuesize  bytes) | (8 bytes)|
+   *                                                          - - - - - - - - - - - - - - - -
+   *
    *  version         - the index format version
    *  keysize         - the size of the key in this index segment
    *  valuesize       - the size of the value in this index segment
@@ -531,14 +568,17 @@ class IndexSegment {
       try {
         rwLock.readLock().lock();
 
-        // write the current version
         writer.writeShort(getVersion());
-        // write key, value size, file end pointer
-        writer.writeInt(this.keySize);
-        writer.writeInt(this.valueSize);
+        if (getVersion() == PersistentIndex.VERSION_2) {
+          writer.writeInt(getPersistedEntrySize());
+        } else {
+          // write the key size
+          writer.writeInt(getPersistedEntrySize() - getValueSize());
+        }
+        writer.writeInt(getValueSize());
         writer.writeLong(safeEndPoint.getOffset());
-        if (getVersion() == PersistentIndex.VERSION_1) {
-          // write last modified time and reset key incase of version 1
+        if (getVersion() != PersistentIndex.VERSION_0) {
+          // write last modified time and reset key in case of version 1
           writer.writeLong(lastModifiedTimeSec.get());
           writer.write(resetKey.getFirst().toBytes());
           writer.writeShort(resetKey.getSecond().ordinal());
@@ -563,6 +603,14 @@ class IndexSegment {
           if (entry.getValue().getOffset().getOffset() + entry.getValue().getSize() <= safeEndPoint.getOffset()) {
             writer.write(entry.getKey().toBytes());
             writer.write(entry.getValue().getBytes().array());
+            if (getVersion() == PersistentIndex.VERSION_2) {
+              // Add padding if necessary
+              int paddingNumBytes = persistedEntrySize - entry.getKey().sizeInBytes() - valueSize;
+              if (paddingNumBytes > 0) {
+                byte[] padding = new byte[paddingNumBytes];
+                writer.write(padding);
+              }
+            }
             logger.trace("IndexSegment : {} writing key - {} value - offset {} size {} fileEndOffset {}",
                 getFile().getAbsolutePath(), entry.getKey(), entry.getValue().getOffset(), entry.getValue().getSize(),
                 safeEndPoint);
@@ -601,27 +649,45 @@ class IndexSegment {
       mmap = raf.getChannel().map(FileChannel.MapMode.READ_ONLY, 0, indexFile.length());
       mmap.position(0);
       version = mmap.getShort();
-      indexSizeExcludingEntries =
-          VERSION_FIELD_LENGTH + KEY_SIZE_FIELD_LENGTH + VALUE_SIZE_FIELD_LENGTH + LOG_END_OFFSET_FIELD_LENGTH
-              + CRC_FIELD_LENGTH;
+      StoreKey storeKey;
+      int keySize;
+      short resetKeyType;
       switch (version) {
-        case 0:
+        case PersistentIndex.VERSION_0:
+          indexSizeExcludingEntries = VERSION_FIELD_LENGTH + KEY_OR_ENTRY_SIZE_FIELD_LENGTH + VALUE_SIZE_FIELD_LENGTH
+              + LOG_END_OFFSET_FIELD_LENGTH + CRC_FIELD_LENGTH;
           keySize = mmap.getInt();
           valueSize = mmap.getInt();
+          persistedEntrySize = keySize + valueSize;
           endOffset.set(new Offset(startOffset.getName(), mmap.getLong()));
           lastModifiedTimeSec.set(indexFile.lastModified() / 1000);
           firstKeyRelativeOffset = indexSizeExcludingEntries - CRC_FIELD_LENGTH;
           break;
-        case 1:
+        case PersistentIndex.VERSION_1:
           keySize = mmap.getInt();
+          valueSize = mmap.getInt();
+          persistedEntrySize = keySize + valueSize;
+          endOffset.set(new Offset(startOffset.getName(), mmap.getLong()));
+          lastModifiedTimeSec.set(mmap.getLong());
+          storeKey = factory.getStoreKey(new DataInputStream(new ByteBufferInputStream(mmap)));
+          resetKeyType = mmap.getShort();
+          resetKey = new Pair<>(storeKey, PersistentIndex.IndexEntryType.values()[resetKeyType]);
+          indexSizeExcludingEntries = VERSION_FIELD_LENGTH + KEY_OR_ENTRY_SIZE_FIELD_LENGTH + VALUE_SIZE_FIELD_LENGTH
+              + LOG_END_OFFSET_FIELD_LENGTH + CRC_FIELD_LENGTH + (LAST_MODIFIED_TIME_FIELD_LENGTH + resetKey.getFirst()
+              .sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH);
+          firstKeyRelativeOffset = indexSizeExcludingEntries - CRC_FIELD_LENGTH;
+          break;
+        case PersistentIndex.VERSION_2:
+          persistedEntrySize = mmap.getInt();
           valueSize = mmap.getInt();
           endOffset.set(new Offset(startOffset.getName(), mmap.getLong()));
           lastModifiedTimeSec.set(mmap.getLong());
-          StoreKey storeKey = factory.getStoreKey(new DataInputStream(new ByteBufferInputStream(mmap)));
-          short resetKeyType = mmap.getShort();
+          storeKey = factory.getStoreKey(new DataInputStream(new ByteBufferInputStream(mmap)));
+          resetKeyType = mmap.getShort();
           resetKey = new Pair<>(storeKey, PersistentIndex.IndexEntryType.values()[resetKeyType]);
-          indexSizeExcludingEntries +=
-              (LAST_MODIFIED_TIME_FIELD_LENGTH + resetKey.getFirst().sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH);
+          indexSizeExcludingEntries = VERSION_FIELD_LENGTH + KEY_OR_ENTRY_SIZE_FIELD_LENGTH + VALUE_SIZE_FIELD_LENGTH
+              + LOG_END_OFFSET_FIELD_LENGTH + CRC_FIELD_LENGTH + (LAST_MODIFIED_TIME_FIELD_LENGTH + resetKey.getFirst()
+              .sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH);
           firstKeyRelativeOffset = indexSizeExcludingEntries - CRC_FIELD_LENGTH;
           break;
         default:
@@ -662,77 +728,87 @@ class IndexSegment {
       switch (version) {
         case PersistentIndex.VERSION_0:
         case PersistentIndex.VERSION_1:
-          keySize = stream.readInt();
+          int keySize = stream.readInt();
           valueSize = stream.readInt();
-          long logEndOffset = stream.readLong();
-          indexSizeExcludingEntries =
-              VERSION_FIELD_LENGTH + KEY_SIZE_FIELD_LENGTH + VALUE_SIZE_FIELD_LENGTH + LOG_END_OFFSET_FIELD_LENGTH
-                  + CRC_FIELD_LENGTH;
-          if (version == PersistentIndex.VERSION_0) {
-            lastModifiedTimeSec.set(indexFile.lastModified() / 1000);
-          } else if (version == PersistentIndex.VERSION_1) {
-            lastModifiedTimeSec.set(stream.readLong());
-            StoreKey storeKey = factory.getStoreKey(stream);
-            short resetKeyType = stream.readShort();
-            resetKey = new Pair<>(storeKey, PersistentIndex.IndexEntryType.values()[resetKeyType]);
-            indexSizeExcludingEntries +=
-                (LAST_MODIFIED_TIME_FIELD_LENGTH + resetKey.getFirst().sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH);
-          }
-          firstKeyRelativeOffset = indexSizeExcludingEntries - CRC_FIELD_LENGTH;
-          logger.trace("IndexSegment : {} reading log end offset {} from file", indexFile.getAbsolutePath(),
-              logEndOffset);
-          long maxEndOffset = Long.MIN_VALUE;
-          while (stream.available() > CRC_FIELD_LENGTH) {
-            StoreKey key = factory.getStoreKey(stream);
-            byte[] value = new byte[valueSize];
-            stream.read(value);
-            IndexValue blobValue = new IndexValue(startOffset.getName(), ByteBuffer.wrap(value), version);
-            long offsetInLogSegment = blobValue.getOffset().getOffset();
-            // ignore entries that have offsets outside the log end offset that this index represents
-            if (offsetInLogSegment + blobValue.getSize() <= logEndOffset) {
-              index.put(key, blobValue);
-              logger.trace("IndexSegment : {} putting key {} in index offset {} size {}", indexFile.getAbsolutePath(),
-                  key, blobValue.getOffset(), blobValue.getSize());
-              // regenerate the bloom filter for in memory indexes
-              bloomFilter.add(ByteBuffer.wrap(key.toBytes()));
-              // add to the journal
-              if (blobValue.getOriginalMessageOffset() != IndexValue.UNKNOWN_ORIGINAL_MESSAGE_OFFSET
-                  && offsetInLogSegment != blobValue.getOriginalMessageOffset()
-                  && blobValue.getOriginalMessageOffset() >= startOffset.getOffset()) {
-                // we add an entry for the original message offset if it is within the same index segment
-                journal.addEntry(new Offset(startOffset.getName(), blobValue.getOriginalMessageOffset()), key);
-              }
-              journal.addEntry(blobValue.getOffset(), key);
-              sizeWritten.addAndGet(key.sizeInBytes() + valueSize);
-              numberOfItems.incrementAndGet();
-              if (offsetInLogSegment + blobValue.getSize() > maxEndOffset) {
-                maxEndOffset = offsetInLogSegment + blobValue.getSize();
-              }
-            } else {
-              logger.info(
-                  "IndexSegment : {} ignoring index entry outside the log end offset that was not synced logEndOffset "
-                      + "{} key {} entryOffset {} entrySize {} entryDeleteState {}", indexFile.getAbsolutePath(),
-                  logEndOffset, key, blobValue.getOffset(), blobValue.getSize(),
-                  blobValue.isFlagSet(IndexValue.Flags.Delete_Index));
-            }
-          }
-          endOffset.set(new Offset(startOffset.getName(), maxEndOffset));
-          logger.trace("IndexSegment : {} setting end offset for index {}", indexFile.getAbsolutePath(), maxEndOffset);
-          long crc = crcStream.getValue();
-          if (crc != stream.readLong()) {
-            // reset structures
-            keySize = KEY_SIZE_INVALID_VALUE;
-            valueSize = VALUE_SIZE_INVALID_VALUE;
-            endOffset.set(startOffset);
-            index.clear();
-            bloomFilter.clear();
-            throw new StoreException("IndexSegment : " + indexFile.getAbsolutePath() + " crc check does not match",
-                StoreErrorCodes.Index_Creation_Failure);
-          }
+          persistedEntrySize = keySize + valueSize;
+          indexSizeExcludingEntries = VERSION_FIELD_LENGTH + KEY_OR_ENTRY_SIZE_FIELD_LENGTH + VALUE_SIZE_FIELD_LENGTH
+              + LOG_END_OFFSET_FIELD_LENGTH + CRC_FIELD_LENGTH;
+          break;
+        case PersistentIndex.VERSION_2:
+          persistedEntrySize = stream.readInt();
+          valueSize = stream.readInt();
+          indexSizeExcludingEntries = VERSION_FIELD_LENGTH + KEY_OR_ENTRY_SIZE_FIELD_LENGTH + VALUE_SIZE_FIELD_LENGTH
+              + LOG_END_OFFSET_FIELD_LENGTH + CRC_FIELD_LENGTH;
           break;
         default:
           throw new StoreException("IndexSegment : " + indexFile.getAbsolutePath() + " invalid version in index file ",
               StoreErrorCodes.Index_Version_Error);
+      }
+      long logEndOffset = stream.readLong();
+      if (version == PersistentIndex.VERSION_0) {
+        lastModifiedTimeSec.set(indexFile.lastModified() / 1000);
+      } else if (version == PersistentIndex.VERSION_1 || version == PersistentIndex.VERSION_2) {
+        lastModifiedTimeSec.set(stream.readLong());
+        StoreKey storeKey = factory.getStoreKey(stream);
+        short resetKeyType = stream.readShort();
+        resetKey = new Pair<>(storeKey, PersistentIndex.IndexEntryType.values()[resetKeyType]);
+        indexSizeExcludingEntries +=
+            (LAST_MODIFIED_TIME_FIELD_LENGTH + resetKey.getFirst().sizeInBytes() + RESET_KEY_TYPE_FIELD_LENGTH);
+      }
+      firstKeyRelativeOffset = indexSizeExcludingEntries - CRC_FIELD_LENGTH;
+      logger.trace("IndexSegment : {} reading log end offset {} from file", indexFile.getAbsolutePath(), logEndOffset);
+      long maxEndOffset = Long.MIN_VALUE;
+      while (stream.available() > CRC_FIELD_LENGTH) {
+        StoreKey key = factory.getStoreKey(stream);
+        byte[] value = new byte[valueSize];
+        stream.read(value);
+        if (version == PersistentIndex.VERSION_2) {
+          byte[] padding = new byte[persistedEntrySize - valueSize - key.sizeInBytes()];
+          stream.read(padding);
+        }
+        IndexValue blobValue = new IndexValue(startOffset.getName(), ByteBuffer.wrap(value), version);
+        long offsetInLogSegment = blobValue.getOffset().getOffset();
+        // ignore entries that have offsets outside the log end offset that this index represents
+        if (offsetInLogSegment + blobValue.getSize() <= logEndOffset) {
+          index.put(key, blobValue);
+          logger.trace("IndexSegment : {} putting key {} in index offset {} size {}", indexFile.getAbsolutePath(), key,
+              blobValue.getOffset(), blobValue.getSize());
+          // regenerate the bloom filter for in memory indexes
+          bloomFilter.add(ByteBuffer.wrap(key.toBytes()));
+          // add to the journal
+          if (blobValue.getOriginalMessageOffset() != IndexValue.UNKNOWN_ORIGINAL_MESSAGE_OFFSET
+              && offsetInLogSegment != blobValue.getOriginalMessageOffset()
+              && blobValue.getOriginalMessageOffset() >= startOffset.getOffset()) {
+            // we add an entry for the original message offset if it is within the same index segment
+            journal.addEntry(new Offset(startOffset.getName(), blobValue.getOriginalMessageOffset()), key);
+          }
+          journal.addEntry(blobValue.getOffset(), key);
+          // sizeWritten is only used for in-memory segments, and for those the padding does not come into picture.
+          sizeWritten.addAndGet(key.sizeInBytes() + valueSize);
+          numberOfItems.incrementAndGet();
+          if (offsetInLogSegment + blobValue.getSize() > maxEndOffset) {
+            maxEndOffset = offsetInLogSegment + blobValue.getSize();
+          }
+        } else {
+          logger.info(
+              "IndexSegment : {} ignoring index entry outside the log end offset that was not synced logEndOffset "
+                  + "{} key {} entryOffset {} entrySize {} entryDeleteState {}", indexFile.getAbsolutePath(),
+              logEndOffset, key, blobValue.getOffset(), blobValue.getSize(),
+              blobValue.isFlagSet(IndexValue.Flags.Delete_Index));
+        }
+      }
+      endOffset.set(new Offset(startOffset.getName(), maxEndOffset));
+      logger.trace("IndexSegment : {} setting end offset for index {}", indexFile.getAbsolutePath(), maxEndOffset);
+      long crc = crcStream.getValue();
+      if (crc != stream.readLong()) {
+        // reset structures
+        persistedEntrySize = ENTRY_SIZE_INVALID_VALUE;
+        valueSize = VALUE_SIZE_INVALID_VALUE;
+        endOffset.set(startOffset);
+        index.clear();
+        bloomFilter.clear();
+        throw new StoreException("IndexSegment : " + indexFile.getAbsolutePath() + " crc check does not match",
+            StoreErrorCodes.Index_Creation_Failure);
       }
     } catch (IOException e) {
       throw new StoreException("IndexSegment : " + indexFile.getAbsolutePath() + " IO error while reading from file ",

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -578,7 +578,7 @@ class IndexSegment {
         writer.writeInt(getValueSize());
         writer.writeLong(safeEndPoint.getOffset());
         if (getVersion() != PersistentIndex.VERSION_0) {
-          // write last modified time and reset key in case of version 1
+          // write last modified time and reset key in case of version != 0
           writer.writeLong(lastModifiedTimeSec.get());
           writer.write(resetKey.getFirst().toBytes());
           writer.writeShort(resetKey.getSecond().ordinal());

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -101,6 +101,7 @@ class IndexValue {
         containerId = UNKNOWN_CONTAINER_ID;
         break;
       case PersistentIndex.VERSION_1:
+      case PersistentIndex.VERSION_2:
         if (value.capacity() != INDEX_VALUE_SIZE_IN_BYTES_V1) {
           throw new IllegalArgumentException("Invalid buffer size for version 1");
         }
@@ -314,6 +315,7 @@ class IndexValue {
         value.position(0);
         break;
       case PersistentIndex.VERSION_1:
+      case PersistentIndex.VERSION_2:
         value = ByteBuffer.allocate(INDEX_VALUE_SIZE_IN_BYTES_V1);
         value.putLong(size);
         value.putLong(offset.getOffset());
@@ -336,7 +338,7 @@ class IndexValue {
   public String toString() {
     return "Offset: " + offset + ", Size: " + getSize() + ", Deleted: " + isFlagSet(Flags.Delete_Index)
         + ", ExpiresAtMs: " + getExpiresAtMs() + ", Original Message Offset: " + getOriginalMessageOffset() + (
-        version == PersistentIndex.VERSION_1 ? (", OperationTimeAtSecs " + getOperationTimeInMs() + ", ServiceId "
+        version != PersistentIndex.VERSION_0 ? (", OperationTimeAtSecs " + getOperationTimeInMs() + ", ServiceId "
             + getServiceId() + ", ContainerId " + getContainerId()) : "");
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
@@ -322,7 +322,7 @@ class CuratedLogIndexState {
 
   /**
    * Appends random data of size {@code size} to the {@link #log}.
-   * @param size the size of data that needs to be appeneded.
+   * @param size the size of data that needs to be appended.
    * @return the data that was appended.
    * @throws IOException
    */
@@ -345,9 +345,17 @@ class CuratedLogIndexState {
    * @return a {@link MockId} that is unique and has not been generated before in this run.
    */
   MockId getUniqueId() {
+    return getUniqueId(10);
+  }
+
+  /**
+   * @param length the length of the string to use to create the {@link MockId}.
+   * @return a {@link MockId} that is unique and has not been generated before in this run.
+   */
+  MockId getUniqueId(int length) {
     MockId id;
     do {
-      id = new MockId(UtilsTest.getRandomString(10));
+      id = new MockId(UtilsTest.getRandomString(length));
     } while (generatedKeys.contains(id));
     generatedKeys.add(id);
     return id;

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -664,7 +664,7 @@ class MockIndexSegmentV0 extends IndexSegment {
 }
 
 /**
- * Mock {@link IndexSegment} that uses version {@link PersistentIndex#VERSION_0}
+ * Mock {@link IndexSegment} that uses version {@link PersistentIndex#VERSION_1}
  */
 class MockIndexSegmentV1 extends IndexSegment {
   private final int persistedEntrySizeV1;

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -173,6 +173,9 @@ public class IndexSegmentTest {
     }
   }
 
+  // helpers
+  // comprehensiveTest() helpers
+
   /**
    * Comprehensive tests for {@link IndexSegment}.
    * 1. Creates a segment and checks the getters to make sure they return the right values
@@ -249,9 +252,6 @@ public class IndexSegmentTest {
     }
   }
 
-  // helpers
-  // comprehensiveTest() helpers
-
   /**
    * @return a random log segment name.
    */
@@ -304,6 +304,8 @@ public class IndexSegmentTest {
    * @param segment the {@link IndexSegment} to add the entries to.
    * @param referenceIndex the {@link NavigableMap} to add all the entries to. This represents the source of truth for
    *                       all checks.
+   * @param includeSmallKeys if true, entries that are added will include small keys.
+   * @param includeLargeKeys if true, entries that are added will include large keys.
    * @return {@link List} of {@link IndexEntry}s that were added to the {@link IndexSegment}
    * @throws StoreException
    */

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -45,12 +45,15 @@ import static org.junit.Assert.*;
 
 
 /**
- * Tests for {@link IndexSegment}.s
+ * Tests for {@link IndexSegment}s
  */
 @RunWith(Parameterized.class)
 public class IndexSegmentTest {
   private static final int CUSTOM_ID_SIZE = 10;
   private static final int KEY_SIZE = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE)).sizeInBytes();
+  private static final int SMALLER_KEY_SIZE = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE / 2)).sizeInBytes();
+  private static final int LARGER_KEY_SIZE =
+      new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE + CUSTOM_ID_SIZE / 2)).sizeInBytes();
   private static final StoreConfig STORE_CONFIG = new StoreConfig(new VerifiableProperties(new Properties()));
   private static final Time time = new MockTime();
   private static final long DELETE_FILE_SPAN_SIZE = 10;
@@ -74,7 +77,8 @@ public class IndexSegmentTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{PersistentIndex.VERSION_0}, {PersistentIndex.VERSION_1}});
+    return Arrays.asList(
+        new Object[][]{{PersistentIndex.VERSION_0}, {PersistentIndex.VERSION_1}, {PersistentIndex.VERSION_2}});
   }
 
   /**
@@ -97,62 +101,18 @@ public class IndexSegmentTest {
   }
 
   /**
-   * Comprehensive tests for {@link IndexSegment}.
-   * 1. Creates a segment and checks the getters to make sure they return the right values
-   * 2. Adds some put entries with random sizes, checks getters again and exercises {@link IndexSegment#find(StoreKey)}
-   * and {@link IndexSegment#getEntriesSince(StoreKey, FindEntriesCondition, List, AtomicLong)}.
-   * 3. Adds some delete entries (deletes some existing put entries and creates deletes for puts not in this segment)
-   * and does the same checks as #2.
-   * 4. Writes index to a file and loads it mapped and unmapped and does all the checks in #2 once again along with
-   * checking that journal entries are populated correctly.
-   * @throws IOException
-   * @throws StoreException
+   * Comprehensive tests for {@link IndexSegment}
    */
   @Test
   public void comprehensiveTest() throws IOException, StoreException, InterruptedException {
-    String[] logSegmentNames = {LogSegmentNameHelper.generateFirstSegmentName(false), generateRandomLogSegmentName()};
-    for (String logSegmentName : logSegmentNames) {
-      long writeStartOffset = Utils.getRandomLong(TestUtils.RANDOM, 1000);
-      Offset startOffset = new Offset(logSegmentName, writeStartOffset);
-      NavigableMap<MockId, IndexValue> referenceIndex = new TreeMap<>();
-      // advance time so that last modified time for VERSION_1 has different last modified times for different index
-      // segments
-      time.sleep(10 * Time.MsPerSec);
-      IndexSegment indexSegment = generateIndexSegment(startOffset);
-      Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey = null;
-      verifyIndexSegmentDetails(indexSegment, startOffset, 0, false, startOffset.getOffset(), time.milliseconds(),
-          null);
-      int numItems = 10;
-      List<Long> offsets = new ArrayList<>();
-      offsets.add(writeStartOffset);
-      for (int i = 0; i < numItems - 1; i++) {
-        // size has to be > 0 (no record is 0 sized)
-        long size = Utils.getRandomLong(TestUtils.RANDOM, 1000) + 1;
-        offsets.add(writeStartOffset + size);
-        writeStartOffset += size;
+    if (version == PersistentIndex.VERSION_2) {
+      for (boolean includeSmall : new boolean[]{false, true}) {
+        for (boolean includeLarge : new boolean[]{false, true}) {
+          doComprehensiveTest(version, includeSmall, includeLarge);
+        }
       }
-      long lastEntrySize = Utils.getRandomLong(TestUtils.RANDOM, 1000) + 1;
-      long endOffset = offsets.get(offsets.size() - 1) + lastEntrySize;
-      List<IndexEntry> newEntries = addPutEntries(offsets, lastEntrySize, indexSegment, referenceIndex);
-      if (version == PersistentIndex.VERSION_1) {
-        resetKey = new Pair<>(newEntries.get(0).getKey(), PersistentIndex.IndexEntryType.PUT);
-      }
-      verifyIndexSegmentDetails(indexSegment, startOffset, offsets.size(), false, endOffset,
-          time.seconds() * Time.MsPerSec, resetKey);
-      verifyFind(referenceIndex, indexSegment);
-      verifyGetEntriesSince(referenceIndex, indexSegment);
-
-      int extraIdsToDelete = 10;
-      Set<MockId> idsToDelete = getIdsToDelete(referenceIndex, extraIdsToDelete);
-      Map<Offset, MockId> extraOffsetsToCheck = addDeleteEntries(idsToDelete, indexSegment, referenceIndex);
-      endOffset += idsToDelete.size() * DELETE_FILE_SPAN_SIZE;
-      numItems += extraIdsToDelete;
-      verifyIndexSegmentDetails(indexSegment, startOffset, numItems, false, endOffset, time.milliseconds(), resetKey);
-      verifyFind(referenceIndex, indexSegment);
-      verifyGetEntriesSince(referenceIndex, indexSegment);
-      indexSegment.writeIndexSegmentToFile(indexSegment.getEndOffset());
-      verifyReadFromFile(referenceIndex, indexSegment.getFile(), startOffset, numItems, endOffset, time.milliseconds(),
-          resetKey, extraOffsetsToCheck);
+    } else {
+      doComprehensiveTest(version, false, false);
     }
   }
 
@@ -213,6 +173,82 @@ public class IndexSegmentTest {
     }
   }
 
+  /**
+   * Comprehensive tests for {@link IndexSegment}.
+   * 1. Creates a segment and checks the getters to make sure they return the right values
+   * 2. Adds some put entries with random sizes, checks getters again and exercises {@link IndexSegment#find(StoreKey)}
+   * and {@link IndexSegment#getEntriesSince(StoreKey, FindEntriesCondition, List, AtomicLong)}.
+   * 3. Adds some delete entries (deletes some existing put entries and creates deletes for puts not in this segment)
+   * and does the same checks as #2.
+   * 4. Writes index to a file and loads it mapped and unmapped and does all the checks in #2 once again along with
+   * checking that journal entries are populated correctly.
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void doComprehensiveTest(short version, boolean includeSmallKeys, boolean includeLargeKeys)
+      throws IOException, StoreException, InterruptedException {
+    String[] logSegmentNames = {LogSegmentNameHelper.generateFirstSegmentName(false), generateRandomLogSegmentName()};
+    int valueSize = version == PersistentIndex.VERSION_0 ? IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0
+        : IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1;
+    for (String logSegmentName : logSegmentNames) {
+      long writeStartOffset = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+      Offset startOffset = new Offset(logSegmentName, writeStartOffset);
+      NavigableMap<MockId, IndexValue> referenceIndex = new TreeMap<>();
+      // advance time so that last modified time for VERSION_1 has different last modified times for different index
+      // segments
+      time.sleep(10 * Time.MsPerSec);
+      IndexSegment indexSegment = generateIndexSegment(startOffset);
+      Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey = null;
+      verifyIndexSegmentDetails(indexSegment, startOffset, 0, 0, false, startOffset.getOffset(), time.milliseconds(),
+          null);
+      int numItems = 10;
+      int numSmallKeys = 0;
+      int numLargeKeys = 0;
+      List<Long> offsets = new ArrayList<>();
+      offsets.add(writeStartOffset);
+      for (int i = 0; i < numItems - 1; i++) {
+        // size has to be > 0 (no record is 0 sized)
+        long size = Utils.getRandomLong(TestUtils.RANDOM, 1000) + 1;
+        offsets.add(writeStartOffset + size);
+        writeStartOffset += size;
+        if (i % 3 == 1 && includeSmallKeys) {
+          numSmallKeys++;
+        }
+        if (i % 3 == 2 && includeLargeKeys) {
+          numLargeKeys++;
+        }
+      }
+      long lastEntrySize = Utils.getRandomLong(TestUtils.RANDOM, 1000) + 1;
+      long endOffset = offsets.get(offsets.size() - 1) + lastEntrySize;
+      List<IndexEntry> newEntries =
+          addPutEntries(offsets, lastEntrySize, indexSegment, referenceIndex, includeSmallKeys, includeLargeKeys);
+      if (version != PersistentIndex.VERSION_0) {
+        resetKey = new Pair<>(newEntries.get(0).getKey(), PersistentIndex.IndexEntryType.PUT);
+      }
+      int expectedSizeWritten =
+          SMALLER_KEY_SIZE * numSmallKeys + LARGER_KEY_SIZE * numLargeKeys + KEY_SIZE * (numItems - numSmallKeys
+              - numLargeKeys) + numItems * valueSize;
+      verifyIndexSegmentDetails(indexSegment, startOffset, numItems, expectedSizeWritten, false, endOffset,
+          time.seconds() * Time.MsPerSec, resetKey);
+      verifyFind(referenceIndex, indexSegment);
+      verifyGetEntriesSince(referenceIndex, indexSegment);
+
+      int extraIdsToDelete = 10;
+      Set<MockId> idsToDelete = getIdsToDelete(referenceIndex, extraIdsToDelete);
+      Map<Offset, MockId> extraOffsetsToCheck = addDeleteEntries(idsToDelete, indexSegment, referenceIndex);
+      endOffset += idsToDelete.size() * DELETE_FILE_SPAN_SIZE;
+      numItems += extraIdsToDelete;
+      expectedSizeWritten += extraIdsToDelete * (KEY_SIZE + valueSize);
+      verifyIndexSegmentDetails(indexSegment, startOffset, numItems, expectedSizeWritten, false, endOffset,
+          time.milliseconds(), resetKey);
+      verifyFind(referenceIndex, indexSegment);
+      verifyGetEntriesSince(referenceIndex, indexSegment);
+      indexSegment.writeIndexSegmentToFile(indexSegment.getEndOffset());
+      verifyReadFromFile(referenceIndex, indexSegment.getFile(), startOffset, numItems, expectedSizeWritten, endOffset,
+          time.milliseconds(), resetKey, extraOffsetsToCheck);
+    }
+  }
+
   // helpers
   // comprehensiveTest() helpers
 
@@ -233,11 +269,17 @@ public class IndexSegmentTest {
   private IndexSegment generateIndexSegment(Offset startOffset) {
     IndexSegment indexSegment;
     if (version == PersistentIndex.VERSION_0) {
-      indexSegment = new MockIndexSegmentV0(tempDir.getAbsolutePath(), startOffset, STORE_KEY_FACTORY, KEY_SIZE,
-          IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0, STORE_CONFIG, metrics, time);
+      indexSegment = new MockIndexSegmentV0(tempDir.getAbsolutePath(), startOffset, STORE_KEY_FACTORY,
+          KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0, STORE_CONFIG,
+          metrics, time);
+    } else if (version == PersistentIndex.VERSION_1) {
+      indexSegment = new MockIndexSegmentV1(tempDir.getAbsolutePath(), startOffset, STORE_KEY_FACTORY,
+          KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1, STORE_CONFIG,
+          metrics, time);
     } else {
-      indexSegment = new IndexSegment(tempDir.getAbsolutePath(), startOffset, STORE_KEY_FACTORY, KEY_SIZE,
-          IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1, STORE_CONFIG, metrics, time);
+      indexSegment = new IndexSegment(tempDir.getAbsolutePath(), startOffset, STORE_KEY_FACTORY,
+          KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1, STORE_CONFIG,
+          metrics, time);
     }
     return indexSegment;
   }
@@ -260,18 +302,25 @@ public class IndexSegmentTest {
    * @param offsets the offsets to add the entries at. Difference b/w two entries will be used to compute size.
    * @param lastEntrySize the size of the last entry in {@code offsets}.
    * @param segment the {@link IndexSegment} to add the entries to.
-   * @param referenceIndex the {@link NavigableMap} to add all the entries to. This repreents the source of truth for
+   * @param referenceIndex the {@link NavigableMap} to add all the entries to. This represents the source of truth for
    *                       all checks.
    * @return {@link List} of {@link IndexEntry}s that were added to the {@link IndexSegment}
    * @throws StoreException
    */
   private List<IndexEntry> addPutEntries(List<Long> offsets, long lastEntrySize, IndexSegment segment,
-      NavigableMap<MockId, IndexValue> referenceIndex) throws StoreException {
+      NavigableMap<MockId, IndexValue> referenceIndex, boolean includeSmallKeys, boolean includeLargeKeys)
+      throws StoreException {
     List<IndexEntry> addedEntries = new ArrayList<>();
     for (int i = 0; i < offsets.size(); i++) {
       MockId id;
       do {
-        id = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE));
+        if (includeSmallKeys && i % 3 == 1) {
+          id = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE / 2));
+        } else if (includeLargeKeys && i % 3 == 2) {
+          id = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE + CUSTOM_ID_SIZE / 2));
+        } else {
+          id = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE));
+        }
       } while (referenceIndex.containsKey(id));
       long offset = offsets.get(i);
       long size = i == offsets.size() - 1 ? lastEntrySize : offsets.get(i + 1) - offset;
@@ -291,30 +340,33 @@ public class IndexSegmentTest {
    * values.
    * @param indexSegment the {@link IndexSegment} to test.
    * @param startOffset the expected start {@link Offset} of the {@code indexSegment}
-   * @param numItems the expected numner of items the {@code indexSegment}
+   * @param numItems the expected number of items the {@code indexSegment}
+   * @param sizeWritten the expected number of bytes written to the {@code indexSegment}
    * @param isMapped the expected mapped state of the {@code indexSegment}
    * @param endOffset the expected end offset of the {@code indexSegment}
    * @param lastModifiedTimeInMs the last modified time in ms
    * @param resetKey the reset key for the index segment
    */
-  private void verifyIndexSegmentDetails(IndexSegment indexSegment, Offset startOffset, int numItems, boolean isMapped,
-      long endOffset, long lastModifiedTimeInMs, Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey) {
+  private void verifyIndexSegmentDetails(IndexSegment indexSegment, Offset startOffset, int numItems, int sizeWritten,
+      boolean isMapped, long endOffset, long lastModifiedTimeInMs,
+      Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey) {
     String logSegmentName = startOffset.getName();
-    long valueSize = version == 0 ? IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0 : IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1;
-    long indexEntrySize = KEY_SIZE + valueSize;
+    long valueSize = version == PersistentIndex.VERSION_0 ? IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0
+        : IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1;
+    long indexPersistedEntrySize = indexSegment.getPersistedEntrySize();
     assertEquals("LogSegment name not as expected", logSegmentName, indexSegment.getLogSegmentName());
     assertEquals("Start offset not as expected", startOffset, indexSegment.getStartOffset());
     assertEquals("End offset not as expected", new Offset(logSegmentName, endOffset), indexSegment.getEndOffset());
     assertEquals("Mapped state is incorrect", isMapped, indexSegment.isMapped());
-    assertEquals("Key size is incorrect", KEY_SIZE, indexSegment.getKeySize());
+    assertEquals("Entry size is incorrect: " + version, indexPersistedEntrySize, indexSegment.getPersistedEntrySize());
     assertEquals("Value size is incorrect", valueSize, indexSegment.getValueSize());
     assertEquals("Reset key mismatch ", resetKey, indexSegment.getResetKey());
-    if (version == PersistentIndex.VERSION_1) {
+    if (version != PersistentIndex.VERSION_0) {
       assertEquals("Last modified time is incorrect", lastModifiedTimeInMs, indexSegment.getLastModifiedTimeMs());
     }
     // incase of version 0, last modified time is calculated based on SystemTime and hence cannot verify for equivalency
     if (!isMapped) {
-      assertEquals("Size written not as expected", indexEntrySize * numItems, indexSegment.getSizeWritten());
+      assertEquals("Size written not as expected", sizeWritten, indexSegment.getSizeWritten());
       assertEquals("Number of items not as expected", numItems, indexSegment.getNumberOfItems());
     }
 
@@ -509,7 +561,8 @@ public class IndexSegmentTest {
    * @param referenceIndex the index entries to be used as reference.
    * @param file the {@link File} to be used to load the index.
    * @param startOffset the expected start {@link Offset} of the {@link IndexSegment}
-   * @param numItems the expected numner of items the {@code indexSegment}
+   * @param numItems the expected number of items the {@code indexSegment}
+   * @param expectedSizeWritten the expected number of bytes written to the {@code indexSegment}
    * @param endOffset the expected end offset of the {@code indexSegment}
    * @param lastModifiedTimeInMs the last modified time of the index segment in ms
    * @param resetKey the resetKey of the index segment
@@ -519,12 +572,14 @@ public class IndexSegmentTest {
    * @throws StoreException
    */
   private void verifyReadFromFile(NavigableMap<MockId, IndexValue> referenceIndex, File file, Offset startOffset,
-      int numItems, long endOffset, long lastModifiedTimeInMs, Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey,
-      Map<Offset, MockId> extraOffsetsToCheck) throws IOException, StoreException {
+      int numItems, int expectedSizeWritten, long endOffset, long lastModifiedTimeInMs,
+      Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey, Map<Offset, MockId> extraOffsetsToCheck)
+      throws IOException, StoreException {
     // read from file (unmapped) and verify that everything is ok
     Journal journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
     IndexSegment fromDisk = createIndexSegmentFromFile(file, false, journal);
-    verifyIndexSegmentDetails(fromDisk, startOffset, numItems, false, endOffset, lastModifiedTimeInMs, resetKey);
+    verifyIndexSegmentDetails(fromDisk, startOffset, numItems, expectedSizeWritten, false, endOffset,
+        lastModifiedTimeInMs, resetKey);
     verifyFind(referenceIndex, fromDisk);
     verifyGetEntriesSince(referenceIndex, fromDisk);
     // journal should contain all the entries
@@ -534,7 +589,8 @@ public class IndexSegmentTest {
     // read from file (mapped) and verify that everything is ok
     journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
     fromDisk = createIndexSegmentFromFile(file, true, journal);
-    verifyIndexSegmentDetails(fromDisk, startOffset, numItems, true, endOffset, lastModifiedTimeInMs, resetKey);
+    verifyIndexSegmentDetails(fromDisk, startOffset, numItems, expectedSizeWritten, true, endOffset,
+        lastModifiedTimeInMs, resetKey);
     verifyFind(referenceIndex, fromDisk);
     verifyGetEntriesSince(referenceIndex, fromDisk);
     // journal should not contain any entries
@@ -581,10 +637,12 @@ public class IndexSegmentTest {
  * Mock {@link IndexSegment} that uses version {@link PersistentIndex#VERSION_0}
  */
 class MockIndexSegmentV0 extends IndexSegment {
+  private final int persistedEntrySizeV0;
 
-  MockIndexSegmentV0(String dataDir, Offset startOffset, StoreKeyFactory factory, int keySize, int valueSize,
+  MockIndexSegmentV0(String dataDir, Offset startOffset, StoreKeyFactory factory, int entrySize, int valueSize,
       StoreConfig config, StoreMetrics metrics, Time time) {
-    super(dataDir, startOffset, factory, keySize, valueSize, config, metrics, time);
+    super(dataDir, startOffset, factory, entrySize, valueSize, config, metrics, time);
+    persistedEntrySizeV0 = entrySize;
   }
 
   @Override
@@ -596,4 +654,33 @@ class MockIndexSegmentV0 extends IndexSegment {
   short getVersion() {
     return PersistentIndex.VERSION_0;
   }
+
+  @Override
+  int getPersistedEntrySize() {
+    return persistedEntrySizeV0;
+  }
 }
+
+/**
+ * Mock {@link IndexSegment} that uses version {@link PersistentIndex#VERSION_0}
+ */
+class MockIndexSegmentV1 extends IndexSegment {
+  private final int persistedEntrySizeV1;
+
+  MockIndexSegmentV1(String dataDir, Offset startOffset, StoreKeyFactory factory, int entrySize, int valueSize,
+      StoreConfig config, StoreMetrics metrics, Time time) {
+    super(dataDir, startOffset, factory, entrySize, valueSize, config, metrics, time);
+    persistedEntrySizeV1 = entrySize;
+  }
+
+  @Override
+  short getVersion() {
+    return PersistentIndex.VERSION_1;
+  }
+
+  @Override
+  int getPersistedEntrySize() {
+    return persistedEntrySizeV1;
+  }
+}
+

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -988,14 +988,104 @@ public class IndexTest {
 
   /**
    * Tests the index segment roll over when there is a change in IndexValue size. With introduction of
-   * {@link PersistentIndex#VERSION_1} there is a change in IndexValue
+   * {@link PersistentIndex#VERSION_1} there is a change in IndexValue.
    * @throws StoreException
    * @throws IOException
    */
   @Test
   public void testIndexSegmentRollOverNewIndexSegmentVersion() throws StoreException, IOException {
-    indexSegmentRollOverTest(true);
-    indexSegmentRollOverTest(false);
+    indexSegmentRollOverTest(PersistentIndex.VERSION_0, true);
+    indexSegmentRollOverTest(PersistentIndex.VERSION_0, false);
+    indexSegmentRollOverTest(PersistentIndex.VERSION_1, true);
+    indexSegmentRollOverTest(PersistentIndex.VERSION_1, false);
+  }
+
+  /**
+   * Tests index segment rollover behavior with respect to key size changes. For the current version
+   * ({@link PersistentIndex#VERSION_2}), a change in key size should cause a rollover only if the persistedEntrySize of
+   * the active segment is smaller than the entry size of the incoming entry.
+   * @throws StoreException
+   * @throws IOException
+   */
+  @Test
+  public void testIndexSegmentRollOverKeySizeChange() throws StoreException, IOException {
+    state.closeAndClearIndex();
+    int persistedEntryMinBytes = 100;
+    state.properties.put("store.index.persisted.entry.min.bytes", Long.toString(persistedEntryMinBytes));
+    state.properties.put("store.index.max.number.of.inmem.elements", Integer.toString(10));
+    StoreConfig config = new StoreConfig(new VerifiableProperties(state.properties));
+    state.reloadIndex(false, false);
+
+    List<IndexEntry> indexEntries = new ArrayList<>();
+    int indexCount = state.index.getIndexSegments().size();
+    int serOverheadBytes = state.getUniqueId(10).sizeInBytes() - 10;
+
+    int latestSegmentExpectedEntrySize = config.storeIndexPersistedEntryMinBytes;
+    // add first entry with size under storeIndexPersistedEntryMinBytes.
+    int keySize =
+        config.storeIndexPersistedEntryMinBytes/2 - IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1 - serOverheadBytes;
+    addEntriesAndAssert(indexEntries, keySize, 1, ++indexCount, latestSegmentExpectedEntrySize);
+
+    // Now, the active segment consists of one element. Add 2nd element of a smaller key size; and entry size still under
+    // storeIndexPersistedEntryMinBytes.
+    keySize = keySize / 2;
+    addEntriesAndAssert(indexEntries, keySize, 1, indexCount, latestSegmentExpectedEntrySize);
+
+    // 3rd element with key size greater than the first entry, but still under storeIndexPersistedEntryMinBytes.
+    keySize = keySize * 3;
+    addEntriesAndAssert(indexEntries, keySize, 1, indexCount, latestSegmentExpectedEntrySize);
+
+    // 4th element with key size increase, and entry size at exactly storeIndexPersistedEntryMinBytes.
+    // This should also not cause a rollover.
+    keySize = config.storeIndexPersistedEntryMinBytes - IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1 - serOverheadBytes;
+    addEntriesAndAssert(indexEntries, keySize, 1, indexCount, latestSegmentExpectedEntrySize);
+
+    // 5th element key size increase, and above storeIndexPersistedEntryMinBytes. This continues to be supported via
+    // a rollover.
+    keySize = config.storeIndexPersistedEntryMinBytes - IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1 - serOverheadBytes + 1;
+    addEntriesAndAssert(indexEntries, keySize, 1, ++indexCount, ++latestSegmentExpectedEntrySize);
+
+    // 2nd and 3rd element in the next segment of original size. This should be accommodated in the same segment.
+    keySize = config.storeIndexPersistedEntryMinBytes - IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1 - serOverheadBytes;
+    addEntriesAndAssert(indexEntries, keySize, 2, indexCount, latestSegmentExpectedEntrySize);
+
+    // verify index values
+    verifyIndexValues(indexEntries);
+
+    // Verify that a decrease in the config value for persistedEntryMinBytes does not affect the loaded segment.
+    // Now close and reload index with a change in the minPersistedBytes.
+    state.properties.put("store.index.persisted.entry.min.bytes", Long.toString(persistedEntryMinBytes / 2));
+    state.reloadIndex(true, false);
+    keySize = latestSegmentExpectedEntrySize - IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1 - serOverheadBytes;
+    addEntriesAndAssert(indexEntries, keySize, 7, indexCount, latestSegmentExpectedEntrySize);
+
+    // At this point, index will rollover due to max number of entries being reached. Verify that the new segment that is
+    // created honors the new config value.
+    config = new StoreConfig(new VerifiableProperties(state.properties));
+    latestSegmentExpectedEntrySize = config.storeIndexPersistedEntryMinBytes;
+    keySize = config.storeIndexPersistedEntryMinBytes - IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1 - serOverheadBytes;
+    addEntriesAndAssert(indexEntries, keySize, 1, ++indexCount, latestSegmentExpectedEntrySize);
+
+    // verify index values
+    verifyIndexValues(indexEntries);
+
+    // Verify that an increase in the config value for persistedEntryMinBytes does not affect the loaded segment.
+    // Now close and reload index with a change in the minPersistedBytes.
+    state.properties.put("store.index.persisted.entry.min.bytes", Long.toString(persistedEntryMinBytes * 2));
+    state.reloadIndex(true, false);
+    // Make sure we add entries that can fit in the latest segment.
+    keySize = latestSegmentExpectedEntrySize - IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1 - serOverheadBytes;
+    addEntriesAndAssert(indexEntries, keySize, 9, indexCount, latestSegmentExpectedEntrySize);
+
+    // At this point, index will rollover due to max number of entries being reached. Verify that the new segment that is
+    // created has the new entry size.
+    config = new StoreConfig(new VerifiableProperties(state.properties));
+    keySize = latestSegmentExpectedEntrySize - IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1 - serOverheadBytes;
+    latestSegmentExpectedEntrySize = config.storeIndexPersistedEntryMinBytes;
+    addEntriesAndAssert(indexEntries, keySize, 1, ++indexCount, latestSegmentExpectedEntrySize);
+
+    // verify index values
+    verifyIndexValues(indexEntries);
   }
 
   /**
@@ -2177,40 +2267,47 @@ public class IndexTest {
 
   /**
    * Tests that the index segment rolls over when there is a version change in the index value or index segment
+   * @param indexVersion the version of the index segment that will get rolled over.
    * @param rollOverWithPutRecord {@code true} if the entry that causes rollover should be a put record,
    *                              {@code false} if the entry that causes rollover should be a delete record
    * @throws StoreException
    * @throws IOException
    */
-  private void indexSegmentRollOverTest(boolean rollOverWithPutRecord) throws StoreException, IOException {
+  private void indexSegmentRollOverTest(short indexVersion, boolean rollOverWithPutRecord)
+      throws StoreException, IOException {
     state.closeAndClearIndex();
     Offset currentEndOffset = state.index.getCurrentEndOffset();
 
     List<IndexEntry> indexEntries = new ArrayList<>();
-    // create an index entry in Version_0
+    // create an index entry in older version.
     IndexEntry entry = new IndexEntry(state.getUniqueId(),
         IndexValueTest.getIndexValue(CuratedLogIndexState.PUT_RECORD_SIZE, currentEndOffset, state.time.milliseconds(),
-            PersistentIndex.VERSION_0));
-    // create Index Segment in PersistentIndex.Version_0
-    IndexSegment indexSegment = generateIndexSegmentV0(entry.getValue().getOffset(), entry.getKey().sizeInBytes(),
-        entry.getValue().getBytes().capacity());
+            indexVersion));
+    Offset startOffset = entry.getValue().getOffset();
+    int entrySize = entry.getKey().sizeInBytes() + entry.getValue().getBytes().capacity();
+    int valueSize = entry.getValue().getBytes().capacity();
+    IndexSegment indexSegment =
+        indexVersion == PersistentIndex.VERSION_0 ? generateIndexSegmentV0(startOffset, entrySize, valueSize)
+            : generateIndexSegmentV1(startOffset, entrySize, valueSize);
     state.appendToLog(CuratedLogIndexState.PUT_RECORD_SIZE);
     FileSpan fileSpan = state.log.getFileSpanForMessage(currentEndOffset, CuratedLogIndexState.PUT_RECORD_SIZE);
     indexSegment.addEntry(entry, fileSpan.getEndOffset());
     indexEntries.add(entry);
     // add more entries to the segment
     indexEntries.addAll(addPutEntries(fileSpan.getEndOffset(), indexSegment, 2, CuratedLogIndexState.PUT_RECORD_SIZE,
-        Utils.Infinite_Time));
-    // persist the index segment of version 0
+        Utils.Infinite_Time, 10));
+    // persist the index segment of older version.
     indexSegment.writeIndexSegmentToFile(indexSegment.getEndOffset());
 
     state.reloadIndex(false, false);
+    assertEquals("Reloaded index segments should have the same version they were created in", indexVersion,
+        state.index.getIndexSegments().lastEntry().getValue().getVersion());
     int indexCount = state.index.getIndexSegments().size();
     // add an entry and verify if roll over happened
     currentEndOffset = state.index.getCurrentEndOffset();
     if (rollOverWithPutRecord) {
       indexEntries.addAll(
-          addPutEntries(currentEndOffset, null, 1, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time));
+          addPutEntries(currentEndOffset, null, 1, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time, 10));
     } else {
       IndexEntry entryToDelete = indexEntries.get(TestUtils.RANDOM.nextInt(indexEntries.size()));
       state.appendToLog(state.DELETE_RECORD_SIZE);
@@ -2222,31 +2319,70 @@ public class IndexTest {
     assertEquals("Index roll over should have happened ", indexCount + 1, state.index.getIndexSegments().size());
     currentEndOffset = state.index.getCurrentEndOffset();
     indexEntries.addAll(
-        addPutEntries(currentEndOffset, null, 2, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time));
+        addPutEntries(currentEndOffset, null, 2, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time, 10));
     assertEquals("Index roll over should not have happened ", indexCount + 1, state.index.getIndexSegments().size());
     // verify index values
     verifyIndexValues(indexEntries);
   }
 
   /**
+   * Adds entries to the index and asserts that the number of index segments and the persistedEntrySizes of the latest
+   * segment are as expected.
+   * @param indexEntries the list of {@link IndexEntry} to fill with the entries that are added to the index
+   *                     (used for verification by the caller)
+   * @param keySize the length of the ids used within the keys that are to be created for the entries.
+   * @param numEntriesToAdd the number of entries to be added.
+   * @param expectedSegmentCount the expected number of index segments after the entries are added.
+   * @param latestSegmentExpectedEntrySize the expected persistedEntrySize of the latest segment after the entries are
+   *                                       added.
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void addEntriesAndAssert(List<IndexEntry> indexEntries, int keySize, int numEntriesToAdd,
+      int expectedSegmentCount, int latestSegmentExpectedEntrySize) throws IOException, StoreException {
+    Offset currentEndOffset = state.index.getCurrentEndOffset();
+    indexEntries.addAll(addPutEntries(currentEndOffset, null, numEntriesToAdd, CuratedLogIndexState.PUT_RECORD_SIZE,
+        Utils.Infinite_Time, keySize));
+    assertEquals("Index rollover has or has not happened as expected ", expectedSegmentCount,
+        state.index.getIndexSegments().size());
+    assertEquals(latestSegmentExpectedEntrySize,
+        state.index.getIndexSegments().lastEntry().getValue().getPersistedEntrySize());
+  }
+
+  /**
    * Generate {@link IndexSegment} of version {@link PersistentIndex#VERSION_0}
    * @param startOffset the start offset of the {@link IndexSegment}
-   * @param keySize The key size that this segment supports
+   * @param entrySize The entry size that this segment supports
    * @param valueSize The value size that this segment supports
    * @return the {@link IndexSegment} created of version {@link PersistentIndex#VERSION_0}
    */
-  private IndexSegment generateIndexSegmentV0(Offset startOffset, int keySize, int valueSize) {
+  private IndexSegment generateIndexSegmentV0(Offset startOffset, int entrySize, int valueSize) {
     MetricRegistry metricRegistry = new MetricRegistry();
     StoreMetrics metrics = new StoreMetrics(tempDir.getAbsolutePath(), metricRegistry);
     StoreConfig config = new StoreConfig(new VerifiableProperties(state.properties));
-    return new MockIndexSegmentV0(tempDir.getAbsolutePath(), startOffset, state.STORE_KEY_FACTORY, keySize, valueSize,
-        config, metrics, state.time);
+    return new MockIndexSegmentV0(tempDir.getAbsolutePath(), startOffset, CuratedLogIndexState.STORE_KEY_FACTORY,
+        entrySize, valueSize, config, metrics, state.time);
+  }
+
+  /**
+   * Generate {@link IndexSegment} of version {@link PersistentIndex#VERSION_1}
+   * @param startOffset the start offset of the {@link IndexSegment}
+   * @param entrySize The entry size that this segment supports
+   * @param valueSize The value size that this segment supports
+   * @return the {@link IndexSegment} created of version {@link PersistentIndex#VERSION_1}
+   */
+  private IndexSegment generateIndexSegmentV1(Offset startOffset, int entrySize, int valueSize) {
+    MetricRegistry metricRegistry = new MetricRegistry();
+    StoreMetrics metrics = new StoreMetrics(tempDir.getAbsolutePath(), metricRegistry);
+    StoreConfig config = new StoreConfig(new VerifiableProperties(state.properties));
+    return new MockIndexSegmentV1(tempDir.getAbsolutePath(), startOffset, CuratedLogIndexState.STORE_KEY_FACTORY,
+        entrySize, valueSize, config, metrics, state.time);
   }
 
   /**
    * Adds {@link IndexEntry}s to the given {@link IndexSegment} for {@link IndexValue}s of version
-   * {@link PersistentIndex#VERSION_0} or to the actual {@link PersistentIndex} for {@link IndexValue}s of version
-   * {@link PersistentIndex#CURRENT_VERSION}
+   * {@link PersistentIndex#VERSION_0} or {@link PersistentIndex#VERSION_1} or to the actual {@link PersistentIndex} for
+   * {@link IndexValue}s of version {@link PersistentIndex#CURRENT_VERSION}
    * @param prevEntryEndOffset end offset of last {@link IndexEntry}
    * @param indexSegment the {@link IndexSegment} to which put entries need to be added. If {@code null},
    *                     {@link IndexEntry}s will be added to the {@link PersistentIndex}
@@ -2258,19 +2394,19 @@ public class IndexTest {
    * @throws StoreException
    */
   private List<IndexEntry> addPutEntries(Offset prevEntryEndOffset, IndexSegment indexSegment, int count, long size,
-      long expiresAtMs) throws IOException, StoreException {
+      long expiresAtMs, int idLength) throws IOException, StoreException {
     List<IndexEntry> indexEntries = new ArrayList<>();
     for (int i = 0; i < count; i++) {
       state.appendToLog(size);
       FileSpan fileSpan = state.log.getFileSpanForMessage(prevEntryEndOffset, size);
       IndexEntry entry;
       if (indexSegment != null) {
-        entry = new IndexEntry(state.getUniqueId(),
+        entry = new IndexEntry(state.getUniqueId(idLength),
             IndexValueTest.getIndexValue(size, prevEntryEndOffset, expiresAtMs, state.time.milliseconds(),
                 UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID, indexSegment.getVersion()));
         indexSegment.addEntry(entry, fileSpan.getEndOffset());
       } else {
-        entry = new IndexEntry(state.getUniqueId(),
+        entry = new IndexEntry(state.getUniqueId(idLength),
             new IndexValue(size, prevEntryEndOffset, (byte) 0, expiresAtMs, state.time.milliseconds()));
         state.index.addToIndex(entry, fileSpan);
       }

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -331,7 +331,7 @@ public class IndexValueTest {
    *                              in the same log segment. Set to -1 otherwise.
    * @return the {@link IndexValue} thus constructed
    */
-  private static IndexValue getIndexValue(long size, Offset offset, byte flags, long expiresAtMs,
+  static IndexValue getIndexValue(long size, Offset offset, byte flags, long expiresAtMs,
       long originalMessageOffset) {
     ByteBuffer value = ByteBuffer.allocate(IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0);
     value.putLong(size);

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -40,12 +40,15 @@ public class IndexValueTest {
   private final short version;
 
   /**
-   * Running for {@link PersistentIndex#VERSION_0} and {@link PersistentIndex#VERSION_1}
-   * @return an array with both the versions ({@link PersistentIndex#VERSION_0} and {@link PersistentIndex#VERSION_1}).
+   * Running for {@link PersistentIndex#VERSION_0}, {@link PersistentIndex#VERSION_1} and
+   * {@link PersistentIndex#VERSION_2}
+   * @return an array with versions ({@link PersistentIndex#VERSION_0}, {@link PersistentIndex#VERSION_1} and
+   * {@link PersistentIndex#VERSION_2}).
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{PersistentIndex.VERSION_0}, {PersistentIndex.VERSION_1}});
+    return Arrays.asList(
+        new Object[][]{{PersistentIndex.VERSION_0}, {PersistentIndex.VERSION_1}, {PersistentIndex.VERSION_2}});
   }
 
   /**
@@ -104,6 +107,7 @@ public class IndexValueTest {
               UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID);
           break;
         case PersistentIndex.VERSION_1:
+        case PersistentIndex.VERSION_2:
           verifyIndexValue(value, logSegmentName, size, offset, false, expirationTime.getValue(), offset,
               expectedOperationTimeV1, serviceId, containerId);
           break;
@@ -144,6 +148,7 @@ public class IndexValueTest {
             Utils.Infinite_Time, UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID);
         break;
       case PersistentIndex.VERSION_1:
+      case PersistentIndex.VERSION_2:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, oldOffset,
             expectedOperationTimeV1, serviceId, containerId);
         break;
@@ -157,6 +162,7 @@ public class IndexValueTest {
             UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID);
         break;
       case PersistentIndex.VERSION_1:
+      case PersistentIndex.VERSION_2:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, -1,
             expectedOperationTimeV1, serviceId, containerId);
         break;
@@ -175,6 +181,7 @@ public class IndexValueTest {
             UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID);
         break;
       case PersistentIndex.VERSION_1:
+      case PersistentIndex.VERSION_2:
         verifyIndexValue(newValue, newLogSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, -1,
             expectedOperationTimeV1, serviceId, containerId);
         break;
@@ -208,6 +215,7 @@ public class IndexValueTest {
         expectedExpiryValue = expiresAtMs;
         break;
       case PersistentIndex.VERSION_1:
+      case PersistentIndex.VERSION_2:
         expectedExpiryValue = expiresAtMs >= 0 ? expiresAtMs : Utils.Infinite_Time;
         break;
     }


### PR DESCRIPTION
In order to support accepting blobs with different key sizes without
causing a continuous rollover of index segments, introduce a new config
for the minimum size of entries in a segment along with padding to
make sure all the entries in a segment are of the same size when persisted.

[Here](https://docs.google.com/document/d/1-Iyl-SJxVvz7fVb-EIS9baq82QxDWqRcK1C4rz5ACh0/edit?usp=sharing) is a more detailed write-up on this.