### PR TITLE
Do larger IO for putRequest

### DIFF
--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatInputStream.java
@@ -98,6 +98,11 @@ public abstract class MessageFormatInputStream extends InputStream {
     return totalRead > 0 ? totalRead : -1;
   }
 
+  @Override
+  public int available() {
+    return (buffer == null ? 0 : buffer.remaining()) + (int) (streamLength - streamRead) + crc.remaining();
+  }
+
   public long getSize() {
     return messageLength;
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -475,6 +475,7 @@ class Log implements Write {
           "Cannot add segments past the current active segment. Active segment is [" + activeSegment.getName()
               + "]. Tried to add [" + segment.getName() + "]");
     }
+    segment.dropBufferForAppend();
     if (increaseUsedSegmentCount) {
       remainingUnallocatedSegments.decrementAndGet();
     }

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -170,9 +170,7 @@ class Log implements Write {
     LogSegment newActiveSegment = segmentsByName.get(name);
     if (newActiveSegment != activeSegment) {
       // If activeSegment needs to be changed, then drop buffer for old activeSegment and init buffer for new activeSegment.
-      if (activeSegment != null) {
-        activeSegment.dropBufferForAppend();
-      }
+      activeSegment.dropBufferForAppend();
       activeSegment = newActiveSegment;
       activeSegment.initBufferForAppend();
     }
@@ -352,7 +350,6 @@ class Log implements Write {
    * @throws IOException if there is any I/O error during initialization.
    */
   private void initialize(List<LogSegment> segmentsToLoad, long segmentCapacityInBytes) throws IOException {
-    metrics.registerByteBufferForAppendTotalCount(LogSegment.byteBufferForAppendTotalCount);
     if (segmentsToLoad.size() == 0) {
       // bootstrapping log.
       segmentsToLoad = Collections.singletonList(checkArgsAndGetFirstSegment(segmentCapacityInBytes));

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -214,8 +214,10 @@ class LogSegment implements Read, Write {
    * Free {@link LogSegment#byteBufferForAppend}.
    */
   void dropBufferForAppend() {
-    byteBufferForAppend = null;
-    byteBufferForAppendTotalCount.decrementAndGet();
+    if (byteBufferForAppend != null) {
+      byteBufferForAppend = null;
+      byteBufferForAppendTotalCount.decrementAndGet();
+    }
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -204,7 +204,7 @@ class LogSegment implements Read, Write {
    */
   void initBufferForAppend() throws IOException{
     if (byteBufferForAppend != null) {
-      throw new IOException("has been initialized");
+      throw new IOException("ByteBufferForAppend has been initialized.");
     }
     byteBufferForAppend = ByteBuffer.allocateDirect(BYTE_BUFFER_SIZE_FOR_APPEND);
     byteBufferForAppendTotalCount.incrementAndGet();

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -21,7 +21,6 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
@@ -191,6 +190,9 @@ public class StoreMetrics {
         registry.histogram(MetricRegistry.name(BlobStoreStats.class, name + "StatsRecentEntryQueueSize"));
     statsForwardScanEntryCount =
         registry.histogram(MetricRegistry.name(BlobStoreStats.class, name + "StatsForwardScanEntryCount"));
+    Gauge<Integer> byteBufferForAppendTotalCountGauge = LogSegment.byteBufferForAppendTotalCount::get;
+    registry.register(MetricRegistry.name(Log.class, name + "ByteBufferForAppendTotalCount"),
+        byteBufferForAppendTotalCountGauge);
   }
 
   void initializeIndexGauges(String storeId, final PersistentIndex index, final long capacityInBytes) {
@@ -262,23 +264,6 @@ public class StoreMetrics {
   }
 
   /**
-   * Register the {@link LogSegment#byteBufferForAppendTotalCount} to track buffer allocate for PUT.
-   * @param byteBufferForAppendTotalCount total buffer allocated.
-   */
-  void registerByteBufferForAppendTotalCount(final AtomicInteger byteBufferForAppendTotalCount) {
-    Gauge<Integer> byteBufferForAppendTotalCountGauge = byteBufferForAppendTotalCount::get;
-    registry.register(MetricRegistry.name(Log.class, "ByteBufferForAppendTotalCount"),
-        byteBufferForAppendTotalCountGauge);
-  }
-
-  /**
-   * Deregister the Gauge for {@link LogSegment#byteBufferForAppendTotalCount}.
-   */
-  void deregisterByteBufferForAppendTotalCountGauge() {
-    registry.remove(MetricRegistry.name(Log.class, "ByteBufferForAppendTotalCount"));
-  }
-
-  /**
    * Deregister the Metrics related to the given {@code store}.
    * @param storeId the {@link BlobStore} for which some Metrics should be deregistered.
    */
@@ -286,6 +271,5 @@ public class StoreMetrics {
     deregisterIndexGauges(storeId);
     deregisterHardDeleteMetric(storeId);
     deregisterCompactorGauges(storeId);
-    deregisterByteBufferForAppendTotalCountGauge();
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
@@ -261,6 +262,23 @@ public class StoreMetrics {
   }
 
   /**
+   * Register the {@link LogSegment#byteBufferForAppendTotalCount} to track buffer allocate for PUT.
+   * @param byteBufferForAppendTotalCount total buffer allocated.
+   */
+  void registerByteBufferForAppendTotalCount(final AtomicInteger byteBufferForAppendTotalCount) {
+    Gauge<Integer> byteBufferForAppendTotalCountGauge = byteBufferForAppendTotalCount::get;
+    registry.register(MetricRegistry.name(Log.class, "ByteBufferForAppendTotalCount"),
+        byteBufferForAppendTotalCountGauge);
+  }
+
+  /**
+   * Deregister the Gauge for {@link LogSegment#byteBufferForAppendTotalCount}.
+   */
+  void deregisterByteBufferForAppendTotalCountGauge() {
+    registry.remove(MetricRegistry.name(Log.class, "ByteBufferForAppendTotalCount"));
+  }
+
+  /**
    * Deregister the Metrics related to the given {@code store}.
    * @param storeId the {@link BlobStore} for which some Metrics should be deregistered.
    */
@@ -268,5 +286,6 @@ public class StoreMetrics {
     deregisterIndexGauges(storeId);
     deregisterHardDeleteMetric(storeId);
     deregisterCompactorGauges(storeId);
+    deregisterByteBufferForAppendTotalCountGauge();
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.*;
  */
 public class LogSegmentTest {
   private static final int STANDARD_SEGMENT_SIZE = 1024;
-  private static final int BIG_SEGMENT_SIZE = 3 * LogSegment.THREAD_LOCAL_BYTE_BUFFER_SIZE;
+  private static final int BIG_SEGMENT_SIZE = 3 * LogSegment.BYTE_BUFFER_SIZE_FOR_APPEND;
 
   private final File tempDir;
   private final StoreMetrics metrics;
@@ -79,6 +79,7 @@ public class LogSegmentTest {
   public void basicWriteAndReadTest() throws IOException {
     String segmentName = "log_current";
     LogSegment segment = getSegment(segmentName, STANDARD_SEGMENT_SIZE, true);
+    segment.initBufferForAppend();
     try {
       assertEquals("Name of segment is inconsistent with what was provided", segmentName, segment.getName());
       assertEquals("Capacity of segment is inconsistent with what was provided", STANDARD_SEGMENT_SIZE,
@@ -571,11 +572,12 @@ public class LogSegmentTest {
   private void doAppendTest(Appender appender) throws IOException {
     String currSegmentName = "log_current";
     LogSegment segment = getSegment(currSegmentName, BIG_SEGMENT_SIZE, true);
+    segment.initBufferForAppend();
     try {
       long writeStartOffset = segment.getStartOffset();
       byte[] bufOne = TestUtils.getRandomBytes(BIG_SEGMENT_SIZE / 6);
       byte[] bufTwo = TestUtils.getRandomBytes(BIG_SEGMENT_SIZE / 9);
-      byte[] bufThree = TestUtils.getRandomBytes(LogSegment.THREAD_LOCAL_BYTE_BUFFER_SIZE * 2 + 3);
+      byte[] bufThree = TestUtils.getRandomBytes(LogSegment.BYTE_BUFFER_SIZE_FOR_APPEND * 2 + 3);
 
       appender.append(segment, ByteBuffer.wrap(bufOne));
       assertEquals("End offset is not as expected", writeStartOffset + bufOne.length, segment.getEndOffset());


### PR DESCRIPTION
This is a proposed change to address #972 . 

The change is to replace `tansferFrom` which does multiple 8k direct buffer allocation + 8k `pwrite` with `fileChannel.write(1MB buffer, ...)1.`


