### PR TITLE
Add support for encryption keys in the protocol

### DIFF
--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -98,7 +98,7 @@ class PutRequestV4ForTest extends PutRequest {
   public PutRequestV4ForTest(int correlationId, String clientId, BlobId blobId, BlobProperties properties,
       ByteBuffer usermetadata, ByteBuffer blob, long blobSize, BlobType blobType, byte[] blobKey) {
     super(correlationId, clientId, blobId, properties, usermetadata, blob, blobSize, blobType, blobKey);
-    versionId = PutRequest.Put_Request_Version_V4;
+    versionId = PutRequest.PUT_REQUEST_VERSION_V4;
   }
 }
 
@@ -135,13 +135,13 @@ public class RequestResponseTest {
       boolean doInvalidTest) throws IOException {
     doTest((short) -1, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata, blobType, blob,
         blobSize, blobKey, null);
-    doTest(PutRequest.Put_Request_Version_V4, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata,
+    doTest(PutRequest.PUT_REQUEST_VERSION_V4, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata,
         blobType, blob, blobSize, null, null);
-    doTest(PutRequest.Put_Request_Version_V4, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata,
+    doTest(PutRequest.PUT_REQUEST_VERSION_V4, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata,
         blobType, blob, blobSize, new byte[0], null);
-    doTest(PutRequest.Put_Request_Version_V4, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata,
+    doTest(PutRequest.PUT_REQUEST_VERSION_V4, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata,
         blobType, blob, blobSize, null, null);
-    doTest(PutRequest.Put_Request_Version_V4, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata,
+    doTest(PutRequest.PUT_REQUEST_VERSION_V4, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata,
         blobType, blob, blobSize, blobKey, blobKey);
     if (doInvalidTest) {
       doTest(InvalidVersionPutRequest.Put_Request_Invalid_version, clusterMap, correlationId, clientId, blobId,
@@ -191,7 +191,7 @@ public class RequestResponseTest {
           }
           break;
 
-        case PutRequest.Put_Request_Version_V4:
+        case PutRequest.PUT_REQUEST_VERSION_V4:
           request =
               new PutRequestV4ForTest(correlationId, clientId, blobId, blobProperties, ByteBuffer.wrap(userMetadata),
                   ByteBuffer.wrap(blob), blobSize, blobType, blobKey);

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -128,11 +128,10 @@ public class RequestResponseTest {
    * @param blob the blob content.
    * @param blobSize the size of the blob.
    * @param blobKey the encryption key of the blob.
-   * @param doInvalidTest whether tests for invalid put requests should be done.
    */
   private void testPutRequest(MockClusterMap clusterMap, int correlationId, String clientId, BlobId blobId,
-      BlobProperties blobProperties, byte[] userMetadata, BlobType blobType, byte[] blob, int blobSize, byte[] blobKey,
-      boolean doInvalidTest) throws IOException {
+      BlobProperties blobProperties, byte[] userMetadata, BlobType blobType, byte[] blob, int blobSize, byte[] blobKey)
+      throws IOException {
     doTest((short) -1, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata, blobType, blob,
         blobSize, blobKey, null);
     doTest(PutRequest.PUT_REQUEST_VERSION_V4, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata,
@@ -141,10 +140,6 @@ public class RequestResponseTest {
         blobType, blob, blobSize, new byte[0], null);
     doTest(PutRequest.PUT_REQUEST_VERSION_V4, clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata,
         blobType, blob, blobSize, blobKey, blobKey);
-    if (doInvalidTest) {
-      doTest(InvalidVersionPutRequest.Put_Request_Invalid_version, clusterMap, correlationId, clientId, blobId,
-          blobProperties, userMetadata, blobType, blob, blobSize, blobKey, null);
-    }
   }
 
   /**
@@ -246,28 +241,30 @@ public class RequestResponseTest {
         new BlobProperties(blobSize, "serviceID", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM));
     testPutRequest(clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata, BlobType.DataBlob, blob,
-        blobSize, blobKey, true);
+        blobSize, blobKey);
+    doTest(InvalidVersionPutRequest.Put_Request_Invalid_version, clusterMap, correlationId, clientId, blobId,
+        blobProperties, userMetadata, BlobType.DataBlob, blob, blobSize, blobKey, null);
 
     // Put Request with size in blob properties different from the data size and blob type: Data blob.
     blobProperties =
         new BlobProperties(blobSize * 10, "serviceID", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM));
     testPutRequest(clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata, BlobType.DataBlob, blob,
-        blobSize, blobKey, false);
+        blobSize, blobKey);
 
     // Put Request with size in blob properties different from the data size and blob type: Metadata blob.
     blobProperties =
         new BlobProperties(blobSize * 10, "serviceID", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM));
     testPutRequest(clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata, BlobType.MetadataBlob,
-        blob, blobSize, blobKey, false);
+        blob, blobSize, blobKey);
 
     // Put Request with empty user metadata.
     byte[] emptyUserMetadata = new byte[0];
     blobProperties = new BlobProperties(blobSize, "serviceID", "memberId", "contentType", false, Utils.Infinite_Time,
         Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM));
     testPutRequest(clusterMap, correlationId, clientId, blobId, blobProperties, emptyUserMetadata, BlobType.DataBlob,
-        blob, blobSize, blobKey, true);
+        blob, blobSize, blobKey);
 
     // Response test
     PutResponse response = new PutResponse(1234, clientId, ServerErrorCode.No_Error);

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -951,7 +951,7 @@ class PutOperation {
     protected PutRequest createPutRequest() {
       return new PutRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
           chunkBlobId, chunkBlobProperties, ByteBuffer.wrap(userMetadata), buf.duplicate(), buf.remaining(),
-          BlobType.DataBlob);
+          BlobType.DataBlob, null);
     }
 
     /**
@@ -1228,7 +1228,7 @@ class PutOperation {
     protected PutRequest createPutRequest() {
       return new PutRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
           chunkBlobId, finalBlobProperties, ByteBuffer.wrap(userMetadata), buf.duplicate(), buf.remaining(),
-          BlobType.MetadataBlob);
+          BlobType.MetadataBlob, null);
     }
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
@@ -68,7 +68,7 @@ class DirectSender implements Runnable {
       for (int i = 0; i < blobIds.size(); i++) {
         PutRequest putRequest =
             new PutRequest(1, "client1", blobIds.get(i), blobProperties, ByteBuffer.wrap(usermetadata),
-                ByteBuffer.wrap(data), blobProperties.getBlobSize(), BlobType.DataBlob);
+                ByteBuffer.wrap(data), blobProperties.getBlobSize(), BlobType.DataBlob, null);
 
         channel.send(putRequest);
         InputStream putResponseStream = channel.receive().getInputStream();

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -333,7 +333,7 @@ public class ServerHardDeleteTest {
       throws IOException {
     PutRequest putRequest0 =
         new PutRequest(1, "client1", blobId, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-            properties.getBlobSize(), BlobType.DataBlob);
+            properties.getBlobSize(), BlobType.DataBlob, null);
     channel.send(putRequest0);
     InputStream putResponseStream = channel.receive().getInputStream();
     PutResponse response0 = PutResponse.readFrom(new DataInputStream(putResponseStream));

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -117,7 +117,7 @@ public final class ServerTestUtil {
       // put blob 1
       PutRequest putRequest =
           new PutRequest(1, "client1", blobId1, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       BlockingChannel channel =
           getBlockingChannelBasedOnPortType(targetPort, "localhost", clientSSLSocketFactory, clientSSLConfig);
       channel.connect();
@@ -129,7 +129,7 @@ public final class ServerTestUtil {
       // put blob 2
       PutRequest putRequest2 =
           new PutRequest(1, "client1", blobId2, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       channel.send(putRequest2);
       putResponseStream = channel.receive().getInputStream();
       PutResponse response2 = PutResponse.readFrom(new DataInputStream(putResponseStream));
@@ -138,7 +138,7 @@ public final class ServerTestUtil {
       // put blob 3
       PutRequest putRequest3 =
           new PutRequest(1, "client1", blobId3, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       channel.send(putRequest3);
       putResponseStream = channel.receive().getInputStream();
       PutResponse response3 = PutResponse.readFrom(new DataInputStream(putResponseStream));
@@ -149,7 +149,7 @@ public final class ServerTestUtil {
           new BlobProperties(31870, "serviceid1", "ownerid", "jpeg", false, 0, accountId, containerId);
       PutRequest putRequest4 =
           new PutRequest(1, "client1", blobId4, propertiesExpired, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       channel.send(putRequest4);
       putResponseStream = channel.receive().getInputStream();
       PutResponse response4 = PutResponse.readFrom(new DataInputStream(putResponseStream));
@@ -320,13 +320,13 @@ public final class ServerTestUtil {
     // Send put requests for an existing blobId for the exact blob to simulate a request arriving late.
     PutRequest latePutRequest1 =
         new PutRequest(1, "client1", blobId, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-            properties.getBlobSize(), BlobType.DataBlob);
+            properties.getBlobSize(), BlobType.DataBlob, null);
     PutRequest latePutRequest2 =
         new PutRequest(1, "client2", blobId, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-            properties.getBlobSize(), BlobType.DataBlob);
+            properties.getBlobSize(), BlobType.DataBlob, null);
     PutRequest latePutRequest3 =
         new PutRequest(1, "client3", blobId, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-            properties.getBlobSize(), BlobType.DataBlob);
+            properties.getBlobSize(), BlobType.DataBlob, null);
     channelToDatanode1.send(latePutRequest1);
     InputStream putResponseStream = channelToDatanode1.receive().getInputStream();
     PutResponse response = PutResponse.readFrom(new DataInputStream(putResponseStream));
@@ -912,7 +912,7 @@ public final class ServerTestUtil {
       // put blob 1
       PutRequest putRequest =
           new PutRequest(1, "client1", blobId1, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       expectedTokenSize += getPutRecordSize(properties, blobId1, ByteBuffer.wrap(usermetadata), data);
 
       BlockingChannel channel1 =
@@ -932,7 +932,7 @@ public final class ServerTestUtil {
       // put blob 2
       PutRequest putRequest2 =
           new PutRequest(1, "client1", blobId2, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       expectedTokenSize += getPutRecordSize(properties, blobId3, ByteBuffer.wrap(usermetadata), data);
       System.out.println("Expected size after first put " + expectedTokenSize);
       channel2.send(putRequest2);
@@ -942,7 +942,7 @@ public final class ServerTestUtil {
       // put blob 3
       PutRequest putRequest3 =
           new PutRequest(1, "client1", blobId3, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       expectedTokenSize += getPutRecordSize(properties, blobId3, ByteBuffer.wrap(usermetadata), data);
       System.out.println("Expected size after first put " + expectedTokenSize);
       channel3.send(putRequest3);
@@ -953,7 +953,7 @@ public final class ServerTestUtil {
       // put blob 4
       putRequest =
           new PutRequest(1, "client1", blobId4, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       expectedTokenSize += getPutRecordSize(properties, blobId4, ByteBuffer.wrap(usermetadata), data);
       System.out.println("Expected size after first put " + expectedTokenSize);
       channel1.send(putRequest);
@@ -964,7 +964,7 @@ public final class ServerTestUtil {
       // put blob 5
       putRequest2 =
           new PutRequest(1, "client1", blobId5, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       expectedTokenSize += getPutRecordSize(properties, blobId5, ByteBuffer.wrap(usermetadata), data);
       System.out.println("Expected size after first put " + expectedTokenSize);
       channel2.send(putRequest2);
@@ -975,7 +975,7 @@ public final class ServerTestUtil {
       // put blob 6
       putRequest3 =
           new PutRequest(1, "client1", blobId6, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       expectedTokenSize += getPutRecordSize(properties, blobId6, ByteBuffer.wrap(usermetadata), data);
       System.out.println("Expected size after first put " + expectedTokenSize);
       channel3.send(putRequest3);
@@ -1127,7 +1127,7 @@ public final class ServerTestUtil {
       // put blob 7
       putRequest2 =
           new PutRequest(1, "client1", blobId7, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       expectedTokenSize += getPutRecordSize(properties, blobId7, ByteBuffer.wrap(usermetadata), data);
       channel2.send(putRequest2);
       putResponseStream = channel2.receive().getInputStream();
@@ -1137,7 +1137,7 @@ public final class ServerTestUtil {
       // put blob 8
       putRequest3 =
           new PutRequest(1, "client1", blobId8, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       expectedTokenSize += getPutRecordSize(properties, blobId8, ByteBuffer.wrap(usermetadata), data);
       channel3.send(putRequest3);
       putResponseStream = channel3.receive().getInputStream();
@@ -1147,7 +1147,7 @@ public final class ServerTestUtil {
       // put blob 9
       putRequest2 =
           new PutRequest(1, "client1", blobId9, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       expectedTokenSize += getPutRecordSize(properties, blobId9, ByteBuffer.wrap(usermetadata), data);
       channel2.send(putRequest2);
       putResponseStream = channel2.receive().getInputStream();
@@ -1157,7 +1157,7 @@ public final class ServerTestUtil {
       // put blob 10
       putRequest3 =
           new PutRequest(1, "client1", blobId10, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       expectedTokenSize += getPutRecordSize(properties, blobId10, ByteBuffer.wrap(usermetadata), data);
       channel3.send(putRequest3);
       putResponseStream = channel3.receive().getInputStream();
@@ -1167,7 +1167,7 @@ public final class ServerTestUtil {
       // put blob 11
       putRequest2 =
           new PutRequest(1, "client1", blobId11, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
-              properties.getBlobSize(), BlobType.DataBlob);
+              properties.getBlobSize(), BlobType.DataBlob, null);
       expectedTokenSize += getPutRecordSize(properties, blobId11, ByteBuffer.wrap(usermetadata), data);
       channel2.send(putRequest2);
       putResponseStream = channel2.receive().getInputStream();

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -421,7 +421,7 @@ public class AmbryRequestsTest {
         case PutRequest:
           BlobProperties properties = new BlobProperties(0, "serviceId", blobId.getAccountId(), blobId.getAccountId());
           request = new PutRequest(correlationId, clientId, blobId, properties, ByteBuffer.allocate(0),
-              ByteBuffer.allocate(0), 0, BlobType.DataBlob);
+              ByteBuffer.allocate(0), 0, BlobType.DataBlob, null);
           break;
         case DeleteRequest:
           request = new DeleteRequest(correlationId, clientId, blobId, SystemTime.getInstance().milliseconds());

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
@@ -229,7 +229,7 @@ public class DirectoryUploader {
       ByteBufferInputStream blobStream = new ByteBufferInputStream(stream, size);
       PutRequest putRequest =
           new PutRequest(correlationId.incrementAndGet(), "consumerThread", blobId, blobProperties, userMetaData,
-              blobStream.getByteBuffer(), size, BlobType.DataBlob);
+              blobStream.getByteBuffer(), size, BlobType.DataBlob, null);
 
       if (enableVerboseLogging) {
         System.out.println("Put Request to a replica : " + putRequest + " for blobId " + blobId);

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
@@ -347,7 +347,7 @@ public class ServerWritePerformance {
                 props.getContainerId(), partitionId);
             PutRequest putRequest =
                 new PutRequest(0, "perf", blobId, props, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(blob),
-                    props.getBlobSize(), BlobType.DataBlob);
+                    props.getBlobSize(), BlobType.DataBlob, null);
             ReplicaId replicaId = partitionId.getReplicaIds().get(0);
             Port port = replicaId.getDataNodeId().getPortToConnectTo();
             channel = connectionPool.checkOutConnection(replicaId.getDataNodeId().getHostname(), port, 10000);


### PR DESCRIPTION
Add support for encryption keys in put requests. PutRequest V4 is introduced
for this purpose. This patch does not enable it in the write path. This change
should first go to all the servers so they understand V4. A subsequent patch will
then enable V4 in the write path.