### PR TITLE
Treating one more exception message as a client disconnect

### DIFF
--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -73,6 +73,7 @@ public class Utils {
    */
   public static final int MAX_PORT_NUM = 65535;
   private static final String CLIENT_RESET_EXCEPTION_MSG = "Connection reset by peer";
+  private static final String CLIENT_BROKEN_PIPE_EXCEPTION_MSG = "Broken pipe";
   private static final Logger logger = LoggerFactory.getLogger(Utils.class);
 
   // The read*String methods assume that the underlying stream is blocking
@@ -833,7 +834,8 @@ public class Utils {
    * @return {@code true} this cause indicates a possible early termination from the client. {@code false} otherwise.
    */
   public static boolean isPossibleClientTermination(Throwable cause) {
-    return cause instanceof IOException && CLIENT_RESET_EXCEPTION_MSG.equals(cause.getMessage());
+    return cause instanceof IOException && (CLIENT_RESET_EXCEPTION_MSG.equals(cause.getMessage())
+        || CLIENT_BROKEN_PIPE_EXCEPTION_MSG.equals(cause.getMessage()));
   }
 
   /**

--- a/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
@@ -429,6 +429,9 @@ public class UtilsTest {
     Exception exception = new IOException("Connection reset by peer");
     assertTrue("Should be declared as a client termination", Utils.isPossibleClientTermination(exception));
 
+    exception = new IOException("Broken pipe");
+    assertTrue("Should be declared as a client termination", Utils.isPossibleClientTermination(exception));
+
     exception = new IOException("Connection not reset by peer");
     assertFalse("Should not be declared as a client termination", Utils.isPossibleClientTermination(exception));
     exception = Utils.convertToClientTerminationException(exception);


### PR DESCRIPTION
Intended to catch these exceptions at `NettyResponseChannel` and `RouterUtils`

```
DEBUG [NettyResponseChannel] [RequestResponseHandlerThread-0] [] Exception encountered after channel [] became inactive
java.io.IOException: Broken pipe
```

```
ERROR [RouterUtils] [RequestResponseHandlerThread-0] Router operation met with a system health error:
java.io.IOException: Broken pipe
```