### PR TITLE
Using the repl policy in container to choose partition

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/commons/SSLFactory.java
+++ b/ambry-api/src/main/java/com.github.ambry/commons/SSLFactory.java
@@ -15,7 +15,6 @@ package com.github.ambry.commons;
 
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.utils.Utils;
-import java.lang.reflect.InvocationTargetException;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 

--- a/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
@@ -58,13 +58,6 @@ public class FrontendConfig {
   public final String frontendSecurityServiceFactory;
 
   /**
-   * The AccountServiceFactory that needs to be used by AmbryBlobStorageService to get account-related information.
-   */
-  @Config("frontend.account.service.factory")
-  @Default("com.github.ambry.account.InMemoryUnknownAccountServiceFactory")
-  public final String frontendAccountServiceFactory;
-
-  /**
    * The UrlSigningServiceFactory that needs to be used by AmbryBlobStorageService to sign and verify URLs.
    */
   @Config("frontend.url.signing.service.factory")
@@ -139,8 +132,6 @@ public class FrontendConfig {
         "com.github.ambry.frontend.AmbryIdConverterFactory");
     frontendSecurityServiceFactory = verifiableProperties.getString("frontend.security.service.factory",
         "com.github.ambry.frontend.AmbrySecurityServiceFactory");
-    frontendAccountServiceFactory = verifiableProperties.getString("frontend.account.service.factory",
-        "com.github.ambry.account.InMemoryUnknownAccountServiceFactory");
     frontendUrlSigningServiceFactory = verifiableProperties.getString("frontend.url.signing.service.factory",
         "com.github.ambry.frontend.AmbryUrlSigningServiceFactory");
     frontendPathPrefixesToRemove =

--- a/ambry-api/src/main/java/com.github.ambry/config/RestServerConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RestServerConfig.java
@@ -63,6 +63,13 @@ public class RestServerConfig {
   public final String restServerResponseHandlerFactory;
 
   /**
+   * The AccountServiceFactory that needs to be used by AmbryBlobStorageService to get account-related information.
+   */
+  @Config("rest.server.account.service.factory")
+  @Default("com.github.ambry.account.InMemoryUnknownAccountServiceFactory")
+  public final String restServerAccountServiceFactory;
+
+  /**
    * The RouterFactory that needs to be used by the RestServer
    * for bootstrapping the Router.
    */
@@ -103,6 +110,8 @@ public class RestServerConfig {
         verifiableProperties.getIntInRange("rest.server.response.handler.scaling.unit.count", 5, 0, Integer.MAX_VALUE);
     restServerResponseHandlerFactory = verifiableProperties.getString("rest.server.response.handler.factory",
         "com.github.ambry.rest.AsyncRequestResponseHandlerFactory");
+    restServerAccountServiceFactory = verifiableProperties.getString("rest.server.account.service.factory",
+        "com.github.ambry.account.InMemoryUnknownAccountServiceFactory");
     restServerRouterFactory = verifiableProperties.getString("rest.server.router.factory",
         "com.github.ambry.router.NonBlockingRouterFactory");
     restServerPublicAccessLogRequestHeaders =

--- a/ambry-api/src/main/java/com.github.ambry/router/RouterException.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/RouterException.java
@@ -49,6 +49,6 @@ public class RouterException extends Exception {
     }
 
     RouterException that = (RouterException) o;
-    return this.errorCode == that.errorCode && this.getCause() == that.getCause();
+    return this.errorCode == that.errorCode && this.getCause().equals(that.getCause());
   }
 }

--- a/ambry-api/src/test/java/com.github.ambry/account/InMemAccountService.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/InMemAccountService.java
@@ -17,7 +17,6 @@ package com.github.ambry.account;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -103,7 +102,7 @@ public class InMemAccountService implements AccountService {
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     // no op
   }
 
@@ -147,6 +146,20 @@ public class InMemAccountService implements AccountService {
             .build();
     updateAccounts(Collections.singletonList(account));
     return account;
+  }
+
+  /**
+   * Adds {@code replicationPolicy} to {@code container}.
+   * @param container the {@link Container} to add the replication policy to.
+   * @param replicationPolicy the replication policy to add to {@code container}.
+   * @return the new container object with the appropriate replication policy if the operation suceeded. {@code null}
+   * otherwise
+   */
+  public Container addReplicationPolicyToContainer(Container container, String replicationPolicy) {
+    Container newContainer = new ContainerBuilder(container).setReplicationPolicy(replicationPolicy).build();
+    Account account = getAccountById(container.getParentAccountId());
+    Account newAccount = new AccountBuilder(account).addOrUpdateContainer(newContainer).build();
+    return updateAccounts(Collections.singleton(newAccount)) ? newContainer : null;
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageServiceFactory.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockBlobStorageServiceFactory.java
@@ -13,8 +13,8 @@
  */
 package com.github.ambry.rest;
 
+import com.github.ambry.account.AccountService;
 import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.commons.Notifier;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.router.Router;
 
@@ -31,7 +31,7 @@ public class MockBlobStorageServiceFactory implements BlobStorageServiceFactory 
   private final Router router;
 
   public MockBlobStorageServiceFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
-      RestResponseHandler restResponseHandler, Router router, Notifier notifier) {
+      RestResponseHandler restResponseHandler, Router router, AccountService accountService) {
     this.verifiableProperties = verifiableProperties;
     this.restResponseHandler = restResponseHandler;
     this.router = router;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
@@ -37,7 +37,8 @@ public class MockClusterAgentsFactory implements ClusterAgentsFactory {
   @Override
   public MockClusterMap getClusterMap() throws IOException {
     if (mockClusterMap == null) {
-      mockClusterMap = new MockClusterMap(enableSslPorts, numNodes, numMountPointsPerNode, numStoresPerMountPoint);
+      mockClusterMap = new MockClusterMap(enableSslPorts, numNodes, numMountPointsPerNode, numStoresPerMountPoint,
+          false);
     }
     return mockClusterMap;
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -55,8 +55,8 @@ public class MockClusterMap implements ClusterMap {
   /**
    * The default constructor sets up a 9 node cluster with 3 mount points in each, with 3 default partitions/replicas
    * per mount point. It will also add replicas for a "special" partition. The distribution of these replicas will be
-   * 3 in the chosen "local" datacenter and 2 everywhere else. This will amount to a total of 9/10 replicas per node and
-   * 88 replicas across the cluster.
+   * 3 in the chosen "local" datacenter and 2 everywhere else. This will amount to a total of 9 or 10 replicas per node
+   * and 88 replicas across the cluster.
    *
    * If this cluster map is going to be used to start a cluster, use it judiciously to avoid resource consumption issues
    * on the test machine.

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -39,7 +39,6 @@ public class MockClusterMap implements ClusterMap {
   protected final Map<Long, PartitionId> partitions;
   protected final List<MockDataNodeId> dataNodes;
   protected final int numMountPointsPerNode;
-  protected final int numStoresPerMountPoint;
   protected final List<String> dataCentersInClusterMap = new ArrayList<>();
   private final ClusterMapUtils.PartitionSelectionHelper partitionSelectionHelper;
   protected boolean partitionsUnavailable = false;
@@ -51,48 +50,53 @@ public class MockClusterMap implements ClusterMap {
   // allow this to be changed to support some tests
   private String localDatacenterName;
 
+  private final MockPartitionId specialPartition;
+
   /**
-   * The default constructor sets up a 9 node cluster with 3 mount points in each, with 3 partitions/replicas per
-   * mount point which amount to a total of 9 replicas per node and 81 replicas across the cluster. If this cluster map
-   * is going to be used to start a cluster, use it judiciously to avoid resource consumption issues on the test
-   * machine.
+   * The default constructor sets up a 9 node cluster with 3 mount points in each, with 3 default partitions/replicas
+   * per mount point. It will also add replicas for a "special" partition. The distribution of these replicas will be
+   * 3 in the chosen "local" datacenter and 2 everywhere else. This will amount to a total of 9/10 replicas per node and
+   * 88 replicas across the cluster.
+   *
+   * If this cluster map is going to be used to start a cluster, use it judiciously to avoid resource consumption issues
+   * on the test machine.
    */
   public MockClusterMap() throws IOException {
-    this(false, 9, 3, 3);
+    this(false, 9, 3, 3, false);
   }
 
   /**
    * Creates and returns a mock cluster map.
    * <p>
-   *
-   * In doing so, this actually creates the mock cluster itself, by setting up nodes,
-   * mount points and replicas for partitions on these nodes. (The mock nodes will not be started automatically,
-   * however).
-   * <p>
-   *
-   * The parameters to this method determine the number of mock datanodes that will be created in the cluster,
-   * the number of mount points that will be created on each of these mock datanodes,
-   * and the number of stores that will be created on each mount point. Stores correspond to replicas,
-   * so the number of stores also determines the number of replicas that will be created on a node (which is
-   * going to be the number of mount points per node multiplied by the number of stores per mount point). Since every
-   * partition will be present on every datanode, this is also the number of partitions that will be created across the
-   * cluster. The total number of replicas across the cluster will therefore be this number multiplied by the
-   * number of nodes. This is therefore the number of stores that will be created by the test on the machine on which
-   * it runs - and the resource consumption on the machine is a function of this number. Tests that start a cluster or
-   * a server should therefore keep these parameters to the minimum required for testing intended functionality
-   * correctly (however, tests that only create the MockClusterMap but do not start the cluster or servers will not
-   * end up using any significant resources, and should be fine).
-   *
+   * The parameters to this method determine the number of mock datanodes that will be created in the cluster, the
+   * number of mount points that will be created on each of these mock datanodes, and the number of "default" stores
+   * that will be created on each mount point and whether there will be stores that host a "special" partition. Stores
+   * correspond to replicas, so the number of stores also determines the number of replicas that will be created on a
+   * node (which is going to be the number of mount points per node multiplied by the number of default stores per mount
+   * point and possibly an extra store if a replica of the special partition resides on the node). Every default
+   * partition is available on every node however the special partition is only available on a subset. These parameters
+   * determine resource consumption so tests that start a cluster or a server should therefore keep these parameters to
+   * the minimum required for testing intended functionality correctly (however, tests that only create the
+   * MockClusterMap but do not start the cluster or servers will not end up using any significant resources, and should
+   * be fine).
+   * <p/>
+   * The "special" partition will be created only if
+   * 1. The parameter {@code createOnlyDefaultPartitionClass} is {@code false}.
+   * 2. {@code numNodes} >= 4
+   * 3. There are at least 3 nodes in the designated "local" datacenter.
+   * To determine whether a "special" partition was created, use the function {@link #getSpecialPartition()}.
+   * The "special" partition has 3 replicas in the designated "local" datacenter and 2 replicas in all other datacenters
    * @param numNodes number of mock datanodes that will be created (every 3 of which will be put in a separate
    *                 datacenter).
    * @param numMountPointsPerNode number of mount points (mocking disks) that will be created in each datanode.
-   * @param numStoresPerMountPoint the number of stores that will be created on each mount point.
+   * @param numDefaultStoresPerMountPoint the number of stores that will be created on each mount point.
+   * @param createOnlyDefaultPartitionClass if {@code true}, does not attempt to create the "special" partition. If
+   *                                        {@code false}, attempts to do so. See javadoc of function for more details
    */
-  public MockClusterMap(boolean enableSSLPorts, int numNodes, int numMountPointsPerNode, int numStoresPerMountPoint)
-      throws IOException {
+  public MockClusterMap(boolean enableSSLPorts, int numNodes, int numMountPointsPerNode,
+      int numDefaultStoresPerMountPoint, boolean createOnlyDefaultPartitionClass) throws IOException {
     this.enableSSLPorts = enableSSLPorts;
     this.numMountPointsPerNode = numMountPointsPerNode;
-    this.numStoresPerMountPoint = numStoresPerMountPoint;
     dataNodes = new ArrayList<MockDataNodeId>(numNodes);
     //Every group of 3 nodes will be put in the same DC.
     int dcIndex = 0;
@@ -120,20 +124,23 @@ public class MockClusterMap implements ClusterMap {
     // create partitions
     long partitionId = 0;
     for (int i = 0; i < dataNodes.get(0).getMountPaths().size(); i++) {
-      for (int j = 0; j < numStoresPerMountPoint; j++) {
+      for (int j = 0; j < numDefaultStoresPerMountPoint; j++) {
         PartitionId id = new MockPartitionId(partitionId, DEFAULT_PARTITION_CLASS, dataNodes, i);
         partitions.put(partitionId, id);
         partitionId++;
       }
     }
-    if (numNodes > 3 && dcToDataNodes.get(localDatacenterName).size() > 2) {
+    if (!createOnlyDefaultPartitionClass && numNodes >= 4 && dcToDataNodes.get(localDatacenterName).size() >= 3) {
       // create one "special partition" that has 3 replicas in the local datacenter (as configured on startup) and
       // 2 everywhere else
       List<MockDataNodeId> nodeIds = new ArrayList<>();
       dcToDataNodes.forEach(
           (s, mockDataNodeIds) -> nodeIds.addAll(mockDataNodeIds.subList(0, localDatacenterName.equals(s) ? 3 : 2)));
-      PartitionId id = new MockPartitionId(partitionId, SPECIAL_PARTITION_CLASS, nodeIds, 0);
+      MockPartitionId id = new MockPartitionId(partitionId, SPECIAL_PARTITION_CLASS, nodeIds, 0);
       partitions.put(partitionId, id);
+      specialPartition = id;
+    } else {
+      specialPartition = null;
     }
     partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName);
   }
@@ -220,7 +227,7 @@ public class MockClusterMap implements ClusterMap {
     if (idx < 0 || idx >= dataCentersInClusterMap.size()) {
       return null;
     }
-    return dataCentersInClusterMap.get(id);
+    return dataCentersInClusterMap.get(idx);
   }
 
   @Override
@@ -264,6 +271,13 @@ public class MockClusterMap implements ClusterMap {
       metricRegistry = new MetricRegistry();
     }
     return metricRegistry;
+  }
+
+  /**
+   * @return the special {@link MockPartitionId} if it was created.
+   */
+  public MockPartitionId getSpecialPartition() {
+    return specialPartition;
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
@@ -61,7 +61,7 @@ public class MockDataNodeId extends DataNodeId {
    * {@link #getPortToConnectTo()}
    * @param sslEnabledDataCenters list of datacenters to which ssl is enabled.
    */
-  public void setSslEnabledDataCenters(ArrayList<String> sslEnabledDataCenters) {
+  public void setSslEnabledDataCenters(List<String> sslEnabledDataCenters) {
     this.sslEnabledDataCenters = sslEnabledDataCenters;
   }
 

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -81,7 +81,7 @@ public class BlobIdTest {
     referenceDatacenterId = bytes[0];
     referenceAccountId = getRandomShort(random);
     referenceContainerId = getRandomShort(random);
-    referencePartitionId = referenceClusterMap.getWritablePartitionIds(null).get(0);
+    referencePartitionId = referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     referenceIsEncrypted = random.nextBoolean();
   }
 
@@ -169,7 +169,8 @@ public class BlobIdTest {
     for (boolean isEncrypted : isEncryptedValues) {
       BlobId blobIdV4 =
           new BlobId(BLOB_ID_V4, random.nextBoolean() ? BlobIdType.NATIVE : BlobIdType.CRAFTED, (byte) 1, (short) 1,
-              (short) 1, referenceClusterMap.getWritablePartitionIds(null).get(random.nextInt(3)), isEncrypted);
+              (short) 1, referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS)
+              .get(random.nextInt(3)), isEncrypted);
       assertEquals("V4 should return true or false based on its encrypted bit", isEncrypted,
           BlobId.isEncrypted(blobIdV4.getID()));
     }
@@ -601,7 +602,8 @@ public class BlobIdTest {
     short accountId = getRandomShort(random);
     short containerId = getRandomShort(random);
     BlobIdType type = random.nextBoolean() ? BlobIdType.NATIVE : BlobIdType.CRAFTED;
-    PartitionId partitionId = referenceClusterMap.getWritablePartitionIds(null).get(random.nextInt(3));
+    PartitionId partitionId =
+        referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(random.nextInt(3));
     boolean isEncrypted = random.nextBoolean();
     return new BlobId(version, type, datacenterId, accountId, containerId, partitionId, isEncrypted);
   }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AccountAndContainerInjector.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AccountAndContainerInjector.java
@@ -23,8 +23,6 @@ import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -39,7 +37,7 @@ import static com.github.ambry.rest.RestUtils.*;
 /**
  * Helper class to resolve and add {@link Account} and {@link Container} details to requests.
  */
-public class AccountAndContainerInjector implements Closeable {
+public class AccountAndContainerInjector {
   private static final Set<String> requiredAmbryHeadersForPutWithServiceId = Collections.singleton(Headers.SERVICE_ID);
   private static final Set<String> requiredAmbryHeadersForPutWithAccountAndContainerName = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(Headers.TARGET_ACCOUNT_NAME, Headers.TARGET_CONTAINER_NAME)));
@@ -252,10 +250,5 @@ public class AccountAndContainerInjector implements Closeable {
               + accountNameFromHeader + "'. Account returned by backend: '" + account.getName() + "'.",
           RestServiceErrorCode.InternalServerError);
     }
-  }
-
-  @Override
-  public void close() throws IOException {
-    accountService.close();
   }
 }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -149,7 +149,6 @@ class AmbryBlobStorageService implements BlobStorageService {
         idConverter.close();
         idConverter = null;
       }
-      accountAndContainerInjector.close();
       logger.info("AmbryBlobStorageService shutdown complete");
     } catch (IOException e) {
       logger.error("Downstream service close failed", e);

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
@@ -22,6 +22,7 @@ import com.github.ambry.rest.BlobStorageServiceFactory;
 import com.github.ambry.rest.RestResponseHandler;
 import com.github.ambry.router.Router;
 import com.github.ambry.utils.Utils;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,17 +55,13 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
    */
   public AmbryBlobStorageServiceFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
       RestResponseHandler responseHandler, Router router, AccountService accountService) {
-    if (verifiableProperties == null || clusterMap == null || responseHandler == null || router == null) {
-      throw new IllegalArgumentException("Null arguments were provided during instantiation!");
-    } else {
-      frontendConfig = new FrontendConfig(verifiableProperties);
-      frontendMetrics = new FrontendMetrics(clusterMap.getMetricRegistry());
-      this.verifiableProperties = verifiableProperties;
-      this.clusterMap = clusterMap;
-      this.responseHandler = responseHandler;
-      this.router = router;
-      this.accountService = accountService;
-    }
+    this.verifiableProperties = Objects.requireNonNull(verifiableProperties, "Provided VerifiableProperties is null");
+    this.clusterMap = Objects.requireNonNull(clusterMap, "Provided ClusterMap is null");
+    this.responseHandler = Objects.requireNonNull(responseHandler, "Provided RestResponseHandler is null");
+    this.router = Objects.requireNonNull(router, "Provided Router is null");
+    this.accountService = Objects.requireNonNull(accountService, "Provided AccountService is null");
+    frontendConfig = new FrontendConfig(verifiableProperties);
+    frontendMetrics = new FrontendMetrics(clusterMap.getMetricRegistry());
     logger.trace("Instantiated AmbryBlobStorageServiceFactory");
   }
 

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
@@ -14,9 +14,7 @@
 package com.github.ambry.frontend;
 
 import com.github.ambry.account.AccountService;
-import com.github.ambry.account.AccountServiceFactory;
 import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.commons.Notifier;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.rest.BlobStorageService;
@@ -41,7 +39,7 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
   private final ClusterMap clusterMap;
   private final RestResponseHandler responseHandler;
   private final Router router;
-  private final Notifier notifier;
+  private final AccountService accountService;
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   /**
@@ -51,11 +49,11 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
    * @param responseHandler the {@link RestResponseHandler} that can be used to submit responses that need to be sent
    *                        out.
    * @param router the {@link Router} to use.
-   * @param notifier the {@link Notifier} to use.
+   * @param accountService the {@link AccountService} to use.
    * @throws IllegalArgumentException if any of the arguments are null.
    */
   public AmbryBlobStorageServiceFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
-      RestResponseHandler responseHandler, Router router, Notifier notifier) {
+      RestResponseHandler responseHandler, Router router, AccountService accountService) {
     if (verifiableProperties == null || clusterMap == null || responseHandler == null || router == null) {
       throw new IllegalArgumentException("Null arguments were provided during instantiation!");
     } else {
@@ -65,7 +63,7 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
       this.clusterMap = clusterMap;
       this.responseHandler = responseHandler;
       this.router = router;
-      this.notifier = notifier;
+      this.accountService = accountService;
     }
     logger.trace("Instantiated AmbryBlobStorageServiceFactory");
   }
@@ -77,10 +75,6 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
   @Override
   public BlobStorageService getBlobStorageService() {
     try {
-      AccountServiceFactory accountServiceFactory =
-          Utils.getObj(frontendConfig.frontendAccountServiceFactory, verifiableProperties,
-              clusterMap.getMetricRegistry(), notifier);
-      AccountService accountService = accountServiceFactory.getAccountService();
       IdConverterFactory idConverterFactory =
           Utils.getObj(frontendConfig.frontendIdConverterFactory, verifiableProperties, clusterMap.getMetricRegistry());
       UrlSigningServiceFactory urlSigningServiceFactory =

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
@@ -13,7 +13,7 @@
  */
 package com.github.ambry.frontend;
 
-import com.github.ambry.account.MockNotifier;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.config.VerifiableProperties;
@@ -47,7 +47,7 @@ public class AmbryBlobStorageServiceFactoryTest {
     AmbryBlobStorageServiceFactory ambryBlobStorageServiceFactory =
         new AmbryBlobStorageServiceFactory(verifiableProperties, new MockClusterMap(),
             new MockRestRequestResponseHandler(), new InMemoryRouter(verifiableProperties, new MockClusterMap()),
-            new MockNotifier());
+            new InMemAccountService(false, true));
     BlobStorageService ambryBlobStorageService = ambryBlobStorageServiceFactory.getBlobStorageService();
     assertNotNull("No BlobStorageService returned", ambryBlobStorageService);
     assertEquals("Did not receive an AmbryBlobStorageService instance",
@@ -69,7 +69,8 @@ public class AmbryBlobStorageServiceFactoryTest {
 
     // VerifiableProperties null.
     try {
-      new AmbryBlobStorageServiceFactory(null, clusterMap, restResponseHandler, router, new MockNotifier());
+      new AmbryBlobStorageServiceFactory(null, clusterMap, restResponseHandler, router,
+          new InMemAccountService(false, true));
       fail("Instantiation should have failed because one of the arguments was null");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
@@ -77,7 +78,8 @@ public class AmbryBlobStorageServiceFactoryTest {
 
     // ClusterMap null.
     try {
-      new AmbryBlobStorageServiceFactory(verifiableProperties, null, restResponseHandler, router, new MockNotifier());
+      new AmbryBlobStorageServiceFactory(verifiableProperties, null, restResponseHandler, router,
+          new InMemAccountService(false, true));
       fail("Instantiation should have failed because one of the arguments was null");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
@@ -85,7 +87,8 @@ public class AmbryBlobStorageServiceFactoryTest {
 
     // RestResponseHandler null.
     try {
-      new AmbryBlobStorageServiceFactory(verifiableProperties, clusterMap, null, router, new MockNotifier());
+      new AmbryBlobStorageServiceFactory(verifiableProperties, clusterMap, null, router,
+          new InMemAccountService(false, true));
       fail("Instantiation should have failed because one of the arguments was null");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
@@ -94,7 +97,7 @@ public class AmbryBlobStorageServiceFactoryTest {
     // Router null.
     try {
       new AmbryBlobStorageServiceFactory(verifiableProperties, clusterMap, restResponseHandler, null,
-          new MockNotifier());
+          new InMemAccountService(false, true));
       fail("Instantiation should have failed because one of the arguments was null");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.frontend;
 
+import com.github.ambry.account.AccountService;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
@@ -66,40 +67,45 @@ public class AmbryBlobStorageServiceFactoryTest {
     ClusterMap clusterMap = new MockClusterMap();
     RestResponseHandler restResponseHandler = new MockRestRequestResponseHandler();
     Router router = new InMemoryRouter(verifiableProperties, clusterMap);
+    AccountService accountService = new InMemAccountService(false, true);
 
     // VerifiableProperties null.
     try {
-      new AmbryBlobStorageServiceFactory(null, clusterMap, restResponseHandler, router,
-          new InMemAccountService(false, true));
-      fail("Instantiation should have failed because one of the arguments was null");
-    } catch (IllegalArgumentException e) {
+      new AmbryBlobStorageServiceFactory(null, clusterMap, restResponseHandler, router, accountService);
+      fail("Instantiation should have failed because VerifiableProperties was null");
+    } catch (NullPointerException e) {
       // expected. Nothing to do.
     }
 
     // ClusterMap null.
     try {
-      new AmbryBlobStorageServiceFactory(verifiableProperties, null, restResponseHandler, router,
-          new InMemAccountService(false, true));
-      fail("Instantiation should have failed because one of the arguments was null");
-    } catch (IllegalArgumentException e) {
+      new AmbryBlobStorageServiceFactory(verifiableProperties, null, restResponseHandler, router, accountService);
+      fail("Instantiation should have failed because ClusterMap was null");
+    } catch (NullPointerException e) {
       // expected. Nothing to do.
     }
 
     // RestResponseHandler null.
     try {
-      new AmbryBlobStorageServiceFactory(verifiableProperties, clusterMap, null, router,
-          new InMemAccountService(false, true));
-      fail("Instantiation should have failed because one of the arguments was null");
-    } catch (IllegalArgumentException e) {
+      new AmbryBlobStorageServiceFactory(verifiableProperties, clusterMap, null, router, accountService);
+      fail("Instantiation should have failed because RestResponseHandler was null");
+    } catch (NullPointerException e) {
       // expected. Nothing to do.
     }
 
     // Router null.
     try {
-      new AmbryBlobStorageServiceFactory(verifiableProperties, clusterMap, restResponseHandler, null,
-          new InMemAccountService(false, true));
-      fail("Instantiation should have failed because one of the arguments was null");
-    } catch (IllegalArgumentException e) {
+      new AmbryBlobStorageServiceFactory(verifiableProperties, clusterMap, restResponseHandler, null, accountService);
+      fail("Instantiation should have failed because Router was null");
+    } catch (NullPointerException e) {
+      // expected. Nothing to do.
+    }
+
+    // AccountService null.
+    try {
+      new AmbryBlobStorageServiceFactory(verifiableProperties, clusterMap, restResponseHandler, router, null);
+      fail("Instantiation should have failed because AccountService was null");
+    } catch (NullPointerException e) {
       // expected. Nothing to do.
     }
   }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -161,8 +161,8 @@ public class AmbryBlobStorageServiceTest {
     router = new InMemoryRouter(verifiableProperties, clusterMap);
     responseHandler = new FrontendTestResponseHandler();
     referenceBlobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-        Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds(null).get(0),
-        false);
+        Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
     referenceBlobIdStr = referenceBlobId.getID();
     ambryBlobStorageService = getAmbryBlobStorageService();
     responseHandler.start();
@@ -493,50 +493,57 @@ public class AmbryBlobStorageServiceTest {
       // aid=refAId, cid=refCId
       String blobId =
           new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
-              refContainer.getId(), clusterMap.getWritablePartitionIds(null).get(0), false).getID();
+              refContainer.getId(), clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
+              false).getID();
       verifyAccountAndContainerFromBlobId(blobId, refAccount, refContainer, RestServiceErrorCode.NotFound);
 
       // aid=refAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
-          Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds(null).get(0), false).getID();
+          Container.UNKNOWN_CONTAINER_ID,
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=refAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
-          (short) -1234, clusterMap.getWritablePartitionIds(null).get(0), false).getID();
+          (short) -1234, clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
+          false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=unknownAId, cid=refCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, refContainer.getId(), clusterMap.getWritablePartitionIds(null).get(0),
-          false).getID();
+          Account.UNKNOWN_ACCOUNT_ID, refContainer.getId(),
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=unknownAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds(null).get(0),
-          false).getID();
+          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, InMemAccountService.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
           RestServiceErrorCode.NotFound);
 
       // aid=unknownAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, (short) -1234, clusterMap.getWritablePartitionIds(null).get(0), false).getID();
+          Account.UNKNOWN_ACCOUNT_ID, (short) -1234,
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=nonExistAId, cid=refCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
-          refContainer.getId(), clusterMap.getWritablePartitionIds(null).get(0), false).getID();
+          refContainer.getId(), clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
+          false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
 
       // aid=nonExistAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
-          Container.UNKNOWN_CONTAINER_ID, clusterMap.getWritablePartitionIds(null).get(0), false).getID();
+          Container.UNKNOWN_CONTAINER_ID,
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
 
       // aid=nonExistAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
-          (short) -11, clusterMap.getWritablePartitionIds(null).get(0), false).getID();
+          (short) -11, clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
+          false).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
     }
   }
@@ -557,7 +564,8 @@ public class AmbryBlobStorageServiceTest {
     // it does not matter what AID and CID are supplied when constructing blobId in v1.
     // expect unknown account and container for v1 blob IDs that went through request processing only.
     String blobId = new BlobId(BlobId.BLOB_ID_V1, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-        refAccount.getId(), refContainer.getId(), clusterMap.getWritablePartitionIds(null).get(0), false).getID();
+        refAccount.getId(), refContainer.getId(),
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
     verifyAccountAndContainerFromBlobId(blobId, InMemAccountService.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
         RestServiceErrorCode.NotFound);
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -477,6 +477,7 @@ public class FrontendIntegrationTest {
     properties.put("rest.server.blob.storage.service.factory",
         "com.github.ambry.frontend.AmbryBlobStorageServiceFactory");
     properties.put("rest.server.router.factory", "com.github.ambry.router.InMemoryRouterFactory");
+    properties.put("rest.server.account.service.factory", "com.github.ambry.account.InMemAccountServiceFactory");
     properties.put("netty.server.port", Integer.toString(PLAINTEXT_SERVER_PORT));
     properties.put("netty.server.ssl.port", Integer.toString(SSL_SERVER_PORT));
     properties.put("netty.server.enable.ssl", "true");
@@ -485,7 +486,6 @@ public class FrontendIntegrationTest {
     // to test that multipart requests over a certain size fail
     properties.put("netty.multipart.post.max.size.bytes", Long.toString(MAX_MULTIPART_POST_SIZE_BYTES));
     TestSSLUtils.addSSLProperties(properties, "", SSLFactory.Mode.SERVER, trustStoreFile, "frontend");
-    properties.put("frontend.account.service.factory", "com.github.ambry.account.InMemAccountServiceFactory");
     // add key for singleKeyManagementService
     properties.put("kms.default.container.key", TestUtils.getRandomKey(32));
     return new VerifiableProperties(properties);

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
@@ -51,7 +51,7 @@ public class FrontendUtilsTest {
     byte referenceDatacenterId = bytes[0];
     short referenceAccountId = getRandomShort(TestUtils.RANDOM);
     short referenceContainerId = getRandomShort(TestUtils.RANDOM);
-    PartitionId referencePartitionId = referenceClusterMap.getWritablePartitionIds(null).get(0);
+    PartitionId referencePartitionId = referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     boolean referenceIsEncrypted = TestUtils.RANDOM.nextBoolean();
     short[] versions = {BlobId.BLOB_ID_V3, BlobId.BLOB_ID_V4};
     for (short version : versions) {

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
@@ -97,7 +97,7 @@ public class GetSignedUrlHandlerTest {
 
     BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, REF_ACCOUNT.getId(), REF_CONTAINER.getId(),
-        CLUSTER_MAP.getWritablePartitionIds(null).get(0), false);
+        CLUSTER_MAP.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
     idConverterFactory.translation = blobId.getID();
     // GET (also makes sure that the IDConverter is used)
     restRequest = new MockRestRequest(MockRestRequest.DUMMY_DATA, null);

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -220,7 +220,8 @@ public class RequestResponseTest {
     String clientId = "client";
     BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM), clusterMap.getWritablePartitionIds(null).get(0), false);
+        Utils.getRandomShort(TestUtils.RANDOM),
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
     byte[] userMetadata = new byte[50];
     TestUtils.RANDOM.nextBytes(userMetadata);
     int blobKeyLength = TestUtils.RANDOM.nextInt(4096);
@@ -282,8 +283,8 @@ public class RequestResponseTest {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds(null).get(0),
-        false);
+        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
     ArrayList<BlobId> blobIdList = new ArrayList<BlobId>();
     blobIdList.add(id1);
     PartitionRequestInfo partitionRequestInfo1 = new PartitionRequestInfo(new MockPartitionId(), blobIdList);
@@ -307,8 +308,8 @@ public class RequestResponseTest {
     messageInfoList.add(messageInfo);
     messageMetadataList.add(messageMetadata);
     PartitionResponseInfo partitionResponseInfo =
-        new PartitionResponseInfo(clusterMap.getWritablePartitionIds(null).get(0), messageInfoList,
-            messageMetadataList);
+        new PartitionResponseInfo(clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
+            messageInfoList, messageMetadataList);
     List<PartitionResponseInfo> partitionResponseInfoList = new ArrayList<PartitionResponseInfo>();
     partitionResponseInfoList.add(partitionResponseInfo);
     byte[] buf = TestUtils.getRandomBytes(1000);
@@ -351,8 +352,8 @@ public class RequestResponseTest {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds(null).get(0),
-        false);
+        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
     short[] versions = new short[]{DeleteRequest.DELETE_REQUEST_VERSION_1, DeleteRequest.DELETE_REQUEST_VERSION_2};
     for (short version : versions) {
       long deletionTimeMs = Utils.getRandomLong(TestUtils.RANDOM, Long.MAX_VALUE);
@@ -391,8 +392,8 @@ public class RequestResponseTest {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds(null).get(0),
-        false);
+        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
     List<ReplicaMetadataRequestInfo> replicaMetadataRequestInfoList = new ArrayList<ReplicaMetadataRequestInfo>();
     ReplicaMetadataRequestInfo replicaMetadataRequestInfo =
         new ReplicaMetadataRequestInfo(new MockPartitionId(), new MockFindToken(0, 1000), "localhost", "path");
@@ -422,9 +423,9 @@ public class RequestResponseTest {
     MessageInfo messageInfo = new MessageInfo(id1, 1000, accountId, containerId, operationTimeMs);
     List<MessageInfo> messageInfoList = new ArrayList<MessageInfo>();
     messageInfoList.add(messageInfo);
-    ReplicaMetadataResponseInfo responseInfo =
-        new ReplicaMetadataResponseInfo(clusterMap.getWritablePartitionIds(null).get(0), new MockFindToken(0, 1000),
-            messageInfoList, 1000);
+    ReplicaMetadataResponseInfo responseInfo = new ReplicaMetadataResponseInfo(
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), new MockFindToken(0, 1000),
+        messageInfoList, 1000);
     List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList = new ArrayList<ReplicaMetadataResponseInfo>();
     replicaMetadataResponseInfoList.add(responseInfo);
     ReplicaMetadataResponse response =
@@ -465,7 +466,7 @@ public class RequestResponseTest {
     String clientId = "client";
     for (AdminRequestOrResponseType type : AdminRequestOrResponseType.values()) {
       MockClusterMap clusterMap = new MockClusterMap();
-      PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
+      PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
       // with a valid partition id
       AdminRequest adminRequest = new AdminRequest(type, id, correlationId, clientId);
       DataInputStream requestStream = serAndPrepForRead(adminRequest, -1, true);
@@ -506,7 +507,7 @@ public class RequestResponseTest {
   @Test
   public void catchupStatusAdminRequestTest() throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
-    PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     int correlationId = 1234;
     String clientId = "client";
     // request
@@ -579,8 +580,8 @@ public class RequestResponseTest {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId, clusterMap.getWritablePartitionIds(null).get(0),
-        false);
+        ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
     short[] versions = new short[]{TtlUpdateRequest.TTL_UPDATE_REQUEST_VERSION_1};
     for (short version : versions) {
       TtlUpdateRequest ttlUpdateRequest =
@@ -617,7 +618,7 @@ public class RequestResponseTest {
    */
   private void doBlobStoreControlAdminRequestTest(boolean enable) throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
-    PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     int correlationId = 1234;
     String clientId = "client";
     // test BlobStore Control request
@@ -718,7 +719,7 @@ public class RequestResponseTest {
   private void doRequestControlAdminRequestTest(RequestOrResponseType requestOrResponseType, boolean enable)
       throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
-    PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     int correlationId = 1234;
     String clientId = "client";
     AdminRequest adminRequest =
@@ -744,7 +745,7 @@ public class RequestResponseTest {
    */
   private void doReplicationControlAdminRequestTest(List<String> origins, boolean enable) throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
-    PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     int correlationId = 1234;
     String clientId = "client";
     AdminRequest adminRequest =

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -307,8 +307,11 @@ public class ReplicationTest {
   @Test
   public void replicaThreadTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
-    Host localHost = new Host(clusterMap.getDataNodeIds().get(0), clusterMap);
-    Host remoteHost = new Host(clusterMap.getDataNodeIds().get(1), clusterMap);
+    // to make sure we select hosts with the SPECIAL_PARTITION_CLASS, pick hosts from the replicas of that partition
+    PartitionId specialPartitionId = clusterMap.getWritablePartitionIds(MockClusterMap.SPECIAL_PARTITION_CLASS).get(0);
+    // these hosts have replicas of the "special" partition and all the other partitions.
+    Host localHost = new Host(specialPartitionId.getReplicaIds().get(0).getDataNodeId(), clusterMap);
+    Host remoteHost = new Host(specialPartitionId.getReplicaIds().get(1).getDataNodeId(), clusterMap);
 
     short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
     List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -110,8 +110,9 @@ public class ReplicationTest {
   @Test
   public void replicationAllPauseTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
-    Host localHost = new Host(clusterMap.getDataNodeIds().get(0), clusterMap);
-    Host remoteHost = new Host(clusterMap.getDataNodeIds().get(1), clusterMap);
+    Pair<Host, Host> localAndRemoteHosts = getLocalAndRemoteHosts(clusterMap);
+    Host localHost = localAndRemoteHosts.getFirst();
+    Host remoteHost = localAndRemoteHosts.getSecond();
 
     List<PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     for (PartitionId partitionId : partitionIds) {
@@ -206,8 +207,9 @@ public class ReplicationTest {
   @Test
   public void replicationPauseTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
-    Host localHost = new Host(clusterMap.getDataNodeIds().get(0), clusterMap);
-    Host remoteHost = new Host(clusterMap.getDataNodeIds().get(1), clusterMap);
+    Pair<Host, Host> localAndRemoteHosts = getLocalAndRemoteHosts(clusterMap);
+    Host localHost = localAndRemoteHosts.getFirst();
+    Host remoteHost = localAndRemoteHosts.getSecond();
 
     List<PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     for (PartitionId partitionId : partitionIds) {
@@ -307,11 +309,9 @@ public class ReplicationTest {
   @Test
   public void replicaThreadTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
-    // to make sure we select hosts with the SPECIAL_PARTITION_CLASS, pick hosts from the replicas of that partition
-    PartitionId specialPartitionId = clusterMap.getWritablePartitionIds(MockClusterMap.SPECIAL_PARTITION_CLASS).get(0);
-    // these hosts have replicas of the "special" partition and all the other partitions.
-    Host localHost = new Host(specialPartitionId.getReplicaIds().get(0).getDataNodeId(), clusterMap);
-    Host remoteHost = new Host(specialPartitionId.getReplicaIds().get(1).getDataNodeId(), clusterMap);
+    Pair<Host, Host> localAndRemoteHosts = getLocalAndRemoteHosts(clusterMap);
+    Host localHost = localAndRemoteHosts.getFirst();
+    Host remoteHost = localAndRemoteHosts.getSecond();
 
     short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
     List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
@@ -559,6 +559,20 @@ public class ReplicationTest {
     assertEquals(token4, remoteReplicaInfo.getToken());
     assertEquals(token4, remoteReplicaInfo.getTokenToPersist());
     remoteReplicaInfo.onTokenPersisted();
+  }
+
+  /**
+   * Selects a local and remote host for replication tests that need it.
+   * @param clusterMap the {@link MockClusterMap} to use.
+   * @return a {@link Pair} with the first entry being the "local" host and the second, the "remote" host.
+   */
+  private Pair<Host, Host> getLocalAndRemoteHosts(MockClusterMap clusterMap) {
+    // to make sure we select hosts with the SPECIAL_PARTITION_CLASS, pick hosts from the replicas of that partition
+    PartitionId specialPartitionId = clusterMap.getWritablePartitionIds(MockClusterMap.SPECIAL_PARTITION_CLASS).get(0);
+    // these hosts have replicas of the "special" partition and all the other partitions.
+    Host localHost = new Host(specialPartitionId.getReplicaIds().get(0).getDataNodeId(), clusterMap);
+    Host remoteHost = new Host(specialPartitionId.getReplicaIds().get(1).getDataNodeId(), clusterMap);
+    return new Pair<>(localHost, remoteHost);
   }
 
   /**

--- a/ambry-rest/src/main/java/com.github.ambry.rest/RestServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/RestServer.java
@@ -303,7 +303,7 @@ public class RestServer {
 
       accountService.close();
       long accountServiceCloseTime = System.currentTimeMillis();
-      elapsedTime = accountServiceCloseTime - responseHandlerShutdownTime;
+      elapsedTime = accountServiceCloseTime - routerCloseTime;
       logger.info("Account service close took {} ms", elapsedTime);
       restServerMetrics.accountServiceCloseTimeInMs.update(elapsedTime);
 

--- a/ambry-rest/src/test/java/com.github.ambry.rest/FaultyFactory.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/FaultyFactory.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.rest;
 
+import com.github.ambry.account.AccountService;
+import com.github.ambry.account.AccountServiceFactory;
 import com.github.ambry.router.Router;
 import com.github.ambry.router.RouterFactory;
 
@@ -22,24 +24,19 @@ import com.github.ambry.router.RouterFactory;
  * <p/>
  * Public because factories are usually constructed via {@link com.github.ambry.utils.Utils#getObj(String, Object...)}
  */
-public class FaultyFactory implements BlobStorageServiceFactory, NioServerFactory, RestRequestHandlerFactory, RestResponseHandlerFactory, RouterFactory {
+public class FaultyFactory implements AccountServiceFactory, BlobStorageServiceFactory, NioServerFactory, RestRequestHandlerFactory, RestResponseHandlerFactory, RouterFactory {
 
   // for RestResponseHandlerFactory
   public FaultyFactory(Object obj1, Object obj2) {
     // don't care.
   }
 
-  // for RestRequestHandlerFactory
+  // for RestRequestHandlerFactory and AccountServiceFactory
   public FaultyFactory(Object obj1, Object obj2, Object obj3) {
     // don't care.
   }
 
-  // for RouterFactory
-  public FaultyFactory(Object obj1, Object obj2, Object obj3, Object obj4) {
-    // don't care.
-  }
-
-  // for BlobStorageServiceFactory
+  // for BlobStorageServiceFactory and RouterFactory
   public FaultyFactory(Object obj1, Object obj2, Object obj3, Object obj4, Object obj5) {
     // don't care.
   }
@@ -71,6 +68,11 @@ public class FaultyFactory implements BlobStorageServiceFactory, NioServerFactor
 
   @Override
   public RestRequestHandler getRestRequestHandler() throws InstantiationException {
+    return null;
+  }
+
+  @Override
+  public AccountService getAccountService() throws InstantiationException {
     return null;
   }
 }

--- a/ambry-rest/src/test/java/com.github.ambry.rest/RestServerTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/RestServerTest.java
@@ -185,6 +185,7 @@ public class RestServerTest {
     doBadFactoryClassTest("rest.server.router.factory");
     doBadFactoryClassTest("rest.server.response.handler.factory");
     doBadFactoryClassTest("rest.server.request.handler.factory");
+    doBadFactoryClassTest("rest.server.account.service.factory");
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -80,7 +80,8 @@ class GetBlobInfoOperation extends GetOperation {
    * @param isEncrypted if encrypted bit set based on original string of a {@link BlobId}
    */
   GetBlobInfoOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
-      ResponseHandler responseHandler, BlobId blobId, GetBlobOptionsInternal options, Callback<GetBlobResultInternal> callback, RouterCallback routerCallback, KeyManagementService kms,
+      ResponseHandler responseHandler, BlobId blobId, GetBlobOptionsInternal options,
+      Callback<GetBlobResultInternal> callback, RouterCallback routerCallback, KeyManagementService kms,
       CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time, boolean isEncrypted) {
     super(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback,
         routerMetrics.getBlobInfoLocalColoLatencyMs, routerMetrics.getBlobInfoCrossColoLatencyMs,

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
@@ -14,6 +14,7 @@
 package com.github.ambry.router;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.AccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.config.ClusterMapConfig;
@@ -44,6 +45,7 @@ public class NonBlockingRouterFactory implements RouterFactory {
   private final NetworkConfig networkConfig;
   private final NetworkMetrics networkMetrics;
   private final NotificationSystem notificationSystem;
+  private final AccountService accountService;
   private final Time time;
   private final NetworkClientFactory networkClientFactory;
   private final KeyManagementService kms;
@@ -60,10 +62,11 @@ public class NonBlockingRouterFactory implements RouterFactory {
    * @param notificationSystem the {@link NotificationSystem} to use to log operations.
    * @param sslFactory the {@link SSLFactory} to support SSL transmissions. Required if SSL is enabled for any
    *                   datacenters.
+   * @param accountService the {@link AccountService} to use.
    * @throws Exception if any of the arguments are null or if instantiation of KMS or CryptoService fails
    */
   public NonBlockingRouterFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
-      NotificationSystem notificationSystem, SSLFactory sslFactory) throws Exception {
+      NotificationSystem notificationSystem, SSLFactory sslFactory, AccountService accountService) throws Exception {
     if (verifiableProperties == null || clusterMap == null || notificationSystem == null) {
       throw new IllegalArgumentException("Null argument passed in");
     }
@@ -78,6 +81,7 @@ public class NonBlockingRouterFactory implements RouterFactory {
     }
     this.clusterMap = clusterMap;
     this.notificationSystem = notificationSystem;
+    this.accountService = accountService;
     MetricRegistry registry = clusterMap.getMetricRegistry();
     routerMetrics = new NonBlockingRouterMetrics(clusterMap);
     networkConfig = new NetworkConfig(verifiableProperties);
@@ -106,7 +110,7 @@ public class NonBlockingRouterFactory implements RouterFactory {
   public Router getRouter() {
     try {
       return new NonBlockingRouter(routerConfig, routerMetrics, networkClientFactory, notificationSystem, clusterMap,
-          kms, cryptoService, cryptoJobHandler, time, defaultPartitionClass);
+          kms, cryptoService, cryptoJobHandler, accountService, time, defaultPartitionClass);
     } catch (IOException e) {
       throw new IllegalStateException("Error instantiating NonBlocking Router ", e);
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.Account;
+import com.github.ambry.account.AccountService;
+import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
@@ -53,6 +56,7 @@ class PutManager {
   private final KeyManagementService kms;
   private final CryptoService cryptoService;
   private final CryptoJobHandler cryptoJobHandler;
+  private final AccountService accountService;
   private final Time time;
   private final Thread chunkFillerThread;
   private final Object chunkFillerSynchronizer = new Object();
@@ -101,6 +105,7 @@ class PutManager {
    * @param kms {@link KeyManagementService} to assist in fetching container keys for encryption or decryption
    * @param cryptoService {@link CryptoService} to assist in encryption or decryption
    * @param cryptoJobHandler {@link CryptoJobHandler} to assist in the execution of crypto jobs
+   * @param accountService the {@link AccountService} to use.
    * @param defaultPartitionClass the default partition class to choose partitions from (if none is found in the
    *                              container config). Can be {@code null} if no affinity is required for the puts for
    *                              which the container contains no partition class hints.
@@ -108,8 +113,8 @@ class PutManager {
    */
   PutManager(ClusterMap clusterMap, ResponseHandler responseHandler, NotificationSystem notificationSystem,
       RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, RouterCallback routerCallback, String suffix,
-      KeyManagementService kms, CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time,
-      String defaultPartitionClass) {
+      KeyManagementService kms, CryptoService cryptoService, CryptoJobHandler cryptoJobHandler,
+      AccountService accountService, Time time, String defaultPartitionClass) {
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.notificationSystem = notificationSystem;
@@ -133,6 +138,7 @@ class PutManager {
     this.kms = kms;
     this.cryptoService = cryptoService;
     this.cryptoJobHandler = cryptoJobHandler;
+    this.accountService = accountService;
     this.time = time;
     putOperations = Collections.newSetFromMap(new ConcurrentHashMap<PutOperation, Boolean>());
     correlationIdToPutOperation = new HashMap<Integer, PutOperation>();
@@ -151,12 +157,29 @@ class PutManager {
    */
   void submitPutBlobOperation(BlobProperties blobProperties, byte[] userMetaData, ReadableStreamChannel channel,
       FutureResult<String> futureResult, Callback<String> callback) {
+    String partitionClass = getPartitionClass(blobProperties);
     PutOperation putOperation =
         new PutOperation(routerConfig, routerMetrics, clusterMap, responseHandler, notificationSystem, userMetaData,
             channel, futureResult, callback, routerCallback, chunkArrivalListener, kms, cryptoService, cryptoJobHandler,
-            time, blobProperties, defaultPartitionClass);
+            time, blobProperties, partitionClass);
     putOperations.add(putOperation);
     putOperation.startReadingFromChannel();
+  }
+
+  /**
+   * @param blobProperties the properties of the blob being put
+   * @return the partition class as required by the properties
+   */
+  private String getPartitionClass(BlobProperties blobProperties) {
+    String partitionClass = defaultPartitionClass;
+    Account account = accountService.getAccountById(blobProperties.getAccountId());
+    if (account != null) {
+      Container container = account.getContainerById(blobProperties.getContainerId());
+      if (container != null && container.getReplicationPolicy() != null) {
+        partitionClass = container.getReplicationPolicy();
+      }
+    }
+    return partitionClass;
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -892,9 +892,8 @@ class PutOperation {
             passedInBlobProperties.isPrivate(), passedInBlobProperties.getTimeToLiveInSeconds(),
             passedInBlobProperties.getCreationTimeInMs(), passedInBlobProperties.getAccountId(),
             passedInBlobProperties.getContainerId(), passedInBlobProperties.isEncrypted());
-        operationTracker =
-            new SimpleOperationTracker(routerConfig.routerDatacenterName, partitionId, false, null, true,
-                Integer.MAX_VALUE, routerConfig.routerPutSuccessTarget, routerConfig.routerPutRequestParallelism);
+        operationTracker = new SimpleOperationTracker(routerConfig.routerDatacenterName, partitionId, false, null, true,
+            Integer.MAX_VALUE, routerConfig.routerPutSuccessTarget, routerConfig.routerPutRequestParallelism);
         correlationIdToChunkPutRequestInfo.clear();
         state = ChunkState.Ready;
       } catch (RouterException e) {
@@ -1124,7 +1123,8 @@ class PutOperation {
       List<? extends PartitionId> partitions = clusterMap.getWritablePartitionIds(partitionClass);
       partitions.removeAll(partitionIdsToExclude);
       if (partitions.isEmpty()) {
-        throw new RouterException("No writable partitions available.", RouterErrorCode.AmbryUnavailable);
+        throw new RouterException("No writable partitions of class " + partitionClass + " available.",
+            RouterErrorCode.AmbryUnavailable);
       }
       PartitionId selected = partitions.get(ThreadLocalRandom.current().nextInt(partitions.size()));
       if (partitionClass != null && !partitionClass.equals(selected.getPartitionClass())) {

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -152,7 +152,7 @@ public class ChunkFillTest {
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
             putUserMetadata, putChannel, futureResult, null,
             new RouterCallback(networkClientFactory.getNetworkClient(), new ArrayList<BackgroundDeleteRequest>()), null,
-            null, null, null, new MockTime(), putBlobProperties, null);
+            null, null, null, new MockTime(), putBlobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
     op.startReadingFromChannel();
     numChunks = RouterUtils.getNumChunksForBlobAndChunkSize(blobSize, chunkSize);
     // largeBlobSize is not a multiple of chunkSize
@@ -261,7 +261,7 @@ public class ChunkFillTest {
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
             putUserMetadata, putChannel, futureResult, null, routerCallback, null, kms, cryptoService, cryptoJobHandler,
-            time, putBlobProperties, null);
+            time, putBlobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
     op.startReadingFromChannel();
     numChunks = RouterUtils.getNumChunksForBlobAndChunkSize(blobSize, chunkSize);
     compositeBuffers = new ByteBuffer[numChunks];

--- a/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
@@ -541,7 +541,7 @@ public class CryptoJobHandlerTest {
     byte dc = (byte) TestUtils.RANDOM.nextInt(3);
     BlobId.BlobIdType type = TestUtils.RANDOM.nextBoolean() ? BlobId.BlobIdType.NATIVE : BlobId.BlobIdType.CRAFTED;
     return new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), type, dc, getRandomShort(TestUtils.RANDOM),
-        getRandomShort(TestUtils.RANDOM), referenceClusterMap.getWritablePartitionIds(null).get(0), false);
+        getRandomShort(TestUtils.RANDOM), referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.PartitionId;
@@ -100,8 +101,8 @@ public class DeleteManagerTest {
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(clusterMap),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), new LoggingNotificationSystem(), clusterMap, null, null, null,
-        mockTime, null);
-    List<PartitionId> mockPartitions = clusterMap.getWritablePartitionIds(null);
+        new InMemAccountService(false, true), mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
+    List<PartitionId> mockPartitions = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
     partition = mockPartitions.get(ThreadLocalRandom.current().nextInt(mockPartitions.size()));
     blobId =
         new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
@@ -299,7 +300,7 @@ public class DeleteManagerTest {
     router = new NonBlockingRouter(new RouterConfig(vProps), new NonBlockingRouterMetrics(clusterMap),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), new LoggingNotificationSystem(), clusterMap, null, null, null,
-        mockTime, null);
+        new InMemAccountService(false, true), mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
     ServerErrorCode[] serverErrorCodes = new ServerErrorCode[9];
     serverErrorCodes[0] = ServerErrorCode.Blob_Not_Found;
     serverErrorCodes[1] = ServerErrorCode.Data_Corrupt;

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.BlobId;
@@ -138,7 +139,8 @@ public class GetBlobInfoOperationTest {
         new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build(), false,
         routerMetrics.ageAtGet);
     mockServerLayout = new MockServerLayout(mockClusterMap);
-    replicasCount = mockClusterMap.getWritablePartitionIds(null).get(0).getReplicaIds().size();
+    replicasCount =
+        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0).getReplicaIds().size();
     responseHandler = new ResponseHandler(mockClusterMap);
     networkClientFactory = new MockNetworkClientFactory(vprops, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
         CHECKOUT_TIMEOUT_MS, mockServerLayout, time);
@@ -148,7 +150,7 @@ public class GetBlobInfoOperationTest {
     }
     router = new NonBlockingRouter(new RouterConfig(vprops), new NonBlockingRouterMetrics(mockClusterMap),
         networkClientFactory, new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService, cryptoJobHandler,
-        time, null);
+        new InMemAccountService(false, true), time, MockClusterMap.DEFAULT_PARTITION_CLASS);
     short accountId = Utils.getRandomShort(random);
     short containerId = Utils.getRandomShort(random);
     blobProperties =
@@ -193,13 +195,12 @@ public class GetBlobInfoOperationTest {
 
   /**
    * Test {@link GetBlobInfoOperation} instantiation and validate the get methods.
-   * @throws Exception
    */
   @Test
-  public void testInstantiation() throws Exception {
+  public void testInstantiation() {
     BlobId blobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(random), Utils.getRandomShort(random),
-        mockClusterMap.getWritablePartitionIds(null).get(0), false);
+        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
     Callback<GetBlobResultInternal> getOperationCallback = (result, exception) -> {
       // no op.
     };

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.BlobIdFactory;
@@ -185,7 +186,8 @@ public class GetBlobOperationTest {
     routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
     options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().build(), false, routerMetrics.ageAtGet);
     mockServerLayout = new MockServerLayout(mockClusterMap);
-    replicasCount = mockClusterMap.getWritablePartitionIds(null).get(0).getReplicaIds().size();
+    replicasCount =
+        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0).getReplicaIds().size();
     responseHandler = new ResponseHandler(mockClusterMap);
     MockNetworkClientFactory networkClientFactory =
         new MockNetworkClientFactory(vprops, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
@@ -197,7 +199,8 @@ public class GetBlobOperationTest {
       cryptoJobHandler = new CryptoJobHandler(CryptoJobHandlerTest.DEFAULT_THREAD_COUNT);
     }
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap), networkClientFactory,
-        new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService, cryptoJobHandler, time, null);
+        new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService, cryptoJobHandler,
+        new InMemAccountService(false, true), time, MockClusterMap.DEFAULT_PARTITION_CLASS);
     mockNetworkClient = networkClientFactory.getMockNetworkClient();
     routerCallback = new RouterCallback(mockNetworkClient, new ArrayList<BackgroundDeleteRequest>());
   }
@@ -235,7 +238,8 @@ public class GetBlobOperationTest {
 
     blobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         mockClusterMap.getLocalDatacenterId(), Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM), mockClusterMap.getWritablePartitionIds(null).get(0), false);
+        Utils.getRandomShort(TestUtils.RANDOM),
+        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
     blobIdStr = blobId.getID();
     // test a good case
     // operationCount is not incremented here as this operation is not taken to completion.

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
@@ -431,7 +432,8 @@ public class GetManagerTest {
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), new LoggingNotificationSystem(), mockClusterMap, kms,
-        cryptoService, cryptoJobHandler, mockTime, null);
+        cryptoService, cryptoJobHandler, new InMemAccountService(false, true), mockTime,
+        MockClusterMap.DEFAULT_PARTITION_CLASS);
     return router;
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouterFactory.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouterFactory.java
@@ -13,7 +13,9 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.AccountService;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.notification.NotificationSystem;
 
@@ -32,14 +34,14 @@ public class InMemoryRouterFactory implements RouterFactory {
   private final ClusterMap clusterMap;
 
   public InMemoryRouterFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
-      NotificationSystem notificationSystem, Object sslFactory) {
+      NotificationSystem notificationSystem, SSLFactory sslFactory, AccountService accountService) {
     this.verifiableProperties = verifiableProperties;
     this.notificationSystem = notificationSystem;
     this.clusterMap = clusterMap;
   }
 
   @Override
-  public Router getRouter() throws InstantiationException {
+  public Router getRouter() {
     latestInstance = new InMemoryRouter(verifiableProperties, notificationSystem, clusterMap);
     return latestInstance;
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -157,9 +157,9 @@ public class PutManagerTest {
       // size in [1, chunkSize]
       requestAndResultsList.clear();
       requestAndResultsList.add(new RequestAndResult(random.nextInt(chunkSize) + 1));
-      // since the puts are processed one at a time, it is fair to check the last partition class set
       mockClusterMap.clearLastNRequestedPartitionClasses();
       submitPutsAndAssertSuccess(true);
+      // since the puts are processed one at a time, it is fair to check the last partition class set
       checkLastRequestPartitionClasses(1, MockClusterMap.DEFAULT_PARTITION_CLASS);
     }
   }
@@ -173,9 +173,9 @@ public class PutManagerTest {
     for (int i = 1; i < 10; i++) {
       requestAndResultsList.clear();
       requestAndResultsList.add(new RequestAndResult(chunkSize * i));
-      // since the puts are processed one "large" blob at a time, it is fair to check the last partition classes set
       mockClusterMap.clearLastNRequestedPartitionClasses();
       submitPutsAndAssertSuccess(true);
+      // since the puts are processed one "large" blob at a time, it is fair to check the last partition classes set
       // one extra call if there is a metadata blob
       checkLastRequestPartitionClasses(i == 1 ? 1 : i + 1, MockClusterMap.DEFAULT_PARTITION_CLASS);
     }
@@ -189,9 +189,9 @@ public class PutManagerTest {
     for (int i = 1; i < 10; i++) {
       requestAndResultsList.clear();
       requestAndResultsList.add(new RequestAndResult(chunkSize * i + random.nextInt(chunkSize - 1) + 1));
-      // since the puts are processed one "large" blob at a time, it is fair to check the last partition classes set
       mockClusterMap.clearLastNRequestedPartitionClasses();
       submitPutsAndAssertSuccess(true);
+      // since the puts are processed one "large" blob at a time, it is fair to check the last partition classes set
       checkLastRequestPartitionClasses(i + 2, MockClusterMap.DEFAULT_PARTITION_CLASS);
     }
   }
@@ -662,9 +662,9 @@ public class PutManagerTest {
       for (Map.Entry<Container, String> containerAndPartClass : containerToPartClass.entrySet()) {
         requestAndResultsList.clear();
         requestAndResultsList.add(new RequestAndResult(sizeAndChunkCount.getKey(), containerAndPartClass.getKey()));
-        // since the puts are processed one at a time, it is fair to check the last partition class set
         mockClusterMap.clearLastNRequestedPartitionClasses();
         submitPutsAndAssertSuccess(true);
+        // since the puts are processed one at a time, it is fair to check the last partition class set
         checkLastRequestPartitionClasses(sizeAndChunkCount.getValue(), containerAndPartClass.getValue());
       }
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -676,8 +676,8 @@ public class PutManagerTest {
     requestAndResultsList.add(new RequestAndResult(chunkSize, container));
     mockClusterMap.clearLastNRequestedPartitionClasses();
     submitPutsAndAssertFailure(new RouterException("", RouterErrorCode.UnexpectedInternalError), true, false, false);
-    // because of how the non-encrypted flow is, prepareForSending() will be called twice
-    checkLastRequestPartitionClasses(testEncryption ? 1 : 2, nonExistentClass);
+    // because of how the non-encrypted flow is, prepareForSending() may be called twice. So not checking for count
+    checkLastRequestPartitionClasses(-1, nonExistentClass);
   }
 
   /**
@@ -1071,14 +1071,16 @@ public class PutManagerTest {
   /**
    * Checks the last {@code expectedCount} partition classes requested from the clustermap to make sure they match with
    * {@code expectedClass}
-   * @param expectedCount the number of times the {@code expectedClass} was requested.
+   * @param expectedCount the number of times the {@code expectedClass} was requested. If < 0, the check is ignored
    * @param expectedClass the partition class requested
    */
   private void checkLastRequestPartitionClasses(int expectedCount, String expectedClass) {
     List<String> lastNRequestedPartitionClasses = mockClusterMap.getLastNRequestedPartitionClasses();
-    assertEquals("Last requested partition class count is not as expected", expectedCount,
-        lastNRequestedPartitionClasses.size());
-    List<String> partitionClassesExpected = Collections.nCopies(expectedCount, expectedClass);
+    if (expectedCount >= 0) {
+      assertEquals("Last requested partition class count is not as expected", expectedCount,
+          lastNRequestedPartitionClasses.size());
+    }
+    List<String> partitionClassesExpected = Collections.nCopies(lastNRequestedPartitionClasses.size(), expectedClass);
     assertEquals("Last requested partition classes not as expected", partitionClassesExpected,
         lastNRequestedPartitionClasses);
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.BlobId;
@@ -36,6 +39,7 @@ import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
+import com.github.ambry.utils.UtilsTest;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,6 +50,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -76,6 +81,7 @@ public class PutManagerTest {
   private final MockServerLayout mockServerLayout;
   private final MockTime mockTime = new MockTime();
   private final MockClusterMap mockClusterMap;
+  private final InMemAccountService accountService;
   // this is a reference to the state used by the mockSelector. just allows tests to manipulate the state.
   private AtomicReference<MockSelectorState> mockSelectorState = new AtomicReference<MockSelectorState>();
   private TestNotificationSystem notificationSystem;
@@ -123,6 +129,7 @@ public class PutManagerTest {
     mockServerLayout = new MockServerLayout(mockClusterMap);
     notificationSystem = new TestNotificationSystem();
     instantiateNewRouterForPuts = true;
+    accountService = new InMemAccountService(false, true);
   }
 
   /**
@@ -520,7 +527,7 @@ public class PutManagerTest {
             putChannel, null);
     ByteBuffer src = ByteBuffer.wrap(requestAndResult.putContent);
     pushWithDelay(src, putChannel, blobSize, future);
-    future.await();
+    future.await(5, TimeUnit.SECONDS);
     requestAndResult.result = future;
   }
 
@@ -544,7 +551,7 @@ public class PutManagerTest {
     putChannel.beBad();
 
     pushWithDelay(src, putChannel, blobSize, future);
-    future.await();
+    future.await(5, TimeUnit.SECONDS);
     requestAndResult.result = future;
     Exception expectedException = new Exception("Channel encountered an error");
     assertFailure(expectedException, true);
@@ -622,6 +629,58 @@ public class PutManagerTest {
   }
 
   /**
+   * Tests that the replication policy in the container is respected
+   * @throws Exception
+   */
+  @Test
+  public void testReplPolicyToPartitionClassMapping() throws Exception {
+    Account refAccount = accountService.createAndAddRandomAccount();
+    Map<Container, String> containerToPartClass = new HashMap<>();
+    Iterator<Container> allContainers = refAccount.getAllContainers().iterator();
+    Container container = allContainers.next();
+    // container with null replication policy
+    container = accountService.addReplicationPolicyToContainer(container, null);
+    containerToPartClass.put(container, MockClusterMap.DEFAULT_PARTITION_CLASS);
+    container = allContainers.next();
+    // container with configured default replication policy
+    container = accountService.addReplicationPolicyToContainer(container, MockClusterMap.DEFAULT_PARTITION_CLASS);
+    containerToPartClass.put(container, MockClusterMap.DEFAULT_PARTITION_CLASS);
+    container = allContainers.next();
+    // container with a special replication policy
+    container = accountService.addReplicationPolicyToContainer(container, MockClusterMap.SPECIAL_PARTITION_CLASS);
+    containerToPartClass.put(container, MockClusterMap.SPECIAL_PARTITION_CLASS);
+    // adding this to test the random account and container case (does not actually happen if coming from the frontend)
+    containerToPartClass.put(null, MockClusterMap.DEFAULT_PARTITION_CLASS);
+
+    Map<Integer, Integer> sizeToChunkCount = new HashMap<>();
+    // simple
+    sizeToChunkCount.put(random.nextInt(chunkSize) + 1, 1);
+    int count = random.nextInt(8) + 3;
+    // composite
+    sizeToChunkCount.put(chunkSize * count, count + 1);
+    for (Map.Entry<Integer, Integer> sizeAndChunkCount : sizeToChunkCount.entrySet()) {
+      for (Map.Entry<Container, String> containerAndPartClass : containerToPartClass.entrySet()) {
+        requestAndResultsList.clear();
+        requestAndResultsList.add(new RequestAndResult(sizeAndChunkCount.getKey(), containerAndPartClass.getKey()));
+        // since the puts are processed one at a time, it is fair to check the last partition class set
+        mockClusterMap.clearLastNRequestedPartitionClasses();
+        submitPutsAndAssertSuccess(true);
+        checkLastRequestPartitionClasses(sizeAndChunkCount.getValue(), containerAndPartClass.getValue());
+      }
+    }
+
+    // exception if there is no partition class that conforms to the replication policy
+    String nonExistentClass = UtilsTest.getRandomString(3);
+    accountService.addReplicationPolicyToContainer(container, nonExistentClass);
+    requestAndResultsList.clear();
+    requestAndResultsList.add(new RequestAndResult(chunkSize, container));
+    mockClusterMap.clearLastNRequestedPartitionClasses();
+    submitPutsAndAssertFailure(new RouterException("", RouterErrorCode.UnexpectedInternalError), true, false, false);
+    // because of how the non-encrypted flow is, prepareForSending() will be called twice
+    checkLastRequestPartitionClasses(testEncryption ? 1 : 2, nonExistentClass);
+  }
+
+  /**
    * Push from the src to the putChannel in random sized writes, with possible delays.
    * @param src the input {@link ByteBuffer}
    * @param putChannel the destination {@link MockReadableStreamChannel}
@@ -680,7 +739,7 @@ public class PutManagerTest {
     router = new NonBlockingRouter(new RouterConfig(vProps), metrics,
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), notificationSystem, mockClusterMap, kms, cryptoService,
-        cryptoJobHandler, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
+        cryptoJobHandler, accountService, mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
     return router;
   }
 
@@ -701,7 +760,7 @@ public class PutManagerTest {
    * @param shouldCloseRouterAfter whether the router should be closed after the operation.
    */
   private void submitPutsAndAssertSuccess(boolean shouldCloseRouterAfter) throws Exception {
-    submitPut().await();
+    submitPut().await(5, TimeUnit.SECONDS);
     assertSuccess();
     if (shouldCloseRouterAfter) {
       assertCloseCleanup();
@@ -728,7 +787,7 @@ public class PutManagerTest {
         mockTime.sleep(CHECKOUT_TIMEOUT_MS + 1);
       } while (!doneLatch.await(1, TimeUnit.MILLISECONDS));
     } else {
-      doneLatch.await();
+      doneLatch.await(5, TimeUnit.SECONDS);
     }
     assertFailure(expectedException, testNotifications);
     if (shouldCloseRouterAfter) {
@@ -757,7 +816,7 @@ public class PutManagerTest {
                 new ByteBufferReadableStreamChannel(ByteBuffer.wrap(requestAndResult.putContent));
             requestAndResult.result = (FutureResult<String>) router.putBlob(requestAndResult.putBlobProperties,
                 requestAndResult.putUserMetadata, putChannel, null);
-            requestAndResult.result.await();
+            requestAndResult.result.await(5, TimeUnit.SECONDS);
           } catch (Exception e) {
             requestAndResult.result = new FutureResult<>();
             requestAndResult.result.done(null, e);
@@ -986,7 +1045,7 @@ public class PutManagerTest {
    */
   private boolean exceptionsAreEqual(Exception a, Exception b) {
     if (a instanceof RouterException) {
-      return a.equals(b);
+      return ((RouterException) a).getErrorCode().equals(((RouterException) b).getErrorCode());
     } else {
       return a.getClass() == b.getClass() && a.getMessage().equals(b.getMessage());
     }
@@ -1019,7 +1078,7 @@ public class PutManagerTest {
     List<String> lastNRequestedPartitionClasses = mockClusterMap.getLastNRequestedPartitionClasses();
     assertEquals("Last requested partition class count is not as expected", expectedCount,
         lastNRequestedPartitionClasses.size());
-    List<String> partitionClassesExpected = Collections.nCopies(expectedCount, MockClusterMap.DEFAULT_PARTITION_CLASS);
+    List<String> partitionClassesExpected = Collections.nCopies(expectedCount, expectedClass);
     assertEquals("Last requested partition classes not as expected", partitionClassesExpected,
         lastNRequestedPartitionClasses);
   }
@@ -1031,8 +1090,13 @@ public class PutManagerTest {
     FutureResult<String> result;
 
     RequestAndResult(int blobSize) {
+      this(blobSize, null);
+    }
+
+    RequestAndResult(int blobSize, Container container) {
       putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
-          Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), testEncryption);
+          container == null ? Utils.getRandomShort(TestUtils.RANDOM) : container.getParentAccountId(),
+          container == null ? Utils.getRandomShort(TestUtils.RANDOM) : container.getId(), testEncryption);
       putUserMetadata = new byte[10];
       random.nextBytes(putUserMetadata);
       putContent = new byte[blobSize];
@@ -1085,7 +1149,6 @@ public class PutManagerTest {
         for (Map.Entry<String, StoredBlob> blobEntry : mockServer.getBlobs().entrySet()) {
           if (blobIdsVisited.add(blobEntry.getKey())) {
             StoredBlob blob = blobEntry.getValue();
-            System.out.println(blobEntry.getKey());
             verifyNotification(blobEntry.getKey(), NotificationBlobType.DataChunk, blob.properties);
           }
         }

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -76,7 +76,7 @@ import static org.junit.Assert.*;
 @RunWith(Parameterized.class)
 public class PutManagerTest {
   static final GeneralSecurityException GSE = new GeneralSecurityException("Exception to throw for tests");
-  private static final long MAX_WAIT_MS = 2000;
+  private static final long MAX_WAIT_MS = 5000;
   private final boolean testEncryption;
   private final MockServerLayout mockServerLayout;
   private final MockTime mockTime = new MockTime();
@@ -221,7 +221,7 @@ public class PutManagerTest {
     submitPutsAndAssertSuccess(false);
     //future.get() for operation with bad callback should still succeed
     future.get();
-    Assert.assertTrue("Callback not called.", callbackCalled.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue("Callback not called.", callbackCalled.await(MAX_WAIT_MS, TimeUnit.MILLISECONDS));
     assertEquals("All operations should be finished.", 0, router.getOperationsCount());
     Assert.assertTrue("Router should not be closed", router.isOpen());
     // Test that PutManager is still operational
@@ -527,7 +527,7 @@ public class PutManagerTest {
             putChannel, null);
     ByteBuffer src = ByteBuffer.wrap(requestAndResult.putContent);
     pushWithDelay(src, putChannel, blobSize, future);
-    future.await(5, TimeUnit.SECONDS);
+    future.await(MAX_WAIT_MS, TimeUnit.MILLISECONDS);
     requestAndResult.result = future;
   }
 
@@ -551,7 +551,7 @@ public class PutManagerTest {
     putChannel.beBad();
 
     pushWithDelay(src, putChannel, blobSize, future);
-    future.await(5, TimeUnit.SECONDS);
+    future.await(MAX_WAIT_MS, TimeUnit.MILLISECONDS);
     requestAndResult.result = future;
     Exception expectedException = new Exception("Channel encountered an error");
     assertFailure(expectedException, true);
@@ -760,7 +760,7 @@ public class PutManagerTest {
    * @param shouldCloseRouterAfter whether the router should be closed after the operation.
    */
   private void submitPutsAndAssertSuccess(boolean shouldCloseRouterAfter) throws Exception {
-    submitPut().await(5, TimeUnit.SECONDS);
+    submitPut().await(MAX_WAIT_MS, TimeUnit.MILLISECONDS);
     assertSuccess();
     if (shouldCloseRouterAfter) {
       assertCloseCleanup();
@@ -787,7 +787,7 @@ public class PutManagerTest {
         mockTime.sleep(CHECKOUT_TIMEOUT_MS + 1);
       } while (!doneLatch.await(1, TimeUnit.MILLISECONDS));
     } else {
-      doneLatch.await(5, TimeUnit.SECONDS);
+      doneLatch.await(MAX_WAIT_MS, TimeUnit.MILLISECONDS);
     }
     assertFailure(expectedException, testNotifications);
     if (shouldCloseRouterAfter) {
@@ -816,7 +816,7 @@ public class PutManagerTest {
                 new ByteBufferReadableStreamChannel(ByteBuffer.wrap(requestAndResult.putContent));
             requestAndResult.result = (FutureResult<String>) router.putBlob(requestAndResult.putBlobProperties,
                 requestAndResult.putUserMetadata, putChannel, null);
-            requestAndResult.result.await(5, TimeUnit.SECONDS);
+            requestAndResult.result.await(MAX_WAIT_MS, TimeUnit.MILLISECONDS);
           } catch (Exception e) {
             requestAndResult.result = new FutureResult<>();
             requestAndResult.result.done(null, e);

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -105,7 +105,7 @@ public class PutOperationTest {
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
             userMetadata, channel, future, null,
             new RouterCallback(mockNetworkClient, new ArrayList<BackgroundDeleteRequest>()), null, null, null, null,
-            time, blobProperties, null);
+            time, blobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
     op.startReadingFromChannel();
     List<RequestInfo> requestInfos = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestInfos;
@@ -213,7 +213,7 @@ public class PutOperationTest {
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
             userMetadata, channel, future, null,
             new RouterCallback(mockNetworkClient, new ArrayList<BackgroundDeleteRequest>()), null, null, null, null,
-            time, blobProperties, null);
+            time, blobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
     RouterErrorCode[] routerErrorCodes = new RouterErrorCode[5];
     routerErrorCodes[0] = RouterErrorCode.OperationTimedOut;
     routerErrorCodes[1] = RouterErrorCode.UnexpectedInternalError;

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterFactoryTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterFactoryTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.config.VerifiableProperties;
@@ -63,6 +64,7 @@ public class RouterFactoryTest {
   @Test
   public void testRouterFactory() throws Exception {
     VerifiableProperties verifiableProperties = getVerifiableProperties();
+    InMemAccountService accountService = new InMemAccountService(false, true);
     List<FactoryAndRouter> factoryAndRouters = new ArrayList<FactoryAndRouter>();
     factoryAndRouters.add(new FactoryAndRouter("com.github.ambry.router.NonBlockingRouterFactory",
         "com.github.ambry.router.NonBlockingRouter"));
@@ -70,7 +72,7 @@ public class RouterFactoryTest {
     for (FactoryAndRouter factoryAndRouter : factoryAndRouters) {
       RouterFactory routerFactory =
           Utils.getObj(factoryAndRouter.factoryStr, verifiableProperties, new MockClusterMap(),
-              new LoggingNotificationSystem(), null);
+              new LoggingNotificationSystem(), null, accountService);
       Router router = routerFactory.getRouter();
       Assert.assertEquals("Did not receive expected Router instance", factoryAndRouter.routerStr,
           router.getClass().getCanonicalName());

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
@@ -39,7 +39,7 @@ public class RouterUtilsTest {
     } catch (Exception e) {
       fail("Should not get any exception.");
     }
-    partition = clusterMap.getWritablePartitionIds(null).get(0);
+    partition = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         clusterMap.getLocalDatacenterId(), Utils.getRandomShort(random), Utils.getRandomShort(random), partition,
         false);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
@@ -51,7 +51,7 @@ class DirectSender implements Runnable {
     MockClusterMap clusterMap = cluster.getClusterMap();
     this.channel = channel;
     blobIds = new ArrayList<>(totalBlobsToPut);
-    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
+    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
     for (int i = 0; i < totalBlobsToPut; i++) {
       int partitionIndex = new Random().nextInt(partitionIds.size());
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -87,8 +87,8 @@ public class MockCluster {
       if (sslEnabledDataCenterList != null) {
         dataNodes.get(i).setSslEnabledDataCenters(sslEnabledDataCenterList);
       }
-      initializeServer(dataNodes.get(i), sslProps, enableHardDeletes, prefetchDataNodeIndex == i,
-          notificationSystem, time);
+      initializeServer(dataNodes.get(i), sslProps, enableHardDeletes, prefetchDataNodeIndex == i, notificationSystem,
+          time);
     }
   }
 
@@ -293,7 +293,7 @@ class MockNotificationSystem implements NotificationSystem {
       PartitionId partitionId = blobIdObj.getPartition();
       numberOfReplicas = partitionId.getReplicaIds().size();
     } catch (Exception e) {
-      throw new IllegalArgumentException("Invalid blob ID: " + blobId);
+      throw new IllegalArgumentException("Invalid blob ID: " + blobId, e);
     }
     objectTracker.computeIfAbsent(blobId, k -> new Tracker(numberOfReplicas)).trackCreation(sourceHost, port);
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -87,7 +87,7 @@ public class MockCluster {
       if (sslEnabledDataCenterList != null) {
         dataNodes.get(i).setSslEnabledDataCenters(sslEnabledDataCenterList);
       }
-      initializeServer(dataNodes.get(i), sslProps, enableHardDeletes, prefetchDataNodeIndex == i ? true : false,
+      initializeServer(dataNodes.get(i), sslProps, enableHardDeletes, prefetchDataNodeIndex == i,
           notificationSystem, time);
     }
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerPlaintextTest.java
@@ -15,6 +15,8 @@ package com.github.ambry.server;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.server.RouterServerTestFramework.*;
 import com.github.ambry.utils.SystemTime;
@@ -22,6 +24,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +51,9 @@ public class RouterServerPlaintextTest {
   private static long plainTextSendBytesCountBeforeTest;
   private static long plainTextReceiveBytesCountBeforeTest;
 
+  private static Account refAccount;
+  private static List<Container> refContainers = new ArrayList<>();
+
   /**
    * Running for both regular and encrypted blobs
    * @return an array with both {@code false} and {@code true}.
@@ -67,9 +73,10 @@ public class RouterServerPlaintextTest {
 
   @BeforeClass
   public static void initializeTests() throws Exception {
-    MockNotificationSystem notificationSystem = new MockNotificationSystem(9);
     Properties properties = getRouterProperties("DC1");
-    plaintextCluster = new MockCluster(notificationSystem, false, SystemTime.getInstance());
+    plaintextCluster = new MockCluster(false, SystemTime.getInstance());
+    MockNotificationSystem notificationSystem = new MockNotificationSystem(plaintextCluster.getClusterMap());
+    plaintextCluster.initializeServers(notificationSystem);
     plaintextCluster.startServers();
     MockClusterMap routerClusterMap = plaintextCluster.getClusterMap();
     // MockClusterMap returns a new registry by default. This is to ensure that each node (server, router and so on,
@@ -78,6 +85,23 @@ public class RouterServerPlaintextTest {
     routerClusterMap.createAndSetPermanentMetricRegistry();
     testFramework = new RouterServerTestFramework(properties, routerClusterMap, notificationSystem);
     routerMetricRegistry = routerClusterMap.getMetricRegistry();
+
+    refAccount = testFramework.accountService.createAndAddRandomAccount();
+    Iterator<Container> allContainers = refAccount.getAllContainers().iterator();
+    // container with null replication policy
+    Container container = allContainers.next();
+    container = testFramework.accountService.addReplicationPolicyToContainer(container, null);
+    refContainers.add(container);
+    // container with configured default replication policy
+    container = allContainers.next();
+    container =
+        testFramework.accountService.addReplicationPolicyToContainer(container, MockClusterMap.DEFAULT_PARTITION_CLASS);
+    refContainers.add(container);
+    // container with a special replication policy
+    container = allContainers.next();
+    container =
+        testFramework.accountService.addReplicationPolicyToContainer(container, MockClusterMap.SPECIAL_PARTITION_CLASS);
+    refContainers.add(container);
   }
 
   @AfterClass
@@ -156,7 +180,8 @@ public class RouterServerPlaintextTest {
           break;
       }
       int blobSize = random.nextInt(100 * 1024);
-      opChains.add(testFramework.startOperationChain(blobSize, i, operations));
+      int contIdx = i % refContainers.size();
+      opChains.add(testFramework.startOperationChain(blobSize, refContainers.get(contIdx), i, operations));
     }
     testFramework.checkOperationChains(opChains);
   }
@@ -182,8 +207,9 @@ public class RouterServerPlaintextTest {
       operations.add(OperationType.GET_DELETED_SUCCESS);
       operations.add(OperationType.GET_INFO_DELETED_SUCCESS);
       int blobSize = random.nextInt(100 * 1024);
-      testFramework.checkOperationChains(
-          Collections.singletonList(testFramework.startOperationChain(blobSize, i, operations)));
+      int contIdx = i % refContainers.size();
+      testFramework.checkOperationChains(Collections.singletonList(
+          testFramework.startOperationChain(blobSize, refContainers.get(contIdx), i, operations)));
     }
   }
 
@@ -207,7 +233,7 @@ public class RouterServerPlaintextTest {
       operations.add(OperationType.GET_DELETED);
       operations.add(OperationType.GET_DELETED_SUCCESS);
       operations.add(OperationType.GET_INFO_DELETED_SUCCESS);
-      opChains.add(testFramework.startOperationChain(blobSize, i, operations));
+      opChains.add(testFramework.startOperationChain(blobSize, null, i, operations));
     }
     testFramework.checkOperationChains(opChains);
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerSSLTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerSSLTest.java
@@ -77,8 +77,9 @@ public class RouterServerSSLTest {
     Properties routerProps = getRouterProperties("DC1");
     TestSSLUtils.addSSLProperties(routerProps, sslEnabledDataCentersStr, SSLFactory.Mode.CLIENT, trustStoreFile,
         "router-client");
-    MockNotificationSystem notificationSystem = new MockNotificationSystem(9);
-    sslCluster = new MockCluster(notificationSystem, serverSSLProps, false, SystemTime.getInstance());
+    sslCluster = new MockCluster(serverSSLProps, false, SystemTime.getInstance());
+    MockNotificationSystem notificationSystem = new MockNotificationSystem(sslCluster.getClusterMap());
+    sslCluster.initializeServers(notificationSystem);
     sslCluster.startServers();
     MockClusterMap routerClusterMap = sslCluster.getClusterMap();
     // MockClusterMap returns a new registry by default. This is to ensure that each node (server, router and so on,
@@ -166,7 +167,7 @@ public class RouterServerSSLTest {
           break;
       }
       int blobSize = random.nextInt(100 * 1024);
-      opChains.add(testFramework.startOperationChain(blobSize, i, operations));
+      opChains.add(testFramework.startOperationChain(blobSize, null, i, operations));
     }
     testFramework.checkOperationChains(opChains);
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -195,6 +195,8 @@ class RouterServerTestFramework {
   /**
    * Check for blob ID validity.
    * @param blobId the blobId
+   * @param properties the blob properties associated with the blob (to check that the blob was put in the right
+   *                   partition)
    * @param operationName a name for the operation being checked
    */
   private void checkBlobId(String blobId, BlobProperties properties, String operationName) throws IOException {

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.server;
 
+import com.github.ambry.account.Account;
+import com.github.ambry.account.Container;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
@@ -53,9 +56,9 @@ import org.junit.Assert;
  * This class provides a framework for creating router/server integration test cases. It instantiates a non-blocking
  * router from the provided properties, cluster and notification system. The user defines chains of operations on a
  * certain blob (i.e. putBlob, getBlobInfo, deleteBlob). These chains can be executed asynchronously using the
- * {@link #startOperationChain(int, int, Queue)} method. The results of each stage of the chains can be checked using
- * the {@link #checkOperationChains(List)} method. See {@link RouterServerPlaintextTest} and {@link RouterServerSSLTest}
- * for example usage.
+ * {@link #startOperationChain(int, Container, int, Queue)} method. The results of each stage of the chains can be
+ * checked using the {@link #checkOperationChains(List)} method. See {@link RouterServerPlaintextTest} and
+ * {@link RouterServerSSLTest} for example usage.
  */
 class RouterServerTestFramework {
   static final int AWAIT_TIMEOUT = 20;
@@ -66,6 +69,8 @@ class RouterServerTestFramework {
   private final MockNotificationSystem notificationSystem;
   private final Router router;
   private boolean testEncryption = false;
+
+  final InMemAccountService accountService = new InMemAccountService(false, true);
 
   public static String sslSendBytesMetricName = Selector.class.getName() + ".SslSendBytesRate";
   public static String sslReceiveBytesMetricName = Selector.class.getName() + ".SslReceiveBytesRate";
@@ -84,10 +89,9 @@ class RouterServerTestFramework {
       MockNotificationSystem notificationSystem) throws Exception {
     this.clusterMap = clusterMap;
     this.notificationSystem = notificationSystem;
-
     VerifiableProperties routerVerifiableProps = new VerifiableProperties(routerProps);
     router = new NonBlockingRouterFactory(routerVerifiableProps, clusterMap, notificationSystem,
-        ServerTestUtil.getSSLFactoryIfRequired(routerVerifiableProps)).getRouter();
+        ServerTestUtil.getSSLFactoryIfRequired(routerVerifiableProps), accountService).getRouter();
   }
 
   /**
@@ -130,7 +134,7 @@ class RouterServerTestFramework {
       if (opChain.blobId != null) {
         blobsPut++;
         PartitionId partitionId = new BlobId(opChain.blobId, clusterMap).getPartition();
-        int count = partitionCount.containsKey(partitionId) ? partitionCount.get(partitionId) : 0;
+        int count = partitionCount.getOrDefault(partitionId, 0);
         partitionCount.put(partitionId, count + 1);
       }
     }
@@ -148,17 +152,18 @@ class RouterServerTestFramework {
   /**
    * Create an {@link OperationChain} from a queue of {@link OperationType}s.  Start the operation chain asynchronously.
    * @param blobSize the size of the blob generated for put operations.
+   * @param container the {@link Container} to put the blob into (can be {@code null}}
    * @param chainId a numeric identifying the operation chain.
    * @param operations the queue of operations to perform in the chain
    * @return an {@link OperationChain} object describing the started chain.
    */
-  OperationChain startOperationChain(int blobSize, int chainId, Queue<OperationType> operations) {
+  OperationChain startOperationChain(int blobSize, Container container, int chainId, Queue<OperationType> operations) {
     byte[] userMetadata = new byte[1000];
     byte[] data = new byte[blobSize];
     TestUtils.RANDOM.nextBytes(userMetadata);
     TestUtils.RANDOM.nextBytes(data);
-    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
-    short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+    short accountId = container == null ? Utils.getRandomShort(TestUtils.RANDOM) : container.getParentAccountId();
+    short containerId = container == null ? Utils.getRandomShort(TestUtils.RANDOM) : container.getId();
     BlobProperties properties = new BlobProperties(blobSize, "serviceid1", accountId, containerId, testEncryption);
     OperationChain opChain = new OperationChain(chainId, properties, userMetadata, data, operations);
     continueChain(opChain);
@@ -192,8 +197,19 @@ class RouterServerTestFramework {
    * @param blobId the blobId
    * @param operationName a name for the operation being checked
    */
-  private static void checkBlobId(String blobId, String operationName) {
+  private void checkBlobId(String blobId, BlobProperties properties, String operationName) throws IOException {
     Assert.assertNotNull("Null blobId for operation: " + operationName, blobId);
+    BlobId id = new BlobId(blobId, clusterMap);
+    String partitionClass = MockClusterMap.DEFAULT_PARTITION_CLASS;
+    Account account = accountService.getAccountById(properties.getAccountId());
+    if (account != null) {
+      Container container = account.getContainerById(properties.getContainerId());
+      if (container != null && container.getReplicationPolicy() != null) {
+        partitionClass = container.getReplicationPolicy();
+      }
+    }
+    Assert.assertTrue("Partition that blob was put not as required by container",
+        clusterMap.getWritablePartitionIds(partitionClass).contains(id.getPartition()));
   }
 
   /**
@@ -274,7 +290,7 @@ class RouterServerTestFramework {
     TestFuture<String> testFuture = new TestFuture<String>(future, genLabel("putBlob", false), opChain) {
       @Override
       void check() throws Exception {
-        checkBlobId(get(), getOperationName());
+        checkBlobId(get(), opChain.properties, getOperationName());
       }
     };
     opChain.testFutures.add(testFuture);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -79,9 +79,9 @@ public class ServerHardDeleteTest {
 
   @Before
   public void initialize() throws Exception {
-    notificationSystem = new MockNotificationSystem(1);
     mockClusterAgentsFactory = new MockClusterAgentsFactory(false, 1, 1, 1);
     mockClusterMap = mockClusterAgentsFactory.getClusterMap();
+    notificationSystem = new MockNotificationSystem(mockClusterMap);
     time = new MockTime(SystemTime.getInstance().milliseconds());
     Properties props = new Properties();
     props.setProperty("host.name", mockClusterMap.getDataNodes().get(0).getHostname());
@@ -265,7 +265,7 @@ public class ServerHardDeleteTest {
     properties.add(new BlobProperties(31878, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
         Utils.getRandomShort(TestUtils.RANDOM), true));
 
-    List<PartitionId> partitionIds = mockClusterMap.getWritablePartitionIds(null);
+    List<PartitionId> partitionIds = mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
     PartitionId chosenPartition = partitionIds.get(0);
     blobIdList = new ArrayList<>(9);
     for (int i = 0; i < 9; i++) {

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerPlaintextTokenTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerPlaintextTokenTest.java
@@ -21,8 +21,6 @@ import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -67,8 +65,9 @@ public class ServerPlaintextTokenTest {
     routerProps = new Properties();
     routerProps.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
     routerProps.setProperty("clustermap.default.partition.class", MockClusterMap.DEFAULT_PARTITION_CLASS);
-    notificationSystem = new MockNotificationSystem(9);
-    plaintextCluster = new MockCluster(notificationSystem, false, SystemTime.getInstance());
+    plaintextCluster = new MockCluster(false, SystemTime.getInstance());
+    notificationSystem = new MockNotificationSystem(plaintextCluster.getClusterMap());
+    plaintextCluster.initializeServers(notificationSystem);
     plaintextCluster.startServers();
   }
 
@@ -83,12 +82,11 @@ public class ServerPlaintextTokenTest {
   }
 
   @Test
-  public void endToEndReplicationWithMultiNodeSinglePartitionTest()
-      throws InterruptedException, IOException, InstantiationException, URISyntaxException, GeneralSecurityException {
+  public void endToEndReplicationWithMultiNodeSinglePartitionTest() {
     DataNodeId dataNodeId = plaintextCluster.getClusterMap().getDataNodeIds().get(0);
     ArrayList<String> dataCenterList = Utils.splitString("DC1,DC2,DC3", ",");
     List<DataNodeId> dataNodes = plaintextCluster.getOneDataNodeFromEachDatacenter(dataCenterList);
-    ServerTestUtil.endToEndReplicationWithMultiNodeSinglePartitionTest("DC1", "", dataNodeId.getPort(),
+    ServerTestUtil.endToEndReplicationWithMultiNodeSinglePartitionTest("DC1", dataNodeId.getPort(),
         new Port(dataNodes.get(0).getPort(), PortType.PLAINTEXT),
         new Port(dataNodes.get(1).getPort(), PortType.PLAINTEXT),
         new Port(dataNodes.get(2).getPort(), PortType.PLAINTEXT), plaintextCluster, null, null, notificationSystem,

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerSSLTokenTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerSSLTokenTest.java
@@ -23,8 +23,6 @@ import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -77,8 +75,9 @@ public class ServerSSLTokenTest {
     routerProps = new Properties();
     routerProps.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
     TestSSLUtils.addSSLProperties(routerProps, "DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "router-client");
-    notificationSystem = new MockNotificationSystem(9);
-    sslCluster = new MockCluster(notificationSystem, serverSSLProps, false, SystemTime.getInstance());
+    sslCluster = new MockCluster(serverSSLProps, false, SystemTime.getInstance());
+    notificationSystem = new MockNotificationSystem(sslCluster.getClusterMap());
+    sslCluster.initializeServers(notificationSystem);
     sslCluster.startServers();
     //client
     sslFactory = SSLFactory.getNewInstance(clientSSLConfig);
@@ -99,12 +98,11 @@ public class ServerSSLTokenTest {
   }
 
   @Test
-  public void endToEndSSLReplicationWithMultiNodeSinglePartitionTest()
-      throws InterruptedException, IOException, InstantiationException, URISyntaxException, GeneralSecurityException {
+  public void endToEndSSLReplicationWithMultiNodeSinglePartitionTest() {
     DataNodeId dataNodeId = sslCluster.getClusterMap().getDataNodeIds().get(0);
     ArrayList<String> dataCenterList = new ArrayList<String>(Arrays.asList("DC1", "DC2", "DC3"));
     List<DataNodeId> dataNodes = sslCluster.getOneDataNodeFromEachDatacenter(dataCenterList);
-    ServerTestUtil.endToEndReplicationWithMultiNodeSinglePartitionTest("DC1", "DC2,DC3", dataNodeId.getPort(),
+    ServerTestUtil.endToEndReplicationWithMultiNodeSinglePartitionTest("DC1", dataNodeId.getPort(),
         new Port(dataNodes.get(0).getSSLPort(), PortType.SSL), new Port(dataNodes.get(1).getSSLPort(), PortType.SSL),
         new Port(dataNodes.get(2).getSSLPort(), PortType.SSL), sslCluster, clientSSLConfig, clientSSLSocketFactory,
         notificationSystem, routerProps, testEncryption);

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -136,7 +136,8 @@ public class AmbryRequestsTest {
    */
   @Test
   public void scheduleCompactionSuccessTest() throws InterruptedException, IOException {
-    List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
+    List<? extends PartitionId> partitionIds =
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
     for (PartitionId id : partitionIds) {
       doScheduleCompactionTest(id, ServerErrorCode.No_Error);
       assertEquals("Partition scheduled for compaction not as expected", id,
@@ -154,7 +155,7 @@ public class AmbryRequestsTest {
     // partitionId not specified
     doScheduleCompactionTest(null, ServerErrorCode.Bad_Request);
 
-    PartitionId id = clusterMap.getWritablePartitionIds(null).get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
 
     // store is not started - Disk_Unavailable
     storageManager.returnNullStore = true;
@@ -196,7 +197,8 @@ public class AmbryRequestsTest {
     RequestOrResponseType[] requestOrResponseTypes =
         {RequestOrResponseType.PutRequest, RequestOrResponseType.DeleteRequest, RequestOrResponseType.GetRequest, RequestOrResponseType.ReplicaMetadataRequest};
     for (RequestOrResponseType requestType : requestOrResponseTypes) {
-      List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
+      List<? extends PartitionId> partitionIds =
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
       for (PartitionId id : partitionIds) {
         doRequestControlRequestTest(requestType, id);
       }
@@ -222,7 +224,8 @@ public class AmbryRequestsTest {
    */
   @Test
   public void controlReplicationSuccessTest() throws InterruptedException, IOException {
-    List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
+    List<? extends PartitionId> partitionIds =
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
     for (PartitionId id : partitionIds) {
       doControlReplicationTest(id, ServerErrorCode.No_Error);
     }
@@ -238,11 +241,12 @@ public class AmbryRequestsTest {
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = false;
     sendAndVerifyReplicationControlRequest(Collections.EMPTY_LIST, false,
-        clusterMap.getWritablePartitionIds(null).get(0), ServerErrorCode.Bad_Request);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), ServerErrorCode.Bad_Request);
     replicationManager.reset();
     replicationManager.exceptionToThrow = new IllegalStateException();
     sendAndVerifyReplicationControlRequest(Collections.EMPTY_LIST, false,
-        clusterMap.getWritablePartitionIds(null).get(0), ServerErrorCode.Unknown_Error);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
+        ServerErrorCode.Unknown_Error);
     // PartitionUnknown is hard to simulate without betraying knowledge of the internals of MockClusterMap.
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -203,7 +203,7 @@ public class HardDeleter implements Runnable {
         return;
       }
 
-        /* First create the readOptionsList */
+      /* First create the readOptionsList */
       List<BlobReadOptions> readOptionsList = hardDeleteRecoveryRange.getBlobReadOptionsList();
 
         /* Next, perform the log write. The token file does not have to be persisted again as only entries that are
@@ -334,7 +334,7 @@ public class HardDeleter implements Runnable {
    * This method will be called before the log is flushed.
    */
   void preLogFlush() {
-      /* Save the current start token before the log gets flushed */
+    /* Save the current start token before the log gets flushed */
     startTokenBeforeLogFlush = startToken;
   }
 
@@ -342,7 +342,7 @@ public class HardDeleter implements Runnable {
    * This method will be called after the log is flushed.
    */
   void postLogFlush() {
-      /* start token saved before the flush is now safe to be persisted */
+    /* start token saved before the flush is now safe to be persisted */
     startTokenSafeToPersist = startTokenBeforeLogFlush;
   }
 
@@ -556,7 +556,7 @@ public class HardDeleter implements Runnable {
       EnumSet<StoreGetOptions> getOptions = EnumSet.of(StoreGetOptions.Store_Include_Deleted);
       List<BlobReadOptions> readOptionsList = new ArrayList<BlobReadOptions>(messageInfoList.size());
 
-        /* First create the readOptionsList */
+      /* First create the readOptionsList */
       for (MessageInfo info : messageInfoList) {
         if (!enabled.get()) {
           throw new StoreException("Aborting, store is shutting down", StoreErrorCodes.Store_Shutting_Down);
@@ -577,8 +577,8 @@ public class HardDeleter implements Runnable {
       Iterator<HardDeleteInfo> hardDeleteIterator = hardDelete.getHardDeleteMessages(readSet, factory, null);
       Iterator<BlobReadOptions> readOptionsIterator = readOptionsList.iterator();
 
-        /* Next, get the information to persist hard delete recovery info. Get all the information and save it, as only
-         * after the whole range is persisted can we start with the actual log write */
+      /* Next, get the information to persist hard delete recovery info. Get all the information and save it, as only
+       * after the whole range is persisted can we start with the actual log write */
       while (hardDeleteIterator.hasNext()) {
         if (!enabled.get()) {
           throw new StoreException("Aborting hard deletes as store is shutting down",
@@ -604,7 +604,7 @@ public class HardDeleter implements Runnable {
 
       persistCleanupToken();
 
-        /* Finally, write the hard delete stream into the Log */
+      /* Finally, write the hard delete stream into the Log */
       for (LogWriteInfo logWriteInfo : logWriteInfoList) {
         if (!enabled.get()) {
           throw new StoreException("Aborting hard deletes as store is shutting down",

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -73,7 +73,9 @@ public class StorageManagerTest {
    */
   @After
   public void cleanupCluster() throws IOException {
-    clusterMap.cleanup();
+    if (clusterMap != null) {
+      clusterMap.cleanup();
+    }
   }
 
   /**
@@ -165,7 +167,8 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
     dataNodes.add(dataNode);
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
+    MockPartitionId invalidPartition =
+        new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
     List<? extends ReplicaId> invalidPartitionReplicas = invalidPartition.getReplicaIds();
     StorageManager storageManager = createStorageManager(replicas, metricRegistry);
     PartitionId id = null;
@@ -202,7 +205,8 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
     dataNodes.add(dataNode);
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
+    MockPartitionId invalidPartition =
+        new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
     List<? extends ReplicaId> invalidPartitionReplicas = invalidPartition.getReplicaIds();
     StorageManager storageManager = createStorageManager(replicas, metricRegistry);
     PartitionId id = null;
@@ -227,7 +231,8 @@ public class StorageManagerTest {
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
     dataNodes.add(dataNode);
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
+    MockPartitionId invalidPartition =
+        new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
     List<? extends ReplicaId> invalidPartitionReplicas = invalidPartition.getReplicaIds();
     StorageManager storageManager = createStorageManager(replicas, metricRegistry);
     storageManager.start();
@@ -405,7 +410,8 @@ public class StorageManagerTest {
         getCounterValue(counters, DiskSpaceAllocator.class.getName(), "DiskSpaceAllocatorInitFailureCount"));
     assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "TotalStoreStartFailures"));
     assertEquals(0, getCounterValue(counters, DiskManager.class.getName(), "DiskMountPathFailures"));
-    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, Collections.<MockDataNodeId>emptyList(), 0);
+    MockPartitionId invalidPartition = new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS,
+        Collections.<MockDataNodeId>emptyList(), 0);
     assertNull("Should not have found a store for an invalid partition.", storageManager.getStore(invalidPartition));
     assertEquals("Compaction thread count is incorrect", dataNode.getMountPaths().size(),
         TestUtils.numThreadsByThisName(CompactionManager.THREAD_NAME_PREFIX));

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -62,7 +62,7 @@ public class StorageManagerTest {
    */
   @Before
   public void initializeCluster() throws IOException {
-    clusterMap = new MockClusterMap(false, 1, 3, 3);
+    clusterMap = new MockClusterMap(false, 1, 3, 3, false);
     metricRegistry = clusterMap.getMetricRegistry();
     generateConfigs(false);
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
@@ -54,6 +54,7 @@ public class StoreMessageReadSetTest {
   public static List<Object[]> data() {
     return Arrays.asList(new Object[][]{{false}, {true}});
   }
+
   private static final StoreKeyFactory STORE_KEY_FACTORY;
 
   static {

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/NettyPerfClient.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/NettyPerfClient.java
@@ -69,7 +69,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
-import joptsimple.OptionSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouterFactory.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouterFactory.java
@@ -15,6 +15,7 @@ package com.github.ambry.tools.perf.rest;
 
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.AccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.config.VerifiableProperties;
@@ -42,10 +43,11 @@ public class PerfRouterFactory implements RouterFactory {
    * @param clusterMap the {@link ClusterMap} whose {@link MetricRegistry} needs to be used.
    * @param notificationSystem the {@link NotificationSystem} to use (can be {@code null}).
    * @param sslFactory the {@link SSLFactory} to use (can be {@code null}).
+   * @param accountService the {@link AccountService} to use. Can be {@code null}.
    * @throws IllegalArgumentException if any of the required arguments are null.
    */
   public PerfRouterFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
-      NotificationSystem notificationSystem, SSLFactory sslFactory) {
+      NotificationSystem notificationSystem, SSLFactory sslFactory, AccountService accountService) {
     if (verifiableProperties == null || clusterMap == null) {
       throw new IllegalArgumentException("One of the arguments is null");
     } else {

--- a/build.gradle
+++ b/build.gradle
@@ -260,6 +260,8 @@ project(':ambry-rest') {
         testCompile project(':ambry-commons').sourceSets.test.output
         testCompile project(':ambry-router').sourceSets.main.output
         testCompile project(':ambry-router').sourceSets.test.output
+        testCompile project(':ambry-account').sourceSets.main.output
+        testCompile project(':ambry-account').sourceSets.test.output
         testCompile "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
     }
 }
@@ -280,6 +282,8 @@ project(':ambry-router') {
         testCompile project(':ambry-utils').sourceSets.test.output
         testCompile project(':ambry-network').sourceSets.test.output
         testCompile project(':ambry-commons').sourceSets.test.output
+        testCompile project(':ambry-account').sourceSets.main.output
+        testCompile project(':ambry-account').sourceSets.test.output
     }
 }
 

--- a/config/frontend.properties
+++ b/config/frontend.properties
@@ -12,6 +12,7 @@
 
 # rest server
 rest.server.blob.storage.service.factory=com.github.ambry.frontend.AmbryBlobStorageServiceFactory
+# rest.server.account.service.factory=com.github.ambry.account.HelixAccountServiceFactory
 
 # router
 router.hostname=localhost
@@ -28,9 +29,6 @@ clustermap.host.name=localhost
 # helix property store
 # helix.property.store.zk.client.connect.string=localhost:2182
 # helix.property.store.root.path=/ambry/Ambry_Dev/helixPropertyStore
-
-# frontend
-# frontend.account.service.factory=com.github.ambry.account.HelixAccountServiceFactory
 
 #kms
 kms.default.container.key=B374A26A71490437AA024E4FADD5B497FDFF1A8EA6FF12F6FB65AF2720B59CCF


### PR DESCRIPTION
This commit adds the ability in the Router to choose a partition to write to based on the replication policy defined in the container