### PR TITLE
Add SSL handshake and first byte metrics

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetrics.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetrics.java
@@ -29,6 +29,7 @@ public class RestRequestMetrics {
   static final String NIO_REQUEST_PROCESSING_TIME_SUFFIX = "NioRequestProcessingTimeInMs";
   static final String NIO_RESPONSE_PROCESSING_TIME_SUFFIX = "NioResponseProcessingTimeInMs";
   static final String NIO_ROUND_TRIP_TIME_SUFFIX = "NioRoundTripTimeInMs";
+  static final String NIO_FIRST_BYTE_SENT_TIME_SUFFIX = "NioFirstByteSentTimeInMs";
 
   static final String SC_REQUEST_PROCESSING_TIME_SUFFIX = "ScRequestProcessingTimeInMs";
   static final String SC_REQUEST_PROCESSING_WAIT_TIME_SUFFIX = "ScRequestProcessingWaitTimeInMs";
@@ -42,6 +43,7 @@ public class RestRequestMetrics {
   final Histogram nioRequestProcessingTimeInMs;
   final Histogram nioResponseProcessingTimeInMs;
   final Histogram nioRoundTripTimeInMs;
+  final Histogram nioFirstByteSentTimeInMs;
 
   final Histogram scRequestProcessingTimeInMs;
   final Histogram scRequestProcessingWaitTimeInMs;
@@ -72,6 +74,8 @@ public class RestRequestMetrics {
         metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + NIO_RESPONSE_PROCESSING_TIME_SUFFIX));
     nioRoundTripTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + NIO_ROUND_TRIP_TIME_SUFFIX));
+    nioFirstByteSentTimeInMs =
+        metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + NIO_FIRST_BYTE_SENT_TIME_SUFFIX));
 
     scRequestProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + SC_REQUEST_PROCESSING_TIME_SUFFIX));

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetrics.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetrics.java
@@ -29,7 +29,7 @@ public class RestRequestMetrics {
   static final String NIO_REQUEST_PROCESSING_TIME_SUFFIX = "NioRequestProcessingTimeInMs";
   static final String NIO_RESPONSE_PROCESSING_TIME_SUFFIX = "NioResponseProcessingTimeInMs";
   static final String NIO_ROUND_TRIP_TIME_SUFFIX = "NioRoundTripTimeInMs";
-  static final String NIO_FIRST_BYTE_SENT_TIME_SUFFIX = "NioFirstByteSentTimeInMs";
+  static final String NIO_TIME_TO_FIRST_BYTE_SUFFIX = "NioTimeToFirstByteInMs";
 
   static final String SC_REQUEST_PROCESSING_TIME_SUFFIX = "ScRequestProcessingTimeInMs";
   static final String SC_REQUEST_PROCESSING_WAIT_TIME_SUFFIX = "ScRequestProcessingWaitTimeInMs";
@@ -43,7 +43,7 @@ public class RestRequestMetrics {
   final Histogram nioRequestProcessingTimeInMs;
   final Histogram nioResponseProcessingTimeInMs;
   final Histogram nioRoundTripTimeInMs;
-  final Histogram nioFirstByteSentTimeInMs;
+  final Histogram nioTimeToFirstByteInMs;
 
   final Histogram scRequestProcessingTimeInMs;
   final Histogram scRequestProcessingWaitTimeInMs;
@@ -74,8 +74,8 @@ public class RestRequestMetrics {
         metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + NIO_RESPONSE_PROCESSING_TIME_SUFFIX));
     nioRoundTripTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + NIO_ROUND_TRIP_TIME_SUFFIX));
