### PR TITLE
Add optional hint to include exception message in response

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestServiceException.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestServiceException.java
@@ -19,23 +19,54 @@ package com.github.ambry.rest;
  */
 public class RestServiceException extends Exception {
   private final RestServiceErrorCode error;
+  private final boolean includeExceptionMessageInResponse;
 
+  /**
+   * @param message the exception message.
+   * @param error the {@link RestServiceErrorCode}.
+   */
   public RestServiceException(String message, RestServiceErrorCode error) {
-    super(message);
-    this.error = error;
+    this(message, error, false);
   }
 
+  /**
+   * @param message the exception message.
+   * @param e the exception cause.
+   * @param error the {@link RestServiceErrorCode}.
+   */
   public RestServiceException(String message, Throwable e, RestServiceErrorCode error) {
     super(message, e);
     this.error = error;
+    includeExceptionMessageInResponse = false;
   }
 
+  /**
+   * @param e the exception cause.
+   * @param error the {@link RestServiceErrorCode}.
+   */
   public RestServiceException(Throwable e, RestServiceErrorCode error) {
     super(e);
     this.error = error;
+    includeExceptionMessageInResponse = false;
+  }
+
+  /**
+   * @param message the exception message.
+   * @param error the {@link RestServiceErrorCode}.
+   * @param includeExceptionMessageInResponse {@code true} to hint that the exception message should be returned to the
+   *                                          client as a response header.
+   */
+  public RestServiceException(String message, RestServiceErrorCode error, boolean includeExceptionMessageInResponse) {
+    super(message);
+    this.error = error;
+    this.includeExceptionMessageInResponse = includeExceptionMessageInResponse;
   }
 
   public RestServiceErrorCode getErrorCode() {
-    return this.error;
+    return error;
+  }
+
+  public boolean shouldIncludeExceptionMessageInResponse() {
+    return includeExceptionMessageInResponse;
   }
 }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -381,10 +381,11 @@ class NettyResponseChannel implements RestResponseChannel {
     RestServiceErrorCode restServiceErrorCode = null;
     String errReason = null;
     if (cause instanceof RestServiceException) {
-      restServiceErrorCode = ((RestServiceException) cause).getErrorCode();
+      RestServiceException restServiceException = (RestServiceException) cause;
+      restServiceErrorCode = restServiceException.getErrorCode();
       errorResponseStatus = ResponseStatus.getResponseStatus(restServiceErrorCode);
       status = getHttpResponseStatus(errorResponseStatus);
-      if (status == HttpResponseStatus.BAD_REQUEST) {
+      if (status == HttpResponseStatus.BAD_REQUEST || restServiceException.shouldIncludeExceptionMessageInResponse()) {
         errReason = new String(
             Utils.getRootCause(cause).getMessage().replaceAll("[\n\t\r]", " ").getBytes(StandardCharsets.US_ASCII),
             StandardCharsets.US_ASCII);


### PR DESCRIPTION
Add a flag that we can set to provide the x-ambry-failure-reason
response header on certain non 400 error responses.

This can be used to provide clients with additional diagnostic
information on certain non bad request errors without setting
the header on all error responses.