### PR TITLE
Ensuring that the private blob properties matches that of the container

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -239,7 +239,7 @@ public class RestUtils {
       }
     }
 
-    return new BlobProperties(-1, serviceId, ownerId, contentType, isPrivate(args), ttl, account.getId(),
+    return new BlobProperties(-1, serviceId, ownerId, contentType, container.isPrivate(), ttl, account.getId(),
         container.getId());
   }
 

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -113,18 +113,15 @@ public class RestUtilsTest {
     tooManyValuesTest(headers, RestUtils.Headers.TTL);
     // no internal keys for account and container
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId, false,
-        false);
+    setAmbryHeadersForPut(headers, ttl, serviceId, null, contentType, ownerId, false);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InternalServerError);
     // no internal keys for account
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId, false,
-        true);
+    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId, false);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InternalServerError);
     // no internal keys for container
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId, true,
-        false);
+    setAmbryHeadersForPut(headers, ttl, serviceId, null, contentType, ownerId, true);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InternalServerError);
 
     // no failures.
@@ -728,11 +725,10 @@ public class RestUtilsTest {
    * @param contentType sets the {@link RestUtils.Headers#AMBRY_CONTENT_TYPE} header.
    * @param ownerId sets the {@link RestUtils.Headers#OWNER_ID} header. Optional - if not required, send null.
    * @param insertAccount {@code true} if {@link Account} info has to be injected into the headers.
-   * @param insertContainer {@code true} if {@link Container} info has to be injected into the headers.
    * @throws JSONException
    */
   private void setAmbryHeadersForPut(JSONObject headers, String ttlInSecs, String serviceId, Container container,
-      String contentType, String ownerId, boolean insertAccount, boolean insertContainer) throws JSONException {
+      String contentType, String ownerId, boolean insertAccount) throws JSONException {
     headers.putOpt(RestUtils.Headers.TTL, ttlInSecs);
     headers.putOpt(RestUtils.Headers.SERVICE_ID, serviceId);
     headers.putOpt(RestUtils.Headers.AMBRY_CONTENT_TYPE, contentType);
@@ -740,7 +736,7 @@ public class RestUtilsTest {
     if (insertAccount) {
       headers.putOpt(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY, Account.UNKNOWN_ACCOUNT);
     }
-    if (insertContainer) {
+    if (container != null) {
       headers.putOpt(RestUtils.InternalKeys.TARGET_CONTAINER_KEY, container);
     }
   }
@@ -758,7 +754,7 @@ public class RestUtilsTest {
    */
   private void setAmbryHeadersForPut(JSONObject headers, String ttlInSecs, String serviceId, Container container,
       String contentType, String ownerId) throws JSONException {
-    setAmbryHeadersForPut(headers, ttlInSecs, serviceId, container, contentType, ownerId, true, true);
+    setAmbryHeadersForPut(headers, ttlInSecs, serviceId, container, contentType, ownerId, true);
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -724,6 +724,7 @@ public class RestUtilsTest {
    * @param headers the {@link JSONObject} where the headers should be set.
    * @param ttlInSecs sets the {@link RestUtils.Headers#TTL} header.
    * @param serviceId sets the {@link RestUtils.Headers#SERVICE_ID} header.
+   * @param container used to set the container for {@link RestUtils.InternalKeys#TARGET_CONTAINER_KEY}.
    * @param contentType sets the {@link RestUtils.Headers#AMBRY_CONTENT_TYPE} header.
    * @param ownerId sets the {@link RestUtils.Headers#OWNER_ID} header. Optional - if not required, send null.
    * @param insertAccount {@code true} if {@link Account} info has to be injected into the headers.
@@ -750,6 +751,7 @@ public class RestUtilsTest {
    * @param headers the {@link JSONObject} where the headers should be set.
    * @param ttlInSecs sets the {@link RestUtils.Headers#TTL} header.
    * @param serviceId sets the {@link RestUtils.Headers#SERVICE_ID} header.
+   * @param container used to set the container for {@link RestUtils.InternalKeys#TARGET_CONTAINER_KEY}.
    * @param contentType sets the {@link RestUtils.Headers#AMBRY_CONTENT_TYPE} header.
    * @param ownerId sets the {@link RestUtils.Headers#OWNER_ID} header. Optional - if not required, send null.
    * @throws JSONException

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -22,6 +22,7 @@ import com.github.ambry.router.GetBlobOptions;
 import com.github.ambry.utils.Crc32;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
@@ -30,10 +31,12 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.TimeZone;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -56,9 +59,12 @@ public class RestUtilsTest {
   @Test
   public void getBlobPropertiesGoodInputTest() throws Exception {
     JSONObject headers = new JSONObject();
-    setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), Boolean.toString(RANDOM.nextBoolean()),
-        generateRandomString(10), "image/gif", generateRandomString(10));
-    verifyBlobPropertiesConstructionSuccess(headers);
+    Container[] containers = {Container.DEFAULT_PRIVATE_CONTAINER, Container.DEFAULT_PUBLIC_CONTAINER};
+    for (Container container : containers) {
+      setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), generateRandomString(10), container,
+          "image/gif", generateRandomString(10));
+      verifyBlobPropertiesConstructionSuccess(headers);
+    }
   }
 
   /**
@@ -69,7 +75,6 @@ public class RestUtilsTest {
   @Test
   public void getBlobPropertiesVariedInputTest() throws Exception {
     String ttl = Long.toString(RANDOM.nextInt(10000));
-    String isPrivate = Boolean.toString(RANDOM.nextBoolean());
     String serviceId = generateRandomString(10);
     String contentType = "image/gif";
     String ownerId = generateRandomString(10);
@@ -78,89 +83,157 @@ public class RestUtilsTest {
     // failure required.
     // ttl not a number.
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, "NaN", isPrivate, serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, "NaN", serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
     // ttl < -1.
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, "-2", isPrivate, serviceId, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
-    // isPrivate not true or false.
-    headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, "!(true||false)", serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, "-2", serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
     // serviceId missing.
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, null, contentType, ownerId);
+    setAmbryHeadersForPut(headers, ttl, null, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.MissingArgs);
     // serviceId null.
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, null, contentType, ownerId);
+    setAmbryHeadersForPut(headers, ttl, null, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId);
     headers.put(RestUtils.Headers.SERVICE_ID, JSONObject.NULL);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
     // contentType missing.
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, null, ownerId);
+    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, null, ownerId);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.MissingArgs);
     // contentType null.
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, null, ownerId);
+    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, null, ownerId);
     headers.put(RestUtils.Headers.AMBRY_CONTENT_TYPE, JSONObject.NULL);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
     // too many values for some headers.
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId);
     tooManyValuesTest(headers, RestUtils.Headers.TTL);
-    tooManyValuesTest(headers, RestUtils.Headers.PRIVATE);
     // no internal keys for account and container
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, false, false, RestServiceErrorCode.InternalServerError);
+    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId, false,
+        false);
+    verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InternalServerError);
     // no internal keys for account
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, false, true, RestServiceErrorCode.InternalServerError);
+    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId, false,
+        true);
+    verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InternalServerError);
     // no internal keys for container
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, true, false, RestServiceErrorCode.InternalServerError);
+    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId, true,
+        false);
+    verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InternalServerError);
 
     // no failures.
     // ttl missing. Should be infinite time by default.
-    // isPrivate missing. Should be false by default.
     // ownerId missing.
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, null, null, serviceId, contentType, null);
+    setAmbryHeadersForPut(headers, null, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, null);
     verifyBlobPropertiesConstructionSuccess(headers);
 
     // ttl null.
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, null, isPrivate, serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, null, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId);
     headers.put(RestUtils.Headers.TTL, JSONObject.NULL);
-    verifyBlobPropertiesConstructionSuccess(headers);
-
-    // isPrivate null.
-    headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, ownerId);
-    headers.put(RestUtils.Headers.PRIVATE, JSONObject.NULL);
     verifyBlobPropertiesConstructionSuccess(headers);
 
     // ownerId null.
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, null);
+    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, null);
     headers.put(RestUtils.Headers.OWNER_ID, JSONObject.NULL);
     verifyBlobPropertiesConstructionSuccess(headers);
 
     // blobSize null (should be ignored)
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, null);
+    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId);
     headers.put(RestUtils.Headers.BLOB_SIZE, JSONObject.NULL);
     verifyBlobPropertiesConstructionSuccess(headers);
 
     // blobSize negative (should succeed)
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, ttl, isPrivate, serviceId, contentType, null);
+    setAmbryHeadersForPut(headers, ttl, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId);
     headers.put(RestUtils.Headers.BLOB_SIZE, -1);
     verifyBlobPropertiesConstructionSuccess(headers);
+  }
+
+  /**
+   * Tests for {@link RestUtils#isPrivate(Map)}
+   * @throws Exception
+   */
+  @Test
+  public void isPrivateTest() throws Exception {
+    String serviceId = generateRandomString(10);
+    String contentType = "image/gif";
+    JSONObject headers = new JSONObject();
+    // using this just to help with setting the other necessary headers - doesn't matter what the container is, the
+    // PRIVATE header won't have been set.
+    setAmbryHeadersForPut(headers, null, serviceId, Container.DEFAULT_PRIVATE_CONTAINER, contentType, null);
+
+    // isPrivate not true or false.
+    headers.put(RestUtils.Headers.PRIVATE, "!(true || false)");
+    RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
+    try {
+      RestUtils.isPrivate(restRequest.getArgs());
+      fail("An exception was expected but none were thrown");
+    } catch (RestServiceException e) {
+      assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.InvalidArgs, e.getErrorCode());
+    }
+
+    // isPrivate null.
+    headers.put(RestUtils.Headers.PRIVATE, JSONObject.NULL);
+    restRequest = createRestRequest(RestMethod.POST, "/", headers);
+    assertFalse("isPrivate should be false because it was not set", RestUtils.isPrivate(restRequest.getArgs()));
+
+    // isPrivate false
+    headers.put(RestUtils.Headers.PRIVATE, "false");
+    restRequest = createRestRequest(RestMethod.POST, "/", headers);
+    assertFalse("isPrivate should be false because it was set to false", RestUtils.isPrivate(restRequest.getArgs()));
+
+    // isPrivate true
+    headers.put(RestUtils.Headers.PRIVATE, "true");
+    restRequest = createRestRequest(RestMethod.POST, "/", headers);
+    assertTrue("isPrivate should be true because it was set to true", RestUtils.isPrivate(restRequest.getArgs()));
+  }
+
+  /**
+   * Tests for {@link RestUtils#ensureRequiredHeadersOrThrow(RestRequest, Set)}.
+   * @throws Exception
+   */
+  @Test
+  public void ensureRequiredHeadersOrThrowTest() throws Exception {
+    JSONObject headers = new JSONObject();
+    Set<String> requiredHeaders = new HashSet<>(Arrays.asList("required_a", "required_b", "required_c"));
+    for (String requiredHeader : requiredHeaders) {
+      headers.put(requiredHeader, UtilsTest.getRandomString(10));
+    }
+    headers.put(UtilsTest.getRandomString(10), UtilsTest.getRandomString(10));
+
+    // success test
+    RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
+    RestUtils.ensureRequiredHeadersOrThrow(restRequest, requiredHeaders);
+
+    // failure test
+    // null
+    headers.put(requiredHeaders.iterator().next(), JSONObject.NULL);
+    restRequest = createRestRequest(RestMethod.POST, "/", headers);
+    try {
+      RestUtils.ensureRequiredHeadersOrThrow(restRequest, requiredHeaders);
+      fail("Should have failed because one of the required headers has a bad value");
+    } catch (RestServiceException e) {
+      assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.InvalidArgs, e.getErrorCode());
+    }
+    // not present
+    headers.remove(requiredHeaders.iterator().next());
+    restRequest = createRestRequest(RestMethod.POST, "/", headers);
+    try {
+      RestUtils.ensureRequiredHeadersOrThrow(restRequest, requiredHeaders);
+      fail("Should have failed because one of the required headers is not present");
+    } catch (RestServiceException e) {
+      assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.MissingArgs, e.getErrorCode());
+    }
   }
 
   /**
@@ -180,8 +253,8 @@ public class RestUtilsTest {
   @Test
   public void getUserMetadataGoodInputTest() throws Exception {
     JSONObject headers = new JSONObject();
-    setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), Boolean.toString(RANDOM.nextBoolean()),
-        generateRandomString(10), "image/gif", generateRandomString(10));
+    setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), generateRandomString(10),
+        Container.DEFAULT_PUBLIC_CONTAINER, "image/gif", generateRandomString(10));
     Map<String, String> userMetadata = new HashMap<String, String>();
     userMetadata.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key1", "value1");
     userMetadata.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key2", "value2");
@@ -212,8 +285,8 @@ public class RestUtilsTest {
   @Test
   public void getUserMetadataUnusualInputTest() throws Exception {
     JSONObject headers = new JSONObject();
-    setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), Boolean.toString(RANDOM.nextBoolean()),
-        generateRandomString(10), "image/gif", generateRandomString(10));
+    setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), generateRandomString(10),
+        Container.DEFAULT_PUBLIC_CONTAINER, "image/gif", generateRandomString(10));
     Map<String, String> userMetadata = new HashMap<String, String>();
     String key1 = RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key1";
     userMetadata.put(key1, "value1");
@@ -249,8 +322,8 @@ public class RestUtilsTest {
   @Test
   public void getEmptyUserMetadataInputTest() throws Exception {
     JSONObject headers = new JSONObject();
-    setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), Boolean.toString(RANDOM.nextBoolean()),
-        generateRandomString(10), "image/gif", generateRandomString(10));
+    setAmbryHeadersForPut(headers, Long.toString(RANDOM.nextInt(10000)), generateRandomString(10),
+        Container.DEFAULT_PUBLIC_CONTAINER, "image/gif", generateRandomString(10));
     Map<String, String> userMetadata = new HashMap<String, String>();
     setUserMetadataHeaders(headers, userMetadata);
 
@@ -650,19 +723,40 @@ public class RestUtilsTest {
    * Any other headers have to be set explicitly.
    * @param headers the {@link JSONObject} where the headers should be set.
    * @param ttlInSecs sets the {@link RestUtils.Headers#TTL} header.
-   * @param isPrivate sets the {@link RestUtils.Headers#PRIVATE} header. Allowed values: true, false.
+   * @param serviceId sets the {@link RestUtils.Headers#SERVICE_ID} header.
+   * @param contentType sets the {@link RestUtils.Headers#AMBRY_CONTENT_TYPE} header.
+   * @param ownerId sets the {@link RestUtils.Headers#OWNER_ID} header. Optional - if not required, send null.
+   * @param insertAccount {@code true} if {@link Account} info has to be injected into the headers.
+   * @param insertContainer {@code true} if {@link Container} info has to be injected into the headers.
+   * @throws JSONException
+   */
+  private void setAmbryHeadersForPut(JSONObject headers, String ttlInSecs, String serviceId, Container container,
+      String contentType, String ownerId, boolean insertAccount, boolean insertContainer) throws JSONException {
+    headers.putOpt(RestUtils.Headers.TTL, ttlInSecs);
+    headers.putOpt(RestUtils.Headers.SERVICE_ID, serviceId);
+    headers.putOpt(RestUtils.Headers.AMBRY_CONTENT_TYPE, contentType);
+    headers.putOpt(RestUtils.Headers.OWNER_ID, ownerId);
+    if (insertAccount) {
+      headers.putOpt(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY, Account.UNKNOWN_ACCOUNT);
+    }
+    if (insertContainer) {
+      headers.putOpt(RestUtils.InternalKeys.TARGET_CONTAINER_KEY, container);
+    }
+  }
+
+  /**
+   * Sets headers that helps build {@link BlobProperties} on the server. See argument list for the headers that are set.
+   * Any other headers have to be set explicitly.
+   * @param headers the {@link JSONObject} where the headers should be set.
+   * @param ttlInSecs sets the {@link RestUtils.Headers#TTL} header.
    * @param serviceId sets the {@link RestUtils.Headers#SERVICE_ID} header.
    * @param contentType sets the {@link RestUtils.Headers#AMBRY_CONTENT_TYPE} header.
    * @param ownerId sets the {@link RestUtils.Headers#OWNER_ID} header. Optional - if not required, send null.
    * @throws JSONException
    */
-  private void setAmbryHeadersForPut(JSONObject headers, String ttlInSecs, String isPrivate, String serviceId,
+  private void setAmbryHeadersForPut(JSONObject headers, String ttlInSecs, String serviceId, Container container,
       String contentType, String ownerId) throws JSONException {
-    headers.putOpt(RestUtils.Headers.TTL, ttlInSecs);
-    headers.putOpt(RestUtils.Headers.PRIVATE, isPrivate);
-    headers.putOpt(RestUtils.Headers.SERVICE_ID, serviceId);
-    headers.putOpt(RestUtils.Headers.AMBRY_CONTENT_TYPE, contentType);
-    headers.putOpt(RestUtils.Headers.OWNER_ID, ownerId);
+    setAmbryHeadersForPut(headers, ttlInSecs, serviceId, container, contentType, ownerId, true, true);
   }
 
   /**
@@ -673,19 +767,17 @@ public class RestUtilsTest {
    */
   private void verifyBlobPropertiesConstructionSuccess(JSONObject headers) throws Exception {
     RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
-    restRequest.setArg(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY, Account.UNKNOWN_ACCOUNT);
-    restRequest.setArg(RestUtils.InternalKeys.TARGET_CONTAINER_KEY, Container.UNKNOWN_CONTAINER);
+    Account account = (Account) headers.get(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY);
+    Container container = (Container) headers.get(RestUtils.InternalKeys.TARGET_CONTAINER_KEY);
+    restRequest.setArg(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY, account);
+    restRequest.setArg(RestUtils.InternalKeys.TARGET_CONTAINER_KEY, container);
     BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
     long expectedTTL = Utils.Infinite_Time;
     if (headers.has(RestUtils.Headers.TTL) && !JSONObject.NULL.equals(headers.get(RestUtils.Headers.TTL))) {
       expectedTTL = headers.getLong(RestUtils.Headers.TTL);
     }
     assertEquals("Blob TTL does not match", expectedTTL, blobProperties.getTimeToLiveInSeconds());
-    boolean expectedIsPrivate = false;
-    if (headers.has(RestUtils.Headers.PRIVATE) && !JSONObject.NULL.equals(headers.get(RestUtils.Headers.PRIVATE))) {
-      expectedIsPrivate = headers.getBoolean(RestUtils.Headers.PRIVATE);
-    }
-    assertEquals("Blob isPrivate does not match", expectedIsPrivate, blobProperties.isPrivate());
+    assertEquals("Blob isPrivate does not match", container.isPrivate(), blobProperties.isPrivate());
     assertEquals("Blob service ID does not match", headers.getString(RestUtils.Headers.SERVICE_ID),
         blobProperties.getServiceId());
     assertEquals("Blob content type does not match", headers.getString(RestUtils.Headers.AMBRY_CONTENT_TYPE),
@@ -694,8 +786,8 @@ public class RestUtilsTest {
       assertEquals("Blob owner ID does not match", headers.getString(RestUtils.Headers.OWNER_ID),
           blobProperties.getOwnerId());
     }
-    assertEquals("Target account id does not match", Account.UNKNOWN_ACCOUNT_ID, blobProperties.getAccountId());
-    assertEquals("Target container id does not match", Container.UNKNOWN_CONTAINER_ID, blobProperties.getContainerId());
+    assertEquals("Target account id does not match", account.getId(), blobProperties.getAccountId());
+    assertEquals("Target container id does not match", container.getId(), blobProperties.getContainerId());
   }
 
   /**
@@ -732,33 +824,8 @@ public class RestUtilsTest {
    */
   private void verifyBlobPropertiesConstructionFailure(JSONObject headers, RestServiceErrorCode expectedCode)
       throws JSONException, UnsupportedEncodingException, URISyntaxException {
-    verifyBlobPropertiesConstructionFailure(headers, true, true, expectedCode);
-  }
-
-  /**
-   * Verifies that {@link RestUtils#buildBlobProperties(Map<String,Object>)} fails if given a request with bad
-   * arguments.
-   * @param headers the headers that were provided to the request.
-   * @param shouldInsertAccount {@code true} to insert {@link Account#UNKNOWN_ACCOUNT} object into the {@link RestRequest},
-   *                                        {@code false} otherwise.
-   * @param shouldInsertContainer {@code true} to insert {@link Container#UNKNOWN_CONTAINER} object into the {@link RestRequest},
-   *                                        {@code false} otherwise.
-   * @param expectedCode the expected {@link RestServiceErrorCode} because of the failure.
-   * @throws JSONException
-   * @throws UnsupportedEncodingException
-   * @throws URISyntaxException
-   */
-  private void verifyBlobPropertiesConstructionFailure(JSONObject headers, boolean shouldInsertAccount,
-      boolean shouldInsertContainer, RestServiceErrorCode expectedCode)
-      throws JSONException, UnsupportedEncodingException, URISyntaxException {
+    RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
     try {
-      RestRequest restRequest = createRestRequest(RestMethod.POST, "/", headers);
-      if (shouldInsertAccount) {
-        restRequest.setArg(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY, Account.UNKNOWN_ACCOUNT);
-      }
-      if (shouldInsertContainer) {
-        restRequest.setArg(RestUtils.InternalKeys.TARGET_CONTAINER_KEY, Container.UNKNOWN_CONTAINER);
-      }
       RestUtils.buildBlobProperties(restRequest.getArgs());
       fail("An exception was expected but none were thrown");
     } catch (RestServiceException e) {

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -404,47 +404,19 @@ public class AmbryBlobStorageServiceTest {
    */
   @Test
   public void postGetHeadDeleteTest() throws Exception {
-    final int CONTENT_LENGTH = 1024;
-    ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(CONTENT_LENGTH));
-    String serviceId = "postGetHeadDeleteServiceID";
-    String contentType = "application/octet-stream";
-    String ownerId = "postGetHeadDeleteOwnerID";
-    JSONObject headers = new JSONObject();
-    setAmbryHeadersForPut(headers, 7200, false, serviceId, contentType, ownerId, refAccount.getName(),
-        refContainer.getName());
-    Map<String, String> userMetadata = new HashMap<>();
-    userMetadata.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key1", "value1");
-    userMetadata.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key2", "value2");
-    RestUtilsTest.setUserMetadataHeaders(headers, userMetadata);
-    String blobId = postBlobAndVerify(headers, content, refAccount, refContainer);
-
-    headers.put(RestUtils.Headers.BLOB_SIZE, (long) CONTENT_LENGTH);
-    getBlobAndVerify(blobId, null, null, headers, content, refAccount, refContainer);
-    getBlobAndVerify(blobId, null, GetOption.None, headers, content, refAccount, refContainer);
-    getHeadAndVerify(blobId, null, null, headers);
-    getHeadAndVerify(blobId, null, GetOption.None, headers);
-
-    ByteRange range = ByteRange.fromStartOffset(ThreadLocalRandom.current().nextLong(CONTENT_LENGTH));
-    getBlobAndVerify(blobId, range, null, headers, content, refAccount, refContainer);
-    getHeadAndVerify(blobId, range, null, headers);
-
-    range = ByteRange.fromLastNBytes(ThreadLocalRandom.current().nextLong(CONTENT_LENGTH + 1));
-    getBlobAndVerify(blobId, range, null, headers, content, refAccount, refContainer);
-    getHeadAndVerify(blobId, range, null, headers);
-
-    long random1 = ThreadLocalRandom.current().nextLong(CONTENT_LENGTH);
-    long random2 = ThreadLocalRandom.current().nextLong(CONTENT_LENGTH);
-    range = ByteRange.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2));
-    getBlobAndVerify(blobId, range, null, headers, content, refAccount, refContainer);
-    getHeadAndVerify(blobId, range, null, headers);
-
-    getNotModifiedBlobAndVerify(blobId, null);
-    getUserMetadataAndVerify(blobId, null, headers);
-    getBlobInfoAndVerify(blobId, null, headers);
-    deleteBlobAndVerify(blobId);
-
-    // check GET, HEAD and DELETE after delete.
-    verifyOperationsAfterDelete(blobId, headers, content);
+    // valid account and container names passed as part of POST
+    for (Container container : refAccount.getAllContainers()) {
+      doPostGetHeadDeleteTest(refAccount, container, refAccount.getName(), container.isPrivate(), refAccount,
+          container);
+    }
+    // valid account and container names but only serviceId passed as part of POST
+    doPostGetHeadDeleteTest(null, null, refAccount.getName(), false, refAccount, refDefaultPublicContainer);
+    doPostGetHeadDeleteTest(null, null, refAccount.getName(), true, refAccount, refDefaultPrivateContainer);
+    // unrecognized serviceId
+    doPostGetHeadDeleteTest(null, null, "unknown_service_id", false, Account.UNKNOWN_ACCOUNT,
+        Container.DEFAULT_PUBLIC_CONTAINER);
+    doPostGetHeadDeleteTest(null, null, "unknown_service_id", true, Account.UNKNOWN_ACCOUNT,
+        Container.DEFAULT_PRIVATE_CONTAINER);
   }
 
   /**
@@ -483,10 +455,10 @@ public class AmbryBlobStorageServiceTest {
    */
   @Test
   public void injectionAccountAndContainerForPutTest() throws Exception {
-    injectAccountAndContainerForPutAndVerify(true, true);
-    injectAccountAndContainerForPutAndVerify(true, false);
-    injectAccountAndContainerForPutAndVerify(false, true);
-    injectAccountAndContainerForPutAndVerify(false, false);
+    injectAccountAndContainerForPutAndVerify(refDefaultPrivateContainer, true);
+    injectAccountAndContainerForPutAndVerify(refDefaultPrivateContainer, false);
+    injectAccountAndContainerForPutAndVerify(refDefaultPublicContainer, true);
+    injectAccountAndContainerForPutAndVerify(refDefaultPublicContainer, false);
   }
 
   /**
@@ -591,8 +563,8 @@ public class AmbryBlobStorageServiceTest {
     accountService = new FrontendTestAccountService(true);
     ambryBlobStorageService = getAmbryBlobStorageService();
     ambryBlobStorageService.start();
-    postBlobAndVerifyWithAccountAndContainer(refAccount.getName(), refContainer.getName(), "serviceId", false, null,
-        null, RestServiceErrorCode.InternalServerError);
+    postBlobAndVerifyWithAccountAndContainer(refAccount.getName(), refContainer.getName(), "serviceId",
+        refContainer.isPrivate(), null, null, RestServiceErrorCode.InternalServerError);
   }
 
   /**
@@ -1000,8 +972,8 @@ public class AmbryBlobStorageServiceTest {
           break;
         case POST:
           JSONObject headers = new JSONObject();
-          setAmbryHeadersForPut(headers, Utils.Infinite_Time, false, "test-serviceID", "text/plain", "test-ownerId",
-              refAccount.getName(), refContainer.getName());
+          setAmbryHeadersForPut(headers, Utils.Infinite_Time, refContainer.isPrivate(), "test-serviceID", "text/plain",
+              "test-ownerId", refAccount.getName(), refContainer.getName());
           restRequest = createRestRequest(restMethod, "/", headers, null);
           doOperation(restRequest, restResponseChannel);
           fail("POST should have detected a RestServiceException because of a bad router");
@@ -1015,6 +987,62 @@ public class AmbryBlobStorageServiceTest {
   }
 
   // postGetHeadDeleteTest() helpers
+
+  /**
+   * Tests blob POST, GET, HEAD and DELETE operations on the given {@code container}.
+   * @param toPostAccount the {@link Account} to use in post headers. Can be {@code null} if only using service ID.
+   * @param toPostContainer the {@link Container} to use in post headers. Can be {@code null} if only using service ID.
+   * @param serviceId the serviceId to use for the POST
+   * @param isPrivate the isPrivate flag to pass as part of the POST
+   * @param expectedAccount the {@link Account} details that are eventually expected to be populated.
+   * @param expectedContainer the {@link Container} details that are eventually expected to be populated.
+   * @throws Exception
+   */
+  private void doPostGetHeadDeleteTest(Account toPostAccount, Container toPostContainer, String serviceId,
+      boolean isPrivate, Account expectedAccount, Container expectedContainer) throws Exception {
+    final int CONTENT_LENGTH = 1024;
+    ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(CONTENT_LENGTH));
+    String contentType = "application/octet-stream";
+    String ownerId = "postGetHeadDeleteOwnerID";
+    JSONObject headers = new JSONObject();
+    String accountNameInPost = toPostAccount != null ? toPostAccount.getName() : null;
+    String containerNameInPost = toPostContainer != null ? toPostContainer.getName() : null;
+    setAmbryHeadersForPut(headers, 7200, isPrivate, serviceId, contentType, ownerId, accountNameInPost,
+        containerNameInPost);
+    Map<String, String> userMetadata = new HashMap<>();
+    userMetadata.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key1", "value1");
+    userMetadata.put(RestUtils.Headers.USER_META_DATA_HEADER_PREFIX + "key2", "value2");
+    RestUtilsTest.setUserMetadataHeaders(headers, userMetadata);
+    String blobId = postBlobAndVerify(headers, content, expectedAccount, expectedContainer);
+
+    headers.put(RestUtils.Headers.BLOB_SIZE, (long) CONTENT_LENGTH);
+    getBlobAndVerify(blobId, null, null, headers, content, expectedAccount, expectedContainer);
+    getBlobAndVerify(blobId, null, GetOption.None, headers, content, expectedAccount, expectedContainer);
+    getHeadAndVerify(blobId, null, null, headers);
+    getHeadAndVerify(blobId, null, GetOption.None, headers);
+
+    ByteRange range = ByteRange.fromStartOffset(ThreadLocalRandom.current().nextLong(CONTENT_LENGTH));
+    getBlobAndVerify(blobId, range, null, headers, content, expectedAccount, expectedContainer);
+    getHeadAndVerify(blobId, range, null, headers);
+
+    range = ByteRange.fromLastNBytes(ThreadLocalRandom.current().nextLong(CONTENT_LENGTH + 1));
+    getBlobAndVerify(blobId, range, null, headers, content, expectedAccount, expectedContainer);
+    getHeadAndVerify(blobId, range, null, headers);
+
+    long random1 = ThreadLocalRandom.current().nextLong(CONTENT_LENGTH);
+    long random2 = ThreadLocalRandom.current().nextLong(CONTENT_LENGTH);
+    range = ByteRange.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2));
+    getBlobAndVerify(blobId, range, null, headers, content, expectedAccount, expectedContainer);
+    getHeadAndVerify(blobId, range, null, headers);
+
+    getNotModifiedBlobAndVerify(blobId, null);
+    getUserMetadataAndVerify(blobId, null, headers);
+    getBlobInfoAndVerify(blobId, null, headers);
+    deleteBlobAndVerify(blobId);
+
+    // check GET, HEAD and DELETE after delete.
+    verifyOperationsAfterDelete(blobId, headers, content, expectedAccount, expectedContainer);
+  }
 
   /**
    * Posts a blob with the given {@code headers} and {@code content}.
@@ -1283,10 +1311,12 @@ public class AmbryBlobStorageServiceTest {
    * @param blobId the ID of the blob that was deleted.
    * @param expectedHeaders the expected headers in the response if the right options are provided.
    * @param expectedContent the expected content of the blob if the right options are provided.
+   * @param expectedAccount the {@link Account} details that are eventually expected to be populated.
+   * @param expectedContainer the {@link Container} details that are eventually expected to be populated.
    * @throws Exception
    */
-  private void verifyOperationsAfterDelete(String blobId, JSONObject expectedHeaders, ByteBuffer expectedContent)
-      throws Exception {
+  private void verifyOperationsAfterDelete(String blobId, JSONObject expectedHeaders, ByteBuffer expectedContent,
+      Account expectedAccount, Container expectedContainer) throws Exception {
     RestRequest restRequest = createRestRequest(RestMethod.GET, blobId, null, null);
     verifyGone(restRequest);
 
@@ -1298,7 +1328,7 @@ public class AmbryBlobStorageServiceTest {
 
     GetOption[] options = {GetOption.Include_Deleted_Blobs, GetOption.Include_All};
     for (GetOption option : options) {
-      getBlobAndVerify(blobId, null, option, expectedHeaders, expectedContent, refAccount, refContainer);
+      getBlobAndVerify(blobId, null, option, expectedHeaders, expectedContent, expectedAccount, expectedContainer);
       getNotModifiedBlobAndVerify(blobId, option);
       getUserMetadataAndVerify(blobId, option, expectedHeaders);
       getBlobInfoAndVerify(blobId, option, expectedHeaders);
@@ -1401,8 +1431,8 @@ public class AmbryBlobStorageServiceTest {
       JSONObject headers = new JSONObject();
       List<ByteBuffer> contents = null;
       if (restMethod.equals(RestMethod.POST)) {
-        setAmbryHeadersForPut(headers, 7200, false, "doExternalServicesBadInputTest", "application/octet-stream",
-            "doExternalServicesBadInputTest", refAccount.getName(), refContainer.getName());
+        setAmbryHeadersForPut(headers, 7200, refContainer.isPrivate(), "doExternalServicesBadInputTest",
+            "application/octet-stream", "doExternalServicesBadInputTest", refAccount.getName(), refContainer.getName());
         contents = new ArrayList<>(1);
         contents.add(null);
       }
@@ -1444,8 +1474,8 @@ public class AmbryBlobStorageServiceTest {
         case POST:
           testRouter.exceptionOpType = FrontendTestRouter.OpType.PutBlob;
           JSONObject headers = new JSONObject();
-          setAmbryHeadersForPut(headers, 7200, false, "routerExceptionPipelineTest", "application/octet-stream",
-              "routerExceptionPipelineTest", refAccount.getName(), refContainer.getName());
+          setAmbryHeadersForPut(headers, 7200, refContainer.isPrivate(), "routerExceptionPipelineTest",
+              "application/octet-stream", "routerExceptionPipelineTest", refAccount.getName(), refContainer.getName());
           checkRouterExceptionPipeline(exceptionMsg, createRestRequest(restMethod, "/", headers, null));
           break;
         case DELETE:
@@ -1602,12 +1632,12 @@ public class AmbryBlobStorageServiceTest {
 
   /**
    * Puts blobs and verify injected target {@link Account} and {@link Container}.
-   * @param isPrivate {@code true} to put private blobs, otherwise public blobs.
+   * @param container the {@link Container} to use.
    * @param shouldAllowServiceIdBasedPut {@code true} if PUT requests with serviceId parsed as {@link Account} name is
    *                                                 allowed; {@code false} otherwise.
    * @throws Exception
    */
-  private void injectAccountAndContainerForPutAndVerify(boolean isPrivate, boolean shouldAllowServiceIdBasedPut)
+  private void injectAccountAndContainerForPutAndVerify(Container container, boolean shouldAllowServiceIdBasedPut)
       throws Exception {
     configProps.setProperty("frontend.allow.service.id.based.post.request",
         String.valueOf(shouldAllowServiceIdBasedPut));
@@ -1618,109 +1648,109 @@ public class AmbryBlobStorageServiceTest {
     populateAccountService();
 
     // should succeed when serviceId-based PUT requests are allowed.
-    postBlobAndVerifyWithAccountAndContainer(null, null, "serviceId", isPrivate,
+    postBlobAndVerifyWithAccountAndContainer(null, null, "serviceId", container.isPrivate(),
         shouldAllowServiceIdBasedPut ? Account.UNKNOWN_ACCOUNT : null,
-        shouldAllowServiceIdBasedPut ? (isPrivate ? Container.DEFAULT_PRIVATE_CONTAINER
+        shouldAllowServiceIdBasedPut ? (container.isPrivate() ? Container.DEFAULT_PRIVATE_CONTAINER
             : Container.DEFAULT_PUBLIC_CONTAINER) : null,
         shouldAllowServiceIdBasedPut ? null : RestServiceErrorCode.BadRequest);
 
     // should fail, because accountName needs to be specified.
-    postBlobAndVerifyWithAccountAndContainer(null, "dummyContainerName", "serviceId", isPrivate, null, null,
+    postBlobAndVerifyWithAccountAndContainer(null, "dummyContainerName", "serviceId", container.isPrivate(), null, null,
         RestServiceErrorCode.MissingArgs);
 
     // should fail, because account name from serviceId could not be located in account service.
-    postBlobAndVerifyWithAccountAndContainer(null, Container.UNKNOWN_CONTAINER_NAME, "serviceId", isPrivate, null, null,
-        RestServiceErrorCode.InvalidContainer);
+    postBlobAndVerifyWithAccountAndContainer(null, Container.UNKNOWN_CONTAINER_NAME, "serviceId", container.isPrivate(),
+        null, null, RestServiceErrorCode.InvalidContainer);
 
     // should fail, because accountName needs to be specified.
-    postBlobAndVerifyWithAccountAndContainer(null, refContainer.getName(), "serviceId", isPrivate, null, null,
-        RestServiceErrorCode.MissingArgs);
+    postBlobAndVerifyWithAccountAndContainer(null, refContainer.getName(), "serviceId", container.isPrivate(), null,
+        null, RestServiceErrorCode.MissingArgs);
 
     // should fail, because accountName is not allowed.
-    postBlobAndVerifyWithAccountAndContainer(Account.UNKNOWN_ACCOUNT_NAME, null, "serviceId", isPrivate, null, null,
-        RestServiceErrorCode.InvalidAccount);
-
-    // should fail, because accountName is not allowed.
-    postBlobAndVerifyWithAccountAndContainer(Account.UNKNOWN_ACCOUNT_NAME, "dummyContainerName", "serviceId", isPrivate,
+    postBlobAndVerifyWithAccountAndContainer(Account.UNKNOWN_ACCOUNT_NAME, null, "serviceId", container.isPrivate(),
         null, null, RestServiceErrorCode.InvalidAccount);
 
     // should fail, because accountName is not allowed.
+    postBlobAndVerifyWithAccountAndContainer(Account.UNKNOWN_ACCOUNT_NAME, "dummyContainerName", "serviceId",
+        container.isPrivate(), null, null, RestServiceErrorCode.InvalidAccount);
+
+    // should fail, because accountName is not allowed.
     postBlobAndVerifyWithAccountAndContainer(Account.UNKNOWN_ACCOUNT_NAME, Container.UNKNOWN_CONTAINER_NAME,
-        "serviceId", isPrivate, null, null, RestServiceErrorCode.InvalidAccount);
+        "serviceId", container.isPrivate(), null, null, RestServiceErrorCode.InvalidAccount);
 
     // should fail, because accountName is not allowed.
     postBlobAndVerifyWithAccountAndContainer(Account.UNKNOWN_ACCOUNT_NAME, refContainer.getName(), "serviceId",
-        isPrivate, null, null, RestServiceErrorCode.InvalidAccount);
+        container.isPrivate(), null, null, RestServiceErrorCode.InvalidAccount);
 
     // should fail, because container name needs to be specified
-    postBlobAndVerifyWithAccountAndContainer(refAccount.getName(), null, "serviceId", isPrivate, null, null,
+    postBlobAndVerifyWithAccountAndContainer(refAccount.getName(), null, "serviceId", container.isPrivate(), null, null,
         RestServiceErrorCode.MissingArgs);
 
     // should fail, because containerName does not exist.
-    postBlobAndVerifyWithAccountAndContainer(refAccount.getName(), "dummyContainerName", "serviceId", isPrivate, null,
-        null, RestServiceErrorCode.InvalidContainer);
+    postBlobAndVerifyWithAccountAndContainer(refAccount.getName(), "dummyContainerName", "serviceId",
+        container.isPrivate(), null, null, RestServiceErrorCode.InvalidContainer);
 
     // should fail, because containerName is not allowed.
     postBlobAndVerifyWithAccountAndContainer(refAccount.getName(), Container.UNKNOWN_CONTAINER_NAME, "serviceId",
-        isPrivate, null, null, RestServiceErrorCode.InvalidContainer);
+        container.isPrivate(), null, null, RestServiceErrorCode.InvalidContainer);
 
     // should succeed.
     String blobIdStr =
-        postBlobAndVerifyWithAccountAndContainer(refAccount.getName(), refContainer.getName(), "serviceId", isPrivate,
-            refAccount, refContainer, null);
+        postBlobAndVerifyWithAccountAndContainer(refAccount.getName(), refContainer.getName(), "serviceId",
+            container.isPrivate(), refAccount, refContainer, null);
     // should succeed.
     verifyAccountAndContainerFromBlobId(blobIdStr, refAccount, refContainer, null);
 
     // should fail, because containerName needs to be specified.
-    postBlobAndVerifyWithAccountAndContainer("dummyAccountName", null, "serviceId", isPrivate, null, null,
+    postBlobAndVerifyWithAccountAndContainer("dummyAccountName", null, "serviceId", container.isPrivate(), null, null,
         RestServiceErrorCode.MissingArgs);
 
     // should fail, because accountName does not exist.
-    postBlobAndVerifyWithAccountAndContainer("dummyAccountName", "dummyContainerName", "serviceId", isPrivate, null,
-        null, RestServiceErrorCode.InvalidAccount);
+    postBlobAndVerifyWithAccountAndContainer("dummyAccountName", "dummyContainerName", "serviceId",
+        container.isPrivate(), null, null, RestServiceErrorCode.InvalidAccount);
 
     // should fail, because container name is now allowed.
     postBlobAndVerifyWithAccountAndContainer("dummyAccountName", Container.UNKNOWN_CONTAINER_NAME, "serviceId",
-        isPrivate, null, null, RestServiceErrorCode.InvalidContainer);
+        container.isPrivate(), null, null, RestServiceErrorCode.InvalidContainer);
 
     // should fail, because accountName does not exist.
-    postBlobAndVerifyWithAccountAndContainer("dummyAccountName", refContainer.getName(), "serviceId", isPrivate, null,
+    postBlobAndVerifyWithAccountAndContainer("dummyAccountName", refContainer.getName(), "serviceId",
+        container.isPrivate(), null, null, RestServiceErrorCode.InvalidAccount);
+
+    // should fail, because accountName implicitly set by serviceId is not allowed.
+    postBlobAndVerifyWithAccountAndContainer(null, null, Account.UNKNOWN_ACCOUNT_NAME, container.isPrivate(), null,
         null, RestServiceErrorCode.InvalidAccount);
 
     // should fail, because accountName implicitly set by serviceId is not allowed.
-    postBlobAndVerifyWithAccountAndContainer(null, null, Account.UNKNOWN_ACCOUNT_NAME, isPrivate, null, null,
-        RestServiceErrorCode.InvalidAccount);
-
-    // should fail, because accountName implicitly set by serviceId is not allowed.
-    postBlobAndVerifyWithAccountAndContainer(null, "dummyContainerName", Account.UNKNOWN_ACCOUNT_NAME, isPrivate, null,
-        null, RestServiceErrorCode.InvalidAccount);
+    postBlobAndVerifyWithAccountAndContainer(null, "dummyContainerName", Account.UNKNOWN_ACCOUNT_NAME,
+        container.isPrivate(), null, null, RestServiceErrorCode.InvalidAccount);
 
     // should fail, because accountName implicitly set by serviceId is not allowed.
     postBlobAndVerifyWithAccountAndContainer(null, Container.UNKNOWN_CONTAINER_NAME, Account.UNKNOWN_ACCOUNT_NAME,
-        isPrivate, null, null, RestServiceErrorCode.InvalidAccount);
+        container.isPrivate(), null, null, RestServiceErrorCode.InvalidAccount);
 
     // should fail, because accountName implicitly set by serviceId is not allowed.
-    postBlobAndVerifyWithAccountAndContainer(null, refContainer.getName(), Account.UNKNOWN_ACCOUNT_NAME, isPrivate,
-        null, null, RestServiceErrorCode.InvalidAccount);
+    postBlobAndVerifyWithAccountAndContainer(null, refContainer.getName(), Account.UNKNOWN_ACCOUNT_NAME,
+        container.isPrivate(), null, null, RestServiceErrorCode.InvalidAccount);
 
     // should succeed if the serviceId-based PUT requests are allowed, but this is a special case that account is
     // created without the legacy containers for public and private put.
-    postBlobAndVerifyWithAccountAndContainer(null, null, refAccount.getName(), isPrivate,
+    postBlobAndVerifyWithAccountAndContainer(null, null, refAccount.getName(), container.isPrivate(),
         shouldAllowServiceIdBasedPut ? refAccount : null,
-        shouldAllowServiceIdBasedPut ? (isPrivate ? refDefaultPrivateContainer : refDefaultPublicContainer) : null,
-        shouldAllowServiceIdBasedPut ? null : RestServiceErrorCode.BadRequest);
+        shouldAllowServiceIdBasedPut ? (container.isPrivate() ? refDefaultPrivateContainer : refDefaultPublicContainer)
+            : null, shouldAllowServiceIdBasedPut ? null : RestServiceErrorCode.BadRequest);
 
     // should fail, because accountName needs to be specified.
-    postBlobAndVerifyWithAccountAndContainer(null, "dummyContainerName", refAccount.getName(), isPrivate, null, null,
-        RestServiceErrorCode.MissingArgs);
+    postBlobAndVerifyWithAccountAndContainer(null, "dummyContainerName", refAccount.getName(), container.isPrivate(),
+        null, null, RestServiceErrorCode.MissingArgs);
 
     // should fail, because accountName implicitly set by serviceId does not have the default container.
-    postBlobAndVerifyWithAccountAndContainer(null, Container.UNKNOWN_CONTAINER_NAME, refAccount.getName(), isPrivate,
-        null, null, RestServiceErrorCode.InvalidContainer);
+    postBlobAndVerifyWithAccountAndContainer(null, Container.UNKNOWN_CONTAINER_NAME, refAccount.getName(),
+        container.isPrivate(), null, null, RestServiceErrorCode.InvalidContainer);
 
     // should fail, because accountName needs to be specified.
-    postBlobAndVerifyWithAccountAndContainer(null, refContainer.getName(), refAccount.getName(), isPrivate, null, null,
-        RestServiceErrorCode.MissingArgs);
+    postBlobAndVerifyWithAccountAndContainer(null, refContainer.getName(), refAccount.getName(), container.isPrivate(),
+        null, null, RestServiceErrorCode.MissingArgs);
 
     Container legacyContainerForPublicBlob =
         new ContainerBuilder(Container.DEFAULT_PUBLIC_CONTAINER_ID, "containerForLegacyPublicPut",
@@ -1735,26 +1765,26 @@ public class AmbryBlobStorageServiceTest {
             .addOrUpdateContainer(legacyContainerForPublicBlob)
             .build();
     accountService.updateAccounts(Collections.singletonList(accountWithTwoDefaultContainers));
-    if (isPrivate) {
+    if (container.isPrivate()) {
       // should succeed if serviceId-based PUT requests are allowed.
-      postBlobAndVerifyWithAccountAndContainer(null, null, accountWithTwoDefaultContainers.getName(), isPrivate,
-          shouldAllowServiceIdBasedPut ? accountWithTwoDefaultContainers : null,
+      postBlobAndVerifyWithAccountAndContainer(null, null, accountWithTwoDefaultContainers.getName(),
+          container.isPrivate(), shouldAllowServiceIdBasedPut ? accountWithTwoDefaultContainers : null,
           shouldAllowServiceIdBasedPut ? accountWithTwoDefaultContainers.getContainerById(
               Container.DEFAULT_PRIVATE_CONTAINER_ID) : null,
           shouldAllowServiceIdBasedPut ? null : RestServiceErrorCode.BadRequest);
       // should fail, because accountName needs to be specified.
       postBlobAndVerifyWithAccountAndContainer(null, "dummyContainerName", accountWithTwoDefaultContainers.getName(),
-          isPrivate, null, null, RestServiceErrorCode.MissingArgs);
+          container.isPrivate(), null, null, RestServiceErrorCode.MissingArgs);
     } else {
       // should succeed if serviceId-based PUT requests are allowed.
-      postBlobAndVerifyWithAccountAndContainer(null, null, accountWithTwoDefaultContainers.getName(), isPrivate,
-          shouldAllowServiceIdBasedPut ? accountWithTwoDefaultContainers : null,
+      postBlobAndVerifyWithAccountAndContainer(null, null, accountWithTwoDefaultContainers.getName(),
+          container.isPrivate(), shouldAllowServiceIdBasedPut ? accountWithTwoDefaultContainers : null,
           shouldAllowServiceIdBasedPut ? accountWithTwoDefaultContainers.getContainerById(
               Container.DEFAULT_PUBLIC_CONTAINER_ID) : null,
           shouldAllowServiceIdBasedPut ? null : RestServiceErrorCode.BadRequest);
       // should fail, because accountName needs to be specified.
       postBlobAndVerifyWithAccountAndContainer(null, "dummyContainerName", accountWithTwoDefaultContainers.getName(),
-          isPrivate, null, null, RestServiceErrorCode.MissingArgs);
+          container.isPrivate(), null, null, RestServiceErrorCode.MissingArgs);
     }
   }
 }


### PR DESCRIPTION
This commit fixes a bug where the private property in blob properties is set using the x-ambry-private header which can be different from the private property of the container being uploaded to.