### PR TITLE
Instantiate Notifier in HelixAccountServiceFactory ctor

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
@@ -53,7 +53,7 @@ public class HelixAccountServiceFactory implements AccountServiceFactory {
     storeConfig = new HelixPropertyStoreConfig(verifiableProperties);
     accountServiceConfig = new HelixAccountServiceConfig(verifiableProperties);
     accountServiceMetrics = new AccountServiceMetrics(metricRegistry);
-    this.notifier =
+    notifier =
         accountServiceConfig.zkClientConnectString.equals(HelixAccountServiceConfig.INVALID_ZK_CLIENT_CONNECT_STRING)
             ? null : new HelixNotifier(accountServiceConfig.zkClientConnectString, storeConfig);
   }

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
@@ -39,10 +39,10 @@ import org.slf4j.LoggerFactory;
 public class HelixAccountServiceFactory implements AccountServiceFactory {
   private static final String HELIX_ACCOUNT_UPDATER_PREFIX = "helix-account-updater";
   private final Logger logger = LoggerFactory.getLogger(getClass());
-  private final HelixPropertyStoreConfig storeConfig;
-  private final HelixAccountServiceConfig accountServiceConfig;
-  private final AccountServiceMetrics accountServiceMetrics;
-  private final Notifier<String> notifier;
+  protected final HelixPropertyStoreConfig storeConfig;
+  protected final HelixAccountServiceConfig accountServiceConfig;
+  protected final AccountServiceMetrics accountServiceMetrics;
+  protected final Notifier<String> notifier;
 
   /**
    * Constructor.
@@ -50,12 +50,19 @@ public class HelixAccountServiceFactory implements AccountServiceFactory {
    * @param metricRegistry The {@link MetricRegistry} for metrics tracking. Cannot be {@code null}.
    */
   public HelixAccountServiceFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry) {
-    storeConfig = new HelixPropertyStoreConfig(verifiableProperties);
-    accountServiceConfig = new HelixAccountServiceConfig(verifiableProperties);
-    accountServiceMetrics = new AccountServiceMetrics(metricRegistry);
-    notifier =
-        accountServiceConfig.zkClientConnectString.equals(HelixAccountServiceConfig.INVALID_ZK_CLIENT_CONNECT_STRING)
-            ? null : new HelixNotifier(accountServiceConfig.zkClientConnectString, storeConfig);
+    this(new HelixPropertyStoreConfig(verifiableProperties), new HelixAccountServiceConfig(verifiableProperties),
+        new AccountServiceMetrics(metricRegistry),
+        new HelixNotifier(new HelixAccountServiceConfig(verifiableProperties).zkClientConnectString,
+            new HelixPropertyStoreConfig(verifiableProperties)));
+  }
+
+  protected HelixAccountServiceFactory(HelixPropertyStoreConfig storeConfig,
+      HelixAccountServiceConfig accountServiceConfig, AccountServiceMetrics accountServiceMetrics,
+      Notifier<String> notifier) {
+    this.storeConfig = storeConfig;
+    this.accountServiceConfig = accountServiceConfig;
+    this.accountServiceMetrics = accountServiceMetrics;
+    this.notifier = notifier;
   }
 
   @Override

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
@@ -56,6 +56,13 @@ public class HelixAccountServiceFactory implements AccountServiceFactory {
             new HelixPropertyStoreConfig(verifiableProperties)));
   }
 
