### PR TITLE
Catch disk I/O errors and dynamically shutdown BlobStore

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -258,6 +258,13 @@ public class StoreConfig {
   public final IndexMemState storeIndexMemState;
   public static final String storeIndexMemStateName = "store.index.mem.state";
 
+  /**
+   * Specifies the threshold I/O error count of store to trigger shutdown operation on the store.
+   */
+  @Config("store.io.error.count.to.trigger.shutdown")
+  @Default("Integer.MAX_VALUE")
+  public final int storeIoErrorCountToTriggerShutdown;
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -312,6 +319,9 @@ public class StoreConfig {
         verifiableProperties.getIntInRange(storeTtlUpdateBufferTimeSecondsName, 60 * 60 * 24, 0, Integer.MAX_VALUE);
     storeIndexMemState =
         IndexMemState.valueOf(verifiableProperties.getString(storeIndexMemStateName, IndexMemState.NOT_IN_MEM.name()));
+    storeIoErrorCountToTriggerShutdown =
+        verifiableProperties.getIntInRange("store.io.error.count.to.trigger.shutdown", Integer.MAX_VALUE, 1,
+            Integer.MAX_VALUE);
   }
 }
 

--- a/ambry-api/src/main/java/com.github.ambry/store/MessageWriteSet.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageWriteSet.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.store;
 
-import java.io.IOException;
 import java.util.List;
 
 
