### PR TITLE
Add wiring to pass AccountService to SecurityService

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/account/AclService.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/AclService.java
@@ -15,6 +15,7 @@
 package com.github.ambry.account;
 
 import com.github.ambry.router.Callback;
+import java.io.Closeable;
 
 
 /**
@@ -22,7 +23,7 @@ import com.github.ambry.router.Callback;
  * be fast, since it will potentially be used on the critical path.
  * @param <P> the type for the principal. This is generic to allow for different requester authentication schemes.
  */
-public interface AclService<P> {
+public interface AclService<P> extends Closeable {
 
   /**
    * Makes a resource access decision.

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
@@ -14,6 +14,7 @@
 package com.github.ambry.frontend;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.AccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -35,13 +36,13 @@ import org.slf4j.LoggerFactory;
  * instance on {@link #getBlobStorageService()}.
  */
 public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory {
+  private final MetricRegistry metricRegistry;
   private final FrontendConfig frontendConfig;
   private final FrontendMetrics frontendMetrics;
+  private final VerifiableProperties verifiableProperties;
   private final ClusterMap clusterMap;
   private final RestResponseHandler responseHandler;
   private final Router router;
-  private final IdConverterFactory idConverterFactory;
-  private final SecurityServiceFactory securityServiceFactory;
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   /**
@@ -54,20 +55,17 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
    * @throws IllegalArgumentException if any of the arguments are null.
    */
   public AmbryBlobStorageServiceFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
-      RestResponseHandler responseHandler, Router router) throws Exception {
+      RestResponseHandler responseHandler, Router router) {
     if (verifiableProperties == null || clusterMap == null || responseHandler == null || router == null) {
       throw new IllegalArgumentException("Null arguments were provided during instantiation!");
     } else {
-      MetricRegistry metricRegistry = clusterMap.getMetricRegistry();
+      metricRegistry = clusterMap.getMetricRegistry();
       frontendConfig = new FrontendConfig(verifiableProperties);
       frontendMetrics = new FrontendMetrics(metricRegistry);
+      this.verifiableProperties = verifiableProperties;
       this.clusterMap = clusterMap;
       this.responseHandler = responseHandler;
       this.router = router;
-      idConverterFactory =
-          Utils.getObj(frontendConfig.frontendIdConverterFactory, verifiableProperties, metricRegistry);
-      securityServiceFactory = Utils.getObj(frontendConfig.frontendSecurityServiceFactory, verifiableProperties,
-          clusterMap.getMetricRegistry());
     }
     logger.trace("Instantiated AmbryBlobStorageServiceFactory");
   }
@@ -78,7 +76,18 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
    */
   @Override
   public BlobStorageService getBlobStorageService() {
-    return new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, idConverterFactory,
-        securityServiceFactory, clusterMap);
+    try {
+      // TODO get account service from factory here and pass it into AmbryBlobStorageService.
+      AccountService accountService = null;
+      IdConverterFactory idConverterFactory =
+          Utils.getObj(frontendConfig.frontendIdConverterFactory, verifiableProperties, metricRegistry);
+      SecurityServiceFactory securityServiceFactory =
+          Utils.getObj(frontendConfig.frontendSecurityServiceFactory, verifiableProperties, metricRegistry,
+              accountService);
+      return new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, idConverterFactory,
+          securityServiceFactory, clusterMap);
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not instantiate AmbryBlobStorageService", e);
+    }
   }
 }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
  * instance on {@link #getBlobStorageService()}.
  */
 public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory {
-  private final MetricRegistry metricRegistry;
   private final FrontendConfig frontendConfig;
   private final FrontendMetrics frontendMetrics;
   private final VerifiableProperties verifiableProperties;
@@ -59,9 +58,8 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
     if (verifiableProperties == null || clusterMap == null || responseHandler == null || router == null) {
       throw new IllegalArgumentException("Null arguments were provided during instantiation!");
     } else {
-      metricRegistry = clusterMap.getMetricRegistry();
       frontendConfig = new FrontendConfig(verifiableProperties);
-      frontendMetrics = new FrontendMetrics(metricRegistry);
+      frontendMetrics = new FrontendMetrics(clusterMap.getMetricRegistry());
       this.verifiableProperties = verifiableProperties;
       this.clusterMap = clusterMap;
       this.responseHandler = responseHandler;
@@ -80,10 +78,10 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
       // TODO get account service from factory here and pass it into AmbryBlobStorageService.
       AccountService accountService = null;
       IdConverterFactory idConverterFactory =
-          Utils.getObj(frontendConfig.frontendIdConverterFactory, verifiableProperties, metricRegistry);
+          Utils.getObj(frontendConfig.frontendIdConverterFactory, verifiableProperties, clusterMap.getMetricRegistry());
       SecurityServiceFactory securityServiceFactory =
-          Utils.getObj(frontendConfig.frontendSecurityServiceFactory, verifiableProperties, metricRegistry,
-              accountService);
+          Utils.getObj(frontendConfig.frontendSecurityServiceFactory, verifiableProperties,
+              clusterMap.getMetricRegistry(), accountService);
       return new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, idConverterFactory,
           securityServiceFactory, clusterMap);
     } catch (Exception e) {

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityServiceFactory.java
@@ -14,6 +14,7 @@
 package com.github.ambry.frontend;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.AccountService;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.rest.SecurityService;
@@ -30,7 +31,8 @@ public class AmbrySecurityServiceFactory implements SecurityServiceFactory {
   private final FrontendConfig frontendConfig;
   private final FrontendMetrics frontendMetrics;
 
-  public AmbrySecurityServiceFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry) {
+  public AmbrySecurityServiceFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
+      AccountService accountService) {
     frontendConfig = new FrontendConfig(verifiableProperties);
     frontendMetrics = new FrontendMetrics(metricRegistry);
   }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -117,7 +117,7 @@ public class AmbryBlobStorageServiceTest {
     RestRequestMetricsTracker.setDefaults(metricRegistry);
     frontendConfig = new FrontendConfig(verifiableProperties);
     idConverterFactory = new AmbryIdConverterFactory(verifiableProperties, metricRegistry);
-    securityServiceFactory = new AmbrySecurityServiceFactory(verifiableProperties, metricRegistry);
+    securityServiceFactory = new AmbrySecurityServiceFactory(verifiableProperties, metricRegistry, null);
     clusterMap = new MockClusterMap();
     router = new InMemoryRouter(verifiableProperties, clusterMap);
     responseHandler = new FrontendTestResponseHandler();

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceFactoryTest.java
@@ -32,8 +32,9 @@ public class AmbrySecurityServiceFactoryTest {
    */
   @Test
   public void getAmbrySecurityServiceFactoryTest() throws InstantiationException {
-    SecurityService securityService = new AmbrySecurityServiceFactory(new VerifiableProperties(new Properties()),
-        new MetricRegistry()).getSecurityService();
+    SecurityService securityService =
+        new AmbrySecurityServiceFactory(new VerifiableProperties(new Properties()), new MetricRegistry(),
+            null).getSecurityService();
     Assert.assertNotNull(securityService);
   }
 }


### PR DESCRIPTION
This passes AccountService as an argument to the SecurityServiceFactory
constructor. This will allow components in SecurityService
implementations to access AccountService.