### PR TITLE
Add all replicas to OperationTracker if originating DC is unknown

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -119,13 +119,14 @@ class SimpleOperationTracker implements OperationTracker {
         }
       }
     }
-    if (includeNonOriginatingDcReplicas) {
+    if (includeNonOriginatingDcReplicas || originatingDcName == null) {
       replicaPool.addAll(backupReplicas);
       replicaPool.addAll(downReplicas);
     } else {
       // This is for get request only. Take replicasRequired copy of replicas to do the request
       // Please note replicasRequired is 6 because total number of local and originating replicas is always <= 6.
       // This may no longer be true with partition classes and flexible replication.
+      // Don't do this if originatingDcName is unknown.
       while (replicaPool.size() < replicasRequired && backupReplicas.size() > 0) {
         replicaPool.add(backupReplicas.pollFirst());
       }

--- a/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
@@ -325,6 +325,37 @@ public class OperationTrackerTest {
   }
 
   /**
+   * Test to ensure all replicas are candidates if originatingDcName is unknown.
+   */
+  @Test
+  public void replicasOrderingTestOriginatingUnknown() {
+    initialize();
+    originatingDcName = null;
+    OperationTracker ot = getOperationTracker(true, 3, 3, false, 6);
+    sendRequests(ot, 3, false);
+    for (int i = 0; i < 3; i++) {
+      ReplicaId replica = inflightReplicas.poll();
+      ot.onResponse(replica, false);
+    }
+    sendRequests(ot, 3, false);
+    for (int i = 0; i < 3; i++) {
+      ReplicaId replica = inflightReplicas.poll();
+      ot.onResponse(replica, false);
+    }
+    assertEquals("Should have 0 replica in flight.", 0, inflightReplicas.size());
+    assertFalse("Operation should have not succeeded", ot.hasSucceeded());
+    assertFalse("Operation should have not been done", ot.isDone());
+    sendRequests(ot, 3, false);
+    for (int i = 0; i < 3; i++) {
+      ReplicaId replica = inflightReplicas.poll();
+      ot.onResponse(replica, true);
+    }
+    assertEquals("Should have 0 replica in flight.", 0, inflightReplicas.size());
+    assertTrue("Operation should have succeeded", ot.hasSucceeded());
+    assertTrue("Operation should be done", ot.isDone());
+  }
+
+  /**
    * Test to ensure that replicas in originating DC are first priority when originating DC is local DC.
    */
   @Test


### PR DESCRIPTION
Old blobIds may have no originating DC info, it's better to add
all replicas to OperationTracker. Patch to #827.