### PR TITLE
Introducing "Replica_Unavailable" as a new type of ServerErrorCode

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaEventType.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaEventType.java
@@ -17,5 +17,5 @@ package com.github.ambry.clustermap;
  * The response codes conveyed to the cluster map when there is a replica related event.
  */
 public enum ReplicaEventType {
-  Node_Response, Node_Timeout, Disk_Error, Disk_Ok, Partition_ReadOnly
+  Node_Response, Node_Timeout, Disk_Error, Disk_Ok, Partition_ReadOnly, Replica_Unavailable, Replica_Response
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaEventType.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaEventType.java
@@ -17,5 +17,38 @@ package com.github.ambry.clustermap;
  * The response codes conveyed to the cluster map when there is a replica related event.
  */
 public enum ReplicaEventType {
-  Node_Response, Node_Timeout, Disk_Error, Disk_Ok, Partition_ReadOnly, Replica_Unavailable, Replica_Response
+  /**
+   * Node is up and responds in time.
+   */
+  Node_Response,
+
+  /**
+   * Node fails to respond before timeout and connection is lost.
+   */
+  Node_Timeout,
+
+  /**
+   * Disk is in bad state due to failures/errors.
+   */
+  Disk_Error,
+
+  /**
+   * Disk responds in time and is proper functioning.
+   */
+  Disk_Ok,
+
+  /**
+   * The partition which replica belongs to is in ReadOnly state.
+   */
+  Partition_ReadOnly,
+
+  /**
+   * The replica is unavailable because it is either stopped or unreachable.
+   */
+  Replica_Unavailable,
+
+  /**
+   * The replica responds in time and is available for requests.
+   */
+  Replica_Available
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -56,6 +56,20 @@ public class ClusterMapConfig {
   public final int clusterMapFixedTimeoutDiskRetryBackoffMs;
 
   /**
+   * The threshold for the number of errors to tolerate for a replica.
+   */
+  @Config("clustermap.fixedtimeout.replica.error.threshold")
+  @Default("1")
+  public final int clusterMapFixedTimeoutReplicaErrorThreshold;
+
+  /**
+   * The time to wait before a replica is retried after it has been determined to be down.
+   */
+  @Config("clustermap.fixedtimeout.replica.retry.backoff.ms")
+  @Default("10 * 60 * 1000")
+  public final int clusterMapFixedTimeoutReplicaRetryBackoffMs;
+
+  /**
    * List of Datacenters to which local node needs SSL encryption to communicate
    */
   @Config("clustermap.ssl.enabled.datacenters")
@@ -150,6 +164,11 @@ public class ClusterMapConfig {
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.disk.error.threshold", 1, 1, 100);
     clusterMapFixedTimeoutDiskRetryBackoffMs =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.disk.retry.backoff.ms", 10 * 60 * 1000, 1,
+            30 * 60 * 1000);
+    clusterMapFixedTimeoutReplicaErrorThreshold =
+        verifiableProperties.getIntInRange("clustermap.fixedtimeout.replica.error.threshold", 1, 1, 100);
+    clusterMapFixedTimeoutReplicaRetryBackoffMs =
+        verifiableProperties.getIntInRange("clustermap.fixedtimeout.replica.retry.backoff.ms", 10 * 60 * 1000, 1,
             30 * 60 * 1000);
     clusterMapSslEnabledDatacenters = verifiableProperties.getString("clustermap.ssl.enabled.datacenters", "");
     clusterMapClusterAgentsFactory = verifiableProperties.getString("clustermap.clusteragents.factory",

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
@@ -140,8 +140,7 @@ class AmbryDataNode implements DataNodeId {
       throw new IllegalStateException("Incompatible objects to compare");
     }
     AmbryDataNode other = (AmbryDataNode) o;
-    int compare = (plainTextPort.getPort() < other.plainTextPort.getPort()) ? -1
-        : ((plainTextPort.getPort() == other.plainTextPort.getPort()) ? 0 : 1);
+    int compare = Integer.compare(plainTextPort.getPort(), other.plainTextPort.getPort());
     if (compare == 0) {
       compare = hostName.compareTo(other.hostName);
     }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
@@ -17,6 +17,7 @@ import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.utils.Utils;
+import java.util.Comparator;
 import java.util.List;
 import java.util.TreeSet;
 import org.slf4j.Logger;
@@ -140,11 +141,8 @@ class AmbryDataNode implements DataNodeId {
       throw new IllegalStateException("Incompatible objects to compare");
     }
     AmbryDataNode other = (AmbryDataNode) o;
-    int compare = Integer.compare(plainTextPort.getPort(), other.plainTextPort.getPort());
-    if (compare == 0) {
-      compare = hostName.compareTo(other.hostName);
-    }
-    return compare;
+    return Comparator.comparingInt((AmbryDataNode k) -> k.plainTextPort.getPort()).
+        thenComparing(k -> k.hostName).compare(this, other);
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
@@ -116,7 +116,7 @@ class AmbryReplica implements ReplicaId, Resource {
 
   @Override
   public boolean isDown() {
-    return disk.getState() == HardwareState.UNAVAILABLE || isStopped;
+    return disk.getState() == HardwareState.UNAVAILABLE || resourceStatePolicy.isDown() || isStopped;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.clustermap;
 
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,26 +25,32 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
 /**
  * {@link ReplicaId} implementation to use within dynamic cluster managers.
  */
-class AmbryReplica implements ReplicaId {
+class AmbryReplica implements ReplicaId, Resource {
   private final AmbryPartition partition;
   private final AmbryDisk disk;
   private final long capacityBytes;
   private volatile boolean isSealed;
   private volatile boolean isStopped = false;
+  private final ResourceStatePolicy resourceStatePolicy;
 
   /**
    * Instantiate an AmbryReplica instance.
+   * @param clusterMapConfig the {@link ClusterMapConfig} to use.
    * @param partition the {@link AmbryPartition} of which this is a replica.
    * @param disk the {@link AmbryDisk} on which this replica resides.
    * @param capacityBytes the capacity in bytes for this replica.
    * @param isSealed whether this replica is in sealed state.
    */
-  AmbryReplica(AmbryPartition partition, AmbryDisk disk, long capacityBytes, boolean isSealed) {
+  AmbryReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, AmbryDisk disk, long capacityBytes,
+      boolean isSealed) throws Exception {
     this.partition = partition;
     this.disk = disk;
     this.capacityBytes = capacityBytes;
     this.isSealed = isSealed;
     validate();
+    ResourceStatePolicyFactory resourceStatePolicyFactory =
+        Utils.getObj(clusterMapConfig.clusterMapResourceStatePolicyFactory, this, disk.getState(), clusterMapConfig);
+    this.resourceStatePolicy = resourceStatePolicyFactory.getResourceStatePolicy();
   }
 
   /**
@@ -113,6 +121,20 @@ class AmbryReplica implements ReplicaId {
   @Override
   public String toString() {
     return "Replica[" + getDataNodeId().getHostname() + ":" + getDataNodeId().getPort() + ":" + getReplicaPath() + "]";
+  }
+
+  /**
+   * Take actions, if any, when this replica is unavailable.
+   */
+  void onReplicaUnavailable() {
+    resourceStatePolicy.onError();
+  }
+
+  /**
+   * Take actions, if any, when this replica is back in a good state.
+   */
+  void onReplicaResponse() {
+    resourceStatePolicy.onSuccess();
   }
 }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
@@ -30,7 +30,7 @@ class AmbryReplica implements ReplicaId, Resource {
   private final AmbryDisk disk;
   private final long capacityBytes;
   private volatile boolean isSealed;
-  private volatile boolean isStopped = false;
+  private volatile boolean isStopped;
   private final ResourceStatePolicy resourceStatePolicy;
 
   /**
@@ -41,15 +41,16 @@ class AmbryReplica implements ReplicaId, Resource {
    * @param capacityBytes the capacity in bytes for this replica.
    * @param isSealed whether this replica is in sealed state.
    */
-  AmbryReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, AmbryDisk disk, long capacityBytes,
-      boolean isSealed) throws Exception {
+  AmbryReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, AmbryDisk disk, HardwareState state,
+      long capacityBytes, boolean isSealed) throws Exception {
     this.partition = partition;
     this.disk = disk;
     this.capacityBytes = capacityBytes;
     this.isSealed = isSealed;
+    this.isStopped = state == HardwareState.UNAVAILABLE;
     validate();
     ResourceStatePolicyFactory resourceStatePolicyFactory =
-        Utils.getObj(clusterMapConfig.clusterMapResourceStatePolicyFactory, this, disk.getState(), clusterMapConfig);
+        Utils.getObj(clusterMapConfig.clusterMapResourceStatePolicyFactory, this, state, clusterMapConfig);
     this.resourceStatePolicy = resourceStatePolicyFactory.getResourceStatePolicy();
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
@@ -38,20 +38,22 @@ class AmbryReplica implements ReplicaId, Resource {
    * @param clusterMapConfig the {@link ClusterMapConfig} to use.
    * @param partition the {@link AmbryPartition} of which this is a replica.
    * @param disk the {@link AmbryDisk} on which this replica resides.
+   * @param isReplicaStopped whether this replica is stopped or not.
    * @param capacityBytes the capacity in bytes for this replica.
    * @param isSealed whether this replica is in sealed state.
    */
-  AmbryReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, AmbryDisk disk, HardwareState state,
+  AmbryReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, AmbryDisk disk, boolean isReplicaStopped,
       long capacityBytes, boolean isSealed) throws Exception {
     this.partition = partition;
     this.disk = disk;
     this.capacityBytes = capacityBytes;
     this.isSealed = isSealed;
-    this.isStopped = state == HardwareState.UNAVAILABLE;
+    isStopped = isReplicaStopped;
     validate();
     ResourceStatePolicyFactory resourceStatePolicyFactory =
-        Utils.getObj(clusterMapConfig.clusterMapResourceStatePolicyFactory, this, state, clusterMapConfig);
-    this.resourceStatePolicy = resourceStatePolicyFactory.getResourceStatePolicy();
+        Utils.getObj(clusterMapConfig.clusterMapResourceStatePolicyFactory, this, HardwareState.AVAILABLE,
+            clusterMapConfig);
+    resourceStatePolicy = resourceStatePolicyFactory.getResourceStatePolicy();
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DataNode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DataNode.java
@@ -18,6 +18,7 @@ import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.utils.Utils;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -291,10 +292,7 @@ class DataNode implements DataNodeId {
     }
 
     DataNode other = (DataNode) o;
-    int compare = (portNum < other.portNum) ? -1 : ((portNum == other.portNum) ? 0 : 1);
-    if (compare == 0) {
-      compare = hostname.compareTo(other.hostname);
-    }
-    return compare;
+    return Comparator.comparingInt((DataNode k) -> k.portNum).
+        thenComparing(k -> k.hostname).compare(this, other);
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/FixedBackoffResourceStatePolicyFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/FixedBackoffResourceStatePolicyFactory.java
@@ -31,6 +31,10 @@ public class FixedBackoffResourceStatePolicyFactory implements ResourceStatePoli
       resourceStatePolicy = new FixedBackoffResourceStatePolicy(resource, initialState == HardwareState.UNAVAILABLE,
           clusterMapConfig.clusterMapFixedTimeoutDiskErrorThreshold,
           clusterMapConfig.clusterMapFixedTimeoutDiskRetryBackoffMs, SystemTime.getInstance());
+    } else if (resource instanceof ReplicaId) {
+      resourceStatePolicy = new FixedBackoffResourceStatePolicy(resource, initialState == HardwareState.UNAVAILABLE,
+          clusterMapConfig.clusterMapFixedTimeoutReplicaErrorThreshold,
+          clusterMapConfig.clusterMapFixedTimeoutReplicaRetryBackoffMs, SystemTime.getInstance());
     }
 
     if (resourceStatePolicy == null) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -468,11 +468,9 @@ class HelixClusterManager implements ClusterMap {
             }
             ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, datanode, replicaCapacity);
             // Create replica associated with this node.
-            HardwareState replicaState = diskState == HardwareState.UNAVAILABLE ? diskState
-                : (stoppedReplicas.contains(partitionName) ? HardwareState.UNAVAILABLE : HardwareState.AVAILABLE);
             AmbryReplica replica =
-                new AmbryReplica(clusterMapConfig, mappedPartition, disk, replicaState, replicaCapacity,
-                    sealedReplicas.contains(partitionName));
+                new AmbryReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
+                    replicaCapacity, sealedReplicas.contains(partitionName));
             ambryPartitionToAmbryReplicas.get(mappedPartition).add(replica);
             ambryDataNodeToAmbryReplicas.get(datanode).add(replica);
           }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -231,6 +231,12 @@ class HelixClusterManager implements ClusterMap {
       case Partition_ReadOnly:
         replica.getPartitionId().onPartitionReadOnly();
         break;
+      case Replica_Unavailable:
+        replica.onReplicaUnavailable();
+        break;
+      case Replica_Response:
+        replica.onReplicaResponse();
+        break;
     }
   }
 
@@ -460,7 +466,7 @@ class HelixClusterManager implements ClusterMap {
             ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, datanode, replicaCapacity);
             // Create replica associated with this node.
             AmbryReplica replica =
-                new AmbryReplica(mappedPartition, disk, replicaCapacity, sealedReplicas.contains(partitionName));
+                new AmbryReplica(clusterMapConfig, mappedPartition, disk, replicaCapacity, sealedReplicas.contains(partitionName));
             ambryPartitionToAmbryReplicas.get(mappedPartition).add(replica);
             ambryDataNodeToAmbryReplicas.get(datanode).add(replica);
           }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
@@ -162,23 +162,21 @@ public class DynamicClusterManagerComponentsTest {
 
     // AmbryReplica tests
     try {
-      new AmbryReplica(clusterMapConfig1, null, disk1, HardwareState.AVAILABLE, MAX_REPLICA_CAPACITY_IN_BYTES, false);
+      new AmbryReplica(clusterMapConfig1, null, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
       fail("Replica initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
     }
 
     try {
-      new AmbryReplica(clusterMapConfig1, partition1, null, HardwareState.AVAILABLE, MAX_REPLICA_CAPACITY_IN_BYTES,
-          false);
+      new AmbryReplica(clusterMapConfig1, partition1, null, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
       fail("Replica initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
     }
 
     try {
-      new AmbryReplica(clusterMapConfig1, partition1, disk1, HardwareState.AVAILABLE, MAX_REPLICA_CAPACITY_IN_BYTES + 1,
-          false);
+      new AmbryReplica(clusterMapConfig1, partition1, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES + 1, false);
       fail("Replica initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
@@ -186,17 +184,19 @@ public class DynamicClusterManagerComponentsTest {
 
     // Create a few replicas and make the mockClusterManagerCallback aware of the association.
     AmbryReplica replica1 =
-        new AmbryReplica(clusterMapConfig1, partition1, disk1, HardwareState.AVAILABLE, MAX_REPLICA_CAPACITY_IN_BYTES, false);
+        new AmbryReplica(clusterMapConfig1, partition1, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica1);
     AmbryReplica replica2 =
-        new AmbryReplica(clusterMapConfig1, partition2, disk1, HardwareState.AVAILABLE, MIN_REPLICA_CAPACITY_IN_BYTES, false);
+        new AmbryReplica(clusterMapConfig1, partition2, disk1, false, MIN_REPLICA_CAPACITY_IN_BYTES, false);
     mockClusterManagerCallback.addReplicaToPartition(partition2, replica2);
     AmbryReplica replica3 =
-        new AmbryReplica(clusterMapConfig2, partition1, disk2, HardwareState.AVAILABLE, MIN_REPLICA_CAPACITY_IN_BYTES, false);
+        new AmbryReplica(clusterMapConfig2, partition1, disk2, false, MIN_REPLICA_CAPACITY_IN_BYTES, false);
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica3);
-    AmbryReplica replica4 = new AmbryReplica(clusterMapConfig2, partition2, disk2, HardwareState.AVAILABLE, MIN_REPLICA_CAPACITY_IN_BYTES, true);
+    AmbryReplica replica4 =
+        new AmbryReplica(clusterMapConfig2, partition2, disk2, false, MIN_REPLICA_CAPACITY_IN_BYTES, true);
     mockClusterManagerCallback.addReplicaToPartition(partition2, replica4);
-    AmbryReplica replica5 = new AmbryReplica(clusterMapConfig1, partition1, disk1, HardwareState.UNAVAILABLE, MIN_REPLICA_CAPACITY_IN_BYTES, false);
+    AmbryReplica replica5 =
+        new AmbryReplica(clusterMapConfig1, partition1, disk1, true, MIN_REPLICA_CAPACITY_IN_BYTES, false);
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica5);
 
     sealedStateChangeCounter.incrementAndGet();
@@ -207,7 +207,7 @@ public class DynamicClusterManagerComponentsTest {
     assertEquals(replica1.getPartitionId(), peerReplicas.get(0).getPartitionId());
     assertEquals(replica3, peerReplicas.get(0));
     assertEquals(replica5, peerReplicas.get(1));
-    assertEquals("Replica should be in stopped state", true, peerReplicas.get(1).isDown());
+    assertTrue("Replica should be in stopped state", peerReplicas.get(1).isDown());
 
     List<AmbryReplica> replicaList1 = partition1.getReplicaIds();
     List<AmbryReplica> replicaList2 = partition2.getReplicaIds();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
@@ -162,34 +162,37 @@ public class DynamicClusterManagerComponentsTest {
 
     // AmbryReplica tests
     try {
-      new AmbryReplica(null, disk1, MAX_REPLICA_CAPACITY_IN_BYTES, false);
+      new AmbryReplica(clusterMapConfig1, null, disk1, MAX_REPLICA_CAPACITY_IN_BYTES, false);
       fail("Replica initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
     }
 
     try {
-      new AmbryReplica(partition1, null, MAX_REPLICA_CAPACITY_IN_BYTES, false);
+      new AmbryReplica(clusterMapConfig1, partition1, null, MAX_REPLICA_CAPACITY_IN_BYTES, false);
       fail("Replica initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
     }
 
     try {
-      new AmbryReplica(partition1, disk1, MAX_REPLICA_CAPACITY_IN_BYTES + 1, false);
+      new AmbryReplica(clusterMapConfig1, partition1, disk1, MAX_REPLICA_CAPACITY_IN_BYTES + 1, false);
       fail("Replica initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
     }
 
     // Create a few replicas and make the mockClusterManagerCallback aware of the association.
-    AmbryReplica replica1 = new AmbryReplica(partition1, disk1, MAX_REPLICA_CAPACITY_IN_BYTES, false);
+    AmbryReplica replica1 =
+        new AmbryReplica(clusterMapConfig1, partition1, disk1, MAX_REPLICA_CAPACITY_IN_BYTES, false);
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica1);
-    AmbryReplica replica2 = new AmbryReplica(partition2, disk1, MIN_REPLICA_CAPACITY_IN_BYTES, false);
+    AmbryReplica replica2 =
+        new AmbryReplica(clusterMapConfig1, partition2, disk1, MIN_REPLICA_CAPACITY_IN_BYTES, false);
     mockClusterManagerCallback.addReplicaToPartition(partition2, replica2);
-    AmbryReplica replica3 = new AmbryReplica(partition1, disk2, MIN_REPLICA_CAPACITY_IN_BYTES, false);
+    AmbryReplica replica3 =
+        new AmbryReplica(clusterMapConfig2, partition1, disk2, MIN_REPLICA_CAPACITY_IN_BYTES, false);
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica3);
-    AmbryReplica replica4 = new AmbryReplica(partition2, disk2, MIN_REPLICA_CAPACITY_IN_BYTES, true);
+    AmbryReplica replica4 = new AmbryReplica(clusterMapConfig2, partition2, disk2, MIN_REPLICA_CAPACITY_IN_BYTES, true);
     mockClusterManagerCallback.addReplicaToPartition(partition2, replica4);
     sealedStateChangeCounter.incrementAndGet();
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -78,6 +78,9 @@ public class HelixClusterManagerTest {
   private final PartitionRangeCheckParams defaultRo;
   private final PartitionRangeCheckParams specialRo;
 
+  /**
+   * Resource state associated with datanode, disk and replica.
+   */
   enum ResourceState {
     Node_Up, Node_Down, Disk_Up, Disk_Down, Replica_Up, Replica_Down
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -282,7 +282,7 @@ public class HelixClusterManagerTest {
     assertEquals(HardwareState.UNAVAILABLE, dataNode.getState());
     assertEquals(HardwareState.UNAVAILABLE, disk.getState());
 
-    // Trigger a successful event to bring the resources up.
+    // Trigger a successful node event to bring the resources up.
     clusterManager.onReplicaEvent(replica, ReplicaEventType.Node_Response);
     assertFalse(replica.isDown());
     assertEquals(HardwareState.AVAILABLE, dataNode.getState());
@@ -297,10 +297,28 @@ public class HelixClusterManagerTest {
     // node should still be available even on disk error.
     assertEquals(HardwareState.AVAILABLE, dataNode.getState());
 
+    // Trigger a successful disk event to bring the resources up.
     clusterManager.onReplicaEvent(replica, ReplicaEventType.Disk_Ok);
     assertFalse(replica.isDown());
     assertEquals(HardwareState.AVAILABLE, dataNode.getState());
     assertEquals(HardwareState.AVAILABLE, disk.getState());
+
+    if (!useComposite) {
+      // Similar tests for replica.
+      for (int i = 0; i < clusterMapConfig.clusterMapFixedTimeoutReplicaErrorThreshold; i++) {
+        clusterManager.onReplicaEvent(replica, ReplicaEventType.Replica_Unavailable);
+      }
+      assertTrue(replica.isDown());
+      assertEquals(HardwareState.AVAILABLE, disk.getState());
+      // node should still be available even on disk error.
+      assertEquals(HardwareState.AVAILABLE, dataNode.getState());
+
+      // Trigger a successful replica event to bring the resources up.
+      clusterManager.onReplicaEvent(replica, ReplicaEventType.Replica_Available);
+      assertFalse(replica.isDown());
+      assertEquals(HardwareState.AVAILABLE, dataNode.getState());
+      assertEquals(HardwareState.AVAILABLE, disk.getState());
+    }
 
     // The following does not do anything currently.
     clusterManager.onReplicaEvent(replica, ReplicaEventType.Partition_ReadOnly);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -17,6 +17,8 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.TestUtils.*;
+import com.github.ambry.commons.ResponseHandler;
+import com.github.ambry.commons.ServerErrorCode;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.ByteBufferInputStream;
@@ -75,6 +77,10 @@ public class HelixClusterManagerTest {
   private final PartitionRangeCheckParams specialRw;
   private final PartitionRangeCheckParams defaultRo;
   private final PartitionRangeCheckParams specialRo;
+
+  enum ResourceState {
+    Node_Up, Node_Down, Disk_Up, Disk_Down, Replica_Up, Replica_Down
+  }
 
   @Parameterized.Parameters
   public static List<Object[]> data() {
@@ -326,6 +332,48 @@ public class HelixClusterManagerTest {
   }
 
   /**
+   * Test that {@link ResponseHandler} works as expected in the presence of various types of server events. The test also
+   * verifies the states of datanode, disk and replica are changed correctly based on server event.
+   */
+  @Test
+  public void onServerEventTest() {
+    if (useComposite) {
+      return;
+    }
+    // Test configuration: we select the disk from one datanode and select the replica on that disk
+
+    // Initial state: disk is down; Server event: Replica_Unavailable; Expected result: disk becomes available again
+    mockServerEventsAndVerify(
+        new ResourceState[]{ResourceState.Node_Up, ResourceState.Disk_Down, ResourceState.Replica_Down},
+        ServerErrorCode.Replica_Unavailable,
+        new ResourceState[]{ResourceState.Node_Up, ResourceState.Disk_Up, ResourceState.Replica_Down});
+
+    // Initial state: disk is down; Server event: Temporarily_Disabled; Expected result: disk becomes available again
+    mockServerEventsAndVerify(
+        new ResourceState[]{ResourceState.Node_Up, ResourceState.Disk_Down, ResourceState.Replica_Down},
+        ServerErrorCode.Temporarily_Disabled,
+        new ResourceState[]{ResourceState.Node_Up, ResourceState.Disk_Up, ResourceState.Replica_Down});
+
+    // Initial state: disk and replica are down; Server event: Partition_ReadOnly; Expected result: disk and replica become available again
+    mockServerEventsAndVerify(
+        new ResourceState[]{ResourceState.Node_Up, ResourceState.Disk_Down, ResourceState.Replica_Down},
+        ServerErrorCode.Partition_ReadOnly,
+        new ResourceState[]{ResourceState.Node_Up, ResourceState.Disk_Up, ResourceState.Replica_Up});
+
+    // Initial state: everything is up; Server event: IO_Error; Expected result: disk and replica become unavailable
+    mockServerEventsAndVerify(
+        new ResourceState[]{ResourceState.Node_Up, ResourceState.Disk_Up, ResourceState.Replica_Up},
+        ServerErrorCode.IO_Error,
+        new ResourceState[]{ResourceState.Node_Up, ResourceState.Disk_Down, ResourceState.Replica_Down});
+
+    // Initial state: everything is up; Server event: Disk_Unavailable; Expected result: disk and replica become unavailable
+    mockServerEventsAndVerify(
+        new ResourceState[]{ResourceState.Node_Up, ResourceState.Disk_Up, ResourceState.Replica_Up},
+        ServerErrorCode.Disk_Unavailable,
+        new ResourceState[]{ResourceState.Node_Up, ResourceState.Disk_Down, ResourceState.Replica_Down});
+  }
+
+  /**
    * Test that the changes to the sealed states of replicas get reflected correctly in the cluster manager.
    * This also tests multiple InstanceConfig change callbacks (including multiple such callbacks tagged as
    * {@link org.apache.helix.NotificationContext.Type#INIT} and that they are dealt with correctly.
@@ -513,6 +561,59 @@ public class HelixClusterManagerTest {
   }
 
   // Helpers
+
+  /**
+   * The helper method sets up initial states for datanode, disk and replica. Then it triggers specified server event and
+   * verifies the states of datanode, disk and replica are expected after event.
+   * @param initialStates the initial states for datanode, disk and replica (default order).
+   * @param serverErrorCode the {@link ServerErrorCode} received for mocking event.
+   * @param expectedStates the expected states for datanode, disk and replica (default order).
+   */
+  private void mockServerEventsAndVerify(ResourceState[] initialStates, ServerErrorCode serverErrorCode,
+      ResourceState[] expectedStates) {
+    ResponseHandler handler = new ResponseHandler(clusterManager);
+    ReplicaId replica = clusterManager.getWritablePartitionIds(null).get(0).getReplicaIds().get(0);
+    DataNodeId dataNode = replica.getDataNodeId();
+    assertTrue(clusterManager.getReplicaIds(dataNode).contains(replica));
+    DiskId disk = replica.getDiskId();
+
+    // Verify that everything is up in the beginning.
+    assertFalse(replica.isDown());
+    assertEquals(HardwareState.AVAILABLE, dataNode.getState());
+    assertEquals(HardwareState.AVAILABLE, disk.getState());
+
+    // Mock initial states for node, disk and replica
+    if (initialStates[0] == ResourceState.Node_Down) {
+      for (int i = 0; i < clusterMapConfig.clusterMapFixedTimeoutDatanodeErrorThreshold; i++) {
+        clusterManager.onReplicaEvent(replica, ReplicaEventType.Node_Timeout);
+      }
+    } else if (initialStates[1] == ResourceState.Disk_Down) {
+      for (int i = 0; i < clusterMapConfig.clusterMapFixedTimeoutDiskErrorThreshold; i++) {
+        clusterManager.onReplicaEvent(replica, ReplicaEventType.Disk_Error);
+      }
+    } else if (initialStates[2] == ResourceState.Replica_Down) {
+      for (int i = 0; i < clusterMapConfig.clusterMapFixedTimeoutReplicaErrorThreshold; i++) {
+        clusterManager.onReplicaEvent(replica, ReplicaEventType.Replica_Unavailable);
+      }
+    }
+
+    // Make sure node, disk and replica match specified initial states
+    assertEquals(initialStates[2], replica.isDown() ? ResourceState.Replica_Down : ResourceState.Replica_Up);
+    assertEquals(initialStates[1],
+        disk.getState() == HardwareState.UNAVAILABLE ? ResourceState.Disk_Down : ResourceState.Disk_Up);
+    assertEquals(initialStates[0],
+        dataNode.getState() == HardwareState.UNAVAILABLE ? ResourceState.Node_Down : ResourceState.Node_Up);
+
+    // Trigger server event
+    handler.onEvent(replica, serverErrorCode);
+
+    // Verify node, disk and replica match expected states after server event
+    assertEquals(expectedStates[2], replica.isDown() ? ResourceState.Replica_Down : ResourceState.Replica_Up);
+    assertEquals(expectedStates[1],
+        disk.getState() == HardwareState.UNAVAILABLE ? ResourceState.Disk_Down : ResourceState.Disk_Up);
+    assertEquals(expectedStates[0],
+        dataNode.getState() == HardwareState.UNAVAILABLE ? ResourceState.Node_Down : ResourceState.Node_Up);
+  }
 
   /**
    * Get the counter value for the metric in {@link HelixClusterManagerMetrics} with the given suffix.

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
@@ -153,6 +153,26 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   /**
+   * Set or reset the stopped state of the replica for the given partition on the given instance.
+   * @param partition the {@link AmbryPartition}
+   * @param instance the instance name.
+   * @param isStopped if true, the replica will be marked as stopped; otherwise it is proper functioning.
+   * @param tagAsInit whether the InstanceConfig notification should be tagged with
+   *                  {@link org.apache.helix.NotificationContext.Type#INIT}
+   */
+  void setReplicaStoppedState(AmbryPartition partition, String instance, boolean isStopped, boolean tagAsInit) {
+    InstanceConfig instanceConfig = getInstanceConfig(clusterName, instance);
+    List<String> stoppedReplicas = ClusterMapUtils.getStoppedReplicas(instanceConfig);
+    if (isStopped) {
+      stoppedReplicas.add(partition.toPathString());
+    } else {
+      stoppedReplicas.remove(partition.toPathString());
+    }
+    instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, stoppedReplicas);
+    triggerInstanceConfigChangeNotification(tagAsInit);
+  }
+
+  /**
    * Associate the given Helix manager with this admin.
    * @param helixManager the {@link MockHelixManager} to associate this admin with.
    */

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -88,14 +88,25 @@ public class MockHelixCluster {
    * Set or reset the replica state for the given partition on the given instance.
    * @param partition the partition whose replica needs the state change.
    * @param instance the instance hosting the replica.
-   * @param isSealed whether to set or reset the state.
+   * @param stateType the type of state to be set or reset.
+   * @param setState whether to set or reset the state.
    * @param tagAsInit whether the InstanceConfig notification should be tagged with
    *                  {@link org.apache.helix.NotificationContext.Type#INIT}
    */
-  void setReplicaSealedState(AmbryPartition partition, String instance, boolean isSealed, boolean tagAsInit) {
+  void setReplicaState(AmbryPartition partition, String instance, TestUtils.ReplicaStateType stateType,
+      boolean setState, boolean tagAsInit) {
     for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
       if (helixAdmin.getInstancesInCluster(clusterName).contains(instance)) {
-        helixAdmin.setReplicaSealedState(partition, instance, isSealed, tagAsInit);
+        switch (stateType) {
+          case SealedState:
+            helixAdmin.setReplicaSealedState(partition, instance, setState, tagAsInit);
+            break;
+          case StoppedState:
+            helixAdmin.setReplicaStoppedState(partition, instance, setState, tagAsInit);
+            break;
+          default:
+            throw new IllegalStateException("Unrecognized state type");
+        }
       }
     }
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -35,6 +35,10 @@ public class TestUtils {
 
   static final String DEFAULT_PARTITION_CLASS = "defaultPartitionClass";
 
+  enum ReplicaStateType {
+    SealedState, StoppedState
+  }
+
   public static String getLocalHost() {
     try {
       return InetAddress.getByName("localhost").getCanonicalHostName().toLowerCase();

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ResponseHandler.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ResponseHandler.java
@@ -59,7 +59,6 @@ public class ResponseHandler {
       case Temporarily_Disabled:
       case Replica_Unavailable:
         clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Replica_Unavailable);
-        clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Disk_Ok);
         break;
       default:
         // other server error codes

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ResponseHandler.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ResponseHandler.java
@@ -58,6 +58,7 @@ public class ResponseHandler {
         break;
       case Temporarily_Disabled:
       case Replica_Unavailable:
+        clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Disk_Ok);
         clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Replica_Unavailable);
         break;
       default:

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ResponseHandler.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ResponseHandler.java
@@ -53,9 +53,18 @@ public class ResponseHandler {
         break;
       case Partition_ReadOnly:
         clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Partition_ReadOnly);
-        //fall through
-      default:
         clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Disk_Ok);
+        clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Replica_Response);
+        break;
+      case Temporarily_Disabled:
+      case Replica_Unavailable:
+        clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Replica_Unavailable);
+        clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Disk_Ok);
+        break;
+      default:
+        // other server error codes
+        clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Disk_Ok);
+        clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Replica_Response);
         break;
     }
     // Regardless of what the error code is (or there is no error), it is a node response event.

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ResponseHandler.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ResponseHandler.java
@@ -54,7 +54,7 @@ public class ResponseHandler {
       case Partition_ReadOnly:
         clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Partition_ReadOnly);
         clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Disk_Ok);
-        clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Replica_Response);
+        clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Replica_Available);
         break;
       case Temporarily_Disabled:
       case Replica_Unavailable:
@@ -64,7 +64,7 @@ public class ResponseHandler {
       default:
         // other server error codes
         clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Disk_Ok);
-        clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Replica_Response);
+        clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Replica_Available);
         break;
     }
     // Regardless of what the error code is (or there is no error), it is a node response event.

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -143,15 +143,15 @@ public class ResponseHandlerTest {
     expectedEventTypes.put(ServerErrorCode.Disk_Unavailable,
         new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Error});
     expectedEventTypes.put(ServerErrorCode.Partition_ReadOnly,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Partition_ReadOnly, ReplicaEventType.Replica_Response});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Partition_ReadOnly, ReplicaEventType.Replica_Available});
     expectedEventTypes.put(ServerErrorCode.Replica_Unavailable,
         new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Unavailable});
     expectedEventTypes.put(ServerErrorCode.Temporarily_Disabled,
         new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Unavailable});
     expectedEventTypes.put(ServerErrorCode.Unknown_Error,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Response});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Available});
     expectedEventTypes.put(ServerErrorCode.No_Error,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Response});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Available});
     expectedEventTypes.put(NetworkClientErrorCode.NetworkError, new ReplicaEventType[]{ReplicaEventType.Node_Timeout});
     expectedEventTypes.put(NetworkClientErrorCode.ConnectionUnavailable, new ReplicaEventType[]{});
     expectedEventTypes.put(new RouterException("", RouterErrorCode.UnexpectedInternalError), new ReplicaEventType[]{});

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -146,9 +146,11 @@ public class ResponseHandlerTest {
         new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
             ReplicaEventType.Partition_ReadOnly, ReplicaEventType.Replica_Available});
     expectedEventTypes.put(ServerErrorCode.Replica_Unavailable,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Replica_Unavailable});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
