### PR TITLE
Adding encrypted info in the BlobId flag

### DIFF
--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -568,8 +568,8 @@ public class BlobId extends StoreKey {
           break;
         case BLOB_ID_V3:
           byte blobIdFlag = stream.readByte();
-          type = BlobIdType.values()[blobIdFlag & 0x3];
-          isEncrypted = (blobIdFlag & 0x4) != 0;
+          type = BlobIdType.values()[blobIdFlag & BLOBID_TYPE_MASK];
+          isEncrypted = (blobIdFlag & IS_ENCRYPTED_MASK) != 0;
           datacenterId = stream.readByte();
           accountId = stream.readShort();
           containerId = stream.readShort();

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -117,22 +117,6 @@ public class BlobId extends StoreKey {
    * @param accountId The id of the {@link Account} to be embedded into the blob. Only relevant for V2 and above.
    * @param containerId The id of the {@link Container} to be embedded into the blob. Only relevant for V2 and above.
    * @param partitionId The partition where this blob is to be stored. Cannot be {@code null}.
-   */
-  public BlobId(short version, BlobIdType type, byte datacenterId, short accountId, short containerId,
-      PartitionId partitionId) {
-    this(version, type, datacenterId, accountId, containerId, partitionId, false, UUID.randomUUID().toString());
-  }
-
-  /**
-   * Constructs a new BlobId by taking arguments for the required fields.
-   * Not all the fields in the constructor may be used in constructing it. The current active version determines what
-   * fields will be used.
-   * @param version the version in which this blob should be created.
-   * @param type The {@link BlobIdType} of the blob to be created. Only relevant for V3 and above.
-   * @param datacenterId The id of the datacenter to be embedded into the blob. Only relevant for V2 and above.
-   * @param accountId The id of the {@link Account} to be embedded into the blob. Only relevant for V2 and above.
-   * @param containerId The id of the {@link Container} to be embedded into the blob. Only relevant for V2 and above.
-   * @param partitionId The partition where this blob is to be stored. Cannot be {@code null}.
    * @param isEncrypted {@code true} if blob that this blobId represents is encrypted. {@code false} otherwise
    */
   public BlobId(short version, BlobIdType type, byte datacenterId, short accountId, short containerId,

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -75,6 +75,13 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
  * | version | flag  | datacenterId | accountId | containerId | partitionId | uuidSize | uuid     |
  * | (short) | (byte)| (byte)       | (short)   | (short)     | (n bytes)   | (int)    | (n bytes)|
  * +---------+----------------------+-----------+-------------+-------------+----------+----------+
+ *
+ * Flag format: 1 Byte
+ * +--------------+-------------+---------------+
+ * |  1 to 5 bits |    6th bit  | 7 and 8th bit |
+ * |  un-assigned | IsEncrypted |  BlobIdType   |
+ * +--------------+-------------+---------------+
+ *
  * </pre>
  */
 
@@ -88,6 +95,8 @@ public class BlobId extends StoreKey {
   private static final short DATACENTER_ID_FIELD_LENGTH_IN_BYTES = Byte.BYTES;
   private static final short ACCOUNT_ID_FIELD_LENGTH_IN_BYTES = Short.BYTES;
   private static final short CONTAINER_ID_FIELD_LENGTH_IN_BYTES = Short.BYTES;
+  private static final int BLOBID_TYPE_MASK = 0x3;
+  private static final int IS_ENCRYPTED_MASK = 0x4;
 
   private final short version;
   private final BlobIdType type;
@@ -301,7 +310,7 @@ public class BlobId extends StoreKey {
   }
 
   /**
-   * @return {@code true} if the blob that this id presents is encrypted. {@code false} otherwise
+   * @return {@code true} if the blob that this id represents is encrypted. {@code false} otherwise
    */
   public boolean isEncrypted() {
     return isEncrypted;
@@ -323,8 +332,8 @@ public class BlobId extends StoreKey {
         break;
       case BLOB_ID_V2:
       case BLOB_ID_V3:
-        byte flag = (byte) (type.ordinal() & 0x3);
-        flag = isEncrypted ? (byte) (flag | 0x4) : flag;
+        byte flag = (byte) (type.ordinal() & BLOBID_TYPE_MASK);
+        flag |= isEncrypted ? IS_ENCRYPTED_MASK : 0;
         idBuf.put(flag);
         idBuf.put(datacenterId);
         idBuf.putShort(accountId);

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -95,7 +95,7 @@ public class BlobId extends StoreKey {
   private static final short DATACENTER_ID_FIELD_LENGTH_IN_BYTES = Byte.BYTES;
   private static final short ACCOUNT_ID_FIELD_LENGTH_IN_BYTES = Short.BYTES;
   private static final short CONTAINER_ID_FIELD_LENGTH_IN_BYTES = Short.BYTES;
-  private static final int BLOBID_TYPE_MASK = 0x3;
+  private static final int BLOB_ID_TYPE_MASK = 0x3;
   private static final int IS_ENCRYPTED_MASK = 0x4;
 
   private final short version;
@@ -332,7 +332,7 @@ public class BlobId extends StoreKey {
         break;
       case BLOB_ID_V2:
       case BLOB_ID_V3:
-        byte flag = (byte) (type.ordinal() & BLOBID_TYPE_MASK);
+        byte flag = (byte) (type.ordinal() & BLOB_ID_TYPE_MASK);
         flag |= isEncrypted ? IS_ENCRYPTED_MASK : 0;
         idBuf.put(flag);
         idBuf.put(datacenterId);
@@ -568,7 +568,7 @@ public class BlobId extends StoreKey {
           break;
         case BLOB_ID_V3:
           byte blobIdFlag = stream.readByte();
-          type = BlobIdType.values()[blobIdFlag & BLOBID_TYPE_MASK];
+          type = BlobIdType.values()[blobIdFlag & BLOB_ID_TYPE_MASK];
           isEncrypted = (blobIdFlag & IS_ENCRYPTED_MASK) != 0;
           datacenterId = stream.readByte();
           accountId = stream.readShort();

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -210,13 +210,13 @@ public class BlobIdTest {
     BlobId inputs[];
     if (version >= BLOB_ID_V3) {
       inputs = new BlobId[]{new BlobId(version, BlobIdType.NATIVE, referenceDatacenterId, referenceAccountId,
-          referenceContainerId, referencePartitionId), new BlobId(version, BlobIdType.CRAFTED, referenceDatacenterId,
-          referenceAccountId, referenceContainerId, referencePartitionId)};
+          referenceContainerId, referencePartitionId, false), new BlobId(version, BlobIdType.CRAFTED,
+          referenceDatacenterId, referenceAccountId, referenceContainerId, referencePartitionId, false)};
       assertFalse("isCrafted() should be false for native id", BlobId.isCrafted(inputs[0].getID()));
       assertTrue("isCrafted() should be true for crafted id", BlobId.isCrafted(inputs[1].getID()));
     } else {
       inputs = new BlobId[]{new BlobId(version, referenceType, referenceDatacenterId, referenceAccountId,
-          referenceContainerId, referencePartitionId)};
+          referenceContainerId, referencePartitionId, false)};
       assertFalse("isCrafted() should be false for ids below BLOB_ID_V3", BlobId.isCrafted(inputs[0].getID()));
     }
     short newAccountId = (short) (referenceAccountId + 1 + TestUtils.RANDOM.nextInt(100));

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -122,10 +122,10 @@ public class BlobIdTest {
    */
   @Test
   public void testBlobIdFlag() throws Exception {
-    boolean[] isEncrytpedValues = {true, false};
+    boolean[] isEncryptedValues = {true, false};
     if (version >= BLOB_ID_V3) {
       for (BlobIdType type : BlobIdType.values()) {
-        for (boolean isEncrypted : isEncrytpedValues) {
+        for (boolean isEncrypted : isEncryptedValues) {
           BlobId blobId = new BlobId(BLOB_ID_V3, type, referenceDatacenterId, referenceAccountId, referenceContainerId,
               referencePartitionId, isEncrypted);
           BlobId blobIdSerDed =

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -131,7 +131,7 @@ public class BlobIdTest {
           BlobId blobIdSerDed =
               new BlobId(new DataInputStream(new ByteArrayInputStream(blobId.toBytes())), referenceClusterMap);
           assertEquals("The type should match the original's type", type, blobIdSerDed.getType());
-          assertEquals("The isEcnrypted should match the original", isEncrypted, blobIdSerDed.isEncrypted());
+          assertEquals("The isEncrypted should match the original", isEncrypted, blobIdSerDed.isEncrypted());
         }
       }
     }
@@ -438,14 +438,14 @@ public class BlobIdTest {
         assertEquals("Wrong account id in blobId: " + blobId, Account.UNKNOWN_ACCOUNT_ID, blobId.getAccountId());
         assertEquals("Wrong container id in blobId: " + blobId, Container.UNKNOWN_CONTAINER_ID,
             blobId.getContainerId());
-        assertEquals("Wrong isEncrypted value in blobId: " + blobId, false, blobId.isEncrypted());
+        assertFalse("Wrong isEncrypted value in blobId: " + blobId, blobId.isEncrypted());
         break;
       case BLOB_ID_V2:
         assertEquals("Wrong type in blobId: " + blobId, BlobIdType.NATIVE, blobId.getType());
         assertEquals("Wrong datacenter id in blobId: " + blobId, datacenterId, blobId.getDatacenterId());
         assertEquals("Wrong account id in blobId: " + blobId, accountId, blobId.getAccountId());
         assertEquals("Wrong container id in blobId: " + blobId, containerId, blobId.getContainerId());
-        assertEquals("Wrong isEncrypted value id in blobId: " + blobId, false, blobId.isEncrypted());
+        assertFalse("Wrong isEncrypted value id in blobId: " + blobId, blobId.isEncrypted());
         break;
       case BLOB_ID_V3:
         assertEquals("Wrong type in blobId: " + blobId, type, blobId.getType());

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -56,6 +56,7 @@ public class BlobIdTest {
   private final short referenceContainerId;
   private final ClusterMap referenceClusterMap;
   private final PartitionId referencePartitionId;
+  private final boolean referenceIsEncrypted;
 
   /**
    * Running for both {@link BlobId#BLOB_ID_V1} and {@link BlobId#BLOB_ID_V2}
@@ -81,6 +82,7 @@ public class BlobIdTest {
     referenceAccountId = getRandomShort(random);
     referenceContainerId = getRandomShort(random);
     referencePartitionId = referenceClusterMap.getWritablePartitionIds().get(0);
+    referenceIsEncrypted = random.nextBoolean();
   }
 
   /**
@@ -89,10 +91,10 @@ public class BlobIdTest {
   @Test
   public void testBuildBlobId() throws Exception {
     BlobId blobId = new BlobId(version, referenceType, referenceDatacenterId, referenceAccountId, referenceContainerId,
-        referencePartitionId);
+        referencePartitionId, referenceIsEncrypted);
     assertEquals("Wrong blobId version", version, getVersionFromBlobString(blobId.getID()));
     assertBlobIdFieldValues(version, blobId, referenceType, referenceDatacenterId, referenceAccountId,
-        referenceContainerId, referencePartitionId);
+        referenceContainerId, referencePartitionId, referenceIsEncrypted);
   }
 
   /**
@@ -102,7 +104,7 @@ public class BlobIdTest {
   @Test
   public void testSerDes() throws Exception {
     BlobId blobId = new BlobId(version, referenceType, referenceDatacenterId, referenceAccountId, referenceContainerId,
-        referencePartitionId);
+        referencePartitionId, referenceIsEncrypted);
     deserializeBlobIdAndAssert(version, blobId.getID());
     BlobId blobIdSerDed =
         new BlobId(new DataInputStream(new ByteArrayInputStream(blobId.toBytes())), referenceClusterMap);
@@ -115,18 +117,22 @@ public class BlobIdTest {
   }
 
   /**
-   * Test that the {@link BlobIdType} is honored by V3 and above.
+   * Test that the BlobId flag is honored by V3 and above.
    * @throws Exception
    */
   @Test
-  public void testBlobIdType() throws Exception {
+  public void testBlobIdFlag() throws Exception {
+    boolean[] isEncrytpedValues = {true, false};
     if (version >= BLOB_ID_V3) {
       for (BlobIdType type : BlobIdType.values()) {
-        BlobId blobId = new BlobId(BLOB_ID_V3, type, referenceDatacenterId, referenceAccountId, referenceContainerId,
-            referencePartitionId);
-        BlobId blobIdSerDed =
-            new BlobId(new DataInputStream(new ByteArrayInputStream(blobId.toBytes())), referenceClusterMap);
-        assertEquals("The type should match the original's type", type, blobIdSerDed.getType());
+        for (boolean isEncrypted : isEncrytpedValues) {
+          BlobId blobId = new BlobId(BLOB_ID_V3, type, referenceDatacenterId, referenceAccountId, referenceContainerId,
+              referencePartitionId, isEncrypted);
+          BlobId blobIdSerDed =
+              new BlobId(new DataInputStream(new ByteArrayInputStream(blobId.toBytes())), referenceClusterMap);
+          assertEquals("The type should match the original's type", type, blobIdSerDed.getType());
+          assertEquals("The isEcnrypted should match the original", isEncrypted, blobIdSerDed.isEncrypted());
+        }
       }
     }
   }
@@ -389,7 +395,7 @@ public class BlobIdTest {
       assertEquals("Wrong base-64 ID in blobId: " + blobId, srcBlobIdStr, blobId.getID());
       assertEquals("Wrong blobId version", version, getVersionFromBlobString(blobId.getID()));
       assertBlobIdFieldValues(version, blobId, referenceType, referenceDatacenterId, referenceAccountId,
-          referenceContainerId, referencePartitionId);
+          referenceContainerId, referencePartitionId, referenceIsEncrypted);
     }
   }
 
@@ -418,10 +424,11 @@ public class BlobIdTest {
    *                    expected value will become {@link Container#UNKNOWN_CONTAINER_ID}. For v2, {@code null} will make
    *                    the assertion against {@link Container#UNKNOWN_CONTAINER_ID}.
    * @param partitionId The expected partitionId.
+   * @param isEncrypted {@code true} expected {@code isEncrypted}. This will be of no effect if version is set to v1 and v2.
    * @throws Exception Any unexpected exception.
    */
   private void assertBlobIdFieldValues(short version, BlobId blobId, BlobIdType type, byte datacenterId,
-      short accountId, short containerId, PartitionId partitionId) throws Exception {
+      short accountId, short containerId, PartitionId partitionId, boolean isEncrypted) throws Exception {
     assertTrue("Used unrecognized version", Arrays.asList(BlobId.getAllValidVersions()).contains(version));
     assertEquals("Wrong partition id in blobId: " + blobId, partitionId, blobId.getPartition());
     switch (version) {
@@ -431,18 +438,21 @@ public class BlobIdTest {
         assertEquals("Wrong account id in blobId: " + blobId, Account.UNKNOWN_ACCOUNT_ID, blobId.getAccountId());
         assertEquals("Wrong container id in blobId: " + blobId, Container.UNKNOWN_CONTAINER_ID,
             blobId.getContainerId());
+        assertEquals("Wrong isEncrypted value in blobId: " + blobId, false, blobId.isEncrypted());
         break;
       case BLOB_ID_V2:
         assertEquals("Wrong type in blobId: " + blobId, BlobIdType.NATIVE, blobId.getType());
         assertEquals("Wrong datacenter id in blobId: " + blobId, datacenterId, blobId.getDatacenterId());
         assertEquals("Wrong account id in blobId: " + blobId, accountId, blobId.getAccountId());
         assertEquals("Wrong container id in blobId: " + blobId, containerId, blobId.getContainerId());
+        assertEquals("Wrong isEncrypted value id in blobId: " + blobId, false, blobId.isEncrypted());
         break;
       case BLOB_ID_V3:
         assertEquals("Wrong type in blobId: " + blobId, type, blobId.getType());
         assertEquals("Wrong datacenter id in blobId: " + blobId, datacenterId, blobId.getDatacenterId());
         assertEquals("Wrong account id in blobId: " + blobId, accountId, blobId.getAccountId());
         assertEquals("Wrong container id in blobId: " + blobId, containerId, blobId.getContainerId());
+        assertEquals("Wrong isEncrypted value in blobId: " + blobId, isEncrypted, blobId.isEncrypted());
         break;
       default:
         fail("Unrecognized version");
@@ -484,6 +494,7 @@ public class BlobIdTest {
     short containerId = getRandomShort(random);
     BlobIdType type = random.nextBoolean() ? BlobIdType.NATIVE : BlobIdType.CRAFTED;
     PartitionId partitionId = referenceClusterMap.getWritablePartitionIds().get(random.nextInt(3));
-    return new BlobId(version, type, datacenterId, accountId, containerId, partitionId);
+    boolean isEncrypted = random.nextBoolean();
+    return new BlobId(version, type, datacenterId, accountId, containerId, partitionId, isEncrypted);
   }
 }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -157,7 +157,7 @@ public class AmbryBlobStorageServiceTest {
     router = new InMemoryRouter(verifiableProperties, clusterMap);
     responseHandler = new FrontendTestResponseHandler();
     referenceBlobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-        Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0));
+        Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0), false);
     referenceBlobIdStr = referenceBlobId.getID();
     ambryBlobStorageService = getAmbryBlobStorageService();
     responseHandler.start();
@@ -484,49 +484,49 @@ public class AmbryBlobStorageServiceTest {
       // aid=refAId, cid=refCId
       String blobId =
           new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
-              refContainer.getId(), clusterMap.getWritablePartitionIds().get(0)).getID();
+              refContainer.getId(), clusterMap.getWritablePartitionIds().get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, refAccount, refContainer, RestServiceErrorCode.NotFound);
 
       // aid=refAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
-          Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0)).getID();
+          Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=refAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
-          (short) -1234, clusterMap.getWritablePartitionIds().get(0)).getID();
+          (short) -1234, clusterMap.getWritablePartitionIds().get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=unknownAId, cid=refCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, refContainer.getId(), clusterMap.getWritablePartitionIds().get(0)).getID();
+          Account.UNKNOWN_ACCOUNT_ID, refContainer.getId(), clusterMap.getWritablePartitionIds().get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=unknownAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-          clusterMap.getWritablePartitionIds().get(0)).getID();
+          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0),
+          false).getID();
       verifyAccountAndContainerFromBlobId(blobId, Account.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
           RestServiceErrorCode.NotFound);
 
       // aid=unknownAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, (short) -1234, clusterMap.getWritablePartitionIds().get(0)).getID();
+          Account.UNKNOWN_ACCOUNT_ID, (short) -1234, clusterMap.getWritablePartitionIds().get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=nonExistAId, cid=refCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
-          refContainer.getId(), clusterMap.getWritablePartitionIds().get(0)).getID();
+          refContainer.getId(), clusterMap.getWritablePartitionIds().get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
 
       // aid=nonExistAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
-          Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0)).getID();
+          Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
 
       // aid=nonExistAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
-          (short) -11, clusterMap.getWritablePartitionIds().get(0)).getID();
+          (short) -11, clusterMap.getWritablePartitionIds().get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
     }
   }
