### PR TITLE
Add support for xids in the cluster manager

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -152,6 +152,13 @@ public class ClusterMapConfig {
   @Default(MAX_REPLICAS_ALL_DATACENTERS)
   public final String clusterMapDefaultPartitionClass;
 
+  /**
+   * The current xid for this cluster manager. Any changes beyond this xid will be ignored by the cluster manager.
+   */
+  @Config("clustermap.current.xid")
+  @Default("Long.MAX")
+  public final Long clustermapCurrentXid;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -181,5 +188,6 @@ public class ClusterMapConfig {
     clusterMapResolveHostnames = verifiableProperties.getBoolean("clustermap.resolve.hostnames", true);
     clusterMapDefaultPartitionClass =
         verifiableProperties.getString("clustermap.default.partition.class", MAX_REPLICAS_ALL_DATACENTERS);
+    clustermapCurrentXid = verifiableProperties.getLong("clustermap.current.xid", Long.MAX_VALUE);
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -52,6 +52,7 @@ public class ClusterMapUtils {
   static final String DATACENTER_STR = "datacenter";
   static final String DATACENTER_ID_STR = "id";
   static final String SCHEMA_VERSION_STR = "schemaVersion";
+  static final String XID_STR = "xid";
   static final int MIN_PORT = 1025;
   static final int MAX_PORT = 65535;
   static final long MIN_REPLICA_CAPACITY_IN_BYTES = 1024 * 1024 * 1024L;
@@ -178,6 +179,17 @@ public class ClusterMapUtils {
   static Integer getSslPortStr(InstanceConfig instanceConfig) {
     String sslPortStr = instanceConfig.getRecord().getSimpleField(SSLPORT_STR);
     return sslPortStr == null ? null : Integer.valueOf(sslPortStr);
+  }
+
+  /**
+   * Get the xid associated with this instance. The xid is like a timestamp or a change number, so if it is absent,
+   * a value representing the earliest point in time is returned.
+   * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
+   * @return the xid associated with the given instance.
+   */
+  static Long getXid(InstanceConfig instanceConfig) {
+    String xid = instanceConfig.getRecord().getSimpleField(XID_STR);
+    return xid == null ? Long.MIN_VALUE : Long.valueOf(xid);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -187,7 +187,7 @@ public class ClusterMapUtils {
    * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
    * @return the xid associated with the given instance.
    */
-  static Long getXid(InstanceConfig instanceConfig) {
+  static long getXid(InstanceConfig instanceConfig) {
     String xid = instanceConfig.getRecord().getSimpleField(XID_STR);
     return xid == null ? Long.MIN_VALUE : Long.valueOf(xid);
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -581,8 +581,7 @@ class HelixBootstrapUpgradeUtil {
    * @param hardwareLayout the {@link HardwareLayout} of the static clustermap.
    * @param partitionLayout the {@link PartitionLayout} of the static clustermap.
    */
-  private void verifyEquivalencyWithStaticClusterMap(HardwareLayout hardwareLayout, PartitionLayout partitionLayout)
-      throws Exception {
+  private void verifyEquivalencyWithStaticClusterMap(HardwareLayout hardwareLayout, PartitionLayout partitionLayout) {
     String clusterNameInStaticClusterMap = hardwareLayout.getClusterName();
     info("Verifying equivalency of static cluster: " + clusterNameInStaticClusterMap + " with the "
         + "corresponding cluster in Helix: " + clusterName);
@@ -605,8 +604,8 @@ class HelixBootstrapUpgradeUtil {
    * @param clusterName the cluster to be verified.
    * @param partitionLayout the {@link PartitionLayout} of the static clustermap.
    */
-  private void verifyDataNodeAndDiskEquivalencyInDc(Datacenter dc, String clusterName, PartitionLayout partitionLayout)
-      throws Exception {
+  private void verifyDataNodeAndDiskEquivalencyInDc(Datacenter dc, String clusterName,
+      PartitionLayout partitionLayout) {
     // The following properties are immaterial for the tool, but the ClusterMapConfig mandates their presence.
     Properties props = new Properties();
     props.setProperty("clustermap.host.name", "localhost");

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -74,7 +74,7 @@ class HelixClusterManager implements ClusterMap {
   private final AtomicLong sealedStateChangeCounter = new AtomicLong(0);
   final HelixClusterManagerMetrics helixClusterManagerMetrics;
   private final PartitionSelectionHelper partitionSelectionHelper;
-  private final long currentXid;
+  private long currentXid;
 
   /**
    * Instantiate a HelixClusterManager.
@@ -700,6 +700,21 @@ class HelixClusterManager implements ClusterMap {
     long getAllocatedUsableCapacity() {
       return clusterWideAllocatedUsableCapacityBytes;
     }
+  }
+
+  /**
+   * @return the current xid;
+   */
+  protected long getCurrentXid() {
+    return currentXid;
+  }
+
+  /**
+   * Set the current xid;
+   * @param newXid the new xid to set.
+   */
+  protected void setCurrentXid(long newXid) {
+    currentXid = newXid;
   }
 }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -354,6 +354,7 @@ class HelixClusterManager implements ClusterMap {
               logger.info(
                   "Ignoring instanceConfig for {} because the xid associated with it ({}) is later than current xid ({})",
                   instanceName, instanceXid, currentXid);
+              helixClusterManagerMetrics.ignoredUpdatesCount.inc();
             }
             break;
           default:
@@ -391,9 +392,10 @@ class HelixClusterManager implements ClusterMap {
                 }
               }
             } else {
-              logger.info(
+              logger.trace(
                   "Ignoring instanceConfig change for {} because the xid associated with it ({}) is later than current xid ({})",
                   instanceName, instanceXid, currentXid);
+              helixClusterManagerMetrics.ignoredUpdatesCount.inc();
             }
             break;
           default:
@@ -700,21 +702,6 @@ class HelixClusterManager implements ClusterMap {
     long getAllocatedUsableCapacity() {
       return clusterWideAllocatedUsableCapacityBytes;
     }
-  }
-
-  /**
-   * @return the current xid;
-   */
-  protected long getCurrentXid() {
-    return currentXid;
-  }
-
-  /**
-   * Set the current xid;
-   * @param newXid the new xid to set.
-   */
-  protected void setCurrentXid(long newXid) {
-    currentXid = newXid;
   }
 }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
@@ -37,6 +37,7 @@ class HelixClusterManagerMetrics {
   public final Counter getDataNodeIdMismatchCount;
   public final Counter getReplicaIdsMismatchCount;
   public final Counter getDataNodeIdsMismatchCount;
+  public final Counter ignoredUpdatesCount;
 
   public Gauge<Long> helixClusterManagerInstantiationFailed;
 
@@ -72,6 +73,8 @@ class HelixClusterManagerMetrics {
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getReplicaIdsMismatchCount"));
     getDataNodeIdsMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getDataNodeIdsMismatchCount"));
+    ignoredUpdatesCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "ignoredUpdatesCount"));
   }
 
   void initializeInstantiationMetric(final boolean instantiated) {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -507,6 +507,7 @@ public class HelixClusterManagerTest {
     aheadInstanceConfig.getRecord().setSimpleField(XID_STR, Long.toString(CURRENT_XID + 1));
     HelixClusterManager clusterManager =
         new HelixClusterManager(clusterMapConfig, hostname, helixManagerFactory, new MetricRegistry());
+    assertEquals(CURRENT_XID, clusterManager.getCurrentXid());
     assertEquals(instanceCount - 1, clusterManager.getDataNodeIds().size());
     for (AmbryDataNode dataNode : clusterManager.getDataNodeIds()) {
       String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
@@ -527,6 +528,7 @@ public class HelixClusterManagerTest {
         ignoreInstanceConfig.getRecord()
             .setListField(STOPPED_REPLICAS_STR,
                 Collections.singletonList(ignoreInstanceReplica.getPartitionId().toPathString()));
+        break;
       }
     }
     helixCluster.triggerInstanceConfigChangeNotification();
@@ -535,6 +537,7 @@ public class HelixClusterManagerTest {
 
     // Now advance the current xid of the cluster manager.
     clusterManager.setCurrentXid(CURRENT_XID + 3);
+    assertEquals(CURRENT_XID + 3, clusterManager.getCurrentXid());
     helixCluster.triggerInstanceConfigChangeNotification();
     // Now the change should get absorbed.
     assertTrue(ignoreInstanceReplica.isDown());

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -507,7 +507,6 @@ public class HelixClusterManagerTest {
     aheadInstanceConfig.getRecord().setSimpleField(XID_STR, Long.toString(CURRENT_XID + 1));
     HelixClusterManager clusterManager =
         new HelixClusterManager(clusterMapConfig, hostname, helixManagerFactory, new MetricRegistry());
-    assertEquals(CURRENT_XID, clusterManager.getCurrentXid());
     assertEquals(instanceCount - 1, clusterManager.getDataNodeIds().size());
     for (AmbryDataNode dataNode : clusterManager.getDataNodeIds()) {
       String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
@@ -535,9 +534,8 @@ public class HelixClusterManagerTest {
     // Because the XID was higher, the change reflecting this replica being stopped will not be absorbed.
     assertFalse(ignoreInstanceReplica.isDown());
 
-    // Now advance the current xid of the cluster manager.
-    clusterManager.setCurrentXid(CURRENT_XID + 3);
-    assertEquals(CURRENT_XID + 3, clusterManager.getCurrentXid());
+    // Now advance the current xid of the cluster manager (simulated by moving back the xid in the InstanceConfig).
+    ignoreInstanceConfig.getRecord().setSimpleField(XID_STR, Long.toString(CURRENT_XID - 2));
     helixCluster.triggerInstanceConfigChangeNotification();
     // Now the change should get absorbed.
     assertTrue(ignoreInstanceReplica.isDown());

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -39,6 +39,7 @@ import java.util.Random;
 import java.util.Set;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
+import org.apache.helix.model.InstanceConfig;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
@@ -46,6 +47,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
 
@@ -70,6 +72,7 @@ public class HelixClusterManagerTest {
   private Map<String, Counter> counters;
   private final boolean useComposite;
   private final String hardwareLayoutPath;
+  private static final long CURRENT_XID = 64;
 
   // for verifying getPartitions() and getWritablePartitions()
   private static final String SPECIAL_PARTITION_CLASS = "specialPartitionClass";
@@ -152,6 +155,7 @@ public class HelixClusterManagerTest {
     props.setProperty("clustermap.cluster.name", clusterNamePrefixInHelix + clusterNameStatic);
     props.setProperty("clustermap.datacenter.name", localDc);
     props.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
+    props.setProperty("clustermap.current.xid", Long.toString(CURRENT_XID));
     clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     MockHelixManagerFactory helixManagerFactory = new MockHelixManagerFactory(helixCluster, null);
     if (useComposite) {
@@ -480,6 +484,60 @@ public class HelixClusterManagerTest {
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
     // this triggers a notification.
     helixCluster.upgradeWithNewHardwareLayout(hardwareLayoutPath);
+  }
+
+  /**
+   * Tests that if the xid of an InstanceConfig change is greater than the current xid of the cluster manager, then that
+   * change is ignored - both during initialization as well as with post-initialization InstanceConfig changes.
+   */
+  @Test
+  public void xidTest() throws Exception {
+    if (useComposite) {
+      return;
+    }
+    // Close the one initialized in the constructor, as this test needs to test initialization flow as well.
+    clusterManager.close();
+
+    // Initialization path:
+    MockHelixManagerFactory helixManagerFactory = new MockHelixManagerFactory(helixCluster, null);
+    List<InstanceConfig> instanceConfigs = helixCluster.getAllInstanceConfigs();
+    int instanceCount = instanceConfigs.size();
+    InstanceConfig aheadInstanceConfig =
+        instanceConfigs.get(com.github.ambry.utils.TestUtils.RANDOM.nextInt(instanceConfigs.size()));
+    aheadInstanceConfig.getRecord().setSimpleField(XID_STR, Long.toString(CURRENT_XID + 1));
+    HelixClusterManager clusterManager =
+        new HelixClusterManager(clusterMapConfig, hostname, helixManagerFactory, new MetricRegistry());
+    assertEquals(instanceCount - 1, clusterManager.getDataNodeIds().size());
+    for (AmbryDataNode dataNode : clusterManager.getDataNodeIds()) {
+      String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
+      assertFalse(instanceName.equals(aheadInstanceConfig.getInstanceName()));
+    }
+
+    // Post-initialization InstanceConfig change:
+    InstanceConfig ignoreInstanceConfig =
+        instanceConfigs.get(com.github.ambry.utils.TestUtils.RANDOM.nextInt(instanceConfigs.size()));
+    String ignoreInstanceName = ignoreInstanceConfig.getInstanceName();
+    ignoreInstanceConfig.getRecord().setSimpleField(XID_STR, Long.toString(CURRENT_XID + 2));
+
+    AmbryReplica ignoreInstanceReplica = null;
+    for (AmbryDataNode dataNode : clusterManager.getDataNodeIds()) {
+      String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
+      if (instanceName.equals(ignoreInstanceName)) {
+        ignoreInstanceReplica = clusterManager.getReplicaIds(dataNode).get(0);
+        ignoreInstanceConfig.getRecord()
+            .setListField(STOPPED_REPLICAS_STR,
+                Collections.singletonList(ignoreInstanceReplica.getPartitionId().toPathString()));
+      }
+    }
+    helixCluster.triggerInstanceConfigChangeNotification();
+    // Because the XID was higher, the change reflecting this replica being stopped will not be absorbed.
+    assertFalse(ignoreInstanceReplica.isDown());
+
+    // Now advance the current xid of the cluster manager.
+    clusterManager.setCurrentXid(CURRENT_XID + 3);
+    helixCluster.triggerInstanceConfigChangeNotification();
+    // Now the change should get absorbed.
+    assertTrue(ignoreInstanceReplica.isDown());
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -206,6 +206,14 @@ public class MockHelixCluster {
     return instanceConfig;
   }
 
+  List<InstanceConfig> getAllInstanceConfigs() {
+    List<InstanceConfig> configs = new ArrayList<>();
+    for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
+      configs.addAll(helixAdmin.getInstanceConfigs(clusterName));
+    }
+    return configs;
+  }
+
   /**
    * Get the instances that have replicas for the given partition.
    * @param partition the partition name of the partition.

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -58,6 +58,13 @@ public class MockHelixCluster {
   void upgradeWithNewHardwareLayout(String hardwareLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName, 3,
         false, false, helixAdminFactory);
+    triggerInstanceConfigChangeNotification();
+  }
+
+  /**
+   * Trigger an InstanceConfig change notification for all datacenters.
+   */
+  void triggerInstanceConfigChangeNotification() {
     for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
       helixAdmin.triggerInstanceConfigChangeNotification(false);
     }


### PR DESCRIPTION
Xids allows for selectively ignoring certain InstanceConfig changes.
This is aimed to help during deployments.