### PR TITLE
Enabling MessageInfoList V3 and DeleteMessageFormat V2

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
@@ -15,9 +15,6 @@ package com.github.ambry.store;
 
 import com.github.ambry.utils.Utils;
 
-import static com.github.ambry.account.Account.*;
-import static com.github.ambry.account.Container.*;
-
 
 /**
  * A message info class that contains basic info about a message
@@ -32,62 +29,6 @@ public class MessageInfo {
   private final short accountId;
   private final short containerId;
   private final long operationTimeMs;
-
-  /**
-   * Construct an instance of MessageInfo.
-   * @param key the {@link StoreKey} associated with this message.
-   * @param size the size of this message.
-   * @param expirationTimeInMs the time at which the message will expire. A value of -1 means no expiration.
-   * @todo: remove this constructor once MessageInfo V3 is enabled
-   */
-  public MessageInfo(StoreKey key, long size, long expirationTimeInMs) {
-    this(key, size, false, expirationTimeInMs);
-  }
-
-  /**
-   * Construct an instance of MessageInfo.
-   * @param key the {@link StoreKey} associated with this message.
-   * @param size the size of this message.
-   * @param deleted {@code true} if the message is deleted, {@code false} otherwise
-   * @todo: remove this constructor once MessageInfo V3 is enabled
-   */
-  public MessageInfo(StoreKey key, long size, boolean deleted) {
-    this(key, size, deleted, Utils.Infinite_Time);
-  }
-
-  /**
-   * Construct an instance of MessageInfo.
-   * @param key the {@link StoreKey} associated with this message.
-   * @param size the size of this message.
-   * @param deleted {@code true} if the message is deleted, {@code false} otherwise
-   * @param expirationTimeInMs the time at which the message will expire. A value of -1 means no expiration.
-   * @todo: remove this constructor once MessageInfo V3 is enabled
-   */
-  public MessageInfo(StoreKey key, long size, boolean deleted, long expirationTimeInMs) {
-    this(key, size, deleted, expirationTimeInMs, null);
-  }
-
-  /**
-   * Construct an instance of MessageInfo.
-   * @param key the {@link StoreKey} associated with this message.
-   * @param size the size of this message.
-   * @todo: remove this constructor once MessageInfo V3 is enabled
-   */
-  public MessageInfo(StoreKey key, long size) {
-    this(key, size, Utils.Infinite_Time);
-  }
-
-  /**
-   * Construct an instance of MessageInfo.
-   * @param key the {@link StoreKey} associated with this message.
-   * @param size the size of this message.
-   * @param deleted {@code true} if the message is deleted, {@code false} otherwise
-   * @param expirationTimeInMs the time at which the message will expire. A value of -1 means no expiration.
-   * @param crc the crc associated with this message. If unavailable, pass in null.
-   */
-  public MessageInfo(StoreKey key, long size, boolean deleted, long expirationTimeInMs, Long crc) {
-    this(key, size, deleted, expirationTimeInMs, crc, UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID, Utils.Infinite_Time);
-  }
 
   /**
    * Construct an instance of MessageInfo.

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
@@ -80,7 +80,8 @@ public class BlobStoreHardDelete implements MessageStoreHardDelete {
               != MessageFormatRecord.Message_Header_Invalid_Relative_Offset) {
             BlobProperties properties = MessageFormatRecord.deserializeBlobProperties(stream);
             return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
-                Utils.addSecondsToEpochTime(properties.getCreationTimeInMs(), properties.getTimeToLiveInSeconds()));
+                Utils.addSecondsToEpochTime(properties.getCreationTimeInMs(), properties.getTimeToLiveInSeconds()),
+                properties.getAccountId(), properties.getContainerId(), properties.getCreationTimeInMs());
           } else {
             DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(stream);
             return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true,

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
@@ -79,7 +79,8 @@ public class BlobStoreRecovery implements MessageStoreRecovery {
               MessageInfo info =
                   new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(),
                       Utils.addSecondsToEpochTime(properties.getCreationTimeInMs(),
-                          properties.getTimeToLiveInSeconds()));
+                          properties.getTimeToLiveInSeconds()), properties.getAccountId(), properties.getContainerId(),
+                      properties.getCreationTimeInMs());
               messageRecovered.add(info);
             } else {
               DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(stream);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/DeleteMessageFormatV1InputStream.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/DeleteMessageFormatV1InputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import java.nio.ByteBuffer;
 
 
 /**
- * Represents a message that consist of the delete record.
+ * Represents a message that consist of the delete record in version {@link MessageFormatRecord.Delete_Format_V1}
  * This format is used to delete a blob
  *
  *  - - - - - - - - - - - - -
@@ -30,11 +30,11 @@ import java.nio.ByteBuffer;
  *  - - - - - - - - - - - - -
  *
  */
