### PR TITLE
Tracking the age of a blob at its time of access

### DIFF
--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -83,7 +83,7 @@ public class AmbrySecurityServiceTest {
     REF_ACCOUNT = ACCOUNT_SERVICE.createAndAddRandomAccount();
     REF_CONTAINER = REF_ACCOUNT.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
     DEFAULT_INFO = new BlobInfo(
-        new BlobProperties(Utils.getRandomLong(TestUtils.RANDOM, 1000) + 1, SERVICE_ID, OWNER_ID, "image/gif", false,
+        new BlobProperties(Utils.getRandomLong(TestUtils.RANDOM, 1000) + 100, SERVICE_ID, OWNER_ID, "image/gif", false,
             Utils.Infinite_Time, REF_ACCOUNT.getId(), REF_CONTAINER.getId(), false), null);
     ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(Account.UNKNOWN_ACCOUNT));
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -309,9 +309,10 @@ class GetBlobInfoOperation extends GetOperation {
     ByteBuffer encryptionKey = messageMetadata == null ? null : messageMetadata.getEncryptionKey();
     // @todo use the encryption key for decryption.
     if (operationResult == null) {
-      operationResult = new GetBlobResultInternal(new GetBlobResult(
-          new BlobInfo(MessageFormatRecord.deserializeBlobProperties(payload),
-              MessageFormatRecord.deserializeUserMetadata(payload).array()), null), null);
+      BlobInfo blobInfo = new BlobInfo(MessageFormatRecord.deserializeBlobProperties(payload),
+          MessageFormatRecord.deserializeUserMetadata(payload).array());
+      getOptions().ageAtAccessTracker.trackAgeAtAccess(blobInfo.getBlobProperties().getCreationTimeInMs());
+      operationResult = new GetBlobResultInternal(new GetBlobResult(blobInfo, null), null);
     } else {
       // If the successTarget is 1, this case will never get executed.
       // If it is more than 1, then, different responses will have to be reconciled in some way. Here is where that

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -894,6 +894,7 @@ class GetBlobOperation extends GetOperation {
         } else {
           BlobAll blobAll = MessageFormatRecord.deserializeBlobAll(payload, blobIdFactory);
           blobInfo = blobAll.getBlobInfo();
+          getOptions().ageAtAccessTracker.trackAgeAtAccess(blobInfo.getBlobProperties().getCreationTimeInMs());
           blobData = blobAll.getBlobData();
           encryptionKey = blobAll.getBlobEncryptionKey();
         }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -253,15 +253,19 @@ class GetManager {
 class GetBlobOptionsInternal {
   final GetBlobOptions getBlobOptions;
   final boolean getChunkIdsOnly;
+  final NonBlockingRouterMetrics.AgeAtAccessMetrics ageAtAccessTracker;
 
   /**
    * Construct an GetBlobOptionsInternal instance
    * @param getBlobOptions the {@link GetBlobOptions} associated with this instance.
    * @param getChunkIdsOnly {@code true} if this operation is to fetch just the chunk ids of a composite blob.
+   * @param ageAtAccessTracker the {@link NonBlockingRouterMetrics.AgeAtAccessMetrics} tracker to use.
    */
-  GetBlobOptionsInternal(GetBlobOptions getBlobOptions, boolean getChunkIdsOnly) {
+  GetBlobOptionsInternal(GetBlobOptions getBlobOptions, boolean getChunkIdsOnly,
+      NonBlockingRouterMetrics.AgeAtAccessMetrics ageAtAccessTracker) {
     this.getBlobOptions = getBlobOptions;
     this.getChunkIdsOnly = getChunkIdsOnly;
+    this.ageAtAccessTracker = ageAtAccessTracker;
   }
 }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -144,7 +144,7 @@ class NonBlockingRouter implements Router {
     }
     routerMetrics.operationQueuingRate.mark();
     final FutureResult<GetBlobResult> futureResult = new FutureResult<>();
-    GetBlobOptionsInternal internalOptions = new GetBlobOptionsInternal(options, false);
+    GetBlobOptionsInternal internalOptions = new GetBlobOptionsInternal(options, false, routerMetrics.ageAtGet);
     if (isOpen.get()) {
       getOperationController().getBlob(blobId, internalOptions, new Callback<GetBlobResultInternal>() {
         @Override
@@ -301,7 +301,7 @@ class NonBlockingRouter implements Router {
     currentBackgroundOperationsCount.incrementAndGet();
     GetBlobOptionsInternal options =
         new GetBlobOptionsInternal(new GetBlobOptions(GetBlobOptions.OperationType.Data, GetOption.Include_All, null),
-            true);
+            true, routerMetrics.ageAtDelete);
     backgroundDeleter.getBlob(blobId, options, callback);
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -300,7 +300,7 @@ class NonBlockingRouter implements Router {
     currentOperationsCount.incrementAndGet();
     currentBackgroundOperationsCount.incrementAndGet();
     GetBlobOptionsInternal options =
-        new GetBlobOptionsInternal(new GetBlobOptions(GetBlobOptions.OperationType.Data, GetOption.Include_All, null),
+        new GetBlobOptionsInternal(new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.Include_All, null),
             true, routerMetrics.ageAtDelete);
     backgroundDeleter.getBlob(blobId, options, callback);
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -559,7 +559,7 @@ public class NonBlockingRouterMetrics {
     private final Counter betweenWeekAndMonthOld;
     private final Counter betweenMonthAndThreeMonthsOld;
     private final Counter betweenThreeMonthsAndSixMonthsOld;
-    private final Counter betweenSizeMonthsAndYearOld;
+    private final Counter betweenSixMonthsAndYearOld;
     private final Counter moreThanYearOld;
 
     /**
@@ -582,8 +582,8 @@ public class NonBlockingRouterMetrics {
           registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "BetweenMonthAndThreeMonthsOld"));
       betweenThreeMonthsAndSixMonthsOld = registry.counter(
           MetricRegistry.name(NonBlockingRouter.class, accessType, "BetweenThreeMonthsAndSixMonthsOld"));
-      betweenSizeMonthsAndYearOld =
-          registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "BetweenSizeMonthsAndYearOld"));
+      betweenSixMonthsAndYearOld =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "BetweenSixMonthsAndYearOld"));
       moreThanYearOld = registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "MoreThanYearOld"));
     }
 
@@ -609,7 +609,7 @@ public class NonBlockingRouterMetrics {
       } else if (ageInMs < TimeUnit.DAYS.toMillis(30 * 6)) {
         betweenThreeMonthsAndSixMonthsOld.inc();
       } else if (ageInMs < TimeUnit.DAYS.toMillis(30 * 12)) {
-        betweenSizeMonthsAndYearOld.inc();
+        betweenSixMonthsAndYearOld.inc();
       } else {
         moreThanYearOld.inc();
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -20,8 +20,10 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.utils.SystemTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 
@@ -128,6 +130,10 @@ public class NonBlockingRouterMetrics {
   public final Histogram getBlobInfoLocalColoLatencyMs;
   public final Histogram getBlobInfoCrossColoLatencyMs;
   public final Counter getBlobInfoPastDueCount;
+
+  // Workload characteristics
+  public final AgeAtAccessMetrics ageAtGet;
+  public final AgeAtAccessMetrics ageAtDelete;
 
   // Map that stores dataNode-level metrics.
   private final Map<DataNodeId, NodeLevelMetrics> dataNodeToMetrics;
@@ -283,6 +289,10 @@ public class NonBlockingRouterMetrics {
     getBlobInfoCrossColoLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(GetBlobInfoOperation.class, "CrossColoLatencyMs"));
     getBlobInfoPastDueCount = metricRegistry.counter(MetricRegistry.name(GetBlobInfoOperation.class, "PastDueCount"));
+
+    // Workload
+    ageAtGet = new AgeAtAccessMetrics(metricRegistry, "OnGet");
+    ageAtDelete = new AgeAtAccessMetrics(metricRegistry, "OnDelete");
   }
 
   /**
@@ -534,6 +544,75 @@ public class NonBlockingRouterMetrics {
           registry.counter(MetricRegistry.name(GetBlobOperation.class, dataNodeName, "GetRequestErrorCount"));
       deleteRequestErrorCount =
           registry.counter(MetricRegistry.name(DeleteOperation.class, dataNodeName, "DeleteRequestErrorCount"));
+    }
+  }
+
+  /**
+   * Tracks the age of a blob at the time of access.
+   */
+  public static class AgeAtAccessMetrics {
+    private final Histogram ageInMs;
+    private final Counter lessThanMinuteOld;
+    private final Counter betweenMinuteAndHourOld;
+    private final Counter betweenHourAndDayOld;
+    private final Counter betweenDayAndWeekOld;
+    private final Counter betweenWeekAndMonthOld;
+    private final Counter betweenMonthAndThreeMonthsOld;
+    private final Counter betweenThreeMonthsAndSixMonthsOld;
+    private final Counter betweenSizeMonthsAndYearOld;
+    private final Counter moreThanYearOld;
+
+    /**
+     * @param registry the {@link MetricRegistry} to use.
+     * @param accessType the type of access (get, delete).
+     */
+    private AgeAtAccessMetrics(MetricRegistry registry, String accessType) {
+      ageInMs = registry.histogram(MetricRegistry.name(NonBlockingRouter.class, accessType, "AgeInMs"));
+      lessThanMinuteOld =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "LessThanMinuteOld"));
+      betweenMinuteAndHourOld =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "BetweenMinuteAndHourOld"));
+      betweenHourAndDayOld =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "BetweenHourAndDayOld"));
+      betweenDayAndWeekOld =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "BetweenDayAndWeekOld"));
+      betweenWeekAndMonthOld =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "BetweenWeekAndMonthOld"));
+      betweenMonthAndThreeMonthsOld =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "BetweenMonthAndThreeMonthsOld"));
+      betweenThreeMonthsAndSixMonthsOld = registry.counter(
+          MetricRegistry.name(NonBlockingRouter.class, accessType, "BetweenThreeMonthsAndSixMonthsOld"));
+      betweenSizeMonthsAndYearOld =
+          registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "BetweenSizeMonthsAndYearOld"));
+      moreThanYearOld = registry.counter(MetricRegistry.name(NonBlockingRouter.class, accessType, "MoreThanYearOld"));
+    }
+
+    /**
+     * Tracks the age of the time of access.
+     * @param creationTimeMs the time of creation of the blob.
+     */
+    void trackAgeAtAccess(long creationTimeMs) {
+      long ageInMs = SystemTime.getInstance().milliseconds() - creationTimeMs;
+      this.ageInMs.update(ageInMs);
+      if (ageInMs < TimeUnit.MINUTES.toMillis(1)) {
+        lessThanMinuteOld.inc();
+      } else if (ageInMs < TimeUnit.HOURS.toMillis(1)) {
+        betweenMinuteAndHourOld.inc();
+      } else if (ageInMs < TimeUnit.DAYS.toMillis(1)) {
+        betweenHourAndDayOld.inc();
+      } else if (ageInMs < TimeUnit.DAYS.toMillis(7)) {
+        betweenDayAndWeekOld.inc();
+      } else if (ageInMs < TimeUnit.DAYS.toMillis(30)) {
+        betweenWeekAndMonthOld.inc();
+      } else if (ageInMs < TimeUnit.DAYS.toMillis(30 * 3)) {
+        betweenMonthAndThreeMonthsOld.inc();
+      } else if (ageInMs < TimeUnit.DAYS.toMillis(30 * 6)) {
+        betweenThreeMonthsAndSixMonthsOld.inc();
+      } else if (ageInMs < TimeUnit.DAYS.toMillis(30 * 12)) {
+        betweenSizeMonthsAndYearOld.inc();
+      } else {
+        moreThanYearOld.inc();
+      }
     }
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -85,8 +85,7 @@ public class GetBlobInfoOperationTest {
   private final String operationTrackerType;
   private final GetTestRequestRegistrationCallbackImpl requestRegistrationCallback =
       new GetTestRequestRegistrationCallbackImpl();
-  private final GetBlobOptionsInternal options = new GetBlobOptionsInternal(
-      new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build(), false);
+  private final GetBlobOptionsInternal options;
 
   private class GetTestRequestRegistrationCallbackImpl implements RequestRegistrationCallback<GetOperation> {
     private List<RequestInfo> requestListToFill;
@@ -118,6 +117,9 @@ public class GetBlobInfoOperationTest {
     routerConfig = new RouterConfig(vprops);
     mockClusterMap = new MockClusterMap();
     routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
+    options = new GetBlobOptionsInternal(
+        new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build(), false,
+        routerMetrics.ageAtGet);
     mockServerLayout = new MockServerLayout(mockClusterMap);
     replicasCount = mockClusterMap.getWritablePartitionIds().get(0).getReplicaIds().size();
     responseHandler = new ResponseHandler(mockClusterMap);


### PR DESCRIPTION
Adding metrics to track the age of a blob at the time is either got or deleted. This will help determine workload characteristics that may help make better decisions for future design or for tuning of configuration parameters.