+  /**
+   * Constructor.
+   * @param storeConfig The {@link HelixPropertyStoreConfig} to use.
+   * @param accountServiceConfig The {@link HelixAccountServiceConfig} to use.
+   * @param accountServiceMetrics The {@link AccountServiceMetrics} to report metrics.
+   * @param notifier The {@link Notifier} to start a {@link HelixAccountService}.
+   */
   protected HelixAccountServiceFactory(HelixPropertyStoreConfig storeConfig,
       HelixAccountServiceConfig accountServiceConfig, AccountServiceMetrics accountServiceMetrics,
       Notifier<String> notifier) {

--- a/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountServiceFactory.java
@@ -14,7 +14,6 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.commons.Notifier;
 import com.github.ambry.config.VerifiableProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,10 +29,9 @@ public class InMemoryUnknownAccountServiceFactory implements AccountServiceFacto
    * Constructor.
    * @param verifiableProperties The properties to get a {@link HelixAccountService} instance. Cannot be {@code null}.
    * @param metricRegistry The {@link MetricRegistry} for metrics tracking. Cannot be {@code null}.
-   * @param notifier The {@link Notifier} used to get a {@link HelixAccountService}.
    */
-  public InMemoryUnknownAccountServiceFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
-      Notifier<String> notifier) {
+  public InMemoryUnknownAccountServiceFactory(VerifiableProperties verifiableProperties,
+      MetricRegistry metricRegistry) {
   }
 
   @Override

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -70,7 +70,7 @@ import static org.junit.Assert.fail;
 public class HelixAccountServiceTest {
   private static final int ZK_CLIENT_CONNECTION_TIMEOUT_MS = 20000;
   private static final int ZK_CLIENT_SESSION_TIMEOUT_MS = 20000;
-  private static final String ZK_CONNECT_STRING = "";
+  private static final String ZK_CONNECT_STRING = "dummyHost:dummyPort";
   private static final String STORE_ROOT_PATH = "/ambry_test/helix_account_service";
   private static final Random random = new Random();
   private static final String BAD_ACCOUNT_METADATA_STRING = "badAccountMetadataString";
@@ -111,8 +111,7 @@ public class HelixAccountServiceTest {
         String.valueOf(ZK_CLIENT_CONNECTION_TIMEOUT_MS));
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "zk.client.session.timeout.ms",
         String.valueOf(ZK_CLIENT_SESSION_TIMEOUT_MS));
-    helixConfigProps.setProperty(HelixAccountServiceConfig.HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string",
-        ZK_CONNECT_STRING);
+    helixConfigProps.setProperty(HelixAccountServiceConfig.ZK_CLIENT_CONNECT_STRING_KEY, ZK_CONNECT_STRING);
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "root.path", STORE_ROOT_PATH);
     accountBackupDir = Paths.get(TestUtils.getTempDir("account-backup")).toAbsolutePath();
     helixConfigProps.setProperty(HelixAccountServiceConfig.BACKUP_DIRECTORY_KEY, accountBackupDir.toString());

