### PR TITLE
Generate bloom file and persist when initializing existing IndexSegment

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -175,8 +175,6 @@ class IndexSegment {
         map(false);
         bloomFile = new File(indexFile.getParent(), indexSegmentFilenamePrefix + BLOOM_FILE_NAME_SUFFIX);
         if (!bloomFile.exists()) {
-          bloomFilter = FilterFactory.getFilter(config.storeIndexMaxNumberOfInmemElements,
-              config.storeIndexBloomMaxFalsePositiveProbability);
           generateBloomFileAndPersist();
         }
         // Load the bloom filter for this index
@@ -390,6 +388,7 @@ class IndexSegment {
   private void generateBloomFileAndPersist() throws IOException {
     List<IndexEntry> entries = new ArrayList<>();
     getIndexEntriesSince(null, new FindEntriesCondition(Long.MAX_VALUE), entries, new AtomicLong(0), true);
+    bloomFilter = FilterFactory.getFilter(entries.size(), config.storeIndexBloomMaxFalsePositiveProbability);
     for (IndexEntry entry : entries) {
       bloomFilter.add(ByteBuffer.wrap(entry.getKey().toBytes()));
     }

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -175,23 +175,24 @@ class IndexSegment {
         map(false);
         bloomFile = new File(indexFile.getParent(), indexSegmentFilenamePrefix + BLOOM_FILE_NAME_SUFFIX);
         if (!bloomFile.exists()) {
-          generateBloomFileAndPersist();
+          generateBloomFilterAndPersist();
+        } else {
+          // Load the bloom filter for this index
+          // We need to load the bloom filter only for mapped indexes
+          CrcInputStream crcBloom = new CrcInputStream(new FileInputStream(bloomFile));
+          DataInputStream stream = new DataInputStream(crcBloom);
+          bloomFilter = FilterFactory.deserialize(stream);
+          long crcValue = crcBloom.getValue();
+          if (crcValue != stream.readLong()) {
+            // TODO metrics
+            // we don't recover the filter. we just by pass the filter. Crc corrections will be done
+            // by the scrubber
+            bloomFilter = null;
+            logger.error("IndexSegment : {} error validating crc for bloom filter for {}", indexFile.getAbsolutePath(),
+                bloomFile.getAbsolutePath());
+          }
+          stream.close();
         }
-        // Load the bloom filter for this index
-        // We need to load the bloom filter only for mapped indexes
-        CrcInputStream crcBloom = new CrcInputStream(new FileInputStream(bloomFile));
-        DataInputStream stream = new DataInputStream(crcBloom);
-        bloomFilter = FilterFactory.deserialize(stream);
-        long crcValue = crcBloom.getValue();
-        if (crcValue != stream.readLong()) {
-          // TODO metrics
-          // we don't recover the filter. we just by pass the filter. Crc corrections will be done
-          // by the scrubber
-          bloomFilter = null;
-          logger.error("IndexSegment : {} error validating crc for bloom filter for {}", indexFile.getAbsolutePath(),
-              bloomFile.getAbsolutePath());
-        }
-        stream.close();
       } else {
         index = new ConcurrentSkipListMap<>();
         bloomFilter = FilterFactory.getFilter(config.storeIndexMaxNumberOfInmemElements,
@@ -382,29 +383,30 @@ class IndexSegment {
   }
 
   /**
-   * Generate bloom file by walking through all index entries in this segment and persist it.
+   * Generate bloom filter by walking through all index entries in this segment and persist it.
    * @throws IOException
    */
-  private void generateBloomFileAndPersist() throws IOException {
+  private void generateBloomFilterAndPersist() throws IOException {
     List<IndexEntry> entries = new ArrayList<>();
     getIndexEntriesSince(null, new FindEntriesCondition(Long.MAX_VALUE), entries, new AtomicLong(0), true);
     bloomFilter = FilterFactory.getFilter(entries.size(), config.storeIndexBloomMaxFalsePositiveProbability);
     for (IndexEntry entry : entries) {
       bloomFilter.add(ByteBuffer.wrap(entry.getKey().toBytes()));
     }
-    persistBloomFile();
+    persistBloomFilter();
   }
 
   /**
-   * Persist the bloom file.
+   * Persist the bloom filter.
    * @throws IOException
    */
-  private void persistBloomFile() throws IOException {
+  private void persistBloomFilter() throws IOException {
     CrcOutputStream crcStream = new CrcOutputStream(new FileOutputStream(bloomFile));
     DataOutputStream stream = new DataOutputStream(crcStream);
     FilterFactory.serialize(bloomFilter, stream);
     long crcValue = crcStream.getValue();
     stream.writeLong(crcValue);
+    stream.close();
   }
 
   /**
@@ -759,7 +761,7 @@ class IndexSegment {
     // we should be fine reading bloom filter here without synchronization as the index is read only
     // we only persist the bloom filter once during its entire lifetime
     if (persistBloom) {
-      persistBloomFile();
+      persistBloomFilter();
     }
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -51,7 +51,6 @@ import static org.junit.Assert.*;
  */
 @RunWith(Parameterized.class)
 public class IndexSegmentTest {
-  private static final String BLOOM_FILE_NAME_SUFFIX = "bloom";
   private static final int CUSTOM_ID_SIZE = 10;
   private static final int KEY_SIZE = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE)).sizeInBytes();
   private static final int SMALLER_KEY_SIZE = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE / 2)).sizeInBytes();
@@ -772,9 +771,10 @@ public class IndexSegmentTest {
     assertNull("Journal should not have any entries", journal.getFirstOffset());
 
     // delete the bloom file
-    File BloomFile = new File(file.getParent(),
-        IndexSegment.generateIndexSegmentFilenamePrefix(startOffset) + BLOOM_FILE_NAME_SUFFIX);
-    BloomFile.delete();
+    File bloomFile = new File(file.getParent(),
+        IndexSegment.generateIndexSegmentFilenamePrefix(startOffset) + IndexSegment.BLOOM_FILE_NAME_SUFFIX);
+    assertTrue("File could not be deleted", bloomFile.delete());
+    assertFalse("Bloom file should not exist", bloomFile.exists());
 
     // read from file (mapped) again and verify that everything is ok
     journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.*;
  */
 @RunWith(Parameterized.class)
 public class IndexSegmentTest {
+  private static final String BLOOM_FILE_NAME_SUFFIX = "bloom";
   private static final int CUSTOM_ID_SIZE = 10;
   private static final int KEY_SIZE = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE)).sizeInBytes();
   private static final int SMALLER_KEY_SIZE = new MockId(UtilsTest.getRandomString(CUSTOM_ID_SIZE / 2)).sizeInBytes();
@@ -756,10 +757,8 @@ public class IndexSegmentTest {
     // read from file (unmapped) and verify that everything is ok
     Journal journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
     IndexSegment fromDisk = createIndexSegmentFromFile(file, false, journal);
-    verifyIndexSegmentDetails(fromDisk, startOffset, numItems, expectedSizeWritten, false, endOffset,
-        lastModifiedTimeInMs, resetKey);
-    verifyFind(referenceIndex, fromDisk);
-    verifyGetEntriesSince(referenceIndex, fromDisk);
+    verifyAllForIndexSegmentFromFile(referenceIndex, fromDisk, startOffset, numItems, expectedSizeWritten, false,
+        endOffset, lastModifiedTimeInMs, resetKey);
     // journal should contain all the entries
     verifyJournal(referenceIndex, journal);
     fromDisk.map(true);
@@ -767,12 +766,47 @@ public class IndexSegmentTest {
     // read from file (mapped) and verify that everything is ok
     journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
     fromDisk = createIndexSegmentFromFile(file, true, journal);
-    verifyIndexSegmentDetails(fromDisk, startOffset, numItems, expectedSizeWritten, true, endOffset,
+    verifyAllForIndexSegmentFromFile(referenceIndex, fromDisk, startOffset, numItems, expectedSizeWritten, true,
+        endOffset, lastModifiedTimeInMs, resetKey);
+    // journal should not contain any entries
+    assertNull("Journal should not have any entries", journal.getFirstOffset());
+
+    // delete the bloom file
+    File BloomFile = new File(file.getParent(),
+        IndexSegment.generateIndexSegmentFilenamePrefix(startOffset) + BLOOM_FILE_NAME_SUFFIX);
+    BloomFile.delete();
+
+    // read from file (mapped) again and verify that everything is ok
+    journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
+    fromDisk = createIndexSegmentFromFile(file, true, journal);
+    verifyAllForIndexSegmentFromFile(referenceIndex, fromDisk, startOffset, numItems, expectedSizeWritten, true,
+        endOffset, lastModifiedTimeInMs, resetKey);
+    // journal should not contain any entries
+    assertNull("Journal should not have any entries", journal.getFirstOffset());
+  }
+
+  /**
+   * Verify all for an {@link IndexSegment} created from the given {@code file} in terms of both sanity and find operations.
+   * @param referenceIndex the index entries to be used as reference.
+   * @param fromDisk the {@link IndexSegment} created from file.
+   * @param startOffset the expected start {@link Offset} of the {@link IndexSegment}
+   * @param numItems the expected number of items the {@code indexSegment}
+   * @param expectedSizeWritten the expected number of bytes written to the {@code indexSegment}
+   * @param isMapped the expected mapped state of the {@code indexSegment}
+   * @param endOffset the expected end offset of the {@code indexSegment}
+   * @param lastModifiedTimeInMs the last modified time of the index segment in ms
+   * @param resetKey the resetKey of the index segment
+   * @throws IOException
+   * @throws StoreException
+   */
+  private void verifyAllForIndexSegmentFromFile(NavigableMap<MockId, NavigableSet<IndexValue>> referenceIndex,
+      IndexSegment fromDisk, Offset startOffset, int numItems, int expectedSizeWritten, boolean isMapped,
+      long endOffset, long lastModifiedTimeInMs, Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey)
+      throws StoreException, IOException {
+    verifyIndexSegmentDetails(fromDisk, startOffset, numItems, expectedSizeWritten, isMapped, endOffset,
         lastModifiedTimeInMs, resetKey);
     verifyFind(referenceIndex, fromDisk);
     verifyGetEntriesSince(referenceIndex, fromDisk);
-    // journal should not contain any entries
-    assertNull("Journal should not have any entries", journal.getFirstOffset());
   }
 
   /**

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -779,6 +779,7 @@ public class IndexSegmentTest {
     // read from file (mapped) again and verify that everything is ok
     journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
     fromDisk = createIndexSegmentFromFile(file, true, journal);
+    assertTrue("Bloom file does not exist", bloomFile.exists());
     verifyAllForIndexSegmentFromFile(referenceIndex, fromDisk, startOffset, numItems, expectedSizeWritten, true,
         endOffset, lastModifiedTimeInMs, resetKey);
     // journal should not contain any entries


### PR DESCRIPTION
When initializing IndexSegment, if it should be mapped to memory and bloom
file doesn't exist, we generate the bloom file and persist it.
(./gradlew build && ./gradlew test)