### PR TITLE
Introduce BufferedInputStream for non MessageFormatFlags.All cases.

### DIFF
--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatSend.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatSend.java
@@ -320,6 +320,9 @@ class MessageReadSetIndexInputStream extends InputStream {
     if (off < 0 || len < 0 || len > b.length - off) {
       throw new IndexOutOfBoundsException();
     }
+    if (len == 0) {
+      return 0;
+    }
     if (currentOffset >= messageReadSet.sizeInBytes(indexToRead)) {
       return -1;
     }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatSend.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatSend.java
@@ -52,7 +52,7 @@ public class MessageFormatSend implements Send {
   private long sizeWrittenFromCurrentIndex;
   private StoreKeyFactory storeKeyFactory;
   private Logger logger = LoggerFactory.getLogger(getClass());
-  private final int BufferedInputStreamBufferSize = 1024;
+  private final int BUFFERED_INPUT_STREAM_BUFFER_SIZE = 256;
 
   private class SendInfo {
     private long relativeOffset;
@@ -114,7 +114,8 @@ public class MessageFormatSend implements Send {
         } else {
           long startTime = SystemTime.getInstance().milliseconds();
           BufferedInputStream bufferedInputStream =
-              new BufferedInputStream(new MessageReadSetIndexInputStream(readSet, i, 0), BufferedInputStreamBufferSize);
+              new BufferedInputStream(new MessageReadSetIndexInputStream(readSet, i, 0),
+                  BUFFERED_INPUT_STREAM_BUFFER_SIZE);
           // read and verify header version
           byte[] headerVersionBytes = new byte[Version_Field_Size_In_Bytes];
           bufferedInputStream.read(headerVersionBytes, 0, Version_Field_Size_In_Bytes);

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatSend.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatSend.java
@@ -52,6 +52,7 @@ public class MessageFormatSend implements Send {
   private long sizeWrittenFromCurrentIndex;
   private StoreKeyFactory storeKeyFactory;
   private Logger logger = LoggerFactory.getLogger(getClass());
+  private final int BufferedInputStreamBufferSize = 1024;
 
   private class SendInfo {
     private long relativeOffset;
@@ -113,11 +114,8 @@ public class MessageFormatSend implements Send {
         } else {
           long startTime = SystemTime.getInstance().milliseconds();
           BufferedInputStream bufferedInputStream =
-              new BufferedInputStream(new MessageReadSetIndexInputStream(readSet, i, 0), 1024);
-          logger.trace("Calculate offsets, BufferedInputStream initialization time: {}",
-              SystemTime.getInstance().milliseconds() - startTime);
-
-          startTime = SystemTime.getInstance().milliseconds();
+              new BufferedInputStream(new MessageReadSetIndexInputStream(readSet, i, 0), BufferedInputStreamBufferSize);
+          // read and verify header version
           byte[] headerVersionBytes = new byte[Version_Field_Size_In_Bytes];
           bufferedInputStream.read(headerVersionBytes, 0, Version_Field_Size_In_Bytes);
           short version = ByteBuffer.wrap(headerVersionBytes).getShort();
@@ -129,29 +127,25 @@ public class MessageFormatSend implements Send {
           logger.trace("Calculate offsets, read and verify header version time: {}",
               SystemTime.getInstance().milliseconds() - startTime);
 
-          startTime = SystemTime.getInstance().milliseconds();
+          // read and verify header
           byte[] headerBytes = new byte[getHeaderSizeForVersion(version)];
           bufferedInputStream.read(headerBytes, Version_Field_Size_In_Bytes,
               headerBytes.length - Version_Field_Size_In_Bytes);
-          logger.trace("Calculate offsets, read header time: {}", SystemTime.getInstance().milliseconds() - startTime);
 
-          startTime = SystemTime.getInstance().milliseconds();
           ByteBuffer header = ByteBuffer.wrap(headerBytes);
           header.putShort(version);
-          header.clear();
+          header.rewind();
           MessageHeader_Format headerFormat = getMessageHeader(version, header);
           headerFormat.verifyHeader();
-          logger.trace("Calculate offsets, verify header time: {}",
-              SystemTime.getInstance().milliseconds() - startTime);
 
-          startTime = SystemTime.getInstance().milliseconds();
+          // read and verify storeKey
           StoreKey storeKey = storeKeyFactory.getStoreKey(new DataInputStream(bufferedInputStream));
           if (storeKey.compareTo(readSet.getKeyAt(i)) != 0) {
             throw new MessageFormatException(
                 "Id mismatch between metadata and store - metadataId " + readSet.getKeyAt(i) + " storeId " + storeKey,
                 MessageFormatErrorCodes.Store_Key_Id_MisMatch);
           }
-          logger.trace("Calculate offsets, read and verify storeKey time: {}",
+          logger.trace("Calculate offsets, read and verify header time: {}",
               SystemTime.getInstance().milliseconds() - startTime);
 
           startTime = SystemTime.getInstance().milliseconds();

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatSendTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatSendTest.java
@@ -686,6 +686,7 @@ public class MessageFormatSendTest {
   /**
    * Test Exceptions cases for {@link MessageReadSetIndexInputStream}
    * IndexOutOfBoundsException should be thrown if offset or length is invalid.
+   * 0 is expected if length requested is 0.
    * -1 is expected if no more data available.
    */
   @Test
@@ -699,6 +700,8 @@ public class MessageFormatSendTest {
     MessageReadSet readSet = new MockMessageReadSet(listBuf, storeKeys);
     MessageReadSetIndexInputStream stream = new MessageReadSetIndexInputStream(readSet, 0, 0);
     byte[] bufOutput = new byte[1024];
+    Assert.assertEquals("Should return 0 if length requested is 0", 0, stream.read(bufOutput, 0, 0));
+    Assert.assertEquals("Should return 0 if length requested is 0", 0, stream.read(bufOutput, 1, 0));
     try {
       stream.read(bufOutput, -1, 10);
       Assert.fail("IndexOutOfBoundsException is expected.");


### PR DESCRIPTION
Use BufferedInputStream to reduce disk IO and system call for getBlobInfo, getUserMetadata, getBlobProperties and getBlob(body only).

New jar is tested in staging environment, logger.trace shows 0 ms for each step and getBlobInfo total latency is close to others. 