### PR TITLE
Making more classes required for SecurityServiceFactory public

### DIFF
--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AccountAndContainerInjector.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AccountAndContainerInjector.java
@@ -49,7 +49,7 @@ public class AccountAndContainerInjector implements Closeable {
   private final FrontendMetrics frontendMetrics;
   private final FrontendConfig frontendConfig;
 
-  protected AccountAndContainerInjector(AccountService accountService, FrontendMetrics frontendMetrics,
+  public AccountAndContainerInjector(AccountService accountService, FrontendMetrics frontendMetrics,
       FrontendConfig frontendConfig) {
     this.accountService = accountService;
     this.frontendMetrics = frontendMetrics;

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
@@ -25,7 +25,7 @@ import com.github.ambry.rest.RestRequestMetrics;
  * <p/>
  * Exports metrics that are triggered by the Ambry frontend to the provided {@link MetricRegistry}.
  */
-class FrontendMetrics {
+public class FrontendMetrics {
   private static final String BLOB = "Blob";
   private static final String BLOB_INFO = "BlobInfo";
   private static final String USER_METADATA = "UserMetadata";


### PR DESCRIPTION
Since AccountAndContainerInjector is now one of the inputs to the
SecurityServiceFactory impls, all of its inputs must be publicly
constructible.