### PR TITLE
Modify selector metrics to remove timeout cases.

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -320,11 +320,11 @@ public class Selector implements Selectable {
     // check ready keys
     long startSelect = time.milliseconds();
     int readyKeys = select(timeoutMs);
+    this.metrics.selectorSelectCount.inc();
 
     if (readyKeys > 0) {
       long endSelect = time.milliseconds();
       this.metrics.selectorSelectTime.update(endSelect - startSelect);
-      this.metrics.selectorSelectCount.inc();
       Set<SelectionKey> keys = nioSelector.selectedKeys();
       Iterator<SelectionKey> iter = keys.iterator();
       while (iter.hasNext()) {
@@ -374,11 +374,10 @@ public class Selector implements Selectable {
       }
       checkUnreadyConnectionsStatus();
       this.metrics.selectorIOCount.inc();
+      this.metrics.selectorIOTime.update(time.milliseconds() - endSelect);
     }
     disconnected.addAll(closedConnections);
     closedConnections.clear();
-    long endIo = time.milliseconds();
-    this.metrics.selectorIOTime.update(endIo - endSelect);
   }
 
   /**

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -320,11 +320,11 @@ public class Selector implements Selectable {
     // check ready keys
     long startSelect = time.milliseconds();
     int readyKeys = select(timeoutMs);
-    long endSelect = time.milliseconds();
-    this.metrics.selectorSelectTime.update(endSelect - startSelect);
-    this.metrics.selectorSelectCount.inc();
 
     if (readyKeys > 0) {
+      long endSelect = time.milliseconds();
+      this.metrics.selectorSelectTime.update(endSelect - startSelect);
+      this.metrics.selectorSelectCount.inc();
       Set<SelectionKey> keys = nioSelector.selectedKeys();
       Iterator<SelectionKey> iter = keys.iterator();
       while (iter.hasNext()) {


### PR DESCRIPTION
SelectorTime and SelectorIOTime are calculated only if keys are ready.
selectorIOCount and selectorCount can be a set of comparative for timeout and non-timeout cases.  