### PR TITLE
Adding a config for providing a default GetOption at the frontend

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.config;
 
+import com.github.ambry.protocol.GetOption;
+import com.github.ambry.router.GetBlobOptions;
 import java.util.Arrays;
 import java.util.List;
 
@@ -123,6 +125,15 @@ public class FrontendConfig {
   @Default("5 * 60")
   public final long frontendUrlSignerDefaultUrlTtlSecs;
 
+  /**
+   * The default {@link GetOption} that the frontend has to use when constructing
+   * {@link GetBlobOptions} for {@link com.github.ambry.router.Router#getBlob(String, GetBlobOptions)}
+   * (or the callback equivalent).
+   */
+  @Config("frontend.default.router.get.option")
+  @Default("GetOption.None")
+  public final GetOption frontendDefaultRouterGetOption;
+
   public FrontendConfig(VerifiableProperties verifiableProperties) {
     frontendCacheValiditySeconds = verifiableProperties.getLong("frontend.cache.validity.seconds", 365 * 24 * 60 * 60);
     frontendOptionsValiditySeconds = verifiableProperties.getLong("frontend.options.validity.seconds", 24 * 60 * 60);
@@ -152,5 +163,7 @@ public class FrontendConfig {
     frontendUrlSignerDefaultUrlTtlSecs =
         verifiableProperties.getLongInRange("frontend.url.signer.default.url.ttl.secs", 5 * 60, 0,
             frontendUrlSignerMaxUrlTtlSecs);
+    frontendDefaultRouterGetOption =
+        GetOption.valueOf(verifiableProperties.getString("frontend.default.router.get.option", GetOption.None.name()));
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -551,19 +551,21 @@ public class RestUtils {
   /**
    * Gets the {@link GetOption} required by the request.
    * @param restRequest the representation of the request.
+   * @param defaultGetOption the {@link GetOption} to use if the {@code restRequest} doesn't have one. Can be
+   * {@code null}.
    * @return the required {@link GetOption}. Defaults to {@link GetOption#None}.
    * @throws RestServiceException if the {@link RestUtils.Headers#GET_OPTION} is present but not recognized.
    */
-  public static GetOption getGetOption(RestRequest restRequest) throws RestServiceException {
-    GetOption options = GetOption.None;
-    Map<String, Object> args = restRequest.getArgs();
-    Object value = args.get(RestUtils.Headers.GET_OPTION);
+  public static GetOption getGetOption(RestRequest restRequest, GetOption defaultGetOption)
+      throws RestServiceException {
+    GetOption option = defaultGetOption == null ? GetOption.None : defaultGetOption;
+    Object value = restRequest.getArgs().get(RestUtils.Headers.GET_OPTION);
     if (value != null) {
       String str = (String) value;
       boolean foundMatch = false;
       for (GetOption getOption : GetOption.values()) {
         if (str.equalsIgnoreCase(getOption.name())) {
-          options = getOption;
+          option = getOption;
           foundMatch = true;
           break;
         }
@@ -573,7 +575,7 @@ public class RestUtils {
             RestServiceErrorCode.InvalidArgs);
       }
     }
-    return options;
+    return option;
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -676,7 +676,7 @@ public class RestUtilsTest {
   }
 
   /**
-   * Tests {@link RestUtils#getGetOption(RestRequest)}.
+   * Tests {@link RestUtils#getGetOption(RestRequest, GetOption)}.
    * @throws Exception
    */
   @Test
@@ -685,17 +685,22 @@ public class RestUtilsTest {
       JSONObject headers = new JSONObject();
       headers.put(RestUtils.Headers.GET_OPTION, option.toString().toLowerCase());
       RestRequest restRequest = createRestRequest(RestMethod.GET, "/", headers);
-      assertEquals("Option returned not as expected", option, RestUtils.getGetOption(restRequest));
+      assertEquals("Option returned not as expected", option, RestUtils.getGetOption(restRequest, null));
+      assertEquals("Option returned not as expected", option, RestUtils.getGetOption(restRequest, option));
+      assertEquals("Option returned not as expected", option, RestUtils.getGetOption(restRequest, GetOption.None));
     }
     // no value defined
     RestRequest restRequest = createRestRequest(RestMethod.GET, "/", null);
-    assertEquals("Option returned not as expected", GetOption.None, RestUtils.getGetOption(restRequest));
+    assertEquals("Option returned not as expected", GetOption.None, RestUtils.getGetOption(restRequest, null));
+    for (GetOption option : GetOption.values()) {
+      assertEquals("Option returned not as expected", option, RestUtils.getGetOption(restRequest, option));
+    }
     // bad value
     JSONObject headers = new JSONObject();
     headers.put(RestUtils.Headers.GET_OPTION, "non_existent_option");
     restRequest = createRestRequest(RestMethod.GET, "/", headers);
     try {
-      RestUtils.getGetOption(restRequest);
+      RestUtils.getGetOption(restRequest, GetOption.None);
       fail("Should have failed to get GetOption because value of header is invalid");
     } catch (RestServiceException e) {
       assertEquals("Unexpected RestServiceErrorCode", RestServiceErrorCode.InvalidArgs, e.getErrorCode());
@@ -1024,8 +1029,10 @@ public class RestUtilsTest {
    * @throws org.json.JSONException
    */
   public static void setUserMetadataHeaders(JSONObject headers, Map<String, String> userMetadata) throws JSONException {
-    for (String key : userMetadata.keySet()) {
-      headers.put(key, userMetadata.get(key));
+    if (userMetadata != null) {
+      for (String key : userMetadata.keySet()) {
+        headers.put(key, userMetadata.get(key));
+      }
     }
   }
 }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -179,8 +179,8 @@ class AmbryBlobStorageService implements BlobStorageService {
         getSignedUrlHandler.handle(restRequest, restResponseChannel,
             (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
       } else {
-        GetBlobOptions options =
-            RestUtils.buildGetBlobOptions(restRequest.getArgs(), subresource, RestUtils.getGetOption(restRequest));
+        GetBlobOptions options = RestUtils.buildGetBlobOptions(restRequest.getArgs(), subresource,
+            RestUtils.getGetOption(restRequest, frontendConfig.frontendDefaultRouterGetOption));
         GetCallback routerCallback = new GetCallback(restRequest, restResponseChannel, subresource, options);
         SecurityProcessRequestCallback securityCallback =
             new SecurityProcessRequestCallback(restRequest, restResponseChannel, routerCallback);
@@ -546,7 +546,7 @@ class AmbryBlobStorageService implements BlobStorageService {
               }
               break;
             case HEAD:
-              GetOption getOption = RestUtils.getGetOption(restRequest);
+              GetOption getOption = RestUtils.getGetOption(restRequest, frontendConfig.frontendDefaultRouterGetOption);
               // inject encryption metrics if need be
               if (BlobId.isEncrypted(result)) {
                 RestRequestMetrics requestMetrics =

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -1284,7 +1284,7 @@ public class AmbryBlobStorageServiceTest {
   }
 
   /**
-   * Tests blob conditional TTL udpate and DELETE operations on the given {@code container}.
+   * Tests blob conditional TTL update and DELETE operations on the given {@code container}.
    * @param expectedAccount the {@link Account} to use in post headers.
    * @param expectedContainer the {@link Container} to use in post headers.
    * @param serviceId the serviceId to use for the POST

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -959,7 +959,7 @@ public class MessageFormatRecord {
       DataInputStream dataStream = new DataInputStream(crcStream);
       short accountId = dataStream.readShort();
       short containerId = dataStream.readShort();
-      long udpateTimeInMs = dataStream.readLong();
+      long updateTimeInMs = dataStream.readLong();
       long actualCRC = crcStream.getValue();
       long expectedCRC = dataStream.readLong();
       if (actualCRC != expectedCRC) {
@@ -967,7 +967,7 @@ public class MessageFormatRecord {
             "update record data is corrupt. Expected CRC: " + expectedCRC + ", Actual CRC: " + actualCRC,
             MessageFormatErrorCodes.Data_Corrupt);
       }
-      return new UpdateRecord(accountId, containerId, udpateTimeInMs, new DeleteSubRecord());
+      return new UpdateRecord(accountId, containerId, updateTimeInMs, new DeleteSubRecord());
     }
   }
 


### PR DESCRIPTION
This change adds the ability to configure a default `GetOption` for all GET requests from the frontend to the `Router`. This can be useful if a lot of blobs were accidentally deleted or expired.