### PR TITLE
Add V5 support to BlobID.getLongForm()

### DIFF
--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -463,6 +463,7 @@ public class BlobId extends StoreKey {
       case BLOB_ID_V2:
       case BLOB_ID_V3:
       case BLOB_ID_V4:
+      case BLOB_ID_V5:
         sb.append(":").append(type);
         sb.append(":").append(datacenterId);
         sb.append(":").append(accountId);

--- a/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/BlobIdTest.java
@@ -356,7 +356,7 @@ public class BlobIdTest {
     BlobId blobIdV2 = getRandomBlobId(BLOB_ID_V2);
     BlobId blobIdV3 = getRandomBlobId(BLOB_ID_V3);
     BlobId blobIdV4 = getRandomBlobId(BLOB_ID_V4);
-    BlobId blobIdV5 = getRandomBlobId(BLOB_ID_V4);
+    BlobId blobIdV5 = getRandomBlobId(BLOB_ID_V5);
     // test v1
     assertTrue("isAccountContainerMatch() should always return true for  V1 blobID.",
         blobIdV1.isAccountContainerMatch(blobIdV1.getAccountId(), blobIdV1.getContainerId()));

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -468,7 +468,7 @@ public class AmbryBlobStorageServiceTest {
    */
   @Test
   public void injectionAccountAndContainerForGetHeadDeleteBlobIdTest() throws Exception {
-    for (short version : new Short[]{BlobId.BLOB_ID_V2, BlobId.BLOB_ID_V3, BlobId.BLOB_ID_V4}) {
+    for (short version : new Short[]{BlobId.BLOB_ID_V2, BlobId.BLOB_ID_V3, BlobId.BLOB_ID_V4, BlobId.BLOB_ID_V5}) {
       populateAccountService();
 
       // aid=refAId, cid=refCId

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
@@ -54,7 +54,7 @@ public class FrontendUtilsTest {
     PartitionId referencePartitionId =
         referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     boolean referenceIsEncrypted = TestUtils.RANDOM.nextBoolean();
-    short[] versions = {BlobId.BLOB_ID_V3, BlobId.BLOB_ID_V4};
+    short[] versions = {BlobId.BLOB_ID_V3, BlobId.BLOB_ID_V4, BlobId.BLOB_ID_V5};
     for (short version : versions) {
       BlobId blobId =
           new BlobId(version, referenceType, referenceDatacenterId, referenceAccountId, referenceContainerId,


### PR DESCRIPTION
Prevent runtime exceptions if this method is used after V5 is enabled.