### PR TITLE
Resolves possible race conditions for PartitionsState on init

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -133,6 +133,10 @@ class HelixClusterManager implements ClusterMap {
       initializationException.compareAndSet(null, e);
     }
     if (initializationException.get() == null) {
+      // resolve the status of all partitions before completing initialization
+      for (AmbryPartition partition : partitionMap.values()) {
+        partition.resolvePartitionState();
+      }
       initializeCapacityStats();
       helixClusterManagerMetrics.initializeInstantiationMetric(true);
       helixClusterManagerMetrics.initializeDatacenterMetrics();


### PR DESCRIPTION
`AmbryPartition` is initialized with state = `READ_WRITE`. The state is resolved on the first call to `getPartitionState()`. This may cause some race conditions just after init causing the clustermap to return RO partitions as RW if certain conditions are met. This change resolves `PartitionState` before init is complete to avoid such race conditions.