### PR TITLE
Improve Helix Update tool

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -52,6 +52,7 @@ public class ClusterMapUtils {
   static final long MAX_REPLICA_CAPACITY_IN_BYTES = 10L * 1024 * 1024 * 1024 * 1024;
   static final long MIN_DISK_CAPACITY_IN_BYTES = 10L * 1024 * 1024 * 1024;
   static final long MAX_DISK_CAPACITY_IN_BYTES = 10L * 1024 * 1024 * 1024 * 1024;
+  static final int CURRENT_SCHEMA_VERSION = 0;
 
   /**
    * Stores all zk related info for a DC.

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -21,22 +21,26 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LeaderStandbySMD;
-import org.apache.helix.model.builder.AutoModeISBuilder;
+import org.apache.helix.model.builder.SemiAutoModeISBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -73,20 +77,21 @@ import org.json.JSONObject;
  *    "datacenter" : "dc1",                                # [datacenterName]
  *    "rackId" : "1611",                                   # [rackId]
  *    "sslPort": "27088"                                   # [sslPort]
+ *    "schemaVersion": "0"                                 # [schema version]
+ *    "xid" : "0"                                          # [xid (last update to the data in this InstanceConfig)]
  *  }
  *}
  */
 class HelixBootstrapUpgradeUtil {
   private final StaticClusterManager staticClusterMap;
   private final Map<String, HelixAdmin> adminForDc = new HashMap<>();
-  // The set of partitions already present in Helix when this tool is run.
-  private final TreeSet<Long> existingPartitions = new TreeSet<>();
-  // The set of resources already present in Helix when this tool is run.
-  private final TreeSet<Long> existingResources = new TreeSet<>();
-  private final String localDc;
-  private final String clusterName;
+  private final HashMap<String, HashMap<DiskId, SortedSet<Replica>>> instanceToDiskReplicasMap = new HashMap<>();
+  private final HashMap<String, HashMap<String, DataNodeId>> dcToInstanceNameToDataNodeId = new HashMap<>();
+  final String clusterName;
   private final int maxPartitionsInOneResource;
+  private final boolean dryRun;
   private Map<String, ClusterMapUtils.DcZkInfo> dataCenterToZkAddress;
+  private static final Logger logger = LoggerFactory.getLogger("Helix bootstrap tool");
 
   /**
    * Takes in the path to the files that make up the static cluster map and adds or updates the cluster map information
@@ -96,20 +101,50 @@ class HelixBootstrapUpgradeUtil {
    * @param zkLayoutPath the path to the zookeeper layout file.
    * @param clusterNamePrefix the prefix that when combined with the cluster name in the static cluster map files
    *                          will give the cluster name in Helix to bootstrap or upgrade.
-   * @param localDc the name of the local datacenter. This can be null.
    * @param maxPartitionsInOneResource the maximum number of Ambry partitions to group under a single Helix resource.
+   * @param dryRun if true, perform a dry run; do not update anything in Helix.
    * @param helixAdminFactory the {@link HelixAdminFactory} to use to instantiate {@link HelixAdmin}
    * @throws IOException if there is an error reading a file.
    * @throws JSONException if there is an error parsing the JSON content in any of the files.
    */
   static void bootstrapOrUpgrade(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
-      String clusterNamePrefix, String localDc, int maxPartitionsInOneResource, HelixAdminFactory helixAdminFactory)
+      String clusterNamePrefix, int maxPartitionsInOneResource, boolean dryRun, HelixAdminFactory helixAdminFactory)
       throws Exception {
+    if (dryRun) {
+      info("==== This is a dry run ====");
+      info("No changes will be made to the information in Helix (except adding the cluster if it does not exist.");
+    }
     HelixBootstrapUpgradeUtil clusterMapToHelixMapper =
-        new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, localDc,
-            maxPartitionsInOneResource);
-    clusterMapToHelixMapper.updateClusterMapInHelix(helixAdminFactory);
-    clusterMapToHelixMapper.validateAndClose();
+        new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix,
+            maxPartitionsInOneResource, dryRun);
+    if (dryRun) {
+      info("To drop the cluster, run this tool again with the '--dropCluster {}' argument.",
+          clusterMapToHelixMapper.clusterName);
+    }
+    clusterMapToHelixMapper.updateClusterMapInHelixAlt(helixAdminFactory);
+    if (!dryRun) {
+      info("Validating static and Helix clustermaps");
+      clusterMapToHelixMapper.validateAndClose();
+    }
+  }
+
+  /**
+   * Drop a cluster from Helix.
+   * @param zkLayoutPath the path to the zookeeper layout file.
+   * @param clusterName the name of the cluster in Helix.
+   * @param helixAdminFactory the {@link HelixAdminFactory} to use to instantiate {@link HelixAdmin}
+   * @throws Exception if there is an error reading a file or in parsing json.
+   */
+  static void dropCluster(String zkLayoutPath, String clusterName, HelixAdminFactory helixAdminFactory)
+      throws Exception {
+    Map<String, ClusterMapUtils.DcZkInfo> dataCenterToZkAddress =
+        ClusterMapUtils.parseDcJsonAndPopulateDcInfo(Utils.readStringFromFile(zkLayoutPath));
+    info("Dropping cluster {} from Helix", clusterName);
+    for (Map.Entry<String, ClusterMapUtils.DcZkInfo> entry : dataCenterToZkAddress.entrySet()) {
+      HelixAdmin admin = helixAdminFactory.getHelixAdmin(entry.getValue().getZkConnectStr());
+      admin.dropCluster(clusterName);
+      info("Dropped cluster from {}", entry.getKey());
+    }
   }
 
   /**
@@ -119,21 +154,21 @@ class HelixBootstrapUpgradeUtil {
    * @param zkLayoutPath the path to the zookeeper layout file.
    * @param clusterNamePrefix the prefix that when combined with the cluster name in the static cluster map files
    *                          will give the cluster name in Helix to bootstrap or upgrade.
-   * @param localDc the name of the local datacenter. This can be null.
+   * @param dryRun if true, perform a dry run; do not update anything in Helix.
    * @throws IOException if there is an error reading a file.
    * @throws JSONException if there is an error parsing the JSON content in any of the files.
    */
   private HelixBootstrapUpgradeUtil(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
-      String clusterNamePrefix, String localDc, int maxPartitionsInOneResource) throws Exception {
-    this.localDc = localDc;
+      String clusterNamePrefix, int maxPartitionsInOneResource, boolean dryRun) throws Exception {
     this.maxPartitionsInOneResource = maxPartitionsInOneResource;
+    this.dryRun = dryRun;
     this.dataCenterToZkAddress = ClusterMapUtils.parseDcJsonAndPopulateDcInfo(Utils.readStringFromFile(zkLayoutPath));
 
     Properties props = new Properties();
     // The following properties are immaterial for the tool, but the ClusterMapConfig mandates their presence.
     props.setProperty("clustermap.host.name", "localhost");
     props.setProperty("clustermap.cluster.name", "");
-    props.setProperty("clustermap.datacenter.name", localDc == null ? "" : localDc);
+    props.setProperty("clustermap.datacenter.name", "");
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     if (new File(partitionLayoutPath).exists()) {
       staticClusterMap =
@@ -145,13 +180,33 @@ class HelixBootstrapUpgradeUtil {
     }
     String clusterNameInStaticClusterMap = staticClusterMap.partitionLayout.getClusterName();
     this.clusterName = clusterNamePrefix + clusterNameInStaticClusterMap;
-    System.out.println(
-        "Associating static Ambry cluster \"" + clusterNameInStaticClusterMap + "\" with cluster\"" + clusterName
-            + "\" in Helix");
+    info("Associating static Ambry cluster \"" + clusterNameInStaticClusterMap + "\" with cluster\"" + clusterName
+        + "\" in Helix");
     for (Datacenter datacenter : staticClusterMap.hardwareLayout.getDatacenters()) {
       if (!dataCenterToZkAddress.keySet().contains(datacenter.getName())) {
         throw new IllegalArgumentException(
             "There is no ZK host for datacenter " + datacenter.getName() + " in the static clustermap");
+      }
+    }
+  }
+
+  /**
+   * Read from the static cluster map and populate a map of {@link DataNodeId} -> list of its {@link ReplicaId}.
+   */
+  private void populateInstancesAndPartitionsMap() {
+    for (DataNodeId dataNodeId : staticClusterMap.getDataNodeIds()) {
+      dcToInstanceNameToDataNodeId.computeIfAbsent(dataNodeId.getDatacenterName(), k -> new HashMap<>())
+          .put(getInstanceName(dataNodeId), dataNodeId);
+      for (DiskId disk : ((DataNode) dataNodeId).getDisks()) {
+        instanceToDiskReplicasMap.computeIfAbsent(getInstanceName(dataNodeId), k -> new HashMap<>())
+            .put(disk, new TreeSet<>(new ReplicaComparator()));
+      }
+    }
+    for (PartitionId partitionId : staticClusterMap.getAllPartitionIds()) {
+      for (ReplicaId replicaId : partitionId.getReplicaIds()) {
+        instanceToDiskReplicasMap.get(getInstanceName(replicaId.getDataNodeId()))
+            .get(replicaId.getDiskId())
+            .add((Replica) replicaId);
       }
     }
   }
@@ -164,31 +219,255 @@ class HelixBootstrapUpgradeUtil {
    * tool groups together partitions under resources, with a limit to the number of partitions that will be grouped
    * under a single resource.
    *
+   * The logic is as follows to optimize a single setInstanceConfig() all for any node:
+   *
+   * for each datacenter/admin:
+   *   for each instance in datacenter present in both static clustermap and Helix:
+   *     get replicas it hosts with their sealed state and capacity from static.
+   *     newInstanceConfig = create one with the replicas and other information for the instance.
+   *     existingInstanceConfig = get InstanceConfig from helix;
+   *     if (newInstanceConfig.equals(existingInstanceConfig)):
+   *         continue;
+   *     else:
+   *       setInstanceConfig(newInstanceConfig);
+   *     endif
+   *   endfor
+   *
+   *   for each instance in datacenter present in static clustermap but not in Helix:
+   *     get replicas it hosts with their sealed state and capacity from static.
+   *     newInstanceConfig = create one with the replicas and other information for the instance.
+   *     addNewInstanceInHelix(newInstanceConfig);
+   *   endfor
+   *
+   *   // Optional:
+   *   for each instance in Helix not present in static:
+   *     dropInstanceFromHelix()
+   *   endfor
+   * endfor
+   *
    * @param helixAdminFactory the {@link HelixAdminFactory} to use to instantiate {@link HelixAdmin}
    */
-  private void updateClusterMapInHelix(HelixAdminFactory helixAdminFactory) {
+
+  private void updateClusterMapInHelixAlt(HelixAdminFactory helixAdminFactory) {
+    info("Initializing admins and possibly adding cluster in Helix (if non-existent)");
     initializeAdminsAndAddCluster(helixAdminFactory);
-    HelixAdmin refAdmin = localDc != null ? adminForDc.get(localDc) : adminForDc.values().iterator().next();
-    populateResourcesAndPartitionsSet(refAdmin);
-    addNewDataNodes();
-    long nextResource = existingResources.isEmpty() ? 1 : existingResources.last() + 1;
-    List<Partition> partitionsUnderNextResource = new ArrayList<>();
-    for (PartitionId partitionId : staticClusterMap.partitionLayout.getPartitions()) {
-      Partition partition = (Partition) partitionId;
-      if (existingPartitions.contains(partition.getId())) {
-        updatePartitionInfoIfChanged(partition);
-      } else {
-        partitionsUnderNextResource.add(partition);
+    info("Initialized");
+    info("Populating resources and partitions set");
+    info("Populated resources and partitions set");
+    populateInstancesAndPartitionsMap();
+    for (Datacenter dc : staticClusterMap.hardwareLayout.getDatacenters()) {
+      info("\n=======Starting datacenter: {}=========\n", dc.getName());
+      HelixAdmin dcAdmin = adminForDc.get(dc.getName());
+      Map<String, Set<String>> partitionsToInstancesInDc = new HashMap<>();
+      info("Getting list of instances in {}", dc.getName());
+      Set<String> instancesInHelix = new HashSet<>(dcAdmin.getInstancesInCluster(clusterName));
+      Set<String> instancesInStatic = new HashSet<>(dcToInstanceNameToDataNodeId.get(dc.getName()).keySet());
+      Set<String> instancesInBoth = new HashSet<>(instancesInHelix);
+      // set instances in both correctly.
+      instancesInBoth.retainAll(instancesInStatic);
+      // set instances in Helix only correctly.
+      instancesInHelix.removeAll(instancesInBoth);
+      // set instances in Static only correctly.
+      instancesInStatic.removeAll(instancesInBoth);
+      int totalInstances = instancesInBoth.size() + instancesInHelix.size() + instancesInStatic.size();
+      for (String instanceName : instancesInBoth) {
+        InstanceConfig instanceConfigInHelix = dcAdmin.getInstanceConfig(clusterName, instanceName);
+        InstanceConfig instanceConfigFromStatic =
+            createInstanceConfigFromStaticInfo(dcToInstanceNameToDataNodeId.get(dc.getName()).get(instanceName),
+                partitionsToInstancesInDc);
+        // Note about the following check: This compares ZNode data for exact equality, which suffices for now.
+        // However, in the future, this needs to discount comparisons for certain things that are dynamically set by
+        // instances (and hence will have outdated information in the static map). Such as
+        // 1. RO/RW status of replicas.
+        // 2. Replica availability (for which support has not yet been added).
+        // 3. xid (for which support has not yet been added).
+        if (!instanceConfigFromStatic.getRecord().equals(instanceConfigInHelix.getRecord())) {
+          info(
+              "Instance {} already present in Helix, but InstanceConfig has changed, updating. Remaining instances: {}",
+              instanceName, --totalInstances);
+          // Continuing on the note above, if there is indeed a change, we must make a call on whether RO/RW, replica
+          // availability and so on should be updated at all (if not, instanceConfigFromStatic should be replaced with
+          // the appropriate instanceConfig that is constructed with the correct values from both.
+          if (!dryRun) {
+            dcAdmin.setInstanceConfig(clusterName, instanceName, instanceConfigFromStatic);
+          }
+        } else {
+          info("Instance {} already present in Helix, with same InstanceConfig, skipping. Remaining instances: {}",
+              instanceName, --totalInstances);
+        }
+      }
+
+      for (String instanceName : instancesInStatic) {
+        InstanceConfig instanceConfigFromStatic =
+            createInstanceConfigFromStaticInfo(dcToInstanceNameToDataNodeId.get(dc.getName()).get(instanceName),
+                partitionsToInstancesInDc);
+        info("Instance {} is new, adding to Helix. Remaining instances: {}", instanceName, --totalInstances);
+        if (!dryRun) {
+          dcAdmin.addInstance(clusterName, instanceConfigFromStatic);
+        }
+      }
+
+      for (String instanceName : instancesInHelix) {
+        info("Instance {} is in Helix, but not in static. Ignoring for now. Remaining instances: {}", --totalInstances);
+        // At this time we are not allowing for dropping instances, to be safe.
+        //if (!dryRun) {
+        //  dcAdmin.dropInstance(clusterName, new InstanceConfig(instanceName));
+        //}
+      }
+
+      // Process those partitions that are already under resources. Just update their instance sets if that has changed.
+      info(
+          "Done adding all instances in {}, now scanning resources in Helix and ensuring instance set for partitions are the same.",
+          dc.getName());
+      long maxResource = -1;
+      for (String resourceName : dcAdmin.getResourcesInCluster(clusterName)) {
+        if (!resourceName.matches("\\d+")) {
+          // there may be other resources created under the cluster (say, for stats) that are not part of the
+          // cluster map. These will be ignored.
+          info("Ignoring resource {} as it is not part of the cluster map", resourceName);
+          continue;
+        }
+        maxResource = Math.max(maxResource, Long.valueOf(resourceName));
+        IdealState resourceIs = dcAdmin.getResourceIdealState(clusterName, resourceName);
+        for (String partitionName : resourceIs.getPartitionSet()) {
+          Set<String> instanceSetInHelix = resourceIs.getInstanceSet(partitionName);
+          Set<String> instanceSetInStatic = partitionsToInstancesInDc.remove(partitionName);
+          if (instanceSetInHelix.equals(instanceSetInStatic)) {
+            info("Instance set is the same for partition {} which is under resource {}", partitionName, resourceName);
+          } else {
+            info("Different instance sets for partition {} which is under resource {}. Updating Helix using static.",
+                partitionName, resourceName);
+            ArrayList<String> instances = new ArrayList<>(instanceSetInStatic);
+            Collections.shuffle(instances);
+            resourceIs.setPreferenceList(partitionName, instances);
+            if (!dryRun) {
+              dcAdmin.setResourceIdealState(clusterName, resourceName, resourceIs);
+            }
+          }
+        }
+      }
+
+      info("Done updating all existing partitions, now adding new partitions under new resources, if any.");
+      long nextResource = maxResource + 1;
+      TreeMap<String, Set<String>> partitionsUnderNextResource = new TreeMap<>();
+      for (Map.Entry<String, Set<String>> entry : partitionsToInstancesInDc.entrySet()) {
+        partitionsUnderNextResource.put(entry.getKey(), entry.getValue());
         if (partitionsUnderNextResource.size() == maxPartitionsInOneResource) {
-          addNewAmbryPartitions(partitionsUnderNextResource, Long.toString(nextResource));
+          info("maxPartitions reached for resource {}, adding them under it", nextResource);
+          addPartitionsUnderResource(dcAdmin, dc.getName(), partitionsUnderNextResource, Long.toString(nextResource));
+          info("Added partitions from {} to {} under resource {}", partitionsUnderNextResource.firstKey(),
+              partitionsUnderNextResource.lastKey(), nextResource);
           partitionsUnderNextResource.clear();
           nextResource++;
         }
       }
+      if (!partitionsUnderNextResource.isEmpty()) {
+        info("last resource " + nextResource + ", actually adding all newly added partitions");
+        addPartitionsUnderResource(dcAdmin, dc.getName(), partitionsUnderNextResource, Long.toString(nextResource));
+        info("Added all remaining partitions {} to {} under resource {}", partitionsUnderNextResource.firstKey(),
+            partitionsUnderNextResource.lastKey(), nextResource);
+      }
+      info("Done with {}\n", dc.getName());
     }
-    if (!partitionsUnderNextResource.isEmpty()) {
-      addNewAmbryPartitions(partitionsUnderNextResource, Long.toString(nextResource));
+  }
+
+  /**
+   * A comparator for replicas that compares based on the partition ids.
+   */
+  private class ReplicaComparator implements Comparator<ReplicaId> {
+    @Override
+    public int compare(ReplicaId a, ReplicaId b) {
+      return a.getPartitionId().compareTo(b.getPartitionId());
     }
+  }
+
+  /**
+   * Create an {@link InstanceConfig} for the given node from the static cluster information.
+   * @param node the {@link DataNodeId}
+   * @param partitionToInstances the map of partitions to instances that will be populated for this instance.
+   * @return the constructed {@link InstanceConfig}
+   */
+  private InstanceConfig createInstanceConfigFromStaticInfo(DataNodeId node,
+      Map<String, Set<String>> partitionToInstances) {
+    String instanceName = getInstanceName(node);
+    InstanceConfig instanceConfig = new InstanceConfig(instanceName);
+    instanceConfig.setHostName(node.getHostname());
+    instanceConfig.setPort(Integer.toString(node.getPort()));
+    if (node.hasSSLPort()) {
+      instanceConfig.getRecord().setSimpleField(ClusterMapUtils.SSLPORT_STR, Integer.toString(node.getSSLPort()));
+    }
+    instanceConfig.getRecord().setSimpleField(ClusterMapUtils.DATACENTER_STR, node.getDatacenterName());
+    instanceConfig.getRecord().setSimpleField(ClusterMapUtils.RACKID_STR, node.getRackId());
+    instanceConfig.getRecord()
+        .setSimpleField(ClusterMapUtils.SCHEMA_VERSION_STR, Integer.toString(ClusterMapUtils.CURRENT_SCHEMA_VERSION));
+    // xid support has not yet been added.
+
+    List<String> sealedPartitionsList = new ArrayList<>();
+
+    Map<String, Map<String, String>> diskInfos = new HashMap<>();
+    for (HashMap.Entry<DiskId, SortedSet<Replica>> diskToReplicas : instanceToDiskReplicasMap.get(instanceName)
+        .entrySet()) {
+      DiskId disk = diskToReplicas.getKey();
+      SortedSet<Replica> replicasInDisk = diskToReplicas.getValue();
+      // Note: An instance config has to contain the information for each disk about the replicas it hosts.
+      // This information will be initialized to the empty string - but will be updated whenever the partition
+      // is added to the cluster.
+      String replicasStr = "";
+      for (ReplicaId replicaId : replicasInDisk) {
+        Replica replica = (Replica) replicaId;
+        replicasStr +=
+            replica.getPartition().getId() + ClusterMapUtils.REPLICAS_STR_SEPARATOR + replica.getCapacityInBytes()
+                + ClusterMapUtils.REPLICAS_DELIM_STR;
+        if (replica.isSealed()) {
+          sealedPartitionsList.add(Long.toString(replica.getPartition().getId()));
+        }
+        partitionToInstances.computeIfAbsent(Long.toString(replica.getPartition().getId()), k -> new HashSet<>())
+            .add(instanceName);
+      }
+      Map<String, String> diskInfo = new HashMap<>();
+      diskInfo.put(ClusterMapUtils.DISK_CAPACITY_STR, Long.toString(disk.getRawCapacityInBytes()));
+      diskInfo.put(ClusterMapUtils.DISK_STATE, ClusterMapUtils.AVAILABLE_STR);
+      diskInfo.put(ClusterMapUtils.REPLICAS_STR, replicasStr);
+      diskInfos.put(disk.getMountPath(), diskInfo);
+    }
+    instanceConfig.getRecord().setMapFields(diskInfos);
+    instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, sealedPartitionsList);
+    return instanceConfig;
+  }
+
+  /**
+   * Add partitions under a given resource.
+   * @param dcAdmin the {@link HelixAdmin} to use.
+   * @param dcName the name of the datacenter in which this resource is being added.
+   * @param partitionsToInstances the map reflecting partitions to instances hosting its replicas. All these partitions
+   *                              will be added under the given resource
+   * @param resourceName the name of the resource under which the given partitions are to be added.
+   */
+  private void addPartitionsUnderResource(HelixAdmin dcAdmin, String dcName,
+      Map<String, Set<String>> partitionsToInstances, String resourceName) {
+    // Multiple resources are created and partitions are grouped under these resources upto a maximum threshold.
+    if (partitionsToInstances.isEmpty()) {
+      throw new IllegalArgumentException("Cannot add resource with zero partitions");
+    }
+    SemiAutoModeISBuilder resourceISBuilder = new SemiAutoModeISBuilder(resourceName);
+    int numReplicas = 0;
+    resourceISBuilder.setStateModel(LeaderStandbySMD.name);
+    info("Adding partitions for instances in " + dcName);
+    for (Map.Entry<String, Set<String>> entry : partitionsToInstances.entrySet()) {
+      String partitionName = entry.getKey();
+      numReplicas = entry.getValue().size();
+      String[] instances = entry.getValue().toArray(new String[0]);
+      Collections.shuffle(Arrays.asList(instances));
+      resourceISBuilder.assignPreferenceList(partitionName, instances);
+    }
+    resourceISBuilder.setNumPartitions(partitionsToInstances.size());
+    resourceISBuilder.setNumReplica(numReplicas);
+    IdealState idealState = resourceISBuilder.build();
+    if (!dryRun) {
+      dcAdmin.addResource(clusterName, resourceName, idealState);
+    }
+    info("Added " + partitionsToInstances.size() + " new partitions under resource " + resourceName + " in datacenter "
+        + dcName);
   }
 
   /**
@@ -201,270 +480,11 @@ class HelixBootstrapUpgradeUtil {
       adminForDc.put(entry.getKey(), admin);
       // Add a cluster entry in every DC
       if (!admin.getClusters().contains(clusterName)) {
+        info("Adding cluster {} in {}", clusterName, entry.getKey());
         admin.addCluster(clusterName);
         admin.addStateModelDef(clusterName, LeaderStandbySMD.name, LeaderStandbySMD.build());
       }
     }
-  }
-
-  /**
-   * Populate the set of existing resources and existing partitions in the cluster. This assumes that all partitions
-   * and resources exist in all datacenters (This assumption helps simplify the logic. This can be gotten rid of in
-   * the future if need be).
-   * @param dcAdmin the reference admin (preferably the admin to the zookeeper server in the local datacenter).
-   */
-  private void populateResourcesAndPartitionsSet(HelixAdmin dcAdmin) {
-    for (String resource : dcAdmin.getResourcesInCluster(clusterName)) {
-      existingResources.add(Long.valueOf(resource));
-      for (String partition : dcAdmin.getResourceIdealState(clusterName, resource).getPartitionSet()) {
-        existingPartitions.add(Long.valueOf(partition));
-      }
-    }
-  }
-
-  /**
-   * Add nodes in the static cluster map that is not already present in Helix.
-   * Ignores those that are already present. This is to make upgrades smooth.
-   *
-   * Replica/Partition information is not updated by this method. That is updated when
-   * replicas and partitions are added.
-   *
-   * At this time, node removals are not dealt with.
-   */
-  private void addNewDataNodes() {
-    for (Datacenter dc : staticClusterMap.hardwareLayout.getDatacenters()) {
-      HelixAdmin dcAdmin = adminForDc.get(dc.getName());
-      for (DataNode node : dc.getDataNodes()) {
-        String instanceName = getInstanceName(node);
-        if (!dcAdmin.getInstancesInCluster(clusterName).contains(instanceName)) {
-          InstanceConfig instanceConfig = new InstanceConfig(instanceName);
-          instanceConfig.setHostName(node.getHostname());
-          instanceConfig.setPort(Integer.toString(node.getPort()));
-
-          // populate mountPath -> Disk information.
-          Map<String, Map<String, String>> diskInfos = new HashMap<>();
-          for (Disk disk : node.getDisks()) {
-            Map<String, String> diskInfo = new HashMap<>();
-            diskInfo.put(ClusterMapUtils.DISK_CAPACITY_STR, Long.toString(disk.getRawCapacityInBytes()));
-            diskInfo.put(ClusterMapUtils.DISK_STATE, ClusterMapUtils.AVAILABLE_STR);
-            // Note: An instance config has to contain the information for each disk about the replicas it hosts.
-            // This information will be initialized to the empty string - but will be updated whenever the partition
-            // is added to the cluster.
-            diskInfo.put(ClusterMapUtils.REPLICAS_STR, "");
-            diskInfos.put(disk.getMountPath(), diskInfo);
-          }
-
-          // Add all instance configuration.
-          instanceConfig.getRecord().setMapFields(diskInfos);
-          if (node.hasSSLPort()) {
-            instanceConfig.getRecord().setSimpleField(ClusterMapUtils.SSLPORT_STR, Integer.toString(node.getSSLPort()));
-          }
-          instanceConfig.getRecord().setSimpleField(ClusterMapUtils.DATACENTER_STR, node.getDatacenterName());
-          instanceConfig.getRecord().setSimpleField(ClusterMapUtils.RACKID_STR, node.getRackId());
-          instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, new ArrayList<String>());
-
-          // Finally, add this node to the DC.
-          dcAdmin.addInstance(clusterName, instanceConfig);
-        }
-      }
-      System.out.println("Added all new nodes in datacenter " + dc.getName());
-    }
-  }
-
-  /**
-   * Goes through each existing partition and updates the {@link PartitionState} and capacity information for the
-   * replicas in each of the instances that hosts a replica for this partition, if it has changed and is different from
-   * the current information in the static cluster map.
-   * @param partition the partition whose {@link PartitionState} and/or capacity may have to be updated.
-   */
-  private void updatePartitionInfoIfChanged(Partition partition) {
-    for (Map.Entry<String, HelixAdmin> entry : adminForDc.entrySet()) {
-      String dcName = entry.getKey();
-      HelixAdmin dcAdmin = entry.getValue();
-      String partitionName = Long.toString(partition.getId());
-      long replicaCapacityInStatic = partition.getReplicaCapacityInBytes();
-      boolean isSealed = partition.getPartitionState().equals(PartitionState.READ_ONLY);
-      List<ReplicaId> replicaList = getReplicasInDc(partition, dcName);
-      for (ReplicaId replicaId : replicaList) {
-        DataNodeId node = replicaId.getDataNodeId();
-        String instanceName = getInstanceName(node);
-        InstanceConfig instanceConfig = dcAdmin.getInstanceConfig(clusterName, instanceName);
-        boolean shouldSetInstanceConfig = false;
-        if (updateSealedStateIfRequired(partitionName, instanceConfig, isSealed)) {
-          System.out.println(
-              "Sealed state change of partition " + partitionName + " will be updated for instance " + instanceName);
-          shouldSetInstanceConfig = true;
-        }
-        if (updateReplicaCapacityIfRequired(partitionName, instanceConfig, replicaId.getMountPath(),
-            replicaCapacityInStatic)) {
-          System.out.println(
-              "Replica capacity change of partition " + partitionName + " will be updated for instance" + instanceName);
-          shouldSetInstanceConfig = true;
-        }
-        if (shouldSetInstanceConfig) {
-          dcAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
-          System.out.println("Successfully updated InstanceConfig for instance " + instanceName);
-        }
-      }
-    }
-  }
-
-  /**
-   * Update the sealed state of the given partition on the node corresponding to the given {@link InstanceConfig}, if
-   * there has been a change.
-   * @param partitionName the partition
-   * @param instanceConfig the {@link InstanceConfig} of the node.
-   * @param isSealed whether the partition is in SEALED state in the static cluster map.
-   * @return true, if the {@link InstanceConfig} was updated by this method; false otherwise.
-   */
-  private boolean updateSealedStateIfRequired(String partitionName, InstanceConfig instanceConfig, boolean isSealed) {
-    boolean instanceConfigUpdated = false;
-    List<String> currentSealedPartitions = instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
-    List<String> newSealedPartitionsList = new ArrayList<>(currentSealedPartitions);
-    if (isSealed && !currentSealedPartitions.contains(partitionName)) {
-      newSealedPartitionsList.add(partitionName);
-    } else if (!isSealed && currentSealedPartitions.contains(partitionName)) {
-      newSealedPartitionsList.remove(partitionName);
-    }
-    if (!currentSealedPartitions.equals(newSealedPartitionsList)) {
-      instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, newSealedPartitionsList);
-      instanceConfigUpdated = true;
-    }
-    return instanceConfigUpdated;
-  }
-
-  /**
-   * Update replica capacity for the given partition on the node corresponding to the given
-   * {@link InstanceConfig}, if there has been a change.
-   * @param partitionName the partition
-   * @param instanceConfig the {@link InstanceConfig} of the node.
-   * @param mountPath the mount path of the replica.
-   * @return true, if the {@link InstanceConfig} was updated by this method; false otherwise.
-   */
-  private boolean updateReplicaCapacityIfRequired(String partitionName, InstanceConfig instanceConfig, String mountPath,
-      long actualReplicaCapacity) {
-    boolean instanceConfigUpdated = false;
-    Map<String, String> diskInfo = instanceConfig.getRecord().getMapField(mountPath);
-    String currentReplicasStr = diskInfo.get(ClusterMapUtils.REPLICAS_STR);
-    StringBuilder newReplicaStrBuilder = new StringBuilder();
-    List<String> replicaInfoList = Arrays.asList(currentReplicasStr.split(ClusterMapUtils.REPLICAS_DELIM_STR));
-    for (String replicaInfo : replicaInfoList) {
-      String[] info = replicaInfo.split(ClusterMapUtils.REPLICAS_STR_SEPARATOR);
-      if (info[0].equals(partitionName)) {
-        long capacityInHelix = Long.valueOf(info[1]);
-        if (capacityInHelix != actualReplicaCapacity) {
-          info[1] = Long.toString(actualReplicaCapacity);
-        }
-      }
-      newReplicaStrBuilder.append(info[0])
-          .append(ClusterMapUtils.REPLICAS_STR_SEPARATOR)
-          .append(info[1])
-          .append(ClusterMapUtils.REPLICAS_DELIM_STR);
-    }
-    String newReplicaStr = newReplicaStrBuilder.toString();
-    if (!currentReplicasStr.equals(newReplicaStr)) {
-      diskInfo.put(ClusterMapUtils.REPLICAS_STR, newReplicaStr);
-      instanceConfig.getRecord().setMapField(mountPath, diskInfo);
-      instanceConfigUpdated = true;
-    }
-    return instanceConfigUpdated;
-  }
-
-  /**
-   * Adds all partitions to every datacenter with replicas in nodes as specified in the static clustermap (unless it
-   * was already added).
-   *
-   * The assumption is that in the static layout, every partition is contained in every colo. We make this assumption
-   * to ensure that partitions are grouped under the same resource in all colos (since the resource id is not
-   * something that is present today in the static cluster map). This is not a strict requirement though, but helps
-   * ease the logic.
-   *
-   * Note: 1. We ensure that the partition names are unique in the Ambry cluster even across resources.
-   *       2. New Ambry partitions will not be added to Helix resources that are already present before the call to this
-   *          method.
-   */
-  private void addNewAmbryPartitions(List<Partition> partitions, String resourceName) {
-    // In the future, a resource may be used to group together partitions of a container. For now, multiple
-    // resources are created and partitions are grouped under these resources upto a maximum threshold.
-    if (partitions.isEmpty()) {
-      throw new IllegalArgumentException("Cannot add resource with zero partitions");
-    }
-    for (Map.Entry<String, HelixAdmin> entry : adminForDc.entrySet()) {
-      String dcName = entry.getKey();
-      HelixAdmin dcAdmin = entry.getValue();
-      AutoModeISBuilder resourceISBuilder = new AutoModeISBuilder(resourceName);
-      int numReplicas = 0;
-      resourceISBuilder.setStateModel(LeaderStandbySMD.name);
-      for (Partition partition : partitions) {
-        String partitionName = Long.toString(partition.getId());
-        boolean sealed = partition.getPartitionState().equals(PartitionState.READ_ONLY);
-        List<ReplicaId> replicaList = getReplicasInDc(partition, dcName);
-        numReplicas = replicaList.size();
-        String[] instances = updateInstancesAndGetInstanceNames(dcAdmin, partitionName, replicaList, sealed);
-        Collections.shuffle(Arrays.asList(instances));
-        resourceISBuilder.assignPreferenceList(partitionName, instances);
-      }
-      resourceISBuilder.setNumPartitions(partitions.size());
-      resourceISBuilder.setNumReplica(numReplicas);
-      IdealState idealState = resourceISBuilder.build();
-      dcAdmin.addResource(clusterName, resourceName, idealState);
-      System.out.println(
-          "Added " + partitions.size() + " new partitions under resource " + resourceName + " in datacenter " + dcName);
-    }
-  }
-
-  /**
-   * Updates instances that hosts replicas of this partition with the replica information (including the mount points
-   * on which these replicas should reside, which will be purely an instance level information).
-   * @param dcAdmin the admin to the Zk server on which this operation is to be done.
-   * @param partitionName the partition name.
-   * @param replicaList the list of replicas of this partition.
-   * @param sealed whether the given partition state is sealed.
-   * @return an array of Strings containing the names of the instances on which the replicas of this partition reside.
-   */
-  private String[] updateInstancesAndGetInstanceNames(HelixAdmin dcAdmin, String partitionName,
-      List<ReplicaId> replicaList, boolean sealed) {
-    String[] instances = new String[replicaList.size()];
-    for (int i = 0; i < replicaList.size(); i++) {
-      Replica replica = (Replica) replicaList.get(i);
-      DataNodeId node = replica.getDataNodeId();
-      String instanceName = getInstanceName(node);
-      instances[i] = instanceName;
-      InstanceConfig instanceConfig = dcAdmin.getInstanceConfig(clusterName, instanceName);
-      Map<String, String> diskInfo = instanceConfig.getRecord().getMapField(replica.getMountPath());
-      String replicasStr = diskInfo.get(ClusterMapUtils.REPLICAS_STR);
-      replicasStr +=
-          replica.getPartition().getId() + ClusterMapUtils.REPLICAS_STR_SEPARATOR + replica.getCapacityInBytes()
-              + ClusterMapUtils.REPLICAS_DELIM_STR;
-      diskInfo.put(ClusterMapUtils.REPLICAS_STR, replicasStr);
-      instanceConfig.getRecord().setMapField(replica.getMountPath(), diskInfo);
-      if (sealed) {
-        List<String> currentSealedPartitions = instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
-        List<String> newSealedPartitionsList = new ArrayList<>(currentSealedPartitions);
-        newSealedPartitionsList.add(partitionName);
-        instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, newSealedPartitionsList);
-      }
-      dcAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
-    }
-    return instances;
-  }
-
-  /**
-   * Helper method to get the list of {@link ReplicaId} of all replicas of a partition in the given datacenter.
-   * @param partition the partition of interest.
-   * @param dcName the datacenter to which the returned replicas should belong.
-   * @return a list of {@link ReplicaId} of all replicas of the given partition in the given datacenter.
-   */
-  private List<ReplicaId> getReplicasInDc(Partition partition, String dcName) {
-    // returns a copy unlike getReplicas()
-    List<ReplicaId> replicaList = partition.getReplicaIds();
-    ListIterator<ReplicaId> iter = replicaList.listIterator();
-    while (iter.hasNext()) {
-      if (!iter.next().getDataNodeId().getDatacenterName().equals(dcName)) {
-        iter.remove();
-      }
-    }
-    return replicaList;
   }
 
   /**
@@ -498,7 +518,7 @@ class HelixBootstrapUpgradeUtil {
   private void verifyEquivalencyWithStaticClusterMap(HardwareLayout hardwareLayout, PartitionLayout partitionLayout)
       throws Exception {
     String clusterNameInStaticClusterMap = hardwareLayout.getClusterName();
-    System.out.println("Verifying equivalency of static cluster: " + clusterNameInStaticClusterMap + " with the "
+    info("Verifying equivalency of static cluster: " + clusterNameInStaticClusterMap + " with the "
         + "corresponding cluster in Helix: " + clusterName);
     for (Datacenter dc : hardwareLayout.getDatacenters()) {
       HelixAdmin admin = adminForDc.get(dc.getName());
@@ -508,7 +528,7 @@ class HelixBootstrapUpgradeUtil {
       verifyResourcesAndPartitionEquivalencyInDc(dc, clusterName, partitionLayout);
       verifyDataNodeAndDiskEquivalencyInDc(dc, clusterName, partitionLayout);
     }
-    System.out.println("Successfully verified equivalency of static cluster: " + clusterNameInStaticClusterMap
+    info("Successfully verified equivalency of static cluster: " + clusterNameInStaticClusterMap
         + " with the corresponding cluster in Helix: " + clusterName);
   }
 
@@ -596,6 +616,7 @@ class HelixBootstrapUpgradeUtil {
     }
     ensureOrThrow(allInstancesInHelix.isEmpty(),
         "Following instances in Helix not found in the clustermap " + allInstancesInHelix);
+    info("Successfully verified datanode and disk equivalency in dc {}", dc.getName());
   }
 
   /**
@@ -610,6 +631,10 @@ class HelixBootstrapUpgradeUtil {
     HelixAdmin admin = adminForDc.get(dc.getName());
     Map<String, Set<String>> allPartitionsToInstancesInHelix = new HashMap<>();
     for (String resourceName : admin.getResourcesInCluster(clusterName)) {
+      if (!resourceName.matches("\\d+")) {
+        info("Ignoring resource {} as it is not part of the cluster map", resourceName);
+        continue;
+      }
       IdealState resourceIS = admin.getResourceIdealState(clusterName, resourceName);
       ensureOrThrow(resourceIS.getStateModelDefRef().equals(LeaderStandbySMD.name),
           "StateModel name mismatch for resource " + resourceName);
@@ -628,21 +653,24 @@ class HelixBootstrapUpgradeUtil {
       Partition partition = (Partition) partitionId;
       String partitionName = Long.toString(partition.getId());
       Set<String> replicaHostsInHelix = allPartitionsToInstancesInHelix.remove(partitionName);
+      Set<String> expectedInHelix = new HashSet<>();
       ensureOrThrow(replicaHostsInHelix != null, "No replicas found for partition " + partitionName + " in Helix");
       for (Replica replica : partition.getReplicas()) {
         if (replica.getDataNodeId().getDatacenterName().equals(dcName)) {
           String instanceName = getInstanceName(replica.getDataNodeId());
+          expectedInHelix.add(instanceName);
           ensureOrThrow(replicaHostsInHelix.remove(instanceName),
               "Instance " + instanceName + " for the given " + "replica in the clustermap not found in Helix");
         }
       }
       ensureOrThrow(replicaHostsInHelix.isEmpty(),
-          "More instances in Helix than in clustermap for partition: " + partitionName + " additional instances: "
-              + replicaHostsInHelix);
+          "More instances in Helix than in clustermap for partition: " + partitionName + ", expected: "
+              + expectedInHelix + ", found additional instances: " + replicaHostsInHelix);
     }
     ensureOrThrow(allPartitionsToInstancesInHelix.isEmpty(),
         "More partitions in Helix than in clustermap, additional partitions: "
             + allPartitionsToInstancesInHelix.keySet());
+    info("Successfully verified resources and partitions equivalency in dc {}", dcName);
   }
 
   /**
@@ -677,6 +705,15 @@ class HelixBootstrapUpgradeUtil {
     if (!condition) {
       throw new AssertionError(errStr);
     }
+  }
+
+  /**
+   * Log in INFO mode
+   * @param format format
+   * @param arguments arguments
+   */
+  private static void info(String format, Object... arguments) {
+    logger.info(format, arguments);
   }
 }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -46,7 +46,7 @@ public class MockHelixCluster {
     this.partitionLayoutPath = partitionLayoutPath;
     this.zkLayoutPath = zkLayoutPath;
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        null, 3, helixAdminFactory);
+        3, false, helixAdminFactory);
     this.clusterName = clusterName;
   }
 
