### PR TITLE
Reflect changes in operation name in readme

### DIFF
--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/Readme.md
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/Readme.md
@@ -48,7 +48,7 @@ java -cp ambry.jar com.github.ambry.store.DumpIndexTool --propsFile [Config file
 //Contents of config file
 hardware.layout.file.path=[HardwareLayoutFile]
 partition.layout.file.path=[PartitionLayoutFile]
-type.of.operation=DumpIndex
+type.of.operation=DumpIndexFile
 file.to.read=[indexFile]
 silent=false
 ```
@@ -59,7 +59,7 @@ java -cp ambry.jar com.github.ambry.store.DumpIndexTool  --propsFile [Config fil
 //Contents of config file
 hardware.layout.file.path=[HardwareLayoutFile]
 partition.layout.file.path=[PartitionLayoutFile]
-type.of.operation=DumpIndex
+type.of.operation=DumpIndexFile
 file.to.read=[indexFile]
 blobId.list=blobid1,blobid2,blobid3
 silent=false


### PR DESCRIPTION
The `DumpIndex` operation was renamed to `DumpIndexFile` in 62eeacb. Updated readme.md to reflect that.