### PR TITLE
Add AccountUpdateTool option to specify container version

### DIFF
--- a/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
@@ -124,9 +124,9 @@ class AccountTestUtils {
         String containerDescription = UUID.randomUUID().toString();
         boolean containerCaching = random.nextBoolean();
         // TODO make these randomly generated once V2 container writes are enabled
-        boolean containerEncryption = Container.ENCRYPTED_DEFAULT_VALUE;
-        boolean containerPreviousEncryption = Container.PREVIOUSLY_ENCRYPTED_DEFAULT_VALUE;
-        boolean mediaScanDisabled = Container.MEDIA_SCAN_DISABLED_DEFAULT_VALUE;
+        boolean containerEncryption = random.nextBoolean();
+        boolean containerPreviousEncryption = containerEncryption || random.nextBoolean();
+        boolean mediaScanDisabled = random.nextBoolean();
         Container container =
             new ContainerBuilder(containerId, containerName, containerStatus, containerDescription, containerEncryption,
                 containerPreviousEncryption, containerCaching, mediaScanDisabled, accountId).build();

--- a/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
@@ -123,7 +123,6 @@ class AccountTestUtils {
             random.nextBoolean() ? Container.ContainerStatus.ACTIVE : Container.ContainerStatus.INACTIVE;
         String containerDescription = UUID.randomUUID().toString();
         boolean containerCaching = random.nextBoolean();
-        // TODO make these randomly generated once V2 container writes are enabled
         boolean containerEncryption = random.nextBoolean();
         boolean containerPreviousEncryption = containerEncryption || random.nextBoolean();
         boolean mediaScanDisabled = random.nextBoolean();

--- a/ambry-api/src/main/java/com.github.ambry/account/Container.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/Container.java
@@ -345,7 +345,7 @@ public class Container {
   /**
    * @return the JSON version to serialize in.
    */
-  static short getCurrentJsonVersion() {
+  public static short getCurrentJsonVersion() {
     return currentJsonVersion;
   }
 
@@ -354,7 +354,7 @@ public class Container {
    * serialization.
    * @param currentJsonVersion the JSON version to serialize in.
    */
-  static void setCurrentJsonVersion(short currentJsonVersion) {
+  public static void setCurrentJsonVersion(short currentJsonVersion) {
     Container.currentJsonVersion = currentJsonVersion;
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
@@ -152,6 +152,13 @@ public class AccountUpdateTool {
         .ofType(Integer.class)
         .defaultsTo(ZK_CLIENT_SESSION_TIMEOUT_MS);
 
+    ArgumentAcceptingOptionSpec<Short> containerJsonVersionOpt = parser.accepts("containerSchemaVersion",
+        "Optional override for the container JSON version to write in when doing an account update.")
+        .withRequiredArg()
+        .describedAs("container_json_version")
+        .ofType(Short.class)
+        .defaultsTo(Container.getCurrentJsonVersion());
+
     parser.accepts("help", "print this help message.");
 
     parser.accepts("h", "print this help message.");
@@ -166,12 +173,14 @@ public class AccountUpdateTool {
     String zkServer = options.valueOf(zkServerOpt);
     Integer zkConnectionTimeoutMs = options.valueOf(zkConnectionTimeoutMsOpt);
     Integer zkSessionTimeoutMs = options.valueOf(zkSessionTimeoutMsOpt);
+    Short containerJsonVersion = options.valueOf(containerJsonVersionOpt);
     ArrayList<OptionSpec> listOpt = new ArrayList<>();
     listOpt.add(accountJsonFilePathOpt);
     listOpt.add(zkServerOpt);
     ToolUtils.ensureOrExit(listOpt, options, parser);
     try {
-      updateAccount(accountJsonFilePath, zkServer, storePath, zkConnectionTimeoutMs, zkSessionTimeoutMs);
+      updateAccount(accountJsonFilePath, zkServer, storePath, zkConnectionTimeoutMs, zkSessionTimeoutMs,
+          containerJsonVersion);
     } catch (Exception e) {
       System.err.println("Updating accounts failed with exception: " + e);
       e.printStackTrace();
@@ -185,10 +194,12 @@ public class AccountUpdateTool {
    * @param storePath The root path on the {@code ZooKeeper} for account data.
    * @param zkConnectionTimeoutMs The connection timeout in millisecond for connecting {@code ZooKeeper} server.
    * @param zkSessionTimeoutMs The session timeout in millisecond for connecting {@code ZooKeeper} server.
+   * @param containerJsonVersion The {@link Container} JSON version to write in.
    * @throws Exception
    */
   static void updateAccount(String accountJsonFilePath, String zkServer, String storePath, int zkConnectionTimeoutMs,
-      int zkSessionTimeoutMs) throws Exception {
+      int zkSessionTimeoutMs, short containerJsonVersion) throws Exception {
+    Container.setCurrentJsonVersion(containerJsonVersion);
     long startTime = System.currentTimeMillis();
     Collection<Account> accountsToUpdate = getAccountsFromJson(accountJsonFilePath);
     if (!hasDuplicateAccountIdOrName(accountsToUpdate)) {


### PR DESCRIPTION
This allows users to write accounts with a non-default container
json versions. For example, one may want to create an account
that uses the V2 container schema before it is enabled by
default.