### PR TITLE
Introducing "STOPPED" replicas list into Helix InstanceConfig

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipant.java
@@ -39,6 +39,13 @@ public interface ClusterParticipant extends AutoCloseable {
   boolean setReplicaSealedState(ReplicaId replicaId, boolean isSealed);
 
   /**
+   * Set or reset the stopped state of the given replica.
+   * @param replicaId the {@link ReplicaId}
+   * @param isStopped if true, the replica will be marked as stopped; otherwise it will be marked as started.
+   */
+  boolean setReplicaStoppedState(ReplicaId replicaId, boolean isStopped);
+
+  /**
    * Terminate the participant.
    */
   @Override

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipant.java
@@ -33,17 +33,31 @@ public interface ClusterParticipant extends AutoCloseable {
 
   /**
    * Set or reset the sealed state of the given replica.
-   * @param replicaId the {@link ReplicaId}
+   * @param replicaId the {@link ReplicaId} whose sealed state will be updated.
    * @param isSealed if true, the replica will be marked as sealed; otherwise it will be marked as read-write.
+   * @return {@code true} if set replica sealed state was successful. {@code false} if not.
    */
   boolean setReplicaSealedState(ReplicaId replicaId, boolean isSealed);
 
   /**
    * Set or reset the stopped state of the given replica.
-   * @param replicaId the {@link ReplicaId}
+   * @param replicaIds a list of replicas whose stopped state will be updated
    * @param isStopped if true, the replica will be marked as stopped; otherwise it will be marked as started.
+   * @return {@code true} if set replica stopped state was successful. {@code false} if not.
    */
-  boolean setReplicaStoppedState(ReplicaId replicaId, boolean isStopped);
+  boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean isStopped);
+
+  /**
+   * Get a list of replicas that are marked as sealed (read-only).
+   * @return a list of all sealed replicas.
+   */
+  List<String> getSealedReplicas();
+
+  /**
+   * Get a list of replicas that are marked as stopped.
+   * @return a list of all stopped replicas.
+   */
+  List<String> getStoppedReplicas();
 
   /**
    * Terminate the participant.

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipant.java
@@ -42,10 +42,10 @@ public interface ClusterParticipant extends AutoCloseable {
   /**
    * Set or reset the stopped state of the given replica.
    * @param replicaIds a list of replicas whose stopped state will be updated
-   * @param isStopped if true, the replica will be marked as stopped; otherwise it will be marked as started.
+   * @param markStop if true, the replica will be marked as stopped; otherwise it will be marked as started.
    * @return {@code true} if set replica stopped state was successful. {@code false} if not.
    */
-  boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean isStopped);
+  boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean markStop);
 
   /**
    * Get a list of replicas that are marked as sealed (read-only).

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaStatusDelegate.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaStatusDelegate.java
@@ -20,11 +20,11 @@ import com.github.ambry.store.Store;
 /**
  * Delegate class allowing BlobStore to set the replica sealed/stopped status
  */
