### PR TITLE
Add account versioning and local backup on updates

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
@@ -61,8 +61,7 @@ public class AccountServiceMetrics {
         metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "FetchRemoteAccountErrorCount"));
     remoteDataCorruptionErrorCount =
         metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "RemoteDataCorruptionErrorCount"));
-    backupErrorCount =
-        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "BackupErrorCount"));
+    backupErrorCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "BackupErrorCount"));
     nullNotifierCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "NullNotifierCount"));
     accountUpdatesCapturedByScheduledUpdaterCount = metricRegistry.counter(
         MetricRegistry.name(HelixAccountService.class, "AccountUpdatesCapturedByScheduledUpdaterCount"));

--- a/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountServiceMetrics.java
@@ -36,6 +36,7 @@ public class AccountServiceMetrics {
   public final Counter updateAccountErrorCount;
   public final Counter fetchRemoteAccountErrorCount;
   public final Counter remoteDataCorruptionErrorCount;
+  public final Counter backupErrorCount;
   public final Counter nullNotifierCount;
   public final Counter accountUpdatesCapturedByScheduledUpdaterCount;
 
@@ -60,6 +61,8 @@ public class AccountServiceMetrics {
         metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "FetchRemoteAccountErrorCount"));
     remoteDataCorruptionErrorCount =
         metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "RemoteDataCorruptionErrorCount"));
+    backupErrorCount =
+        metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "BackupErrorCount"));
     nullNotifierCount = metricRegistry.counter(MetricRegistry.name(HelixAccountService.class, "NullNotifierCount"));
     accountUpdatesCapturedByScheduledUpdaterCount = metricRegistry.counter(
         MetricRegistry.name(HelixAccountService.class, "AccountUpdatesCapturedByScheduledUpdaterCount"));

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -164,7 +164,6 @@ class HelixAccountService implements AccountService {
           "Background account updater will fetch accounts from remote starting {} ms from now and repeat with interval={} ms",
           initialDelay, config.updaterPollingIntervalMs);
     }
-    open.set(true);
   }
 
   @Override
