### PR TITLE
Enable BlobId v2 write.

### DIFF
--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -71,7 +71,7 @@ public class BlobId extends StoreKey {
   static final short BLOB_ID_V1 = 1;
   // version 2 of the serialized format
   static final short BLOB_ID_V2 = 2;
-  private static final short CURRENT_VERSION = BLOB_ID_V1;
+  private static final short CURRENT_VERSION = BLOB_ID_V2;
   private static final short VERSION_FIELD_LENGTH_IN_BYTES = Short.BYTES;
   private static final short UUID_SIZE_FIELD_LENGTH_IN_BYTES = Integer.BYTES;
   private static final short FLAG_FIELD_LENGTH_IN_BYTES = Byte.BYTES;

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -67,9 +67,7 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
  */
 public class BlobId extends StoreKey {
   public static final byte DEFAULT_FLAG = 0;
-  // version 1 of the serialized format
   static final short BLOB_ID_V1 = 1;
-  // version 2 of the serialized format
   static final short BLOB_ID_V2 = 2;
   private static final short CURRENT_VERSION = BLOB_ID_V2;
   private static final short VERSION_FIELD_LENGTH_IN_BYTES = Short.BYTES;

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdV1.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdV1.java
@@ -19,11 +19,11 @@ import java.io.IOException;
 
 
 /**
- *  A class that makes {@link BlobId#getCurrentVersion()} to return {@link BlobId#BLOB_ID_V2}, which will serialize
- *  a blobId to {@link BlobIdV2}.
+ *  A class that makes {@link BlobId#getCurrentVersion()} to return {@link BlobId#BLOB_ID_V1}, which will serialize
+ *  a blobId to {@link BlobIdV1}.
  */
-public class BlobIdV2 extends BlobId {
-  public BlobIdV2(byte flag, byte datacenterId, short accountId, short containerId, PartitionId partitionId) {
+public class BlobIdV1 extends BlobId {
+  public BlobIdV1(byte flag, byte datacenterId, short accountId, short containerId, PartitionId partitionId) {
     super(flag, datacenterId, accountId, containerId, partitionId);
   }
 
@@ -34,12 +34,12 @@ public class BlobIdV2 extends BlobId {
    * @param clusterMap of the cluster that the blobId belongs to.
    * @throws IOException
    */
-  public BlobIdV2(String id, ClusterMap clusterMap) throws IOException {
+  public BlobIdV1(String id, ClusterMap clusterMap) throws IOException {
     super(id, clusterMap);
   }
 
   @Override
   protected short getCurrentVersion() {
-    return BLOB_ID_V2;
+    return BLOB_ID_V1;
   }
 }

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -13,8 +13,6 @@
  */
 package com.github.ambry.protocol;
 
-import com.github.ambry.account.Account;
-import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.MockClusterMap;
@@ -284,10 +282,8 @@ public class RequestResponseTest {
         Assert.assertEquals("ContainerId mismatch ", id1.getContainerId(), deserializedDeleteRequest.getContainerId());
         Assert.assertEquals("DeletionTime mismatch ", deletionTimeMs, deserializedDeleteRequest.getDeletionTimeInMs());
       } else {
-        Assert.assertEquals("AccountId mismatch ", Account.UNKNOWN_ACCOUNT_ID,
-            deserializedDeleteRequest.getAccountId());
-        Assert.assertEquals("ContainerId mismatch ", Container.UNKNOWN_CONTAINER_ID,
-            deserializedDeleteRequest.getContainerId());
+        Assert.assertEquals("AccountId mismatch ", accountId, deserializedDeleteRequest.getAccountId());
+        Assert.assertEquals("ContainerId mismatch ", containerId, deserializedDeleteRequest.getContainerId());
         Assert.assertEquals("DeletionTime mismatch ", Utils.Infinite_Time,
             deserializedDeleteRequest.getDeletionTimeInMs());
       }


### PR DESCRIPTION
This PR makes all new blobIds to be serialized in V2.

Tets: clean build

Verified from a local deployment:
```
$ curl -i -H "x-ambry-service-id : CUrlUpload"  -H "x-ambry-owner-id : `whoami`" -H "x-ambry-content-type : image/gif" -H "x-ambry-um-description : Demonstration Image" http://localhost:1174/ --data-binary @frontend.log
HTTP/1.1 201 Created
Location: /AAIA____AAAAAQAAAAAAAAAAAAAAJGM5NmE4NDM4LTQzMmItNGUyZS05MWRhLWRlNDZiNWQ4MDA5OA
Date: Tue, 12 Sep 2017 22:46:09 GMT
Content-Length: 0
x-ambry-creation-time: Tue, 12 Sep 2017 22:46:09 GMT

$ curl -i http://localhost:1174/AAIA____AAAAAQAAAAAAAAAAAAAAJGM5ZmRmOGJiLTY1OGQtNDZmNy05YWQ5LTM0ZTcwN2E3NzNkNA/BlobInfo
HTTP/1.1 200 OK
Date: Tue, 12 Sep 2017 22:46:33 GMT
Last-Modified: Tue, 12 Sep 2017 22:44:25 GMT
x-ambry-blob-size: 5416
x-ambry-service-id: CUrlUpload
x-ambry-creation-time: Tue, 12 Sep 2017 22:44:25 GMT
x-ambry-private: false
x-ambry-content-type: image/gif
x-ambry-owner-id: mxia
x-ambry-um-description: Demonstration Image
Content-Length: 0

$ curl http://localhost:1174/AAIA____AAAAAQAAAAAAAAAAAAAAJGM5ZmRmOGJiLTY1OGQtNDZmNy05YWQ5LTM0ZTcwN2E3NzNkNA > /tmp/a.log
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5416  100  5416    0     0   108k      0 --:--:-- --:--:-- --:--:--  110k

$ vi /tmp/a.log

$ curl -i -X DELETE http://localhost:1174/AAIA____AAAAAQAAAAAAAAAAAAAAJGM5ZmRmOGJiLTY1OGQtNDZmNy05YWQ5LTM0ZTcwN2E3NzNkNA
HTTP/1.1 202 Accepted
Date: Tue, 12 Sep 2017 22:47:34 GMT
Content-Length: 0
```