### PR TITLE
Updates to Helix Cluster Map Update tool

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HardwareLayout.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HardwareLayout.java
@@ -123,6 +123,10 @@ class HardwareLayout {
     return dataNodeInHardStateCount.get(hardwareState);
   }
 
+  ClusterMapConfig getClusterMapConfig() {
+    return clusterMapConfig;
+  }
+
   private Map<HardwareState, Long> calculateDataNodeInHardStateCount() {
     Map<HardwareState, Long> dataNodeInStateCount = new HashMap<HardwareState, Long>();
     for (HardwareState hardwareState : HardwareState.values()) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -85,13 +85,13 @@ import org.slf4j.LoggerFactory;
 class HelixBootstrapUpgradeUtil {
   private final StaticClusterManager staticClusterMap;
   private final Map<String, HelixAdmin> adminForDc = new HashMap<>();
-  private final HashMap<String, HashMap<DiskId, SortedSet<Replica>>> instanceToDiskReplicasMap = new HashMap<>();
-  private final HashMap<String, HashMap<String, DataNodeId>> dcToInstanceNameToDataNodeId = new HashMap<>();
+  private final Map<String, Map<DiskId, SortedSet<Replica>>> instanceToDiskReplicasMap = new HashMap<>();
+  private final Map<String, Map<String, DataNodeId>> dcToInstanceNameToDataNodeId = new HashMap<>();
   private final int maxPartitionsInOneResource;
   private final boolean dryRun;
   private final boolean forceRemove;
   private int maxResource = -1;
-  final String clusterName;
+  private final String clusterName;
   private boolean expectMoreInHelixDuringValidate = false;
   private Map<String, Set<String>> instancesNotForceRemovedByDc = new HashMap<>();
   private Map<String, Set<String>> partitionsNotForceRemovedByDc = new HashMap<>();

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -290,8 +290,8 @@ class HelixBootstrapUpgradeUtil {
     maybeAddCluster();
     info("Initialized");
     info("Populating resources and partitions set");
-    info("Populated resources and partitions set");
     populateInstancesAndPartitionsMap();
+    info("Populated resources and partitions set");
     for (Datacenter dc : staticClusterMap.hardwareLayout.getDatacenters()) {
       info("\n=======Starting datacenter: {}=========\n", dc.getName());
       Map<String, Set<String>> partitionsToInstancesInDc = new HashMap<>();
@@ -441,7 +441,7 @@ class HelixBootstrapUpgradeUtil {
       fromIndex = toIndex;
       IdealState idealState = new IdealState(resourceName);
       idealState.setStateModelDefRef(LeaderStandbySMD.name);
-      info("Adding partitions for instances in " + dcName);
+      info("Adding partitions for next resource in {}", dcName);
       for (Map.Entry<String, Set<String>> entry : partitionsUnderNextResource) {
         String partitionName = entry.getKey();
         ArrayList<String> instances = new ArrayList<>(entry.getValue());
@@ -457,8 +457,8 @@ class HelixBootstrapUpgradeUtil {
         dcAdmin.addResource(clusterName, resourceName, idealState);
         resourcesAdded++;
       }
-      info("Added " + partitionsUnderNextResource.size() + " new partitions under resource " + resourceName
-          + " in datacenter " + dcName);
+      info("Added {} new partitions under resource {} in datacenter {}", partitionsUnderNextResource.size(),
+          resourceName, dcName);
     }
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
@@ -69,7 +69,8 @@ class Partition extends PartitionId {
       logger.trace("Partition " + jsonObject.toString());
     }
     this.id = jsonObject.getLong("id");
-    this.partitionClass = jsonObject.getString("partitionClass");
+    this.partitionClass = jsonObject.has("partitionClass") ? jsonObject.getString("partitionClass")
+        : hardwareLayout.getClusterMapConfig().clusterMapDefaultPartitionClass;
     this.partitionState = PartitionState.valueOf(jsonObject.getString("partitionState"));
     this.replicaCapacityInBytes = jsonObject.getLong("replicaCapacityInBytes");
     this.replicas = new ArrayList<Replica>(jsonObject.getJSONArray("replicas").length());

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
@@ -359,7 +359,7 @@ public class MockHelixAdmin implements HelixAdmin {
 
   @Override
   public void setResourceIdealState(String clusterName, String resourceName, IdealState idealState) {
-    throw new IllegalStateException("Not implemented");
+    addResource(clusterName, resourceName, idealState);
   }
 
   @Override

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -45,8 +45,8 @@ public class MockHelixCluster {
     helixAdmins = helixAdminFactory.getAllHelixAdmins();
     this.partitionLayoutPath = partitionLayoutPath;
     this.zkLayoutPath = zkLayoutPath;
-    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        3, false, helixAdminFactory);
+    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName, 3,
+        false, false, helixAdminFactory);
     this.clusterName = clusterName;
   }
 
@@ -56,8 +56,8 @@ public class MockHelixCluster {
    * @throws Exception
    */
   void upgradeWithNewHardwareLayout(String hardwareLayoutPath) throws Exception {
-    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        3, false, helixAdminFactory);
+    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName, 3,
+        false, false, helixAdminFactory);
     for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
       helixAdmin.triggerInstanceConfigChangeNotification(false);
     }

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -163,8 +163,18 @@ public class HelixBootstrapUpgradeToolTest {
     Partition partition2 = (Partition) testPartitionLayout.getPartitionLayout()
         .getPartitions(null)
         .get(RANDOM.nextInt(testPartitionLayout.getPartitionCount()));
-    // Add a replica to partition1.
-    partition1.addReplica(new Replica(partition1, testHardwareLayout.getRandomDisk()));
+
+    // Add a new replica for partition1. Find a disk on a data node that does not already have a replica for partition1.
+    HashSet<DataNodeId> partition1Nodes = new HashSet<>();
+    for (Replica replica : partition1.getReplicas()) {
+      partition1Nodes.add(replica.getDataNodeId());
+    }
+    Disk diskForNewReplica;
+    do {
+      diskForNewReplica = testHardwareLayout.getRandomDisk();
+    } while (partition1Nodes.contains(diskForNewReplica.getDataNode()));
+
+    partition1.addReplica(new Replica(partition1, diskForNewReplica));
     // Remove a replica from partition2.
     partition2.getReplicas().remove(0);
     writeBootstrapOrUpgrade(expectedResourceCount, false);

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -94,7 +94,7 @@ public class HelixBootstrapUpgradeToolTest {
       Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
       try {
         HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-            CLUSTER_NAME_PREFIX, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, new HelixAdminFactory());
+            CLUSTER_NAME_PREFIX, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory());
         Assert.fail("Should have thrown IllegalArgumentException as a zk host is missing for one of the dcs");
       } catch (IllegalArgumentException e) {
         // OK
@@ -110,7 +110,7 @@ public class HelixBootstrapUpgradeToolTest {
     /* Test bootstrap */
     long expectedResourceCount =
         (testPartitionLayout.getPartitionLayout().getPartitionCount() - 1) / DEFAULT_MAX_PARTITIONS_PER_RESOURCE + 1;
-    writeBootstrapOrUpgrade(expectedResourceCount);
+    writeBootstrapOrUpgrade(expectedResourceCount, false);
 
     /* Test Simple Upgrade */
     int numNewNodes = 4;
@@ -118,7 +118,7 @@ public class HelixBootstrapUpgradeToolTest {
     testHardwareLayout.addNewDataNodes(numNewNodes);
     testPartitionLayout.addNewPartitions(numNewPartitions, DEFAULT_PARTITION_CLASS, PartitionState.READ_WRITE, null);
     expectedResourceCount += (numNewPartitions - 1) / DEFAULT_MAX_PARTITIONS_PER_RESOURCE + 1;
-    writeBootstrapOrUpgrade(expectedResourceCount);
+    writeBootstrapOrUpgrade(expectedResourceCount, false);
 
     /* Test sealed state update. */
     Set<Long> partitionIdsBeforeAddition = new HashSet<>();
@@ -143,7 +143,7 @@ public class HelixBootstrapUpgradeToolTest {
     }
 
     expectedResourceCount += (numNewPartitions - 1) / DEFAULT_MAX_PARTITIONS_PER_RESOURCE + 1;
-    writeBootstrapOrUpgrade(expectedResourceCount);
+    writeBootstrapOrUpgrade(expectedResourceCount, false);
 
     // Now, mark the ones that were READ_ONLY as READ_WRITE and vice versa
     for (PartitionId partitionId : testPartitionLayout.getPartitionLayout().getPartitions(null)) {
@@ -154,23 +154,48 @@ public class HelixBootstrapUpgradeToolTest {
         partition.partitionState = PartitionState.READ_ONLY;
       }
     }
-    writeBootstrapOrUpgrade(expectedResourceCount);
+    writeBootstrapOrUpgrade(expectedResourceCount, false);
+
+    // Now, change the replica count for a partition.
+    Partition partition1 = (Partition) testPartitionLayout.getPartitionLayout()
+        .getPartitions(null)
+        .get(RANDOM.nextInt(testPartitionLayout.getPartitionCount()));
+    Partition partition2 = (Partition) testPartitionLayout.getPartitionLayout()
+        .getPartitions(null)
+        .get(RANDOM.nextInt(testPartitionLayout.getPartitionCount()));
+    // Add a replica to partition1.
+    partition1.addReplica(new Replica(partition1, testHardwareLayout.getRandomDisk()));
+    // Remove a replica from partition2.
+    partition2.getReplicas().remove(0);
+    writeBootstrapOrUpgrade(expectedResourceCount, false);
+
+    long expectedResourceCountWithoutRemovals = expectedResourceCount;
+    /* Test instance, partition and resource removal */
+    // Use the initial static clustermap that does not have the upgrades.
+    testHardwareLayout = constructInitialHardwareLayoutJSON(CLUSTER_NAME_IN_STATIC_CLUSTER_MAP);
+    testPartitionLayout =
+        constructInitialPartitionLayoutJSON(testHardwareLayout, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, null);
+    long expectedResourceCountWithRemovals =
+        (testPartitionLayout.getPartitionLayout().getPartitionCount() - 1) / DEFAULT_MAX_PARTITIONS_PER_RESOURCE + 1;
+    writeBootstrapOrUpgrade(expectedResourceCountWithoutRemovals, false);
+    writeBootstrapOrUpgrade(expectedResourceCountWithRemovals, true);
   }
 
   /**
    * Write the layout files out from the constructed in-memory hardware and partition layouts; use the bootstrap tool
    * to update the contents in Helix; verify that the information is consistent between the two.
    * @param expectedResourceCount number of resources expected in Helix for this cluster in each datacenter.
+   * @param forceRemove whether the forceRemove option should be passed when doing the bootstrap/upgrade.
    * @throws IOException if a file read error is encountered.
    * @throws JSONException if a JSON parse error is encountered.
    */
-  private void writeBootstrapOrUpgrade(long expectedResourceCount) throws Exception {
+  private void writeBootstrapOrUpgrade(long expectedResourceCount, boolean forceRemove) throws Exception {
     Utils.writeJsonObjectToFile(zkJson, zkLayoutPath);
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
     // This updates and verifies that the information in Helix is consistent with the one in the static cluster map.
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-        CLUSTER_NAME_PREFIX, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, new HelixAdminFactory());
+        CLUSTER_NAME_PREFIX, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, forceRemove, new HelixAdminFactory());
     verifyResourceCount(testHardwareLayout.getHardwareLayout(), expectedResourceCount);
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry/account/ServiceIdAccountGenTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/account/ServiceIdAccountGenTool.java
@@ -23,6 +23,7 @@ import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.NonOptionArgumentSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -64,7 +65,9 @@ public class ServiceIdAccountGenTool {
       parser.printHelpOn(System.out);
       System.exit(0);
     }
-    ToolUtils.ensureOrExit(Arrays.asList(accountJsonFilePathOpt, firstAccountIdOpt, serviceIdsArg), options, parser);
+    ToolUtils.ensureOrExit(
+        Arrays.asList((OptionSpec) accountJsonFilePathOpt, (OptionSpec) firstAccountIdOpt, (OptionSpec) serviceIdsArg),
+        options, parser);
     generateAccounts((List<String>) options.nonOptionArguments(), options.valueOf(accountJsonFilePathOpt),
         options.valueOf(firstAccountIdOpt));
   }


### PR DESCRIPTION
- Add support for replica count changes for partitions.
- Add an option for force removals of instances and partitions.
- Add an option for validate-only.