-public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
-  public DeleteMessageFormatInputStream(StoreKey key, short accountId, short containerId, long deletionTimeMs)
+public class DeleteMessageFormatV1InputStream extends MessageFormatInputStream {
+  public DeleteMessageFormatV1InputStream(StoreKey key, short accountId, short containerId, long deletionTimeMs)
       throws MessageFormatException {
     int headerSize = MessageFormatRecord.MessageHeader_Format_V1.getHeaderSize();
-    int deleteRecordSize = MessageFormatRecord.Delete_Format_V2.getDeleteRecordSize();
+    int deleteRecordSize = MessageFormatRecord.Delete_Format_V1.getDeleteRecordSize();
     buffer = ByteBuffer.allocate(headerSize + key.sizeInBytes() + deleteRecordSize);
     MessageFormatRecord.MessageHeader_Format_V1.serializeHeader(buffer, deleteRecordSize,
         MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerSize + key.sizeInBytes(),
@@ -42,7 +42,7 @@ public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
         MessageFormatRecord.Message_Header_Invalid_Relative_Offset);
     buffer.put(key.toBytes());
     // set the message as deleted
-    MessageFormatRecord.Delete_Format_V2.serializeDeleteRecord(buffer,
+    MessageFormatRecord.Delete_Format_V1.serializeDeleteRecord(buffer,
         new DeleteRecord(accountId, containerId, deletionTimeMs));
     messageLength = buffer.capacity();
     buffer.flip();

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
@@ -145,47 +145,62 @@ public class MessageFormatInputStreamTest {
 
   @Test
   public void messageFormatDeleteRecordTest() throws IOException, MessageFormatException {
-    StoreKey key = new MockId("id1");
-    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
-    short containerId = Utils.getRandomShort(TestUtils.RANDOM);
-    long deletionTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
-    MessageFormatInputStream messageFormatStream =
-        new DeleteMessageFormatInputStream(key, accountId, containerId, deletionTimeMs);
-    int headerSize = MessageFormatRecord.MessageHeader_Format_V1.getHeaderSize();
-    int deleteRecordSize = MessageFormatRecord.Delete_Format_V1.getDeleteRecordSize();
-    Assert.assertEquals(headerSize + deleteRecordSize + key.sizeInBytes(), messageFormatStream.getSize());
+    short[] versions = {MessageFormatRecord.Delete_Version_V1, MessageFormatRecord.Delete_Version_V2};
+    for (short version : versions) {
+      StoreKey key = new MockId("id1");
+      short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+      long deletionTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
+      MessageFormatInputStream messageFormatStream;
+      if (version == MessageFormatRecord.Delete_Version_V1) {
+        messageFormatStream = new DeleteMessageFormatV1InputStream(key, accountId, containerId, deletionTimeMs);
+      } else {
+        messageFormatStream = new DeleteMessageFormatInputStream(key, accountId, containerId, deletionTimeMs);
+      }
+      int headerSize = MessageFormatRecord.MessageHeader_Format_V1.getHeaderSize();
+      int deleteRecordSize =
+          version == MessageFormatRecord.Delete_Version_V1 ? MessageFormatRecord.Delete_Format_V1.getDeleteRecordSize()
+              : MessageFormatRecord.Delete_Format_V2.getDeleteRecordSize();
+      Assert.assertEquals(headerSize + deleteRecordSize + key.sizeInBytes(), messageFormatStream.getSize());
 
-    // @TODO: fix verifier once we start to serialize in DeleteMsgFormat V2
-    // check header
-    byte[] headerOutput = new byte[headerSize];
-    messageFormatStream.read(headerOutput);
-    ByteBuffer headerBuf = ByteBuffer.wrap(headerOutput);
-    Assert.assertEquals(1, headerBuf.getShort());
-    Assert.assertEquals(deleteRecordSize, headerBuf.getLong());
-    Assert.assertEquals(MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerBuf.getInt());
-    Assert.assertEquals(headerSize + key.sizeInBytes(), headerBuf.getInt());
-    Assert.assertEquals(MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerBuf.getInt());
-    Assert.assertEquals(MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerBuf.getInt());
-    Crc32 crc = new Crc32();
-    crc.update(headerOutput, 0, headerSize - MessageFormatRecord.Crc_Size);
-    Assert.assertEquals(crc.getValue(), headerBuf.getLong());
+      // @TODO: fix verifier once we start to serialize in DeleteMsgFormat V2
+      // check header
+      byte[] headerOutput = new byte[headerSize];
+      messageFormatStream.read(headerOutput);
+      ByteBuffer headerBuf = ByteBuffer.wrap(headerOutput);
+      Assert.assertEquals(1, headerBuf.getShort());
+      Assert.assertEquals(deleteRecordSize, headerBuf.getLong());
+      Assert.assertEquals(MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerBuf.getInt());
+      Assert.assertEquals(headerSize + key.sizeInBytes(), headerBuf.getInt());
+      Assert.assertEquals(MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerBuf.getInt());
+      Assert.assertEquals(MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerBuf.getInt());
+      Crc32 crc = new Crc32();
+      crc.update(headerOutput, 0, headerSize - MessageFormatRecord.Crc_Size);
+      Assert.assertEquals(crc.getValue(), headerBuf.getLong());
 
-    // verify handle
-    byte[] handleOutput = new byte[key.sizeInBytes()];
-    ByteBuffer handleOutputBuf = ByteBuffer.wrap(handleOutput);
-    messageFormatStream.read(handleOutput);
-    byte[] dest = new byte[key.sizeInBytes()];
-    handleOutputBuf.get(dest);
-    Assert.assertArrayEquals(dest, key.toBytes());
+      // verify handle
+      byte[] handleOutput = new byte[key.sizeInBytes()];
+      ByteBuffer handleOutputBuf = ByteBuffer.wrap(handleOutput);
+      messageFormatStream.read(handleOutput);
+      byte[] dest = new byte[key.sizeInBytes()];
+      handleOutputBuf.get(dest);
+      Assert.assertArrayEquals(dest, key.toBytes());
 
-    // check delete record
-    byte[] deleteRecordOutput = new byte[deleteRecordSize];
-    ByteBuffer deleteRecordBuf = ByteBuffer.wrap(deleteRecordOutput);
-    messageFormatStream.read(deleteRecordOutput);
-    Assert.assertEquals(deleteRecordBuf.getShort(), 1);
-    Assert.assertEquals(true, deleteRecordBuf.get() == 1 ? true : false);
-    crc = new Crc32();
-    crc.update(deleteRecordOutput, 0, deleteRecordSize - MessageFormatRecord.Crc_Size);
-    Assert.assertEquals(crc.getValue(), deleteRecordBuf.getLong());
+      // check delete record
+      byte[] deleteRecordOutput = new byte[deleteRecordSize];
+      ByteBuffer deleteRecordBuf = ByteBuffer.wrap(deleteRecordOutput);
+      messageFormatStream.read(deleteRecordOutput);
+      Assert.assertEquals(deleteRecordBuf.getShort(), version);
+      if (version == MessageFormatRecord.Delete_Version_V1) {
+        Assert.assertEquals(true, deleteRecordBuf.get() == 1 ? true : false);
+      } else {
+        Assert.assertEquals("AccountId mismatch", accountId, deleteRecordBuf.getShort());
+        Assert.assertEquals("ContainerId mismatch", containerId, deleteRecordBuf.getShort());
+        Assert.assertEquals("DeletionTime mismatch", deletionTimeMs, deleteRecordBuf.getLong());
+      }
+      crc = new Crc32();
+      crc.update(deleteRecordOutput, 0, deleteRecordSize - MessageFormatRecord.Crc_Size);
+      Assert.assertEquals(crc.getValue(), deleteRecordBuf.getLong());
+    }
   }
 }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
@@ -163,7 +163,6 @@ public class MessageFormatInputStreamTest {
               : MessageFormatRecord.Delete_Format_V2.getDeleteRecordSize();
       Assert.assertEquals(headerSize + deleteRecordSize + key.sizeInBytes(), messageFormatStream.getSize());
 
-      // @TODO: fix verifier once we start to serialize in DeleteMsgFormat V2
       // check header
       byte[] headerOutput = new byte[headerSize];
       messageFormatStream.read(headerOutput);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatWriteSetTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatWriteSetTest.java
@@ -16,6 +16,8 @@ package com.github.ambry.messageformat;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.Write;
 import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
@@ -56,8 +58,10 @@ public class MessageFormatWriteSetTest {
   @Test
   public void writeSetTest() throws IOException {
     byte[] buf = new byte[2000];
-    MessageInfo info1 = new MessageInfo(new MockId("id1"), 1000, 123);
-    MessageInfo info2 = new MessageInfo(new MockId("id2"), 1000, 123);
+    MessageInfo info1 = new MessageInfo(new MockId("id1"), 1000, 123, Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), System.currentTimeMillis() + TestUtils.RANDOM.nextInt());
+    MessageInfo info2 = new MessageInfo(new MockId("id2"), 1000, 123, Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), System.currentTimeMillis() + TestUtils.RANDOM.nextInt());
     List<MessageInfo> infoList = new ArrayList<MessageInfo>();
     infoList.add(info1);
     infoList.add(info2);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
@@ -77,7 +77,8 @@ public class MessageSievingInputStreamTest {
             : new PutMessageFormatBlobV1InputStream(key1, prop1, ByteBuffer.wrap(usermetadata1), stream1,
                 blobContentSize, blobType);
 
-    MessageInfo msgInfo1 = new MessageInfo(key1, messageFormatStream1.getSize());
+    MessageInfo msgInfo1 =
+        new MessageInfo(key1, messageFormatStream1.getSize(), accountId1, containerId1, prop1.getCreationTimeInMs());
 
     // create message stream for blob 2
     StoreKey key2 = new MockId("id2");
@@ -102,7 +103,8 @@ public class MessageSievingInputStreamTest {
             : new PutMessageFormatBlobV1InputStream(key2, prop2, ByteBuffer.wrap(usermetadata2), stream2,
                 blobContentSize, blobType);
 
-    MessageInfo msgInfo2 = new MessageInfo(key2, messageFormatStream2.getSize());
+    MessageInfo msgInfo2 =
+        new MessageInfo(key2, messageFormatStream2.getSize(), accountId2, containerId2, prop2.getCreationTimeInMs());
 
     // create message stream for blob 3
     StoreKey key3 = new MockId("id3");
@@ -127,7 +129,8 @@ public class MessageSievingInputStreamTest {
             : new PutMessageFormatBlobV1InputStream(key3, prop3, ByteBuffer.wrap(usermetadata3), stream3,
                 blobContentSize, blobType);
 
-    MessageInfo msgInfo3 = new MessageInfo(key3, messageFormatStream3.getSize());
+    MessageInfo msgInfo3 =
+        new MessageInfo(key3, messageFormatStream3.getSize(), accountId3, containerId3, prop3.getCreationTimeInMs());
 
     //create input stream for all blob messages together
     byte[] totalMessageStreamContent =
@@ -226,7 +229,8 @@ public class MessageSievingInputStreamTest {
             : new PutMessageFormatBlobV1InputStream(key1, prop1, ByteBuffer.wrap(usermetadata1), stream1,
                 blobContentSize, blobType);
 
-    MessageInfo msgInfo1 = new MessageInfo(key1, messageFormatStream1.getSize());
+    MessageInfo msgInfo1 =
+        new MessageInfo(key1, messageFormatStream1.getSize(), accountId1, containerId1, prop1.getCreationTimeInMs());
 
     // create message stream for blob 2
     StoreKey key2 = new MockId("id2");
@@ -251,7 +255,8 @@ public class MessageSievingInputStreamTest {
             : new PutMessageFormatBlobV1InputStream(key2, prop2, ByteBuffer.wrap(usermetadata2), stream2,
                 blobContentSize, blobType);
 
-    MessageInfo msgInfo2 = new MessageInfo(key2, messageFormatStream2.getSize());
+    MessageInfo msgInfo2 =
+        new MessageInfo(key2, messageFormatStream2.getSize(), accountId2, containerId2, prop2.getCreationTimeInMs());
 
     // corrupt the message stream
     byte[] corruptMessageStream = new byte[(int) messageFormatStream2.getSize()];
@@ -282,7 +287,8 @@ public class MessageSievingInputStreamTest {
             : new PutMessageFormatBlobV1InputStream(key3, prop3, ByteBuffer.wrap(usermetadata3), stream3,
                 blobContentSize, blobType);
 
-    MessageInfo msgInfo3 = new MessageInfo(key3, messageFormatStream3.getSize());
+    MessageInfo msgInfo3 =
+        new MessageInfo(key3, messageFormatStream3.getSize(), accountId3, containerId3, prop3.getCreationTimeInMs());
 
     //create input stream for all blob messages together
     byte[] totalMessageStreamContent =
@@ -348,9 +354,9 @@ public class MessageSievingInputStreamTest {
     try {
       // create message stream for blob 1
       StoreKey key1 = new MockId("id1");
-      short accountId1 = Utils.getRandomShort(TestUtils.RANDOM);
-      short containerId1 = Utils.getRandomShort(TestUtils.RANDOM);
-      BlobProperties prop1 = new BlobProperties(10, "servid1", accountId1, containerId1);
+      short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+      BlobProperties prop1 = new BlobProperties(10, "servid1", accountId, containerId);
       byte[] usermetadata1 = new byte[1000];
       new Random().nextBytes(usermetadata1);
       int blobContentSize = 2000;
@@ -368,13 +374,13 @@ public class MessageSievingInputStreamTest {
               ByteBuffer.wrap(usermetadata1), stream1, blobContentSize, blobType)
               : new PutMessageFormatBlobV1InputStream(key1, prop1, ByteBuffer.wrap(usermetadata1), stream1,
                   blobContentSize, blobType);
-
-      MessageInfo msgInfo1 = new MessageInfo(key1, messageFormatStream1.getSize());
+      MessageInfo msgInfo1 =
+          new MessageInfo(key1, messageFormatStream1.getSize(), accountId, containerId, prop1.getCreationTimeInMs());
 
       // create message stream for blob 2 and mark it as deleted
       StoreKey key2 = new MockId("id2");
-      short accountId = Utils.getRandomShort(TestUtils.RANDOM);
-      short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+      accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      containerId = Utils.getRandomShort(TestUtils.RANDOM);
       long deletionTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
       MessageFormatInputStream messageFormatStream2 =
           new DeleteMessageFormatInputStream(key2, accountId, containerId, deletionTimeMs);
@@ -384,8 +390,8 @@ public class MessageSievingInputStreamTest {
 
       // create message stream for blob 3
       StoreKey key3 = new MockId("id3");
-      short accountId3 = Utils.getRandomShort(TestUtils.RANDOM);
-      short containerId3 = Utils.getRandomShort(TestUtils.RANDOM);
+      accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      containerId = Utils.getRandomShort(TestUtils.RANDOM);
       BlobProperties prop3 = new BlobProperties(10, "servid3", accountId, containerId);
       byte[] usermetadata3 = new byte[1000];
       new Random().nextBytes(usermetadata3);
@@ -405,7 +411,8 @@ public class MessageSievingInputStreamTest {
               : new PutMessageFormatBlobV1InputStream(key3, prop3, ByteBuffer.wrap(usermetadata3), stream3,
                   blobContentSize, blobType);
 
-      MessageInfo msgInfo3 = new MessageInfo(key3, messageFormatStream3.getSize());
+      MessageInfo msgInfo3 =
+          new MessageInfo(key3, messageFormatStream3.getSize(), accountId, containerId, prop3.getCreationTimeInMs());
 
       //create input stream for all blob messages together
       byte[] totalMessageContent = new byte[(int) messageFormatStream1.getSize() + (int) messageFormatStream2.getSize()

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
@@ -41,7 +41,7 @@ public class GetResponse extends Response {
   static final short Get_Response_Version_V2 = 2;
   static final short Get_Response_Version_V3 = 3;
 
-  private static final short currentVersion = Get_Response_Version_V2;
+  private static final short currentVersion = Get_Response_Version_V3;
 
   public GetResponse(int correlationId, String clientId, List<PartitionResponseInfo> partitionResponseInfoList,
       Send send, ServerErrorCode error) {

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
@@ -37,15 +37,15 @@ public class GetResponse extends Response {
   private int partitionResponseInfoSize;
 
   private static int Partition_Response_Info_List_Size = 4;
-  static final short Get_Response_Version_V1 = 1;
-  static final short Get_Response_Version_V2 = 2;
-  static final short Get_Response_Version_V3 = 3;
+  static final short GET_RESPONSE_VERSION_V_1 = 1;
+  static final short GET_RESPONSE_VERSION_V_2 = 2;
+  static final short GET_RESPONSE_VERSION_V_3 = 3;
 
-  private static final short currentVersion = Get_Response_Version_V3;
+  private static final short CURRENT_VERSION = GET_RESPONSE_VERSION_V_3;
 
   public GetResponse(int correlationId, String clientId, List<PartitionResponseInfo> partitionResponseInfoList,
       Send send, ServerErrorCode error) {
-    super(RequestOrResponseType.GetResponse, currentVersion, correlationId, clientId, error);
+    super(RequestOrResponseType.GetResponse, CURRENT_VERSION, correlationId, clientId, error);
     this.partitionResponseInfoList = partitionResponseInfoList;
     this.partitionResponseInfoSize = 0;
     for (PartitionResponseInfo partitionResponseInfo : partitionResponseInfoList) {
@@ -56,7 +56,7 @@ public class GetResponse extends Response {
 
   public GetResponse(int correlationId, String clientId, List<PartitionResponseInfo> partitionResponseInfoList,
       InputStream stream, ServerErrorCode error) {
-    super(RequestOrResponseType.GetResponse, currentVersion, correlationId, clientId, error);
+    super(RequestOrResponseType.GetResponse, CURRENT_VERSION, correlationId, clientId, error);
     this.partitionResponseInfoList = partitionResponseInfoList;
     this.partitionResponseInfoSize = 0;
     for (PartitionResponseInfo partitionResponseInfo : partitionResponseInfoList) {
@@ -66,7 +66,7 @@ public class GetResponse extends Response {
   }
 
   public GetResponse(int correlationId, String clientId, ServerErrorCode error) {
-    super(RequestOrResponseType.GetResponse, currentVersion, correlationId, clientId, error);
+    super(RequestOrResponseType.GetResponse, CURRENT_VERSION, correlationId, clientId, error);
     this.partitionResponseInfoList = null;
     this.partitionResponseInfoSize = 0;
   }
@@ -159,6 +159,6 @@ public class GetResponse extends Response {
    * @return the current version in which new GetResponse objects are created.
    */
   static short getCurrentVersion() {
-    return currentVersion;
+    return CURRENT_VERSION;
   }
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/MessageInfoListSerde.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/MessageInfoListSerde.java
@@ -13,9 +13,12 @@
  */
 package com.github.ambry.protocol;
 
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.store.MessageInfo;
+import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -141,11 +144,15 @@ class MessageInfoListSerde {
       Long crc = null;
       switch (versionToDeserializeIn) {
         case VERSION_1:
-          messageInfoList.add(new MessageInfo(id, size, isDeleted, ttl, crc));
+          messageInfoList.add(
+              new MessageInfo(id, size, isDeleted, ttl, crc, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
+                  Utils.Infinite_Time));
           break;
         case VERSION_2:
           crc = stream.readByte() == CRC_PRESENT ? stream.readLong() : null;
-          messageInfoList.add(new MessageInfo(id, size, isDeleted, ttl, crc));
+          messageInfoList.add(
+              new MessageInfo(id, size, isDeleted, ttl, crc, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
+                  Utils.Infinite_Time));
           break;
         case VERSION_3:
           crc = stream.readByte() == CRC_PRESENT ? stream.readLong() : null;

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PartitionResponseInfo.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PartitionResponseInfo.java
@@ -109,11 +109,11 @@ public class PartitionResponseInfo {
    */
   private static short getMessageInfoListVersion(short getResponseVersion) {
     switch (getResponseVersion) {
-      case GetResponse.Get_Response_Version_V1:
+      case GetResponse.GET_RESPONSE_VERSION_V_1:
         return MessageInfoListSerde.VERSION_1;
-      case GetResponse.Get_Response_Version_V2:
+      case GetResponse.GET_RESPONSE_VERSION_V_2:
         return MessageInfoListSerde.VERSION_2;
-      case GetResponse.Get_Response_Version_V3:
+      case GetResponse.GET_RESPONSE_VERSION_V_3:
         return MessageInfoListSerde.VERSION_3;
       default:
         throw new IllegalArgumentException("Unknown GetResponse version encountered: " + getResponseVersion);

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
@@ -40,7 +40,7 @@ public class ReplicaMetadataResponse extends Response {
   static final short Replica_Metadata_Response_Version_V2 = 2;
   static final short Replica_Metadata_Response_Version_V3 = 3;
 
-  private static final short currentVersion = Replica_Metadata_Response_Version_V2;
+  private static final short currentVersion = Replica_Metadata_Response_Version_V3;
 
   public ReplicaMetadataResponse(int correlationId, String clientId, ServerErrorCode error,
       List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList) {

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
@@ -36,15 +36,15 @@ public class ReplicaMetadataResponse extends Response {
 
   private static int Replica_Metadata_Response_Info_List_Size_In_Bytes = 4;
 
-  static final short Replica_Metadata_Response_Version_V1 = 1;
-  static final short Replica_Metadata_Response_Version_V2 = 2;
-  static final short Replica_Metadata_Response_Version_V3 = 3;
+  static final short REPLICA_METADATA_RESPONSE_VERSION_V_1 = 1;
+  static final short REPLICA_METADATA_RESPONSE_VERSION_V_2 = 2;
+  static final short REPLICA_METADATA_RESPONSE_VERSION_V_3 = 3;
 
-  private static final short currentVersion = Replica_Metadata_Response_Version_V3;
+  private static final short CURRENT_VERSION = REPLICA_METADATA_RESPONSE_VERSION_V_3;
 
   public ReplicaMetadataResponse(int correlationId, String clientId, ServerErrorCode error,
       List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList) {
-    super(RequestOrResponseType.ReplicaMetadataResponse, currentVersion, correlationId, clientId, error);
+    super(RequestOrResponseType.ReplicaMetadataResponse, CURRENT_VERSION, correlationId, clientId, error);
     this.replicaMetadataResponseInfoList = replicaMetadataResponseInfoList;
     this.replicaMetadataResponseInfoListSizeInBytes = 0;
     for (ReplicaMetadataResponseInfo replicaMetadataResponseInfo : replicaMetadataResponseInfoList) {
@@ -53,7 +53,7 @@ public class ReplicaMetadataResponse extends Response {
   }
 
   public ReplicaMetadataResponse(int correlationId, String clientId, ServerErrorCode error) {
-    super(RequestOrResponseType.ReplicaMetadataResponse, currentVersion, correlationId, clientId, error);
+    super(RequestOrResponseType.ReplicaMetadataResponse, CURRENT_VERSION, correlationId, clientId, error);
     replicaMetadataResponseInfoList = null;
     replicaMetadataResponseInfoListSizeInBytes = 0;
   }
@@ -136,6 +136,6 @@ public class ReplicaMetadataResponse extends Response {
    * @return the current version in which new ReplicaMetadataResponse objects are created.
    */
   public static short getCurrentVersion() {
-    return currentVersion;
+    return CURRENT_VERSION;
   }
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponseInfo.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponseInfo.java
@@ -143,11 +143,11 @@ public class ReplicaMetadataResponseInfo {
    */
   private static short getMessageInfoListVersion(short replicaMetadataResponseVersion) {
     switch (replicaMetadataResponseVersion) {
-      case ReplicaMetadataResponse.Replica_Metadata_Response_Version_V1:
+      case ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_1:
         return MessageInfoListSerde.VERSION_1;
-      case ReplicaMetadataResponse.Replica_Metadata_Response_Version_V2:
+      case ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_2:
         return MessageInfoListSerde.VERSION_2;
-      case ReplicaMetadataResponse.Replica_Metadata_Response_Version_V3:
+      case ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_3:
         return MessageInfoListSerde.VERSION_3;
       default:
         throw new IllegalArgumentException(

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -356,7 +356,7 @@ public class RequestResponseTest {
     Assert.assertEquals("MsgInfo size mismatch ", 1000, msgInfo.getSize());
     Assert.assertEquals("MsgInfo key mismatch ", id1, msgInfo.getStoreKey());
     Assert.assertEquals("MsgInfo expiration value mismatch ", Utils.Infinite_Time, msgInfo.getExpirationTimeInMs());
-    if (GetResponse.getCurrentVersion() == GetResponse.Get_Response_Version_V3) {
+    if (ReplicaMetadataResponse.getCurrentVersion() == ReplicaMetadataResponse.Replica_Metadata_Response_Version_V3) {
       Assert.assertEquals("AccountId mismatch ", accountId, msgInfo.getAccountId());
       Assert.assertEquals("ContainerId mismatch ", containerId, msgInfo.getContainerId());
       Assert.assertEquals("OperationTime mismatch ", operationTimeMs, msgInfo.getOperationTimeMs());

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -247,7 +247,7 @@ public class RequestResponseTest {
     Assert.assertEquals(msgInfo.getSize(), 1000);
     Assert.assertEquals(msgInfo.getStoreKey(), id1);
     Assert.assertEquals(msgInfo.getExpirationTimeInMs(), 1000);
-    if (GetResponse.getCurrentVersion() == GetResponse.Get_Response_Version_V3) {
+    if (GetResponse.getCurrentVersion() == GetResponse.GET_RESPONSE_VERSION_V_3) {
       Assert.assertEquals("AccountId mismatch ", accountId, msgInfo.getAccountId());
       Assert.assertEquals("ConatinerId mismatch ", containerId, msgInfo.getContainerId());
       Assert.assertEquals("OperationTime mismatch ", operationTimeMs, msgInfo.getOperationTimeMs());
@@ -356,7 +356,7 @@ public class RequestResponseTest {
     Assert.assertEquals("MsgInfo size mismatch ", 1000, msgInfo.getSize());
     Assert.assertEquals("MsgInfo key mismatch ", id1, msgInfo.getStoreKey());
     Assert.assertEquals("MsgInfo expiration value mismatch ", Utils.Infinite_Time, msgInfo.getExpirationTimeInMs());
-    if (ReplicaMetadataResponse.getCurrentVersion() == ReplicaMetadataResponse.Replica_Metadata_Response_Version_V3) {
+    if (ReplicaMetadataResponse.getCurrentVersion() == ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_3) {
       Assert.assertEquals("AccountId mismatch ", accountId, msgInfo.getAccountId());
       Assert.assertEquals("ContainerId mismatch ", containerId, msgInfo.getContainerId());
       Assert.assertEquals("OperationTime mismatch ", operationTimeMs, msgInfo.getOperationTimeMs());

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -531,7 +531,9 @@ class ReplicaThread implements Runnable {
           MessageFormatInputStream deleteStream =
               new DeleteMessageFormatInputStream(messageInfo.getStoreKey(), messageInfo.getAccountId(),
                   messageInfo.getContainerId(), messageInfo.getOperationTimeMs());
-          MessageInfo info = new MessageInfo(messageInfo.getStoreKey(), deleteStream.getSize(), true);
+          MessageInfo info =
+              new MessageInfo(messageInfo.getStoreKey(), deleteStream.getSize(), true, messageInfo.getAccountId(),
+                  messageInfo.getContainerId(), messageInfo.getOperationTimeMs());
           ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
           infoList.add(info);
           MessageFormatWriteSet writeset = new MessageFormatWriteSet(deleteStream, infoList, false);

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -14,8 +14,6 @@
 package com.github.ambry.replication;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.account.Account;
-import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.DataNodeId;
@@ -66,6 +64,7 @@ import com.github.ambry.store.Write;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.ByteBufferOutputStream;
 import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
@@ -319,26 +318,30 @@ public class ReplicationTest {
       StoreKey toDeleteId =
           addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(localHost, remoteHost), 6).get(0);
 
+      short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      short containerId = Utils.getRandomShort(TestUtils.RANDOM);
       // add an expired message to the remote host only
-      StoreKey id = new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, partitionId);
-      ByteBuffer buffer = getPutMessage(id);
-      remoteHost.addMessage(partitionId, new MessageInfo(id, buffer.remaining(), 1), buffer);
+      StoreKey id =
+          new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, partitionId);
+      Pair<ByteBuffer, BlobProperties> putMsgInfo = getPutMessage(id, accountId, containerId);
+      remoteHost.addMessage(partitionId,
+          new MessageInfo(id, putMsgInfo.getFirst().remaining(), 1, accountId, containerId,
+              putMsgInfo.getSecond().getCreationTimeInMs()), putMsgInfo.getFirst());
       idsToBeIgnored.add(id);
 
       // add 3 messages to the remote host only
       addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 3);
 
       // add a corrupt message to the remote host only
-      id = new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, partitionId);
-      buffer = getPutMessage(id);
-      byte[] data = buffer.array();
+      id = new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, partitionId);
+      putMsgInfo = getPutMessage(id, accountId, containerId);
+      byte[] data = putMsgInfo.getFirst().array();
       // flip every bit in the array
       for (int j = 0; j < data.length; j++) {
         data[j] ^= 0xFF;
       }
-      remoteHost.addMessage(partitionId, new MessageInfo(id, buffer.remaining()), buffer);
+      remoteHost.addMessage(partitionId, new MessageInfo(id, putMsgInfo.getFirst().remaining(), accountId, containerId,
+          putMsgInfo.getSecond().getCreationTimeInMs()), putMsgInfo.getFirst());
       idsToBeIgnored.add(id);
 
       // add 3 messages to the remote host only
@@ -357,7 +360,7 @@ public class ReplicationTest {
 
       // ensure that the first key is not deleted in the local host
       assertNull(toDeleteId + " should not be deleted in the local host",
-          getDeleteInfo(toDeleteId, localHost.infosByPartition.get(partitionId)));
+          getMessageInfo(toDeleteId, localHost.infosByPartition.get(partitionId), true));
     }
 
     Properties properties = new Properties();
@@ -380,13 +383,24 @@ public class ReplicationTest {
             storeKeyFactory, true, clusterMap.getMetricRegistry(), false, localHost.dataNodeId.getDatacenterName(),
             new ResponseHandler(clusterMap));
 
+    Map<PartitionId, List<ByteBuffer>> missingBuffers = remoteHost.getMissingBuffers(localHost.buffersByPartition);
+    for (Map.Entry<PartitionId, List<ByteBuffer>> entry : missingBuffers.entrySet()) {
+      if (partitionIds.indexOf(entry.getKey()) % 2 == 0) {
+        assertEquals("Missing buffers count mismatch", 13, entry.getValue().size());
+      } else {
+        assertEquals("Missing buffers count mismatch", 14, entry.getValue().size());
+      }
+    }
+
     // 1st and 2nd iterations - no keys missing because all data is in both hosts
     // 3rd iteration - 3 missing keys (one expired)
     // 4th iteration - 3 missing keys (one expired) - the corrupt key also shows up as missing but is ignored later
     // 5th iteration - 1 missing key (1 key from prev cycle, 1 deleted key, 1 never present key but deleted in remote)
     // 6th iteration - 2 missing keys (2 entries i.e put,delete of never present key)
     int[] missingKeysCounts = {0, 0, 3, 3, 1, 2};
+    int[] missingBuffersCount = {12, 12, 9, 7, 6, 4};
     int expectedIndex = 0;
+    int missingBuffersIndex = 0;
 
     for (int missingKeysCount : missingKeysCounts) {
       expectedIndex += (batchSize - 1);
@@ -406,6 +420,17 @@ public class ReplicationTest {
         assertEquals("Token should have been set correctly in fixMissingStoreKeys()", response.get(i).remoteToken,
             replicasToReplicate.get(remoteHost.dataNodeId).get(i).getToken());
       }
+      missingBuffers = remoteHost.getMissingBuffers(localHost.buffersByPartition);
+      for (Map.Entry<PartitionId, List<ByteBuffer>> entry : missingBuffers.entrySet()) {
+        if (partitionIds.indexOf(entry.getKey()) % 2 == 0) {
+          assertEquals("Missing buffers count mismatch for iteration count " + missingBuffersIndex,
+              missingBuffersCount[missingBuffersIndex], entry.getValue().size());
+        } else {
+          assertEquals("Missing buffers count mismatch for iteration count " + missingBuffersIndex,
+              missingBuffersCount[missingBuffersIndex] + 1, entry.getValue().size());
+        }
+      }
+      missingBuffersIndex++;
     }
 
     // Test the case where some partitions have missing keys, but not all.
@@ -446,7 +471,7 @@ public class ReplicationTest {
       // test that the first key has been marked deleted
       List<MessageInfo> messageInfos = localHost.infosByPartition.get(entry.getKey());
       StoreKey deletedId = messageInfos.get(0).getStoreKey();
-      assertNotNull(deletedId + " should have been deleted", getDeleteInfo(deletedId, messageInfos));
+      assertNotNull(deletedId + " should have been deleted", getMessageInfo(deletedId, messageInfos, true));
       Map<StoreKey, Boolean> ignoreState = new HashMap<>();
       for (StoreKey toBeIgnored : idsToBeIgnoredByPartition.get(entry.getKey())) {
         ignoreState.put(toBeIgnored, false);
@@ -462,7 +487,7 @@ public class ReplicationTest {
         assertTrue(stateInfo.getKey() + " should have been ignored", stateInfo.getValue());
       }
     }
-    Map<PartitionId, List<ByteBuffer>> missingBuffers = remoteHost.getMissingBuffers(localHost.buffersByPartition);
+    missingBuffers = remoteHost.getMissingBuffers(localHost.buffersByPartition);
     for (Map.Entry<PartitionId, List<ByteBuffer>> entry : missingBuffers.entrySet()) {
       // 1 expired + 1 corrupt + 1 put (never present) + 1 deleted (never present)
       assertEquals(4, entry.getValue().size());
@@ -539,12 +564,15 @@ public class ReplicationTest {
       throws MessageFormatException, IOException {
     List<StoreKey> ids = new ArrayList<>();
     for (int i = 0; i < count; i++) {
-      BlobId id = new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, partitionId);
+      short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+      BlobId id =
+          new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, partitionId);
       ids.add(id);
-      ByteBuffer buffer = getPutMessage(id);
+      Pair<ByteBuffer, BlobProperties> putMsgInfo = getPutMessage(id, accountId, containerId);
       for (Host host : hosts) {
-        host.addMessage(partitionId, new MessageInfo(id, buffer.remaining()), buffer.duplicate());
+        host.addMessage(partitionId, new MessageInfo(id, putMsgInfo.getFirst().remaining(), accountId, containerId,
+            putMsgInfo.getSecond().getCreationTimeInMs()), putMsgInfo.getFirst().duplicate());
       }
     }
     return ids;
@@ -560,34 +588,40 @@ public class ReplicationTest {
    */
   private void addDeleteMessagesToReplicasOfPartition(PartitionId partitionId, StoreKey id, List<Host> hosts)
       throws MessageFormatException, IOException {
-    ByteBuffer buffer = getDeleteMessage(id);
+    MessageInfo putMsg = getMessageInfo(id, hosts.get(0).infosByPartition.get(partitionId), false);
+    long deletionTimeMs = System.currentTimeMillis();
+    ByteBuffer buffer = getDeleteMessage(id, putMsg.getAccountId(), putMsg.getContainerId(), deletionTimeMs);
     for (Host host : hosts) {
-      host.addMessage(partitionId, new MessageInfo(id, buffer.remaining(), true), buffer.duplicate());
+      host.addMessage(partitionId,
+          new MessageInfo(id, buffer.remaining(), true, putMsg.getAccountId(), putMsg.getContainerId(), deletionTimeMs),
+          buffer.duplicate());
     }
   }
 
   /**
    * Constructs an entire message with header, blob properties, user metadata and blob content.
    * @param id id for which the message has to be constructed.
-   * @return {@link ByteBuffer} representing the entire message.
+   * @param accountId accountId of the blob
+   * @param containerId containerId of the blob
+   * @return a {@link Pair} of {@link ByteBuffer} and {@link BlobProperties} representing the entire message and its
+   *         Blob properties
    * @throws MessageFormatException
    * @throws IOException
    */
-  private ByteBuffer getPutMessage(StoreKey id) throws MessageFormatException, IOException {
+  private Pair<ByteBuffer, BlobProperties> getPutMessage(StoreKey id, short accountId, short containerId)
+      throws MessageFormatException, IOException {
     int blobSize = TestUtils.RANDOM.nextInt(500) + 501;
     int userMetadataSize = TestUtils.RANDOM.nextInt(blobSize / 2);
     byte[] blob = new byte[blobSize];
     byte[] usermetadata = new byte[userMetadataSize];
     TestUtils.RANDOM.nextBytes(blob);
     TestUtils.RANDOM.nextBytes(usermetadata);
-    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
-    short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobProperties blobProperties = new BlobProperties(blobSize, "test", accountId, containerId);
 
     MessageFormatInputStream stream = new PutMessageFormatInputStream(id, blobProperties, ByteBuffer.wrap(usermetadata),
         new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize);
     byte[] message = Utils.readBytesFromStream(stream, (int) stream.getSize());
-    return ByteBuffer.wrap(message);
+    return new Pair(ByteBuffer.wrap(message), blobProperties);
   }
 
   /**
@@ -597,26 +631,28 @@ public class ReplicationTest {
    * @throws MessageFormatException
    * @throws IOException
    */
-  private ByteBuffer getDeleteMessage(StoreKey id) throws MessageFormatException, IOException {
-    MessageFormatInputStream stream =
-        new DeleteMessageFormatInputStream(id, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-            SystemTime.getInstance().milliseconds());
+  private ByteBuffer getDeleteMessage(StoreKey id, short accountId, short containerId, long deletionTimeMs)
+      throws MessageFormatException, IOException {
+    MessageFormatInputStream stream = new DeleteMessageFormatInputStream(id, accountId, containerId, deletionTimeMs);
     byte[] message = Utils.readBytesFromStream(stream, (int) stream.getSize());
     return ByteBuffer.wrap(message);
   }
 
   /**
-   * Gets the delete {@link MessageInfo} for {@code id} if present.
+   * Gets the {@link MessageInfo} for {@code id} if present.
    * @param id the {@link StoreKey} to look for.
    * @param messageInfos the {@link MessageInfo} list.
+   * @param deleteMsg {@code true} if delete msg if requested. {@code false} otherwise
    * @return the delete {@link MessageInfo} if it exists in {@code messageInfos}. {@code null otherwise.}
    */
-  private static MessageInfo getDeleteInfo(StoreKey id, List<MessageInfo> messageInfos) {
+  private static MessageInfo getMessageInfo(StoreKey id, List<MessageInfo> messageInfos, boolean deleteMsg) {
     MessageInfo toRet = null;
     for (MessageInfo messageInfo : messageInfos) {
-      if (messageInfo.getStoreKey().equals(id) && messageInfo.isDeleted()) {
-        toRet = messageInfo;
-        break;
+      if (messageInfo.getStoreKey().equals(id)) {
+        if ((deleteMsg && messageInfo.isDeleted()) || (!deleteMsg && !messageInfo.isDeleted())) {
+          toRet = messageInfo;
+          break;
+        }
       }
     }
     return toRet;
@@ -926,7 +962,8 @@ public class ReplicationTest {
           throw new IllegalStateException(e);
         }
         messageInfos.add(new MessageInfo(deleteInfo.getStoreKey(), deleteInfo.getSize(), true,
-            messageInfoFound.getExpirationTimeInMs()));
+            messageInfoFound.getExpirationTimeInMs(), messageInfoFound.getAccountId(),
+            messageInfoFound.getContainerId(), System.currentTimeMillis()));
       }
     }
 
@@ -939,7 +976,7 @@ public class ReplicationTest {
       int index = mockToken.getIndex();
       while (currentSizeOfEntriesInBytes < maxSizeOfEntries && index < messageInfos.size()) {
         MessageInfo messageInfo = messageInfos.get(index);
-        MessageInfo deleteInfo = getDeleteInfo(messageInfo.getStoreKey(), messageInfos);
+        MessageInfo deleteInfo = getMessageInfo(messageInfo.getStoreKey(), messageInfos, true);
         entriesToReturn.add(deleteInfo == null ? messageInfo : deleteInfo);
         // still use the size of the put (if the original picked up is the put.
         currentSizeOfEntriesInBytes += messageInfos.get(index).getSize();
@@ -982,7 +1019,7 @@ public class ReplicationTest {
 
     @Override
     public boolean isKeyDeleted(StoreKey key) throws StoreException {
-      return getDeleteInfo(key, messageInfos) != null;
+      return getMessageInfo(key, messageInfos, true) != null;
     }
 
     @Override
@@ -1093,7 +1130,7 @@ public class ReplicationTest {
           int indexRequested = 0;
           for (int i = startIndex; i < endIndex; i++) {
             MessageInfo messageInfo = partitionInfos.get(i);
-            MessageInfo deleteInfo = getDeleteInfo(messageInfo.getStoreKey(), partitionInfos);
+            MessageInfo deleteInfo = getMessageInfo(messageInfo.getStoreKey(), partitionInfos, true);
             messageInfosToReturn.add(deleteInfo == null ? messageInfo : deleteInfo);
             indexRequested = i;
           }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -332,6 +332,8 @@ public class ReplicationTest {
       // add 3 messages to the remote host only
       addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 3);
 
+      accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      containerId = Utils.getRandomShort(TestUtils.RANDOM);
       // add a corrupt message to the remote host only
       id = new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, partitionId);
       putMsgInfo = getPutMessage(id, accountId, containerId);
@@ -649,7 +651,7 @@ public class ReplicationTest {
     MessageInfo toRet = null;
     for (MessageInfo messageInfo : messageInfos) {
       if (messageInfo.getStoreKey().equals(id)) {
-        if ((deleteMsg && messageInfo.isDeleted()) || (!deleteMsg && !messageInfo.isDeleted())) {
+        if (deleteMsg == messageInfo.isDeleted()) {
           toRet = messageInfo;
           break;
         }

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -13,8 +13,6 @@
  */
 package com.github.ambry.router;
 
-import com.github.ambry.account.Account;
-import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.PartitionId;
@@ -28,6 +26,7 @@ import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -102,8 +101,8 @@ public class DeleteManagerTest {
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), new LoggingNotificationSystem(), clusterMap, mockTime);
     List<PartitionId> mockPartitions = clusterMap.getWritablePartitionIds();
     partition = mockPartitions.get(ThreadLocalRandom.current().nextInt(mockPartitions.size()));
-    blobId = new BlobId(BlobId.DEFAULT_FLAG, clusterMap.getLocalDatacenterId(), Account.UNKNOWN_ACCOUNT_ID,
-        Container.UNKNOWN_CONTAINER_ID, partition);
+    blobId = new BlobId(BlobId.DEFAULT_FLAG, clusterMap.getLocalDatacenterId(), Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), partition);
     blobIdString = blobId.getID();
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -13,8 +13,6 @@
  */
 package com.github.ambry.router;
 
-import com.github.ambry.account.Account;
-import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.BlobId;
@@ -157,8 +155,8 @@ public class GetBlobInfoOperationTest {
   @Test
   public void testInstantiation() throws Exception {
     String blobIdStr =
-        (new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID,
-            Container.UNKNOWN_CONTAINER_ID, mockClusterMap.getWritablePartitionIds().get(0))).getID();
+        (new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(random),
+            Utils.getRandomShort(random), mockClusterMap.getWritablePartitionIds().get(0))).getID();
     Callback<GetBlobResultInternal> getOperationCallback = (result, exception) -> {
       // no op.
     };

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -13,8 +13,6 @@
  */
 package com.github.ambry.router;
 
-import com.github.ambry.account.Account;
-import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.BlobIdFactory;
@@ -37,6 +35,7 @@ import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.router.RouterTestHelpers.*;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -222,8 +221,9 @@ public class GetBlobOperationTest {
           e.getErrorCode());
     }
 
-    blobIdStr = new BlobId(BlobId.DEFAULT_FLAG, mockClusterMap.getLocalDatacenterId(), Account.UNKNOWN_ACCOUNT_ID,
-        Container.UNKNOWN_CONTAINER_ID, mockClusterMap.getWritablePartitionIds().get(0)).getID();
+    blobIdStr =
+        new BlobId(BlobId.DEFAULT_FLAG, mockClusterMap.getLocalDatacenterId(), Utils.getRandomShort(TestUtils.RANDOM),
+            Utils.getRandomShort(TestUtils.RANDOM), mockClusterMap.getWritablePartitionIds().get(0)).getID();
     // test a good case
     // operationCount is not incremented here as this operation is not taken to completion.
     GetBlobOperation op = new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.ServerErrorCode;
 import com.github.ambry.messageformat.BlobProperties;
@@ -297,7 +299,9 @@ class MockServer {
       ByteBufferSend responseSend = new ByteBufferSend(byteBuffer);
       List<MessageInfo> messageInfoList = new ArrayList<MessageInfo>(1);
       List<PartitionResponseInfo> partitionResponseInfoList = new ArrayList<PartitionResponseInfo>();
-      messageInfoList.add(new MessageInfo(key, byteBufferSize));
+      messageInfoList.add(
+          new MessageInfo(key, byteBufferSize, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
+              Utils.Infinite_Time));
       PartitionResponseInfo partitionResponseInfo =
           partitionError == ServerErrorCode.No_Error ? new PartitionResponseInfo(
               getRequest.getPartitionInfoList().get(0).getPartition(), messageInfoList)

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
@@ -13,12 +13,12 @@
  */
 package com.github.ambry.router;
 
-import com.github.ambry.account.Account;
-import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
+import com.github.ambry.utils.Utils;
+import java.util.Random;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,6 +26,7 @@ import static org.junit.Assert.*;
 
 
 public class RouterUtilsTest {
+  Random random = new Random();
   ClusterMap clusterMap;
   PartitionId partition;
   BlobId originalBlobId;
@@ -38,8 +39,8 @@ public class RouterUtilsTest {
       fail("Should not get any exception.");
     }
     partition = clusterMap.getWritablePartitionIds().get(0);
-    originalBlobId = new BlobId(BlobId.DEFAULT_FLAG, clusterMap.getLocalDatacenterId(), Account.UNKNOWN_ACCOUNT_ID,
-        Container.UNKNOWN_CONTAINER_ID, partition);
+    originalBlobId = new BlobId(BlobId.DEFAULT_FLAG, clusterMap.getLocalDatacenterId(), Utils.getRandomShort(random),
+        Utils.getRandomShort(random), partition);
     blobIdStr = originalBlobId.getID();
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -187,8 +187,6 @@ class Tracker {
     creationNotificationsReceived.incrementAndGet();
     if (creationSrcHosts.putIfAbsent(getKey(srcHost, srcPort), true) == null) {
       totalReplicasCreated.countDown();
-      System.out.println(creationSrcHosts.size());
-      System.out.println(numberOfReplicas - totalReplicasCreated.getCount());
     }
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -285,6 +285,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(4).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
+    // TODO: derive the token value automatically
     ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198454);
 
     getAndVerify(channel, 6);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -286,7 +286,7 @@ public class ServerHardDeleteTest {
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
     // TODO: derive the token value automatically
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198454);
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198478);
 
     getAndVerify(channel, 6);
 
@@ -316,7 +316,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(6).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 297967);
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 298003);
 
     getAndVerify(channel, 9);
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -285,7 +285,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(4).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198467);
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198454);
 
     getAndVerify(channel, 6);
 
@@ -315,7 +315,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(6).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 297959);
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 297967);
 
     getAndVerify(channel, 9);
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -514,7 +514,7 @@ public final class ServerTestUtil {
           } else if (j == 2) {
             channel = channel3;
           }
-          DeleteRequest deleteRequest = new DeleteRequest(1, "reptest", blobIds.get(i), Utils.Infinite_Time);
+          DeleteRequest deleteRequest = new DeleteRequest(1, "reptest", blobIds.get(i), System.currentTimeMillis());
           channel.send(deleteRequest);
           InputStream deleteResponseStream = channel.receive().getInputStream();
           DeleteResponse deleteResponse = DeleteResponse.readFrom(new DataInputStream(deleteResponseStream));
@@ -1085,7 +1085,7 @@ public final class ServerTestUtil {
       assertEquals(ServerErrorCode.Blob_Not_Found, resp4.getPartitionResponseInfoList().get(0).getErrorCode());
 
       // delete a blob and ensure it is propagated
-      DeleteRequest deleteRequest = new DeleteRequest(1, "reptest", blobId1, Utils.Infinite_Time);
+      DeleteRequest deleteRequest = new DeleteRequest(1, "reptest", blobId1, System.currentTimeMillis());
       expectedTokenSize += getDeleteRecordSize(blobId1);
       System.out.println("Expected size after first delete " + expectedTokenSize);
       channel1.send(deleteRequest);

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -177,7 +177,9 @@ public class AmbryRequests implements RequestAPI {
                 receivedRequest.getBlobType());
         MessageInfo info = new MessageInfo(receivedRequest.getBlobId(), stream.getSize(), false,
             Utils.addSecondsToEpochTime(receivedRequest.getBlobProperties().getCreationTimeInMs(),
-                receivedRequest.getBlobProperties().getTimeToLiveInSeconds()), receivedRequest.getCrc());
+                receivedRequest.getBlobProperties().getTimeToLiveInSeconds()), receivedRequest.getCrc(),
+            receivedRequest.getBlobProperties().getAccountId(), receivedRequest.getBlobProperties().getContainerId(),
+            receivedRequest.getBlobProperties().getCreationTimeInMs());
         ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
         infoList.add(info);
         MessageFormatWriteSet writeset = new MessageFormatWriteSet(stream, infoList, false);
@@ -375,7 +377,8 @@ public class AmbryRequests implements RequestAPI {
         MessageFormatInputStream stream =
             new DeleteMessageFormatInputStream(deleteRequest.getBlobId(), deleteRequest.getAccountId(),
                 deleteRequest.getContainerId(), deleteRequest.getDeletionTimeInMs());
-        MessageInfo info = new MessageInfo(deleteRequest.getBlobId(), stream.getSize());
+        MessageInfo info = new MessageInfo(deleteRequest.getBlobId(), stream.getSize(), deleteRequest.getAccountId(),
+            deleteRequest.getContainerId(), deleteRequest.getDeletionTimeInMs());
         ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
         infoList.add(info);
         MessageFormatWriteSet writeset = new MessageFormatWriteSet(stream, infoList, false);

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -14,8 +14,6 @@
 package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.account.Account;
-import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.DataNodeId;
@@ -340,8 +338,9 @@ public class AmbryRequestsTest {
     for (PartitionId id : ids) {
       int correlationId = TestUtils.RANDOM.nextInt();
       String clientId = UtilsTest.getRandomString(10);
-      BlobId blobId = new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, id);
+      BlobId blobId =
+          new BlobId(BlobId.DEFAULT_FLAG, ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
+              Utils.getRandomShort(TestUtils.RANDOM), id);
       RequestOrResponse request;
       switch (requestType) {
         case PutRequest:

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -243,8 +243,8 @@ class BlobStore implements Store {
             ArrayList<IndexEntry> indexEntries = new ArrayList<>(messageInfo.size());
             for (MessageInfo info : messageInfo) {
               FileSpan fileSpan = log.getFileSpanForMessage(endOffsetOfLastMessage, info.getSize());
-              IndexValue value =
-                  new IndexValue(info.getSize(), fileSpan.getStartOffset(), info.getExpirationTimeInMs());
+              IndexValue value = new IndexValue(info.getSize(), fileSpan.getStartOffset(), info.getExpirationTimeInMs(),
+                  info.getOperationTimeMs(), info.getAccountId(), info.getContainerId());
               IndexEntry entry = new IndexEntry(info.getStoreKey(), value, info.getCrc());
               indexEntries.add(entry);
               endOffsetOfLastMessage = fileSpan.getEndOffset();
@@ -325,7 +325,7 @@ class BlobStore implements Store {
         int correspondingPutIndex = 0;
         for (MessageInfo info : infoList) {
           FileSpan fileSpan = log.getFileSpanForMessage(endOffsetOfLastMessage, info.getSize());
-          IndexValue deleteIndexValue = index.markAsDeleted(info.getStoreKey(), fileSpan);
+          IndexValue deleteIndexValue = index.markAsDeleted(info.getStoreKey(), fileSpan, info.getOperationTimeMs());
           endOffsetOfLastMessage = fileSpan.getEndOffset();
           blobStoreStats.handleNewDeleteEntry(deleteIndexValue, indexValuesToDelete.get(correspondingPutIndex++));
         }

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
@@ -644,9 +644,10 @@ class BlobStoreCompactor {
             try (BlobReadOptions options = srcIndex.getBlobReadInfo(indexEntry.getKey(),
                 EnumSet.allOf(StoreGetOptions.class))) {
               Offset offset = new Offset(indexSegmentStartOffset.getName(), options.getOffset());
-              IndexValue putValue = new IndexValue(options.getMessageInfo().getSize(), offset,
-                  options.getMessageInfo().getExpirationTimeInMs(), options.getMessageInfo().getOperationTimeMs(),
-                  options.getMessageInfo().getAccountId(), options.getMessageInfo().getContainerId());
+              MessageInfo info = options.getMessageInfo();
+              IndexValue putValue = new IndexValue(info.getSize(), offset,
+                  info.getExpirationTimeInMs(), info.getOperationTimeMs(),
+                  info.getAccountId(), info.getContainerId());
               validEntries.add(new IndexEntry(indexEntry.getKey(), putValue));
             } catch (StoreException e) {
               logger.error("Fetching PUT index entry of {} in {} failed", indexEntry.getKey(), indexSegmentStartOffset);

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
@@ -645,9 +645,9 @@ class BlobStoreCompactor {
                 EnumSet.allOf(StoreGetOptions.class))) {
               Offset offset = new Offset(indexSegmentStartOffset.getName(), options.getOffset());
               MessageInfo info = options.getMessageInfo();
-              IndexValue putValue = new IndexValue(info.getSize(), offset,
-                  info.getExpirationTimeInMs(), info.getOperationTimeMs(),
-                  info.getAccountId(), info.getContainerId());
+              IndexValue putValue =
+                  new IndexValue(info.getSize(), offset, info.getExpirationTimeInMs(), info.getOperationTimeMs(),
+                      info.getAccountId(), info.getContainerId());
               validEntries.add(new IndexEntry(indexEntry.getKey(), putValue));
             } catch (StoreException e) {
               logger.error("Fetching PUT index entry of {} in {} failed", indexEntry.getKey(), indexSegmentStartOffset);

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
@@ -720,7 +720,7 @@ class BlobStoreCompactor {
           if (srcValue.isFlagSet(IndexValue.Flags.Delete_Index)) {
             IndexValue putValue = tgtIndex.findKey(srcIndexEntry.getKey());
             if (putValue != null) {
-              tgtIndex.markAsDeleted(srcIndexEntry.getKey(), fileSpan);
+              tgtIndex.markAsDeleted(srcIndexEntry.getKey(), fileSpan, srcValue.getOperationTimeInMs());
             } else {
               IndexValue tgtValue =
                   new IndexValue(srcValue.getSize(), fileSpan.getStartOffset(), srcValue.getExpiresAtMs(),

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
@@ -644,9 +644,9 @@ class BlobStoreCompactor {
             try (BlobReadOptions options = srcIndex.getBlobReadInfo(indexEntry.getKey(),
                 EnumSet.allOf(StoreGetOptions.class))) {
               Offset offset = new Offset(indexSegmentStartOffset.getName(), options.getOffset());
-              IndexValue putValue =
-                  new IndexValue(options.getSize(), offset, options.getExpiresAtMs(), value.getOperationTimeInMs(),
-                      value.getServiceId(), value.getContainerId());
+              IndexValue putValue = new IndexValue(options.getMessageInfo().getSize(), offset,
+                  options.getMessageInfo().getExpirationTimeInMs(), options.getMessageInfo().getOperationTimeMs(),
+                  options.getMessageInfo().getAccountId(), options.getMessageInfo().getContainerId());
               validEntries.add(new IndexEntry(indexEntry.getKey(), putValue));
             } catch (StoreException e) {
               logger.error("Fetching PUT index entry of {} in {} failed", indexEntry.getKey(), indexSegmentStartOffset);

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
@@ -725,7 +725,7 @@ class BlobStoreCompactor {
             } else {
               IndexValue tgtValue =
                   new IndexValue(srcValue.getSize(), fileSpan.getStartOffset(), srcValue.getExpiresAtMs(),
-                      srcValue.getOperationTimeInMs(), srcValue.getServiceId(), srcValue.getContainerId());
+                      srcValue.getOperationTimeInMs(), srcValue.getAccountId(), srcValue.getContainerId());
               tgtValue.setFlag(IndexValue.Flags.Delete_Index);
               tgtValue.clearOriginalMessageOffset();
               tgtIndex.addToIndex(new IndexEntry(srcIndexEntry.getKey(), tgtValue), fileSpan);
@@ -733,7 +733,7 @@ class BlobStoreCompactor {
           } else {
             IndexValue tgtValue =
                 new IndexValue(srcValue.getSize(), fileSpan.getStartOffset(), srcValue.getExpiresAtMs(),
-                    srcValue.getOperationTimeInMs(), srcValue.getServiceId(), srcValue.getContainerId());
+                    srcValue.getOperationTimeInMs(), srcValue.getAccountId(), srcValue.getContainerId());
             tgtIndex.addToIndex(new IndexEntry(srcIndexEntry.getKey(), tgtValue), fileSpan);
           }
           long lastModifiedTimeSecsToSet =

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreStats.java
@@ -498,8 +498,9 @@ class BlobStoreStats implements StoreStats, Closeable {
   private IndexValue getPutRecordForDeletedKey(StoreKey key, IndexValue deleteIndexValue) throws StoreException {
     BlobReadOptions originalPut = index.getBlobReadInfo(key, EnumSet.allOf(StoreGetOptions.class));
     Offset originalPutOffset = new Offset(originalPut.getLogSegmentName(), originalPut.getOffset());
-    return new IndexValue(originalPut.getSize(), originalPutOffset, originalPut.getExpiresAtMs(),
-        deleteIndexValue.getOperationTimeInMs(), deleteIndexValue.getServiceId(), deleteIndexValue.getContainerId());
+    return new IndexValue(originalPut.getMessageInfo().getSize(), originalPutOffset,
+        originalPut.getMessageInfo().getExpirationTimeInMs(), deleteIndexValue.getOperationTimeInMs(),
+        deleteIndexValue.getServiceId(), deleteIndexValue.getContainerId());
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreStats.java
@@ -352,7 +352,7 @@ class BlobStoreStats implements StoreStats, Closeable {
         IndexValue indexValue = indexEntry.getValue();
         if (!indexValue.isFlagSet(IndexValue.Flags.Delete_Index)) {
           // delete records does not count towards valid data size for quota (containers)
-          updateNestedMapHelper(validDataSizePerContainer, String.valueOf(indexValue.getServiceId()),
+          updateNestedMapHelper(validDataSizePerContainer, String.valueOf(indexValue.getAccountId()),
               String.valueOf(indexValue.getContainerId()), indexValue.getSize());
         }
       }
@@ -500,7 +500,7 @@ class BlobStoreStats implements StoreStats, Closeable {
     Offset originalPutOffset = new Offset(originalPut.getLogSegmentName(), originalPut.getOffset());
     return new IndexValue(originalPut.getMessageInfo().getSize(), originalPutOffset,
         originalPut.getMessageInfo().getExpirationTimeInMs(), deleteIndexValue.getOperationTimeInMs(),
-        deleteIndexValue.getServiceId(), deleteIndexValue.getContainerId());
+        deleteIndexValue.getAccountId(), deleteIndexValue.getContainerId());
   }
 
   /**
@@ -550,7 +550,7 @@ class BlobStoreStats implements StoreStats, Closeable {
       int operator) {
     if (isWithinRange(results.containerForecastStartTimeMs, results.containerLastBucketTimeMs, expOrDelTimeInMs)) {
       results.updateContainerBucket(results.getContainerBucketKey(expOrDelTimeInMs),
-          String.valueOf(indexValue.getServiceId()), String.valueOf(indexValue.getContainerId()),
+          String.valueOf(indexValue.getAccountId()), String.valueOf(indexValue.getContainerId()),
           indexValue.getSize() * operator);
     }
   }
@@ -578,7 +578,7 @@ class BlobStoreStats implements StoreStats, Closeable {
   private void processNewPut(ScanResults results, IndexValue putValue) {
     long expiresAtMs = putValue.getExpiresAtMs();
     if (!isExpired(expiresAtMs, results.containerForecastStartTimeMs)) {
-      results.updateContainerBaseBucket(String.valueOf(putValue.getServiceId()),
+      results.updateContainerBaseBucket(String.valueOf(putValue.getAccountId()),
           String.valueOf(putValue.getContainerId()), putValue.getSize());
       if (expiresAtMs != Utils.Infinite_Time) {
         handleContainerBucketUpdate(results, putValue, expiresAtMs, SUBTRACT);
@@ -629,7 +629,7 @@ class BlobStoreStats implements StoreStats, Closeable {
       IndexValue indexValue = indexEntry.getValue();
       if (!indexValue.isFlagSet(IndexValue.Flags.Delete_Index)) {
         // delete records does not count towards valid data size for quota (containers)
-        results.updateContainerBaseBucket(String.valueOf(indexValue.getServiceId()),
+        results.updateContainerBaseBucket(String.valueOf(indexValue.getAccountId()),
             String.valueOf(indexValue.getContainerId()), indexValue.getSize());
         long expOrDelTimeInMs = indexValue.getExpiresAtMs();
         if (deletedKeys.containsKey(indexEntry.getKey())) {

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -720,7 +720,7 @@ public class HardDeleter implements Runnable {
          later occurrence is the one really associated with this token, it does not affect the safety.
          Persisting more than what is required is okay as hard deleting a blob is an idempotent operation. */
         messageStoreRecoveryListIterator.next();
-        if (blobReadOptionsListIterator.next().getStoreKey().equals(storeKey)) {
+        if (blobReadOptionsListIterator.next().getMessageInfo().getStoreKey().equals(storeKey)) {
           break;
         } else {
           blobReadOptionsListIterator.remove();

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -838,7 +838,7 @@ class IndexSegment {
       IndexValue value = indexEntry.getValue();
       MessageInfo info =
           new MessageInfo(indexEntry.getKey(), value.getSize(), value.isFlagSet(IndexValue.Flags.Delete_Index),
-              value.getExpiresAtMs());
+              value.getExpiresAtMs(), value.getServiceId(), value.getContainerId(), value.getOperationTimeInMs());
       entries.add(info);
     }
     return isNewEntriesAdded;

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -838,7 +838,7 @@ class IndexSegment {
       IndexValue value = indexEntry.getValue();
       MessageInfo info =
           new MessageInfo(indexEntry.getKey(), value.getSize(), value.isFlagSet(IndexValue.Flags.Delete_Index),
-              value.getExpiresAtMs(), value.getServiceId(), value.getContainerId(), value.getOperationTimeInMs());
+              value.getExpiresAtMs(), value.getAccountId(), value.getContainerId(), value.getOperationTimeInMs());
       entries.add(info);
     }
     return isNewEntriesAdded;

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -127,30 +127,6 @@ class IndexValue {
    * @param size the size of the blob that this index value refers to
    * @param offset the {@link Offset} in the {@link Log} where the blob that this index value refers to resides
    * @param expiresAtMs the expiration time in ms at which the blob expires
-   */
-  IndexValue(long size, Offset offset, long expiresAtMs) {
-    this(size, offset, FLAGS_DEFAULT_VALUE, expiresAtMs, offset.getOffset(), (int) Utils.Infinite_Time,
-        UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID);
-  }
-
-  /**
-   * Constructs IndexValue based on the args passed
-   * @param size the size of the blob that this index value refers to
-   * @param offset the {@link Offset} in the {@link Log} where the blob that this index value refers to resides
-   * @param flags the {@link Flags} that needs to be set for the Index Value
-   * @param expiresAtMs the expiration time in ms at which the blob expires
-   * @param operationTimeInMs operation time ins ms of the entry in secs
-   */
-  IndexValue(long size, Offset offset, byte flags, long expiresAtMs, long operationTimeInMs) {
-    this(size, offset, flags, expiresAtMs, offset.getOffset(), operationTimeInMs, UNKNOWN_ACCOUNT_ID,
-        UNKNOWN_CONTAINER_ID);
-  }
-
-  /**
-   * Constructs IndexValue based on the args passed
-   * @param size the size of the blob that this index value refers to
-   * @param offset the {@link Offset} in the {@link Log} where the blob that this index value refers to resides
-   * @param expiresAtMs the expiration time in ms at which the blob expires
    * @param operationTimeInMs operation time in ms of the entry
    * @param serviceId the serviceId that this blob belongs to
    * @param containerId the containerId that this blob belongs to

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -56,7 +56,7 @@ class IndexValue {
 
   private final static int EXPIRES_AT_SECS_SIZE_IN_BYTES_V1 = 4;
   private final static int OPERATION_TIME_SECS_SIZE_IN_BYTES = 4;
-  private final static int SERVICE_ID_SIZE_IN_BYTES = 2;
+  private final static int ACCOUNT_ID_SIZE_IN_BYTES = 2;
   private final static int CONTAINER_ID_SIZE_IN_BYTES = 2;
 
   final static int INDEX_VALUE_SIZE_IN_BYTES_V0 =
@@ -65,7 +65,7 @@ class IndexValue {
 
   final static int INDEX_VALUE_SIZE_IN_BYTES_V1 =
       BLOB_SIZE_IN_BYTES + OFFSET_SIZE_IN_BYTES + FLAG_SIZE_IN_BYTES + EXPIRES_AT_SECS_SIZE_IN_BYTES_V1
-          + ORIGINAL_MESSAGE_OFFSET_SIZE_IN_BYTES + OPERATION_TIME_SECS_SIZE_IN_BYTES + SERVICE_ID_SIZE_IN_BYTES
+          + ORIGINAL_MESSAGE_OFFSET_SIZE_IN_BYTES + OPERATION_TIME_SECS_SIZE_IN_BYTES + ACCOUNT_ID_SIZE_IN_BYTES
           + CONTAINER_ID_SIZE_IN_BYTES;
 
   private long size;
@@ -74,7 +74,7 @@ class IndexValue {
   private final long expiresAtMs;
   private long originalMessageOffset;
   private final long operationTimeInMs;
-  private final short serviceId;
+  private final short accountId;
   private final short containerId;
   private final short version;
 
@@ -97,7 +97,7 @@ class IndexValue {
         expiresAtMs = value.getLong();
         originalMessageOffset = value.getLong();
         operationTimeInMs = (int) Utils.Infinite_Time;
-        serviceId = UNKNOWN_ACCOUNT_ID;
+        accountId = UNKNOWN_ACCOUNT_ID;
         containerId = UNKNOWN_CONTAINER_ID;
         break;
       case PersistentIndex.VERSION_1:
@@ -114,7 +114,7 @@ class IndexValue {
         long operationTimeInSecs = value.getInt();
         operationTimeInMs = operationTimeInSecs != Utils.Infinite_Time ? TimeUnit.SECONDS.toMillis(operationTimeInSecs)
             : Utils.Infinite_Time;
-        serviceId = value.getShort();
+        accountId = value.getShort();
         containerId = value.getShort();
         break;
       default:
@@ -128,11 +128,11 @@ class IndexValue {
    * @param offset the {@link Offset} in the {@link Log} where the blob that this index value refers to resides
    * @param expiresAtMs the expiration time in ms at which the blob expires
    * @param operationTimeInMs operation time in ms of the entry
-   * @param serviceId the serviceId that this blob belongs to
+   * @param accountId the accountId that this blob belongs to
    * @param containerId the containerId that this blob belongs to
    */
-  IndexValue(long size, Offset offset, long expiresAtMs, long operationTimeInMs, short serviceId, short containerId) {
-    this(size, offset, FLAGS_DEFAULT_VALUE, expiresAtMs, offset.getOffset(), operationTimeInMs, serviceId, containerId);
+  IndexValue(long size, Offset offset, long expiresAtMs, long operationTimeInMs, short accountId, short containerId) {
+    this(size, offset, FLAGS_DEFAULT_VALUE, expiresAtMs, offset.getOffset(), operationTimeInMs, accountId, containerId);
   }
 
   /**
@@ -142,12 +142,12 @@ class IndexValue {
    * @param flags the {@link Flags} that needs to be set for the Index Value
    * @param expiresAtMs the expiration time in ms at which the blob expires
    * @param operationTimeInMs operation time in ms of the entry
-   * @param serviceId the serviceId that this blob belongs to
+   * @param accountId the accountId that this blob belongs to
    * @param containerId the containerId that this blob belongs to
    */
-  IndexValue(long size, Offset offset, byte flags, long expiresAtMs, long operationTimeInMs, short serviceId,
+  IndexValue(long size, Offset offset, byte flags, long expiresAtMs, long operationTimeInMs, short accountId,
       short containerId) {
-    this(size, offset, flags, expiresAtMs, offset.getOffset(), operationTimeInMs, serviceId, containerId);
+    this(size, offset, flags, expiresAtMs, offset.getOffset(), operationTimeInMs, accountId, containerId);
   }
 
   /**
@@ -159,11 +159,11 @@ class IndexValue {
    * @param originalMessageOffset the original message offset where the Put record pertaining to a delete record exists
    *                              in the same log segment. Set to {@link #UNKNOWN_ORIGINAL_MESSAGE_OFFSET} otherwise.
    * @param operationTimeInMs the time in ms at which the operation occurred.
-   * @param serviceId the serviceId that this blob belongs to
+   * @param accountId the accountId that this blob belongs to
    * @param containerId the containerId that this blob belongs to
    */
   private IndexValue(long size, Offset offset, byte flags, long expiresAtMs, long originalMessageOffset,
-      long operationTimeInMs, short serviceId, short containerId) {
+      long operationTimeInMs, short accountId, short containerId) {
     this.size = size;
     this.offset = offset;
     this.flags = flags;
@@ -175,7 +175,7 @@ class IndexValue {
     }
     this.originalMessageOffset = originalMessageOffset;
     this.operationTimeInMs = Utils.getTimeInMsToTheNearestSec(operationTimeInMs);
-    this.serviceId = serviceId;
+    this.accountId = accountId;
     this.containerId = containerId;
     version = PersistentIndex.CURRENT_VERSION;
   }
@@ -232,10 +232,10 @@ class IndexValue {
   }
 
   /**
-   * @return the serviceId of the {@link IndexValue}
+   * @return the accountId of the {@link IndexValue}
    */
-  short getServiceId() {
-    return serviceId;
+  short getAccountId() {
+    return accountId;
   }
 
   /**
@@ -300,7 +300,7 @@ class IndexValue {
         value.putLong(originalMessageOffset);
         value.putInt(operationTimeInMs != Utils.Infinite_Time ? (int) (operationTimeInMs / Time.MsPerSec)
             : (int) operationTimeInMs);
-        value.putShort(serviceId);
+        value.putShort(accountId);
         value.putShort(containerId);
         value.position(0);
         break;
@@ -314,7 +314,7 @@ class IndexValue {
   public String toString() {
     return "Offset: " + offset + ", Size: " + getSize() + ", Deleted: " + isFlagSet(Flags.Delete_Index)
         + ", ExpiresAtMs: " + getExpiresAtMs() + ", Original Message Offset: " + getOriginalMessageOffset() + (
-        version != PersistentIndex.VERSION_0 ? (", OperationTimeAtSecs " + getOperationTimeInMs() + ", ServiceId "
-            + getServiceId() + ", ContainerId " + getContainerId()) : "");
+        version != PersistentIndex.VERSION_0 ? (", OperationTimeAtSecs " + getOperationTimeInMs() + ", AccountId "
+            + getAccountId() + ", ContainerId " + getContainerId()) : "");
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -654,7 +654,8 @@ class PersistentIndex {
       throw new StoreException("Id " + id + " has expired ttl in index " + dataDir, StoreErrorCodes.TTL_Expired);
     } else {
       readOptions = new BlobReadOptions(log, value.getOffset(), value.getSize(), value.getExpiresAtMs(), id,
-          value.isFlagSet(IndexValue.Flags.Delete_Index), journal.getCrcOfKey(id));
+          value.isFlagSet(IndexValue.Flags.Delete_Index), journal.getCrcOfKey(id), value.getServiceId(),
+          value.getContainerId(), value.getOperationTimeInMs());
     }
     return readOptions;
   }
@@ -707,11 +708,12 @@ class PersistentIndex {
         Offset offset = new Offset(logSegmentName, value.getOriginalMessageOffset());
         readOptions =
             new BlobReadOptions(log, offset, deletedBlobInfo.getSize(), deletedBlobInfo.getExpirationTimeInMs(),
-                deletedBlobInfo.getStoreKey());
+                deletedBlobInfo.getStoreKey(), deletedBlobInfo.getAccountId(), deletedBlobInfo.getContainerId(),
+                deletedBlobInfo.getOperationTimeMs());
       } else if (putValue != null) {
         // PUT record in a different log segment.
-        readOptions =
-            new BlobReadOptions(log, putValue.getOffset(), putValue.getSize(), putValue.getExpiresAtMs(), key);
+        readOptions = new BlobReadOptions(log, putValue.getOffset(), putValue.getSize(), putValue.getExpiresAtMs(), key,
+            putValue.getServiceId(), putValue.getContainerId(), putValue.getOperationTimeInMs());
       } else {
         // PUT record no longer available.
         throw new StoreException("Did not find PUT index entry for key [" + key

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -614,7 +614,6 @@ class PersistentIndex {
       // it is possible that during recovery, the PUT record need not exist because it had been replaced by a
       // delete record in the map in IndexSegment but not written yet because the safe end point hadn't been reached
       // SEE: NOTE in IndexSegment::writeIndexSegmentToFile()
-      // TODO: change service ID and container ID once the MessageInfo has that info.
       newValue =
           new IndexValue(size, fileSpan.getStartOffset(), info.getExpirationTimeInMs(), info.getOperationTimeMs(),
               info.getAccountId(), info.getContainerId());

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -620,14 +620,14 @@ class PersistentIndex {
       newValue.clearOriginalMessageOffset();
     } else {
       newValue = new IndexValue(value.getSize(), value.getOffset(), value.getExpiresAtMs(), deletionTimeMs,
-          value.getServiceId(), value.getContainerId());
+          value.getAccountId(), value.getContainerId());
       newValue.setNewOffset(fileSpan.getStartOffset());
       newValue.setNewSize(size);
     }
     newValue.setFlag(IndexValue.Flags.Delete_Index);
     addToIndex(new IndexEntry(id, newValue, null), fileSpan);
     return new IndexValue(newValue.getSize(), newValue.getOffset(), newValue.getFlags(), newValue.getExpiresAtMs(),
-        newValue.getOperationTimeInMs(), newValue.getServiceId(), newValue.getContainerId());
+        newValue.getOperationTimeInMs(), newValue.getAccountId(), newValue.getContainerId());
   }
 
   /**
@@ -654,7 +654,7 @@ class PersistentIndex {
     } else {
       readOptions = new BlobReadOptions(log, value.getOffset(),
           new MessageInfo(id, value.getSize(), value.isFlagSet(IndexValue.Flags.Delete_Index), value.getExpiresAtMs(),
-              journal.getCrcOfKey(id), value.getServiceId(), value.getContainerId(), value.getOperationTimeInMs()));
+              journal.getCrcOfKey(id), value.getAccountId(), value.getContainerId(), value.getOperationTimeInMs()));
     }
     return readOptions;
   }
@@ -712,7 +712,7 @@ class PersistentIndex {
       } else if (putValue != null) {
         // PUT record in a different log segment.
         readOptions = new BlobReadOptions(log, putValue.getOffset(),
-            new MessageInfo(key, putValue.getSize(), putValue.getExpiresAtMs(), putValue.getServiceId(),
+            new MessageInfo(key, putValue.getSize(), putValue.getExpiresAtMs(), putValue.getAccountId(),
                 putValue.getContainerId(), putValue.getOperationTimeInMs()));
       } else {
         // PUT record no longer available.
@@ -796,7 +796,7 @@ class PersistentIndex {
                     IndexEntryType.ANY, indexSegments);
             messageEntries.add(
                 new MessageInfo(entry.getKey(), value.getSize(), value.isFlagSet(IndexValue.Flags.Delete_Index),
-                    value.getExpiresAtMs(), value.getServiceId(), value.getContainerId(),
+                    value.getExpiresAtMs(), value.getAccountId(), value.getContainerId(),
                     value.getOperationTimeInMs()));
             currentTotalSizeOfEntries += value.getSize();
             offsetEnd = entry.getOffset();
@@ -1100,7 +1100,7 @@ class PersistentIndex {
                   indexSegments);
           messageEntries.add(
               new MessageInfo(entry.getKey(), value.getSize(), value.isFlagSet(IndexValue.Flags.Delete_Index),
-                  value.getExpiresAtMs(), value.getServiceId(), value.getContainerId(), value.getOperationTimeInMs()));
+                  value.getExpiresAtMs(), value.getAccountId(), value.getContainerId(), value.getOperationTimeInMs()));
           currentTotalSizeOfEntries.addAndGet(value.getSize());
           if (!findEntriesCondition.proceed(currentTotalSizeOfEntries.get(),
               currentSegment.getLastModifiedTimeSecs())) {
@@ -1190,7 +1190,7 @@ class PersistentIndex {
         IndexValue indexValue = findKey(messageInfo.getStoreKey());
         messageInfo = new MessageInfo(messageInfo.getStoreKey(), messageInfo.getSize(),
             indexValue.isFlagSet(IndexValue.Flags.Delete_Index), messageInfo.getExpirationTimeInMs(),
-            indexValue.getServiceId(), indexValue.getContainerId(), indexValue.getOperationTimeInMs());
+            indexValue.getAccountId(), indexValue.getContainerId(), indexValue.getOperationTimeInMs());
         messageEntriesIterator.set(messageInfo);
       }
     }
@@ -1354,7 +1354,7 @@ class PersistentIndex {
                     IndexEntryType.ANY, indexSegments);
             if (value.isFlagSet(IndexValue.Flags.Delete_Index)) {
               messageEntries.add(
-                  new MessageInfo(entry.getKey(), value.getSize(), true, value.getExpiresAtMs(), value.getServiceId(),
+                  new MessageInfo(entry.getKey(), value.getSize(), true, value.getExpiresAtMs(), value.getAccountId(),
                       value.getContainerId(), value.getOperationTimeInMs()));
             }
             offsetEnd = entry.getOffset();

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -653,9 +653,9 @@ class PersistentIndex {
     } else if (isExpired(value) && !getOptions.contains(StoreGetOptions.Store_Include_Expired)) {
       throw new StoreException("Id " + id + " has expired ttl in index " + dataDir, StoreErrorCodes.TTL_Expired);
     } else {
-      readOptions = new BlobReadOptions(log, value.getOffset(), value.getSize(), value.getExpiresAtMs(), id,
-          value.isFlagSet(IndexValue.Flags.Delete_Index), journal.getCrcOfKey(id), value.getServiceId(),
-          value.getContainerId(), value.getOperationTimeInMs());
+      readOptions = new BlobReadOptions(log, value.getOffset(),
+          new MessageInfo(id, value.getSize(), value.isFlagSet(IndexValue.Flags.Delete_Index), value.getExpiresAtMs(),
+              journal.getCrcOfKey(id), value.getServiceId(), value.getContainerId(), value.getOperationTimeInMs()));
     }
     return readOptions;
   }
@@ -706,14 +706,15 @@ class PersistentIndex {
           }
         }
         Offset offset = new Offset(logSegmentName, value.getOriginalMessageOffset());
-        readOptions =
-            new BlobReadOptions(log, offset, deletedBlobInfo.getSize(), deletedBlobInfo.getExpirationTimeInMs(),
-                deletedBlobInfo.getStoreKey(), deletedBlobInfo.getAccountId(), deletedBlobInfo.getContainerId(),
-                deletedBlobInfo.getOperationTimeMs());
+        readOptions = new BlobReadOptions(log, offset,
+            new MessageInfo(deletedBlobInfo.getStoreKey(), deletedBlobInfo.getSize(),
+                deletedBlobInfo.getExpirationTimeInMs(), deletedBlobInfo.getAccountId(),
+                deletedBlobInfo.getContainerId(), deletedBlobInfo.getOperationTimeMs()));
       } else if (putValue != null) {
         // PUT record in a different log segment.
-        readOptions = new BlobReadOptions(log, putValue.getOffset(), putValue.getSize(), putValue.getExpiresAtMs(), key,
-            putValue.getServiceId(), putValue.getContainerId(), putValue.getOperationTimeInMs());
+        readOptions = new BlobReadOptions(log, putValue.getOffset(),
+            new MessageInfo(key, putValue.getSize(), putValue.getExpiresAtMs(), putValue.getServiceId(),
+                putValue.getContainerId(), putValue.getOperationTimeInMs()));
       } else {
         // PUT record no longer available.
         throw new StoreException("Did not find PUT index entry for key [" + key

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
@@ -59,10 +59,7 @@ class BlobReadOptions implements Comparable<BlobReadOptions>, Closeable {
     segmentView = segment.getView();
     this.offset = offset;
     this.info = info;
-    logger.trace("BlobReadOption offset {} size {} expiresAtMs {} storeKey {} isDeleted {} crc {} accountId {} "
-            + "containerId {} operationTimeMs {} ", offset, info.getSize(), info.getExpirationTimeInMs(),
-        info.getStoreKey(), info.isDeleted(), info.getCrc(), info.getAccountId(), info.getContainerId(),
-        info.getOperationTimeMs());
+    logger.trace("BlobReadOption offset {} size {} MessageInfo {} ", offset, info.getSize(), info);
   }
 
   String getLogSegmentName() {

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMessageReadSet.java
@@ -13,7 +13,10 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
 import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.Utils;
 import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.File;
@@ -93,7 +96,8 @@ class BlobReadOptions implements Comparable<BlobReadOptions>, Closeable {
   }
 
   MessageInfo getMessageInfo() {
-    return new MessageInfo(storeKey, size, isDeleted, expiresAtMs, crc);
+    return new MessageInfo(storeKey, size, isDeleted, expiresAtMs, crc, Account.UNKNOWN_ACCOUNT_ID,
+        Container.UNKNOWN_CONTAINER_ID, Utils.Infinite_Time);
   }
 
   File getFile() {

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
@@ -510,10 +510,13 @@ public class BlobStoreCompactorTest {
     MockId idFromAnotherSegment = state.getIdToDeleteFromLogSegment(state.log.getFirstSegment());
     state.addDeleteEntry(idFromAnotherSegment);
 
-    // 9. Delete entry for an Put entry that doesn't exist. However, if it existed, it wouldn't have been eligible for
+    // 9. Delete entry for a Put entry that doesn't exist. However, if it existed, it wouldn't have been eligible for
     // cleanup
     // the delete record itself won't be cleaned up
-    state.addDeleteEntry(state.getUniqueId());
+    MockId uniqueId = state.getUniqueId();
+    state.addDeleteEntry(uniqueId,
+        new MessageInfo(uniqueId, Integer.MAX_VALUE, Utils.Infinite_Time, Utils.getRandomShort(TestUtils.RANDOM),
+            Utils.getRandomShort(TestUtils.RANDOM), state.time.milliseconds()));
 
     // fill up the rest of the segment + one more
     writeDataToMeetRequiredSegmentCount(numFinalSegmentsCount, null);

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
@@ -1500,7 +1500,7 @@ public class BlobStoreCompactorTest {
     assertEquals("Unexpected expiresAtMs in IndexValue", value.getExpiresAtMs(), valueFromStore.getExpiresAtMs());
     assertEquals("Unexpected op time in IndexValue ", value.getOperationTimeInMs(),
         valueFromStore.getOperationTimeInMs());
-    assertEquals("Unexpected service ID in IndexValue", value.getServiceId(), valueFromStore.getServiceId());
+    assertEquals("Unexpected account ID in IndexValue", value.getAccountId(), valueFromStore.getAccountId());
     assertEquals("Unexpected container ID in IndexValue", value.getContainerId(), valueFromStore.getContainerId());
     assertEquals("Unexpected flags in IndexValue", value.getFlags(), valueFromStore.getFlags());
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
@@ -1474,9 +1474,10 @@ public class BlobStoreCompactorTest {
   private void checkRecord(MockId id, BlobReadOptions options) throws IOException {
     MessageReadSet readSet = new StoreMessageReadSet(Arrays.asList(options));
     IndexValue value = state.getExpectedValue(id, true);
-    assertEquals("Unexpected key in BlobReadOptions", id, options.getStoreKey());
-    assertEquals("Unexpected size in BlobReadOptions", value.getSize(), options.getSize());
-    assertEquals("Unexpected expiresAtMs in BlobReadOptions", value.getExpiresAtMs(), options.getExpiresAtMs());
+    assertEquals("Unexpected key in BlobReadOptions", id, options.getMessageInfo().getStoreKey());
+    assertEquals("Unexpected size in BlobReadOptions", value.getSize(), options.getMessageInfo().getSize());
+    assertEquals("Unexpected expiresAtMs in BlobReadOptions", value.getExpiresAtMs(),
+        options.getMessageInfo().getExpirationTimeInMs());
     if (state.index.hardDeleter.enabled.get() && !state.deletedKeys.contains(id)) {
       ByteBuffer readBuf = ByteBuffer.allocate((int) value.getSize());
       ByteBufferOutputStream stream = new ByteBufferOutputStream(readBuf);
@@ -1497,8 +1498,8 @@ public class BlobStoreCompactorTest {
     IndexValue valueFromStore = state.index.findKey(id);
     assertEquals("Unexpected size in IndexValue", value.getSize(), valueFromStore.getSize());
     assertEquals("Unexpected expiresAtMs in IndexValue", value.getExpiresAtMs(), valueFromStore.getExpiresAtMs());
-    assertEquals("Unexpected op time in IndexValue " + value + ", actual " + valueFromStore,
-        value.getOperationTimeInMs(), valueFromStore.getOperationTimeInMs());
+    assertEquals("Unexpected op time in IndexValue ", value.getOperationTimeInMs(),
+        valueFromStore.getOperationTimeInMs());
     assertEquals("Unexpected service ID in IndexValue", value.getServiceId(), valueFromStore.getServiceId());
     assertEquals("Unexpected container ID in IndexValue", value.getContainerId(), valueFromStore.getContainerId());
     assertEquals("Unexpected flags in IndexValue", value.getFlags(), valueFromStore.getFlags());

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
@@ -1494,8 +1494,8 @@ public class BlobStoreCompactorTest {
     IndexValue valueFromStore = state.index.findKey(id);
     assertEquals("Unexpected size in IndexValue", value.getSize(), valueFromStore.getSize());
     assertEquals("Unexpected expiresAtMs in IndexValue", value.getExpiresAtMs(), valueFromStore.getExpiresAtMs());
-    assertEquals("Unexpected op time in IndexValue", value.getOperationTimeInMs(),
-        valueFromStore.getOperationTimeInMs());
+    assertEquals("Unexpected op time in IndexValue " + value + ", actual " + valueFromStore,
+        value.getOperationTimeInMs(), valueFromStore.getOperationTimeInMs());
     assertEquals("Unexpected service ID in IndexValue", value.getServiceId(), valueFromStore.getServiceId());
     assertEquals("Unexpected container ID in IndexValue", value.getContainerId(), valueFromStore.getContainerId());
     assertEquals("Unexpected flags in IndexValue", value.getFlags(), valueFromStore.getFlags());

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
@@ -965,7 +965,7 @@ public class BlobStoreStatsTest {
       for (IndexEntry indexEntry : validEntries) {
         IndexValue indexValue = indexEntry.getValue();
         if (!indexValue.isFlagSet(IndexValue.Flags.Delete_Index)) {
-          updateNestedMapHelper(containerValidSizeMap, String.valueOf(indexValue.getServiceId()),
+          updateNestedMapHelper(containerValidSizeMap, String.valueOf(indexValue.getAccountId()),
               String.valueOf(indexValue.getContainerId()), indexValue.getSize());
         }
       }

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
@@ -91,7 +91,7 @@ public class BlobStoreStatsTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{false, false}, {true, false}});
+    return Arrays.asList(new Object[][]{{false, false}, {true, false}, {false, true}, {true, true}});
   }
 
   /**
@@ -887,9 +887,18 @@ public class BlobStoreStatsTest {
       }
       assertEquals("Mismatch in number of containerIds in serviceId: " + serviceId, innerMap.size(),
           actualContainerValidSizeMap.get(serviceId).size());
+      actualContainerValidSizeMap.remove(serviceId);
     }
-    assertEquals("Mismatch in number of serviceIds", expectedContainerValidSizeMap.size(),
-        actualContainerValidSizeMap.size());
+    for (Map.Entry<String, Map<String, Long>> actualContainerValidSizeEntry : actualContainerValidSizeMap.entrySet()) {
+      if (actualContainerValidSizeEntry.getValue().size() != 0) {
+        assertEquals("Additional values found in actual container valid data size map ", 1,
+            actualContainerValidSizeEntry.getValue().size());
+        for (Map.Entry<String, Long> mapEntry : actualContainerValidSizeEntry.getValue().entrySet()) {
+          assertEquals("Additional values found in actual container valid size map ", 0,
+              mapEntry.getValue().longValue());
+        }
+      }
+    }
 
     return totalValidSize;
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
@@ -891,8 +891,6 @@ public class BlobStoreStatsTest {
     }
     for (Map.Entry<String, Map<String, Long>> actualContainerValidSizeEntry : actualContainerValidSizeMap.entrySet()) {
       if (actualContainerValidSizeEntry.getValue().size() != 0) {
-        assertEquals("Additional values found in actual container valid data size map ", 1,
-            actualContainerValidSizeEntry.getValue().size());
         for (Map.Entry<String, Long> mapEntry : actualContainerValidSizeEntry.getValue().entrySet()) {
           assertEquals("Additional values found in actual container valid size map ", 0,
               mapEntry.getValue().longValue());

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
@@ -15,6 +15,8 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Pair;
@@ -89,7 +91,7 @@ public class BlobStoreStatsTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{false, false}, {true, false}, {false, true}, {true, true}});
+    return Arrays.asList(new Object[][]{{false, false}, {true, false}});
   }
 
   /**
@@ -1037,7 +1039,8 @@ public class BlobStoreStatsTest {
     private final CountDownLatch latch;
 
     MockIndexValue(CountDownLatch latch, Offset offset) {
-      super(0, offset, Utils.Infinite_Time);
+      super(0, offset, Utils.Infinite_Time, Utils.Infinite_Time, Account.UNKNOWN_ACCOUNT_ID,
+          Container.UNKNOWN_CONTAINER_ID);
       this.latch = latch;
     }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -679,16 +679,9 @@ public class BlobStoreTest {
    * @return a {@link MockId} that is unique and has not been generated before in this run.
    */
   private MockId getUniqueId() {
-    return getUniqueId(Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM));
-  }
-
-  /**
-   * @return a {@link MockId} that is unique and has not been generated before in this run.
-   */
-  private MockId getUniqueId(short accountId, short containerId) {
     MockId id;
     do {
-      id = new MockId(UtilsTest.getRandomString(10), accountId, containerId);
+      id = new MockId(UtilsTest.getRandomString(10));
     } while (generatedKeys.contains(id));
     generatedKeys.add(id);
     return id;
@@ -712,8 +705,8 @@ public class BlobStoreTest {
     for (int i = 0; i < count; i++) {
       MockId id = getUniqueId();
       long crc = random.nextLong();
-      MessageInfo info = new MessageInfo(id, size, false, expiresAtMs, crc, id.getAccountId(), id.getContainerId(),
-          Utils.Infinite_Time);
+      MessageInfo info = new MessageInfo(id, size, false, expiresAtMs, crc, Utils.getRandomShort(TestUtils.RANDOM),
+          Utils.getRandomShort(TestUtils.RANDOM), Utils.Infinite_Time);
       ByteBuffer buffer = ByteBuffer.wrap(TestUtils.getRandomBytes((int) size));
       ids.add(id);
       infos.add(info);
@@ -736,8 +729,9 @@ public class BlobStoreTest {
    * @throws StoreException
    */
   private MessageInfo delete(MockId idToDelete) throws StoreException {
+    MessageInfo putMsgInfo = allKeys.get(idToDelete).getFirst();
     MessageInfo info =
-        new MessageInfo(idToDelete, DELETE_RECORD_SIZE, idToDelete.getAccountId(), idToDelete.getContainerId(),
+        new MessageInfo(idToDelete, DELETE_RECORD_SIZE, putMsgInfo.getAccountId(), putMsgInfo.getContainerId(),
             Utils.Infinite_Time);
     ByteBuffer buffer = ByteBuffer.allocate(DELETE_RECORD_SIZE);
     store.delete(new MockMessageWriteSet(Collections.singletonList(info), Collections.singletonList(buffer)));
@@ -1088,8 +1082,8 @@ public class BlobStoreTest {
    * @param expectedErrorCode the expected {@link StoreErrorCodes} for the failure.
    */
   private void verifyPutFailure(MockId idToPut, StoreErrorCodes expectedErrorCode) {
-    MessageInfo info = new MessageInfo(idToPut, PUT_RECORD_SIZE, idToPut.getAccountId(), idToPut.getContainerId(),
-        Utils.Infinite_Time);
+    MessageInfo info = new MessageInfo(idToPut, PUT_RECORD_SIZE, Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), Utils.Infinite_Time);
     MessageWriteSet writeSet =
         new MockMessageWriteSet(Collections.singletonList(info), Collections.singletonList(ByteBuffer.allocate(1)));
     try {
@@ -1108,9 +1102,8 @@ public class BlobStoreTest {
    * @param expectedErrorCode the expected {@link StoreErrorCodes} for the failure.
    */
   private void verifyDeleteFailure(MockId idToDelete, StoreErrorCodes expectedErrorCode) {
-    MessageInfo info =
-        new MessageInfo(idToDelete, DELETE_RECORD_SIZE, idToDelete.getAccountId(), idToDelete.getContainerId(),
-            Utils.Infinite_Time);
+    MessageInfo info = new MessageInfo(idToDelete, DELETE_RECORD_SIZE, Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM), Utils.Infinite_Time);
     MessageWriteSet writeSet =
         new MockMessageWriteSet(Collections.singletonList(info), Collections.singletonList(ByteBuffer.allocate(1)));
     try {
@@ -1189,9 +1182,8 @@ public class BlobStoreTest {
     for (int i = 0; i < mockIdList.size(); i++) {
       bufferList.add(ByteBuffer.allocate(PUT_RECORD_SIZE));
       MockId mockId = (MockId) mockIdList.get(i);
-      messageInfoList.add(
-          new MessageInfo(mockId, PUT_RECORD_SIZE, false, Utils.Infinite_Time, crcList.get(i), mockId.getAccountId(),
-              mockId.getContainerId(), Utils.Infinite_Time));
+      messageInfoList.add(new MessageInfo(mockId, PUT_RECORD_SIZE, false, Utils.Infinite_Time, crcList.get(i),
+          Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), Utils.Infinite_Time));
     }
     MessageWriteSet writeSet = new MockMessageWriteSet(messageInfoList, bufferList);
     // Put the initial two messages.

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -732,7 +732,7 @@ public class BlobStoreTest {
     MessageInfo putMsgInfo = allKeys.get(idToDelete).getFirst();
     MessageInfo info =
         new MessageInfo(idToDelete, DELETE_RECORD_SIZE, putMsgInfo.getAccountId(), putMsgInfo.getContainerId(),
-            Utils.Infinite_Time);
+            time.milliseconds());
     ByteBuffer buffer = ByteBuffer.allocate(DELETE_RECORD_SIZE);
     store.delete(new MockMessageWriteSet(Collections.singletonList(info), Collections.singletonList(buffer)));
     deletedKeys.add(idToDelete);

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -361,7 +361,7 @@ public class BlobStoreTest {
    * @throws IOException
    * @throws StoreException
    */
-  // @Test
+  @Test
   public void basicTest() throws InterruptedException, IOException, StoreException {
     // PUT a key that is slated to expire when time advances by 1s
     MockId addedId = put(1, PUT_RECORD_SIZE, time.seconds() + 1).get(0);
@@ -414,7 +414,7 @@ public class BlobStoreTest {
    * Tests the case where there are many concurrent PUTs.
    * @throws Exception
    */
-  // @Test
+  @Test
   public void concurrentPutTest() throws Exception {
     int blobCount = 4000 / PUT_RECORD_SIZE + 1;
     List<Putter> putters = new ArrayList<>(blobCount);
@@ -430,7 +430,7 @@ public class BlobStoreTest {
    * Tests the case where there are many concurrent GETs.
    * @throws Exception
    */
-  // @Test
+  @Test
   public void concurrentGetTest() throws Exception {
     int extraBlobCount = 4000 / PUT_RECORD_SIZE + 1;
     put(extraBlobCount, PUT_RECORD_SIZE, Utils.Infinite_Time);
@@ -464,7 +464,7 @@ public class BlobStoreTest {
    * Tests the case where there are concurrent PUTs, GETs and DELETEs.
    * @throws Exception
    */
-  // @Test
+  @Test
   public void concurrentAllTest() throws Exception {
     int putBlobCount = 1500 / PUT_RECORD_SIZE + 1;
     List<Putter> putters = new ArrayList<>(putBlobCount);

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -1103,7 +1103,7 @@ public class BlobStoreTest {
    */
   private void verifyDeleteFailure(MockId idToDelete, StoreErrorCodes expectedErrorCode) {
     MessageInfo info = new MessageInfo(idToDelete, DELETE_RECORD_SIZE, Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM), Utils.Infinite_Time);
+        Utils.getRandomShort(TestUtils.RANDOM), System.currentTimeMillis());
     MessageWriteSet writeSet =
         new MockMessageWriteSet(Collections.singletonList(info), Collections.singletonList(ByteBuffer.allocate(1)));
     try {

--- a/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
@@ -284,7 +284,7 @@ class CuratedLogIndexState {
     if (allKeys.containsKey(idToDelete)) {
       IndexValue value = getExpectedValue(idToDelete, true);
       newValue = new IndexValue(value.getSize(), value.getOffset(), value.getFlags(), value.getExpiresAtMs(),
-          time.milliseconds(), value.getServiceId(), value.getContainerId());
+          time.milliseconds(), value.getAccountId(), value.getContainerId());
       newValue.setNewOffset(startOffset);
       newValue.setNewSize(CuratedLogIndexState.DELETE_RECORD_SIZE);
     } else {
@@ -879,7 +879,7 @@ class CuratedLogIndexState {
         assertEquals("Offset does not match", referenceValue.getOffset(), value.getOffset());
         assertEquals("ExpiresAtMs does not match", referenceValue.getExpiresAtMs(), value.getExpiresAtMs());
         assertEquals("Size does not match", referenceValue.getSize(), value.getSize());
-        assertEquals("Service ID does not match", referenceValue.getServiceId(), value.getServiceId());
+        assertEquals("Account ID does not match", referenceValue.getAccountId(), value.getAccountId());
         assertEquals("Container ID does not match", referenceValue.getContainerId(), value.getContainerId());
         assertEquals("Original message offset does not match", referenceValue.getOriginalMessageOffset(),
             value.getOriginalMessageOffset());
@@ -1033,7 +1033,7 @@ class CuratedLogIndexState {
       String segmentName = ((LogSegment) read).getName();
       Pair<MockId, LogEntry> idAndValue = logOrder.get(new Offset(segmentName, offset));
       IndexValue value = idAndValue.getSecond().indexValue;
-      return new MessageInfo(idAndValue.getFirst(), value.getSize(), value.getExpiresAtMs(), value.getServiceId(),
+      return new MessageInfo(idAndValue.getFirst(), value.getSize(), value.getExpiresAtMs(), value.getAccountId(),
           value.getContainerId(), value.getOperationTimeInMs());
     }
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
@@ -260,6 +260,7 @@ class CuratedLogIndexState {
   /**
    * Adds a delete entry in the index (real and reference) for {@code idToDelete}.
    * @param idToDelete the id to be deleted.
+   * @param info the {@link MessageInfo} to use incase of recovery to fetch accountId, containerId and operationTime.
    * @return the {@link FileSpan} of the added entries.
    * @throws InterruptedException
    * @throws IOException

--- a/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
@@ -71,18 +71,21 @@ public class HardDeleterTest {
     void add(MockId id) throws IOException, StoreException {
       Offset offset = new Offset(logSegmentName, nextOffset);
       IndexValue indexValue =
-          new IndexValue(sizeOfEntry, offset, IndexValue.FLAGS_DEFAULT_VALUE, 12345, Utils.Infinite_Time);
+          new IndexValue(sizeOfEntry, offset, IndexValue.FLAGS_DEFAULT_VALUE, 12345, time.milliseconds(),
+              id.getAccountId(), id.getContainerId());
       index.addToIndex(new IndexEntry(id, indexValue),
           new FileSpan(offset, new Offset(logSegmentName, nextOffset + sizeOfEntry)));
       ByteBuffer byteBuffer = ByteBuffer.allocate((int) sizeOfEntry);
       log.appendFrom(byteBuffer);
-      offsetMap.put(nextOffset, new MessageInfo(id, sizeOfEntry));
+      offsetMap.put(nextOffset,
+          new MessageInfo(id, sizeOfEntry, id.getAccountId(), id.getContainerId(), time.milliseconds()));
       nextOffset += sizeOfEntry;
     }
 
     void delete(MockId id) throws IOException, StoreException {
       Offset offset = new Offset(logSegmentName, nextOffset);
-      index.markAsDeleted(id, new FileSpan(offset, new Offset(logSegmentName, nextOffset + sizeOfEntry)));
+      index.markAsDeleted(id, new FileSpan(offset, new Offset(logSegmentName, nextOffset + sizeOfEntry)),
+          time.milliseconds());
       ByteBuffer byteBuffer = ByteBuffer.allocate((int) sizeOfEntry);
       log.appendFrom(byteBuffer);
       nextOffset += sizeOfEntry;

--- a/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.File;
@@ -70,15 +71,16 @@ public class HardDeleterTest {
 
     void add(MockId id) throws IOException, StoreException {
       Offset offset = new Offset(logSegmentName, nextOffset);
+      short acccountId = Utils.getRandomShort(TestUtils.RANDOM);
+      short containerId = Utils.getRandomShort(TestUtils.RANDOM);
       IndexValue indexValue =
-          new IndexValue(sizeOfEntry, offset, IndexValue.FLAGS_DEFAULT_VALUE, 12345, time.milliseconds(),
-              id.getAccountId(), id.getContainerId());
+          new IndexValue(sizeOfEntry, offset, IndexValue.FLAGS_DEFAULT_VALUE, 12345, time.milliseconds(), acccountId,
+              containerId);
       index.addToIndex(new IndexEntry(id, indexValue),
           new FileSpan(offset, new Offset(logSegmentName, nextOffset + sizeOfEntry)));
       ByteBuffer byteBuffer = ByteBuffer.allocate((int) sizeOfEntry);
       log.appendFrom(byteBuffer);
-      offsetMap.put(nextOffset,
-          new MessageInfo(id, sizeOfEntry, id.getAccountId(), id.getContainerId(), time.milliseconds()));
+      offsetMap.put(nextOffset, new MessageInfo(id, sizeOfEntry, acccountId, containerId, time.milliseconds()));
       nextOffset += sizeOfEntry;
     }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -328,7 +328,8 @@ public class IndexSegmentTest {
       long size = i == offsets.size() - 1 ? lastEntrySize : offsets.get(i + 1) - offset;
       IndexValue value =
           IndexValueTest.getIndexValue(size, new Offset(segment.getLogSegmentName(), offset), Utils.Infinite_Time,
-              time.milliseconds(), id.getAccountId(), id.getContainerId(), version);
+              time.milliseconds(), Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM),
+              version);
       IndexEntry entry = new IndexEntry(id, value);
       segment.addEntry(entry, new Offset(segment.getLogSegmentName(), offset + size));
       addedEntries.add(entry);
@@ -542,7 +543,8 @@ public class IndexSegmentTest {
       if (value == null) {
         // create an index value with a random log segment name
         value = IndexValueTest.getIndexValue(1, new Offset(UtilsTest.getRandomString(1), 0), Utils.Infinite_Time,
-            time.milliseconds(), id.getAccountId(), id.getContainerId(), version);
+            time.milliseconds(), Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM),
+            version);
       } else {
         // if in this segment, add to putRecordOffsets so that journal can verify these later
         putRecordOffsets.put(value.getOffset(), id);

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -327,8 +327,8 @@ public class IndexSegmentTest {
       long offset = offsets.get(i);
       long size = i == offsets.size() - 1 ? lastEntrySize : offsets.get(i + 1) - offset;
       IndexValue value =
-          IndexValueTest.getIndexValue(size, new Offset(segment.getLogSegmentName(), offset), time.milliseconds(),
-              version);
+          IndexValueTest.getIndexValue(size, new Offset(segment.getLogSegmentName(), offset), Utils.Infinite_Time,
+              time.milliseconds(), id.getAccountId(), id.getContainerId(), version);
       IndexEntry entry = new IndexEntry(id, value);
       segment.addEntry(entry, new Offset(segment.getLogSegmentName(), offset + size));
       addedEntries.add(entry);
@@ -541,8 +541,8 @@ public class IndexSegmentTest {
       IndexValue value = segment.find(id);
       if (value == null) {
         // create an index value with a random log segment name
-        value =
-            IndexValueTest.getIndexValue(1, new Offset(UtilsTest.getRandomString(1), 0), time.milliseconds(), version);
+        value = IndexValueTest.getIndexValue(1, new Offset(UtilsTest.getRandomString(1), 0), Utils.Infinite_Time,
+            time.milliseconds(), id.getAccountId(), id.getContainerId(), version);
       } else {
         // if in this segment, add to putRecordOffsets so that journal can verify these later
         putRecordOffsets.put(value.getOffset(), id);

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -14,6 +14,8 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.Pair;
@@ -50,8 +52,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static com.github.ambry.account.Account.*;
-import static com.github.ambry.account.Container.*;
 import static com.github.ambry.store.CuratedLogIndexState.*;
 import static org.junit.Assert.*;
 
@@ -197,7 +197,8 @@ public class IndexTest {
           throw new IllegalStateException("No ID was set before making a call to getBlobReadInfo()");
         }
         IndexValue value = state.getExpectedValue(id, true);
-        return new MessageInfo(id, value.getSize(), value.getExpiresAtMs());
+        return new MessageInfo(id, value.getSize(), value.getExpiresAtMs(), value.getServiceId(),
+            value.getContainerId(), value.getOperationTimeInMs());
       }
     };
     state.reloadIndex(true, false);
@@ -258,7 +259,7 @@ public class IndexTest {
     FileSpan fileSpan = state.log.getFileSpanForMessage(state.index.getStartOffset(), 1);
     IndexValue value =
         new IndexValue(1, state.index.getStartOffset(), IndexValue.FLAGS_DEFAULT_VALUE, Utils.Infinite_Time,
-            Utils.Infinite_Time);
+            Utils.Infinite_Time, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID);
     try {
       state.index.addToIndex(new IndexEntry(state.getUniqueId(), value), fileSpan);
       fail("Should have failed because filespan provided < currentIndexEndOffset");
@@ -282,7 +283,7 @@ public class IndexTest {
   }
 
   /**
-   * Tests error cases for {@link PersistentIndex#markAsDeleted(StoreKey, FileSpan)}.
+   * Tests error cases for {@link PersistentIndex#markAsDeleted(StoreKey, FileSpan, long)}.
    * Cases
    * 1. FileSpan end offset < currentIndexEndOffset
    * 2. FileSpan is across segments
@@ -296,7 +297,7 @@ public class IndexTest {
     // FileSpan end offset < currentIndexEndOffset
     FileSpan fileSpan = state.log.getFileSpanForMessage(state.index.getStartOffset(), 1);
     try {
-      state.index.markAsDeleted(state.liveKeys.iterator().next(), fileSpan);
+      state.index.markAsDeleted(state.liveKeys.iterator().next(), fileSpan, state.time.milliseconds());
       fail("Should have failed because filespan provided < currentIndexEndOffset");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
@@ -309,7 +310,7 @@ public class IndexTest {
       Offset endOffset = new Offset(nextLogSegmentName, 0);
       fileSpan = new FileSpan(startOffset, endOffset);
       try {
-        state.index.markAsDeleted(state.liveKeys.iterator().next(), fileSpan);
+        state.index.markAsDeleted(state.liveKeys.iterator().next(), fileSpan, state.time.milliseconds());
         fail("Should have failed because fileSpan provided spanned across segments");
       } catch (IllegalArgumentException e) {
         // expected. Nothing to do.
@@ -320,7 +321,7 @@ public class IndexTest {
     fileSpan = state.log.getFileSpanForMessage(state.index.getCurrentEndOffset(), 5);
     // ID does not exist
     try {
-      state.index.markAsDeleted(state.getUniqueId(), fileSpan);
+      state.index.markAsDeleted(state.getUniqueId(), fileSpan, state.time.milliseconds());
       fail("Should have failed because ID provided for delete does not exist");
     } catch (StoreException e) {
       assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.ID_Not_Found, e.getErrorCode());
@@ -328,7 +329,7 @@ public class IndexTest {
 
     // ID already deleted
     try {
-      state.index.markAsDeleted(state.deletedKeys.iterator().next(), fileSpan);
+      state.index.markAsDeleted(state.deletedKeys.iterator().next(), fileSpan, state.time.milliseconds());
       fail("Should have failed because ID provided for delete is already deleted");
     } catch (StoreException e) {
       assertEquals("Unexpected StoreErrorCode", StoreErrorCodes.ID_Deleted, e.getErrorCode());
@@ -568,8 +569,11 @@ public class IndexTest {
       public void run() {
         try {
           FileSpan fileSpan = state.log.getFileSpanForMessage(logEndOffset.get(), 1);
-          IndexValue value = new IndexValue(1, fileSpan.getStartOffset(), Utils.Infinite_Time);
-          IndexEntry entry = new IndexEntry(state.getUniqueId(), value);
+          MockId putId = state.getUniqueId();
+          IndexValue value =
+              new IndexValue(1, fileSpan.getStartOffset(), Utils.Infinite_Time, state.time.milliseconds(),
+                  putId.getAccountId(), putId.getContainerId());
+          IndexEntry entry = new IndexEntry(putId, value);
           state.index.addToIndex(entry, fileSpan);
           logEndOffset.set(fileSpan.getEndOffset());
           entriesAdded.add(entry);
@@ -661,16 +665,21 @@ public class IndexTest {
   @Test
   public void recoveryFailureTest() {
     // recovery info contains a PUT for a key that already exists
-    MessageInfo info = new MessageInfo(state.liveKeys.iterator().next(), CuratedLogIndexState.PUT_RECORD_SIZE);
+    MessageInfo info = new MessageInfo(state.liveKeys.iterator().next(), CuratedLogIndexState.PUT_RECORD_SIZE,
+        Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, Utils.Infinite_Time);
     doRecoveryFailureTest(info, StoreErrorCodes.Initialization_Error);
     // recovery info contains a PUT for a key that has been deleted
-    info = new MessageInfo(state.deletedKeys.iterator().next(), CuratedLogIndexState.PUT_RECORD_SIZE);
+    info = new MessageInfo(state.deletedKeys.iterator().next(), CuratedLogIndexState.PUT_RECORD_SIZE,
+        Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, Utils.Infinite_Time);
     doRecoveryFailureTest(info, StoreErrorCodes.Initialization_Error);
     // recovery info contains a DELETE for a key that has been deleted
-    info = new MessageInfo(state.deletedKeys.iterator().next(), CuratedLogIndexState.DELETE_RECORD_SIZE, true);
+    info = new MessageInfo(state.deletedKeys.iterator().next(), CuratedLogIndexState.DELETE_RECORD_SIZE, true,
+        Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, Utils.Infinite_Time);
     doRecoveryFailureTest(info, StoreErrorCodes.ID_Deleted);
     // recovery info that contains a PUT beyond the end offset of the log segment
-    info = new MessageInfo(state.getUniqueId(), CuratedLogIndexState.PUT_RECORD_SIZE);
+    MockId uniqueId = state.getUniqueId();
+    info = new MessageInfo(uniqueId, CuratedLogIndexState.PUT_RECORD_SIZE, uniqueId.getAccountId(),
+        uniqueId.getContainerId(), Utils.Infinite_Time);
     doRecoveryFailureTest(info, StoreErrorCodes.Index_Creation_Failure);
   }
 
@@ -738,13 +747,15 @@ public class IndexTest {
     final MockId newId = state.getUniqueId();
     // add to allKeys() so that doFindEntriesSinceTest() works correctly.
     state.allKeys.put(newId, new Pair<IndexValue, IndexValue>(
-        new IndexValue(CuratedLogIndexState.PUT_RECORD_SIZE, firstRecordFileSpan.getStartOffset(), Utils.Infinite_Time),
-        null));
+        new IndexValue(CuratedLogIndexState.PUT_RECORD_SIZE, firstRecordFileSpan.getStartOffset(), Utils.Infinite_Time,
+            state.time.milliseconds(), newId.getAccountId(), newId.getContainerId()), null));
     state.recovery = new MessageStoreRecovery() {
       @Override
       public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
           throws IOException {
-        return Collections.singletonList(new MessageInfo(newId, CuratedLogIndexState.PUT_RECORD_SIZE));
+        return Collections.singletonList(
+            new MessageInfo(newId, CuratedLogIndexState.PUT_RECORD_SIZE, newId.getAccountId(), newId.getContainerId(),
+                Utils.Infinite_Time));
       }
     };
     state.reloadIndex(true, true);
@@ -920,13 +931,15 @@ public class IndexTest {
     final MockId newId = state.getUniqueId();
     // add to allKeys() so that doFindEntriesSinceTest() works correctly.
     state.allKeys.put(newId, new Pair<IndexValue, IndexValue>(
-        new IndexValue(CuratedLogIndexState.PUT_RECORD_SIZE, firstRecordFileSpan.getStartOffset(), Utils.Infinite_Time),
-        null));
+        new IndexValue(CuratedLogIndexState.PUT_RECORD_SIZE, firstRecordFileSpan.getStartOffset(), Utils.Infinite_Time,
+            state.time.milliseconds(), newId.getAccountId(), newId.getContainerId()), null));
     state.recovery = new MessageStoreRecovery() {
       @Override
       public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)
           throws IOException {
-        return Collections.singletonList(new MessageInfo(newId, CuratedLogIndexState.PUT_RECORD_SIZE));
+        return Collections.singletonList(
+            new MessageInfo(newId, CuratedLogIndexState.PUT_RECORD_SIZE, newId.getAccountId(), newId.getContainerId(),
+                Utils.Infinite_Time));
       }
     };
     // change in incarnationId
@@ -1118,9 +1131,10 @@ public class IndexTest {
     FileSpan fileSpan = new FileSpan(state.index.getCurrentEndOffset(),
         new Offset(state.index.getCurrentEndOffset().getName(),
             state.index.getCurrentEndOffset().getOffset() + CuratedLogIndexState.PUT_RECORD_SIZE));
-    IndexValue value =
-        new IndexValue(CuratedLogIndexState.PUT_RECORD_SIZE, fileSpan.getStartOffset(), Utils.Infinite_Time);
     MockId newId = state.getUniqueId();
+    IndexValue value =
+        new IndexValue(CuratedLogIndexState.PUT_RECORD_SIZE, fileSpan.getStartOffset(), Utils.Infinite_Time,
+            state.time.milliseconds(), newId.getAccountId(), newId.getContainerId());
     state.index.addToIndex(new IndexEntry(newId, value), fileSpan);
     try {
       state.index.persistIndex();
@@ -1317,7 +1331,8 @@ public class IndexTest {
       assertNotNull("Value should be successfully fetched", valueFromFind);
       IndexValue expectedValue = state.getExpectedValue(id, !state.deletedKeys.contains(id));
       assertEquals("Offset in value from index not as expected", expectedValue.getOffset(), valueFromFind.getOffset());
-      assertEquals("Bytes from value from index not as expected", expectedValue.getBytes(), valueFromFind.getBytes());
+      assertEquals("Bytes from value from index not as expected for " + id + " ex " + expectedValue + ", actual "
+          + valueFromFind, expectedValue.getBytes(), valueFromFind.getBytes());
     } else {
       assertNull("There should have been no value returned", valueFromFind);
     }
@@ -1551,19 +1566,25 @@ public class IndexTest {
     // 1 PUT record that will be deleted in the next log segment
     MockId idToCreateAndDeleteAcrossSegments = state.getUniqueId();
     state.appendToLog(CuratedLogIndexState.PUT_RECORD_SIZE);
-    activeSegmentInfos.add(new MessageInfo(idToCreateAndDeleteAcrossSegments, CuratedLogIndexState.PUT_RECORD_SIZE));
+    activeSegmentInfos.add(new MessageInfo(idToCreateAndDeleteAcrossSegments, CuratedLogIndexState.PUT_RECORD_SIZE,
+        idToCreateAndDeleteAcrossSegments.getAccountId(), idToCreateAndDeleteAcrossSegments.getContainerId(),
+        Utils.Infinite_Time));
     // 1 PUT record that will remain and covers almost the rest of the active segment.
     long size =
         activeSegment.getCapacityInBytes() - activeSegment.getEndOffset() - (CuratedLogIndexState.DELETE_RECORD_SIZE
             - 1);
     state.appendToLog(size);
-    activeSegmentInfos.add(new MessageInfo(state.getUniqueId(), size));
+    MockId uniqueId = state.getUniqueId();
+    activeSegmentInfos.add(
+        new MessageInfo(uniqueId, size, uniqueId.getAccountId(), uniqueId.getContainerId(), Utils.Infinite_Time));
     MockId idToCreateAndDeleteInSameSegment = state.getUniqueId();
     final List<MessageInfo> nextSegmentInfos = getCuratedSingleSegmentRecoveryInfos(idToCreateAndDeleteInSameSegment);
     // 1 DELETE record for the PUT in the previous segment
     state.appendToLog(CuratedLogIndexState.DELETE_RECORD_SIZE);
     nextSegmentInfos.add(
-        new MessageInfo(idToCreateAndDeleteAcrossSegments, CuratedLogIndexState.DELETE_RECORD_SIZE, true));
+        new MessageInfo(idToCreateAndDeleteAcrossSegments, CuratedLogIndexState.DELETE_RECORD_SIZE, true,
+            idToCreateAndDeleteAcrossSegments.getAccountId(), idToCreateAndDeleteAcrossSegments.getContainerId(),
+            Utils.Infinite_Time));
     final AtomicInteger returnTracker = new AtomicInteger(0);
     state.recovery = new MessageStoreRecovery() {
       @Override
@@ -1607,18 +1628,30 @@ public class IndexTest {
     List<MessageInfo> infos = new ArrayList<>();
     state.appendToLog(3 * CuratedLogIndexState.DELETE_RECORD_SIZE + 4 * CuratedLogIndexState.PUT_RECORD_SIZE);
     // 1 DELETE for a PUT not in the infos
-    infos.add(new MessageInfo(state.getIdToDeleteFromLogSegment(state.log.getFirstSegment()),
-        CuratedLogIndexState.DELETE_RECORD_SIZE, true));
+    MockId idToDelete = state.getIdToDeleteFromLogSegment(state.log.getFirstSegment());
+    infos.add(new MessageInfo(idToDelete, CuratedLogIndexState.DELETE_RECORD_SIZE, true, idToDelete.getAccountId(),
+        idToDelete.getContainerId(), Utils.Infinite_Time));
     // 3 PUT
-    infos.add(new MessageInfo(idToCreateAndDelete, CuratedLogIndexState.PUT_RECORD_SIZE));
-    infos.add(new MessageInfo(state.getUniqueId(), CuratedLogIndexState.PUT_RECORD_SIZE));
-    infos.add(new MessageInfo(state.getUniqueId(), CuratedLogIndexState.PUT_RECORD_SIZE));
+    infos.add(
+        new MessageInfo(idToCreateAndDelete, CuratedLogIndexState.PUT_RECORD_SIZE, idToCreateAndDelete.getAccountId(),
+            idToCreateAndDelete.getContainerId(), Utils.Infinite_Time));
+    MockId uniqueId = state.getUniqueId();
+    infos.add(new MessageInfo(uniqueId, CuratedLogIndexState.PUT_RECORD_SIZE, uniqueId.getAccountId(),
+        uniqueId.getContainerId(), Utils.Infinite_Time));
+    uniqueId = state.getUniqueId();
+    infos.add(new MessageInfo(uniqueId, CuratedLogIndexState.PUT_RECORD_SIZE, uniqueId.getAccountId(),
+        uniqueId.getContainerId(), Utils.Infinite_Time));
     // 1 DELETE for a PUT in the infos
-    infos.add(new MessageInfo(idToCreateAndDelete, CuratedLogIndexState.DELETE_RECORD_SIZE, true));
+    infos.add(new MessageInfo(idToCreateAndDelete, CuratedLogIndexState.DELETE_RECORD_SIZE, true,
+        idToCreateAndDelete.getAccountId(), idToCreateAndDelete.getContainerId(), Utils.Infinite_Time));
     // 1 expired PUT
-    infos.add(new MessageInfo(state.getUniqueId(), CuratedLogIndexState.PUT_RECORD_SIZE, 0));
+    uniqueId = state.getUniqueId();
+    infos.add(new MessageInfo(uniqueId, CuratedLogIndexState.PUT_RECORD_SIZE, 0, uniqueId.getAccountId(),
+        uniqueId.getContainerId(), Utils.Infinite_Time));
     // 1 delete for PUT that does not exist in the index
-    infos.add(new MessageInfo(state.getUniqueId(), CuratedLogIndexState.DELETE_RECORD_SIZE, true));
+    uniqueId = state.getUniqueId();
+    infos.add(new MessageInfo(uniqueId, CuratedLogIndexState.DELETE_RECORD_SIZE, true, uniqueId.getAccountId(),
+        uniqueId.getContainerId(), Utils.Infinite_Time));
     return infos;
   }
 
@@ -1640,6 +1673,9 @@ public class IndexTest {
         assertEquals("Inconsistent size", info.getSize(), value.getSize());
         assertEquals("Inconsistent delete state ", info.isDeleted(), value.isFlagSet(IndexValue.Flags.Delete_Index));
         assertEquals("Inconsistent expiresAtMs", info.getExpirationTimeInMs(), value.getExpiresAtMs());
+        assertEquals("Incorrect accountId", info.getAccountId(), value.getServiceId());
+        assertEquals("Incorrect containerId", info.getContainerId(), value.getContainerId());
+        assertEquals("Incorrect accountId", info.getOperationTimeMs(), value.getOperationTimeInMs());
       }
       currCheckOffset = expectedFileSpan.getEndOffset();
     }
@@ -1658,8 +1694,10 @@ public class IndexTest {
           throws IOException {
         switch (returnTracker.getAndIncrement()) {
           case 0:
+            MockId uniqueId = state.getUniqueId();
             return Collections.singletonList(
-                new MessageInfo(state.getUniqueId(), CuratedLogIndexState.PUT_RECORD_SIZE));
+                new MessageInfo(uniqueId, CuratedLogIndexState.PUT_RECORD_SIZE, uniqueId.getAccountId(),
+                    uniqueId.getContainerId(), Utils.Infinite_Time));
           default:
             return Collections.emptyList();
         }
@@ -2270,16 +2308,13 @@ public class IndexTest {
     Offset currentEndOffset = state.index.getCurrentEndOffset();
 
     List<IndexEntry> indexEntries = new ArrayList<>();
-    // create an index entry in older version.
-    IndexEntry entry = new IndexEntry(state.getUniqueId(),
-        IndexValueTest.getIndexValue(CuratedLogIndexState.PUT_RECORD_SIZE, currentEndOffset, state.time.milliseconds(),
-            indexVersion));
-    Offset startOffset = entry.getValue().getOffset();
-    int entrySize = entry.getKey().sizeInBytes() + entry.getValue().getBytes().capacity();
-    int valueSize = entry.getValue().getBytes().capacity();
-    IndexSegment indexSegment =
-        indexVersion == PersistentIndex.VERSION_0 ? generateIndexSegmentV0(startOffset, entrySize, valueSize)
-            : generateIndexSegmentV1(startOffset, entrySize, valueSize);
+    MockId newId = state.getUniqueId();
+    IndexEntry entry = new IndexEntry(newId,
+        IndexValueTest.getIndexValue(CuratedLogIndexState.PUT_RECORD_SIZE, currentEndOffset, Utils.Infinite_Time,
+            state.time.milliseconds(), newId.getAccountId(), newId.getContainerId(), PersistentIndex.VERSION_0));
+    // create Index Segment in PersistentIndex.Version_0
+    IndexSegment indexSegment = generateIndexSegmentV0(entry.getValue().getOffset(), entry.getKey().sizeInBytes(),
+        entry.getValue().getBytes().capacity());
     state.appendToLog(CuratedLogIndexState.PUT_RECORD_SIZE);
     FileSpan fileSpan = state.log.getFileSpanForMessage(currentEndOffset, CuratedLogIndexState.PUT_RECORD_SIZE);
     indexSegment.addEntry(entry, fileSpan.getEndOffset());
@@ -2304,7 +2339,7 @@ public class IndexTest {
       IndexEntry entryToDelete = indexEntries.get(TestUtils.RANDOM.nextInt(indexEntries.size()));
       state.appendToLog(state.DELETE_RECORD_SIZE);
       fileSpan = state.log.getFileSpanForMessage(currentEndOffset, CuratedLogIndexState.DELETE_RECORD_SIZE);
-      state.index.markAsDeleted(entryToDelete.getKey(), fileSpan);
+      state.index.markAsDeleted(entryToDelete.getKey(), fileSpan, state.time.milliseconds());
       // remove entryToDelete from indexEntries as it will be part of latest index segment
       indexEntries.remove(entryToDelete);
     }
@@ -2394,10 +2429,11 @@ public class IndexTest {
       state.appendToLog(size);
       FileSpan fileSpan = state.log.getFileSpanForMessage(prevEntryEndOffset, size);
       IndexEntry entry;
+      MockId putId = state.getUniqueId();
       if (indexSegment != null) {
-        entry = new IndexEntry(state.getUniqueId(idLength),
+        entry = new IndexEntry(putId,
             IndexValueTest.getIndexValue(size, prevEntryEndOffset, expiresAtMs, state.time.milliseconds(),
-                UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID, indexSegment.getVersion()));
+                putId.getAccountId(), putId.getContainerId(), indexSegment.getVersion()));
         indexSegment.addEntry(entry, fileSpan.getEndOffset());
       } else {
         if (createV0IndexValue) {
@@ -2406,7 +2442,8 @@ public class IndexTest {
           state.index.addToIndex(entry, fileSpan);
         } else {
           entry = new IndexEntry(state.getUniqueId(idLength),
-              new IndexValue(size, prevEntryEndOffset, (byte) 0, expiresAtMs, state.time.milliseconds()));
+              new IndexValue(size, prevEntryEndOffset, (byte) 0, expiresAtMs, state.time.milliseconds(),
+                  putId.getAccountId(), putId.getContainerId()));
           state.index.addToIndex(entry, fileSpan);
         }
       }

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -197,7 +197,7 @@ public class IndexTest {
           throw new IllegalStateException("No ID was set before making a call to getBlobReadInfo()");
         }
         IndexValue value = state.getExpectedValue(id, true);
-        return new MessageInfo(id, value.getSize(), value.getExpiresAtMs(), value.getServiceId(),
+        return new MessageInfo(id, value.getSize(), value.getExpiresAtMs(), value.getAccountId(),
             value.getContainerId(), value.getOperationTimeInMs());
       }
     };
@@ -1633,7 +1633,7 @@ public class IndexTest {
     // 1 DELETE for a PUT not in the infos
     MockId idToDelete = state.getIdToDeleteFromLogSegment(state.log.getFirstSegment());
     IndexValue putValue = state.getExpectedValue(idToDelete, true);
-    infos.add(new MessageInfo(idToDelete, CuratedLogIndexState.DELETE_RECORD_SIZE, true, putValue.getServiceId(),
+    infos.add(new MessageInfo(idToDelete, CuratedLogIndexState.DELETE_RECORD_SIZE, true, putValue.getAccountId(),
         putValue.getContainerId(), state.time.milliseconds()));
     // 3 PUT
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
@@ -1675,7 +1675,7 @@ public class IndexTest {
         assertEquals("Inconsistent size", info.getSize(), value.getSize());
         assertEquals("Inconsistent delete state ", info.isDeleted(), value.isFlagSet(IndexValue.Flags.Delete_Index));
         assertEquals("Inconsistent expiresAtMs", info.getExpirationTimeInMs(), value.getExpiresAtMs());
-        assertEquals("Incorrect accountId", info.getAccountId(), value.getServiceId());
+        assertEquals("Incorrect accountId", info.getAccountId(), value.getAccountId());
         assertEquals("Incorrect containerId", info.getContainerId(), value.getContainerId());
         assertEquals("Incorrect operationTimeMs", Utils.getTimeInMsToTheNearestSec(info.getOperationTimeMs()),
             value.getOperationTimeInMs());
@@ -1956,7 +1956,7 @@ public class IndexTest {
         assertEquals("Inconsistent size", value.getSize(), info.getSize());
       }
       long expiresAtMs = value != null ? value.getExpiresAtMs() : putDelete.getSecond().getExpiresAtMs();
-      short accountId = value != null ? value.getServiceId() : putDelete.getSecond().getServiceId();
+      short accountId = value != null ? value.getAccountId() : putDelete.getSecond().getAccountId();
       short containerId = value != null ? value.getContainerId() : putDelete.getSecond().getContainerId();
       long operationTimeMs =
           putDelete.getSecond() != null ? putDelete.getSecond().getOperationTimeInMs() : value.getOperationTimeInMs();
@@ -2484,7 +2484,7 @@ public class IndexTest {
           value.getOriginalMessageOffset());
       assertEquals("OperationTime mismatch for " + entry.getKey(), expectedValue.getOperationTimeInMs(),
           value.getOperationTimeInMs());
-      assertEquals("ServiceId mismatch for " + entry.getKey(), expectedValue.getServiceId(), value.getServiceId());
+      assertEquals("AccountId mismatch for " + entry.getKey(), expectedValue.getAccountId(), value.getAccountId());
       assertEquals("ContainerId mismatch for " + entry.getKey(), expectedValue.getContainerId(),
           value.getContainerId());
     }

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1293,12 +1293,13 @@ public class IndexTest {
         fail("Should have failed because a StoreException is expected");
       }
       IndexValue putEntryValue = state.getExpectedValue(id, true);
-      assertEquals("StoreKey not as expected", id, options.getStoreKey());
+      assertEquals("StoreKey not as expected", id, options.getMessageInfo().getStoreKey());
       assertEquals("Log Segment Name not as expected", putEntryValue.getOffset().getName(),
           options.getLogSegmentName());
       assertEquals("Offset not as expected", putEntryValue.getOffset().getOffset(), options.getOffset());
-      assertEquals("Size not as expected", putEntryValue.getSize(), options.getSize());
-      assertEquals("ExpiresAtMs not as expected", putEntryValue.getExpiresAtMs(), options.getExpiresAtMs());
+      assertEquals("Size not as expected", putEntryValue.getSize(), options.getMessageInfo().getSize());
+      assertEquals("ExpiresAtMs not as expected", putEntryValue.getExpiresAtMs(),
+          options.getMessageInfo().getExpirationTimeInMs());
     } catch (StoreException e) {
       if (expectedErrorCode == null) {
         throw e;

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -71,7 +71,7 @@ public class IndexValueTest {
     long offset = Utils.getRandomLong(TestUtils.RANDOM, 1000);
     long operationTimeAtMs = Utils.getRandomLong(TestUtils.RANDOM, 1000000) + SystemTime.getInstance().milliseconds();
     long expectedOperationTimeV1 = Utils.getTimeInMsToTheNearestSec(operationTimeAtMs);
-    short serviceId = Utils.getRandomShort(TestUtils.RANDOM);
+    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
 
     Map<Long, Long> expirationTimes = new HashMap<Long, Long>();
@@ -99,7 +99,7 @@ public class IndexValueTest {
     for (Map.Entry<Long, Long> expirationTime : expirationTimes.entrySet()) {
       long expiresAtMs = expirationTime.getKey();
       IndexValue value =
-          getIndexValue(size, new Offset(logSegmentName, offset), expiresAtMs, operationTimeAtMs, serviceId,
+          getIndexValue(size, new Offset(logSegmentName, offset), expiresAtMs, operationTimeAtMs, accountId,
               containerId, version);
       switch (version) {
         case PersistentIndex.VERSION_0:
@@ -109,7 +109,7 @@ public class IndexValueTest {
         case PersistentIndex.VERSION_1:
         case PersistentIndex.VERSION_2:
           verifyIndexValue(value, logSegmentName, size, offset, false, expirationTime.getValue(), offset,
-              expectedOperationTimeV1, serviceId, containerId);
+              expectedOperationTimeV1, accountId, containerId);
           break;
       }
     }
@@ -130,10 +130,10 @@ public class IndexValueTest {
     long expectedExpirationTimeV1 = Utils.getTimeInMsToTheNearestSec(expiresAtMs);
     long operationTimeAtMs = Utils.getRandomLong(TestUtils.RANDOM, 1000000);
     long expectedOperationTimeV1 = Utils.getTimeInMsToTheNearestSec(operationTimeAtMs);
-    short serviceId = Utils.getRandomShort(TestUtils.RANDOM);
+    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     IndexValue value =
-        getIndexValue(oldSize, new Offset(logSegmentName, oldOffset), expiresAtMs, operationTimeAtMs, serviceId,
+        getIndexValue(oldSize, new Offset(logSegmentName, oldOffset), expiresAtMs, operationTimeAtMs, accountId,
             containerId, version);
     long newOffset = Utils.getRandomLong(TestUtils.RANDOM, 1000);
     long newSize = Utils.getRandomLong(TestUtils.RANDOM, 1000);
@@ -150,7 +150,7 @@ public class IndexValueTest {
       case PersistentIndex.VERSION_1:
       case PersistentIndex.VERSION_2:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, oldOffset,
-            expectedOperationTimeV1, serviceId, containerId);
+            expectedOperationTimeV1, accountId, containerId);
         break;
     }
 
@@ -164,7 +164,7 @@ public class IndexValueTest {
       case PersistentIndex.VERSION_1:
       case PersistentIndex.VERSION_2:
         verifyIndexValue(newValue, logSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, -1,
-            expectedOperationTimeV1, serviceId, containerId);
+            expectedOperationTimeV1, accountId, containerId);
         break;
     }
 
@@ -183,7 +183,7 @@ public class IndexValueTest {
       case PersistentIndex.VERSION_1:
       case PersistentIndex.VERSION_2:
         verifyIndexValue(newValue, newLogSegmentName, newSize, newOffset, true, expectedExpirationTimeV1, -1,
-            expectedOperationTimeV1, serviceId, containerId);
+            expectedOperationTimeV1, accountId, containerId);
         break;
     }
   }
@@ -200,13 +200,13 @@ public class IndexValueTest {
    * @param expiresAtMs the expected expiration time in {@code value}.
    * @param originalMessageOffset the original message offset expected in {@code value}.
    * @param operationTimeInMs the operation time in ms
-   * @param serviceId the serviceId of the Index value
+   * @param accountId the accountId of the Index value
    * @param containerId the containerId of the Index value
    */
   private void verifyIndexValue(IndexValue value, String logSegmentName, long size, long offset, boolean isDeleted,
-      long expiresAtMs, long originalMessageOffset, long operationTimeInMs, short serviceId, short containerId) {
+      long expiresAtMs, long originalMessageOffset, long operationTimeInMs, short accountId, short containerId) {
     verifyGetters(value, logSegmentName, size, offset, isDeleted, expiresAtMs, originalMessageOffset, operationTimeInMs,
-        serviceId, containerId);
+        accountId, containerId);
     // serialize and deserialize might change the value of expiry for version1. Any expiry value < -1 after
     // deserialization is considered invalid and expiry value is set to -1
     long expectedExpiryValue = -1;
@@ -220,7 +220,7 @@ public class IndexValueTest {
         break;
     }
     verifyGetters(new IndexValue(logSegmentName, value.getBytes(), version), logSegmentName, size, offset, isDeleted,
-        expectedExpiryValue, originalMessageOffset, operationTimeInMs, serviceId, containerId);
+        expectedExpiryValue, originalMessageOffset, operationTimeInMs, accountId, containerId);
     verifyInvalidValueSize(value, logSegmentName);
   }
 
@@ -235,17 +235,17 @@ public class IndexValueTest {
    * @param expiresAtMs the expected expiration time in {@code value}.
    * @param originalMessageOffset the original message offset expected in {@code value}.
    * @param operationTimeInMs the operation time in ms
-   * @param serviceId the serviceId of the Index value
+   * @param accountId the accountId of the Index value
    * @param containerId the containerId of the Index value
    */
   private void verifyGetters(IndexValue value, String logSegmentName, long size, long offset, boolean isDeleted,
-      long expiresAtMs, long originalMessageOffset, long operationTimeInMs, short serviceId, short containerId) {
+      long expiresAtMs, long originalMessageOffset, long operationTimeInMs, short accountId, short containerId) {
     assertEquals("Size is not as expected", size, value.getSize());
     assertEquals("Offset is not as expected", new Offset(logSegmentName, offset), value.getOffset());
     assertEquals("Delete status not as expected", isDeleted, value.isFlagSet(IndexValue.Flags.Delete_Index));
     assertEquals("ExpiresAtMs not as expected", expiresAtMs, value.getExpiresAtMs());
     assertEquals("Operation time mismatch", operationTimeInMs, value.getOperationTimeInMs());
-    assertEquals("ServiceId mismatch ", serviceId, value.getServiceId());
+    assertEquals("AccountId mismatch ", accountId, value.getAccountId());
     assertEquals("ContainerId mismatch ", containerId, value.getContainerId());
     assertEquals("Original message offset not as expected", originalMessageOffset, value.getOriginalMessageOffset());
   }
@@ -273,18 +273,18 @@ public class IndexValueTest {
    * @param offset the {@link Offset} in the {@link Log} where the blob that this index value refers to resides
    * @param expirationTimeInMs the expiration time in ms at which the blob expires
    * @param operationTimeInMs operation time of the entry in ms
-   * @param serviceId the serviceId that this blob belongs to
+   * @param accountId the accountId that this blob belongs to
    * @param containerId the containerId that this blob belongs to
    * @param version the version with which to construct the {@link IndexValue}
    * @return the {@link IndexValue} thus constructed
    */
   static IndexValue getIndexValue(long size, Offset offset, long expirationTimeInMs, long operationTimeInMs,
-      short serviceId, short containerId, short version) {
+      short accountId, short containerId, short version) {
     if (version == PersistentIndex.VERSION_0) {
       return getIndexValue(size, offset, IndexValue.FLAGS_DEFAULT_VALUE, expirationTimeInMs, offset.getOffset());
     } else {
       return new IndexValue(size, offset, IndexValue.FLAGS_DEFAULT_VALUE, expirationTimeInMs, operationTimeInMs,
-          serviceId, containerId);
+          accountId, containerId);
     }
   }
 
@@ -300,7 +300,7 @@ public class IndexValueTest {
           value.getOffset().getOffset());
     } else {
       return new IndexValue(value.getSize(), value.getOffset(), value.getFlags(), value.getExpiresAtMs(),
-          value.getOperationTimeInMs(), value.getServiceId(), value.getContainerId());
+          value.getOperationTimeInMs(), value.getAccountId(), value.getContainerId());
     }
   }
 
@@ -315,8 +315,7 @@ public class IndexValueTest {
    *                              in the same log segment. Set to -1 otherwise.
    * @return the {@link IndexValue} thus constructed
    */
-  static IndexValue getIndexValue(long size, Offset offset, byte flags, long expiresAtMs,
-      long originalMessageOffset) {
+  static IndexValue getIndexValue(long size, Offset offset, byte flags, long expiresAtMs, long originalMessageOffset) {
     ByteBuffer value = ByteBuffer.allocate(IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V0);
     value.putLong(size);
     value.putLong(offset.getOffset());

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexValueTest.java
@@ -289,22 +289,6 @@ public class IndexValueTest {
   }
 
   /**
-   * Constructs IndexValue based on the args passed and for the given version
-   * @param size the size of the blob that this index value refers to
-   * @param offset the {@link Offset} in the {@link Log} where the blob that this index value refers to resides
-   * @param operationTimeInMs operation time of the entry in ms
-   * @param version the version with which to construct the {@link IndexValue}
-   * @return the {@link IndexValue} thus constructed
-   */
-  static IndexValue getIndexValue(long size, Offset offset, long operationTimeInMs, short version) {
-    if (version == PersistentIndex.VERSION_0) {
-      return getIndexValue(size, offset, IndexValue.FLAGS_DEFAULT_VALUE, Utils.Infinite_Time, offset.getOffset());
-    } else {
-      return new IndexValue(size, offset, IndexValue.FLAGS_DEFAULT_VALUE, Utils.Infinite_Time, operationTimeInMs);
-    }
-  }
-
-  /**
    * Constructs IndexValue based on another {@link IndexValue}
    * @param value the {@link IndexValue} using which to create another {@link IndexValue}
    * @param version the version with which to construct the {@link IndexValue}

--- a/ambry-store/src/test/java/com.github.ambry.store/MockId.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/MockId.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.store;
 
-import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -23,34 +22,14 @@ import java.nio.ByteBuffer;
 public class MockId extends StoreKey {
 
   private String id;
-  private short accountId;
-  private short containerId;
   private static final int Id_Size_In_Bytes = 2;
 
   public MockId(String id) {
     this.id = id;
-    accountId = Utils.getRandomShort(TestUtils.RANDOM);
-    containerId = Utils.getRandomShort(TestUtils.RANDOM);
-  }
-
-  public MockId(String id, short accountId, short containerId) {
-    this.id = id;
-    this.accountId = accountId;
-    this.containerId = containerId;
   }
 
   public MockId(DataInputStream stream) throws IOException {
     id = Utils.readShortString(stream);
-    accountId = stream.readShort();
-    containerId = stream.readShort();
-  }
-
-  public short getAccountId() {
-    return this.accountId;
-  }
-
-  public short getContainerId() {
-    return this.containerId;
   }
 
   @Override
@@ -58,14 +37,12 @@ public class MockId extends StoreKey {
     ByteBuffer idBuf = ByteBuffer.allocate(sizeInBytes());
     idBuf.putShort((short) id.length());
     idBuf.put(id.getBytes());
-    idBuf.putShort(accountId);
-    idBuf.putShort(containerId);
     return idBuf.array();
   }
 
   @Override
   public String getID() {
-    return id + ":" + accountId + ":" + containerId;
+    return id;
   }
 
   @Override
@@ -75,7 +52,7 @@ public class MockId extends StoreKey {
 
   @Override
   public short sizeInBytes() {
-    return (short) (Id_Size_In_Bytes + id.length() + Short.BYTES + Short.BYTES);
+    return (short) (Id_Size_In_Bytes + id.length());
   }
 
   @Override

--- a/ambry-store/src/test/java/com.github.ambry.store/MockId.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/MockId.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -22,27 +23,49 @@ import java.nio.ByteBuffer;
 public class MockId extends StoreKey {
 
   private String id;
+  private short accountId;
+  private short containerId;
   private static final int Id_Size_In_Bytes = 2;
 
   public MockId(String id) {
     this.id = id;
+    accountId = Utils.getRandomShort(TestUtils.RANDOM);
+    containerId = Utils.getRandomShort(TestUtils.RANDOM);
+  }
+
+  public MockId(String id, short accountId, short containerId) {
+    this.id = id;
+    this.accountId = accountId;
+    this.containerId = containerId;
   }
 
   public MockId(DataInputStream stream) throws IOException {
     id = Utils.readShortString(stream);
+    accountId = stream.readShort();
+    containerId = stream.readShort();
+  }
+
+  public short getAccountId() {
+    return this.accountId;
+  }
+
+  public short getContainerId() {
+    return this.containerId;
   }
 
   @Override
   public byte[] toBytes() {
-    ByteBuffer idBuf = ByteBuffer.allocate(Id_Size_In_Bytes + id.length());
+    ByteBuffer idBuf = ByteBuffer.allocate(sizeInBytes());
     idBuf.putShort((short) id.length());
     idBuf.put(id.getBytes());
+    idBuf.putShort(accountId);
+    idBuf.putShort(containerId);
     return idBuf.array();
   }
 
   @Override
   public String getID() {
-    return id;
+    return id + ":" + accountId + ":" + containerId;
   }
 
   @Override
@@ -52,7 +75,7 @@ public class MockId extends StoreKey {
 
   @Override
   public short sizeInBytes() {
-    return (short) (Id_Size_In_Bytes + id.length());
+    return (short) (Id_Size_In_Bytes + id.length() + Short.BYTES + Short.BYTES);
   }
 
   @Override

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
@@ -262,8 +262,8 @@ public class StoreMessageReadSetTest {
 
         try {
           new BlobReadOptions(log, new Offset(firstSegment.getName(), firstSegment.getEndOffset()),
-              new MessageInfo(null, 1, 1, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-                  Utils.Infinite_Time));
+              new MessageInfo(null, 1, 1, Utils.getRandomShort(TestUtils.RANDOM),
+                  Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM)));
           fail("Construction should have failed because offset + size > endOffset");
         } catch (IllegalArgumentException e) {
           // expected. Nothing to do.

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
@@ -263,7 +263,7 @@ public class StoreMessageReadSetTest {
         try {
           new BlobReadOptions(log, new Offset(firstSegment.getName(), firstSegment.getEndOffset()),
               new MessageInfo(null, 1, 1, Utils.getRandomShort(TestUtils.RANDOM),
-                  Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM)));
+                  Utils.getRandomShort(TestUtils.RANDOM), operationTimeMs));
           fail("Construction should have failed because offset + size > endOffset");
         } catch (IllegalArgumentException e) {
           // expected. Nothing to do.

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
@@ -290,18 +290,22 @@ public class StoreMessageReadSetTest {
       MessageInfo msgInfo) {
     assertEquals("LogSegment name not as expected", logSegment.getName(), options.getLogSegmentName());
     assertEquals("Offset not as expected", offset, options.getOffset());
-    assertEquals("Size not as expected", msgInfo.getSize(), options.getSize());
-    assertEquals("ExpiresAtMs not as expected", msgInfo.getExpirationTimeInMs(), options.getExpiresAtMs());
-    assertEquals("StoreKey not as expected", msgInfo.getStoreKey(), options.getStoreKey());
+    assertEquals("Size not as expected", msgInfo.getSize(), options.getMessageInfo().getSize());
+    assertEquals("ExpiresAtMs not as expected", msgInfo.getExpirationTimeInMs(),
+        options.getMessageInfo().getExpirationTimeInMs());
+    assertEquals("StoreKey not as expected", msgInfo.getStoreKey(), options.getMessageInfo().getStoreKey());
     if (verifyInMemFields) {
-      assertEquals("Crc not as expected ", msgInfo.getCrc().longValue(), options.getCrc());
-      assertEquals("AccountId not as expected", msgInfo.getAccountId(), options.getAccountId());
-      assertEquals("ContainerId not as expected", msgInfo.getContainerId(), options.getContainerId());
-      assertEquals("OperationTimeMs not as expected", msgInfo.getOperationTimeMs(), options.getOperationTimeMs());
+      assertEquals("Crc not as expected ", msgInfo.getCrc().longValue(), options.getMessageInfo().getCrc().longValue());
+      assertEquals("AccountId not as expected", msgInfo.getAccountId(), options.getMessageInfo().getAccountId());
+      assertEquals("ContainerId not as expected", msgInfo.getContainerId(), options.getMessageInfo().getContainerId());
+      assertEquals("OperationTimeMs not as expected", msgInfo.getOperationTimeMs(),
+          options.getMessageInfo().getOperationTimeMs());
     } else {
-      assertEquals("AccountId not as expected", Account.UNKNOWN_ACCOUNT_ID, options.getAccountId());
-      assertEquals("ContainerId not as expected", Container.UNKNOWN_CONTAINER_ID, options.getContainerId());
-      assertEquals("OperationTimeMs not as expected", Utils.Infinite_Time, options.getOperationTimeMs());
+      assertEquals("AccountId not as expected", Account.UNKNOWN_ACCOUNT_ID, options.getMessageInfo().getAccountId());
+      assertEquals("ContainerId not as expected", Container.UNKNOWN_CONTAINER_ID,
+          options.getMessageInfo().getContainerId());
+      assertEquals("OperationTimeMs not as expected", Utils.Infinite_Time,
+          options.getMessageInfo().getOperationTimeMs());
     }
     MessageInfo messageInfo = options.getMessageInfo();
     assertEquals("Size not as expected", msgInfo.getSize(), messageInfo.getSize());
@@ -337,8 +341,9 @@ public class StoreMessageReadSetTest {
       BlobReadOptions deSerReadOptions = BlobReadOptions.fromBytes(stream, STORE_KEY_FACTORY, log);
       assertEquals("Ref count of log segment should have increased", 1, segment.refCount());
       verifyGetters(deSerReadOptions, segment, readOptions.getOffset(), false,
-          new MessageInfo(readOptions.getStoreKey(), readOptions.getSize(), readOptions.getExpiresAtMs(),
-              Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, Utils.Infinite_Time));
+          new MessageInfo(readOptions.getMessageInfo().getStoreKey(), readOptions.getMessageInfo().getSize(),
+              readOptions.getMessageInfo().getExpirationTimeInMs(), Account.UNKNOWN_ACCOUNT_ID,
+              Container.UNKNOWN_CONTAINER_ID, Utils.Infinite_Time));
       deSerReadOptions.close();
       assertEquals("Ref count of log segment should have decreased", 0, segment.refCount());
     }
@@ -355,13 +360,13 @@ public class StoreMessageReadSetTest {
     switch (version) {
       case BlobReadOptions.VERSION_0:
         // version length + offset length + size length + expires at length + key size
-        bytes = new byte[2 + 8 + 8 + 8 + readOptions.getStoreKey().sizeInBytes()];
+        bytes = new byte[2 + 8 + 8 + 8 + readOptions.getMessageInfo().getStoreKey().sizeInBytes()];
         ByteBuffer bufWrap = ByteBuffer.wrap(bytes);
         bufWrap.putShort(BlobReadOptions.VERSION_0);
         bufWrap.putLong(readOptions.getOffset());
-        bufWrap.putLong(readOptions.getSize());
-        bufWrap.putLong(readOptions.getExpiresAtMs());
-        bufWrap.put(readOptions.getStoreKey().toBytes());
+        bufWrap.putLong(readOptions.getMessageInfo().getSize());
+        bufWrap.putLong(readOptions.getMessageInfo().getExpirationTimeInMs());
+        bufWrap.put(readOptions.getMessageInfo().getStoreKey().toBytes());
       case BlobReadOptions.VERSION_1:
         bytes = readOptions.toBytes();
         break;

--- a/ambry-tools/src/main/java/com.github.ambry/store/BlobIndexMetrics.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/BlobIndexMetrics.java
@@ -14,6 +14,8 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.messageformat.BlobStoreHardDelete;
@@ -56,8 +58,9 @@ class BlobIndexMetrics extends PersistentIndex {
     synchronized (lock) {
       long startTimeInMs = System.currentTimeMillis();
       long size = new Random().nextInt(10000);
-      IndexEntry entry = new IndexEntry(id, new IndexValue(size, new Offset("", lastOffsetUsed.get()), (byte) 1, 1000,
-          SystemTime.getInstance().seconds()));
+      IndexEntry entry = new IndexEntry(id,
+          new IndexValue(size, new Offset("", lastOffsetUsed.get()), (byte) 1, 1000, SystemTime.getInstance().seconds(),
+              Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID));
       lastOffsetUsed.addAndGet(size);
       long offset = getCurrentEndOffset().getOffset();
       addToIndex(entry, new FileSpan(new Offset("", offset), new Offset("", offset + entry.getValue().getSize())));

--- a/ambry-tools/src/main/java/com.github.ambry/store/CompactionVerifier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/CompactionVerifier.java
@@ -589,8 +589,8 @@ public class CompactionVerifier implements Closeable {
         tgtValue.getExpiresAtMs()) :
         errMsgId + ": ExpiresAt mismatch: old - " + srcValue.getExpiresAtMs() + ", new - " + tgtValue.getExpiresAtMs();
     assert
-        srcValue.getServiceId() == tgtValue.getServiceId() :
-        errMsgId + ": Service ID mismatch: old - " + srcValue.getServiceId() + ", new - " + tgtValue.getServiceId();
+        srcValue.getAccountId() == tgtValue.getAccountId() :
+        errMsgId + ": AccountId ID mismatch: old - " + srcValue.getAccountId() + ", new - " + tgtValue.getAccountId();
     assert
         srcValue.getContainerId() == tgtValue.getContainerId() :
         errMsgId + ": Container ID mismatch: old - " + srcValue.getContainerId() + ", new - "
@@ -671,7 +671,7 @@ public class CompactionVerifier implements Closeable {
                 EnumSet.allOf(StoreGetOptions.class))) {
               Offset putOffset = new Offset(indexSegment.getLogSegmentName(), options.getOffset());
               IndexValue putValue = new IndexValue(options.getMessageInfo().getSize(), putOffset,
-                  options.getMessageInfo().getExpirationTimeInMs(), value.getOperationTimeInMs(), value.getServiceId(),
+                  options.getMessageInfo().getExpirationTimeInMs(), value.getOperationTimeInMs(), value.getAccountId(),
                   value.getContainerId());
               entriesToAdd.add(new IndexEntry(indexEntry.getKey(), putValue));
             }

--- a/ambry-tools/src/main/java/com.github.ambry/store/CompactionVerifier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/CompactionVerifier.java
@@ -670,9 +670,9 @@ public class CompactionVerifier implements Closeable {
             try (BlobReadOptions options = index.getBlobReadInfo(indexEntry.getKey(),
                 EnumSet.allOf(StoreGetOptions.class))) {
               Offset putOffset = new Offset(indexSegment.getLogSegmentName(), options.getOffset());
-              IndexValue putValue =
-                  new IndexValue(options.getSize(), putOffset, options.getExpiresAtMs(), value.getOperationTimeInMs(),
-                      value.getServiceId(), value.getContainerId());
+              IndexValue putValue = new IndexValue(options.getMessageInfo().getSize(), putOffset,
+                  options.getMessageInfo().getExpirationTimeInMs(), value.getOperationTimeInMs(), value.getServiceId(),
+                  value.getContainerId());
               entriesToAdd.add(new IndexEntry(indexEntry.getKey(), putValue));
             }
           }

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerReadPerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerReadPerformance.java
@@ -327,7 +327,7 @@ public class ServerReadPerformance {
                 MessageFormatRecord.deserializeUserMetadata(getResponseUserMetadata.getInputStream());
             long endTimeGetBlobUserMetadata = SystemTime.getInstance().nanoseconds() - startTimeGetBlobUserMetadata;
             // delete the blob
-            DeleteRequest deleteRequest = new DeleteRequest(0, "perf", blobId, Utils.Infinite_Time);
+            DeleteRequest deleteRequest = new DeleteRequest(0, "perf", blobId, System.currentTimeMillis());
             channel.send(deleteRequest);
             DeleteResponse deleteResponse =
                 DeleteResponse.readFrom(new DataInputStream(channel.receive().getInputStream()));

--- a/ambry-tools/src/test/java/com.github.ambry/store/StoreCopierTest.java
+++ b/ambry-tools/src/test/java/com.github.ambry/store/StoreCopierTest.java
@@ -157,12 +157,16 @@ public class StoreCopierTest {
     src.start();
     try {
       deletedId = new MockId("deletedId");
-      addMessage(src, deletedId, Utils.Infinite_Time, false);
+      short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+      addMessage(src, deletedId, Utils.Infinite_Time, false, accountId, containerId, time.milliseconds());
       putId = new MockId("putId");
-      putData = addMessage(src, putId, Utils.Infinite_Time, false);
-      addMessage(src, deletedId, Utils.Infinite_Time, true);
+      putData = addMessage(src, putId, Utils.Infinite_Time, false, Utils.getRandomShort(TestUtils.RANDOM),
+          Utils.getRandomShort(TestUtils.RANDOM), time.milliseconds());
+      addMessage(src, deletedId, Utils.Infinite_Time, true, accountId, containerId, time.milliseconds());
       expiredId = new MockId("expiredId");
-      addMessage(src, expiredId, 0, false);
+      addMessage(src, expiredId, 0, false, Utils.getRandomShort(TestUtils.RANDOM),
+          Utils.getRandomShort(TestUtils.RANDOM), time.milliseconds());
     } finally {
       src.shutdown();
     }
@@ -174,14 +178,18 @@ public class StoreCopierTest {
    * @param key the {@link StoreKey} associated with the message.
    * @param expiryTimeMs the expiry time associated with the message.
    * @param isDelete {@code true} if this is a delete message, {@code false} otherwise.
+   * @param accountId accountId of the blob
+   * @param containerId containerId of the blob
+   * @param operationTimeMs operationTime in ms of put or delete
    * @return the message that was written.
    * @throws IOException
    * @throws StoreException
    */
-  private byte[] addMessage(Store store, StoreKey key, long expiryTimeMs, boolean isDelete)
-      throws IOException, StoreException {
+  private byte[] addMessage(Store store, StoreKey key, long expiryTimeMs, boolean isDelete, short accountId,
+      short containerId, long operationTimeMs) throws IOException, StoreException {
     int size = isDelete ? DELETE_RECORD_SIZE : PUT_RECORD_SIZE;
-    MessageInfo messageInfo = new MessageInfo(key, size, isDelete, expiryTimeMs);
+    MessageInfo messageInfo =
+        new MessageInfo(key, size, isDelete, expiryTimeMs, accountId, containerId, operationTimeMs);
     byte[] data = TestUtils.getRandomBytes(size);
     MessageFormatWriteSet writeSet =
         new MessageFormatWriteSet(new ByteArrayInputStream(data), Collections.singletonList(messageInfo), false);


### PR DESCRIPTION
1. This patch enables MessageInfoList V3 and DeleteMessageFormat V2
2. Fixed all prod codes where defaults were used for operation time and AccountId and ContainerId
3. Fixed tests to generate random AccountId and ContainerId during puts. 

Coding style applied 

SLA: 1 hours
Reviewers: Gopal and Casey