### PR TITLE
Fixing a bug with ensuring account and container injected

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
@@ -22,13 +22,13 @@ import java.util.function.Consumer;
 
 /**
  * An implementation of {@link AccountService} that always has a single entry which is the unknown account. Any
- * queries by account name to this account service will unconditionally return thje unknown account. This
+ * queries by account name to this account service will unconditionally return the unknown account. This
  * account service is in memory, and does not talk to any persistent storage service.
  */
 class InMemoryUnknownAccountService implements AccountService {
   static final Account UNKNOWN_ACCOUNT =
-      new Account(
-          Account.UNKNOWN_ACCOUNT_ID, Account.UNKNOWN_ACCOUNT_NAME, Account.AccountStatus.ACTIVE, Account.SNAPSHOT_VERSION_DEFAULT_VALUE,
+      new Account(Account.UNKNOWN_ACCOUNT_ID, Account.UNKNOWN_ACCOUNT_NAME, Account.AccountStatus.ACTIVE,
+          Account.SNAPSHOT_VERSION_DEFAULT_VALUE,
           Arrays.asList(Container.UNKNOWN_CONTAINER, Container.DEFAULT_PUBLIC_CONTAINER,
               Container.DEFAULT_PRIVATE_CONTAINER));
   private static final Collection<Account> accounts =

--- a/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountService.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.account;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
@@ -20,19 +21,24 @@ import java.util.function.Consumer;
 
 
 /**
- * An implementation of {@link AccountService} that always has a single entry {@link Account#UNKNOWN_ACCOUNT}. Any
- * queries by account name to this account service will unconditionally return {@link Account#UNKNOWN_ACCOUNT}. This
+ * An implementation of {@link AccountService} that always has a single entry which is the unknown account. Any
+ * queries by account name to this account service will unconditionally return thje unknown account. This
  * account service is in memory, and does not talk to any persistent storage service.
  */
 class InMemoryUnknownAccountService implements AccountService {
+  static final Account UNKNOWN_ACCOUNT =
+      new Account(
+          Account.UNKNOWN_ACCOUNT_ID, Account.UNKNOWN_ACCOUNT_NAME, Account.AccountStatus.ACTIVE, Account.SNAPSHOT_VERSION_DEFAULT_VALUE,
+          Arrays.asList(Container.UNKNOWN_CONTAINER, Container.DEFAULT_PUBLIC_CONTAINER,
+              Container.DEFAULT_PRIVATE_CONTAINER));
   private static final Collection<Account> accounts =
-      Collections.unmodifiableCollection(Collections.singletonList(Account.UNKNOWN_ACCOUNT));
+      Collections.unmodifiableCollection(Collections.singletonList(UNKNOWN_ACCOUNT));
   private volatile boolean isOpen = true;
 
   @Override
   public Account getAccountById(short accountId) {
     checkOpen();
-    return accountId == Account.UNKNOWN_ACCOUNT_ID ? Account.UNKNOWN_ACCOUNT : null;
+    return accountId == Account.UNKNOWN_ACCOUNT_ID ? UNKNOWN_ACCOUNT : null;
   }
 
   @Override
@@ -53,7 +59,7 @@ class InMemoryUnknownAccountService implements AccountService {
   public Account getAccountByName(String accountName) {
     checkOpen();
     Objects.requireNonNull(accountName, "accountName cannot be null.");
-    return Account.UNKNOWN_ACCOUNT;
+    return UNKNOWN_ACCOUNT;
   }
 
   @Override

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -713,7 +713,8 @@ public class HelixAccountServiceTest {
       for (Account account : accounts) {
         assertTrue("Account update not received by consumers", expectedAccounts.contains(account));
       }
-      TestUtils.assertException(UnsupportedOperationException.class, () -> accounts.add(Account.UNKNOWN_ACCOUNT), null);
+      TestUtils.assertException(UnsupportedOperationException.class,
+          () -> accounts.add(InMemoryUnknownAccountService.UNKNOWN_ACCOUNT), null);
     }
   }
 

--- a/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
@@ -49,8 +49,9 @@ public class InMemoryUnknownAccountServiceTest {
   @Test
   public void testAllMethods() throws Exception {
     assertEquals("Wrong account", null, accountService.getAccountById(Utils.getRandomShort(random)));
-    assertEquals("Wrong account", Account.UNKNOWN_ACCOUNT, accountService.getAccountById((short) -1));
-    assertEquals("Wrong account", Account.UNKNOWN_ACCOUNT,
+    assertEquals("Wrong account", InMemoryUnknownAccountService.UNKNOWN_ACCOUNT,
+        accountService.getAccountById((short) -1));
+    assertEquals("Wrong account", InMemoryUnknownAccountService.UNKNOWN_ACCOUNT,
         accountService.getAccountByName(UtilsTest.getRandomString(10)));
     assertEquals("Wrong size of account collection", 1, accountService.getAllAccounts().size());
     // updating the InMemoryUnknownAccountService should fail.
@@ -97,7 +98,7 @@ public class InMemoryUnknownAccountServiceTest {
       updatedAccountsReceivedByConsumers.add(updatedAccounts);
     };
     accountService.addAccountUpdateConsumer(accountUpdateConsumer);
-    Account updatedAccount = new AccountBuilder(Account.UNKNOWN_ACCOUNT).name("newName").build();
+    Account updatedAccount = new AccountBuilder(InMemoryUnknownAccountService.UNKNOWN_ACCOUNT).name("newName").build();
     accountService.updateAccounts(Collections.singletonList(updatedAccount));
     assertEquals("Wrong number of updated accounts received by consumer.", 0,
         updatedAccountsReceivedByConsumers.size());

--- a/ambry-api/src/main/java/com.github.ambry/account/Account.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/Account.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.account;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -85,25 +84,14 @@ public class Account {
   static final int SNAPSHOT_VERSION_DEFAULT_VALUE = 0;
 
   /**
-   * The id of {@link #UNKNOWN_ACCOUNT}.
+   * The id of unknown account.
    */
   public static final short UNKNOWN_ACCOUNT_ID = -1;
 
   /**
-   * The name of {@link #UNKNOWN_ACCOUNT}.
+   * The name of the unknown account.
    */
   public static final String UNKNOWN_ACCOUNT_NAME = "ambry-unknown-account";
-
-  /**
-   * An account defined specifically for the blobs put without specifying target account and container. In the
-   * pre-containerization world, a put-blob request does not carry any information which account/container to store
-   * the blob. These blobs are assigned to this account if their service ID does not match a valid account, because the
-   * target account information is unknown.
-   */
-  public static final Account UNKNOWN_ACCOUNT =
-      new Account(UNKNOWN_ACCOUNT_ID, UNKNOWN_ACCOUNT_NAME, AccountStatus.ACTIVE, SNAPSHOT_VERSION_DEFAULT_VALUE,
-          Arrays.asList(Container.UNKNOWN_CONTAINER, Container.DEFAULT_PUBLIC_CONTAINER,
-              Container.DEFAULT_PRIVATE_CONTAINER));
 
   // account member variables
   private final short id;

--- a/ambry-api/src/main/java/com.github.ambry/account/Container.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/Container.java
@@ -255,7 +255,7 @@ public class Container {
   /**
    * A container defined specifically for the blobs put without specifying target container but isPrivate flag is
    * set to {@code true}.
-   * 
+   *
    * DO NOT USE IN PRODUCTION CODE.
    */
   @Deprecated

--- a/ambry-api/src/main/java/com.github.ambry/account/Container.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/Container.java
@@ -229,7 +229,10 @@ public class Container {
    * A container defined specifically for the blobs put without specifying target account and container. In the
    * pre-containerization world, a put-blob request does not carry any information which account/container to store
    * the blob. These blobs are literally put into this container, because the target container information is unknown.
+   *
+   * DO NOT USE IN PRODUCTION CODE.
    */
+  @Deprecated
   public static final Container UNKNOWN_CONTAINER =
       new Container(UNKNOWN_CONTAINER_ID, UNKNOWN_CONTAINER_NAME, UNKNOWN_CONTAINER_STATUS,
           UNKNOWN_CONTAINER_DESCRIPTION, UNKNOWN_CONTAINER_ENCRYPTED_SETTING,
@@ -239,7 +242,10 @@ public class Container {
   /**
    * A container defined specifically for the blobs put without specifying target container but isPrivate flag is
    * set to {@code false}.
+   *
+   * DO NOT USE IN PRODUCTION CODE.
    */
+  @Deprecated
   public static final Container DEFAULT_PUBLIC_CONTAINER =
       new Container(DEFAULT_PUBLIC_CONTAINER_ID, DEFAULT_PUBLIC_CONTAINER_NAME, DEFAULT_PUBLIC_CONTAINER_STATUS,
           DEFAULT_PUBLIC_CONTAINER_DESCRIPTION, DEFAULT_PUBLIC_CONTAINER_ENCRYPTED_SETTING,
@@ -249,7 +255,10 @@ public class Container {
   /**
    * A container defined specifically for the blobs put without specifying target container but isPrivate flag is
    * set to {@code true}.
+   * 
+   * DO NOT USE IN PRODUCTION CODE.
    */
+  @Deprecated
   public static final Container DEFAULT_PRIVATE_CONTAINER =
       new Container(DEFAULT_PRIVATE_CONTAINER_ID, DEFAULT_PRIVATE_CONTAINER_NAME, DEFAULT_PRIVATE_CONTAINER_STATUS,
           DEFAULT_PRIVATE_CONTAINER_DESCRIPTION, DEFAULT_PRIVATE_CONTAINER_ENCRYPTED_SETTING,

--- a/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
@@ -523,12 +523,12 @@ public class AccountContainerTest {
   }
 
   /**
-   * Tests for {@link Account#UNKNOWN_ACCOUNT}, {@link Container#UNKNOWN_CONTAINER},
+   * Tests for {@link InMemAccountService#UNKNOWN_ACCOUNT}, {@link Container#UNKNOWN_CONTAINER},
    * {@link Container#DEFAULT_PUBLIC_CONTAINER}, and {@link Container#DEFAULT_PRIVATE_CONTAINER}.
    */
   @Test
   public void testUnknownAccountAndContainer() {
-    Account unknownAccount = Account.UNKNOWN_ACCOUNT;
+    Account unknownAccount = InMemAccountService.UNKNOWN_ACCOUNT;
     Container unknownContainer = Container.UNKNOWN_CONTAINER;
     Container unknownPublicContainer = Container.DEFAULT_PUBLIC_CONTAINER;
     Container unknownPrivateContainer = Container.DEFAULT_PRIVATE_CONTAINER;

--- a/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
@@ -287,7 +287,6 @@ public class AccountContainerTest {
     Account account3ByBuilder = new AccountBuilder(account2ByBuilder).containers(null).build();
     assertAccountAgainstReference(account3ByBuilder, false, false);
     assertTrue("Container list should be empty.", account3ByBuilder.getAllContainers().isEmpty());
-
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/account/InMemAccountService.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/InMemAccountService.java
@@ -40,8 +40,8 @@ public class InMemAccountService implements AccountService {
    * target account information is unknown.
    */
   public static final Account UNKNOWN_ACCOUNT =
-      new Account(
-          Account.UNKNOWN_ACCOUNT_ID, Account.UNKNOWN_ACCOUNT_NAME, Account.AccountStatus.ACTIVE, Account.SNAPSHOT_VERSION_DEFAULT_VALUE,
+      new Account(Account.UNKNOWN_ACCOUNT_ID, Account.UNKNOWN_ACCOUNT_NAME, Account.AccountStatus.ACTIVE,
+          Account.SNAPSHOT_VERSION_DEFAULT_VALUE,
           Arrays.asList(Container.UNKNOWN_CONTAINER, Container.DEFAULT_PUBLIC_CONTAINER,
               Container.DEFAULT_PRIVATE_CONTAINER));
   private final boolean shouldReturnOnlyUnknown;

--- a/ambry-api/src/test/java/com.github.ambry/account/InMemAccountService.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/InMemAccountService.java
@@ -18,6 +18,7 @@ import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,6 +33,17 @@ import java.util.function.Consumer;
  * Implementation of {@link AccountService} for test. This implementation synchronizes on all methods.
  */
 public class InMemAccountService implements AccountService {
+  /**
+   * An account defined specifically for the blobs put without specifying target account and container. In the
+   * pre-containerization world, a put-blob request does not carry any information which account/container to store
+   * the blob. These blobs are assigned to this account if their service ID does not match a valid account, because the
+   * target account information is unknown.
+   */
+  public static final Account UNKNOWN_ACCOUNT =
+      new Account(
+          Account.UNKNOWN_ACCOUNT_ID, Account.UNKNOWN_ACCOUNT_NAME, Account.AccountStatus.ACTIVE, Account.SNAPSHOT_VERSION_DEFAULT_VALUE,
+          Arrays.asList(Container.UNKNOWN_CONTAINER, Container.DEFAULT_PUBLIC_CONTAINER,
+              Container.DEFAULT_PRIVATE_CONTAINER));
   private final boolean shouldReturnOnlyUnknown;
   private final boolean notifyConsumers;
   private final Map<Short, Account> idToAccountMap = new HashMap<>();
@@ -40,7 +52,7 @@ public class InMemAccountService implements AccountService {
 
   /**
    * Constructor.
-   * @param shouldReturnOnlyUnknown {@code true} if always returns {@link Account#UNKNOWN_ACCOUNT} when queried
+   * @param shouldReturnOnlyUnknown {@code true} if always returns {@link InMemAccountService#UNKNOWN_ACCOUNT} when queried
    *                                                     by account name; {@code false} to do the actual query.
    * @param notifyConsumers {@code true} if consumers should be notified of account changes. {@code false} otherwise.
    */
@@ -51,12 +63,12 @@ public class InMemAccountService implements AccountService {
 
   @Override
   public synchronized Account getAccountById(short accountId) {
-    return shouldReturnOnlyUnknown ? Account.UNKNOWN_ACCOUNT : idToAccountMap.get(accountId);
+    return shouldReturnOnlyUnknown ? UNKNOWN_ACCOUNT : idToAccountMap.get(accountId);
   }
 
   @Override
   public synchronized Account getAccountByName(String accountName) {
-    return shouldReturnOnlyUnknown ? Account.UNKNOWN_ACCOUNT : nameToAccountMap.get(accountName);
+    return shouldReturnOnlyUnknown ? UNKNOWN_ACCOUNT : nameToAccountMap.get(accountName);
   }
 
   @Override

--- a/ambry-api/src/test/java/com.github.ambry/account/InMemAccountServiceFactory.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/InMemAccountServiceFactory.java
@@ -29,7 +29,7 @@ public class InMemAccountServiceFactory implements AccountServiceFactory {
 
   /**
    * Constructor. If the properties contains a field "in.mem.account.service.only.unknown" set to {@code true}, an
-   * {@link InMemAccountService} that only returns {@link Account#UNKNOWN_ACCOUNT} is returned. Otherwise a fully
+   * {@link InMemAccountService} that only returns {@link InMemAccountService#UNKNOWN_ACCOUNT} is returned. Otherwise a fully
    * functional service is returned. These account services are also static (singleton) so the same instance of these
    * services is returned no matter how many times {@link #getAccountService()} is called or different instances of
    * {@link InMemAccountServiceFactory} are created.
@@ -50,7 +50,7 @@ public class InMemAccountServiceFactory implements AccountServiceFactory {
   /**
    * Constructor. Each different configuration for these parameters has a singleton {@link AccountService}.
    * @param returnOnlyUnknown on {@link #getAccountService()}, returns an {@link AccountService} that will only return
-   *                          {@link Account#UNKNOWN_ACCOUNT}.
+   *                          {@link InMemAccountService#UNKNOWN_ACCOUNT}.
    *
    * @param notifyConsumers if {@code true}, will notify consumers when accounts are updated. This cannot be
    *                        {@code true} if {@code returnOnlyUnknown} is {@code true}.

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageService.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageService.java
@@ -13,8 +13,8 @@
  */
 package com.github.ambry.rest;
 
-import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -100,7 +100,7 @@ public class MockBlobStorageService implements BlobStorageService {
   public void handlePost(RestRequest restRequest, RestResponseChannel restResponseChannel) {
     if (shouldProceed(restRequest, restResponseChannel)) {
       try {
-        restRequest.setArg(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY, Account.UNKNOWN_ACCOUNT);
+        restRequest.setArg(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY, InMemAccountService.UNKNOWN_ACCOUNT);
         restRequest.setArg(RestUtils.InternalKeys.TARGET_CONTAINER_KEY, Container.UNKNOWN_CONTAINER);
         BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
         byte[] usermetadata = RestUtils.buildUsermetadata(restRequest.getArgs());

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.rest;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.router.ByteRange;
@@ -801,7 +802,7 @@ public class RestUtilsTest {
     headers.putOpt(RestUtils.Headers.AMBRY_CONTENT_TYPE, contentType);
     headers.putOpt(RestUtils.Headers.OWNER_ID, ownerId);
     if (insertAccount) {
-      headers.putOpt(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY, Account.UNKNOWN_ACCOUNT);
+      headers.putOpt(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY, InMemAccountService.UNKNOWN_ACCOUNT);
     }
     if (container != null) {
       headers.putOpt(RestUtils.InternalKeys.TARGET_CONTAINER_KEY, container);
@@ -911,7 +912,7 @@ public class RestUtilsTest {
     String uri = "?" + extraValueHeader + "=extraVal1&" + extraValueHeader + "=extraVal2";
     try {
       RestRequest restRequest = createRestRequest(RestMethod.POST, uri, headers);
-      restRequest.setArg(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY, Account.UNKNOWN_ACCOUNT);
+      restRequest.setArg(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY, InMemAccountService.UNKNOWN_ACCOUNT);
       restRequest.setArg(RestUtils.InternalKeys.TARGET_CONTAINER_KEY, Container.UNKNOWN_CONTAINER);
       RestUtils.buildBlobProperties(restRequest.getArgs());
       fail("An exception was expected but none were thrown");

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AccountAndContainerInjector.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AccountAndContainerInjector.java
@@ -107,7 +107,7 @@ public class AccountAndContainerInjector implements Closeable {
         logger.debug(
             "Account cannot be found for blobId={} with accountId={}. Setting targetAccount to UNKNOWN_ACCOUNT",
             blobId.getID(), blobId.getAccountId());
-        targetAccount = Account.UNKNOWN_ACCOUNT;
+        targetAccount = accountService.getAccountById(Account.UNKNOWN_ACCOUNT_ID);
       }
     }
     Container targetContainer = targetAccount.getContainerById(blobId.getContainerId());
@@ -135,7 +135,7 @@ public class AccountAndContainerInjector implements Closeable {
     if (targetAccount == null || targetContainer == null) {
       throw new RestServiceException("Account and container were not injected by BlobStorageService",
           RestServiceErrorCode.InternalServerError);
-    } else if (targetAccount.equals(Account.UNKNOWN_ACCOUNT) && targetContainer.equals(Container.UNKNOWN_CONTAINER)) {
+    } else if (targetAccount.getId() == Account.UNKNOWN_ACCOUNT_ID) {
       // This should only occur for V1 blobs, where the blob ID does not contain the actual account and container IDs.
       String serviceId = blobProperties.getServiceId();
       boolean isPrivate = blobProperties.isPrivate();
@@ -161,7 +161,7 @@ public class AccountAndContainerInjector implements Closeable {
           "Account cannot be found for put request with serviceId={}. Setting targetAccount to UNKNOWN_ACCOUNT",
           serviceId);
       // If a migrated account does not exist fall back to the UNKNOWN_ACCOUNT.
-      targetAccount = Account.UNKNOWN_ACCOUNT;
+      targetAccount = accountService.getAccountById(Account.UNKNOWN_ACCOUNT_ID);
     }
     // Either the UNKNOWN_ACCOUNT, or the migrated account should contain default public/private containers
     Container targetContainer = targetAccount.getContainerById(

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -559,11 +559,11 @@ public class AmbryBlobStorageServiceTest {
 
     // test response path account injection for V1 blob IDs
     // public blob with service ID that does not correspond to a valid account
-    verifyResponsePathAccountAndContainerInjection(refAccount.getName() + "extra", false, InMemAccountService.UNKNOWN_ACCOUNT,
-        Container.DEFAULT_PUBLIC_CONTAINER);
+    verifyResponsePathAccountAndContainerInjection(refAccount.getName() + "extra", false,
+        InMemAccountService.UNKNOWN_ACCOUNT, Container.DEFAULT_PUBLIC_CONTAINER);
     // private blob with service ID that does not correspond to a valid account
-    verifyResponsePathAccountAndContainerInjection(refAccount.getName() + "extra", true, InMemAccountService.UNKNOWN_ACCOUNT,
-        Container.DEFAULT_PRIVATE_CONTAINER);
+    verifyResponsePathAccountAndContainerInjection(refAccount.getName() + "extra", true,
+        InMemAccountService.UNKNOWN_ACCOUNT, Container.DEFAULT_PRIVATE_CONTAINER);
     // public blob with service ID that corresponds to a valid account
     verifyResponsePathAccountAndContainerInjection(refAccount.getName(), false, refAccount, refDefaultPublicContainer);
     // private blob with service ID that corresponds to a valid account

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -146,6 +146,7 @@ public class AmbryBlobStorageServiceTest {
     securityServiceFactory = new AmbrySecurityServiceFactory(verifiableProperties, clusterMap, null, urlSigningService,
         accountAndContainerInjector);
     accountService.clear();
+    accountService.updateAccounts(Collections.singleton(InMemAccountService.UNKNOWN_ACCOUNT));
     refAccount = accountService.createAndAddRandomAccount();
     for (Container container : refAccount.getAllContainers()) {
       if (container.getId() == Container.DEFAULT_PUBLIC_CONTAINER_ID) {
@@ -402,24 +403,26 @@ public class AmbryBlobStorageServiceTest {
     accountService.createAndAddRandomAccount();
     // valid account and container names passed as part of POST
     for (Account testAccount : accountService.getAllAccounts()) {
-      for (Container container : testAccount.getAllContainers()) {
-        doPostGetHeadDeleteTest(testAccount, container, testAccount.getName(), !container.isCacheable(), testAccount,
-            container);
+      if (testAccount.getId() != Account.UNKNOWN_ACCOUNT_ID) {
+        for (Container container : testAccount.getAllContainers()) {
+          doPostGetHeadDeleteTest(testAccount, container, testAccount.getName(), !container.isCacheable(), testAccount,
+              container);
+        }
       }
     }
     // valid account and container names but only serviceId passed as part of POST
     doPostGetHeadDeleteTest(null, null, refAccount.getName(), false, refAccount, refDefaultPublicContainer);
     doPostGetHeadDeleteTest(null, null, refAccount.getName(), true, refAccount, refDefaultPrivateContainer);
     // unrecognized serviceId
-    doPostGetHeadDeleteTest(null, null, "unknown_service_id", false, Account.UNKNOWN_ACCOUNT,
+    doPostGetHeadDeleteTest(null, null, "unknown_service_id", false, InMemAccountService.UNKNOWN_ACCOUNT,
         Container.DEFAULT_PUBLIC_CONTAINER);
-    doPostGetHeadDeleteTest(null, null, "unknown_service_id", true, Account.UNKNOWN_ACCOUNT,
+    doPostGetHeadDeleteTest(null, null, "unknown_service_id", true, InMemAccountService.UNKNOWN_ACCOUNT,
         Container.DEFAULT_PRIVATE_CONTAINER);
   }
 
   /**
    * Tests injecting target {@link Account} and {@link Container} for PUT requests. The {@link AccountService} is
-   * prepopulated with a reference account and {@link Account#UNKNOWN_ACCOUNT}. The expected behavior should be:
+   * prepopulated with a reference account and {@link InMemAccountService#UNKNOWN_ACCOUNT}. The expected behavior should be:
    *
    * <pre>
    *   accountHeader    containerHeader   serviceIdHeader     expected Error      injected account      injected container
@@ -461,7 +464,7 @@ public class AmbryBlobStorageServiceTest {
 
   /**
    * Tests injecting target {@link Account} and {@link Container} for GET/HEAD/DELETE blobId string in {@link BlobId#BLOB_ID_V2}.
-   * The {@link AccountService} is prepopulated with a reference account and {@link Account#UNKNOWN_ACCOUNT}. The expected
+   * The {@link AccountService} is prepopulated with a reference account and {@link InMemAccountService#UNKNOWN_ACCOUNT}. The expected
    * behavior should be:
    *
    * <pre>
@@ -509,7 +512,7 @@ public class AmbryBlobStorageServiceTest {
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
           Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0),
           false).getID();
-      verifyAccountAndContainerFromBlobId(blobId, Account.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
+      verifyAccountAndContainerFromBlobId(blobId, InMemAccountService.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
           RestServiceErrorCode.NotFound);
 
       // aid=unknownAId, cid=nonExistCId
@@ -536,7 +539,7 @@ public class AmbryBlobStorageServiceTest {
 
   /**
    * Tests injecting target {@link Account} and {@link Container} for GET/HEAD/DELETE blobId string in {@link BlobId#BLOB_ID_V1}.
-   * The {@link AccountService} is prepopulated with a reference account and {@link Account#UNKNOWN_ACCOUNT}. The expected
+   * The {@link AccountService} is prepopulated with a reference account and {@link InMemAccountService#UNKNOWN_ACCOUNT}. The expected
    * behavior should be:
    * <pre>
    *   AId in blobId    CId in blobId     expected Error      injected account      injected container
@@ -551,15 +554,15 @@ public class AmbryBlobStorageServiceTest {
     // expect unknown account and container for v1 blob IDs that went through request processing only.
     String blobId = new BlobId(BlobId.BLOB_ID_V1, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
         refAccount.getId(), refContainer.getId(), clusterMap.getWritablePartitionIds().get(0), false).getID();
-    verifyAccountAndContainerFromBlobId(blobId, Account.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
+    verifyAccountAndContainerFromBlobId(blobId, InMemAccountService.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
         RestServiceErrorCode.NotFound);
 
     // test response path account injection for V1 blob IDs
     // public blob with service ID that does not correspond to a valid account
-    verifyResponsePathAccountAndContainerInjection(refAccount.getName() + "extra", false, Account.UNKNOWN_ACCOUNT,
+    verifyResponsePathAccountAndContainerInjection(refAccount.getName() + "extra", false, InMemAccountService.UNKNOWN_ACCOUNT,
         Container.DEFAULT_PUBLIC_CONTAINER);
     // private blob with service ID that does not correspond to a valid account
-    verifyResponsePathAccountAndContainerInjection(refAccount.getName() + "extra", true, Account.UNKNOWN_ACCOUNT,
+    verifyResponsePathAccountAndContainerInjection(refAccount.getName() + "extra", true, InMemAccountService.UNKNOWN_ACCOUNT,
         Container.DEFAULT_PRIVATE_CONTAINER);
     // public blob with service ID that corresponds to a valid account
     verifyResponsePathAccountAndContainerInjection(refAccount.getName(), false, refAccount, refDefaultPublicContainer);
@@ -1752,7 +1755,7 @@ public class AmbryBlobStorageServiceTest {
           restMethod == RestMethod.DELETE && deserializedId.getAccountId() == Account.UNKNOWN_ACCOUNT_ID
               && deserializedId.getContainerId() == Container.UNKNOWN_CONTAINER_ID;
       assertEquals("Wrong account object in RestRequest's args",
-          alwaysExpectUnknown ? Account.UNKNOWN_ACCOUNT : expectedAccount,
+          alwaysExpectUnknown ? InMemAccountService.UNKNOWN_ACCOUNT : expectedAccount,
           restRequest.getArgs().get(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY));
       assertEquals("Wrong container object in RestRequest's args",
           alwaysExpectUnknown ? Container.UNKNOWN_CONTAINER : expectedContainer,
@@ -1820,12 +1823,12 @@ public class AmbryBlobStorageServiceTest {
   }
 
   /**
-   * Prepopulates the {@link AccountService} with a reference {@link Account} and {@link Account#UNKNOWN_ACCOUNT}.
+   * Prepopulates the {@link AccountService} with a reference {@link Account} and {@link InMemAccountService#UNKNOWN_ACCOUNT}.
    * @throws Exception
    */
   private void populateAccountService() throws Exception {
     accountService.clear();
-    accountService.updateAccounts(Lists.newArrayList(refAccount, Account.UNKNOWN_ACCOUNT));
+    accountService.updateAccounts(Lists.newArrayList(refAccount, InMemAccountService.UNKNOWN_ACCOUNT));
   }
 
   /**
@@ -1866,7 +1869,7 @@ public class AmbryBlobStorageServiceTest {
 
     // should succeed when serviceId-based PUT requests are allowed.
     postBlobAndVerifyWithAccountAndContainer(null, null, "serviceId", !container.isCacheable(),
-        shouldAllowServiceIdBasedPut ? Account.UNKNOWN_ACCOUNT : null,
+        shouldAllowServiceIdBasedPut ? InMemAccountService.UNKNOWN_ACCOUNT : null,
         shouldAllowServiceIdBasedPut ? (container.isCacheable() ? Container.DEFAULT_PUBLIC_CONTAINER
             : Container.DEFAULT_PRIVATE_CONTAINER) : null,
         shouldAllowServiceIdBasedPut ? null : RestServiceErrorCode.BadRequest);

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -89,7 +89,7 @@ public class AmbrySecurityServiceTest {
     DEFAULT_INFO = new BlobInfo(
         new BlobProperties(Utils.getRandomLong(TestUtils.RANDOM, 1000) + 100, SERVICE_ID, OWNER_ID, "image/gif", false,
             Utils.Infinite_Time, REF_ACCOUNT.getId(), REF_CONTAINER.getId(), false), null);
-    ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(Account.UNKNOWN_ACCOUNT));
+    ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(InMemAccountService.UNKNOWN_ACCOUNT));
   }
 
   /**

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -117,7 +117,7 @@ public class FrontendIntegrationTest {
       SSL_CLIENT_VERIFIABLE_PROPS = TestSSLUtils.createSslProps("", SSLFactory.Mode.CLIENT, trustStoreFile, "client");
       FRONTEND_CONFIG = new FrontendConfig(FRONTEND_VERIFIABLE_PROPS);
       ACCOUNT_SERVICE.clear();
-      ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(Account.UNKNOWN_ACCOUNT));
+      ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(InMemAccountService.UNKNOWN_ACCOUNT));
     } catch (IOException | GeneralSecurityException e) {
       throw new IllegalStateException(e);
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/SingleKeyManagementServiceTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/SingleKeyManagementServiceTest.java
@@ -91,7 +91,7 @@ public class SingleKeyManagementServiceTest {
         new SingleKeyManagementServiceFactory(verifiableProperties, CLUSTER_NAME, REGISTRY).getKeyManagementService();
     kms.close();
     try {
-      kms.getKey(Account.UNKNOWN_ACCOUNT.getId(), Container.UNKNOWN_CONTAINER.getId());
+      kms.getKey(Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID);
       Assert.fail("getKey() on KMS should have failed as KMS is closed");
     } catch (GeneralSecurityException e) {
     }


### PR DESCRIPTION
There is a bug with the equals check before ensuring an account and
container are injected