### PR TITLE
Introducing ability to control replication from certain DCs

### DIFF
--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
@@ -20,5 +20,5 @@ package com.github.ambry.protocol;
  * requests/responses
  */
 public enum AdminRequestOrResponseType {
-  TriggerCompaction, RequestControl
+  TriggerCompaction, RequestControl, ReplicationControl
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminResponse.java
@@ -48,7 +48,7 @@ public class AdminResponse extends Response {
     }
     Short versionId = stream.readShort();
     if (!versionId.equals(ADMIN_RESPONSE_VERSION_V1)) {
-      throw new IllegalStateException("Unrecognized version for AdminResponse: " + ADMIN_RESPONSE_VERSION_V1);
+      throw new IllegalStateException("Unrecognized version for AdminResponse: " + versionId);
     }
     int correlationId = stream.readInt();
     String clientId = Utils.readIntString(stream);

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicationControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicationControlAdminRequest.java
@@ -42,7 +42,7 @@ public class ReplicationControlAdminRequest extends AdminRequest {
       throws IOException {
     Short versionId = stream.readShort();
     if (!versionId.equals(VERSION_V1)) {
-      throw new IllegalStateException("Unrecognized version for ReplicationControlAdminRequest: " + VERSION_V1);
+      throw new IllegalStateException("Unrecognized version for ReplicationControlAdminRequest: " + versionId);
     }
     int listSize = stream.readInt();
     List<String> origins = new ArrayList<>();

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicationControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicationControlAdminRequest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * An admin request used to control replication behavior (enable/disable)
+ */
+public class ReplicationControlAdminRequest extends AdminRequest {
+  private static final short VERSION_V1 = 1;
+
+  private final List<String> origins;
+  private final boolean enable;
+  private final long sizeInBytes;
+
+  /**
+   * Reads from a stream and constructs a {@link ReplicationControlAdminRequest}.
+   * @param stream the stream to read from
+   * @param adminRequest the {@link AdminRequest} that contains some necessary headers.
+   * @return the {@link ReplicationControlAdminRequest} constructed from the {@code stream}.
+   * @throws IOException
+   */
+  public static ReplicationControlAdminRequest readFrom(DataInputStream stream, AdminRequest adminRequest)
+      throws IOException {
+    Short versionId = stream.readShort();
+    if (!versionId.equals(VERSION_V1)) {
+      throw new IllegalStateException("Unrecognized version for ReplicationControlAdminRequest: " + VERSION_V1);
+    }
+    int listSize = stream.readInt();
+    List<String> origins = new ArrayList<>();
+    for (int i = 0; i < listSize; i++) {
+      origins.add(Utils.readIntString(stream, StandardCharsets.UTF_8));
+    }
+    boolean enable = stream.readByte() == 1;
+    return new ReplicationControlAdminRequest(origins, enable, adminRequest);
+  }
+
+  /**
+   * Construct a ReplicationControlAdminRequest
+   * @param origins the list of datacenters from which replication should be enabled/disabled.
+   * @param enable enable/disable flag ({@code true} to enable).
+   * @param adminRequest the {@link AdminRequest} that contains common admin request releated information.
+   */
+  public ReplicationControlAdminRequest(List<String> origins, boolean enable, AdminRequest adminRequest) {
+    super(AdminRequestOrResponseType.ReplicationControl, adminRequest.getPartitionId(), adminRequest.getCorrelationId(),
+        adminRequest.getClientId());
+    this.origins = origins;
+    this.enable = enable;
+    sizeInBytes = computeSizeInBytes();
+  }
+
+  /**
+   * @return the list of datacenters from which replication should be enabled/disabled.
+   */
+  public List<String> getOrigins() {
+    return origins;
+  }
+
+  /**
+   * @return if replication from {@link #getOrigins()} needs to enabled ({@code true}) or disabled ({@code false}).
+   */
+  public boolean shouldEnable() {
+    return enable;
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return sizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    return "ReplicationControlAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId + ", Origins="
+        + origins + ", PartitionId=" + getPartitionId() + "]";
+  }
+
+  @Override
+  protected void serializeIntoBuffer() {
+    super.serializeIntoBuffer();
+    bufferToSend.putShort(VERSION_V1);
+    bufferToSend.putInt(origins.size());
+    for (String origin : origins) {
+      Utils.serializeString(bufferToSend, origin, StandardCharsets.UTF_8);
+    }
+    bufferToSend.put(enable ? (byte) 1 : 0);
+  }
+
+  private long computeSizeInBytes() {
+    // parent size + version size + list length size
+    long size = super.sizeInBytes() + Short.BYTES + Integer.BYTES;
+    for (String origin : origins) {
+      // size of length field
+      size += Integer.BYTES;
+      // size of the byte representation of the string
+      size += origin.getBytes(StandardCharsets.UTF_8).length;
+    }
+    // enable flag size
+    size += Byte.BYTES;
+    return size;
+  }
+}

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicationControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicationControlAdminRequest.java
@@ -23,6 +23,9 @@ import java.util.List;
 
 /**
  * An admin request used to control replication behavior (enable/disable)
+ * <p/>
+ * This request can be used to control replication (at a single storage node) of particular partitions from particular
+ * datacenters (i.e. replication that adds data locally on the given storage node).
  */
 public class ReplicationControlAdminRequest extends AdminRequest {
   private static final short VERSION_V1 = 1;

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicationControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicationControlAdminRequest.java
@@ -36,7 +36,7 @@ public class ReplicationControlAdminRequest extends AdminRequest {
    * @param stream the stream to read from
    * @param adminRequest the {@link AdminRequest} that contains some necessary headers.
    * @return the {@link ReplicationControlAdminRequest} constructed from the {@code stream}.
-   * @throws IOException
+   * @throws IOException if there is any problem reading from the stream
    */
   public static ReplicationControlAdminRequest readFrom(DataInputStream stream, AdminRequest adminRequest)
       throws IOException {
@@ -57,7 +57,7 @@ public class ReplicationControlAdminRequest extends AdminRequest {
    * Construct a ReplicationControlAdminRequest
    * @param origins the list of datacenters from which replication should be enabled/disabled.
    * @param enable enable/disable flag ({@code true} to enable).
-   * @param adminRequest the {@link AdminRequest} that contains common admin request releated information.
+   * @param adminRequest the {@link AdminRequest} that contains common admin request related information.
    */
   public ReplicationControlAdminRequest(List<String> origins, boolean enable, AdminRequest adminRequest) {
     super(AdminRequestOrResponseType.ReplicationControl, adminRequest.getPartitionId(), adminRequest.getCorrelationId(),

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestControlAdminRequest.java
@@ -49,7 +49,7 @@ public class RequestControlAdminRequest extends AdminRequest {
    * Construct a RequestControlAdminRequest
    * @param requestTypeToControl the {@link RequestOrResponseType} to control.
    * @param enable enable/disable flag ({@code true} to enable).
-   * @param adminRequest the {@link AdminRequest} that contains common admin request releated information.
+   * @param adminRequest the {@link AdminRequest} that contains common admin request related information.
    */
   public RequestControlAdminRequest(RequestOrResponseType requestTypeToControl, boolean enable,
       AdminRequest adminRequest) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -134,7 +134,7 @@ class ReplicaThread implements Runnable {
   }
 
   /**
-   * Enables/disables replication on the given {@code id}.
+   * Enables/disables replication on the given {@code ids}.
    * @param ids the {@link PartitionId}s to enable/disable it on.
    * @param enable whether to enable ({@code true}) or disable.
    */

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -17,6 +17,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.commons.ServerErrorCode;
@@ -54,11 +56,14 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +74,8 @@ import org.slf4j.LoggerFactory;
 class ReplicaThread implements Runnable {
 
   private final Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicateGroupedByNode;
+  private final Set<PartitionId> replicatedPartitions = new HashSet<>();
+  private final Set<PartitionId> replicationDisabledPartitions = new HashSet<>();
   private final CountDownLatch shutdownLatch = new CountDownLatch(1);
   private volatile boolean running;
   private boolean waitEnabled;
@@ -89,6 +96,10 @@ class ReplicaThread implements Runnable {
   private final boolean replicatingFromRemoteColo;
   private final boolean replicatingOverSsl;
   private final String datacenterName;
+  private final ReentrantLock lock = new ReentrantLock();
+  private final Condition pauseCondition = lock.newCondition();
+
+  private volatile boolean allDisabled = false;
 
   ReplicaThread(String threadName, Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicateGroupedByNode,
       FindTokenFactory findTokenFactory, ClusterMap clusterMap, AtomicInteger correlationIdGenerator,
@@ -115,6 +126,38 @@ class ReplicaThread implements Runnable {
     this.waitEnabled = !replicatingFromRemoteColo;
     this.replicatingOverSsl = replicatingOverSsl;
     this.datacenterName = datacenterName;
+    for (Map.Entry<DataNodeId, List<RemoteReplicaInfo>> entry : replicasToReplicateGroupedByNode.entrySet()) {
+      for (RemoteReplicaInfo info : entry.getValue()) {
+        replicatedPartitions.add(info.getReplicaId().getPartitionId());
+      }
+    }
+  }
+
+  /**
+   * Enables/disables replication on the given {@code id}.
+   * @param ids the {@link PartitionId}s to enable/disable it on.
+   * @param enable whether to enable ({@code true}) or disable.
+   */
+  void controlReplicationForPartitions(List<? extends PartitionId> ids, boolean enable) {
+    lock.lock();
+    try {
+      for (PartitionId id : ids) {
+        if (replicatedPartitions.contains(id)) {
+          if (enable) {
+            replicationDisabledPartitions.remove(id);
+            allDisabled = false;
+            pauseCondition.signal();
+          } else {
+            replicationDisabledPartitions.add(id);
+            allDisabled = replicatedPartitions.size() == replicationDisabledPartitions.size();
+          }
+          logger.info("Enable status of replication of {} from {} is {}. allDisabled for {} is {}", id, datacenterName,
+              replicationDisabledPartitions.contains(id), getName(), allDisabled);
+        }
+      }
+    } finally {
+      lock.unlock();
+    }
   }
 
   String getName() {
@@ -125,7 +168,8 @@ class ReplicaThread implements Runnable {
   public void run() {
     try {
       logger.trace("Starting replica thread on Local node: " + dataNodeId + " Thread name: " + threadName);
-      List<List<RemoteReplicaInfo>> replicasToReplicate = new ArrayList<>(replicasToReplicateGroupedByNode.size());
+      List<List<RemoteReplicaInfo>> replicasToReplicate =
+          new ArrayList<List<RemoteReplicaInfo>>(replicasToReplicateGroupedByNode.size());
       for (Map.Entry<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicateEntry : replicasToReplicateGroupedByNode.entrySet()) {
         logger.info("Remote node: " + replicasToReplicateEntry.getKey() + " Thread name: " + threadName
             + " ReplicasToReplicate: " + replicasToReplicateEntry.getValue());
@@ -134,6 +178,16 @@ class ReplicaThread implements Runnable {
       logger.info("Begin iteration for thread " + threadName);
       while (running) {
         replicate(replicasToReplicate);
+        lock.lock();
+        try {
+          if (running && allDisabled) {
+            pauseCondition.await();
+          }
+        } catch (Exception e) {
+          logger.error("Received interrupted exception during pause", e);
+        } finally {
+          lock.unlock();
+        }
       }
     } finally {
       running = false;
@@ -142,8 +196,8 @@ class ReplicaThread implements Runnable {
   }
 
   /**
-   * Replicates from the given {@code replicasToReplicate}.
-   * @param replicasToReplicate the remote replicas to replicate from
+   * Replicas from the given replicas
+   * @param replicasToReplicate list of {@link RemoteReplicaInfo} by data node
    */
   void replicate(List<List<RemoteReplicaInfo>> replicasToReplicate) {
     // shuffle the nodes
@@ -183,7 +237,8 @@ class ReplicaThread implements Runnable {
 
       List<RemoteReplicaInfo> activeReplicasPerNode = new ArrayList<RemoteReplicaInfo>();
       for (RemoteReplicaInfo remoteReplicaInfo : replicasToReplicatePerNode) {
-        if (!remoteReplicaInfo.getReplicaId().isDown()) {
+        ReplicaId replicaId = remoteReplicaInfo.getReplicaId();
+        if (!replicationDisabledPartitions.contains(replicaId.getPartitionId()) && !replicaId.isDown()) {
           activeReplicasPerNode.add(remoteReplicaInfo);
         }
       }
@@ -767,6 +822,12 @@ class ReplicaThread implements Runnable {
 
   void shutdown() throws InterruptedException {
     running = false;
+    lock.lock();
+    try {
+      pauseCondition.signal();
+    } finally {
+      lock.unlock();
+    }
     shutdownLatch.await();
   }
 }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -144,9 +144,10 @@ class ReplicaThread implements Runnable {
       for (PartitionId id : ids) {
         if (replicatedPartitions.contains(id)) {
           if (enable) {
-            replicationDisabledPartitions.remove(id);
-            allDisabled = false;
-            pauseCondition.signal();
+            if (replicationDisabledPartitions.remove(id)) {
+              allDisabled = false;
+              pauseCondition.signal();
+            }
           } else {
             replicationDisabledPartitions.add(id);
             allDisabled = replicatedPartitions.size() == replicationDisabledPartitions.size();
@@ -158,6 +159,13 @@ class ReplicaThread implements Runnable {
     } finally {
       lock.unlock();
     }
+  }
+
+  /**
+   * @return {@link Set} of {@link PartitionId}s for which replication is disabled.
+   */
+  Set<PartitionId> getReplicationDisabledPartitions() {
+    return replicationDisabledPartitions;
   }
 
   String getName() {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -377,10 +377,13 @@ public class ReplicationManager {
   }
 
   /**
-   * Enables/disables {@code types} of replication on the given {@code id}s.
+   * Enables/disables {@code types} of replication on the given {@code ids}. The disabling is in-memory and therefore
+   * is not valid across restarts.
    * @param ids the {@link PartitionId}s to enable/disable it on.
    * @param origins the list of datacenters from which replication should be enabled/disabled.
    * @param enable whether to enable ({@code true}) or disable.
+   * @return {@code true} if disabling succeeded, {@code false} otherwise. Disabling fails if {@code origins} is empty
+   * or contains unrecognized datacenters.
    */
   public boolean controlReplicationForPartitions(List<? extends PartitionId> ids, List<String> origins,
       boolean enable) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -379,8 +379,8 @@ public class ReplicationManager {
   }
 
   /**
-   * Enables/disables {@code types} of replication on the given {@code ids}. The disabling is in-memory and therefore
-   * is not valid across restarts.
+   * Enables/disables replication of the given {@code ids} from {@code origins}. The disabling is in-memory and
+   * therefore is not valid across restarts.
    * @param ids the {@link PartitionId}s to enable/disable it on.
    * @param origins the list of datacenters from which replication should be enabled/disabled.
    * @param enable whether to enable ({@code true}) or disable.

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -325,7 +325,7 @@ public class ReplicationMetrics {
    *                           datacenter
    * @param localDatacenter The datacenter on which the {@link ReplicationManager} is running
    */
-  void trackLiveThreadsCount(final Map<String, ArrayList<ReplicaThread>> replicaThreadPools, String localDatacenter) {
+  void trackLiveThreadsCount(final Map<String, List<ReplicaThread>> replicaThreadPools, String localDatacenter) {
     for (final String datacenter : replicaThreadPools.keySet()) {
       Gauge<Integer> liveThreadsPerDatacenter = new Gauge<Integer>() {
         @Override

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -640,6 +640,9 @@ public class ReplicationTest {
     }
   }
 
+  /**
+   * Interface to help perform actions on store events.
+   */
   interface StoreEventListener {
     void onPut(MockStore store, List<MessageInfo> messageInfos);
   }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -86,14 +86,197 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 
+/**
+ * Tests for ReplicaThread
+ */
 public class ReplicationTest {
+
+  /**
+   * Tests pausing all partitions and makes sure that the replica thread pauses. Also tests that it resumes when one
+   * eligible partition is reenabled and that replication completes successfully.
+   * @throws Exception
+   */
+  @Test
+  public void replicationAllPauseTest() throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    Host localHost = new Host(clusterMap.getDataNodeIds().get(0), clusterMap);
+    Host remoteHost = new Host(clusterMap.getDataNodeIds().get(1), clusterMap);
+
+    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+    for (PartitionId partitionId : partitionIds) {
+      // add  10 messages to the remote host only
+      addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 10);
+    }
+
+    Properties properties = new Properties();
+    properties.put("replication.wait.time.between.replicas.ms", "0");
+    ReplicationConfig config = new ReplicationConfig(new VerifiableProperties(properties));
+    ReplicationMetrics replicationMetrics =
+        new ReplicationMetrics(new MetricRegistry(), clusterMap.getReplicaIds(localHost.dataNodeId));
+    replicationMetrics.populatePerColoMetrics(Collections.singleton(remoteHost.dataNodeId.getDatacenterName()));
+    StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
+
+    Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicate = new HashMap<>();
+    CountDownLatch readyToPause = new CountDownLatch(1);
+    CountDownLatch readyToProceed = new CountDownLatch(1);
+    AtomicReference<CountDownLatch> reachedLimitLatch = new AtomicReference<>(new CountDownLatch(1));
+    AtomicReference<Exception> exception = new AtomicReference<>();
+    replicasToReplicate.put(remoteHost.dataNodeId,
+        localHost.getRemoteReplicaInfos(remoteHost, (store, messageInfos) -> {
+          try {
+            readyToPause.countDown();
+            readyToProceed.await();
+            if (store.messageInfos.size() == remoteHost.infosByPartition.get(store.id).size()) {
+              reachedLimitLatch.get().countDown();
+            }
+          } catch (Exception e) {
+            exception.set(e);
+          }
+        }));
+
+    Map<DataNodeId, Host> hosts = new HashMap<>();
+    hosts.put(remoteHost.dataNodeId, remoteHost);
+    int batchSize = 4;
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, batchSize);
+
+    ReplicaThread replicaThread =
+        new ReplicaThread("threadtest", replicasToReplicate, new MockFindTokenFactory(), clusterMap,
+            new AtomicInteger(0), localHost.dataNodeId, connectionPool, config, replicationMetrics, null,
+            storeKeyFactory, true, clusterMap.getMetricRegistry(), false, localHost.dataNodeId.getDatacenterName(),
+            new ResponseHandler(clusterMap));
+    Thread thread = Utils.newThread(replicaThread, false);
+    thread.start();
+
+    // wait to pause replication
+    readyToPause.await(10, TimeUnit.SECONDS);
+    replicaThread.controlReplicationForPartitions(clusterMap.getAllPartitionIds(), false);
+    // signal the replica thread to move forward
+    readyToProceed.countDown();
+    // wait for the thread to go into waiting state
+    assertTrue("Replica thread did not go into waiting state",
+        TestUtils.waitUntilExpectedState(thread, Thread.State.WAITING, 10000));
+    // unpause one partition
+    replicaThread.controlReplicationForPartitions(Collections.singletonList(partitionIds.get(0)), true);
+    // wait for it to catch up
+    reachedLimitLatch.get().await(10, TimeUnit.SECONDS);
+    // reset limit
+    reachedLimitLatch.set(new CountDownLatch(partitionIds.size() - 1));
+    // unpause all partitions
+    replicaThread.controlReplicationForPartitions(clusterMap.getAllPartitionIds(), true);
+    // wait until all catch up
+    reachedLimitLatch.get().await(10, TimeUnit.SECONDS);
+    // shutdown
+    replicaThread.shutdown();
+    if (exception.get() != null) {
+      throw exception.get();
+    }
+    Map<PartitionId, List<MessageInfo>> missingInfos = remoteHost.getMissingInfos(localHost.infosByPartition);
+    for (Map.Entry<PartitionId, List<MessageInfo>> entry : missingInfos.entrySet()) {
+      assertEquals("No infos should be missing", 0, entry.getValue().size());
+    }
+    Map<PartitionId, List<ByteBuffer>> missingBuffers = remoteHost.getMissingBuffers(localHost.buffersByPartition);
+    for (Map.Entry<PartitionId, List<ByteBuffer>> entry : missingBuffers.entrySet()) {
+      assertEquals("No buffers should be missing", 0, entry.getValue().size());
+    }
+  }
+
+  /**
+   * Tests pausing replication for all and individual partitions.
+   * @throws Exception
+   */
+  @Test
+  public void replicationPauseTest() throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    Host localHost = new Host(clusterMap.getDataNodeIds().get(0), clusterMap);
+    Host remoteHost = new Host(clusterMap.getDataNodeIds().get(1), clusterMap);
+
+    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+    for (PartitionId partitionId : partitionIds) {
+      // add  10 messages to the remote host only
+      addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 10);
+    }
+
+    Properties properties = new Properties();
+    properties.put("replication.wait.time.between.replicas.ms", "0");
+    ReplicationConfig config = new ReplicationConfig(new VerifiableProperties(properties));
+    ReplicationMetrics replicationMetrics =
+        new ReplicationMetrics(new MetricRegistry(), clusterMap.getReplicaIds(localHost.dataNodeId));
+    replicationMetrics.populatePerColoMetrics(Collections.singleton(remoteHost.dataNodeId.getDatacenterName()));
+    StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
+    Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicate = new HashMap<>();
+    replicasToReplicate.put(remoteHost.dataNodeId, localHost.getRemoteReplicaInfos(remoteHost, null));
+    Map<DataNodeId, Host> hosts = new HashMap<>();
+    hosts.put(remoteHost.dataNodeId, remoteHost);
+    int batchSize = 4;
+    MockConnectionPool connectionPool = new MockConnectionPool(hosts, clusterMap, batchSize);
+
+    ReplicaThread replicaThread =
+        new ReplicaThread("threadtest", replicasToReplicate, new MockFindTokenFactory(), clusterMap,
+            new AtomicInteger(0), localHost.dataNodeId, connectionPool, config, replicationMetrics, null,
+            storeKeyFactory, true, clusterMap.getMetricRegistry(), false, localHost.dataNodeId.getDatacenterName(),
+            new ResponseHandler(clusterMap));
+
+    Map<PartitionId, Integer> progressTracker = new HashMap<>();
+    PartitionId idToLeaveOut = clusterMap.getAllPartitionIds().get(0);
+    boolean allStopped = false;
+    boolean onlyOneResumed = false;
+    boolean allReenabled = false;
+    while (true) {
+      replicaThread.replicate(new ArrayList<>(replicasToReplicate.values()));
+      boolean replicationDone = true;
+      for (RemoteReplicaInfo replicaInfo : replicasToReplicate.get(remoteHost.dataNodeId)) {
+        PartitionId id = replicaInfo.getReplicaId().getPartitionId();
+        MockFindToken token = (MockFindToken) replicaInfo.getToken();
+        int lastProgress = progressTracker.computeIfAbsent(id, id1 -> 0);
+        int currentProgress = token.getIndex();
+        boolean partDone = currentProgress + 1 == remoteHost.infosByPartition.get(id).size();
+        if (allStopped || (onlyOneResumed && !id.equals(idToLeaveOut))) {
+          assertEquals("There should have been no progress", lastProgress, currentProgress);
+        } else if (!partDone) {
+          assertTrue("There has been no progress", currentProgress > lastProgress);
+          progressTracker.put(id, currentProgress);
+        }
+        replicationDone = replicationDone && partDone;
+      }
+      if (!allStopped && !onlyOneResumed && !allReenabled) {
+        replicaThread.controlReplicationForPartitions(clusterMap.getAllPartitionIds(), false);
+        allStopped = true;
+      } else if (!onlyOneResumed && !allReenabled) {
+        // resume replication for first partition
+        replicaThread.controlReplicationForPartitions(Collections.singletonList(partitionIds.get(0)), true);
+        allStopped = false;
+        onlyOneResumed = true;
+      } else if (!allReenabled) {
+        List<? extends PartitionId> idsToEnable = new ArrayList<>(clusterMap.getAllPartitionIds());
+        // not removing the first partition
+        replicaThread.controlReplicationForPartitions(idsToEnable, true);
+        onlyOneResumed = false;
+        allReenabled = true;
+      }
+      if (replicationDone) {
+        break;
+      }
+    }
+
+    Map<PartitionId, List<MessageInfo>> missingInfos = remoteHost.getMissingInfos(localHost.infosByPartition);
+    for (Map.Entry<PartitionId, List<MessageInfo>> entry : missingInfos.entrySet()) {
+      assertEquals("No infos should be missing", 0, entry.getValue().size());
+    }
+    Map<PartitionId, List<ByteBuffer>> missingBuffers = remoteHost.getMissingBuffers(localHost.buffersByPartition);
+    for (Map.Entry<PartitionId, List<ByteBuffer>> entry : missingBuffers.entrySet()) {
+      assertEquals("No buffers should be missing", 0, entry.getValue().size());
+    }
+  }
 
   /**
    * Tests {@link ReplicaThread#exchangeMetadata(ConnectedChannel, List)} and
@@ -165,7 +348,7 @@ public class ReplicationTest {
     replicationMetrics.populatePerColoMetrics(Collections.singleton(remoteHost.dataNodeId.getDatacenterName()));
     StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
     Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicate = new HashMap<>();
-    replicasToReplicate.put(remoteHost.dataNodeId, localHost.getRemoteReplicaInfos(remoteHost));
+    replicasToReplicate.put(remoteHost.dataNodeId, localHost.getRemoteReplicaInfos(remoteHost, null));
     Map<DataNodeId, Host> hosts = new HashMap<>();
     hosts.put(remoteHost.dataNodeId, remoteHost);
     int batchSize = 4;
@@ -276,7 +459,7 @@ public class ReplicationTest {
     Time time = new MockTime();
     MockFindToken token1 = new MockFindToken(0, 0);
     RemoteReplicaInfo remoteReplicaInfo = new RemoteReplicaInfo(new MockReplicaId(), new MockReplicaId(),
-        new MockStore(new ArrayList<MessageInfo>(), new ArrayList<ByteBuffer>()), token1, tokenPersistInterval, time,
+        new MockStore(null, Collections.EMPTY_LIST, Collections.EMPTY_LIST, null), token1, tokenPersistInterval, time,
         new Port(5000, PortType.PLAINTEXT));
 
     // The equality check is for the reference, which is fine.
@@ -437,6 +620,10 @@ public class ReplicationTest {
     }
   }
 
+  interface StoreEventListener {
+    void onPut(MockStore store, List<MessageInfo> messageInfos);
+  }
+
   /**
    * Representation of a host. Contains all the data for all partitions.
    */
@@ -469,20 +656,21 @@ public class ReplicationTest {
     /**
      * Gets the list of {@link RemoteReplicaInfo} from this host to the given {@code remoteHost}
      * @param remoteHost the host whose replica info is required.
+     * @param listener the {@link StoreEventListener} to use.
      * @return the list of {@link RemoteReplicaInfo} from this host to the given {@code remoteHost}
      */
-    List<RemoteReplicaInfo> getRemoteReplicaInfos(Host remoteHost) {
+    List<RemoteReplicaInfo> getRemoteReplicaInfos(Host remoteHost, StoreEventListener listener) {
       List<? extends ReplicaId> replicaIds = clusterMap.getReplicaIds(dataNodeId);
       List<RemoteReplicaInfo> remoteReplicaInfos = new ArrayList<>();
       for (ReplicaId replicaId : replicaIds) {
         for (ReplicaId peerReplicaId : replicaId.getPeerReplicaIds()) {
           if (peerReplicaId.getDataNodeId().equals(remoteHost.dataNodeId)) {
             PartitionId partitionId = replicaId.getPartitionId();
-            MockStore store = storesByPartition.computeIfAbsent(partitionId, partitionId1 -> new MockStore(
+            MockStore store = storesByPartition.computeIfAbsent(partitionId, partitionId1 -> new MockStore(partitionId,
                 infosByPartition.computeIfAbsent(partitionId1,
                     (Function<PartitionId, List<MessageInfo>>) partitionId2 -> new ArrayList<>()),
                 buffersByPartition.computeIfAbsent(partitionId1,
-                    (Function<PartitionId, List<ByteBuffer>>) partitionId22 -> new ArrayList<>())));
+                    (Function<PartitionId, List<ByteBuffer>>) partitionId22 -> new ArrayList<>()), listener));
             RemoteReplicaInfo remoteReplicaInfo =
                 new RemoteReplicaInfo(peerReplicaId, replicaId, store, new MockFindToken(0, 0), Long.MAX_VALUE,
                     SystemTime.getInstance(), new Port(peerReplicaId.getDataNodeId().getPort(), PortType.PLAINTEXT));
@@ -640,15 +828,19 @@ public class ReplicationTest {
       }
     }
 
+    private final StoreEventListener listener;
     private final DummyLog log;
-    private final List<MessageInfo> messageInfos;
+    final List<MessageInfo> messageInfos;
+    final PartitionId id;
 
-    MockStore(List<MessageInfo> messageInfos, List<ByteBuffer> buffers) {
+    MockStore(PartitionId id, List<MessageInfo> messageInfos, List<ByteBuffer> buffers, StoreEventListener listener) {
       if (messageInfos.size() != buffers.size()) {
         throw new IllegalArgumentException("message info size and buffer size does not match");
       }
       this.messageInfos = messageInfos;
       log = new DummyLog(buffers);
+      this.listener = listener;
+      this.id = id;
     }
 
     @Override
@@ -683,6 +875,9 @@ public class ReplicationTest {
         throw new IllegalStateException(e);
       }
       messageInfos.addAll(newInfos);
+      if (listener != null) {
+        listener.onPut(this, newInfos);
+      }
     }
 
     @Override

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -633,7 +633,7 @@ public class AmbryRequests implements RequestAPI {
                   "Could not set enable status for replication of {} from {} to {}. Check partition validity and"
                       + " origins list", partitionIds, replControlRequest.getOrigins(),
                   replControlRequest.shouldEnable());
-              error = ServerErrorCode.Unknown_Error;
+              error = ServerErrorCode.Bad_Request;
             }
           }
           break;

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -628,10 +628,10 @@ public class AmbryRequests implements RequestAPI {
               partitionIds, replControlRequest.getOrigins(), replControlRequest.shouldEnable())) {
             error = ServerErrorCode.No_Error;
           } else {
-            logger.error("Could not set enable status for replication of {} from {} to {}. Origins list is empty or "
-                    + "contains an unknown datacenter", partitionIds, replControlRequest.getOrigins(),
+            logger.error("Could not set enable status for replication of {} from {} to {}. Check partition validity and"
+                    + " origins list", partitionIds, replControlRequest.getOrigins(),
                 replControlRequest.shouldEnable());
-            error = error == ServerErrorCode.No_Error ? ServerErrorCode.Unknown_Error : error;
+            error = error != ServerErrorCode.Partition_Unknown ? ServerErrorCode.Unknown_Error : error;
           }
           break;
       }

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -631,7 +631,7 @@ public class AmbryRequests implements RequestAPI {
             logger.error("Could not set enable status for replication of {} from {} to {}. Origins list is empty or "
                     + "contains an unknown datacenter", partitionIds, replControlRequest.getOrigins(),
                 replControlRequest.shouldEnable());
-            error = ServerErrorCode.Unknown_Error;
+            error = error == ServerErrorCode.No_Error ? ServerErrorCode.Unknown_Error : error;
           }
           break;
       }

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -624,14 +624,17 @@ public class AmbryRequests implements RequestAPI {
           } else {
             partitionIds = clusterMap.getAllPartitionIds();
           }
-          if (!error.equals(ServerErrorCode.Partition_Unknown) && replicationManager.controlReplicationForPartitions(
-              partitionIds, replControlRequest.getOrigins(), replControlRequest.shouldEnable())) {
-            error = ServerErrorCode.No_Error;
-          } else {
-            logger.error("Could not set enable status for replication of {} from {} to {}. Check partition validity and"
-                    + " origins list", partitionIds, replControlRequest.getOrigins(),
-                replControlRequest.shouldEnable());
-            error = error != ServerErrorCode.Partition_Unknown ? ServerErrorCode.Unknown_Error : error;
+          if (!error.equals(ServerErrorCode.Partition_Unknown)) {
+            if (replicationManager.controlReplicationForPartitions(partitionIds, replControlRequest.getOrigins(),
+                replControlRequest.shouldEnable())) {
+              error = ServerErrorCode.No_Error;
+            } else {
+              logger.error(
+                  "Could not set enable status for replication of {} from {} to {}. Check partition validity and"
+                      + " origins list", partitionIds, replControlRequest.getOrigins(),
+                  replControlRequest.shouldEnable());
+              error = ServerErrorCode.Unknown_Error;
+            }
           }
           break;
       }

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -118,6 +118,12 @@ public class ServerMetrics {
   public final Histogram requestControlResponseSendTimeInMs;
   public final Histogram requestControlRequestTotalTimeInMs;
 
+  public final Histogram replicationControlRequestQueueTimeInMs;
+  public final Histogram replicationControlRequestProcessingTimeInMs;
+  public final Histogram replicationControlResponseQueueTimeInMs;
+  public final Histogram replicationControlResponseSendTimeInMs;
+  public final Histogram replicationControlRequestTotalTimeInMs;
+
   public final Histogram blobSizeInBytes;
   public final Histogram blobUserMetadataSizeInBytes;
 
@@ -135,6 +141,7 @@ public class ServerMetrics {
   public final Meter replicaMetadataRequestRate;
   public final Meter triggerCompactionRequestRate;
   public final Meter requestControlRequestRate;
+  public final Meter replicationControlRequestRate;
 
   public final Meter putSmallBlobRequestRate;
   public final Meter getSmallBlobRequestRate;
@@ -162,7 +169,7 @@ public class ServerMetrics {
   public final Counter idDeletedError;
   public final Counter ttlExpiredError;
   public final Counter badRequestError;
-  public final Counter temporarilyUnavailableError;
+  public final Counter temporarilyDisabledError;
 
   public ServerMetrics(MetricRegistry registry) {
     putBlobRequestQueueTimeInMs =
@@ -301,6 +308,17 @@ public class ServerMetrics {
     requestControlRequestTotalTimeInMs =
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "RequestControlRequestTotalTimeInMs"));
 
+    replicationControlRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "ReplicationControlRequestQueueTimeInMs"));
+    replicationControlRequestProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "ReplicationControlRequestProcessingTimeInMs"));
+    replicationControlResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "ReplicationControlResponseQueueTimeInMs"));
+    replicationControlResponseSendTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "ReplicationControlResponseSendTimeInMs"));
+    replicationControlRequestTotalTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "ReplicationControlRequestTotalTimeInMs"));
+
     blobSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobSize"));
     blobUserMetadataSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobUserMetadataSize"));
 
@@ -321,6 +339,8 @@ public class ServerMetrics {
     triggerCompactionRequestRate =
         registry.meter(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestRate"));
     requestControlRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "RequestControlRequestRate"));
+    replicationControlRequestRate =
+        registry.meter(MetricRegistry.name(AmbryRequests.class, "ReplicationControlRequestRate"));
 
     putSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "PutSmallBlobRequestRate"));
     getSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "GetSmallBlobRequestRate"));
@@ -341,8 +361,7 @@ public class ServerMetrics {
     idNotFoundError = registry.counter(MetricRegistry.name(AmbryRequests.class, "IDNotFoundError"));
     idDeletedError = registry.counter(MetricRegistry.name(AmbryRequests.class, "IDDeletedError"));
     ttlExpiredError = registry.counter(MetricRegistry.name(AmbryRequests.class, "TTLExpiredError"));
-    temporarilyUnavailableError =
-        registry.counter(MetricRegistry.name(AmbryRequests.class, "TemporarilyUnavailableError"));
+    temporarilyDisabledError = registry.counter(MetricRegistry.name(AmbryRequests.class, "TemporarilyDisabledError"));
     badRequestError = registry.counter(MetricRegistry.name(AmbryRequests.class, "BadRequestError"));
     unExpectedStorePutError = registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStorePutError"));
     unExpectedStoreGetError = registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStoreGetError"));

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -232,7 +232,7 @@ public class AmbryRequestsTest {
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = false;
     sendAndVerifyReplicationControlRequest(Collections.EMPTY_LIST, false, clusterMap.getWritablePartitionIds().get(0),
-        ServerErrorCode.Unknown_Error);
+        ServerErrorCode.Bad_Request);
     // PartitionUnknown is hard to simulate without betraying knowledge of the internals of MockClusterMap.
   }
 

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -415,7 +415,8 @@ public class AmbryRequestsTest {
   /**
    * Does the test for {@link AdminRequestOrResponseType#ReplicationControl} by checking that the request is correctly
    * deserialized in {@link AmbryRequests} and passed to the {@link ReplicationManager}.
-   * @param id the {@link PartitionId} to disable replication on. Can be {@code null}.
+   * @param id the {@link PartitionId} to disable replication on. Can be {@code null} in which case replication will
+   *           be enabled/disabled on all partitions.
    * @param expectedServerErrorCode the {@link ServerErrorCode} expected in the response.
    * @throws InterruptedException
    * @throws IOException

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1284,7 +1284,9 @@ public class IndexTest {
     // pause hard delete
     state.index.hardDeleter.pause();
     assertTrue("Hard deletes should have been paused ", state.index.hardDeleter.isPaused());
-    waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP_MS + 1, 10);
+    assertTrue("Hard delete thread did not go into waiting state",
+        TestUtils.waitUntilExpectedState(state.index.hardDeleteThread, Thread.State.WAITING,
+            HardDeleter.HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP_MS + 1));
 
     // delete two entries
     state.addPutEntries(2, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -1299,7 +1301,9 @@ public class IndexTest {
 
     if (reloadIndex) {
       state.reloadIndex(true, true);
-      waitUntilExpectedState(Thread.State.WAITING, HardDeleter.HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP_MS + 1, 10);
+      assertTrue("Hard delete thread did not go into waiting state",
+          TestUtils.waitUntilExpectedState(state.index.hardDeleteThread, Thread.State.WAITING,
+              HardDeleter.HARD_DELETE_SLEEP_TIME_ON_CAUGHT_UP_MS + 1));
       idsToDelete.clear();
       state.addPutEntries(2, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
       idsToDelete.add(state.getIdToDeleteFromIndexSegment(state.referenceIndex.lastKey()));
@@ -2129,24 +2133,6 @@ public class IndexTest {
       }
       state.index.hardDeleter.preLogFlush();
       state.index.hardDeleter.postLogFlush();
-    }
-  }
-
-  /**
-   * Waits until the HardDeleter thread is in the {@code expectedState} for the specified {@code timeToCheckInMs} time.
-   * @param expectedState Expected HardDeleter thread state
-   * @param timeToCheckInMs time for which the state has to be checked for
-   * @param intervalToCheckInMs interval at which the check has to be done
-   */
-  private void waitUntilExpectedState(Thread.State expectedState, long timeToCheckInMs, long intervalToCheckInMs)
-      throws InterruptedException {
-    long timeSoFar = 0;
-    while (expectedState != state.index.hardDeleteThread.getState()) {
-      Thread.sleep(intervalToCheckInMs);
-      timeSoFar += intervalToCheckInMs;
-      if (timeSoFar >= timeToCheckInMs) {
-        fail("Hard Deleter thread state failed to move to " + Thread.State.WAITING + " in " + timeToCheckInMs);
-      }
     }
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
@@ -532,12 +532,12 @@ public class ServerAdminTool implements Closeable {
   }
 
   /**
-   * Sends a {@link RequestControlAdminRequest} to set the enable state of {@code toControl} on {@code partitionIdStr}
-   * to {@code enable} in {@code dataNodeId}.
+   * Sends a {@link RequestControlAdminRequest} to enable/disable replication from {@code origins} for
+   * {@code partitionIdStr} in {@code dataNodeId}.
    * @param dataNodeId the {@link DataNodeId} to contact.
    * @param partitionIdStr the String representation of the {@link PartitionId} to compact. Can be {@code null}.
    * @param origins the names of the datacenters from which replication should be controlled.
-   * @param enable the enable (or disable) status required for {@code toControl}.
+   * @param enable the enable (or disable) status required for replication from {@code origins}.
    * @param clusterMap the {@link ClusterMap} to use.
    * @return the {@link ServerErrorCode} that is returned.
    * @throws IOException

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
@@ -46,6 +46,7 @@ import com.github.ambry.protocol.GetOption;
 import com.github.ambry.protocol.GetRequest;
 import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.PartitionRequestInfo;
+import com.github.ambry.protocol.ReplicationControlAdminRequest;
 import com.github.ambry.protocol.RequestControlAdminRequest;
 import com.github.ambry.protocol.RequestOrResponseType;
 import com.github.ambry.store.StoreKeyFactory;
@@ -63,6 +64,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
@@ -93,7 +95,7 @@ public class ServerAdminTool implements Closeable {
    * The different operations supported by the tool.
    */
   private enum Operation {
-    GetBlobProperties, GetUserMetadata, GetBlob, TriggerCompaction, RequestControl
+    GetBlobProperties, GetUserMetadata, GetBlob, TriggerCompaction, RequestControl, ReplicationControl
   }
 
   /**
@@ -115,7 +117,7 @@ public class ServerAdminTool implements Closeable {
 
     /**
      * The type of operation.
-     * Operations are: GetBlobProperties,GetUserMetadata,GetBlob,TriggerCompaction,RequestControl
+     * Operations are: GetBlobProperties,GetUserMetadata,GetBlob,TriggerCompaction,RequestControl,ReplicationControl
      */
     @Config("type.of.operation")
     final Operation typeOfOperation;
@@ -153,8 +155,8 @@ public class ServerAdminTool implements Closeable {
     /**
      * Comma separated list of the string representations of the partitions to operate on (if applicable).
      * Some requests (TriggerCompaction) will not work with an empty list but some requests treat empty lists as "all
-     * partitions" (RequestControl).
-     * Applicable for: TriggerCompaction,RequestControl
+     * partitions" (RequestControl,ReplicationControl).
+     * Applicable for: TriggerCompaction,RequestControl,ReplicationControl
      */
     @Config("partition.ids")
     @Default("")
@@ -169,12 +171,20 @@ public class ServerAdminTool implements Closeable {
     final RequestOrResponseType requestTypeToControl;
 
     /**
-     * Enables the request type if {@code true}. Disables if {@code false}.
-     * Applicable for: RequestControl
+     * Enables the request type or replication if {@code true}. Disables if {@code false}.
+     * Applicable for: RequestControl,ReplicationControl
      */
-    @Config("request.enable")
+    @Config("enable.state")
     @Default("true")
-    final boolean requestEnable;
+    final boolean enableState;
+
+    /**
+     * The comma separated names of the datacenters from which replication should be controlled.
+     * Applicable for: ReplicationControl
+     */
+    @Config("replication.origins")
+    @Default("")
+    final String[] origins;
 
     /**
      * Path of the file where the data from certain operations will output. For example, the blob from GetBlob and the
@@ -199,7 +209,8 @@ public class ServerAdminTool implements Closeable {
       partitionIds = verifiableProperties.getString("partition.ids", "").split(",");
       requestTypeToControl =
           RequestOrResponseType.valueOf(verifiableProperties.getString("request.type.to.control", "PutRequest"));
-      requestEnable = verifiableProperties.getBoolean("request.enable", true);
+      enableState = verifiableProperties.getBoolean("enable.state", true);
+      origins = verifiableProperties.getString("replication.origins", "").split(",");
       dataOutputFilePath = verifiableProperties.getString("data.output.file.path", "/tmp/ambryResult.out");
     }
   }
@@ -285,14 +296,27 @@ public class ServerAdminTool implements Closeable {
       case RequestControl:
         if (config.partitionIds.length > 0 && !config.partitionIds[0].isEmpty()) {
           for (String partitionId : config.partitionIds) {
-            sendControlRequest(serverAdminTool, clusterMap, dataNodeId, partitionId, config.requestTypeToControl,
-                config.requestEnable);
+            sendRequestControlRequest(serverAdminTool, clusterMap, dataNodeId, partitionId, config.requestTypeToControl,
+                config.enableState);
           }
         } else {
           LOGGER.info("No partition list provided. Requesting enable status of {} to be set to {} on all partitions",
-              config.requestTypeToControl, config.requestEnable);
-          sendControlRequest(serverAdminTool, clusterMap, dataNodeId, null, config.requestTypeToControl,
-              config.requestEnable);
+              config.requestTypeToControl, config.enableState);
+          sendRequestControlRequest(serverAdminTool, clusterMap, dataNodeId, null, config.requestTypeToControl,
+              config.enableState);
+        }
+        break;
+      case ReplicationControl:
+        List<String> origins = Arrays.asList(config.origins);
+        if (config.partitionIds.length > 0 && !config.partitionIds[0].isEmpty()) {
+          for (String partitionId : config.partitionIds) {
+            sendReplicationControlRequest(serverAdminTool, clusterMap, dataNodeId, partitionId, origins,
+                config.enableState);
+          }
+        } else {
+          LOGGER.info("No partition list provided. Requesting enable status for replication from {} to be set to {} on "
+              + "all partitions", origins, config.enableState);
+          sendReplicationControlRequest(serverAdminTool, clusterMap, dataNodeId, null, origins, config.enableState);
         }
         break;
       default:
@@ -327,14 +351,42 @@ public class ServerAdminTool implements Closeable {
    * @throws IOException
    * @throws TimeoutException
    */
-  private static void sendControlRequest(ServerAdminTool serverAdminTool, ClusterMap clusterMap, DataNodeId dataNodeId,
-      String partitionId, RequestOrResponseType toControl, boolean enable) throws IOException, TimeoutException {
+  private static void sendRequestControlRequest(ServerAdminTool serverAdminTool, ClusterMap clusterMap,
+      DataNodeId dataNodeId, String partitionId, RequestOrResponseType toControl, boolean enable)
+      throws IOException, TimeoutException {
     ServerErrorCode errorCode = serverAdminTool.controlRequest(dataNodeId, partitionId, toControl, enable, clusterMap);
     if (errorCode == ServerErrorCode.No_Error) {
       LOGGER.info("{} enable state has been set to {} for {} on {}", toControl, enable, partitionId, dataNodeId);
     } else {
-      LOGGER.error("From {}, received server error code {} for enable state {} request for {} on {}", dataNodeId,
+      LOGGER.error("From {}, received server error code {} for request to set enable state {} for {} on {}", dataNodeId,
           errorCode, enable, toControl, partitionId);
+    }
+  }
+
+  /**
+   * Sends a {@link ReplicationControlAdminRequest} to {@code dataNodeId} to set enable status of replication from
+   * {@code origins} to {@code enable} for {@code partitionId}.
+   * @param serverAdminTool the {@link ServerAdminTool} instance to use.
+   * @param clusterMap the {@link ClusterMap} to use.
+   * @param dataNodeId the {@link DataNodeId} to send the request to.
+   * @param partitionId the partition id (string) on which the operation will take place. Can be {@code null}.
+   * @param origins the names of the datacenters from which replication should be controlled.
+   * @param enable the enable (or disable) status required for {@code toControl}.
+   * @throws IOException
+   * @throws TimeoutException
+   */
+  private static void sendReplicationControlRequest(ServerAdminTool serverAdminTool, ClusterMap clusterMap,
+      DataNodeId dataNodeId, String partitionId, List<String> origins, boolean enable)
+      throws IOException, TimeoutException {
+    ServerErrorCode errorCode =
+        serverAdminTool.controlReplication(dataNodeId, partitionId, origins, enable, clusterMap);
+    if (errorCode == ServerErrorCode.No_Error) {
+      LOGGER.info("Enable state of replication from {} has been set to {} for {} on {}", origins, enable, partitionId,
+          dataNodeId);
+    } else {
+      LOGGER.error(
+          "From {}, received server error code {} for request to set enable state {} for replication from {} for {}",
+          dataNodeId, errorCode, enable, origins, partitionId);
     }
   }
 
@@ -469,10 +521,7 @@ public class ServerAdminTool implements Closeable {
    */
   public ServerErrorCode controlRequest(DataNodeId dataNodeId, String partitionIdStr, RequestOrResponseType toControl,
       boolean enable, ClusterMap clusterMap) throws IOException, TimeoutException {
-    PartitionId targetPartitionId = null;
-    if (partitionIdStr != null) {
-      targetPartitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
-    }
+    PartitionId targetPartitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
     AdminRequest adminRequest =
         new AdminRequest(AdminRequestOrResponseType.RequestControl, targetPartitionId, correlationId.incrementAndGet(),
             CLIENT_ID);
@@ -483,14 +532,41 @@ public class ServerAdminTool implements Closeable {
   }
 
   /**
+   * Sends a {@link RequestControlAdminRequest} to set the enable state of {@code toControl} on {@code partitionIdStr}
+   * to {@code enable} in {@code dataNodeId}.
+   * @param dataNodeId the {@link DataNodeId} to contact.
+   * @param partitionIdStr the String representation of the {@link PartitionId} to compact. Can be {@code null}.
+   * @param origins the names of the datacenters from which replication should be controlled.
+   * @param enable the enable (or disable) status required for {@code toControl}.
+   * @param clusterMap the {@link ClusterMap} to use.
+   * @return the {@link ServerErrorCode} that is returned.
+   * @throws IOException
+   * @throws TimeoutException
+   */
+  public ServerErrorCode controlReplication(DataNodeId dataNodeId, String partitionIdStr, List<String> origins,
+      boolean enable, ClusterMap clusterMap) throws IOException, TimeoutException {
+    PartitionId targetPartitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
+    AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.ReplicationControl, targetPartitionId,
+        correlationId.incrementAndGet(), CLIENT_ID);
+    ReplicationControlAdminRequest controlRequest = new ReplicationControlAdminRequest(origins, enable, adminRequest);
+    ByteBuffer responseBytes = sendRequestGetResponse(dataNodeId, controlRequest);
+    AdminResponse adminResponse = AdminResponse.readFrom(new DataInputStream(new ByteBufferInputStream(responseBytes)));
+    return adminResponse.getError();
+  }
+
+  /**
    * Gets the {@link PartitionId} in the {@code clusterMap} whose string representation matches {@code partitionIdStr}.
    * @param partitionIdStr the string representation of the partition required.
    * @param clusterMap the {@link ClusterMap} to use to list and process {@link PartitionId}s.
    * @return the {@link PartitionId} in the {@code clusterMap} whose string repr matches {@code partitionIdStr}.
+   * {@code null} if {@code partitionIdStr} is {@code null}.
    * @throws IllegalArgumentException if there is no @link PartitionId} in the {@code clusterMap} whose string repr
    * matches {@code partitionIdStr}.
    */
   private PartitionId getPartitionIdFromStr(String partitionIdStr, ClusterMap clusterMap) {
+    if (partitionIdStr == null) {
+      return null;
+    }
     PartitionId targetPartitionId = null;
     List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds();
     for (PartitionId partitionId : partitionIds) {
@@ -519,7 +595,6 @@ public class ServerAdminTool implements Closeable {
    */
   private Pair<ServerErrorCode, InputStream> getGetResponse(DataNodeId dataNodeId, BlobId blobId,
       MessageFormatFlags flags, GetOption getOption, ClusterMap clusterMap) throws Exception {
-    Pair<ServerErrorCode, InputStream> response;
     PartitionRequestInfo partitionRequestInfo =
         new PartitionRequestInfo(blobId.getPartition(), Collections.singletonList(blobId));
     List<PartitionRequestInfo> partitionRequestInfos = new ArrayList<>();

--- a/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
@@ -85,6 +85,25 @@ public class TestUtils {
   }
 
   /**
+   * Waits until the HardDeleter thread is in the {@code expectedState} for the specified {@code timeoutMs} time.
+   * @param thread the thread whose state needs to be checked.
+   * @param expectedState Expected HardDeleter thread state
+   * @param timeoutMs time in ms after which the check is considered failed if {@code expectedState} is not reached.
+   */
+  public static boolean waitUntilExpectedState(Thread thread, Thread.State expectedState, long timeoutMs)
+      throws InterruptedException {
+    long timeSoFar = 0;
+    while (expectedState != thread.getState()) {
+      Thread.sleep(10);
+      timeSoFar += 10;
+      if (timeSoFar >= timeoutMs) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * Succeed if the {@code body} throws an exception of type {@code exceptionClass}, otherwise fail.
    * @param exceptionClass the type of exception that should occur.
    * @param body the body to execute. This should throw an exception of type {@code exceptionClass}

--- a/build.gradle
+++ b/build.gradle
@@ -229,6 +229,7 @@ project(':ambry-protocol') {
                 project(':ambry-utils'),
                 project(':ambry-commons')
         testCompile project(':ambry-clustermap').sourceSets.test.output
+        testCompile project(':ambry-utils').sourceSets.test.output
     }
 }
 


### PR DESCRIPTION
This commits adds the ability to make an admin request to a single storage server to control replication from certain (or all DCs) for certain (or all) partitions.