### PR TITLE
Enabling new HeaderFormat, BlobKeyRecord, GetResponse, ReplicaMetadata version

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -38,10 +38,11 @@ public class BlobProperties {
    * @param serviceId The service id that is creating this blob
    * @param accountId accountId of the user who owns the blob
    * @param containerId containerId of the blob
+   * @param isEncrypted {@code true} if the blob is encrypted, {@code false} otherwise
    */
-  public BlobProperties(long blobSize, String serviceId, short accountId, short containerId) {
+  public BlobProperties(long blobSize, String serviceId, short accountId, short containerId, boolean isEncrypted) {
     this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, SystemTime.getInstance().milliseconds(),
-        accountId, containerId, false);
+        accountId, containerId, isEncrypted);
   }
 
   /**

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -568,7 +568,7 @@ public class AmbryBlobStorageServiceTest {
     ByteBuffer content = ByteBuffer.allocate(0);
     BlobProperties blobProperties =
         new BlobProperties(0, "userMetadataTestOldStyleServiceID", Account.UNKNOWN_ACCOUNT_ID,
-            Container.UNKNOWN_CONTAINER_ID);
+            Container.UNKNOWN_CONTAINER_ID, false);
     byte[] usermetadata = TestUtils.getRandomBytes(25);
     String blobId = router.putBlob(blobProperties, usermetadata, new ByteBufferReadableStreamChannel(content)).get();
 
@@ -2247,16 +2247,16 @@ class FrontendTestRouter implements Router {
     switch (options.getOperationType()) {
       case BlobInfo:
         result = new GetBlobResult(new BlobInfo(
-            new BlobProperties(0, "FrontendTestRouter", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID),
-            new byte[0]), null);
+            new BlobProperties(0, "FrontendTestRouter", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
+                false), new byte[0]), null);
         break;
       case Data:
         result = new GetBlobResult(null, new ByteBufferReadableStreamChannel(ByteBuffer.allocate(0)));
         break;
       default:
         result = new GetBlobResult(new BlobInfo(
-            new BlobProperties(0, "FrontendTestRouter", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID),
-            new byte[0]), new ByteBufferReadableStreamChannel(ByteBuffer.allocate(0)));
+            new BlobProperties(0, "FrontendTestRouter", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
+                false), new byte[0]), new ByteBufferReadableStreamChannel(ByteBuffer.allocate(0)));
         break;
     }
     return completeOperation(result, callback, OpType.GetBlob);

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
@@ -29,7 +29,7 @@ public class BlobPropertiesSerDe {
   static final short VERSION_1 = 1;
   static final short VERSION_2 = 2;
   static final short VERSION_3 = 3;
-  static short CURRENT_VERSION = VERSION_2;
+  static short CURRENT_VERSION = VERSION_3;
   private static final int VERSION_FIELD_SIZE_IN_BYTES = Short.BYTES;
   private static final int TTL_FIELD_SIZE_IN_BYTES = Long.BYTES;
   private static final int PRIVATE_FIELD_SIZE_IN_BYTES = Byte.BYTES;
@@ -41,8 +41,7 @@ public class BlobPropertiesSerDe {
     return VERSION_FIELD_SIZE_IN_BYTES + TTL_FIELD_SIZE_IN_BYTES + PRIVATE_FIELD_SIZE_IN_BYTES
         + CREATION_TIME_FIELD_SIZE_IN_BYTES + BLOB_SIZE_FIELD_SIZE_IN_BYTES + Utils.getIntStringLength(
         properties.getContentType()) + Utils.getIntStringLength(properties.getOwnerId()) + Utils.getIntStringLength(
-        properties.getServiceId()) + Short.BYTES + Short.BYTES + (CURRENT_VERSION == VERSION_3
-        ? ENCRYPTED_FIELD_SIZE_IN_BYTES : 0);
+        properties.getServiceId()) + Short.BYTES + Short.BYTES + ENCRYPTED_FIELD_SIZE_IN_BYTES;
   }
 
   public static BlobProperties getBlobPropertiesFromStream(DataInputStream stream) throws IOException {
@@ -83,8 +82,6 @@ public class BlobPropertiesSerDe {
     Utils.serializeNullableString(outputBuffer, properties.getServiceId());
     outputBuffer.putShort(properties.getAccountId());
     outputBuffer.putShort(properties.getContainerId());
-    if (CURRENT_VERSION == VERSION_3) {
-      outputBuffer.put(properties.isEncrypted() ? (byte) 1 : (byte) 0);
-    }
+    outputBuffer.put(properties.isEncrypted() ? (byte) 1 : (byte) 0);
   }
 }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
@@ -29,7 +29,7 @@ public class BlobPropertiesSerDe {
   static final short VERSION_1 = 1;
   static final short VERSION_2 = 2;
   static final short VERSION_3 = 3;
-  static short CURRENT_VERSION = VERSION_3;
+  static short currentVersion = VERSION_3;
   private static final int VERSION_FIELD_SIZE_IN_BYTES = Short.BYTES;
   private static final int TTL_FIELD_SIZE_IN_BYTES = Long.BYTES;
   private static final int PRIVATE_FIELD_SIZE_IN_BYTES = Byte.BYTES;
@@ -64,7 +64,7 @@ public class BlobPropertiesSerDe {
   }
 
   /**
-   * Serialize {@link BlobProperties} to buffer in the {@link #CURRENT_VERSION}
+   * Serialize {@link BlobProperties} to buffer in the {@link #currentVersion}
    * @param outputBuffer the {@link ByteBuffer} to which {@link BlobProperties} needs to be serialized
    * @param properties the {@link BlobProperties} that needs to be serialized
    */