-    nioFirstByteSentTimeInMs =
-        metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + NIO_FIRST_BYTE_SENT_TIME_SUFFIX));
+    nioTimeToFirstByteInMs =
+        metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + NIO_TIME_TO_FIRST_BYTE_SUFFIX));
 
     scRequestProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(ownerClass, requestType + SC_REQUEST_PROCESSING_TIME_SUFFIX));

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
@@ -67,7 +67,7 @@ public class RestRequestMetricsTracker {
     private final AtomicLong responseProcessingTimeInMs = new AtomicLong(0);
 
     private long requestReceivedTime = 0;
-    private long firstByteSentTimeInMs = 0;
+    private long timeToFirstByteInMs = 0;
     private long roundTripTimeInMs = 0;
 
     /**
@@ -98,13 +98,13 @@ public class RestRequestMetricsTracker {
     }
 
     /**
-     * Marks the time at which response sending began.
+     * Marks the time at which the first byte of the response is sent.
      */
-    public void markFirstByteSent() {
+    public void markTimeToFirstByte() {
       if (requestReceivedTime == 0) {
         throw new IllegalStateException("First response byte was marked as sent without request being marked received");
       }
-      firstByteSentTimeInMs = System.currentTimeMillis() - requestReceivedTime;
+      timeToFirstByteInMs = System.currentTimeMillis() - requestReceivedTime;
     }
 
     /**
@@ -221,7 +221,7 @@ public class RestRequestMetricsTracker {
         metrics.nioRequestProcessingTimeInMs.update(nioMetricsTracker.requestProcessingTimeInMs.get());
         metrics.nioResponseProcessingTimeInMs.update(nioMetricsTracker.responseProcessingTimeInMs.get());
         metrics.nioRoundTripTimeInMs.update(nioMetricsTracker.roundTripTimeInMs);
-        metrics.nioFirstByteSentTimeInMs.update(nioMetricsTracker.firstByteSentTimeInMs);
+        metrics.nioTimeToFirstByteInMs.update(nioMetricsTracker.timeToFirstByteInMs);
 
         metrics.scRequestProcessingTimeInMs.update(scalingMetricsTracker.requestProcessingTimeInMs.get());
         metrics.scRequestProcessingWaitTimeInMs.update(scalingMetricsTracker.requestProcessingWaitTimeInMs.get());

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
@@ -100,7 +100,7 @@ public class RestRequestMetricsTracker {
     /**
      * Marks the time at which the first byte of the response is sent.
      */
-    public void markTimeToFirstByte() {
+    public void markFirstByteSent() {
       if (requestReceivedTime == 0) {
         throw new IllegalStateException("First response byte was marked as sent without request being marked received");
       }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
@@ -67,6 +67,7 @@ public class RestRequestMetricsTracker {
     private final AtomicLong responseProcessingTimeInMs = new AtomicLong(0);
 
     private long requestReceivedTime = 0;
+    private long firstByteSentTimeInMs = 0;
     private long roundTripTimeInMs = 0;
 
     /**
@@ -94,6 +95,16 @@ public class RestRequestMetricsTracker {
      */
     public void markRequestReceived() {
       requestReceivedTime = System.currentTimeMillis();
+    }
+
+    /**
+     * Marks the time at which response sending began.
+     */
+    public void markFirstByteSent() {
+      if (requestReceivedTime == 0) {
+        throw new IllegalStateException("First response byte was marked as sent without request being marked received");
+      }
+      firstByteSentTimeInMs = System.currentTimeMillis() - requestReceivedTime;
     }
 
     /**
@@ -210,6 +221,7 @@ public class RestRequestMetricsTracker {
         metrics.nioRequestProcessingTimeInMs.update(nioMetricsTracker.requestProcessingTimeInMs.get());
         metrics.nioResponseProcessingTimeInMs.update(nioMetricsTracker.responseProcessingTimeInMs.get());
         metrics.nioRoundTripTimeInMs.update(nioMetricsTracker.roundTripTimeInMs);
+        metrics.nioFirstByteSentTimeInMs.update(nioMetricsTracker.firstByteSentTimeInMs);
 
         metrics.scRequestProcessingTimeInMs.update(scalingMetricsTracker.requestProcessingTimeInMs.get());
         metrics.scRequestProcessingWaitTimeInMs.update(scalingMetricsTracker.requestProcessingWaitTimeInMs.get());

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
@@ -122,7 +122,7 @@ public class RestRequestMetricsTrackerTest {
  * provided and then checks for equality once the metrics are recorded.
  */
 class TestMetrics {
-  private static final int REQUEST_SLEEP_TIME = 5;
+  private static final int REQUEST_SLEEP_TIME_MS = 5;
   private final Random random = new Random();
   private final long nioLayerRequestProcessingTime = random.nextInt(Integer.MAX_VALUE);
   private final long nioLayerResponseProcessingTime = random.nextInt(Integer.MAX_VALUE);
@@ -161,12 +161,12 @@ class TestMetrics {
 
     long timeToFirstByte =
         histograms.get(metricPrefix + RestRequestMetrics.NIO_TIME_TO_FIRST_BYTE_SUFFIX).getSnapshot().getValues()[0];
-    assertTrue("NIO time to first byte " + timeToFirstByte + "<" + REQUEST_SLEEP_TIME,
-        timeToFirstByte >= REQUEST_SLEEP_TIME);
+    assertTrue("NIO time to first byte " + timeToFirstByte + "<" + REQUEST_SLEEP_TIME_MS,
+        timeToFirstByte >= REQUEST_SLEEP_TIME_MS);
     long roundTripTime =
         histograms.get(metricPrefix + RestRequestMetrics.NIO_ROUND_TRIP_TIME_SUFFIX).getSnapshot().getValues()[0];
-    assertTrue("NIO round trip time " + roundTripTime + "<" + REQUEST_SLEEP_TIME * 2,
-        roundTripTime >= REQUEST_SLEEP_TIME * 2);
+    assertTrue("NIO round trip time " + roundTripTime + "<" + REQUEST_SLEEP_TIME_MS * 2,
+        roundTripTime >= REQUEST_SLEEP_TIME_MS * 2);
 
     assertEquals("SC request processing time unequal", scRequestProcessingTime,
         histograms.get(metricPrefix + RestRequestMetrics.SC_REQUEST_PROCESSING_TIME_SUFFIX)
@@ -203,9 +203,9 @@ class TestMetrics {
     restRequestMetricsTracker.nioMetricsTracker.addToResponseProcessingTime(nioLayerResponseProcessingTime);
 
     restRequestMetricsTracker.nioMetricsTracker.markRequestReceived();
-    Thread.sleep(REQUEST_SLEEP_TIME);
+    Thread.sleep(REQUEST_SLEEP_TIME_MS);
     restRequestMetricsTracker.nioMetricsTracker.markFirstByteSent();
-    Thread.sleep(REQUEST_SLEEP_TIME);
+    Thread.sleep(REQUEST_SLEEP_TIME_MS);
     restRequestMetricsTracker.nioMetricsTracker.markRequestCompleted();
 
     restRequestMetricsTracker.scalingMetricsTracker.addToRequestProcessingTime(scRequestProcessingTime);

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
@@ -32,7 +32,7 @@ public class RestRequestMetricsTrackerTest {
    * {@link RestRequestMetrics}.
    */
   @Test
-  public void commonCaseTest() {
+  public void commonCaseTest() throws InterruptedException {
     withDefaultsTest(false);
     withDefaultsTest(true);
     withInjectedMetricsTest(false);
@@ -61,7 +61,7 @@ public class RestRequestMetricsTrackerTest {
   public void requestMarkingExceptionsTest() {
     RestRequestMetricsTracker requestMetrics = new RestRequestMetricsTracker();
     try {
-      requestMetrics.nioMetricsTracker.markFirstByteSent();
+      requestMetrics.nioMetricsTracker.markTimeToFirstByte();
       fail("Marking request as complete before marking it received should have thrown exception");
     } catch (IllegalStateException e) {
       // expected. nothing to do.
@@ -88,7 +88,7 @@ public class RestRequestMetricsTrackerTest {
    * Tests recording of metrics without setting a custom {@link RestRequestMetrics}.
    * @param induceFailure if {@code true}, the request is marked as failed.
    */
-  private void withDefaultsTest(boolean induceFailure) {
+  private void withDefaultsTest(boolean induceFailure) throws InterruptedException {
     MetricRegistry metricRegistry = new MetricRegistry();
     RestRequestMetricsTracker.setDefaults(metricRegistry);
     RestRequestMetricsTracker requestMetrics = new RestRequestMetricsTracker();
@@ -103,7 +103,7 @@ public class RestRequestMetricsTrackerTest {
    * Tests recording of metrics after setting a custom {@link RestRequestMetrics}.
    * @param induceFailure if {@code true}, the request is marked as failed.
    */
-  private void withInjectedMetricsTest(boolean induceFailure) {
+  private void withInjectedMetricsTest(boolean induceFailure) throws InterruptedException {
     MetricRegistry metricRegistry = new MetricRegistry();
     RestRequestMetricsTracker.setDefaults(metricRegistry);
     String testRequestType = "Test";
@@ -122,6 +122,7 @@ public class RestRequestMetricsTrackerTest {
  * provided and then checks for equality once the metrics are recorded.
  */
 class TestMetrics {
+  private static final int REQUEST_SLEEP_TIME = 5;
   private final Random random = new Random();
   private final long nioLayerRequestProcessingTime = random.nextInt(Integer.MAX_VALUE);
   private final long nioLayerResponseProcessingTime = random.nextInt(Integer.MAX_VALUE);
@@ -137,7 +138,7 @@ class TestMetrics {
    * @param requestMetrics the instance of {@link RestRequestMetricsTracker} where metrics have to be updated.
    * @param induceFailure if {@code true}, the request is marked as failed.
    */
-  protected TestMetrics(RestRequestMetricsTracker requestMetrics, boolean induceFailure) {
+  protected TestMetrics(RestRequestMetricsTracker requestMetrics, boolean induceFailure) throws InterruptedException {
     updateMetrics(requestMetrics, induceFailure);
     operationErrorCount = induceFailure ? 1 : 0;
   }
@@ -157,6 +158,15 @@ class TestMetrics {
         histograms.get(metricPrefix + RestRequestMetrics.NIO_RESPONSE_PROCESSING_TIME_SUFFIX)
             .getSnapshot()
             .getValues()[0]);
+
+    long timeToFirstByte =
+        histograms.get(metricPrefix + RestRequestMetrics.NIO_TIME_TO_FIRST_BYTE_SUFFIX).getSnapshot().getValues()[0];
+    assertTrue("NIO time to first byte " + timeToFirstByte + "<" + REQUEST_SLEEP_TIME,
+        timeToFirstByte >= REQUEST_SLEEP_TIME);
+    long roundTripTime =
+        histograms.get(metricPrefix + RestRequestMetrics.NIO_ROUND_TRIP_TIME_SUFFIX).getSnapshot().getValues()[0];
+    assertTrue("NIO round trip time " + roundTripTime + "<" + REQUEST_SLEEP_TIME * 2,
+        roundTripTime >= REQUEST_SLEEP_TIME * 2);
 
     assertEquals("SC request processing time unequal", scRequestProcessingTime,
         histograms.get(metricPrefix + RestRequestMetrics.SC_REQUEST_PROCESSING_TIME_SUFFIX)
@@ -187,9 +197,16 @@ class TestMetrics {
    *                                  updated.
    * @param induceFailure if {@code true}, the request is marked as failed.
    */
-  private void updateMetrics(RestRequestMetricsTracker restRequestMetricsTracker, boolean induceFailure) {
+  private void updateMetrics(RestRequestMetricsTracker restRequestMetricsTracker, boolean induceFailure)
+      throws InterruptedException {
     restRequestMetricsTracker.nioMetricsTracker.addToRequestProcessingTime(nioLayerRequestProcessingTime);
     restRequestMetricsTracker.nioMetricsTracker.addToResponseProcessingTime(nioLayerResponseProcessingTime);
+
+    restRequestMetricsTracker.nioMetricsTracker.markRequestReceived();
+    Thread.sleep(REQUEST_SLEEP_TIME);
+    restRequestMetricsTracker.nioMetricsTracker.markTimeToFirstByte();
+    Thread.sleep(REQUEST_SLEEP_TIME);
+    restRequestMetricsTracker.nioMetricsTracker.markRequestCompleted();
 
     restRequestMetricsTracker.scalingMetricsTracker.addToRequestProcessingTime(scRequestProcessingTime);
     restRequestMetricsTracker.scalingMetricsTracker.addToResponseProcessingTime(scResponseProcessingTime);

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
@@ -61,6 +61,13 @@ public class RestRequestMetricsTrackerTest {
   public void requestMarkingExceptionsTest() {
     RestRequestMetricsTracker requestMetrics = new RestRequestMetricsTracker();
     try {
+      requestMetrics.nioMetricsTracker.markFirstByteSent();
+      fail("Marking request as complete before marking it received should have thrown exception");
+    } catch (IllegalStateException e) {
+      // expected. nothing to do.
+    }
+
+    try {
       requestMetrics.nioMetricsTracker.markRequestCompleted();
       fail("Marking request as complete before marking it received should have thrown exception");
     } catch (IllegalStateException e) {

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestRequestMetricsTrackerTest.java
@@ -61,7 +61,7 @@ public class RestRequestMetricsTrackerTest {
   public void requestMarkingExceptionsTest() {
     RestRequestMetricsTracker requestMetrics = new RestRequestMetricsTracker();
     try {
-      requestMetrics.nioMetricsTracker.markTimeToFirstByte();
+      requestMetrics.nioMetricsTracker.markFirstByteSent();
       fail("Marking request as complete before marking it received should have thrown exception");
     } catch (IllegalStateException e) {
       // expected. nothing to do.
@@ -204,7 +204,7 @@ class TestMetrics {
 
     restRequestMetricsTracker.nioMetricsTracker.markRequestReceived();
     Thread.sleep(REQUEST_SLEEP_TIME);
-    restRequestMetricsTracker.nioMetricsTracker.markTimeToFirstByte();
+    restRequestMetricsTracker.nioMetricsTracker.markFirstByteSent();
     Thread.sleep(REQUEST_SLEEP_TIME);
     restRequestMetricsTracker.nioMetricsTracker.markRequestCompleted();
 

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMessageProcessor.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.rest;
 
-import com.codahale.metrics.Histogram;
 import com.github.ambry.config.NettyConfig;
 import com.github.ambry.utils.Utils;
 import io.netty.channel.ChannelHandlerContext;
@@ -226,9 +225,9 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
       long currentTime = System.currentTimeMillis();
       if (firstMessageReceived.compareAndSet(false, true)) {
         if (ctx.pipeline().get(SslHandler.class) != null) {
-          nettyMetrics.sslChannelActiveToMessageReceiveTimeInMs.update(currentTime - channelActiveTimeMs);
+          nettyMetrics.sslChannelActiveToFirstMessageReceiveTimeInMs.update(currentTime - channelActiveTimeMs);
         } else {
-          nettyMetrics.channelActiveToMessageReceiveTimeInMs.update(currentTime - channelActiveTimeMs);
+          nettyMetrics.channelActiveToFirstMessageReceiveTimeInMs.update(currentTime - channelActiveTimeMs);
         }
       }
       boolean recognized = false;

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -47,8 +47,8 @@ public class NettyMetrics {
 
   // Latencies
   // NettyMessageProcessor
-  public final Histogram channelActiveToMessageReceiveTimeInMs;
-  public final Histogram sslChannelActiveToMessageReceiveTimeInMs;
+  public final Histogram channelActiveToFirstMessageReceiveTimeInMs;
+  public final Histogram sslChannelActiveToFirstMessageReceiveTimeInMs;
   public final Histogram requestChunkProcessingTimeInMs;
   // NettyResponseChannel
   public final Histogram channelWriteFailureProcessingTimeInMs;
@@ -168,10 +168,10 @@ public class NettyMetrics {
 
     // Latencies
     // NettyMessageProcessor
-    channelActiveToMessageReceiveTimeInMs = metricRegistry.histogram(
-        MetricRegistry.name(NettyMessageProcessor.class, "ChannelActiveToMessageReceiveTimeInMs"));
-    sslChannelActiveToMessageReceiveTimeInMs = metricRegistry.histogram(
-        MetricRegistry.name(NettyMessageProcessor.class, "SslChannelActiveToMessageReceiveTimeInMs"));
+    channelActiveToFirstMessageReceiveTimeInMs = metricRegistry.histogram(
+        MetricRegistry.name(NettyMessageProcessor.class, "ChannelActiveToFirstMessageReceiveTimeInMs"));
+    sslChannelActiveToFirstMessageReceiveTimeInMs = metricRegistry.histogram(
+        MetricRegistry.name(NettyMessageProcessor.class, "SslChannelActiveToFirstMessageReceiveTimeInMs"));
     requestChunkProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(NettyMessageProcessor.class, "RequestChunkProcessingTimeInMs"));
     // NettyResponseChannel

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -47,6 +47,8 @@ public class NettyMetrics {
 
   // Latencies
   // NettyMessageProcessor
+  public final Histogram channelActiveToMessageReceiveTimeInMs;
+  public final Histogram sslChannelActiveToMessageReceiveTimeInMs;
   public final Histogram requestChunkProcessingTimeInMs;
   // NettyResponseChannel
   public final Histogram channelWriteFailureProcessingTimeInMs;
@@ -133,6 +135,7 @@ public class NettyMetrics {
   // ConnectionStatsHandler
   public final Counter connectionsConnectedCount;
   public final Counter connectionsDisconnectedCount;
+  public final Counter handshakeFailureCount;
 
   // PublicAccessLogHandler
   public final Counter publicAccessLogRequestDisconnectWhileInProgressCount;
@@ -165,6 +168,10 @@ public class NettyMetrics {
 
     // Latencies
     // NettyMessageProcessor
+    channelActiveToMessageReceiveTimeInMs = metricRegistry.histogram(
+        MetricRegistry.name(NettyMessageProcessor.class, "ChannelActiveToMessageReceiveTimeInMs"));
+    sslChannelActiveToMessageReceiveTimeInMs = metricRegistry.histogram(
+        MetricRegistry.name(NettyMessageProcessor.class, "SslChannelActiveToMessageReceiveTimeInMs"));
     requestChunkProcessingTimeInMs =
         metricRegistry.histogram(MetricRegistry.name(NettyMessageProcessor.class, "RequestChunkProcessingTimeInMs"));
     // NettyResponseChannel
@@ -305,6 +312,8 @@ public class NettyMetrics {
         metricRegistry.counter(MetricRegistry.name(ConnectionStatsHandler.class, "ConnectionsConnectedCount"));
     connectionsDisconnectedCount =
         metricRegistry.counter(MetricRegistry.name(ConnectionStatsHandler.class, "ConnectionsDisconnectedCount"));
+    handshakeFailureCount =
+        metricRegistry.counter(MetricRegistry.name(ConnectionStatsHandler.class, "HandshakeFailureCount"));
   }
 
   /**
@@ -312,12 +321,7 @@ public class NettyMetrics {
    * @param openConnectionsCount open connections count to be tracked
    */
   void registerConnectionsStatsHandler(final AtomicLong openConnectionsCount) {
-    Gauge<Long> openConnections = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return openConnectionsCount.get();
-      }
-    };
+    Gauge<Long> openConnections = openConnectionsCount::get;
     metricRegistry.register(MetricRegistry.name(ConnectionStatsHandler.class, "OpenConnections"), openConnections);
   }
 }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -170,7 +170,7 @@ class NettyRequest implements RestRequest {
             RestServiceErrorCode.InvalidArgs);
       }
     } else {
-      size = HttpUtil.getContentLength(request, -1);
+      size = HttpUtil.getContentLength(request, -1L);
     }
 
     // query params.

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -342,6 +342,7 @@ class NettyResponseChannel implements RestResponseChannel {
       writtenThisTime = true;
       long writeProcessingTime = System.currentTimeMillis() - writeProcessingStartTime;
       nettyMetrics.responseMetadataProcessingTimeInMs.update(writeProcessingTime);
+      request.getMetricsTracker().nioMetricsTracker.markFirstByteSent();
     }
     return writtenThisTime;
   }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -343,7 +343,7 @@ class NettyResponseChannel implements RestResponseChannel {
       long writeProcessingTime = System.currentTimeMillis() - writeProcessingStartTime;
       nettyMetrics.responseMetadataProcessingTimeInMs.update(writeProcessingTime);
       if (request != null) {
-        request.getMetricsTracker().nioMetricsTracker.markTimeToFirstByte();
+        request.getMetricsTracker().nioMetricsTracker.markFirstByteSent();
       }
     }
     return writtenThisTime;

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -342,7 +342,9 @@ class NettyResponseChannel implements RestResponseChannel {
       writtenThisTime = true;
       long writeProcessingTime = System.currentTimeMillis() - writeProcessingStartTime;
       nettyMetrics.responseMetadataProcessingTimeInMs.update(writeProcessingTime);
-      request.getMetricsTracker().nioMetricsTracker.markFirstByteSent();
+      if (request != null) {
+        request.getMetricsTracker().nioMetricsTracker.markTimeToFirstByte();
+      }
     }
     return writtenThisTime;
   }


### PR DESCRIPTION
- Add metrics for tracking handshake failures and the time between
  channel creation and when data is received (roughly equivalent to the
  time it takes to initialize an SSL connection)
- Add a metric for the time between receiving a request and sending the
  first byte of the response.
- Fix a Content-Length parsing bug