### PR TITLE
Added option to disable reverse DNS lookups.

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -114,6 +114,14 @@ public class ClusterMapConfig {
   @Default("null")
   public final Integer clusterMapPort;
 
+  /**
+   * Indicates if a reverse DNS lookup should be used to try and obtain the fully qualified domain names of cluster map
+   * host entries.
+   */
+  @Config("clustermap.resolve.hostnames")
+  @Default("true")
+  public final boolean clusterMapResolveHostnames;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -135,5 +143,6 @@ public class ClusterMapConfig {
     clusterMapDatacenterName = verifiableProperties.getString("clustermap.datacenter.name");
     clusterMapHostName = verifiableProperties.getString("clustermap.host.name");
     clusterMapPort = verifiableProperties.getInteger("clustermap.port", null);
+    clusterMapResolveHostnames = verifiableProperties.getBoolean("clustermap.resolve.hostnames", true);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -116,7 +116,12 @@ public class ClusterMapConfig {
 
   /**
    * Indicates if a reverse DNS lookup should be used to try and obtain the fully qualified domain names of cluster map
-   * host entries.
+   * host entries. By default this is enabled and disabling should only be needed when a node's name cannot be 
+   * looked-up via a reverse lookup. For example when the node is known to Ambry by a CNAME record.
+   * 
+   * Beware that disabling this option also prevents Ambry from checking if a nodes naming configuration is 
+   * correct. For example there is no way for Ambry to check if the node config for 'host1.example.com' is actually 
+   * deployed on a host called 'host1.example.com'.
    */
   @Config("clustermap.resolve.hostnames")
   @Default("true")

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
@@ -37,6 +37,7 @@ class AmbryDataNode extends DataNodeId implements Resource {
   private final List<String> sslEnabledDataCenters;
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final ResourceStatePolicy resourceStatePolicy;
+  private final ClusterMapConfig clusterMapConfig;
 
   /**
    * Instantiate an AmbryDataNode object.
@@ -54,6 +55,7 @@ class AmbryDataNode extends DataNodeId implements Resource {
     this.plainTextPort = new Port(portNum, PortType.PLAINTEXT);
     this.sslPort = sslPortNum != null ? new Port(sslPortNum, PortType.SSL) : null;
     this.dataCenterName = dataCenterName;
+    this.clusterMapConfig = clusterMapConfig;
     this.rackId = rackId != null ? rackId : UNKNOWN_RACK_ID;
     this.sslEnabledDataCenters = Utils.splitString(clusterMapConfig.clusterMapSslEnabledDatacenters, ",");
     ResourceStatePolicyFactory resourceStatePolicyFactory =
@@ -68,10 +70,12 @@ class AmbryDataNode extends DataNodeId implements Resource {
    */
   private void validate() {
     // validate hostname
-    String fqdn = getFullyQualifiedDomainName(hostName);
-    if (!fqdn.equals(hostName)) {
-      throw new IllegalStateException(
-          "Hostname for AmbryDataNode (" + hostName + ") does not match its fully qualified domain name: " + fqdn);
+    if (clusterMapConfig.clusterMapResolveHostnames) {
+      String fqdn = getFullyQualifiedDomainName(hostName);
+      if (!fqdn.equals(hostName)) {
+        throw new IllegalStateException(
+                "Hostname for AmbryDataNode (" + hostName + ") does not match its fully qualified domain name: " + fqdn);
+      }
     }
 
     // validate ports

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HardwareLayout.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HardwareLayout.java
@@ -38,6 +38,7 @@ class HardwareLayout {
   private final long diskCount;
   private final Map<HardwareState, Long> dataNodeInHardStateCount;
   private final Map<HardwareState, Long> diskInHardStateCount;
+  private final ClusterMapConfig clusterMapConfig;
 
   private Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -47,6 +48,7 @@ class HardwareLayout {
     }
     this.clusterName = jsonObject.getString("clusterName");
     this.version = jsonObject.getLong("version");
+    this.clusterMapConfig = clusterMapConfig;
 
     this.datacenters = new ArrayList<Datacenter>(jsonObject.getJSONArray("datacenters").length());
     for (int i = 0; i < jsonObject.getJSONArray("datacenters").length(); ++i) {
@@ -202,7 +204,8 @@ class HardwareLayout {
    * @return DataNode or null if not found.
    */
   public DataNode findDataNode(String hostname, int port) {
-    String canonicalHostname = ClusterMapUtils.getFullyQualifiedDomainName(hostname);
+    String canonicalHostname = clusterMapConfig.clusterMapResolveHostnames ? 
+            ClusterMapUtils.getFullyQualifiedDomainName(hostname) : hostname;
     logger.trace("host to find host {} port {}", canonicalHostname, port);
     for (Datacenter datacenter : datacenters) {
       logger.trace("datacenter {}", datacenter.getName());


### PR DESCRIPTION
This commit makes the behavior of Ambry to use a reverse name lookup configurable. By default Ambry (old and current behavior) will do a reverse name lookup with DNS for every clustermap host. When the option `clustermap.resolve.hostnames` is set to `false` Ambry will trust the hostname in the clustermap to be the correct FQDN.

While I agree that reverse DNS should be configured correctly this is not always possible. For example we use Consul to lookup node names. Consul only supports reverse name lookups for local DC's. If you do a reverse name lookup for an IP in another DC Consul won't return a name. Also when a CNAME is used for an Ambry cluster host this will also break things. For comparison Kerberos originally also had a hard requirement to use the reverse resolved name of a host for a service principal. However in the end they also relaxed this because of issues with CNAME's and such.

I'm not really sure if the option name `clustermap.resolve.hostnames` is the best name for this option however it was the best I could think of at the moment.