@@ -72,7 +72,7 @@ public class BlobPropertiesSerDe {
     if (outputBuffer.remaining() < getBlobPropertiesSerDeSize(properties)) {
       throw new IllegalArgumentException("Outut buffer does not have sufficient space to serialize blob properties");
     }
-    outputBuffer.putShort(CURRENT_VERSION);
+    outputBuffer.putShort(currentVersion);
     outputBuffer.putLong(properties.getTimeToLiveInSeconds());
     outputBuffer.put(properties.isPrivate() ? (byte) 1 : (byte) 0);
     outputBuffer.putLong(properties.getCreationTimeInMs());

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
@@ -29,7 +29,6 @@ public class BlobPropertiesSerDe {
   static final short VERSION_1 = 1;
   static final short VERSION_2 = 2;
   static final short VERSION_3 = 3;
-  static short currentVersion = VERSION_3;
   private static final int VERSION_FIELD_SIZE_IN_BYTES = Short.BYTES;
   private static final int TTL_FIELD_SIZE_IN_BYTES = Long.BYTES;
   private static final int PRIVATE_FIELD_SIZE_IN_BYTES = Byte.BYTES;
@@ -64,7 +63,7 @@ public class BlobPropertiesSerDe {
   }
 
   /**
-   * Serialize {@link BlobProperties} to buffer in the {@link #currentVersion}
+   * Serialize {@link BlobProperties} to buffer in the {@link #VERSION_3}
    * @param outputBuffer the {@link ByteBuffer} to which {@link BlobProperties} needs to be serialized
    * @param properties the {@link BlobProperties} that needs to be serialized
    */
@@ -72,7 +71,7 @@ public class BlobPropertiesSerDe {
     if (outputBuffer.remaining() < getBlobPropertiesSerDeSize(properties)) {
       throw new IllegalArgumentException("Outut buffer does not have sufficient space to serialize blob properties");
     }
-    outputBuffer.putShort(currentVersion);
+    outputBuffer.putShort(VERSION_3);
     outputBuffer.putLong(properties.getTimeToLiveInSeconds());
     outputBuffer.put(properties.isPrivate() ? (byte) 1 : (byte) 0);
     outputBuffer.putLong(properties.getCreationTimeInMs());

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteMessageFormatInputStream.java
@@ -33,10 +33,10 @@ import java.nio.ByteBuffer;
 public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
   public DeleteMessageFormatInputStream(StoreKey key, short accountId, short containerId, long deletionTimeMs)
       throws MessageFormatException {
-    int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.HEADER_VERSION_TO_USE);
+    int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.currentHeaderVersionToUse);
     int deleteRecordSize = MessageFormatRecord.Delete_Format_V2.getDeleteRecordSize();
     buffer = ByteBuffer.allocate(headerSize + key.sizeInBytes() + deleteRecordSize);
-    if (MessageFormatRecord.HEADER_VERSION_TO_USE == MessageFormatRecord.Message_Header_Version_V1) {
+    if (MessageFormatRecord.currentHeaderVersionToUse == MessageFormatRecord.Message_Header_Version_V1) {
       MessageFormatRecord.MessageHeader_Format_V1.serializeHeader(buffer, deleteRecordSize,
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerSize + key.sizeInBytes(),
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset,

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteMessageFormatInputStream.java
@@ -33,10 +33,10 @@ import java.nio.ByteBuffer;
 public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
   public DeleteMessageFormatInputStream(StoreKey key, short accountId, short containerId, long deletionTimeMs)
       throws MessageFormatException {
-    int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.currentHeaderVersionToUse);
+    int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.headerVersionToUse);
     int deleteRecordSize = MessageFormatRecord.Delete_Format_V2.getDeleteRecordSize();
     buffer = ByteBuffer.allocate(headerSize + key.sizeInBytes() + deleteRecordSize);
-    if (MessageFormatRecord.currentHeaderVersionToUse == MessageFormatRecord.Message_Header_Version_V1) {
+    if (MessageFormatRecord.headerVersionToUse == MessageFormatRecord.Message_Header_Version_V1) {
       MessageFormatRecord.MessageHeader_Format_V1.serializeHeader(buffer, deleteRecordSize,
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerSize + key.sizeInBytes(),
           MessageFormatRecord.Message_Header_Invalid_Relative_Offset,

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -54,7 +54,7 @@ public class MessageFormatRecord {
   public static final short Metadata_Content_Version_V2 = 2;
   public static final int Message_Header_Invalid_Relative_Offset = -1;
 
-  static short currentHeaderVersionToUse = Message_Header_Version_V2;
+  static short headerVersionToUse = Message_Header_Version_V2;
 
   static boolean isValidHeaderVersion(short headerVersion) {
     switch (headerVersion) {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -54,7 +54,7 @@ public class MessageFormatRecord {
   public static final short Metadata_Content_Version_V2 = 2;
   public static final int Message_Header_Invalid_Relative_Offset = -1;
 
-  static short HEADER_VERSION_TO_USE = Message_Header_Version_V2;
+  static short currentHeaderVersionToUse = Message_Header_Version_V2;
 
   static boolean isValidHeaderVersion(short headerVersion) {
     switch (headerVersion) {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -54,9 +54,7 @@ public class MessageFormatRecord {
   public static final short Metadata_Content_Version_V2 = 2;
   public static final int Message_Header_Invalid_Relative_Offset = -1;
 
-  // @todo temporary variable to determine whether the new header format to support encryption should be enabled.
-  // @todo Set this to true in nodes of a cluster only after all nodes in the cluster understand reading such records.
-  static short HEADER_VERSION_TO_USE = Message_Header_Version_V1;
+  static short HEADER_VERSION_TO_USE = Message_Header_Version_V2;
 
   static boolean isValidHeaderVersion(short headerVersion) {
     switch (headerVersion) {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/PutMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/PutMessageFormatInputStream.java
@@ -41,7 +41,7 @@ public class PutMessageFormatInputStream extends MessageFormatInputStream {
   public PutMessageFormatInputStream(StoreKey key, ByteBuffer blobEncryptionKey, BlobProperties blobProperties,
       ByteBuffer userMetadata, InputStream blobStream, long streamSize, BlobType blobType)
       throws MessageFormatException {
-    if (MessageFormatRecord.currentHeaderVersionToUse == MessageFormatRecord.Message_Header_Version_V2) {
+    if (MessageFormatRecord.headerVersionToUse == MessageFormatRecord.Message_Header_Version_V2) {
       createStreamWithMessageHeaderV2(key, blobEncryptionKey, blobProperties, userMetadata, blobStream, streamSize,
           blobType);
     } else {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/PutMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/PutMessageFormatInputStream.java
@@ -41,7 +41,7 @@ public class PutMessageFormatInputStream extends MessageFormatInputStream {
   public PutMessageFormatInputStream(StoreKey key, ByteBuffer blobEncryptionKey, BlobProperties blobProperties,
       ByteBuffer userMetadata, InputStream blobStream, long streamSize, BlobType blobType)
       throws MessageFormatException {
-    if (MessageFormatRecord.HEADER_VERSION_TO_USE == MessageFormatRecord.Message_Header_Version_V2) {
+    if (MessageFormatRecord.currentHeaderVersionToUse == MessageFormatRecord.Message_Header_Version_V2) {
       createStreamWithMessageHeaderV2(key, blobEncryptionKey, blobProperties, userMetadata, blobStream, streamSize,
           blobType);
     } else {

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -13,8 +13,6 @@
  */
 package com.github.ambry.messageformat;
 
-import com.github.ambry.account.Account;
-import com.github.ambry.account.Container;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
@@ -50,8 +48,7 @@ public class BlobPropertiesTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(
-        new Object[][]{{BlobPropertiesSerDe.VERSION_1}, {BlobPropertiesSerDe.VERSION_2}, {BlobPropertiesSerDe.VERSION_3}});
+    return Arrays.asList(new Object[][]{{BlobPropertiesSerDe.VERSION_1}, {BlobPropertiesSerDe.VERSION_2}, {BlobPropertiesSerDe.VERSION_3}});
   }
 
   public BlobPropertiesTest(short version) {
@@ -73,19 +70,10 @@ public class BlobPropertiesTest {
     short containerIdToExpect = version == BlobPropertiesSerDe.VERSION_1 ? UNKNOWN_CONTAINER_ID : containerId;
     boolean encryptFlagToExpect = version == BlobPropertiesSerDe.VERSION_3 && isEncrypted;
 
-    BlobProperties blobProperties =
-        getBlobProperties(blobSize, isEncrypted, serviceId, accountId, containerId, version);
+    BlobProperties blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
+        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
-    ByteBuffer serializedBuffer = null;
-    if (version == BlobPropertiesSerDe.VERSION_1) {
-      serializedBuffer = getBlobPropsSerDeV1(blobProperties);
-    } else if (version == BlobPropertiesSerDe.VERSION_2) {
-      serializedBuffer = getBlobPropsSerDeV2(blobProperties);
-    } else {
-      serializedBuffer = ByteBuffer.allocate(BlobPropertiesSerDe.getBlobPropertiesSerDeSize(blobProperties));
-      BlobPropertiesSerDe.serializeBlobProperties(serializedBuffer, blobProperties);
-    }
-    serializedBuffer.flip();
+    ByteBuffer serializedBuffer = serializeBlobPropertiesSerDe(blobProperties, version);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, Utils.Infinite_Time, accountIdToExpect,
@@ -93,36 +81,20 @@ public class BlobPropertiesTest {
     assertTrue(blobProperties.getCreationTimeInMs() > 0);
     assertTrue(blobProperties.getCreationTimeInMs() <= System.currentTimeMillis());
 
-    blobProperties = getBlobProperties(blobSize, false, serviceId, accountId, containerId, version);
-
-    if (version == BlobPropertiesSerDe.VERSION_1) {
-      serializedBuffer = getBlobPropsSerDeV1(blobProperties);
-    } else if (version == BlobPropertiesSerDe.VERSION_2) {
-      serializedBuffer = getBlobPropsSerDeV2(blobProperties);
-    } else {
-      serializedBuffer = ByteBuffer.allocate(BlobPropertiesSerDe.getBlobPropertiesSerDeSize(blobProperties));
-      BlobPropertiesSerDe.serializeBlobProperties(serializedBuffer, blobProperties);
-    }
-    serializedBuffer.flip();
+    blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
+        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted);
+    serializedBuffer = serializeBlobPropertiesSerDe(blobProperties, version);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, Utils.Infinite_Time, accountIdToExpect,
-        containerIdToExpect, false);
+        containerIdToExpect, encryptFlagToExpect);
 
     blobProperties =
-        getBlobProperties(blobSize, isEncrypted, serviceId, ownerId, contentType, true, timeToLiveInSeconds, accountId,
-            containerId, version);
+        new BlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds, accountId, containerId,
+            isEncrypted);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
 
-    if (version == BlobPropertiesSerDe.VERSION_1) {
-      serializedBuffer = getBlobPropsSerDeV1(blobProperties);
-    } else if (version == BlobPropertiesSerDe.VERSION_2) {
-      serializedBuffer = getBlobPropsSerDeV2(blobProperties);
-    } else {
-      serializedBuffer = ByteBuffer.allocate(BlobPropertiesSerDe.getBlobPropertiesSerDeSize(blobProperties));
-      BlobPropertiesSerDe.serializeBlobProperties(serializedBuffer, blobProperties);
-    }
-    serializedBuffer.flip();
+    serializedBuffer = serializeBlobPropertiesSerDe(blobProperties, version);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds,
@@ -132,18 +104,10 @@ public class BlobPropertiesTest {
 
     long creationTimeMs = SystemTime.getInstance().milliseconds();
     blobProperties =
-        getBlobProperties(blobSize, isEncrypted, serviceId, ownerId, contentType, true, timeToLiveInSeconds,
-            creationTimeMs, accountId, containerId, version);
+        new BlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds, creationTimeMs,
+            accountId, containerId, isEncrypted);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
-    if (version == BlobPropertiesSerDe.VERSION_1) {
-      serializedBuffer = getBlobPropsSerDeV1(blobProperties);
-    } else if (version == BlobPropertiesSerDe.VERSION_2) {
-      serializedBuffer = getBlobPropsSerDeV2(blobProperties);
-    } else {
-      serializedBuffer = ByteBuffer.allocate(BlobPropertiesSerDe.getBlobPropertiesSerDeSize(blobProperties));
-      BlobPropertiesSerDe.serializeBlobProperties(serializedBuffer, blobProperties);
-    }
-    serializedBuffer.flip();
+    serializedBuffer = serializeBlobPropertiesSerDe(blobProperties, version);
 
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
@@ -151,153 +115,79 @@ public class BlobPropertiesTest {
         accountIdToExpect, containerIdToExpect, encryptFlagToExpect);
     assertEquals(blobProperties.getCreationTimeInMs(), creationTimeMs);
 
-    // testValid TTLs only for latest version
-    if (version == BlobPropertiesSerDe.VERSION_3) {
-      long creationTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(creationTimeMs);
-      // valid TTLs
-      long[] validTTLs = new long[]{TimeUnit.HOURS.toSeconds(1), TimeUnit.HOURS.toSeconds(10), TimeUnit.HOURS.toSeconds(
-          100), TimeUnit.DAYS.toSeconds(1), TimeUnit.DAYS.toSeconds(10), TimeUnit.DAYS.toSeconds(
-          100), TimeUnit.DAYS.toSeconds(30 * 12), TimeUnit.DAYS.toSeconds(30 * 12 * 10),
-          Integer.MAX_VALUE - creationTimeInSecs - 1,
-          Integer.MAX_VALUE - creationTimeInSecs,
-          Integer.MAX_VALUE - creationTimeInSecs + 1,
-          Integer.MAX_VALUE - creationTimeInSecs + 100, Integer.MAX_VALUE - creationTimeInSecs + 10000};
-      for (long ttl : validTTLs) {
-        blobProperties =
-            getBlobProperties(blobSize, isEncrypted, serviceId, ownerId, contentType, true, ttl, creationTimeMs,
-                accountId, containerId, version);
-        serializedBuffer = ByteBuffer.allocate(BlobPropertiesSerDe.getBlobPropertiesSerDeSize(blobProperties));
-        BlobPropertiesSerDe.serializeBlobProperties(serializedBuffer, blobProperties);
-        serializedBuffer.flip();
-        blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
-            new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
-        verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, ttl, accountIdToExpect,
-            containerIdToExpect, encryptFlagToExpect);
-      }
+    long creationTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(creationTimeMs);
+    // valid TTLs
+    long[] validTTLs = new long[]{TimeUnit.HOURS.toSeconds(1), TimeUnit.HOURS.toSeconds(10), TimeUnit.HOURS.toSeconds(
+        100), TimeUnit.DAYS.toSeconds(1), TimeUnit.DAYS.toSeconds(10), TimeUnit.DAYS.toSeconds(
+        100), TimeUnit.DAYS.toSeconds(30 * 12), TimeUnit.DAYS.toSeconds(30 * 12 * 10),
+        Integer.MAX_VALUE - creationTimeInSecs - 1,
+        Integer.MAX_VALUE - creationTimeInSecs,
+        Integer.MAX_VALUE - creationTimeInSecs + 1,
+        Integer.MAX_VALUE - creationTimeInSecs + 100, Integer.MAX_VALUE - creationTimeInSecs + 10000};
+    for (long ttl : validTTLs) {
+      blobProperties =
+          new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs, accountId,
+              containerId, isEncrypted);
+      serializedBuffer = serializeBlobPropertiesSerDe(blobProperties, version);
+      blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
+          new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
+      verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, ttl, accountIdToExpect,
+          containerIdToExpect, encryptFlagToExpect);
     }
   }
 
   /**
-   * Creates {@link BlobProperties} based on the args passed for the given version
-   * @param blobSize the size of the blob
-   * @param isEncrypted whether the blob is encrypted
-   * @param serviceId the serviceId associated with the {@link BlobProperties}
-   * @param ownerId the ownerId associated with the {@link BlobProperties}
-   * @param contentType the contentType associated with the {@link BlobProperties}
-   * @param isPrivate refers to whether the blob is private or not
-   * @param timeToLiveInSeconds the time to live associated with the {@link BlobProperties} in secs
-   * @param creationTimeMs creation time of the blob in ms
-   * @param accountId accountId of the user who uploaded the blob
-   * @param containerId containerId of the blob
-   * @param version the version in which {@link BlobProperties} needs to be created
-   * @return the {@link BlobProperties} thus created
+   * Serialize {@link BlobProperties} using {@link BlobPropertiesSerDe} in the given version
+   * @param blobProperties {@link BlobProperties} that needs to be serialized
+   * @param version the version to serialize
+   * @return the {@link ByteBuffer} containing the serialized {@link BlobPropertiesSerDe}
    */
-  private BlobProperties getBlobProperties(long blobSize, boolean isEncrypted, String serviceId, String ownerId,
-      String contentType, boolean isPrivate, long timeToLiveInSeconds, long creationTimeMs, short accountId,
-      short containerId, short version) {
-    if (version == BlobPropertiesSerDe.VERSION_1) {
-      return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
-          creationTimeMs, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, isEncrypted);
-    } else {
-      return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
-          creationTimeMs, accountId, containerId, isEncrypted);
+  private ByteBuffer serializeBlobPropertiesSerDe(BlobProperties blobProperties, short version) {
+    ByteBuffer outputBuffer = null;
+    switch (version) {
+      case BlobPropertiesSerDe.VERSION_1:
+        int size = Version_Field_Size_In_Bytes + Long.BYTES + Byte.BYTES + Long.BYTES + Long.BYTES + Integer.BYTES
+            + Utils.getNullableStringLength(blobProperties.getContentType()) + Integer.BYTES
+            + Utils.getNullableStringLength(blobProperties.getOwnerId()) + Integer.BYTES
+            + Utils.getNullableStringLength(blobProperties.getServiceId());
+        outputBuffer = ByteBuffer.allocate(size);
+        outputBuffer.putShort(VERSION_1);
+        outputBuffer.putLong(blobProperties.getTimeToLiveInSeconds());
+        outputBuffer.put(blobProperties.isPrivate() ? (byte) 1 : (byte) 0);
+        outputBuffer.putLong(blobProperties.getCreationTimeInMs());
+        outputBuffer.putLong(blobProperties.getBlobSize());
+        Utils.serializeNullableString(outputBuffer, blobProperties.getContentType());
+        Utils.serializeNullableString(outputBuffer, blobProperties.getOwnerId());
+        Utils.serializeNullableString(outputBuffer, blobProperties.getServiceId());
+        outputBuffer.flip();
+        break;
+      case BlobPropertiesSerDe.VERSION_2:
+        size = Version_Field_Size_In_Bytes + Long.BYTES + Byte.BYTES + Long.BYTES + Long.BYTES + Integer.BYTES
+            + Utils.getNullableStringLength(blobProperties.getContentType()) + Integer.BYTES
+            + Utils.getNullableStringLength(blobProperties.getOwnerId()) + Integer.BYTES
+            + Utils.getNullableStringLength(blobProperties.getServiceId()) + Short.BYTES + Short.BYTES;
+        outputBuffer = ByteBuffer.allocate(size);
+        outputBuffer.putShort(VERSION_2);
+        outputBuffer.putLong(blobProperties.getTimeToLiveInSeconds());
+        outputBuffer.put(blobProperties.isPrivate() ? (byte) 1 : (byte) 0);
+        outputBuffer.putLong(blobProperties.getCreationTimeInMs());
+        outputBuffer.putLong(blobProperties.getBlobSize());
+        Utils.serializeNullableString(outputBuffer, blobProperties.getContentType());
+        Utils.serializeNullableString(outputBuffer, blobProperties.getOwnerId());
+        Utils.serializeNullableString(outputBuffer, blobProperties.getServiceId());
+        outputBuffer.putShort(blobProperties.getAccountId());
+        outputBuffer.putShort(blobProperties.getContainerId());
+        outputBuffer.flip();
+        break;
+      case BlobPropertiesSerDe.VERSION_3:
+        outputBuffer = ByteBuffer.allocate(BlobPropertiesSerDe.getBlobPropertiesSerDeSize(blobProperties));
+        BlobPropertiesSerDe.serializeBlobProperties(outputBuffer, blobProperties);
+        outputBuffer.flip();
+        break;
     }
-  }
-
-  /**
-   * Creates {@link BlobProperties} based on the args passed for the given version
-   * @param blobSize the size of the blob
-   * @param isEncrypted whether the blob is encrypted
-   * @param serviceId the serviceId associated with the {@link BlobProperties}
-   * @param ownerId the ownerId associated with the {@link BlobProperties}
-   * @param contentType the contentType associated with the {@link BlobProperties}
-   * @param isPrivate refers to whether the blob is private or not
-   * @param timeToLiveInSeconds the time to live associated with the {@link BlobProperties} in secs
-   * @param accountId accountId of the user who uploaded the blob
-   * @param containerId containerId of the blob
-   * @param version the version in which {@link BlobProperties} needs to be created
-   * @return the {@link BlobProperties} thus created
-   */
-  private BlobProperties getBlobProperties(long blobSize, boolean isEncrypted, String serviceId, String ownerId,
-      String contentType, boolean isPrivate, long timeToLiveInSeconds, short accountId, short containerId,
-      short version) {
-    if (version == BlobPropertiesSerDe.VERSION_1) {
-      return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
-          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, isEncrypted);
-    } else {
-      return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds, accountId,
-          containerId, isEncrypted);
-    }
-  }
-
-  /**
-   * Creates {@link BlobProperties} based on the args passed for the given version
-   * @param blobSize the size of the blob
-   * @param isEncrypted whether the blob is encrypted
-   * @param serviceId the serviceId associated with the {@link BlobProperties}
-   * @param accountId accountId of the user who uploaded the blob
-   * @param containerId containerId of the blob
-   * @param version the version in which {@link BlobProperties} needs to be created
-   * @return the {@link BlobProperties} thus created
-   */
-  private BlobProperties getBlobProperties(long blobSize, boolean isEncrypted, String serviceId, short accountId,
-      short containerId, short version) {
-    if (version == BlobPropertiesSerDe.VERSION_1) {
-      return new BlobProperties(blobSize, serviceId, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false);
-    } else if (version == BlobPropertiesSerDe.VERSION_2) {
-      return new BlobProperties(blobSize, serviceId, accountId, containerId, false);
-    } else {
-      return new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
-          SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted);
-    }
-  }
-
-  /**
-   * Creates BlobPropertiesSerDe in V1 and returns the deserialized version of {@link BlobProperties}
-   * @param blobProperties {@link BlobProperties} that needs to be serialized in V1
-   * @return {@link ByteBuffer} representing the serialized form of {@link BlobProperties} in V1
-   */
-  private ByteBuffer getBlobPropsSerDeV1(BlobProperties blobProperties) {
-    int size = Version_Field_Size_In_Bytes + Long.BYTES + Byte.BYTES + Long.BYTES + Long.BYTES + Integer.BYTES
-        + Utils.getNullableStringLength(blobProperties.getContentType()) + Integer.BYTES
-        + Utils.getNullableStringLength(blobProperties.getOwnerId()) + Integer.BYTES + Utils.getNullableStringLength(
-        blobProperties.getServiceId());
-    ByteBuffer outputBuffer = ByteBuffer.allocate(size);
-    outputBuffer.putShort(VERSION_1);
-    outputBuffer.putLong(blobProperties.getTimeToLiveInSeconds());
-    outputBuffer.put(blobProperties.isPrivate() ? (byte) 1 : (byte) 0);
-    outputBuffer.putLong(blobProperties.getCreationTimeInMs());
-    outputBuffer.putLong(blobProperties.getBlobSize());
-    Utils.serializeNullableString(outputBuffer, blobProperties.getContentType());
-    Utils.serializeNullableString(outputBuffer, blobProperties.getOwnerId());
-    Utils.serializeNullableString(outputBuffer, blobProperties.getServiceId());
     return outputBuffer;
   }
-
-  /**
-   * Creates BlobPropertiesSerDe in V2 and returns the deserialized version of {@link BlobProperties}
-   * @param blobProperties {@link BlobProperties} that needs to be serialized in V1
-   * @return {@link ByteBuffer} representing the serialized form of {@link BlobProperties} in V1
-   */
-  private ByteBuffer getBlobPropsSerDeV2(BlobProperties blobProperties) {
-    int size = Version_Field_Size_In_Bytes + Long.BYTES + Byte.BYTES + Long.BYTES + Long.BYTES + Integer.BYTES
-        + Utils.getNullableStringLength(blobProperties.getContentType()) + Integer.BYTES
-        + Utils.getNullableStringLength(blobProperties.getOwnerId()) + Integer.BYTES + Utils.getNullableStringLength(
-        blobProperties.getServiceId()) + Short.BYTES + Short.BYTES;
-    ByteBuffer outputBuffer = ByteBuffer.allocate(size);
-    outputBuffer.putShort(VERSION_2);
-    outputBuffer.putLong(blobProperties.getTimeToLiveInSeconds());
-    outputBuffer.put(blobProperties.isPrivate() ? (byte) 1 : (byte) 0);
-    outputBuffer.putLong(blobProperties.getCreationTimeInMs());
-    outputBuffer.putLong(blobProperties.getBlobSize());
-    Utils.serializeNullableString(outputBuffer, blobProperties.getContentType());
-    Utils.serializeNullableString(outputBuffer, blobProperties.getOwnerId());
-    Utils.serializeNullableString(outputBuffer, blobProperties.getServiceId());
-    outputBuffer.putShort(blobProperties.getAccountId());
-    outputBuffer.putShort(blobProperties.getContainerId());
-    return outputBuffer;
-  }
-
+  
   /**
    * Verify {@link BlobProperties} for its constituent values
    * @param blobProperties the {@link BlobProperties} that needs to be compared against

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -48,7 +48,8 @@ public class BlobPropertiesTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{BlobPropertiesSerDe.VERSION_1}, {BlobPropertiesSerDe.VERSION_2}, {BlobPropertiesSerDe.VERSION_3}});
+    return Arrays.asList(
+        new Object[][]{{BlobPropertiesSerDe.VERSION_1}, {BlobPropertiesSerDe.VERSION_2}, {BlobPropertiesSerDe.VERSION_3}});
   }
 
   public BlobPropertiesTest(short version) {
@@ -73,7 +74,7 @@ public class BlobPropertiesTest {
     BlobProperties blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
         SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
-    ByteBuffer serializedBuffer = serializeBlobPropertiesSerDe(blobProperties, version);
+    ByteBuffer serializedBuffer = serializeBlobPropertiesInVersion(blobProperties, version);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, Utils.Infinite_Time, accountIdToExpect,
@@ -83,7 +84,7 @@ public class BlobPropertiesTest {
 
     blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
         SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted);
-    serializedBuffer = serializeBlobPropertiesSerDe(blobProperties, version);
+    serializedBuffer = serializeBlobPropertiesInVersion(blobProperties, version);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, Utils.Infinite_Time, accountIdToExpect,
@@ -94,7 +95,7 @@ public class BlobPropertiesTest {
             isEncrypted);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
 
-    serializedBuffer = serializeBlobPropertiesSerDe(blobProperties, version);
+    serializedBuffer = serializeBlobPropertiesInVersion(blobProperties, version);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds,
@@ -107,7 +108,7 @@ public class BlobPropertiesTest {
         new BlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds, creationTimeMs,
             accountId, containerId, isEncrypted);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
-    serializedBuffer = serializeBlobPropertiesSerDe(blobProperties, version);
+    serializedBuffer = serializeBlobPropertiesInVersion(blobProperties, version);
 
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
@@ -128,7 +129,7 @@ public class BlobPropertiesTest {
       blobProperties =
           new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs, accountId,
               containerId, isEncrypted);
-      serializedBuffer = serializeBlobPropertiesSerDe(blobProperties, version);
+      serializedBuffer = serializeBlobPropertiesInVersion(blobProperties, version);
       blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
           new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
       verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, ttl, accountIdToExpect,
@@ -142,7 +143,7 @@ public class BlobPropertiesTest {
    * @param version the version to serialize
    * @return the {@link ByteBuffer} containing the serialized {@link BlobPropertiesSerDe}
    */
-  private ByteBuffer serializeBlobPropertiesSerDe(BlobProperties blobProperties, short version) {
+  private ByteBuffer serializeBlobPropertiesInVersion(BlobProperties blobProperties, short version) {
     ByteBuffer outputBuffer = null;
     switch (version) {
       case BlobPropertiesSerDe.VERSION_1:
@@ -187,7 +188,7 @@ public class BlobPropertiesTest {
     }
     return outputBuffer;
   }
-  
+
   /**
    * Verify {@link BlobProperties} for its constituent values
    * @param blobProperties the {@link BlobProperties} that needs to be compared against

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -226,9 +226,9 @@ public class BlobPropertiesTest {
   private BlobProperties getBlobProperties(long blobSize, boolean isEncrypted, String serviceId, short accountId,
       short containerId, short version) {
     if (version == BlobPropertiesSerDe.VERSION_1) {
-      return new BlobProperties(blobSize, serviceId, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID);
+      return new BlobProperties(blobSize, serviceId, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false);
     } else if (version == BlobPropertiesSerDe.VERSION_2) {
-      return new BlobProperties(blobSize, serviceId, accountId, containerId);
+      return new BlobProperties(blobSize, serviceId, accountId, containerId, false);
     } else {
       return new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
           SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -74,7 +74,7 @@ public class BlobPropertiesTest {
     BlobProperties blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
         SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
-    ByteBuffer serializedBuffer = serializeBlobPropertiesInVersion(blobProperties, version);
+    ByteBuffer serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, Utils.Infinite_Time, accountIdToExpect,
@@ -84,7 +84,7 @@ public class BlobPropertiesTest {
 
     blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
         SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted);
-    serializedBuffer = serializeBlobPropertiesInVersion(blobProperties, version);
+    serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, Utils.Infinite_Time, accountIdToExpect,
@@ -95,7 +95,7 @@ public class BlobPropertiesTest {
             isEncrypted);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
 
-    serializedBuffer = serializeBlobPropertiesInVersion(blobProperties, version);
+    serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds,
@@ -108,7 +108,7 @@ public class BlobPropertiesTest {
         new BlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds, creationTimeMs,
             accountId, containerId, isEncrypted);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
-    serializedBuffer = serializeBlobPropertiesInVersion(blobProperties, version);
+    serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
 
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
@@ -129,7 +129,7 @@ public class BlobPropertiesTest {
       blobProperties =
           new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs, accountId,
               containerId, isEncrypted);
-      serializedBuffer = serializeBlobPropertiesInVersion(blobProperties, version);
+      serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
       blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
           new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
       verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, ttl, accountIdToExpect,
@@ -140,10 +140,9 @@ public class BlobPropertiesTest {
   /**
    * Serialize {@link BlobProperties} using {@link BlobPropertiesSerDe} in the given version
    * @param blobProperties {@link BlobProperties} that needs to be serialized
-   * @param version the version to serialize
    * @return the {@link ByteBuffer} containing the serialized {@link BlobPropertiesSerDe}
    */
-  private ByteBuffer serializeBlobPropertiesInVersion(BlobProperties blobProperties, short version) {
+  private ByteBuffer serializeBlobPropertiesInVersion(BlobProperties blobProperties) {
     ByteBuffer outputBuffer = null;
     switch (version) {
       case BlobPropertiesSerDe.VERSION_1:

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -47,12 +47,12 @@ public class BlobPropertiesTest {
 
   @BeforeClass
   public static void saveVersionToUse() {
-    serDeVersionSaved = BlobPropertiesSerDe.CURRENT_VERSION;
+    serDeVersionSaved = BlobPropertiesSerDe.currentVersion;
   }
 
   @After
   public void resetVersionToUse() {
-    BlobPropertiesSerDe.CURRENT_VERSION = serDeVersionSaved;
+    BlobPropertiesSerDe.currentVersion = serDeVersionSaved;
   }
 
   /**
@@ -80,7 +80,7 @@ public class BlobPropertiesTest {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     boolean isEncrypted = TestUtils.RANDOM.nextBoolean();
 
-    BlobPropertiesSerDe.CURRENT_VERSION = version;
+    BlobPropertiesSerDe.currentVersion = version;
 
     short accountIdToExpect = version == BlobPropertiesSerDe.VERSION_1 ? UNKNOWN_ACCOUNT_ID : accountId;
     short containerIdToExpect = version == BlobPropertiesSerDe.VERSION_1 ? UNKNOWN_CONTAINER_ID : containerId;

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
@@ -45,12 +45,12 @@ public class BlobStoreHardDeleteTest {
 
   @BeforeClass
   public static void saveMessageFormatHeaderVersionToUse() {
-    messageFormatHeaderVersionSaved = MessageFormatRecord.currentHeaderVersionToUse;
+    messageFormatHeaderVersionSaved = MessageFormatRecord.headerVersionToUse;
   }
 
   @After
   public void resetMessageFormatHeaderVersionToUse() {
-    MessageFormatRecord.currentHeaderVersionToUse = messageFormatHeaderVersionSaved;
+    MessageFormatRecord.headerVersionToUse = messageFormatHeaderVersionSaved;
   }
 
   @Parameterized.Parameters
@@ -60,7 +60,7 @@ public class BlobStoreHardDeleteTest {
   }
 
   public BlobStoreHardDeleteTest(short headerVersionToUse) {
-    MessageFormatRecord.currentHeaderVersionToUse = headerVersionToUse;
+    MessageFormatRecord.headerVersionToUse = headerVersionToUse;
   }
 
   public class ReadImp implements Read {
@@ -145,7 +145,7 @@ public class BlobStoreHardDeleteTest {
       readSet.addMessage(buffer.position(), keys[2], (int) msg2.getSize());
       writeToBuffer(msg2, (int) msg2.getSize());
       HardDeleteRecoveryMetadata hardDeleteRecoveryMetadata =
-          new HardDeleteRecoveryMetadata(MessageFormatRecord.currentHeaderVersionToUse,
+          new HardDeleteRecoveryMetadata(MessageFormatRecord.headerVersionToUse,
               MessageFormatRecord.UserMetadata_Version_V1, USERMETADATA_SIZE, blobVersions[2], blobTypes[2], BLOB_SIZE,
               keys[2]);
       recoveryInfoList.add(hardDeleteRecoveryMetadata.toBytes());
@@ -157,7 +157,7 @@ public class BlobStoreHardDeleteTest {
       // This should succeed.
       readSet.addMessage(buffer.position(), keys[3], (int) msg4.getSize());
       writeToBufferAndCorruptBlobRecord(msg4, (int) msg4.getSize());
-      hardDeleteRecoveryMetadata = new HardDeleteRecoveryMetadata(MessageFormatRecord.currentHeaderVersionToUse,
+      hardDeleteRecoveryMetadata = new HardDeleteRecoveryMetadata(MessageFormatRecord.headerVersionToUse,
           MessageFormatRecord.UserMetadata_Version_V1, USERMETADATA_SIZE, blobVersions[3], blobTypes[3], BLOB_SIZE,
           keys[3]);
       recoveryInfoList.add(hardDeleteRecoveryMetadata.toBytes());

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
@@ -45,12 +45,12 @@ public class BlobStoreHardDeleteTest {
 
   @BeforeClass
   public static void saveMessageFormatHeaderVersionToUse() {
-    messageFormatHeaderVersionSaved = MessageFormatRecord.HEADER_VERSION_TO_USE;
+    messageFormatHeaderVersionSaved = MessageFormatRecord.currentHeaderVersionToUse;
   }
 
   @After
   public void resetMessageFormatHeaderVersionToUse() {
-    MessageFormatRecord.HEADER_VERSION_TO_USE = messageFormatHeaderVersionSaved;
+    MessageFormatRecord.currentHeaderVersionToUse = messageFormatHeaderVersionSaved;
   }
 
   @Parameterized.Parameters
@@ -60,7 +60,7 @@ public class BlobStoreHardDeleteTest {
   }
 
   public BlobStoreHardDeleteTest(short headerVersionToUse) {
-    MessageFormatRecord.HEADER_VERSION_TO_USE = headerVersionToUse;
+    MessageFormatRecord.currentHeaderVersionToUse = headerVersionToUse;
   }
 
   public class ReadImp implements Read {
@@ -145,7 +145,7 @@ public class BlobStoreHardDeleteTest {
       readSet.addMessage(buffer.position(), keys[2], (int) msg2.getSize());
       writeToBuffer(msg2, (int) msg2.getSize());
       HardDeleteRecoveryMetadata hardDeleteRecoveryMetadata =
-          new HardDeleteRecoveryMetadata(MessageFormatRecord.HEADER_VERSION_TO_USE,
+          new HardDeleteRecoveryMetadata(MessageFormatRecord.currentHeaderVersionToUse,
               MessageFormatRecord.UserMetadata_Version_V1, USERMETADATA_SIZE, blobVersions[2], blobTypes[2], BLOB_SIZE,
               keys[2]);
       recoveryInfoList.add(hardDeleteRecoveryMetadata.toBytes());
@@ -157,7 +157,7 @@ public class BlobStoreHardDeleteTest {
       // This should succeed.
       readSet.addMessage(buffer.position(), keys[3], (int) msg4.getSize());
       writeToBufferAndCorruptBlobRecord(msg4, (int) msg4.getSize());
-      hardDeleteRecoveryMetadata = new HardDeleteRecoveryMetadata(MessageFormatRecord.HEADER_VERSION_TO_USE,
+      hardDeleteRecoveryMetadata = new HardDeleteRecoveryMetadata(MessageFormatRecord.currentHeaderVersionToUse,
           MessageFormatRecord.UserMetadata_Version_V1, USERMETADATA_SIZE, blobVersions[3], blobTypes[3], BLOB_SIZE,
           keys[3]);
       recoveryInfoList.add(hardDeleteRecoveryMetadata.toBytes());

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
@@ -123,12 +123,12 @@ public class BlobStoreRecoveryTest {
 
   @BeforeClass
   public static void saveMessageFormatHeaderVersionToUse() {
-    messageFormatHeaderVersionSaved = MessageFormatRecord.HEADER_VERSION_TO_USE;
+    messageFormatHeaderVersionSaved = MessageFormatRecord.currentHeaderVersionToUse;
   }
 
   @After
   public void resetMessageFormatHeaderVersionToUse() {
-    MessageFormatRecord.HEADER_VERSION_TO_USE = messageFormatHeaderVersionSaved;
+    MessageFormatRecord.currentHeaderVersionToUse = messageFormatHeaderVersionSaved;
   }
 
   @Parameterized.Parameters
@@ -138,7 +138,7 @@ public class BlobStoreRecoveryTest {
   }
 
   public BlobStoreRecoveryTest(short headerVersionToUse) {
-    MessageFormatRecord.HEADER_VERSION_TO_USE = headerVersionToUse;
+    MessageFormatRecord.currentHeaderVersionToUse = headerVersionToUse;
   }
 
   public class ReadImp implements Read {

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
@@ -171,13 +171,13 @@ public class BlobStoreRecoveryTest {
 
       // 2nd message
       PutMessageFormatInputStream msg2 = new PutMessageFormatInputStream(keys[1], ByteBuffer.wrap(encryptionKey),
-          new BlobProperties(4000, "test", accountId, containerId), ByteBuffer.wrap(usermetadata),
+          new BlobProperties(4000, "test", accountId, containerId, false), ByteBuffer.wrap(usermetadata),
           new ByteBufferInputStream(ByteBuffer.wrap(blob)), 4000);
 
       // 3rd message (null encryption key)
-      PutMessageFormatInputStream msg3 =
-          new PutMessageFormatInputStream(keys[2], null, new BlobProperties(4000, "test", accountId, containerId),
-              ByteBuffer.wrap(usermetadata), new ByteBufferInputStream(ByteBuffer.wrap(blob)), 4000);
+      PutMessageFormatInputStream msg3 = new PutMessageFormatInputStream(keys[2], null,
+          new BlobProperties(4000, "test", accountId, containerId, false), ByteBuffer.wrap(usermetadata),
+          new ByteBufferInputStream(ByteBuffer.wrap(blob)), 4000);
 
       // 4th message
       DeleteMessageFormatInputStream msg4 =
@@ -185,7 +185,7 @@ public class BlobStoreRecoveryTest {
 
       // 5th message
       PutMessageFormatInputStream msg5 = new PutMessageFormatInputStream(keys[3], ByteBuffer.wrap(encryptionKey),
-          new BlobProperties(4000, "test", accountId, containerId), ByteBuffer.wrap(usermetadata),
+          new BlobProperties(4000, "test", accountId, containerId, false), ByteBuffer.wrap(usermetadata),
           new ByteBufferInputStream(ByteBuffer.wrap(blob)), 4000);
 
       buffer = ByteBuffer.allocate(

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
@@ -123,12 +123,12 @@ public class BlobStoreRecoveryTest {
 
   @BeforeClass
   public static void saveMessageFormatHeaderVersionToUse() {
-    messageFormatHeaderVersionSaved = MessageFormatRecord.currentHeaderVersionToUse;
+    messageFormatHeaderVersionSaved = MessageFormatRecord.headerVersionToUse;
   }
 
   @After
   public void resetMessageFormatHeaderVersionToUse() {
-    MessageFormatRecord.currentHeaderVersionToUse = messageFormatHeaderVersionSaved;
+    MessageFormatRecord.headerVersionToUse = messageFormatHeaderVersionSaved;
   }
 
   @Parameterized.Parameters
@@ -138,7 +138,7 @@ public class BlobStoreRecoveryTest {
   }
 
   public BlobStoreRecoveryTest(short headerVersionToUse) {
-    MessageFormatRecord.currentHeaderVersionToUse = headerVersionToUse;
+    MessageFormatRecord.headerVersionToUse = headerVersionToUse;
   }
 
   public class ReadImp implements Read {

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
@@ -62,7 +62,7 @@ public class MessageFormatInputStreamTest {
     StoreKeyFactory keyFactory = new MockIdFactory();
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
-    BlobProperties prop = new BlobProperties(10, "servid", accountId, containerId);
+    BlobProperties prop = new BlobProperties(10, "servid", accountId, containerId, false);
     byte[] encryptionKey = new byte[100];
     new Random().nextBytes(encryptionKey);
     byte[] usermetadata = new byte[1000];

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
@@ -36,12 +36,12 @@ public class MessageFormatInputStreamTest {
 
   @BeforeClass
   public static void saveMessageFormatHeaderVersionToUse() {
-    messageFormatHeaderVersionSaved = MessageFormatRecord.currentHeaderVersionToUse;
+    messageFormatHeaderVersionSaved = MessageFormatRecord.headerVersionToUse;
   }
 
   @After
   public void resetMessageFormatHeaderVersionToUse() {
-    MessageFormatRecord.currentHeaderVersionToUse = messageFormatHeaderVersionSaved;
+    MessageFormatRecord.headerVersionToUse = messageFormatHeaderVersionSaved;
   }
 
   /**
@@ -71,7 +71,7 @@ public class MessageFormatInputStreamTest {
     byte[] data = new byte[blobContentSize];
     new Random().nextBytes(data);
     long blobSize = -1;
-    MessageFormatRecord.currentHeaderVersionToUse =
+    MessageFormatRecord.headerVersionToUse =
         useV2Header ? MessageFormatRecord.Message_Header_Version_V2 : MessageFormatRecord.Message_Header_Version_V1;
     if (blobVersion == MessageFormatRecord.Blob_Version_V1) {
       blobSize = MessageFormatRecord.Blob_Format_V1.getBlobRecordSize(blobContentSize);
@@ -250,7 +250,7 @@ public class MessageFormatInputStreamTest {
         useV2Header = false;
       } else {
         messageFormatStream = new DeleteMessageFormatInputStream(key, accountId, containerId, deletionTimeMs);
-        useV2Header = MessageFormatRecord.currentHeaderVersionToUse == MessageFormatRecord.Message_Header_Version_V2;
+        useV2Header = MessageFormatRecord.headerVersionToUse == MessageFormatRecord.Message_Header_Version_V2;
       }
       int headerSize = MessageFormatRecord.getHeaderSizeForVersion(
           useV2Header ? MessageFormatRecord.Message_Header_Version_V2 : MessageFormatRecord.Message_Header_Version_V1);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
@@ -36,12 +36,12 @@ public class MessageFormatInputStreamTest {
 
   @BeforeClass
   public static void saveMessageFormatHeaderVersionToUse() {
-    messageFormatHeaderVersionSaved = MessageFormatRecord.HEADER_VERSION_TO_USE;
+    messageFormatHeaderVersionSaved = MessageFormatRecord.currentHeaderVersionToUse;
   }
 
   @After
   public void resetMessageFormatHeaderVersionToUse() {
-    MessageFormatRecord.HEADER_VERSION_TO_USE = messageFormatHeaderVersionSaved;
+    MessageFormatRecord.currentHeaderVersionToUse = messageFormatHeaderVersionSaved;
   }
 
   /**
@@ -71,7 +71,7 @@ public class MessageFormatInputStreamTest {
     byte[] data = new byte[blobContentSize];
     new Random().nextBytes(data);
     long blobSize = -1;
-    MessageFormatRecord.HEADER_VERSION_TO_USE =
+    MessageFormatRecord.currentHeaderVersionToUse =
         useV2Header ? MessageFormatRecord.Message_Header_Version_V2 : MessageFormatRecord.Message_Header_Version_V1;
     if (blobVersion == MessageFormatRecord.Blob_Version_V1) {
       blobSize = MessageFormatRecord.Blob_Format_V1.getBlobRecordSize(blobContentSize);
@@ -250,7 +250,7 @@ public class MessageFormatInputStreamTest {
         useV2Header = false;
       } else {
         messageFormatStream = new DeleteMessageFormatInputStream(key, accountId, containerId, deletionTimeMs);
-        useV2Header = MessageFormatRecord.HEADER_VERSION_TO_USE == MessageFormatRecord.Message_Header_Version_V2;
+        useV2Header = MessageFormatRecord.currentHeaderVersionToUse == MessageFormatRecord.Message_Header_Version_V2;
       }
       int headerSize = MessageFormatRecord.getHeaderSizeForVersion(
           useV2Header ? MessageFormatRecord.Message_Header_Version_V2 : MessageFormatRecord.Message_Header_Version_V1);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -30,9 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static com.github.ambry.account.Account.*;
@@ -44,18 +42,6 @@ import static org.junit.Assert.*;
 
 
 public class MessageFormatRecordTest {
-  private static short serDeVersionSaved;
-
-  @BeforeClass
-  public static void saveVersionToUse() {
-    serDeVersionSaved = BlobPropertiesSerDe.currentVersion;
-  }
-
-  @After
-  public void resetVersionToUse() {
-    BlobPropertiesSerDe.currentVersion = serDeVersionSaved;
-  }
-
   @Test
   public void deserializeTest() {
     try {
@@ -187,7 +173,6 @@ public class MessageFormatRecordTest {
     // Test Blob property Format V1 for all versions of BlobPropertiesSerDe
     short[] versions = new short[]{VERSION_1, VERSION_2, VERSION_3};
     for (short version : versions) {
-      BlobPropertiesSerDe.currentVersion = version;
       BlobProperties properties;
       long blobSize = TestUtils.RANDOM.nextLong();
       long ttl = TestUtils.RANDOM.nextInt();

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -187,6 +187,7 @@ public class MessageFormatRecordTest {
     // Test Blob property Format V1 for all versions of BlobPropertiesSerDe
     short[] versions = new short[]{VERSION_1, VERSION_2, VERSION_3};
     for (short version : versions) {
+      System.out.println("Version " + version);
       BlobPropertiesSerDe.CURRENT_VERSION = version;
       BlobProperties properties;
       long blobSize = TestUtils.RANDOM.nextLong();
@@ -205,6 +206,9 @@ public class MessageFormatRecordTest {
       if (version == VERSION_1) {
         stream = ByteBuffer.allocate(getBlobPropertiesV1RecordSize(properties));
         serializeBlobPropertiesV1Record(stream, properties);
+      } else if (version == VERSION_2) {
+        stream = ByteBuffer.allocate(getBlobPropertiesV2RecordSize(properties));
+        serializeBlobPropertiesV2Record(stream, properties);
       } else {
         stream = ByteBuffer.allocate(getBlobPropertiesRecordSize(properties));
         MessageFormatRecord.BlobProperties_Format_V1.serializeBlobPropertiesRecord(stream, properties);
@@ -260,7 +264,7 @@ public class MessageFormatRecordTest {
   }
 
   /**
-   * Returns {@link BlobProperties} record size in version1
+   * Returns {@link BlobProperties} record size in version {@link BlobPropertiesSerDe#VERSION_1}
    * @param properties {@link BlobProperties} for which size is requested
    * @return the size of the {@link BlobPropertiesSerDe} in version {@link BlobPropertiesSerDe#VERSION_1}
    */
@@ -285,6 +289,51 @@ public class MessageFormatRecordTest {
     Utils.serializeNullableString(outputBuffer, properties.getContentType());
     Utils.serializeNullableString(outputBuffer, properties.getOwnerId());
     Utils.serializeNullableString(outputBuffer, properties.getServiceId());
+  }
+
+  /**
+   * Serialize {@link BlobProperties} in version {@link BlobPropertiesSerDe#VERSION_2}
+   * @param outputBuffer {@link ByteBuffer} to serialize the {@link BlobProperties}
+   * @param properties {@link BlobProperties} to be serialized
+   */
+  private void serializeBlobPropertiesV2Record(ByteBuffer outputBuffer, BlobProperties properties) {
+    int startOffset = outputBuffer.position();
+    outputBuffer.putShort(BlobProperties_Version_V1);
+    putBlobPropertiesToBufferV2(outputBuffer, properties);
+    Crc32 crc = new Crc32();
+    crc.update(outputBuffer.array(), startOffset, getBlobPropertiesV2RecordSize(properties) - Crc_Size);
+    outputBuffer.putLong(crc.getValue());
+  }
+
+  /**
+   * Returns {@link BlobProperties} record size in version {@link BlobPropertiesSerDe#VERSION_2}
+   * @param properties {@link BlobProperties} for which size is requested
+   * @return the size of the {@link BlobPropertiesSerDe} in version {@link BlobPropertiesSerDe#VERSION_2}
+   */
+  private int getBlobPropertiesV2RecordSize(BlobProperties properties) {
+    int size = Version_Field_Size_In_Bytes + Long.BYTES + Byte.BYTES + Long.BYTES + Long.BYTES + Integer.BYTES
+        + Utils.getNullableStringLength(properties.getContentType()) + Integer.BYTES + Utils.getNullableStringLength(
+        properties.getOwnerId()) + Integer.BYTES + Utils.getNullableStringLength(properties.getServiceId())
+        + Short.BYTES + Short.BYTES;
+    return Version_Field_Size_In_Bytes + size + Crc_Size;
+  }
+
+  /**
+   * Serialize {@link BlobProperties} to buffer in the {@link BlobPropertiesSerDe#VERSION_2}
+   * @param outputBuffer the {@link ByteBuffer} to which {@link BlobProperties} needs to be serialized
+   * @param properties the {@link BlobProperties} that needs to be serialized
+   */
+  private static void putBlobPropertiesToBufferV2(ByteBuffer outputBuffer, BlobProperties properties) {
+    outputBuffer.putShort(VERSION_2);
+    outputBuffer.putLong(properties.getTimeToLiveInSeconds());
+    outputBuffer.put(properties.isPrivate() ? (byte) 1 : (byte) 0);
+    outputBuffer.putLong(properties.getCreationTimeInMs());
+    outputBuffer.putLong(properties.getBlobSize());
+    Utils.serializeNullableString(outputBuffer, properties.getContentType());
+    Utils.serializeNullableString(outputBuffer, properties.getOwnerId());
+    Utils.serializeNullableString(outputBuffer, properties.getServiceId());
+    outputBuffer.putShort(properties.getAccountId());
+    outputBuffer.putShort(properties.getContainerId());
   }
 
   /**

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -48,12 +48,12 @@ public class MessageFormatRecordTest {
 
   @BeforeClass
   public static void saveVersionToUse() {
-    serDeVersionSaved = BlobPropertiesSerDe.CURRENT_VERSION;
+    serDeVersionSaved = BlobPropertiesSerDe.currentVersion;
   }
 
   @After
   public void resetVersionToUse() {
-    BlobPropertiesSerDe.CURRENT_VERSION = serDeVersionSaved;
+    BlobPropertiesSerDe.currentVersion = serDeVersionSaved;
   }
 
   @Test
@@ -187,8 +187,7 @@ public class MessageFormatRecordTest {
     // Test Blob property Format V1 for all versions of BlobPropertiesSerDe
     short[] versions = new short[]{VERSION_1, VERSION_2, VERSION_3};
     for (short version : versions) {
-      System.out.println("Version " + version);
-      BlobPropertiesSerDe.CURRENT_VERSION = version;
+      BlobPropertiesSerDe.currentVersion = version;
       BlobProperties properties;
       long blobSize = TestUtils.RANDOM.nextLong();
       long ttl = TestUtils.RANDOM.nextInt();

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatSendTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatSendTest.java
@@ -45,12 +45,12 @@ public class MessageFormatSendTest {
 
   @BeforeClass
   public static void saveMessageFormatHeaderVersionToUse() {
-    messageFormatHeaderVersionSaved = MessageFormatRecord.HEADER_VERSION_TO_USE;
+    messageFormatHeaderVersionSaved = MessageFormatRecord.currentHeaderVersionToUse;
   }
 
   @After
   public void resetMessageFormatHeaderVersionToUse() {
-    MessageFormatRecord.HEADER_VERSION_TO_USE = messageFormatHeaderVersionSaved;
+    MessageFormatRecord.currentHeaderVersionToUse = messageFormatHeaderVersionSaved;
   }
 
   @Parameterized.Parameters
@@ -105,10 +105,10 @@ public class MessageFormatSendTest {
   public void sendWriteSingleMessageTest() throws Exception {
     if (putFormat.equals(PutMessageFormatInputStream.class.getSimpleName())) {
       ByteBuffer encryptionKey = ByteBuffer.wrap(TestUtils.getRandomBytes(256));
-      MessageFormatRecord.HEADER_VERSION_TO_USE = MessageFormatRecord.Message_Header_Version_V1;
+      MessageFormatRecord.currentHeaderVersionToUse = MessageFormatRecord.Message_Header_Version_V1;
       doSendWriteSingleMessageTest(null, null);
       doSendWriteSingleMessageTest(encryptionKey.duplicate(), null);
-      MessageFormatRecord.HEADER_VERSION_TO_USE = MessageFormatRecord.Message_Header_Version_V2;
+      MessageFormatRecord.currentHeaderVersionToUse = MessageFormatRecord.Message_Header_Version_V2;
       doSendWriteSingleMessageTest(null, null);
       doSendWriteSingleMessageTest(ByteBuffer.allocate(0), ByteBuffer.allocate(0));
       doSendWriteSingleMessageTest(encryptionKey.duplicate(), encryptionKey.duplicate());
@@ -271,7 +271,7 @@ public class MessageFormatSendTest {
    */
   @Test
   public void sendWriteCompositeMessagesTest() throws Exception {
-    short savedVersion = MessageFormatRecord.HEADER_VERSION_TO_USE;
+    short savedVersion = MessageFormatRecord.currentHeaderVersionToUse;
     if (!putFormat.equals(PutMessageFormatInputStream.class.getSimpleName())) {
       return;
     }
@@ -312,7 +312,7 @@ public class MessageFormatSendTest {
     doSendWriteCompositeMessagesTest(blob, userMetadata, storeKeys, encryptionKeys, putFormatComposite2,
         headerFormatComposite2);
 
-    MessageFormatRecord.HEADER_VERSION_TO_USE = savedVersion;
+    MessageFormatRecord.currentHeaderVersionToUse = savedVersion;
   }
 
   /**
@@ -342,7 +342,7 @@ public class MessageFormatSendTest {
 
     MessageFormatInputStream[] putStreams = new MessageFormatInputStream[5];
     for (int i = 0; i < 5; i++) {
-      MessageFormatRecord.HEADER_VERSION_TO_USE = headerVersions[i];
+      MessageFormatRecord.currentHeaderVersionToUse = headerVersions[i];
       if (putFormats[i].equals(PutMessageFormatInputStream.class.getSimpleName())) {
         putStreams[i] =
             new PutMessageFormatInputStream(storeKeys[i], (ByteBuffer) encryptionKeys[i].rewind(), properties[i],

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatSendTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatSendTest.java
@@ -45,12 +45,12 @@ public class MessageFormatSendTest {
 
   @BeforeClass
   public static void saveMessageFormatHeaderVersionToUse() {
-    messageFormatHeaderVersionSaved = MessageFormatRecord.currentHeaderVersionToUse;
+    messageFormatHeaderVersionSaved = MessageFormatRecord.headerVersionToUse;
   }
 
   @After
   public void resetMessageFormatHeaderVersionToUse() {
-    MessageFormatRecord.currentHeaderVersionToUse = messageFormatHeaderVersionSaved;
+    MessageFormatRecord.headerVersionToUse = messageFormatHeaderVersionSaved;
   }
 
   @Parameterized.Parameters
@@ -105,10 +105,10 @@ public class MessageFormatSendTest {
   public void sendWriteSingleMessageTest() throws Exception {
     if (putFormat.equals(PutMessageFormatInputStream.class.getSimpleName())) {
       ByteBuffer encryptionKey = ByteBuffer.wrap(TestUtils.getRandomBytes(256));
-      MessageFormatRecord.currentHeaderVersionToUse = MessageFormatRecord.Message_Header_Version_V1;
+      MessageFormatRecord.headerVersionToUse = MessageFormatRecord.Message_Header_Version_V1;
       doSendWriteSingleMessageTest(null, null);
       doSendWriteSingleMessageTest(encryptionKey.duplicate(), null);
-      MessageFormatRecord.currentHeaderVersionToUse = MessageFormatRecord.Message_Header_Version_V2;
+      MessageFormatRecord.headerVersionToUse = MessageFormatRecord.Message_Header_Version_V2;
       doSendWriteSingleMessageTest(null, null);
       doSendWriteSingleMessageTest(ByteBuffer.allocate(0), ByteBuffer.allocate(0));
       doSendWriteSingleMessageTest(encryptionKey.duplicate(), encryptionKey.duplicate());
@@ -271,7 +271,7 @@ public class MessageFormatSendTest {
    */
   @Test
   public void sendWriteCompositeMessagesTest() throws Exception {
-    short savedVersion = MessageFormatRecord.currentHeaderVersionToUse;
+    short savedVersion = MessageFormatRecord.headerVersionToUse;
     if (!putFormat.equals(PutMessageFormatInputStream.class.getSimpleName())) {
       return;
     }
@@ -312,7 +312,7 @@ public class MessageFormatSendTest {
     doSendWriteCompositeMessagesTest(blob, userMetadata, storeKeys, encryptionKeys, putFormatComposite2,
         headerFormatComposite2);
 
-    MessageFormatRecord.currentHeaderVersionToUse = savedVersion;
+    MessageFormatRecord.headerVersionToUse = savedVersion;
   }
 
   /**
@@ -342,7 +342,7 @@ public class MessageFormatSendTest {
 
     MessageFormatInputStream[] putStreams = new MessageFormatInputStream[5];
     for (int i = 0; i < 5; i++) {
-      MessageFormatRecord.currentHeaderVersionToUse = headerVersions[i];
+      MessageFormatRecord.headerVersionToUse = headerVersions[i];
       if (putFormats[i].equals(PutMessageFormatInputStream.class.getSimpleName())) {
         putStreams[i] =
             new PutMessageFormatInputStream(storeKeys[i], (ByteBuffer) encryptionKeys[i].rewind(), properties[i],

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
@@ -41,12 +41,12 @@ public class MessageSievingInputStreamTest {
 
   @BeforeClass
   public static void saveMessageFormatHeaderVersionToUse() {
-    messageFormatHeaderVersionSaved = MessageFormatRecord.HEADER_VERSION_TO_USE;
+    messageFormatHeaderVersionSaved = MessageFormatRecord.currentHeaderVersionToUse;
   }
 
   @After
   public void resetMessageFormatHeaderVersionToUse() {
-    MessageFormatRecord.HEADER_VERSION_TO_USE = messageFormatHeaderVersionSaved;
+    MessageFormatRecord.currentHeaderVersionToUse = messageFormatHeaderVersionSaved;
   }
 
   @Test
@@ -61,7 +61,7 @@ public class MessageSievingInputStreamTest {
     // MessageSievingInputStream contains put records for 3 valid blobs
     // id1(put record for valid blob), id2(put record for valid blob) and id3(put record for valid blob)
 
-    HEADER_VERSION_TO_USE = Message_Header_Version_V1;
+    currentHeaderVersionToUse = Message_Header_Version_V1;
     byte[] encryptionKey = new byte[100];
     TestUtils.RANDOM.nextBytes(encryptionKey);
     // create message stream for blob 1
@@ -171,7 +171,7 @@ public class MessageSievingInputStreamTest {
 
     if (blobVersion == Blob_Version_V2) {
       ByteBufferInputStream stream4 = new ByteBufferInputStream(ByteBuffer.wrap(data4));
-      HEADER_VERSION_TO_USE = Message_Header_Version_V2;
+      currentHeaderVersionToUse = Message_Header_Version_V2;
       messageFormatStream4 =
           new PutMessageFormatInputStream(key4, ByteBuffer.wrap(encryptionKey), prop4, ByteBuffer.wrap(usermetadata4),
               stream4, blobContentSize, blobType);
@@ -197,7 +197,7 @@ public class MessageSievingInputStreamTest {
     }
     if (blobVersion == Blob_Version_V2) {
       ByteBufferInputStream stream5 = new ByteBufferInputStream(ByteBuffer.wrap(data5));
-      HEADER_VERSION_TO_USE = Message_Header_Version_V2;
+      currentHeaderVersionToUse = Message_Header_Version_V2;
       messageFormatStream5 =
           new PutMessageFormatInputStream(key5, null, prop5, ByteBuffer.wrap(usermetadata5), stream5, blobContentSize,
               blobType);
@@ -304,7 +304,7 @@ public class MessageSievingInputStreamTest {
   }
 
   private void testInValidBlobs(short blobVersion, BlobType blobType) throws IOException, MessageFormatException {
-    HEADER_VERSION_TO_USE = Message_Header_Version_V1;
+    currentHeaderVersionToUse = Message_Header_Version_V1;
 
     // MessageSievingInputStream contains put records for 2 valid blobs and 1 corrupt blob
     // id1(put record for valid blob), id2(corrupt) and id3(put record for valid blob)
@@ -473,7 +473,7 @@ public class MessageSievingInputStreamTest {
 
     try {
       for (short version : versions) {
-        HEADER_VERSION_TO_USE = version;
+        currentHeaderVersionToUse = version;
         // create message stream for blob 1
         StoreKey key1 = new MockId("id1");
         short accountId = Utils.getRandomShort(TestUtils.RANDOM);
@@ -565,7 +565,7 @@ public class MessageSievingInputStreamTest {
     } catch (IllegalStateException e) {
       Assert.assertTrue("IllegalStateException thrown as expected ", true);
     }
-    HEADER_VERSION_TO_USE = Message_Header_Version_V1;
+    currentHeaderVersionToUse = Message_Header_Version_V1;
   }
 
   private boolean verifyBlob(MessageSievingInputStream validMessageDetectionInputStream, short headerVersion,

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
@@ -68,7 +68,7 @@ public class MessageSievingInputStreamTest {
     StoreKey key1 = new MockId("id1");
     short accountId1 = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId1 = Utils.getRandomShort(TestUtils.RANDOM);
-    BlobProperties prop1 = new BlobProperties(10, "servid1", accountId1, containerId1);
+    BlobProperties prop1 = new BlobProperties(10, "servid1", accountId1, containerId1, false);
     byte[] usermetadata1 = new byte[1000];
     TestUtils.RANDOM.nextBytes(usermetadata1);
     int blobContentSize = 2000;
@@ -101,7 +101,7 @@ public class MessageSievingInputStreamTest {
     StoreKey key2 = new MockId("id2");
     short accountId2 = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId2 = Utils.getRandomShort(TestUtils.RANDOM);
-    BlobProperties prop2 = new BlobProperties(10, "servid2", accountId2, containerId2);
+    BlobProperties prop2 = new BlobProperties(10, "servid2", accountId2, containerId2, false);
     byte[] usermetadata2 = new byte[1000];
     TestUtils.RANDOM.nextBytes(usermetadata2);
     blobContentSize = 2000;
@@ -127,7 +127,7 @@ public class MessageSievingInputStreamTest {
     StoreKey key3 = new MockId("id3");
     short accountId3 = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId3 = Utils.getRandomShort(TestUtils.RANDOM);
-    BlobProperties prop3 = new BlobProperties(10, "servid3", accountId3, containerId3);
+    BlobProperties prop3 = new BlobProperties(10, "servid3", accountId3, containerId3, false);
     byte[] usermetadata3 = new byte[1000];
     TestUtils.RANDOM.nextBytes(usermetadata3);
     blobContentSize = 2000;
@@ -157,7 +157,7 @@ public class MessageSievingInputStreamTest {
     StoreKey key4 = new MockId("id4");
     short accountId4 = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId4 = Utils.getRandomShort(TestUtils.RANDOM);
-    BlobProperties prop4 = new BlobProperties(10, "servid4", accountId4, containerId4);
+    BlobProperties prop4 = new BlobProperties(10, "servid4", accountId4, containerId4, false);
     byte[] usermetadata4 = new byte[1000];
     TestUtils.RANDOM.nextBytes(usermetadata4);
     blobContentSize = 2000;
@@ -184,7 +184,7 @@ public class MessageSievingInputStreamTest {
     StoreKey key5 = new MockId("id5");
     short accountId5 = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId5 = Utils.getRandomShort(TestUtils.RANDOM);
-    BlobProperties prop5 = new BlobProperties(10, "servid5", accountId5, containerId5);
+    BlobProperties prop5 = new BlobProperties(10, "servid5", accountId5, containerId5, false);
     byte[] usermetadata5 = new byte[1000];
     TestUtils.RANDOM.nextBytes(usermetadata5);
     blobContentSize = 2000;
@@ -313,7 +313,7 @@ public class MessageSievingInputStreamTest {
     StoreKey key1 = new MockId("id1");
     short accountId1 = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId1 = Utils.getRandomShort(TestUtils.RANDOM);
-    BlobProperties prop1 = new BlobProperties(10, "servid1", accountId1, containerId1);
+    BlobProperties prop1 = new BlobProperties(10, "servid1", accountId1, containerId1, false);
     byte[] encryptionKey1 = new byte[100];
     TestUtils.RANDOM.nextBytes(encryptionKey1);
     byte[] usermetadata1 = new byte[1000];
@@ -349,7 +349,7 @@ public class MessageSievingInputStreamTest {
     StoreKey key2 = new MockId("id2");
     short accountId2 = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId2 = Utils.getRandomShort(TestUtils.RANDOM);
-    BlobProperties prop2 = new BlobProperties(10, "servid2", accountId2, containerId2);
+    BlobProperties prop2 = new BlobProperties(10, "servid2", accountId2, containerId2, false);
     byte[] encryptionKey2 = new byte[100];
     TestUtils.RANDOM.nextBytes(encryptionKey2);
     byte[] usermetadata2 = new byte[1000];
@@ -383,7 +383,7 @@ public class MessageSievingInputStreamTest {
     StoreKey key3 = new MockId("id3");
     short accountId3 = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId3 = Utils.getRandomShort(TestUtils.RANDOM);
-    BlobProperties prop3 = new BlobProperties(10, "servid3", accountId3, containerId3);
+    BlobProperties prop3 = new BlobProperties(10, "servid3", accountId3, containerId3, false);
     byte[] encryptionKey3 = new byte[100];
     TestUtils.RANDOM.nextBytes(encryptionKey3);
     byte[] usermetadata3 = new byte[1000];
@@ -478,7 +478,7 @@ public class MessageSievingInputStreamTest {
         StoreKey key1 = new MockId("id1");
         short accountId = Utils.getRandomShort(TestUtils.RANDOM);
         short containerId = Utils.getRandomShort(TestUtils.RANDOM);
-        BlobProperties prop1 = new BlobProperties(10, "servid1", accountId, containerId);
+        BlobProperties prop1 = new BlobProperties(10, "servid1", accountId, containerId, false);
         byte[] encryptionKey1 = new byte[100];
         TestUtils.RANDOM.nextBytes(encryptionKey1);
         byte[] usermetadata1 = new byte[1000];
@@ -516,7 +516,7 @@ public class MessageSievingInputStreamTest {
         StoreKey key3 = new MockId("id3");
         accountId = Utils.getRandomShort(TestUtils.RANDOM);
         containerId = Utils.getRandomShort(TestUtils.RANDOM);
-        BlobProperties prop3 = new BlobProperties(10, "servid3", accountId, containerId);
+        BlobProperties prop3 = new BlobProperties(10, "servid3", accountId, containerId, false);
         byte[] encryptionKey3 = new byte[100];
         TestUtils.RANDOM.nextBytes(encryptionKey3);
         byte[] usermetadata3 = new byte[1000];

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageSievingInputStreamTest.java
@@ -41,12 +41,12 @@ public class MessageSievingInputStreamTest {
 
   @BeforeClass
   public static void saveMessageFormatHeaderVersionToUse() {
-    messageFormatHeaderVersionSaved = MessageFormatRecord.currentHeaderVersionToUse;
+    messageFormatHeaderVersionSaved = MessageFormatRecord.headerVersionToUse;
   }
 
   @After
   public void resetMessageFormatHeaderVersionToUse() {
-    MessageFormatRecord.currentHeaderVersionToUse = messageFormatHeaderVersionSaved;
+    MessageFormatRecord.headerVersionToUse = messageFormatHeaderVersionSaved;
   }
 
   @Test
@@ -61,7 +61,7 @@ public class MessageSievingInputStreamTest {
     // MessageSievingInputStream contains put records for 3 valid blobs
     // id1(put record for valid blob), id2(put record for valid blob) and id3(put record for valid blob)
 
-    currentHeaderVersionToUse = Message_Header_Version_V1;
+    headerVersionToUse = Message_Header_Version_V1;
     byte[] encryptionKey = new byte[100];
     TestUtils.RANDOM.nextBytes(encryptionKey);
     // create message stream for blob 1
@@ -171,7 +171,7 @@ public class MessageSievingInputStreamTest {
 
     if (blobVersion == Blob_Version_V2) {
       ByteBufferInputStream stream4 = new ByteBufferInputStream(ByteBuffer.wrap(data4));
-      currentHeaderVersionToUse = Message_Header_Version_V2;
+      headerVersionToUse = Message_Header_Version_V2;
       messageFormatStream4 =
           new PutMessageFormatInputStream(key4, ByteBuffer.wrap(encryptionKey), prop4, ByteBuffer.wrap(usermetadata4),
               stream4, blobContentSize, blobType);
@@ -197,7 +197,7 @@ public class MessageSievingInputStreamTest {
     }
     if (blobVersion == Blob_Version_V2) {
       ByteBufferInputStream stream5 = new ByteBufferInputStream(ByteBuffer.wrap(data5));
-      currentHeaderVersionToUse = Message_Header_Version_V2;
+      headerVersionToUse = Message_Header_Version_V2;
       messageFormatStream5 =
           new PutMessageFormatInputStream(key5, null, prop5, ByteBuffer.wrap(usermetadata5), stream5, blobContentSize,
               blobType);
@@ -304,7 +304,7 @@ public class MessageSievingInputStreamTest {
   }
 
   private void testInValidBlobs(short blobVersion, BlobType blobType) throws IOException, MessageFormatException {
-    currentHeaderVersionToUse = Message_Header_Version_V1;
+    headerVersionToUse = Message_Header_Version_V1;
 
     // MessageSievingInputStream contains put records for 2 valid blobs and 1 corrupt blob
     // id1(put record for valid blob), id2(corrupt) and id3(put record for valid blob)
@@ -473,7 +473,7 @@ public class MessageSievingInputStreamTest {
 
     try {
       for (short version : versions) {
-        currentHeaderVersionToUse = version;
+        headerVersionToUse = version;
         // create message stream for blob 1
         StoreKey key1 = new MockId("id1");
         short accountId = Utils.getRandomShort(TestUtils.RANDOM);
@@ -565,7 +565,7 @@ public class MessageSievingInputStreamTest {
     } catch (IllegalStateException e) {
       Assert.assertTrue("IllegalStateException thrown as expected ", true);
     }
-    currentHeaderVersionToUse = Message_Header_Version_V1;
+    headerVersionToUse = Message_Header_Version_V1;
   }
 
   private boolean verifyBlob(MessageSievingInputStream validMessageDetectionInputStream, short headerVersion,

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
@@ -42,8 +42,7 @@ public class GetResponse extends Response {
   static final short GET_RESPONSE_VERSION_V_3 = 3;
   static final short GET_RESPONSE_VERSION_V_4 = 4;
 
-  // @todo change this to V4 once V4 is understood by all.
-  static short CURRENT_VERSION = GET_RESPONSE_VERSION_V_3;
+  static short CURRENT_VERSION = GET_RESPONSE_VERSION_V_4;
 
   public GetResponse(int correlationId, String clientId, List<PartitionResponseInfo> partitionResponseInfoList,
       Send send, ServerErrorCode error) {

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
@@ -41,8 +41,7 @@ public class ReplicaMetadataResponse extends Response {
   static final short REPLICA_METADATA_RESPONSE_VERSION_V_3 = 3;
   static final short REPLICA_METADATA_RESPONSE_VERSION_V_4 = 4;
 
-  // @todo change this to V4 once all servers understand V4.
-  private static final short CURRENT_VERSION = REPLICA_METADATA_RESPONSE_VERSION_V_3;
+  private static final short CURRENT_VERSION = REPLICA_METADATA_RESPONSE_VERSION_V_4;
 
   public ReplicaMetadataResponse(int correlationId, String clientId, ServerErrorCode error,
       List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList) {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -618,7 +618,7 @@ public class ReplicationTest {
     byte[] encryptionKey = TestUtils.RANDOM.nextBoolean() ? new byte[encryptionKeySize] : null;
     TestUtils.RANDOM.nextBytes(blob);
     TestUtils.RANDOM.nextBytes(usermetadata);
-    BlobProperties blobProperties = new BlobProperties(blobSize, "test", accountId, containerId);
+    BlobProperties blobProperties = new BlobProperties(blobSize, "test", accountId, containerId, encryptionKey != null);
 
     MessageFormatInputStream stream =
         new PutMessageFormatInputStream(id, encryptionKey == null ? null : ByteBuffer.wrap(encryptionKey),

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -150,7 +150,7 @@ class RouterServerTestFramework {
     TestUtils.RANDOM.nextBytes(data);
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
-    BlobProperties properties = new BlobProperties(blobSize, "serviceid1", accountId, containerId);
+    BlobProperties properties = new BlobProperties(blobSize, "serviceid1", accountId, containerId, false);
     OperationChain opChain = new OperationChain(chainId, properties, userMetadata, data, operations);
     continueChain(opChain);
     return opChain;

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -294,6 +294,9 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(4).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
+    // Changes in this patch: a. New header version has 4 more bytes compared to preivous b. BlobProperties increased by 1 byte
+    // c. Encryption Key Record size is 114 for an encryptionKey of size 100. EncryptionKeyRecord could be null if not applicable.
+    // Delta: 7 * 4 (headers for 7 records) + 1*6 (BlobProperties for 6 put records) + 114*3 = 376
     ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198896);
 
     getAndVerify(channel, 6);
@@ -326,6 +329,9 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(6).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
+    // changes in this patch: a. New header version has 4 more bytes compared to preivous b. BlobProperties increased by 1 byte
+    // c. Encryption Key Record size is 114 for an encryptionKey of size 100. EncryptionKeyRecord could be null if not applicable.
+    // Delta: 6*4 (header) + 3*1 ( blob props) + 114*2 = 225 + 376 (from previous checkpoint) = 631
     ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 298712);
 
     getAndVerify(channel, 9);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -226,7 +226,7 @@ public class ServerHardDeleteTest {
     Random random = new Random();
     for (int i = 0; i < 9; i++) {
       if (i % 2 == 0) {
-        encryptionKey.add(new byte[100 + i]);
+        encryptionKey.add(new byte[100]);
         random.nextBytes(encryptionKey.get(i));
       } else {
         encryptionKey.add(null);
@@ -294,7 +294,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(4).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198902);
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198896);
 
     getAndVerify(channel, 6);
 
@@ -326,7 +326,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(6).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 298732);
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 298712);
 
     getAndVerify(channel, 9);
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -239,25 +239,25 @@ public class ServerHardDeleteTest {
 
     properties = new ArrayList<>(9);
     properties.add(new BlobProperties(31870, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM)));
+        Utils.getRandomShort(TestUtils.RANDOM), true));
     properties.add(new BlobProperties(31871, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM)));
+        Utils.getRandomShort(TestUtils.RANDOM), false));
     properties.add(new BlobProperties(31872, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM)));
+        Utils.getRandomShort(TestUtils.RANDOM), true));
     properties.add(
         new BlobProperties(31873, "serviceid1", "ownerid", "jpeg", false, 0, Utils.getRandomShort(TestUtils.RANDOM),
             Utils.getRandomShort(TestUtils.RANDOM), false));
     properties.add(new BlobProperties(31874, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM)));
+        Utils.getRandomShort(TestUtils.RANDOM), true));
     properties.add(
         new BlobProperties(31875, "serviceid1", "ownerid", "jpeg", false, 0, Utils.getRandomShort(TestUtils.RANDOM),
             Utils.getRandomShort(TestUtils.RANDOM), false));
     properties.add(new BlobProperties(31876, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM)));
+        Utils.getRandomShort(TestUtils.RANDOM), true));
     properties.add(new BlobProperties(31877, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM)));
+        Utils.getRandomShort(TestUtils.RANDOM), false));
     properties.add(new BlobProperties(31878, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM)));
+        Utils.getRandomShort(TestUtils.RANDOM), true));
 
     List<PartitionId> partitionIds = mockClusterMap.getWritablePartitionIds();
     PartitionId chosenPartition = partitionIds.get(0);
@@ -285,6 +285,7 @@ public class ServerHardDeleteTest {
     // delete blob 1
     deleteBlob(blobIdList.get(1), channel);
     zeroOutBlobContent(1);
+
     // delete blob 4
     deleteBlob(blobIdList.get(4), channel);
     zeroOutBlobContent(4);
@@ -293,7 +294,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(4).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198520);
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198902);
 
     getAndVerify(channel, 6);
 
@@ -312,9 +313,11 @@ public class ServerHardDeleteTest {
     // delete blob 3 that is expired.
     deleteBlob(blobIdList.get(3), channel);
     zeroOutBlobContent(3);
+
     // delete blob 0
     deleteBlob(blobIdList.get(0), channel);
     zeroOutBlobContent(0);
+
     // delete blob 6.
     deleteBlob(blobIdList.get(6), channel);
     zeroOutBlobContent(6);
@@ -323,7 +326,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(6).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 298081);
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 298732);
 
     getAndVerify(channel, 9);
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -294,7 +294,7 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(4).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    // Changes in this patch: a. New header version has 4 more bytes compared to preivous b. BlobProperties increased by 1 byte
+    // Changes in this patch: a. New header version has 4 more bytes compared to previous b. BlobProperties increased by 1 byte
     // c. Encryption Key Record size is 114 for an encryptionKey of size 100. EncryptionKeyRecord could be null if not applicable.
     // Delta: 7 * 4 (headers for 7 records) + 1*6 (BlobProperties for 6 put records) + 114*3 = 376
     ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198896);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -890,11 +890,11 @@ public final class ServerTestUtil {
       for (int i = 0; i < 11; i++) {
         short accountId = Utils.getRandomShort(TestUtils.RANDOM);
         short containerId = Utils.getRandomShort(TestUtils.RANDOM);
-        propertyList.add(new BlobProperties(1000, "serviceid1", accountId, containerId, true));
+        boolean isEncrypted = TestUtils.RANDOM.nextBoolean();
+        propertyList.add(new BlobProperties(1000, "serviceid1", accountId, containerId, isEncrypted));
         blobIdList.add(
             new BlobId(BlobId.DEFAULT_FLAG, clusterMap.getLocalDatacenterId(), accountId, containerId, partition));
         dataList.add(TestUtils.getRandomBytes(1000));
-        boolean isEncrypted = TestUtils.RANDOM.nextBoolean();
         if (isEncrypted) {
           encryptionKeyList.add(TestUtils.getRandomBytes(128));
         } else {
@@ -1049,7 +1049,6 @@ public final class ServerTestUtil {
       GetResponse resp3 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
       //System.out.println("response from get " + resp3.getError());
       try {
-        // todo: fix once router support encryption. Might have to decrypt to compare data
         BlobData blobData = MessageFormatRecord.deserializeBlob(resp3.getInputStream());
         byte[] blobout = new byte[(int) blobData.getSize()];
         int readsize = 0;
@@ -1430,7 +1429,6 @@ public final class ServerTestUtil {
 
   private static void checkBlobContent(MockClusterMap clusterMap, BlobId blobId, BlockingChannel channel,
       byte[] dataToCheck) throws IOException, MessageFormatException {
-    // todo: fix once router support encryption. Might have to decryt to compare data
     ArrayList<BlobId> listIds = new ArrayList<BlobId>();
     listIds.add(blobId);
     ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -439,7 +439,7 @@ public class AmbryRequestsTest {
       RequestOrResponse request;
       switch (requestType) {
         case PutRequest:
-          BlobProperties properties = new BlobProperties(0, "serviceId", blobId.getAccountId(), blobId.getAccountId());
+          BlobProperties properties = new BlobProperties(0, "serviceId", blobId.getAccountId(), blobId.getAccountId(), false);
           request = new PutRequest(correlationId, clientId, blobId, properties, ByteBuffer.allocate(0),
               ByteBuffer.allocate(0), 0, BlobType.DataBlob, null);
           break;

--- a/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogTest.java
@@ -491,8 +491,9 @@ public class LogTest {
       for (int i = 0; i < numToCreate; i++) {
         long pos;
         do {
-          pos = Utils.getRandomLong(TestUtils.RANDOM, 1000);
+          pos = Utils.getRandomLong(TestUtils.RANDOM, 1000000);
         } while (positionsGenerated.contains(pos));
+        positionsGenerated.add(pos);
         long gen = Utils.getRandomLong(TestUtils.RANDOM, 1000);
         String name = LogSegmentNameHelper.getName(pos, gen);
         File file = create(LogSegmentNameHelper.nameToFilename(name));
@@ -577,6 +578,9 @@ public class LogTest {
     LogSegment nextSegment = log.getFirstSegment();
     assertNull("Prev segment should be null", log.getPrevSegment(nextSegment));
     for (String segmentName : expectedSegmentNames) {
+      assertNotNull(
+          "Next segment is null -  expectedSegmentNames=" + expectedSegmentNames + ". Expected next=" + segmentName,
+          nextSegment);
       assertEquals("Next segment is not as expected - expectedSegmentNames=" + expectedSegmentNames, segmentName,
           nextSegment.getName());
       LogSegment segment = log.getSegment(segmentName);

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
@@ -105,8 +105,6 @@ class DumpDataHelper {
         if (header.hasEncryptionKeyRecord()) {
           blobEncryptionKey = MessageFormatRecord.deserializeBlobEncryptionKey(streamlog);
           encryptionKey = "EncryptionKey found which is of size " + blobEncryptionKey.remaining();
-        } else {
-          encryptionKey = "No encryptionKey ";
         }
         BlobProperties props = MessageFormatRecord.deserializeBlobProperties(streamlog);
         expiresAtMs = Utils.addSecondsToEpochTime(props.getCreationTimeInMs(), props.getTimeToLiveInSeconds());

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpDataTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpDataTool.java
@@ -318,8 +318,8 @@ public class DumpDataTool {
       compareIndexValueToLogEntry(blobId, indexValue, logBlobRecordInfo);
       if (!logBlobRecordInfo.isDeleted) {
         logger.trace("{}", logBlobRecordInfo.messageHeader + "\n " + logBlobRecordInfo.blobId.getID() + "\n"
-            + logBlobRecordInfo.blobProperty + "\n" + logBlobRecordInfo.userMetadata + "\n"
-            + logBlobRecordInfo.blobDataOutput);
+            + logBlobRecordInfo.blobEncryptionKey + "\n" + logBlobRecordInfo.blobProperty + "\n"
+            + logBlobRecordInfo.userMetadata + "\n" + logBlobRecordInfo.blobDataOutput);
       } else {
         logger.trace("{}", logBlobRecordInfo.messageHeader + "\n " + logBlobRecordInfo.blobId.getID() + "\n"
             + logBlobRecordInfo.deleteMsg);

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpLogTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpLogTool.java
@@ -191,14 +191,16 @@ public class DumpLogTool {
         if (!logBlobRecordInfo.isDeleted) {
           if (blobs != null) {
             if (blobs.contains(logBlobRecordInfo.blobId.getID())) {
-              logger.info("{}\n{}\n{}\n{}\n{}", logBlobRecordInfo.messageHeader, logBlobRecordInfo.blobId,
-                  logBlobRecordInfo.blobProperty, logBlobRecordInfo.userMetadata, logBlobRecordInfo.blobDataOutput);
+              logger.info("{}\n{}\n{}\n{}\n{}\n{}", logBlobRecordInfo.messageHeader, logBlobRecordInfo.blobId,
+                  logBlobRecordInfo.blobEncryptionKey, logBlobRecordInfo.blobProperty, logBlobRecordInfo.userMetadata,
+                  logBlobRecordInfo.blobDataOutput);
               updateBlobIdToLogRecordMap(blobIdToLogRecord, logBlobRecordInfo.blobId.getID(), currentOffset,
                   !logBlobRecordInfo.isDeleted, logBlobRecordInfo.isExpired);
             }
           } else if (!silent) {
-            logger.info("{}\n{}\n{}\n{}\n{} end offset {}", logBlobRecordInfo.messageHeader, logBlobRecordInfo.blobId,
-                logBlobRecordInfo.blobProperty, logBlobRecordInfo.userMetadata, logBlobRecordInfo.blobDataOutput,
+            logger.info("{}\n{}\n{}\n{}\n{}\n{} end offset {}", logBlobRecordInfo.messageHeader,
+                logBlobRecordInfo.blobId, logBlobRecordInfo.blobEncryptionKey, logBlobRecordInfo.blobProperty,
+                logBlobRecordInfo.userMetadata, logBlobRecordInfo.blobDataOutput,
                 (currentOffset + logBlobRecordInfo.totalRecordSize));
             updateBlobIdToLogRecordMap(blobIdToLogRecord, logBlobRecordInfo.blobId.getID(), currentOffset,
                 !logBlobRecordInfo.isDeleted, logBlobRecordInfo.isExpired);

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ConcurrencyTestTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ConcurrencyTestTool.java
@@ -619,7 +619,7 @@ public class ConcurrencyTestTool {
       final byte[] blob = new byte[randomNum];
       byte[] usermetadata = new byte[random.nextInt(1024)];
       BlobProperties props =
-          new BlobProperties(randomNum, "test", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID);
+          new BlobProperties(randomNum, "test", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false);
       final FutureResult futureResult = new FutureResult();
       try {
         final long startTimeInMs = SystemTime.getInstance().milliseconds();

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
@@ -149,7 +149,8 @@ public class DirectoryUploader {
               + " cannot be put using this tool.");
         }
         BlobProperties props =
-            new BlobProperties(f.length(), "migration", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID);
+            new BlobProperties(f.length(), "migration", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
+                false);
         byte[] usermetadata = new byte[1];
         FileInputStream stream = null;
         try {

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
@@ -337,7 +337,7 @@ public class ServerWritePerformance {
           byte[] blob = new byte[randomNum];
           byte[] usermetadata = new byte[new Random().nextInt(1024)];
           BlobProperties props =
-              new BlobProperties(randomNum, "test", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID);
+              new BlobProperties(randomNum, "test", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false);
           ConnectedChannel channel = null;
           try {
             List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds();

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
@@ -63,7 +63,7 @@ class PerfRouter implements Router {
   public PerfRouter(PerfConfig perfConfig, PerfRouterMetrics perfRouterMetrics) {
     this.perfRouterMetrics = perfRouterMetrics;
     blobProperties = new BlobProperties(perfConfig.perfBlobSize, "PerfRouter", Account.UNKNOWN_ACCOUNT_ID,
-        Container.UNKNOWN_CONTAINER_ID);
+        Container.UNKNOWN_CONTAINER_ID, false);
     usermetadata = getRandomString(perfConfig.perfUserMetadataSize).getBytes();
     chunk = new byte[perfConfig.perfRouterChunkSize];
     random.nextBytes(chunk);


### PR DESCRIPTION
Enabling new storage format changes
1. HeaderFormat
2. BlobKeyRecord
3. GetResponse
4. ReplicaMetadata

Fixed tools as well.

Coding style applied.
Reviewers: Gopal and Priyesh
SLA: 15 mins
