### PR TITLE
Fixing the index segment size check when writing PersistentIndex

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -1496,11 +1496,10 @@ class PersistentIndex {
       final Timer.Context context = metrics.indexFlushTime.time();
       try {
         ConcurrentSkipListMap<Offset, IndexSegment> indexSegments = validIndexSegments;
-        int indexSegmentsSize = indexSegments.size();
-        if (indexSegmentsSize > 0) {
-          // before iterating the map, get the current file end pointer
-          Map.Entry<Offset, IndexSegment> lastEntry = indexSegments.lastEntry();
+        Map.Entry<Offset, IndexSegment> lastEntry = indexSegments.lastEntry();
+        if (lastEntry != null) {
           IndexSegment currentInfo = lastEntry.getValue();
+          // before iterating the map, get the current file end pointer
           Offset indexEndOffsetBeforeFlush = currentInfo.getEndOffset();
           Offset logEndOffsetBeforeFlush = log.getEndOffset();
           if (logEndOffsetBeforeFlush.compareTo(indexEndOffsetBeforeFlush) < 0) {
@@ -1519,8 +1518,8 @@ class PersistentIndex {
             hardDeleter.postLogFlush();
           }
 
-          IndexSegment prevInfo =
-              indexSegmentsSize > 1 ? indexSegments.lowerEntry(lastEntry.getKey()).getValue() : null;
+          Map.Entry<Offset, IndexSegment> prevEntry = indexSegments.lowerEntry(lastEntry.getKey());
+          IndexSegment prevInfo = prevEntry != null ? prevEntry.getValue() : null;
           List<IndexSegment> prevInfosToWrite = new ArrayList<>();
           Offset currentLogEndPointer = log.getEndOffset();
           while (prevInfo != null && !prevInfo.isMapped()) {

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1117,6 +1117,12 @@ public class IndexTest {
    */
   @Test
   public void indexPersistorTest() throws InterruptedException, IOException, StoreException {
+    // make sure persistor is persisting all segments
+    int numIndexSegments = state.index.getIndexSegments().size();
+    state.index.persistIndex();
+    int numIndexFiles = tempDir.listFiles(PersistentIndex.INDEX_SEGMENT_FILE_FILTER).length;
+    assertEquals("Not as many files written as there were index segments", numIndexSegments, numIndexFiles);
+
     // add new entries which may not be persisted
     // call persist and reload the index (index.close() is never called)
     Offset indexEndOffset = state.index.getCurrentEndOffset();

--- a/ambry-tools/src/main/java/com.github.ambry/store/ConsistencyCheckerTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/ConsistencyCheckerTool.java
@@ -169,9 +169,11 @@ public class ConsistencyCheckerTool {
   }
 
   /**
-   * Executes the operation with the help of properties passed during initialization of {@link DumpDataTool}
+   * Checks for consistency b/w {@code replicas} by comparing their index processing results and determining replication
+   * status.
    * @param replicas the replicas b/w which consistency has to be checked
-   * @return {@code true} if no real inconsistent blobs. {@code false}
+   * @return a pair whose first element is a {@link Boolean} indicating consistency ({@code true} if consistent,
+   * {@code false} otherwise) and the second element is a map from replica to the index processing results.
    * @throws Exception
    */
   public Pair<Boolean, Map<File, DumpIndexTool.IndexProcessingResults>> checkConsistency(File[] replicas)

--- a/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
@@ -236,8 +236,9 @@ public class StoreCopier implements Closeable {
 
   /**
    * Copies data starting from {@code startToken} until all the data is copied.
-   * @param startToken the {@link FindToken} to start copying from. Does not perform any duplication checks at
-   *                   destination.
+   * @param startToken the {@link FindToken} to start copying from. It is expected that start token does not cause
+   *                   the copier to attempt to copy blobs that have already been copied. If that happens, the boolean
+   *                   in the return value will be {@code true}.
    * @return a {@link Pair} of the {@link FindToken} until which data has been copied and a {@link Boolean} indicating
    * whether the source had problems that were skipped over - like duplicates ({@code true} indicates that there were).
    * @throws IOException if there is any I/O error while copying.

--- a/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
@@ -24,6 +24,7 @@ import com.github.ambry.messageformat.BlobStoreRecovery;
 import com.github.ambry.messageformat.MessageFormatWriteSet;
 import com.github.ambry.tools.util.ToolUtils;
 import com.github.ambry.utils.ByteBufferChannel;
+import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
@@ -224,7 +225,7 @@ public class StoreCopier implements Closeable {
       return;
     }
     try {
-      shutDownExecutorService(scheduler, 1, TimeUnit.SECONDS);
+      shutDownExecutorService(scheduler, 5, TimeUnit.MINUTES);
       src.shutdown();
       tgt.shutdown();
       isOpen = false;
@@ -237,12 +238,14 @@ public class StoreCopier implements Closeable {
    * Copies data starting from {@code startToken} until all the data is copied.
    * @param startToken the {@link FindToken} to start copying from. Does not perform any duplication checks at
    *                   destination.
-   * @return the {@link FindToken} until which data has been copied.
+   * @return a {@link Pair} of the {@link FindToken} until which data has been copied and a {@link Boolean} indicating
+   * whether the source had problems that were skipped over - like duplicates ({@code true} indicates that there were).
    * @throws IOException if there is any I/O error while copying.
    * @throws StoreException if there is any exception dealing with the stores.
    */
-  public FindToken copy(FindToken startToken) throws IOException, StoreException {
-    FindToken lastToken = null;
+  public Pair<FindToken, Boolean> copy(FindToken startToken) throws IOException, StoreException {
+    boolean sourceHasProblems = false;
+    FindToken lastToken;
     FindToken token = startToken;
     do {
       lastToken = token;
@@ -255,27 +258,32 @@ public class StoreCopier implements Closeable {
           if (messageInfo.getSize() > Integer.MAX_VALUE) {
             throw new IllegalStateException("Cannot copy blobs whose size > Integer.MAX_VALUE");
           }
-          int size = (int) messageInfo.getSize();
-          StoreInfo storeInfo =
-              src.get(Collections.singletonList(messageInfo.getStoreKey()), EnumSet.noneOf(StoreGetOptions.class));
-          MessageReadSet readSet = storeInfo.getMessageReadSet();
-          byte[] buf = new byte[size];
-          readSet.writeTo(0, new ByteBufferChannel(ByteBuffer.wrap(buf)), 0, size);
-          Message message = new Message(messageInfo, new ByteArrayInputStream(buf));
-          for (Transformer transformer : transformers) {
-            message = transformer.transform(message);
+          if (tgt.findMissingKeys(Collections.singletonList(messageInfo.getStoreKey())).size() == 1) {
+            int size = (int) messageInfo.getSize();
+            StoreInfo storeInfo =
+                src.get(Collections.singletonList(messageInfo.getStoreKey()), EnumSet.noneOf(StoreGetOptions.class));
+            MessageReadSet readSet = storeInfo.getMessageReadSet();
+            byte[] buf = new byte[size];
+            readSet.writeTo(0, new ByteBufferChannel(ByteBuffer.wrap(buf)), 0, size);
+            Message message = new Message(messageInfo, new ByteArrayInputStream(buf));
+            for (Transformer transformer : transformers) {
+              message = transformer.transform(message);
+            }
+            MessageFormatWriteSet writeSet =
+                new MessageFormatWriteSet(message.getStream(), Collections.singletonList(message.getMessageInfo()),
+                    false);
+            tgt.put(writeSet);
+            logger.trace("Copied {} as {}", messageInfo.getStoreKey(), message.getMessageInfo().getStoreKey());
+          } else {
+            logger.warn("Found a duplicate entry for {} while copying data", messageInfo.getStoreKey());
+            sourceHasProblems = true;
           }
-          MessageFormatWriteSet writeSet =
-              new MessageFormatWriteSet(message.getStream(), Collections.singletonList(message.getMessageInfo()),
-                  false);
-          tgt.put(writeSet);
-          logger.trace("Copied {} as {}", messageInfo.getStoreKey(), message.getMessageInfo().getStoreKey());
         }
       }
       token = findInfo.getFindToken();
       logger.info("[{}] [{}] {}% copied", Thread.currentThread().getName(), storeId,
           df.format(token.getBytesRead() * 100.0 / src.getSizeInBytes()));
     } while (!token.equals(lastToken));
-    return token;
+    return new Pair<>(token, sourceHasProblems);
   }
 }

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -813,8 +813,8 @@ public class Utils {
     executorService.shutdown();
     try {
       if (!executorService.awaitTermination(shutdownTimeout, timeUnit)) {
-        logger.warn("ExecutorService is not shut down successfully within {} ms, forcing an immediate shutdown.",
-            shutdownTimeout);
+        logger.warn("ExecutorService is not shut down successfully within {} {}, forcing an immediate shutdown.",
+            shutdownTimeout, timeUnit);
         executorService.shutdownNow();
         if (!executorService.awaitTermination(shutdownTimeout, timeUnit)) {
           logger.error("ExecutorService cannot be shut down successfully.");


### PR DESCRIPTION
Fixes #790 and Fixes #501 

Also fixes a lot of duplicate put record handling in the `StoreCopier`, `DiskReformatter` and `ConsistencyCheckerTool`