@@ -547,7 +547,7 @@ public class AmbryBlobStorageServiceTest {
     // it does not matter what AID and CID are supplied when constructing blobId in v1.
     // expect unknown account and container for v1 blob IDs that went through request processing only.
     String blobId = new BlobId(BlobId.BLOB_ID_V1, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-        refAccount.getId(), refContainer.getId(), clusterMap.getWritablePartitionIds().get(0)).getID();
+        refAccount.getId(), refContainer.getId(), clusterMap.getWritablePartitionIds().get(0), false).getID();
     verifyAccountAndContainerFromBlobId(blobId, Account.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
         RestServiceErrorCode.NotFound);
 
@@ -782,7 +782,7 @@ public class AmbryBlobStorageServiceTest {
     for (PartitionId partitionId : partitionIds) {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partitionId);
+          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partitionId, false);
       RestRequest restRequest =
           createRestRequest(RestMethod.GET, blobId.getID() + "/" + RestUtils.SubResource.Replicas, null, null);
       MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
@@ -1615,7 +1615,7 @@ public class AmbryBlobStorageServiceTest {
         contents.add(null);
       }
       String blobIdStr = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, (byte) -1, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, clusterMap.getAllPartitionIds().get(0)).getID();
+          Container.UNKNOWN_CONTAINER_ID, clusterMap.getAllPartitionIds().get(0), false).getID();
       try {
         doOperation(createRestRequest(restMethod, blobIdStr, headers, contents), new MockRestResponseChannel());
         fail("Operation " + restMethod

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -281,7 +281,7 @@ public class FrontendIntegrationTest {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-          partitionId);
+          partitionId, false);
       FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
           blobId.getID() + "/" + RestUtils.SubResource.Replicas, Unpooled.buffer(0));
       Queue<HttpObject> responseParts = nettyClient.sendRequest(httpRequest, null, null).get();

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetReplicasHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetReplicasHandlerTest.java
@@ -68,7 +68,7 @@ public class GetReplicasHandlerTest {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-          partitionId);
+          partitionId, false);
       MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
       ReadableStreamChannel channel = getReplicasHandler.getReplicas(blobId.getID(), restResponseChannel);
       assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getStatus());

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
@@ -97,7 +97,7 @@ public class GetSignedUrlHandlerTest {
 
     BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, REF_ACCOUNT.getId(), REF_CONTAINER.getId(),
-        CLUSTER_MAP.getWritablePartitionIds().get(0));
+        CLUSTER_MAP.getWritablePartitionIds().get(0), false);
     idConverterFactory.translation = blobId.getID();
     // GET (also makes sure that the IDConverter is used)
     restRequest = new MockRestRequest(MockRestRequest.DUMMY_DATA, null);

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/MessageInfoAndMetadataListSerDeTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/MessageInfoAndMetadataListSerDeTest.java
@@ -61,12 +61,12 @@ public class MessageInfoAndMetadataListSerDeTest {
     short[] containerIds = {10, 11, 12, 13};
     StoreKey[] keys =
         {new BlobId(TestUtils.getRandomElement(BlobId.getAllValidVersions()), BlobId.BlobIdType.NATIVE, (byte) 0,
-            accountIds[0], containerIds[0], partitionId), new BlobId(
+            accountIds[0], containerIds[0], partitionId, false), new BlobId(
             TestUtils.getRandomElement(BlobId.getAllValidVersions()), BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[1],
-            containerIds[1], partitionId), new BlobId(TestUtils.getRandomElement(BlobId.getAllValidVersions()),
-            BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[2], containerIds[2], partitionId), new BlobId(
+            containerIds[1], partitionId, false), new BlobId(TestUtils.getRandomElement(BlobId.getAllValidVersions()),
+            BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[2], containerIds[2], partitionId, false), new BlobId(
             TestUtils.getRandomElement(BlobId.getAllValidVersions()), BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[3],
-            containerIds[3], partitionId)};
+            containerIds[3], partitionId, false)};
     long[] blobSizes = {1024, 2048, 4096, 8192};
     long[] operationTimes = {SystemTime.getInstance().milliseconds(),
         SystemTime.getInstance().milliseconds() + 10,

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -220,7 +220,7 @@ public class RequestResponseTest {
     String clientId = "client";
     BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM), clusterMap.getWritablePartitionIds().get(0));
