### PR TITLE
Do storeKey conversion for keys in GET/DELETE requests

### DIFF
--- a/ambry-api/src/test/java/com.github.ambry/store/MockStoreKeyConverterFactory.java
+++ b/ambry-api/src/test/java/com.github.ambry/store/MockStoreKeyConverterFactory.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.store;
 
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.VerifiableProperties;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,19 +24,37 @@ import java.util.Map;
  * A mock factory of {@link StoreKeyConverterFactory}.  Creates MockStoreKeyConverter.
  */
 public class MockStoreKeyConverterFactory implements StoreKeyConverterFactory {
-  private StoreKeyConverter storeKeyConverter = new MockStoreKeyConverter();
+  private final StoreKeyConverter storeKeyConverter = new MockStoreKeyConverter();
   private Map<StoreKey, StoreKey> conversionMap;
   private Exception exception;
+
+  public MockStoreKeyConverterFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry) {
+  }
 
   @Override
   public StoreKeyConverter getStoreKeyConverter() {
     return storeKeyConverter;
   }
 
+  /**
+   * Set conversionMap for reference.
+   * @param conversionMap used by {@link MockStoreKeyConverter}.
+   */
   public void setConversionMap(Map<StoreKey, StoreKey> conversionMap) {
     this.conversionMap = conversionMap;
   }
 
+  /**
+   * Get the conversionMap used by {@link MockStoreKeyConverter}
+   */
+  public Map<StoreKey, StoreKey> getConversionMap() {
+    return conversionMap;
+  }
+
+  /**
+   * Set Exception for {@link MockStoreKeyConverter#convert(Collection)}
+   * @param e is the exception to be thrown.
+   */
   public void setException(Exception e) {
     this.exception = e;
   }

