### PR TITLE
Adding a tool that ensures a storage node's peers have caught up

### DIFF
--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/SafeServerShutdownTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/SafeServerShutdownTool.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.tools.admin;
+
+import com.github.ambry.clustermap.ClusterAgentsFactory;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.commons.SSLFactory;
+import com.github.ambry.commons.ServerErrorCode;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.Config;
+import com.github.ambry.config.Default;
+import com.github.ambry.config.SSLConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.protocol.RequestOrResponseType;
+import com.github.ambry.tools.util.ToolUtils;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Tool that can be used to make sure an Ambry storage node is safe for shutdown.
+ * </p>
+ * This is not meant for cases where the node is going to be restarted without changing any data (new code deployments,
+ * config changes etc). This is meant for cases where a node is going down for maintenance and it is useful to make
+ * sure that all the data in it has been successfully replicated. For example, this tool can be used before a node
+ * is shutdown to run {@link com.github.ambry.store.DiskReformatter} on it.
+ * <p/>
+ * Note: The tool does not actually shutdown the node - it simply makes sure that all its peers have caught up
+ * completely.
+ */
+public class SafeServerShutdownTool {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerAdminTool.class);
+
+  private final ServerAdminTool serverAdminTool;
+  private final Time time;
+
+  private static class SafeServerShutdownToolConfig {
+
+    /**
+     * The path to the hardware layout file. Needed if using
+     * {@link com.github.ambry.clustermap.StaticClusterAgentsFactory}.
+     */
+    @Config("hardware.layout.file.path")
+    @Default("")
+    final String hardwareLayoutFilePath;
+
+    /**
+     * The path to the partition layout file. Needed if using
+     * {@link com.github.ambry.clustermap.StaticClusterAgentsFactory}.
+     */
+    @Config("partition.layout.file.path")
+    @Default("")
+    final String partitionLayoutFilePath;
+
+    /**
+     * The hostname of the target server as it appears in the partition layout.
+     */
+    @Config("hostname")
+    @Default("localhost")
+    final String hostname;
+
+    /**
+     * The port of the target server in the partition layout (need not be the actual port to connect to).
+     */
+    @Config("port")
+    @Default("6667")
+    final int port;
+
+    /**
+     * The peers' lag at which the node targeted will shut off all operations that cause log growth in order to allow
+     * peers to completely catch up.
+     */
+    @Config("log.growth.pause.lag.threshold.bytes")
+    @Default("20 * 1024 * 1024")
+    final long logGrowthPauseLagThresholdBytes;
+
+    /**
+     * The amount of time in (seconds) to wait before declaring safe shutdown as not possible.
+     */
+    @Config("timeout.secs")
+    @Default("Long.MAX_VALUE")
+    final long timeoutSecs;
+
+    /**
+     * Constructs the configs associated with the tool.
+     * @param verifiableProperties the props to use to load the config.
+     */
+    SafeServerShutdownToolConfig(VerifiableProperties verifiableProperties) {
+      hardwareLayoutFilePath = verifiableProperties.getString("hardware.layout.file.path", "");
+      partitionLayoutFilePath = verifiableProperties.getString("partition.layout.file.path", "");
+      hostname = verifiableProperties.getString("hostname", "localhost");
+      port = verifiableProperties.getIntInRange("port", 6667, 1, 65535);
+      logGrowthPauseLagThresholdBytes =
+          verifiableProperties.getLongInRange("log.growth.pause.lag.threshold.bytes", 20 * 1024 * 1024, 0,
+              Long.MAX_VALUE);
+      timeoutSecs = verifiableProperties.getLongInRange("timeout.secs", Long.MAX_VALUE, 0, Long.MAX_VALUE);
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    VerifiableProperties verifiableProperties = ToolUtils.getVerifiableProperties(args);
+    SafeServerShutdownToolConfig config = new SafeServerShutdownToolConfig(verifiableProperties);
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    try (ClusterMap clusterMap = ((ClusterAgentsFactory) Utils.getObj(clusterMapConfig.clusterMapClusterAgentsFactory,
+        clusterMapConfig, config.hardwareLayoutFilePath, config.partitionLayoutFilePath)).getClusterMap()) {
+      SSLFactory sslFactory = !clusterMapConfig.clusterMapSslEnabledDatacenters.isEmpty() ? new SSLFactory(
+          new SSLConfig(verifiableProperties)) : null;
+      try (ServerAdminTool serverAdminTool = new ServerAdminTool(clusterMap.getMetricRegistry(), sslFactory,
+          verifiableProperties)) {
+        DataNodeId dataNodeId = clusterMap.getDataNodeId(config.hostname, config.port);
+        if (dataNodeId == null) {
+          throw new IllegalArgumentException(
+              "Could not find a data node corresponding to " + config.hostname + ":" + config.port);
+        }
+        SafeServerShutdownTool safeServerShutdownTool =
+            new SafeServerShutdownTool(serverAdminTool, SystemTime.getInstance());
+        int exitStatus =
+            safeServerShutdownTool.prepareServerForShutdown(dataNodeId, config.logGrowthPauseLagThresholdBytes,
+                config.timeoutSecs) ? 0 : 1;
+        System.exit(exitStatus);
+      }
+    }
+  }
+
+  /**
+   * @param serverAdminTool the {@link ServerAdminTool} to use to make requests.
+   * @param time the {@link Time} instance to use for the timeout.
+   */
+  public SafeServerShutdownTool(ServerAdminTool serverAdminTool, Time time) {
+    this.serverAdminTool = serverAdminTool;
+    this.time = time;
+  }
+
+  /**
+   * Prepares a server for safe shutdown by ensuring that all its peers have caught up to it. Does this by
+   * 1. Ensuring that all peers are within {@code logGrowthPauseLagThresholdBytes} for all partitions on
+   * {@code dataNodeId}
+   * 2. Disabling PUT, DELETE and inbound replication on {@code dataNodeId}.
+   * 3. Ensuring that all peers are fully caught up (no lag) for all partitions on {@code dataNodeId}.
+   * <p/>
+   * If the operation fails after #2, an attempt is made to undo the changes in #2. If that fails, an
+   *  {@link IllegalStateException} will be thrown.
+   * @param dataNodeId the {@link DataNodeId} that has to be prepared for shutdown.
+   * @param logGrowthPauseLagThresholdBytes the peer lag (in bytes) at which PUT, DELETE and inbound replication will
+   *                                        be shut off on {@code dataNodeId}.
+   * @param timeoutSecs the number of seconds after which the operation will be considered failed.
+   * @return {@code true} if the server is safe for shutdown (all peers are fully caught up). {@code false} otherwise.
+   * @throws IllegalStateException if the operation failed and the reset of server state failed.
+   * @throws InterruptedException if there are any interruptions while waiting for catch up.
+   * @throws IOException if there is any I/O error.
+   * @throws TimeoutException if there are timeout errors while making network requests.
+   */
+  public boolean prepareServerForShutdown(DataNodeId dataNodeId, long logGrowthPauseLagThresholdBytes, long timeoutSecs)
+      throws InterruptedException, IOException, TimeoutException {
+    long startTimeSecs = time.seconds();
+    boolean success = false;
+    // 1. Make sure the peers of the node have caught up till the logGrowthPauseLagThresholdBytes
+    LOGGER.info("Waiting until peers of {} are within {} bytes for all partitions", dataNodeId,
+        logGrowthPauseLagThresholdBytes);
+    if (waitTillCatchupOrTimeout(dataNodeId, logGrowthPauseLagThresholdBytes, startTimeSecs + timeoutSecs)) {
+      // 2. Disable all requests that result in log growth (PUT, DELETE and inbound replication).
+      LOGGER.info("Disabling PUT, DELETE and inbound replication on {} for all partitions", dataNodeId);
+      if (controlLogGrowth(dataNodeId, false)) {
+        // 3. Make sure the peers of the node have completely caught up
+        LOGGER.info("Waiting until peers of {} have completely caught up for all partitions", dataNodeId);
+        success = waitTillCatchupOrTimeout(dataNodeId, 0, startTimeSecs + timeoutSecs);
+      }
+    }
+    LOGGER.info("Server safe for shutdown: {}", success);
+    if (!success && !controlLogGrowth(dataNodeId, true)) {
+      throw new IllegalStateException("Could not reset state of " + dataNodeId + ". Please reset manually");
+    }
+    return success;
+  }
+
+  /**
+   * Waits until the lag of all peers of {@code dataNodeId} for all partitions <=
+   * {@code acceptableLagInBytes} or until time moves past {@code timeoutAtSecs}.
+   * @param dataNodeId the {@link DataNodeId} to ask for peer lag details.
+   * @param acceptableLagInBytes that lag in bytes that is considered "caught up".
+   * @param timeoutAtSecs the absolute time (in secs) at which the wait is considered failed.
+   * @return if the server's peers are confirmed to be within {@code acceptableLagInBytes}. {@code false} otherwise.
+   * @throws InterruptedException if there are any interruptions while waiting for catch up.
+   * @throws IOException if there is any I/O error.
+   * @throws TimeoutException if there are timeout errors while making network requests.
+   */
+  private boolean waitTillCatchupOrTimeout(DataNodeId dataNodeId, long acceptableLagInBytes, long timeoutAtSecs)
+      throws InterruptedException, IOException, TimeoutException {
+    boolean isCaughtUp;
+    do {
+      isCaughtUp = serverAdminTool.isCaughtUp(dataNodeId, null, acceptableLagInBytes).getSecond();
+      if (!isCaughtUp) {
+        // sleep for 5s
+        time.sleep(TimeUnit.SECONDS.toMillis(5));
+      }
+    } while (!isCaughtUp && time.seconds() < timeoutAtSecs);
+    return isCaughtUp;
+  }
+
+  /**
+   * Disables/enables requests (PUT, DELETE, inbound replication) on {@code dataNodeId} that cause the logs the grow.
+   * @param dataNodeId the {@link DataNodeId} where log growth has to be controlled.
+   * @param enableGrowth {@code true} if the requests need to be enabled, {@code false} if they need to be disabled.
+   * @return {@code true} if the requested operation succeeded. {@code false} otherwise.
+   * @throws IOException if there is any I/O error.
+   * @throws TimeoutException if there are timeout errors while making network requests.
+   */
+  private boolean controlLogGrowth(DataNodeId dataNodeId, boolean enableGrowth) throws IOException, TimeoutException {
+    return serverAdminTool.controlRequest(dataNodeId, null, RequestOrResponseType.PutRequest, enableGrowth)
+        == ServerErrorCode.No_Error
+        && serverAdminTool.controlRequest(dataNodeId, null, RequestOrResponseType.DeleteRequest, enableGrowth)
+        == ServerErrorCode.No_Error
+        && serverAdminTool.controlReplication(dataNodeId, null, Collections.EMPTY_LIST, enableGrowth)
+        == ServerErrorCode.No_Error;
+  }
+}

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
@@ -292,8 +292,9 @@ public class ServerAdminTool implements Closeable {
         break;
       case TriggerCompaction:
         if (config.partitionIds.length > 0 && !config.partitionIds[0].isEmpty()) {
-          for (String partitionId : config.partitionIds) {
-            ServerErrorCode errorCode = serverAdminTool.triggerCompaction(dataNodeId, partitionId, clusterMap);
+          for (String partitionIdStr : config.partitionIds) {
+            PartitionId partitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
+            ServerErrorCode errorCode = serverAdminTool.triggerCompaction(dataNodeId, partitionId);
             if (errorCode == ServerErrorCode.No_Error) {
               LOGGER.info("Compaction has been triggered for {} on {}", partitionId, dataNodeId);
             } else {
@@ -307,35 +308,36 @@ public class ServerAdminTool implements Closeable {
         break;
       case RequestControl:
         if (config.partitionIds.length > 0 && !config.partitionIds[0].isEmpty()) {
-          for (String partitionId : config.partitionIds) {
-            sendRequestControlRequest(serverAdminTool, clusterMap, dataNodeId, partitionId, config.requestTypeToControl,
+          for (String partitionIdStr : config.partitionIds) {
+            PartitionId partitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
+            sendRequestControlRequest(serverAdminTool, dataNodeId, partitionId, config.requestTypeToControl,
                 config.enableState);
           }
         } else {
           LOGGER.info("No partition list provided. Requesting enable status of {} to be set to {} on all partitions",
               config.requestTypeToControl, config.enableState);
-          sendRequestControlRequest(serverAdminTool, clusterMap, dataNodeId, null, config.requestTypeToControl,
-              config.enableState);
+          sendRequestControlRequest(serverAdminTool, dataNodeId, null, config.requestTypeToControl, config.enableState);
         }
         break;
       case ReplicationControl:
         List<String> origins = Arrays.asList(config.origins);
         if (config.partitionIds.length > 0 && !config.partitionIds[0].isEmpty()) {
-          for (String partitionId : config.partitionIds) {
-            sendReplicationControlRequest(serverAdminTool, clusterMap, dataNodeId, partitionId, origins,
-                config.enableState);
+          for (String partitionIdStr : config.partitionIds) {
+            PartitionId partitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
+            sendReplicationControlRequest(serverAdminTool, dataNodeId, partitionId, origins, config.enableState);
           }
         } else {
           LOGGER.info("No partition list provided. Requesting enable status for replication from {} to be set to {} on "
               + "all partitions", origins, config.enableState);
-          sendReplicationControlRequest(serverAdminTool, clusterMap, dataNodeId, null, origins, config.enableState);
+          sendReplicationControlRequest(serverAdminTool, dataNodeId, null, origins, config.enableState);
         }
         break;
       case CatchupStatus:
         if (config.partitionIds.length > 0 && !config.partitionIds[0].isEmpty()) {
-          for (String partitionId : config.partitionIds) {
+          for (String partitionIdStr : config.partitionIds) {
+            PartitionId partitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
             Pair<ServerErrorCode, Boolean> response =
-                serverAdminTool.isCaughtUp(dataNodeId, partitionId, config.acceptableLagInBytes, clusterMap);
+                serverAdminTool.isCaughtUp(dataNodeId, partitionId, config.acceptableLagInBytes);
             if (response.getFirst() == ServerErrorCode.No_Error) {
               LOGGER.info("Replicas are {} within {} for {}", response.getSecond() ? "" : "NOT",
                   config.acceptableLagInBytes, partitionId);
@@ -346,7 +348,7 @@ public class ServerAdminTool implements Closeable {
           }
         } else {
           Pair<ServerErrorCode, Boolean> response =
-              serverAdminTool.isCaughtUp(dataNodeId, null, config.acceptableLagInBytes, clusterMap);
+              serverAdminTool.isCaughtUp(dataNodeId, null, config.acceptableLagInBytes);
           if (response.getFirst() == ServerErrorCode.No_Error) {
             LOGGER.info("Replicas are {} within {} for all partitions", response.getSecond() ? "" : "NOT",
                 config.acceptableLagInBytes);
@@ -365,6 +367,33 @@ public class ServerAdminTool implements Closeable {
   }
 
   /**
+   * Gets the {@link PartitionId} in the {@code clusterMap} whose string representation matches {@code partitionIdStr}.
+   * @param partitionIdStr the string representation of the partition required.
+   * @param clusterMap the {@link ClusterMap} to use to list and process {@link PartitionId}s.
+   * @return the {@link PartitionId} in the {@code clusterMap} whose string repr matches {@code partitionIdStr}.
+   * {@code null} if {@code partitionIdStr} is {@code null}.
+   * @throws IllegalArgumentException if there is no @link PartitionId} in the {@code clusterMap} whose string repr
+   * matches {@code partitionIdStr}.
+   */
+  public static PartitionId getPartitionIdFromStr(String partitionIdStr, ClusterMap clusterMap) {
+    if (partitionIdStr == null) {
+      return null;
+    }
+    PartitionId targetPartitionId = null;
+    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds();
+    for (PartitionId partitionId : partitionIds) {
+      if (partitionId.isEqual(partitionIdStr)) {
+        targetPartitionId = partitionId;
+        break;
+      }
+    }
+    if (targetPartitionId == null) {
+      throw new IllegalArgumentException("Partition Id is not valid: [" + partitionIdStr + "]");
+    }
+    return targetPartitionId;
+  }
+
+  /**
    * Writes the content of {@code buffer} into {@link ServerAdminToolConfig#dataOutputFilePath}.
    * @param buffer the {@link ByteBuffer} whose content needs to be written.
    * @param outputFileStream the {@link FileOutputStream} to write to.
@@ -380,7 +409,6 @@ public class ServerAdminTool implements Closeable {
    * Sends a {@link RequestControlAdminRequest} to {@code dataNodeId} to set enable status of {@code toControl} to
    * {@code enable} for {@code partitionId}.
    * @param serverAdminTool the {@link ServerAdminTool} instance to use.
-   * @param clusterMap the {@link ClusterMap} to use.
    * @param dataNodeId the {@link DataNodeId} to send the request to.
    * @param partitionId the partition id (string) on which the operation will take place. Can be {@code null}.
    * @param toControl the {@link RequestOrResponseType} to control.
@@ -388,10 +416,9 @@ public class ServerAdminTool implements Closeable {
    * @throws IOException
    * @throws TimeoutException
    */
-  private static void sendRequestControlRequest(ServerAdminTool serverAdminTool, ClusterMap clusterMap,
-      DataNodeId dataNodeId, String partitionId, RequestOrResponseType toControl, boolean enable)
-      throws IOException, TimeoutException {
-    ServerErrorCode errorCode = serverAdminTool.controlRequest(dataNodeId, partitionId, toControl, enable, clusterMap);
+  private static void sendRequestControlRequest(ServerAdminTool serverAdminTool, DataNodeId dataNodeId,
+      PartitionId partitionId, RequestOrResponseType toControl, boolean enable) throws IOException, TimeoutException {
+    ServerErrorCode errorCode = serverAdminTool.controlRequest(dataNodeId, partitionId, toControl, enable);
     if (errorCode == ServerErrorCode.No_Error) {
       LOGGER.info("{} enable state has been set to {} for {} on {}", toControl, enable, partitionId, dataNodeId);
     } else {
@@ -404,19 +431,16 @@ public class ServerAdminTool implements Closeable {
    * Sends a {@link ReplicationControlAdminRequest} to {@code dataNodeId} to set enable status of replication from
    * {@code origins} to {@code enable} for {@code partitionId}.
    * @param serverAdminTool the {@link ServerAdminTool} instance to use.
-   * @param clusterMap the {@link ClusterMap} to use.
    * @param dataNodeId the {@link DataNodeId} to send the request to.
-   * @param partitionId the partition id (string) on which the operation will take place. Can be {@code null}.
+   * @param partitionId the partition id  on which the operation will take place. Can be {@code null}.
    * @param origins the names of the datacenters from which replication should be controlled.
    * @param enable the enable (or disable) status required for {@code toControl}.
    * @throws IOException
    * @throws TimeoutException
    */
-  private static void sendReplicationControlRequest(ServerAdminTool serverAdminTool, ClusterMap clusterMap,
-      DataNodeId dataNodeId, String partitionId, List<String> origins, boolean enable)
-      throws IOException, TimeoutException {
-    ServerErrorCode errorCode =
-        serverAdminTool.controlReplication(dataNodeId, partitionId, origins, enable, clusterMap);
+  private static void sendReplicationControlRequest(ServerAdminTool serverAdminTool, DataNodeId dataNodeId,
+      PartitionId partitionId, List<String> origins, boolean enable) throws IOException, TimeoutException {
+    ServerErrorCode errorCode = serverAdminTool.controlReplication(dataNodeId, partitionId, origins, enable);
     if (errorCode == ServerErrorCode.No_Error) {
       LOGGER.info("Enable state of replication from {} has been set to {} for {} on {}", origins, enable, partitionId,
           dataNodeId);
@@ -528,17 +552,16 @@ public class ServerAdminTool implements Closeable {
   /**
    * Triggers compaction on {@code dataNodeId} for the partition defined in {@code partitionIdStr}.
    * @param dataNodeId the {@link DataNodeId} to contact.
-   * @param partitionIdStr the String representation of the {@link PartitionId} to compact.
-   * @param clusterMap the {@link ClusterMap} to use.
+   * @param partitionId the {@link PartitionId} to compact.
    * @return the {@link ServerErrorCode} that is returned.
    * @throws IOException
    * @throws TimeoutException
    */
-  public ServerErrorCode triggerCompaction(DataNodeId dataNodeId, String partitionIdStr, ClusterMap clusterMap)
+  public ServerErrorCode triggerCompaction(DataNodeId dataNodeId, PartitionId partitionId)
       throws IOException, TimeoutException {
-    PartitionId targetPartitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
-    AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.TriggerCompaction, targetPartitionId,
-        correlationId.incrementAndGet(), CLIENT_ID);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.TriggerCompaction, partitionId, correlationId.incrementAndGet(),
+            CLIENT_ID);
     ByteBuffer responseBytes = sendRequestGetResponse(dataNodeId, adminRequest);
     AdminResponse adminResponse = AdminResponse.readFrom(new DataInputStream(new ByteBufferInputStream(responseBytes)));
     return adminResponse.getError();
@@ -548,19 +571,17 @@ public class ServerAdminTool implements Closeable {
    * Sends a {@link RequestControlAdminRequest} to set the enable state of {@code toControl} on {@code partitionIdStr}
    * to {@code enable} in {@code dataNodeId}.
    * @param dataNodeId the {@link DataNodeId} to contact.
-   * @param partitionIdStr the String representation of the {@link PartitionId} to compact. Can be {@code null}.
+   * @param partitionId the {@link PartitionId} to control requests to. Can be {@code null}.
    * @param toControl the {@link RequestOrResponseType} to control.
    * @param enable the enable (or disable) status required for {@code toControl}.
-   * @param clusterMap the {@link ClusterMap} to use.
    * @return the {@link ServerErrorCode} that is returned.
    * @throws IOException
    * @throws TimeoutException
    */
-  public ServerErrorCode controlRequest(DataNodeId dataNodeId, String partitionIdStr, RequestOrResponseType toControl,
-      boolean enable, ClusterMap clusterMap) throws IOException, TimeoutException {
-    PartitionId targetPartitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
+  public ServerErrorCode controlRequest(DataNodeId dataNodeId, PartitionId partitionId, RequestOrResponseType toControl,
+      boolean enable) throws IOException, TimeoutException {
     AdminRequest adminRequest =
-        new AdminRequest(AdminRequestOrResponseType.RequestControl, targetPartitionId, correlationId.incrementAndGet(),
+        new AdminRequest(AdminRequestOrResponseType.RequestControl, partitionId, correlationId.incrementAndGet(),
             CLIENT_ID);
     RequestControlAdminRequest controlRequest = new RequestControlAdminRequest(toControl, enable, adminRequest);
     ByteBuffer responseBytes = sendRequestGetResponse(dataNodeId, controlRequest);
@@ -569,22 +590,21 @@ public class ServerAdminTool implements Closeable {
   }
 
   /**
-   * Sends a {@link RequestControlAdminRequest} to enable/disable replication from {@code origins} for
+   * Sends a {@link ReplicationControlAdminRequest} to enable/disable replication from {@code origins} for
    * {@code partitionIdStr} in {@code dataNodeId}.
    * @param dataNodeId the {@link DataNodeId} to contact.
-   * @param partitionIdStr the String representation of the {@link PartitionId} to compact. Can be {@code null}.
+   * @param partitionId the {@link PartitionId} to control replication for. Can be {@code null}.
    * @param origins the names of the datacenters from which replication should be controlled.
    * @param enable the enable (or disable) status required for replication from {@code origins}.
-   * @param clusterMap the {@link ClusterMap} to use.
    * @return the {@link ServerErrorCode} that is returned.
    * @throws IOException
    * @throws TimeoutException
    */
-  public ServerErrorCode controlReplication(DataNodeId dataNodeId, String partitionIdStr, List<String> origins,
-      boolean enable, ClusterMap clusterMap) throws IOException, TimeoutException {
-    PartitionId targetPartitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
-    AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.ReplicationControl, targetPartitionId,
-        correlationId.incrementAndGet(), CLIENT_ID);
+  public ServerErrorCode controlReplication(DataNodeId dataNodeId, PartitionId partitionId, List<String> origins,
+      boolean enable) throws IOException, TimeoutException {
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.ReplicationControl, partitionId, correlationId.incrementAndGet(),
+            CLIENT_ID);
     ReplicationControlAdminRequest controlRequest = new ReplicationControlAdminRequest(origins, enable, adminRequest);
     ByteBuffer responseBytes = sendRequestGetResponse(dataNodeId, controlRequest);
     AdminResponse adminResponse = AdminResponse.readFrom(new DataInputStream(new ByteBufferInputStream(responseBytes)));
@@ -594,52 +614,24 @@ public class ServerAdminTool implements Closeable {
   /**
    * Sends a {@link CatchupStatusAdminRequest} for {@code partitionIdStr} to {@code dataNodeId}.
    * @param dataNodeId the {@link DataNodeId} to contact.
-   * @param partitionIdStr the String representation of the {@link PartitionId} to compact. If {@code null}, status is
-   *                       for all partitions on {@code dataNodeId}
+   * @param partitionId the {@link PartitionId} to check catchup status for. If {@code null}, status is for all
+   *                    partitions on {@code dataNodeId}
    * @param acceptableLagInBytes that lag in bytes that is considered OK.
-   * @param clusterMap the {@link ClusterMap} to use.
-   * @return the {@link ServerErrorCode} and the catchup status that is returned.
+   * @return the {@link ServerErrorCode} and the catchup status that is returned if the error code is
+   *          {@link ServerErrorCode#No_Error}, otherwise {@code false}.
    * @throws IOException
    * @throws TimeoutException
    */
-  public Pair<ServerErrorCode, Boolean> isCaughtUp(DataNodeId dataNodeId, String partitionIdStr,
-      long acceptableLagInBytes, ClusterMap clusterMap) throws IOException, TimeoutException {
-    PartitionId targetPartitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
+  public Pair<ServerErrorCode, Boolean> isCaughtUp(DataNodeId dataNodeId, PartitionId partitionId,
+      long acceptableLagInBytes) throws IOException, TimeoutException {
     AdminRequest adminRequest =
-        new AdminRequest(AdminRequestOrResponseType.CatchupStatus, targetPartitionId, correlationId.incrementAndGet(),
+        new AdminRequest(AdminRequestOrResponseType.CatchupStatus, partitionId, correlationId.incrementAndGet(),
             CLIENT_ID);
     CatchupStatusAdminRequest catchupStatusRequest = new CatchupStatusAdminRequest(acceptableLagInBytes, adminRequest);
     ByteBuffer responseBytes = sendRequestGetResponse(dataNodeId, catchupStatusRequest);
     CatchupStatusAdminResponse response =
         CatchupStatusAdminResponse.readFrom(new DataInputStream(new ByteBufferInputStream(responseBytes)));
-    return new Pair<>(response.getError(), response.isCaughtUp());
-  }
-
-  /**
-   * Gets the {@link PartitionId} in the {@code clusterMap} whose string representation matches {@code partitionIdStr}.
-   * @param partitionIdStr the string representation of the partition required.
-   * @param clusterMap the {@link ClusterMap} to use to list and process {@link PartitionId}s.
-   * @return the {@link PartitionId} in the {@code clusterMap} whose string repr matches {@code partitionIdStr}.
-   * {@code null} if {@code partitionIdStr} is {@code null}.
-   * @throws IllegalArgumentException if there is no @link PartitionId} in the {@code clusterMap} whose string repr
-   * matches {@code partitionIdStr}.
-   */
-  private PartitionId getPartitionIdFromStr(String partitionIdStr, ClusterMap clusterMap) {
-    if (partitionIdStr == null) {
-      return null;
-    }
-    PartitionId targetPartitionId = null;
-    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds();
-    for (PartitionId partitionId : partitionIds) {
-      if (partitionId.isEqual(partitionIdStr)) {
-        targetPartitionId = partitionId;
-        break;
-      }
-    }
-    if (targetPartitionId == null) {
-      throw new IllegalArgumentException("Partition Id is not valid: [" + partitionIdStr + "]");
-    }
-    return targetPartitionId;
+    return new Pair<>(response.getError(), response.getError() == ServerErrorCode.No_Error && response.isCaughtUp());
   }
 
   /**

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -58,6 +58,14 @@ public class Utils {
    * time).
    */
   public static final long Infinite_Time = -1;
+  /**
+   * The lowest possible port number.
+   */
+  public static final int MIN_PORT_NUM = 1;
+  /**
+   * The highest possible port number.
+   */
+  public static final int MAX_PORT_NUM = 65535;
   private static final Logger logger = LoggerFactory.getLogger(Utils.class);
 
   // The read*String methods assume that the underlying stream is blocking


### PR DESCRIPTION
This tool can be used when bringing storage nodes down for maintenance
that may affect data.

`ServerAdminTool` has been refactored a little to get rid of the requirement to provide the `ClusterMap` to some of its APIs. No new functionality or functions have been added.