### PR TITLE
Changing behavior of ReplControl for empty origin list input

### DIFF
--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -37,6 +37,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import org.junit.Assert;
@@ -451,8 +452,14 @@ public class RequestResponseTest {
    */
   @Test
   public void replicationControlAdminRequestTest() throws IOException {
-    doReplicationControlAdminRequestTest(true);
-    doReplicationControlAdminRequestTest(false);
+    int numOrigins = TestUtils.RANDOM.nextInt(8) + 2;
+    List<String> origins = new ArrayList<>();
+    for (int i = 0; i < numOrigins; i++) {
+      origins.add(UtilsTest.getRandomString(TestUtils.RANDOM.nextInt(8) + 2));
+    }
+    doReplicationControlAdminRequestTest(origins, true);
+    doReplicationControlAdminRequestTest(origins, false);
+    doReplicationControlAdminRequestTest(Collections.EMPTY_LIST, true);
   }
 
   /**
@@ -550,21 +557,17 @@ public class RequestResponseTest {
   /**
    * Does the actual test of ser/de of {@link ReplicationControlAdminRequest} and checks for equality of fields with
    * reference data.
+   * @param origins the origins list to use in {@link ReplicationControlAdminRequest}.
    * @param enable the value for the enable field in {@link ReplicationControlAdminRequest}.
    * @throws IOException
    */
-  private void doReplicationControlAdminRequestTest(boolean enable) throws IOException {
+  private void doReplicationControlAdminRequestTest(List<String> origins, boolean enable) throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
     PartitionId id = clusterMap.getWritablePartitionIds().get(0);
     int correlationId = 1234;
     String clientId = "client";
     AdminRequest adminRequest =
         new AdminRequest(AdminRequestOrResponseType.ReplicationControl, id, correlationId, clientId);
-    int numOrigins = TestUtils.RANDOM.nextInt(8) + 2;
-    List<String> origins = new ArrayList<>();
-    for (int i = 0; i < numOrigins; i++) {
-      origins.add(UtilsTest.getRandomString(TestUtils.RANDOM.nextInt(8) + 2));
-    }
     ReplicationControlAdminRequest controlRequest = new ReplicationControlAdminRequest(origins, enable, adminRequest);
     DataInputStream requestStream = serAndPrepForRead(controlRequest, -1, true);
     AdminRequest deserializedAdminRequest =

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -382,14 +382,18 @@ public class ReplicationManager {
    * Enables/disables replication of the given {@code ids} from {@code origins}. The disabling is in-memory and
    * therefore is not valid across restarts.
    * @param ids the {@link PartitionId}s to enable/disable it on.
-   * @param origins the list of datacenters from which replication should be enabled/disabled.
+   * @param origins the list of datacenters from which replication should be enabled/disabled. Having an empty list
+   *                disables replication from all datacenters.
    * @param enable whether to enable ({@code true}) or disable.
    * @return {@code true} if disabling succeeded, {@code false} otherwise. Disabling fails if {@code origins} is empty
    * or contains unrecognized datacenters.
    */
   public boolean controlReplicationForPartitions(List<? extends PartitionId> ids, List<String> origins,
       boolean enable) {
-    if (origins.isEmpty() || !replicaThreadPools.keySet().containsAll(origins)) {
+    if (origins.isEmpty()) {
+      origins = new ArrayList<>(replicaThreadPools.keySet());
+    }
+    if (!replicaThreadPools.keySet().containsAll(origins)) {
       return false;
     }
     for (String origin : origins) {

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -508,6 +508,9 @@ public class AmbryRequestsTest {
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = true;
     sendAndVerifyReplicationControlRequest(origins, true, id, expectedServerErrorCode);
+    replicationManager.reset();
+    replicationManager.controlReplicationReturnVal = true;
+    sendAndVerifyReplicationControlRequest(Collections.EMPTY_LIST, true, id, expectedServerErrorCode);
   }
 
   /**


### PR DESCRIPTION
Empty origin list now means all origins (similar to no partition meaning all partitions). This helps with disabling replication in all DCs without actually having to find and enumerate their names