### PR TITLE
Allows CatchupStatus req to spec num replicas that hv to be caught up

### DIFF
--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -494,8 +494,10 @@ public class RequestResponseTest {
     String clientId = "client";
     // request
     long acceptableLag = Utils.getRandomLong(TestUtils.RANDOM, 10000);
+    short numCaughtUpPerPartition = (short) TestUtils.RANDOM.nextInt(Short.MAX_VALUE);
     AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.CatchupStatus, id, correlationId, clientId);
-    CatchupStatusAdminRequest catchupStatusRequest = new CatchupStatusAdminRequest(acceptableLag, adminRequest);
+    CatchupStatusAdminRequest catchupStatusRequest =
+        new CatchupStatusAdminRequest(acceptableLag, numCaughtUpPerPartition, adminRequest);
     DataInputStream requestStream = serAndPrepForRead(catchupStatusRequest, -1, true);
     AdminRequest deserializedAdminRequest =
         deserAdminRequestAndVerify(requestStream, clusterMap, correlationId, clientId,
@@ -504,6 +506,8 @@ public class RequestResponseTest {
         CatchupStatusAdminRequest.readFrom(requestStream, deserializedAdminRequest);
     Assert.assertEquals("Acceptable lag not as set", acceptableLag,
         deserializedCatchupStatusRequest.getAcceptableLagInBytes());
+    Assert.assertEquals("Num caught up per partition not as set", numCaughtUpPerPartition,
+        deserializedCatchupStatusRequest.getNumReplicasCaughtUpPerPartition());
     // response
     boolean isCaughtUp = TestUtils.RANDOM.nextBoolean();
     ServerErrorCode[] values = ServerErrorCode.values();

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -494,7 +494,7 @@ public class RequestResponseTest {
     String clientId = "client";
     // request
     long acceptableLag = Utils.getRandomLong(TestUtils.RANDOM, 10000);
-    short numCaughtUpPerPartition = (short) TestUtils.RANDOM.nextInt(Short.MAX_VALUE);
+    short numCaughtUpPerPartition = Utils.getRandomShort(TestUtils.RANDOM);
     AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.CatchupStatus, id, correlationId, clientId);
     CatchupStatusAdminRequest catchupStatusRequest =
         new CatchupStatusAdminRequest(acceptableLag, numCaughtUpPerPartition, adminRequest);

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -157,7 +157,7 @@ class ReplicaThread implements Runnable {
             replicationDisabledPartitions.add(id);
             allDisabled = allReplicatedPartitions.size() == replicationDisabledPartitions.size();
           }
-          logger.info("Enable status of replication of {} from {} is {}. allDisabled for {} is {}", id, datacenterName,
+          logger.info("Disable status of replication of {} from {} is {}. allDisabled for {} is {}", id, datacenterName,
               replicationDisabledPartitions.contains(id), getName(), allDisabled);
         }
       }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -259,7 +259,7 @@ public class AmbryRequestsTest {
     assertTrue("This test needs more than one replica for the first partition to work", replicaIds.size() > 1);
 
     long acceptableLagInBytes = 100;
-    
+
     // cases with a given partition id
     // all replicas of given partition < acceptableLag
     generateLagOverrides(0, acceptableLagInBytes - 1);
@@ -286,8 +286,6 @@ public class AmbryRequestsTest {
     // all replicas of this partition > acceptableLag
     generateLagOverrides(acceptableLagInBytes + 1, acceptableLagInBytes + 1);
     doCatchupStatusTest(id, acceptableLagInBytes, Short.MAX_VALUE, ServerErrorCode.No_Error, false);
-    // if num expected replicas == 0, this succeeds
-    doCatchupStatusTest(id, acceptableLagInBytes, (short) 0, ServerErrorCode.No_Error, true);
 
     // cases with no partition id provided
     // all replicas of all partitions < acceptableLag
@@ -310,8 +308,6 @@ public class AmbryRequestsTest {
     // all replicas of all partitions > acceptableLag
     generateLagOverrides(acceptableLagInBytes + 1, acceptableLagInBytes + 1);
     doCatchupStatusTest(null, acceptableLagInBytes, Short.MAX_VALUE, ServerErrorCode.No_Error, false);
-    // if num expected replicas == 0, this succeeds
-    doCatchupStatusTest(null, acceptableLagInBytes, (short) 0, ServerErrorCode.No_Error, true);
   }
 
   /**
@@ -320,6 +316,12 @@ public class AmbryRequestsTest {
    */
   @Test
   public void catchupStatusFailureTest() throws InterruptedException, IOException {
+    // acceptableLagInBytes < 0
+    doCatchupStatusTest(null, -1, Short.MAX_VALUE, ServerErrorCode.Bad_Request, false);
+    // numReplicasCaughtUpPerPartition = 0
+    doCatchupStatusTest(null, 0, (short) 0, ServerErrorCode.Bad_Request, false);
+    // numReplicasCaughtUpPerPartition < 0
+    doCatchupStatusTest(null, 0, (short) -1, ServerErrorCode.Bad_Request, false);
     // replication manager error
     replicationManager.reset();
     replicationManager.exceptionToThrow = new IllegalStateException();

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -655,7 +655,7 @@ public class Utils {
   /**
    * Returns a random short using the {@code Random} passed as arg
    * @param random the {@link Random} object that needs to be used to generate the random short
-   * @return a random short
+   * @return a random short in the range [0, Short.MAX_VALUE].
    */
   public static short getRandomShort(Random random) {
     return (short) random.nextInt(Short.MAX_VALUE + 1);


### PR DESCRIPTION
This takes care of the case where some replicas might be down or might have undergone a recreation event. For most applications having "some" replicas caught up is good enough since those replicas can then propagate the changes.