### PR TITLE
Max size for getIndexEntries() should be Long.MAX_VALUE

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreStats.java
@@ -415,7 +415,7 @@ class BlobStoreStats implements StoreStats, Closeable {
   private List<IndexEntry> getIndexEntries(IndexSegment indexSegment) throws StoreException {
     List<IndexEntry> indexEntries = new ArrayList<>();
     try {
-      indexSegment.getIndexEntriesSince(null, new FindEntriesCondition(Integer.MAX_VALUE), indexEntries,
+      indexSegment.getIndexEntriesSince(null, new FindEntriesCondition(Long.MAX_VALUE), indexEntries,
           new AtomicLong(0), true);
       diskIOScheduler.getSlice(BlobStoreStats.IO_SCHEDULER_JOB_TYPE, BlobStoreStats.IO_SCHEDULER_JOB_ID,
           indexEntries.size());


### PR DESCRIPTION
Due to this bug, logSegment size can't be calculated correctly if logSegmentSize > Integer.Max. 

It’s not straightforward to add test to cover this bug. Also, it depends on the caller of `findEntriesSince()`, we can’t control the caller in most the cases. Therefore, test is not added. 