+        Utils.getRandomShort(TestUtils.RANDOM), clusterMap.getWritablePartitionIds().get(0), false);
     byte[] userMetadata = new byte[50];
     TestUtils.RANDOM.nextBytes(userMetadata);
     int blobKeyLength = TestUtils.RANDOM.nextInt(4096);
@@ -282,7 +282,8 @@ public class RequestResponseTest {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds().get(0));
+        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds().get(0),
+        false);
     ArrayList<BlobId> blobIdList = new ArrayList<BlobId>();
     blobIdList.add(id1);
     PartitionRequestInfo partitionRequestInfo1 = new PartitionRequestInfo(new MockPartitionId(), blobIdList);
@@ -349,7 +350,8 @@ public class RequestResponseTest {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds().get(0));
+        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds().get(0),
+        false);
     short[] versions = new short[]{DeleteRequest.DELETE_REQUEST_VERSION_1, DeleteRequest.DELETE_REQUEST_VERSION_2};
     for (short version : versions) {
       long deletionTimeMs = Utils.getRandomLong(TestUtils.RANDOM, Long.MAX_VALUE);
@@ -388,7 +390,8 @@ public class RequestResponseTest {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds().get(0));
+        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds().get(0),
+        false);
     List<ReplicaMetadataRequestInfo> replicaMetadataRequestInfoList = new ArrayList<ReplicaMetadataRequestInfo>();
     ReplicaMetadataRequestInfo replicaMetadataRequestInfo =
         new ReplicaMetadataRequestInfo(new MockPartitionId(), new MockFindToken(0, 1000), "localhost", "path");

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -325,7 +325,7 @@ public class ReplicationTest {
       // add an expired message to the remote host only
       StoreKey id =
           new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId,
-              containerId, partitionId);
+              containerId, partitionId, false);
       Pair<ByteBuffer, MessageInfo> putMsgInfo = getPutMessage(id, accountId, containerId);
       remoteHost.addMessage(partitionId,
           new MessageInfo(id, putMsgInfo.getFirst().remaining(), 1, accountId, containerId,
@@ -339,7 +339,7 @@ public class ReplicationTest {
       containerId = Utils.getRandomShort(TestUtils.RANDOM);
       // add a corrupt message to the remote host only
       id = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId,
-          containerId, partitionId);
+          containerId, partitionId, false);
       putMsgInfo = getPutMessage(id, accountId, containerId);
       byte[] data = putMsgInfo.getFirst().array();
       // flip every bit in the array
@@ -573,7 +573,7 @@ public class ReplicationTest {
       short containerId = Utils.getRandomShort(TestUtils.RANDOM);
       short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
       BlobId id = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId,
-          containerId, partitionId);
+          containerId, partitionId, false);
       ids.add(id);
       Pair<ByteBuffer, MessageInfo> putMsgInfo = getPutMessage(id, accountId, containerId);
       for (Host host : hosts) {

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -820,7 +820,7 @@ class PutOperation {
         partitionId = getPartitionForPut(attemptedPartitionIds);
         chunkBlobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
             clusterMap.getLocalDatacenterId(), passedInBlobProperties.getAccountId(),
-            passedInBlobProperties.getContainerId(), partitionId);
+            passedInBlobProperties.getContainerId(), partitionId, passedInBlobProperties.isEncrypted());
         chunkBlobProperties = new BlobProperties(chunkBlobSize, passedInBlobProperties.getServiceId(),
             passedInBlobProperties.getOwnerId(), passedInBlobProperties.getContentType(),
             passedInBlobProperties.isPrivate(), passedInBlobProperties.getTimeToLiveInSeconds(),

--- a/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
@@ -523,7 +523,7 @@ public class CryptoJobHandlerTest {
     byte dc = (byte) TestUtils.RANDOM.nextInt(3);
     BlobId.BlobIdType type = TestUtils.RANDOM.nextBoolean() ? BlobId.BlobIdType.NATIVE : BlobId.BlobIdType.CRAFTED;
     return new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), type, dc, getRandomShort(TestUtils.RANDOM),
-        getRandomShort(TestUtils.RANDOM), referenceClusterMap.getWritablePartitionIds().get(0));
+        getRandomShort(TestUtils.RANDOM), referenceClusterMap.getWritablePartitionIds().get(0), false);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -105,7 +105,7 @@ public class DeleteManagerTest {
     partition = mockPartitions.get(ThreadLocalRandom.current().nextInt(mockPartitions.size()));
     blobId =
         new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), partition);
