### PR TITLE
Adding support for log4j in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ subprojects {
         unitTestCompile sourceSets.test.output
         unitTestCompile configurations.testCompile
         unitTestRuntime configurations.testRuntime
+        testRuntime project(':log4j-test-config')
     }
 
     test {

--- a/log4j-test-config/src/main/resources/log4j.properties
+++ b/log4j-test-config/src/main/resources/log4j.properties
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+
+ambry.log.dir=logs
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.additivity.state.change.logger=false
+
+# Define the file appender for Public Access Log
+log4j.appender.PublicAccessLog=org.apache.log4j.FileAppender
+log4j.appender.PublicAccessLog.File=${ambry.log.dir}/publicAccessLog.out
+# Define the layout for file appender
+log4j.appender.PublicAccessLog.layout=org.apache.log4j.PatternLayout
+log4j.appender.PublicAccessLog.layout.conversionPattern=%m%n
+
+log4j.logger.PublicAccessLogger = WARN, PublicAccessLog
+log4j.additivity.PublicAccessLogger = false
+
+# Package specific levels:
+log4j.logger.org.apache.helix=WARN
+log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.org.I0Itec.zkclient=WARN

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,4 +21,5 @@ include 'ambry-api',
         'ambry-protocol',
         'ambry-rest',
         'ambry-router',
-        'ambry-frontend'
+        'ambry-frontend',
+        'log4j-test-config'


### PR DESCRIPTION
This will print the logs in the intellij log window providing more information about tests. This also enables setting logging levels via the `./gradlew` command. For example, if `./gradlew -i build` is run, all the tests will print any logs at INFO level.  This should help with debugging.

https://docs.gradle.org/current/userguide/logging.html