### PR TITLE
Add AccessDenied error code and ambry-error-code header

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/ResponseStatus.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/ResponseStatus.java
@@ -21,13 +21,19 @@ public enum ResponseStatus {
   /**
    * 200 OK - Resource found and all good.
    */
-  Ok, /**
+  Ok,
+
+  /**
    * 201 - Resource was created.
    */
-  Created, /**
+  Created,
+
+  /**
    * 202 - Request was accepted.
    */
-  Accepted, /**
+  Accepted,
+
+  /**
    * 206 - Partial content.
    */
   PartialContent,
@@ -36,26 +42,39 @@ public enum ResponseStatus {
    * 304 Not Modified
    */
   NotModified,
+
   // 4xx
   /**
    * 400 - Request was not correct.
    */
-  BadRequest, /**
+  BadRequest,
+
+  /**
    * 401 - Request Unauthorized
    */
-  Unauthorized, /**
+  Unauthorized,
+
+  /**
    * 403 - Request forbidden
    */
-  Forbidden, /**
+  Forbidden,
+
+  /**
    * 404 Not Found - Resource was not found.
    */
-  NotFound, /**
+  NotFound,
+
+  /**
    * 407 - Proxy authentication required
    */
-  ProxyAuthenticationRequired, /**
+  ProxyAuthenticationRequired,
+
+  /**
    * 410 Gone - Resource has been deleted or has expired.
    */
-  Gone, /**
+  Gone,
+
+  /**
    * 416 Range Not Satisfiable - A range request is invalid or outside of the bounds of an object.
    */
   RangeNotSatisfiable,
@@ -87,6 +106,7 @@ public enum ResponseStatus {
       case UnsupportedHttpMethod:
         return ResponseStatus.BadRequest;
       case ResourceDirty:
+      case AccessDenied:
         return ResponseStatus.Forbidden;
       case Unauthorized:
         return ResponseStatus.Unauthorized;

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
@@ -54,6 +54,11 @@ public enum RestServiceErrorCode {
   ResourceDirty,
 
   /**
+   * An authenticated client is not authorized to access a resource.
+   */
+  AccessDenied,
+
+  /**
    * Client has sent a request that cannot be processed due to authorization failure.
    */
   Unauthorized,

--- a/ambry-rest/src/test/java/com.github.ambry.rest/MockSSLSession.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/MockSSLSession.java
@@ -25,18 +25,18 @@ import javax.net.ssl.SSLSessionContext;
  * A mock of {@link SSLSession} that either delegates to a passed in {@link SSLSession}, or returns the provided
  * objects.
  */
-class MockSSLSession implements SSLSession {
+public class MockSSLSession implements SSLSession {
   private SSLSession delegateSession;
-  private Certificate peerCertToReturn;
+  private Certificate[] peerCertsToReturn;
 
   /**
    * @param delegateSession An {@link SSLSession} to delegate to in most cases.
-   * @param peerCertToReturn If not {@code null}, return this certificate in {@link #getPeerCertificates()} instead of
-   *                         delegating.
+   * @param peerCertsToReturn If not {@code null}, return these certificates in {@link #getPeerCertificates()} instead
+   *                          of delegating.
    */
-  MockSSLSession(SSLSession delegateSession, Certificate peerCertToReturn) {
+  MockSSLSession(SSLSession delegateSession, Certificate[] peerCertsToReturn) {
     this.delegateSession = delegateSession;
-    this.peerCertToReturn = peerCertToReturn;
+    this.peerCertsToReturn = peerCertsToReturn;
   }
 
   @Override
@@ -91,8 +91,8 @@ class MockSSLSession implements SSLSession {
 
   @Override
   public Certificate[] getPeerCertificates() throws SSLPeerUnverifiedException {
-    if (peerCertToReturn != null) {
-      return new Certificate[]{peerCertToReturn};
+    if (peerCertsToReturn != null) {
+      return peerCertsToReturn;
     }
     return delegateSession.getPeerCertificates();
   }

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -39,6 +39,7 @@ import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.stream.ChunkedWriteHandler;
@@ -81,6 +82,7 @@ public class NettyResponseChannelTest {
     REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.ResourceScanInProgress,
         HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED);
     REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.ResourceDirty, HttpResponseStatus.FORBIDDEN);
+    REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.AccessDenied, HttpResponseStatus.FORBIDDEN);
     REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.InternalServerError,
         HttpResponseStatus.INTERNAL_SERVER_ERROR);
     REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.RangeNotSatisfiable,
@@ -420,6 +422,13 @@ public class NettyResponseChannelTest {
         assertTrue("Could not find failure reason header.", containsFailureReasonHeader);
       } else {
         assertFalse("Should not have found failure reason header.", containsFailureReasonHeader);
+      }
+      if (HttpStatusClass.CLIENT_ERROR.contains(response.status().code())) {
+        assertEquals("Wrong error code", entry.getKey(),
+            RestServiceErrorCode.valueOf(response.headers().get(NettyResponseChannel.ERROR_CODE_HEADER)));
+      } else {
+        assertFalse("Should not have found error code header",
+            response.headers().contains(NettyResponseChannel.ERROR_CODE_HEADER));
       }
       if (response instanceof FullHttpResponse) {
         // assert that there is no content

--- a/ambry-rest/src/test/java/com.github.ambry.rest/PublicAccessLogHandlerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/PublicAccessLogHandlerTest.java
@@ -27,6 +27,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -331,7 +332,8 @@ public class PublicAccessLogHandlerTest {
       SSLEngine sslEngine = SSL_CONTEXT.newEngine(channel.alloc());
       // HttpRequests pass through the SslHandler without a handshake (it only operates on ByteBuffers) so we have
       // to mock certain methods of SSLEngine and SSLSession to ensure that we can test certificate logging.
-      SSLEngine mockSSLEngine = new MockSSLEngine(sslEngine, new MockSSLSession(sslEngine.getSession(), PEER_CERT));
+      SSLEngine mockSSLEngine =
+          new MockSSLEngine(sslEngine, new MockSSLSession(sslEngine.getSession(), new Certificate[]{PEER_CERT}));
       channel.pipeline().addLast(new SslHandler(mockSSLEngine));
     }
     channel.pipeline()


### PR DESCRIPTION
- Add a new AccessDenied error code that will map to 403 Forbidden, 401
  Unauthorized generally does not apply to situations where an
  authenticated user is not authorized to access a resource.
- Add an ambry-error-code response header that lets the user know the
  RestServiceErrorCode on 4xx responses.