### PR TITLE
Fix race condition between notification and updating account.

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
@@ -17,8 +17,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.commons.Notifier;
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.VerifiableProperties;
-import java.util.Collections;
-import java.util.List;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
@@ -62,13 +60,11 @@ public class HelixAccountServiceFactory implements AccountServiceFactory {
     logger.info("Starting a HelixAccountService");
     ZkClient zkClient = new ZkClient(storeConfig.zkClientConnectString, storeConfig.zkClientSessionTimeoutMs,
         storeConfig.zkClientConnectionTimeoutMs, new ZNRecordSerializer());
-    List<String> subscribedPaths = Collections.singletonList(storeConfig.rootPath);
     HelixPropertyStore<ZNRecord> helixStore =
-        new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(zkClient), storeConfig.rootPath, subscribedPaths);
+        new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(zkClient), storeConfig.rootPath, null);
     logger.info("HelixPropertyStore started with zkClientConnectString={}, zkClientSessionTimeoutMs={}, "
-            + "zkClientConnectionTimeoutMs={}, rootPath={}, subscribedPaths={}", storeConfig.zkClientConnectString,
-        storeConfig.zkClientSessionTimeoutMs, storeConfig.zkClientConnectionTimeoutMs, storeConfig.rootPath,
-        subscribedPaths);
+            + "zkClientConnectionTimeoutMs={}, rootPath={}", storeConfig.zkClientConnectString,
+        storeConfig.zkClientSessionTimeoutMs, storeConfig.zkClientConnectionTimeoutMs, storeConfig.rootPath);
     HelixAccountService helixAccountService = new HelixAccountService(helixStore, accountServiceMetrics, notifier);
     long spentTimeMs = System.currentTimeMillis() - startTimeMs;
     logger.info("HelixAccountService started, took {} ms", spentTimeMs);
@@ -76,4 +72,3 @@ public class HelixAccountServiceFactory implements AccountServiceFactory {
     return helixAccountService;
   }
 }
-


### PR DESCRIPTION
This PR fixes the race condition between receiving notification for
account update and fetching the actual account update.

`HelixPropertyStore` has its own cache, and it listens to the change of ZK. For any reason, if FE receives the notification for account change is received earlier than `HelixPropertyStore` receives the notification for data update in ZK, or earlier than the update actually propagated to the `HelixPropertyStore`, FE will read the outdated accounts though they are already updated in ZK.

There is no explicit way to disable the cache for `HelixPropertyStore`. Per the Helix team suggestion, removing the subscribed paths meaning that do not listen to the changes for these paths, which implicitly makes reading these paths directly fetch from remote.

Have verified in local deployment.

Test: clean build