### PR TITLE
fix a bug in accountUpdateTool

### DIFF
--- a/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
@@ -171,7 +171,7 @@ public class AccountUpdateTool {
     listOpt.add(zkServerOpt);
     ToolUtils.ensureOrExit(listOpt, options, parser);
     try {
-      updateAccount(accountJsonFilePath, storePath, zkServer, zkConnectionTimeoutMs, zkSessionTimeoutMs);
+      updateAccount(accountJsonFilePath, zkServer, storePath, zkConnectionTimeoutMs, zkSessionTimeoutMs);
     } catch (Exception e) {
       System.err.println("Updating accounts failed with exception: " + e);
       e.printStackTrace();


### PR DESCRIPTION
The order of the parameters was incorrect when they are passed.

Tested in calling the tool from main.