+            ReplicaEventType.Replica_Unavailable});
     expectedEventTypes.put(ServerErrorCode.Temporarily_Disabled,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Replica_Unavailable});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
+            ReplicaEventType.Replica_Unavailable});
     expectedEventTypes.put(ServerErrorCode.Unknown_Error,
         new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
             ReplicaEventType.Replica_Available});

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -143,15 +143,18 @@ public class ResponseHandlerTest {
     expectedEventTypes.put(ServerErrorCode.Disk_Unavailable,
         new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Error});
     expectedEventTypes.put(ServerErrorCode.Partition_ReadOnly,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Partition_ReadOnly, ReplicaEventType.Replica_Available});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
+            ReplicaEventType.Partition_ReadOnly, ReplicaEventType.Replica_Available});
     expectedEventTypes.put(ServerErrorCode.Replica_Unavailable,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Unavailable});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Replica_Unavailable});
     expectedEventTypes.put(ServerErrorCode.Temporarily_Disabled,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Unavailable});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Replica_Unavailable});
     expectedEventTypes.put(ServerErrorCode.Unknown_Error,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Available});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
+            ReplicaEventType.Replica_Available});
     expectedEventTypes.put(ServerErrorCode.No_Error,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Available});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
+            ReplicaEventType.Replica_Available});
     expectedEventTypes.put(NetworkClientErrorCode.NetworkError, new ReplicaEventType[]{ReplicaEventType.Node_Timeout});
     expectedEventTypes.put(NetworkClientErrorCode.ConnectionUnavailable, new ReplicaEventType[]{});
     expectedEventTypes.put(new RouterException("", RouterErrorCode.UnexpectedInternalError), new ReplicaEventType[]{});

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -143,11 +143,15 @@ public class ResponseHandlerTest {
     expectedEventTypes.put(ServerErrorCode.Disk_Unavailable,
         new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Error});
     expectedEventTypes.put(ServerErrorCode.Partition_ReadOnly,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Partition_ReadOnly});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Partition_ReadOnly, ReplicaEventType.Replica_Response});