@@ -27,7 +26,7 @@ public interface MessageWriteSet {
    * @param writeChannel The write interface to write the messages to
    * @return The size in bytes that was written to the write interface
    */
-  public long writeTo(Write writeChannel) throws IOException;
+  public long writeTo(Write writeChannel) throws StoreException;
 
   /**
    * Returns info about the messages contained in this write set. The messages

--- a/ambry-api/src/main/java/com.github.ambry/store/StoreErrorCodes.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/StoreErrorCodes.java
@@ -33,5 +33,7 @@ public enum StoreErrorCodes {
   Authorization_Failure,
   Unknown_Error,
   Already_Updated,
-  Update_Not_Allowed
+  Update_Not_Allowed,
+  File_Not_Found,
+  Channel_Closed
 }

--- a/ambry-api/src/main/java/com.github.ambry/store/StoreException.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/StoreException.java
@@ -14,6 +14,9 @@
 package com.github.ambry.store;
 
 public class StoreException extends Exception {
+  public static final String INTERNAL_ERROR_STR =
+      "a fault occurred in a recent unsafe memory access operation in compiled Java code";
+  public static final String IO_ERROR_STR = "Input/output error";
   private static final long serialVersionUID = 1;
   private final StoreErrorCodes error;
 

--- a/ambry-api/src/main/java/com.github.ambry/store/Write.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/Write.java
@@ -27,7 +27,7 @@ public interface Write {
    * successfully written
    * @param buffer The buffer from which data needs to be written from
    * @return The number of bytes written to the write interface
-   * @throws StoreException
+   * @throws StoreException if store error occurs when writing into underlying interface
    */
   int appendFrom(ByteBuffer buffer) throws StoreException;
 
@@ -36,7 +36,7 @@ public interface Write {
    * to the interface.
    * @param channel The channel from which data needs to be written from
    * @param size The amount of data in bytes to be written from the channel
-   * @throws StoreException
+   * @throws StoreException if store error occurs when writing into underlying interface
    */
   void appendFrom(ReadableByteChannel channel, long size) throws StoreException;
 }

--- a/ambry-api/src/main/java/com.github.ambry/store/Write.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/Write.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.store;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 
@@ -28,16 +27,16 @@ public interface Write {
    * successfully written
    * @param buffer The buffer from which data needs to be written from
    * @return The number of bytes written to the write interface
-   * @throws IOException
+   * @throws StoreException
    */
-  int appendFrom(ByteBuffer buffer) throws IOException;
+  int appendFrom(ByteBuffer buffer) throws StoreException;
 
   /**
    * Appends the channel to the underlying write interface. Writes "size" number of bytes
    * to the interface.
    * @param channel The channel from which data needs to be written from
    * @param size The amount of data in bytes to be written from the channel
-   * @throws IOException
+   * @throws StoreException
    */
-  void appendFrom(ReadableByteChannel channel, long size) throws IOException;
+  void appendFrom(ReadableByteChannel channel, long size) throws StoreException;
 }

--- a/ambry-api/src/test/java/com.github.ambry/store/MockWrite.java
+++ b/ambry-api/src/test/java/com.github.ambry/store/MockWrite.java
@@ -51,6 +51,8 @@ public class MockWrite implements Write {
         channel.read(buf);
       }
     } catch (IOException e) {
+      // The IOException message may vary in different java versions. As code evolves, we may need to update IO_ERROR_STR
+      // in StoreException (based on java version that is being employed) to correctly capture disk I/O related errors.
       StoreErrorCodes errorCode =
           e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
       throw new StoreException(errorCode.toString() + " while writing into store", e, errorCode);

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatWriteSet.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatWriteSet.java
@@ -15,6 +15,7 @@ package com.github.ambry.messageformat;
 
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MessageWriteSet;
+import com.github.ambry.store.StoreException;
 import com.github.ambry.store.Write;
 import com.github.ambry.utils.ByteBufferInputStream;
 import java.io.IOException;
@@ -47,7 +48,7 @@ public class MessageFormatWriteSet implements MessageWriteSet {
   }
 
   @Override
-  public long writeTo(Write writeChannel) throws IOException {
+  public long writeTo(Write writeChannel) throws StoreException {
     ReadableByteChannel readableByteChannel = Channels.newChannel(streamToWrite);
     long sizeWritten = 0;
     for (MessageInfo info : streamInfo) {

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatWriteSetTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatWriteSetTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.messageformat;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MockId;
 import com.github.ambry.store.MockWrite;
+import com.github.ambry.store.StoreException;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
@@ -30,7 +31,7 @@ import org.junit.Test;
 public class MessageFormatWriteSetTest {
 
   @Test
-  public void writeSetTest() throws IOException {
+  public void writeSetTest() throws IOException, StoreException {
     byte[] buf = new byte[2000];
     MessageInfo info1 = new MessageInfo(new MockId("id1"), 1000, 123, Utils.getRandomShort(TestUtils.RANDOM),
         Utils.getRandomShort(TestUtils.RANDOM), System.currentTimeMillis() + TestUtils.RANDOM.nextInt());

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -515,10 +515,10 @@ class ReplicaThread implements Runnable {
    * @param remoteNode The remote node from which replication needs to happen
    * @param remoteReplicaInfo The remote replica that contains information about the remote replica id
    * @return List of store keys that are missing from the local store
-   * @throws Exception
+   * @throws StoreException
    */
   private Set<StoreKey> getMissingStoreKeys(ReplicaMetadataResponseInfo replicaMetadataResponseInfo,
-      DataNodeId remoteNode, RemoteReplicaInfo remoteReplicaInfo) throws Exception {
+      DataNodeId remoteNode, RemoteReplicaInfo remoteReplicaInfo) throws StoreException {
     long startTime = SystemTime.getInstance().milliseconds();
     List<MessageInfo> messageInfoList = replicaMetadataResponseInfo.getMessageInfoList();
     Map<StoreKey, StoreKey> remoteToConvertedNonNull = new HashMap<>();

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -515,7 +515,7 @@ class ReplicaThread implements Runnable {
    * @param remoteNode The remote node from which replication needs to happen
    * @param remoteReplicaInfo The remote replica that contains information about the remote replica id
    * @return List of store keys that are missing from the local store
-   * @throws StoreException
+   * @throws StoreException if store error (usually IOError) occurs when getting missing keys.
    */
   private Set<StoreKey> getMissingStoreKeys(ReplicaMetadataResponseInfo replicaMetadataResponseInfo,
       DataNodeId remoteNode, RemoteReplicaInfo remoteReplicaInfo) throws StoreException {

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -209,7 +209,7 @@ public class AmbryRequests implements RequestAPI {
                 receivedRequest.getBlobProperties().getTimeToLiveInSeconds()), receivedRequest.getCrc(),
             receivedRequest.getBlobProperties().getAccountId(), receivedRequest.getBlobProperties().getContainerId(),
             receivedRequest.getBlobProperties().getCreationTimeInMs());
-        ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
+        ArrayList<MessageInfo> infoList = new ArrayList<>();
         infoList.add(info);
         MessageFormatWriteSet writeset = new MessageFormatWriteSet(stream, infoList, false);
         Store storeToPut = storageManager.getStore(receivedRequest.getBlobId().getPartition());

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -562,9 +562,10 @@ public class AmbryRequestsTest {
    * @throws InterruptedException
    * @throws IOException
    * @throws MessageFormatException
+   * @throws StoreException
    */
   @Test
-  public void ttlUpdateTest() throws InterruptedException, IOException, MessageFormatException {
+  public void ttlUpdateTest() throws InterruptedException, IOException, MessageFormatException, StoreException {
     MockPartitionId id =
         (MockPartitionId) clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     int correlationId = TestUtils.RANDOM.nextInt();
@@ -724,9 +725,9 @@ public class AmbryRequestsTest {
    * @param size the size of data to read. If this size is greater than the amount of data in {@code messageWriteSet},
    *             then this function will loop infinitely
    * @return a {@link ByteBuffer} containing data of size {@code size} from {@code messageWriteSet}
-   * @throws IOException
+   * @throws StoreException
    */
-  private ByteBuffer getDataInWriteSet(MessageWriteSet messageWriteSet, int size) throws IOException {
+  private ByteBuffer getDataInWriteSet(MessageWriteSet messageWriteSet, int size) throws StoreException {
     MockWrite write = new MockWrite(size);
     long sizeWritten = 0;
     while (sizeWritten < size) {
@@ -1051,7 +1052,8 @@ public class AmbryRequestsTest {
    * @throws MessageFormatException
    */
   private void doTtlUpdate(int correlationId, String clientId, BlobId blobId, long expiresAtMs, long opTimeMs,
-      ServerErrorCode expectedErrorCode) throws InterruptedException, IOException, MessageFormatException {
+      ServerErrorCode expectedErrorCode)
+      throws InterruptedException, IOException, MessageFormatException, StoreException {
     TtlUpdateRequest request = new TtlUpdateRequest(correlationId, clientId, blobId, expiresAtMs, opTimeMs);
     sendAndVerifyOperationRequest(request, expectedErrorCode, true);
     if (expectedErrorCode == ServerErrorCode.No_Error) {
@@ -1103,9 +1105,10 @@ public class AmbryRequestsTest {
    * @param messageWriteSet the {@link MessageWriteSet} received at the {@link Store}
    * @throws IOException
    * @throws MessageFormatException
+   * @throws StoreException
    */
   private void verifyTtlUpdate(BlobId blobId, long expiresAtMs, long opTimeMs, MessageWriteSet messageWriteSet)
-      throws IOException, MessageFormatException {
+      throws IOException, MessageFormatException, StoreException {
     BlobId key = (BlobId) conversionMap.getOrDefault(blobId, blobId);
     assertEquals("There should be one message in the write set", 1, messageWriteSet.getMessageSetInfo().size());
     MessageInfo info = messageWriteSet.getMessageSetInfo().get(0);
@@ -1277,9 +1280,8 @@ public class AmbryRequestsTest {
 
           @Override
           public void doPrefetch(int index, long relativeOffset, long size) {
-            return;
           }
-        }, Collections.EMPTY_LIST);
+        }, Collections.emptyList());
       }
 
       @Override

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -716,6 +716,7 @@ class BlobStore implements Store {
     if (count == config.storeIoErrorCountToTriggerShutdown) {
       logger.error("Shutting down BlobStore {} because IO error count exceeds threshold", storeId);
       shutdown();
+      metrics.storeIoErrorTriggeredShutdownCount.inc();
     }
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,13 +67,14 @@ class BlobStore implements Store {
   private final long thresholdBytesHigh;
   private final long thresholdBytesLow;
   private final long ttlUpdateBufferTimeMs;
+  private final AtomicInteger errorCount;
 
   private Log log;
   private BlobStoreCompactor compactor;
-  private PersistentIndex index;
   private BlobStoreStats blobStoreStats;
   private boolean started;
   private FileLock fileLock;
+  protected PersistentIndex index;
 
   /**
    * States representing the different scenarios that can occur when a set of messages are to be written to the store.
@@ -166,6 +168,7 @@ class BlobStore implements Store {
     this.thresholdBytesHigh = (long) (capacityInBytes * (threshold / 100.0));
     this.thresholdBytesLow = (long) (capacityInBytes * ((threshold - delta) / 100.0));
     ttlUpdateBufferTimeMs = TimeUnit.SECONDS.toMillis(config.storeTtlUpdateBufferTimeSeconds);
+    errorCount = new AtomicInteger(0);
     logger.debug(
         "The enable state of replicaStatusDelegate is {} on store {}. The high threshold is {} bytes and the low threshold is {} bytes",
         config.storeReplicaStatusDelegateEnable, storeId, this.thresholdBytesHigh, this.thresholdBytesLow);
@@ -220,6 +223,7 @@ class BlobStore implements Store {
                 taskScheduler, diskIOScheduler, metrics);
         checkCapacityAndUpdateReplicaStatusDelegate();
         logger.trace("The store {} is successfully started", storeId);
+        onSuccess();
         started = true;
         if (replicaId != null) {
           replicaId.markDiskUp();
@@ -273,8 +277,12 @@ class BlobStore implements Store {
       for (int i = 0; i < readSet.count(); i++) {
         messageInfoList.add(indexMessages.get(readSet.getKeyAt(i)));
       }
+      onSuccess();
       return new StoreInfo(readSet, messageInfoList);
     } catch (StoreException e) {
+      if (e.getErrorCode() == StoreErrorCodes.IOError) {
+        onError();
+      }
       throw e;
     } catch (Exception e) {
       throw new StoreException("Unknown exception while trying to fetch blobs from store " + dataDir, e,
@@ -413,10 +421,12 @@ class BlobStore implements Store {
           logger.trace("All entries were absent, and were written to the store successfully");
           break;
       }
+      onSuccess();
     } catch (StoreException e) {
+      if (e.getErrorCode() == StoreErrorCodes.IOError) {
+        onError();
+      }
       throw e;
-    } catch (IOException e) {
-      throw new StoreException("IO error while trying to put blobs to store " + dataDir, e, StoreErrorCodes.IOError);
     } catch (Exception e) {
       throw new StoreException("Unknown error while trying to put blobs to store " + dataDir, e,
           StoreErrorCodes.Unknown_Error);
@@ -482,11 +492,12 @@ class BlobStore implements Store {
         }
         logger.trace("Store : {} delete has been marked in the index ", dataDir);
       }
+      onSuccess();
     } catch (StoreException e) {
+      if (e.getErrorCode() == StoreErrorCodes.IOError) {
+        onError();
+      }
       throw e;
-    } catch (IOException e) {
-      throw new StoreException("IO error while trying to delete blobs from store " + dataDir, e,
-          StoreErrorCodes.IOError);
     } catch (Exception e) {
       throw new StoreException("Unknown error while trying to delete blobs from store " + dataDir, e,
           StoreErrorCodes.Unknown_Error);
@@ -577,11 +588,12 @@ class BlobStore implements Store {
         }
         logger.trace("Store : {} ttl update has been marked in the index ", dataDir);
       }
+      onSuccess();
     } catch (StoreException e) {
+      if (e.getErrorCode() == StoreErrorCodes.IOError) {
+        onError();
+      }
       throw e;
-    } catch (IOException e) {
-      throw new StoreException("IO error while trying to update ttl of blobs from store " + dataDir, e,
-          StoreErrorCodes.IOError);
     } catch (Exception e) {
       throw new StoreException("Unknown error while trying to update ttl of blobs from store " + dataDir, e,
           StoreErrorCodes.Unknown_Error);
@@ -595,7 +607,14 @@ class BlobStore implements Store {
     checkStarted();
     final Timer.Context context = metrics.findEntriesSinceResponse.time();
     try {
-      return index.findEntriesSince(token, maxTotalSizeOfEntries);
+      FindInfo findInfo = index.findEntriesSince(token, maxTotalSizeOfEntries);
+      onSuccess();
+      return findInfo;
+    } catch (StoreException e) {
+      if (e.getErrorCode() == StoreErrorCodes.IOError) {
+        onError();
+      }
+      throw e;
     } finally {
       context.stop();
     }
@@ -606,7 +625,14 @@ class BlobStore implements Store {
     checkStarted();
     final Timer.Context context = metrics.findMissingKeysResponse.time();
     try {
-      return index.findMissingKeys(keys);
+      Set<StoreKey> missingKeys = index.findMissingKeys(keys);
+      onSuccess();
+      return missingKeys;
+    } catch (StoreException e) {
+      if (e.getErrorCode() == StoreErrorCodes.IOError) {
+        onError();
+      }
+      throw e;
     } finally {
       context.stop();
     }
@@ -683,6 +709,31 @@ class BlobStore implements Store {
   }
 
   /**
+   * On an exception/error, if error count exceeds threshold, properly shutdown store.
+   */
+  private void onError() throws StoreException {
+    int count = errorCount.incrementAndGet();
+    if (count == config.storeIoErrorCountToTriggerShutdown) {
+      logger.error("Shutting down BlobStore {} because IO error count exceeds threshold", storeId);
+      shutdown();
+    }
+  }
+
+  /**
+   * If store restarted successfully or at least one operation succeeded, reset the error count.
+   */
+  private void onSuccess() {
+    errorCount.getAndSet(0);
+  }
+
+  /**
+   * @return errorCount of store.
+   */
+  AtomicInteger getErrorCount() {
+    return errorCount;
+  }
+
+  /**
    * @return the {@link DiskSpaceRequirements} for this store to provide to
    * {@link DiskSpaceAllocator#initializePool(Collection)}. This will be {@code null} if this store uses a non-segmented
    * log. This is because it does not require any additional/swap segments.
@@ -742,9 +793,8 @@ class BlobStore implements Store {
   /**
    * Detects duplicates in {@code writeSet}
    * @param writeSet the {@link MessageWriteSet} to detect duplicates in
-   * @throws StoreException if a duplicate is detected
    */
-  private void checkDuplicates(MessageWriteSet writeSet) throws StoreException {
+  private void checkDuplicates(MessageWriteSet writeSet) {
     List<MessageInfo> infos = writeSet.getMessageSetInfo();
     if (infos.size() > 1) {
       Set<StoreKey> seenKeys = new HashSet<>();

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
@@ -258,7 +258,7 @@ class BlobStoreCompactor {
   int getSwapSegmentsInUse() throws StoreException {
     String[] tempSegments = dataDir.list(TEMP_LOG_SEGMENTS_FILTER);
     if (tempSegments == null) {
-      throw new StoreException("Error occured while listing files in data dir:" + dataDir.getAbsolutePath(),
+      throw new StoreException("Error occurred while listing files in data dir:" + dataDir.getAbsolutePath(),
           StoreErrorCodes.IOError);
     }
     return tempSegments.length;
@@ -425,9 +425,9 @@ class BlobStoreCompactor {
    * 3. Deleting the clean shutdown file associated with the index of the swap spaces.
    * 4. Resetting state.
    * @param recovering {@code true} if this function was called in the context of recovery. {@code false} otherwise.
-   * @throws IOException if there were I/O errors during cleanup.
+   * @throws StoreException if there were store exception during cleanup.
    */
-  private void cleanup(boolean recovering) throws IOException {
+  private void cleanup(boolean recovering) throws StoreException {
     cleanupLogAndIndexSegments(recovering);
     File cleanShutdownFile = new File(dataDir, TARGET_INDEX_CLEAN_SHUTDOWN_FILE_NAME);
     if (cleanShutdownFile.exists() && !cleanShutdownFile.delete()) {
@@ -1152,9 +1152,9 @@ class BlobStoreCompactor {
    * Adds the log segments with names {@code logSegmentNames} to the application log instance.
    * @param logSegmentNames the names of the log segments to commit.
    * @param recovering {@code true} if this function was called in the context of recovery. {@code false} otherwise.
-   * @throws IOException if there were any I/O errors creating a log segment
+   * @throws StoreException if there were any store exception creating a log segment
    */
-  private void addNewLogSegmentsToSrcLog(List<String> logSegmentNames, boolean recovering) throws IOException {
+  private void addNewLogSegmentsToSrcLog(List<String> logSegmentNames, boolean recovering) throws StoreException {
     logger.debug("Adding {} in {} to the application log", logSegmentNames, storeId);
     for (String logSegmentName : logSegmentNames) {
       File segmentFile = new File(dataDir, LogSegmentNameHelper.nameToFilename(logSegmentName));
@@ -1168,10 +1168,9 @@ class BlobStoreCompactor {
    * removes all the index segments that refer to the log segments that will be cleaned up from the application index.
    * The change is atomic with the use of {@link PersistentIndex#changeIndexSegments(List, Set)}.
    * @param logSegmentNames the names of the log segments whose index segments need to be committed.
-   * @throws IOException if there were any I/O errors in setting up the index segment.
    * @throws StoreException if there were any problems committing the changed index segments.
    */
-  private void updateSrcIndex(List<String> logSegmentNames) throws IOException, StoreException {
+  private void updateSrcIndex(List<String> logSegmentNames) throws StoreException {
     Set<Offset> indexSegmentsToRemove = new HashSet<>();
     for (String logSegmentName : compactionLog.getCompactionDetails().getLogSegmentsUnderCompaction()) {
       indexSegmentsToRemove.addAll(getIndexSegmentDetails(logSegmentName).keySet());
@@ -1241,7 +1240,7 @@ class BlobStoreCompactor {
    * @param recovering {@code true} if this function was called in the context of recovery. {@code false} otherwise.
    * @throws IOException
    */
-  private void cleanupLogAndIndexSegments(boolean recovering) throws IOException {
+  private void cleanupLogAndIndexSegments(boolean recovering) throws StoreException {
     CompactionDetails details = compactionLog.getCompactionDetails();
     List<String> segmentsUnderCompaction = details.getLogSegmentsUnderCompaction();
     logger.debug("Cleaning up {} (and related index segments) in {}", segmentsUnderCompaction, storeId);

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreStats.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreStats.java
@@ -20,7 +20,6 @@ import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -503,14 +502,14 @@ class BlobStoreStats implements StoreStats, Closeable {
           false);
       diskIOScheduler.getSlice(BlobStoreStats.IO_SCHEDULER_JOB_TYPE, BlobStoreStats.IO_SCHEDULER_JOB_ID,
           indexEntries.size());
-    } catch (IOException e) {
+      addPutEntriesForDelete(indexSegment.getStartOffset().getOffset(), indexEntries);
+      indexEntries.sort(KEY_OFFSET_COMPARATOR);
+      updateExpiryTimeForAllPuts(indexEntries);
+    } catch (StoreException e) {
       throw new StoreException(
-          String.format("I/O exception while getting entries from index segment for store %s", storeId), e,
-          StoreErrorCodes.IOError);
+          String.format("Exception while getting entries from index segment for store %s : %s", storeId,
+              e.getMessage()), e, e.getErrorCode());
     }
-    addPutEntriesForDelete(indexSegment.getStartOffset().getOffset(), indexEntries);
-    indexEntries.sort(KEY_OFFSET_COMPARATOR);
-    updateExpiryTimeForAllPuts(indexEntries);
     return indexEntries;
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -73,6 +73,7 @@ public class StoreMetrics {
   public final Counter ttlUpdateAuthorizationFailureCount;
   public final Counter keyInFindEntriesAbsent;
   public final Counter duplicateKeysInBatch;
+  public final Counter storeIoErrorTriggeredShutdownCount;
 
   // Compaction related metrics
   public final Counter compactionFixStateCount;
@@ -164,6 +165,8 @@ public class StoreMetrics {
         registry.counter(MetricRegistry.name(BlobStore.class, name + "TtlUpdateAuthorizationFailureCount"));
     keyInFindEntriesAbsent = registry.counter(MetricRegistry.name(BlobStore.class, name + "KeyInFindEntriesAbsent"));
     duplicateKeysInBatch = registry.counter(MetricRegistry.name(BlobStore.class, name + "DuplicateKeysInBatch"));
+    storeIoErrorTriggeredShutdownCount =
+        registry.counter(MetricRegistry.name(BlobStore.class, name + "StoreIoErrorTriggeredShutdownCount"));
     compactionFixStateCount = registry.counter(MetricRegistry.name(BlobStoreCompactor.class, name + "FixStateCount"));
     compactionCopyRateInBytes = registry.meter(MetricRegistry.name(BlobStoreCompactor.class, name + "CopyRateInBytes"));
     compactionBytesReclaimedCount =

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
@@ -2251,10 +2251,10 @@ public class BlobStoreCompactorTest {
      * Creates an instance of InterruptionInducingLog.
      * @param addSegmentCallCountToInterruptAt number of allowed calls to {@link #addSegment(LogSegment, boolean)}.
      * @param dropSegmentCallCountToInterruptAt number of allowed calls to {@link #dropSegment(String, boolean)}.
-     * @throws IOException
+     * @throws StoreException
      */
     InterruptionInducingLog(int addSegmentCallCountToInterruptAt, int dropSegmentCallCountToInterruptAt)
-        throws IOException {
+        throws StoreException {
       super(tempDirStr, state.log.getCapacityInBytes(), state.log.getSegmentCapacity(),
           StoreTestUtils.DEFAULT_DISK_SPACE_ALLOCATOR, new StoreMetrics(new MetricRegistry()));
       // set end offsets correctly
@@ -2284,7 +2284,7 @@ public class BlobStoreCompactorTest {
     }
 
     @Override
-    void dropSegment(String segmentName, boolean decreaseUsedSegmentCount) throws IOException {
+    void dropSegment(String segmentName, boolean decreaseUsedSegmentCount) throws StoreException {
       segmentsDropped++;
       if (segmentsDropped == dropSegmentCallCountToInterruptAt) {
         throwExceptionIfRequired();

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreStatsTest.java
@@ -44,9 +44,11 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -148,6 +150,28 @@ public class BlobStoreStatsTest {
     advanceTimeToNextSecond();
     verifyAndGetContainerValidSize(blobStoreStats, state.time.milliseconds());
     blobStoreStats.close();
+  }
+
+  /**
+   * Test get valid data size per container failure due to I/O error.
+   * @throws StoreException
+   */
+  @Test
+  public void testContainerValidDataSizeFailure() throws StoreException {
+    assumeTrue(!bucketingEnabled);
+    PersistentIndex mockIndex = Mockito.spy(state.index);
+    BlobStoreStats blobStoreStats =
+        new BlobStoreStats("", mockIndex, 0, BUCKET_SPAN_IN_MS, 0, QUEUE_PROCESSOR_PERIOD_IN_Ms,
+            DEFAULT_WAIT_TIMEOUT_SECS, state.time, indexScannerScheduler, queueProcessorScheduler, diskIOScheduler,
+            METRICS);
+    doThrow(new StoreException(StoreException.IO_ERROR_STR, StoreErrorCodes.IOError)).when(mockIndex)
+        .findKey(any(StoreKey.class));
+    try {
+      blobStoreStats.getValidDataSizeByContainer(state.time.milliseconds());
+      fail("should fail when getting valid date size");
+    } catch (StoreException e) {
+      assertEquals("Mismatch in error code", StoreErrorCodes.IOError, e.getErrorCode());
+    }
   }
 
   /**

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -1157,6 +1157,7 @@ public class BlobStoreTest {
       assertEquals("Mismatch in error code", StoreErrorCodes.IOError, e.getErrorCode());
     }
     // verify error count keeps track of StoreException and shut down store properly
+    assertEquals("Mismatch in triggered shutdown counter", 1, metrics.storeIoErrorTriggeredShutdownCount.getCount());
     assertFalse("Store should shutdown because error count exceeded threshold", testStore2.isStarted());
 
     reloadStore();

--- a/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
@@ -408,9 +408,9 @@ class CuratedLogIndexState {
    * Appends random data of size {@code size} to the {@link #log}.
    * @param size the size of data that needs to be appended.
    * @return the data that was appended.
-   * @throws IOException
+   * @throws StoreException
    */
-  byte[] appendToLog(long size) throws IOException {
+  byte[] appendToLog(long size) throws StoreException {
     byte[] bytes = TestUtils.getRandomBytes((int) size);
     if (size > CuratedLogIndexState.HARD_DELETE_START_OFFSET) {
       // ensure at least one byte is set to 1 for hard delete verification purposes
@@ -742,9 +742,9 @@ class CuratedLogIndexState {
    * 1. It contains no duplicate entries.
    * 2. The ordering of PUT and DELETE entries is correct.
    * 3. There are no offsets in the log not accounted for in the index.
-   * @throws IOException
+   * @throws StoreException
    */
-  void verifyRealIndexSanity() throws IOException {
+  void verifyRealIndexSanity() throws StoreException {
     IndexSegment prevIndexSegment = null;
     for (IndexSegment indexSegment : index.getIndexSegments().values()) {
       Offset indexSegmentStartOffset = indexSegment.getStartOffset();

--- a/ambry-store/src/test/java/com.github.ambry.store/MockMessageWriteSet.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/MockMessageWriteSet.java
@@ -14,7 +14,6 @@
 package com.github.ambry.store;
 
 import com.github.ambry.utils.ByteBufferInputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
@@ -22,11 +21,13 @@ import java.util.List;
 
 
 /**
- * A mock implementation of {@link MessageWriteSet} to help write to a {@link Store}
+ * A mock implementation of {@link MessageWriteSet} to help write to a {@link Store} and simulate cases where
+ * IOException occurred.
  */
 public class MockMessageWriteSet implements MessageWriteSet {
   final List<ByteBuffer> buffers;
   final List<MessageInfo> infos;
+  final StoreException exception;
 
   /**
    * Constructor taking fixed lists of {@link MessageInfo} and {@link ByteBuffer}.
@@ -34,8 +35,19 @@ public class MockMessageWriteSet implements MessageWriteSet {
    * @param buffers
    */
   public MockMessageWriteSet(List<MessageInfo> infos, List<ByteBuffer> buffers) {
+    this(infos, buffers, null);
+  }
+
+  /**
+   * Constructor taking fixed lists of {@link MessageInfo} and {@link ByteBuffer} and specified {@link StoreException}
+   * @param infos
+   * @param buffers
+   * @param exception
+   */
+  public MockMessageWriteSet(List<MessageInfo> infos, List<ByteBuffer> buffers, StoreException exception) {
     this.infos = infos;
     this.buffers = buffers;
+    this.exception = exception;
   }
 
   /**
@@ -44,6 +56,7 @@ public class MockMessageWriteSet implements MessageWriteSet {
   public MockMessageWriteSet() {
     this.infos = new ArrayList<>();
     this.buffers = new ArrayList<>();
+    this.exception = null;
   }
 
   /**
@@ -57,7 +70,10 @@ public class MockMessageWriteSet implements MessageWriteSet {
   }
 
   @Override
-  public long writeTo(Write writeChannel) throws IOException {
+  public long writeTo(Write writeChannel) throws StoreException {
+    if (exception != null) {
+      throw exception;
+    }
     long sizeWritten = 0;
     for (ByteBuffer buffer : buffers) {
       sizeWritten += buffer.remaining();

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreMessageReadSetTest.java
@@ -95,7 +95,7 @@ public class StoreMessageReadSetTest {
    * @throws IOException
    */
   @Test
-  public void storeMessageReadSetTest() throws IOException {
+  public void storeMessageReadSetTest() throws IOException, StoreException {
     int logCapacity = 2000;
     int segCapacity = 1000;
     Log log = new Log(tempDir.getAbsolutePath(), logCapacity, segCapacity, StoreTestUtils.DEFAULT_DISK_SPACE_ALLOCATOR,
@@ -241,7 +241,7 @@ public class StoreMessageReadSetTest {
    * @throws IOException
    */
   @Test
-  public void blobReadOptionsTest() throws IOException {
+  public void blobReadOptionsTest() throws IOException, StoreException {
     int logCapacity = 2000;
     int[] segCapacities = {2000, 1000};
     for (int segCapacity : segCapacities) {

--- a/ambry-tools/src/main/java/com.github.ambry/store/CompactionVerifier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/CompactionVerifier.java
@@ -673,7 +673,7 @@ public class CompactionVerifier implements Closeable {
         indexEntries.addAll(entriesToAdd);
         Collections.sort(indexEntries, PersistentIndex.INDEX_ENTRIES_OFFSET_COMPARATOR);
         LOGGER.info("Loaded entries from {}", indexSegment.getFile());
-      } catch (IOException | StoreException e) {
+      } catch (StoreException e) {
         throw new IllegalStateException(e);
       }
       indexEntriesIterator = indexEntries.iterator();


### PR DESCRIPTION
- Rewrite catch exception in multiple files to ensure
  StoreException.IOError only used for real disk I/O errors
- Maintain error count for each store and shutdown store if
  number of I/O error count exceeds threshold
- This PR is to address the issue #941 
- ./gradlew build && ./gradlew test