### PR TITLE
Fixing a build failure due to runtime class dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,6 +245,7 @@ project(':ambry-rest') {
         testCompile project(':ambry-clustermap').sourceSets.test.output
         testCompile project(':ambry-utils').sourceSets.test.output
         testCompile project(':ambry-commons').sourceSets.test.output
+        testCompile project(':ambry-router').sourceSets.main.output
         testCompile project(':ambry-router').sourceSets.test.output
         testCompile "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
     }


### PR DESCRIPTION
In #693, the InMemoryRouter was moved to the ambry-router module and
a test source dependency on ambry-router was added to ambry-rest.
However, a dependency on the main source was not added and InMemoryRouter
uses some code in the main source. This was causing a NoClassDefFoundError.
This commit adds a dependency for the tests on the main source of ambry-router
which should fix the problem

This exception is visible in intellij in unchanged code
```
java.lang.NoClassDefFoundError: com/github/ambry/router/RouterUtils
	at com.github.ambry.router.InMemoryRouter.getBlob(InMemoryRouter.java:162)
	at com.github.ambry.rest.MockBlobStorageService.handleGet(MockBlobStorageService.java:92)
	at com.github.ambry.rest.AsyncRequestWorker.processRequest(AsyncRequestResponseHandler.java:426)
	at com.github.ambry.rest.AsyncRequestWorker.run(AsyncRequestResponseHandler.java:306)
	at java.lang.Thread.run(Thread.java:745)
```

With this change, it no longer shows up.