+    expectedEventTypes.put(ServerErrorCode.Replica_Unavailable,
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Unavailable});
+    expectedEventTypes.put(ServerErrorCode.Temporarily_Disabled,
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Unavailable});
     expectedEventTypes.put(ServerErrorCode.Unknown_Error,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Response});
     expectedEventTypes.put(ServerErrorCode.No_Error,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Response});
     expectedEventTypes.put(NetworkClientErrorCode.NetworkError, new ReplicaEventType[]{ReplicaEventType.Node_Timeout});
     expectedEventTypes.put(NetworkClientErrorCode.ConnectionUnavailable, new ReplicaEventType[]{});
     expectedEventTypes.put(new RouterException("", RouterErrorCode.UnexpectedInternalError), new ReplicaEventType[]{});

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -385,7 +385,7 @@ public final class ServerTestUtil {
       channel.send(putRequest);
       putResponseStream = channel.receive().getInputStream();
       response = PutResponse.readFrom(new DataInputStream(putResponseStream));
-      assertEquals("Put blob on stopped store should fail", ServerErrorCode.Disk_Unavailable, response.getError());
+      assertEquals("Put blob on stopped store should fail", ServerErrorCode.Replica_Unavailable, response.getError());
 
       // get a blob properties on a stopped store, which should fail
       ids = new ArrayList<BlobId>();
@@ -399,7 +399,7 @@ public final class ServerTestUtil {
       channel.send(getRequest1);
       stream = channel.receive().getInputStream();
       resp1 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
-      assertEquals("Get blob properties on stopped store should fail", ServerErrorCode.Disk_Unavailable,
+      assertEquals("Get blob properties on stopped store should fail", ServerErrorCode.Replica_Unavailable,
           resp1.getPartitionResponseInfoList().get(0).getErrorCode());
 
       // delete a blob on a stopped store, which should fail
@@ -407,7 +407,7 @@ public final class ServerTestUtil {
       channel.send(deleteRequest);
       stream = channel.receive().getInputStream();
       DeleteResponse deleteResponse = DeleteResponse.readFrom(new DataInputStream(stream));
-      assertEquals("Delete blob on stopped store should fail", ServerErrorCode.Disk_Unavailable,
+      assertEquals("Delete blob on stopped store should fail", ServerErrorCode.Replica_Unavailable,
           deleteResponse.getError());
 
       // start the store via AdminRequest
@@ -1182,7 +1182,7 @@ public final class ServerTestUtil {
     channel.send(putRequest2);
     InputStream putResponseStream = channel.receive().getInputStream();
     PutResponse response2 = PutResponse.readFrom(new DataInputStream(putResponseStream));
-    assertEquals("Put blob on stopped store should fail", ServerErrorCode.Disk_Unavailable, response2.getError());
+    assertEquals("Put blob on stopped store should fail", ServerErrorCode.Replica_Unavailable, response2.getError());
 
     // get a blob properties on a stopped store, which should fail
     ArrayList<BlobId> ids = new ArrayList<BlobId>();
@@ -1195,7 +1195,7 @@ public final class ServerTestUtil {
     channel.send(getRequest1);
     stream = channel.receive().getInputStream();
     GetResponse resp1 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
-    assertEquals("Get blob properties on stopped store should fail", ServerErrorCode.Disk_Unavailable,
+    assertEquals("Get blob properties on stopped store should fail", ServerErrorCode.Replica_Unavailable,
         resp1.getPartitionResponseInfoList().get(0).getErrorCode());
 
     // delete a blob on a stopped store, which should fail
@@ -1203,7 +1203,7 @@ public final class ServerTestUtil {
     channel.send(deleteRequest);
     stream = channel.receive().getInputStream();
     DeleteResponse deleteResponse = DeleteResponse.readFrom(new DataInputStream(stream));
-    assertEquals("Delete blob on stopped store should fail", ServerErrorCode.Disk_Unavailable,
+    assertEquals("Delete blob on stopped store should fail", ServerErrorCode.Replica_Unavailable,
         deleteResponse.getError());
 
     // start the store via AdminRequest

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -168,6 +168,7 @@ public class ServerMetrics {
 
   public final Counter partitionUnknownError;
   public final Counter diskUnavailableError;
+  public final Counter replicaUnavailableError;
   public final Counter partitionReadOnlyError;
   public final Counter storeIOError;
   public final Counter unExpectedStorePutError;
@@ -398,6 +399,7 @@ public class ServerMetrics {
 
     partitionUnknownError = registry.counter(MetricRegistry.name(AmbryRequests.class, "PartitionUnknownError"));
     diskUnavailableError = registry.counter(MetricRegistry.name(AmbryRequests.class, "DiskUnavailableError"));
+    replicaUnavailableError = registry.counter(MetricRegistry.name(AmbryRequests.class, "ReplicaUnavailableError"));
     partitionReadOnlyError = registry.counter(MetricRegistry.name(AmbryRequests.class, "PartitionReadOnlyError"));
     storeIOError = registry.counter(MetricRegistry.name(AmbryRequests.class, "StoreIOError"));
     idAlreadyExistError = registry.counter(MetricRegistry.name(AmbryRequests.class, "IDAlreadyExistError"));

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -1088,10 +1088,10 @@ public class AmbryRequestsTest {
         ServerErrorCode.Unknown_Error, true);
     MockStorageManager.runtimeException = null;
 
-    // store is not started/is stopped/otherwise unavailable - Disk_Unavailable
+    // store is not started/is stopped/otherwise unavailable - Replica_Unavailable
     storageManager.returnNullStore = true;
     sendAndVerifyOperationRequest(RequestOrResponseType.TtlUpdateRequest, Collections.singletonList(id),
-        ServerErrorCode.Disk_Unavailable, false);
+        ServerErrorCode.Replica_Unavailable, false);
     storageManager.returnNullStore = false;
     // PartitionUnknown is hard to simulate without betraying knowledge of the internals of MockClusterMap.
 

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -179,9 +179,9 @@ public class AmbryRequestsTest {
 
     PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
 
-    // store is not started - Disk_Unavailable
+    // store is not started - Replica_Unavailable
     storageManager.returnNullStore = true;
-    doScheduleCompactionTest(id, ServerErrorCode.Disk_Unavailable);
+    doScheduleCompactionTest(id, ServerErrorCode.Replica_Unavailable);
     storageManager.returnNullStore = false;
     // PartitionUnknown is hard to simulate without betraying knowledge of the internals of MockClusterMap.
 
@@ -477,7 +477,7 @@ public class AmbryRequestsTest {
     adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
     blobStoreControlAdminRequest =
         new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Disk_Unavailable);
+    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Replica_Unavailable);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
     storageManager.returnNullStore = false;
     // test invalid numReplicasCaughtUpPerPartition

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,7 @@ project(':ambry-clustermap') {
         compile "org.apache.helix:helix-core:$helixVersion"
         compile "com.codahale.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"
+        testCompile project(':ambry-commons')
         testCompile project(':ambry-utils').sourceSets.test.output
     }
 }


### PR DESCRIPTION
- Instantiate new resourceStatePolicy for replica resources
- Handle both Replica_Unavailable and Temporarily_Disabled error
- Add "Replica_Unavailable" and "Replica_Response" into ReplicaEventType
- Address issue #883, #900
- ./gradlew build && ./gradlew test