### PR TITLE
Cleanup replication code

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -69,22 +69,6 @@ public class ReplicationConfig {
   public final long replicationFetchSizeInBytes;
 
   /**
-   * The time for which replication waits between replication of remote replicas of a partition
-   */
-  @Config("replication.wait.time.between.replicas.ms")
-  @Default("1000")
-  public final int replicaWaitTimeBetweenReplicasMs;
-
-  /**
-   * The max lag above which replication does not wait between replicas. A larger value would slow down replication
-   * while reduces the chance of conflicts with direct puts. A smaller value would speed up replication but
-   * increase the chance of conflicts with direct puts
-   */
-  @Config("replication.max.lag.for.wait.time.in.bytes")
-  @Default("5242880")
-  public final long replicationMaxLagForWaitTimeInBytes;
-
-  /**
    * Whether message stream should be tested for validity so that only valid ones are considered during replication
    */
   @Config("replication.validate.message.stream")
@@ -107,10 +91,6 @@ public class ReplicationConfig {
         verifiableProperties.getIntInRange("replication.token.flush.delay.seconds", 5, 1, Integer.MAX_VALUE);
     replicationFetchSizeInBytes =
         verifiableProperties.getLongInRange("replication.fetch.size.in.bytes", 1048576, 1, Long.MAX_VALUE);
-    replicaWaitTimeBetweenReplicasMs =
-        verifiableProperties.getIntInRange("replication.wait.time.between.replicas.ms", 1000, 0, 1000000);
-    replicationMaxLagForWaitTimeInBytes =
-        verifiableProperties.getLongInRange("replication.max.lag.for.wait.time.in.bytes", 5242880, 0, 104857600);
     replicationValidateMessageStream = verifiableProperties.getBoolean("replication.validate.message.stream", false);
   }
 }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -120,7 +120,6 @@ public class ReplicationTest {
     }
 
     Properties properties = new Properties();
-    properties.put("replication.wait.time.between.replicas.ms", "0");
     ReplicationConfig config = new ReplicationConfig(new VerifiableProperties(properties));
     ReplicationMetrics replicationMetrics =
         new ReplicationMetrics(new MetricRegistry(), clusterMap.getReplicaIds(localHost.dataNodeId));
@@ -216,7 +215,6 @@ public class ReplicationTest {
     }
 
     Properties properties = new Properties();
-    properties.put("replication.wait.time.between.replicas.ms", "0");
     ReplicationConfig config = new ReplicationConfig(new VerifiableProperties(properties));
     ReplicationMetrics replicationMetrics =
         new ReplicationMetrics(new MetricRegistry(), clusterMap.getReplicaIds(localHost.dataNodeId));
@@ -371,7 +369,6 @@ public class ReplicationTest {
     }
 
     Properties properties = new Properties();
-    properties.put("replication.wait.time.between.replicas.ms", "0");
     ReplicationConfig config = new ReplicationConfig(new VerifiableProperties(properties));
     ReplicationMetrics replicationMetrics =
         new ReplicationMetrics(new MetricRegistry(), clusterMap.getReplicaIds(localHost.dataNodeId));

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -122,7 +122,6 @@ public class MockCluster {
     props.setProperty("store.enable.hard.delete", Boolean.toString(enableHardDeletes));
     props.setProperty("store.deleted.message.retention.days", "1");
     props.setProperty("replication.token.flush.interval.seconds", "5");
-    props.setProperty("replication.wait.time.between.replicas.ms", "50");
     props.setProperty("replication.validate.message.stream", "true");
     props.setProperty("clustermap.cluster.name", "test");
     props.setProperty("clustermap.datacenter.name", "DC1");

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -1137,7 +1137,7 @@ public final class ServerTestUtil {
       putFutures.add(future);
     }
     for (Future<String> future : putFutures) {
-      future.get(1, TimeUnit.SECONDS);
+      future.get(5, TimeUnit.SECONDS);
     }
     assertTrue("Did not receive all callbacks in time", callbackLatch.await(1, TimeUnit.SECONDS));
     if (exceptionRef.get() != null) {


### PR DESCRIPTION
Now that the wait time hack is out, take out the related code and configs.