@@ -57,7 +57,7 @@ public class MockHelixCluster {
    */
   void upgradeWithNewHardwareLayout(String hardwareLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        null, 3, helixAdminFactory);
+        3, false, helixAdminFactory);
     for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
       helixAdmin.triggerInstanceConfigChangeNotification(false);
     }

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -93,7 +93,7 @@ public class HelixBootstrapUpgradeToolTest {
       Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
       try {
         HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-            CLUSTER_NAME_PREFIX, "DC1", DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory());
+            CLUSTER_NAME_PREFIX, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, new HelixAdminFactory());
         Assert.fail("Should have thrown IllegalArgumentException as a zk host is missing for one of the dcs");
       } catch (IllegalArgumentException e) {
         // OK
@@ -168,7 +168,7 @@ public class HelixBootstrapUpgradeToolTest {
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
     // This updates and verifies that the information in Helix is consistent with the one in the static cluster map.
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-        CLUSTER_NAME_PREFIX, "DC1", DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory());
+        CLUSTER_NAME_PREFIX, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, new HelixAdminFactory());
     verifyResourceCount(testHardwareLayout.getHardwareLayout(), expectedResourceCount);
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -92,7 +92,7 @@ public class HelixBootstrapUpgradeTool {
     OptionParser parser = new OptionParser();
 
     OptionSpec dropClusterOpt = parser.accepts("dropCluster",
-        "(Optional argument) If present, must be accompanied with and only with the clusterNamePrefix argument");
+        "(Optional argument) If present, must be accompanied with and only with the clusterName argument");
 
     ArgumentAcceptingOptionSpec<String> hardwareLayoutPathOpt =
         parser.accepts("hardwareLayoutPath", "The path to the hardware layout json file")
