### PR TITLE
Compaction read buffer size can be same as clean up rate

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -72,7 +72,7 @@ class CompactionManager {
         triggers.add(Trigger.valueOf(trigger.toUpperCase()));
       }
       compactionExecutor = new CompactionExecutor(triggers, storeConfig.storeCompactionMinBufferSize == 0 ? 0
-          : Math.max(2 * storeConfig.storeCleanupOperationsBytesPerSec, storeConfig.storeCompactionMinBufferSize));
+          : Math.max(storeConfig.storeCleanupOperationsBytesPerSec, storeConfig.storeCompactionMinBufferSize));
       try {
         CompactionPolicyFactory compactionPolicyFactory =
             Utils.getObj(storeConfig.storeCompactionPolicyFactory, storeConfig, time);


### PR DESCRIPTION
Less than storeCleanupOperationsBytesPerSec doesn't make sense. So let's make it at least storeCleanupOperationsBytesPerSec. 