### PR TITLE
Ensure that known data chunk deletions do not initiate background deletes

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/router/Callback.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/Callback.java
@@ -25,5 +25,5 @@ public interface Callback<T> {
    * @param result The result of the request. This would be non null when the request executed successfully
    * @param exception The exception that was reported on execution of the request
    */
-  public void onCompletion(T result, Exception exception);
+  void onCompletion(T result, Exception exception);
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -283,15 +283,14 @@ class NonBlockingRouter implements Router {
         // It is expected that these requests will not always succeed. For example, this may have been triggered by a
         // duplicate delete and the blob could have already been hard deleted, so the deserialization can fail, or the
         // blob could have been garbage collected and not found at all and so on.
-        logger.trace(
-            "Encountered exception when attempting to get chunks of a possibly composite deleted blob " + blobId,
-            exception);
+        logger.trace("Encountered exception when attempting to get chunks of a possibly composite deleted blob {} ",
+            blobId, exception);
       } else if (result.getBlobResult != null) {
         logger.error("Unexpected result returned by background get operation to fetch chunk ids.");
       } else if (result.storeKeys != null) {
         List<BackgroundDeleteRequest> deleteRequests = new ArrayList<>(result.storeKeys.size());
         for (StoreKey storeKey : result.storeKeys) {
-          logger.trace("Initiating delete of chunk blob: " + storeKey);
+          logger.trace("Initiating delete of chunk blob {}: ", storeKey);
           deleteRequests.add(new BackgroundDeleteRequest(storeKey, serviceId));
         }
         initiateBackgroundDeletes(deleteRequests);

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -290,7 +290,7 @@ class NonBlockingRouter implements Router {
       } else if (result.storeKeys != null) {
         List<BackgroundDeleteRequest> deleteRequests = new ArrayList<>(result.storeKeys.size());
         for (StoreKey storeKey : result.storeKeys) {
-          logger.trace("Initiating delete of chunk blob {}: ", storeKey);
+          logger.trace("Initiating delete of chunk blob: {}", storeKey);
           deleteRequests.add(new BackgroundDeleteRequest(storeKey, serviceId));
         }
         initiateBackgroundDeletes(deleteRequests);

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +64,7 @@ class MockServer {
   private boolean getErrorOnDataBlobOnly = false;
   private final ClusterMap clusterMap;
   private final String dataCenter;
+  private final HashMap<RequestOrResponseType, Integer> requestCounts = new HashMap<>();
 
   MockServer(ClusterMap clusterMap, String dataCenter) {
     this.clusterMap = clusterMap;
@@ -84,6 +86,8 @@ class MockServer {
         hardError != null ? hardError : serverErrors.size() > 0 ? serverErrors.poll() : ServerErrorCode.No_Error;
     RequestOrResponseType type = ((RequestOrResponse) send).getRequestType();
     RequestOrResponse response;
+    int count = requestCounts.getOrDefault(type, 0);
+    requestCounts.put(type, count + 1);
     switch (type) {
       case PutRequest:
         response = makePutResponse((PutRequest) send, serverError);
@@ -427,6 +431,15 @@ class MockServer {
    */
   public void setBlobFormatVersion(short blobFormatVersion) {
     this.blobFormatVersion = blobFormatVersion;
+  }
+
+  /**
+   * Get the count of requests of the given type.
+   * @param type the type of request
+   * @return the count of requests this server has received of the given type.
+   */
+  public int getCount(RequestOrResponseType type) {
+    return requestCounts.getOrDefault(type, 0);
   }
 }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
@@ -45,7 +45,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -64,7 +63,7 @@ class MockServer {
   private boolean getErrorOnDataBlobOnly = false;
   private final ClusterMap clusterMap;
   private final String dataCenter;
-  private final HashMap<RequestOrResponseType, Integer> requestCounts = new HashMap<>();
+  private final ConcurrentHashMap<RequestOrResponseType, Integer> requestCounts = new ConcurrentHashMap<>();
 
   MockServer(ClusterMap clusterMap, String dataCenter) {
     this.clusterMap = clusterMap;

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServerLayout.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServerLayout.java
@@ -15,6 +15,7 @@ package com.github.ambry.router;
 
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.protocol.RequestOrResponseType;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,6 +58,19 @@ class MockServerLayout {
    */
   public Collection<MockServer> getMockServers() {
     return mockServers.values();
+  }
+
+  /**
+   * Get the count of requests of the given type received within the servers in this layout.
+   * @param type the type of request
+   * @return the count of requests this server layout has received of the given type.
+   */
+  public int getCount(RequestOrResponseType type) {
+    int count = 0;
+    for (MockServer mockServer : mockServers.values()) {
+      count += mockServer.getCount(type);
+    }
+    return count;
   }
 }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -27,6 +27,8 @@ import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.protocol.GetOption;
+import com.github.ambry.protocol.RequestOrResponseType;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
@@ -193,6 +195,14 @@ public class NonBlockingRouterTest {
     router.getBlob(blobId, new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build())
         .get();
     router.deleteBlob(blobId, null).get();
+    try {
+      router.getBlob(blobId, new GetBlobOptionsBuilder().build()).get();
+    } catch (ExecutionException e) {
+      RouterException r = (RouterException) e.getCause();
+      Assert.assertEquals("BlobDeleted error is expected", RouterErrorCode.BlobDeleted, r.getErrorCode());
+    }
+    router.getBlob(blobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_Deleted_Blobs).build()).get();
+    router.getBlob(blobId, new GetBlobOptionsBuilder().getOption(GetOption.Include_All).build()).get();
     router.close();
     assertExpectedThreadCounts(0, 0);
 
@@ -451,6 +461,7 @@ public class NonBlockingRouterTest {
     String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel).get();
     String deleteServiceId = "delete-service";
     Set<String> blobsToBeDeleted = getBlobsInServers(mockServerLayout);
+    int getRequestCount = mockServerLayout.getCount(RequestOrResponseType.GetRequest);
     // The second iteration is to test the case where the blob was already deleted.
     // The third iteration is to test the case where the blob has expired.
     for (int i = 0; i < 3; i++) {
@@ -475,6 +486,11 @@ public class NonBlockingRouterTest {
             : BackgroundDeleteRequest.SERVICE_ID_PREFIX + deleteServiceId;
         Assert.assertEquals("Unexpected service ID for deleted blob", expectedServiceId, blobIdAndServiceId.getValue());
       }
+      // For 1 chunk deletion attempt, 1 background operation for Get is initiated which results in 2 Get Requests at
+      // the servers.
+      getRequestCount += 2;
+      Assert.assertEquals("Only one attempt of chunk deletion should have been done", getRequestCount,
+          mockServerLayout.getCount(RequestOrResponseType.GetRequest));
     }
 
     deletesDoneLatch.set(new CountDownLatch(5));


### PR DESCRIPTION
Ensure that chunk deletions initiated by operations such as composite
blob deletions do not attempt any more background chunk deletions. Given
that they are known to be data chunks, the Get requests are unnecessary.

Also background chunk deletion operations are expected to fail from time to
time in the presence of duplicate deletes and such. Therefore, use trace logging
to log these errors and not error logging.