### PR TITLE
Send failure-reason header on all client errors

### DIFF
--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -384,7 +384,7 @@ class NettyResponseChannel implements RestResponseChannel {
       restServiceErrorCode = ((RestServiceException) cause).getErrorCode();
       errorResponseStatus = ResponseStatus.getResponseStatus(restServiceErrorCode);
       status = getHttpResponseStatus(errorResponseStatus);
-      if (status == HttpResponseStatus.BAD_REQUEST) {
+      if (HttpStatusClass.CLIENT_ERROR.contains(status.code())) {
         errReason = new String(
             Utils.getRootCause(cause).getMessage().replaceAll("[\n\t\r]", " ").getBytes(StandardCharsets.US_ASCII),
             StandardCharsets.US_ASCII);

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -418,17 +418,14 @@ public class NettyResponseChannelTest {
       HttpResponseStatus expectedStatus = getExpectedHttpResponseStatus(errorCode);
       assertEquals("Unexpected response status", expectedStatus, response.status());
       boolean containsFailureReasonHeader = response.headers().contains(NettyResponseChannel.FAILURE_REASON_HEADER);
-      if (expectedStatus == HttpResponseStatus.BAD_REQUEST) {
-        assertTrue("Could not find failure reason header.", containsFailureReasonHeader);
-      } else {
-        assertFalse("Should not have found failure reason header.", containsFailureReasonHeader);
-      }
       if (HttpStatusClass.CLIENT_ERROR.contains(response.status().code())) {
         assertEquals("Wrong error code", errorCode,
             RestServiceErrorCode.valueOf(response.headers().get(NettyResponseChannel.ERROR_CODE_HEADER)));
+        assertTrue("Could not find failure reason header.", containsFailureReasonHeader);
       } else {
         assertFalse("Should not have found error code header",
             response.headers().contains(NettyResponseChannel.ERROR_CODE_HEADER));
+        assertFalse("Should not have found failure reason header.", containsFailureReasonHeader);
       }
       if (response instanceof FullHttpResponse) {
         // assert that there is no content


### PR DESCRIPTION
This will give users some more information about why they are getting a certain 4xx errors.