### PR TITLE
Log thread death reasons instead of printing

### DIFF
--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -229,10 +229,8 @@ public class Utils {
   public static Thread newThread(String name, Runnable runnable, boolean daemon) {
     Thread thread = new Thread(runnable, name);
     thread.setDaemon(daemon);
-    thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-      public void uncaughtException(Thread t, Throwable e) {
-        e.printStackTrace();
-      }
+    thread.setUncaughtExceptionHandler((t, e) -> {
+      logger.error("Encountered throwable in {}", t, e);
     });
     return thread;
   }


### PR DESCRIPTION
This was done for the non-named `Utils.newThread(...)` method but not this one. We use this method for AsyncRequestResponseHandler worker threads.