@@ -580,7 +579,7 @@ class HelixAccountService implements AccountService {
       } else {
         for (Account account : updatedAccounts) {
           try {
-            accountMap.put(String.valueOf(account.getId()), account.toJson().toString());
+            accountMap.put(String.valueOf(account.getId()), account.toJson(true).toString());
           } catch (Exception e) {
             String message = "Updating accounts failed because unexpected exception occurred when updating accountId="
                 + account.getId() + " accountName=" + account.getName();
@@ -648,7 +647,7 @@ class HelixAccountService implements AccountService {
       backupContent.put(PREVIOUS_STATE_KEY, previousStateArray);
       JSONArray updatedAccountsArray = new JSONArray();
       for (Account account : updatedAccounts) {
-        updatedAccountsArray.put(account.toJson());
+        updatedAccountsArray.put(account.toJson(true));
       }
       backupContent.put(succeeded ? COMMITED_UPDATE_KEY : FAILED_UPDATE_KEY, updatedAccountsArray);
       return backupContent;

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -17,9 +17,11 @@ import com.github.ambry.commons.Notifier;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
@@ -39,6 +41,7 @@ import org.I0Itec.zkclient.DataUpdater;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.HelixPropertyStore;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -89,10 +92,11 @@ class HelixAccountService implements AccountService {
   static final String FULL_ACCOUNT_METADATA_PATH = "/account_metadata/full_data";
   private static final String ZN_RECORD_ID = "full_account_metadata";
   // backup constants
-  static final String BACKUP_EXT = ".bak";
-  static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyymmdd'T'hhmmss'-'");
+  static final String BACKUP_EXT = "bak";
+  static final String SEP = ".";
+  static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
   static final String SUCCEEDED_KEY = "succeeded";
-  static final String OLD_STATE_KEY = "oldState";
+  static final String PREVIOUS_STATE_KEY = "previousState";
   static final String COMMITED_UPDATE_KEY = "committedUpdate";
   static final String FAILED_UPDATE_KEY = "failedUpdate";
 
@@ -593,31 +597,62 @@ class HelixAccountService implements AccountService {
     /**
      * Save the state from zookeeper from before the update and after the update to disk.
      * This will write the backup content string to the disk with the following file name format:
-     * {@code {yyyymmdd}T{hhmmss}-{unique long}.bak}.
+     * {@code {yyyyMMdd}T{HHmmss}-{unique long}.bak}.
      * If there are multiple files with the same timestamp, the unique long will prevent the file names from clashing.
+     * @param succeeded {@code true} iff the update succeeded.
      */
     void persistBackup(boolean succeeded) {
-      String prefix = LocalDateTime.now().format(TIMESTAMP_FORMATTER);
       try {
-        JSONObject backupContent = new JSONObject();
-        backupContent.put(SUCCEEDED_KEY, succeeded);
-        if (remoteAccountInfoMap != null) {
-          for (Account account : remoteAccountInfoMap.getAccounts()) {
-            backupContent.accumulate(OLD_STATE_KEY, account.toJson());
-          }
-        }
-        String updatedAccountsKey = succeeded ? COMMITED_UPDATE_KEY : FAILED_UPDATE_KEY;
-        for (Account account : updatedAccounts) {
-          backupContent.accumulate(updatedAccountsKey, account.toJson());
-        }
-
-        Path filepath = Files.createTempFile(backupDirPath, prefix, BACKUP_EXT);
-        try (BufferedWriter writer = Files.newBufferedWriter(filepath)) {
+        String timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER);
+        JSONObject backupContent = getBackupContent(succeeded);
+        try (BufferedWriter writer = getWriter(timestamp)) {
           backupContent.write(writer);
+          writer.flush();
         }
       } catch (JSONException | IOException e) {
-        logger.error("Could not write backup file with prefix {}", prefix, e);
+        logger.error("Could not write backup file", e);
       }
+    }
+
+    /**
+     * @param timestamp the timestamp for the backup file
+     * @return a {@link BufferedWriter} for the backup file.
+     * @throws IOException if the file could not be created.
+     */
+    private BufferedWriter getWriter(String timestamp) throws IOException {
+      for (long n = 0; n < Long.MAX_VALUE; n++) {
+        Path filepath = backupDirPath.resolve(timestamp + SEP + n + SEP + BACKUP_EXT);
+        try {
+          return Files.newBufferedWriter(filepath, StandardOpenOption.CREATE_NEW);
+        } catch (FileAlreadyExistsException e) {
+          // retry with a new suffix.
+        }
+      }
+      throw new IOException("Could not create a unique file with timestamp " + timestamp);
+    }
+
+    /**
+     * @param succeeded {@code true} iff the update succeeded.
+     * @return a {@link JSONObject} containing the content for the local backup.
+     * @throws JSONException
+     */
+    private JSONObject getBackupContent(boolean succeeded) throws JSONException {
+      JSONObject backupContent = new JSONObject();
+      backupContent.put(SUCCEEDED_KEY, succeeded);
+      JSONArray previousStateArray = new JSONArray();
+      if (remoteAccountInfoMap != null) {
+        for (Account account : remoteAccountInfoMap.getAccounts()) {
+          // We want to include the snapshot version read from zookeeper, not snapshot version + 1
+          previousStateArray.put(account.toJson(false));
+        }
+      }
+      backupContent.put(PREVIOUS_STATE_KEY, previousStateArray);
+      JSONArray updatedAccountsArray = new JSONArray();
+      for (Account account : updatedAccounts) {
+        updatedAccountsArray.put(account.toJson());
+      }
+      backupContent.put(succeeded ? COMMITED_UPDATE_KEY : FAILED_UPDATE_KEY, updatedAccountsArray);
+      return backupContent;
     }
   }
 }

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -607,7 +607,6 @@ class HelixAccountService implements AccountService {
         JSONObject backupContent = getBackupContent(succeeded);
         try (BufferedWriter writer = getWriter(timestamp)) {
           backupContent.write(writer);
-          writer.flush();
         }
       } catch (JSONException | IOException e) {
         logger.error("Could not write backup file", e);

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
@@ -15,6 +15,7 @@ package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.commons.Notifier;
+import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.Utils;
@@ -38,6 +39,7 @@ public class HelixAccountServiceFactory implements AccountServiceFactory {
   private static final String HELIX_ACCOUNT_UPDATER_PREFIX = "helix-account-updater";
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final HelixPropertyStoreConfig storeConfig;
+  private final HelixAccountServiceConfig accountServiceConfig;
   private final AccountServiceMetrics accountServiceMetrics;
   private final Notifier<String> notifier;
 
@@ -50,29 +52,34 @@ public class HelixAccountServiceFactory implements AccountServiceFactory {
   public HelixAccountServiceFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
       Notifier<String> notifier) {
     storeConfig = new HelixPropertyStoreConfig(verifiableProperties);
+    accountServiceConfig = new HelixAccountServiceConfig(verifiableProperties);
     accountServiceMetrics = new AccountServiceMetrics(metricRegistry);
     this.notifier = notifier;
   }
 
   @Override
   public AccountService getAccountService() {
-    long startTimeMs = System.currentTimeMillis();
-    logger.info("Starting a HelixAccountService");
-    ZkClient zkClient = new ZkClient(storeConfig.zkClientConnectString, storeConfig.zkClientSessionTimeoutMs,
-        storeConfig.zkClientConnectionTimeoutMs, new ZNRecordSerializer());
-    HelixPropertyStore<ZNRecord> helixStore =
-        new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(zkClient), storeConfig.rootPath, null);
-    logger.info("HelixPropertyStore started with zkClientConnectString={}, zkClientSessionTimeoutMs={}, "
-            + "zkClientConnectionTimeoutMs={}, rootPath={}", storeConfig.zkClientConnectString,
-        storeConfig.zkClientSessionTimeoutMs, storeConfig.zkClientConnectionTimeoutMs, storeConfig.rootPath);
-    ScheduledExecutorService scheduler =
-        storeConfig.accountUpdaterPollingIntervalMs > 0 ? Utils.newScheduler(1, HELIX_ACCOUNT_UPDATER_PREFIX, false)
-            : null;
-    HelixAccountService helixAccountService =
-        new HelixAccountService(helixStore, accountServiceMetrics, notifier, scheduler, storeConfig);
-    long spentTimeMs = System.currentTimeMillis() - startTimeMs;
-    logger.info("HelixAccountService started, took {} ms", spentTimeMs);
-    accountServiceMetrics.startupTimeInMs.update(spentTimeMs);
-    return helixAccountService;
+    try {
+      long startTimeMs = System.currentTimeMillis();
+      logger.info("Starting a HelixAccountService");
+      ZkClient zkClient = new ZkClient(storeConfig.zkClientConnectString, storeConfig.zkClientSessionTimeoutMs,
+          storeConfig.zkClientConnectionTimeoutMs, new ZNRecordSerializer());
+      HelixPropertyStore<ZNRecord> helixStore =
+          new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(zkClient), storeConfig.rootPath, null);
+      logger.info("HelixPropertyStore started with zkClientConnectString={}, zkClientSessionTimeoutMs={}, "
+              + "zkClientConnectionTimeoutMs={}, rootPath={}", storeConfig.zkClientConnectString,
+          storeConfig.zkClientSessionTimeoutMs, storeConfig.zkClientConnectionTimeoutMs, storeConfig.rootPath);
+      ScheduledExecutorService scheduler =
+          accountServiceConfig.updaterPollingIntervalMs > 0 ? Utils.newScheduler(1, HELIX_ACCOUNT_UPDATER_PREFIX, false)
+              : null;
+      HelixAccountService helixAccountService =
+          new HelixAccountService(helixStore, accountServiceMetrics, notifier, scheduler, accountServiceConfig);
+      long spentTimeMs = System.currentTimeMillis() - startTimeMs;
+      logger.info("HelixAccountService started, took {} ms", spentTimeMs);
+      accountServiceMetrics.startupTimeInMs.update(spentTimeMs);
+      return helixAccountService;
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not instantiate HelixAccountService", e);
+    }
   }
 }

--- a/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -56,7 +55,6 @@ class AccountTestUtils {
    * @param accountService The {@link AccountService} to assert {@link Account} existence.
    */
   static void assertAccountInAccountService(Account account, AccountService accountService) {
-    account = adjustSnapshotVersion(account, 1);
     Account accountFoundById = accountService.getAccountById(account.getId());
     Account accountFoundByName = accountService.getAccountByName(account.getName());
     assertEquals("Account got by name from accountService does not match account to assert.", account,
@@ -140,25 +138,5 @@ class AccountTestUtils {
       idToRefContainerMap.put(accountId, idToContainers);
     }
     assertEquals("Wrong number of generated accounts", accountCount, idToRefAccountMap.size());
-  }
-
-  /**
-   * Increment or decrement the snapshot version of the provided {@link Account}.
-   * @param account the {@link Account} to modify.
-   * @param offset the offset to adjust the snapshot version by.
-   * @return the modified {@link Account}.
-   */
-  static Account adjustSnapshotVersion(Account account, int offset) {
-    return new AccountBuilder(account).snapshotVersion(account.getSnapshotVersion() + offset).build();
-  }
-
-  /**
-   * Increment or decrement the snapshot version of the provided {@link Account}s.
-   * @param accounts a {@link Collection} of {@link Account}s to modify.
-   * @param offset the offset to adjust the snapshot version by.
-   * @return a {@link Collection} of modified {@link Account}.
-   */
-  static Collection<Account> adjustSnapsotVersions(Collection<Account> accounts, int offset) {
-    return accounts.stream().map(account -> adjustSnapshotVersion(account, offset)).collect(Collectors.toList());
   }
 }

--- a/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
-import org.json.JSONException;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -56,12 +56,13 @@ class AccountTestUtils {
    * @param accountService The {@link AccountService} to assert {@link Account} existence.
    */
   static void assertAccountInAccountService(Account account, AccountService accountService) {
+    account = adjustSnapshotVersion(account, 1);
     Account accountFoundById = accountService.getAccountById(account.getId());
     Account accountFoundByName = accountService.getAccountByName(account.getName());
-    assertEquals("Account got by id from accountService does not match account got by name.", accountFoundById,
+    assertEquals("Account got by name from accountService does not match account to assert.", account,
         accountFoundByName);
-    assertEquals("Account got by id from accountService does not match the account to assert", accountFoundById,
-        account);
+    assertEquals("Account got by id from accountService does not match the account to assert", account,
+        accountFoundById);
     assertEquals("The number of containers in the account is wrong.", accountFoundById.getAllContainers().size(),
         account.getAllContainers().size());
     for (Container container : account.getAllContainers()) {
@@ -132,12 +133,22 @@ class AccountTestUtils {
         containers.add(container);
         idToContainers.put(containerId, container);
       }
-      Account account = new AccountBuilder(accountId, accountName, accountStatus, containers).build();
+      Account account = new AccountBuilder(accountId, accountName, accountStatus).containers(containers).build();
       assertEquals("Wrong number of generated containers for the account", containerCountPerAccount,
           account.getAllContainers().size());
       idToRefAccountMap.put(accountId, account);
       idToRefContainerMap.put(accountId, idToContainers);
     }
     assertEquals("Wrong number of generated accounts", accountCount, idToRefAccountMap.size());
+  }
+
+  /**
+   * Increment or decrement the snapshot version of the provided {@link Account}.
+   * @param account the {@link Account} to modify.
+   * @param offset the offset to adjust the snapshot version by.
+   * @return
+   */
+  static Account adjustSnapshotVersion(Account account, int offset) {
+    return new AccountBuilder(account).snapshotVersion(account.getSnapshotVersion() + offset).build();
   }
 }

--- a/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
@@ -146,9 +146,19 @@ class AccountTestUtils {
    * Increment or decrement the snapshot version of the provided {@link Account}.
    * @param account the {@link Account} to modify.
    * @param offset the offset to adjust the snapshot version by.
-   * @return
+   * @return the modified {@link Account}.
    */
   static Account adjustSnapshotVersion(Account account, int offset) {
     return new AccountBuilder(account).snapshotVersion(account.getSnapshotVersion() + offset).build();
+  }
+
+  /**
+   * Increment or decrement the snapshot version of the provided {@link Account}s.
+   * @param accounts a {@link Collection} of {@link Account}s to modify.
+   * @param offset the offset to adjust the snapshot version by.
+   * @return a {@link Collection} of modified {@link Account}.
+   */
+  static Collection<Account> adjustSnapsotVersions(Collection<Account> accounts, int offset) {
+    return accounts.stream().map(account -> adjustSnapshotVersion(account, offset)).collect(Collectors.toList());
   }
 }

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -263,7 +263,7 @@ public class HelixAccountServiceTest {
   @Test
   public void testReadBadZNRecordCase3() throws Exception {
     Map<String, String> mapValue = new HashMap<>();
-    mapValue.put(String.valueOf(refAccount.getId()), refAccount.toJson().toString());
+    mapValue.put(String.valueOf(refAccount.getId()), refAccount.toJson(true).toString());
     ZNRecord zNRecord = makeZNRecordWithMapField(null, "key", mapValue);
     updateAndWriteZNRecord(zNRecord, true);
   }
@@ -278,7 +278,7 @@ public class HelixAccountServiceTest {
   @Test
   public void testReadBadZNRecordCase4() throws Exception {
     Map<String, String> mapValue = new HashMap<>();
-    mapValue.put("-1", refAccount.toJson().toString());
+    mapValue.put("-1", refAccount.toJson(true).toString());
     ZNRecord zNRecord = makeZNRecordWithMapField(null, ACCOUNT_METADATA_MAP_KEY, mapValue);
     updateAndWriteZNRecord(zNRecord, false);
   }
@@ -307,7 +307,7 @@ public class HelixAccountServiceTest {
   public void testReadBadZNRecordCase6() throws Exception {
     ZNRecord zNRecord = new ZNRecord(String.valueOf(System.currentTimeMillis()));
     Map<String, String> accountMap = new HashMap<>();
-    accountMap.put(String.valueOf(refAccount.getId()), refAccount.toJson().toString());
+    accountMap.put(String.valueOf(refAccount.getId()), refAccount.toJson(true).toString());
     accountMap.put(String.valueOf(refAccount.getId() + 1), BAD_ACCOUNT_METADATA_STRING);
     zNRecord.setMapField(ACCOUNT_METADATA_MAP_KEY, accountMap);
     updateAndWriteZNRecord(zNRecord, false);
@@ -709,7 +709,7 @@ public class HelixAccountServiceTest {
 
   /**
    * PrePopulates a collection of self-conflicting {@link Account}s, which will impact {@link HelixAccountService}
-   * startup and udpate.
+   * startup and update.
    * @param accounts The self-conflicting {@link Account}s.
    */
   private void readAndUpdateBadRecord(Collection<Account> accounts) throws Exception {
@@ -788,7 +788,7 @@ public class HelixAccountServiceTest {
     ZNRecord zNRecord = new ZNRecord(String.valueOf(System.currentTimeMillis()));
     Map<String, String> accountMap = new HashMap<>();
     for (Account account : accounts) {
-      accountMap.put(String.valueOf(account.getId()), account.toJson().toString());
+      accountMap.put(String.valueOf(account.getId()), account.toJson(true).toString());
     }
     zNRecord.setMapField(ACCOUNT_METADATA_MAP_KEY, accountMap);
     // Write account metadata into HelixPropertyStore.

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -751,17 +751,6 @@ public class HelixAccountServiceTest {
   }
 
   /**
-   * @return the serialized account metadata for each account present in zookeeper.
-   */
-  private Collection<String> getSerializedAccountsFromZk() {
-    HelixPropertyStore<ZNRecord> helixStore = mockHelixAccountServiceFactory.getHelixStore(storeConfig);
-    return Optional.ofNullable(helixStore.get(FULL_ACCOUNT_METADATA_PATH, null, AccessOption.PERSISTENT))
-        .flatMap(znRecord -> Optional.ofNullable(znRecord.getMapField(ACCOUNT_METADATA_MAP_KEY)))
-        .map(Map::values)
-        .orElse(Collections.emptyList());
-  }
-
-  /**
    * Check that the provided backup file matches the data in the corresponding serialized accounts.
    * @param expectedAccounts the expected {@link Account}s.
    * @param backupPath the {@link Path} to the backup file.

--- a/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
@@ -54,7 +54,7 @@ public class InMemoryUnknownAccountServiceTest {
         accountService.getAccountByName(UtilsTest.getRandomString(10)));
     assertEquals("Wrong size of account collection", 1, accountService.getAllAccounts().size());
     // updating the InMemoryUnknownAccountService should fail.
-    Account account = new AccountBuilder((short) 1, "a", Account.AccountStatus.INACTIVE, null).build();
+    Account account = new AccountBuilder((short) 1, "a", Account.AccountStatus.INACTIVE).build();
     assertFalse("Wrong return value from an unsuccessful update operation",
         accountService.updateAccounts(Collections.singletonList(account)));
     assertEquals("Wrong size of account collection", 1, accountService.getAllAccounts().size());
@@ -97,11 +97,11 @@ public class InMemoryUnknownAccountServiceTest {
       updatedAccountsReceivedByConsumers.add(updatedAccounts);
     };
     accountService.addAccountUpdateConsumer(accountUpdateConsumer);
-    Account updatedAccount = new AccountBuilder(Account.UNKNOWN_ACCOUNT).setName("newName").build();
+    Account updatedAccount = new AccountBuilder(Account.UNKNOWN_ACCOUNT).name("newName").build();
     accountService.updateAccounts(Collections.singletonList(updatedAccount));
     assertEquals("Wrong number of updated accounts received by consumer.", 0,
         updatedAccountsReceivedByConsumers.size());
-    Account newAccount = new AccountBuilder((short) 1, "newAccount", Account.AccountStatus.ACTIVE, null).build();
+    Account newAccount = new AccountBuilder((short) 1, "newAccount", Account.AccountStatus.ACTIVE).build();
     accountService.updateAccounts(Collections.singletonList(newAccount));
     assertEquals("Wrong number of updated accounts received by consumer.", 0,
         updatedAccountsReceivedByConsumers.size());

--- a/ambry-api/src/main/java/com.github.ambry/account/Account.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/Account.java
@@ -192,7 +192,6 @@ public class Account {
     return metadata;
   }
 
-
   /**
    * Deserializes a {@link JSONObject} to an account object.
    * @param json The {@link JSONObject} to deserialize.

--- a/ambry-api/src/main/java/com.github.ambry/account/Account.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/Account.java
@@ -97,7 +97,7 @@ public class Account {
   /**
    * An account defined specifically for the blobs put without specifying target account and container. In the
    * pre-containerization world, a put-blob request does not carry any information which account/container to store
-   * the blob. Thee blobs are put under this account if their service ID does not match a valid account, because the
+   * the blob. These blobs are assigned to this account if their service ID does not match a valid account, because the
    * target account information is unknown.
    */
   public static final Account UNKNOWN_ACCOUNT =
@@ -171,16 +171,8 @@ public class Account {
   }
 
   /**
-   * Gets the metadata of the account in {@link JSONObject}. This will increment the snapshot version by one.
-   * @return The metadata of the account in {@link JSONObject}.
-   * @throws JSONException If fails to compose the metadata in {@link JSONObject}.
-   */
-  JSONObject toJson() throws JSONException {
-    return toJson(true);
-  }
-
-  /**
-   * Gets the metadata of the account in {@link JSONObject}. This will increment the snapshot version by one.
+   * Gets the metadata of the account in {@link JSONObject}. This will increment the snapshot version by one if
+   * {@code incrementSnapshotVersion} is {@code true}.
    * @param incrementSnapshotVersion {@code true} to increment the snapshot version by one.
    * @return The metadata of the account in {@link JSONObject}.
    * @throws JSONException If fails to compose the metadata in {@link JSONObject}.
@@ -300,13 +292,7 @@ public class Account {
     if (status != account.status) {
       return false;
     }
-    if (snapshotVersion != account.snapshotVersion) {
-      return false;
-    }
-    if (!containerIdToContainerMap.equals(account.containerIdToContainerMap)) {
-      return false;
-    }
-    return containerNameToContainerMap.equals(account.containerNameToContainerMap);
+    return containerIdToContainerMap.equals(account.containerIdToContainerMap);
   }
 
   @Override

--- a/ambry-api/src/main/java/com.github.ambry/account/AccountBuilder.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/AccountBuilder.java
@@ -30,6 +30,7 @@ public class AccountBuilder {
   private short id;
   private String name;
   private AccountStatus status;
+  private int snapshotVersion = Account.SNAPSHOT_VERSION_DEFAULT_VALUE;
   private Map<Short, Container> idToContainerMetadataMap = new HashMap<>();
 
   /**
@@ -44,6 +45,7 @@ public class AccountBuilder {
     id = origin.getId();
     name = origin.getName();
     status = origin.getStatus();
+    snapshotVersion = origin.getSnapshotVersion();
     for (Container container : origin.getAllContainers()) {
       idToContainerMetadataMap.put(container.getId(), container);
     }
@@ -57,17 +59,11 @@ public class AccountBuilder {
    *           calling {@link #build()}.
    * @param status The status of the {@link Account}. Can be {@code null}, but should be set before
    *           calling {@link #build()}.
-   * @param containers A collection of {@link Container}s to add. Can be {@code null}.
    */
-  public AccountBuilder(short id, String name, AccountStatus status, Collection<Container> containers) {
+  public AccountBuilder(short id, String name, AccountStatus status) {
     this.id = id;
     this.name = name;
     this.status = status;
-    if (containers != null) {
-      for (Container container : containers) {
-        idToContainerMetadataMap.put(container.getId(), container);
-      }
-    }
   }
 
   /**
@@ -75,7 +71,7 @@ public class AccountBuilder {
    * @param id The id to set.
    * @return This builder.
    */
-  public AccountBuilder setId(short id) {
+  public AccountBuilder id(short id) {
     this.id = id;
     return this;
   }
@@ -85,7 +81,7 @@ public class AccountBuilder {
    * @param name The name to set.
    * @return This builder.
    */
-  public AccountBuilder setName(String name) {
+  public AccountBuilder name(String name) {
     this.name = name;
     return this;
   }
@@ -95,8 +91,33 @@ public class AccountBuilder {
    * @param status The id to set.
    * @return This builder.
    */
-  public AccountBuilder setStatus(AccountStatus status) {
+  public AccountBuilder status(AccountStatus status) {
     this.status = status;
+    return this;
+  }
+
+  /**
+   * Sets the snapshot version of the {@link Account} to build.
+   * @param snapshotVersion The version to set.
+   * @return This builder.
+   */
+  public AccountBuilder snapshotVersion(int snapshotVersion) {
+    this.snapshotVersion = snapshotVersion;
+    return this;
+  }
+
+  /**
+   * Clear the set of containers for the {@link Account} to build and add the provided ones.
+   * @param containers A collection of {@link Container}s to use. Can be {@code null} to just remove all containers.
+   * @return This builder.
+   */
+  public AccountBuilder containers(Collection<Container> containers) {
+    idToContainerMetadataMap.clear();
+    if (containers != null) {
+      for (Container container : containers) {
+        idToContainerMetadataMap.put(container.getId(), container);
+      }
+    }
     return this;
   }
 
@@ -137,6 +158,6 @@ public class AccountBuilder {
    * @throws IllegalStateException If any required fields is not set or there is inconsistency in containers.
    */
   public Account build() {
-    return new Account(id, name, status, idToContainerMetadataMap.values());
+    return new Account(id, name, status, snapshotVersion, idToContainerMetadataMap.values());
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/account/AccountService.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/AccountService.java
@@ -58,7 +58,7 @@ public interface AccountService extends Closeable {
    *   When updating {@link Account}s, {@code AccountService} will check that there is no conflict between the
    *   {@link Account}s to update and the existing {@link Account}s. Two {@link Account}s can be conflicting with
    *   each other if they have different account Ids but the same account name. If there is any conflict, the
-   *   update operation will fail for <em>ALL</em> the {@link Account}s to udpate. Below lists the possible cases
+   *   update operation will fail for <em>ALL</em> the {@link Account}s to update. Below lists the possible cases
    *   when there is conflict.
    * </p>
    * <pre>

--- a/ambry-api/src/main/java/com.github.ambry/account/ContainerBlobsResource.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/ContainerBlobsResource.java
@@ -19,7 +19,7 @@ package com.github.ambry.account;
  *
  */
 public class ContainerBlobsResource implements AclService.Resource {
-  private static final String RESOURCE_TYPE = "ContainerBlobs";
+  public static final String RESOURCE_TYPE = "ContainerBlobs";
   private static final String SEPARATOR = "_";
 
   private final String resourceId;

--- a/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
@@ -56,7 +56,7 @@ public class ContainerBuilder {
 
   /**
    * Constructor for a {@link ContainerBuilder} taking individual arguments.
-   * @param id The id of the {@link Container} to build.
+   * @param id The setId of the {@link Container} to build.
    * @param name The name of the {@link Container}.
    * @param status The status of the {@link Container}.
    * @param description The description of the {@link Container}.
@@ -66,7 +66,7 @@ public class ContainerBuilder {
    * @param cacheable {@code true} if cache control headers should be set to allow CDNs and browsers to cache blobs in
 *                  this container.
    * @param mediaScanDisabled {@code true} if media scanning for content in this container should be disabled.
-   * @param parentAccountId The id of the parent {@link Account} of the {@link Container} to build.
+   * @param parentAccountId The setId of the parent {@link Account} of the {@link Container} to build.
    */
   public ContainerBuilder(short id, String name, ContainerStatus status, String description, boolean encrypted,
       boolean previouslyEncrypted, boolean cacheable, boolean mediaScanDisabled, short parentAccountId) {
@@ -82,8 +82,8 @@ public class ContainerBuilder {
   }
 
   /**
-   * Sets the id of the {@link Container} to build.
-   * @param id The id to set.
+   * Sets the setId of the {@link Container} to build.
+   * @param id The setId to set.
    * @return This builder.
    */
   public ContainerBuilder setId(short id) {
@@ -152,8 +152,8 @@ public class ContainerBuilder {
   }
 
   /**
-   * Sets the id of the parent {@link Account} of the {@link Container} to build.
-   * @param parentAccountId The parent {@link Account} id to set.
+   * Sets the setId of the parent {@link Account} of the {@link Container} to build.
+   * @param parentAccountId The parent {@link Account} setId to set.
    * @return This builder.
    */
   public ContainerBuilder setParentAccountId(short parentAccountId) {
@@ -162,7 +162,7 @@ public class ContainerBuilder {
   }
 
   /**
-   * Builds a {@link Container} object. {@code id}, {@code name}, {@code status}, {@code isPrivate}, and
+   * Builds a {@link Container} object. {@code setId}, {@code name}, {@code status}, {@code isPrivate}, and
    * {@code parentAccountId} are required before build.
    * @return A {@link Container} object.
    * @throws IllegalStateException If any required fields is not set.

--- a/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
@@ -62,9 +62,9 @@ public class ContainerBuilder {
    * @param description The description of the {@link Container}.
    * @param encrypted {@code true} if blobs in the {@link Container} should be encrypted, {@code false} otherwise.
    * @param previouslyEncrypted {@code true} if this {@link Container} was encrypted in the past, or currently, and a
-*                            subset of blobs in it could still be encrypted.
+   *                            subset of blobs in it could still be encrypted.
    * @param cacheable {@code true} if cache control headers should be set to allow CDNs and browsers to cache blobs in
-*                  this container.
+   *                  this container.
    * @param mediaScanDisabled {@code true} if media scanning for content in this container should be disabled.
    * @param parentAccountId The id of the parent {@link Account} of the {@link Container} to build.
    */

--- a/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
@@ -56,7 +56,7 @@ public class ContainerBuilder {
 
   /**
    * Constructor for a {@link ContainerBuilder} taking individual arguments.
-   * @param id The setId of the {@link Container} to build.
+   * @param id The id of the {@link Container} to build.
    * @param name The name of the {@link Container}.
    * @param status The status of the {@link Container}.
    * @param description The description of the {@link Container}.
@@ -66,7 +66,7 @@ public class ContainerBuilder {
    * @param cacheable {@code true} if cache control headers should be set to allow CDNs and browsers to cache blobs in
 *                  this container.
    * @param mediaScanDisabled {@code true} if media scanning for content in this container should be disabled.
-   * @param parentAccountId The setId of the parent {@link Account} of the {@link Container} to build.
+   * @param parentAccountId The id of the parent {@link Account} of the {@link Container} to build.
    */
   public ContainerBuilder(short id, String name, ContainerStatus status, String description, boolean encrypted,
       boolean previouslyEncrypted, boolean cacheable, boolean mediaScanDisabled, short parentAccountId) {
@@ -82,8 +82,8 @@ public class ContainerBuilder {
   }
 
   /**
-   * Sets the setId of the {@link Container} to build.
-   * @param id The setId to set.
+   * Sets the ID of the {@link Container} to build.
+   * @param id The ID to set.
    * @return This builder.
    */
   public ContainerBuilder setId(short id) {
@@ -152,8 +152,8 @@ public class ContainerBuilder {
   }
 
   /**
-   * Sets the setId of the parent {@link Account} of the {@link Container} to build.
-   * @param parentAccountId The parent {@link Account} setId to set.
+   * Sets the ID of the parent {@link Account} of the {@link Container} to build.
+   * @param parentAccountId The parent {@link Account} ID to set.
    * @return This builder.
    */
   public ContainerBuilder setParentAccountId(short parentAccountId) {
@@ -162,7 +162,7 @@ public class ContainerBuilder {
   }
 
   /**
-   * Builds a {@link Container} object. {@code setId}, {@code name}, {@code status}, {@code isPrivate}, and
+   * Builds a {@link Container} object. {@code id}, {@code name}, {@code status}, {@code isPrivate}, and
    * {@code parentAccountId} are required before build.
    * @return A {@link Container} object.
    * @throws IllegalStateException If any required fields is not set.

--- a/ambry-api/src/main/java/com.github.ambry/commons/Notifier.java
+++ b/ambry-api/src/main/java/com.github.ambry/commons/Notifier.java
@@ -33,7 +33,7 @@ public interface Notifier<T> {
   public boolean publish(String topic, T message);
 
   /**
-   * Let a {@link TopicListener} subscribe a topic. After subscription, it will receive the messages
+   * Let a {@link TopicListener} subscribe to a topic. After subscription, it will receive the messages
    * published for the topic.
    * @param topic The topic to subscribe.
    * @param listener The {@link TopicListener} who subscribes the topic.
@@ -41,7 +41,7 @@ public interface Notifier<T> {
   public void subscribe(String topic, TopicListener<T> listener);
 
   /**
-   * Let a {@link TopicListener} unsubscribe a topic, so it will no longer receive the messages for
+   * Let a {@link TopicListener} unsubscribe from a topic, so it will no longer receive the messages for
    * the topic.
    * @param topic The topic to unsubscribe.
    * @param listener The {@link TopicListener} who unsubscribes the topic.

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.config;
+
+/**
+ * Config for {@link HelixAccountServiceConfig}
+ */
+public class HelixAccountServiceConfig {
+  public static final String HELIX_ACCOUNT_SERVICE_PREFIX = "helix.account.service.";
+  public static final String UPDATER_POLLING_INTERVAL_MS_KEY =
+      HELIX_ACCOUNT_SERVICE_PREFIX + "updater.polling.interval.ms";
+  public static final String UPDATER_SHUT_DOWN_TIMEOUT_MS_KEY =
+      HELIX_ACCOUNT_SERVICE_PREFIX + "updater.shut.down.timeout.ms";
+  public static final String BACKUP_DIRECTORY_KEY = HELIX_ACCOUNT_SERVICE_PREFIX + "backup.dir";
+
+  /**
+   * The time interval in second between two consecutive account pulling for the background account updater of
+   * {@code HelixAccountService}. Setting to 0 to disable it.
+   */
+  @Config(UPDATER_POLLING_INTERVAL_MS_KEY)
+  @Default("60 * 60 * 1000")
+  public final int updaterPollingIntervalMs;
+
+  /**
+   * The timeout in ms to shut down the account updater of {@code HelixAccountService}.
+   */
+  @Config(UPDATER_SHUT_DOWN_TIMEOUT_MS_KEY)
+  @Default("60 * 1000")
+  public final int updaterShutDownTimeoutMs;
+
+  /**
+   * The directory on the local machine where account data backups will be stored before updating accounts.
+   * If this string is empty, backups will be disabled.
+   */
+  @Config(BACKUP_DIRECTORY_KEY)
+  @Default("")
+  public final String backupDir;
+
+  public HelixAccountServiceConfig(VerifiableProperties verifiableProperties) {
+    updaterPollingIntervalMs =
+        verifiableProperties.getIntInRange(UPDATER_POLLING_INTERVAL_MS_KEY, 60 * 60 * 1000, 0, Integer.MAX_VALUE);
+    updaterShutDownTimeoutMs =
+        verifiableProperties.getIntInRange(UPDATER_SHUT_DOWN_TIMEOUT_MS_KEY, 60 * 1000, 1, Integer.MAX_VALUE);
+    backupDir = verifiableProperties.getString(BACKUP_DIRECTORY_KEY, "");
+  }
+}

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixPropertyStoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixPropertyStoreConfig.java
@@ -51,27 +51,6 @@ public class HelixPropertyStoreConfig {
   @Default("/ambry/defaultCluster/helixPropertyStore")
   public final String rootPath;
 
-  /**
-   * The time interval in second between two consecutive account pulling for the background account updater of
-   * {@code HelixAccountService}. Setting to 0 to disable it.
-   */
-  @Config(HELIX_PROPERTY_STORE_PREFIX + "account.service.polling.interval.ms")
-  @Default("60 * 60 * 1000")
-  // @todo This config by its nature should not appear in HelixPropertyStoreConfig. An ultimate fix would require
-  // @todo separation between HelixAccount-related and Notifier-related configs, and this config should go to the
-  // @todo HelixAccountServiceConfig.
-  public final int accountUpdaterPollingIntervalMs;
-
-  /**
-   * The timeout in ms to shut down the account updater of {@code HelixAccountService}.
-   */
-  @Config(HELIX_PROPERTY_STORE_PREFIX + "account.service.shut.down.timeout.ms")
-  @Default("60 * 1000")
-  // @todo This config by its nature should not appear in HelixPropertyStoreConfig. An ultimate fix would require
-  // @todo separation between HelixAccount-related and Notifier-related configs, and this config should go to the
-  // @todo HelixAccountServiceConfig.
-  public final int accountUpdaterShutDownTimeoutMs;
-
   public HelixPropertyStoreConfig(VerifiableProperties verifiableProperties) {
     zkClientConnectionTimeoutMs =
         verifiableProperties.getIntInRange(HELIX_PROPERTY_STORE_PREFIX + "zk.client.connection.timeout.ms", 20 * 1000,
@@ -83,11 +62,5 @@ public class HelixPropertyStoreConfig {
         INVALID_ZK_CLIENT_CONNECT_STRING);
     rootPath = verifiableProperties.getString(HELIX_PROPERTY_STORE_PREFIX + "root.path",
         "/ambry/defaultCluster/helixPropertyStore");
-    accountUpdaterPollingIntervalMs =
-        verifiableProperties.getIntInRange(HELIX_PROPERTY_STORE_PREFIX + "account.updater.polling.interval.ms",
-            60 * 60 * 1000, 0, Integer.MAX_VALUE);
-    accountUpdaterShutDownTimeoutMs =
-        verifiableProperties.getIntInRange(HELIX_PROPERTY_STORE_PREFIX + "account.updater.shut.down.timeout.ms",
-            60 * 1000, 1, Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -264,8 +264,8 @@ public class RestUtils {
     // This field should not matter on newly created blobs, because all privacy/cacheability decisions should be made
     // based on the container properties and ACLs. For now, BlobProperties still includes this field, though.
     boolean isPrivate = !container.isCacheable();
-    return new BlobProperties(-1, serviceId, ownerId, contentType, isPrivate, ttl, account.getId(),
-        container.getId(), container.isEncrypted());
+    return new BlobProperties(-1, serviceId, ownerId, contentType, isPrivate, ttl, account.getId(), container.getId(),
+        container.isEncrypted());
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
@@ -282,6 +282,12 @@ public class AccountContainerTest {
     accountBuilder = new AccountBuilder(accountByBuilder);
     Account account2ByBuilder = accountBuilder.build();
     assertAccountAgainstReference(account2ByBuilder, true, true);
+
+    // clear containers
+    Account account3ByBuilder = new AccountBuilder(account2ByBuilder).containers(null).build();
+    assertAccountAgainstReference(account3ByBuilder, false, false);
+    assertTrue("Container list should be empty.", account3ByBuilder.getAllContainers().isEmpty());
+
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
@@ -646,7 +646,8 @@ public class AccountContainerTest {
     if (compareMetadata) {
       assertAccountJsonSerDe(false, account);
       assertAccountJsonSerDe(true, account);
-    } if (compareContainer) {
+    }
+    if (compareContainer) {
       Collection<Container> containersFromAccount = account.getAllContainers();
       assertEquals("Wrong number of containers.", CONTAINER_COUNT, containersFromAccount.size());
       assertEquals(CONTAINER_COUNT, containersFromAccount.size());

--- a/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
@@ -47,6 +47,7 @@ public class AccountContainerTest {
   private short refAccountId;
   private String refAccountName;
   private AccountStatus refAccountStatus;
+  private int refAccountSnapshotVersion = SNAPSHOT_VERSION_DEFAULT_VALUE;
   private JSONObject refAccountJson;
 
   // Reference Container fields
@@ -80,12 +81,14 @@ public class AccountContainerTest {
     refAccountId = Utils.getRandomShort(random);
     refAccountName = UUID.randomUUID().toString();
     refAccountStatus = random.nextBoolean() ? AccountStatus.ACTIVE : AccountStatus.INACTIVE;
+    refAccountSnapshotVersion = random.nextInt();
     initializeRefContainers();
     refAccountJson = new JSONObject();
     refAccountJson.put(Account.JSON_VERSION_KEY, Account.JSON_VERSION_1);
     refAccountJson.put(ACCOUNT_ID_KEY, refAccountId);
     refAccountJson.put(ACCOUNT_NAME_KEY, refAccountName);
-    refAccountJson.put(Account.STATUS_KEY, refAccountStatus.name());
+    refAccountJson.put(Account.STATUS_KEY, refAccountStatus);
+    refAccountJson.put(SNAPSHOT_VERSION_KEY, refAccountSnapshotVersion);
     refAccountJson.put(CONTAINERS_KEY, containerJsonList);
   }
 
@@ -104,7 +107,7 @@ public class AccountContainerTest {
   @Test
   public void testConstructAccountAndContainerFromArguments() throws JSONException {
     Account accountFromArguments =
-        new AccountBuilder(refAccountId, refAccountName, refAccountStatus, refContainers).build();
+        new Account(refAccountId, refAccountName, refAccountStatus, refAccountSnapshotVersion, refContainers);
     assertAccountAgainstReference(accountFromArguments, true, true);
   }
 
@@ -244,7 +247,7 @@ public class AccountContainerTest {
   @Test
   public void testToString() throws JSONException {
     Account account = Account.fromJson(refAccountJson);
-    assertEquals("Account[" + account.getId() + "]", account.toString());
+    assertEquals("Account[" + account.getId() + "," + account.getSnapshotVersion() + "]", account.toString());
     for (int i = 0; i < CONTAINER_COUNT; i++) {
       Container container = Container.fromJson(containerJsonList.get(i), refAccountId);
       assertEquals("Container[" + account.getId() + ":" + container.getId() + "]", container.toString());
@@ -260,7 +263,8 @@ public class AccountContainerTest {
   @Test
   public void testAccountBuilder() throws JSONException {
     // build an account with arguments supplied
-    AccountBuilder accountBuilder = new AccountBuilder(refAccountId, refAccountName, refAccountStatus, null);
+    AccountBuilder accountBuilder =
+        new AccountBuilder(refAccountId, refAccountName, refAccountStatus).snapshotVersion(refAccountSnapshotVersion);
     Account accountByBuilder = accountBuilder.build();
     assertAccountAgainstReference(accountByBuilder, false, false);
 
@@ -352,9 +356,9 @@ public class AccountContainerTest {
     short updatedAccountId = (short) (refAccountId + 1);
     String updatedAccountName = refAccountName + "-updated";
     Account.AccountStatus updatedAccountStatus = Account.AccountStatus.INACTIVE;
-    accountBuilder.setId(updatedAccountId);
-    accountBuilder.setName(updatedAccountName);
-    accountBuilder.setStatus(updatedAccountStatus);
+    accountBuilder.id(updatedAccountId);
+    accountBuilder.name(updatedAccountName);
+    accountBuilder.status(updatedAccountStatus);
 
     try {
       accountBuilder.build();
@@ -378,7 +382,7 @@ public class AccountContainerTest {
     for (Container container : origin.getAllContainers()) {
       accountBuilder.addOrUpdateContainer(container);
     }
-    accountBuilder.setId(refAccountId);
+    accountBuilder.id(refAccountId);
     updatedAccount = accountBuilder.build();
     assertEquals(origin.getAllContainers().toString(), updatedAccount.getAllContainers().toString());
   }
@@ -582,7 +586,7 @@ public class AccountContainerTest {
     // UNKNOWN_ACCOUNT
     assertEquals("Wrong id for UNKNOWN_ACCOUNT", Account.UNKNOWN_ACCOUNT_ID, unknownAccount.getId());
     assertEquals("Wrong name for UNKNOWN_ACCOUNT", Account.UNKNOWN_ACCOUNT_NAME, unknownAccount.getName());
-    assertEquals("Wrong status for UNKNOWN_ACCOUNT", Account.UNKNOWN_ACCOUNT_STATUS, unknownAccount.getStatus());
+    assertEquals("Wrong status for UNKNOWN_ACCOUNT", AccountStatus.ACTIVE, unknownAccount.getStatus());
     assertEquals("Wrong number of containers for UNKNOWN_ACCOUNT", 3, unknownAccount.getAllContainers().size());
     assertEquals("Wrong unknown container get from UNKNOWN_ACCOUNT", Container.UNKNOWN_CONTAINER,
         unknownAccount.getContainerById(Container.UNKNOWN_CONTAINER_ID));
@@ -599,9 +603,8 @@ public class AccountContainerTest {
   @Test
   public void testAccountEqual() throws Exception {
     // Check two accounts with same fields but no containers.
-    Account accountNoContainer = new AccountBuilder(refAccountId, refAccountName, refAccountStatus, null).build();
-    Account accountNoContainerDuplicate =
-        new AccountBuilder(refAccountId, refAccountName, refAccountStatus, null).build();
+    Account accountNoContainer = new AccountBuilder(refAccountId, refAccountName, refAccountStatus).build();
+    Account accountNoContainerDuplicate = new AccountBuilder(refAccountId, refAccountName, refAccountStatus).build();
     assertTrue("Two accounts should be equal.", accountNoContainer.equals(accountNoContainerDuplicate));
 
     // Check two accounts with same fields and containers.
@@ -621,8 +624,7 @@ public class AccountContainerTest {
             refContainerMediaScanDisabledValues.get(0), refAccountId).build();
     refContainers.remove(0);
     refContainers.add(updatedContainer);
-    Account accountWithModifiedContainers =
-        new AccountBuilder(refAccountId, refAccountName, refAccountStatus, refContainers).build();
+    Account accountWithModifiedContainers = new AccountBuilder(refAccountId, refAccountName, refAccountStatus).build();
     assertFalse("Two accounts should not be equal.", accountWithContainers.equals(accountWithModifiedContainers));
   }
 
@@ -640,12 +642,24 @@ public class AccountContainerTest {
     assertEquals(refAccountId, account.getId());
     assertEquals(refAccountName, account.getName());
     assertEquals(refAccountStatus, account.getStatus());
+    assertEquals("Snapshot versions do not match", refAccountSnapshotVersion, account.getSnapshotVersion());
     if (compareMetadata) {
-      // The order of containers in json string may be different, so we cannot compare the exact string.
-      assertEquals("Wrong metadata JsonObject from toJson()", refAccountJson.toString().length(),
-          account.toJson().toString().length());
       assertEquals("Failed to compare account to a reference account", Account.fromJson(refAccountJson), account);
-      assertEquals("Wrong behavior in serialize and then deserialize", account, Account.fromJson(account.toJson()));
+
+      // when an account is serialized the snapshot version is incremented by one.
+      JSONObject expectedAccountJson =
+          deepCopy(refAccountJson).put(SNAPSHOT_VERSION_KEY, refAccountSnapshotVersion + 1);
+      JSONObject accountJson = account.toJson();
+      // extra check for snapshot version since the lengths would likely not differ even if the snapshot version wasn't
+      // incremented correctly
+      assertEquals("Snapshot versions in JSON do not match", expectedAccountJson.get(SNAPSHOT_VERSION_KEY),
+          account.toJson().get(SNAPSHOT_VERSION_KEY));
+      // The order of containers in json string may be different, so we cannot compare the exact string.
+      assertEquals("Wrong metadata JsonObject from toJson()", expectedAccountJson.toString().length(),
+          accountJson.toString().length());
+      Account expectedAccount = new AccountBuilder(account).snapshotVersion(refAccountSnapshotVersion + 1).build();
+      assertEquals("Wrong behavior in serialize and then deserialize", expectedAccount,
+          Account.fromJson(account.toJson()));
     }
     if (compareContainer) {
       Collection<Container> containersFromAccount = account.getAllContainers();
@@ -727,7 +741,8 @@ public class AccountContainerTest {
   private void createAccountWithBadContainersAndFail(List<Container> containers,
       Class<? extends Exception> exceptionClass) throws Exception {
     TestUtils.assertException(exceptionClass,
-        () -> new Account(refAccountId, refAccountName, refAccountStatus, containers), null);
+        () -> new Account(refAccountId, refAccountName, refAccountStatus, SNAPSHOT_VERSION_DEFAULT_VALUE, containers),
+        null);
   }
 
   /**
@@ -738,7 +753,7 @@ public class AccountContainerTest {
    */
   private void buildAccountWithMissingFieldsAndFail(String name, AccountStatus status,
       Class<? extends Exception> exceptionClass) throws Exception {
-    AccountBuilder accountBuilder = new AccountBuilder(refAccountId, name, status, null);
+    AccountBuilder accountBuilder = new AccountBuilder(refAccountId, name, status);
     TestUtils.assertException(exceptionClass, accountBuilder::build, null);
   }
 

--- a/ambry-api/src/test/java/com.github.ambry/account/InMemAccountService.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/InMemAccountService.java
@@ -129,8 +129,11 @@ public class InMemAccountService implements AccountService {
         new ContainerBuilder(Container.DEFAULT_PUBLIC_CONTAINER).setParentAccountId(refAccountId).build();
     Container privateContainer =
         new ContainerBuilder(Container.DEFAULT_PRIVATE_CONTAINER).setParentAccountId(refAccountId).build();
-    Account account = new AccountBuilder(refAccountId, refAccountName, refAccountStatus,
-        Arrays.asList(publicContainer, privateContainer, randomContainer)).build();
+    Account account =
+        new AccountBuilder(refAccountId, refAccountName, refAccountStatus).addOrUpdateContainer(publicContainer)
+            .addOrUpdateContainer(privateContainer)
+            .addOrUpdateContainer(randomContainer)
+            .build();
     updateAccounts(Collections.singletonList(account));
     return account;
   }

--- a/ambry-api/src/test/java/com.github.ambry/account/InMemAccountService.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/InMemAccountService.java
@@ -18,7 +18,6 @@ import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
@@ -74,7 +74,7 @@ class AmbryDataNode extends DataNodeId implements Resource {
       String fqdn = getFullyQualifiedDomainName(hostName);
       if (!fqdn.equals(hostName)) {
         throw new IllegalStateException(
-                "Hostname for AmbryDataNode (" + hostName + ") does not match its fully qualified domain name: " + fqdn);
+            "Hostname for AmbryDataNode (" + hostName + ") does not match its fully qualified domain name: " + fqdn);
       }
     }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DataNode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DataNode.java
@@ -60,8 +60,9 @@ class DataNode extends DataNodeId {
     this.clusterMapConfig = clusterMapConfig;
     this.sslEnabledDataCenters = Utils.splitString(clusterMapConfig.clusterMapSslEnabledDatacenters, ",");
 
-    this.hostname = clusterMapConfig.clusterMapResolveHostnames ? 
-            getFullyQualifiedDomainName(jsonObject.getString("hostname")) : jsonObject.getString("hostname"); 
+    this.hostname =
+        clusterMapConfig.clusterMapResolveHostnames ? getFullyQualifiedDomainName(jsonObject.getString("hostname"))
+            : jsonObject.getString("hostname");
     this.portNum = jsonObject.getInt("port");
     try {
       ResourceStatePolicyFactory resourceStatePolicyFactory =
@@ -209,7 +210,7 @@ class DataNode extends DataNodeId {
       String fqdn = getFullyQualifiedDomainName(hostname);
       if (!fqdn.equals(hostname)) {
         throw new IllegalStateException(
-                "Hostname for DataNode (" + hostname + ") does not match its fully qualified domain name: " + fqdn + ".");
+            "Hostname for DataNode (" + hostname + ") does not match its fully qualified domain name: " + fqdn + ".");
       }
     }
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HardwareLayout.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HardwareLayout.java
@@ -204,8 +204,8 @@ class HardwareLayout {
    * @return DataNode or null if not found.
    */
   public DataNode findDataNode(String hostname, int port) {
-    String canonicalHostname = clusterMapConfig.clusterMapResolveHostnames ? 
-            ClusterMapUtils.getFullyQualifiedDomainName(hostname) : hostname;
+    String canonicalHostname =
+        clusterMapConfig.clusterMapResolveHostnames ? ClusterMapUtils.getFullyQualifiedDomainName(hostname) : hostname;
     logger.trace("host to find host {} port {}", canonicalHostname, port);
     for (Datacenter datacenter : datacenters) {
       logger.trace("datacenter {}", datacenter.getName());

--- a/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
@@ -146,8 +146,7 @@ public class AccountUpdateToolTest {
   public void testCreateAccount() throws Exception {
     assertEquals("Wrong number of accounts", 0, accountService.getAllAccounts().size());
     createOrUpdateAccountsAndWait(idToRefAccountMap.values());
-    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT,
-        accountService);
+    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT, accountService);
   }
 
   /**
@@ -158,8 +157,7 @@ public class AccountUpdateToolTest {
   public void testUpdateAccount() throws Exception {
     // first, create NUM_REF_ACCOUNT accounts through the tool
     createOrUpdateAccountsAndWait(idToRefAccountMap.values());
-    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT,
-        accountService);
+    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT, accountService);
 
     // then, update the name of all the accounts again through the tool
     String accountNameAppendix = "-accountNameAppendix";

--- a/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
@@ -245,6 +245,7 @@ public class AccountUpdateToolTest {
   private static void writeAccountsToFile(Collection<Account> accounts, String filePath) throws Exception {
     JSONArray accountArray = new JSONArray();
     for (Account account : accounts) {
+      // AccountUpdateTool will re-serialize, so we do not want the snapshot version to be incremented twice.
       accountArray.put(account.toJson(false));
     }
     writeJsonArrayToFile(accountArray, filePath);

--- a/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
@@ -146,7 +146,8 @@ public class AccountUpdateToolTest {
   public void testCreateAccount() throws Exception {
     assertEquals("Wrong number of accounts", 0, accountService.getAllAccounts().size());
     createOrUpdateAccountsAndWait(idToRefAccountMap.values());
-    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT, accountService);
+    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT,
+        accountService);
   }
 
   /**
@@ -157,14 +158,15 @@ public class AccountUpdateToolTest {
   public void testUpdateAccount() throws Exception {
     // first, create NUM_REF_ACCOUNT accounts through the tool
     createOrUpdateAccountsAndWait(idToRefAccountMap.values());
-    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT, accountService);
+    assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT,
+        accountService);
 
     // then, update the name of all the accounts again through the tool
     String accountNameAppendix = "-accountNameAppendix";
     String containerNameAppendix = "-containerNameAppendix";
     Collection<Account> updatedAccounts = new ArrayList<>();
     for (Account account : accountService.getAllAccounts()) {
-      AccountBuilder accountBuilder = new AccountBuilder(account).setName(account.getName() + accountNameAppendix);
+      AccountBuilder accountBuilder = new AccountBuilder(account).name(account.getName() + accountNameAppendix);
       for (Container container : account.getAllContainers()) {
         accountBuilder.addOrUpdateContainer(
             new ContainerBuilder(container).setName(container.getName() + containerNameAppendix).build());
@@ -183,10 +185,8 @@ public class AccountUpdateToolTest {
   public void testUpdateConflictAccounts() throws Exception {
     Collection<Account> idConflictAccounts = new ArrayList<>();
     // id conflict
-    idConflictAccounts.add(new AccountBuilder((short) 1, "account1", Account.AccountStatus.INACTIVE, null).build());
-    idConflictAccounts.add(new AccountBuilder((short) 1, "account2", Account.AccountStatus.INACTIVE, null).build());
-    TestUtils.assertException(IllegalArgumentException.class, () -> createOrUpdateAccountsAndWait(idConflictAccounts),
-        null);
+    idConflictAccounts.add(new AccountBuilder((short) 1, "account1", Account.AccountStatus.INACTIVE).build());
+    idConflictAccounts.add(new AccountBuilder((short) 1, "account2", Account.AccountStatus.INACTIVE).build());
     TestUtils.assertException(IllegalArgumentException.class, () -> createOrUpdateAccountsAndWait(idConflictAccounts),
         null);
     Thread.sleep(100);
@@ -194,10 +194,8 @@ public class AccountUpdateToolTest {
 
     // name conflict
     Collection<Account> nameConflictAccounts = new ArrayList<>();
-    nameConflictAccounts.add(new AccountBuilder((short) 1, "account1", Account.AccountStatus.INACTIVE, null).build());
-    nameConflictAccounts.add(new AccountBuilder((short) 2, "account1", Account.AccountStatus.INACTIVE, null).build());
-    TestUtils.assertException(IllegalArgumentException.class, () -> createOrUpdateAccountsAndWait(nameConflictAccounts),
-        null);
+    nameConflictAccounts.add(new AccountBuilder((short) 1, "account1", Account.AccountStatus.INACTIVE).build());
+    nameConflictAccounts.add(new AccountBuilder((short) 2, "account1", Account.AccountStatus.INACTIVE).build());
     TestUtils.assertException(IllegalArgumentException.class, () -> createOrUpdateAccountsAndWait(nameConflictAccounts),
         null);
     Thread.sleep(100);
@@ -247,7 +245,7 @@ public class AccountUpdateToolTest {
   private static void writeAccountsToFile(Collection<Account> accounts, String filePath) throws Exception {
     JSONArray accountArray = new JSONArray();
     for (Account account : accounts) {
-      accountArray.put(account.toJson());
+      accountArray.put(account.toJson(false));
     }
     writeJsonArrayToFile(accountArray, filePath);
   }

--- a/ambry-tools/src/main/java/com.github.ambry/account/ServiceIdAccountGenTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/account/ServiceIdAccountGenTool.java
@@ -87,7 +87,7 @@ public class ServiceIdAccountGenTool {
           new ContainerBuilder(Container.DEFAULT_PUBLIC_CONTAINER).setParentAccountId(curAccountId).build();
       Container defaultPrivateContainer =
           new ContainerBuilder(Container.DEFAULT_PRIVATE_CONTAINER).setParentAccountId(curAccountId).build();
-      Account account = new AccountBuilder(curAccountId, serviceId, Account.AccountStatus.ACTIVE,
+      Account account = new AccountBuilder(curAccountId, serviceId, Account.AccountStatus.ACTIVE).containers(
           Arrays.asList(defaultPublicContainer, defaultPrivateContainer)).build();
       accounts.put(account.toJson());
       curAccountId++;

--- a/ambry-tools/src/main/java/com.github.ambry/account/ServiceIdAccountGenTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/account/ServiceIdAccountGenTool.java
@@ -89,7 +89,7 @@ public class ServiceIdAccountGenTool {
           new ContainerBuilder(Container.DEFAULT_PRIVATE_CONTAINER).setParentAccountId(curAccountId).build();
       Account account = new AccountBuilder(curAccountId, serviceId, Account.AccountStatus.ACTIVE).containers(
           Arrays.asList(defaultPublicContainer, defaultPrivateContainer)).build();
-      accounts.put(account.toJson());
+      accounts.put(account.toJson(true));
       curAccountId++;
     }
     Utils.writeJsonArrayToFile(accounts, outputFile);

--- a/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
@@ -82,13 +82,13 @@ public final class ToolUtils {
    * @param properties the {@link Properties} that need to be updated
    */
   public static void addClusterMapProperties(Properties properties) {
-    if(properties.getProperty("clustermap.cluster.name") == null) {
+    if (properties.getProperty("clustermap.cluster.name") == null) {
       properties.setProperty("clustermap.cluster.name", "dev");
     }
-    if(properties.getProperty("clustermap.datacenter.name") == null) {
+    if (properties.getProperty("clustermap.datacenter.name") == null) {
       properties.setProperty("clustermap.datacenter.name", "DataCenter");
     }
-    if(properties.getProperty("clustermap.host.name") == null) {
+    if (properties.getProperty("clustermap.host.name") == null) {
       properties.setProperty("clustermap.host.name", "localhost");
     }
   }


### PR DESCRIPTION
- Add snapshot versioning to accounts. If the snapshot version in
  zookeeper does not match the expected value provided, the update will
  fail.
- Add simple backups on updateAccount calls. This will persist the state
  of the account map that was previously in zookeeper and the accounts
  that were updated.