### PR TITLE
Add bits for BlobDataType in BlobId flag.

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -165,7 +165,7 @@ public class RouterConfig {
    * The version to use for new BlobIds.
    */
   @Config("router.blobid.current.version")
-  @Default("5")
+  @Default("4")
   public final short routerBlobidCurrentVersion;
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -165,7 +165,7 @@ public class RouterConfig {
    * The version to use for new BlobIds.
    */
   @Config("router.blobid.current.version")
-  @Default("4")
+  @Default("5")
   public final short routerBlobidCurrentVersion;
 
   /**
@@ -242,7 +242,7 @@ public class RouterConfig {
     routerLatencyToleranceQuantile =
         verifiableProperties.getDoubleInRange("router.latency.tolerance.quantile", 0.9, 0.0, 1.0);
     routerBlobidCurrentVersion =
-        verifiableProperties.getShortFromAllowedValues("router.blobid.current.version", (short) 4,
+        verifiableProperties.getShortFromAllowedValues("router.blobid.current.version", (short) 5,
             new Short[]{1, 2, 3, 4, 5});
     routerKeyManagementServiceFactory = verifiableProperties.getString("router.key.management.service.factory",
         "com.github.ambry.router.SingleKeyManagementServiceFactory");

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -165,7 +165,7 @@ public class RouterConfig {
    * The version to use for new BlobIds.
    */
   @Config("router.blobid.current.version")
-  @Default("3")
+  @Default("5")
   public final short routerBlobidCurrentVersion;
 
   /**
@@ -242,8 +242,8 @@ public class RouterConfig {
     routerLatencyToleranceQuantile =
         verifiableProperties.getDoubleInRange("router.latency.tolerance.quantile", 0.9, 0.0, 1.0);
     routerBlobidCurrentVersion =
-        verifiableProperties.getShortFromAllowedValues("router.blobid.current.version", (short) 3,
-            new Short[]{1, 2, 3, 4});
+        verifiableProperties.getShortFromAllowedValues("router.blobid.current.version", (short) 5,
+            new Short[]{1, 2, 3, 4, 5});
     routerKeyManagementServiceFactory = verifiableProperties.getString("router.key.management.service.factory",
         "com.github.ambry.router.SingleKeyManagementServiceFactory");
     routerCryptoServiceFactory = verifiableProperties.getString("router.crypto.service.factory",

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -242,7 +242,7 @@ public class RouterConfig {
     routerLatencyToleranceQuantile =
         verifiableProperties.getDoubleInRange("router.latency.tolerance.quantile", 0.9, 0.0, 1.0);
     routerBlobidCurrentVersion =
-        verifiableProperties.getShortFromAllowedValues("router.blobid.current.version", (short) 5,
+        verifiableProperties.getShortFromAllowedValues("router.blobid.current.version", (short) 4,
             new Short[]{1, 2, 3, 4, 5});
     routerKeyManagementServiceFactory = verifiableProperties.getString("router.key.management.service.factory",
         "com.github.ambry.router.SingleKeyManagementServiceFactory");

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -686,7 +686,7 @@ public class BlobId extends StoreKey {
     /**
      * Indicates a composite (metadata) blob.
      */
-    COMPOSITE,
+    METADATA,
 
     /**
      * Indicates a data chunk within a composite blob.

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -104,7 +104,7 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
  *
  * <br>
  * Version 5, which is the same as Version 4 but with additional info in the flag byte.  Flag bits 4 and 5
- * are used to specify the Blob Data Type, which can be Simple, Composite, or DataChunk.
+ * are used to specify the Blob Data Type, which can be Simple, Metadata, or DataChunk.
  * <br>
  * <pre>
  * +---------+-------+--------------+-----------+-------------+-------------+----------+----------+

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -18,6 +18,7 @@ import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.messageformat.BlobData;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Pair;
@@ -100,6 +101,24 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
  * +--------------+-------------+---------------+
  *
  * </pre>
+ *
+ * <br>
+ * Version 5, which is the same as Version 4 but with additional info in the flag byte.  Flag bits 4 and 5
+ * are used to specify the Blob Data Type, which can be Simple, Composite, or DataChunk.
+ * <br>
+ * <pre>
+ * +---------+-------+--------------+-----------+-------------+-------------+----------+----------+
+ * | version | flag  | datacenterId | accountId | containerId | partitionId | uuidSize | uuid     |
+ * | (short) | (byte)| (byte)       | (short)   | (short)     | (n bytes)   | (int)    | (n bytes)|
+ * +---------+----------------------+-----------+-------------+-------------+----------+----------+
+ *
+ * Flag format: 1 Byte
+ * +--------------+---------------+-------------+---------------+
+ * |  1 to 3 bits | 4 and 5th bit |    6th bit  | 7 and 8th bit |
+ * |  un-assigned | BlobDataType  | IsEncrypted |  BlobIdType   |
+ * +--------------+---------------+-------------+---------------|
+
+ * </pre>
  */
 
 public class BlobId extends StoreKey {
@@ -107,6 +126,7 @@ public class BlobId extends StoreKey {
   public static final short BLOB_ID_V2 = 2;
   public static final short BLOB_ID_V3 = 3;
   public static final short BLOB_ID_V4 = 4;
+  public static final short BLOB_ID_V5 = 5;
   private static final short VERSION_FIELD_LENGTH_IN_BYTES = Short.BYTES;
   private static final short UUID_SIZE_FIELD_LENGTH_IN_BYTES = Integer.BYTES;
   private static final short FLAG_FIELD_LENGTH_IN_BYTES = Byte.BYTES;
@@ -115,6 +135,8 @@ public class BlobId extends StoreKey {
   private static final short CONTAINER_ID_FIELD_LENGTH_IN_BYTES = Short.BYTES;
   private static final int BLOB_ID_TYPE_MASK = 0x3;
   private static final int IS_ENCRYPTED_MASK = 0x4;
+  private static final int BLOB_DATA_TYPE_MASK = 0x18;
+  private static final int BLOB_DATA_TYPE_SHIFT = 3;
 
   private final short version;
   private final BlobIdType type;
@@ -124,6 +146,7 @@ public class BlobId extends StoreKey {
   private final PartitionId partitionId;
   private final String uuid;
   private final boolean isEncrypted;
+  private BlobDataType blobDataType;
 
   /**
    * Constructs a new BlobId by taking arguments for the required fields.
@@ -141,7 +164,29 @@ public class BlobId extends StoreKey {
    */
   public BlobId(short version, BlobIdType type, byte datacenterId, short accountId, short containerId,
       PartitionId partitionId, boolean isEncrypted) {
-    this(version, type, datacenterId, accountId, containerId, partitionId, isEncrypted, UUID.randomUUID().toString());
+    this(version, type, datacenterId, accountId, containerId, partitionId, isEncrypted, null,
+        UUID.randomUUID().toString());
+  }
+
+  /**
+   * Constructs a new BlobId by taking arguments for the required fields.
+   * Not all the fields in the constructor may be used in constructing it. The current active version determines what
+   * fields will be used.
+   * @param version the version in which this blob should be created.
+   * @param type The {@link BlobIdType} of the blob to be created. Only relevant for V3 and above.
+   * @param datacenterId The id of the datacenter to be embedded into the blob. Only relevant for V2 and above.
+   * @param accountId The id of the {@link Account} to be embedded into the blob. Only relevant for V2 and above.
+   * @param containerId The id of the {@link Container} to be embedded into the blob. Only relevant for V2 and above.
+   * @param partitionId The partition where this blob is to be stored. Cannot be {@code null}.
+   * @param isEncrypted {@code true} if blob that this blobId represents is encrypted. {@code false} otherwise.
+   *                                Valid for {@link BlobId#BLOB_ID_V4} and above.
+   * @param blobDataType The blob data type.
+   *
+   */
+  public BlobId(short version, BlobIdType type, byte datacenterId, short accountId, short containerId,
+      PartitionId partitionId, boolean isEncrypted, BlobDataType blobDataType) {
+    this(version, type, datacenterId, accountId, containerId, partitionId, isEncrypted, blobDataType,
+        UUID.randomUUID().toString());
   }
 
   /**
@@ -155,10 +200,11 @@ public class BlobId extends StoreKey {
    * @param containerId The id of the {@link Container} to be embedded into the blob. Only relevant for V2 and above.
    * @param partitionId The partition where this blob is to be stored. Cannot be {@code null}.
    * @param isEncrypted {@code true} if blob that this blobId represents is encrypted. {@code false} otherwise
+   * @param blobDataType The blob data type.
    * @param uuid The uuid that is to be used to construct this id.
    */
   private BlobId(short version, BlobIdType type, byte datacenterId, short accountId, short containerId,
-      PartitionId partitionId, boolean isEncrypted, String uuid) {
+      PartitionId partitionId, boolean isEncrypted, BlobDataType blobDataType, String uuid) {
     if (partitionId == null) {
       throw new IllegalArgumentException("partitionId cannot be null");
     }
@@ -191,6 +237,14 @@ public class BlobId extends StoreKey {
         this.containerId = containerId;
         this.isEncrypted = isEncrypted;
         break;
+      case BLOB_ID_V5:
+        this.type = type;
+        this.datacenterId = datacenterId;
+        this.accountId = accountId;
+        this.containerId = containerId;
+        this.isEncrypted = isEncrypted;
+        this.blobDataType = blobDataType;
+        break;
       default:
         throw new IllegalArgumentException("blobId version=" + version + " not supported");
     }
@@ -217,6 +271,7 @@ public class BlobId extends StoreKey {
     accountId = preamble.accountId;
     containerId = preamble.containerId;
     isEncrypted = preamble.isEncrypted;
+    blobDataType = preamble.blobDataType;
     partitionId = clusterMap.getPartitionIdFromStream(stream);
     if (partitionId == null) {
       throw new IllegalArgumentException("Partition ID cannot be null");
@@ -263,6 +318,7 @@ public class BlobId extends StoreKey {
       case BLOB_ID_V2:
       case BLOB_ID_V3:
       case BLOB_ID_V4:
+      case BLOB_ID_V5:
         return (short) (FLAG_FIELD_LENGTH_IN_BYTES + DATACENTER_ID_FIELD_LENGTH_IN_BYTES
             + ACCOUNT_ID_FIELD_LENGTH_IN_BYTES + CONTAINER_ID_FIELD_LENGTH_IN_BYTES + sizeForBlobIdV1);
       default:
@@ -327,7 +383,7 @@ public class BlobId extends StoreKey {
   /**
    * Gets the BlobId type of this blobId. If this information was not available when the blobId was formed, it
    * will return {@link BlobIdType#NATIVE}.
-   * @return The flag of the blobId.
+   * @return The BlobIdType of the blobId.
    */
   public BlobIdType getType() {
     return type;
@@ -338,6 +394,13 @@ public class BlobId extends StoreKey {
    */
   private boolean isEncrypted() {
     return isEncrypted;
+  }
+
+  /**
+   * @return the {@link BlobDataType} for the blob.
+   */
+  public BlobDataType getBlobDataType() {
+    return blobDataType;
   }
 
   /**
@@ -377,6 +440,17 @@ public class BlobId extends StoreKey {
       case BLOB_ID_V4:
         flag = (byte) (type.ordinal() & BLOB_ID_TYPE_MASK);
         flag |= isEncrypted ? IS_ENCRYPTED_MASK : 0;
+        idBuf.put(flag);
+        idBuf.put(datacenterId);
+        idBuf.putShort(accountId);
+        idBuf.putShort(containerId);
+        break;
+      case BLOB_ID_V5:
+        flag = (byte) (type.ordinal() & BLOB_ID_TYPE_MASK);
+        flag |= isEncrypted ? IS_ENCRYPTED_MASK : 0;
+        if (blobDataType != null) {
+          flag |= (blobDataType.ordinal() << BLOB_DATA_TYPE_SHIFT);
+        }
         idBuf.put(flag);
         idBuf.put(datacenterId);
         idBuf.putShort(accountId);
@@ -475,6 +549,7 @@ public class BlobId extends StoreKey {
           break;
         case BLOB_ID_V3:
         case BLOB_ID_V4:
+        case BLOB_ID_V5:
           result = uuid.compareTo(other.uuid);
           break;
         default:
@@ -505,7 +580,7 @@ public class BlobId extends StoreKey {
    * @return all valid versions of BlobId.
    */
   public static Short[] getAllValidVersions() {
-    return new Short[]{BLOB_ID_V1, BLOB_ID_V2, BLOB_ID_V3, BLOB_ID_V4};
+    return new Short[]{BLOB_ID_V1, BLOB_ID_V2, BLOB_ID_V3, BLOB_ID_V4, BLOB_ID_V5};
   }
 
   /**
@@ -530,7 +605,7 @@ public class BlobId extends StoreKey {
       throw new IllegalArgumentException("Target version for crafting must be V3 or higher");
     }
     return new BlobId(targetVersion, BlobIdType.CRAFTED, inputId.getDatacenterId(), accountId, containerId,
-        inputId.partitionId, inputId.isEncrypted, inputId.uuid);
+        inputId.partitionId, inputId.isEncrypted, null, inputId.uuid);
   }
 
   /**
@@ -572,6 +647,18 @@ public class BlobId extends StoreKey {
   }
 
   /**
+   * Returns the blob data type of a given Blob id.
+   * @param idStr the blobId in string form.
+   * @return the {@Link BlobDataType} indicating the data type of the blob.
+   * @throws IOException if the input is not a valid Blob id.
+   */
+  public static BlobDataType getBlobDataType(String idStr) throws IOException {
+    BlobIdPreamble blobIdPreamble =
+        new BlobIdPreamble(new DataInputStream(new ByteBufferInputStream(ByteBuffer.wrap(Base64.decodeBase64(idStr)))));
+    return blobIdPreamble.blobDataType;
+  }
+
+  /**
    * Indicates the context in which a {@link BlobId} gets created.
    */
   public enum BlobIdType {
@@ -588,6 +675,26 @@ public class BlobId extends StoreKey {
   }
 
   /**
+   * Indicates the type of blob this is.
+   */
+  public enum BlobDataType {
+    /**
+     * Indicates a fully contained blob.
+     */
+    SIMPLE,
+
+    /**
+     * Indicates a composite (metadata) blob.
+     */
+    COMPOSITE,
+
+    /**
+     * Indicates a data chunk within a composite blob.
+     */
+    DATACHUNK
+  }
+
+  /**
    * A class that can hold all the information embedded in a BlobId up to and not including the {@link PartitionId}
    * The preamble can be parsed off a blob id string without a {@link ClusterMap}.
    */
@@ -598,6 +705,7 @@ public class BlobId extends StoreKey {
     final short accountId;
     final short containerId;
     final boolean isEncrypted;
+    BlobDataType blobDataType;
 
     /**
      * Construct a BlobIdPreamble object by reading all the fields from a BlobId up to and not including the
@@ -608,6 +716,7 @@ public class BlobId extends StoreKey {
     BlobIdPreamble(DataInputStream stream) throws IOException {
       version = stream.readShort();
       byte blobIdFlag;
+      blobDataType = null;
       switch (version) {
         case BLOB_ID_V1:
           type = BlobIdType.NATIVE;
@@ -636,6 +745,16 @@ public class BlobId extends StoreKey {
           blobIdFlag = stream.readByte();
           type = BlobIdType.values()[blobIdFlag & BLOB_ID_TYPE_MASK];
           isEncrypted = (blobIdFlag & IS_ENCRYPTED_MASK) != 0;
+          datacenterId = stream.readByte();
+          accountId = stream.readShort();
+          containerId = stream.readShort();
+          break;
+        case BLOB_ID_V5:
+          blobIdFlag = stream.readByte();
+          type = BlobIdType.values()[blobIdFlag & BLOB_ID_TYPE_MASK];
+          isEncrypted = (blobIdFlag & IS_ENCRYPTED_MASK) != 0;
+          int dataTypeOrdinal = (blobIdFlag & BLOB_DATA_TYPE_MASK) >> BLOB_DATA_TYPE_SHIFT;
+          blobDataType = dataTypeOrdinal < BlobDataType.values().length ? BlobDataType.values()[dataTypeOrdinal] : null;
           datacenterId = stream.readByte();
           accountId = stream.readShort();
           containerId = stream.readShort();

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -224,6 +224,9 @@ public class BlobId extends StoreKey {
         this.accountId = accountId;
         this.containerId = containerId;
         this.isEncrypted = isEncrypted;
+        if (blobDataType == null) {
+          throw new IllegalArgumentException("blobDataType can't be null for id version " + BLOB_ID_V5);
+        }
         this.blobDataType = blobDataType;
         break;
       default:
@@ -429,9 +432,7 @@ public class BlobId extends StoreKey {
       case BLOB_ID_V5:
         flag = (byte) (type.ordinal() & BLOB_ID_TYPE_MASK);
         flag |= isEncrypted ? IS_ENCRYPTED_MASK : 0;
-        if (blobDataType != null) {
-          flag |= (blobDataType.ordinal() << BLOB_DATA_TYPE_SHIFT);
-        }
+        flag |= (blobDataType.ordinal() << BLOB_DATA_TYPE_SHIFT);
         idBuf.put(flag);
         idBuf.put(datacenterId);
         idBuf.putShort(accountId);

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -116,7 +116,6 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
  * |  1 to 3 bits | 4 and 5th bit |    6th bit  | 7 and 8th bit |
  * |  un-assigned | BlobDataType  | IsEncrypted |  BlobIdType   |
  * +--------------+---------------+-------------+---------------|
-
  * </pre>
  */
 
@@ -587,7 +586,7 @@ public class BlobId extends StoreKey {
       throw new IllegalArgumentException("Target version for crafting must be V3 or higher");
     }
     return new BlobId(targetVersion, BlobIdType.CRAFTED, inputId.getDatacenterId(), accountId, containerId,
-        inputId.partitionId, inputId.isEncrypted, null, inputId.uuid);
+        inputId.partitionId, inputId.isEncrypted, inputId.blobDataType, inputId.uuid);
   }
 
   /**

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -632,6 +632,7 @@ public class BlobIdTest {
     PartitionId partitionId =
         referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(random.nextInt(3));
     boolean isEncrypted = random.nextBoolean();
-    return new BlobId(version, type, datacenterId, accountId, containerId, partitionId, isEncrypted, null);
+    BlobDataType dataType = BlobDataType.values()[random.nextInt(BlobDataType.values().length)];
+    return new BlobId(version, type, datacenterId, accountId, containerId, partitionId, isEncrypted, dataType);
   }
 }

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -129,7 +129,7 @@ public class BlobIdTest {
       for (BlobIdType type : BlobIdType.values()) {
         for (boolean isEncrypted : isEncryptedValues) {
           BlobId blobId = new BlobId(version, type, referenceDatacenterId, referenceAccountId, referenceContainerId,
-              referencePartitionId, isEncrypted);
+              referencePartitionId, isEncrypted, null);
           BlobId blobIdSerDed =
               new BlobId(new DataInputStream(new ByteArrayInputStream(blobId.toBytes())), referenceClusterMap);
           assertEquals("The type should match the original's type", type, blobIdSerDed.getType());
@@ -183,7 +183,7 @@ public class BlobIdTest {
       BlobId blobIdV4 =
           new BlobId(BLOB_ID_V4, random.nextBoolean() ? BlobIdType.NATIVE : BlobIdType.CRAFTED, (byte) 1, (short) 1,
               (short) 1, referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS)
-              .get(random.nextInt(3)), isEncrypted);
+              .get(random.nextInt(3)), isEncrypted, null);
       assertEquals("V4 should return true or false based on its encrypted bit", isEncrypted,
           BlobId.isEncrypted(blobIdV4.getID()));
     }
@@ -284,13 +284,13 @@ public class BlobIdTest {
     BlobId inputs[];
     if (version >= BLOB_ID_V3) {
       inputs = new BlobId[]{new BlobId(version, BlobIdType.NATIVE, referenceDatacenterId, referenceAccountId,
-          referenceContainerId, referencePartitionId, false), new BlobId(version, BlobIdType.CRAFTED,
-          referenceDatacenterId, referenceAccountId, referenceContainerId, referencePartitionId, false)};
+          referenceContainerId, referencePartitionId, false, null), new BlobId(version, BlobIdType.CRAFTED,
+          referenceDatacenterId, referenceAccountId, referenceContainerId, referencePartitionId, false, null)};
       assertFalse("isCrafted() should be false for native id", BlobId.isCrafted(inputs[0].getID()));
       assertTrue("isCrafted() should be true for crafted id", BlobId.isCrafted(inputs[1].getID()));
     } else {
       inputs = new BlobId[]{new BlobId(version, referenceType, referenceDatacenterId, referenceAccountId,
-          referenceContainerId, referencePartitionId, false)};
+          referenceContainerId, referencePartitionId, false, null)};
       assertFalse("isCrafted() should be false for ids below BLOB_ID_V3", BlobId.isCrafted(inputs[0].getID()));
     }
     short newAccountId = (short) (referenceAccountId + 1 + TestUtils.RANDOM.nextInt(100));
@@ -555,6 +555,7 @@ public class BlobIdTest {
         assertEquals("Wrong container id in blobId: " + blobId, Container.UNKNOWN_CONTAINER_ID,
             blobId.getContainerId());
         assertFalse("Wrong isEncrypted value in blobId: " + blobId, BlobId.isEncrypted(blobId.getID()));
+        assertNull("Expected null blobDataType in blobId", blobId.getBlobDataType());
         break;
       case BLOB_ID_V2:
         assertEquals("Wrong type in blobId: " + blobId, BlobIdType.NATIVE, blobId.getType());
@@ -562,6 +563,7 @@ public class BlobIdTest {
         assertEquals("Wrong account id in blobId: " + blobId, accountId, blobId.getAccountId());
         assertEquals("Wrong container id in blobId: " + blobId, containerId, blobId.getContainerId());
         assertFalse("Wrong isEncrypted value id in blobId: " + blobId, BlobId.isEncrypted(blobId.getID()));
+        assertNull("Expected null blobDataType in blobId", blobId.getBlobDataType());
         break;
       case BLOB_ID_V3:
         assertEquals("Wrong type in blobId: " + blobId, type, blobId.getType());
@@ -569,6 +571,7 @@ public class BlobIdTest {
         assertEquals("Wrong account id in blobId: " + blobId, accountId, blobId.getAccountId());
         assertEquals("Wrong container id in blobId: " + blobId, containerId, blobId.getContainerId());
         assertFalse("Wrong isEncrypted value id in blobId: " + blobId, BlobId.isEncrypted(blobId.getID()));
+        assertNull("Expected null blobDataType in blobId", blobId.getBlobDataType());
         break;
       case BLOB_ID_V4:
         assertEquals("Wrong type in blobId: " + blobId, type, blobId.getType());
@@ -576,6 +579,7 @@ public class BlobIdTest {
         assertEquals("Wrong account id in blobId: " + blobId, accountId, blobId.getAccountId());
         assertEquals("Wrong container id in blobId: " + blobId, containerId, blobId.getContainerId());
         assertEquals("Wrong isEncrypted value in blobId: " + blobId, isEncrypted, BlobId.isEncrypted(blobId.getID()));
+        assertNull("Expected null blobDataType in blobId", blobId.getBlobDataType());
         break;
       case BLOB_ID_V5:
         assertEquals("Wrong type in blobId: " + blobId, type, blobId.getType());
@@ -628,6 +632,6 @@ public class BlobIdTest {
     PartitionId partitionId =
         referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(random.nextInt(3));
     boolean isEncrypted = random.nextBoolean();
-    return new BlobId(version, type, datacenterId, accountId, containerId, partitionId, isEncrypted);
+    return new BlobId(version, type, datacenterId, accountId, containerId, partitionId, isEncrypted, null);
   }
 }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -162,7 +162,7 @@ public class AmbryBlobStorageServiceTest {
     responseHandler = new FrontendTestResponseHandler();
     referenceBlobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
         Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
     referenceBlobIdStr = referenceBlobId.getID();
     ambryBlobStorageService = getAmbryBlobStorageService();
     responseHandler.start();
@@ -494,56 +494,56 @@ public class AmbryBlobStorageServiceTest {
       String blobId =
           new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
               refContainer.getId(), clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
-              false).getID();
+              false, null).getID();
       verifyAccountAndContainerFromBlobId(blobId, refAccount, refContainer, RestServiceErrorCode.NotFound);
 
       // aid=refAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
           Container.UNKNOWN_CONTAINER_ID,
-          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=refAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
           (short) -1234, clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
-          false).getID();
+          false, null).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=unknownAId, cid=refCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
           Account.UNKNOWN_ACCOUNT_ID, refContainer.getId(),
-          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=unknownAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
           Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
       verifyAccountAndContainerFromBlobId(blobId, InMemAccountService.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
           RestServiceErrorCode.NotFound);
 
       // aid=unknownAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
           Account.UNKNOWN_ACCOUNT_ID, (short) -1234,
-          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=nonExistAId, cid=refCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
           refContainer.getId(), clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
-          false).getID();
+          false, null).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
 
       // aid=nonExistAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
           Container.UNKNOWN_CONTAINER_ID,
-          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
 
       // aid=nonExistAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
           (short) -11, clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
-          false).getID();
+          false, null).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
     }
   }
@@ -565,7 +565,7 @@ public class AmbryBlobStorageServiceTest {
     // expect unknown account and container for v1 blob IDs that went through request processing only.
     String blobId = new BlobId(BlobId.BLOB_ID_V1, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
         refAccount.getId(), refContainer.getId(),
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false).getID();
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
     verifyAccountAndContainerFromBlobId(blobId, InMemAccountService.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
         RestServiceErrorCode.NotFound);
 
@@ -801,7 +801,7 @@ public class AmbryBlobStorageServiceTest {
     for (PartitionId partitionId : partitionIds) {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partitionId, false);
+          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partitionId, false, null);
       RestRequest restRequest =
           createRestRequest(RestMethod.GET, blobId.getID() + "/" + RestUtils.SubResource.Replicas, null, null);
       MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
@@ -1731,7 +1731,7 @@ public class AmbryBlobStorageServiceTest {
         contents.add(null);
       }
       String blobIdStr = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, (byte) -1, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, clusterMap.getAllPartitionIds(null).get(0), false).getID();
+          Container.UNKNOWN_CONTAINER_ID, clusterMap.getAllPartitionIds(null).get(0), false, null).getID();
       try {
         doOperation(createRestRequest(restMethod, blobIdStr, headers, contents), new MockRestResponseChannel());
         fail("Operation " + restMethod

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -162,7 +162,8 @@ public class AmbryBlobStorageServiceTest {
     responseHandler = new FrontendTestResponseHandler();
     referenceBlobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
         Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
     referenceBlobIdStr = referenceBlobId.getID();
     ambryBlobStorageService = getAmbryBlobStorageService();
     responseHandler.start();
@@ -494,56 +495,61 @@ public class AmbryBlobStorageServiceTest {
       String blobId =
           new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
               refContainer.getId(), clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
-              false, null).getID();
+              false, BlobId.BlobDataType.DATACHUNK).getID();
       verifyAccountAndContainerFromBlobId(blobId, refAccount, refContainer, RestServiceErrorCode.NotFound);
 
       // aid=refAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
           Container.UNKNOWN_CONTAINER_ID,
-          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+          BlobId.BlobDataType.DATACHUNK).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=refAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, refAccount.getId(),
           (short) -1234, clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
-          false, null).getID();
+          false, BlobId.BlobDataType.DATACHUNK).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=unknownAId, cid=refCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
           Account.UNKNOWN_ACCOUNT_ID, refContainer.getId(),
-          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+          BlobId.BlobDataType.DATACHUNK).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=unknownAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
           Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+          BlobId.BlobDataType.DATACHUNK).getID();
       verifyAccountAndContainerFromBlobId(blobId, InMemAccountService.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
           RestServiceErrorCode.NotFound);
 
       // aid=unknownAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
           Account.UNKNOWN_ACCOUNT_ID, (short) -1234,
-          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+          BlobId.BlobDataType.DATACHUNK).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidContainer);
 
       // aid=nonExistAId, cid=refCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
           refContainer.getId(), clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
-          false, null).getID();
+          false, BlobId.BlobDataType.DATACHUNK).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
 
       // aid=nonExistAId, cid=unknownCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
           Container.UNKNOWN_CONTAINER_ID,
-          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
+          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+          BlobId.BlobDataType.DATACHUNK).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
 
       // aid=nonExistAId, cid=nonExistCId
       blobId = new BlobId(version, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, (short) -1234,
           (short) -11, clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
-          false, null).getID();
+          false, BlobId.BlobDataType.DATACHUNK).getID();
       verifyAccountAndContainerFromBlobId(blobId, null, null, RestServiceErrorCode.InvalidAccount);
     }
   }
@@ -565,7 +571,8 @@ public class AmbryBlobStorageServiceTest {
     // expect unknown account and container for v1 blob IDs that went through request processing only.
     String blobId = new BlobId(BlobId.BLOB_ID_V1, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
         refAccount.getId(), refContainer.getId(),
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null).getID();
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK).getID();
     verifyAccountAndContainerFromBlobId(blobId, InMemAccountService.UNKNOWN_ACCOUNT, Container.UNKNOWN_CONTAINER,
         RestServiceErrorCode.NotFound);
 
@@ -801,7 +808,7 @@ public class AmbryBlobStorageServiceTest {
     for (PartitionId partitionId : partitionIds) {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partitionId, false, null);
+          Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partitionId, false, BlobId.BlobDataType.DATACHUNK);
       RestRequest restRequest =
           createRestRequest(RestMethod.GET, blobId.getID() + "/" + RestUtils.SubResource.Replicas, null, null);
       MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
@@ -1731,7 +1738,8 @@ public class AmbryBlobStorageServiceTest {
         contents.add(null);
       }
       String blobIdStr = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, (byte) -1, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, clusterMap.getAllPartitionIds(null).get(0), false, null).getID();
+          Container.UNKNOWN_CONTAINER_ID, clusterMap.getAllPartitionIds(null).get(0), false,
+          BlobId.BlobDataType.DATACHUNK).getID();
       try {
         doOperation(createRestRequest(restMethod, blobIdStr, headers, contents), new MockRestResponseChannel());
         fail("Operation " + restMethod

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -282,7 +282,7 @@ public class FrontendIntegrationTest {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-          partitionId, false);
+          partitionId, false, null);
       FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
           blobId.getID() + "/" + RestUtils.SubResource.Replicas, Unpooled.buffer(0));
       ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -282,7 +282,7 @@ public class FrontendIntegrationTest {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-          partitionId, false, null);
+          partitionId, false, BlobId.BlobDataType.DATACHUNK);
       FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
           blobId.getID() + "/" + RestUtils.SubResource.Replicas, Unpooled.buffer(0));
       ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
@@ -58,7 +58,7 @@ public class FrontendUtilsTest {
     for (short version : versions) {
       BlobId blobId =
           new BlobId(version, referenceType, referenceDatacenterId, referenceAccountId, referenceContainerId,
-              referencePartitionId, referenceIsEncrypted);
+              referencePartitionId, referenceIsEncrypted, null);
       BlobId regeneratedBlobId = FrontendUtils.getBlobIdFromString(blobId.getID(), referenceClusterMap);
       assertEquals("BlobId mismatch", blobId, regeneratedBlobId);
       assertBlobIdFieldValues(regeneratedBlobId, referenceType, referenceDatacenterId, referenceAccountId,

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
@@ -58,7 +58,7 @@ public class FrontendUtilsTest {
     for (short version : versions) {
       BlobId blobId =
           new BlobId(version, referenceType, referenceDatacenterId, referenceAccountId, referenceContainerId,
-              referencePartitionId, referenceIsEncrypted, null);
+              referencePartitionId, referenceIsEncrypted, BlobId.BlobDataType.DATACHUNK);
       BlobId regeneratedBlobId = FrontendUtils.getBlobIdFromString(blobId.getID(), referenceClusterMap);
       assertEquals("BlobId mismatch", blobId, regeneratedBlobId);
       assertBlobIdFieldValues(regeneratedBlobId, referenceType, referenceDatacenterId, referenceAccountId,

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetReplicasHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetReplicasHandlerTest.java
@@ -68,7 +68,7 @@ public class GetReplicasHandlerTest {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-          partitionId, false, null);
+          partitionId, false, BlobId.BlobDataType.DATACHUNK);
       MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
       ReadableStreamChannel channel = getReplicasHandler.getReplicas(blobId.getID(), restResponseChannel);
       assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getStatus());

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetReplicasHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetReplicasHandlerTest.java
@@ -68,7 +68,7 @@ public class GetReplicasHandlerTest {
       String originalReplicaStr = partitionId.getReplicaIds().toString().replace(", ", ",");
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID,
-          partitionId, false);
+          partitionId, false, null);
       MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
       ReadableStreamChannel channel = getReplicasHandler.getReplicas(blobId.getID(), restResponseChannel);
       assertEquals("Unexpected response status", ResponseStatus.Ok, restResponseChannel.getStatus());

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
@@ -97,7 +97,7 @@ public class GetSignedUrlHandlerTest {
 
     BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, REF_ACCOUNT.getId(), REF_CONTAINER.getId(),
-        CLUSTER_MAP.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
+        CLUSTER_MAP.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
     idConverterFactory.translation = blobId.getID();
     // GET (also makes sure that the IDConverter is used)
     restRequest = new MockRestRequest(MockRestRequest.DUMMY_DATA, null);

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetSignedUrlHandlerTest.java
@@ -97,7 +97,8 @@ public class GetSignedUrlHandlerTest {
 
     BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, REF_ACCOUNT.getId(), REF_CONTAINER.getId(),
-        CLUSTER_MAP.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
+        CLUSTER_MAP.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
     idConverterFactory.translation = blobId.getID();
     // GET (also makes sure that the IDConverter is used)
     restRequest = new MockRestRequest(MockRestRequest.DUMMY_DATA, null);

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/MessageInfoAndMetadataListSerDeTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/MessageInfoAndMetadataListSerDeTest.java
@@ -67,12 +67,13 @@ public class MessageInfoAndMetadataListSerDeTest {
     Long[] crcs = {null, 100L, Long.MIN_VALUE, Long.MAX_VALUE};
     StoreKey[] keys =
         {new BlobId(TestUtils.getRandomElement(BlobId.getAllValidVersions()), BlobId.BlobIdType.NATIVE, (byte) 0,
-            accountIds[0], containerIds[0], partitionId, false, null), new BlobId(
+            accountIds[0], containerIds[0], partitionId, false, BlobId.BlobDataType.DATACHUNK), new BlobId(
             TestUtils.getRandomElement(BlobId.getAllValidVersions()), BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[1],
-            containerIds[1], partitionId, false, null), new BlobId(TestUtils.getRandomElement(BlobId.getAllValidVersions()),
-            BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[2], containerIds[2], partitionId, false, null), new BlobId(
+            containerIds[1], partitionId, false, BlobId.BlobDataType.DATACHUNK), new BlobId(TestUtils.getRandomElement(BlobId.getAllValidVersions()),
+            BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[2], containerIds[2], partitionId, false,
+            BlobId.BlobDataType.DATACHUNK), new BlobId(
             TestUtils.getRandomElement(BlobId.getAllValidVersions()), BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[3],
-            containerIds[3], partitionId, false, null)};
+            containerIds[3], partitionId, false, BlobId.BlobDataType.DATACHUNK)};
     long[] blobSizes = {1024, 2048, 4096, 8192};
     long[] times = {SystemTime.getInstance().milliseconds(),
         SystemTime.getInstance().milliseconds() - 1,

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/MessageInfoAndMetadataListSerDeTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/MessageInfoAndMetadataListSerDeTest.java
@@ -67,12 +67,12 @@ public class MessageInfoAndMetadataListSerDeTest {
     Long[] crcs = {null, 100L, Long.MIN_VALUE, Long.MAX_VALUE};
     StoreKey[] keys =
         {new BlobId(TestUtils.getRandomElement(BlobId.getAllValidVersions()), BlobId.BlobIdType.NATIVE, (byte) 0,
-            accountIds[0], containerIds[0], partitionId, false), new BlobId(
+            accountIds[0], containerIds[0], partitionId, false, null), new BlobId(
             TestUtils.getRandomElement(BlobId.getAllValidVersions()), BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[1],
-            containerIds[1], partitionId, false), new BlobId(TestUtils.getRandomElement(BlobId.getAllValidVersions()),
-            BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[2], containerIds[2], partitionId, false), new BlobId(
+            containerIds[1], partitionId, false, null), new BlobId(TestUtils.getRandomElement(BlobId.getAllValidVersions()),
+            BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[2], containerIds[2], partitionId, false, null), new BlobId(
             TestUtils.getRandomElement(BlobId.getAllValidVersions()), BlobId.BlobIdType.NATIVE, (byte) 0, accountIds[3],
-            containerIds[3], partitionId, false)};
+            containerIds[3], partitionId, false, null)};
     long[] blobSizes = {1024, 2048, 4096, 8192};
     long[] times = {SystemTime.getInstance().milliseconds(),
         SystemTime.getInstance().milliseconds() - 1,

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -221,7 +221,7 @@ public class RequestResponseTest {
     BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
         Utils.getRandomShort(TestUtils.RANDOM),
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
     byte[] userMetadata = new byte[50];
     TestUtils.RANDOM.nextBytes(userMetadata);
     int blobKeyLength = TestUtils.RANDOM.nextInt(4096);
@@ -286,7 +286,7 @@ public class RequestResponseTest {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
     ArrayList<BlobId> blobIdList = new ArrayList<BlobId>();
     blobIdList.add(id1);
     PartitionRequestInfo partitionRequestInfo1 = new PartitionRequestInfo(new MockPartitionId(), blobIdList);
@@ -355,7 +355,7 @@ public class RequestResponseTest {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
     short[] versions = new short[]{DeleteRequest.DELETE_REQUEST_VERSION_1, DeleteRequest.DELETE_REQUEST_VERSION_2};
     for (short version : versions) {
       long deletionTimeMs = Utils.getRandomLong(TestUtils.RANDOM, Long.MAX_VALUE);
@@ -402,7 +402,7 @@ public class RequestResponseTest {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
     List<ReplicaMetadataRequestInfo> replicaMetadataRequestInfoList = new ArrayList<ReplicaMetadataRequestInfo>();
     ReplicaMetadataRequestInfo replicaMetadataRequestInfo =
         new ReplicaMetadataRequestInfo(new MockPartitionId(), new MockFindToken(0, 1000), "localhost", "path");
@@ -590,7 +590,7 @@ public class RequestResponseTest {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
     short[] versions = new short[]{TtlUpdateRequest.TTL_UPDATE_REQUEST_VERSION_1};
     for (short version : versions) {
       TtlUpdateRequest ttlUpdateRequest =

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -221,7 +221,8 @@ public class RequestResponseTest {
     BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
         Utils.getRandomShort(TestUtils.RANDOM),
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
     byte[] userMetadata = new byte[50];
     TestUtils.RANDOM.nextBytes(userMetadata);
     int blobKeyLength = TestUtils.RANDOM.nextInt(4096);
@@ -286,7 +287,8 @@ public class RequestResponseTest {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
     ArrayList<BlobId> blobIdList = new ArrayList<BlobId>();
     blobIdList.add(id1);
     PartitionRequestInfo partitionRequestInfo1 = new PartitionRequestInfo(new MockPartitionId(), blobIdList);
@@ -355,7 +357,8 @@ public class RequestResponseTest {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
     short[] versions = new short[]{DeleteRequest.DELETE_REQUEST_VERSION_1, DeleteRequest.DELETE_REQUEST_VERSION_2};
     for (short version : versions) {
       long deletionTimeMs = Utils.getRandomLong(TestUtils.RANDOM, Long.MAX_VALUE);
@@ -402,7 +405,8 @@ public class RequestResponseTest {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
     List<ReplicaMetadataRequestInfo> replicaMetadataRequestInfoList = new ArrayList<ReplicaMetadataRequestInfo>();
     ReplicaMetadataRequestInfo replicaMetadataRequestInfo =
         new ReplicaMetadataRequestInfo(new MockPartitionId(), new MockFindToken(0, 1000), "localhost", "path");
@@ -590,7 +594,8 @@ public class RequestResponseTest {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobId id1 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
+        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
     short[] versions = new short[]{TtlUpdateRequest.TTL_UPDATE_REQUEST_VERSION_1};
     for (short version : versions) {
       TtlUpdateRequest ttlUpdateRequest =

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -327,7 +327,7 @@ public class ReplicationTest {
       // add an expired message to the remote host only
       StoreKey id =
           new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId,
-              containerId, partitionId, toEncrypt);
+              containerId, partitionId, toEncrypt, null);
       Pair<ByteBuffer, MessageInfo> putMsgInfo = getPutMessage(id, accountId, containerId, toEncrypt);
       remoteHost.addMessage(partitionId,
           new MessageInfo(id, putMsgInfo.getFirst().remaining(), 1, accountId, containerId,
@@ -342,7 +342,7 @@ public class ReplicationTest {
       toEncrypt = TestUtils.RANDOM.nextBoolean();
       // add a corrupt message to the remote host only
       id = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId,
-          containerId, partitionId, toEncrypt);
+          containerId, partitionId, toEncrypt, null);
       putMsgInfo = getPutMessage(id, accountId, containerId, toEncrypt);
       byte[] data = putMsgInfo.getFirst().array();
       // flip every bit in the array
@@ -590,7 +590,7 @@ public class ReplicationTest {
       short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
       boolean toEncrypt = i % 2 == 0;
       BlobId id = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId,
-          containerId, partitionId, toEncrypt);
+          containerId, partitionId, toEncrypt, null);
       ids.add(id);
       Pair<ByteBuffer, MessageInfo> putMsgInfo = getPutMessage(id, accountId, containerId, toEncrypt);
       for (Host host : hosts) {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -327,7 +327,7 @@ public class ReplicationTest {
       // add an expired message to the remote host only
       StoreKey id =
           new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId,
-              containerId, partitionId, toEncrypt, null);
+              containerId, partitionId, toEncrypt, BlobId.BlobDataType.DATACHUNK);
       Pair<ByteBuffer, MessageInfo> putMsgInfo = getPutMessage(id, accountId, containerId, toEncrypt);
       remoteHost.addMessage(partitionId,
           new MessageInfo(id, putMsgInfo.getFirst().remaining(), 1, accountId, containerId,
@@ -342,7 +342,7 @@ public class ReplicationTest {
       toEncrypt = TestUtils.RANDOM.nextBoolean();
       // add a corrupt message to the remote host only
       id = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId,
-          containerId, partitionId, toEncrypt, null);
+          containerId, partitionId, toEncrypt, BlobId.BlobDataType.DATACHUNK);
       putMsgInfo = getPutMessage(id, accountId, containerId, toEncrypt);
       byte[] data = putMsgInfo.getFirst().array();
       // flip every bit in the array
@@ -590,7 +590,7 @@ public class ReplicationTest {
       short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
       boolean toEncrypt = i % 2 == 0;
       BlobId id = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId,
-          containerId, partitionId, toEncrypt, null);
+          containerId, partitionId, toEncrypt, BlobId.BlobDataType.DATACHUNK);
       ids.add(id);
       Pair<ByteBuffer, MessageInfo> putMsgInfo = getPutMessage(id, accountId, containerId, toEncrypt);
       for (Host host : hosts) {

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -887,7 +887,7 @@ class PutOperation {
         BlobDataType blobDataType = null;
         if (isMetadataChunk()) {
           blobDataType = BlobDataType.METADATA;
-        } else if (this.chunkIndex == 0) {
+        } else if (chunkIndex == 0) {
           // TODO: need more data to distinguish between Simple and Data Chunk
           blobDataType = BlobDataType.DATACHUNK;
         } else {

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -886,16 +886,10 @@ class PutOperation {
         // Determine data type to set
         BlobDataType blobDataType = null;
         if (isMetadataChunk()) {
-          blobDataType = BlobDataType.COMPOSITE;
+          blobDataType = BlobDataType.METADATA;
         } else if (this.chunkIndex == 0) {
-          if (chunkFillingCompletedSuccessfully) {
-            // Note: this variable can be true even if additional chunks are filled!
-            //blobDataType = BlobDataType.SIMPLE;
-            blobDataType = BlobDataType.DATACHUNK;
-          } else {
-            // TODO: need more data to distinguish between Simple and Data Chunk
-            blobDataType = BlobDataType.DATACHUNK;
-          }
+          // TODO: need more data to distinguish between Simple and Data Chunk
+          blobDataType = BlobDataType.DATACHUNK;
         } else {
           blobDataType = BlobDataType.DATACHUNK;
         }

--- a/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
@@ -542,7 +542,8 @@ public class CryptoJobHandlerTest {
     BlobId.BlobIdType type = TestUtils.RANDOM.nextBoolean() ? BlobId.BlobIdType.NATIVE : BlobId.BlobIdType.CRAFTED;
     return new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), type, dc, getRandomShort(TestUtils.RANDOM),
         getRandomShort(TestUtils.RANDOM),
-        referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
+        referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
@@ -542,7 +542,7 @@ public class CryptoJobHandlerTest {
     BlobId.BlobIdType type = TestUtils.RANDOM.nextBoolean() ? BlobId.BlobIdType.NATIVE : BlobId.BlobIdType.CRAFTED;
     return new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), type, dc, getRandomShort(TestUtils.RANDOM),
         getRandomShort(TestUtils.RANDOM),
-        referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
+        referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -106,7 +106,7 @@ public class DeleteManagerTest {
     partition = mockPartitions.get(ThreadLocalRandom.current().nextInt(mockPartitions.size()));
     blobId =
         new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), partition, false);
+            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), partition, false, null);
     blobIdString = blobId.getID();
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -106,7 +106,8 @@ public class DeleteManagerTest {
     partition = mockPartitions.get(ThreadLocalRandom.current().nextInt(mockPartitions.size()));
     blobId =
         new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), partition, false, null);
+            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), partition, false,
+            BlobId.BlobDataType.DATACHUNK);
     blobIdString = blobId.getID();
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -200,7 +200,8 @@ public class GetBlobInfoOperationTest {
   public void testInstantiation() {
     BlobId blobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(random), Utils.getRandomShort(random),
-        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
+        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
     Callback<GetBlobResultInternal> getOperationCallback = (result, exception) -> {
       // no op.
     };

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -200,7 +200,7 @@ public class GetBlobInfoOperationTest {
   public void testInstantiation() {
     BlobId blobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(random), Utils.getRandomShort(random),
-        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
+        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
     Callback<GetBlobResultInternal> getOperationCallback = (result, exception) -> {
       // no op.
     };

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -239,7 +239,8 @@ public class GetBlobOperationTest {
     blobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         mockClusterMap.getLocalDatacenterId(), Utils.getRandomShort(TestUtils.RANDOM),
         Utils.getRandomShort(TestUtils.RANDOM),
-        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
+        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        BlobId.BlobDataType.DATACHUNK);
     blobIdStr = blobId.getID();
     // test a good case
     // operationCount is not incremented here as this operation is not taken to completion.

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -239,7 +239,7 @@ public class GetBlobOperationTest {
     blobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
         mockClusterMap.getLocalDatacenterId(), Utils.getRandomShort(TestUtils.RANDOM),
         Utils.getRandomShort(TestUtils.RANDOM),
-        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false);
+        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false, null);
     blobIdStr = blobId.getID();
     // test a good case
     // operationCount is not incremented here as this operation is not taken to completion.

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
@@ -391,7 +391,7 @@ class InMemoryBlobPoster implements Runnable {
     try {
       String blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
           postData.getBlobProperties().getAccountId(), postData.getBlobProperties().getContainerId(),
-          getPartitionForPut(), false, null).getID();
+          getPartitionForPut(), false, BlobId.BlobDataType.DATACHUNK).getID();
       if (blobs.containsKey(blobId)) {
         exception = new RouterException("Blob ID duplicate created.", RouterErrorCode.UnexpectedInternalError);
       }

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
@@ -391,7 +391,7 @@ class InMemoryBlobPoster implements Runnable {
     try {
       String blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
           postData.getBlobProperties().getAccountId(), postData.getBlobProperties().getContainerId(),
-          getPartitionForPut(), false).getID();
+          getPartitionForPut(), false, null).getID();
       if (blobs.containsKey(blobId)) {
         exception = new RouterException("Blob ID duplicate created.", RouterErrorCode.UnexpectedInternalError);
       }

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -878,7 +878,7 @@ public class PutManagerTest {
 
     if (request.getBlobType() == BlobType.MetadataBlob) {
       notificationBlobType = NotificationBlobType.Composite;
-      assertEquals("Expected composite", BlobDataType.COMPOSITE, origBlobId.getBlobDataType());
+      assertEquals("Expected metadata", BlobDataType.METADATA, origBlobId.getBlobDataType());
       byte[] data = Utils.readBytesFromStream(request.getBlobStream(), (int) request.getBlobSize());
       CompositeBlobInfo compositeBlobInfo = MetadataContentSerDe.deserializeMetadataContentRecord(ByteBuffer.wrap(data),
           new BlobIdFactory(mockClusterMap));

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.BlobId.BlobDataType;
 import com.github.ambry.commons.BlobIdFactory;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
@@ -873,8 +874,11 @@ public class PutManagerTest {
     ByteBuffer serializedRequest = serializedRequests.get(blobId);
     PutRequest.ReceivedPutRequest request = deserializePutRequest(serializedRequest);
     NotificationBlobType notificationBlobType;
+    BlobId origBlobId = new BlobId(blobId, mockClusterMap);
+
     if (request.getBlobType() == BlobType.MetadataBlob) {
       notificationBlobType = NotificationBlobType.Composite;
+      assertEquals("Expected composite", BlobDataType.COMPOSITE, origBlobId.getBlobDataType());
       byte[] data = Utils.readBytesFromStream(request.getBlobStream(), (int) request.getBlobSize());
       CompositeBlobInfo compositeBlobInfo = MetadataContentSerDe.deserializeMetadataContentRecord(ByteBuffer.wrap(data),
           new BlobIdFactory(mockClusterMap));
@@ -883,10 +887,14 @@ public class PutManagerTest {
       List<StoreKey> dataBlobIds = compositeBlobInfo.getKeys();
       assertEquals("Number of chunks is not as expected",
           RouterUtils.getNumChunksForBlobAndChunkSize(originalPutContent.length, chunkSize), dataBlobIds.size());
+      // Verify all dataBlobIds are DataChunk
+      for (StoreKey key: dataBlobIds) {
+        BlobId origDataBlobId = (BlobId) key;
+        assertEquals("Expected datachunk", BlobDataType.DATACHUNK, origDataBlobId.getBlobDataType());
+      }
       // verify user-metadata
       if (properties.isEncrypted()) {
         ByteBuffer userMetadata = request.getUsermetadata();
-        BlobId origBlobId = new BlobId(blobId, mockClusterMap);
         // reason to directly call run() instead of spinning up a thread instead of calling start() is that, any exceptions or
         // assertion failures in non main thread will not fail the test.
         new DecryptJob(origBlobId, request.getBlobEncryptionKey().duplicate(), null, userMetadata, cryptoService, kms,
@@ -903,6 +911,11 @@ public class PutManagerTest {
           serializedRequests);
     } else {
       notificationBlobType = NotificationBlobType.Simple;
+      // TODO: Currently, we don't have the logic to distinguish Simple vs DataChunk for the first chunk
+      // Once the logic is fixed we should assert Simple.
+      BlobDataType dataType = origBlobId.getBlobDataType();
+      assertTrue("Invalid blob data type", dataType == BlobDataType.DATACHUNK || dataType == BlobDataType.SIMPLE);
+
       byte[] content = Utils.readBytesFromStream(request.getBlobStream(), (int) request.getBlobSize());
       if (!properties.isEncrypted()) {
         Assert.assertArrayEquals("Input blob and written blob should be the same", originalPutContent, content);
@@ -911,7 +924,6 @@ public class PutManagerTest {
         notificationSystem.verifyNotification(blobId, notificationBlobType, request.getBlobProperties());
       } else {
         ByteBuffer userMetadata = request.getUsermetadata();
-        BlobId origBlobId = new BlobId(blobId, mockClusterMap);
         // reason to directly call run() instead of spinning up a thread instead of calling start() is that, any exceptions or
         // assertion failures in non main thread will not fail the test.
         new DecryptJob(origBlobId, request.getBlobEncryptionKey().duplicate(), ByteBuffer.wrap(content), userMetadata,

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
@@ -42,7 +42,7 @@ public class RouterUtilsTest {
     partition = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         clusterMap.getLocalDatacenterId(), Utils.getRandomShort(random), Utils.getRandomShort(random), partition,
-        false, null);
+        false, BlobId.BlobDataType.DATACHUNK);
     blobIdStr = originalBlobId.getID();
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
@@ -42,7 +42,7 @@ public class RouterUtilsTest {
     partition = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         clusterMap.getLocalDatacenterId(), Utils.getRandomShort(random), Utils.getRandomShort(random), partition,
-        false);
+        false, null);
     blobIdStr = originalBlobId.getID();
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
@@ -56,7 +56,7 @@ class DirectSender implements Runnable {
       int partitionIndex = new Random().nextInt(partitionIds.size());
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           clusterMap.getLocalDatacenterId(), blobProperties.getAccountId(), blobProperties.getContainerId(),
-          partitionIds.get(partitionIndex), false);
+          partitionIds.get(partitionIndex), false, null);
       blobIds.add(blobId);
     }
     this.data = data;

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
@@ -56,7 +56,7 @@ class DirectSender implements Runnable {
       int partitionIndex = new Random().nextInt(partitionIds.size());
       BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           clusterMap.getLocalDatacenterId(), blobProperties.getAccountId(), blobProperties.getContainerId(),
-          partitionIds.get(partitionIndex), false, null);
+          partitionIds.get(partitionIndex), false, BlobId.BlobDataType.DATACHUNK);
       blobIds.add(blobId);
     }
     this.data = data;

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -271,7 +271,7 @@ public class ServerHardDeleteTest {
     for (int i = 0; i < 9; i++) {
       blobIdList.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           mockClusterMap.getLocalDatacenterId(), properties.get(i).getAccountId(), properties.get(i).getContainerId(),
-          chosenPartition, false, null));
+          chosenPartition, false, BlobId.BlobDataType.DATACHUNK));
     }
 
     BlockingChannel channel =

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -271,7 +271,7 @@ public class ServerHardDeleteTest {
     for (int i = 0; i < 9; i++) {
       blobIdList.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           mockClusterMap.getLocalDatacenterId(), properties.get(i).getAccountId(), properties.get(i).getContainerId(),
-          chosenPartition, false));
+          chosenPartition, false, null));
     }
 
     BlockingChannel channel =

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -125,15 +125,20 @@ public final class ServerTestUtil {
       List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
       short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
       BlobId blobId1 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false, null);
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId2 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false, null);
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId3 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false, null);
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId4 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false, null);
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false,
+          BlobId.BlobDataType.DATACHUNK);
       BlobId blobId5 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false, null);
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false,
+          BlobId.BlobDataType.DATACHUNK);
       // put blob 1
       PutRequest putRequest =
           new PutRequest(1, "client1", blobId1, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
@@ -351,7 +356,7 @@ public final class ServerTestUtil {
       partition = (MockPartitionId) clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
       ids.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           clusterMap.getLocalDatacenterId(), properties.getAccountId(), properties.getContainerId(), partition, false,
-          null));
+          BlobId.BlobDataType.DATACHUNK));
       partitionRequestInfoList.clear();
       partitionRequestInfo = new PartitionRequestInfo(partition, ids);
       partitionRequestInfoList.add(partitionRequestInfo);
@@ -1203,7 +1208,7 @@ public final class ServerTestUtil {
     byte[] data = new byte[3187];
     BlobProperties properties = new BlobProperties(3187, "serviceid1", accountId, containerId, false);
     BlobId blobId2 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        clusterMap.getLocalDatacenterId(), accountId, containerId, partitionId, false, null);
+        clusterMap.getLocalDatacenterId(), accountId, containerId, partitionId, false, BlobId.BlobDataType.DATACHUNK);
     PutRequest putRequest2 =
         new PutRequest(1, "clientId2", blobId2, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
             properties.getBlobSize(), BlobType.DataBlob, null);
@@ -1311,7 +1316,7 @@ public final class ServerTestUtil {
         short containerId = Utils.getRandomShort(TestUtils.RANDOM);
         propertyList.add(new BlobProperties(1000, "serviceid1", accountId, containerId, testEncryption));
         blobIdList.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-            clusterMap.getLocalDatacenterId(), accountId, containerId, partition, false, null));
+            clusterMap.getLocalDatacenterId(), accountId, containerId, partition, false, BlobId.BlobDataType.DATACHUNK));
         dataList.add(TestUtils.getRandomBytes(1000));
         if (testEncryption) {
           encryptionKeyList.add(TestUtils.getRandomBytes(128));
@@ -1544,7 +1549,7 @@ public final class ServerTestUtil {
           (MockPartitionId) clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
       ids.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           clusterMap.getLocalDatacenterId(), propertyList.get(0).getAccountId(), propertyList.get(0).getContainerId(),
-          mockPartitionId, false, null));
+          mockPartitionId, false, BlobId.BlobDataType.DATACHUNK));
       partitionRequestInfoList.clear();
       partitionRequestInfo = new PartitionRequestInfo(mockPartitionId, ids);
       partitionRequestInfoList.add(partitionRequestInfo);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -125,15 +125,15 @@ public final class ServerTestUtil {
       List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
       short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
       BlobId blobId1 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false);
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false, null);
       BlobId blobId2 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false);
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false, null);
       BlobId blobId3 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false);
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false, null);
       BlobId blobId4 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false);
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false, null);
       BlobId blobId5 = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false);
+          properties.getAccountId(), properties.getContainerId(), partitionIds.get(0), false, null);
       // put blob 1
       PutRequest putRequest =
           new PutRequest(1, "client1", blobId1, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
@@ -350,7 +350,8 @@ public final class ServerTestUtil {
       ids = new ArrayList<BlobId>();
       partition = (MockPartitionId) clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
       ids.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-          clusterMap.getLocalDatacenterId(), properties.getAccountId(), properties.getContainerId(), partition, false));
+          clusterMap.getLocalDatacenterId(), properties.getAccountId(), properties.getContainerId(), partition, false,
+          null));
       partitionRequestInfoList.clear();
       partitionRequestInfo = new PartitionRequestInfo(partition, ids);
       partitionRequestInfoList.add(partitionRequestInfo);
@@ -1202,7 +1203,7 @@ public final class ServerTestUtil {
     byte[] data = new byte[3187];
     BlobProperties properties = new BlobProperties(3187, "serviceid1", accountId, containerId, false);
     BlobId blobId2 = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-        clusterMap.getLocalDatacenterId(), accountId, containerId, partitionId, false);
+        clusterMap.getLocalDatacenterId(), accountId, containerId, partitionId, false, null);
     PutRequest putRequest2 =
         new PutRequest(1, "clientId2", blobId2, properties, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
             properties.getBlobSize(), BlobType.DataBlob, null);
@@ -1310,7 +1311,7 @@ public final class ServerTestUtil {
         short containerId = Utils.getRandomShort(TestUtils.RANDOM);
         propertyList.add(new BlobProperties(1000, "serviceid1", accountId, containerId, testEncryption));
         blobIdList.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-            clusterMap.getLocalDatacenterId(), accountId, containerId, partition, false));
+            clusterMap.getLocalDatacenterId(), accountId, containerId, partition, false, null));
         dataList.add(TestUtils.getRandomBytes(1000));
         if (testEncryption) {
           encryptionKeyList.add(TestUtils.getRandomBytes(128));
@@ -1543,7 +1544,7 @@ public final class ServerTestUtil {
           (MockPartitionId) clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
       ids.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           clusterMap.getLocalDatacenterId(), propertyList.get(0).getAccountId(), propertyList.get(0).getContainerId(),
-          mockPartitionId, false));
+          mockPartitionId, false, null));
       partitionRequestInfoList.clear();
       partitionRequestInfo = new PartitionRequestInfo(mockPartitionId, ids);
       partitionRequestInfoList.add(partitionRequestInfo);

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -553,10 +553,10 @@ public class AmbryRequestsTest {
     for (int i = 0; i < 10; i++) {
       BlobId originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-          Utils.getRandomShort(TestUtils.RANDOM), partitionId, false);
+          Utils.getRandomShort(TestUtils.RANDOM), partitionId, false, null);
       BlobId convertedBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.CRAFTED,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, originalBlobId.getAccountId(), originalBlobId.getContainerId(),
-          partitionId, false);
+          partitionId, false, null);
       conversionMap.put(originalBlobId, convertedBlobId);
       validKeysInStore.add(convertedBlobId);
       blobIds.add(originalBlobId);
@@ -566,7 +566,7 @@ public class AmbryRequestsTest {
     // Check a valid key mapped to null
     BlobId originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM), partitionId, false);
+        Utils.getRandomShort(TestUtils.RANDOM), partitionId, false, null);
     blobIds.add(originalBlobId);
     conversionMap.put(originalBlobId, null);
     validKeysInStore.add(originalBlobId);
@@ -575,7 +575,7 @@ public class AmbryRequestsTest {
     // Check a invalid key mapped to null
     originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM), partitionId, false);
+        Utils.getRandomShort(TestUtils.RANDOM), partitionId, false, null);
     blobIds.add(originalBlobId);
     conversionMap.put(originalBlobId, null);
     sendAndVerifyGetOriginalStoreKeys(blobIds, ServerErrorCode.Blob_Not_Found);
@@ -722,10 +722,10 @@ public class AmbryRequestsTest {
       String clientId = UtilsTest.getRandomString(10);
       BlobId originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-          Utils.getRandomShort(TestUtils.RANDOM), id, false);
+          Utils.getRandomShort(TestUtils.RANDOM), id, false, null);
       BlobId convertedBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.CRAFTED,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, originalBlobId.getAccountId(), originalBlobId.getContainerId(), id,
-          false);
+          false, null);
       conversionMap.put(originalBlobId, convertedBlobId);
       validKeysInStore.add(convertedBlobId);
       RequestOrResponse request;

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -553,10 +553,10 @@ public class AmbryRequestsTest {
     for (int i = 0; i < 10; i++) {
       BlobId originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-          Utils.getRandomShort(TestUtils.RANDOM), partitionId, false, null);
+          Utils.getRandomShort(TestUtils.RANDOM), partitionId, false, BlobId.BlobDataType.DATACHUNK);
       BlobId convertedBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.CRAFTED,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, originalBlobId.getAccountId(), originalBlobId.getContainerId(),
-          partitionId, false, null);
+          partitionId, false, BlobId.BlobDataType.DATACHUNK);
       conversionMap.put(originalBlobId, convertedBlobId);
       validKeysInStore.add(convertedBlobId);
       blobIds.add(originalBlobId);
@@ -566,7 +566,7 @@ public class AmbryRequestsTest {
     // Check a valid key mapped to null
     BlobId originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM), partitionId, false, null);
+        Utils.getRandomShort(TestUtils.RANDOM), partitionId, false, BlobId.BlobDataType.DATACHUNK);
     blobIds.add(originalBlobId);
     conversionMap.put(originalBlobId, null);
     validKeysInStore.add(originalBlobId);
@@ -575,7 +575,7 @@ public class AmbryRequestsTest {
     // Check a invalid key mapped to null
     originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-        Utils.getRandomShort(TestUtils.RANDOM), partitionId, false, null);
+        Utils.getRandomShort(TestUtils.RANDOM), partitionId, false, BlobId.BlobDataType.DATACHUNK);
     blobIds.add(originalBlobId);
     conversionMap.put(originalBlobId, null);
     sendAndVerifyGetOriginalStoreKeys(blobIds, ServerErrorCode.Blob_Not_Found);
@@ -722,10 +722,10 @@ public class AmbryRequestsTest {
       String clientId = UtilsTest.getRandomString(10);
       BlobId originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, Utils.getRandomShort(TestUtils.RANDOM),
-          Utils.getRandomShort(TestUtils.RANDOM), id, false, null);
+          Utils.getRandomShort(TestUtils.RANDOM), id, false, BlobId.BlobDataType.DATACHUNK);
       BlobId convertedBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.CRAFTED,
           ClusterMapUtils.UNKNOWN_DATACENTER_ID, originalBlobId.getAccountId(), originalBlobId.getContainerId(), id,
-          false, null);
+          false, BlobId.BlobDataType.DATACHUNK);
       conversionMap.put(originalBlobId, convertedBlobId);
       validKeysInStore.add(convertedBlobId);
       RequestOrResponse request;

--- a/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
@@ -227,7 +227,7 @@ public class IndexWritePerformance {
           PartitionId partition = map.getWritablePartitionIds(null).get(0);
           indexesWithMetrics.get(indexToUse)
               .addToIndexRandomData(new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, map.getLocalDatacenterId(),
-                  Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partition, false));
+                  Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partition, false, null));
           throttler.maybeThrottle(1);
         }
       } catch (Exception e) {

--- a/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/IndexWritePerformance.java
@@ -227,7 +227,8 @@ public class IndexWritePerformance {
           PartitionId partition = map.getWritablePartitionIds(null).get(0);
           indexesWithMetrics.get(indexToUse)
               .addToIndexRandomData(new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, map.getLocalDatacenterId(),
-                  Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partition, false, null));
+                  Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partition, false,
+                  BlobId.BlobDataType.DATACHUNK));
           throttler.maybeThrottle(1);
         }
       } catch (Exception e) {

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
@@ -161,7 +161,7 @@ public class DirectoryUploader {
         try {
           int replicaCount = 0;
           BlobId blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, datacenterId, props.getAccountId(),
-              props.getContainerId(), partitionId, false);
+              props.getContainerId(), partitionId, false, null);
           List<ReplicaId> successList = new ArrayList<>();
           List<ReplicaId> failureList = new ArrayList<>();
           for (ReplicaId replicaId : blobId.getPartition().getReplicaIds()) {

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/DirectoryUploader.java
@@ -161,7 +161,7 @@ public class DirectoryUploader {
         try {
           int replicaCount = 0;
           BlobId blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, datacenterId, props.getAccountId(),
-              props.getContainerId(), partitionId, false, null);
+              props.getContainerId(), partitionId, false, BlobId.BlobDataType.DATACHUNK);
           List<ReplicaId> successList = new ArrayList<>();
           List<ReplicaId> failureList = new ArrayList<>();
           for (ReplicaId replicaId : blobId.getPartition().getReplicaIds()) {

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
@@ -350,7 +350,7 @@ public class ServerWritePerformance {
             int index = (int) getRandomLong(rand, partitionIds.size());
             PartitionId partitionId = partitionIds.get(index);
             BlobId blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-                props.getAccountId(), props.getContainerId(), partitionId, false, null);
+                props.getAccountId(), props.getContainerId(), partitionId, false, BlobId.BlobDataType.DATACHUNK);
             PutRequest putRequest =
                 new PutRequest(0, "perf", blobId, props, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(blob),
                     props.getBlobSize(), BlobType.DataBlob, null);

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/ServerWritePerformance.java
@@ -350,7 +350,7 @@ public class ServerWritePerformance {
             int index = (int) getRandomLong(rand, partitionIds.size());
             PartitionId partitionId = partitionIds.get(index);
             BlobId blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-                props.getAccountId(), props.getContainerId(), partitionId, false);
+                props.getAccountId(), props.getContainerId(), partitionId, false, null);
             PutRequest putRequest =
                 new PutRequest(0, "perf", blobId, props, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(blob),
                     props.getBlobSize(), BlobType.DataBlob, null);


### PR DESCRIPTION
Fixes #940.
Two bits in flag used for data type values {SIMPLE, COMPOSITE, DATACHUNK}.
At this stage, all non-composite blobs are tagged as DATACHUNK as I encountered issues distinguishing between SIMPLE and DATACHUNK.
Issue #971 was raised to track the remaining work.