### PR TITLE
Provide the option to use direct IO in compaction.

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -90,6 +90,14 @@ public class StoreConfig {
   public final int storeCompactionOperationsBytesPerSec;
 
   /**
+   * Whether direct IO are to be enable or not for compaction.
+   * This is only supported on > Linux 2.6
+   */
+  @Config("store.compaction.enable.direct.io")
+  @Default("false")
+  public final boolean storeCompactionEnableDirectIO;
+
+  /**
    * The minimum buffer size for compaction copy phase.
    */
   @Config("store.compaction.min.buffer.size")
@@ -265,6 +273,7 @@ public class StoreConfig {
     storeCompactionOperationsBytesPerSec =
         verifiableProperties.getIntInRange("store.compaction.operations.bytes.per.sec", 1 * 1024 * 1024, 1,
             Integer.MAX_VALUE);
+    storeCompactionEnableDirectIO = verifiableProperties.getBoolean("store.compaction.enable.direct.io", false);
     storeCompactionMinBufferSize =
         verifiableProperties.getIntInRange("store.compaction.min.buffer.size", 10 * 1024 * 1024, 0, Integer.MAX_VALUE);
     storeEnableHardDelete = verifiableProperties.getBoolean("store.enable.hard.delete", false);

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -22,7 +22,6 @@ import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -713,7 +712,7 @@ class BlobStore implements Store {
    * @throws IOException if there is any error creating the {@link CompactionLog}.
    * @throws StoreException if there are any errors during the compaction.
    */
-  void compact(CompactionDetails details, ByteBuffer bundleReadBuffer) throws IOException, StoreException {
+  void compact(CompactionDetails details, byte[] bundleReadBuffer) throws IOException, StoreException {
     checkStarted();
     compactor.compact(details, bundleReadBuffer);
     checkCapacityAndUpdateReplicaStatusDelegate();
@@ -725,7 +724,7 @@ class BlobStore implements Store {
    * @throws StoreException if there are any errors during the compaction.
    * @param bundleReadBuffer the preAllocated buffer for bundle read in compaction copy phase.
    */
-  void maybeResumeCompaction(ByteBuffer bundleReadBuffer) throws StoreException {
+  void maybeResumeCompaction(byte[] bundleReadBuffer) throws StoreException {
     checkStarted();
     if (CompactionLog.isCompactionInProgress(dataDir, storeId)) {
       logger.info("Resuming compaction of {}", this);

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -177,7 +177,7 @@ class CompactionManager {
     private final Set<BlobStore> storesDisabledCompaction = ConcurrentHashMap.newKeySet();
     private final LinkedBlockingDeque<BlobStore> storesToCheck = new LinkedBlockingDeque<>();
     private final long waitTimeMs = TimeUnit.HOURS.toMillis(storeConfig.storeCompactionCheckFrequencyInHours);
-    private final ByteBuffer bundleReadBuffer;
+    private final byte[] bundleReadBuffer;
 
     private volatile boolean enabled = false;
 
@@ -189,7 +189,7 @@ class CompactionManager {
      */
     CompactionExecutor(EnumSet<Trigger> triggers, int bundleReadBufferSize) {
       this.triggers = triggers;
-      bundleReadBuffer = bundleReadBufferSize == 0 ? null : ByteBuffer.allocateDirect(bundleReadBufferSize);
+      bundleReadBuffer = bundleReadBufferSize == 0 ? null : new byte[bundleReadBufferSize];
       logger.info("Buffer size is {} in compaction thread for {}", bundleReadBufferSize, mountPath);
     }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -128,8 +128,20 @@ class Log implements Write {
   }
 
   /**
-   * {@inheritDoc}
-   * <p/>
+   * Appends the given {@code byteArray} to the active log segment in direct IO manner.
+   * The {@code byteArray} will be written to a single log segment i.e. its data will not exist across segments.
+   * @param byteArray The buffer from which data needs to be written from
+   * @return the number of bytes written.
+   * @throws IllegalArgumentException if the {@code byteArray.length} is greater than a single segment's size.
+   * @throws IllegalStateException if there no more capacity in the log.
+   * @throws IOException if there was an I/O error while writing.
+   */
+  int appendFromDirectly(byte[] byteArray, int offset, int length) throws IOException {
+    rollOverIfRequired(length);
+    return activeSegment.appendFromDirectly(byteArray, offset, length);
+  }
+
+  /**
    * Appends the given data to the active log segment. The data will be written to a single log segment i.e. the data
    * will not exist across segments.
    * @param channel The channel from which data needs to be written from

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -188,7 +188,6 @@ class LogSegment implements Read, Write {
   }
 
   /**
-   * {@inheritDoc}
    * <p/>
    * Attempts to write the {@code byteArray} to this segment in direct IO manner.
    * <p/>

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -276,11 +276,6 @@ class LogSegment implements Read, Write {
    */
   void readIntoDirectly(byte[] byteArray, long position, int length) throws IOException {
     validateReadRange(position, length);
-    if (file.length() < position + length) {
-      throw new IOException(
-          "Requested range exceed file length. position = " + position + " length = " + length + "fileLength = "
-              + file.length());
-    }
     // TODO: Try to avoid opening file on every opeartion.
     try (DirectRandomAccessFile directFile = new DirectRandomAccessFile(file, "r", 2 * 1024 * 1024)) {
       directFile.seek(position);

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -388,7 +388,7 @@ public class BlobStoreTest {
       //that the store is now read-write
       time.sleep(TimeUnit.DAYS.toMillis(8));
       store.compact(store.getCompactionDetails(new CompactAllPolicy(defaultConfig, time)),
-          ByteBuffer.allocateDirect(PUT_RECORD_SIZE * 2 + 1));
+          new byte[PUT_RECORD_SIZE * 2 + 1]);
       verify(replicaStatusDelegate, times(2)).unseal(replicaId);
 
       //Test if replicaId is erroneously true that it updates the status upon startup

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
@@ -20,7 +20,6 @@ import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -127,8 +126,8 @@ public class CompactionManagerTest {
 
   /**
    * Tests that compaction is triggered on all stores provided they do not misbehave. Also includes a store that is
-   * not ready for compaction. Ensures that {@link BlobStore#maybeResumeCompaction(ByteBuffer)} is called before
-   * {@link BlobStore#compact(CompactionDetails, ByteBuffer)} is called.
+   * not ready for compaction. Ensures that {@link BlobStore#maybeResumeCompaction(byte[])} is called before
+   * {@link BlobStore#compact(CompactionDetails, byte[])} is called.
    * @throws Exception
    */
   @Test
@@ -472,7 +471,7 @@ public class CompactionManagerTest {
     }
 
     @Override
-    void compact(CompactionDetails details, ByteBuffer bundleReadBuffer) {
+    void compact(CompactionDetails details, byte[] bundleReadBuffer) {
       compactCalled = true;
       compactCallsCountdown.countDown();
       if (details == null) {
@@ -486,7 +485,7 @@ public class CompactionManagerTest {
     }
 
     @Override
-    void maybeResumeCompaction(ByteBuffer bundleReadBuffer) {
+    void maybeResumeCompaction(byte[] bundleReadBuffer) {
       if (resumeCompactionCalled) {
         callOrderException = new Exception("maybeResumeCompaction() called more than once");
       }

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -654,6 +654,13 @@ public class Utils {
   }
 
   /**
+   * @return true if current operating system is Linux.
+   */
+  public static boolean isLinux() {
+    return System.getProperty("os.name").toLowerCase().startsWith("linux");
+  }
+
+  /**
    * Ensures that a given File is present. The file is pre-allocated with a given capacity using fallocate on linux
    * @param file file path to create and allocate
    * @param capacityBytes the number of bytes to pre-allocate
@@ -663,7 +670,7 @@ public class Utils {
     if (!file.exists()) {
       file.createNewFile();
     }
-    if (System.getProperty("os.name").toLowerCase().startsWith("linux")) {
+    if (isLinux()) {
       Runtime runtime = Runtime.getRuntime();
       Process process = runtime.exec("fallocate --keep-size -l " + capacityBytes + " " + file.getAbsolutePath());
       try {

--- a/build.gradle
+++ b/build.gradle
@@ -194,6 +194,7 @@ project(':ambry-store') {
         compile project(':ambry-api'),
                 project(':ambry-utils')
         compile "com.codahale.metrics:metrics-core:$metricsVersion"
+        compile "net.smacke:jaydio:$jaydioVersion"
         testCompile project(':ambry-clustermap')
         testCompile project(':ambry-clustermap').sourceSets.test.output
         testCompile project(':ambry-utils').sourceSets.test.output

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -21,4 +21,5 @@ ext {
     nettyTcnativeVersion = "2.0.7.Final"
     helixVersion = "0.6.9"
     jacksonVersion = "1.8.5"
+    jaydioVersion = "0.1"
 }


### PR DESCRIPTION
Introduce direct IO read/write in copyRecords. 
This will be enabled only when the system is Linux and the config for compactionDirectIO is on. 