### PR TITLE
 Adding partitionClass and account quota reports for stats aggregation

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/server/StatsHeader.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/StatsHeader.java
@@ -35,6 +35,7 @@ public class StatsHeader {
   private int storesContactedCount;
   private int storesRespondedCount;
   private List<String> unreachableStores;
+  // TODO: add hostname and change unreachableStores to Map<Disk, List<Store>> unreachableStoresOnDisk
 
   public StatsHeader(StatsDescription description, long timestamp, int storesContactedCount, int storesRespondedCount,
       List<String> unreachableStores) {

--- a/ambry-api/src/main/java/com.github.ambry/server/StatsReportType.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/StatsReportType.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.server;
+
+/**
+ * Type of stats reports which are used by StatsManager and would be transmitted to Helix. Do not change this order. Add
+ * new entries to the end of the list.
+ */
+public enum StatsReportType {
+  PARTITION_CLASS_REPORT, ACCOUNT_REPORT
+}

--- a/ambry-api/src/main/java/com.github.ambry/store/StoreStats.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/StoreStats.java
@@ -14,8 +14,10 @@
 
 package com.github.ambry.store;
 
+import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.utils.Pair;
+import java.util.Map;
 
 
 /**
@@ -40,10 +42,19 @@ public interface StoreStats {
   Pair<Long, Long> getValidSize(TimeRange timeRange) throws StoreException;
 
   /**
-   * Fetches stats for the corresponding {@link Store} as a {@link StatsSnapshot}.
+   * Fetches stats for the corresponding {@link Store} as a single {@link StatsSnapshot}.
    * @param referenceTimeInMs the reference time in ms until which deletes and expiration are relevant
    * @return a {@link StatsSnapshot} with relevant stats
    * @throws StoreException
    */
   StatsSnapshot getStatsSnapshot(long referenceTimeInMs) throws StoreException;
+
+  /**
+   * Fetches all types of stats for the corresponding {@link Store} as a map whose key is {@link StatsReportType} and
+   * value is {@link StatsSnapshot}.
+   * @param referenceTimeInMs the reference time in ms until which deletes and expiration are relevant
+   * @return a map of all types of {@link StatsSnapshot} associated with relevant stats reports
+   * @throws StoreException
+   */
+  Map<StatsReportType, StatsSnapshot> getAllStatsSnapshots(long referenceTimeInMs) throws StoreException;
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterAggregator.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterAggregator.java
@@ -14,6 +14,7 @@
 
 package com.github.ambry.clustermap;
 
+import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.server.StatsWrapper;
 import com.github.ambry.utils.Pair;
@@ -35,7 +36,7 @@ public class HelixClusterAggregator {
   private static final Logger logger = LoggerFactory.getLogger(HelixClusterAggregator.class);
   private final ObjectMapper mapper = new ObjectMapper();
   private final long relevantTimePeriodInMs;
-  private final List<String> exceptionOccurredInstances = new ArrayList<>();
+  private final Map<StatsReportType, List<String>> exceptionOccurredInstances = new HashMap<>();
 
   HelixClusterAggregator(long relevantTimePeriodInMinutes) {
     relevantTimePeriodInMs = TimeUnit.MINUTES.toMillis(relevantTimePeriodInMinutes);
@@ -46,39 +47,59 @@ public class HelixClusterAggregator {
    * aggregation with them.
    * @param statsWrappersJSON a {@link Map} of instance name to JSON string representation of {@link StatsWrapper} objects from the
    *                          node level
+   * @param type the type of stats report which is enum defined in {@link StatsReportType}
    * @return a {@link Pair} of Strings whose values represents valid quota stats across all partitions.
-   * First element is the raw (sum) aggregated stats and second element is average(aggregated) stats for all replicas
-   * for each partition.
+   * First element is the raw (sum) aggregated stats and second element is largest valid stats for all replicas
+   * for each partition. Here "valid" means the timestamp is within valid time range indicating the report is up-to-date.
    * @throws IOException
+   * @throws IllegalArgumentException
    */
-  Pair<String, String> doWork(Map<String, String> statsWrappersJSON) throws IOException {
-    StatsSnapshot partitionSnapshot = new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>());
+  Pair<String, String> doWork(Map<String, String> statsWrappersJSON, StatsReportType type)
+      throws IOException, IllegalArgumentException {
+    StatsSnapshot partitionSnapshot = new StatsSnapshot(0L, new HashMap<>());
     Map<String, Long> partitionTimestampMap = new HashMap<>();
-    StatsSnapshot rawPartitionSnapshot = new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>());
-    exceptionOccurredInstances.clear();
+    StatsSnapshot rawPartitionSnapshot = new StatsSnapshot(0L, new HashMap<>());
+    exceptionOccurredInstances.remove(type);
     for (Map.Entry<String, String> statsWrapperJSON : statsWrappersJSON.entrySet()) {
       if (statsWrapperJSON != null && statsWrapperJSON.getValue() != null) {
         try {
           StatsWrapper snapshotWrapper = mapper.readValue(statsWrapperJSON.getValue(), StatsWrapper.class);
           StatsWrapper snapshotWrapperCopy = mapper.readValue(statsWrapperJSON.getValue(), StatsWrapper.class);
-
-          combineRaw(rawPartitionSnapshot, snapshotWrapper);
-          combine(partitionSnapshot, snapshotWrapperCopy, statsWrapperJSON.getKey(), partitionTimestampMap);
+          combineRawData(rawPartitionSnapshot, snapshotWrapper);
+          if (type == StatsReportType.ACCOUNT_REPORT) {
+            combineValidDataByAccount(partitionSnapshot, snapshotWrapperCopy, statsWrapperJSON.getKey(),
+                partitionTimestampMap);
+          } else if (type == StatsReportType.PARTITION_CLASS_REPORT) {
+            combineValidDataByPartitionClass(partitionSnapshot, snapshotWrapperCopy, statsWrapperJSON.getKey(),
+                partitionTimestampMap);
+          }
         } catch (Exception e) {
           logger.error("Exception occurred while processing stats from {}", statsWrapperJSON.getKey(), e);
-          exceptionOccurredInstances.add(statsWrapperJSON.getKey());
+          exceptionOccurredInstances.computeIfAbsent(type, key -> new ArrayList<>()).add(statsWrapperJSON.getKey());
         }
       }
     }
     if (logger.isTraceEnabled()) {
       logger.trace("Combined raw snapshot {}", mapper.writeValueAsString(rawPartitionSnapshot));
-      logger.trace("Combined snapshot {}", mapper.writeValueAsString(partitionSnapshot));
+      logger.trace("Combined valid snapshot {}", mapper.writeValueAsString(partitionSnapshot));
     }
-    StatsSnapshot reducedRawSnapshot = reduce(rawPartitionSnapshot);
-    StatsSnapshot reducedSnapshot = reduce(partitionSnapshot);
+    StatsSnapshot reducedRawSnapshot = null;
+    StatsSnapshot reducedSnapshot = null;
+    switch (type) {
+      case ACCOUNT_REPORT:
+        reducedRawSnapshot = reduceByAccount(rawPartitionSnapshot);
+        reducedSnapshot = reduceByAccount(partitionSnapshot);
+        break;
+      case PARTITION_CLASS_REPORT:
+        reducedRawSnapshot = reduceByPartitionClass(rawPartitionSnapshot);
+        reducedSnapshot = reduceByPartitionClass(partitionSnapshot);
+        break;
+      default:
+        throw new IllegalArgumentException("Unrecognized stats report type: " + type);
+    }
     if (logger.isTraceEnabled()) {
       logger.trace("Reduced raw snapshot {}", mapper.writeValueAsString(reducedRawSnapshot));
-      logger.trace("Reduced snapshot {}", mapper.writeValueAsString(reducedSnapshot));
+      logger.trace("Reduced valid snapshot {}", mapper.writeValueAsString(reducedSnapshot));
     }
     return new Pair<>(mapper.writeValueAsString(reducedRawSnapshot), mapper.writeValueAsString(reducedSnapshot));
   }
@@ -88,21 +109,22 @@ public class HelixClusterAggregator {
    * @param rawBaseSnapshot the raw base {@link StatsSnapshot} which will contain the aggregated result
    * @param snapshotWrapper the {@link StatsSnapshot} to be added to the raw base {@link StatsSnapshot}
    */
-  private void combineRaw(StatsSnapshot rawBaseSnapshot, StatsWrapper snapshotWrapper) {
-    Map<String, StatsSnapshot> partitionSnapshotMap = snapshotWrapper.getSnapshot().getSubMap();
-    if (partitionSnapshotMap == null) {
+  private void combineRawData(StatsSnapshot rawBaseSnapshot, StatsWrapper snapshotWrapper) {
+    Map<String, StatsSnapshot> snapshotMap = snapshotWrapper.getSnapshot().getSubMap();
+    if (snapshotMap == null) {
       logger.info("There is no partition in given StatsSnapshot, skip aggregation on it.");
       return;
     }
     long totalValue = rawBaseSnapshot.getValue();
-    Map<String, StatsSnapshot> basePartitionSnapshotMap = rawBaseSnapshot.getSubMap();
-    for (Map.Entry<String, StatsSnapshot> partitionSnapshot : partitionSnapshotMap.entrySet()) {
-      if (basePartitionSnapshotMap.containsKey(partitionSnapshot.getKey())) {
-        StatsSnapshot.aggregate(basePartitionSnapshotMap.get(partitionSnapshot.getKey()), partitionSnapshot.getValue());
+    Map<String, StatsSnapshot> baseSnapshotMap = rawBaseSnapshot.getSubMap();
+    for (Map.Entry<String, StatsSnapshot> snapshotEntry : snapshotMap.entrySet()) {
+      StatsSnapshot baseSnapshot = baseSnapshotMap.get(snapshotEntry.getKey());
+      if (baseSnapshot != null) {
+        StatsSnapshot.aggregate(baseSnapshot, snapshotEntry.getValue());
       } else {
-        basePartitionSnapshotMap.put(partitionSnapshot.getKey(), partitionSnapshot.getValue());
+        baseSnapshotMap.put(snapshotEntry.getKey(), snapshotEntry.getValue());
       }
-      totalValue += partitionSnapshot.getValue().getValue();
+      totalValue += snapshotEntry.getValue().getValue();
     }
     rawBaseSnapshot.setValue(totalValue);
   }
@@ -116,13 +138,47 @@ public class HelixClusterAggregator {
    *       given partition entry has a greater value.
    *    b) Timestamp of a given partition entry is one aggregation period newer (greater) than the timestamp of the
    *       base entry.
+   * The combined snapshot is represented in following format:
+   * {
+   *   value: 1000,
+   *   subMap: {
+   *     Partition[0]: {
+   *       value: 400,
+   *       subMap: {
+   *         Account[0]: {
+   *           value: 400,
+   *           subMap: {
+   *             Container[0]: {
+   *               value: 400
+   *               subMap: null
+   *             }
+   *           }
+   *         }
+   *       }
+   *     },
+   *     Partition[1]: {
+   *       value: 600,
+   *       subMap: {
+   *         Account[1]: {
+   *           value: 600,
+   *           subMap: {
+   *             Container[1]:{
+   *               value: 600,
+   *               subMap: null
+   *             }
+   *           }
+   *         }
+   *       }
+   *     }
+   *   }
+   * }
    * @param baseSnapshot the base {@link StatsSnapshot} which will contain the aggregated result
-   * @param snapshotWrapper the {@link StatsSnapshot} to be aggregated to the base {@link StatsSnapshot}
+   * @param snapshotWrapper the {@link StatsSnapshot} from each instance to be aggregated to the base {@link StatsSnapshot}
    * @param instance new instance from which snapshot is being combined
    * @param partitionTimestampMap a {@link Map} of partition to timestamp to keep track the current timestamp of each
    *                              partition entry in the base {@link StatsSnapshot}
    */
-  private void combine(StatsSnapshot baseSnapshot, StatsWrapper snapshotWrapper, String instance,
+  private void combineValidDataByAccount(StatsSnapshot baseSnapshot, StatsWrapper snapshotWrapper, String instance,
       Map<String, Long> partitionTimestampMap) {
     Map<String, StatsSnapshot> partitionSnapshotMap = snapshotWrapper.getSnapshot().getSubMap();
     if (partitionSnapshotMap == null) {
@@ -154,7 +210,7 @@ public class HelixClusterAggregator {
           logger.trace("Ignoring snapshot from {} for partition {}", instance, partitionId);
         }
       } else {
-        logger.trace("First entry for partition {} is from {}", partitionId, instance);
+        logger.debug("First entry for partition {} is from {}", partitionId, instance);
         basePartitionSnapshotMap.put(partitionId, partitionSnapshot.getValue());
         partitionTimestampMap.put(partitionId, snapshotTimestamp);
         totalValue += partitionSnapshot.getValue().getValue();
@@ -164,12 +220,131 @@ public class HelixClusterAggregator {
   }
 
   /**
+   * Aggregate the given {@link StatsSnapshot} with the base {@link StatsSnapshot} by partition class with same rules defined
+   * in {@link #combineValidDataByAccount(StatsSnapshot, StatsWrapper, String, Map)}.
+   *
+   * The workflow of this method is as follows:
+   * 1. check if basePartitionClassMap contains given partitionClass. If yes, go to step 2; If not, directly put it into basePartitionClassMap
+   *    and update partitionTimestampMap by adding all < partition, timestamp > pairs associated with given partitionClass
+   * 2. for each partition in given partitionClass, check if basePartitionMap contains it. If yes, go to step 3;
+   *    if not, put the partition into basePartitionMap and update partitionTimestampMap by adding the partition and its timestamp.
+   * 3. compute the delta value and delta time between given partition and existing partition. Update total value and
+   *    partitionTimestampMap based on following rules:
+   *      a) if abs(delta time) is within relevantTimePeriodInMs and delta value > 0, replace existing partition with given partition.
+   *      b) if delta time > relevantTimePeriodInMs, which means given partition is newer than existing partition,
+   *         then replace existing partition with given one.
+   * 4. otherwise, ignore the partition(replica) because it is either stale or not the replica with largest value.
+   * 5. update basePartitionClassMap with up-to-date basePartitionMap and partitionClassTotalVal.
+   *
+   * The combined snapshot is represented in following format:
+   * {
+   *   value: 1000,
+   *   subMap:{
+   *     PartitionClass_1: {
+   *       value: 400,
+   *       subMap: {
+   *         Partition[1]:{
+   *           value: 400,
+   *           subMap: {
+   *             Account[1]_Container[1]:{
+   *               value: 400,
+   *               subMap: null
+   *             }
+   *           }
+   *         }
+   *       }
+   *     },
+   *     PartitionClass_2: {
+   *       value: 600,
+   *       subMap:{
+   *         Partition[2]:{
+   *           value: 600,
+   *           subMap:{
+   *             Account[2]_Container[2]:{
+   *               value: 600,
+   *               subMap: null
+   *             }
+   *           }
+   *         }
+   *       }
+   *     }
+   *   }
+   * }
+   * @param baseSnapshot the base {@link StatsSnapshot} which will contain the aggregated result
+   * @param snapshotWrapper the {@link StatsSnapshot} from each instance to be aggregated to the base {@link StatsSnapshot}
+   * @param instance new instance from which snapshot is being combined
+   * @param partitionTimestampMap a {@link Map} of partition to timestamp to keep track the current timestamp of each
+   *                              partition entry in the base {@link StatsSnapshot}
+   */
+  private void combineValidDataByPartitionClass(StatsSnapshot baseSnapshot, StatsWrapper snapshotWrapper,
+      String instance, Map<String, Long> partitionTimestampMap) {
+    Map<String, StatsSnapshot> partitionClassSnapshotMap = snapshotWrapper.getSnapshot().getSubMap();
+    if (partitionClassSnapshotMap == null) {
+      logger.info("There is no partition in given StatsSnapshot, skip aggregation on it.");
+      return;
+    }
+    long totalValue = baseSnapshot.getValue();
+    long snapshotTimestamp = snapshotWrapper.getHeader().getTimestamp();
+    Map<String, StatsSnapshot> basePartitionClassMap = baseSnapshot.getSubMap();
+
+    for (Map.Entry<String, StatsSnapshot> partitionClassSnapshot : partitionClassSnapshotMap.entrySet()) {
+      String partitionClassId = partitionClassSnapshot.getKey();
+      if (basePartitionClassMap.containsKey(partitionClassId)) {
+        Map<String, StatsSnapshot> basePartitionMap = basePartitionClassMap.get(partitionClassId).getSubMap();
+        long partitionClassTotalVal = basePartitionClassMap.get(partitionClassId).getValue();
+        for (Map.Entry<String, StatsSnapshot> partitionSnapshot : partitionClassSnapshot.getValue()
+            .getSubMap()
+            .entrySet()) {
+          String partitionId = partitionSnapshot.getKey();
+          if (basePartitionMap.containsKey(partitionId)) {
+            long deltaInValue = partitionSnapshot.getValue().getValue() - basePartitionMap.get(partitionId).getValue();
+            long deltaInTimeMs = snapshotTimestamp - partitionTimestampMap.get(partitionId);
+            if (Math.abs(deltaInTimeMs) < relevantTimePeriodInMs && deltaInValue > 0) {
+              basePartitionMap.put(partitionId, partitionSnapshot.getValue());
+              partitionTimestampMap.put(partitionId, snapshotTimestamp);
+              totalValue += deltaInValue;
+              partitionClassTotalVal += deltaInValue;
+            } else if (deltaInTimeMs > relevantTimePeriodInMs) {
+              basePartitionMap.put(partitionId, partitionSnapshot.getValue());
+              partitionTimestampMap.put(partitionId, snapshotTimestamp);
+              totalValue += deltaInValue;
+              partitionClassTotalVal += deltaInValue;
+            } else {
+              logger.trace("Ignoring snapshot from {} for partition {}", instance, partitionId);
+            }
+          } else {
+            basePartitionMap.put(partitionId, partitionSnapshot.getValue());
+            partitionTimestampMap.put(partitionId, snapshotTimestamp);
+            totalValue += partitionSnapshot.getValue().getValue();
+            partitionClassTotalVal += partitionSnapshot.getValue().getValue();
+          }
+        }
+        //update partitionClass snapshot
+        basePartitionClassMap.get(partitionClassId).setSubMap(basePartitionMap);
+        basePartitionClassMap.get(partitionClassId).setValue(partitionClassTotalVal);
+      } else {
+        logger.trace("First entry for partitionClass {} is from {}", partitionClassId, instance);
+        basePartitionClassMap.put(partitionClassId, partitionClassSnapshot.getValue());
+        // put all partitions associated with this partitionClass into partitionTimestampMap on their first occurrence.
+        for (String partitionIdStr : partitionClassSnapshot.getValue().getSubMap().keySet()) {
+          partitionTimestampMap.put(partitionIdStr, snapshotTimestamp);
+        }
+        // add aggregated value in this partition class to totalValue
+        totalValue += partitionClassSnapshot.getValue().getValue();
+      }
+    }
+    baseSnapshot.setValue(totalValue);
+    baseSnapshot.setSubMap(basePartitionClassMap);
+  }
+
+  /**
    * Reduce the given {@link StatsSnapshot} whose first level mapped by partitions to a shallower {@link StatsSnapshot}
-   * by adding entries belonging to the same partition together.
+   * by adding entries belonging to each partition together and aggregating based on account. The level of partition
+   * would be removed after reduce completes.
    * @param statsSnapshot the {@link StatsSnapshot} to be reduced
    * @return the reduced {@link StatsSnapshot}
    */
-  private StatsSnapshot reduce(StatsSnapshot statsSnapshot) {
+  private StatsSnapshot reduceByAccount(StatsSnapshot statsSnapshot) {
     StatsSnapshot reducedSnapshot = new StatsSnapshot(0L, null);
     if (statsSnapshot.getSubMap() != null) {
       for (StatsSnapshot snapshot : statsSnapshot.getSubMap().values()) {
@@ -180,9 +355,36 @@ public class HelixClusterAggregator {
   }
 
   /**
+   * Reduce the given {@link StatsSnapshot} whose first level mapped by PartitionClass to a shallower {@link StatsSnapshot}.
+   * by adding entries belonging to each partition together and aggregating based on partition class. The partition level
+   * would be removed after reduce completes.
+   * @param statsSnapshot the {@link StatsSnapshot} to be reduced
+   * @return the reduced {@link StatsSnapshot}
+   */
+  static StatsSnapshot reduceByPartitionClass(StatsSnapshot statsSnapshot) {
+    StatsSnapshot returnSnapshot = new StatsSnapshot(statsSnapshot.getValue(), new HashMap<>());
+    Map<String, StatsSnapshot> partitionClassSnapshots = statsSnapshot.getSubMap();
+    if (partitionClassSnapshots != null) {
+      for (Map.Entry<String, StatsSnapshot> partitionClassSnapshotEntry : partitionClassSnapshots.entrySet()) {
+        StatsSnapshot partitionClassSnapshot = partitionClassSnapshotEntry.getValue();
+        StatsSnapshot reducedPartitionClassSnapshot = new StatsSnapshot(0L, null);
+        if (partitionClassSnapshot.getSubMap() != null) {
+          for (StatsSnapshot snapshot : partitionClassSnapshot.getSubMap().values()) {
+            StatsSnapshot.aggregate(reducedPartitionClassSnapshot, snapshot);
+          }
+          returnSnapshot.getSubMap().put(partitionClassSnapshotEntry.getKey(), reducedPartitionClassSnapshot);
+        }
+      }
+    }
+    return returnSnapshot;
+  }
+
+  /**
+   * Get exception occurred instances for certain {@link StatsReportType}
+   * @param type the type of stats report to use.
    * @return the list of instances on which exception occurred during cluster wide stats aggregation.
    */
-  List<String> getExceptionOccurredInstances() {
-    return exceptionOccurredInstances;
+  List<String> getExceptionOccurredInstances(StatsReportType type) {
+    return exceptionOccurredInstances.get(type);
   }
 }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterAggregatorTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterAggregatorTest.java
@@ -15,13 +15,16 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.server.StatsHeader;
+import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.server.StatsWrapper;
 import com.github.ambry.utils.Pair;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -44,40 +47,76 @@ public class HelixClusterAggregatorTest {
   }
 
   /**
-   * Basic tests to verify the cluster wide aggregation.
+   * Basic tests to verify the cluster wide raw data and valid data aggregation. The tests are performed to verify stats
+   * aggregation for both account aggregated report and partition class aggregated report.
    * @throws IOException
    */
   @Test
   public void testDoWorkBasic() throws IOException {
     int nodeCount = 3;
     Random random = new Random();
-    List<StatsSnapshot> storeSnapshots = new ArrayList<>();
+    List<StatsSnapshot> storeSnapshotsForAccount = new ArrayList<>();
+    List<StatsSnapshot> storeSnapshotsForPartitionClass = new ArrayList<>();
+    // create snapshots for 3 stores with 3 accounts, 4 accounts and 5 accounts respectively.
     for (int i = 3; i < 6; i++) {
-      storeSnapshots.add(generateStoreStats(i, 3, random));
+      storeSnapshotsForAccount.add(generateStoreStats(i, 3, random, StatsReportType.ACCOUNT_REPORT));
+      storeSnapshotsForPartitionClass.add(generateStoreStats(i, 3, random, StatsReportType.PARTITION_CLASS_REPORT));
     }
-    StatsWrapper nodeStats = generateNodeStats(storeSnapshots, DEFAULT_TIMESTAMP);
-    String nodeStatsJSON = mapper.writeValueAsString(nodeStats);
-    StatsWrapper emptyNodeStats = generateNodeStats(Collections.EMPTY_LIST, DEFAULT_TIMESTAMP);
-    String emptyNodeStatsJSON = mapper.writeValueAsString(emptyNodeStats);
+    StatsWrapper nodeStatsForAccount =
+        generateNodeStats(storeSnapshotsForAccount, DEFAULT_TIMESTAMP, StatsReportType.ACCOUNT_REPORT);
+    StatsWrapper nodeStatsForPartitionClass =
+        generateNodeStats(storeSnapshotsForPartitionClass, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
+    StatsWrapper emptyNodeForAccount =
+        generateNodeStats(Collections.EMPTY_LIST, DEFAULT_TIMESTAMP, StatsReportType.ACCOUNT_REPORT);
+    StatsWrapper emptyNodeForPartitionClass =
+        generateNodeStats(Collections.EMPTY_LIST, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
 
-    Map<String, String> statsWrappersJSON = new HashMap<>();
+    String nodeStatsJSONForAccount = mapper.writeValueAsString(nodeStatsForAccount);
+    String nodeStatsJSONForPartitionClass = mapper.writeValueAsString(nodeStatsForPartitionClass);
+    String emptyJSONForAccount = mapper.writeValueAsString(emptyNodeForAccount);
+    String emptyJSONForPartitionClass = mapper.writeValueAsString(emptyNodeForPartitionClass);
+    Map<String, String> instanceStatsForAccount = new HashMap<>();
+    Map<String, String> instanceStatsForPartitionClass = new HashMap<>();
+    // Each node has exactly same nodeStatsJSON, the purpose is to ensure raw_data_size field and valid_data_size field
+    // have different expected aggregated report.
+    // For raw_data_size field, it simply sums up value from replicas of partition on all nodes even if they are exactly same;
+    // For valid_data_size field, it filters out the replica(s) of a specific partition within valid time range and
+    // selects the replica with highest value.
     for (int i = 0; i < nodeCount; i++) {
-      statsWrappersJSON.put("Store_" + i, (nodeStatsJSON));
+      instanceStatsForAccount.put("Instance_" + i, (nodeStatsJSONForAccount));
+      instanceStatsForPartitionClass.put("Instance_" + i, (nodeStatsJSONForPartitionClass));
     }
-    statsWrappersJSON.put("Store_" + nodeCount, emptyNodeStatsJSON);
-    statsWrappersJSON.put(EXCEPTION_INSTANCE_NAME, "");
-    for (int i = 1; i < storeSnapshots.size(); i++) {
-      StatsSnapshot.aggregate(storeSnapshots.get(0), storeSnapshots.get(i));
+    // Add two special cases into instance-to-stats map for testing:
+    // (1) empty stats report from certain instance
+    // (2) corrupted/invalid stats report from certain instance (this is simulated by empty string)
+    instanceStatsForAccount.put("Instance_" + nodeCount, emptyJSONForAccount);
+    instanceStatsForPartitionClass.put("Instance_" + nodeCount, emptyJSONForPartitionClass);
+    instanceStatsForAccount.put(EXCEPTION_INSTANCE_NAME, "");
+    instanceStatsForPartitionClass.put(EXCEPTION_INSTANCE_NAME, "");
+    //aggregate all snapshots into the first snapshot in storeSnapshots list
+    for (int i = 1; i < storeSnapshotsForAccount.size(); i++) {
+      StatsSnapshot.aggregate(storeSnapshotsForAccount.get(0), storeSnapshotsForAccount.get(i));
     }
-    Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON);
-    StatsSnapshot expectedSnapshot = storeSnapshots.get(0);
-    // verify cluster wide raw aggregation
-    StatsSnapshot rawSnapshot = mapper.readValue(results.getFirst(), StatsSnapshot.class);
-    assertEquals("Mismatch in total value of all accounts", nodeCount * expectedSnapshot.getValue(),
-        rawSnapshot.getValue());
-    Map<String, StatsSnapshot> rawAccountMap = rawSnapshot.getSubMap();
-    assertEquals("Mismatch in number of accounts", expectedSnapshot.getSubMap().size(), rawAccountMap.size());
-    for (Map.Entry<String, StatsSnapshot> accountEntry : expectedSnapshot.getSubMap().entrySet()) {
+    Pair<String, String> resultsForAccount =
+        clusterAggregator.doWork(instanceStatsForAccount, StatsReportType.ACCOUNT_REPORT);
+    Pair<String, String> resultsForPartitionClass =
+        clusterAggregator.doWork(instanceStatsForPartitionClass, StatsReportType.PARTITION_CLASS_REPORT);
+    // since all nodes have exactly same statsSnapshot, aggregated snapshot of storeSnapshots list on single node is what
+    // we expect for valid data aggregation.
+    StatsSnapshot expectedAccountSnapshot = storeSnapshotsForAccount.get(0);
+    StatsSnapshot expectedPartitionClassSnapshot =
+        HelixClusterAggregator.reduceByPartitionClass(nodeStatsForPartitionClass.getSnapshot());
+
+    // verify cluster-wide aggregation on raw data
+    StatsSnapshot rawSnapshotForAccount = mapper.readValue(resultsForAccount.getFirst(), StatsSnapshot.class);
+    StatsSnapshot rawSnapshotForPartitionClass =
+        mapper.readValue(resultsForPartitionClass.getFirst(), StatsSnapshot.class);
+
+    assertEquals("Mismatch in total value of account report", nodeCount * expectedAccountSnapshot.getValue(),
+        rawSnapshotForAccount.getValue());
+    Map<String, StatsSnapshot> rawAccountMap = rawSnapshotForAccount.getSubMap();
+    assertEquals("Mismatch in number of accounts", expectedAccountSnapshot.getSubMap().size(), rawAccountMap.size());
+    for (Map.Entry<String, StatsSnapshot> accountEntry : expectedAccountSnapshot.getSubMap().entrySet()) {
       assertTrue("Expected account entry not found in the raw aggregated snapshot",
           rawAccountMap.containsKey(accountEntry.getKey()));
       assertEquals("Mismatch in account value", nodeCount * accountEntry.getValue().getValue(),
@@ -92,127 +131,330 @@ public class HelixClusterAggregatorTest {
             rawContainerMap.get(containerEntry.getKey()).getValue());
       }
     }
-    // verify cluster wide aggregation
-    StatsSnapshot actualSnapshot = mapper.readValue(results.getSecond(), StatsSnapshot.class);
-    assertTrue("Mismatch in the aggregated snapshot", expectedSnapshot.equals(actualSnapshot));
+
+    assertEquals("Mismatch in total value of partitionClass report",
+        nodeCount * nodeStatsForPartitionClass.getSnapshot().getValue(), rawSnapshotForPartitionClass.getValue());
+    assertEquals("Mismatch in number of partition classes", nodeStatsForPartitionClass.getSnapshot().getSubMap().size(),
+        rawSnapshotForPartitionClass.getSubMap().size());
+    Map<String, StatsSnapshot> rawPartitionClassMap = rawSnapshotForPartitionClass.getSubMap();
+    Map<String, StatsSnapshot> nodePartitionClassMap =
+        expectedPartitionClassSnapshot.getSubMap();//nodeStatsForPartitionClass.getSnapshot().getSubMap();
+    for (Map.Entry<String, StatsSnapshot> partitionClassEntry : rawPartitionClassMap.entrySet()) {
+      String partitionClassId = partitionClassEntry.getKey();
+      Map<String, StatsSnapshot> nodeContainerMap = nodePartitionClassMap.get(partitionClassId).getSubMap();
+      assertEquals("Mismatch in value of partition class: " + partitionClassId,
+          nodeCount * nodePartitionClassMap.get(partitionClassId).getValue(),
+          partitionClassEntry.getValue().getValue());
+      assertEquals("Mismatch in number of containers in partition class: " + partitionClassId, nodeContainerMap.size(),
+          partitionClassEntry.getValue().getSubMap().size());
+      for (Map.Entry<String, StatsSnapshot> containerEntry : partitionClassEntry.getValue().getSubMap().entrySet()) {
+        String containerIdStr = containerEntry.getKey();
+        assertEquals("Mismatch in value of container: " + containerIdStr,
+            nodeCount * nodeContainerMap.get(containerIdStr).getValue(), containerEntry.getValue().getValue());
+      }
+    }
+
+    // verify that cluster wide aggregation on valid data obeys two rules: (1) within valid time range; (2) selects replica with highest value
+    StatsSnapshot validSnapshotForAccount = mapper.readValue(resultsForAccount.getSecond(), StatsSnapshot.class);
+    assertTrue("Mismatch in the aggregated snapshot with valid time range at account level",
+        expectedAccountSnapshot.equals(validSnapshotForAccount));
+    StatsSnapshot validSnapshotForPartitionClass =
+        mapper.readValue(resultsForPartitionClass.getSecond(), StatsSnapshot.class);
+    assertTrue("Mismatch in the aggregated snapshot with valid time range at partitionClass level",
+        expectedPartitionClassSnapshot.equals(validSnapshotForPartitionClass));
     // verify aggregator keeps track of instances where exception occurred.
-    assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
-        clusterAggregator.getExceptionOccurredInstances());
+    for (StatsReportType type : EnumSet.allOf(StatsReportType.class)) {
+      assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
+          clusterAggregator.getExceptionOccurredInstances(type));
+    }
   }
 
   /**
-   * Tests to verify cluster wide aggregation with outdated node stats.
+   * Test stats aggregation with different number of stores on different nodes.
+   * Only used for partitionClass aggregation testing.
    * @throws IOException
    */
   @Test
-  public void testDoWorkWithOutdatedNode() throws IOException {
+  public void testDoWorkWithDiffNumberOfStores() throws IOException {
+    List<StatsSnapshot> storeSnapshots1 = new ArrayList<>();
+    List<StatsSnapshot> storeSnapshots2 = new ArrayList<>();
+    List<StatsSnapshot> storeSnapshots2Copy = new ArrayList<>();
+    int seed = 1111;
+    for (int i = 3; i < 6; i++) {
+      if (i < 5) {
+        storeSnapshots1.add(generateStoreStats(i, 3, new Random(seed), StatsReportType.PARTITION_CLASS_REPORT));
+      }
+      storeSnapshots2.add(generateStoreStats(i, 3, new Random(seed), StatsReportType.PARTITION_CLASS_REPORT));
+      storeSnapshots2Copy.add(generateStoreStats(i, 3, new Random(seed), StatsReportType.PARTITION_CLASS_REPORT));
+    }
+    StatsWrapper nodeStatsWrapper1 =
+        generateNodeStats(storeSnapshots1, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
+    StatsWrapper nodeStatsWrapper2 =
+        generateNodeStats(storeSnapshots2, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
+    StatsWrapper nodeStatsWrapper2Copy =
+        generateNodeStats(storeSnapshots2Copy, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
+    Map<String, String> instanceStatsMap = new LinkedHashMap<>();
+    instanceStatsMap.put("Instance_1", mapper.writeValueAsString(nodeStatsWrapper1));
+    instanceStatsMap.put("Instance_2", mapper.writeValueAsString(nodeStatsWrapper2));
+
+    Pair<String, String> results = clusterAggregator.doWork(instanceStatsMap, StatsReportType.PARTITION_CLASS_REPORT);
+
+    // verify aggregation on raw data
+    StatsSnapshot expectedRawSnapshot = new StatsSnapshot(0L, null);
+    StatsSnapshot.aggregate(expectedRawSnapshot, nodeStatsWrapper1.getSnapshot());
+    StatsSnapshot.aggregate(expectedRawSnapshot, nodeStatsWrapper2Copy.getSnapshot());
+    expectedRawSnapshot = HelixClusterAggregator.reduceByPartitionClass(expectedRawSnapshot);
+    StatsSnapshot rawSnapshot = mapper.readValue(results.getFirst(), StatsSnapshot.class);
+    assertTrue("Mismatch in the raw data aggregated snapshot", expectedRawSnapshot.equals(rawSnapshot));
+
+    // verify aggregation on valid data
+    StatsSnapshot expectedValidsnapshot =
+        HelixClusterAggregator.reduceByPartitionClass(nodeStatsWrapper2.getSnapshot());
+    StatsSnapshot validSnapshot = mapper.readValue(results.getSecond(), StatsSnapshot.class);
+    assertTrue("Mismatch in the valid data aggregated snapshot", expectedValidsnapshot.equals(validSnapshot));
+  }
+
+  /**
+   * Tests to verify cluster wide aggregation with outdated node stats for account stats report.
+   * @throws IOException
+   */
+  @Test
+  public void testDoWorkWithOutdatedNodeForAccount() throws IOException {
     long seed = 1111;
     List<StatsSnapshot> upToDateStoreSnapshots = new ArrayList<>();
     List<StatsSnapshot> outdatedStoreSnapshots = new ArrayList<>();
-    upToDateStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed)));
-    outdatedStoreSnapshots.add(generateStoreStats(6, 3, new Random(seed)));
+    upToDateStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed), StatsReportType.ACCOUNT_REPORT));
+    outdatedStoreSnapshots.add(generateStoreStats(6, 3, new Random(seed), StatsReportType.ACCOUNT_REPORT));
     StatsWrapper upToDateNodeStats =
-        generateNodeStats(upToDateStoreSnapshots, TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES));
-    StatsWrapper outdatedNodeStats = generateNodeStats(outdatedStoreSnapshots, 0);
+        generateNodeStats(upToDateStoreSnapshots, TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES),
+            StatsReportType.ACCOUNT_REPORT);
+    StatsWrapper outdatedNodeStats = generateNodeStats(outdatedStoreSnapshots, 0, StatsReportType.ACCOUNT_REPORT);
     StatsWrapper emptyNodeStats =
-        generateNodeStats(Collections.EMPTY_LIST, TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES));
-    Map<String, String> statsWrappersJSON = new HashMap<>();
-    statsWrappersJSON.put("Store_0", mapper.writeValueAsString(outdatedNodeStats));
-    statsWrappersJSON.put("Store_1", mapper.writeValueAsString(upToDateNodeStats));
-    statsWrappersJSON.put("Store_2", mapper.writeValueAsString(emptyNodeStats));
-    statsWrappersJSON.put(EXCEPTION_INSTANCE_NAME, "");
-    Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON);
+        generateNodeStats(Collections.EMPTY_LIST, TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES),
+            StatsReportType.ACCOUNT_REPORT);
+    Map<String, String> instanceStatsMap = new LinkedHashMap<>();
+    instanceStatsMap.put("Instance_0", mapper.writeValueAsString(outdatedNodeStats));
+    instanceStatsMap.put("Instance_1", mapper.writeValueAsString(upToDateNodeStats));
+    instanceStatsMap.put("Instance_2", mapper.writeValueAsString(emptyNodeStats));
+    instanceStatsMap.put(EXCEPTION_INSTANCE_NAME, "");
+    Pair<String, String> results = clusterAggregator.doWork(instanceStatsMap, StatsReportType.ACCOUNT_REPORT);
     StatsSnapshot expectedSnapshot = upToDateStoreSnapshots.get(0);
-    // verify cluster wide aggregation with outdated node stats
+    // verify cluster wide aggregation on valid data with outdated node stats
     StatsSnapshot actualSnapshot = mapper.readValue(results.getSecond(), StatsSnapshot.class);
-    assertTrue("Mismatch in the aggregated snapshot", expectedSnapshot.equals(actualSnapshot));
-    // verify cluster wide raw aggregation with outdated node stats
+    assertTrue("Mismatch in the valid data aggregated snapshot", expectedSnapshot.equals(actualSnapshot));
+    // verify cluster wide aggregation on raw data with outdated node stats
     StatsSnapshot.aggregate(expectedSnapshot, outdatedStoreSnapshots.get(0));
     StatsSnapshot rawSnapshot = mapper.readValue(results.getFirst(), StatsSnapshot.class);
-    assertTrue("Mismatch in the raw aggregated snapshot", expectedSnapshot.equals(rawSnapshot));
+    assertTrue("Mismatch in the raw data aggregated snapshot", expectedSnapshot.equals(rawSnapshot));
     // verify aggregator keeps track of instances where exception occurred.
     assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
-        clusterAggregator.getExceptionOccurredInstances());
+        clusterAggregator.getExceptionOccurredInstances(StatsReportType.ACCOUNT_REPORT));
   }
 
   /**
-   * Tests to verify cluster aggregation with node stats that contain different partition stats.
+   * Tests to verify cluster wide aggregation with outdated node stats for partition class stats report.
    * @throws IOException
    */
   @Test
-  public void testDoWorkWithDiffNodeStats() throws IOException {
-    long seed = 1234;
-    List<StatsSnapshot> greaterStoreSnapshots = new ArrayList<>();
-    List<StatsSnapshot> smallerStoreSnapshots = new ArrayList<>();
-    greaterStoreSnapshots.add(generateStoreStats(6, 3, new Random(seed)));
-    smallerStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed)));
-    StatsWrapper greaterNodeStats = generateNodeStats(greaterStoreSnapshots, DEFAULT_TIMESTAMP);
-    StatsWrapper smallerNodeStats = generateNodeStats(smallerStoreSnapshots, DEFAULT_TIMESTAMP);
-    StatsWrapper emptyNodeStats = generateNodeStats(Collections.EMPTY_LIST, DEFAULT_TIMESTAMP);
-    Map<String, String> statsWrappersJSON = new HashMap<>();
-    statsWrappersJSON.put("Store_0", mapper.writeValueAsString(smallerNodeStats));
-    statsWrappersJSON.put("Store_1", mapper.writeValueAsString(greaterNodeStats));
-    statsWrappersJSON.put("Store_2", mapper.writeValueAsString(emptyNodeStats));
-    statsWrappersJSON.put(EXCEPTION_INSTANCE_NAME, "");
-    Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON);
-    StatsSnapshot expectedSnapshot = greaterStoreSnapshots.get(0);
-    // verify cluster wide aggregation with different node stats
-    StatsSnapshot actualSnapshot = mapper.readValue(results.getSecond(), StatsSnapshot.class);
-    assertTrue("Mismatch in the aggregated snapshot", expectedSnapshot.equals(actualSnapshot));
-    // verify cluster wide raw aggregation with different node stats
-    StatsSnapshot.aggregate(expectedSnapshot, smallerStoreSnapshots.get(0));
+  public void testDoWorkWithOutdatedNodeForPartitionClass() throws IOException {
+    long seed = 1111;
+    List<StatsSnapshot> upToDateStoreSnapshots = new ArrayList<>();
+    List<StatsSnapshot> outdatedStoreSnapshots = new ArrayList<>();
+    upToDateStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed), StatsReportType.PARTITION_CLASS_REPORT));
+    outdatedStoreSnapshots.add(generateStoreStats(6, 3, new Random(seed), StatsReportType.PARTITION_CLASS_REPORT));
+    StatsWrapper upToDateNodeStats =
+        generateNodeStats(upToDateStoreSnapshots, TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES),
+            StatsReportType.PARTITION_CLASS_REPORT);
+    StatsWrapper outdatedNodeStats =
+        generateNodeStats(outdatedStoreSnapshots, 0, StatsReportType.PARTITION_CLASS_REPORT);
+    StatsWrapper emptyNodeStats =
+        generateNodeStats(Collections.EMPTY_LIST, TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES),
+            StatsReportType.PARTITION_CLASS_REPORT);
+    Map<String, String> instanceStatsMap = new LinkedHashMap<>();
+    instanceStatsMap.put("Instance_0", mapper.writeValueAsString(outdatedNodeStats));
+    instanceStatsMap.put("Instance_1", mapper.writeValueAsString(upToDateNodeStats));
+    instanceStatsMap.put("Instance_2", mapper.writeValueAsString(emptyNodeStats));
+    instanceStatsMap.put(EXCEPTION_INSTANCE_NAME, "");
+    Pair<String, String> results = clusterAggregator.doWork(instanceStatsMap, StatsReportType.PARTITION_CLASS_REPORT);
+
+    // verify cluster wide aggregation on raw data with outdated node stats
+    StatsSnapshot expectedRawSnapshot = new StatsSnapshot(0L, new HashMap<>());
+
+    StatsSnapshot.aggregate(expectedRawSnapshot, outdatedNodeStats.getSnapshot());
+    StatsSnapshot.aggregate(expectedRawSnapshot, upToDateNodeStats.getSnapshot());
+    expectedRawSnapshot = HelixClusterAggregator.reduceByPartitionClass(expectedRawSnapshot);
     StatsSnapshot rawSnapshot = mapper.readValue(results.getFirst(), StatsSnapshot.class);
-    assertTrue("Mismatch in the raw aggregated snapshot", expectedSnapshot.equals(rawSnapshot));
+    assertTrue("Mismatch in the raw data aggregated snapshot", expectedRawSnapshot.equals(rawSnapshot));
+
+    StatsSnapshot expectedSnapshot = HelixClusterAggregator.reduceByPartitionClass(upToDateNodeStats.getSnapshot());
+
+    // verify cluster wide aggregation on valid data with outdated node stats
+    StatsSnapshot actualSnapshot = mapper.readValue(results.getSecond(), StatsSnapshot.class);
+    assertTrue("Mismatch in the valid data aggregated snapshot", expectedSnapshot.equals(actualSnapshot));
     // verify aggregator keeps track of instances where exception occurred.
     assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
-        clusterAggregator.getExceptionOccurredInstances());
+        clusterAggregator.getExceptionOccurredInstances(StatsReportType.PARTITION_CLASS_REPORT));
   }
 
   /**
-   * Given a {@link List} of {@link StatsSnapshot}s and a timestamp generate a {@link StatsWrapper} that would have been
-   * produced by a node.
-   * @param storeSnapshots a {@link List} of store level {@link StatsSnapshot}s.
+   * Tests to verify cluster wide aggregation at account level with node stats that contain different partition stats.
+   * @throws IOException
+   */
+  @Test
+  public void testDoWorkWithDiffNodeStatsForAccount() throws IOException {
+    long seed = 1234;
+    List<StatsSnapshot> greaterStoreSnapshots = new ArrayList<>();
+    List<StatsSnapshot> smallerStoreSnapshots = new ArrayList<>();
+    greaterStoreSnapshots.add(generateStoreStats(6, 3, new Random(seed), StatsReportType.ACCOUNT_REPORT));
+    smallerStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed), StatsReportType.ACCOUNT_REPORT));
+    StatsWrapper greaterNodeStats =
+        generateNodeStats(greaterStoreSnapshots, DEFAULT_TIMESTAMP, StatsReportType.ACCOUNT_REPORT);
+    StatsWrapper smallerNodeStats =
+        generateNodeStats(smallerStoreSnapshots, DEFAULT_TIMESTAMP, StatsReportType.ACCOUNT_REPORT);
+    StatsWrapper emptyNodeStats =
+        generateNodeStats(Collections.EMPTY_LIST, DEFAULT_TIMESTAMP, StatsReportType.ACCOUNT_REPORT);
+    Map<String, String> instanceStatsMap = new LinkedHashMap<>();
+    instanceStatsMap.put("Instance_0", mapper.writeValueAsString(smallerNodeStats));
+    instanceStatsMap.put("Instance_1", mapper.writeValueAsString(greaterNodeStats));
+    instanceStatsMap.put("Instance_2", mapper.writeValueAsString(emptyNodeStats));
+    instanceStatsMap.put(EXCEPTION_INSTANCE_NAME, "");
+    Pair<String, String> results = clusterAggregator.doWork(instanceStatsMap, StatsReportType.ACCOUNT_REPORT);
+    StatsSnapshot expectedSnapshot = greaterStoreSnapshots.get(0);
+
+    // verify cluster wide aggregation on valid data with different node stats
+    StatsSnapshot actualSnapshot = mapper.readValue(results.getSecond(), StatsSnapshot.class);
+    assertTrue("Mismatch in the valid data aggregated snapshot", expectedSnapshot.equals(actualSnapshot));
+    // verify cluster wide aggregation on raw data with different node stats
+    StatsSnapshot.aggregate(expectedSnapshot, smallerStoreSnapshots.get(0));
+    StatsSnapshot rawSnapshot = mapper.readValue(results.getFirst(), StatsSnapshot.class);
+    assertTrue("Mismatch in the raw data aggregated snapshot", expectedSnapshot.equals(rawSnapshot));
+    // verify aggregator keeps track of instances where exception occurred.
+    assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
+        clusterAggregator.getExceptionOccurredInstances(StatsReportType.ACCOUNT_REPORT));
+  }
+
+  /**
+   * Tests to verify cluster wide aggregation at partition class level with node stats that contain different partition stats.
+   * @throws IOException
+   */
+  @Test
+  public void testDoWorkWithDiffNodeStatsForPartitionClass() throws IOException {
+    long seed = 1234;
+    List<StatsSnapshot> greaterStoreSnapshots = new ArrayList<>();
+    List<StatsSnapshot> mediumStoreSnapshots = new ArrayList<>();
+    List<StatsSnapshot> smallerStoreSnapshots = new ArrayList<>();
+    greaterStoreSnapshots.add(generateStoreStats(6, 3, new Random(seed), StatsReportType.PARTITION_CLASS_REPORT));
+    mediumStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed), StatsReportType.PARTITION_CLASS_REPORT));
+    smallerStoreSnapshots.add(generateStoreStats(4, 3, new Random(seed), StatsReportType.PARTITION_CLASS_REPORT));
+    StatsWrapper greaterNodeStats =
+        generateNodeStats(greaterStoreSnapshots, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
+    StatsWrapper mediumNodeStats =
+        generateNodeStats(mediumStoreSnapshots, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
+    StatsWrapper smallerNodeStats =
+        generateNodeStats(smallerStoreSnapshots, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
+    StatsWrapper emptyNodeStats =
+        generateNodeStats(Collections.EMPTY_LIST, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
+
+    Map<String, String> instanceStatsMap = new LinkedHashMap<>();
+    // testing order is (1)smaller, (2)greater, (3)medium (4)empty (5)invalid to ensure the aggregation can correctly choose the replica with largest value
+    instanceStatsMap.put("Instance_0", mapper.writeValueAsString(smallerNodeStats));
+    instanceStatsMap.put("Instance_1", mapper.writeValueAsString(greaterNodeStats));
+    instanceStatsMap.put("Instance_2", mapper.writeValueAsString(mediumNodeStats));
+    instanceStatsMap.put("Instance_3", mapper.writeValueAsString(emptyNodeStats));
+    instanceStatsMap.put(EXCEPTION_INSTANCE_NAME, "");
+    Pair<String, String> partitionClassResults =
+        clusterAggregator.doWork(instanceStatsMap, StatsReportType.PARTITION_CLASS_REPORT);
+
+    // verify cluster wide aggregation on raw data with different node stats
+    StatsSnapshot expectedRawSnapshot = new StatsSnapshot(0L, new HashMap<>());
+    StatsSnapshot.aggregate(expectedRawSnapshot, smallerNodeStats.getSnapshot());
+    StatsSnapshot.aggregate(expectedRawSnapshot, mediumNodeStats.getSnapshot());
+    StatsSnapshot.aggregate(expectedRawSnapshot, greaterNodeStats.getSnapshot());
+
+    StatsSnapshot rawSnapshot = mapper.readValue(partitionClassResults.getFirst(), StatsSnapshot.class);
+    expectedRawSnapshot = HelixClusterAggregator.reduceByPartitionClass(expectedRawSnapshot);
+    assertTrue("Mismatch in the raw data aggregated snapshot", expectedRawSnapshot.equals(rawSnapshot));
+
+    // verify cluster wide aggregation on valid data with different node stats
+    StatsSnapshot validSnapshot = mapper.readValue(partitionClassResults.getSecond(), StatsSnapshot.class);
+    StatsSnapshot expectedValidSnapshot = HelixClusterAggregator.reduceByPartitionClass(greaterNodeStats.getSnapshot());
+    assertTrue("Mismatch in the valid data aggregated snapshot", expectedValidSnapshot.equals(validSnapshot));
+    // verify aggregator keeps track of instances where exception occurred.
+    assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
+        clusterAggregator.getExceptionOccurredInstances(StatsReportType.PARTITION_CLASS_REPORT));
+  }
+
+  /**
+   * Given a {@link List} of {@link StatsSnapshot}s, a timestamp and specified {@link StatsReportType}, the method
+   * will generate a {@link StatsWrapper} that would have been produced by a node
+   * @param storeSnapshots a {@link List} of store level {@link StatsSnapshot}s
    * @param timestamp the timestamp to be attached to the generated {@link StatsWrapper}
+   * @param type the type of stats report which is enum defined in {@link StatsReportType}
    * @return the generated node level {@link StatsWrapper}
    */
-  private StatsWrapper generateNodeStats(List<StatsSnapshot> storeSnapshots, long timestamp) {
+  private StatsWrapper generateNodeStats(List<StatsSnapshot> storeSnapshots, long timestamp, StatsReportType type) {
     Map<String, StatsSnapshot> partitionMap = new HashMap<>();
+    Map<String, StatsSnapshot> partitionClassMap = new HashMap<>();
+    String[] PARTITION_CLASS = new String[]{"PartitionClass1", "PartitionClass2"};
     long total = 0;
     int numbOfPartitions = storeSnapshots.size();
     for (int i = 0; i < numbOfPartitions; i++) {
-      StatsSnapshot partitionSnapshot = storeSnapshots.get(i);
-      partitionMap.put(String.format("partition_%d", i), partitionSnapshot);
-      total += partitionSnapshot.getValue();
+      String PartitionIdStr = "Partition[" + i + "]";
+      StatsSnapshot storeSnapshot = storeSnapshots.get(i);
+      partitionMap.put(PartitionIdStr, storeSnapshot);
+      total += storeSnapshot.getValue();
+      if (type == StatsReportType.PARTITION_CLASS_REPORT) {
+        String partitionClassStr = PARTITION_CLASS[i % PARTITION_CLASS.length];
+        StatsSnapshot partitionClassSnapshot =
+            partitionClassMap.getOrDefault(partitionClassStr, new StatsSnapshot(0L, new HashMap<>()));
+        partitionClassSnapshot.setValue(partitionClassSnapshot.getValue() + storeSnapshot.getValue());
+        partitionClassSnapshot.getSubMap().put(PartitionIdStr, storeSnapshot);
+        partitionClassMap.put(partitionClassStr, partitionClassSnapshot);
+      }
     }
-    StatsSnapshot nodeSnapshot = new StatsSnapshot(total, partitionMap);
+    StatsSnapshot nodeSnapshot = null;
+    if (type == StatsReportType.ACCOUNT_REPORT) {
+      nodeSnapshot = new StatsSnapshot(total, partitionMap);
+    } else if (type == StatsReportType.PARTITION_CLASS_REPORT) {
+      nodeSnapshot = new StatsSnapshot(total, partitionClassMap);
+    }
     StatsHeader header =
         new StatsHeader(StatsHeader.StatsDescription.QUOTA, timestamp, numbOfPartitions, numbOfPartitions,
-            Collections.EMPTY_LIST);
+            Collections.emptyList());
     return new StatsWrapper(header, nodeSnapshot);
   }
 
   /**
-   * Generate a quota {@link StatsSnapshot} based on the given parameters that would have been produced by a
+   * Generate a specific quota {@link StatsSnapshot} based on the given parameters that would have been produced by a
    * {@link com.github.ambry.store.Store}.
    * @param accountCount number of account entry in the {@link StatsSnapshot}
    * @param containerCount number of container entry in the {@link StatsSnapshot}
    * @param random the random generator to be used
+   * @param type the type of stats report which is enum defined in {@link StatsReportType}
    * @return the generated store level {@link StatsSnapshot}
    */
-  private StatsSnapshot generateStoreStats(int accountCount, int containerCount, Random random) {
-    Map<String, StatsSnapshot> accountMap = new HashMap<>();
+  private StatsSnapshot generateStoreStats(int accountCount, int containerCount, Random random, StatsReportType type) {
+    Map<String, StatsSnapshot> subMap = new HashMap<>();
     long totalSize = 0;
     for (int i = 0; i < accountCount; i++) {
+      String accountIdStr = "Account[" + i + "]";
       Map<String, StatsSnapshot> containerMap = new HashMap<>();
       long subTotalSize = 0;
       for (int j = 0; j < containerCount; j++) {
+        String containerIdStr = "Container[" + j + "]";
         long validSize = random.nextInt(2501) + 500;
         subTotalSize += validSize;
-        containerMap.put(String.format("containerId_%d", j), new StatsSnapshot(validSize, null));
+        if (type == StatsReportType.ACCOUNT_REPORT) {
+          containerMap.put(containerIdStr, new StatsSnapshot(validSize, null));
+        } else if (type == StatsReportType.PARTITION_CLASS_REPORT) {
+          subMap.put(accountIdStr + "_" + containerIdStr, new StatsSnapshot(validSize, null));
+        }
       }
       totalSize += subTotalSize;
-      accountMap.put(String.format("accountId_%d", i), new StatsSnapshot(subTotalSize, containerMap));
+      if (type == StatsReportType.ACCOUNT_REPORT) {
+        subMap.put(accountIdStr, new StatsSnapshot(subTotalSize, containerMap));
+      }
     }
-    return new StatsSnapshot(totalSize, accountMap);
+    return new StatsSnapshot(totalSize, subMap);
   }
 }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
@@ -73,7 +73,8 @@ public class MockPartitionId implements PartitionId {
   @Override
   public int compareTo(PartitionId o) {
     MockPartitionId mockPartition = (MockPartitionId) o;
-    return (partition < mockPartition.partition) ? -1 : ((partition == mockPartition.partition) ? 0 : 1);
+    return (partition < mockPartition.partition) ? -1
+        : ((partition.longValue() == mockPartition.partition.longValue()) ? 0 : 1);
   }
 
   @Override
@@ -92,7 +93,7 @@ public class MockPartitionId implements PartitionId {
 
     MockPartitionId mockPartition = (MockPartitionId) o;
 
-    if (partition != mockPartition.partition) {
+    if (partition.longValue() != mockPartition.partition.longValue()) {
       return false;
     }
 

--- a/ambry-server/src/main/java/com.github.ambry.server/QuotaHealthReport.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/QuotaHealthReport.java
@@ -14,7 +14,6 @@
 
 package com.github.ambry.server;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.helix.healthcheck.HealthReportProvider;
 
@@ -34,14 +33,12 @@ class QuotaHealthReport extends HealthReportProvider implements AmbryHealthRepor
   }
 
   /**
-   * Get the node wide aggregated quota stats in this node
+   * Get all types of node wide aggregated quota stats in this node
    * @return a {@link Map} with the aggregated quota stats mapped with {@link QuotaHealthReport}'s static key
    */
   @Override
   public Map<String, String> getRecentHealthReport() {
-    Map<String, String> report = new HashMap<>();
-    report.put(QUOTA_STATS_FIELD_NAME, statsManager.getNodeStatsInJSON());
-    return report;
+    return statsManager.getNodeStatsInJSON();
   }
 
   @Override


### PR DESCRIPTION
- enable datanode to send both partitionClass and account level stats to
Helix
- make cluster wide stats aggregation generate two separate reports
- partially verified in Perf cluster