### PR TITLE
Add accountName/containerName to NotificationSystem

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/notification/NotificationSystem.java
+++ b/ambry-api/src/main/java/com.github.ambry/notification/NotificationSystem.java
@@ -29,24 +29,31 @@ public interface NotificationSystem extends Closeable {
    * Notifies the underlying system when a new blob is created
    * @param blobId The id of the blob that was created
    * @param blobProperties The blob properties for the blob
+   * @param accountName The account name for the blob
+   * @param containerName The container name for the blob
    * @param notificationBlobType The {@link NotificationBlobType} of this blob.
    */
-  void onBlobCreated(String blobId, BlobProperties blobProperties, NotificationBlobType notificationBlobType);
+  void onBlobCreated(String blobId, BlobProperties blobProperties, String accountName, String containerName,
+      NotificationBlobType notificationBlobType);
 
   /**
    * Notifies the underlying system when the ttl of an existing blob is updated
    * @param blobId The id of the blob whose ttl was updated
    * @param serviceId The service ID of the service that updated the tll of the blob. This can be null if unknown
-   * @param expiresAtMs the new expiry time (in ms) of the blob
+   * @param expiresAtMs The new expiry time (in ms) of the blob
+   * @param accountName The account name for the blob
+   * @param containerName The container name for the blob
    */
-  void onBlobTtlUpdated(String blobId, String serviceId, long expiresAtMs);
+  void onBlobTtlUpdated(String blobId, String serviceId, long expiresAtMs, String accountName, String containerName);
 
   /**
    * Notifies the underlying system when an existing blob is deleted
    * @param blobId The id of the blob that was deleted
    * @param serviceId The service ID of the service deleting the blob. This can be null if unknown.
+   * @param accountName The account name for the blob
+   * @param containerName The container name for the blob
    */
-  void onBlobDeleted(String blobId, String serviceId);
+  void onBlobDeleted(String blobId, String serviceId, String accountName, String containerName);
 
   /**
    * Notifies the underlying system when a blob is replicated to a node

--- a/ambry-commons/src/main/java/com.github.ambry.commons/LoggingNotificationSystem.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/LoggingNotificationSystem.java
@@ -36,18 +36,24 @@ public class LoggingNotificationSystem implements NotificationSystem {
   }
 
   @Override
-  public void onBlobCreated(String blobId, BlobProperties blobProperties, NotificationBlobType notificationBlobType) {
-    logger.debug("onBlobCreated " + blobId + ", " + blobProperties + ", " + notificationBlobType);
+  public void onBlobCreated(String blobId, BlobProperties blobProperties, String accountName, String containerName,
+      NotificationBlobType notificationBlobType) {
+    logger.debug("onBlobCreated " + blobId + ", blobProperties " + blobProperties + ", accountName " + accountName
+        + ", containerName " + containerName + ", blobType " + notificationBlobType);
   }
 
   @Override
-  public void onBlobTtlUpdated(String blobId, String serviceId, long expiresAtMs) {
-    logger.debug("onBlobTtlUpdated " + blobId + ", " + serviceId + ", " + expiresAtMs);
+  public void onBlobTtlUpdated(String blobId, String serviceId, long expiresAtMs, String accountName,
+      String containerName) {
+    logger.debug(
+        "onBlobTtlUpdated " + blobId + ", serviceId " + serviceId + ", accountName " + accountName + ", containerName "
+            + containerName + ", " + expiresAtMs);
   }
 
   @Override
-  public void onBlobDeleted(String blobId, String serviceId) {
-    logger.debug("onBlobDeleted " + blobId, ", " + serviceId);
+  public void onBlobDeleted(String blobId, String serviceId, String accountName, String containerName) {
+    logger.debug("onBlobDeleted " + blobId,
+        ", " + serviceId + ", accountName " + accountName + ", containerName " + containerName);
   }
 
   @Override

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyMessageProcessorTest.java
@@ -437,18 +437,20 @@ public class NettyMessageProcessorTest {
     protected volatile CountDownLatch operationCompleted = new CountDownLatch(1);
 
     @Override
-    public void onBlobCreated(String blobId, BlobProperties blobProperties, NotificationBlobType notificationBlobType) {
+    public void onBlobCreated(String blobId, BlobProperties blobProperties, String accountName, String containerName,
+        NotificationBlobType notificationBlobType) {
       blobIdOperatedOn = blobId;
       operationCompleted.countDown();
     }
 
     @Override
-    public void onBlobTtlUpdated(String blobId, String serviceId, long expiresAtMs) {
+    public void onBlobTtlUpdated(String blobId, String serviceId, long expiresAtMs, String accountName,
+        String containerName) {
       throw new IllegalStateException("Not implemented");
     }
 
     @Override
-    public void onBlobDeleted(String blobId, String serviceId) {
+    public void onBlobDeleted(String blobId, String serviceId, String accountName, String containerName) {
       throw new IllegalStateException("Not implemented");
     }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -506,10 +506,11 @@ class NonBlockingRouter implements Router {
       getManager =
           new GetManager(clusterMap, responseHandler, routerConfig, routerMetrics, routerCallback, kms, cryptoService,
               cryptoJobHandler, time);
-      deleteManager = new DeleteManager(clusterMap, responseHandler, notificationSystem, routerConfig, routerMetrics,
-          routerCallback, time);
+      deleteManager = new DeleteManager(clusterMap, responseHandler, accountService, notificationSystem, routerConfig,
+          routerMetrics, routerCallback, time);
       ttlUpdateManager =
-          new TtlUpdateManager(clusterMap, responseHandler, notificationSystem, routerConfig, routerMetrics, time);
+          new TtlUpdateManager(clusterMap, responseHandler, notificationSystem, accountService, routerConfig,
+              routerMetrics, time);
       requestResponseHandlerThread = Utils.newThread("RequestResponseHandlerThread-" + suffix, this, true);
       requestResponseHandlerThread.start();
       routerMetrics.initializeOperationControllerMetrics(requestResponseHandlerThread);

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -159,7 +159,8 @@ class PutManager {
       FutureResult<String> futureResult, Callback<String> callback) {
     String partitionClass = getPartitionClass(blobProperties);
     PutOperation putOperation =
-        new PutOperation(routerConfig, routerMetrics, clusterMap, responseHandler, notificationSystem, userMetaData,
+        new PutOperation(routerConfig, routerMetrics, clusterMap, responseHandler, notificationSystem, accountService,
+            userMetaData,
             channel, futureResult, callback, routerCallback, chunkArrivalListener, kms, cryptoService, cryptoJobHandler,
             time, blobProperties, partitionClass);
     putOperations.add(putOperation);

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -13,10 +13,14 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.Account;
+import com.github.ambry.account.AccountService;
+import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.RouterConfig;
+import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,5 +105,21 @@ class RouterUtils {
    */
   static int getNumChunksForBlobAndChunkSize(long blobSize, int chunkSize) {
     return (int) (blobSize == 0 ? 1 : (blobSize - 1) / chunkSize + 1);
+  }
+
+  /**
+   * Return accountName and containerName in a {@link Pair}.
+   * @param accountService the accountService to translate accountId to name.
+   * @param accountId the accountId to translate.
+   * @param accountId the containerId to translate.
+   * @return accountName and containerName in a {@link Pair}.
+   */
+  static Pair<String, String> getAccountContainerName(AccountService accountService, short accountId,
+      short containerId) {
+    Account account = accountService.getAccountById(accountId);
+    String accountName = account == null ? null : account.getName();
+    Container container = account == null ? null : account.getContainerById(containerId);
+    String containerName = container == null ? null : container.getName();
+    return new Pair<>(accountName, containerName);
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.BlobId;
@@ -150,7 +151,7 @@ public class ChunkFillTest {
     MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
-            putUserMetadata, putChannel, futureResult, null,
+            new InMemAccountService(true, false), putUserMetadata, putChannel, futureResult, null,
             new RouterCallback(networkClientFactory.getNetworkClient(), new ArrayList<BackgroundDeleteRequest>()), null,
             null, null, null, new MockTime(), putBlobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
     op.startReadingFromChannel();
@@ -260,8 +261,8 @@ public class ChunkFillTest {
         new MockRouterCallback(networkClientFactory.getNetworkClient(), Collections.EMPTY_LIST);
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
-            putUserMetadata, putChannel, futureResult, null, routerCallback, null, kms, cryptoService, cryptoJobHandler,
-            time, putBlobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
+            new InMemAccountService(true, false), putUserMetadata, putChannel, futureResult, null, routerCallback, null,
+            kms, cryptoService, cryptoJobHandler, time, putBlobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
     op.startReadingFromChannel();
     numChunks = RouterUtils.getNumChunksForBlobAndChunkSize(blobSize, chunkSize);
     compositeBuffers = new ByteBuffer[numChunks];

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
@@ -214,7 +214,7 @@ public class InMemoryRouter implements Router {
       if (!deletedBlobs.contains(blobId) && blobs.containsKey(blobId)) {
         deletedBlobs.add(blobId);
         if (notificationSystem != null) {
-          notificationSystem.onBlobDeleted(blobId, serviceId);
+          notificationSystem.onBlobDeleted(blobId, serviceId, null, null);
         }
       } else if (!deletedBlobs.contains(blobId)) {
         exception = new RouterException("Blob not found", RouterErrorCode.BlobDoesNotExist);
@@ -245,7 +245,7 @@ public class InMemoryRouter implements Router {
         long newTtlSecs = Utils.getTtlInSecsFromExpiryMs(expiresAtMs, currentProps.getCreationTimeInMs());
         blob.blobProperties.setTimeToLiveInSeconds(newTtlSecs);
         if (notificationSystem != null) {
-          notificationSystem.onBlobTtlUpdated(blobId, serviceId, expiresAtMs);
+          notificationSystem.onBlobTtlUpdated(blobId, serviceId, expiresAtMs, null, null);
         }
       } else if (deletedBlobs.contains(blobId)) {
         exception = new RouterException("Blob has been deleted", RouterErrorCode.BlobDeleted);
@@ -394,7 +394,7 @@ class InMemoryBlobPoster implements Runnable {
           new InMemoryRouter.InMemoryBlob(postData.getBlobProperties(), postData.getUsermetadata(), blobData);
       blobs.put(blobId, blob);
       if (notificationSystem != null) {
-        notificationSystem.onBlobCreated(blobId, postData.getBlobProperties(), NotificationBlobType.Simple);
+        notificationSystem.onBlobCreated(blobId, postData.getBlobProperties(), null, null, NotificationBlobType.Simple);
       }
       operationResult = blobId;
     } catch (RouterException e) {

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -430,7 +430,7 @@ public class NonBlockingRouterTest {
     final Map<String, String> blobsThatAreDeleted = new HashMap<>();
     LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
       @Override
-      public void onBlobDeleted(String blobId, String serviceId) {
+      public void onBlobDeleted(String blobId, String serviceId, String accountName, String containerName) {
         blobsThatAreDeleted.put(blobId, serviceId);
         deletesDoneLatch.countDown();
       }
@@ -500,7 +500,7 @@ public class NonBlockingRouterTest {
     final Map<String, String> blobsThatAreDeleted = new HashMap<>();
     LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
       @Override
-      public void onBlobDeleted(String blobId, String serviceId) {
+      public void onBlobDeleted(String blobId, String serviceId, String accountName, String containerName) {
         blobsThatAreDeleted.put(blobId, serviceId);
         deletesDoneLatch.get().countDown();
       }
@@ -590,7 +590,7 @@ public class NonBlockingRouterTest {
     final AtomicReference<String> receivedDeleteServiceId = new AtomicReference<>();
     LoggingNotificationSystem deleteTrackingNotificationSystem = new LoggingNotificationSystem() {
       @Override
-      public void onBlobDeleted(String blobId, String serviceId) {
+      public void onBlobDeleted(String blobId, String serviceId, String accountName, String containerName) {
         deletesInitiated.incrementAndGet();
         receivedDeleteServiceId.set(serviceId);
       }
@@ -803,9 +803,10 @@ public class NonBlockingRouterTest {
     testResponseDeserializationError(opHelper, networkClient, blobId);
 
     opHelper = new OperationHelper(OperationType.DELETE);
-    deleteManager = new DeleteManager(mockClusterMap, mockResponseHandler, new LoggingNotificationSystem(),
-        new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
-        new RouterCallback(null, new ArrayList<BackgroundDeleteRequest>()), mockTime);
+    deleteManager =
+        new DeleteManager(mockClusterMap, mockResponseHandler, accountService, new LoggingNotificationSystem(),
+            new RouterConfig(verifiableProperties), new NonBlockingRouterMetrics(mockClusterMap),
+            new RouterCallback(null, new ArrayList<BackgroundDeleteRequest>()), mockTime);
     testFailureDetectorNotification(opHelper, networkClient, failedReplicaIds, blobId, successfulResponseCount,
         invalidResponse, -1);
     // Test that if a failed response comes before the operation is completed, failure detector is notified.

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -1128,7 +1128,8 @@ public class PutManagerTest {
     Map<String, List<BlobCreatedEvent>> blobCreatedEvents = new HashMap<>();
 
     @Override
-    public void onBlobCreated(String blobId, BlobProperties blobProperties, NotificationBlobType notificationBlobType) {
+    public void onBlobCreated(String blobId, BlobProperties blobProperties, String accountName, String containerName,
+        NotificationBlobType notificationBlobType) {
       List<BlobCreatedEvent> events = blobCreatedEvents.get(blobId);
       if (events == null) {
         events = new ArrayList<>();

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
@@ -103,7 +104,7 @@ public class PutOperationTest {
     MockNetworkClient mockNetworkClient = new MockNetworkClient();
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
-            userMetadata, channel, future, null,
+            new InMemAccountService(true, false), userMetadata, channel, future, null,
             new RouterCallback(mockNetworkClient, new ArrayList<BackgroundDeleteRequest>()), null, null, null, null,
             time, blobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
     op.startReadingFromChannel();
@@ -211,7 +212,7 @@ public class PutOperationTest {
     MockNetworkClient mockNetworkClient = new MockNetworkClient();
     PutOperation op =
         new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
-            userMetadata, channel, future, null,
+            new InMemAccountService(true, false), userMetadata, channel, future, null,
             new RouterCallback(mockNetworkClient, new ArrayList<BackgroundDeleteRequest>()), null, null, null, null,
             time, blobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
     RouterErrorCode[] routerErrorCodes = new RouterErrorCode[5];

--- a/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.account.AccountService;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
@@ -83,6 +84,7 @@ public class TtlUpdateManagerTest {
   private final List<String> blobIds = new ArrayList<>(BLOBS_COUNT);
   private final TtlUpdateNotificationSystem notificationSystem = new TtlUpdateNotificationSystem();
   private final int serverCount = serverLayout.getMockServers().size();
+  private final AccountService accountService = new InMemAccountService(true, false);
 
   /**
    * Sets up all required components including a blob.
@@ -109,7 +111,8 @@ public class TtlUpdateManagerTest {
       blobIds.add(blobId);
     }
     ttlUpdateManager =
-        new TtlUpdateManager(clusterMap, new ResponseHandler(clusterMap), notificationSystem, routerConfig, metrics,
+        new TtlUpdateManager(clusterMap, new ResponseHandler(clusterMap), notificationSystem, accountService,
+            routerConfig, metrics,
             time);
     networkClient = networkClientFactory.getNetworkClient();
   }
@@ -486,7 +489,8 @@ class TtlUpdateNotificationSystem extends LoggingNotificationSystem {
   private final AtomicReference<Boolean> mismatchedData = new AtomicReference<>(false);
 
   @Override
-  public void onBlobTtlUpdated(String blobId, String serviceId, long expiresAtMs) {
+  public void onBlobTtlUpdated(String blobId, String serviceId, long expiresAtMs, String accountName,
+      String containerName) {
     updatesInitiated.incrementAndGet();
     if (receivedUpdateServiceId.get() == null) {
       receivedUpdateServiceId.set(serviceId);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -382,17 +382,19 @@ class MockNotificationSystem implements NotificationSystem {
   }
 
   @Override
-  public void onBlobCreated(String blobId, BlobProperties blobProperties, NotificationBlobType notificationBlobType) {
+  public void onBlobCreated(String blobId, BlobProperties blobProperties, String accountName, String containerName,
+      NotificationBlobType notificationBlobType) {
     // ignore
   }
 
   @Override
-  public void onBlobTtlUpdated(String blobId, String serviceId, long expiresAtMs) {
+  public void onBlobTtlUpdated(String blobId, String serviceId, long expiresAtMs, String accountName,
+      String containerName) {
     // ignore
   }
 
   @Override
-  public void onBlobDeleted(String blobId, String serviceId) {
+  public void onBlobDeleted(String blobId, String serviceId, String accountName, String containerName) {
     // ignore
   }
 


### PR DESCRIPTION
Introduced `AccountService` to `*Manager`.
Added a method `getAccountContainerName` to translate `accoutId` and `containerId`.
Changed `NotificationSystem` interface. 