### PR TITLE
Fix NPE when building blobProperties without account and container

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -211,7 +211,14 @@ public class RestUtils {
    */
   public static BlobProperties buildBlobProperties(Map<String, Object> args) throws RestServiceException {
     Account account = (Account) args.get(InternalKeys.TARGET_ACCOUNT_KEY);
+    if (account == null) {
+      throw new RestServiceException(InternalKeys.TARGET_ACCOUNT_KEY + " is not set", RestServiceErrorCode.MissingArgs);
+    }
     Container container = (Container) args.get(InternalKeys.TARGET_CONTAINER_KEY);
+    if (container == null) {
+      throw new RestServiceException(InternalKeys.TARGET_CONTAINER_KEY + " is not set",
+          RestServiceErrorCode.MissingArgs);
+    }
     String serviceId = getHeader(args, Headers.SERVICE_ID, true);
     String contentType = getHeader(args, Headers.AMBRY_CONTENT_TYPE, true);
     String ownerId = getHeader(args, Headers.OWNER_ID, false);

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -212,12 +212,13 @@ public class RestUtils {
   public static BlobProperties buildBlobProperties(Map<String, Object> args) throws RestServiceException {
     Account account = (Account) args.get(InternalKeys.TARGET_ACCOUNT_KEY);
     if (account == null) {
-      throw new RestServiceException(InternalKeys.TARGET_ACCOUNT_KEY + " is not set", RestServiceErrorCode.MissingArgs);
+      throw new RestServiceException(InternalKeys.TARGET_ACCOUNT_KEY + " is not set",
+          RestServiceErrorCode.InternalServerError);
     }
     Container container = (Container) args.get(InternalKeys.TARGET_CONTAINER_KEY);
     if (container == null) {
       throw new RestServiceException(InternalKeys.TARGET_CONTAINER_KEY + " is not set",
-          RestServiceErrorCode.MissingArgs);
+          RestServiceErrorCode.InternalServerError);
     }
     String serviceId = getHeader(args, Headers.SERVICE_ID, true);
     String contentType = getHeader(args, Headers.AMBRY_CONTENT_TYPE, true);

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -114,15 +114,15 @@ public class RestUtilsTest {
     // no internal keys for account and container
     headers = new JSONObject();
     setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, false, false, RestServiceErrorCode.MissingArgs);
+    verifyBlobPropertiesConstructionFailure(headers, false, false, RestServiceErrorCode.InternalServerError);
     // no internal keys for account
     headers = new JSONObject();
     setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, false, true, RestServiceErrorCode.MissingArgs);
+    verifyBlobPropertiesConstructionFailure(headers, false, true, RestServiceErrorCode.InternalServerError);
     // no internal keys for container
     headers = new JSONObject();
     setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, true, false, RestServiceErrorCode.MissingArgs);
+    verifyBlobPropertiesConstructionFailure(headers, true, false, RestServiceErrorCode.InternalServerError);
 
     // no failures.
     // ttl missing. Should be infinite time by default.


### PR DESCRIPTION
When using RestUtils#buildBlobProperties without account and container
object injected in the RestRequest, it throws NPE. This PR makes it to
explicitly throw RestServerException instead of NPE.

Test: clean build