--- a/ambry-api/src/test/java/com.github.ambry/store/MockStoreKeyConverterFactory.java
+++ b/ambry-api/src/test/java/com.github.ambry/store/MockStoreKeyConverterFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * A mock factory of {@link StoreKeyConverterFactory}.  Creates MockStoreKeyConverter.
+ */
+public class MockStoreKeyConverterFactory implements StoreKeyConverterFactory {
+  private StoreKeyConverter storeKeyConverter = new MockStoreKeyConverter();
+  private Map<StoreKey, StoreKey> conversionMap;
+  private Exception exception;
+
+  @Override
+  public StoreKeyConverter getStoreKeyConverter() {
+    return storeKeyConverter;
+  }
+
+  public void setConversionMap(Map<StoreKey, StoreKey> conversionMap) {
+    this.conversionMap = conversionMap;
+  }
+
+  public void setException(Exception e) {
+    this.exception = e;
+  }
+
+  /**
+   * A mock implementation of {@link StoreKeyConverter}.
+   */
+  private class MockStoreKeyConverter implements StoreKeyConverter {
+    @Override
+    public Map<StoreKey, StoreKey> convert(Collection<? extends StoreKey> input) throws Exception {
+      if (exception != null) {
+        throw exception;
+      }
+      Map<StoreKey, StoreKey> output = new HashMap<>();
+      if (input != null) {
+        input.forEach((storeKey) -> output.put(storeKey, conversionMap.get(storeKey)));
+      }
+      return output;
+    }
+  }
+}

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -415,8 +415,8 @@ public class AmbryRequests implements RequestAPI {
         response =
             new DeleteResponse(deleteRequest.getCorrelationId(), deleteRequest.getClientId(), ServerErrorCode.No_Error);
         if (notification != null) {
-          notification.onBlobReplicaDeleted(currentNode.getHostname(), currentNode.getPort(),
-              deleteRequest.getBlobId().getID(), BlobReplicaSourceType.PRIMARY);
+          notification.onBlobReplicaDeleted(currentNode.getHostname(), currentNode.getPort(), convertedStoreKey.getID(),
+              BlobReplicaSourceType.PRIMARY);
         }
       }
     } catch (StoreException e) {

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -70,6 +70,7 @@ import com.github.ambry.store.StoreErrorCodes;
 import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreGetOptions;
 import com.github.ambry.store.StoreInfo;
+import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.SystemTime;
@@ -82,6 +83,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
@@ -307,7 +309,7 @@ public class AmbryRequests implements RequestAPI {
               storeGetOptions =
                   EnumSet.of(StoreGetOptions.Store_Include_Deleted, StoreGetOptions.Store_Include_Expired);
             }
-            StoreInfo info = storeToGet.get(partitionRequestInfo.getBlobIds(), storeGetOptions);
+            StoreInfo info = storeToGet.get(getConvertedStoreKeys(partitionRequestInfo.getBlobIds()), storeGetOptions);
             MessageFormatSend blobsToSend =
                 new MessageFormatSend(info.getMessageReadSet(), getRequest.getMessageFormatFlag(), messageFormatMetrics,
                     storeKeyFactory, enableDataPrefetch);
@@ -393,6 +395,7 @@ public class AmbryRequests implements RequestAPI {
     long startTime = SystemTime.getInstance().milliseconds();
     DeleteResponse response = null;
     try {
+      StoreKey convertedStoreKey = getConvertedStoreKeys(Collections.singletonList(deleteRequest.getBlobId())).get(0);
       ServerErrorCode error =
           validateRequest(deleteRequest.getBlobId().getPartition(), RequestOrResponseType.DeleteRequest, false);
       if (error != ServerErrorCode.No_Error) {
@@ -400,9 +403,9 @@ public class AmbryRequests implements RequestAPI {
         response = new DeleteResponse(deleteRequest.getCorrelationId(), deleteRequest.getClientId(), error);
       } else {
         MessageFormatInputStream stream =
-            new DeleteMessageFormatInputStream(deleteRequest.getBlobId(), deleteRequest.getAccountId(),
+            new DeleteMessageFormatInputStream(convertedStoreKey, deleteRequest.getAccountId(),
                 deleteRequest.getContainerId(), deleteRequest.getDeletionTimeInMs());
-        MessageInfo info = new MessageInfo(deleteRequest.getBlobId(), stream.getSize(), deleteRequest.getAccountId(),
+        MessageInfo info = new MessageInfo(convertedStoreKey, stream.getSize(), deleteRequest.getAccountId(),
             deleteRequest.getContainerId(), deleteRequest.getDeletionTimeInMs());
         ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
         infoList.add(info);
@@ -1060,5 +1063,17 @@ public class AmbryRequests implements RequestAPI {
       }
     }
     return isAcceptable;
+  }
+
+  /**
+   * Convert StoreKeys based on {@link StoreKeyConverterFactory}
+   * @param storeKeys A list of original storeKeys.
+   * @return A list of converted storeKeys.
+   */
+  private List<StoreKey> getConvertedStoreKeys(List<? extends StoreKey> storeKeys) throws Exception {
+    Map<StoreKey, StoreKey> convertionMap = storeKeyConverterFactory.getStoreKeyConverter().convert(storeKeys);
+    List<StoreKey> convertedStoreKeys = new ArrayList<>();
+    storeKeys.stream().forEach(storeKey -> convertedStoreKeys.add(convertionMap.get(storeKey)));
+    return convertedStoreKeys;
   }
 }

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -409,9 +409,9 @@ public class AmbryRequests implements RequestAPI {
             deleteRequest.getContainerId(), deleteRequest.getDeletionTimeInMs());
         ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
         infoList.add(info);
-        MessageFormatWriteSet writeset = new MessageFormatWriteSet(stream, infoList, false);
+        MessageFormatWriteSet writeSet = new MessageFormatWriteSet(stream, infoList, false);
         Store storeToDelete = storageManager.getStore(deleteRequest.getBlobId().getPartition());
-        storeToDelete.delete(writeset);
+        storeToDelete.delete(writeSet);
         response =
             new DeleteResponse(deleteRequest.getCorrelationId(), deleteRequest.getClientId(), ServerErrorCode.No_Error);
         if (notification != null) {
@@ -1071,9 +1071,12 @@ public class AmbryRequests implements RequestAPI {
    * @return A list of converted storeKeys.
    */
   private List<StoreKey> getConvertedStoreKeys(List<? extends StoreKey> storeKeys) throws Exception {
-    Map<StoreKey, StoreKey> convertionMap = storeKeyConverterFactory.getStoreKeyConverter().convert(storeKeys);
+    Map<StoreKey, StoreKey> conversionMap = storeKeyConverterFactory.getStoreKeyConverter().convert(storeKeys);
     List<StoreKey> convertedStoreKeys = new ArrayList<>();
-    storeKeys.stream().forEach(storeKey -> convertedStoreKeys.add(convertionMap.get(storeKey)));
+    for (StoreKey key : storeKeys) {
+      StoreKey convertedKey = conversionMap.get(key);
+      convertedStoreKeys.add(convertedKey == null ? key : convertedKey);
+    }
     return convertedStoreKeys;
   }
 }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -72,6 +72,7 @@ import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreGetOptions;
 import com.github.ambry.store.StoreInfo;
 import com.github.ambry.store.StoreKey;
+import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.store.StoreStats;
 import com.github.ambry.utils.ByteBufferChannel;
@@ -98,6 +99,7 @@ import java.util.Set;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -127,8 +129,11 @@ public class AmbryRequestsTest {
     dataNodeId = clusterMap.getDataNodeIds().get(0);
     replicationManager =
         MockReplicationManager.getReplicationManager(verifiableProperties, storageManager, clusterMap, dataNodeId);
+    StoreKeyConverterFactory storeKeyConverterFactory =
+        new StoreKeyConverterFactoryImpl(mock(VerifiableProperties.class), mock(MetricRegistry.class));
     ambryRequests = new AmbryRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
-        clusterMap.getMetricRegistry(), FIND_TOKEN_FACTORY, null, replicationManager, null, false, null);
+        clusterMap.getMetricRegistry(), FIND_TOKEN_FACTORY, null, replicationManager, null, false,
+        storeKeyConverterFactory);
   }
 
   /**

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -134,7 +134,7 @@ public class AmbryRequestsTest {
     dataNodeId = clusterMap.getDataNodeIds().get(0);
     replicationManager =
         MockReplicationManager.getReplicationManager(verifiableProperties, storageManager, clusterMap, dataNodeId);
-    storeKeyConverterFactory = new MockStoreKeyConverterFactory();
+    storeKeyConverterFactory = new MockStoreKeyConverterFactory(null, null);
     storeKeyConverterFactory.setConversionMap(conversionMap);
     ambryRequests = new AmbryRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
         clusterMap.getMetricRegistry(), FIND_TOKEN_FACTORY, null, replicationManager, null, false,


### PR DESCRIPTION
@dharju Looks like we don't need a mock `StoreKeyConverterFactory` for test. `StoreKeyConverterImplNoOp` with existing tests can cover the new added method `getConvertedStoreKeys`. 