### PR TITLE
Makes notifier nullable for HelixAccountService

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
@@ -35,6 +35,7 @@ public class AccountServiceMetrics {
   public final Counter updateAccountErrorCount;
   public final Counter fetchRemoteAccountErrorCount;
   public final Counter remoteDataCorruptionErrorCount;
+  public final Counter nullNotifierCount;
 
   public AccountServiceMetrics(MetricRegistry metricRegistry) {
     // Histogram
@@ -55,5 +56,7 @@ public class AccountServiceMetrics {
         metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "FetchRemoteAccountErrorCount"));
     remoteDataCorruptionErrorCount =
         metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "RemoteDataCorruptionErrorCount"));
+    nullNotifierCount =
+        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "NullNotifierCount"));
   }
 }

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
@@ -44,13 +44,10 @@ public class HelixAccountServiceFactory implements AccountServiceFactory {
    * Constructor.
    * @param verifiableProperties The properties to get a {@link HelixAccountService} instance. Cannot be {@code null}.
    * @param metricRegistry The {@link MetricRegistry} for metrics tracking. Cannot be {@code null}.
-   * @param notifier The {@link Notifier} used to get a {@link HelixAccountService}. Cannot be {@code null}.
+   * @param notifier The {@link Notifier} used to get a {@link HelixAccountService}. Can be {@code null}.
    */
   public HelixAccountServiceFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
       Notifier<String> notifier) {
-    if (verifiableProperties == null || metricRegistry == null || notifier == null) {
-      throw new IllegalArgumentException("verifiableProperties or metricRegistry or notifier cannot be null");
-    }
     storeConfig = new HelixPropertyStoreConfig(verifiableProperties);
     accountServiceMetrics = new AccountServiceMetrics(metricRegistry);
     this.notifier = notifier;

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -346,7 +346,7 @@ public class HelixAccountServiceTest {
       new MockHelixAccountServiceFactory(null, new MetricRegistry(), notifier,
           shouldUseMockHelixStore).getAccountService();
       fail("should have thrown");
-    } catch (IllegalArgumentException e) {
+    } catch (NullPointerException e) {
       // expected
     }
 
@@ -354,17 +354,12 @@ public class HelixAccountServiceTest {
       new MockHelixAccountServiceFactory(vHelixConfigProps, null, notifier,
           shouldUseMockHelixStore).getAccountService();
       fail("should have thrown");
-    } catch (IllegalArgumentException e) {
+    } catch (NullPointerException e) {
       // expected
     }
 
-    try {
-      new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), null,
-          shouldUseMockHelixStore).getAccountService();
-      fail("should have thrown");
-    } catch (IllegalArgumentException e) {
-      // expected
-    }
+    new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), null,
+        shouldUseMockHelixStore).getAccountService();
 
     accountService = mockHelixAccountServiceFactory.getAccountService();
     try {

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -358,8 +358,15 @@ public class BlobId extends StoreKey {
     return Utils.hashcode(new Object[]{version, partitionId, uuid});
   }
 
-  /**
-   * Gets the value of {@link #CURRENT_VERSION}.
+  /**<p>
+   *   Gets the value of {@link #CURRENT_VERSION}.
+   * </p>
+   * <p>
+   *   It is typically not a good practice to call overridable methods from constructor. However, there could not be
+   *   cleaner way to set the {@link #version} field by either calling this method, or by reading from an input stream
+   *   from {@link BlobId#BlobId(String, ClusterMap)}, and also because this method simply returns a static final value
+   *   that does not depend on the state of an instance.
+   * </p>
    * @return The value of {@link #CURRENT_VERSION}.
    */
   protected short getCurrentVersion() {


### PR DESCRIPTION
This PR makes notifier nuallable for HelixAccountService.

HelixAccountService (or any account service) should not have a
dependency on Notifier. An account service implementation just interacts
with the storage to handle account create/read/update. These
functionalities should not depend on existence of a notifier. Without a
notifier, an account service may perform create/update without any
problem, and can read accounts during its initial start.

Test: clean build