### PR TITLE
Introducing the concept of "partition class"

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -32,7 +32,8 @@ public interface ClusterMap extends AutoCloseable {
   PartitionId getPartitionIdFromStream(InputStream stream) throws IOException;
 
   /**
-   * Gets a list of partitions that are available for writes. The returned list can be manipulated.
+   * Gets a list of partitions that are available for writes. Gets a mutable shallow copy of the list of the partitions
+   * that are available for writes
    * @param partitionClass the partition class whose writable partitions are required. Can be {@code null}
    * @return a list of all writable partitions belonging to the partition class (or all writable partitions if
    * {@code partitionClass} is {@code null})
@@ -40,7 +41,7 @@ public interface ClusterMap extends AutoCloseable {
   List<? extends PartitionId> getWritablePartitionIds(String partitionClass);
 
   /**
-   * Gets a list of all partitions in the cluster. The returned list can be manipulated.
+   * Gets a list of all partitions in the cluster.  Gets a mutable shallow copy of the list of all partitions.
    * @param partitionClass the partition class whose partitions are required. Can be {@code null}
    * @return a list of all partitions belonging to the partition class (or all partitions if {@code partitionClass} is
    * {@code null})

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -32,15 +32,20 @@ public interface ClusterMap extends AutoCloseable {
   PartitionId getPartitionIdFromStream(InputStream stream) throws IOException;
 
   /**
-   * Gets a list of partitions that are available for writes.
+   * Gets a list of partitions that are available for writes. The returned list can be manipulated.
+   * @param partitionClass the partition class whose writable partitions are required. Can be {@code null}
+   * @return a list of all writable partitions belonging to the partition class (or all writable partitions if
+   * {@code partitionClass} is {@code null})
    */
-  List<? extends PartitionId> getWritablePartitionIds();
+  List<? extends PartitionId> getWritablePartitionIds(String partitionClass);
 
   /**
-   * Gets a list of all partitions in the cluster
-   * @return a list of all partitions in the cluster
+   * Gets a list of all partitions in the cluster. The returned list can be manipulated.
+   * @param partitionClass the partition class whose partitions are required. Can be {@code null}
+   * @return a list of all partitions belonging to the partition class (or all partitions if {@code partitionClass} is
+   * {@code null})
    */
-  List<? extends PartitionId> getAllPartitionIds();
+  List<? extends PartitionId> getAllPartitionIds(String partitionClass);
 
   /**
    * Checks if datacenter name corresponds to some datacenter in this cluster map's hardware layout.

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionId.java
@@ -60,4 +60,9 @@ public abstract class PartitionId implements Resource, Comparable<PartitionId> {
    * @return Strictly numerical string representation of the {@code PartitionId}.
    */
   public abstract String toPathString();
+
+  /**
+   * @return the partition class that this partition belongs to
+   */
+  public abstract String getPartitionClass();
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -18,6 +18,8 @@ package com.github.ambry.config;
  */
 public class ClusterMapConfig {
 
+  private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
+
   /**
    * The factory class used to get the resource state policies.
    */
@@ -133,7 +135,7 @@ public class ClusterMapConfig {
    * The partition class to assign to a partition if one is not supplied
    */
   @Config("clustermap.default.partition.class")
-  @Default("max-replicas-all-datacenters")
+  @Default(MAX_REPLICAS_ALL_DATACENTERS)
   public final String clusterMapDefaultPartitionClass;
 
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
@@ -159,6 +161,6 @@ public class ClusterMapConfig {
     clusterMapPort = verifiableProperties.getInteger("clustermap.port", null);
     clusterMapResolveHostnames = verifiableProperties.getBoolean("clustermap.resolve.hostnames", true);
     clusterMapDefaultPartitionClass =
-        verifiableProperties.getString("clustermap.default.partition.class", "max-replicas-all-datacenters");
+        verifiableProperties.getString("clustermap.default.partition.class", MAX_REPLICAS_ALL_DATACENTERS);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -129,6 +129,13 @@ public class ClusterMapConfig {
   @Default("true")
   public final boolean clusterMapResolveHostnames;
 
+  /**
+   * The partition class to assign to a partition if one is not supplied
+   */
+  @Config("clustermap.default.partition.class")
+  @Default("max-replicas-all-datacenters")
+  public final String clusterMapDefaultPartitionClass;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -151,5 +158,7 @@ public class ClusterMapConfig {
     clusterMapHostName = verifiableProperties.getString("clustermap.host.name");
     clusterMapPort = verifiableProperties.getInteger("clustermap.port", null);
     clusterMapResolveHostnames = verifiableProperties.getBoolean("clustermap.resolve.hostnames", true);
+    clusterMapDefaultPartitionClass =
+        verifiableProperties.getString("clustermap.default.partition.class", "max-replicas-all-datacenters");
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ServerConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ServerConfig.java
@@ -69,7 +69,6 @@ public class ServerConfig {
         verifiableProperties.getBoolean("server.stats.publish.health.report.enabled", false);
     serverQuotaStatsAggregateIntervalInMinutes =
         verifiableProperties.getLong("server.quota.stats.aggregate.interval.in.minutes", 60);
-    serverEnableStoreDataPrefetch =
-        verifiableProperties.getBoolean("server.enable.store.data.prefetch", false);
+    serverEnableStoreDataPrefetch = verifiableProperties.getBoolean("server.enable.store.data.prefetch", false);
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
@@ -28,10 +28,12 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 class AmbryPartition extends PartitionId {
   private final Long id;
+  private final String partitionClass;
   private final ClusterManagerCallback clusterManagerCallback;
+  private final Lock stateChangeLock = new ReentrantLock();
+
   private volatile PartitionState state;
   private long lastUpdatedSealedStateChangeCounter = 0;
-  private final Lock stateChangeLock = new ReentrantLock();
 
   private static final short VERSION_FIELD_SIZE_IN_BYTES = 2;
   private static final short CURRENT_VERSION = 1;
@@ -40,12 +42,14 @@ class AmbryPartition extends PartitionId {
   /**
    * Instantiate an AmbryPartition instance.
    * @param id the id associated with this partition.
+   * @param partitionClass the partition class that this partition belongs to
    * @param clusterManagerCallback the {@link ClusterManagerCallback} to use to make callbacks
    *                               to the {@link HelixClusterManager}
    * The initial state defaults to {@link PartitionState#READ_WRITE}.
    */
-  AmbryPartition(long id, ClusterManagerCallback clusterManagerCallback) {
+  AmbryPartition(long id, String partitionClass, ClusterManagerCallback clusterManagerCallback) {
     this.id = id;
+    this.partitionClass = partitionClass;
     this.clusterManagerCallback = clusterManagerCallback;
     this.state = PartitionState.READ_WRITE;
   }
@@ -119,6 +123,11 @@ class AmbryPartition extends PartitionId {
   @Override
   public String toPathString() {
     return id.toString();
+  }
+
+  @Override
+  public String getPartitionClass() {
+    return partitionClass;
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapMetrics.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapMetrics.java
@@ -244,7 +244,7 @@ class ClusterMapMetrics {
 
   private boolean isMajorityOfReplicasDown() {
     boolean isMajorityReplicasDown = false;
-    for (PartitionId partition : partitionLayout.getPartitions()) {
+    for (PartitionId partition : partitionLayout.getPartitions(null)) {
       List<? extends ReplicaId> replicas = partition.getReplicaIds();
       int replicaCount = replicas.size();
       int downReplicas = 0;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -271,7 +271,7 @@ public class ClusterMapUtils {
      */
     void updatePartitions(Collection<? extends PartitionId> allPartitions, String localDatacenterName) {
       this.allPartitions = allPartitions;
-      partitionIdsByClassAndLocalReplicaCount = new HashMap<>();
+      partitionIdsByClassAndLocalReplicaCount = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
       for (PartitionId partition : allPartitions) {
         String partitionClass = partition.getPartitionClass();
         int localReplicaCount = 0;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -16,9 +16,13 @@ package com.github.ambry.clustermap;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import org.apache.helix.model.InstanceConfig;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -223,6 +227,135 @@ public class ClusterMapUtils {
     } else if (diskCapacityInBytes > MAX_DISK_CAPACITY_IN_BYTES) {
       throw new IllegalStateException(
           "Invalid disk capacity: " + diskCapacityInBytes + " is more than " + MAX_DISK_CAPACITY_IN_BYTES);
+    }
+  }
+
+  /**
+   * Check whether all replicas of the given {@link PartitionId} are up.
+   * @param partition the {@link PartitionId} to check.
+   * @return true if all associated replicas are up; false otherwise.
+   */
+  static boolean areAllReplicasForPartitionUp(PartitionId partition) {
+    for (ReplicaId replica : partition.getReplicaIds()) {
+      if (replica.isDown()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Helper class to perform common operations like maintaining partitions by partition class and returning all/writable
+   * partitions.
+   * <p/>
+   * Not thread safe.
+   */
+  static class PartitionSelectionHelper {
+    private Collection<? extends PartitionId> allPartitions;
+    private Map<String, SortedMap<Integer, List<PartitionId>>> partitionIdsByClassAndLocalReplicaCount;
+
+    /**
+     * @param allPartitions the list of all {@link PartitionId}s
+     * @param localDatacenterName the name of the local datacenter. Can be null if datacenter specific replica counts
+     *                            are not required.
+     */
+    PartitionSelectionHelper(Collection<? extends PartitionId> allPartitions, String localDatacenterName) {
+      updatePartitions(allPartitions, localDatacenterName);
+    }
+
+    /**
+     * Updates the partitions tracked by this helper.
+     * @param allPartitions the list of all {@link PartitionId}s
+     * @param localDatacenterName the name of the local datacenter. Can be null if datacenter specific replica counts
+     *                            are not required.
+     */
+    void updatePartitions(Collection<? extends PartitionId> allPartitions, String localDatacenterName) {
+      this.allPartitions = allPartitions;
+      partitionIdsByClassAndLocalReplicaCount = new HashMap<>();
+      for (PartitionId partition : allPartitions) {
+        String partitionClass = partition.getPartitionClass();
+        int localReplicaCount = 0;
+        for (ReplicaId replicaId : partition.getReplicaIds()) {
+          if (localDatacenterName != null && !localDatacenterName.isEmpty() && replicaId.getDataNodeId()
+              .getDatacenterName()
+              .equals(localDatacenterName)) {
+            localReplicaCount++;
+          }
+        }
+        if (!partitionIdsByClassAndLocalReplicaCount.containsKey(partitionClass)) {
+          partitionIdsByClassAndLocalReplicaCount.put(partitionClass, new TreeMap<>());
+        }
+        SortedMap<Integer, List<PartitionId>> replicaCountToPartitionIds =
+            partitionIdsByClassAndLocalReplicaCount.get(partitionClass);
+        if (!replicaCountToPartitionIds.containsKey(localReplicaCount)) {
+          replicaCountToPartitionIds.put(localReplicaCount, new ArrayList<>());
+        }
+        replicaCountToPartitionIds.get(localReplicaCount).add(partition);
+      }
+    }
+
+    /**
+     * Gets all partitions belonging to the {@code paritionClass} (all partitions if it is {@code null}).
+     * @param partitionClass the class of the partitions desired. Can be {@code null}.
+     * @return all the partitions in {@code partitionClass} (all partitions if it is {@code null})
+     */
+    List<PartitionId> getPartitions(String partitionClass) {
+      return getPartitionsInClass(partitionClass, false);
+    }
+
+    /**
+     * Returns all the partitions that are in state {@link PartitionState#READ_WRITE} AND have the highest number of
+     * replicas in the local datacenter for the given {@code partitionClass}.
+     * <p/>
+     * Also attempts to return only partitions with healthy replicas but if no such partitions are found, returns all
+     * the eligible partitions irrespective of replica health.
+     * <p/>
+     * If {@code partitionClass} is {@code null}, gets writable partitions from all partition classes.
+     * @param partitionClass the class of the partitions desired. Can be {@code null}.
+     * @return all the writable partitions in {@code partitionClass} with the highest replica count in the local
+     * datacenter (all writable partitions if it is {@code null}).
+     */
+    List<PartitionId> getWritablePartitions(String partitionClass) {
+      List<PartitionId> writablePartitions = new ArrayList<>();
+      List<PartitionId> healthyWritablePartitions = new ArrayList<>();
+      for (PartitionId partition : getPartitionsInClass(partitionClass, true)) {
+        if (partition.getPartitionState() == PartitionState.READ_WRITE) {
+          writablePartitions.add(partition);
+          if (areAllReplicasForPartitionUp((partition))) {
+            healthyWritablePartitions.add(partition);
+          }
+        }
+      }
+      return healthyWritablePartitions.isEmpty() ? writablePartitions : healthyWritablePartitions;
+    }
+
+    /**
+     * Returns the partitions belonging to the {@code partitionClass}. Returns all partitions if {@code partitionClass}
+     * is {@code null}.
+     * @param partitionClass the class of the partitions desired.
+     * @param highestReplicaCountOnly if {@code true}, returns only the partitions with the highest number of replicas
+     *                                in the local datacenter.
+     * @return the partitions belonging to the {@code partitionClass}. Returns all partitions if {@code partitionClass}
+     * is {@code null}.
+     */
+    private List<PartitionId> getPartitionsInClass(String partitionClass, boolean highestReplicaCountOnly) {
+      List<PartitionId> toReturn = new ArrayList<>();
+      if (partitionClass == null) {
+        toReturn.addAll(allPartitions);
+      } else if (partitionIdsByClassAndLocalReplicaCount.containsKey(partitionClass)) {
+        SortedMap<Integer, List<PartitionId>> partitionsByReplicaCount =
+            partitionIdsByClassAndLocalReplicaCount.get(partitionClass);
+        if (highestReplicaCountOnly) {
+          toReturn.addAll(partitionsByReplicaCount.get(partitionsByReplicaCount.lastKey()));
+        } else {
+          for (List<PartitionId> partitionIds : partitionIdsByClassAndLocalReplicaCount.get(partitionClass).values()) {
+            toReturn.addAll(partitionIds);
+          }
+        }
+      } else {
+        throw new IllegalArgumentException("Unrecognized partition class " + partitionClass);
+      }
+      return toReturn;
     }
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -282,15 +282,9 @@ public class ClusterMapUtils {
             localReplicaCount++;
           }
         }
-        if (!partitionIdsByClassAndLocalReplicaCount.containsKey(partitionClass)) {
-          partitionIdsByClassAndLocalReplicaCount.put(partitionClass, new TreeMap<>());
-        }
         SortedMap<Integer, List<PartitionId>> replicaCountToPartitionIds =
-            partitionIdsByClassAndLocalReplicaCount.get(partitionClass);
-        if (!replicaCountToPartitionIds.containsKey(localReplicaCount)) {
-          replicaCountToPartitionIds.put(localReplicaCount, new ArrayList<>());
-        }
-        replicaCountToPartitionIds.get(localReplicaCount).add(partition);
+            partitionIdsByClassAndLocalReplicaCount.computeIfAbsent(partitionClass, key -> new TreeMap<>());
+        replicaCountToPartitionIds.computeIfAbsent(localReplicaCount, key -> new ArrayList<>()).add(partition);
       }
     }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -67,31 +67,35 @@ class CompositeClusterManager implements ClusterMap {
   }
 
   /**
+   * {@inheritDoc}
    * Get writable partition ids from both the underlying {@link StaticClusterManager} and the underlying
    * {@link HelixClusterManager}. Compare the two and if there is a mismatch, update a metric.
+   * @param partitionClass the partition class whose writable partitions are required. Can be {@code null}
    * @return a list of writable partition ids from the underlying {@link StaticClusterManager}.
    */
   @Override
-  public List<PartitionId> getWritablePartitionIds() {
-    List<PartitionId> staticWritablePartitionIds = staticClusterManager.getWritablePartitionIds();
+  public List<PartitionId> getWritablePartitionIds(String partitionClass) {
+    List<PartitionId> staticWritablePartitionIds = staticClusterManager.getWritablePartitionIds(partitionClass);
     if (helixClusterManager != null) {
-      if (!areEqual(staticWritablePartitionIds, helixClusterManager.getWritablePartitionIds())) {
-        helixClusterManagerMetrics.getAllPartitionIdsMismatchCount.inc();
+      if (!areEqual(staticWritablePartitionIds, helixClusterManager.getWritablePartitionIds(partitionClass))) {
+        helixClusterManagerMetrics.getWritablePartitionIdsMismatchCount.inc();
       }
     }
     return staticWritablePartitionIds;
   }
 
   /**
+   * {@inheritDoc}
    * Get all partition ids from both the underlying {@link StaticClusterManager} and the underlying
    * {@link HelixClusterManager}. Compare the two and if there is a mismatch, update a metric.
+   * @param partitionClass the partition class whose partitions are required. Can be {@code null}
    * @return a list of partition ids from the underlying {@link StaticClusterManager}.
    */
   @Override
-  public List<PartitionId> getAllPartitionIds() {
-    List<PartitionId> staticPartitionIds = staticClusterManager.getAllPartitionIds();
+  public List<PartitionId> getAllPartitionIds(String partitionClass) {
+    List<PartitionId> staticPartitionIds = staticClusterManager.getAllPartitionIds(partitionClass);
     if (helixClusterManager != null) {
-      if (!areEqual(staticPartitionIds, helixClusterManager.getAllPartitionIds())) {
+      if (!areEqual(staticPartitionIds, helixClusterManager.getAllPartitionIds(partitionClass))) {
         helixClusterManagerMetrics.getAllPartitionIdsMismatchCount.inc();
       }
     }
@@ -233,10 +237,10 @@ class CompositeClusterManager implements ClusterMap {
   /**
    * Check if two lists of partitions are equivalent
    * @param partitionListOne {@link List} of {@link PartitionId}s to compare
-   * @param partitionListTwo {@link List} of {@link AmbryPartition}s to compare
+   * @param partitionListTwo {@link List} of {@link PartitionId}s to compare
    * @return {@code true} if both list are equal, {@code false} otherwise
    */
-  private boolean areEqual(List<PartitionId> partitionListOne, List<AmbryPartition> partitionListTwo) {
+  private boolean areEqual(List<PartitionId> partitionListOne, List<PartitionId> partitionListTwo) {
     Set<String> partitionStringsOne = new HashSet<>();
     for (PartitionId partitionId : partitionListOne) {
       partitionStringsOne.add(partitionId.toString());

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -72,6 +72,7 @@ class HelixClusterManager implements ClusterMap {
   private final AtomicReference<Exception> initializationException = new AtomicReference<>();
   private final AtomicLong sealedStateChangeCounter = new AtomicLong(0);
   final HelixClusterManagerMetrics helixClusterManagerMetrics;
+  private final PartitionSelectionHelper partitionSelectionHelper;
 
   /**
    * Instantiate a HelixClusterManager.
@@ -146,6 +147,8 @@ class HelixClusterManager implements ClusterMap {
           initializationException.get());
     }
     localDatacenterId = dcToDcZkInfo.get(clusterMapConfig.clusterMapDatacenterName).dcZkInfo.getDcId();
+    partitionSelectionHelper =
+        new PartitionSelectionHelper(partitionMap.values(), clusterMapConfig.clusterMapDatacenterName);
   }
 
   /**
@@ -230,30 +233,14 @@ class HelixClusterManager implements ClusterMap {
     return partition;
   }
 
-  /**
-   * @return list of partition ids that are in {@link PartitionState#READ_WRITE}.
-   */
   @Override
-  public List<AmbryPartition> getWritablePartitionIds() {
-    List<AmbryPartition> writablePartitions = new ArrayList<>();
-    List<AmbryPartition> healthyWritablePartitions = new ArrayList<>();
-    for (AmbryPartition partition : partitionNameToAmbryPartition.values()) {
-      if (partition.getPartitionState() == PartitionState.READ_WRITE) {
-        writablePartitions.add(partition);
-        if (areAllReplicasForPartitionUp(partition)) {
-          healthyWritablePartitions.add(partition);
-        }
-      }
-    }
-    return healthyWritablePartitions.isEmpty() ? writablePartitions : healthyWritablePartitions;
+  public List<PartitionId> getWritablePartitionIds(String partitionClass) {
+    return partitionSelectionHelper.getWritablePartitions(partitionClass);
   }
 
-  /**
-   * @return list of all partition ids in the cluster
-   */
   @Override
-  public List<AmbryPartition> getAllPartitionIds() {
-    return new ArrayList<>(partitionNameToAmbryPartition.values());
+  public List<PartitionId> getAllPartitionIds(String partitionClass) {
+    return partitionSelectionHelper.getPartitions(partitionClass);
   }
 
   /**
@@ -265,20 +252,6 @@ class HelixClusterManager implements ClusterMap {
       dcInfo.helixManager.disconnect();
     }
     dcToDcZkInfo.clear();
-  }
-
-  /**
-   * Check whether all replicas of the given {@link AmbryPartition} are up.
-   * @param partition the {@link AmbryPartition} to check.
-   * @return true if all associated replicas are up; false otherwise.
-   */
-  private boolean areAllReplicasForPartitionUp(AmbryPartition partition) {
-    for (AmbryReplica replica : ambryPartitionToAmbryReplicas.get(partition)) {
-      if (replica.isDown()) {
-        return false;
-      }
-    }
-    return true;
   }
 
   /**
@@ -454,8 +427,12 @@ class HelixClusterManager implements ClusterMap {
             // partition name and replica name are the same.
             String partitionName = info[0];
             long replicaCapacity = Long.valueOf(info[1]);
+            String partitionClass = clusterMapConfig.clusterMapDefaultPartitionClass;
+            if (info.length > 2) {
+              partitionClass = info[2];
+            }
             AmbryPartition mappedPartition =
-                new AmbryPartition(Long.valueOf(partitionName), helixClusterManagerCallback);
+                new AmbryPartition(Long.valueOf(partitionName), partitionClass, helixClusterManagerCallback);
             // Ensure only one AmbryPartition entry goes in to the mapping based on the name.
             AmbryPartition existing = partitionNameToAmbryPartition.putIfAbsent(partitionName, mappedPartition);
             if (existing != null) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
@@ -41,16 +41,18 @@ class Partition extends PartitionId {
   private static final short Current_Version = 1;
   private static final int Partition_Size_In_Bytes = Version_Field_Size_In_Bytes + 8;
 
-  private Long id;
+  private final List<Replica> replicas;
+  private final Long id;
   PartitionState partitionState;
   long replicaCapacityInBytes;
-  List<Replica> replicas;
+  String partitionClass;
 
   private Logger logger = LoggerFactory.getLogger(getClass());
 
-  Partition(long id, PartitionState partitionState, long replicaCapacityInBytes) {
+  Partition(long id, String partitionClass, PartitionState partitionState, long replicaCapacityInBytes) {
     logger.trace("Partition " + id + ", " + partitionState + ", " + replicaCapacityInBytes);
     this.id = id;
+    this.partitionClass = partitionClass;
     this.partitionState = partitionState;
     this.replicaCapacityInBytes = replicaCapacityInBytes;
     this.replicas = new ArrayList<Replica>();
@@ -67,6 +69,7 @@ class Partition extends PartitionId {
       logger.trace("Partition " + jsonObject.toString());
     }
     this.id = jsonObject.getLong("id");
+    this.partitionClass = jsonObject.getString("partitionClass");
     this.partitionState = PartitionState.valueOf(jsonObject.getString("partitionState"));
     this.replicaCapacityInBytes = jsonObject.getLong("replicaCapacityInBytes");
     this.replicas = new ArrayList<Replica>(jsonObject.getJSONArray("replicas").length());
@@ -129,6 +132,11 @@ class Partition extends PartitionId {
     return Long.toString(id);
   }
 
+  @Override
+  public String getPartitionClass() {
+    return partitionClass;
+  }
+
   // For constructing new Partition
   void addReplica(Replica replica) {
     replicas.add(replica);
@@ -162,6 +170,7 @@ class Partition extends PartitionId {
 
   JSONObject toJSONObject() throws JSONException {
     JSONObject jsonObject = new JSONObject().put("id", id)
+        .put("partitionClass", partitionClass)
         .put("partitionState", partitionState)
         .put("replicaCapacityInBytes", replicaCapacityInBytes)
         .put("replicas", new JSONArray());

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
@@ -48,7 +48,7 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
       String partitionLayoutFilePath) throws JSONException, IOException {
     this(clusterMapConfig, new PartitionLayout(
         new HardwareLayout(new JSONObject(readStringFromFile(hardwareLayoutFilePath)), clusterMapConfig),
-        new JSONObject(readStringFromFile(partitionLayoutFilePath))));
+        new JSONObject(readStringFromFile(partitionLayoutFilePath)), clusterMapConfig.clusterMapDatacenterName));
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -73,13 +73,13 @@ class StaticClusterManager implements ClusterMap {
   // --------------------------------------
 
   @Override
-  public List<PartitionId> getWritablePartitionIds() {
-    return partitionLayout.getWritablePartitions();
+  public List<PartitionId> getWritablePartitionIds(String partitionClass) {
+    return partitionLayout.getWritablePartitions(partitionClass);
   }
 
   @Override
-  public List<PartitionId> getAllPartitionIds() {
-    return partitionLayout.getPartitions();
+  public List<PartitionId> getAllPartitionIds(String partitionClass) {
+    return partitionLayout.getPartitions(partitionClass);
   }
 
   @Override
@@ -114,7 +114,7 @@ class StaticClusterManager implements ClusterMap {
 
   List<Replica> getReplicas(DataNodeId dataNodeId) {
     List<Replica> replicas = new ArrayList<Replica>();
-    for (PartitionId partition : partitionLayout.getPartitions()) {
+    for (PartitionId partition : partitionLayout.getPartitions(null)) {
       for (Replica replica : ((Partition) partition).getReplicas()) {
         if (replica.getDataNodeId().equals(dataNodeId)) {
           replicas.add(replica);
@@ -155,7 +155,7 @@ class StaticClusterManager implements ClusterMap {
 
   long getAllocatedRawCapacityInBytes(Datacenter datacenter) {
     long allocatedRawCapacityInBytes = 0;
-    for (PartitionId partition : partitionLayout.getPartitions()) {
+    for (PartitionId partition : partitionLayout.getPartitions(null)) {
       for (Replica replica : ((Partition) partition).getReplicas()) {
         Disk disk = (Disk) replica.getDiskId();
         if (disk.getDataNode().getDatacenter().equals(datacenter)) {
@@ -168,7 +168,7 @@ class StaticClusterManager implements ClusterMap {
 
   long getAllocatedRawCapacityInBytes(DataNodeId dataNode) {
     long allocatedRawCapacityInBytes = 0;
-    for (PartitionId partition : partitionLayout.getPartitions()) {
+    for (PartitionId partition : partitionLayout.getPartitions(null)) {
       for (Replica replica : ((Partition) partition).getReplicas()) {
         Disk disk = (Disk) replica.getDiskId();
         if (disk.getDataNode().equals(dataNode)) {
@@ -181,7 +181,7 @@ class StaticClusterManager implements ClusterMap {
 
   long getAllocatedRawCapacityInBytes(Disk disk) {
     long allocatedRawCapacityInBytes = 0;
-    for (PartitionId partition : partitionLayout.getPartitions()) {
+    for (PartitionId partition : partitionLayout.getPartitions(null)) {
       for (Replica replica : ((Partition) partition).getReplicas()) {
         Disk currentDisk = (Disk) replica.getDiskId();
         if (currentDisk.equals(disk)) {
@@ -232,8 +232,8 @@ class StaticClusterManager implements ClusterMap {
     return maxCapacityDisk;
   }
 
-  PartitionId addNewPartition(List<Disk> disks, long replicaCapacityInBytes) {
-    return partitionLayout.addNewPartition(disks, replicaCapacityInBytes);
+  PartitionId addNewPartition(List<Disk> disks, long replicaCapacityInBytes, String partitionClass) {
+    return partitionLayout.addNewPartition(disks, replicaCapacityInBytes, partitionClass);
   }
 
   // Determine if there is enough capacity to allocate a PartitionId.
@@ -379,14 +379,15 @@ class StaticClusterManager implements ClusterMap {
    * Allocate partitions for {@code numPartitions} new partitions on all datacenters.
    *
    * @param numPartitions How many partitions to allocate.
+   * @param partitionClass the partition class that the created partitions must be tagged with
    * @param replicaCountPerDatacenter The number of replicas per partition on each datacenter
    * @param replicaCapacityInBytes How large each replica (of a partition) should be
    * @param attemptNonRackAwareOnFailure {@code true} if we should attempt a non rack-aware allocation if a rack-aware
    *                                     one is not possible.
    * @return A list of the new {@link PartitionId}s.
    */
-  List<PartitionId> allocatePartitions(int numPartitions, int replicaCountPerDatacenter, long replicaCapacityInBytes,
-      boolean attemptNonRackAwareOnFailure) {
+  List<PartitionId> allocatePartitions(int numPartitions, String partitionClass, int replicaCountPerDatacenter,
+      long replicaCapacityInBytes, boolean attemptNonRackAwareOnFailure) {
     ArrayList<PartitionId> partitions = new ArrayList<PartitionId>(numPartitions);
     int partitionsAllocated = 0;
     while (checkEnoughUnallocatedRawCapacity(replicaCountPerDatacenter, replicaCapacityInBytes)
@@ -397,11 +398,10 @@ class StaticClusterManager implements ClusterMap {
             attemptNonRackAwareOnFailure);
         disksToAllocate.addAll(disks);
       }
-      partitions.add(partitionLayout.addNewPartition(disksToAllocate, replicaCapacityInBytes));
+      partitions.add(partitionLayout.addNewPartition(disksToAllocate, replicaCapacityInBytes, partitionClass));
       partitionsAllocated++;
       System.out.println("Allocated " + partitionsAllocated + " new partitions so far.");
     }
-
     return partitions;
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.network.Port;
+import com.github.ambry.network.PortType;
+import com.github.ambry.utils.UtilsTest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class ClusterMapUtilsTest {
+
+  /**
+   * Tests for {@link ClusterMapUtils#areAllReplicasForPartitionUp(PartitionId)}.
+   */
+  @Test
+  public void areAllReplicasForPartitionUpTest() {
+    MockDataNodeId dn1 = getDataNodeId("dn1", "DC1");
+    MockDataNodeId dn2 = getDataNodeId("dn2", "DC2");
+    MockPartitionId partitionId = new MockPartitionId(1, "default", Arrays.asList(dn1, dn2), 0);
+    MockReplicaId replicaId1 = (MockReplicaId) partitionId.getReplicaIds().get(0);
+    MockReplicaId replicaId2 = (MockReplicaId) partitionId.getReplicaIds().get(1);
+    assertTrue("All replicas should be up", ClusterMapUtils.areAllReplicasForPartitionUp(partitionId));
+    replicaId1.markReplicaDownStatus(true);
+    assertFalse("Not all replicas should be up", ClusterMapUtils.areAllReplicasForPartitionUp(partitionId));
+    replicaId2.markReplicaDownStatus(true);
+    assertFalse("Not all replicas should be up", ClusterMapUtils.areAllReplicasForPartitionUp(partitionId));
+    replicaId1.markReplicaDownStatus(false);
+    assertFalse("Not all replicas should be up", ClusterMapUtils.areAllReplicasForPartitionUp(partitionId));
+    replicaId2.markReplicaDownStatus(false);
+    assertTrue("All replicas should be up", ClusterMapUtils.areAllReplicasForPartitionUp(partitionId));
+  }
+
+  /**
+   * Tests for all functions in {@link ClusterMapUtils.PartitionSelectionHelper}
+   */
+  @Test
+  public void partitionSelectionHelperTest() {
+    // set up partitions for tests
+    // 2 partitions with 3 replicas in two datacenters "DC1" and "DC2" (class "max-replicas-all-sites")
+    // 2 partitions with 3 replicas in "DC1" and 1 replica in "DC2" (class "max-local-one-remote")
+    // 2 partitions with 3 replicas in "DC2" and 1 replica in "DC1" (class "max-local-one-remote")
+    final String dc1 = "DC1";
+    final String dc2 = "DC2";
+    final String maxReplicasAllSites = "max-replicas-all-sites";
+    final String maxLocalOneRemote = "max-local-one-remote";
+
+    MockDataNodeId dc1Dn1 = getDataNodeId("dc1dn1", dc1);
+    MockDataNodeId dc1Dn2 = getDataNodeId("dc1dn2", dc1);
+    MockDataNodeId dc1Dn3 = getDataNodeId("dc1dn3", dc1);
+    MockDataNodeId dc2Dn1 = getDataNodeId("dc2dn1", dc2);
+    MockDataNodeId dc2Dn2 = getDataNodeId("dc2dn2", dc2);
+    MockDataNodeId dc2Dn3 = getDataNodeId("dc2dn3", dc2);
+    List<MockDataNodeId> allDataNodes = Arrays.asList(dc1Dn1, dc1Dn2, dc1Dn3, dc2Dn1, dc2Dn2, dc2Dn3);
+    MockPartitionId everywhere1 = new MockPartitionId(1, maxReplicasAllSites, allDataNodes, 0);
+    MockPartitionId everywhere2 = new MockPartitionId(2, maxReplicasAllSites, allDataNodes, 0);
+    MockPartitionId majorDc11 =
+        new MockPartitionId(3, maxLocalOneRemote, Arrays.asList(dc1Dn1, dc1Dn2, dc1Dn3, dc2Dn1), 0);
+    MockPartitionId majorDc12 =
+        new MockPartitionId(4, maxLocalOneRemote, Arrays.asList(dc1Dn1, dc1Dn2, dc1Dn3, dc2Dn2), 0);
+    MockPartitionId majorDc21 =
+        new MockPartitionId(5, maxLocalOneRemote, Arrays.asList(dc2Dn1, dc2Dn2, dc2Dn3, dc1Dn1), 0);
+    MockPartitionId majorDc22 =
+        new MockPartitionId(6, maxLocalOneRemote, Arrays.asList(dc2Dn1, dc2Dn2, dc2Dn3, dc1Dn2), 0);
+
+    Collection<MockPartitionId> allPartitionIdsMain = Collections.unmodifiableSet(
+        new HashSet<>(Arrays.asList(everywhere1, everywhere2, majorDc11, majorDc12, majorDc21, majorDc22)));
+    ClusterMapUtils.PartitionSelectionHelper psh =
+        new ClusterMapUtils.PartitionSelectionHelper(allPartitionIdsMain, null);
+
+    String[] dcsToTry = {null, "", dc1, dc2};
+    for (String dc : dcsToTry) {
+      Set<MockPartitionId> allPartitionIds = new HashSet<>(allPartitionIdsMain);
+      resetPartitions(allPartitionIds);
+      psh.updatePartitions(allPartitionIds, dc);
+
+      // getPartitions()
+      assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getPartitions(null));
+      assertCollectionEquals("Partitions returned for " + maxReplicasAllSites + " not as expected",
+          Arrays.asList(everywhere1, everywhere2), psh.getPartitions(maxReplicasAllSites));
+      assertCollectionEquals("Partitions returned for " + maxLocalOneRemote + " not as expected",
+          Arrays.asList(majorDc11, majorDc12, majorDc21, majorDc22), psh.getPartitions(maxLocalOneRemote));
+      try {
+        psh.getPartitions(UtilsTest.getRandomString(3));
+        fail("partition class is invalid, should have thrown");
+      } catch (IllegalArgumentException e) {
+        // expected. Nothing to do.
+      }
+
+      // getWritablePartitions()
+      Set<MockPartitionId> expectedWritableForMaxLocalOneRemote = null;
+      MockPartitionId candidate1 = null;
+      MockPartitionId candidate2 = null;
+      if (dc != null) {
+        switch (dc) {
+          case dc1:
+            candidate1 = majorDc11;
+            candidate2 = majorDc12;
+            expectedWritableForMaxLocalOneRemote = new HashSet<>(Arrays.asList(majorDc11, majorDc12));
+            break;
+          case dc2:
+            candidate1 = majorDc21;
+            candidate2 = majorDc22;
+            expectedWritableForMaxLocalOneRemote = new HashSet<>(Arrays.asList(majorDc21, majorDc22));
+            break;
+        }
+      }
+      // invalid class
+      try {
+        psh.getWritablePartitions(UtilsTest.getRandomString(3));
+        fail("partition class is invalid, should have thrown");
+      } catch (IllegalArgumentException e) {
+        // expected. Nothing to do.
+      }
+      verifyWritablePartitionsReturned(psh, allPartitionIds, maxReplicasAllSites, everywhere1, everywhere2,
+          maxLocalOneRemote, expectedWritableForMaxLocalOneRemote);
+      if (candidate1 != null && candidate2 != null) {
+        verifyWritablePartitionsReturned(psh, allPartitionIds, maxLocalOneRemote, candidate1, candidate2,
+            maxReplicasAllSites, new HashSet<>(Arrays.asList(everywhere1, everywhere2)));
+      }
+    }
+  }
+
+  /**
+   * @param hostname the host name of the {@link MockDataNodeId}.
+   * @param dc the name of the dc of the {@link MockDataNodeId}.
+   * @return a {@link MockDataNodeId} based on {@code hostname} and {@code dc}.
+   */
+  private MockDataNodeId getDataNodeId(String hostname, String dc) {
+    return new MockDataNodeId(hostname, Collections.singletonList(new Port(6667, PortType.PLAINTEXT)),
+        Collections.singletonList("/tmp"), dc);
+  }
+
+  /**
+   * Resets all partitions by marking them {@link PartitionState#READ_WRITE} and marking all replicas as up.
+   * @param toReset all the partition ids to reset.
+   */
+  private void resetPartitions(Collection<MockPartitionId> toReset) {
+    for (MockPartitionId partitionId : toReset) {
+      for (ReplicaId replicaId : partitionId.getReplicaIds()) {
+        ((MockReplicaId) replicaId).markReplicaDownStatus(false);
+        ((MockReplicaId) replicaId).setSealedState(false);
+      }
+    }
+  }
+
+  /**
+   * Asserts that elements in collection {@code actual} is equal to the ones in {@code expected} irrespective of
+   * ordering.
+   * @param message the message to print if they are not equal.
+   * @param expected the expected elements
+   * @param actual the actual elements
+   */
+  private void assertCollectionEquals(String message, Collection<? extends PartitionId> expected,
+      Collection<? extends PartitionId> actual) {
+    assertEquals(message, new HashSet<>(expected), new HashSet<>(actual));
+  }
+
+  /**
+   * Verifies that the values returned {@link ClusterMapUtils.PartitionSelectionHelper#getWritablePartitions(String)} is
+   * correct.
+   * @param psh the {@link ClusterMapUtils.PartitionSelectionHelper} instance to use.
+   * @param allPartitionIds all the partitions that are in clustermap
+   * @param classBeingTested the partition class being tested
+   * @param testedPart1 a partition in {@code classBeingTested}
+   * @param testedPart2 another partition in {@code classBeingTested}
+   * @param classsNotBeingTested a partition class is not being tested (to check that changes to partitions in
+   * {@code classBeingTested} aren't affected).
+   * @param expectedReturnForClassNotBeingTested the list of partitions that can expected to be returned for
+   *                                             {@code classsNotBeingTested}.
+   */
+  private void verifyWritablePartitionsReturned(ClusterMapUtils.PartitionSelectionHelper psh,
+      Set<MockPartitionId> allPartitionIds, String classBeingTested, MockPartitionId testedPart1,
+      MockPartitionId testedPart2, String classsNotBeingTested,
+      Set<MockPartitionId> expectedReturnForClassNotBeingTested) {
+    Set<MockPartitionId> expectedReturnForClassBeingTested = new HashSet<>(Arrays.asList(testedPart1, testedPart2));
+    // no problematic scenarios
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
+        psh.getWritablePartitions(classBeingTested));
+    // one replica of one partition of "classBeingTested" down
+    ((MockReplicaId) testedPart1.getReplicaIds().get(0)).markReplicaDownStatus(true);
+    allPartitionIds.remove(testedPart1);
+    expectedReturnForClassBeingTested.remove(testedPart1);
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
+        psh.getWritablePartitions(classBeingTested));
+    // one replica of other partition of "classBeingTested" down too
+    ((MockReplicaId) testedPart2.getReplicaIds().get(0)).markReplicaDownStatus(true);
+    allPartitionIds.remove(testedPart2);
+    // if both have a replica down, then even though both are unhealthy, they are both returned.
+    expectedReturnForClassBeingTested.add(testedPart1);
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
+        psh.getWritablePartitions(classBeingTested));
+    if (expectedReturnForClassNotBeingTested != null) {
+      assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassNotBeingTested,
+          psh.getWritablePartitions(classsNotBeingTested));
+    }
+    ((MockReplicaId) testedPart1.getReplicaIds().get(0)).markReplicaDownStatus(false);
+    ((MockReplicaId) testedPart2.getReplicaIds().get(0)).markReplicaDownStatus(false);
+    allPartitionIds.add(testedPart1);
+    allPartitionIds.add(testedPart2);
+
+    // one partition of "classBeingTested" is READ_ONLY
+    ((MockReplicaId) testedPart1.getReplicaIds().get(0)).setSealedState(true);
+    allPartitionIds.remove(testedPart1);
+    expectedReturnForClassBeingTested.remove(testedPart1);
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
+        psh.getWritablePartitions(classBeingTested));
+    // all READ_ONLY
+    ((MockReplicaId) testedPart2.getReplicaIds().get(0)).setSealedState(true);
+    allPartitionIds.remove(testedPart2);
+    expectedReturnForClassBeingTested.remove(testedPart2);
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
+        psh.getWritablePartitions(classBeingTested));
+    if (expectedReturnForClassNotBeingTested != null) {
+      assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassNotBeingTested,
+          psh.getWritablePartitions(classsNotBeingTested));
+    }
+    ((MockReplicaId) testedPart1.getReplicaIds().get(0)).setSealedState(false);
+    ((MockReplicaId) testedPart2.getReplicaIds().get(0)).setSealedState(false);
+    allPartitionIds.add(testedPart1);
+    allPartitionIds.add(testedPart2);
+    expectedReturnForClassBeingTested.add(testedPart1);
+    expectedReturnForClassBeingTested.remove(testedPart2);
+  }
+}

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.PortType;
+import com.github.ambry.utils.UtilsTest;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -148,12 +149,16 @@ public class DynamicClusterManagerComponentsTest {
     // All partitions are READ_WRITE initially.
     sealedStateChangeCounter = new AtomicLong(0);
     MockClusterManagerCallback mockClusterManagerCallback = new MockClusterManagerCallback();
-    AmbryPartition partition1 = new AmbryPartition(1, mockClusterManagerCallback);
-    AmbryPartition partition2 = new AmbryPartition(2, mockClusterManagerCallback);
+    String partition1Class = UtilsTest.getRandomString(10);
+    String partition2Class = UtilsTest.getRandomString(10);
+    AmbryPartition partition1 = new AmbryPartition(1, partition1Class, mockClusterManagerCallback);
+    AmbryPartition partition2 = new AmbryPartition(2, partition2Class, mockClusterManagerCallback);
     assertTrue(partition1.isEqual(partition1.toPathString()));
     assertTrue(partition1.compareTo(partition1) == 0);
     assertFalse(partition1.isEqual(partition2.toPathString()));
     assertTrue(partition1.compareTo(partition2) != 0);
+    assertEquals("Partition class not as expected", partition1Class, partition1.getPartitionClass());
+    assertEquals("Partition class not as expected", partition2Class, partition2.getPartitionClass());
 
     // AmbryReplica tests
     try {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
@@ -23,22 +23,25 @@ import java.util.List;
  */
 public class MockPartitionId extends PartitionId {
 
-  Long partition;
+  final Long partition;
   public List<ReplicaId> replicaIds;
   private PartitionState partitionState = PartitionState.READ_WRITE;
+  private final String partitionClass;
 
   public MockPartitionId() {
-    this(0L);
+    this(0L, MockClusterMap.DEFAULT_PARTITION_CLASS);
   }
 
-  public MockPartitionId(long partition) {
+  public MockPartitionId(long partition, String partitionClass) {
     this.partition = partition;
+    this.partitionClass = partitionClass;
     replicaIds = new ArrayList<>(0);
   }
 
-  public MockPartitionId(long partition, List<MockDataNodeId> dataNodes, int mountPathIndexToUse) {
+  public MockPartitionId(long partition, String partitionClass, List<MockDataNodeId> dataNodes,
+      int mountPathIndexToUse) {
     this.partition = partition;
-
+    this.partitionClass = partitionClass;
     this.replicaIds = new ArrayList<ReplicaId>(dataNodes.size());
     for (MockDataNodeId dataNode : dataNodes) {
       MockReplicaId replicaId = new MockReplicaId(dataNode.getPort(), this, dataNode, mountPathIndexToUse);
@@ -123,6 +126,11 @@ public class MockPartitionId extends PartitionId {
   @Override
   public String toPathString() {
     return String.valueOf(partition);
+  }
+
+  @Override
+  public String getPartitionClass() {
+    return partitionClass;
   }
 
   public void cleanUp() {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/PartitionLayoutTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/PartitionLayoutTest.java
@@ -13,23 +13,28 @@
  */
 package com.github.ambry.clustermap;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.json.JSONException;
 import org.junit.Test;
 
+import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
 
 
 public class PartitionLayoutTest {
   @Test
   public void basics() throws JSONException {
-    TestUtils.TestPartitionLayout testPartitionLayout =
-        new TestUtils.TestPartitionLayout(new TestUtils.TestHardwareLayout("Alpha"));
+    TestHardwareLayout hardwareLayout = new TestHardwareLayout("Alpha");
+    String dc = hardwareLayout.getHardwareLayout().getDatacenters().get(0).getName();
+    TestPartitionLayout testPartitionLayout = new TestPartitionLayout(hardwareLayout, dc);
 
     PartitionLayout partitionLayout = testPartitionLayout.getPartitionLayout();
 
-    assertEquals(partitionLayout.getVersion(), TestUtils.TestPartitionLayout.defaultVersion);
+    assertEquals(partitionLayout.getVersion(), TestPartitionLayout.defaultVersion);
     assertEquals(partitionLayout.getClusterName(), "Alpha");
-    assertEquals(partitionLayout.getPartitions().size(), testPartitionLayout.getPartitionCount());
+    assertEquals(partitionLayout.getPartitions(null).size(), testPartitionLayout.getPartitionCount());
     assertEquals(partitionLayout.getPartitionCount(), testPartitionLayout.getPartitionCount());
     assertEquals(partitionLayout.getAllocatedRawCapacityInBytes(),
         testPartitionLayout.getAllocatedRawCapacityInBytes());
@@ -43,20 +48,90 @@ public class PartitionLayoutTest {
 
   @Test
   public void validation() throws JSONException {
-    TestUtils.TestHardwareLayout testHardwareLayout = new TestUtils.TestHardwareLayout("Alpha");
+    TestHardwareLayout testHardwareLayout = new TestHardwareLayout("Alpha");
 
     try {
-      TestUtils.TestPartitionLayout tpl = new TestUtils.TestPartitionLayoutWithDuplicatePartitions(testHardwareLayout);
+      TestPartitionLayout tpl = new TestPartitionLayoutWithDuplicatePartitions(testHardwareLayout);
       fail("Should have failed validation:" + tpl.getPartitionLayout().toString());
     } catch (IllegalStateException e) {
       // Expected.
     }
 
     try {
-      TestUtils.TestPartitionLayout tpl = new TestUtils.TestPartitionLayoutWithDuplicateReplicas(testHardwareLayout);
+      TestPartitionLayout tpl = new TestPartitionLayoutWithDuplicateReplicas(testHardwareLayout);
       fail("Should have failed validation:" + tpl.getPartitionLayout().toString());
     } catch (IllegalStateException e) {
       // Expected.
     }
+  }
+
+  /**
+   * Tests for {@link PartitionLayout#getPartitions(String)} and {@link PartitionLayout#getWritablePartitions(String)}.
+   * @throws JSONException
+   */
+  @Test
+  public void getPartitionsTest() throws JSONException {
+    String specialPartitionClass = "specialPartitionClass";
+    TestHardwareLayout hardwareLayout = new TestHardwareLayout("Alpha");
+    String dc = hardwareLayout.getRandomDatacenter().getName();
+    TestPartitionLayout testPartitionLayout = new TestPartitionLayout(hardwareLayout, dc);
+    assertTrue("There should be more than 1 replica per partition in each DC for this test to work",
+        testPartitionLayout.replicaCountPerDc > 1);
+    PartitionRangeCheckParams defaultRw =
+        new PartitionRangeCheckParams(0, testPartitionLayout.partitionCount, DEFAULT_PARTITION_CLASS,
+            PartitionState.READ_WRITE);
+    // add 15 RW partitions for the special class
+    PartitionRangeCheckParams specialRw =
+        new PartitionRangeCheckParams(defaultRw.rangeEnd + 1, 15, specialPartitionClass, PartitionState.READ_WRITE);
+    testPartitionLayout.addNewPartitions(specialRw.count, specialPartitionClass, PartitionState.READ_WRITE, dc);
+    // add 10 RO partitions for the default class
+    PartitionRangeCheckParams defaultRo =
+        new PartitionRangeCheckParams(specialRw.rangeEnd + 1, 10, DEFAULT_PARTITION_CLASS, PartitionState.READ_ONLY);
+    testPartitionLayout.addNewPartitions(defaultRo.count, DEFAULT_PARTITION_CLASS, PartitionState.READ_ONLY, dc);
+    // add 5 RO partitions for the special class
+    PartitionRangeCheckParams specialRo =
+        new PartitionRangeCheckParams(defaultRo.rangeEnd + 1, 5, specialPartitionClass, PartitionState.READ_ONLY);
+    testPartitionLayout.addNewPartitions(specialRo.count, specialPartitionClass, PartitionState.READ_ONLY, dc);
+
+    PartitionLayout partitionLayout = testPartitionLayout.getPartitionLayout();
+    // "good" cases for getPartitions() and getWritablePartitions() only
+    // getPartitions(), class null
+    List<PartitionId> returnedPartitions = partitionLayout.getPartitions(null);
+    checkReturnedPartitions(returnedPartitions, Arrays.asList(defaultRw, defaultRo, specialRw, specialRo));
+    // getWritablePartitions(), class null
+    returnedPartitions = partitionLayout.getWritablePartitions(null);
+    checkReturnedPartitions(returnedPartitions, Arrays.asList(defaultRw, specialRw));
+
+    // getPartitions(), class default
+    returnedPartitions = partitionLayout.getPartitions(DEFAULT_PARTITION_CLASS);
+    checkReturnedPartitions(returnedPartitions, Arrays.asList(defaultRw, defaultRo));
+    // getWritablePartitions(), class default
+    returnedPartitions = partitionLayout.getWritablePartitions(DEFAULT_PARTITION_CLASS);
+    checkReturnedPartitions(returnedPartitions, Collections.singletonList(defaultRw));
+
+    // getPartitions(), class special
+    returnedPartitions = partitionLayout.getPartitions(specialPartitionClass);
+    checkReturnedPartitions(returnedPartitions, Arrays.asList(specialRw, specialRo));
+    // getWritablePartitions(), class special
+    returnedPartitions = partitionLayout.getWritablePartitions(specialPartitionClass);
+    checkReturnedPartitions(returnedPartitions, Collections.singletonList(specialRw));
+
+    // to test the dc affinity, we pick one datanode from "dc" and insert 1 replica for part1 (special class) in "dc"
+    // and make sure that it is returned in getPartitions() but not in getWritablePartitions() (because all the other
+    // partitions have more than 1 replica in "dc").
+    DataNode dataNode = hardwareLayout.getRandomDataNodeFromDc(dc);
+    Partition partition =
+        partitionLayout.addNewPartition(dataNode.getDisks().subList(0, 1), testPartitionLayout.replicaCapacityInBytes,
+            specialPartitionClass);
+    PartitionRangeCheckParams extraPartCheckParams =
+        new PartitionRangeCheckParams(specialRo.rangeEnd + 1, 1, specialPartitionClass, PartitionState.READ_WRITE);
+    // getPartitions(), class special
+    returnedPartitions = partitionLayout.getPartitions(specialPartitionClass);
+    assertTrue("Added partition should exist in returned partitions", returnedPartitions.contains(partition));
+    checkReturnedPartitions(returnedPartitions, Arrays.asList(specialRw, specialRo, extraPartCheckParams));
+    // getWritablePartitions(), class special
+    returnedPartitions = partitionLayout.getWritablePartitions(specialPartitionClass);
+    assertFalse("Added partition should not exist in returned partitions", returnedPartitions.contains(partition));
+    checkReturnedPartitions(returnedPartitions, Collections.singletonList(specialRw));
   }
 }

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -81,7 +81,7 @@ public class BlobIdTest {
     referenceDatacenterId = bytes[0];
     referenceAccountId = getRandomShort(random);
     referenceContainerId = getRandomShort(random);
-    referencePartitionId = referenceClusterMap.getWritablePartitionIds().get(0);
+    referencePartitionId = referenceClusterMap.getWritablePartitionIds(null).get(0);
     referenceIsEncrypted = random.nextBoolean();
   }
 
@@ -384,7 +384,8 @@ public class BlobIdTest {
    */
   private void generateAndAssertBadBlobId(Short version) throws Exception {
     List<String> invalidBlobIdLikeList = new ArrayList<>();
-    PartitionId badPartitionId = new MockPartitionId(200000, Collections.EMPTY_LIST, 0);
+    PartitionId badPartitionId =
+        new MockPartitionId(200000, MockClusterMap.DEFAULT_PARTITION_CLASS, Collections.EMPTY_LIST, 0);
     String goodUUID = UUID.randomUUID().toString();
 
     // Partition ID not in cluster map
@@ -600,7 +601,7 @@ public class BlobIdTest {
     short accountId = getRandomShort(random);
     short containerId = getRandomShort(random);
     BlobIdType type = random.nextBoolean() ? BlobIdType.NATIVE : BlobIdType.CRAFTED;
-    PartitionId partitionId = referenceClusterMap.getWritablePartitionIds().get(random.nextInt(3));
+    PartitionId partitionId = referenceClusterMap.getWritablePartitionIds(null).get(random.nextInt(3));
     boolean isEncrypted = random.nextBoolean();
     return new BlobId(version, type, datacenterId, accountId, containerId, partitionId, isEncrypted);
   }

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -169,7 +169,7 @@ public class BlobIdTest {
     for (boolean isEncrypted : isEncryptedValues) {
       BlobId blobIdV4 =
           new BlobId(BLOB_ID_V4, random.nextBoolean() ? BlobIdType.NATIVE : BlobIdType.CRAFTED, (byte) 1, (short) 1,
-              (short) 1, referenceClusterMap.getWritablePartitionIds().get(random.nextInt(3)), isEncrypted);
+              (short) 1, referenceClusterMap.getWritablePartitionIds(null).get(random.nextInt(3)), isEncrypted);
       assertEquals("V4 should return true or false based on its encrypted bit", isEncrypted,
           BlobId.isEncrypted(blobIdV4.getID()));
     }

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -59,12 +59,12 @@ public class ResponseHandlerTest {
     }
 
     @Override
-    public List<PartitionId> getWritablePartitionIds() {
+    public List<PartitionId> getWritablePartitionIds(String partitionClass) {
       return null;
     }
 
     @Override
-    public List<PartitionId> getAllPartitionIds() {
+    public List<PartitionId> getAllPartitionIds(String partitionClass) {
       return null;
     }
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -161,7 +161,8 @@ public class AmbryBlobStorageServiceTest {
     router = new InMemoryRouter(verifiableProperties, clusterMap);
     responseHandler = new FrontendTestResponseHandler();
     referenceBlobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-        Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0), false);
+        Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds(null).get(0),
+        false);
     referenceBlobIdStr = referenceBlobId.getID();
     ambryBlobStorageService = getAmbryBlobStorageService();
     responseHandler.start();
@@ -492,49 +493,50 @@ public class AmbryBlobStorageServiceTest {
       // aid=refAId, cid=refCId
       String blobId =
           new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
-              refContainer.getId(), clusterMap.getWritablePartitionIds().get(0), false).getID();
+              refContainer.getId(), clusterMap.getWritablePartitionIds(null).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, refAccount, refContainer, RestServiceErrorCode.NotFound);
 
       // aid=refAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
-          Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0), false).getID();
+          Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds(null).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=refAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
-          (short) -1234, clusterMap.getWritablePartitionIds().get(0), false).getID();
+          (short) -1234, clusterMap.getWritablePartitionIds(null).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=unknownAId, cid=refCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, refContainer.getId(), clusterMap.getWritablePartitionIds().get(0), false).getID();
+          Account.UNKNOWN_ACCOUNT_ID, refContainer.getId(), clusterMap.getWritablePartitionIds(null).get(0),
+          false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=unknownAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0),
+          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds(null).get(0),
           false).getID();
       verifyAccountAndContainerFromBlobId(blobId, InMemAccountService.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
           RestServiceErrorCode.NotFound);
 
       // aid=unknownAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, (short) -1234, clusterMap.getWritablePartitionIds().get(0), false).getID();
+          Account.UNKNOWN_ACCOUNT_ID, (short) -1234, clusterMap.getWritablePartitionIds(null).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=nonExistAId, cid=refCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
-          refContainer.getId(), clusterMap.getWritablePartitionIds().get(0), false).getID();
+          refContainer.getId(), clusterMap.getWritablePartitionIds(null).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
 
       // aid=nonExistAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
-          Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds().get(0), false).getID();
+          Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds(null).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
 
       // aid=nonExistAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
-          (short) -11, clusterMap.getWritablePartitionIds().get(0), false).getID();
+          (short) -11, clusterMap.getWritablePartitionIds(null).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
     }
   }
@@ -555,7 +557,7 @@ public class AmbryBlobStorageServiceTest {
     // it does not matter what AID and CID are supplied when constructing blobId in v1.
     // expect unknown account and container for v1 blob IDs that went through request processing only.
     String blobId = new BlobId(BlobId.BLOB_ID_V1, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-        refAccount.getId(), refContainer.getId(), clusterMap.getWritablePartitionIds().get(0), false).getID();
+        refAccount.getId(), refContainer.getId(), clusterMap.getWritablePartitionIds(null).get(0), false).getID();
     verifyAccountAndContainerFromBlobId(blobId, InMemAccountService.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
         RestServiceErrorCode.NotFound);
 
@@ -787,7 +789,7 @@ public class AmbryBlobStorageServiceTest {
    */
   @Test
   public void getReplicasTest() throws Exception {
-    List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+    List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
     for (PartitionId partitionId : partitionIds) {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
@@ -1721,7 +1723,7 @@ public class AmbryBlobStorageServiceTest {
         contents.add(null);
       }
       String blobIdStr = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, (byte) -1, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, clusterMap.getAllPartitionIds().get(0), false).getID();
+          Container.UNKNOWN_CONTAINER_ID, clusterMap.getAllPartitionIds(null).get(0), false).getID();
       try {
         doOperation(createRestRequest(restMethod, blobIdStr, headers, contents), new MockRestResponseChannel());
         fail("Operation " + restMethod

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -277,7 +277,7 @@ public class FrontendIntegrationTest {
    */
   @Test
   public void getReplicasTest() throws Exception {
-    List<? extends PartitionId> partitionIds = CLUSTER_MAP.getWritablePartitionIds();
+    List<? extends PartitionId> partitionIds = CLUSTER_MAP.getWritablePartitionIds(null);
     for (PartitionId partitionId : partitionIds) {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
@@ -51,7 +51,7 @@ public class FrontendUtilsTest {
     byte referenceDatacenterId = bytes[0];
     short referenceAccountId = getRandomShort(TestUtils.RANDOM);
     short referenceContainerId = getRandomShort(TestUtils.RANDOM);
-    PartitionId referencePartitionId = referenceClusterMap.getWritablePartitionIds().get(0);
+    PartitionId referencePartitionId = referenceClusterMap.getWritablePartitionIds(null).get(0);
     boolean referenceIsEncrypted = TestUtils.RANDOM.nextBoolean();
     short[] versions = {BlobId.BLOB_ID_V3, BlobId.BLOB_ID_V4};
     for (short version : versions) {

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
@@ -279,21 +280,21 @@ class TailoredPeersClusterMap implements ClusterMap {
     List<MockDataNodeId> partNodes = new ArrayList<>();
     partNodes.add(datanodes.get(DATANODE_NAMES[0]));
     partNodes.add(datanodes.get(DATANODE_NAMES[1]));
-    partitions.add(new MockPartitionId(0, partNodes, 0));
+    partitions.add(new MockPartitionId(0, MockClusterMap.DEFAULT_PARTITION_CLASS, partNodes, 0));
     partNodes.clear();
     partNodes.add(datanodes.get(DATANODE_NAMES[0]));
     partNodes.add(datanodes.get(DATANODE_NAMES[1]));
-    partitions.add(new MockPartitionId(1, partNodes, 0));
+    partitions.add(new MockPartitionId(1, MockClusterMap.DEFAULT_PARTITION_CLASS, partNodes, 0));
     partNodes.clear();
     partNodes.add(datanodes.get(DATANODE_NAMES[0]));
     partNodes.add(datanodes.get(DATANODE_NAMES[2]));
-    partitions.add(new MockPartitionId(2, partNodes, 0));
+    partitions.add(new MockPartitionId(2, MockClusterMap.DEFAULT_PARTITION_CLASS, partNodes, 0));
     partNodes.clear();
     partNodes.add(datanodes.get(DATANODE_NAMES[0]));
-    partitions.add(new MockPartitionId(3, partNodes, 0));
+    partitions.add(new MockPartitionId(3, MockClusterMap.DEFAULT_PARTITION_CLASS, partNodes, 0));
     partNodes.clear();
     partNodes.add(datanodes.get(DATANODE_NAMES[3]));
-    partitions.add(new MockPartitionId(4, partNodes, 0));
+    partitions.add(new MockPartitionId(4, MockClusterMap.DEFAULT_PARTITION_CLASS, partNodes, 0));
 
     peerMap.put(DATANODE_NAMES[0], new HashSet(Arrays.asList(DATANODE_NAMES[1], DATANODE_NAMES[2])));
     peerMap.put(DATANODE_NAMES[1], new HashSet(Arrays.asList(DATANODE_NAMES[0])));
@@ -307,12 +308,12 @@ class TailoredPeersClusterMap implements ClusterMap {
   }
 
   @Override
-  public List<? extends PartitionId> getWritablePartitionIds() {
+  public List<? extends PartitionId> getWritablePartitionIds(String partitionClass) {
     throw new IllegalStateException();
   }
 
   @Override
-  public List<? extends PartitionId> getAllPartitionIds() {
+  public List<? extends PartitionId> getAllPartitionIds(String partitionClass) {
     throw new IllegalStateException();
   }
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetReplicasHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetReplicasHandlerTest.java
@@ -63,7 +63,7 @@ public class GetReplicasHandlerTest {
    */
   @Test
   public void getReplicasTest() throws Exception {
-    List<? extends PartitionId> partitionIds = CLUSTER_MAP.getWritablePartitionIds();
+    List<? extends PartitionId> partitionIds = CLUSTER_MAP.getWritablePartitionIds(null);
     for (PartitionId partitionId : partitionIds) {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
@@ -97,7 +97,7 @@ public class GetSignedUrlHandlerTest {
 
     BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, REF_ACCOUNT.getId(), REF_CONTAINER.getId(),
-        CLUSTER_MAP.getWritablePartitionIds().get(0), false);
+        CLUSTER_MAP.getWritablePartitionIds(null).get(0), false);
     idConverterFactory.translation = blobId.getID();
     // GET (also makes sure that the IDConverter is used)
     restRequest = new MockRestRequest(MockRestRequest.DUMMY_DATA, null);

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -220,7 +220,7 @@ public class RequestResponseTest {
     String clientId = "client";
     BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM), clusterMap.getWritablePartitionIds().get(0), false);
+        Utils.getRandomShort(TestUtils.RANDOM), clusterMap.getWritablePartitionIds(null).get(0), false);
     byte[] userMetadata = new byte[50];
     TestUtils.RANDOM.nextBytes(userMetadata);
     int blobKeyLength = TestUtils.RANDOM.nextInt(4096);
@@ -282,7 +282,7 @@ public class RequestResponseTest {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds().get(0),
+        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds(null).get(0),
         false);
     ArrayList<BlobId> blobIdList = new ArrayList<BlobId>();
     blobIdList.add(id1);
@@ -307,7 +307,8 @@ public class RequestResponseTest {
     messageInfoList.add(messageInfo);
     messageMetadataList.add(messageMetadata);
     PartitionResponseInfo partitionResponseInfo =
-        new PartitionResponseInfo(clusterMap.getWritablePartitionIds().get(0), messageInfoList, messageMetadataList);
+        new PartitionResponseInfo(clusterMap.getWritablePartitionIds(null).get(0), messageInfoList,
+            messageMetadataList);
     List<PartitionResponseInfo> partitionResponseInfoList = new ArrayList<PartitionResponseInfo>();
     partitionResponseInfoList.add(partitionResponseInfo);
     byte[] buf = TestUtils.getRandomBytes(1000);
@@ -350,7 +351,7 @@ public class RequestResponseTest {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds().get(0),
+        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds(null).get(0),
         false);
     short[] versions = new short[]{DeleteRequest.DELETE_REQUEST_VERSION_1, DeleteRequest.DELETE_REQUEST_VERSION_2};
     for (short version : versions) {
@@ -390,7 +391,7 @@ public class RequestResponseTest {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds().get(0),
+        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds(null).get(0),
         false);
     List<ReplicaMetadataRequestInfo> replicaMetadataRequestInfoList = new ArrayList<ReplicaMetadataRequestInfo>();
     ReplicaMetadataRequestInfo replicaMetadataRequestInfo =
@@ -422,7 +423,7 @@ public class RequestResponseTest {
     List<MessageInfo> messageInfoList = new ArrayList<MessageInfo>();
     messageInfoList.add(messageInfo);
     ReplicaMetadataResponseInfo responseInfo =
-        new ReplicaMetadataResponseInfo(clusterMap.getWritablePartitionIds().get(0), new MockFindToken(0, 1000),
+        new ReplicaMetadataResponseInfo(clusterMap.getWritablePartitionIds(null).get(0), new MockFindToken(0, 1000),
             messageInfoList, 1000);
     List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList = new ArrayList<ReplicaMetadataResponseInfo>();
     replicaMetadataResponseInfoList.add(responseInfo);
@@ -464,7 +465,7 @@ public class RequestResponseTest {
     String clientId = "client";
     for (AdminRequestOrResponseType type : AdminRequestOrResponseType.values()) {
       MockClusterMap clusterMap = new MockClusterMap();
-      PartitionId id = clusterMap.getWritablePartitionIds().get(0);
+      PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
       // with a valid partition id
       AdminRequest adminRequest = new AdminRequest(type, id, correlationId, clientId);
       DataInputStream requestStream = serAndPrepForRead(adminRequest, -1, true);
@@ -505,7 +506,7 @@ public class RequestResponseTest {
   @Test
   public void catchupStatusAdminRequestTest() throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
-    PartitionId id = clusterMap.getWritablePartitionIds().get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
     int correlationId = 1234;
     String clientId = "client";
     // request
@@ -616,7 +617,7 @@ public class RequestResponseTest {
    */
   private void doBlobStoreControlAdminRequestTest(boolean enable) throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
-    PartitionId id = clusterMap.getWritablePartitionIds().get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
     int correlationId = 1234;
     String clientId = "client";
     // test BlobStore Control request
@@ -717,7 +718,7 @@ public class RequestResponseTest {
   private void doRequestControlAdminRequestTest(RequestOrResponseType requestOrResponseType, boolean enable)
       throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
-    PartitionId id = clusterMap.getWritablePartitionIds().get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
     int correlationId = 1234;
     String clientId = "client";
     AdminRequest adminRequest =
@@ -743,7 +744,7 @@ public class RequestResponseTest {
    */
   private void doReplicationControlAdminRequestTest(List<String> origins, boolean enable) throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
-    PartitionId id = clusterMap.getWritablePartitionIds().get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
     int correlationId = 1234;
     String clientId = "client";
     AdminRequest adminRequest =

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -579,7 +579,7 @@ public class RequestResponseTest {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds().get(0),
+        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds(null).get(0),
         false);
     short[] versions = new short[]{TtlUpdateRequest.TTL_UPDATE_REQUEST_VERSION_1};
     for (short version : versions) {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -113,7 +113,7 @@ public class ReplicationTest {
     Host localHost = new Host(clusterMap.getDataNodeIds().get(0), clusterMap);
     Host remoteHost = new Host(clusterMap.getDataNodeIds().get(1), clusterMap);
 
-    List<PartitionId> partitionIds = clusterMap.getAllPartitionIds();
+    List<PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     for (PartitionId partitionId : partitionIds) {
       // add  10 messages to the remote host only
       addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 10);
@@ -161,8 +161,8 @@ public class ReplicationTest {
     assertEquals("There should be no disabled partitions", 0, replicaThread.getReplicationDisabledPartitions().size());
     // wait to pause replication
     readyToPause.await(10, TimeUnit.SECONDS);
-    replicaThread.controlReplicationForPartitions(clusterMap.getAllPartitionIds(), false);
-    Set<PartitionId> expectedPaused = new HashSet<>(clusterMap.getAllPartitionIds());
+    replicaThread.controlReplicationForPartitions(clusterMap.getAllPartitionIds(null), false);
+    Set<PartitionId> expectedPaused = new HashSet<>(clusterMap.getAllPartitionIds(null));
     assertEquals("Disabled partitions sets do not match", expectedPaused,
         replicaThread.getReplicationDisabledPartitions());
     // signal the replica thread to move forward
@@ -180,7 +180,7 @@ public class ReplicationTest {
     // reset limit
     reachedLimitLatch.set(new CountDownLatch(partitionIds.size() - 1));
     // unpause all partitions
-    replicaThread.controlReplicationForPartitions(clusterMap.getAllPartitionIds(), true);
+    replicaThread.controlReplicationForPartitions(clusterMap.getAllPartitionIds(null), true);
     assertEquals("There should be no disabled partitions", 0, replicaThread.getReplicationDisabledPartitions().size());
     // wait until all catch up
     reachedLimitLatch.get().await(10, TimeUnit.SECONDS);
@@ -209,7 +209,7 @@ public class ReplicationTest {
     Host localHost = new Host(clusterMap.getDataNodeIds().get(0), clusterMap);
     Host remoteHost = new Host(clusterMap.getDataNodeIds().get(1), clusterMap);
 
-    List<PartitionId> partitionIds = clusterMap.getAllPartitionIds();
+    List<PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     for (PartitionId partitionId : partitionIds) {
       // add  10 messages to the remote host only
       addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 10);
@@ -236,7 +236,7 @@ public class ReplicationTest {
             new ResponseHandler(clusterMap));
 
     Map<PartitionId, Integer> progressTracker = new HashMap<>();
-    PartitionId idToLeaveOut = clusterMap.getAllPartitionIds().get(0);
+    PartitionId idToLeaveOut = clusterMap.getAllPartitionIds(null).get(0);
     boolean allStopped = false;
     boolean onlyOneResumed = false;
     boolean allReenabled = false;
@@ -261,8 +261,8 @@ public class ReplicationTest {
         replicationDone = replicationDone && partDone;
       }
       if (!allStopped && !onlyOneResumed && !allReenabled) {
-        replicaThread.controlReplicationForPartitions(clusterMap.getAllPartitionIds(), false);
-        expectedPaused.addAll(clusterMap.getAllPartitionIds());
+        replicaThread.controlReplicationForPartitions(clusterMap.getAllPartitionIds(null), false);
+        expectedPaused.addAll(clusterMap.getAllPartitionIds(null));
         assertEquals("Disabled partitions sets do not match", expectedPaused,
             replicaThread.getReplicationDisabledPartitions());
         allStopped = true;
@@ -276,7 +276,7 @@ public class ReplicationTest {
         onlyOneResumed = true;
       } else if (!allReenabled) {
         // not removing the first partition
-        replicaThread.controlReplicationForPartitions(clusterMap.getAllPartitionIds(), true);
+        replicaThread.controlReplicationForPartitions(clusterMap.getAllPartitionIds(null), true);
         onlyOneResumed = false;
         allReenabled = true;
         expectedPaused.clear();
@@ -311,7 +311,7 @@ public class ReplicationTest {
     Host remoteHost = new Host(clusterMap.getDataNodeIds().get(1), clusterMap);
 
     short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
-    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
     Map<PartitionId, List<StoreKey>> idsToBeIgnoredByPartition = new HashMap<>();
     for (int i = 0; i < partitionIds.size(); i++) {
       List<StoreKey> idsToBeIgnored = new ArrayList<>();

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -962,8 +962,7 @@ class GetBlobOperation extends GetOperation {
               decryptCallbackResultInfo.exception);
           setOperationException(
               new RouterException("Exception thrown on decrypting content for " + blobType + " blob " + blobId,
-                  decryptCallbackResultInfo.exception,
-                  RouterErrorCode.UnexpectedInternalError));
+                  decryptCallbackResultInfo.exception, RouterErrorCode.UnexpectedInternalError));
           progressTracker.setDecryptionFailed();
         } else {
           // in case of Metadata blob, only user-metadata needs decryption if the blob is encrypted

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
@@ -49,6 +49,7 @@ public class NonBlockingRouterFactory implements RouterFactory {
   private final KeyManagementService kms;
   private final CryptoService cryptoService;
   private final CryptoJobHandler cryptoJobHandler;
+  private final String defaultPartitionClass;
   private static final Logger logger = LoggerFactory.getLogger(NonBlockingRouterFactory.class);
 
   /**
@@ -66,7 +67,8 @@ public class NonBlockingRouterFactory implements RouterFactory {
     if (verifiableProperties == null || clusterMap == null || notificationSystem == null) {
       throw new IllegalArgumentException("Null argument passed in");
     }
-    if (sslFactory == null && new ClusterMapConfig(verifiableProperties).clusterMapSslEnabledDatacenters.length() > 0) {
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    if (sslFactory == null && clusterMapConfig.clusterMapSslEnabledDatacenters.length() > 0) {
       throw new IllegalArgumentException("NonBlockingRouter requires SSL, but sslFactory is null");
     }
     routerConfig = new RouterConfig(verifiableProperties);
@@ -92,6 +94,7 @@ public class NonBlockingRouterFactory implements RouterFactory {
         Utils.getObj(routerConfig.routerCryptoServiceFactory, verifiableProperties, registry);
     cryptoService = cryptoServiceFactory.getCryptoService();
     cryptoJobHandler = new CryptoJobHandler(routerConfig.routerCryptoJobsWorkerCount);
+    defaultPartitionClass = clusterMapConfig.clusterMapDefaultPartitionClass;
     logger.trace("Instantiated NonBlockingRouterFactory");
   }
 
@@ -103,7 +106,7 @@ public class NonBlockingRouterFactory implements RouterFactory {
   public Router getRouter() {
     try {
       return new NonBlockingRouter(routerConfig, routerMetrics, networkClientFactory, notificationSystem, clusterMap,
-          kms, cryptoService, cryptoJobHandler, time);
+          kms, cryptoService, cryptoJobHandler, time, defaultPartitionClass);
     } catch (IOException e) {
       throw new IllegalStateException("Error instantiating NonBlocking Router ", e);
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -72,6 +72,7 @@ class PutManager {
   private final RouterConfig routerConfig;
   private final ResponseHandler responseHandler;
   private final NonBlockingRouterMetrics routerMetrics;
+  private final String defaultPartitionClass;
 
   private class PutRequestRegistrationCallbackImpl implements RequestRegistrationCallback<PutOperation> {
     private List<RequestInfo> requestListToFill;
@@ -100,17 +101,22 @@ class PutManager {
    * @param kms {@link KeyManagementService} to assist in fetching container keys for encryption or decryption
    * @param cryptoService {@link CryptoService} to assist in encryption or decryption
    * @param cryptoJobHandler {@link CryptoJobHandler} to assist in the execution of crypto jobs
+   * @param defaultPartitionClass the default partition class to choose partitions from (if none is found in the
+   *                              container config). Can be {@code null} if no affinity is required for the puts for
+   *                              which the container contains no partition class hints.
    * @param time The {@link Time} instance to use.
    */
   PutManager(ClusterMap clusterMap, ResponseHandler responseHandler, NotificationSystem notificationSystem,
       RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, RouterCallback routerCallback, String suffix,
-      KeyManagementService kms, CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time) {
+      KeyManagementService kms, CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time,
+      String defaultPartitionClass) {
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.notificationSystem = notificationSystem;
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
     this.routerCallback = routerCallback;
+    this.defaultPartitionClass = defaultPartitionClass;
     this.chunkArrivalListener = new ByteBufferAsyncWritableChannel.ChannelEventListener() {
       @Override
       public void onEvent(ByteBufferAsyncWritableChannel.EventType e) {
@@ -145,18 +151,12 @@ class PutManager {
    */
   void submitPutBlobOperation(BlobProperties blobProperties, byte[] userMetaData, ReadableStreamChannel channel,
       FutureResult<String> futureResult, Callback<String> callback) {
-    try {
-      PutOperation putOperation =
-          new PutOperation(routerConfig, routerMetrics, clusterMap, responseHandler, notificationSystem, userMetaData,
-              channel, futureResult, callback, routerCallback, chunkArrivalListener, kms, cryptoService,
-              cryptoJobHandler, time, blobProperties);
-      putOperations.add(putOperation);
-      putOperation.startReadingFromChannel();
-    } catch (RouterException e) {
-      routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.onPutBlobError(e, blobProperties != null && blobProperties.isEncrypted());
-      NonBlockingRouter.completeOperation(futureResult, callback, null, e);
-    }
+    PutOperation putOperation =
+        new PutOperation(routerConfig, routerMetrics, clusterMap, responseHandler, notificationSystem, userMetaData,
+            channel, futureResult, callback, routerCallback, chunkArrivalListener, kms, cryptoService, cryptoJobHandler,
+            time, blobProperties, defaultPartitionClass);
+    putOperations.add(putOperation);
+    putOperation.startReadingFromChannel();
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -80,6 +80,7 @@ class PutOperation {
   private final NotificationSystem notificationSystem;
   private final BlobProperties passedInBlobProperties;
   private final byte[] userMetadata;
+  private final String partitionClass;
   private final ReadableStreamChannel channel;
   private final ByteBufferAsyncWritableChannel chunkFillerChannel;
   private final FutureResult<String> futureResult;
@@ -148,7 +149,7 @@ class PutOperation {
    * @param clusterMap the {@link ClusterMap} of the cluster
    * @param responseHandler the {@link ResponseHandler} responsible for failure detection.
    * @param notificationSystem the {@link NotificationSystem} to use for blob creation notifications.
-   *@param userMetadata the userMetadata associated with the put operation.
+   * @param userMetadata the userMetadata associated with the put operation.
    * @param channel the {@link ReadableStreamChannel} containing the blob data.
    * @param futureResult the future that will contain the result of the operation.
    * @param callback the callback that is to be called when the operation completes.
@@ -158,6 +159,7 @@ class PutOperation {
    * @param cryptoJobHandler {@link CryptoJobHandler} to assist in the execution of crypto jobs
    * @param time the Time instance to use.
    * @param blobProperties the BlobProperties associated with the put operation.
+   * @param partitionClass the partition class to choose partitions from. Can be {@code null} if no affinity is required
    * @throws RouterException if there is an error in constructing the PutOperation with the given parameters.
    */
   PutOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
@@ -165,7 +167,7 @@ class PutOperation {
       ReadableStreamChannel channel, FutureResult<String> futureResult, Callback<String> callback,
       RouterCallback routerCallback, ByteBufferAsyncWritableChannel.ChannelEventListener writableChannelEventListener,
       KeyManagementService kms, CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time,
-      BlobProperties blobProperties) throws RouterException {
+      BlobProperties blobProperties, String partitionClass) {
     submissionTimeMs = time.milliseconds();
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
@@ -174,6 +176,7 @@ class PutOperation {
     this.notificationSystem = notificationSystem;
     this.passedInBlobProperties = blobProperties;
     this.userMetadata = userMetadata;
+    this.partitionClass = partitionClass;
     this.channel = channel;
     this.futureResult = futureResult;
     this.callback = callback;
@@ -629,8 +632,8 @@ class PutOperation {
       } else {
         Integer currentOperationExceptionLevel = null;
         if (operationException.get() instanceof RouterException) {
-          currentOperationExceptionLevel = getPrecedenceLevel(
-              ((RouterException) operationException.get()).getErrorCode());
+          currentOperationExceptionLevel =
+              getPrecedenceLevel(((RouterException) operationException.get()).getErrorCode());
         } else {
           currentOperationExceptionLevel = getPrecedenceLevel(RouterErrorCode.UnexpectedInternalError);
         }
@@ -880,7 +883,7 @@ class PutOperation {
         if (partitionId != null) {
           attemptedPartitionIds.add(partitionId);
         }
-        partitionId = getPartitionForPut(attemptedPartitionIds);
+        partitionId = getPartitionForPut(partitionClass, attemptedPartitionIds);
         chunkBlobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
             clusterMap.getLocalDatacenterId(), passedInBlobProperties.getAccountId(),
             passedInBlobProperties.getContainerId(), partitionId, passedInBlobProperties.isEncrypted());
@@ -896,8 +899,8 @@ class PutOperation {
       } catch (RouterException e) {
         setOperationExceptionAndComplete(e);
       } catch (Exception e) {
-        setOperationExceptionAndComplete(new RouterException("Operation tracker could not be initialized", e,
-            RouterErrorCode.UnexpectedInternalError));
+        setOperationExceptionAndComplete(
+            new RouterException("Prepare for sending failed", e, RouterErrorCode.UnexpectedInternalError));
       }
     }
 
@@ -1109,18 +1112,25 @@ class PutOperation {
 
     /**
      * Choose a random {@link PartitionId} for putting the current chunk and return it.
+     * @param partitionClass the partition class to choose partitions from.
      * @param partitionIdsToExclude the list of {@link PartitionId}s that should be excluded from consideration.
      * @return the chosen {@link PartitionId}
      * @throws RouterException
      */
-    protected PartitionId getPartitionForPut(List<PartitionId> partitionIdsToExclude) throws RouterException {
+    protected PartitionId getPartitionForPut(String partitionClass, List<? extends PartitionId> partitionIdsToExclude)
+        throws RouterException {
       // getWritablePartitions creates and returns a new list, so it is safe to manipulate it.
-      List<? extends PartitionId> partitions = clusterMap.getWritablePartitionIds();
+      List<? extends PartitionId> partitions = clusterMap.getWritablePartitionIds(partitionClass);
       partitions.removeAll(partitionIdsToExclude);
       if (partitions.isEmpty()) {
         throw new RouterException("No writable partitions available.", RouterErrorCode.AmbryUnavailable);
       }
-      return partitions.get(ThreadLocalRandom.current().nextInt(partitions.size()));
+      PartitionId selected = partitions.get(ThreadLocalRandom.current().nextInt(partitions.size()));
+      if (partitionClass != null && !partitionClass.equals(selected.getPartitionClass())) {
+        throw new IllegalStateException(
+            "Selected partition's class [" + selected.getPartitionClass() + "] is not as required: " + partitionClass);
+      }
+      return selected;
     }
 
     /**

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -152,7 +152,7 @@ public class ChunkFillTest {
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
             putUserMetadata, putChannel, futureResult, null,
             new RouterCallback(networkClientFactory.getNetworkClient(), new ArrayList<BackgroundDeleteRequest>()), null,
-            null, null, null, new MockTime(), putBlobProperties);
+            null, null, null, new MockTime(), putBlobProperties, null);
     op.startReadingFromChannel();
     numChunks = RouterUtils.getNumChunksForBlobAndChunkSize(blobSize, chunkSize);
     // largeBlobSize is not a multiple of chunkSize
@@ -261,7 +261,7 @@ public class ChunkFillTest {
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
             putUserMetadata, putChannel, futureResult, null, routerCallback, null, kms, cryptoService, cryptoJobHandler,
-            time, putBlobProperties);
+            time, putBlobProperties, null);
     op.startReadingFromChannel();
     numChunks = RouterUtils.getNumChunksForBlobAndChunkSize(blobSize, chunkSize);
     compositeBuffers = new ByteBuffer[numChunks];

--- a/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
@@ -541,7 +541,7 @@ public class CryptoJobHandlerTest {
     byte dc = (byte) TestUtils.RANDOM.nextInt(3);
     BlobId.BlobIdType type = TestUtils.RANDOM.nextBoolean() ? BlobId.BlobIdType.NATIVE : BlobId.BlobIdType.CRAFTED;
     return new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), type, dc, getRandomShort(TestUtils.RANDOM),
-        getRandomShort(TestUtils.RANDOM), referenceClusterMap.getWritablePartitionIds().get(0), false);
+        getRandomShort(TestUtils.RANDOM), referenceClusterMap.getWritablePartitionIds(null).get(0), false);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -100,8 +100,8 @@ public class DeleteManagerTest {
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(clusterMap),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), new LoggingNotificationSystem(), clusterMap, null, null, null,
-        mockTime);
-    List<PartitionId> mockPartitions = clusterMap.getWritablePartitionIds();
+        mockTime, null);
+    List<PartitionId> mockPartitions = clusterMap.getWritablePartitionIds(null);
     partition = mockPartitions.get(ThreadLocalRandom.current().nextInt(mockPartitions.size()));
     blobId =
         new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
@@ -299,7 +299,7 @@ public class DeleteManagerTest {
     router = new NonBlockingRouter(new RouterConfig(vProps), new NonBlockingRouterMetrics(clusterMap),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), new LoggingNotificationSystem(), clusterMap, null, null, null,
-        mockTime);
+        mockTime, null);
     ServerErrorCode[] serverErrorCodes = new ServerErrorCode[9];
     serverErrorCodes[0] = ServerErrorCode.Blob_Not_Found;
     serverErrorCodes[1] = ServerErrorCode.Data_Corrupt;

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -138,7 +138,7 @@ public class GetBlobInfoOperationTest {
         new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build(), false,
         routerMetrics.ageAtGet);
     mockServerLayout = new MockServerLayout(mockClusterMap);
-    replicasCount = mockClusterMap.getWritablePartitionIds().get(0).getReplicaIds().size();
+    replicasCount = mockClusterMap.getWritablePartitionIds(null).get(0).getReplicaIds().size();
     responseHandler = new ResponseHandler(mockClusterMap);
     networkClientFactory = new MockNetworkClientFactory(vprops, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
         CHECKOUT_TIMEOUT_MS, mockServerLayout, time);
@@ -148,7 +148,7 @@ public class GetBlobInfoOperationTest {
     }
     router = new NonBlockingRouter(new RouterConfig(vprops), new NonBlockingRouterMetrics(mockClusterMap),
         networkClientFactory, new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService, cryptoJobHandler,
-        time);
+        time, null);
     short accountId = Utils.getRandomShort(random);
     short containerId = Utils.getRandomShort(random);
     blobProperties =
@@ -199,7 +199,7 @@ public class GetBlobInfoOperationTest {
   public void testInstantiation() throws Exception {
     BlobId blobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(random), Utils.getRandomShort(random),
-        mockClusterMap.getWritablePartitionIds().get(0), false);
+        mockClusterMap.getWritablePartitionIds(null).get(0), false);
     Callback<GetBlobResultInternal> getOperationCallback = (result, exception) -> {
       // no op.
     };

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -185,7 +185,7 @@ public class GetBlobOperationTest {
     routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
     options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().build(), false, routerMetrics.ageAtGet);
     mockServerLayout = new MockServerLayout(mockClusterMap);
-    replicasCount = mockClusterMap.getWritablePartitionIds().get(0).getReplicaIds().size();
+    replicasCount = mockClusterMap.getWritablePartitionIds(null).get(0).getReplicaIds().size();
     responseHandler = new ResponseHandler(mockClusterMap);
     MockNetworkClientFactory networkClientFactory =
         new MockNetworkClientFactory(vprops, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
@@ -197,7 +197,7 @@ public class GetBlobOperationTest {
       cryptoJobHandler = new CryptoJobHandler(CryptoJobHandlerTest.DEFAULT_THREAD_COUNT);
     }
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap), networkClientFactory,
-        new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService, cryptoJobHandler, time);
+        new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService, cryptoJobHandler, time, null);
     mockNetworkClient = networkClientFactory.getMockNetworkClient();
     routerCallback = new RouterCallback(mockNetworkClient, new ArrayList<BackgroundDeleteRequest>());
   }
@@ -235,7 +235,7 @@ public class GetBlobOperationTest {
 
     blobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         mockClusterMap.getLocalDatacenterId(), Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM), mockClusterMap.getWritablePartitionIds().get(0), false);
+        Utils.getRandomShort(TestUtils.RANDOM), mockClusterMap.getWritablePartitionIds(null).get(0), false);
     blobIdStr = blobId.getID();
     // test a good case
     // operationCount is not incremented here as this operation is not taken to completion.

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -431,7 +431,7 @@ public class GetManagerTest {
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), new LoggingNotificationSystem(), mockClusterMap, kms,
-        cryptoService, cryptoJobHandler, mockTime);
+        cryptoService, cryptoJobHandler, mockTime, null);
     return router;
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
@@ -409,7 +409,7 @@ class InMemoryBlobPoster implements Runnable {
    * @throws RouterException
    */
   private PartitionId getPartitionForPut() throws RouterException {
-    List<? extends PartitionId> partitions = clusterMap.getWritablePartitionIds();
+    List<? extends PartitionId> partitions = clusterMap.getWritablePartitionIds(null);
     if (partitions.isEmpty()) {
       throw new RouterException("No writable partitions available.", RouterErrorCode.AmbryUnavailable);
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -175,7 +175,7 @@ public class NonBlockingRouterTest {
     router = new NonBlockingRouter(new RouterConfig(verifiableProperties), routerMetrics,
         new MockNetworkClientFactory(verifiableProperties, null, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), new LoggingNotificationSystem(), mockClusterMap, kms,
-        cryptoService, cryptoJobHandler, mockTime);
+        cryptoService, cryptoJobHandler, mockTime, null);
   }
 
   private void setOperationParams() {
@@ -343,7 +343,7 @@ public class NonBlockingRouterTest {
     router = new NonBlockingRouter(new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, new MockServerLayout(mockClusterMap), mockTime), new LoggingNotificationSystem(),
-        mockClusterMap, kms, cryptoService, cryptoJobHandler, mockTime);
+        mockClusterMap, kms, cryptoService, cryptoJobHandler, mockTime, null);
 
     assertExpectedThreadCounts(2, 1);
 
@@ -418,7 +418,7 @@ public class NonBlockingRouterTest {
     router = new NonBlockingRouter(new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), deleteTrackingNotificationSystem, mockClusterMap, kms,
-        cryptoService, cryptoJobHandler, mockTime);
+        cryptoService, cryptoJobHandler, mockTime, null);
 
     setOperationParams();
 
@@ -488,7 +488,7 @@ public class NonBlockingRouterTest {
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), deleteTrackingNotificationSystem, mockClusterMap, kms,
-        cryptoService, cryptoJobHandler, mockTime);
+        cryptoService, cryptoJobHandler, mockTime, null);
     setOperationParams();
     String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel).get();
     String deleteServiceId = "delete-service";
@@ -576,7 +576,7 @@ public class NonBlockingRouterTest {
     router = new NonBlockingRouter(new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(verifiableProperties, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), deleteTrackingNotificationSystem, mockClusterMap, kms,
-        cryptoService, cryptoJobHandler, mockTime);
+        cryptoService, cryptoJobHandler, mockTime, null);
     setOperationParams();
     String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel).get();
     router.deleteBlob(blobId, deleteServiceId, null).get();
@@ -666,7 +666,7 @@ public class NonBlockingRouterTest {
     putManager = new PutManager(mockClusterMap, mockResponseHandler, new LoggingNotificationSystem(),
         new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
         new RouterCallback(networkClient, new ArrayList<BackgroundDeleteRequest>()), "0", localKMS, cryptoService,
-        cryptoJobHandler, mockTime);
+        cryptoJobHandler, mockTime, null);
     OperationHelper opHelper = new OperationHelper(OperationType.PUT);
     testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, null, successfulResponseCount,
         invalidResponse, -1);

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -105,7 +105,7 @@ public class PutOperationTest {
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
             userMetadata, channel, future, null,
             new RouterCallback(mockNetworkClient, new ArrayList<BackgroundDeleteRequest>()), null, null, null, null,
-            time, blobProperties);
+            time, blobProperties, null);
     op.startReadingFromChannel();
     List<RequestInfo> requestInfos = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestInfos;
@@ -213,7 +213,7 @@ public class PutOperationTest {
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
             userMetadata, channel, future, null,
             new RouterCallback(mockNetworkClient, new ArrayList<BackgroundDeleteRequest>()), null, null, null, null,
-            time, blobProperties);
+            time, blobProperties, null);
     RouterErrorCode[] routerErrorCodes = new RouterErrorCode[5];
     routerErrorCodes[0] = RouterErrorCode.OperationTimedOut;
     routerErrorCodes[1] = RouterErrorCode.UnexpectedInternalError;

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
@@ -39,7 +39,7 @@ public class RouterUtilsTest {
     } catch (Exception e) {
       fail("Should not get any exception.");
     }
-    partition = clusterMap.getWritablePartitionIds().get(0);
+    partition = clusterMap.getWritablePartitionIds(null).get(0);
     originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         clusterMap.getLocalDatacenterId(), Utils.getRandomShort(random), Utils.getRandomShort(random), partition,
         false);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
@@ -51,7 +51,7 @@ class DirectSender implements Runnable {
     MockClusterMap clusterMap = cluster.getClusterMap();
     this.channel = channel;
     blobIds = new ArrayList<>(totalBlobsToPut);
-    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
     for (int i = 0; i < totalBlobsToPut; i++) {
       int partitionIndex = new Random().nextInt(partitionIds.size());
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -81,8 +81,8 @@ public class MockCluster {
         if (sslEnabledDataCentersStr != null) {
           dataNodes.get(i).setSslEnabledDataCenters(sslEnabledDataCenterList);
         }
-        initializeServer(dataNodes.get(i), sslProps, enableHardDeletes,
-            prefetchDataNodeIndex == i ? true : false, time);
+        initializeServer(dataNodes.get(i), sslProps, enableHardDeletes, prefetchDataNodeIndex == i ? true : false,
+            time);
       }
     } catch (InstantiationException e) {
       // clean up other servers which was started already

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Queue;
 import java.util.Random;
 import org.junit.After;
@@ -67,6 +68,7 @@ public class RouterServerPlaintextTest {
   @BeforeClass
   public static void initializeTests() throws Exception {
     MockNotificationSystem notificationSystem = new MockNotificationSystem(9);
+    Properties properties = getRouterProperties("DC1");
     plaintextCluster = new MockCluster(notificationSystem, false, SystemTime.getInstance());
     plaintextCluster.startServers();
     MockClusterMap routerClusterMap = plaintextCluster.getClusterMap();
@@ -74,7 +76,7 @@ public class RouterServerPlaintextTest {
     // get a different registry. But at this point all server nodes have been initialized, and we want the router and
     // its components, which are going to be created, to use the same registry.
     routerClusterMap.createAndSetPermanentMetricRegistry();
-    testFramework = new RouterServerTestFramework(getRouterProperties("DC1"), routerClusterMap, notificationSystem);
+    testFramework = new RouterServerTestFramework(properties, routerClusterMap, notificationSystem);
     routerMetricRegistry = routerClusterMap.getMetricRegistry();
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -134,7 +134,7 @@ class RouterServerTestFramework {
         partitionCount.put(partitionId, count + 1);
       }
     }
-    double numPartitions = clusterMap.getWritablePartitionIds().size();
+    double numPartitions = clusterMap.getWritablePartitionIds(null).size();
     if (opChains.size() > numPartitions) {
       double blobBalanceThreshold = BALANCE_FACTOR * Math.ceil(blobsPut / numPartitions);
       for (Map.Entry<PartitionId, Integer> entry : partitionCount.entrySet()) {
@@ -183,6 +183,7 @@ class RouterServerTestFramework {
     properties.setProperty("clustermap.datacenter.name", routerDatacenter);
     properties.setProperty("clustermap.host.name", "localhost");
     properties.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
+    properties.setProperty("clustermap.default.partition.class", MockClusterMap.DEFAULT_PARTITION_CLASS);
     return properties;
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -92,6 +92,7 @@ public class ServerHardDeleteTest {
     props.setProperty("clustermap.cluster.name", "test");
     props.setProperty("clustermap.datacenter.name", "DC1");
     props.setProperty("clustermap.host.name", "localhost");
+    props.setProperty("clustermap.default.partition.class", MockClusterMap.DEFAULT_PARTITION_CLASS);
     VerifiableProperties propverify = new VerifiableProperties(props);
     server = new AmbryServer(propverify, mockClusterAgentsFactory, notificationSystem, time);
     server.startup();
@@ -99,8 +100,12 @@ public class ServerHardDeleteTest {
 
   @After
   public void cleanup() throws IOException {
-    server.shutdown();
-    mockClusterMap.cleanup();
+    if (server != null) {
+      server.shutdown();
+    }
+    if (mockClusterMap != null) {
+      mockClusterMap.cleanup();
+    }
   }
 
   /**
@@ -260,7 +265,7 @@ public class ServerHardDeleteTest {
     properties.add(new BlobProperties(31878, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
         Utils.getRandomShort(TestUtils.RANDOM), true));
 
-    List<PartitionId> partitionIds = mockClusterMap.getWritablePartitionIds();
+    List<PartitionId> partitionIds = mockClusterMap.getWritablePartitionIds(null);
     PartitionId chosenPartition = partitionIds.get(0);
     blobIdList = new ArrayList<>(9);
     for (int i = 0; i < 9; i++) {

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerPlaintextTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.server;
 
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.utils.SystemTime;
@@ -44,6 +45,7 @@ public class ServerPlaintextTest {
   public static void initializeTests() throws Exception {
     routerProps = new Properties();
     routerProps.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
+    routerProps.setProperty("clustermap.default.partition.class", MockClusterMap.DEFAULT_PARTITION_CLASS);
     notificationSystem = new MockNotificationSystem(9);
     plaintextCluster = new MockCluster(notificationSystem, false, SystemTime.getInstance());
     plaintextCluster.startServers();

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerPlaintextTokenTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerPlaintextTokenTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.server;
 
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.utils.SystemTime;
@@ -65,6 +66,7 @@ public class ServerPlaintextTokenTest {
   public void initializeTests() throws Exception {
     routerProps = new Properties();
     routerProps.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
+    routerProps.setProperty("clustermap.default.partition.class", MockClusterMap.DEFAULT_PARTITION_CLASS);
     notificationSystem = new MockNotificationSystem(9);
     plaintextCluster = new MockCluster(notificationSystem, false, SystemTime.getInstance());
     plaintextCluster.startServers();

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerSSLTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerSSLTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.server;
 
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.commons.TestSSLUtils;
 import com.github.ambry.config.SSLConfig;
@@ -67,6 +68,7 @@ public class ServerSSLTest {
     TestSSLUtils.addSSLProperties(serverSSLProps, "DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server");
     routerProps = new Properties();
     routerProps.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
+    routerProps.setProperty("clustermap.default.partition.class", MockClusterMap.DEFAULT_PARTITION_CLASS);
     TestSSLUtils.addSSLProperties(routerProps, "DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "router-client");
     notificationSystem = new MockNotificationSystem(9);
     sslCluster = new MockCluster(notificationSystem, serverSSLProps, false, SystemTime.getInstance());

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -121,7 +121,7 @@ public final class ServerTestUtil {
       if (testEncryption) {
         TestUtils.RANDOM.nextBytes(encryptionKey);
       }
-      List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+      List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
       short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
       BlobId blobId1 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
           properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false);
@@ -176,7 +176,7 @@ public final class ServerTestUtil {
 
       // get blob properties
       ArrayList<BlobId> ids = new ArrayList<BlobId>();
-      MockPartitionId partition = (MockPartitionId) clusterMap.getWritablePartitionIds().get(0);
+      MockPartitionId partition = (MockPartitionId) clusterMap.getWritablePartitionIds(null).get(0);
       ids.add(blobId1);
       ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
       PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(partition, ids);
@@ -198,7 +198,7 @@ public final class ServerTestUtil {
 
       // get blob properties with expired flag set
       ids = new ArrayList<BlobId>();
-      partition = (MockPartitionId) clusterMap.getWritablePartitionIds().get(0);
+      partition = (MockPartitionId) clusterMap.getWritablePartitionIds(null).get(0);
       ids.add(blobId1);
       partitionRequestInfoList = new ArrayList<>();
       partitionRequestInfo = new PartitionRequestInfo(partition, ids);
@@ -221,7 +221,7 @@ public final class ServerTestUtil {
       // get blob properties for expired blob
       // 1. With no flag
       ArrayList<BlobId> idsExpired = new ArrayList<>();
-      MockPartitionId partitionExpired = (MockPartitionId) clusterMap.getWritablePartitionIds().get(0);
+      MockPartitionId partitionExpired = (MockPartitionId) clusterMap.getWritablePartitionIds(null).get(0);
       idsExpired.add(blobId4);
       ArrayList<PartitionRequestInfo> partitionRequestInfoListExpired = new ArrayList<>();
       PartitionRequestInfo partitionRequestInfoExpired = new PartitionRequestInfo(partitionExpired, idsExpired);
@@ -236,7 +236,7 @@ public final class ServerTestUtil {
 
       // 2. With Include_Expired flag
       idsExpired = new ArrayList<>();
-      partitionExpired = (MockPartitionId) clusterMap.getWritablePartitionIds().get(0);
+      partitionExpired = (MockPartitionId) clusterMap.getWritablePartitionIds(null).get(0);
       idsExpired.add(blobId4);
       partitionRequestInfoListExpired = new ArrayList<>();
       partitionRequestInfoExpired = new PartitionRequestInfo(partitionExpired, idsExpired);
@@ -342,7 +342,7 @@ public final class ServerTestUtil {
       // fetch blob that does not exist
       // get blob properties
       ids = new ArrayList<BlobId>();
-      partition = (MockPartitionId) clusterMap.getWritablePartitionIds().get(0);
+      partition = (MockPartitionId) clusterMap.getWritablePartitionIds(null).get(0);
       ids.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           clusterMap.getLocalDatacenterId(), properties.getAccountId(), properties.getContainerId(), partition, false));
       partitionRequestInfoList.clear();
@@ -376,7 +376,7 @@ public final class ServerTestUtil {
 
       // get a blob properties on a stopped store, which should fail
       ids = new ArrayList<BlobId>();
-      partition = (MockPartitionId) clusterMap.getWritablePartitionIds().get(0);
+      partition = (MockPartitionId) blobId1.getPartition();
       ids.add(blobId1);
       partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
       partitionRequestInfo = new PartitionRequestInfo(partition, ids);
@@ -424,7 +424,7 @@ public final class ServerTestUtil {
 
       // get a blob on a restarted store , which should succeed
       ids = new ArrayList<BlobId>();
-      PartitionId partitionId = clusterMap.getWritablePartitionIds().get(0);
+      PartitionId partitionId = clusterMap.getWritablePartitionIds(null).get(0);
       ids.add(blobId1);
       partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
       partitionRequestInfo = new PartitionRequestInfo(partitionId, ids);
@@ -452,7 +452,8 @@ public final class ServerTestUtil {
       e.printStackTrace();
       Assert.fail();
     } finally {
-      List<? extends ReplicaId> replicaIds = cluster.getClusterMap().getWritablePartitionIds().get(0).getReplicaIds();
+      List<? extends ReplicaId> replicaIds =
+          cluster.getClusterMap().getWritablePartitionIds(null).get(0).getReplicaIds();
       for (ReplicaId replicaId : replicaIds) {
         MockReplicaId mockReplicaId = (MockReplicaId) replicaId;
         ((MockDiskId) mockReplicaId.getDiskId()).setDiskState(HardwareState.AVAILABLE, true);
@@ -1295,7 +1296,7 @@ public final class ServerTestUtil {
       ArrayList<byte[]> encryptionKeyList = new ArrayList<>();
       byte[] usermetadata = new byte[1000];
       TestUtils.RANDOM.nextBytes(usermetadata);
-      PartitionId partition = clusterMap.getWritablePartitionIds().get(0);
+      PartitionId partition = clusterMap.getWritablePartitionIds(null).get(0);
 
       for (int i = 0; i < 11; i++) {
         short accountId = Utils.getRandomShort(TestUtils.RANDOM);
@@ -1404,7 +1405,7 @@ public final class ServerTestUtil {
 
       // get blob properties
       ArrayList<BlobId> ids = new ArrayList<BlobId>();
-      MockPartitionId mockPartitionId = (MockPartitionId) clusterMap.getWritablePartitionIds().get(0);
+      MockPartitionId mockPartitionId = (MockPartitionId) clusterMap.getWritablePartitionIds(null).get(0);
       ids.add(blobIdList.get(2));
       ArrayList<PartitionRequestInfo> partitionRequestInfoList = new ArrayList<PartitionRequestInfo>();
       PartitionRequestInfo partitionRequestInfo = new PartitionRequestInfo(mockPartitionId, ids);
@@ -1529,7 +1530,7 @@ public final class ServerTestUtil {
       // fetch blob that does not exist
       // get blob properties
       ids = new ArrayList<BlobId>();
-      mockPartitionId = (MockPartitionId) clusterMap.getWritablePartitionIds().get(0);
+      mockPartitionId = (MockPartitionId) clusterMap.getWritablePartitionIds(null).get(0);
       ids.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           clusterMap.getLocalDatacenterId(), propertyList.get(0).getAccountId(), propertyList.get(0).getContainerId(),
           mockPartitionId, false));

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -113,8 +113,8 @@ public class AmbryRequests implements RequestAPI {
 
   public AmbryRequests(StorageManager storageManager, RequestResponseChannel requestResponseChannel,
       ClusterMap clusterMap, DataNodeId nodeId, MetricRegistry registry, FindTokenFactory findTokenFactory,
-      NotificationSystem operationNotification, ReplicationManager replicationManager,
-      StoreKeyFactory storeKeyFactory, boolean enableDataPrefetch) {
+      NotificationSystem operationNotification, ReplicationManager replicationManager, StoreKeyFactory storeKeyFactory,
+      boolean enableDataPrefetch) {
     this.storageManager = storageManager;
     this.requestResponseChannel = requestResponseChannel;
     this.clusterMap = clusterMap;
@@ -230,7 +230,6 @@ public class AmbryRequests implements RequestAPI {
       publicAccessLogger.info("{} {} processingTime {}", receivedRequest, response, processingTime);
       metrics.putBlobProcessingTimeInMs.update(processingTime);
       metrics.updatePutBlobProcessingTimeBySize(receivedRequest.getBlobSize(), processingTime);
-
     }
     sendPutResponse(requestResponseChannel, response, request, metrics.putBlobResponseQueueTimeInMs,
         metrics.putBlobSendTimeInMs, metrics.putBlobTotalTimeInMs, totalTimeSpent, receivedRequest.getBlobSize(),

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -136,7 +136,7 @@ public class AmbryRequestsTest {
    */
   @Test
   public void scheduleCompactionSuccessTest() throws InterruptedException, IOException {
-    List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+    List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
     for (PartitionId id : partitionIds) {
       doScheduleCompactionTest(id, ServerErrorCode.No_Error);
       assertEquals("Partition scheduled for compaction not as expected", id,
@@ -154,7 +154,7 @@ public class AmbryRequestsTest {
     // partitionId not specified
     doScheduleCompactionTest(null, ServerErrorCode.Bad_Request);
 
-    PartitionId id = clusterMap.getWritablePartitionIds().get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
 
     // store is not started - Disk_Unavailable
     storageManager.returnNullStore = true;
@@ -196,7 +196,7 @@ public class AmbryRequestsTest {
     RequestOrResponseType[] requestOrResponseTypes =
         {RequestOrResponseType.PutRequest, RequestOrResponseType.DeleteRequest, RequestOrResponseType.GetRequest, RequestOrResponseType.ReplicaMetadataRequest};
     for (RequestOrResponseType requestType : requestOrResponseTypes) {
-      List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+      List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
       for (PartitionId id : partitionIds) {
         doRequestControlRequestTest(requestType, id);
       }
@@ -222,7 +222,7 @@ public class AmbryRequestsTest {
    */
   @Test
   public void controlReplicationSuccessTest() throws InterruptedException, IOException {
-    List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+    List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
     for (PartitionId id : partitionIds) {
       doControlReplicationTest(id, ServerErrorCode.No_Error);
     }
@@ -237,12 +237,12 @@ public class AmbryRequestsTest {
   public void controlReplicationFailureTest() throws InterruptedException, IOException {
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = false;
-    sendAndVerifyReplicationControlRequest(Collections.EMPTY_LIST, false, clusterMap.getWritablePartitionIds().get(0),
-        ServerErrorCode.Bad_Request);
+    sendAndVerifyReplicationControlRequest(Collections.EMPTY_LIST, false,
+        clusterMap.getWritablePartitionIds(null).get(0), ServerErrorCode.Bad_Request);
     replicationManager.reset();
     replicationManager.exceptionToThrow = new IllegalStateException();
-    sendAndVerifyReplicationControlRequest(Collections.EMPTY_LIST, false, clusterMap.getWritablePartitionIds().get(0),
-        ServerErrorCode.Unknown_Error);
+    sendAndVerifyReplicationControlRequest(Collections.EMPTY_LIST, false,
+        clusterMap.getWritablePartitionIds(null).get(0), ServerErrorCode.Unknown_Error);
     // PartitionUnknown is hard to simulate without betraying knowledge of the internals of MockClusterMap.
   }
 
@@ -253,7 +253,7 @@ public class AmbryRequestsTest {
    */
   @Test
   public void catchupStatusSuccessTest() throws InterruptedException, IOException {
-    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds();
+    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     assertTrue("This test needs more than one partition to work", partitionIds.size() > 1);
     PartitionId id = partitionIds.get(0);
     ReplicaId thisPartRemoteRep = getRemoteReplicaId(id);
@@ -338,7 +338,7 @@ public class AmbryRequestsTest {
    */
   @Test
   public void controlBlobStoreSuccessTest() throws InterruptedException, IOException {
-    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds();
+    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     PartitionId id = partitionIds.get(0);
     List<? extends ReplicaId> replicaIds = id.getReplicaIds();
     assertTrue("This test needs more than one replica for the first partition to work", replicaIds.size() > 1);
@@ -386,7 +386,7 @@ public class AmbryRequestsTest {
    */
   @Test
   public void startBlobStoreFailureTest() throws InterruptedException, IOException {
-    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds();
+    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     PartitionId id = partitionIds.get(0);
     int correlationId = TestUtils.RANDOM.nextInt();
     String clientId = UtilsTest.getRandomString(10);
@@ -441,7 +441,7 @@ public class AmbryRequestsTest {
    */
   @Test
   public void stopBlobStoreFailureTest() throws InterruptedException, IOException {
-    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds();
+    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     PartitionId id = partitionIds.get(0);
     int correlationId = TestUtils.RANDOM.nextInt();
     String clientId = UtilsTest.getRandomString(10);
@@ -589,7 +589,7 @@ public class AmbryRequestsTest {
       throws InterruptedException, IOException {
     List<? extends PartitionId> idsToTest;
     if (id == null) {
-      idsToTest = clusterMap.getAllPartitionIds();
+      idsToTest = clusterMap.getAllPartitionIds(null);
     } else {
       idsToTest = Collections.singletonList(id);
     }
@@ -748,7 +748,7 @@ public class AmbryRequestsTest {
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     List<PartitionId> idsVal;
     if (id == null) {
-      idsVal = clusterMap.getAllPartitionIds();
+      idsVal = clusterMap.getAllPartitionIds(null);
     } else {
       idsVal = Collections.singletonList(id);
     }
@@ -789,7 +789,7 @@ public class AmbryRequestsTest {
    */
   private void generateLagOverrides(long base, long upperBound) {
     replicationManager.lagOverrides = new HashMap<>();
-    for (PartitionId partitionId : clusterMap.getAllPartitionIds()) {
+    for (PartitionId partitionId : clusterMap.getAllPartitionIds(null)) {
       for (ReplicaId replicaId : partitionId.getReplicaIds()) {
         String key = MockReplicationManager.getPartitionLagKey(partitionId, replicaId.getDataNodeId().getHostname(),
             replicaId.getReplicaPath());

--- a/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
@@ -15,6 +15,7 @@
 package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.config.DiskManagerConfig;
@@ -96,9 +97,11 @@ public class StatsManagerTest {
     Pair<StatsSnapshot, StatsSnapshot> baseSliceAndNewSlice = new Pair<>(preAggregatedSnapshot, null);
     for (int i = 0; i < 2; i++) {
       baseSliceAndNewSlice = decomposeSnapshot(baseSliceAndNewSlice.getFirst());
-      storeMap.put(new MockPartitionId(i), new MockStore(new MockStoreStats(baseSliceAndNewSlice.getSecond(), false)));
+      storeMap.put(new MockPartitionId(i, MockClusterMap.DEFAULT_PARTITION_CLASS),
+          new MockStore(new MockStoreStats(baseSliceAndNewSlice.getSecond(), false)));
     }
-    storeMap.put(new MockPartitionId(2), new MockStore(new MockStoreStats(baseSliceAndNewSlice.getFirst(), false)));
+    storeMap.put(new MockPartitionId(2, MockClusterMap.DEFAULT_PARTITION_CLASS),
+        new MockStore(new MockStoreStats(baseSliceAndNewSlice.getFirst(), false)));
     StorageManager storageManager = new MockStorageManager(storeMap);
     Properties properties = new Properties();
     properties.put("stats.output.file.path", outputFileString);
@@ -143,9 +146,9 @@ public class StatsManagerTest {
   @Test
   public void testStatsManagerWithProblematicStores() throws StoreException, IOException {
     Map<PartitionId, Store> problematicStoreMap = new HashMap<>();
-    problematicStoreMap.put(new MockPartitionId(1), null);
+    problematicStoreMap.put(new MockPartitionId(1, MockClusterMap.DEFAULT_PARTITION_CLASS), null);
     Store exceptionStore = new MockStore(new MockStoreStats(null, true));
-    problematicStoreMap.put(new MockPartitionId(2), exceptionStore);
+    problematicStoreMap.put(new MockPartitionId(2, MockClusterMap.DEFAULT_PARTITION_CLASS), exceptionStore);
     StatsManager testStatsManager =
         new StatsManager(new MockStorageManager(problematicStoreMap), new ArrayList<>(problematicStoreMap.keySet()),
             new MetricRegistry(), config, new MockTime());
@@ -159,8 +162,8 @@ public class StatsManagerTest {
     // test for the scenario where some stores are healthy and some are bad
     Map<PartitionId, Store> mixedStoreMap = new HashMap<>(storeMap);
     unreachableStores.clear();
-    mixedStoreMap.put(new MockPartitionId(3), null);
-    mixedStoreMap.put(new MockPartitionId(4), exceptionStore);
+    mixedStoreMap.put(new MockPartitionId(3, MockClusterMap.DEFAULT_PARTITION_CLASS), null);
+    mixedStoreMap.put(new MockPartitionId(4, MockClusterMap.DEFAULT_PARTITION_CLASS), exceptionStore);
     testStatsManager = new StatsManager(new MockStorageManager(mixedStoreMap), new ArrayList<>(mixedStoreMap.keySet()),
         new MetricRegistry(), config, new MockTime());
     actualSnapshot = new StatsSnapshot(0L, null);

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -123,7 +123,8 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
     dataNodes.add(dataNode);
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, dataNodes, 0);
+    MockPartitionId invalidPartition =
+        new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
     List<? extends ReplicaId> invalidPartitionReplicas = invalidPartition.getReplicaIds();
     StorageManager storageManager = createStorageManager(replicas, metricRegistry);
     storageManager.start();
@@ -164,7 +165,7 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
     dataNodes.add(dataNode);
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, dataNodes, 0);
+    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
     List<? extends ReplicaId> invalidPartitionReplicas = invalidPartition.getReplicaIds();
     StorageManager storageManager = createStorageManager(replicas, metricRegistry);
     PartitionId id = null;
@@ -201,7 +202,7 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
     dataNodes.add(dataNode);
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, dataNodes, 0);
+    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
     List<? extends ReplicaId> invalidPartitionReplicas = invalidPartition.getReplicaIds();
     StorageManager storageManager = createStorageManager(replicas, metricRegistry);
     PartitionId id = null;
@@ -226,7 +227,7 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
     dataNodes.add(dataNode);
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, dataNodes, 0);
+    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
     List<? extends ReplicaId> invalidPartitionReplicas = invalidPartition.getReplicaIds();
     StorageManager storageManager = createStorageManager(replicas, metricRegistry);
     storageManager.start();
@@ -404,7 +405,7 @@ public class StorageManagerTest {
         getCounterValue(counters, DiskSpaceAllocator.class.getName(), "DiskSpaceAllocatorInitFailureCount"));
     assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "TotalStoreStartFailures"));
     assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "DiskMountPathFailures"));
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, Collections.<MockDataNodeId>emptyList(), 0);
+    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, Collections.<MockDataNodeId>emptyList(), 0);
     assertNull("Should not have found a store for an invalid partition.", storageManager.getStore(invalidPartition));
     assertEquals("Compaction thread count is incorrect", dataNode.getMountPaths().size(),
         TestUtils.numThreadsByThisName(CompactionManager.THREAD_NAME_PREFIX));
@@ -508,7 +509,7 @@ public class StorageManagerTest {
     properties.put("disk.manager.enable.segment.pooling", "true");
     properties.put("store.compaction.triggers", "Periodic,Admin");
     if (segmentedLog) {
-      long replicaCapacity = clusterMap.getAllPartitionIds().get(0).getReplicaIds().get(0).getCapacityInBytes();
+      long replicaCapacity = clusterMap.getAllPartitionIds(null).get(0).getReplicaIds().get(0).getCapacityInBytes();
       properties.put("store.segment.size.in.bytes", Long.toString(replicaCapacity / 2L));
     }
     VerifiableProperties vProps = new VerifiableProperties(properties);

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/PartitionManager.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/PartitionManager.java
@@ -117,8 +117,8 @@ public class PartitionManager {
       ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(new Properties()));
       if (fileString == null) {
         manager = (new StaticClusterAgentsFactory(clusterMapConfig, new PartitionLayout(
-            new HardwareLayout(new JSONObject(Utils.readStringFromFile(hardwareLayoutPath)),
-                clusterMapConfig)))).getClusterMap();
+            new HardwareLayout(new JSONObject(Utils.readStringFromFile(hardwareLayoutPath)), clusterMapConfig),
+            null))).getClusterMap();
       } else {
         manager =
             (new StaticClusterAgentsFactory(clusterMapConfig, hardwareLayoutPath, partitionLayoutPath)).getClusterMap();
@@ -131,8 +131,8 @@ public class PartitionManager {
         int numberOfPartitions = options.valueOf(numberOfPartitionsOpt);
         int numberOfReplicas = options.valueOf(numberOfReplicasPerDatacenterOpt);
         long replicaCapacityInBytes = options.valueOf(replicaCapacityInBytesOpt);
-        manager.allocatePartitions(numberOfPartitions, numberOfReplicas, replicaCapacityInBytes,
-            attemptNonRackAwareOnFailure);
+        manager.allocatePartitions(numberOfPartitions, clusterMapConfig.clusterMapDefaultPartitionClass,
+            numberOfReplicas, replicaCapacityInBytes, attemptNonRackAwareOnFailure);
       } else if (operationType.compareToIgnoreCase("AddReplicas") == 0) {
         listOpt.add(partitionIdsToAddReplicasToOpt);
         listOpt.add(datacenterToAddReplicasToOpt);
@@ -141,13 +141,13 @@ public class PartitionManager {
         String partitionIdsToAddReplicas = options.valueOf(partitionIdsToAddReplicasToOpt);
         String datacenterToAddReplicasTo = options.valueOf(datacenterToAddReplicasToOpt);
         if (partitionIdsToAddReplicas.compareToIgnoreCase(".") == 0) {
-          for (PartitionId partitionId : manager.getAllPartitionIds()) {
+          for (PartitionId partitionId : manager.getAllPartitionIds(null)) {
             manager.addReplicas(partitionId, datacenterToAddReplicasTo, attemptNonRackAwareOnFailure);
           }
         } else {
           String[] partitionIds = partitionIdsToAddReplicas.split(",");
           for (String partitionId : partitionIds) {
-            for (PartitionId partitionInCluster : manager.getAllPartitionIds()) {
+            for (PartitionId partitionInCluster : manager.getAllPartitionIds(null)) {
               if (partitionInCluster.isEqual(partitionId)) {
                 manager.addReplicas(partitionInCluster, datacenterToAddReplicasTo, attemptNonRackAwareOnFailure);
               }

--- a/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
@@ -224,7 +224,7 @@ public class IndexWritePerformance {
           // choose a random index
           int indexToUse = new Random().nextInt(indexesWithMetrics.size());
           // Does not matter what partition we use
-          PartitionId partition = map.getWritablePartitionIds().get(0);
+          PartitionId partition = map.getWritablePartitionIds(null).get(0);
           indexesWithMetrics.get(indexToUse)
               .addToIndexRandomData(new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, map.getLocalDatacenterId(),
                   Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partition, false));

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
@@ -90,7 +90,7 @@ public class DirectoryUploader {
   }
 
   private void setPartitionId(ClusterMap clusterMap, String partitionStr, boolean enableVerboseLogging) {
-    for (PartitionId writablePartition : clusterMap.getWritablePartitionIds()) {
+    for (PartitionId writablePartition : clusterMap.getWritablePartitionIds(null)) {
       if (writablePartition.toString().equalsIgnoreCase(partitionStr)) {
         partitionId = writablePartition;
         break;

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
@@ -401,7 +401,7 @@ public class ServerAdminTool implements Closeable {
       return null;
     }
     PartitionId targetPartitionId = null;
-    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds();
+    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     for (PartitionId partitionId : partitionIds) {
       if (partitionId.isEqual(partitionIdStr)) {
         targetPartitionId = partitionId;

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
@@ -346,7 +346,7 @@ public class ServerWritePerformance {
               new BlobProperties(randomNum, "test", Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false);
           ConnectedChannel channel = null;
           try {
-            List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds();
+            List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
             int index = (int) getRandomLong(rand, partitionIds.size());
             PartitionId partitionId = partitionIds.get(index);
             BlobId blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),

--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,7 @@ project(':ambry-store') {
         compile project(':ambry-api'),
                 project(':ambry-utils')
         compile "com.codahale.metrics:metrics-core:$metricsVersion"
+        testCompile project(':ambry-clustermap')
         testCompile project(':ambry-clustermap').sourceSets.test.output
         testCompile project(':ambry-utils').sourceSets.test.output
     }

--- a/config/PartitionLayout.json
+++ b/config/PartitionLayout.json
@@ -4,6 +4,7 @@
     "partitions": [
         {
             "id": 0,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_WRITE",
             "replicaCapacityInBytes": 10737418240,
             "replicas": [

--- a/config/PartitionLayoutHelix.json
+++ b/config/PartitionLayoutHelix.json
@@ -4,6 +4,7 @@
     "partitions": [
         {
             "id": 10,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_WRITE",
             "replicaCapacityInBytes": 107374182400,
             "replicas": [
@@ -41,6 +42,7 @@
         },
         {
             "id": 20,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_ONLY",
             "replicaCapacityInBytes": 107374182400,
             "replicas": [
@@ -78,6 +80,7 @@
         },
         {
             "id": 30,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_WRITE",
             "replicaCapacityInBytes": 107374182400,
             "replicas": [
@@ -115,6 +118,7 @@
         },
         {
             "id": 40,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_WRITE",
             "replicaCapacityInBytes": 107374182400,
             "replicas": [

--- a/config/PartitionLayoutLocalOnePartitionThreeReplicas.json
+++ b/config/PartitionLayoutLocalOnePartitionThreeReplicas.json
@@ -4,6 +4,7 @@
     "partitions": [
         {
             "id": 0,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_WRITE",
             "replicaCapacityInBytes": 10737418240,
             "replicas": [

--- a/config/PartitionLayoutMultiPartition.json
+++ b/config/PartitionLayoutMultiPartition.json
@@ -4,6 +4,7 @@
     "partitions": [
         {
             "id": 0,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_WRITE",
             "replicaCapacityInBytes": 10737418240,
             "replicas": [
@@ -26,6 +27,7 @@
         },
         {
             "id": 1,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_WRITE",
             "replicaCapacityInBytes": 10737418240,
             "replicas": [
@@ -48,6 +50,7 @@
         },
         {
             "id": 2,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_WRITE",
             "replicaCapacityInBytes": 10737418240,
             "replicas": [
@@ -70,6 +73,7 @@
         },
         {
             "id": 3,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_WRITE",
             "replicaCapacityInBytes": 10737418240,
             "replicas": [
@@ -92,6 +96,7 @@
         },
         {
             "id": 4,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_WRITE",
             "replicaCapacityInBytes": 10737418240,
             "replicas": [
@@ -114,6 +119,7 @@
         },
         {
             "id": 5,
+            "partitionClass": "max-replicas-all-datacenters",
             "partitionState": "READ_WRITE",
             "replicaCapacityInBytes": 10737418240,
             "replicas": [


### PR DESCRIPTION
Partitions can now be requested by the "class" they belong to. The next step is to have a container config to dictate what partition class a blob should go to.

Most of the changes are in test files or because a widely used API was changed.
Suggested order of review:
1. Files under ambry-api
2. Files under ambry-clustermap
3. Files under ambry-router
4. The rest