### PR TITLE
Providing a configuration for keeping the index in memory

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -239,6 +239,14 @@ public class StoreConfig {
   public final int storeTtlUpdateBufferTimeSeconds;
   public static final String storeTtlUpdateBufferTimeSecondsName = "store.ttl.update.buffer.time.seconds";
 
+  /**
+   * Specifies whether all index segments should be kept in memory (as opposed to a specific subset).
+   */
+  @Config(storeKeepIndexInMemoryName)
+  @Default("false")
+  public final boolean storeKeepIndexInMemory;
+  public static final String storeKeepIndexInMemoryName = "store.keep.index.in.memory";
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -290,6 +298,7 @@ public class StoreConfig {
     storeValidateAuthorization = verifiableProperties.getBoolean("store.validate.authorization", false);
     storeTtlUpdateBufferTimeSeconds =
         verifiableProperties.getIntInRange(storeTtlUpdateBufferTimeSecondsName, 60 * 60 * 24, 0, Integer.MAX_VALUE);
+    storeKeepIndexInMemory = verifiableProperties.getBoolean(storeKeepIndexInMemoryName, false);
   }
 }
 

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -138,9 +138,9 @@ public class BlobId extends StoreKey {
 
   private final short version;
   private final BlobIdType type;
-  private final Byte datacenterId;
-  private final Short accountId;
-  private final Short containerId;
+  private final byte datacenterId;
+  private final short accountId;
+  private final short containerId;
   private final PartitionId partitionId;
   private final String uuid;
   private final boolean isEncrypted;
@@ -515,11 +515,11 @@ public class BlobId extends StoreKey {
         case BLOB_ID_V2:
           result = type.compareTo(other.type);
           if (result == 0) {
-            result = datacenterId.compareTo(other.datacenterId);
+            result = Byte.compare(datacenterId, other.datacenterId);
             if (result == 0) {
-              result = accountId.compareTo(other.accountId);
+              result = Short.compare(accountId, other.accountId);
               if (result == 0) {
-                result = containerId.compareTo(other.containerId);
+                result = Short.compare(containerId, other.containerId);
                 if (result == 0) {
                   result = partitionId.compareTo(other.partitionId);
                   if (result == 0) {

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
@@ -386,7 +386,7 @@ class BlobStoreCompactor {
     tgtLog.close();
     // persist the bloom of the "latest" index segment if it exists
     if (numSwapsUsed > 0) {
-      tgtIndex.getIndexSegments().lastEntry().getValue().map(true);
+      tgtIndex.getIndexSegments().lastEntry().getValue().seal();
     } else {
       // there were no valid entries copied, return any temp segments back to the pool
       logger.trace("Cleaning up temp segments in {} because no swap spaces were used", storeId);

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -188,11 +188,11 @@ class PersistentIndex {
     try {
       journal.startBootstrap();
       for (int i = 0; i < indexFiles.size(); i++) {
-        // We mark as immutable all the index segments except the most recent index segment.
+        // We mark as sealed all the index segments except the most recent index segment.
         // The recent index segment would go through recovery after they have been
         // read into memory
-        boolean immutable = i < indexFiles.size() - 1;
-        IndexSegment info = new IndexSegment(indexFiles.get(i), immutable, factory, config, metrics, journal, time);
+        boolean sealed = i < indexFiles.size() - 1;
+        IndexSegment info = new IndexSegment(indexFiles.get(i), sealed, factory, config, metrics, journal, time);
         logger.info("Index : {} loaded index segment {} with start offset {} and end offset {} ", datadir,
             indexFiles.get(i), info.getStartOffset(), info.getEndOffset());
         validIndexSegments.put(info.getStartOffset(), info);
@@ -1637,7 +1637,7 @@ class PersistentIndex {
           IndexSegment prevInfo = prevEntry != null ? prevEntry.getValue() : null;
           List<IndexSegment> prevInfosToWrite = new ArrayList<>();
           Offset currentLogEndPointer = log.getEndOffset();
-          while (prevInfo != null && !prevInfo.isImmutable()) {
+          while (prevInfo != null && !prevInfo.isSealed()) {
             if (prevInfo.getEndOffset().compareTo(currentLogEndPointer) > 0) {
               String message = "The read only index cannot have a file end pointer " + prevInfo.getEndOffset()
                   + " greater than the log end offset " + currentLogEndPointer;

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -188,11 +188,11 @@ class PersistentIndex {
     try {
       journal.startBootstrap();
       for (int i = 0; i < indexFiles.size(); i++) {
-        // We map all the index segments except the most recent index segment.
+        // We mark as immutable all the index segments except the most recent index segment.
         // The recent index segment would go through recovery after they have been
         // read into memory
-        boolean map = i < indexFiles.size() - 1;
-        IndexSegment info = new IndexSegment(indexFiles.get(i), map, factory, config, metrics, journal, time);
+        boolean immutable = i < indexFiles.size() - 1;
+        IndexSegment info = new IndexSegment(indexFiles.get(i), immutable, factory, config, metrics, journal, time);
         logger.info("Index : {} loaded index segment {} with start offset {} and end offset {} ", datadir,
             indexFiles.get(i), info.getStartOffset(), info.getEndOffset());
         validIndexSegments.put(info.getStartOffset(), info);
@@ -1637,7 +1637,7 @@ class PersistentIndex {
           IndexSegment prevInfo = prevEntry != null ? prevEntry.getValue() : null;
           List<IndexSegment> prevInfosToWrite = new ArrayList<>();
           Offset currentLogEndPointer = log.getEndOffset();
-          while (prevInfo != null && !prevInfo.isMapped()) {
+          while (prevInfo != null && !prevInfo.isImmutable()) {
             if (prevInfo.getEndOffset().compareTo(currentLogEndPointer) > 0) {
               String message = "The read only index cannot have a file end pointer " + prevInfo.getEndOffset()
                   + " greater than the log end offset " + currentLogEndPointer;
@@ -1651,7 +1651,7 @@ class PersistentIndex {
             IndexSegment toWrite = prevInfosToWrite.get(i);
             logger.trace("Index : {} writing prev index with end offset {}", dataDir, toWrite.getEndOffset());
             toWrite.writeIndexSegmentToFile(toWrite.getEndOffset());
-            toWrite.map(true);
+            toWrite.seal();
           }
           currentInfo.writeIndexSegmentToFile(indexEndOffsetBeforeFlush);
         }

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -54,7 +54,7 @@ public class StoreMetrics {
   public final Timer hardDeleteTime;
   public final Counter putEntryDeletedInfoMismatchCount;
   public final Counter nonzeroMessageRecovery;
-  public final Counter blobFoundInActiveSegmentCount;
+  public final Counter blobFoundInMemSegmentCount;
   public final Counter bloomAccessedCount;
   public final Counter bloomPositiveCount;
   public final Counter bloomFalsePositiveCount;
@@ -132,8 +132,8 @@ public class StoreMetrics {
         registry.counter(MetricRegistry.name(PersistentIndex.class, name + "PutEntryDeletedInfoMismatchCount"));
     nonzeroMessageRecovery =
         registry.counter(MetricRegistry.name(PersistentIndex.class, name + "NonZeroMessageRecovery"));
-    blobFoundInActiveSegmentCount =
-        registry.counter(MetricRegistry.name(IndexSegment.class, name + "BlobFoundInActiveSegmentCount"));
+    blobFoundInMemSegmentCount =
+        registry.counter(MetricRegistry.name(IndexSegment.class, name + "BlobFoundInMemSegmentCount"));
     bloomAccessedCount = registry.counter(MetricRegistry.name(IndexSegment.class, name + "BloomAccessedCount"));
     bloomPositiveCount = registry.counter(MetricRegistry.name(IndexSegment.class, name + "BloomPositiveCount"));
     bloomFalsePositiveCount =

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
@@ -1424,8 +1424,8 @@ public class BlobStoreCompactorTest {
       Offset indexSegmentStartOffset = indexSegmentEntry.getKey();
       assertTrue("Index segment does not refer to any active log segments",
           allSegmentNames.contains(indexSegmentEntry.getKey().getName()));
-      assertEquals("Index segment mapped state not as expected",
-          !indexSegmentStartOffset.equals(lastIndexSegmentStartOffset), indexSegmentEntry.getValue().isMapped());
+      assertEquals("Index segment mutable state not as expected",
+          !indexSegmentStartOffset.equals(lastIndexSegmentStartOffset), indexSegmentEntry.getValue().isImmutable());
     }
     // verify sanity of compacted index
     state.verifyRealIndexSanity();

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
@@ -1424,8 +1424,8 @@ public class BlobStoreCompactorTest {
       Offset indexSegmentStartOffset = indexSegmentEntry.getKey();
       assertTrue("Index segment does not refer to any active log segments",
           allSegmentNames.contains(indexSegmentEntry.getKey().getName()));
-      assertEquals("Index segment mutable state not as expected",
-          !indexSegmentStartOffset.equals(lastIndexSegmentStartOffset), indexSegmentEntry.getValue().isImmutable());
+      assertEquals("Index segment sealed state not as expected",
+          !indexSegmentStartOffset.equals(lastIndexSegmentStartOffset), indexSegmentEntry.getValue().isSealed());
     }
     // verify sanity of compacted index
     state.verifyRealIndexSanity();


### PR DESCRIPTION
Currently any sealed index segment is memory mapped. This commit separates the concept of a sealed `IndexSegment` and a memory mapped `IndexSegment` to allow for experimenting with keeping the whole index in memory

(lower priority review for now)

Assuming a 0.1% index size to log size ratio, this will require about 1G of memory for 1T of data on disk.

Fixes #1036 