+            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), partition, false);
     blobIdString = blobId.getID();
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -198,7 +198,7 @@ public class GetBlobInfoOperationTest {
   public void testInstantiation() throws Exception {
     String blobIdStr = (new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(random), Utils.getRandomShort(random),
-        mockClusterMap.getWritablePartitionIds().get(0))).getID();
+        mockClusterMap.getWritablePartitionIds().get(0), false)).getID();
     Callback<GetBlobResultInternal> getOperationCallback = (result, exception) -> {
       // no op.
     };

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -243,7 +243,7 @@ public class GetBlobOperationTest {
 
     blobIdStr = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         mockClusterMap.getLocalDatacenterId(), Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM), mockClusterMap.getWritablePartitionIds().get(0)).getID();
+        Utils.getRandomShort(TestUtils.RANDOM), mockClusterMap.getWritablePartitionIds().get(0), false).getID();
     // test a good case
     // operationCount is not incremented here as this operation is not taken to completion.
     GetBlobOperation op = new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobIdStr,

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
@@ -355,7 +355,7 @@ class InMemoryBlobPoster implements Runnable {
     try {
       String blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
           postData.getBlobProperties().getAccountId(), postData.getBlobProperties().getContainerId(),
-          getPartitionForPut()).getID();
+          getPartitionForPut(), false).getID();
       if (blobs.containsKey(blobId)) {
         exception = new RouterException("Blob ID duplicate created.", RouterErrorCode.UnexpectedInternalError);
       }

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
@@ -41,7 +41,8 @@ public class RouterUtilsTest {
     }
     partition = clusterMap.getWritablePartitionIds().get(0);
     originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        clusterMap.getLocalDatacenterId(), Utils.getRandomShort(random), Utils.getRandomShort(random), partition);
