### PR TITLE
Allowing for multiple values for the same key in IndexSegment

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
@@ -552,7 +552,7 @@ class BlobStoreCompactor {
     diskIOScheduler.getSlice(INDEX_SEGMENT_READ_JOB_NAME, INDEX_SEGMENT_READ_JOB_NAME, 1);
     // get all entries
     indexSegmentToCopy.getIndexEntriesSince(null, new FindEntriesCondition(Long.MAX_VALUE), allIndexEntries,
-        new AtomicLong(0));
+        new AtomicLong(0), true);
 
     // save a token for restart (the key gets ignored but is required to be non null for construction)
     StoreFindToken safeToken =

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreStats.java
@@ -416,7 +416,7 @@ class BlobStoreStats implements StoreStats, Closeable {
     List<IndexEntry> indexEntries = new ArrayList<>();
     try {
       indexSegment.getIndexEntriesSince(null, new FindEntriesCondition(Integer.MAX_VALUE), indexEntries,
-          new AtomicLong(0));
+          new AtomicLong(0), true);
       diskIOScheduler.getSlice(BlobStoreStats.IO_SCHEDULER_JOB_TYPE, BlobStoreStats.IO_SCHEDULER_JOB_ID,
           indexEntries.size());
     } catch (IOException e) {

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -203,7 +203,7 @@ public class HardDeleter implements Runnable {
         return;
       }
 
-        /* First create the readOptionsList */
+      /* First create the readOptionsList */
       List<BlobReadOptions> readOptionsList = hardDeleteRecoveryRange.getBlobReadOptionsList();
 
         /* Next, perform the log write. The token file does not have to be persisted again as only entries that are
@@ -334,7 +334,7 @@ public class HardDeleter implements Runnable {
    * This method will be called before the log is flushed.
    */
   void preLogFlush() {
-      /* Save the current start token before the log gets flushed */
+    /* Save the current start token before the log gets flushed */
     startTokenBeforeLogFlush = startToken;
   }
 
@@ -342,7 +342,7 @@ public class HardDeleter implements Runnable {
    * This method will be called after the log is flushed.
    */
   void postLogFlush() {
-      /* start token saved before the flush is now safe to be persisted */
+    /* start token saved before the flush is now safe to be persisted */
     startTokenSafeToPersist = startTokenBeforeLogFlush;
   }
 
@@ -556,7 +556,7 @@ public class HardDeleter implements Runnable {
       EnumSet<StoreGetOptions> getOptions = EnumSet.of(StoreGetOptions.Store_Include_Deleted);
       List<BlobReadOptions> readOptionsList = new ArrayList<BlobReadOptions>(messageInfoList.size());
 
-        /* First create the readOptionsList */
+      /* First create the readOptionsList */
       for (MessageInfo info : messageInfoList) {
         if (!enabled.get()) {
           throw new StoreException("Aborting, store is shutting down", StoreErrorCodes.Store_Shutting_Down);
@@ -577,8 +577,8 @@ public class HardDeleter implements Runnable {
       Iterator<HardDeleteInfo> hardDeleteIterator = hardDelete.getHardDeleteMessages(readSet, factory, null);
       Iterator<BlobReadOptions> readOptionsIterator = readOptionsList.iterator();
 
-        /* Next, get the information to persist hard delete recovery info. Get all the information and save it, as only
-         * after the whole range is persisted can we start with the actual log write */
+      /* Next, get the information to persist hard delete recovery info. Get all the information and save it, as only
+       * after the whole range is persisted can we start with the actual log write */
       while (hardDeleteIterator.hasNext()) {
         if (!enabled.get()) {
           throw new StoreException("Aborting hard deletes as store is shutting down",
@@ -604,7 +604,7 @@ public class HardDeleter implements Runnable {
 
       persistCleanupToken();
 
-        /* Finally, write the hard delete stream into the Log */
+      /* Finally, write the hard delete stream into the Log */
       for (LogWriteInfo logWriteInfo : logWriteInfoList) {
         if (!enabled.get()) {
           throw new StoreException("Aborting hard deletes as store is shutting down",

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -809,6 +809,14 @@ class IndexSegment {
             bloomFilter.add(ByteBuffer.wrap(key.toBytes()));
           }
           // add to the journal
+          long oMsgOff = blobValue.getOriginalMessageOffset();
+          if (oMsgOff != IndexValue.UNKNOWN_ORIGINAL_MESSAGE_OFFSET && offsetInLogSegment != oMsgOff
+              && oMsgOff >= startOffset.getOffset()
+              && journal.getKeyAtOffset(new Offset(startOffset.getName(), oMsgOff)) == null) {
+            // we add an entry for the original message offset if it is within the same index segment and
+            // an entry is not already in the journal
+            journal.addEntry(new Offset(startOffset.getName(), blobValue.getOriginalMessageOffset()), key);
+          }
           journal.addEntry(blobValue.getOffset(), key);
           // sizeWritten is only used for in-memory segments, and for those the padding does not come into picture.
           sizeWritten.addAndGet(key.sizeInBytes() + valueSize);

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -914,7 +914,7 @@ class IndexSegment {
         }
       } else {
         logger.error("IndexSegment : " + indexFile.getAbsolutePath() + " index not found for key " + key);
-        // TODO: metric here?
+        metrics.keyInFindEntriesAbsent.inc();
       }
     } else if (key == null || index.containsKey(key)) {
       ConcurrentNavigableMap<StoreKey, NavigableSet<IndexValue>> tempMap = index;
@@ -936,7 +936,7 @@ class IndexSegment {
       }
     } else {
       logger.error("IndexSegment : " + indexFile.getAbsolutePath() + " key not found: " + key);
-      // TODO: metric here?
+      metrics.keyInFindEntriesAbsent.inc();
     }
     if (oneEntryPerKey) {
       eliminateDuplicates(entriesLocal);

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -33,10 +33,17 @@ import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -99,7 +106,9 @@ class IndexSegment {
   private Offset prevSafeEndPoint = null;
   // reset key refers to the first StoreKey that is added to the index segment
   private Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey = null;
-  protected ConcurrentSkipListMap<StoreKey, IndexValue> index = null;
+  private ConcurrentSkipListMap<StoreKey, NavigableSet<IndexValue>> index = null;
+
+  static final Comparator<IndexValue> INDEX_VALUE_COMPARATOR = Comparator.comparing(IndexValue::getOffset);
 
   /**
    * Creates a new segment
@@ -183,7 +192,7 @@ class IndexSegment {
         }
         stream.close();
       } else {
-        index = new ConcurrentSkipListMap<StoreKey, IndexValue>();
+        index = new ConcurrentSkipListMap<>();
         bloomFilter = FilterFactory.getFilter(config.storeIndexMaxNumberOfInmemElements,
             config.storeIndexBloomMaxFalsePositiveProbability);
         bloomFile = new File(indexFile.getParent(), indexSegmentFilenamePrefix + BLOOM_FILE_NAME_SUFFIX);
@@ -312,16 +321,16 @@ class IndexSegment {
    * @return The blob index value that represents the key or null if not found
    * @throws StoreException
    */
-  IndexValue find(StoreKey keyToFind) throws StoreException {
-    IndexValue toReturn = null;
+  NavigableSet<IndexValue> find(StoreKey keyToFind) throws StoreException {
+    NavigableSet<IndexValue> toReturn = null;
     try {
       rwLock.readLock().lock();
       if (!mapped.get()) {
-        IndexValue value = index.get(keyToFind);
-        if (value != null) {
+        NavigableSet<IndexValue> values = index.get(keyToFind);
+        if (values != null) {
           metrics.blobFoundInActiveSegmentCount.inc();
         }
-        toReturn = value;
+        toReturn = values;
       } else {
         if (bloomFilter != null) {
           metrics.bloomAccessedCount.inc();
@@ -338,7 +347,8 @@ class IndexSegment {
           // binary search on the mapped file
           ByteBuffer duplicate = mmap.duplicate();
           int low = 0;
-          int high = numberOfEntries(duplicate) - 1;
+          int totalEntries = numberOfEntries(duplicate);
+          int high = totalEntries - 1;
           logger.trace("binary search low : {} high : {}", low, high);
           while (low <= high) {
             int mid = (int) (Math.ceil(high / 2.0 + low / 2.0));
@@ -347,9 +357,8 @@ class IndexSegment {
                 found);
             int result = found.compareTo(keyToFind);
             if (result == 0) {
-              byte[] buf = new byte[valueSize];
-              duplicate.get(buf);
-              toReturn = new IndexValue(startOffset.getName(), ByteBuffer.wrap(buf), getVersion());
+              toReturn = new TreeSet<>(INDEX_VALUE_COMPARATOR);
+              getAllValuesFromMmap(duplicate, keyToFind, mid, totalEntries, toReturn);
               break;
             } else if (result < 0) {
               low = mid + 1;
@@ -369,6 +378,52 @@ class IndexSegment {
       rwLock.readLock().unlock();
     }
     return toReturn;
+  }
+
+  /**
+   * Gets values for all matches for {@code keyToFind} at and in the vicinity of {@code positiveMatchInd}.
+   * @param mmap the mmap to read values off of
+   * @param keyToFind the needle {@link StoreKey}
+   * @param positiveMatchInd the index of a confirmed positive match
+   * @param totalEntries the total number of entries in the index
+   * @param values the set to which the {@link IndexValue}s will be added
+   * @return a pair consisting of the lowest index that matched the key and the highest
+   * @throws IOException if there are problems reading from the mmap
+   */
+  private Pair<Integer, Integer> getAllValuesFromMmap(ByteBuffer mmap, StoreKey keyToFind, int positiveMatchInd,
+      int totalEntries, NavigableSet<IndexValue> values) throws IOException {
+    byte[] buf = new byte[valueSize];
+    // add the value at the positive match and anything after that matches
+    int end = positiveMatchInd;
+    StoreKey found;
+    do {
+      mmap.get(buf);
+      values.add(new IndexValue(startOffset.getName(), ByteBuffer.wrap(buf), getVersion()));
+      end++;
+      if (end < totalEntries) {
+        found = getKeyAt(mmap, end);
+        logger.trace("Index Segment {}: found {} at {}", indexFile.getAbsolutePath(), found, end);
+      } else {
+        break;
+      }
+    } while (found.equals(keyToFind));
+    end--;
+
+    // add any values before the match
+    int start = positiveMatchInd;
+    while (start > 0) {
+      found = getKeyAt(mmap, --start);
+      logger.trace("Index Segment {}: found {} at {}", indexFile.getAbsolutePath(), found, start);
+      if (found.equals(keyToFind)) {
+        mmap.get(buf);
+        values.add(new IndexValue(startOffset.getName(), ByteBuffer.wrap(buf), getVersion()));
+      } else {
+        // we have reached the end of the matches
+        start++;
+        break;
+      }
+    }
+    return new Pair<>(start, end);
   }
 
   private int numberOfEntries(ByteBuffer mmap) {
@@ -418,16 +473,19 @@ class IndexSegment {
               + "originalMessageOffset {} fileEndOffset {}", indexFile.getAbsolutePath(), entry.getKey(),
           entry.getValue().getOffset(), entry.getValue().getSize(), entry.getValue().getExpiresAtMs(),
           entry.getValue().getOriginalMessageOffset(), fileEndOffset);
-      if (index.put(entry.getKey(), entry.getValue()) == null) {
-        numberOfItems.incrementAndGet();
-        sizeWritten.addAndGet(entry.getKey().sizeInBytes() + entry.getValue().getBytes().capacity());
+      boolean isPresent = index.containsKey(entry.getKey());
+      index.computeIfAbsent(entry.getKey(), key -> new ConcurrentSkipListSet<>(INDEX_VALUE_COMPARATOR))
+          .add(entry.getValue());
+      if (!isPresent) {
         bloomFilter.add(ByteBuffer.wrap(entry.getKey().toBytes()));
-        if (resetKey == null) {
-          resetKey = new Pair<>(entry.getKey(),
-              entry.getValue().isFlagSet(IndexValue.Flags.Delete_Index) ? PersistentIndex.IndexEntryType.DELETE
-                  : PersistentIndex.IndexEntryType.PUT);
-        }
       }
+      if (resetKey == null) {
+        resetKey = new Pair<>(entry.getKey(),
+            entry.getValue().isFlagSet(IndexValue.Flags.Delete_Index) ? PersistentIndex.IndexEntryType.DELETE
+                : PersistentIndex.IndexEntryType.PUT);
+      }
+      numberOfItems.incrementAndGet();
+      sizeWritten.addAndGet(entry.getKey().sizeInBytes() + entry.getValue().getBytes().capacity());
       endOffset.set(fileEndOffset);
       long operationTimeInMs = entry.getValue().getOperationTimeInMs();
       if (operationTimeInMs == Utils.Infinite_Time) {
@@ -584,36 +642,22 @@ class IndexSegment {
           writer.writeShort(resetKey.getSecond().ordinal());
         }
 
-        // NOTE: In the event of a crash, it is possible that there is a part of the log that is not covered by the
-        // index. This happens due to the fact that a DELETE that occurs in the same segment as a PUT overwrites the
-        // PUT entry. Consider the following case:-
-        // (entries are of the form ID:TYPE:START_OFFSET-END_OFFSET)
-        // This is the order of operations
-        // A:PUT:0-100
-        // B:PUT:101-200
-        // A:DELETE:201-250
-        // These are the entries in the index segment
-        // A:DELETE:201-250
-        // B:PUT:101-200
-        // If safeEndPoint < 250, then B:PUT:101-200 will be written but not A:DELETE:201-250. If the process were to
-        // crash at this point, the index end offset would be 200 and the span 0-100 would not be represented in the
-        // index.
-        // write the entries
         byte[] maxPaddingBytes = null;
         if (getVersion() == PersistentIndex.VERSION_2) {
           maxPaddingBytes = new byte[persistedEntrySize - valueSize];
         }
-        for (Map.Entry<StoreKey, IndexValue> entry : index.entrySet()) {
-          if (entry.getValue().getOffset().getOffset() + entry.getValue().getSize() <= safeEndPoint.getOffset()) {
-            writer.write(entry.getKey().toBytes());
-            writer.write(entry.getValue().getBytes().array());
-            if (getVersion() == PersistentIndex.VERSION_2) {
-              // Add padding if necessary
-              writer.write(maxPaddingBytes, 0, persistedEntrySize - (entry.getKey().sizeInBytes() + valueSize));
+        for (Map.Entry<StoreKey, NavigableSet<IndexValue>> entry : index.entrySet()) {
+          for (IndexValue value : entry.getValue()) {
+            if (value.getOffset().getOffset() + value.getSize() <= safeEndPoint.getOffset()) {
+              writer.write(entry.getKey().toBytes());
+              writer.write(value.getBytes().array());
+              if (getVersion() == PersistentIndex.VERSION_2) {
+                // Add padding if necessary
+                writer.write(maxPaddingBytes, 0, persistedEntrySize - (entry.getKey().sizeInBytes() + valueSize));
+              }
+              logger.trace("IndexSegment : {} writing key - {} value - offset {} size {} fileEndOffset {}",
+                  getFile().getAbsolutePath(), entry.getKey(), value.getOffset(), value.getSize(), safeEndPoint);
             }
-            logger.trace("IndexSegment : {} writing key - {} value - offset {} size {} fileEndOffset {}",
-                getFile().getAbsolutePath(), entry.getKey(), entry.getValue().getOffset(), entry.getValue().getSize(),
-                safeEndPoint);
           }
         }
         prevSafeEndPoint = safeEndPoint;
@@ -770,18 +814,15 @@ class IndexSegment {
         long offsetInLogSegment = blobValue.getOffset().getOffset();
         // ignore entries that have offsets outside the log end offset that this index represents
         if (offsetInLogSegment + blobValue.getSize() <= logEndOffset) {
-          index.put(key, blobValue);
+          boolean isPresent = index.containsKey(key);
+          index.computeIfAbsent(key, k -> new ConcurrentSkipListSet<>(INDEX_VALUE_COMPARATOR)).add(blobValue);
           logger.trace("IndexSegment : {} putting key {} in index offset {} size {}", indexFile.getAbsolutePath(), key,
               blobValue.getOffset(), blobValue.getSize());
           // regenerate the bloom filter for in memory indexes
-          bloomFilter.add(ByteBuffer.wrap(key.toBytes()));
-          // add to the journal
-          if (blobValue.getOriginalMessageOffset() != IndexValue.UNKNOWN_ORIGINAL_MESSAGE_OFFSET
-              && offsetInLogSegment != blobValue.getOriginalMessageOffset()
-              && blobValue.getOriginalMessageOffset() >= startOffset.getOffset()) {
-            // we add an entry for the original message offset if it is within the same index segment
-            journal.addEntry(new Offset(startOffset.getName(), blobValue.getOriginalMessageOffset()), key);
+          if (!isPresent) {
+            bloomFilter.add(ByteBuffer.wrap(key.toBytes()));
           }
+          // add to the journal
           journal.addEntry(blobValue.getOffset(), key);
           // sizeWritten is only used for in-memory segments, and for those the padding does not come into picture.
           sizeWritten.addAndGet(key.sizeInBytes() + valueSize);
@@ -832,8 +873,8 @@ class IndexSegment {
   boolean getEntriesSince(StoreKey key, FindEntriesCondition findEntriesCondition, List<MessageInfo> entries,
       AtomicLong currentTotalSizeOfEntriesInBytes) throws IOException {
     List<IndexEntry> indexEntries = new ArrayList<>();
-    boolean isNewEntriesAdded =
-        getIndexEntriesSince(key, findEntriesCondition, indexEntries, currentTotalSizeOfEntriesInBytes);
+    boolean areNewEntriesAdded =
+        getIndexEntriesSince(key, findEntriesCondition, indexEntries, currentTotalSizeOfEntriesInBytes, true);
     for (IndexEntry indexEntry : indexEntries) {
       IndexValue value = indexEntry.getValue();
       MessageInfo info =
@@ -841,7 +882,7 @@ class IndexSegment {
               value.getExpiresAtMs(), value.getAccountId(), value.getContainerId(), value.getOperationTimeInMs());
       entries.add(info);
     }
-    return isNewEntriesAdded;
+    return areNewEntriesAdded;
   }
 
   /**
@@ -852,15 +893,17 @@ class IndexSegment {
    * @param findEntriesCondition The condition that determines when to stop fetching entries.
    * @param entries The input entries list that needs to be filled. The entries list can have existing entries
    * @param currentTotalSizeOfEntriesInBytes The current total size in bytes of the entries
+   * @param oneEntryPerKey
    * @return true if any entries were added.
    * @throws IOException
    */
   boolean getIndexEntriesSince(StoreKey key, FindEntriesCondition findEntriesCondition, List<IndexEntry> entries,
-      AtomicLong currentTotalSizeOfEntriesInBytes) throws IOException {
+      AtomicLong currentTotalSizeOfEntriesInBytes, boolean oneEntryPerKey) throws IOException {
     if (!findEntriesCondition.proceed(currentTotalSizeOfEntriesInBytes.get(), getLastModifiedTimeSecs())) {
       return false;
     }
-    int entriesSizeAtStart = entries.size();
+    NavigableSet<IndexValue> values = new TreeSet<>(INDEX_VALUE_COMPARATOR);
+    List<IndexEntry> entriesLocal = new ArrayList<>();
     if (mapped.get()) {
       int index = 0;
       if (key != null) {
@@ -872,29 +915,34 @@ class IndexSegment {
         while (findEntriesCondition.proceed(currentTotalSizeOfEntriesInBytes.get(), getLastModifiedTimeSecs())
             && index < totalEntries) {
           StoreKey newKey = getKeyAt(readBuf, index);
-          byte[] buf = new byte[valueSize];
-          readBuf.get(buf);
           // we include the key in the final list if it is not the initial key or if the initial key was null
           if (key == null || newKey.compareTo(key) != 0) {
-            IndexValue newValue = new IndexValue(startOffset.getName(), ByteBuffer.wrap(buf), getVersion());
-            entries.add(new IndexEntry(newKey, newValue));
-            currentTotalSizeOfEntriesInBytes.addAndGet(newValue.getSize());
+            values.clear();
+            index = getAllValuesFromMmap(readBuf, newKey, index, totalEntries, values).getSecond();
+            for (IndexValue value : values) {
+              entriesLocal.add(new IndexEntry(newKey, value));
+              currentTotalSizeOfEntriesInBytes.addAndGet(value.getSize());
+            }
           }
           index++;
         }
       } else {
         logger.error("IndexSegment : " + indexFile.getAbsolutePath() + " index not found for key " + key);
+        // TODO: metric here?
       }
     } else if (key == null || index.containsKey(key)) {
-      ConcurrentNavigableMap<StoreKey, IndexValue> tempMap = index;
+      ConcurrentNavigableMap<StoreKey, NavigableSet<IndexValue>> tempMap = index;
       if (key != null) {
         tempMap = index.tailMap(key, true);
       }
-      for (Map.Entry<StoreKey, IndexValue> entry : tempMap.entrySet()) {
+      for (Map.Entry<StoreKey, NavigableSet<IndexValue>> entry : tempMap.entrySet()) {
         if (key == null || entry.getKey().compareTo(key) != 0) {
-          IndexValue newValue = new IndexValue(startOffset.getName(), entry.getValue().getBytes(), getVersion());
-          entries.add(new IndexEntry(entry.getKey(), newValue));
-          currentTotalSizeOfEntriesInBytes.addAndGet(entry.getValue().getSize());
+          for (IndexValue value : entry.getValue()) {
+            IndexValue newValue = new IndexValue(startOffset.getName(), value.getBytes(), getVersion());
+            entriesLocal.add(new IndexEntry(entry.getKey(), newValue));
+            currentTotalSizeOfEntriesInBytes.addAndGet(value.getSize());
+          }
+          // will break if size exceeded only after processing ALL entries for a key
           if (!findEntriesCondition.proceed(currentTotalSizeOfEntriesInBytes.get(), getLastModifiedTimeSecs())) {
             break;
           }
@@ -902,8 +950,30 @@ class IndexSegment {
       }
     } else {
       logger.error("IndexSegment : " + indexFile.getAbsolutePath() + " key not found: " + key);
+      // TODO: metric here?
     }
-    return entries.size() > entriesSizeAtStart;
+    if (oneEntryPerKey) {
+      eliminateDuplicates(entriesLocal);
+    }
+    entries.addAll(entriesLocal);
+    return entriesLocal.size() > 0;
+  }
+
+  /**
+   * Eliminates duplicates in {@code entries}
+   * @param entries the entries to eliminate duplicates from.
+   */
+  private void eliminateDuplicates(List<IndexEntry> entries) {
+    Set<StoreKey> setToFindDuplicate = new HashSet<StoreKey>();
+    ListIterator<IndexEntry> iterator = entries.listIterator(entries.size());
+    while (iterator.hasPrevious()) {
+      IndexEntry entry = iterator.previous();
+      if (setToFindDuplicate.contains(entry.getKey())) {
+        iterator.remove();
+      } else {
+        setToFindDuplicate.add(entry.getKey());
+      }
+    }
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -887,7 +887,8 @@ class IndexSegment {
    * @param findEntriesCondition The condition that determines when to stop fetching entries.
    * @param entries The input entries list that needs to be filled. The entries list can have existing entries
    * @param currentTotalSizeOfEntriesInBytes The current total size in bytes of the entries
-   * @param oneEntryPerKey
+   * @param oneEntryPerKey returns only one index entry per key even if the segment has multiple values for the key.
+   *                       Favors DELETE records over all other records. Favors PUT over a TTL update record.
    * @return true if any entries were added.
    * @throws IOException
    */

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexValue.java
@@ -40,7 +40,8 @@ import static com.github.ambry.account.Container.*;
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  *
  */
-class IndexValue {
+class IndexValue implements Comparable<IndexValue> {
+
   enum Flags {
     Delete_Index
   }
@@ -316,5 +317,18 @@ class IndexValue {
         + ", ExpiresAtMs: " + getExpiresAtMs() + ", Original Message Offset: " + getOriginalMessageOffset() + (
         version != PersistentIndex.VERSION_0 ? (", OperationTimeAtSecs " + getOperationTimeInMs() + ", AccountId "
             + getAccountId() + ", ContainerId " + getContainerId()) : "");
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p/>
+   * Compares by {@link Offset}.
+   * @param o the {@link IndexValue} to compare to.
+   * @return a negative integer, zero, or a positive integer as the offset of this {@link IndexValue} is less than,
+   * equal to, or greater than the offset of {@code o}.
+   */
+  @Override
+  public int compareTo(IndexValue o) {
+    return offset.compareTo(o.offset);
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/Journal.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Journal.java
@@ -177,4 +177,13 @@ class Journal {
   Long getCrcOfKey(StoreKey key) {
     return recentCrcs.get(key);
   }
+
+  /**
+   * @param offset the offset of the record whose key is needed
+   * @return the {@link StoreKey} of the record at {@code offset}. {@code null} if the journal is not tracking that
+   * offset
+   */
+  StoreKey getKeyAtOffset(Offset offset) {
+    return journal.get(offset);
+  }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -67,6 +67,7 @@ public class StoreMetrics {
   public final Counter identicalPutAttemptCount;
   public final Counter getAuthorizationFailureCount;
   public final Counter deleteAuthorizationFailureCount;
+  public final Counter keyInFindEntriesAbsent;
 
   // Compaction related metrics
   public final Counter compactionFixStateCount;
@@ -146,6 +147,7 @@ public class StoreMetrics {
         registry.counter(MetricRegistry.name(BlobStore.class, name + "GetAuthorizationFailureCount"));
     deleteAuthorizationFailureCount =
         registry.counter(MetricRegistry.name(BlobStore.class, name + "DeleteAuthorizationFailureCount"));
+    keyInFindEntriesAbsent = registry.counter(MetricRegistry.name(BlobStore.class, name + "KeyInFindEntriesAbsent"));
     compactionFixStateCount = registry.counter(MetricRegistry.name(BlobStoreCompactor.class, name + "FixStateCount"));
     compactionCopyRateInBytes = registry.meter(MetricRegistry.name(BlobStoreCompactor.class, name + "CopyRateInBytes"));
     compactionBytesReclaimedCount =

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Random;
-import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -279,8 +278,9 @@ public class BlobStoreStatsTest {
   public void testValidDataSizeAfterDeletes() throws InterruptedException, StoreException, IOException {
     assumeTrue(!bucketingEnabled);
     BlobStoreStats blobStoreStats = setupBlobStoreStats(0, 0);
-    int numEntries = CuratedLogIndexState.MAX_IN_MEM_ELEMENTS - state.referenceIndex.lastEntry().getValue().size()
-        + CuratedLogIndexState.MAX_IN_MEM_ELEMENTS - 2;
+    int numEntries =
+        state.getMaxInMemElements() - state.referenceIndex.lastEntry().getValue().size() + state.getMaxInMemElements()
+            - 2;
     state.addPutEntries(numEntries, CuratedLogIndexState.PUT_RECORD_SIZE, Utils.Infinite_Time);
 
     long timeInMsBeforeDeletes = state.time.milliseconds();
@@ -958,9 +958,9 @@ public class BlobStoreStatsTest {
    */
   private Map<String, Map<String, Long>> getValidSizeByContainer(long deleteAndExpirationRefTimeInMs) {
     Map<String, Map<String, Long>> containerValidSizeMap = new HashMap<>();
-    for (Map.Entry<Offset, TreeMap<MockId, IndexValue>> segmentEntry : state.referenceIndex.entrySet()) {
+    for (Offset indSegStartOffset : state.referenceIndex.keySet()) {
       List<IndexEntry> validEntries =
-          state.getValidIndexEntriesForIndexSegment(segmentEntry.getKey(), deleteAndExpirationRefTimeInMs,
+          state.getValidIndexEntriesForIndexSegment(indSegStartOffset, deleteAndExpirationRefTimeInMs,
               deleteAndExpirationRefTimeInMs);
       for (IndexEntry indexEntry : validEntries) {
         IndexValue indexValue = indexEntry.getValue();

--- a/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
@@ -869,10 +869,6 @@ class CuratedLogIndexState {
           realIndexEntry.getKey());
       TreeMap<MockId, TreeSet<IndexValue>> referenceIndexSegment = referenceIndexEntry.getValue();
       IndexSegment realIndexSegment = realIndexEntry.getValue();
-      List<MessageInfo> messageInfos = new ArrayList<>();
-      assertTrue("There should have been entries returned from the index segment",
-          realIndexSegment.getEntriesSince(null, new FindEntriesCondition(Long.MAX_VALUE), messageInfos,
-              new AtomicLong(0)));
       for (Map.Entry<MockId, TreeSet<IndexValue>> referenceIndexSegmentEntry : referenceIndexSegment.entrySet()) {
         MockId id = referenceIndexSegmentEntry.getKey();
         NavigableSet<IndexValue> referenceValues = referenceIndexSegmentEntry.getValue();

--- a/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
@@ -233,9 +233,7 @@ class CuratedLogIndexState {
       logOrder.put(fileSpan.getStartOffset(), new Pair<>(id, new LogEntry(dataWritten, value)));
       indexSegmentStartOffsets.put(id, new Pair<Offset, Offset>(indexSegmentStartOffset, null));
       allKeys.put(id, new Pair<IndexValue, IndexValue>(value, null));
-      referenceIndex.get(indexSegmentStartOffset)
-          .computeIfAbsent(id, k -> new TreeSet<>(IndexSegment.INDEX_VALUE_COMPARATOR))
-          .add(value);
+      referenceIndex.get(indexSegmentStartOffset).computeIfAbsent(id, k -> new TreeSet<>()).add(value);
       if (expiresAtMs != Utils.Infinite_Time && expiresAtMs < time.milliseconds()) {
         expiredKeys.add(id);
       } else {
@@ -307,9 +305,7 @@ class CuratedLogIndexState {
     indexSegmentStartOffsets.put(idToDelete, new Pair<>(keyLocations.getFirst(), indexSegmentStartOffset));
     Pair<IndexValue, IndexValue> keyValues = allKeys.get(idToDelete);
     allKeys.put(idToDelete, new Pair<>(keyValues.getFirst(), newValue));
-    referenceIndex.get(indexSegmentStartOffset)
-        .computeIfAbsent(idToDelete, k -> new TreeSet<>(IndexSegment.INDEX_VALUE_COMPARATOR))
-        .add(newValue);
+    referenceIndex.get(indexSegmentStartOffset).computeIfAbsent(idToDelete, k -> new TreeSet<>()).add(newValue);
     endOffsetOfPrevMsg = fileSpan.getEndOffset();
     if (forcePut) {
       index.addToIndex(new IndexEntry(idToDelete, newValue), fileSpan);

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -36,6 +37,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.After;
 import org.junit.Test;
@@ -56,7 +58,7 @@ public class IndexSegmentTest {
   private static final int LARGER_KEY_SIZE =
       new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE + CUSTOM_ID_SIZE / 2)).sizeInBytes();
   private static final StoreConfig STORE_CONFIG = new StoreConfig(new VerifiableProperties(new Properties()));
-  private static final Time time = new MockTime();
+  private static final MockTime time = new MockTime();
   private static final long DELETE_FILE_SPAN_SIZE = 10;
   private static final StoreKeyFactory STORE_KEY_FACTORY;
 
@@ -129,32 +131,40 @@ public class IndexSegmentTest {
     String prevLogSegmentName = LogSegmentNameHelper.getName(0, 0);
     String logSegmentName = LogSegmentNameHelper.getNextPositionName(prevLogSegmentName);
     Offset startOffset = new Offset(logSegmentName, 0);
-    MockId id1 = new MockId("id1");
-    MockId id2 = new MockId("id2");
-    MockId id3 = new MockId("id3");
-    short serviceId = Utils.getRandomShort(TestUtils.RANDOM);
+    MockId id1 = new MockId("0" + UtilsTest.getRandomString(CUSTOM_ID_SIZE - 1));
+    MockId id2 = new MockId("1" + UtilsTest.getRandomString(CUSTOM_ID_SIZE - 1));
+    MockId id3 = new MockId("2" + UtilsTest.getRandomString(CUSTOM_ID_SIZE - 1));
+    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     IndexValue value1 =
         IndexValueTest.getIndexValue(1000, new Offset(logSegmentName, 0), Utils.Infinite_Time, time.milliseconds(),
-            serviceId, containerId, version);
+            accountId, containerId, version);
     IndexValue value2 =
         IndexValueTest.getIndexValue(1000, new Offset(logSegmentName, 1000), Utils.Infinite_Time, time.milliseconds(),
-            serviceId, containerId, version);
+            accountId, containerId, version);
     IndexValue value3 =
         IndexValueTest.getIndexValue(1000, new Offset(logSegmentName, 2000), Utils.Infinite_Time, time.milliseconds(),
-            serviceId, containerId, version);
+            accountId, containerId, version);
+    time.sleep(TimeUnit.SECONDS.toMillis(1));
+    // generate a DELETE
+    IndexValue delValue2 =
+        IndexValueTest.getIndexValue(value2.getSize(), value2.getOffset(), value2.getExpiresAtMs(), time.milliseconds(),
+            value2.getAccountId(), value2.getContainerId(), version);
+    delValue2.setNewOffset(new Offset(logSegmentName, 3000));
+    delValue2.setNewSize(100);
+    delValue2.setFlag(IndexValue.Flags.Delete_Index);
     IndexSegment indexSegment = generateIndexSegment(startOffset);
     // inserting in the opposite order by design to ensure that writes are based on offset ordering and not key ordering
     indexSegment.addEntry(new IndexEntry(id3, value1), new Offset(logSegmentName, 1000));
     indexSegment.addEntry(new IndexEntry(id2, value2), new Offset(logSegmentName, 2000));
     indexSegment.addEntry(new IndexEntry(id1, value3), new Offset(logSegmentName, 3000));
+    indexSegment.addEntry(new IndexEntry(id2, delValue2), new Offset(logSegmentName, 3100));
 
-    // provide end offset such that nothing is written
-    indexSegment.writeIndexSegmentToFile(new Offset(prevLogSegmentName, 0));
-    assertFalse("Index file should not have been created", indexSegment.getFile().exists());
-    // provide end offset such that nothing is written
-    indexSegment.writeIndexSegmentToFile(new Offset(prevLogSegmentName, indexSegment.getStartOffset().getOffset()));
-    assertFalse("Index file should not have been created", indexSegment.getFile().exists());
+    // provide end offsets such that nothing is written
+    checkNonCreationOfIndexSegmentFile(indexSegment, new Offset(prevLogSegmentName, 0));
+    checkNonCreationOfIndexSegmentFile(indexSegment,
+        new Offset(prevLogSegmentName, indexSegment.getStartOffset().getOffset()));
+    checkNonCreationOfIndexSegmentFile(indexSegment, new Offset(logSegmentName, 0));
     List<MockId> shouldBeFound = new ArrayList<>();
     List<MockId> shouldNotBeFound = new ArrayList<>(Arrays.asList(id3, id2, id1));
     for (int safeEndPoint = 1000; safeEndPoint <= 3000; safeEndPoint += 1000) {
@@ -165,12 +175,124 @@ public class IndexSegmentTest {
         Journal journal = new Journal(tempDir.getAbsolutePath(), 3, 3);
         IndexSegment fromDisk =
             new IndexSegment(indexSegment.getFile(), false, STORE_KEY_FACTORY, STORE_CONFIG, metrics, journal, time);
+        assertEquals("Number of items incorrect", shouldBeFound.size(), fromDisk.getNumberOfItems());
         for (MockId id : shouldBeFound) {
-          assertNotNull("Value for key should have been found", fromDisk.find(id));
+          verifyValues(fromDisk, id, 1, false);
         }
         for (MockId id : shouldNotBeFound) {
-          assertNull("Value for key should not have been found", fromDisk.find(id));
+          assertNull("Values for key should not have been found", fromDisk.find(id));
         }
+      }
+    }
+    // now persist the delete too
+    indexSegment.writeIndexSegmentToFile(new Offset(logSegmentName, 3100));
+    Journal journal = new Journal(tempDir.getAbsolutePath(), 3, 3);
+    IndexSegment fromDisk =
+        new IndexSegment(indexSegment.getFile(), false, STORE_KEY_FACTORY, STORE_CONFIG, metrics, journal, time);
+    //assertEquals("Number of items incorrect", 4, fromDisk.getNumberOfItems());
+    for (MockId id : new MockId[]{id1, id2, id3}) {
+      verifyValues(fromDisk, id, id.equals(id2) ? 2 : 1, id.equals(id2));
+    }
+  }
+
+  /**
+   * Tests some corner cases with
+   * {@link IndexSegment#getIndexEntriesSince(StoreKey, FindEntriesCondition, List, AtomicLong, boolean)}
+   * - tests that all values of a key are returned even if the find entries condition max size expires when the first
+   * value is loaded
+   * @throws StoreException
+   */
+  @Test
+  public void getIndexEntriesCornerCasesTest() throws IOException, StoreException {
+    String logSegmentName = LogSegmentNameHelper.getName(0, 0);
+    MockId id1 = new MockId("0" + UtilsTest.getRandomString(CUSTOM_ID_SIZE - 1));
+    MockId id2 = new MockId("1" + UtilsTest.getRandomString(CUSTOM_ID_SIZE - 1));
+    MockId id3 = new MockId("2" + UtilsTest.getRandomString(CUSTOM_ID_SIZE - 1));
+    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+    short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+    IndexValue value1 =
+        IndexValueTest.getIndexValue(1000, new Offset(logSegmentName, 0), Utils.Infinite_Time, time.milliseconds(),
+            accountId, containerId, version);
+    IndexValue value2 =
+        IndexValueTest.getIndexValue(1000, new Offset(logSegmentName, 1000), Utils.Infinite_Time, time.milliseconds(),
+            accountId, containerId, version);
+    IndexValue value3 =
+        IndexValueTest.getIndexValue(1000, new Offset(logSegmentName, 2000), Utils.Infinite_Time, time.milliseconds(),
+            accountId, containerId, version);
+    time.sleep(TimeUnit.SECONDS.toMillis(1));
+    // generate a DELETE
+    IndexValue delValue2 =
+        IndexValueTest.getIndexValue(value2.getSize(), value2.getOffset(), value2.getExpiresAtMs(), time.milliseconds(),
+            value2.getAccountId(), value2.getContainerId(), version);
+    delValue2.setNewOffset(new Offset(logSegmentName, 3000));
+    delValue2.setNewSize(100);
+    delValue2.setFlag(IndexValue.Flags.Delete_Index);
+    IndexSegment indexSegment = generateIndexSegment(new Offset(logSegmentName, 0));
+    // inserting in the opposite order by design to ensure that writes are based on offset ordering and not key ordering
+    indexSegment.addEntry(new IndexEntry(id3, value1), new Offset(logSegmentName, 1000));
+    indexSegment.addEntry(new IndexEntry(id2, value2), new Offset(logSegmentName, 2000));
+    indexSegment.addEntry(new IndexEntry(id1, value3), new Offset(logSegmentName, 3000));
+    indexSegment.addEntry(new IndexEntry(id2, delValue2), new Offset(logSegmentName, 3100));
+
+    indexSegment.writeIndexSegmentToFile(new Offset(logSegmentName, 3100));
+    indexSegment.map(true);
+    List<IndexEntry> entries = new ArrayList<>();
+    for (boolean map : new boolean[]{false, true}) {
+      Journal journal = new Journal(tempDir.getAbsolutePath(), 3, 3);
+      IndexSegment fromDisk =
+          new IndexSegment(indexSegment.getFile(), map, STORE_KEY_FACTORY, STORE_CONFIG, metrics, journal, time);
+      // getIndexEntriesSince with maxSize = 0 should not return anything
+      FindEntriesCondition condition = new FindEntriesCondition(0);
+      assertFalse("getIndexEntriesSince() should not return anything",
+          fromDisk.getIndexEntriesSince(null, condition, entries, new AtomicLong(0), false));
+      assertEquals("There should be no entries returned", 0, entries.size());
+      // getIndexEntriesSince with maxSize <= 1000 should return only the first key (id1)
+      condition = new FindEntriesCondition(1000);
+      assertTrue("getIndexEntriesSince() should return one entry",
+          fromDisk.getIndexEntriesSince(null, condition, entries, new AtomicLong(0), false));
+      assertEquals("There should be one entry returned", 1, entries.size());
+      assertEquals("Key in entry is incorrect", id1, entries.get(0).getKey());
+      assertEquals("Value in entry is incorrect", value3.getBytes(), entries.get(0).getValue().getBytes());
+      entries.clear();
+      // getIndexEntriesSince with maxSize > 1000 and <= 2100 should return three entries
+      for (int maxSize : new int[]{1001, 2100}) {
+        condition = new FindEntriesCondition(maxSize);
+        assertTrue("getIndexEntriesSince() should return entries",
+            fromDisk.getIndexEntriesSince(null, condition, entries, new AtomicLong(0), false));
+        assertEquals("There should be three entries returned", 3, entries.size());
+        assertEquals("Key in entry is incorrect", id1, entries.get(0).getKey());
+        assertEquals("Value in entry is incorrect", value3.getBytes(), entries.get(0).getValue().getBytes());
+        assertEquals("Key in entry is incorrect", id2, entries.get(1).getKey());
+        assertEquals("Value in entry is incorrect", value2.getBytes(), entries.get(1).getValue().getBytes());
+        assertEquals("Key in entry is incorrect", id2, entries.get(2).getKey());
+        assertEquals("Value in entry is incorrect", delValue2.getBytes(), entries.get(2).getValue().getBytes());
+        entries.clear();
+      }
+      // getIndexEntriesSince with maxSize > 2100 should return four entries
+      condition = new FindEntriesCondition(2101);
+      assertTrue("getIndexEntriesSince() should return entries",
+          fromDisk.getIndexEntriesSince(null, condition, entries, new AtomicLong(0), false));
+      assertEquals("There should be four entries returned", 4, entries.size());
+      assertEquals("Key in entry is incorrect", id1, entries.get(0).getKey());
+      assertEquals("Value in entry is incorrect", value3.getBytes(), entries.get(0).getValue().getBytes());
+      assertEquals("Key in entry is incorrect", id2, entries.get(1).getKey());
+      assertEquals("Value in entry is incorrect", value2.getBytes(), entries.get(1).getValue().getBytes());
+      assertEquals("Key in entry is incorrect", id2, entries.get(2).getKey());
+      assertEquals("Value in entry is incorrect", delValue2.getBytes(), entries.get(2).getValue().getBytes());
+      assertEquals("Key in entry is incorrect", id3, entries.get(3).getKey());
+      assertEquals("Value in entry is incorrect", value1.getBytes(), entries.get(3).getValue().getBytes());
+      entries.clear();
+      // getIndexEntriesSince with maxSize > 0 and <= 1100 should return two entries
+      for (int maxSize : new int[]{1, 1100}) {
+        condition = new FindEntriesCondition(maxSize);
+        assertTrue("getIndexEntriesSince() should return entries",
+            fromDisk.getIndexEntriesSince(id1, condition, entries, new AtomicLong(0), false));
+        assertEquals("There should be two entries returned", 2, entries.size());
+        assertEquals("Key in entry is incorrect", id2, entries.get(0).getKey());
+        assertEquals("Value in entry is incorrect", value2.getBytes(), entries.get(0).getValue().getBytes());
+        assertEquals("Key in entry is incorrect", id2, entries.get(1).getKey());
+        assertEquals("Value in entry is incorrect", delValue2.getBytes(), entries.get(1).getValue().getBytes());
+        entries.clear();
       }
     }
   }
@@ -497,7 +619,9 @@ public class IndexSegmentTest {
   private void doGetEntriesSinceTest(NavigableMap<MockId, NavigableSet<IndexValue>> referenceIndex,
       IndexSegment segment, MockId idToCheck, long maxSize, long existingSize, MockId highestExpectedId)
       throws IOException {
+    // test getEntriesSince
     FindEntriesCondition condition = new FindEntriesCondition(maxSize);
+
     List<MessageInfo> entries = new ArrayList<>();
     assertEquals("Unexpected return value from getEntriesSince()", highestExpectedId != null,
         segment.getEntriesSince(idToCheck, condition, entries, new AtomicLong(existingSize)));
@@ -510,6 +634,45 @@ public class IndexSegmentTest {
       }
     } else {
       assertEquals("Entries list is not empty", 0, entries.size());
+    }
+
+    // test getIndexEntriesSince()
+    for (boolean oneEntryPerKey : new boolean[]{true, false}) {
+      List<IndexEntry> indexEntries = new ArrayList<>();
+      assertEquals("Unexpected return value from getIndexEntriesSince()", highestExpectedId != null,
+          segment.getIndexEntriesSince(idToCheck, condition, indexEntries, new AtomicLong(existingSize),
+              oneEntryPerKey));
+      if (highestExpectedId != null) {
+        assertEquals("Highest ID not as expected", highestExpectedId,
+            indexEntries.get(indexEntries.size() - 1).getKey());
+        MockId nextExpectedId = idToCheck == null ? referenceIndex.firstKey() : referenceIndex.higherKey(idToCheck);
+        // gather all index entries that should be there
+        final List<IndexEntry> expectedEntries = new ArrayList<>();
+        while (nextExpectedId != null) {
+          NavigableSet<IndexValue> values = referenceIndex.get(nextExpectedId);
+          if (oneEntryPerKey) {
+            expectedEntries.add(new IndexEntry(nextExpectedId, values.last()));
+          } else {
+            for (IndexValue value : values) {
+              expectedEntries.add(new IndexEntry(nextExpectedId, value));
+            }
+          }
+          if (nextExpectedId.equals(highestExpectedId)) {
+            break;
+          }
+          nextExpectedId = referenceIndex.higherKey(nextExpectedId);
+        }
+        assertEquals("Number of entries not as expected", expectedEntries.size(), indexEntries.size());
+        Iterator<IndexEntry> it = indexEntries.iterator();
+        for (IndexEntry expected : expectedEntries) {
+          assertTrue("There should be more entries", it.hasNext());
+          IndexEntry actual = it.next();
+          assertEquals("Key not as expected", expected.getKey(), actual.getKey());
+          assertEquals("Value not as expected", expected.getValue().getBytes(), actual.getValue().getBytes());
+        }
+      } else {
+        assertEquals("Entries list is not empty", 0, indexEntries.size());
+      }
     }
   }
 
@@ -657,6 +820,38 @@ public class IndexSegmentTest {
     if (extraEntriesCheckState != null) {
       assertFalse("One of the extraOffsetsToCheck was not found", extraEntriesCheckState.values().contains(false));
     }
+  }
+
+  // partialWriteTest() helpers
+
+  /**
+   * Checks that an index segment file is not created
+   * @param indexSegment the index segment to write to file
+   * @param safeEndPoint the safe end point to use to the call to {@link IndexSegment#writeIndexSegmentToFile(Offset)}.
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void checkNonCreationOfIndexSegmentFile(IndexSegment indexSegment, Offset safeEndPoint)
+      throws IOException, StoreException {
+    indexSegment.writeIndexSegmentToFile(safeEndPoint);
+    assertFalse("Index file should not have been created", indexSegment.getFile().exists());
+  }
+
+  /**
+   * Verifies that the values obtained for {@code id} from {@code segment} satisfy the count and deleted state as
+   * provided
+   * @param segment the {@link IndexSegment} to check
+   * @param id the {@link MockId} to find values for
+   * @param valueCount the number of values expected to be returned
+   * @param isDeleted the expected state of the latest value
+   * @throws StoreException
+   */
+  private void verifyValues(IndexSegment segment, MockId id, int valueCount, boolean isDeleted) throws StoreException {
+    NavigableSet<IndexValue> values = segment.find(id);
+    assertNotNull("Values should have been found for " + id, values);
+    assertEquals("Unexpected number of values for " + id, valueCount, values.size());
+    assertEquals("Delete flag not as expected for " + id, isDeleted,
+        values.last().isFlagSet(IndexValue.Flags.Delete_Index));
   }
 }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -188,7 +188,7 @@ public class IndexSegmentTest {
     Journal journal = new Journal(tempDir.getAbsolutePath(), 3, 3);
     IndexSegment fromDisk =
         new IndexSegment(indexSegment.getFile(), false, STORE_KEY_FACTORY, STORE_CONFIG, metrics, journal, time);
-    //assertEquals("Number of items incorrect", 4, fromDisk.getNumberOfItems());
+    assertEquals("Number of items incorrect", 4, fromDisk.getNumberOfItems());
     for (MockId id : new MockId[]{id1, id2, id3}) {
       verifyValues(fromDisk, id, id.equals(id2) ? 2 : 1, id.equals(id2));
     }

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -458,7 +458,7 @@ public class IndexSegmentTest {
       IndexEntry entry = new IndexEntry(id, value);
       segment.addEntry(entry, new Offset(segment.getLogSegmentName(), offset + size));
       addedEntries.add(entry);
-      referenceIndex.computeIfAbsent(id, k -> new TreeSet<>(IndexSegment.INDEX_VALUE_COMPARATOR)).add(value);
+      referenceIndex.computeIfAbsent(id, k -> new TreeSet<>()).add(value);
     }
     return addedEntries;
   }
@@ -733,7 +733,7 @@ public class IndexSegmentTest {
       newValue.setNewSize(DELETE_FILE_SPAN_SIZE);
       segment.addEntry(new IndexEntry(id, newValue),
           new Offset(offset.getName(), offset.getOffset() + DELETE_FILE_SPAN_SIZE));
-      referenceIndex.computeIfAbsent(id, k -> new TreeSet<>(IndexSegment.INDEX_VALUE_COMPARATOR)).add(newValue);
+      referenceIndex.computeIfAbsent(id, k -> new TreeSet<>()).add(newValue);
     }
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -165,7 +165,8 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
     dataNodes.add(dataNode);
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
+    MockPartitionId invalidPartition =
+        new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
     List<? extends ReplicaId> invalidPartitionReplicas = invalidPartition.getReplicaIds();
     StorageManager storageManager = createStorageManager(replicas, metricRegistry);
     PartitionId id = null;
@@ -202,7 +203,8 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
     dataNodes.add(dataNode);
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
+    MockPartitionId invalidPartition =
+        new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
     List<? extends ReplicaId> invalidPartitionReplicas = invalidPartition.getReplicaIds();
     StorageManager storageManager = createStorageManager(replicas, metricRegistry);
     PartitionId id = null;
@@ -227,7 +229,8 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
     dataNodes.add(dataNode);
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
+    MockPartitionId invalidPartition =
+        new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
     List<? extends ReplicaId> invalidPartitionReplicas = invalidPartition.getReplicaIds();
     StorageManager storageManager = createStorageManager(replicas, metricRegistry);
     storageManager.start();
@@ -405,7 +408,8 @@ public class StorageManagerTest {
         getCounterValue(counters, DiskSpaceAllocator.class.getName(), "DiskSpaceAllocatorInitFailureCount"));
     assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "TotalStoreStartFailures"));
     assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "DiskMountPathFailures"));
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, Collections.<MockDataNodeId>emptyList(), 0);
+    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS,
+        Collections.<MockDataNodeId>emptyList(), 0);
     assertNull("Should not have found a store for an invalid partition.", storageManager.getStore(invalidPartition));
     assertEquals("Compaction thread count is incorrect", dataNode.getMountPaths().size(),
         TestUtils.numThreadsByThisName(CompactionManager.THREAD_NAME_PREFIX));

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
@@ -54,6 +54,7 @@ public class StoreMessageReadSetTest {
   public static List<Object[]> data() {
     return Arrays.asList(new Object[][]{{false}, {true}});
   }
+
   private static final StoreKeyFactory STORE_KEY_FACTORY;
 
   static {

--- a/ambry-tools/src/main/java/com.github.ambry/store/CompactionVerifier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/CompactionVerifier.java
@@ -651,7 +651,7 @@ public class CompactionVerifier implements Closeable {
       List<IndexEntry> indexEntries = new ArrayList<>();
       try {
         indexSegment.getIndexEntriesSince(null, new FindEntriesCondition(Long.MAX_VALUE), indexEntries,
-            new AtomicLong(0));
+            new AtomicLong(0), true);
         // for each index entry, if it represents a squashed put entry, add an index entry to account for that.
         List<IndexEntry> entriesToAdd = new ArrayList<>();
         for (IndexEntry indexEntry : indexEntries) {

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpDataTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpDataTool.java
@@ -228,7 +228,7 @@ public class DumpDataTool {
       segment.getEntriesSince(null, new FindEntriesCondition(Long.MAX_VALUE), entries, new AtomicLong(0));
       for (MessageInfo entry : entries) {
         StoreKey key = entry.getStoreKey();
-        IndexValue value = segment.find(key);
+        IndexValue value = segment.find(key).last();
         boolean isDeleted = value.isFlagSet(IndexValue.Flags.Delete_Index);
         if (value.getOffset().getOffset() < logFileSize) {
           boolean success = readFromLogAndVerify(randomAccessFile, key.getID(), value, coveredRanges);

--- a/ambry-tools/src/main/java/com.github.ambry/store/DumpIndexTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/DumpIndexTool.java
@@ -437,7 +437,7 @@ public class DumpIndexTool {
     List<IndexEntry> entries = new ArrayList<>();
     final Timer.Context context = metrics.findAllEntriesPerIndexTimeMs.time();
     try {
-      segment.getIndexEntriesSince(null, new FindEntriesCondition(Long.MAX_VALUE), entries, new AtomicLong(0));
+      segment.getIndexEntriesSince(null, new FindEntriesCondition(Long.MAX_VALUE), entries, new AtomicLong(0), true);
     } finally {
       context.stop();
     }


### PR DESCRIPTION
Currently, an IndexSegment can have only value for a particular key which means that delete entries squash put entries if they occur in the same index segment. This commit changes this behavior to allow the IndexSegment to have more than one value for a key