-public class WriteStatusDelegate {
+public class ReplicaStatusDelegate {
 
   private final ClusterParticipant clusterParticipant;
 
-  public WriteStatusDelegate(ClusterParticipant clusterParticipant) {
+  public ReplicaStatusDelegate(ClusterParticipant clusterParticipant) {
     this.clusterParticipant = clusterParticipant;
   }
 
@@ -50,7 +50,7 @@ public class WriteStatusDelegate {
    * @param isStopped whether to mark the store as stopped ({@code true}).
    * @return {@code true} if state is successful set. {@code false} if not.
    */
-  public boolean setReplicaStoppedState(ReplicaId replicaId, boolean isStopped){
+  public boolean setReplicaStoppedState(ReplicaId replicaId, boolean isStopped) {
     return clusterParticipant.setReplicaStoppedState(replicaId, isStopped);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaStatusDelegate.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaStatusDelegate.java
@@ -14,7 +14,7 @@
 
 package com.github.ambry.clustermap;
 
-import com.github.ambry.store.Store;
+import java.util.List;
 
 
 /**
@@ -30,7 +30,8 @@ public class ReplicaStatusDelegate {
 
   /**
    * Sets replicaId to read-only status
-   * @param replicaId
+   * @param replicaId the {@link ReplicaId} whose status would be set to read-only.
+   * @return {@code true} if replica is successfully sealed. {@code false} if not.
    */
   public boolean seal(ReplicaId replicaId) {
     return clusterParticipant.setReplicaSealedState(replicaId, true);
@@ -38,19 +39,32 @@ public class ReplicaStatusDelegate {
 
   /**
    * Sets replicaId to read-write status
-   * @param replicaId
+   * @param replicaId the {@link ReplicaId} whose status would be set to read-write.
+   * @return {@code true} if replica is successfully unsealed. {@code false} if not.
    */
   public boolean unseal(ReplicaId replicaId) {
     return clusterParticipant.setReplicaSealedState(replicaId, false);
   }
 
   /**
-   * Sets stopped status of given store
-   * @param replicaId the {@link ReplicaId} of the {@link Store} of which the stopped state would be set.
-   * @param isStopped whether to mark the store as stopped ({@code true}).
-   * @return {@code true} if state is successful set. {@code false} if not.
+   * Sets a list of replicaIds to stopped status
+   * @param replicaIds a list of replicas whose status would be set to stopped.
+   * @return {@code true} if replica is successfully marked as stopped. {@code false} if not.
    */
-  public boolean setReplicaStoppedState(ReplicaId replicaId, boolean isStopped) {
-    return clusterParticipant.setReplicaStoppedState(replicaId, isStopped);
+  public boolean markStopped(List<ReplicaId> replicaIds) {
+    return clusterParticipant.setReplicaStoppedState(replicaIds, true);
+  }
+
+  /**
+   * Sets a list of replicaIds to started status
+   * @param replicaIds a list of replicas whose status would be set to started.
+   * @return {@code true} if replica is successfully unmarked and becomes started. {@code false} if not.
+   */
+  public boolean unmarkStopped(List<ReplicaId> replicaIds) {
+    return clusterParticipant.setReplicaStoppedState(replicaIds, false);
+  }
+
+  public List<String> getStoppedReplicas() {
+    return clusterParticipant.getStoppedReplicas();
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/WriteStatusDelegate.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/WriteStatusDelegate.java
@@ -14,8 +14,11 @@
 
 package com.github.ambry.clustermap;
 
+import com.github.ambry.store.Store;
+
+
 /**
- * Delegate class allowing BlobStore to set the replica sealed status
+ * Delegate class allowing BlobStore to set the replica sealed/stopped status
  */
 public class WriteStatusDelegate {
 
@@ -39,5 +42,15 @@ public class WriteStatusDelegate {
    */
   public boolean unseal(ReplicaId replicaId) {
     return clusterParticipant.setReplicaSealedState(replicaId, false);
+  }
+
+  /**
+   * Sets stopped status of given store
+   * @param replicaId the {@link ReplicaId} of the {@link Store} of which the stopped state would be set.
+   * @param isStopped whether to mark the store as stopped ({@code true}).
+   * @return {@code true} if state is successful set. {@code false} if not.
+   */
+  public boolean setReplicaStoppedState(ReplicaId replicaId, boolean isStopped){
+    return clusterParticipant.setReplicaStoppedState(replicaId, isStopped);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -197,12 +197,12 @@ public class StoreConfig {
   public final boolean storeValidateAuthorization;
 
   /**
-   * Enables or disables dynamic sealing/unsealing
+   * Enables or disables ReplicaStatusDelegate to dynamically set the replica sealed/stopped status
    */
-  @Config(storeWriteStatusDelegateEnableName)
+  @Config(storeReplicaStatusDelegateEnableName)
   @Default("false")
-  public final boolean storeWriteStatusDelegateEnable;
-  public static final String storeWriteStatusDelegateEnableName = "store.write.status.delegate.enable";
+  public final boolean storeReplicaStatusDelegateEnable;
+  public static final String storeReplicaStatusDelegateEnableName = "store.replica.status.delegate.enable";
 
   /**
    * Specifies the size threshold (as percentage of maximum size) of a store for converting the chunk to RO from RW
@@ -263,7 +263,7 @@ public class StoreConfig {
     storeStatsIndexEntriesPerSecond =
         verifiableProperties.getIntInRange("store.stats.index.entries.per.second", 240000, 1, Integer.MAX_VALUE);
     storeIndexPersistedEntryMinBytes = verifiableProperties.getInt("store.index.persisted.entry.min.bytes", 115);
-    storeWriteStatusDelegateEnable = verifiableProperties.getBoolean(storeWriteStatusDelegateEnableName, false);
+    storeReplicaStatusDelegateEnable = verifiableProperties.getBoolean(storeReplicaStatusDelegateEnableName, false);
     storeReadOnlyEnableSizeThresholdPercentage =
         verifiableProperties.getIntInRange(storeReadOnlyEnableSizeThresholdPercentageName, 95, 0, 100);
     storeReadWriteEnableSizeThresholdPercentageDelta =

--- a/ambry-api/src/test/java/com.github.ambry/clustermap/ReplicaStatusDelegateTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/clustermap/ReplicaStatusDelegateTest.java
@@ -19,17 +19,17 @@ import org.junit.Test;
 import static org.mockito.Mockito.*;
 
 
-public class WriteStatusDelegateTest {
+public class ReplicaStatusDelegateTest {
 
   /**
-   * Tests WriteStatusDelegate
+   * Tests ReplicaStatusDelegate
    */
   @Test
   public void testDelegate() {
     //Initializes delegate and arguments
     ClusterParticipant clusterParticipant = mock(ClusterParticipant.class);
     ReplicaId replicaId = mock(ReplicaId.class);
-    WriteStatusDelegate delegate = new WriteStatusDelegate(clusterParticipant);
+    ReplicaStatusDelegate delegate = new ReplicaStatusDelegate(clusterParticipant);
 
     //Checks that the right underlying ClusterParticipant methods are called
     verifyZeroInteractions(clusterParticipant);
@@ -38,6 +38,12 @@ public class WriteStatusDelegateTest {
     verifyNoMoreInteractions(clusterParticipant);
     delegate.unseal(replicaId);
     verify(clusterParticipant).setReplicaSealedState(replicaId, false);
+    verifyNoMoreInteractions(clusterParticipant);
+    delegate.setReplicaStoppedState(replicaId, true);
+    verify(clusterParticipant).setReplicaStoppedState(replicaId, true);
+    verifyNoMoreInteractions(clusterParticipant);
+    delegate.setReplicaStoppedState(replicaId, false);
+    verify(clusterParticipant).setReplicaStoppedState(replicaId, false);
     verifyNoMoreInteractions(clusterParticipant);
   }
 }

--- a/ambry-api/src/test/java/com.github.ambry/clustermap/ReplicaStatusDelegateTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/clustermap/ReplicaStatusDelegateTest.java
@@ -14,6 +14,8 @@
 
 package com.github.ambry.clustermap;
 
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Test;
 
 import static org.mockito.Mockito.*;
@@ -30,6 +32,7 @@ public class ReplicaStatusDelegateTest {
     ClusterParticipant clusterParticipant = mock(ClusterParticipant.class);
     ReplicaId replicaId = mock(ReplicaId.class);
     ReplicaStatusDelegate delegate = new ReplicaStatusDelegate(clusterParticipant);
+    List<ReplicaId> replicaIds = Arrays.asList(replicaId);
 
     //Checks that the right underlying ClusterParticipant methods are called
     verifyZeroInteractions(clusterParticipant);
@@ -39,11 +42,14 @@ public class ReplicaStatusDelegateTest {
     delegate.unseal(replicaId);
     verify(clusterParticipant).setReplicaSealedState(replicaId, false);
     verifyNoMoreInteractions(clusterParticipant);
-    delegate.setReplicaStoppedState(replicaId, true);
-    verify(clusterParticipant).setReplicaStoppedState(replicaId, true);
+    delegate.markStopped(replicaIds);
+    verify(clusterParticipant).setReplicaStoppedState(replicaIds, true);
     verifyNoMoreInteractions(clusterParticipant);
-    delegate.setReplicaStoppedState(replicaId, false);
-    verify(clusterParticipant).setReplicaStoppedState(replicaId, false);
+    delegate.unmarkStopped(replicaIds);
+    verify(clusterParticipant).setReplicaStoppedState(replicaIds, false);
+    verifyNoMoreInteractions(clusterParticipant);
+    delegate.getStoppedReplicas();
+    verify(clusterParticipant).getStoppedReplicas();
     verifyNoMoreInteractions(clusterParticipant);
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
@@ -28,6 +28,7 @@ class AmbryReplica implements ReplicaId {
   private final AmbryDisk disk;
   private final long capacityBytes;
   private volatile boolean isSealed;
+  private volatile boolean isStopped = false;
 
   /**
    * Instantiate an AmbryReplica instance.
@@ -95,6 +96,10 @@ class AmbryReplica implements ReplicaId {
     this.isSealed = isSealed;
   }
 
+  void setStoppedState(boolean isStopped) {
+    this.isStopped = isStopped;
+  }
+
   @Override
   public AmbryDisk getDiskId() {
     return disk;
@@ -102,7 +107,7 @@ class AmbryReplica implements ReplicaId {
 
   @Override
   public boolean isDown() {
-    return disk.getState() == HardwareState.UNAVAILABLE;
+    return disk.getState() == HardwareState.UNAVAILABLE || isStopped;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -43,6 +43,7 @@ public class ClusterMapUtils {
   static final String SSLPORT_STR = "sslPort";
   static final String RACKID_STR = "rackId";
   static final String SEALED_STR = "SEALED";
+  static final String STOPPED_REPLICAS_STR = "STOPPED";
   static final String AVAILABLE_STR = "AVAILABLE";
   static final String UNAVAILABLE_STR = "UNAVAILABLE";
   static final String ZKCONNECTSTR_STR = "zkConnectStr";
@@ -138,6 +139,15 @@ public class ClusterMapUtils {
    */
   static List<String> getSealedReplicas(InstanceConfig instanceConfig) {
     return instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
+  }
+
+  /**
+   * Get the list of stopped replicas on a given instance.
+   * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
+   * @return the list of stopped replicas.
+   */
+  static List<String> getStoppedReplicas(InstanceConfig instanceConfig) {
+    return instanceConfig.getRecord().getListField(ClusterMapUtils.STOPPED_REPLICAS_STR);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -18,6 +18,7 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -147,7 +148,8 @@ public class ClusterMapUtils {
    * @return the list of stopped replicas.
    */
   static List<String> getStoppedReplicas(InstanceConfig instanceConfig) {
-    return instanceConfig.getRecord().getListField(ClusterMapUtils.STOPPED_REPLICAS_STR);
+    List<String> stoppedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.STOPPED_REPLICAS_STR);
+    return stoppedReplicas == null ? Collections.emptyList() : stoppedReplicas;
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -532,6 +532,7 @@ class HelixBootstrapUpgradeUtil {
       instanceConfig.getRecord().setMapFields(diskInfos);
     }
     instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, sealedPartitionsList);
+    instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, new ArrayList<>());
     return instanceConfig;
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -217,9 +217,9 @@ class HelixParticipant implements ClusterParticipant {
   }
 
   /**
-   * Get the list of sealed replicas from the HelixAdmin. This method is called only after the helixAdministrationLock
+   * Get the list of stopped replicas from the HelixAdmin. This method is called only after the helixAdministrationLock
    * is taken.
-   * @return list of sealed replicas from HelixAdmin
+   * @return list of stopped replicas from HelixAdmin
    */
   private List<String> getStoppedReplicas() {
     InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(clusterName, instanceName);
@@ -248,7 +248,7 @@ class HelixParticipant implements ClusterParticipant {
   }
 
   /**
-   * Set the list of sealed replicas in the HelixAdmin. This method is called only after the helixAdministrationLock
+   * Set the list of stopped replicas in the HelixAdmin. This method is called only after the helixAdministrationLock
    * is taken.
    * @param stoppedReplicas list of stopped replicas to be set in the HelixAdmin
    * @return whether the operation succeeded or not

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -18,7 +18,6 @@ import com.github.ambry.server.AmbryHealthReport;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -152,15 +151,13 @@ class HelixParticipant implements ClusterParticipant {
     synchronized (helixAdministrationLock) {
       logger.trace("Getting stopped replicas from instanceConfig");
       List<String> stoppedListInHelix = getStoppedReplicas();
-      if (stoppedListInHelix == null) {
-        stoppedListInHelix = new ArrayList<>();
-      }
       Set<String> stoppedSet = new HashSet<>(stoppedListInHelix);
-      boolean stoppedSetUpdated = markStop ? stoppedSet.addAll(replicasToUpdate) : stoppedSet.removeAll(replicasToUpdate);
-      if(stoppedSetUpdated){
+      boolean stoppedSetUpdated =
+          markStop ? stoppedSet.addAll(replicasToUpdate) : stoppedSet.removeAll(replicasToUpdate);
+      if (stoppedSetUpdated) {
         logger.trace("Updating the stopped list in Helix InstanceConfig");
         setStoppedResult = setStoppedReplicas(new ArrayList<>(stoppedSet));
-      }else{
+      } else {
         logger.trace("No replicas should be added or removed, no need to update the stopped list");
         setStoppedResult = true;
       }
@@ -247,7 +244,7 @@ class HelixParticipant implements ClusterParticipant {
       throw new IllegalStateException(
           "No instance config found for cluster: \"" + clusterName + "\", instance: \"" + instanceName + "\"");
     }
-    logger.trace("Setting InstanceConfig with list of sealed replicas: {}", Arrays.toString(sealedReplicas.toArray()));
+    logger.trace("Setting InstanceConfig with list of sealed replicas: {}", sealedReplicas.toArray());
     instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, sealedReplicas);
     return helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
   }
@@ -264,8 +261,7 @@ class HelixParticipant implements ClusterParticipant {
       throw new IllegalStateException(
           "No instance config found for cluster: \"" + clusterName + "\", instance: \"" + instanceName + "\"");
     }
-    logger.trace("Setting InstanceConfig with list of stopped replicas: {}",
-        Arrays.toString(stoppedReplicas.toArray()));
+    logger.trace("Setting InstanceConfig with list of stopped replicas: {}", stoppedReplicas.toArray());
     instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, stoppedReplicas);
     return helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
@@ -114,6 +114,10 @@ class Replica implements ReplicaId {
     return peers;
   }
 
+  void setStoppedState(boolean isStopped) {
+    this.isStopped = isStopped;
+  }
+  
   protected void validatePartition() {
     if (partition == null) {
       throw new IllegalStateException("Partition cannot be null.");

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 class Replica implements ReplicaId {
   private final Partition partition;
   private Disk disk;
+  private volatile boolean isStopped = false;
 
   private Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -91,7 +92,7 @@ class Replica implements ReplicaId {
   @Override
   public boolean isDown() {
     return getDataNodeId().getState() == HardwareState.UNAVAILABLE
-        || getDiskId().getState() == HardwareState.UNAVAILABLE;
+        || getDiskId().getState() == HardwareState.UNAVAILABLE || isStopped;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
@@ -91,7 +91,7 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
         }
 
         @Override
-        public boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean isStopped) {
+        public boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean markStop) {
           return false;
         }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
@@ -88,6 +88,11 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
         public boolean setReplicaSealedState(ReplicaId replicaId, boolean isSealed) {
           return false;
         }
+
+        @Override
+        public boolean setReplicaStoppedState(ReplicaId replicaId, boolean isStopped) {
+          return false;
+        }
       };
     }
     return clusterParticipant;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.server.AmbryHealthReport;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.json.JSONException;
@@ -90,8 +91,18 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
         }
 
         @Override
-        public boolean setReplicaStoppedState(ReplicaId replicaId, boolean isStopped) {
+        public boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean isStopped) {
           return false;
+        }
+
+        @Override
+        public List<String> getSealedReplicas() {
+          return new ArrayList<>();
+        }
+
+        @Override
+        public List<String> getStoppedReplicas() {
+          return new ArrayList<>();
         }
       };
     }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
@@ -17,7 +17,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.server.AmbryHealthReport;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.json.JSONException;
@@ -97,12 +97,12 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
 
         @Override
         public List<String> getSealedReplicas() {
-          return new ArrayList<>();
+          return Collections.emptyList();
         }
 
         @Override
         public List<String> getStoppedReplicas() {
-          return new ArrayList<>();
+          return Collections.emptyList();
         }
       };
     }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
@@ -203,7 +203,7 @@ public class HelixParticipantTest {
 
     //Make sure the current stoppedReplicas list is null
     List<String> stoppedReplicas = helixParticipant.getStoppedReplicas();
-    assertNull("stoppedReplicas is not null", stoppedReplicas);
+    assertTrue("stoppedReplicas list should be empty", stoppedReplicas.isEmpty());
 
     String listName = "stoppedReplicas list";
 
@@ -243,7 +243,7 @@ public class HelixParticipantTest {
     assertTrue(stoppedReplicas.contains(partitionId2));
     assertTrue(stoppedReplicas.contains(partitionId3));
 
-    //Check that invoking setReplicaStoppedState with isStopped == false removes replicaId1, replicaId2 from stopped list
+    //Check that invoking setReplicaStoppedState with markStop == false removes replicaId1, replicaId2 from stopped list
     helixParticipant.setReplicaStoppedState(Arrays.asList(replicaId1, replicaId2), false);
     stoppedReplicas = helixParticipant.getStoppedReplicas();
     listIsExpectedSize(stoppedReplicas, 1, listName);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
@@ -17,6 +17,7 @@ import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -51,6 +52,7 @@ import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -66,25 +68,19 @@ import static org.mockito.Mockito.*;
 public class HelixParticipantTest {
   private final MockHelixManagerFactory helixManagerFactory;
   private final Properties props;
-  private final Properties propsDummy;
   private final String clusterName = "HelixParticipantTestCluster";
+  private final JSONObject zkJson;
 
   public HelixParticipantTest() throws Exception {
     List<com.github.ambry.utils.TestUtils.ZkInfo> zkInfoList = new ArrayList<>();
     zkInfoList.add(new com.github.ambry.utils.TestUtils.ZkInfo(null, "DC0", (byte) 0, 2199, false));
-    JSONObject zkJson = constructZkLayoutJSON(zkInfoList);
+    zkJson = constructZkLayoutJSON(zkInfoList);
     props = new Properties();
     props.setProperty("clustermap.host.name", "localhost");
     props.setProperty("clustermap.port", "2200");
     props.setProperty("clustermap.cluster.name", clusterName);
     props.setProperty("clustermap.datacenter.name", "DC0");
     props.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
-    propsDummy = new Properties(props);
-    propsDummy.setProperty("clustermap.host.name", "dummyHost");
-    propsDummy.setProperty("clustermap.port", "2200");
-    propsDummy.setProperty("clustermap.cluster.name", clusterName);
-    propsDummy.setProperty("clustermap.datacenter.name", "DC0");
-    propsDummy.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
     helixManagerFactory = new MockHelixManagerFactory();
   }
 
@@ -93,7 +89,7 @@ public class HelixParticipantTest {
    * @throws IOException
    */
   @Test
-  public void testSetReplicaSealedState() throws IOException {
+  public void testGetAndSetReplicaSealedState() throws IOException {
     //setup HelixParticipant and dependencies
     String partitionIdStr = "somePartitionId";
     String partitionIdStr2 = "someOtherPartitionId";
@@ -111,7 +107,7 @@ public class HelixParticipantTest {
     helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
 
     //Make sure the current sealedReplicas list is null
-    List<String> sealedReplicas = ClusterMapUtils.getSealedReplicas(instanceConfig);
+    List<String> sealedReplicas = helixParticipant.getSealedReplicas();
     assertNull("sealedReplicas is not null", sealedReplicas);
 
     String listName = "sealedReplicas";
@@ -127,13 +123,13 @@ public class HelixParticipantTest {
 
     //Check that invoking setReplicaSealedState adds the partition to the list of sealed replicas
     helixParticipant.setReplicaSealedState(replicaId, true);
-    sealedReplicas = ClusterMapUtils.getSealedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
+    sealedReplicas = helixParticipant.getSealedReplicas();
     listIsExpectedSize(sealedReplicas, 1, listName);
     assertTrue(sealedReplicas.contains(partitionIdStr));
 
     //Seal another replicaId
     helixParticipant.setReplicaSealedState(replicaId2, true);
-    sealedReplicas = ClusterMapUtils.getSealedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
+    sealedReplicas = helixParticipant.getSealedReplicas();
     listIsExpectedSize(sealedReplicas, 2, listName);
     assertTrue(sealedReplicas.contains(partitionIdStr2));
     assertTrue(sealedReplicas.contains(partitionIdStr));
@@ -143,41 +139,50 @@ public class HelixParticipantTest {
     ReplicaId dup = createMockAmbryReplica(partitionIdStr);
     helixParticipant.setReplicaSealedState(dup, true);
     helixParticipant.setReplicaSealedState(replicaId2, true);
-    sealedReplicas = ClusterMapUtils.getSealedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
+    sealedReplicas = helixParticipant.getSealedReplicas();
     listIsExpectedSize(sealedReplicas, 2, listName);
     assertTrue(sealedReplicas.contains(partitionIdStr2));
     assertTrue(sealedReplicas.contains(partitionIdStr));
 
     //Check that invoking setReplicaSealedState with isSealed == false removes partition from list of sealed replicas
     helixParticipant.setReplicaSealedState(replicaId, false);
-    sealedReplicas = ClusterMapUtils.getSealedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
+    sealedReplicas = helixParticipant.getSealedReplicas();
     listIsExpectedSize(sealedReplicas, 1, listName);
     assertTrue(sealedReplicas.contains(partitionIdStr2));
     assertFalse(sealedReplicas.contains(partitionIdStr));
 
     //Removing a replicaId that's already been removed doesn't hurt anything
     helixParticipant.setReplicaSealedState(replicaId, false);
-    sealedReplicas = ClusterMapUtils.getSealedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
+    sealedReplicas = helixParticipant.getSealedReplicas();
     listIsExpectedSize(sealedReplicas, 1, listName);
 
     //Removing all replicas yields expected behavior (and removal works by partitionId, not replicaId itself)
     dup = createMockAmbryReplica(partitionIdStr2);
     helixParticipant.setReplicaSealedState(dup, false);
-    sealedReplicas = ClusterMapUtils.getSealedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
+    sealedReplicas = helixParticipant.getSealedReplicas();
     listIsExpectedSize(sealedReplicas, 0, listName);
   }
 
   /**
    * Tests setReplicaStoppedState method for {@link HelixParticipant}
    * @throws IOException
+   * @throws JSONException
    */
   @Test
-  public void testSetReplicaStoppedState() throws IOException {
-    //setup HelixParticipant and dependencies
+  public void testGetAndSetReplicaStoppedState() throws IOException, JSONException {
+    //setup HelixParticipant, HelixParticipantDummy and dependencies
+    Properties propsDummy = new Properties(props);
+    propsDummy.setProperty("clustermap.host.name", "dummyHost");
+    propsDummy.setProperty("clustermap.port", "2200");
+    propsDummy.setProperty("clustermap.cluster.name", clusterName);
+    propsDummy.setProperty("clustermap.datacenter.name", "DC0");
+    propsDummy.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
     String partitionId1 = "partitionId1";
     String partitionId2 = "partitionId2";
+    String partitionId3 = "partitionId3";
     ReplicaId replicaId1 = createMockAmbryReplica(partitionId1);
     ReplicaId replicaId2 = createMockAmbryReplica(partitionId2);
+    ReplicaId replicaId3 = createMockAmbryReplica(partitionId3);
     String hostname = "localhost";
     int port = 2200;
     String instanceName = ClusterMapUtils.getInstanceName(hostname, port);
@@ -195,7 +200,7 @@ public class HelixParticipantTest {
     helixAdmin.setInstanceConfig(clusterName, instanceNameDummy, null);
 
     //Make sure the current stoppedReplicas list is null
-    List<String> stoppedReplicas = ClusterMapUtils.getSealedReplicas(instanceConfig);
+    List<String> stoppedReplicas = helixParticipant.getStoppedReplicas();
     assertNull("stoppedReplicas is not null", stoppedReplicas);
 
     String listName = "stoppedReplicas list";
@@ -203,56 +208,53 @@ public class HelixParticipantTest {
     //Check that invoking setReplicaStoppedState with a non-AmbryReplica ReplicaId throws an IllegalArgumentException
     ReplicaId nonAmbryReplica = createMockNotAmbryReplica(partitionId1);
     try {
-      helixParticipant.setReplicaStoppedState(nonAmbryReplica, true);
+      helixParticipant.setReplicaStoppedState(Arrays.asList(nonAmbryReplica), true);
       fail("Expected an IllegalArgumentException here");
-    } catch (Exception e) {
-      assertTrue("Unexpected exception", e instanceof IllegalArgumentException);
+    } catch (IllegalArgumentException e) {
+      // expected. Nothing to do.
     }
 
     //Check that invoking setReplicaStoppedState with null instanceConfig
     try {
-      helixParticipantDummy.setReplicaStoppedState(replicaId1, true);
+      helixParticipantDummy.setReplicaStoppedState(Arrays.asList(replicaId1), true);
       fail("Expected an IllegalStateException here");
-    } catch (Exception e) {
-      assertTrue("Unexpected exception", e instanceof IllegalStateException);
+    } catch (IllegalStateException e) {
+      // expected. Nothing to do.
     }
 
-    //Check that invoking setReplicaStoppedState adds the partition to the list of stopped replicas
-    helixParticipant.setReplicaStoppedState(replicaId1, true);
-    stoppedReplicas = ClusterMapUtils.getStoppedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
-    listIsExpectedSize(stoppedReplicas, 1, listName);
-    assertTrue(stoppedReplicas.contains(partitionId1));
-
-    //Add another replicaId to stopped replica list
-    helixParticipant.setReplicaStoppedState(replicaId2, true);
-    stoppedReplicas = ClusterMapUtils.getStoppedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
+    //Check that invoking setReplicaStoppedState adds the partitions to the list of stopped replicas
+    helixParticipant.setReplicaStoppedState(Arrays.asList(replicaId1, replicaId2), true);
+    stoppedReplicas = helixParticipant.getStoppedReplicas();
     listIsExpectedSize(stoppedReplicas, 2, listName);
+    System.out.println(stoppedReplicas.get(0));
     assertTrue(stoppedReplicas.contains(partitionId1));
     assertTrue(stoppedReplicas.contains(partitionId2));
 
-    //Add same replicaId again to ensure no duplicates in the stopped replica list
-    helixParticipant.setReplicaStoppedState(replicaId1, true);
-    stoppedReplicas = ClusterMapUtils.getStoppedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
-    listIsExpectedSize(stoppedReplicas, 2, listName);
+    //Add replicaId1 again as well as replicaId3 to ensure new replicaId is correctly added and no duplicates in the stopped list
+    helixParticipant.setReplicaStoppedState(Arrays.asList(replicaId1, replicaId3), true);
+    stoppedReplicas = helixParticipant.getStoppedReplicas();
+    listIsExpectedSize(stoppedReplicas, 3, listName);
     assertTrue(stoppedReplicas.contains(partitionId1));
     assertTrue(stoppedReplicas.contains(partitionId2));
+    assertTrue(stoppedReplicas.contains(partitionId3));
 
-    //Check that invoking setReplicaStoppedState with isStopped == false removes replica from list of stopped replicas
-    helixParticipant.setReplicaStoppedState(replicaId1, false);
-    stoppedReplicas = ClusterMapUtils.getStoppedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
+    //Check that invoking setReplicaStoppedState with isStopped == false removes replicaId1, replicaId2 from stopped list
+    helixParticipant.setReplicaStoppedState(Arrays.asList(replicaId1, replicaId2), false);
+    stoppedReplicas = helixParticipant.getStoppedReplicas();
     listIsExpectedSize(stoppedReplicas, 1, listName);
-    assertTrue(stoppedReplicas.contains(partitionId2));
+    assertTrue(stoppedReplicas.contains(partitionId3));
     assertFalse(stoppedReplicas.contains(partitionId1));
+    assertFalse(stoppedReplicas.contains(partitionId2));
 
-    //Removing a replicaId that's already been removed doesn't hurt anything
-    helixParticipant.setReplicaStoppedState(replicaId1, false);
-    stoppedReplicas = ClusterMapUtils.getStoppedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
+    //Removing replicaIds which have already been removed doesn't hurt anything
+    helixParticipant.setReplicaStoppedState(Arrays.asList(replicaId1, replicaId2), false);
+    stoppedReplicas = helixParticipant.getStoppedReplicas();
     listIsExpectedSize(stoppedReplicas, 1, listName);
-    assertTrue(stoppedReplicas.contains(partitionId2));
+    assertTrue(stoppedReplicas.contains(partitionId3));
 
-    //Removing all replicas yields expected behavior
-    helixParticipant.setReplicaStoppedState(replicaId2, false);
-    stoppedReplicas = ClusterMapUtils.getStoppedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
+    //Removing all replicas (including replica not in the list) yields expected behavior
+    helixParticipant.setReplicaStoppedState(Arrays.asList(replicaId2, replicaId3), false);
+    stoppedReplicas = helixParticipant.getStoppedReplicas();
     listIsExpectedSize(stoppedReplicas, 0, listName);
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
@@ -250,7 +250,7 @@ public class HelixParticipantTest {
     listIsExpectedSize(stoppedReplicas, 1, listName);
     assertTrue(stoppedReplicas.contains(partitionId2));
 
-    //Removing all replicas yields expected behavior (and removal works by partitionId, not replicaId itself)
+    //Removing all replicas yields expected behavior
     helixParticipant.setReplicaStoppedState(replicaId2, false);
     stoppedReplicas = ClusterMapUtils.getStoppedReplicas(helixAdmin.getInstanceConfig(clusterName, instanceName));
     listIsExpectedSize(stoppedReplicas, 0, listName);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
@@ -15,6 +15,7 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.server.AmbryHealthReport;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -68,13 +69,25 @@ public class MockClusterAgentsFactory implements ClusterAgentsFactory {
         }
 
         @Override
-        public boolean setReplicaStoppedState(ReplicaId replicaId, boolean isStopped) {
-          if (!(replicaId instanceof MockReplicaId)) {
-            throw new IllegalArgumentException("Not MockReplicaId");
+        public boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean isStopped) {
+          for (ReplicaId replicaId : replicaIds) {
+            if (!(replicaId instanceof MockReplicaId)) {
+              throw new IllegalArgumentException("Not MockReplicaId");
+            }
+            MockReplicaId mockReplicaId = (MockReplicaId) replicaId;
+            mockReplicaId.markReplicaDownStatus(isStopped);
           }
-          MockReplicaId mockReplicaId = (MockReplicaId) replicaId;
-          mockReplicaId.markReplicaDownStatus(isStopped);
           return true;
+        }
+
+        @Override
+        public List<String> getSealedReplicas() {
+          return new ArrayList<>();
+        }
+
+        @Override
+        public List<String> getStoppedReplicas() {
+          return new ArrayList<>();
         }
       };
     }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
@@ -69,13 +69,13 @@ public class MockClusterAgentsFactory implements ClusterAgentsFactory {
         }
 
         @Override
-        public boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean isStopped) {
+        public boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean markStop) {
           for (ReplicaId replicaId : replicaIds) {
             if (!(replicaId instanceof MockReplicaId)) {
               throw new IllegalArgumentException("Not MockReplicaId");
             }
             MockReplicaId mockReplicaId = (MockReplicaId) replicaId;
-            mockReplicaId.markReplicaDownStatus(isStopped);
+            mockReplicaId.markReplicaDownStatus(markStop);
           }
           return true;
         }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
@@ -66,6 +66,16 @@ public class MockClusterAgentsFactory implements ClusterAgentsFactory {
           mockReplicaId.setSealedState(isSealed);
           return true;
         }
+
+        @Override
+        public boolean setReplicaStoppedState(ReplicaId replicaId, boolean isStopped) {
+          if (!(replicaId instanceof MockReplicaId)) {
+            throw new IllegalArgumentException("Not MockReplicaId");
+          }
+          MockReplicaId mockReplicaId = (MockReplicaId) replicaId;
+          mockReplicaId.markReplicaDownStatus(isStopped);
+          return true;
+        }
       };
     }
     return clusterParticipant;

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -806,6 +806,9 @@ public class AmbryRequests implements RequestAPI {
               if (storageManager.controlCompactionForBlobStore(partitionId, true)) {
                 error = ServerErrorCode.No_Error;
                 logger.info("Store is successfully started and functional for partition: {}", partitionId);
+                if (!storageManager.setBlobStoreStoppedState(partitionId, false)) {
+                  logger.info("Fail to remove BlobStore {} from stoppedReplicas list after it is started", partitionId);
+                }
               } else {
                 error = ServerErrorCode.Unknown_Error;
                 logger.error("Enable compaction fails on given BlobStore {}", partitionId);
@@ -843,6 +846,9 @@ public class AmbryRequests implements RequestAPI {
                   if (storageManager.shutdownBlobStore(partitionId)) {
                     error = ServerErrorCode.No_Error;
                     logger.info("Store is successfully shutdown for partition: {}", partitionId);
+                    if (!storageManager.setBlobStoreStoppedState(partitionId, true)) {
+                      logger.info("Fail to add BlobStore {} to stoppedReplicas list after it is stopped", partitionId);
+                    }
                   } else {
                     error = ServerErrorCode.Unknown_Error;
                     logger.error("Shutting down BlobStore fails on {}", partitionId);

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -77,7 +77,6 @@ import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -808,10 +807,10 @@ public class AmbryRequests implements RequestAPI {
                 error = ServerErrorCode.No_Error;
                 logger.info("Store is successfully started and functional for partition: {}", partitionId);
                 List<PartitionId> failToUpdateList =
-                    storageManager.setBlobStoreStoppedState(Arrays.asList(partitionId), false);
+                    storageManager.setBlobStoreStoppedState(Collections.singletonList(partitionId), false);
                 if (!failToUpdateList.isEmpty()) {
-                  logger.info("Fail to remove BlobStore(s) {} from stopped list after start operation completed",
-                      Arrays.toString(failToUpdateList.toArray()));
+                  logger.warn("Fail to remove BlobStore(s) {} from stopped list after start operation completed",
+                      failToUpdateList.toArray());
                 }
               } else {
                 error = ServerErrorCode.Unknown_Error;
@@ -851,10 +850,10 @@ public class AmbryRequests implements RequestAPI {
                     error = ServerErrorCode.No_Error;
                     logger.info("Store is successfully shutdown for partition: {}", partitionId);
                     List<PartitionId> failToUpdateList =
-                        storageManager.setBlobStoreStoppedState(Arrays.asList(partitionId), true);
+                        storageManager.setBlobStoreStoppedState(Collections.singletonList(partitionId), true);
                     if (!failToUpdateList.isEmpty()) {
-                      logger.info("Fail to add BlobStore(s) {} to stopped list after stop operation completed",
-                          Arrays.toString(failToUpdateList.toArray()));
+                      logger.warn("Fail to add BlobStore(s) {} to stopped list after stop operation completed",
+                          failToUpdateList.toArray());
                     }
                   } else {
                     error = ServerErrorCode.Unknown_Error;

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
@@ -19,7 +19,7 @@ import com.github.ambry.clustermap.ClusterAgentsFactory;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.DataNodeId;
-import com.github.ambry.clustermap.WriteStatusDelegate;
+import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ConnectionPoolConfig;
@@ -138,7 +138,7 @@ public class AmbryServer {
       storageManager =
           new StorageManager(storeConfig, diskManagerConfig, scheduler, registry, clusterMap.getReplicaIds(nodeId),
               storeKeyFactory, new BlobStoreRecovery(), new BlobStoreHardDelete(),
-              new WriteStatusDelegate(clusterParticipant), time);
+              new ReplicaStatusDelegate(clusterParticipant), time);
       storageManager.start();
 
       connectionPool = new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, clusterMapConfig, registry);

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -340,6 +340,20 @@ class BlobStore implements Store {
     }
   }
 
+  /**
+   * Update the stopped replicas list based on the state of this store.
+   * @param isStopped whether the store is stopped ({@code true}) or started.
+   * @return {@code true} if StoppedReplicas list has been updated successfully.
+   */
+  public boolean updateStoppedReplicasList(boolean isStopped) {
+    if (writeStatusDelegate != null) {
+      logger.info("Setting replica stopped state via WriteStatusDelegate on replica {}", replicaId);
+      return writeStatusDelegate.setReplicaStoppedState(replicaId, isStopped);
+    }
+    logger.error("The WriteStatusDelegate is not instantiated");
+    return false;
+  }
+
   @Override
   public void put(MessageWriteSet messageSetToWrite) throws StoreException {
     checkStarted();

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -594,7 +594,7 @@ class BlobStore implements Store {
    * @throws StoreException
    */
   DiskSpaceRequirements getDiskSpaceRequirements() throws StoreException {
-    //checkStarted();
+    checkStarted();
     DiskSpaceRequirements requirements = log.isLogSegmented() ? new DiskSpaceRequirements(log.getSegmentCapacity(),
         log.getRemainingUnallocatedSegments(), compactor.getSwapSegmentsInUse()) : null;
     logger.debug("Store {} has disk space requirements: {}", storeId, requirements);

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -339,24 +338,6 @@ class BlobStore implements Store {
     } else {
       logger.debug("The ReplicaStatusDelegate is not instantiated");
     }
-  }
-
-  /**
-   * Update the stopped replicas list based on the state of this store.
-   * @param isStopped whether the store is stopped ({@code true}) or started.
-   * @return {@code true} if StoppedReplicas list has been updated successfully.
-   */
-  boolean updateStoppedReplicasList(boolean isStopped) {
-    boolean updated = false;
-    if (replicaStatusDelegate != null) {
-      logger.info("Setting replica stopped state via ReplicaStatusDelegate on replica {}", replicaId);
-      List<ReplicaId> replicasToUpdate = Arrays.asList(replicaId);
-      updated = isStopped ? replicaStatusDelegate.markStopped(replicasToUpdate)
-          : replicaStatusDelegate.unmarkStopped(replicasToUpdate);
-    } else {
-      logger.error("The ReplicaStatusDelegate is not instantiated");
-    }
-    return updated;
   }
 
   @Override

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -15,7 +15,7 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.Timer;
 import com.github.ambry.clustermap.ReplicaId;
-import com.github.ambry.clustermap.WriteStatusDelegate;
+import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.utils.FileLock;
 import com.github.ambry.utils.Time;
@@ -61,7 +61,7 @@ class BlobStore implements Store {
   private final Time time;
   private final UUID sessionId = UUID.randomUUID();
   private final ReplicaId replicaId;
-  private final WriteStatusDelegate writeStatusDelegate;
+  private final ReplicaStatusDelegate replicaStatusDelegate;
   private final long thresholdBytesHigh;
   private final long thresholdBytesLow;
 
@@ -99,17 +99,17 @@ class BlobStore implements Store {
    * @param factory the {@link StoreKeyFactory} for parsing store keys.
    * @param recovery the {@link MessageStoreRecovery} instance to use.
    * @param hardDelete the {@link MessageStoreHardDelete} instance to use.
-   * @param writeStatusDelegate delegate used to communicate BlobStore write status (sealed or unsealed)
+   * @param replicaStatusDelegate delegate used to communicate BlobStore write status (sealed or unsealed)
    * @param time the {@link Time} instance to use.
    */
   BlobStore(ReplicaId replicaId, StoreConfig config, ScheduledExecutorService taskScheduler,
       ScheduledExecutorService longLivedTaskScheduler, DiskIOScheduler diskIOScheduler,
       DiskSpaceAllocator diskSpaceAllocator, StoreMetrics metrics, StoreMetrics storeUnderCompactionMetrics,
       StoreKeyFactory factory, MessageStoreRecovery recovery, MessageStoreHardDelete hardDelete,
-      WriteStatusDelegate writeStatusDelegate, Time time) {
+      ReplicaStatusDelegate replicaStatusDelegate, Time time) {
     this(replicaId, replicaId.getPartitionId().toString(), config, taskScheduler, longLivedTaskScheduler,
         diskIOScheduler, diskSpaceAllocator, metrics, storeUnderCompactionMetrics, replicaId.getReplicaPath(),
-        replicaId.getCapacityInBytes(), factory, recovery, hardDelete, writeStatusDelegate, time);
+        replicaId.getCapacityInBytes(), factory, recovery, hardDelete, replicaStatusDelegate, time);
   }
 
   /**
@@ -142,7 +142,7 @@ class BlobStore implements Store {
       ScheduledExecutorService longLivedTaskScheduler, DiskIOScheduler diskIOScheduler,
       DiskSpaceAllocator diskSpaceAllocator, StoreMetrics metrics, StoreMetrics storeUnderCompactionMetrics,
       String dataDir, long capacityInBytes, StoreKeyFactory factory, MessageStoreRecovery recovery,
-      MessageStoreHardDelete hardDelete, WriteStatusDelegate writeStatusDelegate, Time time) {
+      MessageStoreHardDelete hardDelete, ReplicaStatusDelegate replicaStatusDelegate, Time time) {
     this.replicaId = replicaId;
     this.storeId = storeId;
     this.dataDir = dataDir;
@@ -157,15 +157,15 @@ class BlobStore implements Store {
     this.factory = factory;
     this.recovery = recovery;
     this.hardDelete = hardDelete;
-    this.writeStatusDelegate = config.storeWriteStatusDelegateEnable ? writeStatusDelegate : null;
+    this.replicaStatusDelegate = config.storeReplicaStatusDelegateEnable ? replicaStatusDelegate : null;
     this.time = time;
     long threshold = config.storeReadOnlyEnableSizeThresholdPercentage;
     long delta = config.storeReadWriteEnableSizeThresholdPercentageDelta;
     this.thresholdBytesHigh = (long) (capacityInBytes * (threshold / 100.0));
     this.thresholdBytesLow = (long) (capacityInBytes * ((threshold - delta) / 100.0));
     logger.debug(
-        "The enable state of writeStatusDelegate is {} on store {}. The high threshold is {} bytes and the low threshold is {} bytes",
-        config.storeWriteStatusDelegateEnable, storeId, this.thresholdBytesHigh, this.thresholdBytesLow);
+        "The enable state of replicaStatusDelegate is {} on store {}. The high threshold is {} bytes and the low threshold is {} bytes",
+        config.storeReplicaStatusDelegateEnable, storeId, this.thresholdBytesHigh, this.thresholdBytesLow);
   }
 
   @Override
@@ -215,7 +215,7 @@ class BlobStore implements Store {
             new BlobStoreStats(storeId, index, config.storeStatsBucketCount, bucketSpanInMs, logSegmentForecastOffsetMs,
                 queueProcessingPeriodInMs, config.storeStatsWaitTimeoutInSecs, time, longLivedTaskScheduler,
                 taskScheduler, diskIOScheduler, metrics);
-        checkCapacityAndUpdateWriteStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
+        checkCapacityAndUpdateReplicaStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
         logger.trace("The store {} is successfully started", storeId);
         started = true;
       } catch (Exception e) {
@@ -309,12 +309,12 @@ class BlobStore implements Store {
    * @param totalCapacity total capacity of the store in bytes
    * @param usedCapacity total used capacity of the store in bytes
    */
-  private void checkCapacityAndUpdateWriteStatusDelegate(long totalCapacity, long usedCapacity) {
-    if (writeStatusDelegate != null) {
+  private void checkCapacityAndUpdateReplicaStatusDelegate(long totalCapacity, long usedCapacity) {
+    if (replicaStatusDelegate != null) {
       logger.debug("The current used capacity is {} bytes on store {}", index.getLogUsedCapacity(),
           replicaId.getPartitionId());
       if (index.getLogUsedCapacity() > thresholdBytesHigh && !replicaId.isSealed()) {
-        if (!writeStatusDelegate.seal(replicaId)) {
+        if (!replicaStatusDelegate.seal(replicaId)) {
           metrics.sealSetError.inc();
           logger.warn("Could not set the partition as read-only status on {}", replicaId);
         } else {
@@ -324,7 +324,7 @@ class BlobStore implements Store {
               replicaId.getPartitionId(), index.getLogUsedCapacity(), thresholdBytesHigh);
         }
       } else if (index.getLogUsedCapacity() <= thresholdBytesLow && replicaId.isSealed()) {
-        if (!writeStatusDelegate.unseal(replicaId)) {
+        if (!replicaStatusDelegate.unseal(replicaId)) {
           metrics.unsealSetError.inc();
           logger.warn("Could not set the partition as read-write status on {}", replicaId);
         } else {
@@ -336,7 +336,7 @@ class BlobStore implements Store {
       }
       //else: maintain current replicaId status if percentFilled between threshold - delta and threshold
     } else {
-      logger.debug("The WriteStatusDelegate is not instantiated");
+      logger.debug("The ReplicaStatusDelegate is not instantiated");
     }
   }
 
@@ -346,11 +346,11 @@ class BlobStore implements Store {
    * @return {@code true} if StoppedReplicas list has been updated successfully.
    */
   public boolean updateStoppedReplicasList(boolean isStopped) {
-    if (writeStatusDelegate != null) {
-      logger.info("Setting replica stopped state via WriteStatusDelegate on replica {}", replicaId);
-      return writeStatusDelegate.setReplicaStoppedState(replicaId, isStopped);
+    if (replicaStatusDelegate != null) {
+      logger.info("Setting replica stopped state via ReplicaStatusDelegate on replica {}", replicaId);
+      return replicaStatusDelegate.setReplicaStoppedState(replicaId, isStopped);
     }
-    logger.error("The WriteStatusDelegate is not instantiated");
+    logger.error("The ReplicaStatusDelegate is not instantiated");
     return false;
   }
 
@@ -395,7 +395,7 @@ class BlobStore implements Store {
               blobStoreStats.handleNewPutEntry(newEntry.getValue());
             }
             logger.trace("Store : {} message set written to index ", dataDir);
-            checkCapacityAndUpdateWriteStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
+            checkCapacityAndUpdateReplicaStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
           }
         }
       }
@@ -615,7 +615,7 @@ class BlobStore implements Store {
   void compact(CompactionDetails details, ByteBuffer bundleReadBuffer) throws IOException, StoreException {
     checkStarted();
     compactor.compact(details, bundleReadBuffer);
-    checkCapacityAndUpdateWriteStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
+    checkCapacityAndUpdateReplicaStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
     logger.trace("One cycle of compaction is completed on the store {}", storeId);
   }
 
@@ -629,7 +629,7 @@ class BlobStore implements Store {
     if (CompactionLog.isCompactionInProgress(dataDir, storeId)) {
       logger.info("Resuming compaction of {}", this);
       compactor.resumeCompaction(bundleReadBuffer);
-      checkCapacityAndUpdateWriteStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
+      checkCapacityAndUpdateReplicaStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
     }
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
@@ -17,7 +17,7 @@ package com.github.ambry.store;
 import com.github.ambry.clustermap.DiskId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
-import com.github.ambry.clustermap.WriteStatusDelegate;
+import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.config.DiskManagerConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.utils.Throttler;
@@ -71,7 +71,7 @@ class DiskManager {
   DiskManager(DiskId disk, List<ReplicaId> replicas, StoreConfig storeConfig, DiskManagerConfig diskManagerConfig,
       ScheduledExecutorService scheduler, StorageManagerMetrics metrics, StoreMetrics storeMainMetrics,
       StoreMetrics storeUnderCompactionMetrics, StoreKeyFactory keyFactory, MessageStoreRecovery recovery,
-      MessageStoreHardDelete hardDelete, WriteStatusDelegate writeStatusDelegate, Time time) {
+      MessageStoreHardDelete hardDelete, ReplicaStatusDelegate replicaStatusDelegate, Time time) {
     this.disk = disk;
     this.metrics = metrics;
     this.time = time;
@@ -84,7 +84,7 @@ class DiskManager {
       if (disk.equals(replica.getDiskId())) {
         BlobStore store =
             new BlobStore(replica, storeConfig, scheduler, longLivedTaskScheduler, diskIOScheduler, diskSpaceAllocator,
-                storeMainMetrics, storeUnderCompactionMetrics, keyFactory, recovery, hardDelete, writeStatusDelegate,
+                storeMainMetrics, storeUnderCompactionMetrics, keyFactory, recovery, hardDelete, replicaStatusDelegate,
                 time);
         stores.put(replica.getPartitionId(), store);
       }

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
@@ -243,6 +243,7 @@ class DiskManager {
   /**
    * Start the BlobStore with given {@link PartitionId} {@code id}.
    * @param id the {@link PartitionId} of the {@link BlobStore} which should be started.
+   * @return {@code true} if start store was successful. {@code false} if not.
    */
   boolean startBlobStore(PartitionId id) {
     BlobStore store = stores.get(id);
@@ -264,6 +265,7 @@ class DiskManager {
   /**
    * Shutdown the BlobStore with given {@link PartitionId} {@code id}.
    * @param id the {@link PartitionId} of the {@link BlobStore} which should be shutdown.
+   * @return {@code true} if shutdown store was successful. {@code false} if not.
    */
   boolean shutdownBlobStore(PartitionId id) {
     BlobStore store = stores.get(id);
@@ -282,6 +284,12 @@ class DiskManager {
     }
   }
 
+  /**
+   * Set the BlobStore stopped state with given {@link PartitionId} {@code id}.
+   * @param id the {@link PartitionId} of the {@link BlobStore} whose stopped state should be set.
+   * @param isStopped whether to mark BlobStore as stopped ({@code true}) or started.
+   * @return {@code true} if set stopped state of store was successful. {@code false} if not.
+   */
   boolean setBlobStoreStoppedState(PartitionId id, boolean isStopped) {
     BlobStore store = stores.get(id);
     if (store == null) {

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
@@ -25,6 +25,7 @@ import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +83,7 @@ class DiskManager {
     diskSpaceAllocator = new DiskSpaceAllocator(diskManagerConfig.diskManagerEnableSegmentPooling,
         new File(disk.getMountPath(), diskManagerConfig.diskManagerReserveFileDirName),
         diskManagerConfig.diskManagerRequiredSwapSegmentsPerSize, metrics);
-    this.stoppedReplicas = stoppedReplicas == null ? new ArrayList<>() : stoppedReplicas;
+    this.stoppedReplicas = stoppedReplicas == null ? Collections.emptyList() : stoppedReplicas;
     for (ReplicaId replica : replicas) {
       if (disk.equals(replica.getDiskId())) {
         BlobStore store =

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
@@ -282,6 +282,16 @@ class DiskManager {
     }
   }
 
+  boolean setBlobStoreStoppedState(PartitionId id, boolean isStopped) {
+    BlobStore store = stores.get(id);
+    if (store == null) {
+      // no need to check if the store is started because this method could be called after store is successfully shutdown.
+      logger.error("store is not found on this disk when trying to update stoppedReplicas list");
+      return false;
+    }
+    return store.updateStoppedReplicasList(isStopped);
+  }
+
   /**
    * Gets all the throttlers that the {@link DiskIOScheduler} will be constructed with.
    * @param config the {@link StoreConfig} with configuration values.

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -24,6 +24,7 @@ import com.github.ambry.config.StoreConfig;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +66,7 @@ public class StorageManager {
     StoreMetrics storeMainMetrics = new StoreMetrics(registry);
     StoreMetrics storeUnderCompactionMetrics = new StoreMetrics("UnderCompaction", registry);
     List<String> stoppedReplicas =
-        replicaStatusDelegate == null ? new ArrayList<>() : replicaStatusDelegate.getStoppedReplicas();
+        replicaStatusDelegate == null ? Collections.emptyList() : replicaStatusDelegate.getStoppedReplicas();
     this.time = time;
     Map<DiskId, List<ReplicaId>> diskToReplicaMap = new HashMap<>();
     for (ReplicaId replica : replicas) {
@@ -229,10 +230,10 @@ public class StorageManager {
   /**
    * Set BlobStore Stopped state with given {@link PartitionId} {@code id}.
    * @param partitionIds a list {@link PartitionId} of the {@link Store} whose stopped state should be set.
-   * @param isStopped whether to mark BlobStore as stopped ({@code true}) or started.
+   * @param markStop whether to mark BlobStore as stopped ({@code true}) or started.
    * @return a list of {@link PartitionId} whose stopped state fails to be updated.
    */
-  public List<PartitionId> setBlobStoreStoppedState(List<PartitionId> partitionIds, boolean isStopped) {
+  public List<PartitionId> setBlobStoreStoppedState(List<PartitionId> partitionIds, boolean markStop) {
     Map<DiskManager, List<PartitionId>> diskManagerToPartitionMap = new HashMap<>();
     List<PartitionId> failToUpdateStores = new ArrayList<>();
     for (PartitionId id : partitionIds) {
@@ -245,7 +246,7 @@ public class StorageManager {
     }
     for (Map.Entry<DiskManager, List<PartitionId>> diskToPartitions : diskManagerToPartitionMap.entrySet()) {
       List<PartitionId> failList =
-          diskToPartitions.getKey().setBlobStoreStoppedState(diskToPartitions.getValue(), isStopped);
+          diskToPartitions.getKey().setBlobStoreStoppedState(diskToPartitions.getValue(), markStop);
       failToUpdateStores.addAll(failList);
     }
     return failToUpdateStores;

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -224,6 +224,15 @@ public class StorageManager {
   }
 
   /**
+   * Set BlobStore Stopped state with given {@link PartitionId} {@code id}.
+   * @param id the {@link PartitionId} of the {@link Store} which would be shutdown.
+   */
+  public boolean setBlobStoreStoppedState(PartitionId id, boolean isStopped) {
+    DiskManager diskManager = partitionToDiskManager.get(id);
+    return diskManager != null && diskManager.setBlobStoreStoppedState(id, isStopped);
+  }
+
+  /**
    * @return the number of compaction threads running.
    */
   int getCompactionThreadCount() {

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -18,7 +18,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.DiskId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
-import com.github.ambry.clustermap.WriteStatusDelegate;
+import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.config.DiskManagerConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.utils.Time;
@@ -59,7 +59,7 @@ public class StorageManager {
   public StorageManager(StoreConfig storeConfig, DiskManagerConfig diskManagerConfig,
       ScheduledExecutorService scheduler, MetricRegistry registry, List<? extends ReplicaId> replicas,
       StoreKeyFactory keyFactory, MessageStoreRecovery recovery, MessageStoreHardDelete hardDelete,
-      WriteStatusDelegate writeStatusDelegate, Time time) throws StoreException {
+      ReplicaStatusDelegate replicaStatusDelegate, Time time) throws StoreException {
     verifyConfigs(storeConfig, diskManagerConfig);
     metrics = new StorageManagerMetrics(registry);
     StoreMetrics storeMainMetrics = new StoreMetrics(registry);
@@ -75,7 +75,7 @@ public class StorageManager {
       List<ReplicaId> replicasForDisk = entry.getValue();
       DiskManager diskManager =
           new DiskManager(disk, replicasForDisk, storeConfig, diskManagerConfig, scheduler, metrics, storeMainMetrics,
-              storeUnderCompactionMetrics, keyFactory, recovery, hardDelete, writeStatusDelegate, time);
+              storeUnderCompactionMetrics, keyFactory, recovery, hardDelete, replicaStatusDelegate, time);
       diskManagers.add(diskManager);
       for (ReplicaId replica : replicasForDisk) {
         partitionToDiskManager.put(replica.getPartitionId(), diskManager);

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -225,7 +225,9 @@ public class StorageManager {
 
   /**
    * Set BlobStore Stopped state with given {@link PartitionId} {@code id}.
-   * @param id the {@link PartitionId} of the {@link Store} which would be shutdown.
+   * @param id the {@link PartitionId} of the {@link Store} whose stopped state should be set.
+   * @param isStopped whether to mark BlobStore as stopped ({@code true}) or started.
+   * @return {@code true} if set stopped state of store was successful. {@code false} if not.
    */
   public boolean setBlobStoreStoppedState(PartitionId id, boolean isStopped) {
     DiskManager diskManager = partitionToDiskManager.get(id);

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -64,6 +64,8 @@ public class StorageManager {
     metrics = new StorageManagerMetrics(registry);
     StoreMetrics storeMainMetrics = new StoreMetrics(registry);
     StoreMetrics storeUnderCompactionMetrics = new StoreMetrics("UnderCompaction", registry);
+    List<String> stoppedReplicas =
+        replicaStatusDelegate == null ? new ArrayList<>() : replicaStatusDelegate.getStoppedReplicas();
     this.time = time;
     Map<DiskId, List<ReplicaId>> diskToReplicaMap = new HashMap<>();
     for (ReplicaId replica : replicas) {
@@ -75,7 +77,8 @@ public class StorageManager {
       List<ReplicaId> replicasForDisk = entry.getValue();
       DiskManager diskManager =
           new DiskManager(disk, replicasForDisk, storeConfig, diskManagerConfig, scheduler, metrics, storeMainMetrics,
-              storeUnderCompactionMetrics, keyFactory, recovery, hardDelete, replicaStatusDelegate, time);
+              storeUnderCompactionMetrics, keyFactory, recovery, hardDelete, replicaStatusDelegate, stoppedReplicas,
+              time);
       diskManagers.add(diskManager);
       for (ReplicaId replica : replicasForDisk) {
         partitionToDiskManager.put(replica.getPartitionId(), diskManager);

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -287,7 +287,7 @@ public class BlobStoreTest {
    */
   @Test
   public void testClusterManagerReplicaStatusDelegateUse() throws StoreException, IOException, InterruptedException {
-    //Setup threshold test properties, replicaId, mock write status delegate
+    //Setup threshold test properties, replicaId, mock replica status delegate
     StoreConfig defaultConfig = changeThreshold(65, 5, true);
     StoreTestUtils.MockReplicaId replicaId = getMockReplicaId(tempDirStr);
     ReplicaStatusDelegate replicaStatusDelegate = mock(ReplicaStatusDelegate.class);
@@ -366,12 +366,13 @@ public class BlobStoreTest {
     StoreConfig defaultConfig = changeThreshold(65, 5, true);
     ReplicaStatusDelegate replicaStatusDelegate = mock(ReplicaStatusDelegate.class);
     store = createBlobStore(replicaId, defaultConfig, replicaStatusDelegate);
+    List<ReplicaId> replicaIds = Arrays.asList(replicaId);
     // test add a new replica into stopped list, which should trigger replicaStatusDelegate to mark replica as stopped
     store.updateStoppedReplicasList(true);
-    verify(replicaStatusDelegate, times(1)).setReplicaStoppedState(replicaId, true);
+    verify(replicaStatusDelegate, times(1)).markStopped(replicaIds);
     // test remove a replica from stopped list, which should trigger replicaStatusDelegate to mark replica as started
     store.updateStoppedReplicasList(false);
-    verify(replicaStatusDelegate, times(1)).setReplicaStoppedState(replicaId, false);
+    verify(replicaStatusDelegate, times(1)).unmarkStopped(replicaIds);
   }
 
   /**

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -353,29 +353,6 @@ public class BlobStoreTest {
   }
 
   /**
-   * Tests update stopped state of blob store via {@link ReplicaStatusDelegate}
-   * Add/remove store into/from stopped replicas list.
-   */
-  @Test
-  public void updateStoppedReplicasListTest() {
-    StoreTestUtils.MockReplicaId replicaId = getMockReplicaId(tempDirStr);
-    store = createBlobStore(replicaId);
-    // test update stopped replicas list when replicaStatusDelegate == null, which should fail
-    assertFalse("Update stopped replica list should fail when delegate is not instantiated",
-        store.updateStoppedReplicasList(true));
-    StoreConfig defaultConfig = changeThreshold(65, 5, true);
-    ReplicaStatusDelegate replicaStatusDelegate = mock(ReplicaStatusDelegate.class);
-    store = createBlobStore(replicaId, defaultConfig, replicaStatusDelegate);
-    List<ReplicaId> replicaIds = Arrays.asList(replicaId);
-    // test add a new replica into stopped list, which should trigger replicaStatusDelegate to mark replica as stopped
-    store.updateStoppedReplicasList(true);
-    verify(replicaStatusDelegate, times(1)).markStopped(replicaIds);
-    // test remove a replica from stopped list, which should trigger replicaStatusDelegate to mark replica as started
-    store.updateStoppedReplicasList(false);
-    verify(replicaStatusDelegate, times(1)).unmarkStopped(replicaIds);
-  }
-
-  /**
    * Tests {@link BlobStore#start()} for corner cases and error cases.
    * Corner cases
    * 1. Creating a directory on first startup
@@ -900,8 +877,9 @@ public class BlobStoreTest {
     for (int i = 0; i < count; i++) {
       MockId id = getUniqueId(accountId, containerId);
       long crc = random.nextLong();
-      MessageInfo info = new MessageInfo(id, size, false, false, expiresAtMs, crc, id.getAccountId(), id.getContainerId(),
-          Utils.Infinite_Time);
+      MessageInfo info =
+          new MessageInfo(id, size, false, false, expiresAtMs, crc, id.getAccountId(), id.getContainerId(),
+              Utils.Infinite_Time);
       ByteBuffer buffer = ByteBuffer.wrap(TestUtils.getRandomBytes((int) size));
       ids.add(id);
       infos.add(info);

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -353,8 +353,8 @@ public class BlobStoreTest {
   }
 
   /**
-   * Tests blob store use of {@link WriteStatusDelegate}
-   * @throws StoreException
+   * Tests update stopped state of blob store via {@link WriteStatusDelegate}
+   * Add/remove store into/from stopped replicas list.
    */
   @Test
   public void updateStoppedReplicasListTest() {

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -15,7 +15,7 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ReplicaId;
-import com.github.ambry.clustermap.WriteStatusDelegate;
+import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.ByteBufferInputStream;
@@ -282,47 +282,47 @@ public class BlobStoreTest {
   }
 
   /**
-   * Tests blob store use of {@link WriteStatusDelegate}
+   * Tests blob store use of {@link ReplicaStatusDelegate}
    * @throws StoreException
    */
   @Test
-  public void testClusterManagerWriteStatusDelegateUse() throws StoreException, IOException, InterruptedException {
+  public void testClusterManagerReplicaStatusDelegateUse() throws StoreException, IOException, InterruptedException {
     //Setup threshold test properties, replicaId, mock write status delegate
     StoreConfig defaultConfig = changeThreshold(65, 5, true);
     StoreTestUtils.MockReplicaId replicaId = getMockReplicaId(tempDirStr);
-    WriteStatusDelegate writeStatusDelegate = mock(WriteStatusDelegate.class);
-    when(writeStatusDelegate.unseal(any())).thenReturn(true);
-    when(writeStatusDelegate.seal(any())).thenReturn(true);
+    ReplicaStatusDelegate replicaStatusDelegate = mock(ReplicaStatusDelegate.class);
+    when(replicaStatusDelegate.unseal(any())).thenReturn(true);
+    when(replicaStatusDelegate.seal(any())).thenReturn(true);
 
     //Restart store
-    restartStore(defaultConfig, replicaId, writeStatusDelegate);
+    restartStore(defaultConfig, replicaId, replicaStatusDelegate);
 
     //Check that after start, because ReplicaId defaults to non-sealed, delegate is not called
-    verifyZeroInteractions(writeStatusDelegate);
+    verifyZeroInteractions(replicaStatusDelegate);
 
     //Verify that putting in data that doesn't go over the threshold doesn't trigger the delegate
     put(1, 50, Utils.Infinite_Time);
-    verifyNoMoreInteractions(writeStatusDelegate);
+    verifyNoMoreInteractions(replicaStatusDelegate);
 
     //Verify that after putting in enough data, the store goes to read only
     List<MockId> addedIds = put(4, 900, Utils.Infinite_Time);
-    verify(writeStatusDelegate, times(1)).seal(replicaId);
+    verify(replicaStatusDelegate, times(1)).seal(replicaId);
 
     //Assumes ClusterParticipant sets replicaId status to true
     replicaId.setSealedState(true);
 
     //Change config threshold but with delegate disabled, verify that nothing happens
-    restartStore(changeThreshold(99, 1, false), replicaId, writeStatusDelegate);
-    verifyNoMoreInteractions(writeStatusDelegate);
+    restartStore(changeThreshold(99, 1, false), replicaId, replicaStatusDelegate);
+    verifyNoMoreInteractions(replicaStatusDelegate);
 
     //Change config threshold to higher, see that it gets changed to unsealed on reset
-    restartStore(changeThreshold(99, 1, true), replicaId, writeStatusDelegate);
-    verify(writeStatusDelegate, times(1)).unseal(replicaId);
+    restartStore(changeThreshold(99, 1, true), replicaId, replicaStatusDelegate);
+    verify(replicaStatusDelegate, times(1)).unseal(replicaId);
     replicaId.setSealedState(false);
 
     //Reset thresholds, verify that it changed back
-    restartStore(defaultConfig, replicaId, writeStatusDelegate);
-    verify(writeStatusDelegate, times(2)).seal(replicaId);
+    restartStore(defaultConfig, replicaId, replicaStatusDelegate);
+    verify(replicaStatusDelegate, times(2)).seal(replicaId);
     replicaId.setSealedState(true);
 
     //Remaining tests only relevant for segmented logs
@@ -334,44 +334,44 @@ public class BlobStoreTest {
 
       //Need to restart blob otherwise compaction will ignore segments in journal (which are all segments right now).
       //By restarting, only last segment will be in journal
-      restartStore(defaultConfig, replicaId, writeStatusDelegate);
-      verifyNoMoreInteractions(writeStatusDelegate);
+      restartStore(defaultConfig, replicaId, replicaStatusDelegate);
+      verifyNoMoreInteractions(replicaStatusDelegate);
 
       //Advance time by 8 days, call compaction to compact segments with deleted data, then verify
       //that the store is now read-write
       time.sleep(TimeUnit.DAYS.toMillis(8));
       store.compact(store.getCompactionDetails(new CompactAllPolicy(defaultConfig, time)),
           ByteBuffer.allocateDirect(PUT_RECORD_SIZE * 2 + 1));
-      verify(writeStatusDelegate, times(2)).unseal(replicaId);
+      verify(replicaStatusDelegate, times(2)).unseal(replicaId);
 
       //Test if replicaId is erroneously true that it updates the status upon startup
       replicaId.setSealedState(true);
-      restartStore(defaultConfig, replicaId, writeStatusDelegate);
-      verify(writeStatusDelegate, times(3)).unseal(replicaId);
+      restartStore(defaultConfig, replicaId, replicaStatusDelegate);
+      verify(replicaStatusDelegate, times(3)).unseal(replicaId);
     }
     store.shutdown();
   }
 
   /**
-   * Tests update stopped state of blob store via {@link WriteStatusDelegate}
+   * Tests update stopped state of blob store via {@link ReplicaStatusDelegate}
    * Add/remove store into/from stopped replicas list.
    */
   @Test
   public void updateStoppedReplicasListTest() {
     StoreTestUtils.MockReplicaId replicaId = getMockReplicaId(tempDirStr);
     store = createBlobStore(replicaId);
-    // test update stopped replicas list when writeStatusDelegate == null, which should fail
+    // test update stopped replicas list when replicaStatusDelegate == null, which should fail
     assertFalse("Update stopped replica list should fail when delegate is not instantiated",
         store.updateStoppedReplicasList(true));
     StoreConfig defaultConfig = changeThreshold(65, 5, true);
-    WriteStatusDelegate writeStatusDelegate = mock(WriteStatusDelegate.class);
-    store = createBlobStore(replicaId, defaultConfig, writeStatusDelegate);
-    // test add a new replica into stopped list, which should trigger writeStatusDelegate to mark replica as stopped
+    ReplicaStatusDelegate replicaStatusDelegate = mock(ReplicaStatusDelegate.class);
+    store = createBlobStore(replicaId, defaultConfig, replicaStatusDelegate);
+    // test add a new replica into stopped list, which should trigger replicaStatusDelegate to mark replica as stopped
     store.updateStoppedReplicasList(true);
-    verify(writeStatusDelegate, times(1)).setReplicaStoppedState(replicaId, true);
-    // test remove a replica from stopped list, which should trigger writeStatusDelegate to mark replica as started
+    verify(replicaStatusDelegate, times(1)).setReplicaStoppedState(replicaId, true);
+    // test remove a replica from stopped list, which should trigger replicaStatusDelegate to mark replica as started
     store.updateStoppedReplicasList(false);
-    verify(writeStatusDelegate, times(1)).setReplicaStoppedState(replicaId, false);
+    verify(replicaStatusDelegate, times(1)).setReplicaStoppedState(replicaId, false);
   }
 
   /**
@@ -1402,11 +1402,12 @@ public class BlobStoreTest {
     return createBlobStore(replicaId, config, null);
   }
 
-  private BlobStore createBlobStore(ReplicaId replicaId, StoreConfig config, WriteStatusDelegate writeStatusDelegate) {
+  private BlobStore createBlobStore(ReplicaId replicaId, StoreConfig config,
+      ReplicaStatusDelegate replicaStatusDelegate) {
     MetricRegistry registry = new MetricRegistry();
     StoreMetrics metrics = new StoreMetrics(registry);
     return new BlobStore(replicaId, config, scheduler, storeStatsScheduler, diskIOScheduler, diskSpaceAllocator,
-        metrics, metrics, STORE_KEY_FACTORY, recovery, hardDelete, writeStatusDelegate, time);
+        metrics, metrics, STORE_KEY_FACTORY, recovery, hardDelete, replicaStatusDelegate, time);
   }
 
   private StoreTestUtils.MockReplicaId getMockReplicaId(String filePath) {
@@ -1420,7 +1421,7 @@ public class BlobStoreTest {
    * @return StoreConfig object with new threshold values
    */
   private StoreConfig changeThreshold(int readOnlyThreshold, int readWriteDeltaThreshold, boolean delegateEnabled) {
-    properties.setProperty(StoreConfig.storeWriteStatusDelegateEnableName, Boolean.toString(delegateEnabled));
+    properties.setProperty(StoreConfig.storeReplicaStatusDelegateEnableName, Boolean.toString(delegateEnabled));
     properties.setProperty(StoreConfig.storeReadOnlyEnableSizeThresholdPercentageName,
         Integer.toString(readOnlyThreshold));
     properties.setProperty(StoreConfig.storeReadWriteEnableSizeThresholdPercentageDeltaName,
@@ -1428,7 +1429,7 @@ public class BlobStoreTest {
     return new StoreConfig(new VerifiableProperties(properties));
   }
 
-  private void restartStore(StoreConfig config, ReplicaId replicaId, WriteStatusDelegate delegate)
+  private void restartStore(StoreConfig config, ReplicaId replicaId, ReplicaStatusDelegate delegate)
       throws StoreException {
     store.shutdown();
     store = createBlobStore(replicaId, config, delegate);

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -263,6 +263,9 @@ public class StorageManagerTest {
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
   }
 
+  /**
+   * Test set stopped state of blobstore with given {@link PartitionId} {@code id} in failure cases.
+   */
   @Test
   public void setBlobStoreStoppedStateFailureTest() throws Exception {
     MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
@@ -288,6 +291,9 @@ public class StorageManagerTest {
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
   }
 
+  /**
+   * Test successfully set stopped state of blobstore with given {@link PartitionId} {@code id}.
+   */
   @Test
   public void setBlobStoreStateSuccessTest() throws Exception {
     MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);


### PR DESCRIPTION
-Introduce "STOPPED" list field in InstanceConfig for Helix.
-Adding setReplicaStoppedState method in Delegate and HelixParticipant.
-Allow BlobStoreControlRequest to update replica stopped state in Helix.
-Rename WriteStatusDelegate to ReplicaStatusDelegate.
-Verified in Perf cluster