+        clusterMap.getLocalDatacenterId(), Utils.getRandomShort(random), Utils.getRandomShort(random), partition,
+        false);
     blobIdStr = originalBlobId.getID();
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
@@ -56,7 +56,7 @@ class DirectSender implements Runnable {
       int partitionIndex = new Random().nextInt(partitionIds.size());
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           clusterMap.getLocalDatacenterId(), blobProperties.getAccountId(), blobProperties.getContainerId(),
-          partitionIds.get(partitionIndex));
+          partitionIds.get(partitionIndex), false);
       blobIds.add(blobId);
     }
     this.data = data;

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -266,7 +266,7 @@ public class ServerHardDeleteTest {
     for (int i = 0; i < 9; i++) {
       blobIdList.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           mockClusterMap.getLocalDatacenterId(), properties.get(i).getAccountId(), properties.get(i).getContainerId(),
-          chosenPartition));
+          chosenPartition, false));
     }
 
     BlockingChannel channel =

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -116,13 +116,13 @@ public final class ServerTestUtil {
       List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
       short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
       BlobId blobId1 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0));
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false);
       BlobId blobId2 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0));
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false);
       BlobId blobId3 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0));
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false);
       BlobId blobId4 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0));
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false);
       // put blob 1
       PutRequest putRequest =
           new PutRequest(1, "client1", blobId1, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
@@ -334,7 +334,7 @@ public final class ServerTestUtil {
       ids = new ArrayList<BlobId>();
       partition = (MockPartitionId) clusterMap.getWritablePartitionIds().get(0);
       ids.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-          clusterMap.getLocalDatacenterId(), properties.getAccountId(), properties.getContainerId(), partition));
