### PR TITLE
Fixes and enhancements to MessageInfoAndMetadataListSerde

### DIFF
--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
@@ -41,6 +41,7 @@ public class GetResponse extends Response {
   static final short GET_RESPONSE_VERSION_V_2 = 2;
   static final short GET_RESPONSE_VERSION_V_3 = 3;
   static final short GET_RESPONSE_VERSION_V_4 = 4;
+  static final short GET_RESPONSE_VERSION_V_5 = 5;
 
   static short CURRENT_VERSION = GET_RESPONSE_VERSION_V_4;
 

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
@@ -40,6 +40,7 @@ public class ReplicaMetadataResponse extends Response {
   static final short REPLICA_METADATA_RESPONSE_VERSION_V_2 = 2;
   static final short REPLICA_METADATA_RESPONSE_VERSION_V_3 = 3;
   static final short REPLICA_METADATA_RESPONSE_VERSION_V_4 = 4;
+  static final short REPLICA_METADATA_RESPONSE_VERSION_V_5 = 5;
 
   private static final short CURRENT_VERSION = REPLICA_METADATA_RESPONSE_VERSION_V_4;
 

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponse.java
@@ -42,7 +42,7 @@ public class ReplicaMetadataResponse extends Response {
   static final short REPLICA_METADATA_RESPONSE_VERSION_V_4 = 4;
   static final short REPLICA_METADATA_RESPONSE_VERSION_V_5 = 5;
 
-  private static final short CURRENT_VERSION = REPLICA_METADATA_RESPONSE_VERSION_V_4;
+  static short CURRENT_VERSION = REPLICA_METADATA_RESPONSE_VERSION_V_4;
 
   public ReplicaMetadataResponse(int correlationId, String clientId, ServerErrorCode error,
       List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList) {

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponseInfo.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponseInfo.java
@@ -16,11 +16,9 @@ package com.github.ambry.protocol;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.ServerErrorCode;
-import com.github.ambry.messageformat.MessageMetadata;
 import com.github.ambry.store.FindToken;
 import com.github.ambry.store.FindTokenFactory;
 import com.github.ambry.store.MessageInfo;
-import com.github.ambry.utils.Pair;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -102,11 +100,11 @@ public class ReplicaMetadataResponseInfo {
       return new ReplicaMetadataResponseInfo(partitionId, error);
     } else {
       FindToken token = factory.getFindToken(stream);
-      Pair<List<MessageInfo>, List<MessageMetadata>> messageInfoAndMetadataList =
+      MessageInfoAndMetadataListSerde messageInfoAndMetadataList =
           MessageInfoAndMetadataListSerde.deserializeMessageInfoAndMetadataList(stream, clusterMap,
               getMessageInfoAndMetadataListSerDeVersion(replicaMetadataResponseVersion));
       long remoteReplicaLag = stream.readLong();
-      return new ReplicaMetadataResponseInfo(partitionId, token, messageInfoAndMetadataList.getFirst(),
+      return new ReplicaMetadataResponseInfo(partitionId, token, messageInfoAndMetadataList.getMessageInfoList(),
           remoteReplicaLag, replicaMetadataResponseVersion);
     }
   }
@@ -154,6 +152,8 @@ public class ReplicaMetadataResponseInfo {
         return MessageInfoAndMetadataListSerde.VERSION_3;
       case ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_4:
         return MessageInfoAndMetadataListSerde.VERSION_4;
+      case ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_5:
+        return MessageInfoAndMetadataListSerde.DETERMINE_VERSION;
       default:
         throw new IllegalArgumentException(
             "Unknown ReplicaMetadataResponse version encountered: " + replicaMetadataResponseVersion);

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -272,6 +272,7 @@ public class RequestResponseTest {
 
   @Test
   public void getRequestResponseTest() throws IOException {
+    testGetRequestResponse(GetResponse.CURRENT_VERSION);
     testGetRequestResponse(GetResponse.GET_RESPONSE_VERSION_V_5);
     testGetRequestResponse(GetResponse.GET_RESPONSE_VERSION_V_4);
     testGetRequestResponse(GetResponse.GET_RESPONSE_VERSION_V_3);
@@ -388,6 +389,13 @@ public class RequestResponseTest {
 
   @Test
   public void replicaMetadataRequestTest() throws IOException {
+    doReplicaMetadataRequestTest(ReplicaMetadataResponse.CURRENT_VERSION);
+    doReplicaMetadataRequestTest(ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_4);
+    doReplicaMetadataRequestTest(ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_5);
+  }
+
+  private void doReplicaMetadataRequestTest(short responseVersionToUse) throws IOException {
+    ReplicaMetadataResponse.CURRENT_VERSION = responseVersionToUse;
     MockClusterMap clusterMap = new MockClusterMap();
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -272,6 +272,7 @@ public class RequestResponseTest {
 
   @Test
   public void getRequestResponseTest() throws IOException {
+    testGetRequestResponse(GetResponse.GET_RESPONSE_VERSION_V_5);
     testGetRequestResponse(GetResponse.GET_RESPONSE_VERSION_V_4);
     testGetRequestResponse(GetResponse.GET_RESPONSE_VERSION_V_3);
   }
@@ -327,7 +328,7 @@ public class RequestResponseTest {
     Assert.assertEquals(msgInfo.getExpirationTimeInMs(), 1000);
     Assert.assertEquals(deserializedGetResponse.getPartitionResponseInfoList().get(0).getMessageMetadataList().size(),
         1);
-    if (GetResponse.getCurrentVersion() == GetResponse.GET_RESPONSE_VERSION_V_4) {
+    if (GetResponse.getCurrentVersion() >= GetResponse.GET_RESPONSE_VERSION_V_4) {
       MessageMetadata messageMetadataInResponse =
           deserializedGetResponse.getPartitionResponseInfoList().get(0).getMessageMetadataList().get(0);
       Assert.assertEquals(messageMetadata.getEncryptionKey().rewind(), messageMetadataInResponse.getEncryptionKey());


### PR DESCRIPTION
- Added new versions for `GetResponse` and `ReplicaMetadataResponse`
- Decoupled these versions from `MessageInfoAndMetadataListSerde` so that it can
evolve independently going forward
- Fixed a bug with the version being passed to the `PartitionResponseInfo` ctor