### PR TITLE
Stop logging client cert when client auth is not required

### DIFF
--- a/ambry-rest/src/test/java/com.github.ambry.rest/PublicAccessLogHandlerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/PublicAccessLogHandlerTest.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
@@ -58,7 +59,9 @@ public class PublicAccessLogHandlerTest {
     try {
       PEER_CERT = new SelfSignedCertificate().cert();
       SelfSignedCertificate localCert = new SelfSignedCertificate();
-      SSL_CONTEXT = SslContextBuilder.forServer(localCert.certificate(), localCert.privateKey()).build();
+      SSL_CONTEXT = SslContextBuilder.forServer(localCert.certificate(), localCert.privateKey())
+          .clientAuth(ClientAuth.REQUIRE)
+          .build();
     } catch (CertificateException | SSLException e) {
       throw new IllegalStateException(e);
     }


### PR DESCRIPTION
This stops the public access logger from looking for client certificates
when client authentication is not required. Unfortunately, there is no
SSLSession method to tell if a peer cert is present without throwing an
exception.

Related to issue #802