### PR TITLE
Introducing a UpdateRecord

### DIFF
--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreHardDelete.java
@@ -87,9 +87,14 @@ public class BlobStoreHardDelete implements MessageStoreHardDelete {
             Utils.addSecondsToEpochTime(properties.getCreationTimeInMs(), properties.getTimeToLiveInSeconds()),
             properties.getAccountId(), properties.getContainerId(), properties.getCreationTimeInMs());
       } else {
-        DeleteRecord deleteRecord = deserializeDeleteRecord(stream);
-        return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true,
-            deleteRecord.getAccountId(), deleteRecord.getContainerId(), deleteRecord.getDeletionTimeInMs());
+        UpdateRecord updateRecord = deserializeUpdateRecord(stream);
+        switch (updateRecord.getType()) {
+          case DELETE:
+            return new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true,
+                updateRecord.getAccountId(), updateRecord.getContainerId(), updateRecord.getUpdateTimeInMs());
+          default:
+            throw new IllegalStateException("Unknown update record type: " + updateRecord.getType());
+        }
       }
     } catch (MessageFormatException e) {
       // log in case where we were not able to parse a message.

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobStoreRecovery.java
@@ -85,11 +85,17 @@ public class BlobStoreRecovery implements MessageStoreRecovery {
               properties.getAccountId(), properties.getContainerId(), properties.getCreationTimeInMs());
           messageRecovered.add(info);
         } else {
-          DeleteRecord deleteRecord = deserializeDeleteRecord(stream);
-          MessageInfo info =
-              new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true,
-                  deleteRecord.getAccountId(), deleteRecord.getContainerId(), deleteRecord.getDeletionTimeInMs());
-          messageRecovered.add(info);
+          UpdateRecord updateRecord = deserializeUpdateRecord(stream);
+          switch (updateRecord.getType()) {
+            case DELETE:
+              MessageInfo info =
+                  new MessageInfo(key, header.capacity() + key.sizeInBytes() + headerFormat.getMessageSize(), true,
+                      updateRecord.getAccountId(), updateRecord.getContainerId(), updateRecord.getUpdateTimeInMs());
+              messageRecovered.add(info);
+              break;
+            default:
+              throw new IllegalStateException("Unknown update record type: " + updateRecord.getType());
+          }
         }
         startOffset = stream.getCurrentPosition();
       }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteMessageFormatInputStream.java
@@ -34,7 +34,7 @@ public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
   public DeleteMessageFormatInputStream(StoreKey key, short accountId, short containerId, long deletionTimeMs)
       throws MessageFormatException {
     int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.headerVersionToUse);
-    int deleteRecordSize = MessageFormatRecord.Delete_Format_V2.getDeleteRecordSize();
+    int deleteRecordSize = MessageFormatRecord.Update_Format_V2.getRecordSize();
     buffer = ByteBuffer.allocate(headerSize + key.sizeInBytes() + deleteRecordSize);
     if (MessageFormatRecord.headerVersionToUse == MessageFormatRecord.Message_Header_Version_V1) {
       MessageFormatRecord.MessageHeader_Format_V1.serializeHeader(buffer, deleteRecordSize,
@@ -50,8 +50,8 @@ public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
     }
     buffer.put(key.toBytes());
     // set the message as deleted
-    MessageFormatRecord.Delete_Format_V2.serializeDeleteRecord(buffer,
-        new DeleteRecord(accountId, containerId, deletionTimeMs));
+    MessageFormatRecord.Update_Format_V2.serialize(buffer,
+        new UpdateRecord(accountId, containerId, deletionTimeMs, new DeleteRecord()));
     messageLength = buffer.capacity();
     buffer.flip();
   }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteRecord.java