+          clusterMap.getLocalDatacenterId(), properties.getAccountId(), properties.getContainerId(), partition, false));
       partitionRequestInfoList.clear();
       partitionRequestInfo = new PartitionRequestInfo(partition, ids);
       partitionRequestInfoList.add(partitionRequestInfo);
@@ -1085,7 +1085,7 @@ public final class ServerTestUtil {
         short containerId = Utils.getRandomShort(TestUtils.RANDOM);
         propertyList.add(new BlobProperties(1000, "serviceid1", accountId, containerId, testEncryption));
         blobIdList.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-            clusterMap.getLocalDatacenterId(), accountId, containerId, partition));
+            clusterMap.getLocalDatacenterId(), accountId, containerId, partition, false));
         dataList.add(TestUtils.getRandomBytes(1000));
         if (testEncryption) {
           encryptionKeyList.add(TestUtils.getRandomBytes(128));
@@ -1315,7 +1315,7 @@ public final class ServerTestUtil {
       mockPartitionId = (MockPartitionId) clusterMap.getWritablePartitionIds().get(0);
       ids.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           clusterMap.getLocalDatacenterId(), propertyList.get(0).getAccountId(), propertyList.get(0).getContainerId(),
-          mockPartitionId));
+          mockPartitionId, false));
       partitionRequestInfoList.clear();
       partitionRequestInfo = new PartitionRequestInfo(mockPartitionId, ids);
       partitionRequestInfoList.add(partitionRequestInfo);

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -436,7 +436,7 @@ public class AmbryRequestsTest {
       String clientId = UtilsTest.getRandomString(10);
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-          Utils.getRandomShort(TestUtils.RANDOM), id);
+          Utils.getRandomShort(TestUtils.RANDOM), id, false);
       RequestOrResponse request;
       switch (requestType) {
         case PutRequest:

--- a/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
@@ -227,7 +227,7 @@ public class IndexWritePerformance {
           PartitionId partition = map.getWritablePartitionIds().get(0);
           indexesWithMetrics.get(indexToUse)
               .addToIndexRandomData(new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, map.getLocalDatacenterId(),
-                  Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partition));
+                  Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partition, false));
           throttler.maybeThrottle(1);
         }
       } catch (Exception e) {

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
@@ -161,7 +161,7 @@ public class DirectoryUploader {
         try {
           int replicaCount = 0;
           BlobId blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, datacenterId, props.getAccountId(),
-              props.getContainerId(), partitionId);
+              props.getContainerId(), partitionId, false);
           List<ReplicaId> successList = new ArrayList<>();
           List<ReplicaId> failureList = new ArrayList<>();
           for (ReplicaId replicaId : blobId.getPartition().getReplicaIds()) {

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
@@ -350,7 +350,7 @@ public class ServerWritePerformance {
             int index = (int) getRandomLong(rand, partitionIds.size());
             PartitionId partitionId = partitionIds.get(index);
             BlobId blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-                props.getAccountId(), props.getContainerId(), partitionId);
+                props.getAccountId(), props.getContainerId(), partitionId, false);
             PutRequest putRequest =
                 new PutRequest(0, "perf", blobId, props, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(blob),
                     props.getBlobSize(), BlobType.DataBlob, null);


### PR DESCRIPTION
This patch adds encrypted info in the flag in BlobId. Once this is merged, will work on https://github.com/linkedin/ambry/pull/816 to fix accordingly

Coding style applied
SLA: 10 mins
Reviewers: Casey