### PR TITLE
Expose static method for getting blob ID version

### DIFF
--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -487,6 +487,18 @@ public class BlobId extends StoreKey {
   }
 
   /**
+   * Returns the version of a given Blob id.
+   * @param idStr the blobId in string form.
+   * @return the blob ID version.
+   * @throws IOException if the input is not a valid Blob id.
+   */
+  public static short getVersion(String idStr) throws IOException {
+    BlobIdPreamble blobIdPreamble =
+        new BlobIdPreamble(new DataInputStream(new ByteBufferInputStream(ByteBuffer.wrap(Base64.decodeBase64(idStr)))));
+    return blobIdPreamble.version;
+  }
+
+  /**
    * Returns the account id and container id associated with the given blob. Note that the blob id may not have a valid
    * account and container id associated with it, in which case this will return {@link Account#UNKNOWN_ACCOUNT_ID} and
    * {@link Container#UNKNOWN_CONTAINER_ID} respectively.

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -462,6 +462,7 @@ public class BlobIdTest {
         (short) accountAndContainer.getFirst());
     assertEquals("Container id from the id string should be the same as the associated container id",
         blobId.getContainerId(), (short) accountAndContainer.getSecond());
+    assertEquals("Unexpected version returned by BlobID.getVersion()", version, BlobId.getVersion(blobId.getID()));
   }
 
   /**


### PR DESCRIPTION
This can be used to fetch the blob ID version without requiring access to a clustermap.