### PR TITLE
Adding a preprocess step in security service

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/frontend/SecurityService.java
+++ b/ambry-api/src/main/java/com.github.ambry/frontend/SecurityService.java
@@ -31,7 +31,15 @@ import java.util.concurrent.Future;
 public interface SecurityService extends Closeable {
 
   /**
-   * Perform security validations (if any) on the {@link RestRequest} asynchronously and invokes the
+   * Performs security validations (if any) before any processing of the {@code restRequest} begins and invokes the
+   * {@code callback} once done.
+   * @param restRequest the {@link RestRequest} to process.
+   * @param callback the callback to invoke once processing is finished.
+   */
+  void preProcessRequest(RestRequest restRequest, Callback<Void> callback);
+
+  /**
+   * Performs security validations (if any) on the {@link RestRequest} asynchronously and invokes the
    * {@link Callback} when the validation completes.
    * @param restRequest {@link RestRequest} upon which validations has to be performed
    * @param callback The {@link Callback} which will be invoked on the completion of the request. Cannot be null.
@@ -39,7 +47,7 @@ public interface SecurityService extends Closeable {
   void processRequest(RestRequest restRequest, Callback<Void> callback);
 
   /**
-   * Perform security validations (if any) on the {@link RestRequest} when it has been fully parsed. That is, when the
+   * Performs security validations (if any) on the {@link RestRequest} when it has been fully parsed. That is, when the
    * {@link RestRequest} has been annotated with any additional arguments (like account and container).
    * Invokes the {@link Callback} when the validation is complete.
    * @param restRequest {@link RestRequest} upon which validations has to be performed
@@ -48,7 +56,7 @@ public interface SecurityService extends Closeable {
   void postProcessRequest(RestRequest restRequest, Callback<Void> callback);
 
   /**
-   * Perform security validations (if any) on the response for {@link RestRequest} asynchronously, sets headers if need
+   * Performs security validations (if any) on the response for {@link RestRequest} asynchronously, sets headers if need
    * be and invokes the {@link Callback} when the validation completes. Similar to
    * {@link SecurityService#processRequest(RestRequest, Callback)}, validations could involve security checks and
    * setting some headers with the response.
@@ -61,10 +69,22 @@ public interface SecurityService extends Closeable {
       Callback<Void> callback);
 
   /**
+   * Similar to {@link #preProcessRequest(RestRequest, Callback)} but returns a {@link Future} instead of requiring
+   * a callback.
+   * @param restRequest {@link RestRequest} upon which validations has to be performed
+   * @return a {@link Future} that is completed when the pre-processing is done.
+   */
+  default Future<Void> preProcessRequest(RestRequest restRequest) {
+    FutureResult<Void> futureResult = new FutureResult<>();
+    preProcessRequest(restRequest, futureResult::done);
+    return futureResult;
+  }
+
+  /**
    * Similar to {@link #processRequest(RestRequest, Callback)} but returns a {@link Future} instead of requiring
    * a callback.
    * @param restRequest {@link RestRequest} upon which validations has to be performed
-   * @return a {@link Future} that is completed when the post-processing is done.
+   * @return a {@link Future} that is completed when the processing is done.
    */
   default Future<Void> processRequest(RestRequest restRequest) {
     FutureResult<Void> futureResult = new FutureResult<>();
@@ -90,7 +110,7 @@ public interface SecurityService extends Closeable {
    * @param restRequest {@link RestRequest} whose response have to be validated
    * @param responseChannel the {@link RestResponseChannel} over which the response is sent
    * @param blobInfo the {@link BlobInfo} pertaining to the rest request made
-   * @return a {@link Future} that is completed when the post-processing is done.
+   * @return a {@link Future} that is completed when the processing is done.
    */
   default Future<Void> processResponse(RestRequest restRequest, RestResponseChannel responseChannel,
       BlobInfo blobInfo) {

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AccountAndContainerInjector.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AccountAndContainerInjector.java
@@ -19,7 +19,6 @@ import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.FrontendConfig;
-import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestServiceErrorCode;
@@ -136,14 +135,14 @@ class AccountAndContainerInjector {
    * @param blobProperties The {@link BlobProperties} that contains the service id and blob privacy setting.
    * @throws RestServiceException if no valid account or container cound be identified for re-injection.
    */
-  void ensureAccountAndContainerInjected(RestRequest restRequest, BlobProperties blobProperties) throws RestServiceException {
+  void ensureAccountAndContainerInjected(RestRequest restRequest, BlobProperties blobProperties)
+      throws RestServiceException {
     Account targetAccount = (Account) restRequest.getArgs().get(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY);
     Container targetContainer = (Container) restRequest.getArgs().get(RestUtils.InternalKeys.TARGET_CONTAINER_KEY);
     if (targetAccount == null || targetContainer == null) {
       throw new RestServiceException("Account and container were not injected by BlobStorageService",
           RestServiceErrorCode.InternalServerError);
-    } else if (targetAccount.equals(Account.UNKNOWN_ACCOUNT) && targetContainer.equals(
-        Container.UNKNOWN_CONTAINER)) {
+    } else if (targetAccount.equals(Account.UNKNOWN_ACCOUNT) && targetContainer.equals(Container.UNKNOWN_CONTAINER)) {
       // This should only occur for V1 blobs, where the blob ID does not contain the actual account and container IDs.
       String serviceId = blobProperties.getServiceId();
       boolean isPrivate = blobProperties.isPrivate();

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
@@ -57,6 +57,7 @@ class FrontendMetrics {
 
   // Rates
   // AmbrySecurityService
+  public final Meter securityServicePreProcessRequestRate;
   public final Meter securityServiceProcessRequestRate;
   public final Meter securityServicePostProcessRequestRate;
   public final Meter securityServiceProcessResponseRate;
@@ -117,7 +118,10 @@ class FrontendMetrics {
   // SecurityPostProcessRequestCallback
   public final Histogram getPeersSecurityPostProcessRequestTimeInMs;
   public final Histogram getSignedUrlSecurityPostProcessRequestTimeInMs;
+  // SecurityProcessResponseCallback
+  public final Histogram getSignedUrlSecurityResponseTimeInMs;
   // AmbrySecurityService
+  public final Histogram securityServicePreProcessRequestTimeInMs;
   public final Histogram securityServiceProcessRequestTimeInMs;
   public final Histogram securityServicePostProcessRequestTimeInMs;
   public final Histogram securityServiceProcessResponseTimeInMs;
@@ -204,6 +208,8 @@ class FrontendMetrics {
 
     // Rates
     // AmbrySecurityService
+    securityServicePreProcessRequestRate =
+        metricRegistry.meter(MetricRegistry.name(AmbrySecurityService.class, "PreProcessRequestRate"));
     securityServiceProcessRequestRate =
         metricRegistry.meter(MetricRegistry.name(AmbrySecurityService.class, "ProcessRequestRate"));
     securityServicePostProcessRequestRate =
@@ -307,7 +313,12 @@ class FrontendMetrics {
         metricRegistry.histogram(MetricRegistry.name(GetPeersHandler.class, "SecurityPostProcessRequestTimeInMs"));
     getSignedUrlSecurityPostProcessRequestTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(GetSignedUrlHandler.class, "SecurityPostProcessRequestTimeInMs"));
+    // SecurityPostProcessResponseCallback
+    getSignedUrlSecurityResponseTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(GetSignedUrlHandler.class, "SecurityResponseTimeInMs"));
     // AmbrySecurityService
+    securityServicePreProcessRequestTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(AmbrySecurityService.class, "RequestPreProcessingTimeInMs"));
     securityServiceProcessRequestTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(AmbrySecurityService.class, "RequestProcessingTimeInMs"));
     securityServicePostProcessRequestTimeInMs =

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/GetSignedUrlHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/GetSignedUrlHandler.java
@@ -209,7 +209,7 @@ class GetSignedUrlHandler {
           restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
           final long processResponseStartTimeMs = SystemTime.getInstance().milliseconds();
           securityService.processResponse(restRequest, restResponseChannel, null,
-              (voidResult, processResponseException) -> {
+              (processResponseResult, processResponseException) -> {
                 metrics.getSignedUrlSecurityResponseTimeInMs.update(
                     SystemTime.getInstance().milliseconds() - processResponseStartTimeMs);
                 callback.onCompletion(null, processResponseException);

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/GetSignedUrlHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/GetSignedUrlHandler.java
@@ -207,12 +207,21 @@ class GetSignedUrlHandler {
           restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
           restResponseChannel.setHeader(RestUtils.Headers.SIGNED_URL, signedUrl);
           restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
+          final long processResponseStartTimeMs = SystemTime.getInstance().milliseconds();
+          securityService.processResponse(restRequest, restResponseChannel, null,
+              (voidResult, processResponseException) -> {
+                metrics.getSignedUrlSecurityResponseTimeInMs.update(
+                    SystemTime.getInstance().milliseconds() - processResponseStartTimeMs);
+                callback.onCompletion(null, processResponseException);
+              });
         }
       } catch (Exception e) {
         exception = e;
       } finally {
         metrics.getSignedUrlProcessingTimeInMs.update(SystemTime.getInstance().milliseconds() - processingStartTimeMs);
-        callback.onCompletion(null, exception);
+        if (exception != null) {
+          callback.onCompletion(null, exception);
+        }
       }
     }
   }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
@@ -121,12 +121,14 @@ public class GetSignedUrlHandlerTest {
     verifyFailureWithMsg(msg);
     securityServiceFactory.mode = FrontendTestSecurityServiceFactory.Mode.ProcessResponse;
     verifyFailureWithMsg(msg);
+
     securityServiceFactory.exceptionToThrow = new IllegalStateException(msg);
     securityServiceFactory.exceptionToReturn = null;
+    securityServiceFactory.mode = FrontendTestSecurityServiceFactory.Mode.ProcessRequest;
     verifyFailureWithMsg(msg);
     securityServiceFactory.mode = FrontendTestSecurityServiceFactory.Mode.PostProcessRequest;
     verifyFailureWithMsg(msg);
-    securityServiceFactory.mode = FrontendTestSecurityServiceFactory.Mode.ProcessRequest;
+    securityServiceFactory.mode = FrontendTestSecurityServiceFactory.Mode.ProcessResponse;
     verifyFailureWithMsg(msg);
   }
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
@@ -119,8 +119,12 @@ public class GetSignedUrlHandlerTest {
     verifyFailureWithMsg(msg);
     securityServiceFactory.mode = FrontendTestSecurityServiceFactory.Mode.PostProcessRequest;
     verifyFailureWithMsg(msg);
+    securityServiceFactory.mode = FrontendTestSecurityServiceFactory.Mode.ProcessResponse;
+    verifyFailureWithMsg(msg);
     securityServiceFactory.exceptionToThrow = new IllegalStateException(msg);
     securityServiceFactory.exceptionToReturn = null;
+    verifyFailureWithMsg(msg);
+    securityServiceFactory.mode = FrontendTestSecurityServiceFactory.Mode.PostProcessRequest;
     verifyFailureWithMsg(msg);
     securityServiceFactory.mode = FrontendTestSecurityServiceFactory.Mode.ProcessRequest;
     verifyFailureWithMsg(msg);


### PR DESCRIPTION
This commit
1) Adds a function to pre-process a request in `SecurityService`
2) Invokes this function on all supported methods in `AmbryBlobStorageService`
3) Invokes processResponse() in `GetSignedUrlHandler`

This change is generally targetted to support the use case where some custom
processing of the request has to happen before any business logic is triggered.

Specifically the change is being executed now in order to support encryption of
signed URLs if required. The idea is that `processResponse() `will encrypt the query
parameters of a signed URL and `preProcessRequest()` will decrypt and insert the
parameters into the `RestRequest` when the signed url is presented for use.