### PR TITLE
Explicitly ignore dynamic new node additions

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -46,7 +46,6 @@ public class ClusterMapUtils {
   static final String DATACENTER_STR = "datacenter";
   static final String DATACENTER_ID_STR = "id";
   static final String SCHEMA_VERSION_STR = "schemaVersion";
-  static final String XID_STR = "xid";
   static final int UNKNOWN_RACK_ID = -1;
   static final int MIN_PORT = 1025;
   static final int MAX_PORT = 65535;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -45,6 +45,8 @@ public class ClusterMapUtils {
   static final String ZKINFO_STR = "zkInfo";
   static final String DATACENTER_STR = "datacenter";
   static final String DATACENTER_ID_STR = "id";
+  static final String SCHEMA_VERSION_STR = "schemaVersion";
+  static final String XID_STR = "xid";
   static final int UNKNOWN_RACK_ID = -1;
   static final int MIN_PORT = 1025;
   static final int MAX_PORT = 65535;
@@ -116,6 +118,17 @@ public class ClusterMapUtils {
   }
 
   /**
+   * Get the schema version associated with the given instance (if any).
+   * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
+   * @return the schema version of the information stored. If the field is absent in the InstanceConfig, the version
+   *         is assumed to be 0, and 0 is returned.
+   */
+  static int getSchemaVersion(InstanceConfig instanceConfig) {
+    String schemaVersionStr = instanceConfig.getRecord().getSimpleField(SCHEMA_VERSION_STR);
+    return schemaVersionStr == null ? 0 : Integer.valueOf(schemaVersionStr);
+  }
+
+  /**
    * Get the list of sealed replicas on a given instance.
    * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
    * @return the list of sealed replicas.
@@ -130,7 +143,8 @@ public class ClusterMapUtils {
    * @return the rack id associated with the given instance.
    */
   static Long getRackId(InstanceConfig instanceConfig) {
-    return Long.valueOf(instanceConfig.getRecord().getSimpleField(RACKID_STR));
+    String rackIdStr = instanceConfig.getRecord().getSimpleField(RACKID_STR);
+    return rackIdStr == null ? null : Long.valueOf(rackIdStr);
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
@@ -227,7 +227,7 @@ public class MockHelixAdmin implements HelixAdmin {
    * @param tagAsInit whether the InstanceConfig notification should be tagged with
    *                  {@link org.apache.helix.NotificationContext.Type#INIT}
    */
-  private void triggerInstanceConfigChangeNotification(boolean tagAsInit) {
+  void triggerInstanceConfigChangeNotification(boolean tagAsInit) {
     for (MockHelixManager helixManager : helixManagersForThisAdmin) {
       helixManager.triggerConfigChangeNotification(tagAsInit);
     }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -28,6 +28,8 @@ public class MockHelixCluster {
   private final MockHelixAdminFactory helixAdminFactory;
   private final Map<String, MockHelixAdmin> helixAdmins;
   private final String clusterName;
+  private final String partitionLayoutPath;
+  private final String zkLayoutPath;
 
   /**
    * Instantiate a MockHelixCluster.
@@ -41,9 +43,24 @@ public class MockHelixCluster {
       throws Exception {
     helixAdminFactory = new MockHelixAdminFactory();
     helixAdmins = helixAdminFactory.getAllHelixAdmins();
+    this.partitionLayoutPath = partitionLayoutPath;
+    this.zkLayoutPath = zkLayoutPath;
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
         null, 3, helixAdminFactory);
     this.clusterName = clusterName;
+  }
+
+  /**
+   * Upgrade based on the hardwareLayout.
+   * @param hardwareLayoutPath the new hardware layout.
+   * @throws Exception
+   */
+  void upgradeWithNewHardwareLayout(String hardwareLayoutPath) throws Exception {
+    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
+        null, 3, helixAdminFactory);
+    for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
+      helixAdmin.triggerInstanceConfigChangeNotification(false);
+    }
   }
 
   /**


### PR DESCRIPTION
Ignore InstanceConfig changes (after initialization) involving new
node additions. Currently this results in a Null Pointer Exception.
Going forward, these should be handled to support dynamic new node
additions.