--- a/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.*;
 public class InMemoryUnknownAccountServiceTest {
   private static final Random random = new Random();
   private AccountService accountService =
-      new InMemoryUnknownAccountServiceFactory(null, null, null).getAccountService();
+      new InMemoryUnknownAccountServiceFactory(null, null).getAccountService();
 
   /**
    * Cleans up if the store already exists.

--- a/ambry-account/src/test/java/com/github/ambry/account/MockHelixAccountServiceFactory.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockHelixAccountServiceFactory.java
@@ -30,10 +30,6 @@ import org.apache.helix.ZNRecord;
  * A mock implementation of {@link AccountServiceFactory}. This is only for testing purpose and is not thread safe.
  */
 public class MockHelixAccountServiceFactory extends HelixAccountServiceFactory {
-  private final HelixPropertyStoreConfig storeConfig;
-  private final HelixAccountServiceConfig accountServiceConfig;
-  private final AccountServiceMetrics accountServiceMetrics;
-  private final Notifier<String> notifier;
   private final String updaterThreadPrefix;
   private final Map<String, MockHelixPropertyStore<ZNRecord>> storeKeyToMockStoreMap = new HashMap<>();
 
@@ -45,11 +41,8 @@ public class MockHelixAccountServiceFactory extends HelixAccountServiceFactory {
    */
   public MockHelixAccountServiceFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
       Notifier<String> notifier, String updaterThreadPrefix) {
-    super(verifiableProperties, metricRegistry);
-    storeConfig = new HelixPropertyStoreConfig(verifiableProperties);
-    accountServiceConfig = new HelixAccountServiceConfig(verifiableProperties);
-    accountServiceMetrics = new AccountServiceMetrics(metricRegistry);
-    this.notifier = notifier;
+    super(new HelixPropertyStoreConfig(verifiableProperties), new HelixAccountServiceConfig(verifiableProperties),
+        new AccountServiceMetrics(metricRegistry), notifier);
     this.updaterThreadPrefix = updaterThreadPrefix;
   }
 

--- a/ambry-account/src/test/java/com/github/ambry/account/MockHelixAccountServiceFactory.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockHelixAccountServiceFactory.java
@@ -40,12 +40,12 @@ public class MockHelixAccountServiceFactory extends HelixAccountServiceFactory {
   /**
    * Constructor.
    * @param verifiableProperties The properties to start a {@link HelixAccountService}.
-   * @param metricRegistry The {@link MetricRegistry} to start a {@link HelixAccountService}.
    * @param notifier The {@link Notifier} to start a {@link HelixAccountService}.
+   * @param metricRegistry The {@link MetricRegistry} to start a {@link HelixAccountService}.
    */
   public MockHelixAccountServiceFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
       Notifier<String> notifier, String updaterThreadPrefix) {
-    super(verifiableProperties, metricRegistry, notifier);
+    super(verifiableProperties, metricRegistry);
     storeConfig = new HelixPropertyStoreConfig(verifiableProperties);
     accountServiceConfig = new HelixAccountServiceConfig(verifiableProperties);
     accountServiceMetrics = new AccountServiceMetrics(metricRegistry);
@@ -58,8 +58,8 @@ public class MockHelixAccountServiceFactory extends HelixAccountServiceFactory {
     try {
       ScheduledExecutorService scheduler =
           accountServiceConfig.updaterPollingIntervalMs > 0 ? Utils.newScheduler(1, updaterThreadPrefix, false) : null;
-      return new HelixAccountService(getHelixStore(storeConfig), accountServiceMetrics, notifier, scheduler,
-          accountServiceConfig);
+      return new HelixAccountService(getHelixStore(accountServiceConfig.zkClientConnectString, storeConfig),
+          accountServiceMetrics, notifier, scheduler, accountServiceConfig);
     } catch (Exception e) {
       throw new IllegalStateException("Could not instantiate HelixAccountService", e);
     }
@@ -67,11 +67,12 @@ public class MockHelixAccountServiceFactory extends HelixAccountServiceFactory {
 
   /**
    * Gets a {@link MockHelixPropertyStore} for the given {@link HelixPropertyStoreConfig}.
+   * @param zkServers the ZooKeeper server address.
    * @param storeConfig A {@link HelixPropertyStoreConfig}.
    * @return A {@link MockHelixPropertyStore} defined by the {@link HelixPropertyStoreConfig}.
    */
-  MockHelixPropertyStore<ZNRecord> getHelixStore(HelixPropertyStoreConfig storeConfig) {
-    return storeKeyToMockStoreMap.computeIfAbsent(storeConfig.zkClientConnectString + storeConfig.rootPath,
+  MockHelixPropertyStore<ZNRecord> getHelixStore(String zkServers, HelixPropertyStoreConfig storeConfig) {
+    return storeKeyToMockStoreMap.computeIfAbsent(zkServers + storeConfig.rootPath,
         path -> new MockHelixPropertyStore<>());
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -26,8 +26,7 @@ public class HelixAccountServiceConfig {
   public static final String INVALID_ZK_CLIENT_CONNECT_STRING = "";
 
   /**
-   * The ZooKeeper server address. This config is required when using {@code HelixAccountService}, but not for
-   * {@code InMemoryUnknownAccountService}.
+   * The ZooKeeper server address. This config is required when using {@code HelixAccountService}.
    */
   @Config(HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string")
   @Default(INVALID_ZK_CLIENT_CONNECT_STRING)

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -23,13 +23,13 @@ public class HelixAccountServiceConfig {
   public static final String UPDATER_SHUT_DOWN_TIMEOUT_MS_KEY =
       HELIX_ACCOUNT_SERVICE_PREFIX + "updater.shut.down.timeout.ms";
   public static final String BACKUP_DIRECTORY_KEY = HELIX_ACCOUNT_SERVICE_PREFIX + "backup.dir";
+  public static final String ZK_CLIENT_CONNECT_STRING_KEY = HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string";
   public static final String INVALID_ZK_CLIENT_CONNECT_STRING = "";
 
   /**
    * The ZooKeeper server address. This config is required when using {@code HelixAccountService}.
    */
-  @Config(HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string")
-  @Default(INVALID_ZK_CLIENT_CONNECT_STRING)
+  @Config(ZK_CLIENT_CONNECT_STRING_KEY)
   public final String zkClientConnectString;
 
   /**
@@ -56,8 +56,8 @@ public class HelixAccountServiceConfig {
   public final String backupDir;
 
   public HelixAccountServiceConfig(VerifiableProperties verifiableProperties) {
-    zkClientConnectString = verifiableProperties.getString(HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string",
-        INVALID_ZK_CLIENT_CONNECT_STRING);
+    zkClientConnectString =
+        verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY, INVALID_ZK_CLIENT_CONNECT_STRING);
     updaterPollingIntervalMs =
         verifiableProperties.getIntInRange(UPDATER_POLLING_INTERVAL_MS_KEY, 60 * 60 * 1000, 0, Integer.MAX_VALUE);
     updaterShutDownTimeoutMs =

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -24,7 +24,6 @@ public class HelixAccountServiceConfig {
       HELIX_ACCOUNT_SERVICE_PREFIX + "updater.shut.down.timeout.ms";
   public static final String BACKUP_DIRECTORY_KEY = HELIX_ACCOUNT_SERVICE_PREFIX + "backup.dir";
   public static final String ZK_CLIENT_CONNECT_STRING_KEY = HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string";
-  public static final String INVALID_ZK_CLIENT_CONNECT_STRING = "";
 
   /**
    * The ZooKeeper server address. This config is required when using {@code HelixAccountService}.
@@ -56,8 +55,7 @@ public class HelixAccountServiceConfig {
   public final String backupDir;
 
   public HelixAccountServiceConfig(VerifiableProperties verifiableProperties) {
-    zkClientConnectString =
-        verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY, INVALID_ZK_CLIENT_CONNECT_STRING);
+    zkClientConnectString = verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY);
     updaterPollingIntervalMs =
         verifiableProperties.getIntInRange(UPDATER_POLLING_INTERVAL_MS_KEY, 60 * 60 * 1000, 0, Integer.MAX_VALUE);
     updaterShutDownTimeoutMs =

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -23,6 +23,15 @@ public class HelixAccountServiceConfig {
   public static final String UPDATER_SHUT_DOWN_TIMEOUT_MS_KEY =
       HELIX_ACCOUNT_SERVICE_PREFIX + "updater.shut.down.timeout.ms";
   public static final String BACKUP_DIRECTORY_KEY = HELIX_ACCOUNT_SERVICE_PREFIX + "backup.dir";
+  public static final String INVALID_ZK_CLIENT_CONNECT_STRING = "";
+
+  /**
+   * The ZooKeeper server address. This config is required when using {@code HelixAccountService}, but not for
+   * {@code InMemoryUnknownAccountService}.
+   */
+  @Config(HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string")
+  @Default(INVALID_ZK_CLIENT_CONNECT_STRING)
+  public final String zkClientConnectString;
 
   /**
    * The time interval in second between two consecutive account pulling for the background account updater of
@@ -48,6 +57,8 @@ public class HelixAccountServiceConfig {
   public final String backupDir;
 
   public HelixAccountServiceConfig(VerifiableProperties verifiableProperties) {
+    zkClientConnectString = verifiableProperties.getString(HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string",
+        INVALID_ZK_CLIENT_CONNECT_STRING);
     updaterPollingIntervalMs =
         verifiableProperties.getIntInRange(UPDATER_POLLING_INTERVAL_MS_KEY, 60 * 60 * 1000, 0, Integer.MAX_VALUE);
     updaterShutDownTimeoutMs =

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixPropertyStoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixPropertyStoreConfig.java
@@ -18,7 +18,6 @@ package com.github.ambry.config;
  */
 public class HelixPropertyStoreConfig {
   public static final String HELIX_PROPERTY_STORE_PREFIX = "helix.property.store.";
-  public static final String INVALID_ZK_CLIENT_CONNECT_STRING = "";
 
   /**
    * Time in ms to time out a connection to a ZooKeeper server.
@@ -36,14 +35,6 @@ public class HelixPropertyStoreConfig {
   public final int zkClientSessionTimeoutMs;
 
   /**
-   * The ZooKeeper server address. This config is required when using {@code HelixAccountService}, but not for
-   * {@code InMemoryUnknownAccountService}.
-   */
-  @Config(HELIX_PROPERTY_STORE_PREFIX + "zk.client.connect.string")
-  @Default(INVALID_ZK_CLIENT_CONNECT_STRING)
-  public final String zkClientConnectString;
-
-  /**
    * The root path of helix property store in the ZooKeeper. Must start with {@code /}, and must not end with {@code /}.
    * It is recommended to make root path in the form of {@code /ambry/<clustername>/helixPropertyStore}
    */
@@ -58,8 +49,6 @@ public class HelixPropertyStoreConfig {
     zkClientSessionTimeoutMs =
         verifiableProperties.getIntInRange(HELIX_PROPERTY_STORE_PREFIX + "zk.client.session.timeout.ms", 20 * 1000, 1,
             Integer.MAX_VALUE);
-    zkClientConnectString = verifiableProperties.getString(HELIX_PROPERTY_STORE_PREFIX + "zk.client.connect.string",
-        INVALID_ZK_CLIENT_CONNECT_STRING);
     rootPath = verifiableProperties.getString(HELIX_PROPERTY_STORE_PREFIX + "root.path",
         "/ambry/defaultCluster/helixPropertyStore");
   }

--- a/ambry-api/src/test/java/com.github.ambry/account/InMemAccountServiceFactory.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/InMemAccountServiceFactory.java
@@ -41,7 +41,7 @@ public class InMemAccountServiceFactory implements AccountServiceFactory {
    * @param metricRegistry will be discarded
    * @param notifier will be discarded
    */
-  public InMemAccountServiceFactory(VerifiableProperties verifiableProperties, Object metricRegistry, Object notifier) {
+  public InMemAccountServiceFactory(VerifiableProperties verifiableProperties, Object metricRegistry) {
     returnOnlyUnknown = verifiableProperties.getBoolean("in.mem.account.service.only.unknown", false);
     notifyConsumers =
         !returnOnlyUnknown && verifiableProperties.getBoolean("in.mem.account.service.notify.consumers", true);

--- a/ambry-commons/src/main/java/com.github.ambry.commons/HelixNotifier.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/HelixNotifier.java
@@ -64,21 +64,23 @@ public class HelixNotifier implements Notifier<String> {
 
   /**
    * A constructor that gets a {@link HelixNotifier} based on {@link HelixPropertyStoreConfig}.
+   * @param zkServers the ZooKeeper server address.
    * @param storeConfig A {@link HelixPropertyStore} used to instantiate a {@link HelixNotifier}. Cannot be {@code null}.
    */
-  public HelixNotifier(HelixPropertyStoreConfig storeConfig) {
+  public HelixNotifier(String zkServers, HelixPropertyStoreConfig storeConfig) {
     if (storeConfig == null) {
       throw new IllegalArgumentException("storeConfig cannot be null");
     }
     long startTimeMs = System.currentTimeMillis();
     logger.info("Starting a HelixNotifier");
-    ZkClient zkClient = new ZkClient(storeConfig.zkClientConnectString, storeConfig.zkClientSessionTimeoutMs,
-        storeConfig.zkClientConnectionTimeoutMs, new ZNRecordSerializer());
+    ZkClient zkClient =
+        new ZkClient(zkServers, storeConfig.zkClientSessionTimeoutMs, storeConfig.zkClientConnectionTimeoutMs,
+            new ZNRecordSerializer());
     List<String> subscribedPaths = Collections.singletonList(storeConfig.rootPath + HelixNotifier.TOPIC_PATH);
     HelixPropertyStore<ZNRecord> helixStore =
         new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(zkClient), storeConfig.rootPath, subscribedPaths);
     logger.info("HelixPropertyStore started with zkClientConnectString={}, zkClientSessionTimeoutMs={}, "
-            + "zkClientConnectionTimeoutMs={}, rootPath={}, subscribedPaths={}", storeConfig.zkClientConnectString,
+            + "zkClientConnectionTimeoutMs={}, rootPath={}, subscribedPaths={}", zkServers,
         storeConfig.zkClientSessionTimeoutMs, storeConfig.zkClientConnectionTimeoutMs, storeConfig.rootPath,
         subscribedPaths);
     this.helixStore = helixStore;

--- a/ambry-commons/src/test/java/com.github.ambry.commons/HelixNotifierTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/HelixNotifierTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.commons;
 
+import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import java.util.ArrayList;
@@ -41,7 +42,7 @@ import static org.junit.Assert.*;
 public class HelixNotifierTest {
   private static final int ZK_CLIENT_CONNECT_TIMEOUT_MS = 20 * 1000;
   private static final int ZK_CLIENT_SESSION_TIMEOUT_MS = 20 * 1000;
-  private static final String ZK_CLIENT_CONNECT_STRING = "dummyHost:dummyPort";
+  public static final String ZK_CLIENT_CONNECT_STRING = "";
   private static final String STORAGE_ROOT_PATH = "/ambry/testCluster/helixPropertyStore";
   private static final long LATCH_TIMEOUT_MS = 1000;
   private static final List<String> receivedTopicsByListener0 = new ArrayList<>();
@@ -311,7 +312,7 @@ public class HelixNotifierTest {
 
     // pass null storeConfig to construct a HelixNotifier
     try {
-      new HelixNotifier((HelixPropertyStoreConfig) null);
+      new HelixNotifier(ZK_CLIENT_CONNECT_STRING, (HelixPropertyStoreConfig) null);
       fail("Should have thrown");
     } catch (IllegalArgumentException e) {
       // expected
@@ -429,7 +430,7 @@ public class HelixNotifierTest {
    * @return A {@link MockHelixPropertyStore} defined by the {@link HelixPropertyStoreConfig}.
    */
   private MockHelixPropertyStore<ZNRecord> getMockHelixStore(HelixPropertyStoreConfig storeConfig) {
-    String storeRootPath = storeConfig.zkClientConnectString + storeConfig.rootPath;
+    String storeRootPath = ZK_CLIENT_CONNECT_STRING + storeConfig.rootPath;
     MockHelixPropertyStore<ZNRecord> helixStore = storeKeyToMockStoreMap.get(storeRootPath);
     if (helixStore == null) {
       helixStore = new MockHelixPropertyStore<>();
@@ -454,7 +455,7 @@ public class HelixNotifierTest {
         String.valueOf(zkClientConnectionTimeoutMs));
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "zk.client.session.timeout.ms",
         String.valueOf(zkClientSessionTimeoutMs));
-    helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "zk.client.connect.string",
+    helixConfigProps.setProperty(HelixAccountServiceConfig.HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string",
         zkClientConnectString);
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "root.path", storeRootPath);
     VerifiableProperties vHelixConfigProps = new VerifiableProperties(helixConfigProps);

--- a/ambry-commons/src/test/java/com.github.ambry.commons/HelixNotifierTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/HelixNotifierTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.*;
 public class HelixNotifierTest {
   private static final int ZK_CLIENT_CONNECT_TIMEOUT_MS = 20 * 1000;
   private static final int ZK_CLIENT_SESSION_TIMEOUT_MS = 20 * 1000;
-  public static final String ZK_CLIENT_CONNECT_STRING = "";
+  private static final String ZK_CLIENT_CONNECT_STRING = "";
   private static final String STORAGE_ROOT_PATH = "/ambry/testCluster/helixPropertyStore";
   private static final long LATCH_TIMEOUT_MS = 1000;
   private static final List<String> receivedTopicsByListener0 = new ArrayList<>();

--- a/ambry-commons/src/test/java/com.github.ambry.commons/HelixNotifierTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/HelixNotifierTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.*;
 public class HelixNotifierTest {
   private static final int ZK_CLIENT_CONNECT_TIMEOUT_MS = 20 * 1000;
   private static final int ZK_CLIENT_SESSION_TIMEOUT_MS = 20 * 1000;
-  private static final String ZK_CLIENT_CONNECT_STRING = "";
+  private static final String ZK_CLIENT_CONNECT_STRING = "dummyHost:dummyPort";
   private static final String STORAGE_ROOT_PATH = "/ambry/testCluster/helixPropertyStore";
   private static final long LATCH_TIMEOUT_MS = 1000;
   private static final List<String> receivedTopicsByListener0 = new ArrayList<>();
@@ -455,8 +455,7 @@ public class HelixNotifierTest {
         String.valueOf(zkClientConnectionTimeoutMs));
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "zk.client.session.timeout.ms",
         String.valueOf(zkClientSessionTimeoutMs));
-    helixConfigProps.setProperty(HelixAccountServiceConfig.HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string",
-        zkClientConnectString);
+    helixConfigProps.setProperty(HelixAccountServiceConfig.ZK_CLIENT_CONNECT_STRING_KEY, zkClientConnectString);
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "root.path", storeRootPath);
     VerifiableProperties vHelixConfigProps = new VerifiableProperties(helixConfigProps);
     return new HelixPropertyStoreConfig(vHelixConfigProps);

--- a/ambry-commons/src/test/java/com.github.ambry.commons/HelixStoreOperator.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/HelixStoreOperator.java
@@ -50,21 +50,23 @@ public class HelixStoreOperator {
 
   /**
    * A constructor that gets a {@link HelixStoreOperator} based on the {@link HelixPropertyStoreConfig}.
+   * @param zkServers the ZooKeeper server address.
    * @param storeConfig A {@link HelixPropertyStore} used to instantiate a {@link HelixStoreOperator}.
    */
-  public HelixStoreOperator(HelixPropertyStoreConfig storeConfig) {
+  public HelixStoreOperator(String zkServers, HelixPropertyStoreConfig storeConfig) {
     if (storeConfig == null) {
       throw new IllegalArgumentException("storeConfig cannot be null");
     }
     long startTimeMs = System.currentTimeMillis();
     logger.info("Starting a HelixStoreOperator");
-    ZkClient zkClient = new ZkClient(storeConfig.zkClientConnectString, storeConfig.zkClientSessionTimeoutMs,
-        storeConfig.zkClientConnectionTimeoutMs, new ZNRecordSerializer());
+    ZkClient zkClient =
+        new ZkClient(zkServers, storeConfig.zkClientSessionTimeoutMs, storeConfig.zkClientConnectionTimeoutMs,
+            new ZNRecordSerializer());
     List<String> subscribedPaths = Collections.singletonList(storeConfig.rootPath);
     HelixPropertyStore<ZNRecord> helixStore =
         new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(zkClient), storeConfig.rootPath, subscribedPaths);
     logger.info("HelixPropertyStore started with zkClientConnectString={}, zkClientSessionTimeoutMs={}, "
-            + "zkClientConnectionTimeoutMs={}, rootPath={}, subscribedPaths={}", storeConfig.zkClientConnectString,
+            + "zkClientConnectionTimeoutMs={}, rootPath={}, subscribedPaths={}", zkServers,
         storeConfig.zkClientSessionTimeoutMs, storeConfig.zkClientConnectionTimeoutMs, storeConfig.rootPath,
         subscribedPaths);
     this.helixStore = helixStore;

--- a/ambry-rest/src/main/java/com.github.ambry.rest/RestServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/RestServer.java
@@ -21,10 +21,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.account.AccountServiceFactory;
 import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.commons.HelixNotifier;
-import com.github.ambry.commons.Notifier;
 import com.github.ambry.commons.SSLFactory;
-import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.RestServerConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.notification.NotificationSystem;
@@ -169,14 +166,9 @@ public class RestServer {
     restServerState = new RestServerState(restServerConfig.restServerHealthCheckUri);
     restServerMetrics = new RestServerMetrics(metricRegistry, restServerState);
 
-    HelixPropertyStoreConfig helixStoreConfig = new HelixPropertyStoreConfig(verifiableProperties);
-    Notifier notifier = null;
-    if (!helixStoreConfig.zkClientConnectString.equals(HelixPropertyStoreConfig.INVALID_ZK_CLIENT_CONNECT_STRING)) {
-      notifier = new HelixNotifier(helixStoreConfig);
-    }
     AccountServiceFactory accountServiceFactory =
         Utils.getObj(restServerConfig.restServerAccountServiceFactory, verifiableProperties,
-            clusterMap.getMetricRegistry(), notifier);
+            clusterMap.getMetricRegistry());
     accountService = accountServiceFactory.getAccountService();
 
     RouterFactory routerFactory =

--- a/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
@@ -80,8 +80,7 @@ public class AccountUpdateToolTest {
   static {
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "root.path",
         HELIX_STORE_ROOT_PATH);
-    helixConfigProps.setProperty(HelixAccountServiceConfig.HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string",
-        ZK_SERVER_ADDRESS);
+    helixConfigProps.setProperty(HelixAccountServiceConfig.ZK_CLIENT_CONNECT_STRING_KEY, ZK_SERVER_ADDRESS);
     vHelixConfigProps = new VerifiableProperties(helixConfigProps);
     storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
     try {

--- a/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.account;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.commons.HelixNotifier;
 import com.github.ambry.commons.HelixStoreOperator;
+import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.TestUtils;
@@ -77,10 +78,10 @@ public class AccountUpdateToolTest {
    * Initialization for all the tests.
    */
   static {
-    helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "zk.client.connect.string",
-        ZK_SERVER_ADDRESS);
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "root.path",
         HELIX_STORE_ROOT_PATH);
+    helixConfigProps.setProperty(HelixAccountServiceConfig.HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string",
+        ZK_SERVER_ADDRESS);
     vHelixConfigProps = new VerifiableProperties(helixConfigProps);
     storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
     try {
@@ -113,15 +114,14 @@ public class AccountUpdateToolTest {
     tempDirPath = getTempDir("accountUpdateTool-");
 
     // clean up data on ZooKeeper
-    storeOperator = new HelixStoreOperator(storeConfig);
+    storeOperator = new HelixStoreOperator(ZK_SERVER_ADDRESS, storeConfig);
     if (storeOperator.exist("/")) {
       storeOperator.delete("/");
     }
 
     // instantiate a HelixAccountService and listen to the change for account metadata
-    notifier = new HelixNotifier(storeConfig);
-    accountService =
-        new HelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier).getAccountService();
+    notifier = new HelixNotifier(ZK_SERVER_ADDRESS, storeConfig);
+    accountService = new HelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry()).getAccountService();
     accountUpdateConsumer = new TestAccountUpdateConsumer();
     accountService.addAccountUpdateConsumer(accountUpdateConsumer);
   }

--- a/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
@@ -16,6 +16,7 @@ package com.github.ambry.account;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.commons.HelixNotifier;
 import com.github.ambry.commons.Notifier;
+import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.tools.util.ToolUtils;
@@ -232,13 +233,11 @@ public class AccountUpdateTool {
         String.valueOf(zkConnectionTimeoutMs));
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "zk.client.session.timeout.ms",
         String.valueOf(zkSessionTimeoutMs));
-    helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "zk.client.connect.string",
+    helixConfigProps.setProperty(HelixAccountServiceConfig.HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string",
         zkServer);
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "root.path", storePath);
     VerifiableProperties vHelixConfigProps = new VerifiableProperties(helixConfigProps);
-    HelixPropertyStoreConfig storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
-    Notifier notifier = new HelixNotifier(storeConfig);
-    return new HelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier).getAccountService();
+    return new HelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry()).getAccountService();
   }
 
   /**

--- a/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
@@ -15,7 +15,6 @@ package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.commons.HelixNotifier;
-import com.github.ambry.commons.Notifier;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -233,8 +232,7 @@ public class AccountUpdateTool {
         String.valueOf(zkConnectionTimeoutMs));
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "zk.client.session.timeout.ms",
         String.valueOf(zkSessionTimeoutMs));
-    helixConfigProps.setProperty(HelixAccountServiceConfig.HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string",
-        zkServer);
+    helixConfigProps.setProperty(HelixAccountServiceConfig.ZK_CLIENT_CONNECT_STRING_KEY, zkServer);
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "root.path", storePath);
     VerifiableProperties vHelixConfigProps = new VerifiableProperties(helixConfigProps);
     return new HelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry()).getAccountService();


### PR DESCRIPTION
- Instantiate Notifier in HelixAccountServiceFactory ctor rather than
pass args.
- Move zkClientConnectString from HelixPropertyStoreConfig to
HelixAccountServiceConfig
- ./gralew build && ./gradlew test succeeded.