### PR TITLE
Supporting replication of TTL updates

### DIFF
--- a/ambry-api/src/test/java/com.github.ambry/store/MockStoreKeyConverterFactory.java
+++ b/ambry-api/src/test/java/com.github.ambry/store/MockStoreKeyConverterFactory.java
@@ -111,8 +111,10 @@ public class MockStoreKeyConverterFactory implements StoreKeyConverterFactory {
 
     @Override
     public StoreKey getConverted(StoreKey storeKey) {
-      if (exception != null || !lastConverted.containsKey(storeKey)) {
+      if (exception != null) {
         throw new IllegalStateException(exception);
+      } else if (!lastConverted.containsKey(storeKey)) {
+        throw new IllegalStateException(storeKey + " has not been converted");
       }
       return lastConverted.get(storeKey);
     }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -824,10 +824,10 @@ class ReplicaThread implements Runnable {
       throws IOException, MessageFormatException, StoreException {
     MessageFormatInputStream ttlUpdateStream =
         new TtlUpdateMessageFormatInputStream(messageInfo.getStoreKey(), messageInfo.getAccountId(),
-            messageInfo.getContainerId(), messageInfo.getOperationTimeMs());
-    MessageInfo info =
-        new MessageInfo(messageInfo.getStoreKey(), ttlUpdateStream.getSize(), false, true, messageInfo.getAccountId(),
-            messageInfo.getContainerId(), messageInfo.getOperationTimeMs());
+            messageInfo.getContainerId(), messageInfo.getExpirationTimeInMs(), messageInfo.getOperationTimeMs());
+    MessageInfo info = new MessageInfo(messageInfo.getStoreKey(), ttlUpdateStream.getSize(), false, true,
+        messageInfo.getExpirationTimeInMs(), messageInfo.getAccountId(), messageInfo.getContainerId(),
+        messageInfo.getOperationTimeMs());
     MessageFormatWriteSet writeSet = new MessageFormatWriteSet(ttlUpdateStream, Collections.singletonList(info), false);
     DataNodeId remoteNode = remoteReplicaInfo.getReplicaId().getDataNodeId();
     try {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -516,7 +516,7 @@ public class ReplicationTest {
     List<Host> remoteHostOnly = Collections.singletonList(remoteHost);
     List<Host> expectedLocalHostOnly = Collections.singletonList(expectedLocalHost);
     List<Host> localHostAndExpectedLocalHost = Arrays.asList(localHost, expectedLocalHost);
-    List<Host> remoteHostAndExpectedLocalHost = Arrays.asList(expectedLocalHost, remoteHost);
+    List<Host> remoteHostAndExpectedLocalHost = Arrays.asList(remoteHost, expectedLocalHost);
     List<Host> allHosts = Arrays.asList(localHost, expectedLocalHost, remoteHost);
     for (PartitionId pid : partitionIds) {
       // add 3 put messages to both hosts (also add to expectedLocal)


### PR DESCRIPTION
Will replicate the TTL update record as long as
1) There is no delete (either in remote or local)
2) The ID is not deprecated

If PUT is present locally, applies the TTL update
If PUT is not present, replicates the PUT and then immediately applies the TTL update