### PR TITLE
Introduce Stop BlobStore API on server side

### DIFF
--- a/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
@@ -33,5 +33,5 @@ public enum ServerErrorCode {
   Unknown_Error,
   Temporarily_Disabled,
   Bad_Request,
-  Catchup_Unfinished
+  Operation_In_Progress
 }

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
@@ -32,5 +32,6 @@ public enum ServerErrorCode {
   Partition_ReadOnly,
   Unknown_Error,
   Temporarily_Disabled,
-  Bad_Request
+  Bad_Request,
+  Catchup_Unfinished
 }

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ServerErrorCode.java
@@ -33,5 +33,5 @@ public enum ServerErrorCode {
   Unknown_Error,
   Temporarily_Disabled,
   Bad_Request,
-  Operation_In_Progress
+  Retry_After_Backoff
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
@@ -20,5 +20,5 @@ package com.github.ambry.protocol;
  * requests/responses
  */
 public enum AdminRequestOrResponseType {
-  TriggerCompaction, RequestControl, ReplicationControl, CatchupStatus, StopBlobStore
+  TriggerCompaction, RequestControl, ReplicationControl, CatchupStatus, BlobStoreControl
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AdminRequestOrResponseType.java
@@ -20,5 +20,5 @@ package com.github.ambry.protocol;
  * requests/responses
  */
 public enum AdminRequestOrResponseType {
-  TriggerCompaction, RequestControl, ReplicationControl, CatchupStatus
+  TriggerCompaction, RequestControl, ReplicationControl, CatchupStatus, StopBlobStore
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/BlobStoreControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/BlobStoreControlAdminRequest.java
@@ -50,7 +50,7 @@ public class BlobStoreControlAdminRequest extends AdminRequest {
         adminRequest.getClientId());
     this.numReplicasCaughtUpPerPartition = numReplicasCaughtUpPerPartition;
     this.enable = enable;
-    // parent size + version size + numReplicasCaughtUpPerPartition size
+    // parent size + version size + numReplicasCaughtUpPerPartition size + enable flag size
     sizeInBytes = super.sizeInBytes() + Short.BYTES + Short.BYTES + Byte.BYTES;
   }
 

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/BlobStoreControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/BlobStoreControlAdminRequest.java
@@ -44,7 +44,8 @@ public class BlobStoreControlAdminRequest extends AdminRequest {
     return new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, enable, adminRequest);
   }
 
-  public BlobStoreControlAdminRequest(short numReplicasCaughtUpPerPartition, boolean enable, AdminRequest adminRequest) {
+  public BlobStoreControlAdminRequest(short numReplicasCaughtUpPerPartition, boolean enable,
+      AdminRequest adminRequest) {
     super(AdminRequestOrResponseType.BlobStoreControl, adminRequest.getPartitionId(), adminRequest.getCorrelationId(),
         adminRequest.getClientId());
     this.numReplicasCaughtUpPerPartition = numReplicasCaughtUpPerPartition;
@@ -61,7 +62,7 @@ public class BlobStoreControlAdminRequest extends AdminRequest {
   }
 
   /**
-   * @return if BlobStore needs to enabled/started ({@code true}) or disabled/stopped ({@code false}).
+   * @return if BlobStore needs to be enabled/started ({@code true}) or disabled/stopped ({@code false}).
    */
   public boolean shouldEnable() {
     return enable;

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/StopBlobStoreAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/StopBlobStoreAdminRequest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+/**
+ *  An admin request used to stop a BlobStore safely.
+ */
+public class StopBlobStoreAdminRequest extends AdminRequest {
+  private static final short VERSION_V1 = 1;
+  private static final short VERSION_V2 = 2;
+  private final long acceptableLagInBytes;
+  private final short numReplicasCaughtUpPerPartition;
+  private final long sizeInBytes;
+
+  /**
+   * Reads from a stream and constructs a {@link StopBlobStoreAdminRequest}.
+   * @param stream the stream to read from
+   * @param adminRequest the {@link AdminRequest} that contains some necessary headers.
+   * @return the {@link StopBlobStoreAdminRequest} constructed from the {@code stream}.
+   * @throws IOException if there is any problem reading from the stream
+   */
+  public static StopBlobStoreAdminRequest readFrom(DataInputStream stream, AdminRequest adminRequest)
+      throws IOException {
+    Short versionId = stream.readShort();
+    long acceptableLagInBytes;
+    short numReplicasCaughtUpPerPartition = Short.MAX_VALUE;
+    switch (versionId) {
+      case VERSION_V1:
+        acceptableLagInBytes = stream.readLong();
+        break;
+      case VERSION_V2:
+        acceptableLagInBytes = stream.readLong();
+        numReplicasCaughtUpPerPartition = stream.readShort();
+        break;
+      default:
+        throw new IllegalStateException("Unrecognized version for StopBlobStoreAdminRequest: " + versionId);
+    }
+    return new StopBlobStoreAdminRequest(acceptableLagInBytes, numReplicasCaughtUpPerPartition, adminRequest);
+  }
+
+  public StopBlobStoreAdminRequest(long acceptableLagInBytes, short numReplicasCaughtUpPerPartition,
+      AdminRequest adminRequest) {
+    super(AdminRequestOrResponseType.StopBlobStore, adminRequest.getPartitionId(), adminRequest.getCorrelationId(),
+        adminRequest.getClientId());
+    this.acceptableLagInBytes = acceptableLagInBytes;
+    this.numReplicasCaughtUpPerPartition = numReplicasCaughtUpPerPartition;
+    // parent size + version size + acceptableLagInBytes size + numReplicasCaughtUpPerPartition size
+    sizeInBytes = super.sizeInBytes() + Short.BYTES + Long.BYTES + Short.BYTES;
+  }
+
+  /**
+   * @return the number of bytes that the remote can lag by which is considered OK.
+   */
+  public long getAcceptableLagInBytes() {
+    return acceptableLagInBytes;
+  }
+
+  /**
+   * @return the least number of replicas that have to be within {@link #getAcceptableLagInBytes()} for each partition.
+   */
+  public short getNumReplicasCaughtUpPerPartition() {
+    return numReplicasCaughtUpPerPartition;
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return sizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    return "StopBlobStoreAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId
+        + ", AcceptableLagInBytes=" + acceptableLagInBytes + ", PartitionId=" + getPartitionId() + "]";
+  }
+
+  @Override
+  protected void serializeIntoBuffer() {
+    super.serializeIntoBuffer();
+    bufferToSend.putShort(VERSION_V2);
+    bufferToSend.putLong(acceptableLagInBytes);
+    bufferToSend.putShort(numReplicasCaughtUpPerPartition);
+  }
+}

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/StopBlobStoreAdminRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/StopBlobStoreAdminRequest.java
@@ -47,7 +47,7 @@ public class StopBlobStoreAdminRequest extends AdminRequest {
         adminRequest.getClientId());
     this.numReplicasCaughtUpPerPartition = numReplicasCaughtUpPerPartition;
     // parent size + version size + numReplicasCaughtUpPerPartition size
-    sizeInBytes = super.sizeInBytes() + Short.BYTES + +Short.BYTES;
+    sizeInBytes = super.sizeInBytes() + Short.BYTES + Short.BYTES;
   }
 
   /**

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -540,33 +540,47 @@ public class RequestResponseTest {
   }
 
   /**
-   * Tests the ser/de of {@link StopBlobStoreAdminRequest} and checks for equality of fields with reference data.
+   * Tests the ser/de of {@link BlobStoreControlAdminRequest} and checks for equality of fields with reference data.
    * @throws IOException
    */
   @Test
-  public void stopBlobStoreAdminRequestTest() throws IOException {
+  public void blobStoreControlAdminRequestTest() throws IOException {
+    doBlobStoreControlAdminRequestTest(true);
+    doBlobStoreControlAdminRequestTest(false);
+  }
+
+  /**
+   * Does the actual test of ser/de of {@link BlobStoreControlAdminRequest} and checks for equality of fields with
+   * reference data.
+   * @param enable the value for the enable field in {@link BlobStoreControlAdminRequest}.
+   * @throws IOException
+   */
+  private void doBlobStoreControlAdminRequestTest(boolean enable)
+      throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
     PartitionId id = clusterMap.getWritablePartitionIds().get(0);
     int correlationId = 1234;
     String clientId = "client";
-    // test stop BlobStore request
+    // test BlobStore Control request
     short numCaughtUpPerPartition = Utils.getRandomShort(TestUtils.RANDOM);
-    AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
-    StopBlobStoreAdminRequest stopBlobStoreAdminRequest =
-        new StopBlobStoreAdminRequest(numCaughtUpPerPartition, adminRequest);
-    DataInputStream requestStream = serAndPrepForRead(stopBlobStoreAdminRequest, -1, true);
+    AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
+    BlobStoreControlAdminRequest blobStoreControlAdminRequest =
+        new BlobStoreControlAdminRequest(numCaughtUpPerPartition, enable, adminRequest);
+    DataInputStream requestStream = serAndPrepForRead(blobStoreControlAdminRequest, -1, true);
     AdminRequest deserializedAdminRequest =
         deserAdminRequestAndVerify(requestStream, clusterMap, correlationId, clientId,
-            AdminRequestOrResponseType.StopBlobStore, id);
-    StopBlobStoreAdminRequest deserializedStopBlobStoreRequest =
-        StopBlobStoreAdminRequest.readFrom(requestStream, deserializedAdminRequest);
+            AdminRequestOrResponseType.BlobStoreControl, id);
+    BlobStoreControlAdminRequest deserializedBlobStoreControlRequest =
+        BlobStoreControlAdminRequest.readFrom(requestStream, deserializedAdminRequest);
     Assert.assertEquals("Num caught up per partition not as set", numCaughtUpPerPartition,
-        deserializedStopBlobStoreRequest.getNumReplicasCaughtUpPerPartition());
+        deserializedBlobStoreControlRequest.getNumReplicasCaughtUpPerPartition());
+    Assert.assertEquals("Enable variable not as set", enable,
+        deserializedBlobStoreControlRequest.shouldEnable());
     // test toString method
-    String correctString = "StopBlobStoreAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId
-        + ", NumReplicasCaughtUpPerPartition=" + deserializedStopBlobStoreRequest.getNumReplicasCaughtUpPerPartition()
-        + ", PartitionId=" + deserializedStopBlobStoreRequest.getPartitionId() + "]";
-    Assert.assertEquals("The test of toString method fails", correctString, "" + deserializedStopBlobStoreRequest);
+    String correctString = "BlobStoreControlAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId
+        + ", NumReplicasCaughtUpPerPartition=" + deserializedBlobStoreControlRequest.getNumReplicasCaughtUpPerPartition()
+        + ", PartitionId=" + deserializedBlobStoreControlRequest.getPartitionId() + "]";
+    Assert.assertEquals("The test of toString method fails", correctString, "" + deserializedBlobStoreControlRequest);
   }
 
   /**

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -555,15 +555,15 @@ public class RequestResponseTest {
    * @param enable the value for the enable field in {@link BlobStoreControlAdminRequest}.
    * @throws IOException
    */
-  private void doBlobStoreControlAdminRequestTest(boolean enable)
-      throws IOException {
+  private void doBlobStoreControlAdminRequestTest(boolean enable) throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
     PartitionId id = clusterMap.getWritablePartitionIds().get(0);
     int correlationId = 1234;
     String clientId = "client";
     // test BlobStore Control request
     short numCaughtUpPerPartition = Utils.getRandomShort(TestUtils.RANDOM);
-    AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
     BlobStoreControlAdminRequest blobStoreControlAdminRequest =
         new BlobStoreControlAdminRequest(numCaughtUpPerPartition, enable, adminRequest);
     DataInputStream requestStream = serAndPrepForRead(blobStoreControlAdminRequest, -1, true);
@@ -574,12 +574,12 @@ public class RequestResponseTest {
         BlobStoreControlAdminRequest.readFrom(requestStream, deserializedAdminRequest);
     Assert.assertEquals("Num caught up per partition not as set", numCaughtUpPerPartition,
         deserializedBlobStoreControlRequest.getNumReplicasCaughtUpPerPartition());
-    Assert.assertEquals("Enable variable not as set", enable,
-        deserializedBlobStoreControlRequest.shouldEnable());
+    Assert.assertEquals("Enable variable not as set", enable, deserializedBlobStoreControlRequest.shouldEnable());
     // test toString method
     String correctString = "BlobStoreControlAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId
-        + ", NumReplicasCaughtUpPerPartition=" + deserializedBlobStoreControlRequest.getNumReplicasCaughtUpPerPartition()
-        + ", PartitionId=" + deserializedBlobStoreControlRequest.getPartitionId() + "]";
+        + ", NumReplicasCaughtUpPerPartition="
+        + deserializedBlobStoreControlRequest.getNumReplicasCaughtUpPerPartition() + ", PartitionId="
+        + deserializedBlobStoreControlRequest.getPartitionId() + "]";
     Assert.assertEquals("The test of toString method fails", correctString, "" + deserializedBlobStoreControlRequest);
   }
 

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -106,7 +106,6 @@ class InvalidVersionPutRequest extends PutRequest {
 
 class OtherVersionStopStoreRequest extends AdminRequest {
   private final short version;
-  //  private final long acceptableLagInBytes = 0;
   private final short numReplicasCaughtUpPerPartition;
   private final long sizeInBytes;
 
@@ -122,7 +121,6 @@ class OtherVersionStopStoreRequest extends AdminRequest {
   protected void serializeIntoBuffer() {
     super.serializeIntoBuffer();
     bufferToSend.putShort(version);
-    //bufferToSend.putLong(acceptableLagInBytes);
     bufferToSend.putShort(numReplicasCaughtUpPerPartition);
   }
 

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -567,18 +567,6 @@ public class RequestResponseTest {
         + ", NumReplicasCaughtUpPerPartition=" + deserializedStopBlobStoreRequest.getNumReplicasCaughtUpPerPartition()
         + ", PartitionId=" + deserializedStopBlobStoreRequest.getPartitionId() + "]";
     Assert.assertEquals("The test of toString method fails", correctString, "" + deserializedStopBlobStoreRequest);
-//    // test invalid version of StopBlobStoreAdminRequest
-//    short invalidVersion = 2;
-//    OtherVersionStopStoreRequest invalidVersionStopStoreRequest =
-//        new OtherVersionStopStoreRequest(adminRequest, invalidVersion, numCaughtUpPerPartition);
-//    requestStream = serAndPrepForRead(invalidVersionStopStoreRequest, -1, true);
-//    try {
-//      deserializedAdminRequest = deserAdminRequestAndVerify(requestStream, clusterMap, correlationId, clientId,
-//          AdminRequestOrResponseType.StopBlobStore, id);
-//      StopBlobStoreAdminRequest.readFrom(requestStream, deserializedAdminRequest);
-//      Assert.fail("Deserialization of StopStoreRequest with invalid version should have thrown an exception.");
-//    } catch (IllegalStateException e) {
-//    }
   }
 
   /**

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -104,6 +104,36 @@ class InvalidVersionPutRequest extends PutRequest {
   }
 }
 
+class OtherVersionStopStoreRequest extends AdminRequest {
+  private final short version;
+  private final long acceptableLagInBytes;
+  private final short numReplicasCaughtUpPerPartition;
+  private final long sizeInBytes;
+
+  OtherVersionStopStoreRequest(AdminRequest adminRequest, short version, long acceptableLagInBytes,
+      short numReplicasCaughtUpPerPartition) {
+    super(AdminRequestOrResponseType.StopBlobStore, adminRequest.getPartitionId(), adminRequest.getCorrelationId(),
+        adminRequest.getClientId());
+    this.version = version;
+    this.acceptableLagInBytes = acceptableLagInBytes;
+    this.numReplicasCaughtUpPerPartition = numReplicasCaughtUpPerPartition;
+    sizeInBytes = super.sizeInBytes() + Short.BYTES + Long.BYTES + Short.BYTES;
+  }
+
+  @Override
+  protected void serializeIntoBuffer() {
+    super.serializeIntoBuffer();
+    bufferToSend.putShort(version);
+    bufferToSend.putLong(acceptableLagInBytes);
+    bufferToSend.putShort(numReplicasCaughtUpPerPartition);
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return sizeInBytes;
+  }
+}
+
 /**
  * Tests for different requests and responses in the protocol.
  */
@@ -537,6 +567,65 @@ public class RequestResponseTest {
     Assert.assertEquals(deserializedCatchupStatusResponse.getClientId(), clientId);
     Assert.assertEquals(deserializedCatchupStatusResponse.getError(), responseErrorCode);
     Assert.assertEquals(deserializedCatchupStatusResponse.isCaughtUp(), isCaughtUp);
+  }
+
+  /**
+   * Tests the ser/de of {@link StopBlobStoreAdminRequest} and checks for equality of fields with reference data.
+   * @throws IOException
+   */
+  @Test
+  public void stopBlobStoreAdminRequestTest() throws IOException {
+    MockClusterMap clusterMap = new MockClusterMap();
+    PartitionId id = clusterMap.getWritablePartitionIds().get(0);
+    int correlationId = 1234;
+    String clientId = "client";
+    // stop BlobStore request
+    long acceptableLag = Utils.getRandomLong(TestUtils.RANDOM, 10000);
+    short numCaughtUpPerPartition = Utils.getRandomShort(TestUtils.RANDOM);
+    AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
+    StopBlobStoreAdminRequest stopBlobStoreAdminRequest =
+        new StopBlobStoreAdminRequest(acceptableLag, numCaughtUpPerPartition, adminRequest);
+    DataInputStream requestStream = serAndPrepForRead(stopBlobStoreAdminRequest, -1, true);
+    AdminRequest deserializedAdminRequest =
+        deserAdminRequestAndVerify(requestStream, clusterMap, correlationId, clientId,
+            AdminRequestOrResponseType.StopBlobStore, id);
+    StopBlobStoreAdminRequest deserializedStopBlobStoreRequest =
+        StopBlobStoreAdminRequest.readFrom(requestStream, deserializedAdminRequest);
+    Assert.assertEquals("Acceptable lag not as set", acceptableLag,
+        deserializedStopBlobStoreRequest.getAcceptableLagInBytes());
+    Assert.assertEquals("Num caught up per partition not as set", numCaughtUpPerPartition,
+        deserializedStopBlobStoreRequest.getNumReplicasCaughtUpPerPartition());
+    // test toString method
+    String correctString = "StopBlobStoreAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId
+        + ", AcceptableLagInBytes=" + deserializedStopBlobStoreRequest.getAcceptableLagInBytes() + ", PartitionId="
+        + deserializedStopBlobStoreRequest.getPartitionId() + "]";
+    Assert.assertEquals("The test of toString method fails", correctString, "" + deserializedStopBlobStoreRequest);
+
+    // test V1 version  of StopBlobStoreAdminRequest
+    acceptableLag = Utils.getRandomLong(TestUtils.RANDOM, 10000);
+    numCaughtUpPerPartition = Utils.getRandomShort(TestUtils.RANDOM);
+    OtherVersionStopStoreRequest versionOneStopStoreRequest =
+        new OtherVersionStopStoreRequest(adminRequest, (short) 1, acceptableLag, numCaughtUpPerPartition);
+    requestStream = serAndPrepForRead(versionOneStopStoreRequest, -1, true);
+    deserializedAdminRequest = deserAdminRequestAndVerify(requestStream, clusterMap, correlationId, clientId,
+        AdminRequestOrResponseType.StopBlobStore, id);
+    deserializedStopBlobStoreRequest = StopBlobStoreAdminRequest.readFrom(requestStream, deserializedAdminRequest);
+    Assert.assertEquals("Acceptable lag not as set", acceptableLag,
+        deserializedStopBlobStoreRequest.getAcceptableLagInBytes());
+    Assert.assertEquals("Num caught up per partition not as pre-defined", Short.MAX_VALUE,
+        deserializedStopBlobStoreRequest.getNumReplicasCaughtUpPerPartition());
+
+    // test invalid version of StopBlobStoreAdminRequest
+    OtherVersionStopStoreRequest invalidVersionStopStoreRequest =
+        new OtherVersionStopStoreRequest(adminRequest, (short) 0, acceptableLag, numCaughtUpPerPartition);
+    requestStream = serAndPrepForRead(invalidVersionStopStoreRequest, -1, true);
+    try {
+      deserializedAdminRequest = deserAdminRequestAndVerify(requestStream, clusterMap, correlationId, clientId,
+          AdminRequestOrResponseType.StopBlobStore, id);
+      StopBlobStoreAdminRequest.readFrom(requestStream, deserializedAdminRequest);
+      Assert.fail("Deserialization of StopStoreRequest with invalid version should have thrown an exception.");
+    } catch (IllegalStateException e) {
+    }
   }
 
   /**

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -104,32 +104,6 @@ class InvalidVersionPutRequest extends PutRequest {
   }
 }
 
-class OtherVersionStopStoreRequest extends AdminRequest {
-  private final short version;
-  private final short numReplicasCaughtUpPerPartition;
-  private final long sizeInBytes;
-
-  OtherVersionStopStoreRequest(AdminRequest adminRequest, short version, short numReplicasCaughtUpPerPartition) {
-    super(AdminRequestOrResponseType.StopBlobStore, adminRequest.getPartitionId(), adminRequest.getCorrelationId(),
-        adminRequest.getClientId());
-    this.version = version;
-    this.numReplicasCaughtUpPerPartition = numReplicasCaughtUpPerPartition;
-    sizeInBytes = super.sizeInBytes() + Short.BYTES + Long.BYTES + Short.BYTES;
-  }
-
-  @Override
-  protected void serializeIntoBuffer() {
-    super.serializeIntoBuffer();
-    bufferToSend.putShort(version);
-    bufferToSend.putShort(numReplicasCaughtUpPerPartition);
-  }
-
-  @Override
-  public long sizeInBytes() {
-    return sizeInBytes;
-  }
-}
-
 /**
  * Tests for different requests and responses in the protocol.
  */
@@ -593,18 +567,18 @@ public class RequestResponseTest {
         + ", NumReplicasCaughtUpPerPartition=" + deserializedStopBlobStoreRequest.getNumReplicasCaughtUpPerPartition()
         + ", PartitionId=" + deserializedStopBlobStoreRequest.getPartitionId() + "]";
     Assert.assertEquals("The test of toString method fails", correctString, "" + deserializedStopBlobStoreRequest);
-    // test invalid version of StopBlobStoreAdminRequest
-    short invalidVersion = 2;
-    OtherVersionStopStoreRequest invalidVersionStopStoreRequest =
-        new OtherVersionStopStoreRequest(adminRequest, invalidVersion, numCaughtUpPerPartition);
-    requestStream = serAndPrepForRead(invalidVersionStopStoreRequest, -1, true);
-    try {
-      deserializedAdminRequest = deserAdminRequestAndVerify(requestStream, clusterMap, correlationId, clientId,
-          AdminRequestOrResponseType.StopBlobStore, id);
-      StopBlobStoreAdminRequest.readFrom(requestStream, deserializedAdminRequest);
-      Assert.fail("Deserialization of StopStoreRequest with invalid version should have thrown an exception.");
-    } catch (IllegalStateException e) {
-    }
+//    // test invalid version of StopBlobStoreAdminRequest
+//    short invalidVersion = 2;
+//    OtherVersionStopStoreRequest invalidVersionStopStoreRequest =
+//        new OtherVersionStopStoreRequest(adminRequest, invalidVersion, numCaughtUpPerPartition);
+//    requestStream = serAndPrepForRead(invalidVersionStopStoreRequest, -1, true);
+//    try {
+//      deserializedAdminRequest = deserAdminRequestAndVerify(requestStream, clusterMap, correlationId, clientId,
+//          AdminRequestOrResponseType.StopBlobStore, id);
+//      StopBlobStoreAdminRequest.readFrom(requestStream, deserializedAdminRequest);
+//      Assert.fail("Deserialization of StopStoreRequest with invalid version should have thrown an exception.");
+//    } catch (IllegalStateException e) {
+//    }
   }
 
   /**

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -786,6 +786,7 @@ public class AmbryRequests implements RequestAPI {
         if (error.equals(ServerErrorCode.No_Error)) {
           if (blobStoreControlAdminRequest.shouldEnable()) {
             // TODO: start BlobStore properly
+            error = ServerErrorCode.Temporarily_Disabled;
           } else {
             Collection<PartitionId> partitionIds = Collections.singletonList(partitionId);
             if (storageManager.disableCompactionForBlobStore(partitionId)) {

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -813,7 +813,10 @@ public class AmbryRequests implements RequestAPI {
                 controlRequestForPartitions(RequestOrResponseType.GetRequest, partitionIds, false);
                 controlRequestForPartitions(RequestOrResponseType.ReplicaMetadataRequest, partitionIds, false);
                 // Shutdown the BlobStore completely
-                storageManager.shutdownBlobStore(partitionId);
+                if (!storageManager.shutdownBlobStore(partitionId)) {
+                  logger.error("Shutting down BlobStore fails on {}", partitionId);
+                  error = ServerErrorCode.Unknown_Error;
+                }
               }
             }
           }

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -797,32 +797,33 @@ public class AmbryRequests implements RequestAPI {
                 // Shutdown the BlobStore completely
                 if (storageManager.shutdownBlobStore(partitionId)) {
                   error = ServerErrorCode.No_Error;
+                  logger.info("store shutdown for partition: {}", partitionId);
                 } else {
-                  logger.error("Shutting down BlobStore fails on {}", partitionId);
                   error = ServerErrorCode.Unknown_Error;
+                  logger.error("Shutting down BlobStore fails on {}", partitionId);
                 }
               } else {
-                error = ServerErrorCode.Operation_In_Progress;
+                error = ServerErrorCode.Retry_After_Backoff;
                 logger.debug("Catchup not done on {}", partitionIds);
               }
             } else {
-              logger.error("Could not disable replication on {}", partitionIds);
               error = ServerErrorCode.Unknown_Error;
+              logger.error("Could not disable replication on {}", partitionIds);
             }
           } else {
             error = ServerErrorCode.Unknown_Error;
             logger.error("Disable compaction on given BlobStore failed for {}", partitionId);
           }
         } else {
-          logger.error("Validate request fails for {}", partitionId);
+          logger.debug("Validate request fails for {} with error code {}", partitionId, error);
         }
       } else {
         error = ServerErrorCode.Partition_Unknown;
-        logger.error("The partition Id should not be null.");
+        logger.debug("The partition Id should not be null.");
       }
     } else {
       error = ServerErrorCode.Bad_Request;
-      logger.error("The number of replicas to catch up should not be less or equal to zero {}",
+      logger.debug("The number of replicas to catch up should not be less or equal to zero {}",
           stopBlobStoreAdminRequest.getNumReplicasCaughtUpPerPartition());
     }
     return new AdminResponse(adminRequest.getCorrelationId(), adminRequest.getClientId(), error);

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -380,7 +380,8 @@ public class ServerMetrics {
     replicationControlRequestRate =
         registry.meter(MetricRegistry.name(AmbryRequests.class, "ReplicationControlRequestRate"));
     catchupStatusRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "CatchupStatusRequestRate"));
-    blobStoreControlRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "BlobStoreControlRequestRate"));
+    blobStoreControlRequestRate =
+        registry.meter(MetricRegistry.name(AmbryRequests.class, "BlobStoreControlRequestRate"));
 
     putSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "PutSmallBlobRequestRate"));
     getSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "GetSmallBlobRequestRate"));

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -130,11 +130,11 @@ public class ServerMetrics {
   public final Histogram catchupStatusResponseSendTimeInMs;
   public final Histogram catchupStatusRequestTotalTimeInMs;
 
-  public final Histogram stopBlobStoreRequestQueueTimeInMs;
-  public final Histogram stopBlobStoreRequestProcessingTimeInMs;
-  public final Histogram stopBlobStoreResponseQueueTimeInMs;
-  public final Histogram stopBlobStoreResponseSendTimeInMs;
-  public final Histogram stopBlobStoreRequestTotalTimeInMs;
+  public final Histogram blobStoreControlRequestQueueTimeInMs;
+  public final Histogram blobStoreControlRequestProcessingTimeInMs;
+  public final Histogram blobStoreControlResponseQueueTimeInMs;
+  public final Histogram blobStoreControlResponseSendTimeInMs;
+  public final Histogram blobStoreControlRequestTotalTimeInMs;
 
   public final Histogram blobSizeInBytes;
   public final Histogram blobUserMetadataSizeInBytes;
@@ -155,7 +155,7 @@ public class ServerMetrics {
   public final Meter requestControlRequestRate;
   public final Meter replicationControlRequestRate;
   public final Meter catchupStatusRequestRate;
-  public final Meter stopBlobStoreRequestRate;
+  public final Meter blobStoreControlRequestRate;
 
   public final Meter putSmallBlobRequestRate;
   public final Meter getSmallBlobRequestRate;
@@ -346,16 +346,16 @@ public class ServerMetrics {
     catchupStatusRequestTotalTimeInMs =
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "CatchupStatusRequestTotalTimeInMs"));
 
-    stopBlobStoreRequestQueueTimeInMs =
-        registry.histogram(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreRequestQueueTimeInMs"));
-    stopBlobStoreRequestProcessingTimeInMs =
-        registry.histogram(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreRequestProcessingTimeInMs"));
-    stopBlobStoreResponseQueueTimeInMs =
-        registry.histogram(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreResponseQueueTimeInMs"));
-    stopBlobStoreResponseSendTimeInMs =
-        registry.histogram(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreResponseSendTimeInMs"));
-    stopBlobStoreRequestTotalTimeInMs =
-        registry.histogram(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreRequestTotalTimeInMs"));
+    blobStoreControlRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobStoreControlRequestQueueTimeInMs"));
+    blobStoreControlRequestProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobStoreControlRequestProcessingTimeInMs"));
+    blobStoreControlResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobStoreControlResponseQueueTimeInMs"));
+    blobStoreControlResponseSendTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobStoreControlResponseSendTimeInMs"));
+    blobStoreControlRequestTotalTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobStoreControlRequestTotalTimeInMs"));
 
     blobSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobSize"));
     blobUserMetadataSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobUserMetadataSize"));
@@ -380,7 +380,7 @@ public class ServerMetrics {
     replicationControlRequestRate =
         registry.meter(MetricRegistry.name(AmbryRequests.class, "ReplicationControlRequestRate"));
     catchupStatusRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "CatchupStatusRequestRate"));
-    stopBlobStoreRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreRequestRate"));
+    blobStoreControlRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "BlobStoreControlRequestRate"));
 
     putSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "PutSmallBlobRequestRate"));
     getSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "GetSmallBlobRequestRate"));

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -130,6 +130,12 @@ public class ServerMetrics {
   public final Histogram catchupStatusResponseSendTimeInMs;
   public final Histogram catchupStatusRequestTotalTimeInMs;
 
+  public final Histogram stopBlobStoreRequestQueueTimeInMs;
+  public final Histogram stopBlobStoreRequestProcessingTimeInMs;
+  public final Histogram stopBlobStoreResponseQueueTimeInMs;
+  public final Histogram stopBlobStoreResponseSendTimeInMs;
+  public final Histogram stopBlobStoreRequestTotalTimeInMs;
+
   public final Histogram blobSizeInBytes;
   public final Histogram blobUserMetadataSizeInBytes;
 
@@ -149,6 +155,7 @@ public class ServerMetrics {
   public final Meter requestControlRequestRate;
   public final Meter replicationControlRequestRate;
   public final Meter catchupStatusRequestRate;
+  public final Meter stopBlobStoreRequestRate;
 
   public final Meter putSmallBlobRequestRate;
   public final Meter getSmallBlobRequestRate;
@@ -339,6 +346,17 @@ public class ServerMetrics {
     catchupStatusRequestTotalTimeInMs =
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "CatchupStatusRequestTotalTimeInMs"));
 
+    stopBlobStoreRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreRequestQueueTimeInMs"));
+    stopBlobStoreRequestProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreRequestProcessingTimeInMs"));
+    stopBlobStoreResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreResponseQueueTimeInMs"));
+    stopBlobStoreResponseSendTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreResponseSendTimeInMs"));
+    stopBlobStoreRequestTotalTimeInMs =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreRequestTotalTimeInMs"));
+
     blobSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobSize"));
     blobUserMetadataSizeInBytes = registry.histogram(MetricRegistry.name(AmbryRequests.class, "BlobUserMetadataSize"));
 
@@ -362,6 +380,7 @@ public class ServerMetrics {
     replicationControlRequestRate =
         registry.meter(MetricRegistry.name(AmbryRequests.class, "ReplicationControlRequestRate"));
     catchupStatusRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "CatchupStatusRequestRate"));
+    stopBlobStoreRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "StopBlobStoreRequestRate"));
 
     putSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "PutSmallBlobRequestRate"));
     getSmallBlobRequestRate = registry.meter(MetricRegistry.name(AmbryRequests.class, "GetSmallBlobRequestRate"));
@@ -393,8 +412,7 @@ public class ServerMetrics {
     unExpectedStoreTTLError = registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStoreTTLError"));
     unExpectedStoreFindEntriesError =
         registry.counter(MetricRegistry.name(AmbryRequests.class, "UnexpectedStoreFindEntriesError"));
-    getAuthorizationFailure =
-        registry.counter(MetricRegistry.name(AmbryRequests.class, "GetAuthorizationFailure"));
+    getAuthorizationFailure = registry.counter(MetricRegistry.name(AmbryRequests.class, "GetAuthorizationFailure"));
     deleteAuthorizationFailure =
         registry.counter(MetricRegistry.name(AmbryRequests.class, "DeleteAuthorizationFailure"));
   }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -339,7 +339,6 @@ public class AmbryRequestsTest {
   @Test
   public void stopBlobStoreSuccessTest() throws InterruptedException, IOException {
     List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds();
-    assertTrue("This test needs more than one partition to work", partitionIds.size() > 1);
     PartitionId id = partitionIds.get(0);
     List<? extends ReplicaId> replicaIds = id.getReplicaIds();
     assertTrue("This test needs more than one replica for the first partition to work", replicaIds.size() > 1);
@@ -388,6 +387,13 @@ public class AmbryRequestsTest {
     stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
     response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Partition_Unknown);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    // test validate request failure
+    storageManager.returnNullStore = true;
+    adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
+    stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
+    response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Disk_Unavailable);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    storageManager.returnNullStore = false;
     // test disable compaction failure
     adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
     stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
@@ -400,7 +406,7 @@ public class AmbryRequestsTest {
     replicationManager.controlReplicationReturnVal = false;
     adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
     stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
-    response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Bad_Request);
+    response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Unknown_Error);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     // test peers catchup failure
     replicationManager.reset();
@@ -409,7 +415,7 @@ public class AmbryRequestsTest {
     generateLagOverrides(1, 1);
     adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
     stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
-    response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Catchup_Unfinished);
+    response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Operation_In_Progress);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     // test shutdown BlobStore failure
     replicationManager.reset();

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -350,7 +350,8 @@ public class AmbryRequestsTest {
     replicationManager.controlReplicationReturnVal = true;
     generateLagOverrides(0, acceptableLagInBytes);
     // stop BlobStore
-    AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
     BlobStoreControlAdminRequest stopBlobStoreAdminRequest =
         new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     Response response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.No_Error);
@@ -375,7 +376,8 @@ public class AmbryRequestsTest {
     String clientId = UtilsTest.getRandomString(10);
     short numReplicasCaughtUpPerPartition = -1;
     // test invalid numReplicasCaughtUpPerPartition
-    AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
     BlobStoreControlAdminRequest blobStoreControlAdminRequest =
         new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     Response response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Bad_Request);
@@ -383,26 +385,30 @@ public class AmbryRequestsTest {
     // test partition unknown
     numReplicasCaughtUpPerPartition = 3;
     adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, null, correlationId, clientId);
-    blobStoreControlAdminRequest = new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
+    blobStoreControlAdminRequest =
+        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Partition_Unknown);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     // test validate request failure
     storageManager.returnNullStore = true;
     adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest = new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
+    blobStoreControlAdminRequest =
+        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Disk_Unavailable);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     storageManager.returnNullStore = false;
     // test disable compaction failure
     adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest = new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
+    blobStoreControlAdminRequest =
+        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     storageManager.returnValueOfDisablingCompaction = false;
     response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     storageManager.returnValueOfDisablingCompaction = true;
     // test disable compaction with runtime exception
     adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest = new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
+    blobStoreControlAdminRequest =
+        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     storageManager.exceptionToThrowOnDisablingCompaction = new IllegalStateException();
     response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
@@ -411,7 +417,8 @@ public class AmbryRequestsTest {
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = false;
     adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest = new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
+    blobStoreControlAdminRequest =
+        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     // test peers catchup failure
@@ -420,7 +427,8 @@ public class AmbryRequestsTest {
     // all replicas of this partition > acceptableLag
     generateLagOverrides(1, 1);
     adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest = new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
+    blobStoreControlAdminRequest =
+        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Retry_After_Backoff);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     // test shutdown BlobStore failure
@@ -429,13 +437,15 @@ public class AmbryRequestsTest {
     storageManager.returnValueOfShutdownBlobStore = false;
     generateLagOverrides(0, 0);
     adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest = new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
+    blobStoreControlAdminRequest =
+        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     // test shutdown BlobStore with runtime exception
     storageManager.exceptionToThrowOnShuttingdownBlobStore = new IllegalStateException();
     adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest = new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
+    blobStoreControlAdminRequest =
+        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     storageManager.exceptionToThrowOnShuttingdownBlobStore = null;

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -351,7 +351,7 @@ public class AmbryRequestsTest {
     replicationManager.controlReplicationReturnVal = true;
     generateLagOverrides(0, acceptableLagInBytes);
     AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
-    StopBlobStoreAdminRequest stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(acceptableLagInBytes, numReplicasCaughtUpPerPartition, adminRequest);
+    StopBlobStoreAdminRequest stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
     Response response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.No_Error);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
   }
@@ -368,30 +368,27 @@ public class AmbryRequestsTest {
     PartitionId id = partitionIds.get(0);
     int correlationId = TestUtils.RANDOM.nextInt();
     String clientId = UtilsTest.getRandomString(10);
-    long acceptableLagInBytes = -1;
     short numReplicasCaughtUpPerPartition = 3;
     // test invalid acceptableLagInBytes
+    //AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
+    //StopBlobStoreAdminRequest stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
+    //Response response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Bad_Request);
+    //assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    // test invalid numReplicasCaughtUpPerPartition
+    numReplicasCaughtUpPerPartition = -1;
     AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
-    StopBlobStoreAdminRequest stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(acceptableLagInBytes, numReplicasCaughtUpPerPartition, adminRequest);
+    StopBlobStoreAdminRequest stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
     Response response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Bad_Request);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
-    // test invalid numReplicasCaughtUpPerPartition
-    acceptableLagInBytes = 0;
-    numReplicasCaughtUpPerPartition = -1;
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
-    stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(acceptableLagInBytes, numReplicasCaughtUpPerPartition, adminRequest);
-    response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Bad_Request);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     // test partition unknown
-    acceptableLagInBytes = 0;
     numReplicasCaughtUpPerPartition = 3;
     adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, null, correlationId, clientId);
-    stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(acceptableLagInBytes, numReplicasCaughtUpPerPartition, adminRequest);
+    stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
     response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Partition_Unknown);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     // test disable compaction failure
     adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
-    stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(acceptableLagInBytes, numReplicasCaughtUpPerPartition, adminRequest);
+    stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
     storageManager.returnValueOfDisablingCompaction = false;
     response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Unknown_Error);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
@@ -400,16 +397,16 @@ public class AmbryRequestsTest {
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = false;
     adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
-    stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(acceptableLagInBytes, numReplicasCaughtUpPerPartition, adminRequest);
+    stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
     response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Bad_Request);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     // test peers catchup failure
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = true;
     // all replicas of this partition > acceptableLag
-    generateLagOverrides(acceptableLagInBytes + 1, acceptableLagInBytes + 1);
+    generateLagOverrides(1,  1);
     adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
-    stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(acceptableLagInBytes, numReplicasCaughtUpPerPartition, adminRequest);
+    stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
     response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Catchup_Unfinished);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
   }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -351,7 +351,8 @@ public class AmbryRequestsTest {
     replicationManager.controlReplicationReturnVal = true;
     generateLagOverrides(0, acceptableLagInBytes);
     AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
-    StopBlobStoreAdminRequest stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
+    StopBlobStoreAdminRequest stopBlobStoreAdminRequest =
+        new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
     Response response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.No_Error);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
   }
@@ -368,16 +369,11 @@ public class AmbryRequestsTest {
     PartitionId id = partitionIds.get(0);
     int correlationId = TestUtils.RANDOM.nextInt();
     String clientId = UtilsTest.getRandomString(10);
-    short numReplicasCaughtUpPerPartition = 3;
-    // test invalid acceptableLagInBytes
-    //AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
-    //StopBlobStoreAdminRequest stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
-    //Response response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Bad_Request);
-    //assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    short numReplicasCaughtUpPerPartition = -1;
     // test invalid numReplicasCaughtUpPerPartition
-    numReplicasCaughtUpPerPartition = -1;
     AdminRequest adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
-    StopBlobStoreAdminRequest stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
+    StopBlobStoreAdminRequest stopBlobStoreAdminRequest =
+        new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
     Response response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Bad_Request);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     // test partition unknown
@@ -404,7 +400,7 @@ public class AmbryRequestsTest {
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = true;
     // all replicas of this partition > acceptableLag
-    generateLagOverrides(1,  1);
+    generateLagOverrides(1, 1);
     adminRequest = new AdminRequest(AdminRequestOrResponseType.StopBlobStore, id, correlationId, clientId);
     stopBlobStoreAdminRequest = new StopBlobStoreAdminRequest(numReplicasCaughtUpPerPartition, adminRequest);
     response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.Catchup_Unfinished);

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -370,7 +370,6 @@ public class AmbryRequestsTest {
   @Test
   public void stopBlobStoreFailureTest() throws InterruptedException, IOException {
     List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds();
-    assertTrue("This test needs more than one partition to work", partitionIds.size() > 1);
     PartitionId id = partitionIds.get(0);
     int correlationId = TestUtils.RANDOM.nextInt();
     String clientId = UtilsTest.getRandomString(10);

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
@@ -243,15 +243,18 @@ class DiskManager {
    * Shutdown the {@link PartitionId} {@code id}.
    * @param id the {@link PartitionId} of the {@link BlobStore} which should be shutdown.
    */
-  void shutdownBlobStore(PartitionId id) {
+  boolean shutdownBlobStore(PartitionId id) {
     BlobStore store = (BlobStore) getStore(id);
-    if (store != null) {
-      try {
-        store.shutdown();
-      } catch (Exception e) {
-        logger.error("Exception while shutting down store {} on disk {}", id, disk, e);
-      }
+    if (store == null) {
+      return false;
     }
+    try {
+      store.shutdown();
+    } catch (Exception e) {
+      logger.error("Exception while shutting down store {} on disk {}", id, disk, e);
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
@@ -247,17 +247,9 @@ class DiskManager {
     BlobStore store = (BlobStore) getStore(id);
     if (store != null) {
       try {
-        Thread shutdownThread = Utils.newThread("store-shutdown-" + id, () -> {
-          try {
-            store.shutdown();
-          } catch (Exception e) {
-            logger.error("Exception while shutting down store {} on disk {}", id, disk, e);
-          }
-        }, false);
-        shutdownThread.start();
-        shutdownThread.join();
+        store.shutdown();
       } catch (Exception e) {
-        logger.error("Could not shut down the store {} on disk {}", id, disk, e);
+        logger.error("Exception while shutting down store {} on disk {}", id, disk, e);
       }
     }
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -199,11 +199,9 @@ public class StorageManager {
    * Shutdown blobstore with given {@link PartitionId} {@code id}.
    * @param id the {@link PartitionId} of the {@link Store} which would be shutdown.
    */
-  public void shutdownBlobStore(PartitionId id){
+  public boolean shutdownBlobStore(PartitionId id) {
     DiskManager diskManager = partitionToDiskManager.get(id);
-    if(diskManager != null){
-      diskManager.shutdownBlobStore(id);
-    }
+    return diskManager != null && diskManager.shutdownBlobStore(id);
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -195,6 +195,13 @@ public class StorageManager {
     }
   }
 
+  public void shutdownBlobStore(PartitionId id){
+    DiskManager diskManager = partitionToDiskManager.get(id);
+    if(diskManager != null){
+      diskManager.shutdownBlobStore(id);
+    }
+  }
+
   /**
    * @return the number of compaction threads running.
    */

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -195,6 +195,10 @@ public class StorageManager {
     }
   }
 
+  /**
+   * Shutdown blobstore with given {@link PartitionId} {@code id}.
+   * @param id the {@link PartitionId} of the {@link Store} which would be shutdown.
+   */
   public void shutdownBlobStore(PartitionId id){
     DiskManager diskManager = partitionToDiskManager.get(id);
     if(diskManager != null){


### PR DESCRIPTION
Add new request type StopBlobStore on server side and finish the API to
handle stopping BlobStore. This commit involves changes in AmbryRequest,
StorageManager, DiskManager, ServerErrorCode, AdminRequestOrResponseType
and the new file StopBlobStoreAdminRequest.