@@ -121,7 +121,6 @@ public class HelixBootstrapUpgradeTool {
 
     ArgumentAcceptingOptionSpec<String> clusterNamePrefixOpt =
         parser.accepts("clusterNamePrefix", "The prefix for the cluster in Helix to bootstrap or upgrade")
-            .requiredUnless(dropClusterOpt)
             .withRequiredArg()
             .describedAs("cluster_name_prefix")
             .ofType(String.class);

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -19,6 +19,7 @@ import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+import joptsimple.OptionSpecBuilder;
 
 
 /**
@@ -90,14 +91,19 @@ public class HelixBootstrapUpgradeTool {
   public static void main(String args[]) throws Exception {
     OptionParser parser = new OptionParser();
 
+    OptionSpec dropClusterOpt = parser.accepts("dropCluster",
+        "(Optional argument) If present, must be accompanied with and only with the clusterNamePrefix argument");
+
     ArgumentAcceptingOptionSpec<String> hardwareLayoutPathOpt =
         parser.accepts("hardwareLayoutPath", "The path to the hardware layout json file")
+            .requiredUnless(dropClusterOpt)
             .withRequiredArg()
             .describedAs("hardware_layout_path")
             .ofType(String.class);
 
     ArgumentAcceptingOptionSpec<String> partitionLayoutPathOpt =
         parser.accepts("partitionLayoutPath", "The path to the partition layout json file")
+            .requiredUnless(dropClusterOpt)
             .withRequiredArg()
             .describedAs("partition_layout_path")
             .ofType(String.class);
@@ -108,44 +114,61 @@ public class HelixBootstrapUpgradeTool {
             + "       \"zkConnectStr\":\"abc.example.com:2199\",\n" + "     },\n" + "     {\n"
             + "       \"datacenter\":\"dc2\",\n" + "       \"zkConnectStr\":\"def.example.com:2300\",\n" + "     },\n"
             + "     {\n" + "       \"datacenter\":\"dc3\",\n" + "       \"zkConnectStr\":\"ghi.example.com:2400\",\n"
-            + "     }\n" + "  ]\n" + "}").
+            + "     }\n" + "  ]\n" + "}").requiredUnless(dropClusterOpt).
         withRequiredArg().
         describedAs("zk_connect_info_path").
         ofType(String.class);
 
     ArgumentAcceptingOptionSpec<String> clusterNamePrefixOpt =
         parser.accepts("clusterNamePrefix", "The prefix for the cluster in Helix to bootstrap or upgrade")
+            .requiredUnless(dropClusterOpt)
             .withRequiredArg()
             .describedAs("cluster_name_prefix")
             .ofType(String.class);
 
-    ArgumentAcceptingOptionSpec<String> localDcOpt =
-        parser.accepts("localDc", "(Optional argument) The local datacenter name")
+    ArgumentAcceptingOptionSpec<String> clusterNameOpt =
+        parser.accepts("clusterName", "The cluster in Helix to drop. This should accompany the dropCluster option")
+            .requiredIf(dropClusterOpt)
             .withRequiredArg()
-            .describedAs("local_dc")
+            .describedAs("cluster_name")
             .ofType(String.class);
 
     ArgumentAcceptingOptionSpec<String> maxPartitionsInOneResourceOpt = parser.accepts("maxPartitionsInOneResource",
         "(Optional argument) The maximum number of partitions that should be grouped under a Helix resource")
+        .requiredUnless(dropClusterOpt)
         .withRequiredArg()
         .describedAs("max_partitions_in_one_resource")
         .ofType(String.class);
+
+    OptionSpecBuilder dryRun =
+        parser.accepts("dryRun", "(Optional argument) Dry run, do not modify the cluster map in Helix.");
 
     OptionSet options = parser.parse(args);
     String hardwareLayoutPath = options.valueOf(hardwareLayoutPathOpt);
     String partitionLayoutPath = options.valueOf(partitionLayoutPathOpt);
     String zkLayoutPath = options.valueOf(zkLayoutPathOpt);
     String clusterNamePrefix = options.valueOf(clusterNamePrefixOpt);
+    String clusterName = options.valueOf(clusterNameOpt);
     ArrayList<OptionSpec> listOpt = new ArrayList<>();
     listOpt.add(hardwareLayoutPathOpt);
     listOpt.add(partitionLayoutPathOpt);
     listOpt.add(zkLayoutPathOpt);
     listOpt.add(clusterNamePrefixOpt);
-    ToolUtils.ensureOrExit(listOpt, options, parser);
-    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-        clusterNamePrefix, options.valueOf(localDcOpt),
-        options.valueOf(maxPartitionsInOneResourceOpt) == null ? DEFAULT_MAX_PARTITIONS_PER_RESOURCE
-            : Integer.valueOf(options.valueOf(maxPartitionsInOneResourceOpt)), new HelixAdminFactory());
+    if (options.has(dropClusterOpt)) {
+      ArrayList<OptionSpec<?>> expectedOpts = new ArrayList<>();
+      expectedOpts.add(dropClusterOpt);
+      expectedOpts.add(clusterNameOpt);
+      expectedOpts.add(zkLayoutPathOpt);
+      ToolUtils.ensureExactOrExit(expectedOpts, options.specs(), parser);
+      HelixBootstrapUpgradeUtil.dropCluster(zkLayoutPath, clusterName, new HelixAdminFactory());
+    } else {
+      ToolUtils.ensureOrExit(listOpt, options, parser);
+      HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
+          clusterNamePrefix,
+          options.valueOf(maxPartitionsInOneResourceOpt) == null ? DEFAULT_MAX_PARTITIONS_PER_RESOURCE
+              : Integer.valueOf(options.valueOf(maxPartitionsInOneResourceOpt)), options.has(dryRun),
+          new HelixAdminFactory());
+    }
   }
 }
 

--- a/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
@@ -17,6 +17,7 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import joptsimple.ArgumentAcceptingOptionSpec;
@@ -108,6 +109,22 @@ public final class ToolUtils {
         parser.printHelpOn(System.err);
         System.exit(1);
       }
+    }
+  }
+
+  /**
+   * Ensures that the given argument list has only and exactly the options in the given list and nothing else.
+   * @param exactExpectedOptions the exact options expected
+   * @param actualOptions the actual options received.
+   * @param parser the {@link OptionParser} used to parse arguments.
+   * @throws IOException if there is a problem writing out usage information.
+   */
+  public static void ensureExactOrExit(List<OptionSpec<?>> exactExpectedOptions, List<OptionSpec<?>> actualOptions,
+      OptionParser parser) throws IOException {
+    if (!new HashSet<>(exactExpectedOptions).equals(new HashSet<>(actualOptions))) {
+      System.err.println("Incompatible options.");
+      parser.printHelpOn(System.err);
+      System.exit(1);
     }
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
@@ -122,7 +122,7 @@ public final class ToolUtils {
   public static void ensureExactOrExit(List<OptionSpec<?>> exactExpectedOptions, List<OptionSpec<?>> actualOptions,
       OptionParser parser) throws IOException {
     if (!new HashSet<>(exactExpectedOptions).equals(new HashSet<>(actualOptions))) {
-      System.err.println("Incompatible options.");
+      System.err.println("***Incompatible options, expected exactly: " + exactExpectedOptions);
       parser.printHelpOn(System.err);
       System.exit(1);
     }


### PR DESCRIPTION
Improve the tool by making it faster and more verbose. In particular,
given that the tool works cross-colo, it keeps the number of ZK calls
it makes to a minimum (at most one per instance plus one per partition).
This patch also makes the tool more robust.