### PR TITLE
Introduce an API to get catchup status of peers

### DIFF
--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequest.java
@@ -34,8 +34,6 @@ public class AdminRequest extends RequestOrResponse {
   private final PartitionId partitionId;
   private final long sizeInBytes;
 
-  private int sizeSent = 0;
-
   /**
    * Reads from a stream and constructs an {@link AdminRequest}.
    * @param stream the {@link DataInputStream} to read from.
@@ -74,21 +72,16 @@ public class AdminRequest extends RequestOrResponse {
 
   @Override
   public long writeTo(WritableByteChannel channel) throws IOException {
-    long written = 0;
     if (bufferToSend == null) {
       serializeIntoBuffer();
       bufferToSend.flip();
     }
-    if (bufferToSend.remaining() > 0) {
-      written = channel.write(bufferToSend);
-      sizeSent += written;
-    }
-    return written;
+    return bufferToSend.hasRemaining() ? channel.write(bufferToSend) : 0;
   }
 
   @Override
   public boolean isSendComplete() {
-    return sizeSent == sizeInBytes();
+    return bufferToSend != null && bufferToSend.remaining() == 0;
   }
 
   @Override

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
@@ -20,5 +20,5 @@ package com.github.ambry.protocol;
  * requests/responses
  */
 public enum AdminRequestOrResponseType {
-  TriggerCompaction, RequestControl, ReplicationControl
+  TriggerCompaction, RequestControl, ReplicationControl, CatchupStatus
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/CatchupStatusAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/CatchupStatusAdminRequest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+/**
+ *  An admin request used to determine if the peers of a storage node have caught up to it.
+ */
+public class CatchupStatusAdminRequest extends AdminRequest {
+  private static final short VERSION_V1 = 1;
+
+  private final long acceptableLagInBytes;
+  private final long sizeInBytes;
+
+  /**
+   * Reads from a stream and constructs a {@link CatchupStatusAdminRequest}.
+   * @param stream the stream to read from
+   * @param adminRequest the {@link AdminRequest} that contains some necessary headers.
+   * @return the {@link CatchupStatusAdminRequest} constructed from the {@code stream}.
+   * @throws IOException if there is any problem reading from the stream
+   */
+  public static CatchupStatusAdminRequest readFrom(DataInputStream stream, AdminRequest adminRequest)
+      throws IOException {
+    Short versionId = stream.readShort();
+    if (!versionId.equals(VERSION_V1)) {
+      throw new IllegalStateException("Unrecognized version for CatchupStatusAdminRequest: " + versionId);
+    }
+    long acceptableLagInBytes = stream.readLong();
+    return new CatchupStatusAdminRequest(acceptableLagInBytes, adminRequest);
+  }
+
+  /**
+   * Construct a CatchupStatusAdminRequest
+   * @param acceptableLagInBytes the number of bytes that the remote can lag by which is considered OK.
+   * @param adminRequest the {@link AdminRequest} that contains common admin request related information.
+   */
+  public CatchupStatusAdminRequest(long acceptableLagInBytes, AdminRequest adminRequest) {
+    super(AdminRequestOrResponseType.CatchupStatus, adminRequest.getPartitionId(), adminRequest.getCorrelationId(),
+        adminRequest.getClientId());
+    this.acceptableLagInBytes = acceptableLagInBytes;
+    // parent size + version size + long size
+    sizeInBytes = super.sizeInBytes() + Short.BYTES + Long.BYTES;
+  }
+
+  /**
+   * @return the number of bytes that the remote can lag by which is considered OK.
+   */
+  public long getAcceptableLagInBytes() {
+    return acceptableLagInBytes;
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return sizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    return "CatchupStatusAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId
+        + ", AcceptableLagInBytes=" + acceptableLagInBytes + ", PartitionId=" + getPartitionId() + "]";
+  }
+
+  @Override
+  protected void serializeIntoBuffer() {
+    super.serializeIntoBuffer();
+    bufferToSend.putShort(VERSION_V1);
+    bufferToSend.putLong(acceptableLagInBytes);
+  }
+}

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/CatchupStatusAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/CatchupStatusAdminRequest.java
@@ -52,7 +52,7 @@ public class CatchupStatusAdminRequest extends AdminRequest {
     super(AdminRequestOrResponseType.CatchupStatus, adminRequest.getPartitionId(), adminRequest.getCorrelationId(),
         adminRequest.getClientId());
     this.acceptableLagInBytes = acceptableLagInBytes;
-    // parent size + version size + long size
+    // parent size + version size + acceptableLagInBytes size
     sizeInBytes = super.sizeInBytes() + Short.BYTES + Long.BYTES;
   }
 

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/CatchupStatusAdminResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/CatchupStatusAdminResponse.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+/**
+ * {@link AdminResponse} for {@link CatchupStatusAdminRequest} that provides catchup status.
+ */
+public class CatchupStatusAdminResponse extends AdminResponse {
+  private static final short VERSION_V1 = 1;
+
+  private final boolean isCaughtUp;
+  private final long sizeInBytes;
+
+  /**
+   * Reads from a stream and constructs a {@link CatchupStatusAdminResponse}.
+   * @param stream the stream to read from
+   * @return the {@link CatchupStatusAdminResponse} constructed from the {@code stream}.
+   * @throws IOException if there is any problem reading from the stream
+   */
+  public static CatchupStatusAdminResponse readFrom(DataInputStream stream) throws IOException {
+    AdminResponse adminResponse = AdminResponse.readFrom(stream);
+    Short versionId = stream.readShort();
+    if (!versionId.equals(VERSION_V1)) {
+      throw new IllegalStateException("Unrecognized version for CatchupStatusAdminResponse: " + versionId);
+    }
+    return new CatchupStatusAdminResponse(stream.readByte() == 1, adminResponse);
+  }
+
+  /**
+   * Construct a CatchupStatusAdminResponse
+   * @param isCaughtUp {@code true} if replicas have caught up. {@code false} otherwise.
+   * @param adminResponse the {@link AdminResponse} that contains common admin response related information.
+   */
+  public CatchupStatusAdminResponse(boolean isCaughtUp, AdminResponse adminResponse) {
+    super(adminResponse.getCorrelationId(), adminResponse.getClientId(), adminResponse.getError());
+    this.isCaughtUp = isCaughtUp;
+    // parent size + version size + byte size
+    sizeInBytes = super.sizeInBytes() + Short.BYTES + Byte.BYTES;
+  }
+
+  /**
+   * @return {@code true} if replicas have caught up. {@code false} otherwise.
+   */
+  public boolean isCaughtUp() {
+    return isCaughtUp;
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return sizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    return "CatchupStatusAdminResponse[ClientId=" + clientId + ", CorrelationId=" + correlationId + ", CaughtUp="
+        + isCaughtUp + "]";
+  }
+
+  @Override
+  protected void serializeIntoBuffer() {
+    super.serializeIntoBuffer();
+    bufferToSend.putShort(VERSION_V1);
+    bufferToSend.put(isCaughtUp ? (byte) 1 : 0);
+  }
+}

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -124,6 +124,12 @@ public class ServerMetrics {
   public final Histogram replicationControlResponseSendTimeInMs;
   public final Histogram replicationControlRequestTotalTimeInMs;
 
+  public final Histogram catchupStatusRequestQueueTimeInMs;
+  public final Histogram catchupStatusRequestProcessingTimeInMs;
+  public final Histogram catchupStatusResponseQueueTimeInMs;
+  public final Histogram catchupStatusResponseSendTimeInMs;
+  public final Histogram catchupStatusRequestTotalTimeInMs;
+
   public final Histogram blobSizeInBytes;
   public final Histogram blobUserMetadataSizeInBytes;
 
@@ -142,6 +148,7 @@ public class ServerMetrics {
   public final Meter triggerCompactionRequestRate;
   public final Meter requestControlRequestRate;
   public final Meter replicationControlRequestRate;
+  public final Meter catchupStatusRequestRate;
 
   public final Meter putSmallBlobRequestRate;
   public final Meter getSmallBlobRequestRate;
@@ -319,6 +326,17 @@ public class ServerMetrics {
     replicationControlRequestTotalTimeInMs =
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "ReplicationControlRequestTotalTimeInMs"));
 
+    catchupStatusRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "CatchupStatusRequestQueueTimeInMs"));
+    catchupStatusRequestProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "CatchupStatusRequestProcessingTimeInMs"));
+    catchupStatusResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "CatchupStatusResponseQueueTimeInMs"));
+    catchupStatusResponseSendTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "CatchupStatusResponseSendTimeInMs"));
+    catchupStatusRequestTotalTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "CatchupStatusRequestTotalTimeInMs"));
+
     blobSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobSize"));
     blobUserMetadataSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobUserMetadataSize"));
 
@@ -341,6 +359,7 @@ public class ServerMetrics {
     requestControlRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "RequestControlRequestRate"));
     replicationControlRequestRate =
         registry.meter(MetricRegistry.name(AmbryRequests.class, "ReplicationControlRequestRate"));
+    catchupStatusRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "CatchupStatusRequestRate"));
 
     putSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "PutSmallBlobRequestRate"));
     getSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "GetSmallBlobRequestRate"));

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -565,7 +565,7 @@ public class AmbryRequestsTest {
   }
 
   /**
-   * Generates lag overrides in {@@code replicationManager} with each lag a number between {@code base} and
+   * Generates lag overrides in {@code replicationManager} with each lag a number between {@code base} and
    * {@code upperBound} both inclusive.
    * @param base the minimum value of lag (inclusive)
    * @param upperBound the maximum value of lag (inclusive)


### PR DESCRIPTION
This commit introduces an API that can be used to query a particular
partition on a storage server (or all partitions) to find whether the
remote replicas of that partition have caught up to within a specified
range of bytes (i.e. lag is "acceptable").