### PR TITLE
Setting a valid datacenter ID in the blob ID

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -75,10 +75,12 @@ public class ClusterMapConfig {
    *   "zkInfo" : [
    *     {
    *       "datacenter":"dc1",
+   *       "id": "1",
    *       "zkConnectStr":"abc.example.com:2199",
    *     },
    *     {
    *       "datacenter":"dc2",
+   *       "id" : "2",
    *       "zkConnectStr":"def.example.com:2300",
    *     }
    *   ]

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -23,8 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.github.ambry.clustermap.ClusterMapUtils.*;
-
 
 /**
  * A cluster manager that is a wrapper over a {@link StaticClusterManager} instance and a {@link HelixClusterManager}
@@ -42,6 +40,11 @@ class CompositeClusterManager implements ClusterMap {
    * @param helixClusterManager the {@link HelixClusterManager} instance to use for comparison of views.
    */
   CompositeClusterManager(StaticClusterManager staticClusterManager, HelixClusterManager helixClusterManager) {
+    if (staticClusterManager.getLocalDatacenterId() != helixClusterManager.getLocalDatacenterId()) {
+      throw new IllegalStateException(
+          "Datacenter ID in the static cluster map [" + staticClusterManager.getLocalDatacenterId()
+              + "] does not match the one in helix [" + helixClusterManager.getLocalDatacenterId() + "]");
+    }
     this.staticClusterManager = staticClusterManager;
     this.helixClusterManager = helixClusterManager;
     this.helixClusterManagerMetrics =
@@ -115,7 +118,7 @@ class CompositeClusterManager implements ClusterMap {
 
   @Override
   public byte getLocalDatacenterId() {
-    return UNKNOWN_DATACENTER_ID;
+    return staticClusterManager.getLocalDatacenterId();
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Datacenter.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Datacenter.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 class Datacenter {
   private final HardwareLayout hardwareLayout;
   private final String name;
+  private final byte id;
   private final ArrayList<DataNode> dataNodes;
   private final long rawCapacityInBytes;
   private boolean rackAware = false;
@@ -47,6 +48,7 @@ class Datacenter {
     }
     this.hardwareLayout = hardwareLayout;
     this.name = jsonObject.getString("name");
+    id = Byte.parseByte(jsonObject.getString("id"));
 
     this.dataNodes = new ArrayList<DataNode>(jsonObject.getJSONArray("dataNodes").length());
     for (int i = 0; i < jsonObject.getJSONArray("dataNodes").length(); ++i) {
@@ -62,6 +64,10 @@ class Datacenter {
 
   String getName() {
     return name;
+  }
+
+  byte getId() {
+    return id;
   }
 
   long getRawCapacityInBytes() {
@@ -132,7 +138,7 @@ class Datacenter {
   }
 
   JSONObject toJSONObject() throws JSONException {
-    JSONObject jsonObject = new JSONObject().put("name", name).put("dataNodes", new JSONArray());
+    JSONObject jsonObject = new JSONObject().put("name", name).put("id", id).put("dataNodes", new JSONArray());
     for (DataNode dataNode : dataNodes) {
       jsonObject.accumulate("dataNodes", dataNode.toJSONObject());
     }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -62,8 +62,9 @@ class HelixParticipant implements ClusterParticipant {
       throw new IllegalStateException("Clustername is empty in clusterMapConfig");
     }
     try {
-      zkConnectStr = ClusterMapUtils.parseZkJsonAndPopulateZkInfo(clusterMapConfig.clusterMapDcsZkConnectStrings)
-          .get(clusterMapConfig.clusterMapDatacenterName);
+      zkConnectStr = ClusterMapUtils.parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings)
+          .get(clusterMapConfig.clusterMapDatacenterName)
+          .getZkConnectStr();
     } catch (JSONException e) {
       throw new IOException("Received JSON exception while parsing ZKInfo json string", e);
     }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
@@ -18,6 +18,7 @@ import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.server.AmbryHealthReport;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -55,15 +56,16 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
    * @param partitionLayout the {@link PartitionLayout} to use.
    */
   StaticClusterAgentsFactory(ClusterMapConfig clusterMapConfig, PartitionLayout partitionLayout) {
-    this.clusterMapConfig = clusterMapConfig;
-    this.partitionLayout = partitionLayout;
+    this.clusterMapConfig = Objects.requireNonNull(clusterMapConfig, "ClusterMapConfig cannot be null");
+    this.partitionLayout = Objects.requireNonNull(partitionLayout, "PartitionLayout cannot be null");
     this.metricRegistry = new MetricRegistry();
   }
 
   @Override
   public StaticClusterManager getClusterMap() {
     if (staticClusterManager == null) {
-      staticClusterManager = new StaticClusterManager(partitionLayout, metricRegistry);
+      staticClusterManager =
+          new StaticClusterManager(partitionLayout, clusterMapConfig.clusterMapDatacenterName, metricRegistry);
     }
     return staticClusterManager;
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -28,7 +28,6 @@ import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.utils.Utils.*;
 
 
@@ -41,6 +40,7 @@ class StaticClusterManager implements ClusterMap {
   protected final PartitionLayout partitionLayout;
   private final MetricRegistry metricRegistry;
   private final ClusterMapMetrics clusterMapMetrics;
+  private final byte localDatacenterId;
 
   private Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -51,7 +51,7 @@ class StaticClusterManager implements ClusterMap {
    */
   private static final int NUM_CHOICES = 2;
 
-  StaticClusterManager(PartitionLayout partitionLayout, MetricRegistry metricRegistry) {
+  StaticClusterManager(PartitionLayout partitionLayout, String localDatacenterName, MetricRegistry metricRegistry) {
     if (logger.isTraceEnabled()) {
       logger.trace("StaticClusterManager " + partitionLayout);
     }
@@ -59,6 +59,8 @@ class StaticClusterManager implements ClusterMap {
     this.partitionLayout = partitionLayout;
     this.metricRegistry = metricRegistry;
     this.clusterMapMetrics = new ClusterMapMetrics(this.hardwareLayout, this.partitionLayout, this.metricRegistry);
+    localDatacenterId = localDatacenterName != null && !localDatacenterName.isEmpty() ? hardwareLayout.findDatacenter(
+        localDatacenterName).getId() : ClusterMapUtils.UNKNOWN_DATACENTER_ID;
   }
 
   void persist(String hardwareLayoutPath, String partitionLayoutPath) throws IOException, JSONException {
@@ -96,7 +98,7 @@ class StaticClusterManager implements ClusterMap {
 
   @Override
   public byte getLocalDatacenterId() {
-    return UNKNOWN_DATACENTER_ID;
+    return localDatacenterId;
   }
 
   @Override

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DataNodeTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DataNodeTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.*;
 class TestDataNode extends DataNode {
   public TestDataNode(String dataCenterName, JSONObject jsonObject, ClusterMapConfig clusterMapConfig)
       throws JSONException {
-    super(new TestDatacenter(TestUtils.getJsonDatacenter(dataCenterName, new JSONArray()), clusterMapConfig),
+    super(new TestDatacenter(TestUtils.getJsonDatacenter(dataCenterName, (byte) 0, new JSONArray()), clusterMapConfig),
         jsonObject, clusterMapConfig);
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DatacenterTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DatacenterTest.java
@@ -91,19 +91,20 @@ public class DatacenterTest {
 
   @Test
   public void basics() throws JSONException {
-    JSONObject jsonObject = TestUtils.getJsonDatacenter("XYZ1", getDataNodes());
+    JSONObject jsonObject = TestUtils.getJsonDatacenter("XYZ1", (byte) 1, getDataNodes());
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
 
     Datacenter datacenter = new TestDatacenter(jsonObject, clusterMapConfig);
 
     assertEquals(datacenter.getName(), "XYZ1");
+    assertEquals(datacenter.getId(), 1);
     assertEquals(datacenter.getDataNodes().size(), dataNodeCount);
     assertEquals(datacenter.getRawCapacityInBytes(), dataNodeCount * diskCount * diskCapacityInBytes);
     assertFalse(datacenter.isRackAware());
     assertEquals(datacenter.toJSONObject().toString(), jsonObject.toString());
     assertEquals(datacenter, new TestDatacenter(datacenter.toJSONObject(), clusterMapConfig));
 
-    jsonObject = TestUtils.getJsonDatacenter("XYZ1", getDataNodesRackAware());
+    jsonObject = TestUtils.getJsonDatacenter("XYZ1", (byte) 1, getDataNodesRackAware());
     datacenter = new TestDatacenter(jsonObject, clusterMapConfig);
     assertTrue(datacenter.isRackAware());
     assertEquals(datacenter.toJSONObject().toString(), jsonObject.toString());
@@ -126,7 +127,7 @@ public class DatacenterTest {
 
     try {
       // Null HardwareLayout
-      jsonObject = TestUtils.getJsonDatacenter("XYZ1", getDataNodes());
+      jsonObject = TestUtils.getJsonDatacenter("XYZ1", (byte) 1, getDataNodes());
       new Datacenter(null, jsonObject, clusterMapConfig);
       fail("Should have failed validation.");
     } catch (IllegalStateException e) {
@@ -134,11 +135,11 @@ public class DatacenterTest {
     }
 
     // Bad datacenter name
-    jsonObject = TestUtils.getJsonDatacenter("", getDataNodes());
+    jsonObject = TestUtils.getJsonDatacenter("", (byte) 1, getDataNodes());
     failValidation(jsonObject, clusterMapConfig);
 
     // Missing rack IDs
-    jsonObject = TestUtils.getJsonDatacenter("XYZ1", getDataNodesPartiallyRackAware());
+    jsonObject = TestUtils.getJsonDatacenter("XYZ1", (byte) 1, getDataNodesPartiallyRackAware());
     failValidation(jsonObject, clusterMapConfig);
   }
 }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -84,8 +84,9 @@ public class HelixClusterManagerTest {
     String tempDirPath = tempDir.getAbsolutePath();
     tempDir.deleteOnExit();
     int port = 2200;
+    byte dcId = (byte) 0;
     for (String dcName : dcs) {
-      dcsToZkInfo.put(dcName, new com.github.ambry.utils.TestUtils.ZkInfo(tempDirPath, dcName, port++, false));
+      dcsToZkInfo.put(dcName, new com.github.ambry.utils.TestUtils.ZkInfo(tempDirPath, dcName, dcId++, port++, false));
     }
     String hardwareLayoutPath = tempDirPath + File.separator + "hardwareLayoutTest.json";
     String partitionLayoutPath = tempDirPath + File.separator + "partitionLayoutTest.json";
@@ -115,7 +116,7 @@ public class HelixClusterManagerTest {
     Properties props = new Properties();
     props.setProperty("clustermap.host.name", hostname);
     props.setProperty("clustermap.cluster.name", clusterNamePrefixInHelix + clusterNameStatic);
-    props.setProperty("clustermap.datacenter.name", "DC0");
+    props.setProperty("clustermap.datacenter.name", dcs[0]);
     props.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
     clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     MockHelixManagerFactory helixManagerFactory = new MockHelixManagerFactory(helixCluster, null);
@@ -158,7 +159,7 @@ public class HelixClusterManagerTest {
     Properties props = new Properties();
     props.setProperty("clustermap.host.name", hostname);
     props.setProperty("clustermap.cluster.name", clusterNamePrefixInHelix + clusterNameStatic);
-    props.setProperty("clustermap.datacenter.name", "DC0");
+    props.setProperty("clustermap.datacenter.name", dcs[0]);
     props.setProperty("clustermap.dcs.zk.connect.strings", invalidZkJson.toString(2));
     ClusterMapConfig invalidClusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     metricRegistry = new MetricRegistry();
@@ -192,6 +193,7 @@ public class HelixClusterManagerTest {
     for (String metricName : clusterManager.getMetricRegistry().getNames()) {
       System.out.println(metricName);
     }
+    assertEquals("Incorrect local datacenter ID", 0, clusterManager.getLocalDatacenterId());
     testPartitionReplicaConsistency();
     testInvalidPartitionId();
     testDatacenterDatanodeReplicas();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
@@ -70,7 +70,7 @@ public class HelixParticipantTest {
 
   public HelixParticipantTest() throws Exception {
     List<com.github.ambry.utils.TestUtils.ZkInfo> zkInfoList = new ArrayList<>();
-    zkInfoList.add(new com.github.ambry.utils.TestUtils.ZkInfo(null, "DC0", 2199, false));
+    zkInfoList.add(new com.github.ambry.utils.TestUtils.ZkInfo(null, "DC0", (byte) 0, 2199, false));
     JSONObject zkJson = constructZkLayoutJSON(zkInfoList);
     props = new Properties();
     props.setProperty("clustermap.host.name", "localhost");

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
@@ -83,12 +83,19 @@ public class StaticClusterManagerTest {
     testPartitionLayout.addNewPartitions(3);
     testPartitionLayout.partitionState = PartitionState.READ_WRITE;
 
+    Datacenter localDatacenter = testHardwareLayout.getRandomDatacenter();
+    Properties props = new Properties();
+    props.setProperty("clustermap.host.name", "localhost");
+    props.setProperty("clustermap.cluster.name", "cluster");
+    props.setProperty("clustermap.datacenter.name", localDatacenter.getName());
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     ClusterMap clusterMapManager =
-        (new StaticClusterAgentsFactory(null, testPartitionLayout.getPartitionLayout())).getClusterMap();
+        (new StaticClusterAgentsFactory(clusterMapConfig, testPartitionLayout.getPartitionLayout())).getClusterMap();
     for (String metricName : clusterMapManager.getMetricRegistry().getNames()) {
       System.out.println(metricName);
     }
 
+    assertEquals("Incorrect local datacenter ID", localDatacenter.getId(), clusterMapManager.getLocalDatacenterId());
     List<? extends PartitionId> writablePartitionIds = clusterMapManager.getWritablePartitionIds();
     List<? extends PartitionId> partitionIds = clusterMapManager.getAllPartitionIds();
     assertEquals(writablePartitionIds.size(), testPartitionLayout.getPartitionCount() - 3);
@@ -131,8 +138,8 @@ public class StaticClusterManagerTest {
     TestUtils.TestHardwareLayout testHardwareLayout = new TestUtils.TestHardwareLayout("Alpha");
     TestUtils.TestPartitionLayout testPartitionLayout = new TestUtils.TestPartitionLayout(testHardwareLayout);
 
-    StaticClusterManager clusterMapManager =
-        (new StaticClusterAgentsFactory(null, testPartitionLayout.getPartitionLayout())).getClusterMap();
+    StaticClusterManager clusterMapManager = (new StaticClusterAgentsFactory(TestUtils.getDummyConfig(),
+        testPartitionLayout.getPartitionLayout())).getClusterMap();
 
     for (Datacenter datacenter : testHardwareLayout.getHardwareLayout().getDatacenters()) {
       assertTrue(clusterMapManager.hasDatacenter(datacenter.getName()));
@@ -145,7 +152,8 @@ public class StaticClusterManagerTest {
     TestUtils.TestHardwareLayout testHardwareLayout = new TestUtils.TestHardwareLayout("Alpha");
     PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout());
 
-    StaticClusterManager clusterMapManager = (new StaticClusterAgentsFactory(null, partitionLayout)).getClusterMap();
+    StaticClusterManager clusterMapManager =
+        (new StaticClusterAgentsFactory(TestUtils.getDummyConfig(), partitionLayout)).getClusterMap();
     int dcCount = testHardwareLayout.getDatacenterCount();
 
     List<PartitionId> partitionIds = clusterMapManager.getWritablePartitionIds();
@@ -165,7 +173,8 @@ public class StaticClusterManagerTest {
     TestUtils.TestHardwareLayout testHardwareLayout = new TestUtils.TestHardwareLayout("Alpha");
     PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout());
 
-    StaticClusterManager clusterMapManager = (new StaticClusterAgentsFactory(null, partitionLayout)).getClusterMap();
+    StaticClusterManager clusterMapManager =
+        (new StaticClusterAgentsFactory(TestUtils.getDummyConfig(), partitionLayout)).getClusterMap();
     List<PartitionId> allocatedPartitions;
 
     try {
@@ -203,7 +212,8 @@ public class StaticClusterManagerTest {
     TestUtils.TestHardwareLayout testHardwareLayout = new TestUtils.TestHardwareLayout("Alpha", true);
     PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout());
 
-    StaticClusterManager clusterMapManager = (new StaticClusterAgentsFactory(null, partitionLayout)).getClusterMap();
+    StaticClusterManager clusterMapManager =
+        (new StaticClusterAgentsFactory(TestUtils.getDummyConfig(), partitionLayout)).getClusterMap();
     List<PartitionId> allocatedPartitions;
 
     // Allocate five partitions that fit within cluster's capacity
@@ -236,7 +246,8 @@ public class StaticClusterManagerTest {
     TestUtils.TestHardwareLayout testHardwareLayout = new TestUtils.TestHardwareLayout("Alpha", true);
     PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout());
 
-    StaticClusterManager clusterMapManager = (new StaticClusterAgentsFactory(null, partitionLayout)).getClusterMap();
+    StaticClusterManager clusterMapManager =
+        (new StaticClusterAgentsFactory(TestUtils.getDummyConfig(), partitionLayout)).getClusterMap();
     List<PartitionId> allocatedPartitions;
     // Require more replicas than there are racks
     allocatedPartitions =
@@ -258,7 +269,8 @@ public class StaticClusterManagerTest {
     TestUtils.TestHardwareLayout testHardwareLayout = new TestUtils.TestHardwareLayout("Alpha");
     PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout());
 
-    StaticClusterManager clusterMapManager = (new StaticClusterAgentsFactory(null, partitionLayout)).getClusterMap();
+    StaticClusterManager clusterMapManager =
+        (new StaticClusterAgentsFactory(TestUtils.getDummyConfig(), partitionLayout)).getClusterMap();
 
     // Confirm initial capacity is available for use
     long raw = clusterMapManager.getRawCapacityInBytes();
@@ -335,8 +347,8 @@ public class StaticClusterManagerTest {
   @Test
   public void validateSimpleConfig() throws Exception {
     Properties props = new Properties();
-    props.setProperty("clustermap.cluster.name", "test");
-    props.setProperty("clustermap.datacenter.name", "dc1");
+    props.setProperty("clustermap.cluster.name", "OneDiskOneReplica");
+    props.setProperty("clustermap.datacenter.name", "Datacenter");
     props.setProperty("clustermap.host.name", "localhost");
     String configDir = System.getProperty("user.dir");
     // intelliJ and gradle return different values for user.dir: gradle includes the sub-project directory. To handle

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -245,9 +245,10 @@ public class TestUtils {
     return jsonArray;
   }
 
-  public static JSONObject getJsonDatacenter(String name, JSONArray dataNodes) throws JSONException {
+  public static JSONObject getJsonDatacenter(String name, byte id, JSONArray dataNodes) throws JSONException {
     JSONObject jsonObject = new JSONObject();
     jsonObject.put("name", name);
+    jsonObject.put("id", id);
     jsonObject.put("dataNodes", dataNodes);
     return jsonObject;
   }
@@ -259,7 +260,7 @@ public class TestUtils {
 
     JSONArray datacenterJSONArray = new JSONArray();
     for (int i = 0; i < names.size(); i++) {
-      datacenterJSONArray.put(getJsonDatacenter(names.get(i), dataNodes.get(i)));
+      datacenterJSONArray.put(getJsonDatacenter(names.get(i), (byte) i, dataNodes.get(i)));
     }
     return datacenterJSONArray;
   }
@@ -735,7 +736,7 @@ public class TestUtils {
     TestUtils.TestHardwareLayout testHardwareLayout = new TestHardwareLayout("Alpha");
     PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout());
 
-    StaticClusterManager clusterMapManager = new StaticClusterManager(partitionLayout, new MetricRegistry());
+    StaticClusterManager clusterMapManager = new StaticClusterManager(partitionLayout, null, new MetricRegistry());
     List<PartitionId> allocatedPartitions;
 
     allocatedPartitions =
@@ -762,11 +763,12 @@ public class TestUtils {
     JSONArray zkInfosJson = new JSONArray();
     for (com.github.ambry.utils.TestUtils.ZkInfo zkInfo : zkInfos) {
       JSONObject zkInfoJson = new JSONObject();
-      zkInfoJson.put("datacenter", zkInfo.getDcName());
-      zkInfoJson.put("zkConnectStr", "localhost:" + zkInfo.getPort());
+      zkInfoJson.put(ClusterMapUtils.DATACENTER_STR, zkInfo.getDcName());
+      zkInfoJson.put(ClusterMapUtils.DATACENTER_ID_STR, zkInfo.getId());
+      zkInfoJson.put(ClusterMapUtils.ZKCONNECTSTR_STR, "localhost:" + zkInfo.getPort());
       zkInfosJson.put(zkInfoJson);
     }
-    return new JSONObject().put("zkInfo", zkInfosJson);
+    return new JSONObject().put(ClusterMapUtils.ZKINFO_STR, zkInfosJson);
   }
 
   /**
@@ -785,6 +787,18 @@ public class TestUtils {
       int partitionCount) throws JSONException {
     return new TestPartitionLayout(testHardwareLayout, partitionCount, PartitionState.READ_WRITE, 1024L * 1024 * 1024,
         3);
+  }
+
+  /**
+   * For use when the the actual values in {@link ClusterMapConfig} are unimportant.
+   * @return a {@link ClusterMapConfig} with some default values.
+   */
+  static ClusterMapConfig getDummyConfig() {
+    Properties props = new Properties();
+    props.setProperty("clustermap.host.name", "localhost");
+    props.setProperty("clustermap.cluster.name", "cluster");
+    props.setProperty("clustermap.datacenter.name", "");
+    return new ClusterMapConfig(new VerifiableProperties(props));
   }
 }
 

--- a/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
@@ -47,6 +47,7 @@ public class AccountUpdateToolTest {
   private static final int NUM_CONTAINER_PER_ACCOUNT = 4;
   private static final int ZK_SERVER_PORT = 2200;
   private static final String DC_NAME = "testDc";
+  private static final byte DC_ID = (byte) 1;
   private static final String ZK_SERVER_ADDRESS = "localhost:" + ZK_SERVER_PORT;
   private static final String HELIX_STORE_ROOT_PATH = "/ambry/defaultCluster/helixPropertyStore";
   private static final Properties helixConfigProps = new Properties();
@@ -71,7 +72,7 @@ public class AccountUpdateToolTest {
     vHelixConfigProps = new VerifiableProperties(helixConfigProps);
     storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
     try {
-      zkInfo = new ZkInfo(tempDirPath, DC_NAME, ZK_SERVER_PORT, true);
+      zkInfo = new ZkInfo(tempDirPath, DC_NAME, DC_ID, ZK_SERVER_PORT, true);
     } catch (IOException e) {
       fail("Failed to instantiate a ZooKeeper server.");
     }

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -39,6 +39,7 @@ public class HelixBootstrapUpgradeToolTest {
   private static String tempDirPath;
   private static final HashMap<String, ZkInfo> dcsToZkInfo = new HashMap<>();
   private static final String dcs[] = new String[]{"DC0", "DC1"};
+  private static final byte ids[] = new byte[]{(byte) 0, (byte) 1};
   private final String hardwareLayoutPath;
   private final String partitionLayoutPath;
   private final String zkLayoutPath;
@@ -62,8 +63,8 @@ public class HelixBootstrapUpgradeToolTest {
   public static void initialize() throws IOException {
     tempDirPath = getTempDir("helixBootstrapUpgrade-");
     int port = 2200;
-    for (String dcName : dcs) {
-      dcsToZkInfo.put(dcName, new ZkInfo(tempDirPath, dcName, port++, true));
+    for (int i = 0; i < dcs.length; i++) {
+      dcsToZkInfo.put(dcs[i], new ZkInfo(tempDirPath, dcs[i], ids[i], port++, true));
     }
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -36,10 +36,12 @@ import joptsimple.OptionSpec;
  *   "zkInfo" : [
  *     {
  *       "datacenter":"dc1",
+ *       "id": "1",
  *       "zkConnectStr":"abc.example.com:2199",
  *     },
  *     {
  *       "datacenter":"dc2",
+ *       "id" : "2",
  *       "zkConnectStr":"def.example.com:2300",
  *     }
  *   ]
@@ -70,10 +72,12 @@ public class HelixBootstrapUpgradeTool {
    *               "zkInfo" : [
    *                 {
    *                   "datacenter":"dc1",
+   *                   "id": "1",
    *                   "zkConnectStr":"abc.example.com:2199",
    *                 },
    *                 {
    *                   "datacenter":"dc2",
+   *                    "id": "2",
    *                   "zkConnectStr":"def.example.com:2300",
    *                 }
    *               ]

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixClusterWideAggregationTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixClusterWideAggregationTool.java
@@ -50,10 +50,12 @@ public class HelixClusterWideAggregationTool {
    *               "zkInfo" : [
    *                 {
    *                   "datacenter":"dc1",
+   *                    "id" : "1",
    *                   "zkConnectStr":"abc.example.com:2199",
    *                 },
    *                 {
    *                   "datacenter":"dc2",
+   *                   "id" : "2",
    *                   "zkConnectStr":"def.example.com:2300",
    *                 }
    *               ]
@@ -65,11 +67,12 @@ public class HelixClusterWideAggregationTool {
 
     ArgumentAcceptingOptionSpec<String> zkLayoutPathOpt = parser.accepts("zkLayoutPath",
         "The path to the json file containing zookeeper connect info. This should be of the following form: \n{\n"
-            + "  \"zkInfo\" : [\n" + "     {\n" + "       \"datacenter\":\"dc1\",\n"
+            + "  \"zkInfo\" : [\n" + "     {\n" + "       \"datacenter\":\"dc1\",\n" + "       \"id\":\"1\",\n"
             + "       \"zkConnectStr\":\"abc.example.com:2199\",\n" + "     },\n" + "     {\n"
-            + "       \"datacenter\":\"dc2\",\n" + "       \"zkConnectStr\":\"def.example.com:2300\",\n" + "     },\n"
-            + "     {\n" + "       \"datacenter\":\"dc3\",\n" + "       \"zkConnectStr\":\"ghi.example.com:2400\",\n"
-            + "     }\n" + "  ]\n" + "}").
+            + "       \"datacenter\":\"dc2\",\n" + "       \"id\":\"2\",\n"
+            + "       \"zkConnectStr\":\"def.example.com:2300\",\n" + "     },\n" + "     {\n"
+            + "       \"datacenter\":\"dc3\",\n" + "       \"id\":\"3\",\n"
+            + "       \"zkConnectStr\":\"ghi.example.com:2400\",\n" + "     }\n" + "  ]\n" + "}").
         withRequiredArg().
         describedAs("zk_connect_info_path").
         ofType(String.class);
@@ -100,9 +103,10 @@ public class HelixClusterWideAggregationTool {
     String clusterName = options.valueOf(clusterNameOpt);
     String workflowName = options.valueOf(workflowNameOpt);
     Long recurrentIntervalInMinutes = options.valueOf(recurrentIntervalInMinutesOpt);
-    Map<String, String> dataCenterToZKAddress =
-        ClusterMapUtils.parseZkJsonAndPopulateZkInfo(Utils.readStringFromFile(zkLayoutPath));
-    for (String zkAddress : dataCenterToZKAddress.values()) {
+    Map<String, ClusterMapUtils.DcZkInfo> dataCenterToZKAddress =
+        ClusterMapUtils.parseDcJsonAndPopulateDcInfo(Utils.readStringFromFile(zkLayoutPath));
+    for (ClusterMapUtils.DcZkInfo zkInfo : dataCenterToZKAddress.values()) {
+      String zkAddress = zkInfo.getZkConnectStr();
       ZkClient zkClient = new ZkClient(zkAddress, SESSION_TIMEOUT, CONNECTION_TIMEOUT, new ZNRecordSerializer());
       TaskDriver taskDriver = new TaskDriver(zkClient, clusterName);
       if (isDelete) {

--- a/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
@@ -160,6 +160,7 @@ public class TestUtils {
    */
   public static class ZkInfo {
     private String dcName;
+    private byte id;
     private int port;
     private String dataDir;
     private String logDir;
@@ -169,10 +170,12 @@ public class TestUtils {
      * Instantiate by starting a Zk server.
      * @param tempDirPath the temporary directory string to use.
      * @param dcName the name of the datacenter.
+     * @param id the id of the datacenter.
      * @param port the port at which this Zk server should run on localhost.
      */
-    public ZkInfo(String tempDirPath, String dcName, int port, boolean start) throws IOException {
+    public ZkInfo(String tempDirPath, String dcName, byte id, int port, boolean start) throws IOException {
       this.dcName = dcName;
+      this.id = id;
       this.port = port;
       this.dataDir = tempDirPath + "/dataDir";
       this.logDir = tempDirPath + "/logDir";
@@ -199,6 +202,10 @@ public class TestUtils {
 
     public String getDcName() {
       return dcName;
+    }
+
+    public byte getId() {
+      return id;
     }
 
     public void shutdown() {

--- a/config/HardwareLayout.json
+++ b/config/HardwareLayout.json
@@ -17,7 +17,8 @@
                     "port": 6667
                 }
             ],
-            "name": "Datacenter"
+            "name": "Datacenter",
+            "id" : "1"
         }
     ]
 }

--- a/config/HardwareLayoutHelix.json
+++ b/config/HardwareLayoutHelix.json
@@ -73,7 +73,8 @@
           "rackId": 1611
         },
       ],
-      "name": "dc1"
+      "name": "dc1",
+      "id" : "1"
     },
     {
       "dataNodes": [
@@ -147,7 +148,8 @@
           "rackId": 316
         },
       ],
-      "name": "dc2"
+      "name": "dc2",
+      "id" : "2"
     }
   ],
   "version": 4

--- a/config/HardwareLayoutLocalThreeNodeOneDisk.json
+++ b/config/HardwareLayoutLocalThreeNodeOneDisk.json
@@ -42,7 +42,8 @@
                     "port": 6672
                 }
             ],
-            "name": "Datacenter"
+            "name": "Datacenter",
+            "id": "1"
         }
     ]
 }

--- a/config/HardwareLayoutLocalThreeNodeOneDiskSsl.json
+++ b/config/HardwareLayoutLocalThreeNodeOneDiskSsl.json
@@ -45,7 +45,8 @@
                     "sslport": 7672
                 }
             ],
-            "name": "Datacenter"
+            "name": "Datacenter",
+            "id": "1"
         }
     ]
 }

--- a/config/HardwareLayoutMultiPartition.json
+++ b/config/HardwareLayoutMultiPartition.json
@@ -71,7 +71,8 @@
                     "port": 6672
                 }
             ],
-            "name": "Datacenter"
+            "name": "Datacenter",
+            "id": "1"
         }
     ]
 }

--- a/config/HardwareLayoutSsl.json
+++ b/config/HardwareLayoutSsl.json
@@ -18,7 +18,8 @@
           "sslPort" : 7667
         }
       ],
-      "name": "Datacenter"
+      "name": "Datacenter",
+      "id": "1"
     }
   ]
 }

--- a/config/frontend_helix.properties
+++ b/config/frontend_helix.properties
@@ -9,19 +9,16 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied.
 #
-
 # rest server
 rest.server.blob.storage.service.factory=com.github.ambry.frontend.AmbryBlobStorageServiceFactory
-
 # router
 router.hostname=localhost
 router.datacenter.name=dc1
 router.put.success.target=1
 router.delete.success.target=1
-
 #clustermap
 clustermap.host.name=localhost
 clustermap.cluster.name=Ambry-Proto
 clustermap.datacenter.name=dc1
 clustermap.clusteragents.factory=com.github.ambry.clustermap.HelixClusterAgentsFactory
-clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", "zkConnectStr":"localhost:2300", } ] }
+clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "id":"1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", , "id":"2", "zkConnectStr":"localhost:2300", } ] }

--- a/config/server1_helix.properties
+++ b/config/server1_helix.properties
@@ -19,4 +19,4 @@ clustermap.datacenter.name=dc1
 clustermap.clusteragents.factory=com.github.ambry.clustermap.CompositeClusterAgentsFactory
 #clustermap.clusteragents.factory=com.github.ambry.clustermap.StaticClusterAgentsFactory
 #clustermap.clusteragents.factory=com.github.ambry.clustermap.HelixClusterAgentsFactory
-clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", "zkConnectStr":"localhost:2300", } ] }
+clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "id":"1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", , "id":"2", "zkConnectStr":"localhost:2300", } ] }

--- a/config/server2_helix.properties
+++ b/config/server2_helix.properties
@@ -17,4 +17,4 @@ clustermap.port=16088
 clustermap.cluster.name=Ambry-Proto
 clustermap.datacenter.name=dc1
 clustermap.clusteragents.factory=com.github.ambry.clustermap.HelixClusterAgentsFactory
-clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", "zkConnectStr":"localhost:2300", } ] }
+clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "id":"1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", , "id":"2", "zkConnectStr":"localhost:2300", } ] }

--- a/config/server3_helix.properties
+++ b/config/server3_helix.properties
@@ -17,4 +17,4 @@ clustermap.port=17088
 clustermap.cluster.name=Ambry-Proto
 clustermap.datacenter.name=dc1
 clustermap.clusteragents.factory=com.github.ambry.clustermap.HelixClusterAgentsFactory
-clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", "zkConnectStr":"localhost:2300", } ] }
+clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "id":"1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", , "id":"2", "zkConnectStr":"localhost:2300", } ] }

--- a/config/server4_helix.properties
+++ b/config/server4_helix.properties
@@ -17,4 +17,4 @@ clustermap.port=18088
 clustermap.cluster.name=Ambry-Proto
 clustermap.datacenter.name=dc2
 clustermap.clusteragents.factory=com.github.ambry.clustermap.HelixClusterAgentsFactory
-clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", "zkConnectStr":"localhost:2300", } ] }
+clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "id":"1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", , "id":"2", "zkConnectStr":"localhost:2300", } ] }

--- a/config/server5_helix.properties
+++ b/config/server5_helix.properties
@@ -17,4 +17,4 @@ clustermap.port=19088
 clustermap.cluster.name=Ambry-Proto
 clustermap.datacenter.name=dc2
 clustermap.clusteragents.factory=com.github.ambry.clustermap.HelixClusterAgentsFactory
-clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", "zkConnectStr":"localhost:2300", } ] }
+clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "id":"1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", , "id":"2", "zkConnectStr":"localhost:2300", } ] }

--- a/config/server6_helix.properties
+++ b/config/server6_helix.properties
@@ -17,4 +17,4 @@ clustermap.port=20088
 clustermap.cluster.name=Ambry-Proto
 clustermap.datacenter.name=dc2
 clustermap.clusteragents.factory=com.github.ambry.clustermap.HelixClusterAgentsFactory
-clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", "zkConnectStr":"localhost:2300", } ] }
+clustermap.dcs.zk.connect.strings={"zkInfo" : [ { "datacenter":"dc1", "id":"1", "zkConnectStr":"localhost:2199", }, { "datacenter":"dc2", , "id":"2", "zkConnectStr":"localhost:2300", } ] }

--- a/config/zkLayout.json
+++ b/config/zkLayout.json
@@ -2,10 +2,12 @@
   "zkInfo" : [
      {
        "datacenter":"dc1",
+       "id" : "1",
        "zkConnectStr":"localhost:2199"
      },
      {
        "datacenter":"dc2",
+       "id" : "2",
        "zkConnectStr":"localhost:2300"
      }
   ]


### PR DESCRIPTION
This commit provides a way of assigning IDs to datacenters so that this information is correctly embedded inside the blob ID. In effect, this will provide information on which DC the blob was created in.

This information could be applied in many ways. Two immediate examples:
1. Cross colo GET requests - Know exactly which DC to proxy to to get the blob
which wasn't found in the local datacenter.
2. Track workload - how often is a blob fetched in a DC it was not created in?