### PR TITLE
Adding account and container names to BlobInfo and HEAD response

### DIFF
--- a/ambry-api/src/test/java/com.github.ambry/account/InMemAccountServiceFactory.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/InMemAccountServiceFactory.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.account;
+
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+
+/**
+ * Factory to create {@link InMemAccountService}. The account services returned are static variables.
+ */
+public class InMemAccountServiceFactory implements AccountServiceFactory {
+  private static final InMemAccountService ONLY_UNKNOWN = new InMemAccountService(true);
+  private static final InMemAccountService ANY_ACCOUNT = new InMemAccountService(false);
+
+  private final boolean returnOnlyUnknown;
+
+  /**
+   * Constructor. If the properties contains a field "in.mem.account.service.only.unknown" set to {@code true}, an
+   * {@link InMemAccountService} that only returns {@link Account#UNKNOWN_ACCOUNT} is returned. Otherwise a fully
+   * functional service is returned. These account services are also static (singleton) so the same instance of these
+   * services is returned no matter how many times {@link #getAccountService()} is called or different instances of
+   * {@link InMemAccountServiceFactory} are created.
+   * @param verifiableProperties The properties to get a {@link InMemAccountService} instance. Cannot be {@code null}.
+   * @param metricRegistry will be discarded
+   * @param notifier will be discarded
+   */
+  public InMemAccountServiceFactory(VerifiableProperties verifiableProperties, Object metricRegistry, Object notifier) {
+    returnOnlyUnknown = verifiableProperties.getBoolean("in.mem.account.service.only.unknown", false);
+  }
+
+  public InMemAccountServiceFactory(boolean returnOnlyUnknown) {
+    this.returnOnlyUnknown = returnOnlyUnknown;
+  }
+
+  @Override
+  public InMemAccountService getAccountService() {
+    return returnOnlyUnknown ? ONLY_UNKNOWN : ANY_ACCOUNT;
+  }
+
+  /**
+   * Implementation of {@link AccountService} for test. This implementation synchronizes on all methods.
+   */
+  public static class InMemAccountService implements AccountService {
+    private final boolean shouldReturnOnlyUnknownAccount;
+    private final Map<Short, Account> idToAccountMap = new HashMap<>();
+    private final Map<String, Account> nameToAccountMap = new HashMap<>();
+    private final Set<Consumer<Collection<Account>>> accountUpdateConsumers = new HashSet<>();
+
+    /**
+     * Constructor.
+     * @param shouldReturnOnlyUnknownAccount {@code true} if always returns {@link Account#UNKNOWN_ACCOUNT} when queried
+     *                                                     by account name; {@code false} to do the actual query.
+     */
+    private InMemAccountService(boolean shouldReturnOnlyUnknownAccount) {
+      this.shouldReturnOnlyUnknownAccount = shouldReturnOnlyUnknownAccount;
+    }
+
+    @Override
+    public synchronized Account getAccountById(short accountId) {
+      return shouldReturnOnlyUnknownAccount ? Account.UNKNOWN_ACCOUNT : idToAccountMap.get(accountId);
+    }
+
+    @Override
+    public synchronized Account getAccountByName(String accountName) {
+      return shouldReturnOnlyUnknownAccount ? Account.UNKNOWN_ACCOUNT : nameToAccountMap.get(accountName);
+    }
+
+    @Override
+    public synchronized boolean updateAccounts(Collection<Account> accounts) {
+      for (Account account : accounts) {
+        idToAccountMap.put(account.getId(), account);
+        nameToAccountMap.put(account.getName(), account);
+      }
+      for (Consumer<Collection<Account>> accountUpdateConsumer : accountUpdateConsumers) {
+        accountUpdateConsumer.accept(accounts);
+      }
+      return true;
+    }
+
+    @Override
+    public synchronized boolean addAccountUpdateConsumer(Consumer<Collection<Account>> accountUpdateConsumer) {
+      Objects.requireNonNull(accountUpdateConsumer, "accountUpdateConsumer to subscribe cannot be null");
+      return accountUpdateConsumers.add(accountUpdateConsumer);
+    }
+
+    @Override
+    public synchronized boolean removeAccountUpdateConsumer(Consumer<Collection<Account>> accountUpdateConsumer) {
+      Objects.requireNonNull(accountUpdateConsumer, "accountUpdateConsumer to unsubscribe cannot be null");
+      return accountUpdateConsumers.remove(accountUpdateConsumer);
+    }
+
+    @Override
+    public synchronized Collection<Account> getAllAccounts() {
+      return idToAccountMap.values();
+    }
+
+    @Override
+    public void close() throws IOException {
+      // no op
+    }
+
+    /**
+     * Clears all the accounts in this {@code AccountService}.
+     */
+    public synchronized void clear() {
+      Collection<Account> allAccounts = idToAccountMap.values();
+      idToAccountMap.clear();
+      nameToAccountMap.clear();
+      for (Consumer<Collection<Account>> accountUpdateConsumer : accountUpdateConsumers) {
+        accountUpdateConsumer.accept(allAccounts);
+      }
+    }
+
+    /**
+     * Creates and adds an {@link Account} to this {@link AccountService}. The account will contain one container
+     * with {@link Container#DEFAULT_PUBLIC_CONTAINER_ID}, one with {@link Container#DEFAULT_PRIVATE_CONTAINER_ID} and
+     * one other random {@link Container}.
+     * @return the {@link Account} that was created and added.
+     */
+    public synchronized Account createAndAddRandomAccount() {
+      short refAccountId;
+      String refAccountName;
+      do {
+        refAccountId = Utils.getRandomShort(TestUtils.RANDOM);
+        refAccountName = UtilsTest.getRandomString(10);
+      } while (idToAccountMap.containsKey(refAccountId) || nameToAccountMap.containsKey(refAccountName));
+      Account.AccountStatus refAccountStatus = Account.AccountStatus.ACTIVE;
+      Container randomContainer = getRandomContainer(refAccountId);
+      Container publicContainer = getDefaultContainer(refAccountId, false);
+      Container privateContainer = getDefaultContainer(refAccountId, true);
+      Account account = new AccountBuilder(refAccountId, refAccountName, refAccountStatus,
+          Arrays.asList(publicContainer, privateContainer, randomContainer)).build();
+      updateAccounts(Collections.singletonList(account));
+      return account;
+    }
+
+    /**
+     * Creates and returns default public/private container for {@code accountId}.
+     * @param accountId the account id for the container
+     * @param isPrivate {@code true} if private container is required. {@code false} for public.
+     * @return default public/private container for {@code accountId}.
+     */
+    private Container getDefaultContainer(short accountId, boolean isPrivate) {
+      Container container;
+      if (isPrivate) {
+        container =
+            new ContainerBuilder(Container.DEFAULT_PRIVATE_CONTAINER_ID, Container.DEFAULT_PRIVATE_CONTAINER_NAME,
+                Container.DEFAULT_PRIVATE_CONTAINER_STATUS, Container.DEFAULT_PRIVATE_CONTAINER_DESCRIPTION,
+                Container.DEFAULT_PRIVATE_CONTAINER_IS_PRIVATE_SETTING, accountId).build();
+      } else {
+        container = new ContainerBuilder(Container.DEFAULT_PUBLIC_CONTAINER_ID, Container.DEFAULT_PUBLIC_CONTAINER_NAME,
+            Container.DEFAULT_PUBLIC_CONTAINER_STATUS, Container.DEFAULT_PUBLIC_CONTAINER_DESCRIPTION,
+            Container.DEFAULT_PUBLIC_CONTAINER_IS_PRIVATE_SETTING, accountId).build();
+      }
+      return container;
+    }
+
+    /**
+     * Creates and returns a random {@link Container} for {@code accountId}.
+     * @param accountId the account id for the container
+     * @return returns a random {@link Container} for {@code accountId}
+     */
+    private Container getRandomContainer(short accountId) {
+      short refContainerId = Utils.getRandomShort(TestUtils.RANDOM);
+      String refContainerName = UtilsTest.getRandomString(10);
+      Container.ContainerStatus refContainerStatus = Container.ContainerStatus.ACTIVE;
+      String refContainerDescription = UtilsTest.getRandomString(10);
+      boolean refContainerPrivacy = TestUtils.RANDOM.nextBoolean();
+      return new ContainerBuilder(refContainerId, refContainerName, refContainerStatus, refContainerDescription,
+          refContainerPrivacy, accountId).build();
+    }
+  }
+}
+

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -267,7 +267,8 @@ class AmbrySecurityService implements SecurityService {
   }
 
   /**
-   * Adds the account and container details to the response headers.
+   * Adds the account and container details to the response headers if the {@code restRequest} contains the target
+   * account and container and they are not generic unknowns.
    * @param restRequest the {@link RestRequest} that contains the {@link Account} and {@link Container} details.
    * @param restResponseChannel the {@link RestResponseChannel} where headers need to be set.
    * @throws RestServiceException if headers cannot be set.

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -254,7 +254,10 @@ class AmbrySecurityService implements SecurityService {
     restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, blobProperties.getBlobSize());
     restResponseChannel.setHeader(RestUtils.Headers.SERVICE_ID, blobProperties.getServiceId());
     restResponseChannel.setHeader(RestUtils.Headers.CREATION_TIME, new Date(blobProperties.getCreationTimeInMs()));
-    restResponseChannel.setHeader(RestUtils.Headers.PRIVATE, blobProperties.isPrivate());
+    Object isPrivateSet = restResponseChannel.getHeader(RestUtils.Headers.PRIVATE);
+    if (isPrivateSet == null || isPrivateSet.toString().isEmpty()) {
+      restResponseChannel.setHeader(RestUtils.Headers.PRIVATE, blobProperties.isPrivate());
+    }
     if (blobProperties.getTimeToLiveInSeconds() != Utils.Infinite_Time) {
       restResponseChannel.setHeader(RestUtils.Headers.TTL, Long.toString(blobProperties.getTimeToLiveInSeconds()));
     }
@@ -282,7 +285,9 @@ class AmbrySecurityService implements SecurityService {
       if (account.getId() != Account.UNKNOWN_ACCOUNT_ID) {
         restResponseChannel.setHeader(RestUtils.Headers.TARGET_ACCOUNT_NAME, ((Account) accountObj).getName());
         if (containerObj != null && containerObj instanceof Container) {
-          restResponseChannel.setHeader(RestUtils.Headers.TARGET_CONTAINER_NAME, ((Container) containerObj).getName());
+          Container container = (Container) containerObj;
+          restResponseChannel.setHeader(RestUtils.Headers.TARGET_CONTAINER_NAME, container.getName());
+          restResponseChannel.setHeader(RestUtils.Headers.PRIVATE, container.isPrivate());
         }
       }
     }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -122,7 +122,7 @@ public class AmbryBlobStorageServiceTest {
   private Container refDefaultPublicContainer;
   private Container refDefaultPrivateContainer;
   private InMemAccountServiceFactory.InMemAccountService accountService =
-      new InMemAccountServiceFactory(false).getAccountService();
+      new InMemAccountServiceFactory(false, true).getAccountService();
 
   /**
    * Sets up the {@link AmbryBlobStorageService} instance before a test.
@@ -548,7 +548,7 @@ public class AmbryBlobStorageServiceTest {
    */
   @Test
   public void accountNameMismatchTest() throws Exception {
-    accountService = new InMemAccountServiceFactory(true).getAccountService();
+    accountService = new InMemAccountServiceFactory(true, false).getAccountService();
     ambryBlobStorageService = getAmbryBlobStorageService();
     ambryBlobStorageService.start();
     postBlobAndVerifyWithAccountAndContainer(refAccount.getName(), refContainer.getName(), "serviceId",

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.account.AccountBuilder;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.account.Container;
 import com.github.ambry.account.ContainerBuilder;
+import com.github.ambry.account.InMemAccountServiceFactory;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.MockClusterMap;
@@ -73,7 +74,6 @@ import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -89,11 +89,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import javax.net.ssl.SSLSession;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -103,10 +103,7 @@ import static org.junit.Assert.*;
  * Unit tests for {@link AmbryBlobStorageService}.
  */
 public class AmbryBlobStorageServiceTest {
-  private static final Account refAccount;
-  private static final Container refContainer;
-  private static final Container refDefaultPublicContainer;
-  private static final Container refDefaultPrivateContainer;
+  private final Account refAccount;
   private final Properties configProps = new Properties();
   private final MetricRegistry metricRegistry = new MetricRegistry();
   private final FrontendMetrics frontendMetrics = new FrontendMetrics(metricRegistry);
@@ -120,22 +117,12 @@ public class AmbryBlobStorageServiceTest {
   private FrontendConfig frontendConfig;
   private VerifiableProperties verifiableProperties;
   private boolean shouldAllowServiceIdBasedPut = true;
-  private AccountService accountService = new FrontendTestAccountService();
   private AmbryBlobStorageService ambryBlobStorageService;
-
-  /**
-   * Randomly generates a reference {@link Account} and {@link Container}s.
-   */
-  static {
-    short refAccountId = Utils.getRandomShort(TestUtils.RANDOM);
-    String refAccountName = UtilsTest.getRandomString(10);
-    Account.AccountStatus refAccountStatus = Account.AccountStatus.ACTIVE;
-    refContainer = getRandomContainer(refAccountId);
-    refDefaultPublicContainer = getDefaultContainer(refAccountId, false);
-    refDefaultPrivateContainer = getDefaultContainer(refAccountId, true);
-    refAccount = new AccountBuilder(refAccountId, refAccountName, refAccountStatus,
-        Arrays.asList(refDefaultPublicContainer, refDefaultPrivateContainer, refContainer)).build();
-  }
+  private Container refContainer;
+  private Container refDefaultPublicContainer;
+  private Container refDefaultPrivateContainer;
+  private InMemAccountServiceFactory.InMemAccountService accountService =
+      new InMemAccountServiceFactory(false).getAccountService();
 
   /**
    * Sets up the {@link AmbryBlobStorageService} instance before a test.
@@ -150,7 +137,16 @@ public class AmbryBlobStorageServiceTest {
     frontendConfig = new FrontendConfig(verifiableProperties);
     idConverterFactory = new AmbryIdConverterFactory(verifiableProperties, metricRegistry);
     securityServiceFactory = new AmbrySecurityServiceFactory(verifiableProperties, metricRegistry, null);
-    accountService.updateAccounts(Collections.singletonList(refAccount));
+    refAccount = accountService.createAndAddRandomAccount();
+    for (Container container : refAccount.getAllContainers()) {
+      if (container.getId() == Container.DEFAULT_PUBLIC_CONTAINER_ID) {
+        refDefaultPublicContainer = container;
+      } else if (container.getId() == Container.DEFAULT_PRIVATE_CONTAINER_ID) {
+        refDefaultPrivateContainer = container;
+      } else {
+        refContainer = container;
+      }
+    }
     clusterMap = new MockClusterMap();
     router = new InMemoryRouter(verifiableProperties, clusterMap);
     responseHandler = new FrontendTestResponseHandler();
@@ -393,19 +389,7 @@ public class AmbryBlobStorageServiceTest {
   @Test
   public void postGetHeadDeleteTest() throws Exception {
     // add another account
-    short accountId;
-    String accountName;
-    do {
-      accountId = Utils.getRandomShort(TestUtils.RANDOM);
-      accountName = UtilsTest.getRandomString(10);
-    } while (accountId == refAccount.getId() || accountName.equals(refAccount.getName()));
-    Container randomContainer = getRandomContainer(accountId);
-    Container defaultPublicContainer = getDefaultContainer(accountId, false);
-    Container defaultPrivateContainer = getDefaultContainer(accountId, true);
-    Account account = new AccountBuilder(accountId, accountName, Account.AccountStatus.ACTIVE,
-        Arrays.asList(defaultPublicContainer, defaultPrivateContainer, randomContainer)).build();
-    accountService.updateAccounts(Collections.singletonList(account));
-
+    accountService.createAndAddRandomAccount();
     // valid account and container names passed as part of POST
     for (Account testAccount : accountService.getAllAccounts()) {
       for (Container container : testAccount.getAllContainers()) {
@@ -564,7 +548,7 @@ public class AmbryBlobStorageServiceTest {
    */
   @Test
   public void accountNameMismatchTest() throws Exception {
-    accountService = new FrontendTestAccountService(true);
+    accountService = new InMemAccountServiceFactory(true).getAccountService();
     ambryBlobStorageService = getAmbryBlobStorageService();
     ambryBlobStorageService.start();
     postBlobAndVerifyWithAccountAndContainer(refAccount.getName(), refContainer.getName(), "serviceId",
@@ -818,41 +802,6 @@ public class AmbryBlobStorageServiceTest {
   // general
 
   /**
-   * Creates and returns default public/private container for {@code accountId}.
-   * @param accountId the account id for the container
-   * @param isPrivate {@code true} if private container is required. {@code false} for public.
-   * @return default public/private container for {@code accountId}.
-   */
-  private static Container getDefaultContainer(short accountId, boolean isPrivate) {
-    Container container;
-    if (isPrivate) {
-      container = new ContainerBuilder(Container.DEFAULT_PRIVATE_CONTAINER_ID, Container.DEFAULT_PRIVATE_CONTAINER_NAME,
-          Container.DEFAULT_PRIVATE_CONTAINER_STATUS, Container.DEFAULT_PRIVATE_CONTAINER_DESCRIPTION,
-          Container.DEFAULT_PRIVATE_CONTAINER_IS_PRIVATE_SETTING, accountId).build();
-    } else {
-      container = new ContainerBuilder(Container.DEFAULT_PUBLIC_CONTAINER_ID, Container.DEFAULT_PUBLIC_CONTAINER_NAME,
-          Container.DEFAULT_PUBLIC_CONTAINER_STATUS, Container.DEFAULT_PUBLIC_CONTAINER_DESCRIPTION,
-          Container.DEFAULT_PUBLIC_CONTAINER_IS_PRIVATE_SETTING, accountId).build();
-    }
-    return container;
-  }
-
-  /**
-   * Creates and returns a random {@link Container} for {@code accountId}.
-   * @param accountId the account id for the container
-   * @return returns a random {@link Container} for {@code accountId}
-   */
-  private static Container getRandomContainer(short accountId) {
-    short refContainerId = Utils.getRandomShort(TestUtils.RANDOM);
-    String refContainerName = UtilsTest.getRandomString(10);
-    Container.ContainerStatus refContainerStatus = Container.ContainerStatus.ACTIVE;
-    String refContainerDescription = UtilsTest.getRandomString(10);
-    boolean refContainerPrivacy = TestUtils.RANDOM.nextBoolean();
-    return new ContainerBuilder(refContainerId, refContainerName, refContainerStatus, refContainerDescription,
-        refContainerPrivacy, accountId).build();
-  }
-
-  /**
    * Method to easily create {@link RestRequest} objects containing a specific request.
    * @param restMethod the {@link RestMethod} desired.
    * @param uri string representation of the desired URI.
@@ -893,9 +842,10 @@ public class AmbryBlobStorageServiceTest {
    */
   private void setAmbryHeadersForPut(JSONObject headers, long ttlInSecs, boolean isPrivate, String serviceId,
       String contentType, String ownerId, String targetAccountName, String targetContainerName) throws JSONException {
-    if (headers != null && ttlInSecs >= -1 && serviceId != null && contentType != null) {
-      headers.put(RestUtils.Headers.TTL, ttlInSecs);
-      headers.put(RestUtils.Headers.PRIVATE, isPrivate);
+    if (headers != null && serviceId != null && contentType != null) {
+      if (ttlInSecs > -1) {
+        headers.put(RestUtils.Headers.TTL, ttlInSecs);
+      }
       headers.put(RestUtils.Headers.SERVICE_ID, serviceId);
       headers.put(RestUtils.Headers.AMBRY_CONTENT_TYPE, contentType);
       if (targetAccountName != null) {
@@ -903,6 +853,8 @@ public class AmbryBlobStorageServiceTest {
       }
       if (targetContainerName != null) {
         headers.put(RestUtils.Headers.TARGET_CONTAINER_NAME, targetContainerName);
+      } else {
+        headers.put(RestUtils.Headers.PRIVATE, isPrivate);
       }
       if (ownerId != null) {
         headers.put(RestUtils.Headers.OWNER_ID, ownerId);
@@ -1057,26 +1009,26 @@ public class AmbryBlobStorageServiceTest {
     headers.put(RestUtils.Headers.BLOB_SIZE, (long) CONTENT_LENGTH);
     getBlobAndVerify(blobId, null, null, headers, content, expectedAccount, expectedContainer);
     getBlobAndVerify(blobId, null, GetOption.None, headers, content, expectedAccount, expectedContainer);
-    getHeadAndVerify(blobId, null, null, headers);
-    getHeadAndVerify(blobId, null, GetOption.None, headers);
+    getHeadAndVerify(blobId, null, null, headers, expectedAccount, expectedContainer);
+    getHeadAndVerify(blobId, null, GetOption.None, headers, expectedAccount, expectedContainer);
 
     ByteRange range = ByteRange.fromStartOffset(ThreadLocalRandom.current().nextLong(CONTENT_LENGTH));
     getBlobAndVerify(blobId, range, null, headers, content, expectedAccount, expectedContainer);
-    getHeadAndVerify(blobId, range, null, headers);
+    getHeadAndVerify(blobId, range, null, headers, expectedAccount, expectedContainer);
 
     range = ByteRange.fromLastNBytes(ThreadLocalRandom.current().nextLong(CONTENT_LENGTH + 1));
     getBlobAndVerify(blobId, range, null, headers, content, expectedAccount, expectedContainer);
-    getHeadAndVerify(blobId, range, null, headers);
+    getHeadAndVerify(blobId, range, null, headers, expectedAccount, expectedContainer);
 
     long random1 = ThreadLocalRandom.current().nextLong(CONTENT_LENGTH);
     long random2 = ThreadLocalRandom.current().nextLong(CONTENT_LENGTH);
     range = ByteRange.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2));
     getBlobAndVerify(blobId, range, null, headers, content, expectedAccount, expectedContainer);
-    getHeadAndVerify(blobId, range, null, headers);
+    getHeadAndVerify(blobId, range, null, headers, expectedAccount, expectedContainer);
 
     getNotModifiedBlobAndVerify(blobId, null);
     getUserMetadataAndVerify(blobId, null, headers);
-    getBlobInfoAndVerify(blobId, null, headers);
+    getBlobInfoAndVerify(blobId, null, headers, expectedAccount, expectedContainer);
     deleteBlobAndVerify(blobId);
 
     // check GET, HEAD and DELETE after delete.
@@ -1228,9 +1180,12 @@ public class AmbryBlobStorageServiceTest {
    * @param blobId the blob ID of the blob to HEAD.
    * @param getOption the options to use while getting the blob.
    * @param expectedHeaders the expected headers in the response.
+   * @param expectedAccount the expected account in the rest request.
+   * @param expectedContainer the expected container in the rest request.
    * @throws Exception
    */
-  private void getBlobInfoAndVerify(String blobId, GetOption getOption, JSONObject expectedHeaders) throws Exception {
+  private void getBlobInfoAndVerify(String blobId, GetOption getOption, JSONObject expectedHeaders,
+      Account expectedAccount, Container expectedContainer) throws Exception {
     JSONObject headers = new JSONObject();
     if (getOption != null) {
       headers.put(RestUtils.Headers.GET_OPTION, getOption.toString());
@@ -1245,8 +1200,9 @@ public class AmbryBlobStorageServiceTest {
     assertNull("Accept-Ranges should not be set", restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
     assertNull("Content-Range header should not be set",
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
-    verifyBlobProperties(expectedHeaders, restResponseChannel);
+    verifyBlobProperties(expectedHeaders, expectedContainer.isPrivate(), restResponseChannel);
     verifyUserMetadataHeaders(expectedHeaders, restResponseChannel);
+    verifyAccountAndContainerHeaders(restResponseChannel, expectedAccount, expectedContainer);
   }
 
   /**
@@ -1255,10 +1211,12 @@ public class AmbryBlobStorageServiceTest {
    * @param range the optional {@link ByteRange} for the request.
    * @param getOption the options to use while getting the blob.
    * @param expectedHeaders the expected headers in the response.
+   * @param expectedAccount the expected account in the rest request.
+   * @param expectedContainer the expected container in the rest request.
    * @throws Exception
    */
-  private void getHeadAndVerify(String blobId, ByteRange range, GetOption getOption, JSONObject expectedHeaders)
-      throws Exception {
+  private void getHeadAndVerify(String blobId, ByteRange range, GetOption getOption, JSONObject expectedHeaders,
+      Account expectedAccount, Container expectedContainer) throws Exception {
     RestRequest restRequest = createRestRequest(RestMethod.HEAD, blobId, createRequestHeaders(range, getOption), null);
     MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
     doOperation(restRequest, restResponseChannel);
@@ -1282,25 +1240,27 @@ public class AmbryBlobStorageServiceTest {
     }
     assertEquals(RestUtils.Headers.CONTENT_LENGTH + " does not match expected", Long.toString(contentLength),
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
-    verifyBlobProperties(expectedHeaders, restResponseChannel);
+    verifyBlobProperties(expectedHeaders, expectedContainer.isPrivate(), restResponseChannel);
+    verifyAccountAndContainerHeaders(restResponseChannel, expectedAccount, expectedContainer);
   }
 
   /**
    * Verifies blob properties from output, to that sent in during input
    * @param expectedHeaders the expected headers in the response.
+   * @param isPrivate {@code true} if the blob is expected to be private
    * @param restResponseChannel the {@link RestResponseChannel} which contains the response.
    * @throws JSONException
    */
-  private void verifyBlobProperties(JSONObject expectedHeaders, MockRestResponseChannel restResponseChannel)
-      throws JSONException {
+  private void verifyBlobProperties(JSONObject expectedHeaders, boolean isPrivate,
+      MockRestResponseChannel restResponseChannel) throws JSONException {
     assertEquals(RestUtils.Headers.BLOB_SIZE + " does not match",
         expectedHeaders.getString(RestUtils.Headers.BLOB_SIZE),
         restResponseChannel.getHeader(RestUtils.Headers.BLOB_SIZE));
     assertEquals(RestUtils.Headers.SERVICE_ID + " does not match",
         expectedHeaders.getString(RestUtils.Headers.SERVICE_ID),
         restResponseChannel.getHeader(RestUtils.Headers.SERVICE_ID));
-    assertEquals(RestUtils.Headers.PRIVATE + " does not match", expectedHeaders.getString(RestUtils.Headers.PRIVATE),
-        restResponseChannel.getHeader(RestUtils.Headers.PRIVATE));
+    assertEquals(RestUtils.Headers.PRIVATE + " does not match", isPrivate,
+        Boolean.valueOf(restResponseChannel.getHeader(RestUtils.Headers.PRIVATE)));
     assertEquals(RestUtils.Headers.AMBRY_CONTENT_TYPE + " does not match",
         expectedHeaders.getString(RestUtils.Headers.AMBRY_CONTENT_TYPE),
         restResponseChannel.getHeader(RestUtils.Headers.AMBRY_CONTENT_TYPE));
@@ -1314,6 +1274,22 @@ public class AmbryBlobStorageServiceTest {
       assertEquals(RestUtils.Headers.OWNER_ID + " does not match",
           expectedHeaders.getString(RestUtils.Headers.OWNER_ID),
           restResponseChannel.getHeader(RestUtils.Headers.OWNER_ID));
+    }
+  }
+
+  /**
+   * Verify that the account and container headers in the response are correct.
+   * @param restResponseChannel the {@link MockRestResponseChannel} to get headers from.
+   * @param expectedAccount the expected {@link Account}.
+   * @param expectedContainer the expected {@link Container}.
+   */
+  private void verifyAccountAndContainerHeaders(MockRestResponseChannel restResponseChannel, Account expectedAccount,
+      Container expectedContainer) {
+    if (expectedAccount.getId() != Account.UNKNOWN_ACCOUNT_ID) {
+      Assert.assertEquals("Account name not as expected", expectedAccount.getName(),
+          restResponseChannel.getHeader(RestUtils.Headers.TARGET_ACCOUNT_NAME));
+      Assert.assertEquals("Container name not as expected", expectedContainer.getName(),
+          restResponseChannel.getHeader(RestUtils.Headers.TARGET_CONTAINER_NAME));
     }
   }
 
@@ -1370,8 +1346,8 @@ public class AmbryBlobStorageServiceTest {
       getBlobAndVerify(blobId, null, option, expectedHeaders, expectedContent, expectedAccount, expectedContainer);
       getNotModifiedBlobAndVerify(blobId, option);
       getUserMetadataAndVerify(blobId, option, expectedHeaders);
-      getBlobInfoAndVerify(blobId, option, expectedHeaders);
-      getHeadAndVerify(blobId, null, option, expectedHeaders);
+      getBlobInfoAndVerify(blobId, option, expectedHeaders, expectedAccount, expectedContainer);
+      getHeadAndVerify(blobId, null, option, expectedHeaders, expectedAccount, expectedContainer);
     }
   }
 
@@ -1647,7 +1623,7 @@ public class AmbryBlobStorageServiceTest {
    * @throws Exception
    */
   private void populateAccountService() throws Exception {
-    ((FrontendTestAccountService) accountService).clear();
+    accountService.clear();
     accountService.updateAccounts(Lists.newArrayList(refAccount, Account.UNKNOWN_ACCOUNT));
   }
 
@@ -2225,74 +2201,3 @@ class FrontendTestRouter implements Router {
   }
 }
 
-/**
- * Implementation of {@link AccountService} for test. This implementation is not thread-safe.
- */
-class FrontendTestAccountService implements AccountService {
-  private final Map<Short, Account> idToAccountMap = new HashMap<>();
-  private final Map<String, Account> nameToAccountMap = new HashMap<>();
-  private boolean shouldReturnUnknownAccountByName = false;
-
-  /**
-   * Constructor.
-   * @param shouldReturnUnknownAccountByName {@code true} if always returns {@link Account#UNKNOWN_ACCOUNT} when queried
-   *                                                     by account name; {@code false} to do the actual query.
-   */
-  FrontendTestAccountService(boolean shouldReturnUnknownAccountByName) {
-    this.shouldReturnUnknownAccountByName = shouldReturnUnknownAccountByName;
-  }
-
-  /**
-   * Constructor with {@link #shouldReturnUnknownAccountByName} set to {@code false}.
-   */
-  FrontendTestAccountService() {
-    this(false);
-  }
-
-  @Override
-  public Account getAccountById(short accountId) {
-    return idToAccountMap.get(accountId);
-  }
-
-  @Override
-  public Account getAccountByName(String accountName) {
-    return shouldReturnUnknownAccountByName ? Account.UNKNOWN_ACCOUNT : nameToAccountMap.get(accountName);
-  }
-
-  @Override
-  public boolean updateAccounts(Collection<Account> accounts) {
-    for (Account account : accounts) {
-      idToAccountMap.put(account.getId(), account);
-      nameToAccountMap.put(account.getName(), account);
-    }
-    return true;
-  }
-
-  @Override
-  public boolean addAccountUpdateConsumer(Consumer<Collection<Account>> accountUpdateConsumer) {
-    throw new UnsupportedOperationException("Not implemented");
-  }
-
-  @Override
-  public boolean removeAccountUpdateConsumer(Consumer<Collection<Account>> accountUpdateConsumer) {
-    throw new UnsupportedOperationException("Not implemented");
-  }
-
-  @Override
-  public Collection<Account> getAllAccounts() {
-    return idToAccountMap.values();
-  }
-
-  @Override
-  public void close() throws IOException {
-    // no op
-  }
-
-  /**
-   * Clears all the accounts in this {@code AccountService}.
-   */
-  void clear() {
-    idToAccountMap.clear();
-    nameToAccountMap.clear();
-  }
-}

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -65,7 +65,7 @@ public class AmbrySecurityServiceTest {
   private static final String SERVICE_ID = "AmbrySecurityService";
   private static final String OWNER_ID = SERVICE_ID;
   private static final InMemAccountServiceFactory.InMemAccountService accountService =
-      new InMemAccountServiceFactory(false).getAccountService();
+      new InMemAccountServiceFactory(false, true).getAccountService();
   private static final Account REF_ACCOUNT = accountService.createAndAddRandomAccount();
   private static final Container REF_CONTAINER = REF_ACCOUNT.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
   private static final BlobInfo DEFAULT_INFO = new BlobInfo(

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -69,7 +69,7 @@ public class AmbrySecurityServiceTest {
   private static final Account REF_ACCOUNT = accountService.createAndAddRandomAccount();
   private static final Container REF_CONTAINER = REF_ACCOUNT.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
   private static final BlobInfo DEFAULT_INFO = new BlobInfo(
-      new BlobProperties(Utils.getRandomLong(TestUtils.RANDOM, 1000) + 1, SERVICE_ID, OWNER_ID, "image/gif", true,
+      new BlobProperties(Utils.getRandomLong(TestUtils.RANDOM, 1000) + 1, SERVICE_ID, OWNER_ID, "image/gif", false,
           Utils.Infinite_Time, REF_ACCOUNT.getId(), REF_CONTAINER.getId()), null);
   private static final BlobInfo UNKNOWN_INFO = new BlobInfo(
       new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, Utils.Infinite_Time, Account.UNKNOWN_ACCOUNT_ID,

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -99,7 +99,7 @@ public class FrontendIntegrationTest {
   private static final VerifiableProperties SSL_CLIENT_VERIFIABLE_PROPS;
   private static final FrontendConfig FRONTEND_CONFIG;
   private static final InMemAccountServiceFactory.InMemAccountService ACCOUNT_SERVICE =
-      new InMemAccountServiceFactory(false).getAccountService();
+      new InMemAccountServiceFactory(false, true).getAccountService();
 
   static {
     try {

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.frontend;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.account.InMemAccountServiceFactory;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.MockClusterMap;
@@ -67,6 +68,7 @@ import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -96,6 +98,8 @@ public class FrontendIntegrationTest {
   private static final VerifiableProperties FRONTEND_VERIFIABLE_PROPS;
   private static final VerifiableProperties SSL_CLIENT_VERIFIABLE_PROPS;
   private static final FrontendConfig FRONTEND_CONFIG;
+  private static final InMemAccountServiceFactory.InMemAccountService ACCOUNT_SERVICE =
+      new InMemAccountServiceFactory(false).getAccountService();
 
   static {
     try {
@@ -105,6 +109,7 @@ public class FrontendIntegrationTest {
       FRONTEND_VERIFIABLE_PROPS = buildFrontendVProps(trustStoreFile);
       SSL_CLIENT_VERIFIABLE_PROPS = TestSSLUtils.createSslProps("", SSLFactory.Mode.CLIENT, trustStoreFile, "client");
       FRONTEND_CONFIG = new FrontendConfig(FRONTEND_VERIFIABLE_PROPS);
+      ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(Account.UNKNOWN_ACCOUNT));
     } catch (IOException | GeneralSecurityException e) {
       throw new IllegalStateException(e);
     }
@@ -174,12 +179,38 @@ public class FrontendIntegrationTest {
    */
   @Test
   public void postGetHeadDeleteTest() throws Exception {
-    doPostGetHeadDeleteTest(0, false, false);
-    doPostGetHeadDeleteTest(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes - 1, false, false);
-    doPostGetHeadDeleteTest(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes, false, false);
-    doPostGetHeadDeleteTest(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes * 3, false, false);
-    // currently there is no difference in the behavior b/w public and private blobs
-    doPostGetHeadDeleteTest(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes * 3, true, false);
+    // add some accounts
+    Account refAccount = ACCOUNT_SERVICE.createAndAddRandomAccount();
+    Container publicContainer = refAccount.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
+    Container privateContainer = refAccount.getContainerById(Container.DEFAULT_PRIVATE_CONTAINER_ID);
+    int refContentSize = FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes * 3;
+    for (int i = 0; i < 2; i++) {
+      ACCOUNT_SERVICE.createAndAddRandomAccount();
+    }
+
+    // with valid account and containers
+    for (Account account : ACCOUNT_SERVICE.getAllAccounts()) {
+      if (account.getId() != Account.UNKNOWN_ACCOUNT_ID) {
+        for (Container container : account.getAllContainers()) {
+          doPostGetHeadDeleteTest(refContentSize, account, container, account.getName(), container.isPrivate(),
+              account.getName(), container.getName(), false);
+        }
+      }
+    }
+    // valid account and container names but only serviceId passed as part of POST
+    doPostGetHeadDeleteTest(refContentSize, null, null, refAccount.getName(), false, refAccount.getName(),
+        publicContainer.getName(), false);
+    doPostGetHeadDeleteTest(refContentSize, null, null, refAccount.getName(), true, refAccount.getName(),
+        privateContainer.getName(), false);
+    // unrecognized serviceId
+    doPostGetHeadDeleteTest(refContentSize, null, null, "unknown_service_id", false, null, null, false);
+    doPostGetHeadDeleteTest(refContentSize, null, null, "unknown_service_id", true, null, null, false);
+    // different sizes
+    for (int contentSize : new int[]{0, FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes
+        - 1, FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes, refContentSize}) {
+      doPostGetHeadDeleteTest(contentSize, refAccount, publicContainer, refAccount.getName(),
+          publicContainer.isPrivate(), refAccount.getName(), publicContainer.getName(), false);
+    }
   }
 
   /**
@@ -188,8 +219,12 @@ public class FrontendIntegrationTest {
    */
   @Test
   public void multipartPostGetHeadTest() throws Exception {
-    doPostGetHeadDeleteTest(0, false, true);
-    doPostGetHeadDeleteTest(1024, false, true);
+    Account refAccount = ACCOUNT_SERVICE.createAndAddRandomAccount();
+    Container refContainer = refAccount.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
+    doPostGetHeadDeleteTest(0, refAccount, refContainer, refAccount.getName(), refContainer.isPrivate(),
+        refAccount.getName(), refContainer.getName(), true);
+    doPostGetHeadDeleteTest(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes * 3, refAccount, refContainer,
+        refAccount.getName(), refContainer.isPrivate(), refAccount.getName(), refContainer.getName(), true);
   }
 
   /*
@@ -336,6 +371,7 @@ public class FrontendIntegrationTest {
     // to test that backpressure does not impede correct operation.
     properties.put("netty.server.request.buffer.watermark", "1");
     TestSSLUtils.addSSLProperties(properties, "", SSLFactory.Mode.SERVER, trustStoreFile, "frontend");
+    properties.put("frontend.account.service.factory", "com.github.ambry.account.InMemAccountServiceFactory");
     return new VerifiableProperties(properties);
   }
 
@@ -344,17 +380,26 @@ public class FrontendIntegrationTest {
   /**
    * Utility to test blob POST, GET, HEAD and DELETE operations for a specified size
    * @param contentSize the size of the blob to be tested
-   * @param isPrivate {@code true} if blob should be marked as private, {@code false} otherwise.
+   * @param toPostAccount the {@link Account} to use in post headers. Can be {@code null} if only using service ID.
+   * @param toPostContainer the {@link Container} to use in post headers. Can be {@code null} if only using service ID.
+   * @param serviceId the serviceId to use for the POST
+   * @param isPrivate the isPrivate flag to pass as part of the POST
+   * @param expectedAccountName the expected account name in some response.
+   * @param expectedContainerName the expected container name in some responses.
    * @param multipartPost {@code true} if multipart POST is desired, {@code false} otherwise.
    * @throws Exception
    */
-  private void doPostGetHeadDeleteTest(int contentSize, boolean isPrivate, boolean multipartPost) throws Exception {
+  private void doPostGetHeadDeleteTest(int contentSize, Account toPostAccount, Container toPostContainer,
+      String serviceId, boolean isPrivate, String expectedAccountName, String expectedContainerName,
+      boolean multipartPost) throws Exception {
     ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(contentSize));
-    String serviceId = "postGetHeadDeleteServiceID";
     String contentType = "application/octet-stream";
     String ownerId = "postGetHeadDeleteOwnerID";
+    String accountNameInPost = toPostAccount != null ? toPostAccount.getName() : null;
+    String containerNameInPost = toPostContainer != null ? toPostContainer.getName() : null;
     HttpHeaders headers = new DefaultHttpHeaders();
-    setAmbryHeadersForPut(headers, 7200, isPrivate, serviceId, contentType, ownerId);
+    setAmbryHeadersForPut(headers, 7200, isPrivate, serviceId, contentType, ownerId, accountNameInPost,
+        containerNameInPost);
     String blobId;
     byte[] usermetadata = null;
     if (multipartPost) {
@@ -366,30 +411,31 @@ public class FrontendIntegrationTest {
       blobId = postBlobAndVerify(headers, content);
     }
     headers.add(RestUtils.Headers.BLOB_SIZE, content.capacity());
-    getBlobAndVerify(blobId, null, null, headers, content);
-    getHeadAndVerify(blobId, null, null, headers);
-    getBlobAndVerify(blobId, null, GetOption.None, headers, content);
-    getHeadAndVerify(blobId, null, GetOption.None, headers);
+    getBlobAndVerify(blobId, null, null, headers, isPrivate, content);
+    getHeadAndVerify(blobId, null, null, headers, isPrivate, expectedAccountName, expectedContainerName);
+    getBlobAndVerify(blobId, null, GetOption.None, headers, isPrivate, content);
+    getHeadAndVerify(blobId, null, GetOption.None, headers, isPrivate, expectedAccountName, expectedContainerName);
     ByteRange range = ByteRange.fromLastNBytes(ThreadLocalRandom.current().nextLong(content.capacity() + 1));
-    getBlobAndVerify(blobId, range, null, headers, content);
-    getHeadAndVerify(blobId, range, null, headers);
+    getBlobAndVerify(blobId, range, null, headers, isPrivate, content);
+    getHeadAndVerify(blobId, range, null, headers, isPrivate, expectedAccountName, expectedContainerName);
     if (contentSize > 0) {
       range = ByteRange.fromStartOffset(ThreadLocalRandom.current().nextLong(content.capacity()));
-      getBlobAndVerify(blobId, range, null, headers, content);
-      getHeadAndVerify(blobId, range, null, headers);
+      getBlobAndVerify(blobId, range, null, headers, isPrivate, content);
+      getHeadAndVerify(blobId, range, null, headers, isPrivate, expectedAccountName, expectedContainerName);
       long random1 = ThreadLocalRandom.current().nextLong(content.capacity());
       long random2 = ThreadLocalRandom.current().nextLong(content.capacity());
       range = ByteRange.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2));
-      getBlobAndVerify(blobId, range, null, headers, content);
-      getHeadAndVerify(blobId, range, null, headers);
+      getBlobAndVerify(blobId, range, null, headers, isPrivate, content);
+      getHeadAndVerify(blobId, range, null, headers, isPrivate, expectedAccountName, expectedContainerName);
     }
     getNotModifiedBlobAndVerify(blobId, null, isPrivate);
     getUserMetadataAndVerify(blobId, null, headers, usermetadata);
-    getBlobInfoAndVerify(blobId, null, headers, usermetadata);
+    getBlobInfoAndVerify(blobId, null, headers, isPrivate, expectedAccountName, expectedContainerName, usermetadata);
     deleteBlobAndVerify(blobId);
 
     // check GET, HEAD and DELETE after delete.
-    verifyOperationsAfterDelete(blobId, headers, content, usermetadata);
+    verifyOperationsAfterDelete(blobId, headers, isPrivate, expectedAccountName, expectedContainerName, content,
+        usermetadata);
   }
 
   /**
@@ -403,16 +449,27 @@ public class FrontendIntegrationTest {
    * @param contentType sets the {@link RestUtils.Headers#AMBRY_CONTENT_TYPE} header. Required and has to be a valid MIME
    *                    type.
    * @param ownerId sets the {@link RestUtils.Headers#OWNER_ID} header. Optional - if not required, send null.
+   * @param targetAccountName sets the {@link RestUtils.Headers#TARGET_ACCOUNT_NAME} header. Can be {@code null}.
+   * @param targetContainerName sets the {@link RestUtils.Headers#TARGET_CONTAINER_NAME} header. Can be {@code null}.
    * @throws IllegalArgumentException if any of {@code headers}, {@code serviceId}, {@code contentType} is null or if
    *                                  {@code contentLength} < 0 or if {@code ttlInSecs} < -1.
    */
   private void setAmbryHeadersForPut(HttpHeaders httpHeaders, long ttlInSecs, boolean isPrivate, String serviceId,
-      String contentType, String ownerId) {
-    if (httpHeaders != null && ttlInSecs >= -1 && serviceId != null && contentType != null) {
-      httpHeaders.add(RestUtils.Headers.TTL, ttlInSecs);
-      httpHeaders.add(RestUtils.Headers.PRIVATE, isPrivate);
+      String contentType, String ownerId, String targetAccountName, String targetContainerName) {
+    if (httpHeaders != null && serviceId != null && contentType != null) {
+      if (ttlInSecs > -1) {
+        httpHeaders.add(RestUtils.Headers.TTL, ttlInSecs);
+      }
       httpHeaders.add(RestUtils.Headers.SERVICE_ID, serviceId);
       httpHeaders.add(RestUtils.Headers.AMBRY_CONTENT_TYPE, contentType);
+      if (targetAccountName != null) {
+        httpHeaders.add(RestUtils.Headers.TARGET_ACCOUNT_NAME, targetAccountName);
+      }
+      if (targetContainerName != null) {
+        httpHeaders.add(RestUtils.Headers.TARGET_CONTAINER_NAME, targetContainerName);
+      } else {
+        httpHeaders.add(RestUtils.Headers.PRIVATE, isPrivate);
+      }
       if (ownerId != null) {
         httpHeaders.add(RestUtils.Headers.OWNER_ID, ownerId);
       }
@@ -455,12 +512,14 @@ public class FrontendIntegrationTest {
    * @param range the {@link ByteRange} for the request.
    * @param getOption the options to use while getting the blob.
    * @param expectedHeaders the expected headers in the response.
+   * @param isPrivate {@code true} if the blob is private, {@code false} if not.
    * @param expectedContent the expected content of the blob.
    * @throws ExecutionException
    * @throws InterruptedException
    */
   private void getBlobAndVerify(String blobId, ByteRange range, GetOption getOption, HttpHeaders expectedHeaders,
-      ByteBuffer expectedContent) throws ExecutionException, InterruptedException, RestServiceException {
+      boolean isPrivate, ByteBuffer expectedContent)
+      throws ExecutionException, InterruptedException, RestServiceException {
     HttpHeaders headers = new DefaultHttpHeaders();
     if (range != null) {
       headers.add(RestUtils.Headers.RANGE, RestTestUtils.getRangeHeaderString(range));
@@ -494,7 +553,7 @@ public class FrontendIntegrationTest {
     if (expectedContentArray.length < FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes) {
       assertEquals("Content-length not as expected", expectedContentArray.length, HttpUtil.getContentLength(response));
     }
-    verifyCacheHeaders(Boolean.parseBoolean(expectedHeaders.get(RestUtils.Headers.PRIVATE)), response);
+    verifyCacheHeaders(isPrivate, response);
     byte[] responseContentArray = getContent(responseParts, expectedContentArray.length).array();
     assertArrayEquals("GET content does not match original content", expectedContentArray, responseContentArray);
     assertTrue("Channel should be active", HttpUtil.isKeepAlive(response));
@@ -559,12 +618,15 @@ public class FrontendIntegrationTest {
    * @param blobId the blob ID of the blob to HEAD.
    * @param getOption the options to use while getting the blob.
    * @param expectedHeaders the expected headers in the response.
+   * @param isPrivate {@code true} if the blob is expected to be private
+   * @param accountName the expected account name in the response.
+   * @param containerName the expected container name in response.
    * @param usermetadata if non-null, this is expected to come as the body.
    * @throws ExecutionException
    * @throws InterruptedException
    */
-  private void getBlobInfoAndVerify(String blobId, GetOption getOption, HttpHeaders expectedHeaders,
-      byte[] usermetadata) throws ExecutionException, InterruptedException {
+  private void getBlobInfoAndVerify(String blobId, GetOption getOption, HttpHeaders expectedHeaders, boolean isPrivate,
+      String accountName, String containerName, byte[] usermetadata) throws ExecutionException, InterruptedException {
     HttpHeaders headers = new DefaultHttpHeaders();
     if (getOption != null) {
       headers.add(RestUtils.Headers.GET_OPTION, getOption.toString());
@@ -575,7 +637,8 @@ public class FrontendIntegrationTest {
     HttpResponse response = (HttpResponse) responseParts.poll();
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
     checkCommonGetHeadHeaders(response.headers());
-    verifyBlobProperties(expectedHeaders, response);
+    verifyBlobProperties(expectedHeaders, isPrivate, response);
+    verifyAccountAndContainerHeaders(accountName, containerName, response);
     verifyUserMetadata(expectedHeaders, response, usermetadata, responseParts);
     assertTrue("Channel should be active", HttpUtil.isKeepAlive(response));
   }
@@ -586,10 +649,14 @@ public class FrontendIntegrationTest {
    * @param range the {@link ByteRange} for the request.
    * @param getOption the options to use while getting the blob.
    * @param expectedHeaders the expected headers in the response.
+   * @param isPrivate {@code true} if the blob is expected to be private
+   * @param accountName the expected account name in the response.
+   * @param containerName the expected container name in the response.
    * @throws ExecutionException
    * @throws InterruptedException
    */
-  private void getHeadAndVerify(String blobId, ByteRange range, GetOption getOption, HttpHeaders expectedHeaders)
+  private void getHeadAndVerify(String blobId, ByteRange range, GetOption getOption, HttpHeaders expectedHeaders,
+      boolean isPrivate, String accountName, String containerName)
       throws ExecutionException, InterruptedException, RestServiceException {
     HttpHeaders headers = new DefaultHttpHeaders();
     if (range != null) {
@@ -619,7 +686,8 @@ public class FrontendIntegrationTest {
     assertEquals(RestUtils.Headers.CONTENT_TYPE + " does not match " + RestUtils.Headers.AMBRY_CONTENT_TYPE,
         expectedHeaders.get(RestUtils.Headers.AMBRY_CONTENT_TYPE),
         response.headers().get(HttpHeaderNames.CONTENT_TYPE));
-    verifyBlobProperties(expectedHeaders, response);
+    verifyBlobProperties(expectedHeaders, isPrivate, response);
+    verifyAccountAndContainerHeaders(accountName, containerName, response);
     discardContent(responseParts, 1);
     assertTrue("Channel should be active", HttpUtil.isKeepAlive(response));
   }
@@ -627,15 +695,16 @@ public class FrontendIntegrationTest {
   /**
    * Verifies blob properties from output, to that sent in during input
    * @param expectedHeaders the expected headers in the response.
+   * @param isPrivate {@code true} if the blob is expected to be private
    * @param response the {@link HttpResponse} that contains the headers.
    */
-  private void verifyBlobProperties(HttpHeaders expectedHeaders, HttpResponse response) {
+  private void verifyBlobProperties(HttpHeaders expectedHeaders, boolean isPrivate, HttpResponse response) {
     assertEquals("Blob size does not match", Long.parseLong(expectedHeaders.get(RestUtils.Headers.BLOB_SIZE)),
         Long.parseLong(response.headers().get(RestUtils.Headers.BLOB_SIZE)));
     assertEquals(RestUtils.Headers.SERVICE_ID + " does not match", expectedHeaders.get(RestUtils.Headers.SERVICE_ID),
         response.headers().get(RestUtils.Headers.SERVICE_ID));
-    assertEquals(RestUtils.Headers.PRIVATE + " does not match", expectedHeaders.get(RestUtils.Headers.PRIVATE),
-        response.headers().get(RestUtils.Headers.PRIVATE));
+    assertEquals(RestUtils.Headers.PRIVATE + " does not match", isPrivate,
+        Boolean.valueOf(response.headers().get(RestUtils.Headers.PRIVATE)));
     assertEquals(RestUtils.Headers.AMBRY_CONTENT_TYPE + " does not match",
         expectedHeaders.get(RestUtils.Headers.AMBRY_CONTENT_TYPE),
         response.headers().get(RestUtils.Headers.AMBRY_CONTENT_TYPE));
@@ -648,6 +717,26 @@ public class FrontendIntegrationTest {
     if (expectedHeaders.contains(RestUtils.Headers.OWNER_ID)) {
       assertEquals(RestUtils.Headers.OWNER_ID + " does not match", expectedHeaders.get(RestUtils.Headers.OWNER_ID),
           response.headers().get(RestUtils.Headers.OWNER_ID));
+    }
+  }
+
+  /**
+   * Verifies the account and container headers in the response
+   * @param accountName the expected account name in {@code response}.
+   * @param containerName the expected container name in {@code response}.
+   * @param response the response received from Ambry.
+   */
+  private void verifyAccountAndContainerHeaders(String accountName, String containerName, HttpResponse response) {
+    String accountNameInResponse = response.headers().get(RestUtils.Headers.TARGET_ACCOUNT_NAME);
+    String containerNameInResponse = response.headers().get(RestUtils.Headers.TARGET_CONTAINER_NAME);
+    if (accountName != null && containerName != null) {
+      assertEquals("Account name does not match that to which blob was uploaded", accountName, accountNameInResponse);
+      assertEquals("Container name does not match that to which blob was uploaded", containerName,
+          containerNameInResponse);
+    } else {
+      assertNull("Response should not have any account name - has " + accountNameInResponse, accountNameInResponse);
+      assertNull("Response should not have any container name - has " + containerNameInResponse,
+          containerNameInResponse);
     }
   }
 
@@ -698,12 +787,15 @@ public class FrontendIntegrationTest {
    * Verifies that the right response code is returned for GET, HEAD and DELETE once a blob is deleted.
    * @param blobId the ID of the blob that was deleted.
    * @param expectedHeaders the expected headers in the response if the right options are provided.
+   * @param isPrivate {@code true} if the blob is expected to be private
+   * @param accountName the expected account name in {@code response}.
+   * @param containerName the expected container name in {@code response}.
    * @param expectedContent the expected content of the blob if the right options are provided.
    * @param usermetadata if non-null, this is expected to come as the body.
    * @throws Exception
    */
-  private void verifyOperationsAfterDelete(String blobId, HttpHeaders expectedHeaders, ByteBuffer expectedContent,
-      byte[] usermetadata) throws Exception {
+  private void verifyOperationsAfterDelete(String blobId, HttpHeaders expectedHeaders, boolean isPrivate,
+      String accountName, String containerName, ByteBuffer expectedContent, byte[] usermetadata) throws Exception {
     HttpHeaders headers = new DefaultHttpHeaders().add(RestUtils.Headers.GET_OPTION, GetOption.None.toString());
     FullHttpRequest httpRequest = buildRequest(HttpMethod.GET, blobId, null, null);
     verifyDeleted(httpRequest, HttpResponseStatus.GONE);
@@ -720,11 +812,11 @@ public class FrontendIntegrationTest {
 
     GetOption[] options = {GetOption.Include_Deleted_Blobs, GetOption.Include_All};
     for (GetOption option : options) {
-      getBlobAndVerify(blobId, null, option, expectedHeaders, expectedContent);
-      getNotModifiedBlobAndVerify(blobId, option, Boolean.parseBoolean(expectedHeaders.get(RestUtils.Headers.PRIVATE)));
+      getBlobAndVerify(blobId, null, option, expectedHeaders, isPrivate, expectedContent);
+      getNotModifiedBlobAndVerify(blobId, option, isPrivate);
       getUserMetadataAndVerify(blobId, option, expectedHeaders, usermetadata);
-      getBlobInfoAndVerify(blobId, option, expectedHeaders, usermetadata);
-      getHeadAndVerify(blobId, null, option, expectedHeaders);
+      getBlobInfoAndVerify(blobId, option, expectedHeaders, isPrivate, accountName, containerName, usermetadata);
+      getHeadAndVerify(blobId, null, option, expectedHeaders, isPrivate, accountName, containerName);
     }
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,8 +26,10 @@ import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import org.junit.After;
 import org.junit.Test;
 
@@ -59,6 +61,7 @@ public class LogTest {
 
   private final File tempDir;
   private final StoreMetrics metrics;
+  private final Set<Long> positionsGenerated = new HashSet<>();
 
   /**
    * Creates a temporary directory to store the segment files.
@@ -473,7 +476,10 @@ public class LogTest {
       segmentNames.add(name);
     } else {
       for (int i = 0; i < numToCreate; i++) {
-        long pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+        long pos;
+        do {
+          pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+        } while (positionsGenerated.contains(pos));
         long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
         String name = LogSegmentNameHelper.getName(pos, gen);
         File file = create(LogSegmentNameHelper.nameToFilename(name));
@@ -556,17 +562,22 @@ public class LogTest {
     LogSegment nextSegment = log.getFirstSegment();
     assertNull("Prev segment should be null", log.getPrevSegment(nextSegment));
     for (String segmentName : expectedSegmentNames) {
-      assertEquals("Next segment is not as expected", segmentName, nextSegment.getName());
+      assertEquals("Next segment is not as expected - expectedSegmentNames=" + expectedSegmentNames, segmentName,
+          nextSegment.getName());
       LogSegment segment = log.getSegment(segmentName);
-      assertEquals("Segment name is not as expected", segmentName, segment.getName());
+      assertEquals("Segment name is not as expected - expectedSegmentNames=" + expectedSegmentNames, segmentName,
+          segment.getName());
       assertEquals("Segment capacity not as expected", expectedSegmentCapacity, segment.getCapacityInBytes());
       assertEquals("Segment returned by getSegment() is incorrect", segment, log.getSegment(segment.getName()));
       nextSegment = log.getNextSegment(segment);
       if (nextSegment != null) {
-        assertEquals("Prev segment not as expected", segment, log.getPrevSegment(nextSegment));
+        assertEquals("Prev segment not as expected - expectedSegmentNames=" + expectedSegmentNames, segment,
+            log.getPrevSegment(nextSegment));
       }
     }
-    assertNull("Next segment should be null", nextSegment);
+    assertNull(
+        "Next segment should be null - expectedSegmentNames=" + expectedSegmentNames + ", nextSegment=" + nextSegment,
+        nextSegment);
   }
 
   /**


### PR DESCRIPTION
This commit adds `x-ambry-target-account` and `x-ambry-target-container` to the response if the account posted to is not `Account.UNKNOWN_ACCOUNT`. It will be added even if the original POST was not made with these headers but contained a x-ambry-service-id that was mapped to the relevant account and container.

Most of the changes are in tests in order to make them work with different accounts and containers.