### PR TITLE
Fix statsBasedCompaction comparator bug

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/StatsBasedCompactionPolicy.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StatsBasedCompactionPolicy.java
@@ -89,7 +89,7 @@ class StatsBasedCompactionPolicy implements CompactionPolicy {
     CostBenefitInfo bestCandidateToCompact = null;
     while (firstEntry != null) {
       Map.Entry<String, Long> endEntry = lastEntry;
-      while (endEntry != null && firstEntry.getKey().compareTo(endEntry.getKey()) <= 0) {
+      while (endEntry != null && LogSegmentNameHelper.COMPARATOR.compare(firstEntry.getKey(),endEntry.getKey()) <= 0) {
         CostBenefitInfo costBenefitInfo =
             getCostBenefitInfo(firstEntry.getKey(), endEntry.getKey(), validDataPerLogSegments, segmentCapacity,
                 segmentHeaderSize, maxBlobSize);

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactAllPolicyTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactAllPolicyTest.java
@@ -52,7 +52,7 @@ public class CompactAllPolicyTest {
    */
   @Test
   public void testGetCompactionDetailsTest() throws StoreException, InterruptedException {
-    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomStrings(1);
+    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomLogSegmentName(1);
     CompactionPolicyTest.verifyCompactionDetails(
         new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs, blobStore.logSegmentsNotInJournal),
         blobStore, compactionPolicy);
@@ -60,7 +60,7 @@ public class CompactAllPolicyTest {
     // random no of valid logSegments
     for (int i = 0; i < 3; i++) {
       int logSegmentCount = TestUtils.RANDOM.nextInt(10) + 1;
-      blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomStrings(logSegmentCount);
+      blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomLogSegmentName(logSegmentCount);
       CompactionPolicyTest.verifyCompactionDetails(
           new CompactionDetails(time.milliseconds() - messageRetentionTimeInMs, blobStore.logSegmentsNotInJournal),
           blobStore, compactionPolicy);

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
@@ -401,7 +401,7 @@ public class CompactionManagerTest {
    * @return the randomly generated {@link CompactionDetails}
    */
   private CompactionDetails generateRandomCompactionDetails(int count) {
-    List<String> logSegmentsNames = CompactionPolicyTest.generateRandomStrings(count);
+    List<String> logSegmentsNames = CompactionPolicyTest.generateRandomLogSegmentName(count);
     return new CompactionDetails(time.milliseconds(), logSegmentsNames);
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionPolicyTest.java
@@ -21,7 +21,6 @@ import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
-import com.github.ambry.utils.UtilsTest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -95,7 +94,7 @@ public class CompactionPolicyTest {
     if (compactionPolicy instanceof StatsBasedCompactionPolicy) {
       bestCandidates = setUpStateForStatsBasedCompactionPolicy(blobStore, mockBlobStoreStats);
     } else if (compactionPolicy instanceof CompactAllPolicy) {
-      blobStore.logSegmentsNotInJournal = generateRandomStrings(3);
+      blobStore.logSegmentsNotInJournal = generateRandomLogSegmentName(3);
       bestCandidates = blobStore.logSegmentsNotInJournal;
     }
 
@@ -133,7 +132,7 @@ public class CompactionPolicyTest {
       if (compactionPolicy instanceof StatsBasedCompactionPolicy) {
         bestCandidates = setUpStateForStatsBasedCompactionPolicy(blobStore, mockBlobStoreStats);
       } else if (compactionPolicy instanceof CompactAllPolicy) {
-        blobStore.logSegmentsNotInJournal = generateRandomStrings(3);
+        blobStore.logSegmentsNotInJournal = generateRandomLogSegmentName(3);
         bestCandidates = blobStore.logSegmentsNotInJournal;
       }
       if (blobStore.usedCapacity < (config.storeMinUsedCapacityToTriggerCompactionInPercentage / 100.0
@@ -162,7 +161,7 @@ public class CompactionPolicyTest {
         bestCandidates = setUpStateForStatsBasedCompactionPolicy(blobStore, mockBlobStoreStats);
         compactionPolicy = new StatsBasedCompactionPolicy(initState.getSecond(), time);
       } else if (compactionPolicy instanceof CompactAllPolicy) {
-        blobStore.logSegmentsNotInJournal = generateRandomStrings(3);
+        blobStore.logSegmentsNotInJournal = generateRandomLogSegmentName(3);
         bestCandidates = blobStore.logSegmentsNotInJournal;
         compactionPolicy = new CompactAllPolicy(initState.getSecond(), time);
       }
@@ -213,7 +212,7 @@ public class CompactionPolicyTest {
     long maxLogSegmentCapacity =
         blobStore.segmentCapacity - blobStore.segmentHeaderSize - mockBlobStoreStats.getMaxBlobSize();
     long logSegmentCount = blobStore.capacityInBytes / blobStore.segmentCapacity;
-    blobStore.logSegmentsNotInJournal = generateRandomStrings((int) logSegmentCount);
+    blobStore.logSegmentsNotInJournal = generateRandomLogSegmentName((int) logSegmentCount);
 
     int bestCandidateRange = 3 + TestUtils.RANDOM.nextInt((int) logSegmentCount - 2);
     int bestCandidateStartIndex = TestUtils.RANDOM.nextInt((int) logSegmentCount - bestCandidateRange + 1);
@@ -230,17 +229,22 @@ public class CompactionPolicyTest {
   }
 
   /**
-   * Generates random strings
-   * @param count the total number of random strings that needs to be generated
-   * @return a {@link List} of random strings of size {@code count}
+   * Generates random log segment names
+   * @param count the total number of random log segment names that needs to be generated
+   * @return a {@link List} of random log segment name of size {@code count}
    */
-  static List<String> generateRandomStrings(int count) {
-    List<String> randomStrings = new ArrayList<>();
-    for (int i = 0; i < count; i++) {
-      randomStrings.add(UtilsTest.getRandomString(5));
+  static List<String> generateRandomLogSegmentName(int count) {
+    List<String> randomLogSegmentNames = new ArrayList<>();
+    while (randomLogSegmentNames.size() < count) {
+      String logSegmentNames =
+          Integer.toString(TestUtils.RANDOM.nextInt(20)) + '_' + Integer.toString(TestUtils.RANDOM.nextInt(20));
+      if (randomLogSegmentNames.contains(logSegmentNames)) {
+        continue;
+      }
+      randomLogSegmentNames.add(logSegmentNames);
     }
-    Collections.sort(randomStrings);
-    return randomStrings;
+    Collections.sort(randomLogSegmentNames, LogSegmentNameHelper.COMPARATOR);
+    return randomLogSegmentNames;
   }
 
   /**
@@ -252,7 +256,7 @@ public class CompactionPolicyTest {
    */
   static NavigableMap<String, Long> generateValidDataSize(List<String> logSegmentNames, List<String> bestCandidates,
       long validDataSizeForBest, long maxLogSegmentCapacity) {
-    NavigableMap<String, Long> validDataSize = new TreeMap<>();
+    NavigableMap<String, Long> validDataSize = new TreeMap<>(LogSegmentNameHelper.COMPARATOR);
     for (String logSegmentName : logSegmentNames) {
       if (bestCandidates.contains(logSegmentName)) {
         validDataSize.put(logSegmentName, validDataSizeForBest);

--- a/ambry-store/src/test/java/com.github.ambry.store/CostBenefitInfoTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CostBenefitInfoTest.java
@@ -32,7 +32,7 @@ public class CostBenefitInfoTest {
   @Test
   public void testCostBenefitInfo() {
     for (int i = 0; i < 5; i++) {
-      List<String> randomSegments = CompactionPolicyTest.generateRandomStrings(3);
+      List<String> randomSegments = CompactionPolicyTest.generateRandomLogSegmentName(3);
       long cost = getRandomCost();
       int benefit = 1 + TestUtils.RANDOM.nextInt(Integer.MAX_VALUE);
       CostBenefitInfo actual = new CostBenefitInfo(randomSegments, cost, benefit);
@@ -45,7 +45,7 @@ public class CostBenefitInfoTest {
    */
   @Test
   public void testCostBenefitInfoForZeroBenefit() {
-    List<String> randomSegments = CompactionPolicyTest.generateRandomStrings(3);
+    List<String> randomSegments = CompactionPolicyTest.generateRandomLogSegmentName(3);
     long cost = getRandomCost();
     int benefit = 0;
     CostBenefitInfo actual = new CostBenefitInfo(randomSegments, cost, benefit);
@@ -57,7 +57,7 @@ public class CostBenefitInfoTest {
    */
   @Test
   public void testCostBenefitInfoComparison() {
-    List<String> randomSegments = CompactionPolicyTest.generateRandomStrings(3);
+    List<String> randomSegments = CompactionPolicyTest.generateRandomLogSegmentName(3);
     long cost = getRandomCost();
     int benefit = 1 + TestUtils.RANDOM.nextInt(Integer.MAX_VALUE - 1);
     CostBenefitInfo one = new CostBenefitInfo(randomSegments, cost, benefit);

--- a/ambry-store/src/test/java/com.github.ambry.store/StatsBasedCompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StatsBasedCompactionPolicyTest.java
@@ -67,7 +67,7 @@ public class StatsBasedCompactionPolicyTest {
     // normal case where in some log segments are non overlapping with journal
     long maxLogSegmentCapacity = blobStore.segmentCapacity - blobStore.segmentHeaderSize - DEFAULT_MAX_BLOB_SIZE;
     long logSegmentCount = blobStore.capacityInBytes / blobStore.segmentCapacity;
-    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomStrings((int) logSegmentCount);
+    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomLogSegmentName((int) logSegmentCount);
     for (int k = 0; k < 5; k++) {
       for (int i = 0; i < logSegmentCount; i++) {
         for (int j = i; j < logSegmentCount; j++) {
@@ -125,7 +125,7 @@ public class StatsBasedCompactionPolicyTest {
   public void testGetCompactionDetailsZeroCostTest() throws StoreException, InterruptedException {
     long maxLogSegmentCapacity = blobStore.segmentCapacity - blobStore.segmentHeaderSize - DEFAULT_MAX_BLOB_SIZE;
     long logSegmentCount = blobStore.capacityInBytes / blobStore.segmentCapacity;
-    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomStrings((int) logSegmentCount);
+    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomLogSegmentName((int) logSegmentCount);
     for (int i = 0; i < logSegmentCount; i++) {
       for (int j = i; j < logSegmentCount; j++) {
         List<String> bestCandidates = blobStore.logSegmentsNotInJournal.subList(i, j + 1);
@@ -148,7 +148,7 @@ public class StatsBasedCompactionPolicyTest {
   public void testLogSegmentsNotInJournal() throws StoreException {
     long maxLogSegmentCapacity = blobStore.segmentCapacity - blobStore.segmentHeaderSize - DEFAULT_MAX_BLOB_SIZE;
     long logSegmentCount = blobStore.capacityInBytes / blobStore.segmentCapacity;
-    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomStrings((int) logSegmentCount);
+    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomLogSegmentName((int) logSegmentCount);
 
     // case 1: 1st best(index_0 to index_3) is in journal, 2nd not in journal
     List<String> bestCandidates = blobStore.logSegmentsNotInJournal.subList(0, 4);
@@ -178,7 +178,7 @@ public class StatsBasedCompactionPolicyTest {
         compactionPolicy);
 
     // case 2: only one potential candidate(index_5 to index_7) to compact which is overlaps with the journal
-    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomStrings((int) logSegmentCount);
+    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomLogSegmentName((int) logSegmentCount);
     bestCandidates = blobStore.logSegmentsNotInJournal.subList(5, 8);
     bestCost = maxLogSegmentCapacity / bestCandidates.size();
     // this best cost is to ensure that no of segments reclaimed will be "bestCandidates" count - 1
@@ -191,7 +191,7 @@ public class StatsBasedCompactionPolicyTest {
 
     // case 3: best candidate's first few segments(index_2 to index7) are non overlapping and the rest are overlapping
     // with journal
-    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomStrings((int) logSegmentCount);
+    blobStore.logSegmentsNotInJournal = CompactionPolicyTest.generateRandomLogSegmentName((int) logSegmentCount);
     bestCandidates = blobStore.logSegmentsNotInJournal.subList(2, 8);
     bestCost = maxLogSegmentCapacity / bestCandidates.size();
     validDataSize =


### PR DESCRIPTION
Stats based compaction failed because of NPE:
```
java.lang.NullPointerException
	at com.github.ambry.store.StatsBasedCompactionPolicy.getCostBenefitInfo(StatsBasedCompactionPolicy.java:129)
	at com.github.ambry.store.StatsBasedCompactionPolicy.getBestCandidateToCompact(StatsBasedCompactionPolicy.java:94)
	at com.github.ambry.store.StatsBasedCompactionPolicy.getCompactionDetails(StatsBasedCompactionPolicy.java:62)
	at com.github.ambry.store.BlobStore.getCompactionDetails(BlobStore.java:496)
	at com.github.ambry.store.CompactionManager.getCompactionDetails(CompactionManager.java:153)
	at com.github.ambry.store.CompactionManager.access$600(CompactionManager.java:34)
	at com.github.ambry.store.CompactionManager$CompactionExecutor.run(CompactionManager.java:219)
	at java.lang.Thread.run(Thread.java:745)
```

The problem is validDataPerLogSegments as a NavigableMap is using LogSegmentNameHelper.COMPARATOR.
However, the while loop in getBestCandidateToCompact is using default String comparator.

The change is to use LogSegmentNameHelper.COMPARATOR and modify tests. 