### PR TITLE
Changing store options when fetching blobs in StoreCopier

### DIFF
--- a/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
@@ -262,7 +262,7 @@ public class StoreCopier implements Closeable {
           if (tgt.findMissingKeys(Collections.singletonList(messageInfo.getStoreKey())).size() == 1) {
             int size = (int) messageInfo.getSize();
             StoreInfo storeInfo =
-                src.get(Collections.singletonList(messageInfo.getStoreKey()), EnumSet.noneOf(StoreGetOptions.class));
+                src.get(Collections.singletonList(messageInfo.getStoreKey()), EnumSet.allOf(StoreGetOptions.class));
             MessageReadSet readSet = storeInfo.getMessageReadSet();
             byte[] buf = new byte[size];
             readSet.writeTo(0, new ByteBufferChannel(ByteBuffer.wrap(buf)), 0, size);


### PR DESCRIPTION
Once it has been determined that a blob is not expired or deleted, it
must be fetched with all the store get options because the blob may
expire b/w the time the `findEntriesSince()` is executed and the time
that it is actually fetched.