### PR TITLE
Add REST support to get data chunk blob IDs of a composite blob.(#528)

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -217,7 +217,9 @@ public class RestUtils {
      * "replicas" here means the string representation of all the replicas (i.e. host:port/path) where the blob might
      * reside.
      */
-    Replicas
+    Replicas,
+
+    BlobChunkIds
   }
 
   public static final class MultipartPost {
@@ -418,9 +420,16 @@ public class RestUtils {
     if (subResource != null && rangeHeaderValue != null) {
       throw new RestServiceException("Ranges not supported for sub-resources.", RestServiceErrorCode.InvalidArgs);
     }
-    return new GetBlobOptionsBuilder().operationType(
-        subResource == null ? GetBlobOptions.OperationType.All : GetBlobOptions.OperationType.BlobInfo)
-        .getOption(getOption)
+    GetBlobOptions.OperationType operationType = null;
+    if (subResource == null) {
+      operationType = GetBlobOptions.OperationType.All;
+    } else if (subResource == SubResource.BlobChunkIds) {
+      // maybe operationtype data is good
+      operationType = GetBlobOptions.OperationType.BlobChunkIds;
+    } else {
+      operationType = GetBlobOptions.OperationType.BlobInfo;
+    }
+    return new GetBlobOptionsBuilder().operationType(operationType).getOption(getOption)
         .range(rangeHeaderValue != null ? RestUtils.buildByteRange(rangeHeaderValue) : null)
         .build();
   }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -219,6 +219,9 @@ public class RestUtils {
      */
     Replicas,
 
+    /**
+     * All Chunk IDs of a composite blob ID returned as content (Admin only).
+     */
     BlobChunkIds
   }
 
@@ -424,7 +427,7 @@ public class RestUtils {
     if (subResource == null) {
       operationType = GetBlobOptions.OperationType.All;
     } else if (subResource == SubResource.BlobChunkIds) {
-      // maybe operationtype data is good
+      // maybe operationtype.Data is better?
       operationType = GetBlobOptions.OperationType.BlobChunkIds;
     } else {
       operationType = GetBlobOptions.OperationType.BlobInfo;

--- a/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptions.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptions.java
@@ -109,6 +109,8 @@ public class GetBlobOptions {
     Data, /**
      * Return just the blob info in the response.
      */
-    BlobInfo;
+    BlobInfo,
+
+    BlobChunkIds
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/router/GetBlobResult.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/GetBlobResult.java
@@ -15,6 +15,8 @@
 package com.github.ambry.router;
 
 import com.github.ambry.messageformat.BlobInfo;
+import com.github.ambry.store.StoreKey;
+import java.util.List;
 
 
 /**
@@ -23,6 +25,7 @@ import com.github.ambry.messageformat.BlobInfo;
 public class GetBlobResult {
   private final BlobInfo blobInfo;
   private final ReadableStreamChannel blobDataChannel;
+  private final List<StoreKey> blobChunkIds;
 
   /**
    * Construct a {@link GetBlobResult}.
@@ -32,6 +35,13 @@ public class GetBlobResult {
   public GetBlobResult(BlobInfo blobInfo, ReadableStreamChannel blobDataChannel) {
     this.blobInfo = blobInfo;
     this.blobDataChannel = blobDataChannel;
+    this.blobChunkIds = null;
+  }
+
+  public GetBlobResult(BlobInfo blobInfo, ReadableStreamChannel blobDataChannel, List<StoreKey> blobChunkIds) {
+    this.blobInfo = blobInfo;
+    this.blobDataChannel = blobDataChannel;
+    this.blobChunkIds = blobChunkIds;
   }
 
   /**
@@ -46,5 +56,9 @@ public class GetBlobResult {
    */
   public ReadableStreamChannel getBlobDataChannel() {
     return blobDataChannel;
+  }
+
+  public List<StoreKey> getBlobChunkIds() {
+    return blobChunkIds;
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/router/GetBlobResult.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/GetBlobResult.java
@@ -30,6 +30,17 @@ public class GetBlobResult {
   /**
    * Construct a {@link GetBlobResult}.
    * @param blobInfo the {@link BlobInfo} for the blob, or {@code null}.
+   */
+
+  public GetBlobResult(BlobInfo blobInfo) {
+    this.blobInfo = blobInfo;
+    this.blobDataChannel = null;
+    this.blobChunkIds = null;
+  }
+
+  /**
+   * Construct a {@link GetBlobResult}.
+   * @param blobInfo the {@link BlobInfo} for the blob, or {@code null}.
    * @param blobDataChannel the {@link ReadableStreamChannel} containing the blob data, or {@code null}.
    */
   public GetBlobResult(BlobInfo blobInfo, ReadableStreamChannel blobDataChannel) {
@@ -38,9 +49,14 @@ public class GetBlobResult {
     this.blobChunkIds = null;
   }
 
-  public GetBlobResult(BlobInfo blobInfo, ReadableStreamChannel blobDataChannel, List<StoreKey> blobChunkIds) {
+  /**
+   * Construct a {@link GetBlobResult}.
+   * @param blobInfo the {@link BlobInfo} for the blob, or {@code null}.
+   * @param blobChunkIds Chunk ids of a composite blob, or {@code null}.
+   */
+  public GetBlobResult(BlobInfo blobInfo, List<StoreKey> blobChunkIds) {
     this.blobInfo = blobInfo;
-    this.blobDataChannel = blobDataChannel;
+    this.blobDataChannel = null;
     this.blobChunkIds = blobChunkIds;
   }
 

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -939,9 +939,15 @@ public class RestUtilsTest {
     doBuildGetBlobOptionsTestForSubResource(args, null, expectedRange, GetBlobOptions.OperationType.All,
         shouldSucceedWithoutSubResource);
     for (RestUtils.SubResource subResource : RestUtils.SubResource.values()) {
-      doBuildGetBlobOptionsTestForSubResource(args, subResource, expectedRange, GetBlobOptions.OperationType.BlobInfo,
-          shouldSucceedWithSubResource);
+      if (subResource == RestUtils.SubResource.BlobChunkIds) {
+        doBuildGetBlobOptionsTestForSubResource(args, subResource, expectedRange, GetBlobOptions.OperationType.BlobChunkIds,
+            shouldSucceedWithSubResource);
+      } else {
+        doBuildGetBlobOptionsTestForSubResource(args, subResource, expectedRange, GetBlobOptions.OperationType.BlobInfo,
+            shouldSucceedWithSubResource);
+      }
     }
+
   }
 
   /**

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -158,6 +158,7 @@ class AmbrySecurityService implements SecurityService {
                 }
                 setCacheHeaders(restRequest, responseChannel);
               } else {
+                // josn here? change
                 if (subResource.equals(RestUtils.SubResource.BlobInfo)) {
                   setBlobPropertiesHeaders(blobInfo.getBlobProperties(), responseChannel);
                   setAccountAndContainerHeaders(restRequest, responseChannel);

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -158,7 +158,6 @@ class AmbrySecurityService implements SecurityService {
                 }
                 setCacheHeaders(restRequest, responseChannel);
               } else {
-                // josn here? change
                 if (subResource.equals(RestUtils.SubResource.BlobInfo)) {
                   setBlobPropertiesHeaders(blobInfo.getBlobProperties(), responseChannel);
                   setAccountAndContainerHeaders(restRequest, responseChannel);

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/GetBlobChunkIdsHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/GetBlobChunkIdsHandler.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.frontend;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.commons.ByteBufferReadableStreamChannel;
+import com.github.ambry.rest.RestResponseChannel;
+import com.github.ambry.rest.RestServiceErrorCode;
+import com.github.ambry.rest.RestServiceException;
+import com.github.ambry.rest.RestUtils;
+import com.github.ambry.router.ReadableStreamChannel;
+import com.github.ambry.store.StoreKey;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Performs the {@link RestUtils.SubResource#Replicas} operation.
+ */
+class GetBlobChunkIdsHandler {
+  private final FrontendMetrics metrics;
+  private final ClusterMap clusterMap;
+  private final Logger logger = LoggerFactory.getLogger(GetBlobChunkIdsHandler.class);
+
+  /**
+   * Instantiate a handler to handle {@link RestUtils.SubResource#Replicas} operations.
+   * @param metrics the {@link FrontendMetrics} instance to use for metrics.
+   * @param clusterMap the {@link ClusterMap} to use to find the replicas of a blob ID.
+   */
+  GetBlobChunkIdsHandler(FrontendMetrics metrics, ClusterMap clusterMap) {
+    this.metrics = metrics;
+    this.clusterMap = clusterMap;
+  }
+
+  /**
+   * Handles {@link RestUtils.SubResource#Replicas} operations by obtaining the replicas of the blob ID from the cluster
+   * map and returning a serialized JSON object in the response.
+   * @param metaBlobId the blob id requested.
+   * @param blobChunkIds the blob chunk IDs of a composite blob.
+   * @param restResponseChannel the {@link RestResponseChannel} to set headers in.
+   * @return a {@link ReadableStreamChannel} that contains the getReplicas response.
+   * @throws RestServiceException if there was any problem constructing the response.
+   */
+  ReadableStreamChannel getBlobChunkIds(String metaBlobId, List<StoreKey> blobChunkIds, RestResponseChannel restResponseChannel)
+      throws RestServiceException {
+    logger.trace("Getting sub-blob keys of meatblob - ", metaBlobId);
+    long startTime = System.currentTimeMillis();
+    ReadableStreamChannel channel = null;
+    try {
+      byte[] subBlobKeysResponseBytes = getBlobChunkIds(metaBlobId, blobChunkIds).toString().getBytes();
+      restResponseChannel.setHeader(RestUtils.Headers.CONTENT_TYPE, "application/json");
+      restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, subBlobKeysResponseBytes.length);
+      channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(subBlobKeysResponseBytes));
+    } finally {
+      metrics.getReplicasProcessingTimeInMs.update(System.currentTimeMillis() - startTime);
+    }
+    return channel;
+  }
+
+  /**
+   * Extracts the blob ID provided by the client and figures out the partition that the blob ID would belong to
+   * based on the cluster map. Using the partition information, returns the list of replicas as a part of a JSONObject.
+   * @param blobChunkIds the blob chunk IDs of a composite blob.
+   * @return A {@link JSONObject} that wraps the replica list.
+   * @throws RestServiceException if there were missing or invalid arguments or if there was a {@link JSONException}
+   *                                or any other while building the response
+   */
+  private JSONObject getBlobChunkIds(String metaBlobId, List<StoreKey> blobChunkIds) throws RestServiceException {
+    try {
+      return packageResult(blobChunkIds);
+    } catch (IllegalArgumentException e) {
+      metrics.invalidBlobIdError.inc();
+      throw new RestServiceException("Invalid blobChunkIds for BlobChunkIds request - " + metaBlobId, e,
+          RestServiceErrorCode.NotFound);
+    } catch (JSONException e) {
+      metrics.responseConstructionError.inc();
+      throw new RestServiceException("Could not create response for GET of BlobChunkIds of " + metaBlobId, e,
+          RestServiceErrorCode.InternalServerError);
+    }
+  }
+
+  /**
+   * Packages the list of replicas into a {@link JSONObject}.
+   * @param blobChunkIds the list of chunk ids that need to packaged into a {@link JSONObject}.
+   * @return A {@link JSONObject} that wraps the replica list.
+   * @throws JSONException if there was an error building the {@link JSONObject}.
+   */
+  private static JSONObject packageResult(List<? extends StoreKey> blobChunkIds) throws JSONException {
+    JSONObject result = new JSONObject();
+    if (blobChunkIds != null) {
+      result.put("MetaBlob", true);
+      result.put("ChunkIds", blobChunkIds);
+    } else {
+      result.put("MetaBlob", false);
+    }
+    return result;
+  }
+}

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -2336,7 +2336,7 @@ class FrontendTestRouter implements Router {
       case BlobInfo:
         result = new GetBlobResult(new BlobInfo(
             new BlobProperties(0, "FrontendTestRouter", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-                false), new byte[0]), null);
+                false), new byte[0]));
         break;
       case Data:
         result = new GetBlobResult(null, new ByteBufferReadableStreamChannel(ByteBuffer.allocate(0)));

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -329,8 +329,7 @@ class GetBlobInfoOperation extends GetOperation {
     if (encryptionKey == null) {
       // if blob is not encrypted, move the state to Complete
       operationResult =
-          new GetBlobResultInternal(new GetBlobResult(new BlobInfo(serverBlobProperties, userMetadata.array()), null),
-              null);
+          new GetBlobResultInternal(new GetBlobResult(new BlobInfo(serverBlobProperties, userMetadata.array())), null);
     } else {
       // submit decrypt job
       progressTracker.initializeDecryptionTracker();
@@ -344,8 +343,8 @@ class GetBlobInfoOperation extends GetOperation {
                 if (exception == null) {
                   logger.trace("Successfully updating decrypt job callback results for {}", blobId);
                   operationResult = new GetBlobResultInternal(
-                      new GetBlobResult(new BlobInfo(serverBlobProperties, result.getDecryptedUserMetadata().array()),
-                          null), null);
+                      new GetBlobResult(new BlobInfo(serverBlobProperties, result.getDecryptedUserMetadata().array())),
+                      null);
                   progressTracker.setDecryptionSuccess();
                 } else {
                   logger.trace("Exception {} thrown on decryption for {}", exception, blobId);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -182,7 +182,7 @@ class GetBlobOperation extends GetOperation {
           List<StoreKey> chunkIds = e == null && compositeBlobInfo != null ? compositeBlobInfo.getKeys() : null;
           // blobInfo.setStoreKeys(chunkIds); // this is not good. storeKeys don't belong blobInfo but getCallback only accept blobInfo
           // operationResult = new GetBlobResultInternal(null, chunkIds);
-          operationResult = new GetBlobResultInternal(new GetBlobResult(blobInfo, blobDataChannel, chunkIds), chunkIds); // add blob info here
+          operationResult = new GetBlobResultInternal(new GetBlobResult(blobInfo, chunkIds), chunkIds); // add blob info here
         } else {
           // Complete the operation from the caller's perspective, so that the caller can start reading from the
           // channel if there is no exception. The operation will not be marked as complete internally as subsequent

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -180,7 +180,9 @@ class GetBlobOperation extends GetOperation {
           // GetManager remove this operation.
           operationCompleted = true;
           List<StoreKey> chunkIds = e == null && compositeBlobInfo != null ? compositeBlobInfo.getKeys() : null;
-          operationResult = new GetBlobResultInternal(null, chunkIds);
+          // blobInfo.setStoreKeys(chunkIds); // this is not good. storeKeys don't belong blobInfo but getCallback only accept blobInfo
+          // operationResult = new GetBlobResultInternal(null, chunkIds);
+          operationResult = new GetBlobResultInternal(new GetBlobResult(blobInfo, blobDataChannel, chunkIds), chunkIds); // add blob info here
         } else {
           // Complete the operation from the caller's perspective, so that the caller can start reading from the
           // channel if there is no exception. The operation will not be marked as complete internally as subsequent
@@ -198,7 +200,7 @@ class GetBlobOperation extends GetOperation {
             routerMetrics.onGetBlobError(e, options);
           }
         }
-        NonBlockingRouter.completeOperation(null, getOperationCallback, operationResult, e);
+        NonBlockingRouter.completeOperation(null, getOperationCallback, operationResult, e); // in NBR.getBlob
       }
     }
     chunk.postCompletionCleanup();
@@ -1077,6 +1079,7 @@ class GetBlobOperation extends GetOperation {
       }
       if (!rangeResolutionFailure) {
         if (options.getChunkIdsOnly) {
+          // here is the options
           chunkIdIterator = null;
           numChunksTotal = 0;
           dataChunks = null;

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -24,6 +24,7 @@ import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.protocol.GetOption;
+import com.github.ambry.protocol.GetRequest;
 import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.protocol.RequestOrResponseType;
 import com.github.ambry.store.StoreKey;
@@ -146,6 +147,8 @@ class NonBlockingRouter implements Router {
     currentOperationsCount.incrementAndGet();
     if (options.getOperationType() == GetBlobOptions.OperationType.BlobInfo) {
       routerMetrics.getBlobInfoOperationRate.mark();
+    } else if (options.getOperationType() == GetBlobOptions.OperationType.BlobChunkIds){
+
     } else {
       routerMetrics.getBlobOperationRate.mark();
     }
@@ -154,7 +157,8 @@ class NonBlockingRouter implements Router {
     }
     routerMetrics.operationQueuingRate.mark();
     final FutureResult<GetBlobResult> futureResult = new FutureResult<>();
-    GetBlobOptionsInternal internalOptions = new GetBlobOptionsInternal(options, false, routerMetrics.ageAtGet);
+    boolean getChunkIdsOnly = options.getOperationType() == GetBlobOptions.OperationType.BlobChunkIds;
+    GetBlobOptionsInternal internalOptions = new GetBlobOptionsInternal(options, getChunkIdsOnly, routerMetrics.ageAtGet);
     if (isOpen.get()) {
       getOperationController().getBlob(blobId, internalOptions, new Callback<GetBlobResultInternal>() {
         @Override
@@ -295,8 +299,9 @@ class NonBlockingRouter implements Router {
         // blob could have been garbage collected and not found at all and so on.
         logger.trace("Encountered exception when attempting to get chunks of a possibly composite deleted blob {} ",
             blobId, exception);
-      } else if (result.getBlobResult != null) {
-        logger.error("Unexpected result returned by background get operation to fetch chunk ids.");
+      //} else if (result.getBlobResult != null) {
+        // here is the place cause ut failure
+      //  logger.error("Unexpected result returned by background get operation to fetch chunk ids.");
       } else if (result.storeKeys != null) {
         List<BackgroundDeleteRequest> deleteRequests = new ArrayList<>(result.storeKeys.size());
         for (StoreKey storeKey : result.storeKeys) {

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
@@ -98,7 +98,7 @@ class PerfRouter implements Router {
           result = new GetBlobResult(null, new PerfRSC(chunk, blobProperties.getBlobSize()));
           break;
         case BlobInfo:
-          result = new GetBlobResult(new BlobInfo(blobProperties, usermetadata), null);
+          result = new GetBlobResult(new BlobInfo(blobProperties, usermetadata));
           break;
       }
       completeOperation(futureResult, callback, result, null);


### PR DESCRIPTION
The reason to add this is mainly for debug purpose, suggested by @cgtz . 
In open-source version, this request is public. 
In internal version, this is an admin request only.

The REST API is GET /ambryid/BlobChunkIds 
JSON is returned in the following format:

{"ChunkIds":["AAIAAf__AAAAAQAAAAAAAAAAAAAAJDg4YjI4MzBkLWNkOGEtNDJlMi05MmRkLTQ0ODgwNWE4YTA0MA","AAIAAf__AAAAAQAAAAAAAAAAAAAAJGJjNjU4YzM1LTQwYjktNDg0Ny1iZmM2LTU4NTczYzAyN2JlNg","AAIAAf__AAAAAQAAAAAAAAAAAAAAJGUxOWZmYzdmLTVmN2QtNGZjNC1iMDI4LTYxZjc3ZjliZWQ5ZQ","AAIAAf__AAAAAQAAAAAAAAAAAAAAJDczNjM4M2Q3LWFkNDYtNGQ2ZS1hODAwLWFiMDgzNTJjODAzMg"],
"MetaBlob":true}

If not a composite blob, just return {"MetaBlob":false}

Some struggles here, need your suggestions for an elegant implementation.

1. Intuitively, BlobChunkIds request is a GetBlobInfo request. However, to use exiting getChunkIdsOnly option, BlobChunkIds request goes to GetBlob request. Good or Bad?

2. A new OperationType is added(BlobChunkIds), this can be avoided by using 'Data'/'All' for BlobChunkIds request. Do we need this new operationType BlobChunkIds.
  