### PR TITLE
Change rackId field to a string

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/DataNodeId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/DataNodeId.java
@@ -71,10 +71,10 @@ public abstract class DataNodeId implements Resource, Comparable<DataNodeId> {
   public abstract String getDatacenterName();
 
   /**
-   * Get the DataNodeId's server rack ID.  If there is no rack ID for this node,
-   * -1 will be returned, so the caller must check that the returned value is non-negative.
+   * Get the DataNodeId's server rack ID.  This is a unique identifier for a failure zone. If there is no rack ID for
+   * this node, null will be returned, so the caller must check that the returned value is non-null
    *
-   * @return a valid rack ID, or a negative number if no rack ID is assigned
+   * @return a valid rack ID, or null if no rack ID is assigned
    */
-  public abstract long getRackId();
+  public abstract String getRackId();
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
@@ -33,7 +33,7 @@ class AmbryDataNode extends DataNodeId implements Resource {
   private final Port plainTextPort;
   private final Port sslPort;
   private final String dataCenterName;
-  private final long rackId;
+  private final String rackId;
   private final List<String> sslEnabledDataCenters;
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final ResourceStatePolicy resourceStatePolicy;
@@ -49,14 +49,14 @@ class AmbryDataNode extends DataNodeId implements Resource {
    * @param sslPortNum the ssl port associated with this data node (may be null).
    * @throws Exception if there is an exception in instantiating the {@link ResourceStatePolicy}
    */
-  AmbryDataNode(String dataCenterName, ClusterMapConfig clusterMapConfig, String hostName, int portNum, Long rackId,
+  AmbryDataNode(String dataCenterName, ClusterMapConfig clusterMapConfig, String hostName, int portNum, String rackId,
       Integer sslPortNum) throws Exception {
     this.hostName = hostName;
     this.plainTextPort = new Port(portNum, PortType.PLAINTEXT);
     this.sslPort = sslPortNum != null ? new Port(sslPortNum, PortType.SSL) : null;
     this.dataCenterName = dataCenterName;
     this.clusterMapConfig = clusterMapConfig;
-    this.rackId = rackId != null ? rackId : UNKNOWN_RACK_ID;
+    this.rackId = rackId;
     this.sslEnabledDataCenters = Utils.splitString(clusterMapConfig.clusterMapSslEnabledDatacenters, ",");
     ResourceStatePolicyFactory resourceStatePolicyFactory =
         Utils.getObj(clusterMapConfig.clusterMapResourceStatePolicyFactory, this, HardwareState.AVAILABLE,
@@ -130,7 +130,7 @@ class AmbryDataNode extends DataNodeId implements Resource {
   }
 
   @Override
-  public long getRackId() {
+  public String getRackId() {
     return rackId;
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -46,7 +46,6 @@ public class ClusterMapUtils {
   static final String DATACENTER_STR = "datacenter";
   static final String DATACENTER_ID_STR = "id";
   static final String SCHEMA_VERSION_STR = "schemaVersion";
-  static final int UNKNOWN_RACK_ID = -1;
   static final int MIN_PORT = 1025;
   static final int MAX_PORT = 65535;
   static final long MIN_REPLICA_CAPACITY_IN_BYTES = 1024 * 1024 * 1024L;
@@ -141,9 +140,8 @@ public class ClusterMapUtils {
    * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
    * @return the rack id associated with the given instance.
    */
-  static Long getRackId(InstanceConfig instanceConfig) {
-    String rackIdStr = instanceConfig.getRecord().getSimpleField(RACKID_STR);
-    return rackIdStr == null ? null : Long.valueOf(rackIdStr);
+  static String getRackId(InstanceConfig instanceConfig) {
+    return instanceConfig.getRecord().getSimpleField(RACKID_STR);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DataNode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DataNode.java
@@ -46,7 +46,7 @@ class DataNode extends DataNodeId {
   private final ArrayList<Disk> disks;
   private final long rawCapacityInBytes;
   private final ResourceStatePolicy dataNodeStatePolicy;
-  private final long rackId;
+  private final String rackId;
   private final ArrayList<String> sslEnabledDataCenters;
   private final ClusterMapConfig clusterMapConfig;
 
@@ -83,15 +83,7 @@ class DataNode extends DataNodeId {
     this.ports = new HashMap<PortType, Port>();
     this.ports.put(PortType.PLAINTEXT, new Port(portNum, PortType.PLAINTEXT));
     populatePorts(jsonObject);
-
-    if (jsonObject.has("rackId")) {
-      this.rackId = jsonObject.getLong("rackId");
-      if (this.rackId < 0) {
-        throw new IllegalStateException("Invalid rackId : " + this.rackId + " is less than 0");
-      }
-    } else {
-      this.rackId = UNKNOWN_RACK_ID;
-    }
+    this.rackId = jsonObject.optString("rackId", null);
 
     validate();
   }
@@ -195,7 +187,7 @@ class DataNode extends DataNodeId {
   }
 
   @Override
-  public long getRackId() {
+  public String getRackId() {
     return rackId;
   }
 
@@ -245,9 +237,7 @@ class DataNode extends DataNodeId {
   JSONObject toJSONObject() throws JSONException {
     JSONObject jsonObject = new JSONObject().put("hostname", hostname).put("port", portNum);
     addSSLPortToJson(jsonObject);
-    if (rackId >= 0) {
-      jsonObject.put("rackId", getRackId());
-    }
+    jsonObject.putOpt("rackId", rackId);
     jsonObject.put("hardwareState",
         dataNodeStatePolicy.isHardDown() ? HardwareState.UNAVAILABLE : HardwareState.AVAILABLE)
         .put("disks", new JSONArray());

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Datacenter.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Datacenter.java
@@ -118,14 +118,15 @@ class Datacenter {
   private void validateRackAwareness() {
     if (dataNodes.size() > 0) {
       Iterator<DataNode> dataNodeIter = dataNodes.iterator();
-      boolean hasRackId = (dataNodeIter.next().getRackId() >= 0);
+      boolean firstHasRackId = (dataNodeIter.next().getRackId() != null);
       while (dataNodeIter.hasNext()) {
-        if (hasRackId != (dataNodeIter.next().getRackId() >= 0)) {
+        boolean currHasRackId = (dataNodeIter.next().getRackId() != null);
+        if (firstHasRackId != currHasRackId) {
           throw new IllegalStateException(
               "dataNodes in datacenter: " + name + " must all have defined rack IDs or none at all");
         }
       }
-      this.rackAware = hasRackId;
+      this.rackAware = firstHasRackId;
     }
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
@@ -259,7 +260,7 @@ class HelixBootstrapUpgradeUtil {
             instanceConfig.getRecord().setSimpleField(ClusterMapUtils.SSLPORT_STR, Integer.toString(node.getSSLPort()));
           }
           instanceConfig.getRecord().setSimpleField(ClusterMapUtils.DATACENTER_STR, node.getDatacenterName());
-          instanceConfig.getRecord().setSimpleField(ClusterMapUtils.RACKID_STR, Long.toString(node.getRackId()));
+          instanceConfig.getRecord().setSimpleField(ClusterMapUtils.RACKID_STR, node.getRackId());
           instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, new ArrayList<String>());
 
           // Finally, add this node to the DC.
@@ -580,7 +581,7 @@ class HelixBootstrapUpgradeUtil {
               .equals(instanceConfig.getRecord().getSimpleField(ClusterMapUtils.DATACENTER_STR)),
           "Datacenter mismatch for instance " + instanceName);
       ensureOrThrow(
-          dataNode.getRackId() == Long.valueOf(instanceConfig.getRecord().getSimpleField(ClusterMapUtils.RACKID_STR)),
+          Objects.equals(dataNode.getRackId(), instanceConfig.getRecord().getSimpleField(ClusterMapUtils.RACKID_STR)),
           "Rack Id mismatch for instance " + instanceName);
       Set<String> sealedReplicasInHelix =
           new HashSet<>(instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR));

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -281,7 +281,7 @@ class StaticClusterManager implements ClusterMap {
    */
   private Disk getBestDiskCandidate(List<DataNode> dataNodes, Set<DataNode> dataNodesUsed, long replicaCapacityInBytes,
       boolean rackAware, int numChoices) {
-    Set<Long> rackIdsUsed = new HashSet<>();
+    Set<String> rackIdsUsed = new HashSet<>();
     if (rackAware) {
       for (DataNode dataNode : dataNodesUsed) {
         rackIdsUsed.add(dataNode.getRackId());

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DataNodeTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DataNodeTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.PortType;
+import java.util.Objects;
 import java.util.Properties;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -58,10 +59,10 @@ class TestDataNode extends DataNode {
     if (getState() != testDataNode.getState()) {
       return false;
     }
-    if (getRackId() != testDataNode.getRackId()) {
+    if (getRawCapacityInBytes() != testDataNode.getRawCapacityInBytes()) {
       return false;
     }
-    return getRawCapacityInBytes() == testDataNode.getRawCapacityInBytes();
+    return Objects.equals(getRackId(), testDataNode.getRackId());
   }
 }
 
@@ -100,7 +101,7 @@ public class DataNodeTest {
     assertEquals(dataNode.getDisks().size(), diskCount);
     assertEquals(dataNode.getRawCapacityInBytes(), diskCount * diskCapacityInBytes);
 
-    assertEquals(-1, dataNode.getRackId());
+    assertEquals(null, dataNode.getRackId());
 
     assertEquals(dataNode.toJSONObject().toString(), jsonObject.toString());
     assertEquals(dataNode, new TestDataNode("datacenter", dataNode.toJSONObject(), clusterMapConfig));
@@ -109,7 +110,7 @@ public class DataNodeTest {
     jsonObject =
         TestUtils.getJsonDataNode(TestUtils.getLocalHost(), 6666, 7666, 42, HardwareState.AVAILABLE, getDisks());
     dataNode = new TestDataNode("datacenter", jsonObject, clusterMapConfig);
-    assertEquals(42, dataNode.getRackId());
+    assertEquals("42", dataNode.getRackId());
 
     assertEquals(dataNode.toJSONObject().toString(), jsonObject.toString());
     assertEquals(dataNode, new TestDataNode("datacenter", dataNode.toJSONObject(), clusterMapConfig));
@@ -166,11 +167,6 @@ public class DataNodeTest {
 
     // same port number for plain text and ssl port
     jsonObject = TestUtils.getJsonDataNode(TestUtils.getLocalHost(), 6666, 6666, HardwareState.AVAILABLE, getDisks());
-    failValidation(jsonObject, clusterMapConfig);
-
-    // bad rack ID
-    jsonObject =
-        TestUtils.getJsonDataNode(TestUtils.getLocalHost(), 6666, 7666, -2, HardwareState.AVAILABLE, getDisks());
     failValidation(jsonObject, clusterMapConfig);
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.*;
 public class DynamicClusterManagerComponentsTest {
   private static final int PORT_NUM1 = 2000;
   private static final int PORT_NUM2 = 2001;
-  private static final long RACK_ID = 1;
+  private static final String RACK_ID = "1";
   private static final int SSL_PORT_NUM = 3000;
   private static final String HOST_NAME = TestUtils.getLocalHost();
   private final ClusterMapConfig clusterMapConfig1;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
@@ -115,8 +115,8 @@ public class MockDataNodeId extends DataNodeId {
   }
 
   @Override
-  public long getRackId() {
-    return -1;
+  public String getRackId() {
+    return null;
   }
 
   public List<String> getMountPaths() {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
@@ -374,17 +374,13 @@ public class StaticClusterManagerTest {
    */
   private static void checkRackUsage(List<PartitionId> allocatedPartitions) {
     for (PartitionId partition : allocatedPartitions) {
-      Map<String, Set<Long>> rackSetByDatacenter = new HashMap<>();
+      Map<String, Set<String>> rackSetByDatacenter = new HashMap<>();
       for (ReplicaId replica : partition.getReplicaIds()) {
         String datacenter = replica.getDataNodeId().getDatacenterName();
-        Set<Long> rackSet = rackSetByDatacenter.get(datacenter);
-        if (rackSet == null) {
-          rackSet = new HashSet<>();
-          rackSetByDatacenter.put(datacenter, rackSet);
-        }
+        Set<String> rackSet = rackSetByDatacenter.computeIfAbsent(datacenter, k -> new HashSet<>());
 
-        long rackId = replica.getDataNodeId().getRackId();
-        if (rackId >= 0) {
+        String rackId = replica.getDataNodeId().getRackId();
+        if (rackId != null) {
           assertFalse("Allocation was not on unique racks", rackSet.contains(rackId));
           rackSet.add(rackId);
         }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -110,7 +110,7 @@ public class TestUtils {
     jsonObject.put("hostname", hostname);
     jsonObject.put("port", port);
     jsonObject.put("sslport", sslPort);
-    jsonObject.put("rackId", rackId);
+    jsonObject.put("rackId", Long.toString(rackId));
     jsonObject.put("hardwareState", hardwareState);
     jsonObject.put("disks", disks);
     return jsonObject;

--- a/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
@@ -42,7 +42,7 @@ public class ConnectionStatsHandler extends ChannelInboundHandlerAdapter {
     metrics.registerConnectionsStatsHandler(openConnections);
     handshakeListener = future -> {
       if (!future.isSuccess()) {
-        logger.info("SSL handshake failed", future.cause());
+        logger.debug("SSL handshake failed", future.cause());
         metrics.handshakeFailureCount.inc();
       }
     };

--- a/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/ConnectionStatsHandler.java
@@ -13,13 +13,10 @@
  */
 package com.github.ambry.rest;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +29,6 @@ import org.slf4j.LoggerFactory;
 public class ConnectionStatsHandler extends ChannelInboundHandlerAdapter {
   private final NettyMetrics metrics;
   private final AtomicLong openConnections;
-  private final GenericFutureListener<Future<Channel>> handshakeListener;
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -40,12 +36,6 @@ public class ConnectionStatsHandler extends ChannelInboundHandlerAdapter {
     this.metrics = metrics;
     openConnections = new AtomicLong(0);
     metrics.registerConnectionsStatsHandler(openConnections);
-    handshakeListener = future -> {
-      if (!future.isSuccess()) {
-        logger.debug("SSL handshake failed", future.cause());
-        metrics.handshakeFailureCount.inc();
-      }
-    };
   }
 
   @Override
@@ -72,7 +62,12 @@ public class ConnectionStatsHandler extends ChannelInboundHandlerAdapter {
   private void logHandshakeStatus(ChannelHandlerContext ctx) {
     SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
     if (sslHandler != null) {
-      sslHandler.handshakeFuture().addListener(handshakeListener);
+      sslHandler.handshakeFuture().addListener(future -> {
+        if (!future.isSuccess()) {
+          logger.debug("SSL handshake failed for channel: {}", ctx.channel(), future.cause());
+          metrics.handshakeFailureCount.inc();
+        }
+      });
     }
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -960,6 +960,7 @@ class GetBlobOperation extends GetOperation {
               decryptCallbackResultInfo.exception);
           setOperationException(
               new RouterException("Exception thrown on decrypting content for " + blobType + " blob " + blobId,
+                  decryptCallbackResultInfo.exception,
                   RouterErrorCode.UnexpectedInternalError));
           progressTracker.setDecryptionFailed();
         } else {


### PR DESCRIPTION
Change the rack ID field from a long to a string to flexibly support failure-zone identifiers.