### PR TITLE
Fix AccountUpdateTool test case

### DIFF
--- a/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
@@ -104,6 +104,7 @@ public class AccountUpdateToolTest {
    * @throws Exception Any unexpected exception.
    */
   public AccountUpdateToolTest(short containerJsonVersion) throws Exception {
+    Container.setCurrentJsonVersion(containerJsonVersion);
     this.containerJsonVersion = containerJsonVersion;
     idToRefAccountMap = new HashMap<>();
     idToRefContainerMap = new HashMap<>();


### PR DESCRIPTION
The container version when generating the reference account needs to
match the version used when using the update tool, otherwise the equals
check will fail since one version can contain fields not supported by
the other version.