### PR TITLE
Removed untimed waits and fixing a test

### DIFF
--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -129,9 +129,11 @@ public class MockCluster {
         new Thread(new ServerShutdown(shutdownLatch, server)).start();
       }
       try {
-        shutdownLatch.await();
+        if (!shutdownLatch.await(1, TimeUnit.MINUTES)) {
+          fail("Did not shutdown in 1 minute");
+        }
       } catch (Exception e) {
-        assertTrue(false);
+        throw new IOException(e);
       }
       clusterMap.cleanup();
     }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -449,7 +449,7 @@ public final class ServerTestUtil {
         Thread threadToRun = new Thread(runnable);
         threadToRun.start();
       }
-      latch.await();
+      assertTrue("Did not put all blobs in 2 minutes", latch.await(2, TimeUnit.MINUTES));
 
       // wait till replication can complete
       List<BlobId> blobIds = new ArrayList<BlobId>();
@@ -1055,7 +1055,7 @@ public final class ServerTestUtil {
               cancelTest, portType, connectionPool, notificationSystem));
       thread.start();
     }
-    verifierLatch.await();
+    assertTrue("Did not verify in 2 minutes", verifierLatch.await(2, TimeUnit.MINUTES));
 
     assertEquals(totalRequests.get(), verifiedRequests.get());
     router.close();


### PR DESCRIPTION
1) Removing untimed waits in server test (only server shutdown is
an untimed wait now)
2) Fixing a test that failed intermittently because test made
assumptions about encoded size