### PR TITLE
Config for limiting size of multipart POST requests

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
@@ -110,6 +110,17 @@ public class NettyConfig {
   @Default("")
   public final Set<String> nettyBlacklistedQueryParams;
 
+  /**
+   * The threshold (in bytes) for POSTs via multipart/form-data.
+   * <p/>
+   * The current netty implementation cannot stream POSTs that come as multipart/form-data. It is useful to set this to
+   * reasonable number to ensure that memory usage is kept in check (i.e. protect against large blob uploads via
+   * multipart/form-data).
+   */
+  @Config("netty.multipart.post.max.size.bytes")
+  @Default("20 * 1024 * 1024")
+  public final long nettyMultipartPostMaxSizeBytes;
+
   public NettyConfig(VerifiableProperties verifiableProperties) {
     nettyServerBossThreadCount = verifiableProperties.getInt("netty.server.boss.thread.count", 1);
     nettyServerIdleTimeSeconds = verifiableProperties.getInt("netty.server.idle.time.seconds", 60);
@@ -126,5 +137,7 @@ public class NettyConfig {
             Integer.MAX_VALUE);
     nettyBlacklistedQueryParams = new HashSet<>(
         Arrays.asList(verifiableProperties.getString("netty.server.blacklisted.query.params", "").split(",")));
+    nettyMultipartPostMaxSizeBytes =
+        verifiableProperties.getLongInRange("netty.multipart.post.max.size.bytes", 20 * 1024 * 1024, 0, Long.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/rest/ResponseStatus.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/ResponseStatus.java
@@ -75,6 +75,11 @@ public enum ResponseStatus {
   Gone,
 
   /**
+   * 413 Request Entity Too Large - The request is larger than what the server is willing to accept
+   */
+  RequestTooLarge,
+
+  /**
    * 416 Range Not Satisfiable - A range request is invalid or outside of the bounds of an object.
    */
   RangeNotSatisfiable,
@@ -92,6 +97,8 @@ public enum ResponseStatus {
    */
   public static ResponseStatus getResponseStatus(RestServiceErrorCode restServiceErrorCode) {
     switch (restServiceErrorCode) {
+      case RequestTooLarge:
+        return ResponseStatus.RequestTooLarge;
       case Deleted:
         return ResponseStatus.Gone;
       case NotFound:

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestServiceErrorCode.java
@@ -134,6 +134,11 @@ public enum RestServiceErrorCode {
   RequestResponseQueuingFailure,
 
   /**
+   * The request is larger than what the server is willing or is configured to accept.
+   */
+  RequestTooLarge,
+
+  /**
    * Indicates that an internal service is unavailable either because it is not started, is shutdown or has crashed.
    */
   ServiceUnavailable,

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -99,7 +99,7 @@ import static org.junit.Assert.*;
 public class FrontendIntegrationTest {
   private static final int PLAINTEXT_SERVER_PORT = 1174;
   private static final int SSL_SERVER_PORT = 1175;
-  private static final int MAX_MULTIPART_POST_SIZE_BYTES = 1048576;
+  private static final int MAX_MULTIPART_POST_SIZE_BYTES = 10 * 10 * 1024;
   private static final ClusterMap CLUSTER_MAP;
   private static final VerifiableProperties FRONTEND_VERIFIABLE_PROPS;
   private static final VerifiableProperties SSL_CLIENT_VERIFIABLE_PROPS;

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -27,6 +27,7 @@ import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.commons.TestSSLUtils;
 import com.github.ambry.config.FrontendConfig;
+import com.github.ambry.config.NettyConfig;
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
@@ -98,6 +99,7 @@ import static org.junit.Assert.*;
 public class FrontendIntegrationTest {
   private static final int PLAINTEXT_SERVER_PORT = 1174;
   private static final int SSL_SERVER_PORT = 1175;
+  private static final int MAX_MULTIPART_POST_SIZE_BYTES = 1048576;
   private static final ClusterMap CLUSTER_MAP;
   private static final VerifiableProperties FRONTEND_VERIFIABLE_PROPS;
   private static final VerifiableProperties SSL_CLIENT_VERIFIABLE_PROPS;
@@ -230,6 +232,21 @@ public class FrontendIntegrationTest {
         refAccount.getName(), refContainer.getName(), true);
     doPostGetHeadDeleteTest(FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes * 3, refAccount, refContainer,
         refAccount.getName(), !refContainer.isCacheable(), refAccount.getName(), refContainer.getName(), true);
+
+    // failure case
+    // size of content being POSTed is higher than what is allowed via multipart/form-data
+    long maxAllowedSizeBytes = new NettyConfig(FRONTEND_VERIFIABLE_PROPS).nettyMultipartPostMaxSizeBytes;
+    ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes((int) maxAllowedSizeBytes + 1));
+    HttpHeaders headers = new DefaultHttpHeaders();
+    setAmbryHeadersForPut(headers, 7200, !refContainer.isCacheable(), refAccount.getName(), "application/octet-stream",
+        null, refAccount.getName(), refContainer.getName());
+    HttpRequest httpRequest = RestTestUtils.createRequest(HttpMethod.POST, "/", headers);
+    HttpPostRequestEncoder encoder = createEncoder(httpRequest, content, ByteBuffer.allocate(0));
+    Queue<HttpObject> responseParts = nettyClient.sendRequest(encoder.finalizeRequest(), encoder, null).get();
+    HttpResponse response = (HttpResponse) responseParts.poll();
+    assertEquals("Unexpected response status", HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, response.status());
+    assertTrue("No Date header", response.headers().getTimeMillis(HttpHeaderNames.DATE, -1) != -1);
+    assertFalse("Channel should not be active", HttpUtil.isKeepAlive(response));
   }
 
   /*
@@ -464,6 +481,8 @@ public class FrontendIntegrationTest {
     properties.put("netty.server.enable.ssl", "true");
     // to test that backpressure does not impede correct operation.
     properties.put("netty.server.request.buffer.watermark", "1");
+    // to test that multipart requests over a certain size fail
+    properties.put("netty.multipart.post.max.size.bytes", Long.toString(MAX_MULTIPART_POST_SIZE_BYTES));
     TestSSLUtils.addSSLProperties(properties, "", SSLFactory.Mode.SERVER, trustStoreFile, "frontend");
     properties.put("frontend.account.service.factory", "com.github.ambry.account.InMemAccountServiceFactory");
     // add key for singleKeyManagementService

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
@@ -285,7 +285,7 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
               && HttpPostRequestDecoder.isMultipart(httpRequest)) {
             nettyMetrics.multipartPostRequestRate.mark();
             request = new NettyMultipartRequest(httpRequest, ctx.channel(), nettyMetrics,
-                nettyConfig.nettyBlacklistedQueryParams);
+                nettyConfig.nettyBlacklistedQueryParams, nettyConfig.nettyMultipartPostMaxSizeBytes);
           } else {
             request =
                 new NettyRequest(httpRequest, ctx.channel(), nettyMetrics, nettyConfig.nettyBlacklistedQueryParams);

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -124,6 +124,7 @@ public class NettyMetrics {
   public final Counter forbiddenCount;
   public final Counter proxyAuthRequiredCount;
   public final Counter rangeNotSatisfiableCount;
+  public final Counter requestTooLargeCount;
   public final Counter throwableCount;
   public final Counter unknownResponseStatusCount;
   // NettyServer
@@ -291,6 +292,8 @@ public class NettyMetrics {
         metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ProxyAuthenticationRequiredCount"));
     rangeNotSatisfiableCount =
         metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "RangeNotSatisfiableCount"));
+    requestTooLargeCount =
+        metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "RequestTooLargeCount"));
     throwableCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ThrowableCount"));
     unknownResponseStatusCount =
         metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "UnknownResponseStatusCount"));

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -470,6 +470,10 @@ class NettyResponseChannel implements RestResponseChannel {
         nettyMetrics.rangeNotSatisfiableCount.inc();
         status = HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE;
         break;
+      case RequestTooLarge:
+        nettyMetrics.requestTooLargeCount.inc();
+        status = HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
+        break;
       case InternalServerError:
         nettyMetrics.internalServerErrorCount.inc();
         status = HttpResponseStatus.INTERNAL_SERVER_ERROR;

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
@@ -370,6 +370,7 @@ public class NettyMultipartRequestTest {
               maxSizeAllowed);
       assertTrue("Request channel is not open", request.isOpen());
       long currentSizeAdded = 0;
+      boolean failedToAdd = false;
       while (!encoder.isEndOfInput()) {
         // Sending null for ctx because the encoder is OK with that.
         HttpContent httpContent = encoder.readChunk(PooledByteBufAllocator.DEFAULT);
@@ -384,12 +385,14 @@ public class NettyMultipartRequestTest {
             fail("Should have failed to add content of size [" + encodedSize
                 + "] because it is over the max size allowed: " + maxSizeAllowed);
           } catch (RestServiceException e) {
+            failedToAdd = true;
             assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.RequestTooLarge, e.getErrorCode());
             break;
           }
         }
         currentSizeAdded += readableBytes;
       }
+      assertEquals("Success state not as expected", maxSizeAllowed < encodedSize, failedToAdd);
     }
   }
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
@@ -92,7 +92,7 @@ public class NettyMultipartRequestTest {
       MockChannel channel = new MockChannel();
       RecvByteBufAllocator expected = channel.config().getRecvByteBufAllocator();
       NettyMultipartRequest request =
-          new NettyMultipartRequest(httpRequest, channel, NETTY_METRICS, Collections.emptySet());
+          new NettyMultipartRequest(httpRequest, channel, NETTY_METRICS, Collections.emptySet(), Long.MAX_VALUE);
       assertTrue("Auto-read should not have been changed", channel.config().isAutoRead());
       assertEquals("RecvByteBufAllocator should not have changed", expected,
           channel.config().getRecvByteBufAllocator());
@@ -104,7 +104,8 @@ public class NettyMultipartRequestTest {
     for (HttpMethod method : methods) {
       HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, method, "/");
       try {
-        new NettyMultipartRequest(httpRequest, new MockChannel(), NETTY_METRICS, Collections.emptySet());
+        new NettyMultipartRequest(httpRequest, new MockChannel(), NETTY_METRICS, Collections.emptySet(),
+            Long.MAX_VALUE);
         fail("Creation of NettyMultipartRequest should have failed for " + method);
       } catch (IllegalArgumentException e) {
         // expected. Nothing to do.
@@ -251,7 +252,8 @@ public class NettyMultipartRequestTest {
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
     HttpPostRequestEncoder encoder = createEncoder(httpRequest, null);
     NettyMultipartRequest request =
-        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS, Collections.emptySet());
+        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS, Collections.emptySet(),
+            Long.MAX_VALUE);
     assertTrue("Request channel is not open", request.isOpen());
     // insert random data
     HttpContent httpContent = new DefaultHttpContent(Unpooled.wrappedBuffer(TestUtils.getRandomBytes(10)));
@@ -320,7 +322,8 @@ public class NettyMultipartRequestTest {
     encoder = createEncoder(httpRequest, files);
     encoder.addBodyAttribute("dummyKey", "dummyValue");
     request =
-        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS, Collections.emptySet());
+        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS, Collections.emptySet(),
+            Long.MAX_VALUE);
     assertTrue("Request channel is not open", request.isOpen());
     while (!encoder.isEndOfInput()) {
       // Sending null for ctx because the encoder is OK with that.
@@ -347,6 +350,49 @@ public class NettyMultipartRequestTest {
     }
   }
 
+  /**
+   * Tests to make sure the max allowed size for multipart requests is enforced.
+   * @throws Exception
+   */
+  @Test
+  public void sizeLimitationTest() throws Exception {
+    int blobPartSize = 1024;
+    // encoding 1024 bytes of data results in 1209 readable bytes from the encoder.
+    int encodedSize = 1209;
+    long[] maxSizesAllowed = {encodedSize + 1, encodedSize, encodedSize - 1, 0};
+    for (long maxSizeAllowed : maxSizesAllowed) {
+      InMemoryFile[] files = {new InMemoryFile(RestUtils.MultipartPost.BLOB_PART,
+          ByteBuffer.wrap(TestUtils.getRandomBytes(blobPartSize)))};
+      HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+      HttpPostRequestEncoder encoder = createEncoder(httpRequest, files);
+      NettyMultipartRequest request =
+          new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS, Collections.emptySet(),
+              maxSizeAllowed);
+      assertTrue("Request channel is not open", request.isOpen());
+      long currentSizeAdded = 0;
+      while (!encoder.isEndOfInput()) {
+        // Sending null for ctx because the encoder is OK with that.
+        HttpContent httpContent = encoder.readChunk(PooledByteBufAllocator.DEFAULT);
+        int readableBytes = httpContent.content().readableBytes();
+        if (currentSizeAdded + readableBytes <= maxSizeAllowed) {
+          request.addContent(httpContent);
+        } else {
+          assertTrue("Max size [" + maxSizeAllowed + "] must be lesser than content size: " + encodedSize,
+              maxSizeAllowed < encodedSize);
+          try {
+            request.addContent(httpContent);
+            fail("Should have failed to add content of size [" + encodedSize
+                + "] because it is over the max size allowed: " + maxSizeAllowed);
+          } catch (RestServiceException e) {
+            assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.RequestTooLarge, e.getErrorCode());
+            break;
+          }
+        }
+        currentSizeAdded += readableBytes;
+      }
+    }
+  }
+
   // helpers
   // general
 
@@ -364,7 +410,8 @@ public class NettyMultipartRequestTest {
     }
     HttpPostRequestEncoder encoder = createEncoder(httpRequest, parts);
     NettyMultipartRequest request =
-        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS, Collections.emptySet());
+        new NettyMultipartRequest(encoder.finalizeRequest(), new MockChannel(), NETTY_METRICS, Collections.emptySet(),
+            Long.MAX_VALUE);
     assertTrue("Request channel is not open", request.isOpen());
     while (!encoder.isEndOfInput()) {
       // Sending null for ctx because the encoder is OK with that.
@@ -470,7 +517,7 @@ public class NettyMultipartRequestTest {
     public final String name;
     public final ByteBuffer content;
 
-    public InMemoryFile(String name, ByteBuffer content) {
+    InMemoryFile(String name, ByteBuffer content) {
       this.name = name;
       this.content = content;
     }

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -88,6 +88,8 @@ public class NettyResponseChannelTest {
         HttpResponseStatus.INTERNAL_SERVER_ERROR);
     REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.RangeNotSatisfiable,
         HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
+    REST_ERROR_CODE_TO_HTTP_STATUS.put(RestServiceErrorCode.RequestTooLarge,
+        HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE);
   }
 
   /**


### PR DESCRIPTION
Multipart POST requests are not streamed and in order to not overwhelm the memory, this commit introduces a config setting to limit the size of data that can be uploaded via multipart/form-data