### PR TITLE
Adding some info to a test failure

### DIFF
--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMultipartRequestTest.java
@@ -392,7 +392,9 @@ public class NettyMultipartRequestTest {
         }
         currentSizeAdded += readableBytes;
       }
-      assertEquals("Success state not as expected", maxSizeAllowed < encodedSize, failedToAdd);
+      assertEquals(
+          "Success state not as expected. maxSizeAllowed=[" + maxSizeAllowed + "], encodedSize expected=[" + encodedSize
+              + "], actual size added=[" + currentSizeAdded + "]", maxSizeAllowed < encodedSize, failedToAdd);
     }
   }
 


### PR DESCRIPTION
Need some more information to validate a test failure to understand if it is making some unreasonable assumptions about size after encoding.

Trying to debug [this](https://travis-ci.org/linkedin/ambry/builds/326128970?utm_source=github_status&utm_medium=notification).