### PR TITLE
Add blacklist for query parameters

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
@@ -103,8 +103,8 @@ public class NettyConfig {
   public final int nettyServerRequestBufferWatermark;
 
   /**
-   * A comma separated list of query parameters that should not be exposed as {@link com.github.ambry.rest.RestRequest}
-   * arguments.
+   * A comma separated list of query parameters that should not be honored when forwarded to the
+   * {@link com.github.ambry.rest.BlobStorageService} layer.
    */
   @Config("netty.server.blacklisted.query.params")
   @Default("")

--- a/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
@@ -13,6 +13,11 @@
  */
 package com.github.ambry.config;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+
 /**
  * Configuration parameters required by Netty.
  */
@@ -97,6 +102,14 @@ public class NettyConfig {
   @Default("32 * 1024 * 1024")
   public final int nettyServerRequestBufferWatermark;
 
+  /**
+   * A comma separated list of query parameters that should not be exposed as {@link com.github.ambry.rest.RestRequest}
+   * arguments.
+   */
+  @Config("netty.server.blacklisted.query.params")
+  @Default("")
+  public final Set<String> nettyBlacklistedQueryParams;
+
   public NettyConfig(VerifiableProperties verifiableProperties) {
     nettyServerBossThreadCount = verifiableProperties.getInt("netty.server.boss.thread.count", 1);
     nettyServerIdleTimeSeconds = verifiableProperties.getInt("netty.server.idle.time.seconds", 60);
@@ -111,5 +124,7 @@ public class NettyConfig {
     nettyServerRequestBufferWatermark =
         verifiableProperties.getIntInRange("netty.server.request.buffer.watermark", 32 * 1024 * 1024, 1,
             Integer.MAX_VALUE);
+    nettyBlacklistedQueryParams = new HashSet<>(
+        Arrays.asList(verifiableProperties.getString("netty.server.blacklisted.query.params", "").split(",")));
   }
 }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
@@ -284,9 +284,11 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
           if ((HttpMethod.POST.equals(httpRequest.method()) || HttpMethod.PUT.equals(httpRequest.method()))
               && HttpPostRequestDecoder.isMultipart(httpRequest)) {
             nettyMetrics.multipartPostRequestRate.mark();
-            request = new NettyMultipartRequest(httpRequest, ctx.channel(), nettyMetrics);
+            request = new NettyMultipartRequest(httpRequest, ctx.channel(), nettyMetrics,
+                nettyConfig.nettyBlacklistedQueryParams);
           } else {
-            request = new NettyRequest(httpRequest, ctx.channel(), nettyMetrics);
+            request =
+                new NettyRequest(httpRequest, ctx.channel(), nettyMetrics, nettyConfig.nettyBlacklistedQueryParams);
           }
           responseChannel.setRequest(request);
           logger.trace("Channel {} now handling request {}", ctx.channel(), request.getUri());

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMultipartRequest.java
@@ -30,6 +30,7 @@ import io.netty.util.ReferenceCountUtil;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.slf4j.Logger;
@@ -57,13 +58,15 @@ class NettyMultipartRequest extends NettyRequest {
    * @param request the {@link HttpRequest} that needs to be wrapped.
    * @param channel the {@link Channel} over which the {@code request} has been received.
    * @param nettyMetrics the {@link NettyMetrics} instance to use.
+   * @param blacklistedQueryParams the set of query params that should not be exposed via {@link #getArgs()}.
    * @throws IllegalArgumentException if {@code request} is null or if the HTTP method defined in {@code request} is
    *                                    anything other than POST.
    * @throws RestServiceException if the HTTP method defined in {@code request} is not recognized as a
    *                                {@link RestMethod}.
    */
-  NettyMultipartRequest(HttpRequest request, Channel channel, NettyMetrics nettyMetrics) throws RestServiceException {
-    super(request, channel, nettyMetrics);
+  NettyMultipartRequest(HttpRequest request, Channel channel, NettyMetrics nettyMetrics,
+    Set<String> blacklistedQueryParams) throws RestServiceException {
+    super(request, channel, nettyMetrics, blacklistedQueryParams);
     // reset auto read state.
     channel.config().setRecvByteBufAllocator(savedAllocator);
     setAutoRead(true);

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -109,11 +109,13 @@ class NettyRequest implements RestRequest {
    * @param request the {@link HttpRequest} that needs to be wrapped.
    * @param channel the {@link Channel} over which the {@code request} has been received.
    * @param nettyMetrics the {@link NettyMetrics} instance to use.
+   * @param blacklistedQueryParams the set of query params that should not be exposed via {@link #getArgs()}.
    * @throws IllegalArgumentException if {@code request} is null.
    * @throws RestServiceException if the {@link HttpMethod} defined in {@code request} is not recognized as a
    *                                {@link RestMethod} or if the {@link RestUtils.Headers#BLOB_SIZE} header is invalid.
    */
-  public NettyRequest(HttpRequest request, Channel channel, NettyMetrics nettyMetrics) throws RestServiceException {
+  public NettyRequest(HttpRequest request, Channel channel, NettyMetrics nettyMetrics,
+      Set<String> blacklistedQueryParams) throws RestServiceException {
     if (request == null || channel == null) {
       throw new IllegalArgumentException("Received null argument(s)");
     }
@@ -171,14 +173,18 @@ class NettyRequest implements RestRequest {
 
     // query params.
     for (Map.Entry<String, List<String>> e : query.parameters().entrySet()) {
-      StringBuilder value = null;
-      if (e.getValue() != null) {
-        StringBuilder combinedValues = combineVals(new StringBuilder(), e.getValue());
-        if (combinedValues.length() > 0) {
-          value = combinedValues;
+      if (!blacklistedQueryParams.contains(e.getKey())) {
+        StringBuilder value = null;
+        if (e.getValue() != null) {
+          StringBuilder combinedValues = combineVals(new StringBuilder(), e.getValue());
+          if (combinedValues.length() > 0) {
+            value = combinedValues;
+          }
         }
+        allArgs.put(e.getKey(), value);
+      } else {
+        logger.info("Encountered blacklisted query parameter {} in request {}", e, request);
       }
-      allArgs.put(e.getKey(), value);
     }
 
     Set<io.netty.handler.codec.http.cookie.Cookie> nettyCookies = null;

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -183,7 +183,7 @@ class NettyRequest implements RestRequest {
         }
         allArgs.put(e.getKey(), value);
       } else {
-        logger.info("Encountered blacklisted query parameter {} in request {}", e, request);
+        logger.debug("Encountered blacklisted query parameter {} in request {}", e, request);
       }
     }
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
@@ -46,6 +46,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -90,7 +91,8 @@ public class NettyMultipartRequestTest {
       HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, method, "/");
       MockChannel channel = new MockChannel();
       RecvByteBufAllocator expected = channel.config().getRecvByteBufAllocator();
-      NettyMultipartRequest request = new NettyMultipartRequest(httpRequest, channel, NETTY_METRICS);
+      NettyMultipartRequest request =
+          new NettyMultipartRequest(httpRequest, channel, NETTY_METRICS, Collections.emptySet());
       assertTrue("Auto-read should not have been changed", channel.config().isAutoRead());
       assertEquals("RecvByteBufAllocator should not have changed", expected,
           channel.config().getRecvByteBufAllocator());
@@ -102,7 +104,7 @@ public class NettyMultipartRequestTest {
     for (HttpMethod method : methods) {
       HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, method, "/");
       try {
-        new NettyMultipartRequest(httpRequest, new MockChannel(), NETTY_METRICS);
+        new NettyMultipartRequest(httpRequest, new MockChannel(), NETTY_METRICS, Collections.emptySet());
         fail("Creation of NettyMultipartRequest should have failed for " + method);
       } catch (IllegalArgumentException e) {
         // expected. Nothing to do.
@@ -249,7 +251,7 @@ public class NettyMultipartRequestTest {
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
     HttpPostRequestEncoder encoder = createEncoder(httpRequest, null);
     NettyMultipartRequest request =
-        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS);
+        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS, Collections.emptySet());
     assertTrue("Request channel is not open", request.isOpen());
     // insert random data
     HttpContent httpContent = new DefaultHttpContent(Unpooled.wrappedBuffer(TestUtils.getRandomBytes(10)));
@@ -317,7 +319,8 @@ public class NettyMultipartRequestTest {
     files[0] = new InMemoryFile(RestUtils.MultipartPost.BLOB_PART, ByteBuffer.wrap(TestUtils.getRandomBytes(256)));
     encoder = createEncoder(httpRequest, files);
     encoder.addBodyAttribute("dummyKey", "dummyValue");
-    request = new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS);
+    request =
+        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS, Collections.emptySet());
     assertTrue("Request channel is not open", request.isOpen());
     while (!encoder.isEndOfInput()) {
       // Sending null for ctx because the encoder is OK with that.
@@ -361,7 +364,7 @@ public class NettyMultipartRequestTest {
     }
     HttpPostRequestEncoder encoder = createEncoder(httpRequest, parts);
     NettyMultipartRequest request =
-        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS);
+        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS, Collections.emptySet());
     assertTrue("Request channel is not open", request.isOpen());
     while (!encoder.isEndOfInput()) {
       // Sending null for ctx because the encoder is OK with that.

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -47,6 +47,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -865,7 +866,7 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
    */
   private void handleRequest(HttpRequest httpRequest) throws Exception {
     writeCallbacksToVerify.clear();
-    request = new NettyRequest(httpRequest, ctx.channel(), nettyMetrics);
+    request = new NettyRequest(httpRequest, ctx.channel(), nettyMetrics, Collections.emptySet());
     restResponseChannel = new NettyResponseChannel(ctx, nettyMetrics);
     restResponseChannel.setRequest(request);
     restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, "application/octet-stream");


### PR DESCRIPTION
Add a configurable blacklist for query parameters. This stops these query parameters from showing up in `NettyRequest.getArgs()`.