### PR TITLE
Fix NullPointerException during Stats Aggregation

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterAggregator.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterAggregator.java
@@ -79,8 +79,12 @@ public class HelixClusterAggregator {
    * @param snapshotWrapper the {@link StatsSnapshot} to be added to the raw base {@link StatsSnapshot}
    */
   private void combineRaw(StatsSnapshot rawBaseSnapshot, StatsWrapper snapshotWrapper) {
-    long totalValue = rawBaseSnapshot.getValue();
     Map<String, StatsSnapshot> partitionSnapshotMap = snapshotWrapper.getSnapshot().getSubMap();
+    if (partitionSnapshotMap == null) {
+      logger.info("There is no partition in given StatsSnapshot, skip aggregation on it.");
+      return;
+    }
+    long totalValue = rawBaseSnapshot.getValue();
     Map<String, StatsSnapshot> basePartitionSnapshotMap = rawBaseSnapshot.getSubMap();
     for (Map.Entry<String, StatsSnapshot> partitionSnapshot : partitionSnapshotMap.entrySet()) {
       if (basePartitionSnapshotMap.containsKey(partitionSnapshot.getKey())) {
@@ -109,10 +113,14 @@ public class HelixClusterAggregator {
    *                              partition entry in the base {@link StatsSnapshot}
    */
   private void combine(StatsSnapshot baseSnapshot, StatsWrapper snapshotWrapper, String instance,
-      Map<String, Long> partitionTimestampMap) throws IOException {
+      Map<String, Long> partitionTimestampMap) {
+    Map<String, StatsSnapshot> partitionSnapshotMap = snapshotWrapper.getSnapshot().getSubMap();
+    if (partitionSnapshotMap == null) {
+      logger.info("There is no partition in given StatsSnapshot, skip aggregation on it.");
+      return;
+    }
     long totalValue = baseSnapshot.getValue();
     long snapshotTimestamp = snapshotWrapper.getHeader().getTimestamp();
-    Map<String, StatsSnapshot> partitionSnapshotMap = snapshotWrapper.getSnapshot().getSubMap();
     Map<String, StatsSnapshot> basePartitionSnapshotMap = baseSnapshot.getSubMap();
     for (Map.Entry<String, StatsSnapshot> partitionSnapshot : partitionSnapshotMap.entrySet()) {
       String partitionId = partitionSnapshot.getKey();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterAggregatorTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterAggregatorTest.java
@@ -56,10 +56,14 @@ public class HelixClusterAggregatorTest {
     }
     StatsWrapper nodeStats = generateNodeStats(storeSnapshots, DEFAULT_TIMESTAMP);
     String nodeStatsJSON = mapper.writeValueAsString(nodeStats);
+    StatsWrapper emptyNodeStats = generateNodeStats(Collections.EMPTY_LIST, DEFAULT_TIMESTAMP);
+    String emptyNodeStatsJSON = mapper.writeValueAsString(emptyNodeStats);
+
     Map<String, String> statsWrappersJSON = new HashMap<>();
     for (int i = 0; i < nodeCount; i++) {
       statsWrappersJSON.put("Store_" + i, (nodeStatsJSON));
     }
+    statsWrappersJSON.put("Store_" + nodeCount, emptyNodeStatsJSON);
     for (int i = 1; i < storeSnapshots.size(); i++) {
       StatsSnapshot.aggregate(storeSnapshots.get(0), storeSnapshots.get(i));
     }
@@ -105,9 +109,12 @@ public class HelixClusterAggregatorTest {
     StatsWrapper upToDateNodeStats =
         generateNodeStats(upToDateStoreSnapshots, TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES));
     StatsWrapper outdatedNodeStats = generateNodeStats(outdatedStoreSnapshots, 0);
+    StatsWrapper emptyNodeStats =
+        generateNodeStats(Collections.EMPTY_LIST, TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES));
     Map<String, String> statsWrappersJSON = new HashMap<>();
     statsWrappersJSON.put("Store_0", mapper.writeValueAsString(outdatedNodeStats));
     statsWrappersJSON.put("Store_1", mapper.writeValueAsString(upToDateNodeStats));
+    statsWrappersJSON.put("Store_2", mapper.writeValueAsString(emptyNodeStats));
     Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON);
     StatsSnapshot expectedSnapshot = upToDateStoreSnapshots.get(0);
     // verify cluster wide aggregation with outdated node stats
@@ -132,9 +139,11 @@ public class HelixClusterAggregatorTest {
     smallerStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed)));
     StatsWrapper greaterNodeStats = generateNodeStats(greaterStoreSnapshots, DEFAULT_TIMESTAMP);
     StatsWrapper smallerNodeStats = generateNodeStats(smallerStoreSnapshots, DEFAULT_TIMESTAMP);
+    StatsWrapper emptyNodeStats = generateNodeStats(Collections.EMPTY_LIST, DEFAULT_TIMESTAMP);
     Map<String, String> statsWrappersJSON = new HashMap<>();
     statsWrappersJSON.put("Store_0", mapper.writeValueAsString(smallerNodeStats));
     statsWrappersJSON.put("Store_1", mapper.writeValueAsString(greaterNodeStats));
+    statsWrappersJSON.put("Store_2", mapper.writeValueAsString(emptyNodeStats));
     Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON);
     StatsSnapshot expectedSnapshot = greaterStoreSnapshots.get(0);
     // verify cluster wide aggregation with different node stats


### PR DESCRIPTION
- fixed NullPointerException when there is no partition on datanode
- skip aggregation on stats coming from empty datanode
- ./gradlew build && ./gradlew test