@@ -17,28 +17,10 @@ package com.github.ambry.messageformat;
  * Contains the delete record info
  */
 public class DeleteRecord {
-  private final short accountId;
-  private final short containerId;
-  private final long deletionTimeInMs;
 
   /**
    * Constructs Delete Record
    */
-  DeleteRecord(short accountId, short containerId, long deletionTimeInMs) {
-    this.accountId = accountId;
-    this.containerId = containerId;
-    this.deletionTimeInMs = deletionTimeInMs;
-  }
-
-  public short getAccountId() {
-    return accountId;
-  }
-
-  public short getContainerId() {
-    return containerId;
-  }
-
-  public long getDeletionTimeInMs() {
-    return deletionTimeInMs;
+  DeleteRecord() {
   }
 }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -45,8 +45,9 @@ public class MessageFormatRecord {
   public static final short Message_Header_Version_V1 = 1;
   public static final short Message_Header_Version_V2 = 2;
   public static final short BlobProperties_Version_V1 = 1;
-  public static final short Delete_Version_V1 = 1;
-  public static final short Delete_Version_V2 = 2;
+  public static final short Update_Version_V1 = 1;
+  public static final short Update_Version_V2 = 2;
+  public static final short Update_Version_V3 = 3;
   public static final short Blob_Encryption_Key_V1 = 1;
   public static final short UserMetadata_Version_V1 = 1;
   public static final short Blob_Version_V1 = 1;
@@ -55,6 +56,8 @@ public class MessageFormatRecord {
   public static final int Message_Header_Invalid_Relative_Offset = -1;
 
   static short headerVersionToUse = Message_Header_Version_V2;
+
+  private static final short Delete_Version_V1 = 1;
 
   static boolean isValidHeaderVersion(short headerVersion) {
     switch (headerVersion) {
@@ -124,17 +127,19 @@ public class MessageFormatRecord {
     }
   }
 
-  public static DeleteRecord deserializeDeleteRecord(InputStream stream) throws IOException, MessageFormatException {
+  public static UpdateRecord deserializeUpdateRecord(InputStream stream) throws IOException, MessageFormatException {
     CrcInputStream crcStream = new CrcInputStream(stream);
     DataInputStream inputStream = new DataInputStream(crcStream);
     short version = inputStream.readShort();
     switch (version) {
-      case Delete_Version_V1:
-        return Delete_Format_V1.deserializeDeleteRecord(crcStream);
-      case Delete_Version_V2:
-        return Delete_Format_V2.deserializeDeleteRecord(crcStream);
+      case Update_Version_V1:
+        return Update_Format_V1.deserialize(crcStream);
+      case Update_Version_V2:
+        return Update_Format_V2.deserialize(crcStream);
+      case Update_Version_V3:
+        return Update_Format_V3.deserialize(crcStream);
       default:
-        throw new MessageFormatException("delete record version not supported",
+        throw new MessageFormatException("update record version not supported: " + version,
             MessageFormatErrorCodes.Unknown_Format_Version);
     }
   }
@@ -284,7 +289,7 @@ public class MessageFormatRecord {
 
     /**
      * @return if this is a put record, the relative offset of the Blob Properties Record from the end of the header. If
-     * this is a delete record, returns {@link #Message_Header_Invalid_Relative_Offset}
+     * this is a update record, returns {@link #Message_Header_Invalid_Relative_Offset}
      */
     int getBlobPropertiesRecordRelativeOffset();
 
@@ -294,10 +299,10 @@ public class MessageFormatRecord {
     int getBlobPropertiesRecordSize();
 
     /**
-     * @return if this is a delete record, the relative offset of the Delete Sub Record from the end of the header. If
-     * this is a put record, returns {@link #Message_Header_Invalid_Relative_Offset}
+     * @return if this is an update record, the relative offset of the Sub Record from the end of the header. If this is
+     * a put record, returns {@link #Message_Header_Invalid_Relative_Offset}
      */
-    int getDeleteRecordRelativeOffset();
+    int getUpdateRecordRelativeOffset();
 
     /**
      * @return if this is a put record with an encryption key sub record, the offset of the encryption key sub record
@@ -347,7 +352,7 @@ public class MessageFormatRecord {
     boolean hasEncryptionKeyRecord();
 
     /**
-     * @return true if this is a put record; false if this is a delete record.
+     * @return true if this is a put record; false if this is a update record.
      */
     boolean isPutRecord();
   }
@@ -356,7 +361,7 @@ public class MessageFormatRecord {
    *
    *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    * |         |              |               |           |               |           |           |
-   * | version | payload size | Blob Property | Delete    | User Metadata | Blob      | Crc       |
+   * | version | payload size | Blob Property | Update    | User Metadata | Blob      | Crc       |
    * |(2 bytes)|   (8 bytes)  | Relative      | Relative  | Relative      | Relative  | (8 bytes) |
    * |         |              | Offset        | Offset    | Offset        | Offset    |           |
    * |         |              | (4 bytes)     | (4 bytes) | (4 bytes)     | (4 bytes) |           |
@@ -366,13 +371,13 @@ public class MessageFormatRecord {
    *  version         - The version of the message header
    *
    *  payload size    - The size of the message payload.
-   *                    (Blob prop record size or delete record size) + user metadata size + blob size
+   *                    (Blob prop record size or update record size) + user metadata size + blob size
    *
    *  blob property   - The offset at which the blob property record is located relative to this message. Only one of
-   *  relative offset   blob property/delete relative offset field can exist. Non existence is indicated by -1
+   *  relative offset   blob property/update relative offset field can exist. Non existence is indicated by -1
    *
-   *  delete          - The offset at which the delete record is located relative to this message. Only one of blob
-   *  relative offset   property/delete relative offset field can exist. Non existence is indicated by -1
+   *  update          - The offset at which the update record is located relative to this message. Only one of blob
+   *  relative offset   property/update relative offset field can exist. Non existence is indicated by -1
    *
    *  user metadata   - The offset at which the user metadata record is located relative to this message. This exist
    *  relative offset   only when blob property record and blob record exist
@@ -397,10 +402,10 @@ public class MessageFormatRecord {
     public static final int Relative_Offset_Field_Sizes_In_Bytes = 4;
     public static final int BlobProperties_Relative_Offset_Field_Offset_In_Bytes =
         Total_Size_Field_Offset_In_Bytes + Total_Size_Field_Size_In_Bytes;
-    public static final int Delete_Relative_Offset_Field_Offset_In_Bytes =
+    public static final int Update_Relative_Offset_Field_Offset_In_Bytes =
         BlobProperties_Relative_Offset_Field_Offset_In_Bytes + Relative_Offset_Field_Sizes_In_Bytes;
     public static final int UserMetadata_Relative_Offset_Field_Offset_In_Bytes =
-        Delete_Relative_Offset_Field_Offset_In_Bytes + Relative_Offset_Field_Sizes_In_Bytes;
+        Update_Relative_Offset_Field_Offset_In_Bytes + Relative_Offset_Field_Sizes_In_Bytes;
     public static final int Blob_Relative_Offset_Field_Offset_In_Bytes =
         UserMetadata_Relative_Offset_Field_Offset_In_Bytes + Relative_Offset_Field_Sizes_In_Bytes;
 
@@ -414,35 +419,35 @@ public class MessageFormatRecord {
     }
 
     public static void serializeHeader(ByteBuffer outputBuffer, long totalSize, int blobPropertiesRecordRelativeOffset,
-        int deleteRecordRelativeOffset, int userMetadataRecordRelativeOffset, int blobRecordRelativeOffset)
+        int updateRecordRelativeOffset, int userMetadataRecordRelativeOffset, int blobRecordRelativeOffset)
         throws MessageFormatException {
-      checkHeaderConstraints(totalSize, blobPropertiesRecordRelativeOffset, deleteRecordRelativeOffset,
+      checkHeaderConstraints(totalSize, blobPropertiesRecordRelativeOffset, updateRecordRelativeOffset,
           userMetadataRecordRelativeOffset, blobRecordRelativeOffset);
       int startOffset = outputBuffer.position();
       outputBuffer.putShort(Message_Header_Version_V1);
       outputBuffer.putLong(totalSize);
       outputBuffer.putInt(blobPropertiesRecordRelativeOffset);
-      outputBuffer.putInt(deleteRecordRelativeOffset);
+      outputBuffer.putInt(updateRecordRelativeOffset);
       outputBuffer.putInt(userMetadataRecordRelativeOffset);
       outputBuffer.putInt(blobRecordRelativeOffset);
       Crc32 crc = new Crc32();
       crc.update(outputBuffer.array(), startOffset, getHeaderSize() - Crc_Size);
       outputBuffer.putLong(crc.getValue());
       logger.trace("serializing header : version {} size {} blobpropertiesrecordrelativeoffset {} "
-              + "deleterecordrelativeoffset {} usermetadatarecordrelativeoffset {} blobrecordrelativeoffset {} crc {}",
-          Message_Header_Version_V1, totalSize, blobPropertiesRecordRelativeOffset, deleteRecordRelativeOffset,
+              + "updaterecordrelativeoffset {} usermetadatarecordrelativeoffset {} blobrecordrelativeoffset {} crc {}",
+          Message_Header_Version_V1, totalSize, blobPropertiesRecordRelativeOffset, updateRecordRelativeOffset,
           userMetadataRecordRelativeOffset, blobPropertiesRecordRelativeOffset, crc.getValue());
     }
 
     // checks the following constraints
     // 1. totalSize is greater than 0
-    // 2. if blobPropertiesRecordRelativeOffset is greater than 0, ensures that deleteRecordRelativeOffset
+    // 2. if blobPropertiesRecordRelativeOffset is greater than 0, ensures that updateRecordRelativeOffset
     //    is set to Message_Header_Invalid_Relative_Offset and userMetadataRecordRelativeOffset
     //    and blobRecordRelativeOffset is positive
-    // 3. if deleteRecordRelativeOffset is greater than 0, ensures that all the other offsets are set to
+    // 3. if updateRecordRelativeOffset is greater than 0, ensures that all the other offsets are set to
     //    Message_Header_Invalid_Relative_Offset
     private static void checkHeaderConstraints(long totalSize, int blobPropertiesRecordRelativeOffset,
-        int deleteRecordRelativeOffset, int userMetadataRecordRelativeOffset, int blobRecordRelativeOffset)
+        int updateRecordRelativeOffset, int userMetadataRecordRelativeOffset, int blobRecordRelativeOffset)
         throws MessageFormatException {
       // check constraints
       if (totalSize <= 0) {
@@ -452,23 +457,23 @@ public class MessageFormatRecord {
       }
 
       if (blobPropertiesRecordRelativeOffset > 0 && (
-          deleteRecordRelativeOffset != Message_Header_Invalid_Relative_Offset || userMetadataRecordRelativeOffset <= 0
+          updateRecordRelativeOffset != Message_Header_Invalid_Relative_Offset || userMetadataRecordRelativeOffset <= 0
               || blobRecordRelativeOffset <= 0)) {
         throw new MessageFormatException(
             "checkHeaderConstraints - blobPropertiesRecordRelativeOffset is greater than 0 "
                 + " but other properties do not satisfy constraints" + " blobPropertiesRecordRelativeOffset "
-                + blobPropertiesRecordRelativeOffset + " deleteRecordRelativeOffset " + deleteRecordRelativeOffset
+                + blobPropertiesRecordRelativeOffset + " updateRecordRelativeOffset " + updateRecordRelativeOffset
                 + " userMetadataRecordRelativeOffset " + userMetadataRecordRelativeOffset + " blobRecordRelativeOffset "
                 + blobRecordRelativeOffset, MessageFormatErrorCodes.Header_Constraint_Error);
       }
 
-      if (deleteRecordRelativeOffset > 0 && (
+      if (updateRecordRelativeOffset > 0 && (
           blobPropertiesRecordRelativeOffset != Message_Header_Invalid_Relative_Offset
               || userMetadataRecordRelativeOffset != Message_Header_Invalid_Relative_Offset
               || blobRecordRelativeOffset != Message_Header_Invalid_Relative_Offset)) {
-        throw new MessageFormatException("checkHeaderConstraints - deleteRecordRelativeOffset is greater than 0 "
+        throw new MessageFormatException("checkHeaderConstraints - updateRecordRelativeOffset is greater than 0 "
             + " but other properties do not satisfy constraints" + " blobPropertiesRecordRelativeOffset "
-            + blobPropertiesRecordRelativeOffset + " deleteRecordRelativeOffset " + deleteRecordRelativeOffset
+            + blobPropertiesRecordRelativeOffset + " updateRecordRelativeOffset " + updateRecordRelativeOffset
             + " userMetadataRecordRelativeOffset " + userMetadataRecordRelativeOffset + " blobRecordRelativeOffset "
             + blobRecordRelativeOffset, MessageFormatErrorCodes.Header_Constraint_Error);
       }
@@ -490,7 +495,7 @@ public class MessageFormatRecord {
 
     @Override
     public int getPayloadRelativeOffset() {
-      return isPutRecord() ? getBlobPropertiesRecordRelativeOffset() : getDeleteRecordRelativeOffset();
+      return isPutRecord() ? getBlobPropertiesRecordRelativeOffset() : getUpdateRecordRelativeOffset();
     }
 
     @Override
@@ -509,8 +514,8 @@ public class MessageFormatRecord {
     }
 
     @Override
-    public int getDeleteRecordRelativeOffset() {
-      return buffer.getInt(Delete_Relative_Offset_Field_Offset_In_Bytes);
+    public int getUpdateRecordRelativeOffset() {
+      return buffer.getInt(Update_Relative_Offset_Field_Offset_In_Bytes);
     }
 
     @Override
@@ -557,7 +562,7 @@ public class MessageFormatRecord {
     @Override
     public void verifyHeader() throws MessageFormatException {
       verifyCrc();
-      checkHeaderConstraints(getMessageSize(), getBlobPropertiesRecordRelativeOffset(), getDeleteRecordRelativeOffset(),
+      checkHeaderConstraints(getMessageSize(), getBlobPropertiesRecordRelativeOffset(), getUpdateRecordRelativeOffset(),
           getUserMetadataRecordRelativeOffset(), getBlobRecordRelativeOffset());
     }
 
@@ -574,7 +579,7 @@ public class MessageFormatRecord {
    *
    *  - - - - - - - - - - - - - - - - - - -- - -- - - - - - - - - - - - - -  - - - - - - - - - - - - - - - - - - - -
    * |         |              |                 |               |           |               |           |           |
-   * | version | payload size | Blob Encryption | Blob Property | Delete    | User Metadata | Blob      | Crc       |
+   * | version | payload size | Blob Encryption | Blob Property | Update    | User Metadata | Blob      | Crc       |
    * |(2 bytes)|   (8 bytes)  | Key Relative    | Relative      | Relative  | Relative      | Relative  | (8 bytes) |
    * |         |              | Offset          | Offset        | Offset    | Offset        | Offset    |           |
    * |         |              | (4 bytes)       | (4 bytes)     | (4 bytes) | (4 bytes)     | (4 bytes) |           |
@@ -584,18 +589,18 @@ public class MessageFormatRecord {
    *  version         - The version of the message header
    *
    *  payload size    - The size of the message payload.
-   *                    Blob Encryption Key Record Size (if present) + (Blob prop record size or delete record size) +
+   *                    Blob Encryption Key Record Size (if present) + (Blob prop record size or update record size) +
    *                    user metadata size + blob size
    *
    *  Blob Encryption - The offset at which the blob encryption key record is located relative to this message.
    *  Key relative      Non-existence of blob key record is indicated by -1. Blob Keys are optionally present for Put
-   *  offset            records. Blob Keys will be absent for Delete records.
+   *  offset            records. Blob Keys will be absent for update records.
    *
    *  blob property   - The offset at which the blob property record is located relative to this message. Only one of
-   *  relative offset   blob property/delete relative offset field can exist. Non existence is indicated by -1
+   *  relative offset   blob property/update relative offset field can exist. Non existence is indicated by -1
    *
-   *  delete          - The offset at which the delete record is located relative to this message. Only one of blob
-   *  relative offset   property/delete relative offset field can exist. Non existence is indicated by -1
+   *  update          - The offset at which the update record is located relative to this message. Only one of blob
+   *  relative offset   property/update relative offset field can exist. Non existence is indicated by -1
    *
    *  user metadata   - The offset at which the user metadata record is located relative to this message. This exist
    *  relative offset   only when blob property record and blob record exist
@@ -621,10 +626,10 @@ public class MessageFormatRecord {
         Total_Size_Field_Offset_In_Bytes + Total_Size_Field_Size_In_Bytes;
     public static final int BlobProperties_Relative_Offset_Field_Offset_In_Bytes =
         Blob_Encryption_Key_Relative_Offset_Field_Offset_In_Bytes + Relative_Offset_Field_Sizes_In_Bytes;
-    public static final int Delete_Relative_Offset_Field_Offset_In_Bytes =
+    public static final int Update_Relative_Offset_Field_Offset_In_Bytes =
         BlobProperties_Relative_Offset_Field_Offset_In_Bytes + Relative_Offset_Field_Sizes_In_Bytes;
     public static final int UserMetadata_Relative_Offset_Field_Offset_In_Bytes =
-        Delete_Relative_Offset_Field_Offset_In_Bytes + Relative_Offset_Field_Sizes_In_Bytes;
+        Update_Relative_Offset_Field_Offset_In_Bytes + Relative_Offset_Field_Sizes_In_Bytes;
     public static final int Blob_Relative_Offset_Field_Offset_In_Bytes =
         UserMetadata_Relative_Offset_Field_Offset_In_Bytes + Relative_Offset_Field_Sizes_In_Bytes;
 
@@ -639,16 +644,16 @@ public class MessageFormatRecord {
 
     public static void serializeHeader(ByteBuffer outputBuffer, long totalSize,
         int blobEncryptionKeyRecordRelativeOffset, int blobPropertiesRecordRelativeOffset,
-        int deleteRecordRelativeOffset, int userMetadataRecordRelativeOffset, int blobRecordRelativeOffset)
+        int updateRecordRelativeOffset, int userMetadataRecordRelativeOffset, int blobRecordRelativeOffset)
         throws MessageFormatException {
       checkHeaderConstraints(totalSize, blobEncryptionKeyRecordRelativeOffset, blobPropertiesRecordRelativeOffset,
-          deleteRecordRelativeOffset, userMetadataRecordRelativeOffset, blobRecordRelativeOffset);
+          updateRecordRelativeOffset, userMetadataRecordRelativeOffset, blobRecordRelativeOffset);
       int startOffset = outputBuffer.position();
       outputBuffer.putShort(Message_Header_Version_V2);
       outputBuffer.putLong(totalSize);
       outputBuffer.putInt(blobEncryptionKeyRecordRelativeOffset);
       outputBuffer.putInt(blobPropertiesRecordRelativeOffset);
-      outputBuffer.putInt(deleteRecordRelativeOffset);
+      outputBuffer.putInt(updateRecordRelativeOffset);
       outputBuffer.putInt(userMetadataRecordRelativeOffset);
       outputBuffer.putInt(blobRecordRelativeOffset);
       Crc32 crc = new Crc32();
@@ -656,21 +661,21 @@ public class MessageFormatRecord {
       outputBuffer.putLong(crc.getValue());
       logger.trace(
           "serializing header : version {} size {} blobencryptionkeyrecordrelativeoffset {} blobpropertiesrecordrelativeoffset {} "
-              + "deleterecordrelativeoffset {} usermetadatarecordrelativeoffset {} blobrecordrelativeoffset {} crc {}",
+              + "updaterecordrelativeoffset {} usermetadatarecordrelativeoffset {} blobrecordrelativeoffset {} crc {}",
           Message_Header_Version_V2, totalSize, blobEncryptionKeyRecordRelativeOffset,
-          blobPropertiesRecordRelativeOffset, deleteRecordRelativeOffset, userMetadataRecordRelativeOffset,
+          blobPropertiesRecordRelativeOffset, updateRecordRelativeOffset, userMetadataRecordRelativeOffset,
           blobPropertiesRecordRelativeOffset, crc.getValue());
     }
 
     // checks the following constraints
     // 1. totalSize is greater than 0
-    // 2. if blobPropertiesRecordRelativeOffset is greater than 0, ensures that deleteRecordRelativeOffset
+    // 2. if blobPropertiesRecordRelativeOffset is greater than 0, ensures that updateRecordRelativeOffset
     //    is set to Message_Header_Invalid_Relative_Offset and userMetadataRecordRelativeOffset
     //    and blobRecordRelativeOffset is positive
-    // 3. if deleteRecordRelativeOffset is greater than 0, ensures that all the other offsets are set to
+    // 3. if updateRecordRelativeOffset is greater than 0, ensures that all the other offsets are set to
     //    Message_Header_Invalid_Relative_Offset
     private static void checkHeaderConstraints(long totalSize, int blobEncryptionKeyRecordRelativeOffset,
-        int blobPropertiesRecordRelativeOffset, int deleteRecordRelativeOffset, int userMetadataRecordRelativeOffset,
+        int blobPropertiesRecordRelativeOffset, int updateRecordRelativeOffset, int userMetadataRecordRelativeOffset,
         int blobRecordRelativeOffset) throws MessageFormatException {
       // check constraints
       if (totalSize <= 0) {
@@ -680,25 +685,25 @@ public class MessageFormatRecord {
       }
 
       if (blobPropertiesRecordRelativeOffset > 0 && (
-          deleteRecordRelativeOffset != Message_Header_Invalid_Relative_Offset || userMetadataRecordRelativeOffset <= 0
+          updateRecordRelativeOffset != Message_Header_Invalid_Relative_Offset || userMetadataRecordRelativeOffset <= 0
               || blobRecordRelativeOffset <= 0)) {
         throw new MessageFormatException(
             "checkHeaderConstraints - blobPropertiesRecordRelativeOffset is greater than 0 "
                 + " but other properties do not satisfy constraints" + " blobPropertiesRecordRelativeOffset "
-                + blobPropertiesRecordRelativeOffset + " deleteRecordRelativeOffset " + deleteRecordRelativeOffset
+                + blobPropertiesRecordRelativeOffset + " updateRecordRelativeOffset " + updateRecordRelativeOffset
                 + " userMetadataRecordRelativeOffset " + userMetadataRecordRelativeOffset + " blobRecordRelativeOffset "
                 + blobRecordRelativeOffset, MessageFormatErrorCodes.Header_Constraint_Error);
       }
 
-      if (deleteRecordRelativeOffset > 0 && (
+      if (updateRecordRelativeOffset > 0 && (
           blobEncryptionKeyRecordRelativeOffset != Message_Header_Invalid_Relative_Offset
               || blobPropertiesRecordRelativeOffset != Message_Header_Invalid_Relative_Offset
               || userMetadataRecordRelativeOffset != Message_Header_Invalid_Relative_Offset
               || blobRecordRelativeOffset != Message_Header_Invalid_Relative_Offset)) {
-        throw new MessageFormatException("checkHeaderConstraints - deleteRecordRelativeOffset is greater than 0 "
+        throw new MessageFormatException("checkHeaderConstraints - updateRecordRelativeOffset is greater than 0 "
             + " but other properties do not satisfy constraints" + " blobEncryptionKeyRelativeOffset "
             + blobEncryptionKeyRecordRelativeOffset + " blobPropertiesRecordRelativeOffset "
-            + blobPropertiesRecordRelativeOffset + " deleteRecordRelativeOffset " + deleteRecordRelativeOffset
+            + blobPropertiesRecordRelativeOffset + " updateRecordRelativeOffset " + updateRecordRelativeOffset
             + " userMetadataRecordRelativeOffset " + userMetadataRecordRelativeOffset + " blobRecordRelativeOffset "
             + blobRecordRelativeOffset, MessageFormatErrorCodes.Header_Constraint_Error);
       }
@@ -734,8 +739,8 @@ public class MessageFormatRecord {
     }
 
     @Override
-    public int getDeleteRecordRelativeOffset() {
-      return buffer.getInt(Delete_Relative_Offset_Field_Offset_In_Bytes);
+    public int getUpdateRecordRelativeOffset() {
+      return buffer.getInt(Update_Relative_Offset_Field_Offset_In_Bytes);
     }
 
     @Override
@@ -784,7 +789,7 @@ public class MessageFormatRecord {
         return hasEncryptionKeyRecord() ? getBlobEncryptionKeyRecordRelativeOffset()
             : getBlobPropertiesRecordRelativeOffset();
       } else {
-        return getDeleteRecordRelativeOffset();
+        return getUpdateRecordRelativeOffset();
       }
     }
 
@@ -797,7 +802,7 @@ public class MessageFormatRecord {
     public void verifyHeader() throws MessageFormatException {
       verifyCrc();
       checkHeaderConstraints(getMessageSize(), getBlobEncryptionKeyRecordRelativeOffset(),
-          getBlobPropertiesRecordRelativeOffset(), getDeleteRecordRelativeOffset(),
+          getBlobPropertiesRecordRelativeOffset(), getUpdateRecordRelativeOffset(),
           getUserMetadataRecordRelativeOffset(), getBlobRecordRelativeOffset());
     }
 
@@ -869,100 +874,247 @@ public class MessageFormatRecord {
    * |(2 bytes)|    (1 byte)   |  (8 bytes) |
    * |         |               |            |
    *  - - - - - - - - - - - - - - - - - - -
-   *  version         - The version of the delete record
+   *  version         - The version of the update record
    *
    *  delete byte     - Takes value 0 or 1. If it is set to 1, it signifies that the blob is deleted. The field
    *                    is required to be able to support undelete in the future if required.
    *
-   *  crc             - The crc of the delete record
+   *  crc             - The crc of the update record
    *
    */
-  public static class Delete_Format_V1 {
+  public static class Update_Format_V1 {
 
-    public static final int Delete_Field_Size_In_Bytes = 1;
-    private static Logger logger = LoggerFactory.getLogger(Delete_Format_V1.class);
+    private static final int Delete_Field_Size_In_Bytes = 1;
 
-    public static int getDeleteRecordSize() {
+    public static int getRecordSize() {
       return Version_Field_Size_In_Bytes + Delete_Field_Size_In_Bytes + Crc_Size;
     }
 
-    public static void serializeDeleteRecord(ByteBuffer outputBuffer, DeleteRecord deleteRecord) {
+    public static void serialize(ByteBuffer outputBuffer, UpdateRecord updateRecord) {
       int startOffset = outputBuffer.position();
-      outputBuffer.putShort(Delete_Version_V1);
+      outputBuffer.putShort(Update_Version_V1);
       outputBuffer.put((byte) 1);
       Crc32 crc = new Crc32();
-      crc.update(outputBuffer.array(), startOffset, getDeleteRecordSize() - Crc_Size);
+      crc.update(outputBuffer.array(), startOffset, getRecordSize() - Crc_Size);
       outputBuffer.putLong(crc.getValue());
     }
 
-    public static DeleteRecord deserializeDeleteRecord(CrcInputStream crcStream)
-        throws IOException, MessageFormatException {
+    static UpdateRecord deserialize(CrcInputStream crcStream) throws IOException, MessageFormatException {
       DataInputStream dataStream = new DataInputStream(crcStream);
       boolean isDeleted = dataStream.readByte() == 1;
       long actualCRC = crcStream.getValue();
       long expectedCRC = dataStream.readLong();
       if (actualCRC != expectedCRC) {
-        logger.error(
-            "corrupt data while parsing delete record Expected CRC " + expectedCRC + " Actual CRC " + actualCRC);
-        throw new MessageFormatException("delete record data is corrupt", MessageFormatErrorCodes.Data_Corrupt);
+        throw new MessageFormatException(
+            "update record data is corrupt. Expected CRC: " + expectedCRC + ", Actual CRC: " + actualCRC,
+            MessageFormatErrorCodes.Data_Corrupt);
       }
-      return new DeleteRecord(UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID, Utils.Infinite_Time);
+      return new UpdateRecord(UNKNOWN_ACCOUNT_ID, UNKNOWN_CONTAINER_ID, Utils.Infinite_Time, new DeleteRecord());
     }
   }
 
   /**
    *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    * |         |               |               |               |             |
-   * | version |   AccountId   |  ContainerId  |  DeletionTime |     Crc     |
+   * | version |   AccountId   |  ContainerId  |  UpdateTime   |     Crc     |
    * |(2 bytes)|    (2 byte2)  |   (2 bytes)   |   (8 bytes)   |  (8 bytes)  |
    * |         |               |               |               |             |
    *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   *  version         - The version of the delete record
+   *  version       - The version of the update record
    *
    *  AccountId     - AccountId that the blob belongs to
    *
    *  ContainerId   - ContainerId that the blob belongs to
    *
-   *  Deletion Time - Time of deletion in Ms
+   *  UpdateTime    - Time of update in Ms
    *
-   *  Crc           - The crc of the delete record
+   *  Crc           - The crc of the update record
    *
    */
-  public static class Delete_Format_V2 {
+  public static class Update_Format_V2 {
 
-    public static final int ACCOUNT_ID_FIELD_SIZE_IN_BYTES = Short.BYTES;
-    public static final int CONTAINER_ID_FIELD_SIZE_IN_BYTES = Short.BYTES;
-    public static final int DELETION_TIME_FIELD_SIZE_IN_BYTES = Long.BYTES;
+    private static final int ACCOUNT_ID_FIELD_SIZE_IN_BYTES = Short.BYTES;
+    private static final int CONTAINER_ID_FIELD_SIZE_IN_BYTES = Short.BYTES;
+    private static final int UPDATE_TIME_FIELD_SIZE_IN_BYTES = Long.BYTES;
 
-    public static int getDeleteRecordSize() {
+    public static int getRecordSize() {
       return Version_Field_Size_In_Bytes + ACCOUNT_ID_FIELD_SIZE_IN_BYTES + CONTAINER_ID_FIELD_SIZE_IN_BYTES
-          + DELETION_TIME_FIELD_SIZE_IN_BYTES + Crc_Size;
+          + UPDATE_TIME_FIELD_SIZE_IN_BYTES + Crc_Size;
     }
 
-    public static void serializeDeleteRecord(ByteBuffer outputBuffer, DeleteRecord deleteRecord) {
+    public static void serialize(ByteBuffer outputBuffer, UpdateRecord updateRecord) {
       int startOffset = outputBuffer.position();
-      outputBuffer.putShort(Delete_Version_V2);
-      outputBuffer.putShort(deleteRecord.getAccountId());
-      outputBuffer.putShort(deleteRecord.getContainerId());
-      outputBuffer.putLong(deleteRecord.getDeletionTimeInMs());
+      outputBuffer.putShort(Update_Version_V2);
+      outputBuffer.putShort(updateRecord.getAccountId());
+      outputBuffer.putShort(updateRecord.getContainerId());
+      outputBuffer.putLong(updateRecord.getUpdateTimeInMs());
       Crc32 crc = new Crc32();
-      crc.update(outputBuffer.array(), startOffset, getDeleteRecordSize() - Crc_Size);
+      crc.update(outputBuffer.array(), startOffset, getRecordSize() - Crc_Size);
       outputBuffer.putLong(crc.getValue());
     }
 
-    public static DeleteRecord deserializeDeleteRecord(CrcInputStream crcStream)
-        throws IOException, MessageFormatException {
+    static UpdateRecord deserialize(CrcInputStream crcStream) throws IOException, MessageFormatException {
       DataInputStream dataStream = new DataInputStream(crcStream);
       short accountId = dataStream.readShort();
       short containerId = dataStream.readShort();
-      long deletionTimeInMs = dataStream.readLong();
+      long udpateTimeInMs = dataStream.readLong();
       long actualCRC = crcStream.getValue();
       long expectedCRC = dataStream.readLong();
       if (actualCRC != expectedCRC) {
-        throw new MessageFormatException("delete record data is corrupt (mismatch in CRC) ",
+        throw new MessageFormatException(
+            "update record data is corrupt. Expected CRC: " + expectedCRC + ", Actual CRC: " + actualCRC,
             MessageFormatErrorCodes.Data_Corrupt);
       }
-      return new DeleteRecord(accountId, containerId, deletionTimeInMs);
+      return new UpdateRecord(accountId, containerId, udpateTimeInMs, new DeleteRecord());
+    }
+  }
+
+  /**
+   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -- - - - - - -
+   * |         |               |               |               |             |            |
+   * | version |   AccountId   |  ContainerId  |  UpdateTime   |  Sub record |    Crc     |
+   * |(2 bytes)|    (2 byte2)  |   (2 bytes)   |   (8 bytes)   |  (n bytes)  |  (8 bytes) |
+   * |         |               |               |               |             |            |
+   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -- - - - - - -
+   *  version       - The version of the update record
+   *
+   *  AccountId     - AccountId that the blob belongs to
+   *
+   *  ContainerId   - ContainerId that the blob belongs to
+   *
+   *  UpdateTime    - Time of update in Ms
+   *
+   *  Sub record    - the sub record related to this update
+   *
+   *  Crc           - The crc of the update record
+   *
+   */
+  public static class Update_Format_V3 {
+
+    private static final int RECORD_TYPE_FIELD_SIZE_IN_BYTES = Short.BYTES;
+    private static final int ACCOUNT_ID_FIELD_SIZE_IN_BYTES = Short.BYTES;
+    private static final int CONTAINER_ID_FIELD_SIZE_IN_BYTES = Short.BYTES;
+    private static final int UPDATE_TIME_FIELD_SIZE_IN_BYTES = Long.BYTES;
+
+    /**
+     * @param type the type of the sub record in this update record.
+     * @return the size of the record if the record were serialized
+     */
+    public static int getRecordSize(UpdateRecord.Type type) {
+      int subRecordSize;
+      switch (type) {
+        case DELETE:
+          subRecordSize = Delete_Format_V1.getRecordSize();
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown update record type: " + type);
+      }
+      return Version_Field_Size_In_Bytes + ACCOUNT_ID_FIELD_SIZE_IN_BYTES + CONTAINER_ID_FIELD_SIZE_IN_BYTES
+          + UPDATE_TIME_FIELD_SIZE_IN_BYTES + RECORD_TYPE_FIELD_SIZE_IN_BYTES + subRecordSize + Crc_Size;
+    }
+
+    /**
+     * Serializes {@code updateRecord} into {@code outputBuffer} in version 3.
+     * @param outputBuffer the buffer to write the serialized bytes into.
+     * @param updateRecord the {@link UpdateRecord} to serialize.
+     */
+    public static void serialize(ByteBuffer outputBuffer, UpdateRecord updateRecord) {
+      int startOffset = outputBuffer.position();
+      outputBuffer.putShort(Update_Version_V3);
+      outputBuffer.putShort(updateRecord.getAccountId());
+      outputBuffer.putShort(updateRecord.getContainerId());
+      outputBuffer.putLong(updateRecord.getUpdateTimeInMs());
+      outputBuffer.putShort((short) updateRecord.getType().ordinal());
+      switch (updateRecord.getType()) {
+        case DELETE:
+          Delete_Format_V1.serialize(outputBuffer, updateRecord.getDeleteRecord());
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown update record type: " + updateRecord.getType());
+      }
+      Crc32 crc = new Crc32();
+      crc.update(outputBuffer.array(), startOffset, getRecordSize(updateRecord.getType()) - Crc_Size);
+      outputBuffer.putLong(crc.getValue());
+    }
+
+    /**
+     * @param crcStream the stream that contains the serialized form of an {@link UpdateRecord} of version 3.
+     * @return the deserialized {@link UpdateRecord}
+     * @throws IOException if there are problems reading from stream.
+     * @throws MessageFormatException if the format of the message is unexpected.
+     */
+    static UpdateRecord deserialize(CrcInputStream crcStream) throws IOException, MessageFormatException {
+      UpdateRecord updateRecord;
+      DataInputStream dataStream = new DataInputStream(crcStream);
+      short accountId = dataStream.readShort();
+      short containerId = dataStream.readShort();
+      long updateTimeInMs = dataStream.readLong();
+      UpdateRecord.Type type = UpdateRecord.Type.values()[dataStream.readShort()];
+      switch (type) {
+        case DELETE:
+          updateRecord = new UpdateRecord(accountId, containerId, updateTimeInMs, getDeleteRecord(dataStream));
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown update record type: " + type);
+      }
+      long actualCRC = crcStream.getValue();
+      long expectedCRC = dataStream.readLong();
+      if (actualCRC != expectedCRC) {
+        throw new MessageFormatException(
+            "update record data is corrupt. Expected CRC: " + expectedCRC + ", Actual CRC: " + actualCRC,
+            MessageFormatErrorCodes.Data_Corrupt);
+      }
+      return updateRecord;
+    }
+
+    /**
+     * @param inputStream the stream that contains the serialized form of an {@link DeleteRecord}.
+     * @return the deserialized {@link DeleteRecord}
+     * @throws IOException if there are problems reading from stream.
+     * @throws MessageFormatException if the format of the message is unexpected.
+     */
+    private static DeleteRecord getDeleteRecord(DataInputStream inputStream)
+        throws IOException, MessageFormatException {
+      short version = inputStream.readShort();
+      switch (version) {
+        case Delete_Version_V1:
+          return Delete_Format_V1.deserialize(inputStream);
+        default:
+          throw new MessageFormatException("delete record version not supported: " + version,
+              MessageFormatErrorCodes.Unknown_Format_Version);
+      }
+    }
+  }
+
+  /**
+   *  - - - - - - - - - - - - -
+   * |         |               |
+   * | version |   delete byte |
+   * |(2 bytes)|    (1 byte)   |
+   * |         |               |
+   *  - - - - - - - - - - - - -
+   *  version         - The version of the delete record
+   *
+   *  delete byte     - Takes value 0 or 1. If it is set to 1, it signifies that the blob is deleted. The field
+   *                    is required to be able to support undelete in the future if required.
+   *
+   */
+  private static class Delete_Format_V1 {
+
+    private static final int Delete_Field_Size_In_Bytes = 1;
+
+    static int getRecordSize() {
+      return Version_Field_Size_In_Bytes + Delete_Field_Size_In_Bytes;
+    }
+
+    static void serialize(ByteBuffer outputBuffer, DeleteRecord deleteRecord) {
+      outputBuffer.putShort(Delete_Version_V1);
+      outputBuffer.put((byte) 1);
+    }
+
+    static DeleteRecord deserialize(DataInputStream stream) throws IOException {
+      boolean isDeleted = stream.readByte() == 1;
+      return new DeleteRecord();
     }
   }
 

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageSievingInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageSievingInputStream.java
@@ -209,7 +209,7 @@ public class MessageSievingInputStream extends InputStream {
             header.getVersion(), header.getMessageSize(), currentOffset,
             header.getBlobEncryptionKeyRecordRelativeOffset(), header.getBlobPropertiesRecordRelativeOffset(),
             header.getUserMetadataRecordRelativeOffset(), header.getBlobRecordRelativeOffset(),
-            header.getDeleteRecordRelativeOffset(), header.getCrc());
+            header.getUpdateRecordRelativeOffset(), header.getCrc());
         logger.trace("Id {} Encryption Key -size {} Blob Properties - blobSize {} Metadata - size {} Blob - size {} ",
             storeKey.getID(), encryptionKey == null ? 0 : encryptionKey.capacity(), props.getBlobSize(),
             metadata.capacity(), blobData.getSize());

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/UpdateRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/UpdateRecord.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.messageformat;
+
+/**
+ * In mem representation of an update record header
+ */
+public class UpdateRecord {
+  public enum Type {
+    DELETE
+  }
+
+  private final Type type;
+  private final DeleteRecord deleteRecord;
+  private final short accountId;
+  private final short containerId;
+  private final long updateTimeInMs;
+
+  /**
+   * @param accountId the account that the blob that this update is associated with belongs to
+   * @param containerId the id of the container that the blob that this update is associated with belongs to
+   * @param updateTimeInMs the time in ms at which the update occurred.
+   * @param deleteRecord the delete record that this update record represents.
+   */
+  UpdateRecord(short accountId, short containerId, long updateTimeInMs, DeleteRecord deleteRecord) {
+    this(accountId, containerId, updateTimeInMs, Type.DELETE, deleteRecord);
+  }
+
+  /**
+   * @param type the type of the update record.
+   * @param deleteRecord the delete record that this update record represents.
+   */
+  private UpdateRecord(short accountId, short containerId, long updateTimeInMs, Type type, DeleteRecord deleteRecord) {
+    this.accountId = accountId;
+    this.containerId = containerId;
+    this.updateTimeInMs = updateTimeInMs;
+    this.type = type;
+    this.deleteRecord = deleteRecord;
+  }
+
+  /**
+   * @return the type of the update record.
+   */
+  public Type getType() {
+    return type;
+  }
+
+  /**
+   * @return the id of the account that the blob that this update is associated with belongs to
+   */
+  public short getAccountId() {
+    return accountId;
+  }
+
+  /**
+   * @return the id of the container that the blob that this update is associated with belongs to
+   */
+  public short getContainerId() {
+    return containerId;
+  }
+
+  /**
+   * @return the time in ms at which the update occurred.
+   */
+  public long getUpdateTimeInMs() {
+    return updateTimeInMs;
+  }
+
+  /**
+   * @return the delete record if type is {@link Type#DELETE}. {@code null} otherwise.
+   */
+  public DeleteRecord getDeleteRecord() {
+    return deleteRecord;
+  }
+}

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
@@ -237,7 +237,7 @@ public class MessageFormatInputStreamTest {
    */
   @Test
   public void messageFormatDeleteRecordTest() throws IOException, MessageFormatException {
-    short[] versions = {MessageFormatRecord.Delete_Version_V1, MessageFormatRecord.Delete_Version_V2};
+    short[] versions = {MessageFormatRecord.Update_Version_V1, MessageFormatRecord.Update_Version_V2};
     for (short version : versions) {
       StoreKey key = new MockId("id1");
       short accountId = Utils.getRandomShort(TestUtils.RANDOM);
@@ -245,7 +245,7 @@ public class MessageFormatInputStreamTest {
       long deletionTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
       MessageFormatInputStream messageFormatStream;
       boolean useV2Header;
-      if (version == MessageFormatRecord.Delete_Version_V1) {
+      if (version == MessageFormatRecord.Update_Version_V1) {
         messageFormatStream = new DeleteMessageFormatV1InputStream(key, accountId, containerId, deletionTimeMs);
         useV2Header = false;
       } else {
@@ -255,8 +255,8 @@ public class MessageFormatInputStreamTest {
       int headerSize = MessageFormatRecord.getHeaderSizeForVersion(
           useV2Header ? MessageFormatRecord.Message_Header_Version_V2 : MessageFormatRecord.Message_Header_Version_V1);
       int deleteRecordSize =
-          version == MessageFormatRecord.Delete_Version_V1 ? MessageFormatRecord.Delete_Format_V1.getDeleteRecordSize()
-              : MessageFormatRecord.Delete_Format_V2.getDeleteRecordSize();
+          version == MessageFormatRecord.Update_Version_V1 ? MessageFormatRecord.Update_Format_V1.getRecordSize()
+              : MessageFormatRecord.Update_Format_V2.getRecordSize();
       Assert.assertEquals(headerSize + deleteRecordSize + key.sizeInBytes(), messageFormatStream.getSize());
 
       // check header
@@ -296,7 +296,7 @@ public class MessageFormatInputStreamTest {
       ByteBuffer deleteRecordBuf = ByteBuffer.wrap(deleteRecordOutput);
       messageFormatStream.read(deleteRecordOutput);
       Assert.assertEquals(deleteRecordBuf.getShort(), version);
-      if (version == MessageFormatRecord.Delete_Version_V1) {
+      if (version == MessageFormatRecord.Update_Version_V1) {
         Assert.assertEquals(true, deleteRecordBuf.get() == 1 ? true : false);
       } else {
         Assert.assertEquals("AccountId mismatch", accountId, deleteRecordBuf.getShort());

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamsForTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamsForTest.java
@@ -56,7 +56,7 @@ class PutMessageFormatBlobV1InputStream extends MessageFormatInputStream {
 }
 
 /**
- * Represents a message that consist of the delete record in version {@link MessageFormatRecord.Delete_Format_V1}
+ * Represents a message that consist of the delete record in version {@link MessageFormatRecord.Update_Format_V1}
  * This format is used to delete a blob
  *
  *  - - - - - - - - - - - - -
@@ -72,7 +72,7 @@ class DeleteMessageFormatV1InputStream extends MessageFormatInputStream {
   DeleteMessageFormatV1InputStream(StoreKey key, short accountId, short containerId, long deletionTimeMs)
       throws MessageFormatException {
     int headerSize = MessageFormatRecord.MessageHeader_Format_V1.getHeaderSize();
-    int deleteRecordSize = MessageFormatRecord.Delete_Format_V1.getDeleteRecordSize();
+    int deleteRecordSize = MessageFormatRecord.Update_Format_V1.getRecordSize();
     buffer = ByteBuffer.allocate(headerSize + key.sizeInBytes() + deleteRecordSize);
     MessageFormatRecord.MessageHeader_Format_V1.serializeHeader(buffer, deleteRecordSize,
         MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerSize + key.sizeInBytes(),
@@ -80,8 +80,7 @@ class DeleteMessageFormatV1InputStream extends MessageFormatInputStream {
         MessageFormatRecord.Message_Header_Invalid_Relative_Offset);
     buffer.put(key.toBytes());
     // set the message as deleted
-    MessageFormatRecord.Delete_Format_V1.serializeDeleteRecord(buffer,
-        new DeleteRecord(accountId, containerId, deletionTimeMs));
+    MessageFormatRecord.Update_Format_V1.serialize(buffer, new UpdateRecord(accountId, containerId, deletionTimeMs, new DeleteRecord()));
     messageLength = buffer.capacity();
     buffer.flip();
   }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -321,70 +321,125 @@ public class MessageFormatRecordTest {
   }
 
   /**
-   * Tests DeleteRecord V1 for serialization and deserialization
+   * Tests UpdateRecord V1 for serialization and deserialization
    * @throws IOException
    * @throws MessageFormatException
    */
   @Test
-  public void testDeleteRecordV1() throws IOException, MessageFormatException {
-    // Test delete V1 record
-    // irrespective of what values are set for acccountId, containerId and deletionTimeMs, legacy values will be returned
-    // with Delete_Format_V1
+  public void testUpdateRecordV1() throws IOException, MessageFormatException {
+    // Test update V1 record
+    // irrespective of what values are set for acccountId, containerId and updateTimeMs, legacy values will be returned
+    // with Update_Format_V1
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
-    long deletionTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
-    ByteBuffer deleteRecord = ByteBuffer.allocate(MessageFormatRecord.Delete_Format_V1.getDeleteRecordSize());
-    MessageFormatRecord.Delete_Format_V1.serializeDeleteRecord(deleteRecord,
-        new DeleteRecord(accountId, containerId, deletionTimeMs));
-    deleteRecord.flip();
-    DeleteRecord deserializeDeleteRecord =
-        MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));
-    Assert.assertEquals("AccountId mismatch ", UNKNOWN_ACCOUNT_ID, deserializeDeleteRecord.getAccountId());
-    Assert.assertEquals("ContainerId mismatch ", UNKNOWN_CONTAINER_ID, deserializeDeleteRecord.getContainerId());
-    Assert.assertEquals("DeletionTime mismatch ", Utils.Infinite_Time, deserializeDeleteRecord.getDeletionTimeInMs());
+    long updateTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
+    ByteBuffer updateRecord = ByteBuffer.allocate(Update_Format_V1.getRecordSize());
+    Update_Format_V1.serialize(updateRecord,
+        new UpdateRecord(accountId, containerId, updateTimeMs, new DeleteRecord()));
+    updateRecord.flip();
+    UpdateRecord deserializeUpdateRecord =
+        MessageFormatRecord.deserializeUpdateRecord(new ByteBufferInputStream(updateRecord));
+    Assert.assertEquals("AccountId mismatch ", UNKNOWN_ACCOUNT_ID, deserializeUpdateRecord.getAccountId());
+    Assert.assertEquals("ContainerId mismatch ", UNKNOWN_CONTAINER_ID, deserializeUpdateRecord.getContainerId());
+    Assert.assertEquals("DeletionTime mismatch ", Utils.Infinite_Time, deserializeUpdateRecord.getUpdateTimeInMs());
+    Assert.assertEquals("Type of update record incorrect", UpdateRecord.Type.DELETE, deserializeUpdateRecord.getType());
+    Assert.assertNotNull("DeleteRecord is null", deserializeUpdateRecord.getDeleteRecord());
 
-    // corrupt delete V1 record
-    deleteRecord.flip();
-    byte toCorrupt = deleteRecord.get(10);
-    deleteRecord.put(10, (byte) (toCorrupt + 1));
+    // corrupt update V1 record
+    updateRecord.flip();
+    byte toCorrupt = updateRecord.get(10);
+    updateRecord.put(10, (byte) (toCorrupt + 1));
     try {
-      MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));
-      fail("Deserialization of a corrupt delete record V1 should have failed ");
+      MessageFormatRecord.deserializeUpdateRecord(new ByteBufferInputStream(updateRecord));
+      fail("Deserialization of a corrupt update record V1 should have failed ");
     } catch (MessageFormatException e) {
       Assert.assertEquals(e.getErrorCode(), MessageFormatErrorCodes.Data_Corrupt);
     }
   }
 
   /**
-   * Tests DeleteRecord V2 for serialization and deserialization
+   * Tests UpdateRecord V2 for serialization and deserialization
    * @throws IOException
    * @throws MessageFormatException
    */
   @Test
-  public void testDeleteRecordV2() throws IOException, MessageFormatException {
-    // Test delete V2 record
-    ByteBuffer deleteRecord = ByteBuffer.allocate(MessageFormatRecord.Delete_Format_V2.getDeleteRecordSize());
+  public void testUpdateRecordV2() throws IOException, MessageFormatException {
+    // Test update V2 record
+    ByteBuffer updateRecord = ByteBuffer.allocate(Update_Format_V2.getRecordSize());
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
-    long deletionTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
-    MessageFormatRecord.Delete_Format_V2.serializeDeleteRecord(deleteRecord,
-        new DeleteRecord(accountId, containerId, deletionTimeMs));
-    deleteRecord.flip();
-    DeleteRecord deserializeDeleteRecord =
-        MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));
-    Assert.assertEquals("AccountId mismatch ", accountId, deserializeDeleteRecord.getAccountId());
-    Assert.assertEquals("ContainerId mismatch ", containerId, deserializeDeleteRecord.getContainerId());
-    Assert.assertEquals("DeletionTime mismatch ", deletionTimeMs, deserializeDeleteRecord.getDeletionTimeInMs());
+    long updateTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
+    Update_Format_V2.serialize(updateRecord,
+        new UpdateRecord(accountId, containerId, updateTimeMs, new DeleteRecord()));
+    updateRecord.flip();
+    UpdateRecord deserializeUpdateRecord =
+        MessageFormatRecord.deserializeUpdateRecord(new ByteBufferInputStream(updateRecord));
+    Assert.assertEquals("AccountId mismatch ", accountId, deserializeUpdateRecord.getAccountId());
+    Assert.assertEquals("ContainerId mismatch ", containerId, deserializeUpdateRecord.getContainerId());
+    Assert.assertEquals("DeletionTime mismatch ", updateTimeMs, deserializeUpdateRecord.getUpdateTimeInMs());
+    Assert.assertEquals("Type of update record incorrect", UpdateRecord.Type.DELETE, deserializeUpdateRecord.getType());
+    Assert.assertNotNull("DeleteRecord is null", deserializeUpdateRecord.getDeleteRecord());
 
-    // corrupt delete V2 record
-    deleteRecord.flip();
-    byte toCorrupt = deleteRecord.get(10);
-    deleteRecord.put(10, (byte) (toCorrupt + 1));
+    // corrupt update V2 record
+    updateRecord.flip();
+    byte toCorrupt = updateRecord.get(10);
+    updateRecord.put(10, (byte) (toCorrupt + 1));
     try {
-      MessageFormatRecord.deserializeDeleteRecord(new ByteBufferInputStream(deleteRecord));
-      fail("Deserialization of a corrupt delete record V2 should have failed ");
+      MessageFormatRecord.deserializeUpdateRecord(new ByteBufferInputStream(updateRecord));
+      fail("Deserialization of a corrupt update record V2 should have failed ");
     } catch (MessageFormatException e) {
       Assert.assertEquals(e.getErrorCode(), MessageFormatErrorCodes.Data_Corrupt);
+    }
+  }
+
+  /**
+   * Tests UpdateRecord V3 for serialization and deserialization
+   * @throws IOException
+   * @throws MessageFormatException
+   */
+  @Test
+  public void testUpdateRecordV3() throws IOException, MessageFormatException {
+    // Test update V3 record
+    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+    short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+    long updateTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
+    for (UpdateRecord.Type type : UpdateRecord.Type.values()) {
+      ByteBuffer updateRecordBuf = ByteBuffer.allocate(Update_Format_V3.getRecordSize(type));
+      UpdateRecord updateRecord = null;
+      switch (type) {
+        case DELETE:
+          DeleteRecord deleteRecord = new DeleteRecord();
+          updateRecord = new UpdateRecord(accountId, containerId, updateTimeMs, deleteRecord);
+          break;
+        default:
+          fail("Unknown update record type: " + type);
+      }
+      Update_Format_V3.serialize(updateRecordBuf, updateRecord);
+      updateRecordBuf.flip();
+      UpdateRecord deserializeUpdateRecord =
+          MessageFormatRecord.deserializeUpdateRecord(new ByteBufferInputStream(updateRecordBuf));
+      Assert.assertEquals("AccountId mismatch ", accountId, deserializeUpdateRecord.getAccountId());
+      Assert.assertEquals("ContainerId mismatch ", containerId, deserializeUpdateRecord.getContainerId());
+      Assert.assertEquals("DeletionTime mismatch ", updateTimeMs, deserializeUpdateRecord.getUpdateTimeInMs());
+      Assert.assertEquals("Type of update record incorrect", type, deserializeUpdateRecord.getType());
+      switch (type) {
+        case DELETE:
+          Assert.assertNotNull("DeleteRecord is null", deserializeUpdateRecord.getDeleteRecord());
+          break;
+        default:
+          fail("Unknown update record type: " + type);
+      }
+
+      // corrupt update V3 record
+      updateRecordBuf.flip();
+      byte toCorrupt = updateRecordBuf.get(10);
+      updateRecordBuf.put(10, (byte) (toCorrupt + 1));
+      try {
+        MessageFormatRecord.deserializeUpdateRecord(new ByteBufferInputStream(updateRecordBuf));
+        fail("Deserialization of a corrupt update record V3 should have failed ");
+      } catch (MessageFormatException e) {
+        Assert.assertEquals(e.getErrorCode(), MessageFormatErrorCodes.Data_Corrupt);
+      }
     }
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -1548,7 +1548,7 @@ public final class ServerTestUtil {
    */
   private static long getDeleteRecordSize(BlobId blobId) {
     return MessageFormatRecord.MessageHeader_Format_V2.getHeaderSize() + blobId.sizeInBytes()
-        + MessageFormatRecord.Delete_Format_V2.getDeleteRecordSize();
+        + MessageFormatRecord.Update_Format_V2.getRecordSize();
   }
 
   /**

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpDataHelper.java
@@ -22,6 +22,7 @@ import com.github.ambry.messageformat.DeleteRecord;
 import com.github.ambry.messageformat.MessageFormatErrorCodes;
 import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatRecord;
+import com.github.ambry.messageformat.UpdateRecord;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -117,10 +118,16 @@ class DumpDataHelper {
         BlobData blobData = MessageFormatRecord.deserializeBlob(streamlog);
         blobDataOutput = "Blob - size " + blobData.getSize();
       } else {
-        DeleteRecord deleteRecord = MessageFormatRecord.deserializeDeleteRecord(streamlog);
-        isDeleted = true;
-        deleteMsg = "delete change : AccountId:" + deleteRecord.getAccountId() + ", ContainerId:"
-            + deleteRecord.getContainerId() + ", DeletionTimeInSecs:" + deleteRecord.getDeletionTimeInMs();
+        UpdateRecord updateRecord = MessageFormatRecord.deserializeUpdateRecord(streamlog);
+        switch (updateRecord.getType()) {
+          case DELETE:
+            isDeleted = true;
+            deleteMsg = "delete change : AccountId:" + updateRecord.getAccountId() + ", ContainerId:"
+                + updateRecord.getContainerId() + ", DeletionTimeInSecs:" + updateRecord.getUpdateTimeInMs();
+            break;
+          default:
+            throw new IllegalStateException("Unrecognized update record type: " + updateRecord.getType());
+        }
       }
       return new LogBlobRecordInfo(messageheader, blobId, encryptionKey, blobProperty, usermetadata, blobDataOutput,
           deleteMsg, isDeleted, isExpired, expiresAtMs, totalRecordSize);

--- a/ambry-tools/src/main/java/com.github.ambry/store/HardDeleteVerifier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/HardDeleteVerifier.java
@@ -22,6 +22,7 @@ import com.github.ambry.messageformat.BlobData;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatRecord;
+import com.github.ambry.messageformat.UpdateRecord;
 import com.github.ambry.tools.util.ToolUtils;
 import com.github.ambry.utils.CrcInputStream;
 import com.github.ambry.utils.Utils;
@@ -458,8 +459,9 @@ public class HardDeleteVerifier {
               } else {
                 unDeletedPuts++;
               }
-            } else {
-              MessageFormatRecord.deserializeDeleteRecord(streamlog);
+            } else if (MessageFormatRecord.deserializeUpdateRecord(streamlog)
+                .getType()
+                .equals(UpdateRecord.Type.DELETE)) {
               deletes++;
             }
             currentOffset += (header.getMessageSize() + buffer.capacity() + id.sizeInBytes());
@@ -605,8 +607,7 @@ public class HardDeleteVerifier {
                     unDeletedPuts++;
                   }
                 }
-              } else {
-                deserializeDeleteRecord(streamlog, oldStreamlog);
+              } else if (deserializeUpdateRecord(streamlog, oldStreamlog)) {
                 deletes++;
               }
             }
@@ -655,28 +656,30 @@ public class HardDeleteVerifier {
     }
   }
 
-  void deserializeDeleteRecord(InputStream streamlog, InputStream oldStreamlog) throws ContinueException {
+  /**
+   * @return {@code true} if this was a delete record, {@code false} otherwise
+   * @throws ContinueException if there is a deser failure in the new log
+   */
+  private boolean deserializeUpdateRecord(InputStream streamlog, InputStream oldStreamlog) throws ContinueException {
+    boolean isDeleteRecord = false;
     boolean caughtException = false;
     boolean caughtExceptionInOld = false;
     try {
-      MessageFormatRecord.deserializeDeleteRecord(streamlog);
-    } catch (MessageFormatException e) {
+      isDeleteRecord = MessageFormatRecord.deserializeUpdateRecord(streamlog).getType().equals(UpdateRecord.Type.DELETE);
+    } catch (Exception e) {
       caughtException = true;
-    } catch (IOException e) {
-      caughtExceptionInOld = true;
     }
 
     try {
-      MessageFormatRecord.deserializeDeleteRecord(oldStreamlog);
-    } catch (MessageFormatException e) {
-      caughtException = true;
-    } catch (IOException e) {
+      MessageFormatRecord.deserializeUpdateRecord(oldStreamlog);
+    } catch (Exception e) {
       caughtExceptionInOld = true;
     }
 
-    if (caughtException) {
+    if (caughtException && !caughtExceptionInOld) {
       throw new ContinueException("delete record could not be deserialized");
     }
+    return isDeleteRecord;
   }
 
   boolean deserializeUserMetadataAndBlob(InputStream streamlog, InputStream oldStreamlog, boolean isDeleted)


### PR DESCRIPTION
In order to support more general updates, this commit introduces the
concept of UpdateRecord. The first two versions of this record are
equivalent to DeleteRecord versions 1 and 2, The third version is
able to encapsulate different types of records.

This commit adds read support. A future commit will convert the
DeleteMessageFormatInputStream to write in the new format.