### PR TITLE
Remove subMap to flattern Stats Report

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/server/StatsHeader.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/StatsHeader.java
@@ -15,12 +15,14 @@
 package com.github.ambry.server;
 
 import java.util.List;
+import org.codehaus.jackson.annotate.JsonAutoDetect;
 
 
 /**
  * A model object that contains metadata information about some reported stats. For example, the kind of stats that is
  * being reported, timestamp and etc.
  */
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class StatsHeader {
   public enum StatsDescription {
     QUOTA

--- a/ambry-api/src/main/java/com.github.ambry/server/StatsHeader.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/StatsHeader.java
@@ -16,6 +16,7 @@ package com.github.ambry.server;
 
 import java.util.List;
 import org.codehaus.jackson.annotate.JsonAutoDetect;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
 
 /**
@@ -23,6 +24,7 @@ import org.codehaus.jackson.annotate.JsonAutoDetect;
  * being reported, timestamp and etc.
  */
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonPropertyOrder({"description", "timestamp", "storesContactedCount", "storesRespondedCount", "unreachableStores"})
 public class StatsHeader {
   public enum StatsDescription {
     QUOTA

--- a/ambry-api/src/main/java/com.github.ambry/server/StatsSnapshot.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/StatsSnapshot.java
@@ -14,7 +14,11 @@
 
 package com.github.ambry.server;
 
+import java.util.HashMap;
 import java.util.Map;
+import org.codehaus.jackson.annotate.JsonAnyGetter;
+import org.codehaus.jackson.annotate.JsonAnySetter;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
 
 /**
@@ -25,6 +29,7 @@ import java.util.Map;
  * {@link StatsSnapshot}'s subMap will contain all the containers in the account that is mapped with. At the leaf level
  * {@link StatsSnapshot}'s subMap will be null.
  */
+@JsonPropertyOrder({"value", "subMap"})
 public class StatsSnapshot {
   private long value;
   private Map<String, StatsSnapshot> subMap;
@@ -50,7 +55,7 @@ public class StatsSnapshot {
 
   public StatsSnapshot(Long value, Map<String, StatsSnapshot> subMap) {
     this.value = value;
-    this.subMap = subMap;
+    this.subMap = subMap;// == null ? new HashMap<>() : subMap;
   }
 
   public StatsSnapshot() {
@@ -61,6 +66,7 @@ public class StatsSnapshot {
     return value;
   }
 
+  @JsonAnyGetter
   public Map<String, StatsSnapshot> getSubMap() {
     return subMap;
   }
@@ -71,6 +77,12 @@ public class StatsSnapshot {
 
   public void setSubMap(Map<String, StatsSnapshot> subMap) {
     this.subMap = subMap;
+  }
+
+  @JsonAnySetter
+  public void add(String str, StatsSnapshot statsSnapshot) {
+    this.subMap = this.subMap == null ? new HashMap<>() : this.subMap;
+    this.subMap.put(str, statsSnapshot);
   }
 
   @Override

--- a/ambry-api/src/main/java/com.github.ambry/server/StatsSnapshot.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/StatsSnapshot.java
@@ -55,7 +55,7 @@ public class StatsSnapshot {
 
   public StatsSnapshot(Long value, Map<String, StatsSnapshot> subMap) {
     this.value = value;
-    this.subMap = subMap;// == null ? new HashMap<>() : subMap;
+    this.subMap = subMap;
   }
 
   public StatsSnapshot() {

--- a/ambry-api/src/main/java/com.github.ambry/server/StatsSnapshot.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/StatsSnapshot.java
@@ -81,8 +81,8 @@ public class StatsSnapshot {
 
   @JsonAnySetter
   public void add(String str, StatsSnapshot statsSnapshot) {
-    this.subMap = this.subMap == null ? new HashMap<>() : this.subMap;
-    this.subMap.put(str, statsSnapshot);
+    subMap = subMap == null ? new HashMap<>() : subMap;
+    subMap.put(str, statsSnapshot);
   }
 
   @Override

--- a/ambry-api/src/main/java/com.github.ambry/server/StatsWrapper.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/StatsWrapper.java
@@ -14,10 +14,16 @@
 
 package com.github.ambry.server;
 
+import org.codehaus.jackson.annotate.JsonAutoDetect;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
+
+
 /**
  * A wrapper model object that contains a {@link StatsSnapshot} and a {@link StatsHeader} with metadata about the
  * {@link StatsSnapshot}.
  */
+@JsonPropertyOrder({"header", "snapshot"})
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class StatsWrapper {
   private StatsHeader header;
   private StatsSnapshot snapshot;

--- a/ambry-api/src/test/java/com.github.ambry/server/StatsSnapshotTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/server/StatsSnapshotTest.java
@@ -25,7 +25,15 @@ import static org.junit.Assert.*;
 import static org.junit.matchers.JUnitMatchers.*;
 
 
+/**
+ * Serialization/deserialization unit tests of {@link StatsSnapshot}.
+ */
 public class StatsSnapshotTest {
+
+  /**
+   * Serialization unit test of {@link StatsSnapshot}.
+   * Test if subMap and null fields are removed from serialized result.
+   */
   @Test
   public void serializeStatsSnapshotTest() throws IOException {
     Long val = 100L;
@@ -36,22 +44,27 @@ public class StatsSnapshotTest {
 
     String result = new ObjectMapper().writeValueAsString(snapshot);
 
-    assertThat(result, containsString("first"));
-    assertThat(result, containsString("second"));
-    assertThat(result, not(containsString("subMap")));
-    assertThat(result, not(containsString("null")));
+    assertThat("Result should contain \"first\" keyword and associated entry", result, containsString("first"));
+    assertThat("Result should contain \"second\" keyword and associated entry", result, containsString("second"));
+    assertThat("Result should not contain \"subMap\" keyword", result, not(containsString("subMap")));
+    assertThat("Result should ignore any null fields", result, not(containsString("null")));
   }
 
+  /**
+   * Deserialization unit test of {@link StatsSnapshot}.
+   * Test if {@link StatsSnapshot} can be reconstructed from json string in the form of a directory or tree (consist of
+   * value and subMap fields).
+   */
   @Test
   public void deserializeStatsSnapshotTest() throws IOException {
     String jsonAsString = "{\"value\":100,\"first\":{\"value\":40},\"second\":{\"value\":60}}";
 
     StatsSnapshot snapshot = new ObjectMapper().readValue(jsonAsString, StatsSnapshot.class);
 
-    assertEquals(100L, snapshot.getValue());
-    assertEquals(40L, snapshot.getSubMap().get("first").getValue());
-    assertEquals(60L, snapshot.getSubMap().get("second").getValue());
-    assertEquals(null, snapshot.getSubMap().get("first").getSubMap());
-    assertEquals(null, snapshot.getSubMap().get("second").getSubMap());
+    assertEquals("Mismatch in total aggregated value for StatsSnapshot", 100L, snapshot.getValue());
+    assertEquals("Mismatch in aggregated value for first account", 40L, snapshot.getSubMap().get("first").getValue());
+    assertEquals("Mismatch in aggregated value for second account", 60L, snapshot.getSubMap().get("second").getValue());
+    assertEquals("The subMap in first account should be null", null, snapshot.getSubMap().get("first").getSubMap());
+    assertEquals("The subMap in second account should be null", null, snapshot.getSubMap().get("second").getSubMap());
   }
 }

--- a/ambry-api/src/test/java/com.github.ambry/server/StatsSnapshotTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/server/StatsSnapshotTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.server;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.junit.matchers.JUnitMatchers.*;
+
+
+public class StatsSnapshotTest {
+  @Test
+  public void serializeStatsSnapshotTest() throws IOException {
+    Long val = 100L;
+    Map<String, StatsSnapshot> subMap = new HashMap<>();
+    subMap.put("first", new StatsSnapshot(40L, null));
+    subMap.put("second", new StatsSnapshot(60L, null));
+    StatsSnapshot snapshot = new StatsSnapshot(val, subMap);
+
+    String result = new ObjectMapper().writeValueAsString(snapshot);
+
+    assertThat(result, containsString("first"));
+    assertThat(result, containsString("second"));
+    assertThat(result, not(containsString("subMap")));
+    assertThat(result, not(containsString("null")));
+  }
+
+  @Test
+  public void deserializeStatsSnapshotTest() throws IOException {
+    String jsonAsString = "{\"value\":100,\"first\":{\"value\":40},\"second\":{\"value\":60}}";
+
+    StatsSnapshot snapshot = new ObjectMapper().readValue(jsonAsString, StatsSnapshot.class);
+
+    assertEquals(100L, snapshot.getValue());
+    assertEquals(40L, snapshot.getSubMap().get("first").getValue());
+    assertEquals(60L, snapshot.getSubMap().get("second").getValue());
+    assertEquals(null, snapshot.getSubMap().get("first").getSubMap());
+    assertEquals(null, snapshot.getSubMap().get("second").getSubMap());
+  }
+}

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterAggregator.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterAggregator.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.codehaus.jackson.annotate.JsonAutoDetect;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +36,6 @@ public class HelixClusterAggregator {
 
   HelixClusterAggregator(long relevantTimePeriodInMinutes) {
     relevantTimePeriodInMs = TimeUnit.MINUTES.toMillis(relevantTimePeriodInMinutes);
-    mapper.setVisibilityChecker(mapper.getVisibilityChecker().withFieldVisibility(JsonAutoDetect.Visibility.ANY));
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterAggregator.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterAggregator.java
@@ -155,7 +155,7 @@ public class HelixClusterAggregator {
     StatsSnapshot reducedSnapshot = new StatsSnapshot(0L, null);
     if (statsSnapshot.getSubMap() != null) {
       for (StatsSnapshot snapshot : statsSnapshot.getSubMap().values()) {
-        statsSnapshot.aggregate(reducedSnapshot, snapshot);
+        StatsSnapshot.aggregate(reducedSnapshot, snapshot);
       }
     }
     return reducedSnapshot;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -56,7 +56,7 @@ class HelixParticipant implements ClusterParticipant {
    * Instantiate a HelixParticipant.
    * @param clusterMapConfig the {@link ClusterMapConfig} associated with this participant.
    * @param helixFactory the {@link HelixFactory} to use to get the {@link HelixManager}.
-   * @throws JSONException if there is an error in parsing the JSON serialized ZK connect string config.
+   * @throws IOException if there is an error in parsing the JSON serialized ZK connect string config.
    */
   HelixParticipant(ClusterMapConfig clusterMapConfig, HelixFactory helixFactory) throws IOException {
     clusterName = clusterMapConfig.clusterMapClusterName;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterAggregatorTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterAggregatorTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import org.codehaus.jackson.annotate.JsonAutoDetect;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 
@@ -41,7 +40,6 @@ public class HelixClusterAggregatorTest {
 
   public HelixClusterAggregatorTest() {
     clusterAggregator = new HelixClusterAggregator(RELEVANT_PERIOD_IN_MINUTES);
-    mapper.setVisibilityChecker(mapper.getVisibilityChecker().withFieldVisibility(JsonAutoDetect.Visibility.ANY));
   }
 
   /**

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
@@ -19,8 +19,6 @@ import com.github.ambry.clustermap.ClusterAgentsFactory;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.DataNodeId;
-import com.github.ambry.clustermap.PartitionId;
-import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.WriteStatusDelegate;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.config.ClusterMapConfig;
@@ -165,11 +163,7 @@ public class AmbryServer {
       networkServer.start();
 
       logger.info("Creating StatsManager to publish stats");
-      List<PartitionId> partitionIds = new ArrayList<>();
-      for (ReplicaId replicaId : clusterMap.getReplicaIds(nodeId)) {
-        partitionIds.add(replicaId.getPartitionId());
-      }
-      statsManager = new StatsManager(storageManager, partitionIds, registry, statsConfig, time);
+      statsManager = new StatsManager(storageManager, clusterMap.getReplicaIds(nodeId), registry, statsConfig, time);
       if (serverConfig.serverStatsPublishLocalEnabled) {
         statsManager.start();
       }

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixClusterWideAggregationTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixClusterWideAggregationTool.java
@@ -118,6 +118,7 @@ public class HelixClusterWideAggregationTool {
               String.format("Failed to delete %s. Workflow not found in cluster %s at %s", workflowName, clusterName,
                   zkAddress));
         }
+        System.out.println(String.format("Successfully delete the workflow: %s from %s", workflowName, clusterName));
       } else {
         try {
           Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);

--- a/build.gradle
+++ b/build.gradle
@@ -129,8 +129,6 @@ project(':ambry-clustermap') {
                 project(':ambry-utils')
         compile "org.apache.helix:helix-core:$helixVersion"
         compile "com.codahale.metrics:metrics-core:$metricsVersion"
-        compile "org.codehaus.jackson:jackson-core-asl:$jacksonVersion"
-        compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
         compile "org.json:json:$jsonVersion"
         testCompile project(':ambry-utils').sourceSets.test.output
     }

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,8 @@ project(':ambry-api') {
     dependencies {
         compile project(':ambry-utils')
         compile "com.codahale.metrics:metrics-core:$metricsVersion"
+        compile "org.codehaus.jackson:jackson-core-asl:$jacksonVersion"
+        compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
         testCompile project(':ambry-utils').sourceSets.test.output
     }
 }
@@ -127,6 +129,8 @@ project(':ambry-clustermap') {
                 project(':ambry-utils')
         compile "org.apache.helix:helix-core:$helixVersion"
         compile "com.codahale.metrics:metrics-core:$metricsVersion"
+        compile "org.codehaus.jackson:jackson-core-asl:$jacksonVersion"
+        compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
         compile "org.json:json:$jsonVersion"
         testCompile project(':ambry-utils').sourceSets.test.output
     }

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -19,4 +19,5 @@ ext {
     javaxVersion = "3.0.1"
     nettyVersion = "4.1.6.Final"
     helixVersion = "0.6.9"
+    jacksonVersion = "1.8.5"
 }


### PR DESCRIPTION
1. Pass the ReplicaIds into StatsManager to get disk info for particular
store.
2. Use JsonAnyGetter and JsonAnySetter annotations in Jackson to
flatten the serialized result(with no "subMap" and ignore NULL fields)
3. Add direct dependency on Jackson 1.8.5 for API module.

Flatten report is verified in perf cluster.