### PR TITLE
Fix config hint

### DIFF
--- a/config/frontend.properties
+++ b/config/frontend.properties
@@ -27,7 +27,6 @@ clustermap.host.name=localhost
 
 # helix property store
 # helix.property.store.zk.client.connect.string=localhost:2182
-# helix.property.store.root.path=/ambry/Ambry_Dev/helixPropertyStore
 
 # frontend
 # frontend.account.service.factory=com.github.ambry.account.HelixAccountServiceFactory


### PR DESCRIPTION
There is no need to specify rootPath for helixPropertyStore. This path
will be automatically composed by taking the cluster name. This PR
removes the comment of root path config to avoid confusion.

Test: no need to test