### PR TITLE
Support adding BlobStore to StorageManager

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
@@ -149,6 +149,30 @@ class AmbryDataNode extends DataNodeId implements Resource {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AmbryDataNode dataNode = (AmbryDataNode) o;
+
+    if (plainTextPort.getPort() != dataNode.plainTextPort.getPort()) {
+      return false;
+    }
+    return hostName.equals(dataNode.hostName);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = hostName.hashCode();
+    result = 31 * result + plainTextPort.getPort();
+    return result;
+  }
+
+  @Override
   public String toString() {
     return "DataNode[" + getHostname() + ":" + getPort() + "]";
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDisk.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDisk.java
@@ -85,6 +85,30 @@ class AmbryDisk implements DiskId, Resource {
     return "Disk[" + datanode.getHostname() + ":" + datanode.getPort() + ":" + getMountPath() + "]";
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AmbryDisk disk = (AmbryDisk) o;
+
+    if (!datanode.equals(disk.datanode)) {
+      return false;
+    }
+    return mountPath.equals(disk.mountPath);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = datanode.hashCode();
+    result = 31 * result + mountPath.hashCode();
+    return result;
+  }
+
   /**
    * @return the {@link AmbryDataNode} associated with this disk.
    */

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
@@ -101,6 +101,24 @@ class AmbryPartition extends PartitionId {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AmbryPartition partition = (AmbryPartition) o;
+    return id.equals(partition.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return (int) (id ^ (id >>> 32));
+  }
+
+  @Override
   public int compareTo(PartitionId o) {
     AmbryPartition other = (AmbryPartition) o;
     return id.compareTo(other.id);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -275,7 +275,7 @@ public class MockClusterMap implements ClusterMap {
     }
   }
 
-  protected static boolean deleteFileOrDirectory(File f) throws IOException {
+  public static boolean deleteFileOrDirectory(File f) throws IOException {
     if (f.exists()) {
       if (f.isDirectory()) {
         File[] children = f.listFiles();

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskSpaceAllocator.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskSpaceAllocator.java
@@ -59,7 +59,7 @@ class DiskSpaceAllocator {
   private final long requiredSwapSegmentsPerSize;
   private final StorageManagerMetrics metrics;
   private final ReserveFileMap reserveFiles = new ReserveFileMap();
-  private PoolState poolState = PoolState.NOT_INVENTORIED;
+  private volatile PoolState poolState = PoolState.NOT_INVENTORIED;
   private Exception inventoryException = null;
 
   /**
@@ -289,7 +289,7 @@ class DiskSpaceAllocator {
       } else {
         while (reserveFiles.getCount(sizeInBytes) > segmentsNeeded) {
           File fileToDelete = reserveFiles.remove(sizeInBytes);
-          if (!fileToDelete.delete()) {
+          if (fileToDelete != null && !fileToDelete.delete()) {
             throw new IOException("Could not delete the following reserve file: " + fileToDelete.getAbsolutePath());
           }
         }


### PR DESCRIPTION
The first step to support dynamically adding partition/replica.

The plan is to support adding partition/replica to StorageManager, ReplicationManager and StatsManager, and finally add a PartitionWatcher to watch changes of partitions on cluster map, and call these add methods.