### PR TITLE
Add metrics for compaction bundle read.

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
@@ -781,9 +781,11 @@ class BlobStoreCompactor {
               srcIndexEntries.get(end).getValue().getOffset().getOffset() + srcIndexEntries.get(end)
                   .getValue()
                   .getSize() - startOffset));
+          srcMetrics.compactionBundleReadBufferUsed.inc();
         }
         // do IO read
-        Utils.readFileToByteBuffer(fileChannel, startOffset, bufferToUse);
+        int ioCount = Utils.readFileToByteBuffer(fileChannel, startOffset, bufferToUse);
+        srcMetrics.compactionBundleReadBufferIoCount.inc(ioCount);
 
         // copy from buffer to tgtLog
         for (int i = start; i <= end; i++) {

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -74,6 +74,8 @@ public class StoreMetrics {
   public final Meter compactionCopyRateInBytes;
   public final Counter compactionBytesReclaimedCount;
   public final Counter compactionBundleReadBufferNotFitIn;
+  public final Counter compactionBundleReadBufferUsed;
+  public final Counter compactionBundleReadBufferIoCount;
 
   // BlobStoreStats metrics
   public final Counter blobStoreStatsIndexScannerErrorCount;
@@ -153,8 +155,12 @@ public class StoreMetrics {
     compactionCopyRateInBytes = registry.meter(MetricRegistry.name(BlobStoreCompactor.class, name + "CopyRateInBytes"));
     compactionBytesReclaimedCount =
         registry.counter(MetricRegistry.name(BlobStoreCompactor.class, name + "CompactionBytesReclaimedCount"));
-    compactionBundleReadBufferNotFitIn=
+    compactionBundleReadBufferNotFitIn =
         registry.counter(MetricRegistry.name(BlobStoreCompactor.class, name + "CompactionBundleReadBufferNotFitIn"));
+    compactionBundleReadBufferUsed =
+        registry.counter(MetricRegistry.name(BlobStoreCompactor.class, name + "CompactionBundleReadBufferUsed"));
+    compactionBundleReadBufferIoCount =
+        registry.counter(MetricRegistry.name(BlobStoreCompactor.class, name + "CompactionBundleReadBufferIoCount"));
     blobStoreStatsIndexScannerErrorCount =
         registry.counter(MetricRegistry.name(BlobStoreStats.class, name + "BlobStoreStatsIndexScannerErrorCount"));
     blobStoreStatsQueueProcessorErrorCount =

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -302,9 +302,11 @@ public class Utils {
    * @param fileChannel from which data to be read from
    * @param offset starting offset of the fileChanel to be read from
    * @param buffer the destination of the read
+   * @return actual io count of fileChannel.read()
    * @throws IOException
    */
-  public static void readFileToByteBuffer(FileChannel fileChannel, long offset, ByteBuffer buffer) throws IOException {
+  public static int readFileToByteBuffer(FileChannel fileChannel, long offset, ByteBuffer buffer) throws IOException {
+    int ioCount = 0;
     int read = 0;
     int expectedRead = buffer.remaining();
     while (buffer.hasRemaining()) {
@@ -316,7 +318,9 @@ public class Utils {
       }
       read += sizeRead;
       offset += sizeRead;
+      ioCount++;
     }
+    return ioCount;
   }
 
   /**


### PR DESCRIPTION
`buffer used count` VS `file channel read count` should be helpful.