### PR TITLE
Prioritize error code in GET/PUT operations

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -182,8 +182,14 @@ abstract class GetOperation {
       if (operationException.get() == null) {
         operationException.set(exception);
       } else {
-        if (getPrecedenceLevel(routerErrorCode) < getPrecedenceLevel(
-            ((RouterException) operationException.get()).getErrorCode())) {
+        Integer currentOperationExceptionLevel = null;
+        if (operationException.get() instanceof RouterException) {
+          currentOperationExceptionLevel =
+              getPrecedenceLevel(((RouterException) operationException.get()).getErrorCode());
+        } else {
+          currentOperationExceptionLevel = getPrecedenceLevel(RouterErrorCode.UnexpectedInternalError);
+        }
+        if (getPrecedenceLevel(routerErrorCode) < currentOperationExceptionLevel) {
           operationException.set(exception);
         }
       }
@@ -207,14 +213,16 @@ abstract class GetOperation {
         return 1;
       case BlobExpired:
         return 2;
-      case AmbryUnavailable:
+      case RangeNotSatisfiable:
         return 3;
-      case UnexpectedInternalError:
+      case AmbryUnavailable:
         return 4;
-      case OperationTimedOut:
+      case UnexpectedInternalError:
         return 5;
-      case BlobDoesNotExist:
+      case OperationTimedOut:
         return 6;
+      case BlobDoesNotExist:
+        return 7;
       default:
         return Integer.MIN_VALUE;
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -627,8 +627,14 @@ class PutOperation {
       if (operationException.get() == null) {
         operationException.set(exception);
       } else {
-        if (getPrecedenceLevel(routerErrorCode) < getPrecedenceLevel(
-            ((RouterException) operationException.get()).getErrorCode())) {
+        Integer currentOperationExceptionLevel = null;
+        if (operationException.get() instanceof RouterException) {
+          currentOperationExceptionLevel = getPrecedenceLevel(
+              ((RouterException) operationException.get()).getErrorCode());
+        } else {
+          currentOperationExceptionLevel = getPrecedenceLevel(RouterErrorCode.UnexpectedInternalError);
+        }
+        if (getPrecedenceLevel(routerErrorCode) < currentOperationExceptionLevel) {
           operationException.set(exception);
         }
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -614,12 +614,50 @@ class PutOperation {
   }
 
   /**
-   * Set the irrecoverable exception associated with this operation. When this is called, the operation has failed.
-   * @param exception the irrecoverable exception associated with this operation.
+   * Set the exception associated with this operation.
+   * First, if current operationException is null, directly set operationException as exception;
+   * Second, if operationException exists, compare ErrorCodes of exception and existing operation Exception depending
+   * on precedence level. An ErrorCode with a smaller precedence level overrides an ErrorCode with a larger precedence
+   * level. Update the operationException if necessary.
+   * @param exception the {@link RouterException} to possibly set.
    */
   void setOperationExceptionAndComplete(Exception exception) {
-    operationException.set(exception);
+    if (exception instanceof RouterException) {
+      RouterErrorCode routerErrorCode = ((RouterException) exception).getErrorCode();
+      if (operationException.get() == null) {
+        operationException.set(exception);
+      } else {
+        if (getPrecedenceLevel(routerErrorCode) < getPrecedenceLevel(
+            ((RouterException) operationException.get()).getErrorCode())) {
+          operationException.set(exception);
+        }
+      }
+    } else {
+      operationException.set(exception);
+    }
     operationCompleted = true;
+  }
+
+  /**
+   * Gets the precedence level for a {@link RouterErrorCode}. A precedence level is a relative priority assigned
+   * to a {@link RouterErrorCode}. If a {@link RouterErrorCode} has not been assigned a precedence level, a
+   * {@code Integer.MIN_VALUE} will be returned.
+   * @param routerErrorCode The {@link RouterErrorCode} for which to get its precedence level.
+   * @return The precedence level of the {@link RouterErrorCode}.
+   */
+  private Integer getPrecedenceLevel(RouterErrorCode routerErrorCode) {
+    switch (routerErrorCode) {
+      case InsufficientCapacity:
+        return 1;
+      case AmbryUnavailable:
+        return 2;
+      case UnexpectedInternalError:
+        return 3;
+      case OperationTimedOut:
+        return 4;
+      default:
+        return Integer.MIN_VALUE;
+    }
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -214,11 +214,13 @@ public class PutOperationTest {
             userMetadata, channel, future, null,
             new RouterCallback(mockNetworkClient, new ArrayList<BackgroundDeleteRequest>()), null, null, null, null,
             time, blobProperties);
-    RouterErrorCode[] routerErrorCodes = new RouterErrorCode[4];
+    RouterErrorCode[] routerErrorCodes = new RouterErrorCode[5];
     routerErrorCodes[0] = RouterErrorCode.OperationTimedOut;
     routerErrorCodes[1] = RouterErrorCode.UnexpectedInternalError;
     routerErrorCodes[2] = RouterErrorCode.AmbryUnavailable;
     routerErrorCodes[3] = RouterErrorCode.InsufficientCapacity;
+    routerErrorCodes[4] = RouterErrorCode.InvalidBlobId;
+
     for (int i = 0; i < routerErrorCodes.length; ++i) {
       op.setOperationExceptionAndComplete(new RouterException("RouterError", routerErrorCodes[i]));
       Assert.assertEquals(((RouterException) op.getOperationException()).getErrorCode(), routerErrorCodes[i]);
@@ -232,6 +234,11 @@ public class PutOperationTest {
     Exception nonRouterException = new Exception();
     op.setOperationExceptionAndComplete(nonRouterException);
     Assert.assertEquals(nonRouterException, op.getOperationException());
+
+    // test edge case where current operationException is non RouterException
+    op.setOperationExceptionAndComplete(new RouterException("RouterError", RouterErrorCode.InsufficientCapacity));
+    Assert.assertEquals(((RouterException) op.getOperationException()).getErrorCode(),
+        RouterErrorCode.InsufficientCapacity);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -193,6 +193,48 @@ public class PutOperationTest {
   }
 
   /**
+   * Test the Errors {@link RouterErrorCode} received by Put Operation. The operation exception is set
+   * based on the priority of these errors.
+   * @throws Exception
+   */
+  @Test
+  public void testSetOperationExceptionAndComplete() throws Exception {
+    int numChunks = NonBlockingRouter.MAX_IN_MEM_CHUNKS + 1;
+    BlobProperties blobProperties =
+        new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
+            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false);
+    byte[] userMetadata = new byte[10];
+    byte[] content = new byte[chunkSize * numChunks];
+    random.nextBytes(content);
+    ReadableStreamChannel channel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content));
+    FutureResult<String> future = new FutureResult<>();
+    MockNetworkClient mockNetworkClient = new MockNetworkClient();
+    PutOperation op =
+        new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
+            userMetadata, channel, future, null,
+            new RouterCallback(mockNetworkClient, new ArrayList<BackgroundDeleteRequest>()), null, null, null, null,
+            time, blobProperties);
+    RouterErrorCode[] routerErrorCodes = new RouterErrorCode[4];
+    routerErrorCodes[0] = RouterErrorCode.OperationTimedOut;
+    routerErrorCodes[1] = RouterErrorCode.UnexpectedInternalError;
+    routerErrorCodes[2] = RouterErrorCode.AmbryUnavailable;
+    routerErrorCodes[3] = RouterErrorCode.InsufficientCapacity;
+    for (int i = 0; i < routerErrorCodes.length; ++i) {
+      op.setOperationExceptionAndComplete(new RouterException("RouterError", routerErrorCodes[i]));
+      Assert.assertEquals(((RouterException) op.getOperationException()).getErrorCode(), routerErrorCodes[i]);
+    }
+    for (int i = routerErrorCodes.length - 1; i >= 0; --i) {
+      op.setOperationExceptionAndComplete(new RouterException("RouterError", routerErrorCodes[i]));
+      Assert.assertEquals(((RouterException) op.getOperationException()).getErrorCode(),
+          routerErrorCodes[routerErrorCodes.length - 1]);
+    }
+
+    Exception nonRouterException = new Exception();
+    op.setOperationExceptionAndComplete(nonRouterException);
+    Assert.assertEquals(nonRouterException, op.getOperationException());
+  }
+
+  /**
    *  Reset the correlation id field of a {@link PutRequest} to 0.
    */
   private void resetCorrelationId(byte[] request) {


### PR DESCRIPTION
Prioritize the error codes for Router Exception received in
GetBlobInfoOperation, GetBlobOperation and PutOperation.