### PR TITLE
Adding a tool that can copy data from one store to another

### DIFF
--- a/ambry-tools/src/main/java/com.github.ambry/store/DiskReformatter.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DiskReformatter.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.StaticClusterAgentsFactory;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.Config;
+import com.github.ambry.config.Default;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.tools.util.ToolUtils;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Reformats all the stores on a given disk.
+ */
+public class DiskReformatter {
+  private static final String TEMP_RELOCATION_DIR_NAME = "temp_relocated_store";
+  private static final String TEMP_COPY_DIR_NAME = "temp_copied_store";
+  private static final Logger logger = LoggerFactory.getLogger(DiskReformatter.class);
+
+  private final DataNodeId dataNodeId;
+  private final long fetchSizeInBytes;
+  private final StoreConfig storeConfig;
+  private final StoreKeyFactory storeKeyFactory;
+  private final ClusterMap clusterMap;
+  private final Time time;
+  private final DiskIOScheduler diskIOScheduler = new DiskIOScheduler(null);
+
+  /**
+   * Config for the reformatter.
+   */
+  private static class DiskReformatterConfig {
+    /**
+     * The path to the hardware layout file.
+     */
+    @Config("hardware.layout.file.path")
+    final String hardwareLayoutFilePath;
+
+    /**
+     * The path to the partition layout file.
+     */
+    @Config("partition.layout.file.path")
+    final String partitionLayoutFilePath;
+
+    /**
+     * The hostname of the target server as it appears in the partition layout.
+     */
+    @Config("datanode.hostname")
+    final String datanodeHostname;
+
+    /**
+     * The port of the target server in the partition layout (need not be the actual port to connect to).
+     */
+    @Config("datanode.port")
+    final int datanodePort;
+
+    /**
+     * The mount path of the disk whose partitions need to be re-formatted
+     */
+    @Config("disk.mount.path")
+    final String diskMountPath;
+
+    /**
+     * The path to the scratch space to which a partition on the disk can be temporarily relocated.
+     */
+    @Config("scratch.path")
+    final String scratchPath;
+
+    /**
+     * The size of each fetch from the source store.
+     */
+    @Config("fetch.size.in.bytes")
+    @Default("4 * 1024 * 1024")
+    final long fetchSizeInBytes;
+
+    /**
+     * Constructs the configs associated with the tool.
+     * @param verifiableProperties the props to use to load the config.
+     */
+    DiskReformatterConfig(VerifiableProperties verifiableProperties) {
+      hardwareLayoutFilePath = verifiableProperties.getString("hardware.layout.file.path");
+      partitionLayoutFilePath = verifiableProperties.getString("partition.layout.file.path");
+      datanodeHostname = verifiableProperties.getString("datanode.hostname");
+      datanodePort = verifiableProperties.getIntInRange("datanode.port", 1, 65535);
+      diskMountPath = verifiableProperties.getString("disk.mount.path");
+      scratchPath = verifiableProperties.getString("scratch.path");
+      fetchSizeInBytes = verifiableProperties.getLongInRange("fetch.size.in.bytes", 4 * 1024 * 1024, 1, Long.MAX_VALUE);
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    VerifiableProperties properties = ToolUtils.getVerifiableProperties(args);
+    DiskReformatterConfig config = new DiskReformatterConfig(properties);
+    StoreConfig storeConfig = new StoreConfig(properties);
+    try (ClusterMap clusterMap = new StaticClusterAgentsFactory(new ClusterMapConfig(properties),
+        config.hardwareLayoutFilePath, config.partitionLayoutFilePath).getClusterMap()) {
+      StoreKeyFactory storeKeyFactory = Utils.getObj(storeConfig.storeKeyFactory, clusterMap);
+      DataNodeId dataNodeId = clusterMap.getDataNodeId(config.datanodeHostname, config.datanodePort);
+      if (dataNodeId == null) {
+        throw new IllegalArgumentException(
+            "Did not find node in clustermap with hostname:port - " + config.datanodeHostname + ":"
+                + config.datanodePort);
+      }
+      DiskReformatter reformatter =
+          new DiskReformatter(dataNodeId, config.fetchSizeInBytes, storeConfig, storeKeyFactory, clusterMap,
+              SystemTime.getInstance());
+      reformatter.reformat(config.diskMountPath, new File(config.scratchPath));
+    }
+  }
+
+  /**
+   * @param dataNodeId the {@link DataNodeId} on which {@code diskMountPath} exists.
+   * @param fetchSizeInBytes the size of each fetch from the source store during copy
+   * @param storeConfig the config for the stores
+   * @param storeKeyFactory the {@link StoreKeyFactory} to use.
+   * @param clusterMap the {@link ClusterMap} to use get details of replicas and partitions.
+   * @param time the {@link Time} instance to use.
+   */
+  public DiskReformatter(DataNodeId dataNodeId, long fetchSizeInBytes, StoreConfig storeConfig,
+      StoreKeyFactory storeKeyFactory, ClusterMap clusterMap, Time time) {
+    this.dataNodeId = dataNodeId;
+    this.fetchSizeInBytes = fetchSizeInBytes;
+    this.storeConfig = storeConfig;
+    this.storeKeyFactory = storeKeyFactory;
+    this.clusterMap = clusterMap;
+    this.time = time;
+  }
+
+  /**
+   * Performs a reformat of the disk.
+   * 1. Copies one partition on the disk to a scratch space
+   * 2. Performs local copies of all other partitions on the disk using {@link StoreCopier} and deletes the source.
+   * 3. Copies the partition in the scratch space back on to the disk
+   * 4. Deletes the folder in the scratch space
+   * @param diskMountPath the mount path of the disk to reformat
+   * @param scratch the scratch space to use
+   * @throws IOException if there is any I/O error during renames, moves or copy.
+   * @throws StoreException if there is any error with {@link Store} operations.
+   */
+  public void reformat(String diskMountPath, File scratch) throws IOException, StoreException {
+    if (!scratch.exists()) {
+      throw new IllegalArgumentException("Scratch space " + scratch + " does not exist");
+    }
+    List<ReplicaId> replicasOnDisk = new ArrayList<>();
+    // populate the replicas on disk
+    List<? extends ReplicaId> replicaIds = clusterMap.getReplicaIds(dataNodeId);
+    for (ReplicaId replicaId : replicaIds) {
+      if (replicaId.getDiskId().getMountPath().equals(diskMountPath)) {
+        replicasOnDisk.add(replicaId);
+      }
+    }
+    if (replicasOnDisk.size() == 0) {
+      throw new IllegalArgumentException("There are no replicas on " + diskMountPath + " of " + dataNodeId);
+    }
+    logger.info("Found {} on {}", replicasOnDisk, diskMountPath);
+
+    // move the last replica id to scratch space
+    ReplicaId toMove = replicasOnDisk.get(replicasOnDisk.size() - 1);
+    File scratchSrc = new File(toMove.getReplicaPath());
+    File scratchTgt = new File(scratch, TEMP_RELOCATION_DIR_NAME);
+    logger.info("Moving {} to {}", scratchSrc, scratchTgt);
+    delete(scratchTgt);
+    Files.move(scratchSrc.toPath(), scratchTgt.toPath());
+
+    // reformat each store, except the one moved, one by one
+    for (int i = 0; i < replicasOnDisk.size() - 1; i++) {
+      ReplicaId replicaId = replicasOnDisk.get(i);
+      File src = new File(replicaId.getReplicaPath());
+      File tgt = new File(replicaId.getMountPath(), TEMP_COPY_DIR_NAME);
+      logger.info("Copying {} to {}", src, tgt);
+      copy(src, tgt, replicaId.getCapacityInBytes());
+      delete(src);
+      if (!tgt.renameTo(src)) {
+        throw new IllegalStateException("Could not rename " + tgt + " to " + src);
+      }
+      logger.info("Done reformatting {}", replicaId);
+    }
+
+    // reformat the moved store
+    copy(scratchTgt, scratchSrc, toMove.getCapacityInBytes());
+    delete(scratchTgt);
+    logger.info("Done reformatting {}", toMove);
+  }
+
+  /**
+   * Copy the partition at {@code src} to {@code tgt} using a {@link StoreCopier}.
+   * @param src the location of the partition to be copied
+   * @param tgt the location where the partition has to be copied to
+   * @param capacityInBytes the capacity of the partition.
+   * @throws IOException if there is any I/O error during copy.
+   * @throws StoreException if there is any error with {@link Store} operations.
+   */
+  private void copy(File src, File tgt, long capacityInBytes) throws IOException, StoreException {
+    try (StoreCopier copier = new StoreCopier(src, tgt, capacityInBytes, fetchSizeInBytes, storeConfig,
+        new MetricRegistry(), storeKeyFactory, diskIOScheduler, Collections.EMPTY_LIST, time)) {
+      copier.copy(new StoreFindTokenFactory(storeKeyFactory).getNewFindToken());
+    }
+  }
+
+  /**
+   * Deletes {@code location}
+   * @param location the location to delete
+   * @throws IOException if there are any problems deleting {@code location}.
+   */
+  private void delete(File location) throws IOException {
+    if (location.exists() && !FileUtils.deleteQuietly(location)) {
+      throw new IOException("Could not delete " + location);
+    }
+  }
+}

--- a/ambry-tools/src/main/java/com.github.ambry/store/DiskReformatter.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DiskReformatter.java
@@ -14,10 +14,10 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.ClusterAgentsFactory;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaId;
-import com.github.ambry.clustermap.StaticClusterAgentsFactory;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.Config;
 import com.github.ambry.config.Default;
@@ -127,8 +127,11 @@ public class DiskReformatter {
     VerifiableProperties properties = ToolUtils.getVerifiableProperties(args);
     DiskReformatterConfig config = new DiskReformatterConfig(properties);
     StoreConfig storeConfig = new StoreConfig(properties);
-    try (ClusterMap clusterMap = new StaticClusterAgentsFactory(new ClusterMapConfig(properties),
-        config.hardwareLayoutFilePath, config.partitionLayoutFilePath).getClusterMap()) {
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(properties);
+    ClusterAgentsFactory clusterAgentsFactory =
+        Utils.getObj(clusterMapConfig.clusterMapClusterAgentsFactory, clusterMapConfig, config.hardwareLayoutFilePath,
+            config.partitionLayoutFilePath);
+    try (ClusterMap clusterMap = clusterAgentsFactory.getClusterMap()) {
       StoreKeyFactory storeKeyFactory = Utils.getObj(storeConfig.storeKeyFactory, clusterMap);
       DataNodeId dataNodeId = clusterMap.getDataNodeId(config.datanodeHostname, config.datanodePort);
       if (dataNodeId == null) {

--- a/ambry-tools/src/main/java/com.github.ambry/store/DiskReformatter.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DiskReformatter.java
@@ -220,6 +220,9 @@ public class DiskReformatter {
     String partIdString = toMove.getPartitionId().toString();
     File scratchSrc = new File(toMove.getReplicaPath());
     File scratchTgt = new File(scratch, partIdString + RELOCATED_DIR_NAME_SUFFIX);
+    if (scratchTgt.exists()) {
+      throw new IllegalStateException(scratchTgt + " already exists");
+    }
     logger.info("Moving {} to {}", scratchSrc, scratchTgt);
     delete(scratchTgt);
     FileUtils.moveDirectory(scratchSrc, scratchTgt);

--- a/ambry-tools/src/main/java/com.github.ambry/store/DiskReformatter.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DiskReformatter.java
@@ -44,8 +44,8 @@ import org.slf4j.LoggerFactory;
  * Reformats all the stores on a given disk.
  *
  * Guide to using this tool:
- * 1. Make sure that the Ambry server is completely shut down before using this tool (i.e there should be no else using
- * those directories).
+ * 1. Make sure that the Ambry server is completely shut down before using this tool (i.e there should be nothing else
+ * using those directories).
  * 2. Make sure that the scratch space provided has enough space for the largest partition on the disk. If the same
  * scratch space is used for multiple disks, ensure that it has enough space for all.
  *

--- a/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.StaticClusterAgentsFactory;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.Config;
+import com.github.ambry.config.Default;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.messageformat.BlobStoreRecovery;
+import com.github.ambry.messageformat.MessageFormatWriteSet;
+import com.github.ambry.tools.util.ToolUtils;
+import com.github.ambry.utils.ByteBufferChannel;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Copies messages from one {@link Store} to another and provides the ability to transform the message along the way.
+ * Does not check whether the destination store fits all the messages from the source store - this check has to be
+ * made before copying
+ * <p/>
+ * This tool requires the source store to *not* return blobs that have already been deleted when
+ * {@link Store#findEntriesSince(FindToken, long)} is called. It is also expected to be run when both locations (src and
+ * tgt) are offline.
+ */
+public class StoreCopier implements Closeable {
+
+  /**
+   * Representation of a message in the store. Contains the {@link MessageInfo} and the {@link InputStream} of data.
+   */
+  public static class Message {
+    private final MessageInfo messageInfo;
+    private final InputStream stream;
+
+    /**
+     * @param messageInfo the {@link MessageInfo} for this message.
+     * @param stream the {@link InputStream} that represents the data of this message.
+     */
+    public Message(MessageInfo messageInfo, InputStream stream) {
+      this.messageInfo = messageInfo;
+      this.stream = stream;
+    }
+
+    /**
+     * @return the {@link MessageInfo} for this message.
+     */
+    public MessageInfo getMessageInfo() {
+      return messageInfo;
+    }
+
+    /**
+     * @return the {@link InputStream} that represents the data of this message.
+     */
+    public InputStream getStream() {
+      return stream;
+    }
+  }
+
+  /**
+   * An interface for a transformation function. Transformations can modify any data in the message (including keys).
+   */
+  public interface Transformer {
+    Message transform(Message message);
+  }
+
+  /**
+   * Config class for the {@link StoreCopier}.
+   */
+  static class CopierConfig {
+
+    /**
+     * The path of the directory where the source store files are.
+     */
+    @Config("src.store.dir")
+    final String srcStoreDirPath;
+
+    /**
+     * The path of the directory where the target store files should be.
+     */
+    @Config("tgt.store.dir")
+    final String tgtStoreDirPath;
+
+    /**
+     * The total capacity of the store.
+     */
+    @Config("store.capacity")
+    final long storeCapacity;
+
+    /**
+     * The size of each fetch from the source store.
+     */
+    @Config("fetch.size.in.bytes")
+    @Default("4 * 1024 * 1024")
+    final long fetchSizeInBytes;
+
+    CopierConfig(VerifiableProperties verifiableProperties) {
+      srcStoreDirPath = verifiableProperties.getString("src.store.dir");
+      tgtStoreDirPath = verifiableProperties.getString("tgt.store.dir");
+      storeCapacity = verifiableProperties.getLong("store.capacity");
+      fetchSizeInBytes = verifiableProperties.getLongInRange("fetch.size.in.bytes", 4 * 1024 * 1024, 1, Long.MAX_VALUE);
+    }
+  }
+
+  private static final Logger logger = LoggerFactory.getLogger(StoreCopier.class);
+
+  private final Store src;
+  private final Store tgt;
+  private final CopierConfig config;
+  private final List<Transformer> transformers;
+  private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+  private boolean isOpen = true;
+
+  public static void main(String[] args) throws Exception {
+    VerifiableProperties properties = ToolUtils.getVerifiableProperties(args);
+    CopierConfig config = new CopierConfig(properties);
+    StoreConfig storeConfig = new StoreConfig(properties);
+    String hardwareLayoutFilePath = properties.getString("hardware.layout.file.path");
+    String partitionLayoutFilePath = properties.getString("partition.layout.file.path");
+    try (
+        ClusterMap clusterMap = new StaticClusterAgentsFactory(new ClusterMapConfig(properties), hardwareLayoutFilePath,
+            partitionLayoutFilePath).getClusterMap()) {
+      StoreKeyFactory storeKeyFactory = Utils.getObj(storeConfig.storeKeyFactory, clusterMap);
+      try (StoreCopier storeCopier = new StoreCopier(config, storeConfig, clusterMap.getMetricRegistry(),
+          storeKeyFactory, new DiskIOScheduler(null), Collections.EMPTY_LIST, SystemTime.getInstance())) {
+        storeCopier.copy(new StoreFindTokenFactory(storeKeyFactory).getNewFindToken());
+      }
+    }
+  }
+
+  /**
+   * @param config {@link CopierConfig} that contains the config for the copier.
+   * @param storeConfig {@link StoreConfig} that contains config to initiate a {@link BlobStore}.
+   * @param metricRegistry {@link MetricRegistry} to use for metrics.
+   * @param storeKeyFactory the {@link StoreKeyFactory} to use for {@link StoreKey}s in the {@link Store}.
+   * @param diskIOScheduler the {@link DiskIOScheduler} to use.
+   * @param transformers the list of {@link Transformer} functions to execute. They will be executed in order.
+   * @param time the {@link Time} instance to use.
+   * @throws StoreException
+   */
+  public StoreCopier(CopierConfig config, StoreConfig storeConfig, MetricRegistry metricRegistry,
+      StoreKeyFactory storeKeyFactory, DiskIOScheduler diskIOScheduler, List<Transformer> transformers, Time time)
+      throws StoreException {
+    this.config = config;
+    this.transformers = transformers;
+    StorageManagerMetrics metrics = new StorageManagerMetrics(metricRegistry);
+    MessageStoreRecovery recovery = new BlobStoreRecovery();
+    src = new BlobStore("src", storeConfig, null, null, diskIOScheduler, metrics, config.srcStoreDirPath,
+        config.storeCapacity, storeKeyFactory, recovery, null, time);
+    tgt = new BlobStore("tgt", storeConfig, scheduler, null, diskIOScheduler, metrics, config.tgtStoreDirPath,
+        config.storeCapacity, storeKeyFactory, recovery, null, time);
+    src.start();
+    tgt.start();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!isOpen) {
+      return;
+    }
+    try {
+      scheduler.shutdown();
+      if (!scheduler.awaitTermination(1, TimeUnit.SECONDS)) {
+        logger.error("Could not shut down scheduler");
+      }
+      src.shutdown();
+      tgt.shutdown();
+      isOpen = false;
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Copies data starting from {@code startToken} until all the data is copied.
+   * @param startToken the {@link FindToken} to start copying from. Does not perform any duplication checks at
+   *                   destination.
+   * @return the {@link FindToken} until which data has been copied.
+   * @throws IOException if there is any I/O error while copying.
+   * @throws StoreException if there is any exception dealing with the stores.
+   */
+  public FindToken copy(FindToken startToken) throws IOException, StoreException {
+    FindToken lastToken = null;
+    FindToken token = startToken;
+    do {
+      lastToken = token;
+      FindInfo findInfo = src.findEntriesSince(lastToken, config.fetchSizeInBytes);
+      List<MessageInfo> messageInfos = findInfo.getMessageEntries();
+      for (MessageInfo messageInfo : messageInfos) {
+        logger.trace("Processing {} - isDeleted: {}, isExpired {}", messageInfo.getStoreKey(), messageInfo.isDeleted(),
+            messageInfo.isExpired());
+        if (!messageInfo.isExpired() && !messageInfo.isDeleted()) {
+          if (messageInfo.getSize() > Integer.MAX_VALUE) {
+            throw new IllegalStateException("Cannot copy blobs whose size > Integer.MAX_VALUE");
+          }
+          int size = (int) messageInfo.getSize();
+          StoreInfo storeInfo =
+              src.get(Collections.singletonList(messageInfo.getStoreKey()), EnumSet.noneOf(StoreGetOptions.class));
+          MessageReadSet readSet = storeInfo.getMessageReadSet();
+          byte[] buf = new byte[size];
+          readSet.writeTo(0, new ByteBufferChannel(ByteBuffer.wrap(buf)), 0, size);
+          Message message = new Message(messageInfo, new ByteArrayInputStream(buf));
+          for (Transformer transformer : transformers) {
+            message = transformer.transform(message);
+          }
+          MessageFormatWriteSet writeSet =
+              new MessageFormatWriteSet(message.getStream(), Collections.singletonList(message.getMessageInfo()),
+                  false);
+          tgt.put(writeSet);
+          logger.trace("Copied {} as {}", messageInfo.getStoreKey(), message.getMessageInfo().getStoreKey());
+        }
+      }
+      token = findInfo.getFindToken();
+      logger.info("Checkpoint at {}", token);
+    } while (!token.equals(lastToken));
+    return token;
+  }
+}

--- a/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
@@ -88,8 +88,15 @@ public class StoreCopier implements Closeable {
 
   /**
    * An interface for a transformation function. Transformations can modify any data in the message (including keys).
+   * Needs to be thread safe.
    */
   public interface Transformer {
+
+    /**
+     * Transforms the input {@link Message} into an output {@link Message}.
+     * @param message the input {@link Message} to change.
+     * @return the output {@link Message}.
+     */
     Message transform(Message message);
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
@@ -260,7 +260,8 @@ public class StoreCopier implements Closeable {
         }
       }
       token = findInfo.getFindToken();
-      logger.info("[{}] {}% copied", storeId, token.getBytesRead() * 100 / src.getSizeInBytes());
+      logger.info("[{}] [{}] {}% copied", Thread.currentThread().getName(), storeId,
+          token.getBytesRead() * 100 / src.getSizeInBytes());
     } while (!token.equals(lastToken));
     return token;
   }

--- a/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
@@ -14,8 +14,8 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.ClusterAgentsFactory;
 import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.clustermap.StaticClusterAgentsFactory;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.Config;
 import com.github.ambry.config.Default;
@@ -159,8 +159,11 @@ public class StoreCopier implements Closeable {
     VerifiableProperties properties = ToolUtils.getVerifiableProperties(args);
     CopierConfig config = new CopierConfig(properties);
     StoreConfig storeConfig = new StoreConfig(properties);
-    try (ClusterMap clusterMap = new StaticClusterAgentsFactory(new ClusterMapConfig(properties),
-        config.hardwareLayoutFilePath, config.partitionLayoutFilePath).getClusterMap()) {
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(properties);
+    ClusterAgentsFactory clusterAgentsFactory =
+        Utils.getObj(clusterMapConfig.clusterMapClusterAgentsFactory, clusterMapConfig, config.hardwareLayoutFilePath,
+            config.partitionLayoutFilePath);
+    try (ClusterMap clusterMap = clusterAgentsFactory.getClusterMap()) {
       StoreKeyFactory storeKeyFactory = Utils.getObj(storeConfig.storeKeyFactory, clusterMap);
       File srcDir = new File(config.srcStoreDirPath);
       File tgtDir = new File(config.tgtStoreDirPath);

--- a/ambry-tools/src/test/java/com.github.ambry/store/StoreCopierTest.java
+++ b/ambry-tools/src/test/java/com.github.ambry/store/StoreCopierTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.messageformat.MessageFormatWriteSet;
+import com.github.ambry.utils.ByteBufferChannel;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Tests functionality of {@link StoreCopier}
+ */
+public class StoreCopierTest {
+
+  private static final String STORE_ID = "copier_test";
+  private static final DiskIOScheduler DISK_IO_SCHEDULER = new DiskIOScheduler(null);
+  private static final StoreKeyFactory STORE_KEY_FACTORY;
+
+  static {
+    try {
+      STORE_KEY_FACTORY = Utils.getObj("com.github.ambry.store.MockIdFactory");
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static final long STORE_CAPACITY = 1000;
+  private static final int PUT_RECORD_SIZE = 53;
+  private static final int DELETE_RECORD_SIZE = 29;
+
+  private final File srcDir;
+  private final File tgtDir;
+  private final StoreCopier _storeCopier;
+  private final StoreConfig storeConfig;
+  private final ClusterMap clusterMap = new MockClusterMap();
+  private final Time time = new MockTime();
+
+  private StoreKey putId;
+  private byte[] putData;
+  private StoreKey expiredId;
+  private StoreKey deletedId;
+
+  /**
+   * Creates temporary directories and sets up some test state.
+   * @throws Exception
+   */
+  public StoreCopierTest() throws Exception {
+    srcDir = StoreTestUtils.createTempDirectory("srcDir-" + UtilsTest.getRandomString(10));
+    tgtDir = StoreTestUtils.createTempDirectory("tgtDir-" + UtilsTest.getRandomString(10));
+    Properties properties = new Properties();
+    properties.setProperty("store.key.factory", MockIdFactory.class.getCanonicalName());
+    properties.setProperty("src.store.dir", srcDir.getAbsolutePath());
+    properties.setProperty("tgt.store.dir", tgtDir.getAbsolutePath());
+    properties.setProperty("store.capacity", Long.toString(STORE_CAPACITY));
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+    StoreCopier.CopierConfig config = new StoreCopier.CopierConfig(verifiableProperties);
+    storeConfig = new StoreConfig(verifiableProperties);
+    setupTestState();
+    time.sleep(1000);
+    _storeCopier =
+        new StoreCopier(config, storeConfig, clusterMap.getMetricRegistry(), STORE_KEY_FACTORY, DISK_IO_SCHEDULER,
+            Collections.EMPTY_LIST, time);
+  }
+
+  /**
+   * Releases all resources and deletes the temporary directories.
+   * @throws IOException
+   */
+  @After
+  public void cleanup() throws IOException {
+    _storeCopier.close();
+    assertTrue(srcDir + " could not be deleted", StoreTestUtils.cleanDirectory(srcDir, true));
+    assertTrue(tgtDir + " could not be deleted", StoreTestUtils.cleanDirectory(tgtDir, true));
+  }
+
+  /**
+   * Tests {@link StoreCopier#copy(FindToken)}.
+   * @throws IOException
+   * @throws StoreException
+   */
+  @Test
+  public void copyTest() throws IOException, StoreException {
+    _storeCopier.copy(new StoreFindTokenFactory(STORE_KEY_FACTORY).getNewFindToken());
+    _storeCopier.close();
+    // copy the store descriptor file over
+    Files.copy(new File(srcDir, StoreDescriptor.STORE_DESCRIPTOR_FILENAME).toPath(),
+        new File(tgtDir, StoreDescriptor.STORE_DESCRIPTOR_FILENAME).toPath(), StandardCopyOption.REPLACE_EXISTING);
+    BlobStore tgt = new BlobStore(STORE_ID, storeConfig, null, null, DISK_IO_SCHEDULER,
+        new StorageManagerMetrics(new MetricRegistry()), tgtDir.getAbsolutePath(), STORE_CAPACITY, STORE_KEY_FACTORY,
+        null, null, time);
+    tgt.start();
+    try {
+      // should not be able to get expired or deleted ids
+      StoreKey[] failKeys = {expiredId, deletedId};
+      for (StoreKey key : failKeys) {
+        try {
+          tgt.get(Collections.singletonList(key), EnumSet.allOf(StoreGetOptions.class));
+          fail("Should have failed to get " + key);
+        } catch (StoreException e) {
+          assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.ID_Not_Found, e.getErrorCode());
+        }
+      }
+      // should be able to get the put id
+      StoreInfo storeInfo = tgt.get(Collections.singletonList(putId), EnumSet.noneOf(StoreGetOptions.class));
+      MessageInfo messageInfo = storeInfo.getMessageReadSetInfo().get(0);
+      assertEquals("Size does not match", putData.length, messageInfo.getSize());
+      assertEquals("Size does not match", putData.length, storeInfo.getMessageReadSet().sizeInBytes(0));
+      assertFalse("Should not be deleted or expired", messageInfo.isDeleted() || messageInfo.isExpired());
+      ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate(putData.length));
+      storeInfo.getMessageReadSet().writeTo(0, channel, 0, putData.length);
+      assertArrayEquals("Data put does not match data copied", putData, channel.getBuffer().array());
+    } finally {
+      tgt.shutdown();
+    }
+  }
+
+  /**
+   * Sets up some test state required to verify the copy.
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void setupTestState() throws IOException, StoreException {
+    BlobStore src = new BlobStore(STORE_ID, storeConfig, null, null, DISK_IO_SCHEDULER,
+        new StorageManagerMetrics(clusterMap.getMetricRegistry()), srcDir.getAbsolutePath(), STORE_CAPACITY,
+        STORE_KEY_FACTORY, null, null, time);
+    src.start();
+    try {
+      deletedId = new MockId("deletedId");
+      addMessage(src, deletedId, Utils.Infinite_Time, false);
+      putId = new MockId("putId");
+      putData = addMessage(src, putId, Utils.Infinite_Time, false);
+      addMessage(src, deletedId, Utils.Infinite_Time, true);
+      expiredId = new MockId("expiredId");
+      addMessage(src, expiredId, 0, false);
+    } finally {
+      src.shutdown();
+    }
+  }
+
+  /**
+   * Adds a message to the given {@code store}.
+   * @param store the {@link Store} to add the message to.
+   * @param key the {@link StoreKey} associated with the message.
+   * @param expiryTimeMs the expiry time associated with the message.
+   * @param isDelete {@code true} if this is a delete message, {@code false} otherwise.
+   * @return the message that was written.
+   * @throws IOException
+   * @throws StoreException
+   */
+  private byte[] addMessage(Store store, StoreKey key, long expiryTimeMs, boolean isDelete)
+      throws IOException, StoreException {
+    int size = isDelete ? DELETE_RECORD_SIZE : PUT_RECORD_SIZE;
+    MessageInfo messageInfo = new MessageInfo(key, size, isDelete, expiryTimeMs);
+    byte[] data = TestUtils.getRandomBytes(size);
+    MessageFormatWriteSet writeSet =
+        new MessageFormatWriteSet(new ByteArrayInputStream(data), Collections.singletonList(messageInfo), false);
+    if (isDelete) {
+      store.delete(writeSet);
+    } else {
+      store.put(writeSet);
+    }
+    return data;
+  }
+}

--- a/ambry-tools/src/test/java/com.github.ambry/store/StoreCopierTest.java
+++ b/ambry-tools/src/test/java/com.github.ambry/store/StoreCopierTest.java
@@ -86,13 +86,12 @@ public class StoreCopierTest {
     properties.setProperty("tgt.store.dir", tgtDir.getAbsolutePath());
     properties.setProperty("store.capacity", Long.toString(STORE_CAPACITY));
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
-    StoreCopier.CopierConfig config = new StoreCopier.CopierConfig(verifiableProperties);
     storeConfig = new StoreConfig(verifiableProperties);
     setupTestState();
     time.sleep(1000);
     _storeCopier =
-        new StoreCopier(config, storeConfig, clusterMap.getMetricRegistry(), STORE_KEY_FACTORY, DISK_IO_SCHEDULER,
-            Collections.EMPTY_LIST, time);
+        new StoreCopier(srcDir, tgtDir, STORE_CAPACITY, 4 * 1024 * 1024, storeConfig, clusterMap.getMetricRegistry(),
+            STORE_KEY_FACTORY, DISK_IO_SCHEDULER, Collections.EMPTY_LIST, time);
   }
 
   /**

--- a/ambry-tools/src/test/java/com.github.ambry/store/StoreCopierTest.java
+++ b/ambry-tools/src/test/java/com.github.ambry/store/StoreCopierTest.java
@@ -89,9 +89,8 @@ public class StoreCopierTest {
     storeConfig = new StoreConfig(verifiableProperties);
     setupTestState();
     time.sleep(1000);
-    _storeCopier =
-        new StoreCopier(srcDir, tgtDir, STORE_CAPACITY, 4 * 1024 * 1024, storeConfig, clusterMap.getMetricRegistry(),
-            STORE_KEY_FACTORY, DISK_IO_SCHEDULER, Collections.EMPTY_LIST, time);
+    _storeCopier = new StoreCopier("test_store", srcDir, tgtDir, STORE_CAPACITY, 4 * 1024 * 1024, storeConfig,
+        clusterMap.getMetricRegistry(), STORE_KEY_FACTORY, DISK_IO_SCHEDULER, Collections.EMPTY_LIST, time);
   }
 
   /**

--- a/build.gradle
+++ b/build.gradle
@@ -222,6 +222,7 @@ project(':ambry-tools') {
         testCompile project(':ambry-clustermap').sourceSets.test.output
         testCompile project(':ambry-account').sourceSets.test.output
         testCompile project(':ambry-commons').sourceSets.test.output
+        testCompile project(':ambry-store').sourceSets.test.output
         testCompile project(':ambry-utils').sourceSets.test.output
     }
 }


### PR DESCRIPTION
The tool also allows transforming the messages in the store during copy. The possible uses of this tool will be when messages in a store need data format changes (for e.g. interconversion b/w segmented and non-segmented logs or if more data needs to be added to the message).