### PR TITLE
Prevent busy polling in replication thread

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -60,6 +60,13 @@ public class ReplicationConfig {
   public final int replicationTokenFlushDelaySeconds;
 
   /**
+   * The time to sleep when the replica thread is being throttled
+   */
+  @Config("replication.sleep.duration.ms")
+  @Default("1000")
+  public final long replicationSleepDurationMs;
+
+  /**
    * The fetch size is an approximate total size that a remote server would return on a fetch request.
    * This is not guaranteed to be always obeyed. For example, if a single blob is larger than the fetch size
    * the entire blob would be returned
@@ -82,6 +89,8 @@ public class ReplicationConfig {
         verifiableProperties.getIntInRange("replication.token.flush.interval.seconds", 300, 5, Integer.MAX_VALUE);
     replicationTokenFlushDelaySeconds =
         verifiableProperties.getIntInRange("replication.token.flush.delay.seconds", 5, 1, Integer.MAX_VALUE);
+    replicationSleepDurationMs =
+        verifiableProperties.getLongInRange("replication.sleep.duration.ms", 1000, 0, Long.MAX_VALUE);
     replicationFetchSizeInBytes =
         verifiableProperties.getLongInRange("replication.fetch.size.in.bytes", 1048576, 1, Long.MAX_VALUE);
   }

--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -60,11 +60,18 @@ public class ReplicationConfig {
   public final int replicationTokenFlushDelaySeconds;
 
   /**
-   * The time to sleep when the replica thread is not doing any useful work
+   * The time to sleep between replication cycles to throttle the replica thread
    */
-  @Config("replication.replica.thread.sleep.duration.ms")
+  @Config("replication.replica.thread.throttle.sleep.duration.ms")
+  @Default("0")
+  public final long replicationThreadThrottleSleepDurationMs;
+
+  /**
+   * The time to sleep between replication cycles when the replica thread is not doing any useful work
+   */
+  @Config("replication.replica.thread.idle.sleep.duration.ms")
   @Default("1000")
-  public final long replicationThreadSleepDurationMs;
+  public final long replicationThreadIdleSleepDurationMs;
 
   /**
    * The time to temporarily disable replication for a replica in order to reduce wasteful network calls
@@ -96,8 +103,12 @@ public class ReplicationConfig {
         verifiableProperties.getIntInRange("replication.token.flush.interval.seconds", 300, 5, Integer.MAX_VALUE);
     replicationTokenFlushDelaySeconds =
         verifiableProperties.getIntInRange("replication.token.flush.delay.seconds", 5, 1, Integer.MAX_VALUE);
-    replicationThreadSleepDurationMs =
-        verifiableProperties.getLongInRange("replication.replica.thread.sleep.duration.ms", 1000, 0, Long.MAX_VALUE);
+    replicationThreadThrottleSleepDurationMs =
+        verifiableProperties.getLongInRange("replication.replica.thread.throttle.sleep.duration.ms", 0, 0,
+            Long.MAX_VALUE);
+    replicationThreadIdleSleepDurationMs =
+        verifiableProperties.getLongInRange("replication.replica.thread.idle.sleep.duration.ms", 1000, 0,
+            Long.MAX_VALUE);
     replicationReplicaBackoffDurationMs =
         verifiableProperties.getLongInRange("replication.synced.replica.backoff.duration.ms", 1000, 0, Long.MAX_VALUE);
     replicationFetchSizeInBytes =

--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -64,21 +64,21 @@ public class ReplicationConfig {
    */
   @Config("replication.replica.thread.throttle.sleep.duration.ms")
   @Default("0")
-  public final long replicationThreadThrottleSleepDurationMs;
+  public final long replicationReplicaThreadThrottleSleepDurationMs;
 
   /**
    * The time to sleep between replication cycles when the replica thread is not doing any useful work
    */
   @Config("replication.replica.thread.idle.sleep.duration.ms")
   @Default("1000")
-  public final long replicationThreadIdleSleepDurationMs;
+  public final long replicationReplicaThreadIdleSleepDurationMs;
 
   /**
    * The time to temporarily disable replication for a replica in order to reduce wasteful network calls
    */
   @Config("replication.synced.replica.backoff.duration.ms")
   @Default("1000")
-  public final long replicationReplicaBackoffDurationMs;
+  public final long replicationSyncedReplicaBackoffDurationMs;
 
   /**
    * The fetch size is an approximate total size that a remote server would return on a fetch request.
@@ -103,13 +103,13 @@ public class ReplicationConfig {
         verifiableProperties.getIntInRange("replication.token.flush.interval.seconds", 300, 5, Integer.MAX_VALUE);
     replicationTokenFlushDelaySeconds =
         verifiableProperties.getIntInRange("replication.token.flush.delay.seconds", 5, 1, Integer.MAX_VALUE);
-    replicationThreadThrottleSleepDurationMs =
+    replicationReplicaThreadThrottleSleepDurationMs =
         verifiableProperties.getLongInRange("replication.replica.thread.throttle.sleep.duration.ms", 0, 0,
             Long.MAX_VALUE);
-    replicationThreadIdleSleepDurationMs =
+    replicationReplicaThreadIdleSleepDurationMs =
         verifiableProperties.getLongInRange("replication.replica.thread.idle.sleep.duration.ms", 1000, 0,
             Long.MAX_VALUE);
-    replicationReplicaBackoffDurationMs =
+    replicationSyncedReplicaBackoffDurationMs =
         verifiableProperties.getLongInRange("replication.synced.replica.backoff.duration.ms", 1000, 0, Long.MAX_VALUE);
     replicationFetchSizeInBytes =
         verifiableProperties.getLongInRange("replication.fetch.size.in.bytes", 1048576, 1, Long.MAX_VALUE);

--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -60,11 +60,18 @@ public class ReplicationConfig {
   public final int replicationTokenFlushDelaySeconds;
 
   /**
-   * The time to sleep when the replica thread is being throttled
+   * The time to sleep when the replica thread is not doing any useful work
    */
   @Config("replication.sleep.duration.ms")
   @Default("1000")
   public final long replicationSleepDurationMs;
+
+  /**
+   * The time to temporarily disable replication for a replica in order to reduce wasteful network calls
+   */
+  @Config("replication.quarantine.duration.ms")
+  @Default("1000")
+  public final long replicationQuarantineDurationMs;
 
   /**
    * The fetch size is an approximate total size that a remote server would return on a fetch request.
@@ -91,6 +98,8 @@ public class ReplicationConfig {
         verifiableProperties.getIntInRange("replication.token.flush.delay.seconds", 5, 1, Integer.MAX_VALUE);
     replicationSleepDurationMs =
         verifiableProperties.getLongInRange("replication.sleep.duration.ms", 1000, 0, Long.MAX_VALUE);
+    replicationQuarantineDurationMs =
+        verifiableProperties.getLongInRange("replication.quarantine.duration.ms", 1000, 0, Long.MAX_VALUE);
     replicationFetchSizeInBytes =
         verifiableProperties.getLongInRange("replication.fetch.size.in.bytes", 1048576, 1, Long.MAX_VALUE);
   }

--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -62,16 +62,16 @@ public class ReplicationConfig {
   /**
    * The time to sleep when the replica thread is not doing any useful work
    */
-  @Config("replication.sleep.duration.ms")
+  @Config("replication.replica.thread.sleep.duration.ms")
   @Default("1000")
-  public final long replicationSleepDurationMs;
+  public final long replicationThreadSleepDurationMs;
 
   /**
    * The time to temporarily disable replication for a replica in order to reduce wasteful network calls
    */
-  @Config("replication.quarantine.duration.ms")
+  @Config("replication.synced.replica.backoff.duration.ms")
   @Default("1000")
-  public final long replicationQuarantineDurationMs;
+  public final long replicationReplicaBackoffDurationMs;
 
   /**
    * The fetch size is an approximate total size that a remote server would return on a fetch request.
@@ -96,10 +96,10 @@ public class ReplicationConfig {
         verifiableProperties.getIntInRange("replication.token.flush.interval.seconds", 300, 5, Integer.MAX_VALUE);
     replicationTokenFlushDelaySeconds =
         verifiableProperties.getIntInRange("replication.token.flush.delay.seconds", 5, 1, Integer.MAX_VALUE);
-    replicationSleepDurationMs =
-        verifiableProperties.getLongInRange("replication.sleep.duration.ms", 1000, 0, Long.MAX_VALUE);
-    replicationQuarantineDurationMs =
-        verifiableProperties.getLongInRange("replication.quarantine.duration.ms", 1000, 0, Long.MAX_VALUE);
+    replicationThreadSleepDurationMs =
+        verifiableProperties.getLongInRange("replication.replica.thread.sleep.duration.ms", 1000, 0, Long.MAX_VALUE);
+    replicationReplicaBackoffDurationMs =
+        verifiableProperties.getLongInRange("replication.synced.replica.backoff.duration.ms", 1000, 0, Long.MAX_VALUE);
     replicationFetchSizeInBytes =
         verifiableProperties.getLongInRange("replication.fetch.size.in.bytes", 1048576, 1, Long.MAX_VALUE);
   }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -255,10 +255,9 @@ class ReplicaThread implements Runnable {
       long startTimeInMs = replicationStartTimeInMs;
 
       List<RemoteReplicaInfo> activeReplicasPerNode = new ArrayList<RemoteReplicaInfo>();
-      boolean inBackoff;
       for (RemoteReplicaInfo remoteReplicaInfo : replicasToReplicatePerNode) {
         ReplicaId replicaId = remoteReplicaInfo.getReplicaId();
-        inBackoff = time.milliseconds() < remoteReplicaInfo.getReEnableReplicationTime();
+        boolean inBackoff = time.milliseconds() < remoteReplicaInfo.getReEnableReplicationTime();
         if (!replicationDisabledPartitions.contains(replicaId.getPartitionId()) && !replicaId.isDown() && !inBackoff) {
           activeReplicasPerNode.add(remoteReplicaInfo);
         }
@@ -313,10 +312,10 @@ class ReplicaThread implements Runnable {
     }
     long sleepDurationMs;
     if (allCaughtUp) {
-      sleepDurationMs = replicationConfig.replicationThreadIdleSleepDurationMs;
+      sleepDurationMs = replicationConfig.replicationReplicaThreadIdleSleepDurationMs;
       replicationMetrics.replicaThreadIdleCount.inc();
     } else {
-      sleepDurationMs = replicationConfig.replicationThreadThrottleSleepDurationMs;
+      sleepDurationMs = replicationConfig.replicationReplicaThreadThrottleSleepDurationMs;
     }
     if (sleepDurationMs > 0) {
       try {
@@ -749,7 +748,7 @@ class ReplicaThread implements Runnable {
       if (exchangeMetadataResponse.serverErrorCode == ServerErrorCode.No_Error) {
         if (remoteReplicaInfo.getToken().equals(exchangeMetadataResponse.remoteToken)) {
           remoteReplicaInfo.setReEnableReplicationTime(
-              time.milliseconds() + replicationConfig.replicationReplicaBackoffDurationMs);
+              time.milliseconds() + replicationConfig.replicationSyncedReplicaBackoffDurationMs);
           replicationMetrics.replicaSyncedBackoffCount.inc();
         }
         if (exchangeMetadataResponse.missingStoreKeys.size() > 0) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -259,8 +259,8 @@ class ReplicaThread implements Runnable {
       boolean quarantined;
       for (RemoteReplicaInfo remoteReplicaInfo : replicasToReplicatePerNode) {
         ReplicaId replicaId = remoteReplicaInfo.getReplicaId();
-        quarantined = remoteReplicaInfo.getQuarantineTime() != Utils.Infinite_Time &&
-            (time.milliseconds() - remoteReplicaInfo.getQuarantineTime()) < replicationConfig.replicationQuarantineDurationMs;
+        quarantined = remoteReplicaInfo.getReEnableReplicationTime() != Utils.Infinite_Time &&
+            time.milliseconds() < remoteReplicaInfo.getReEnableReplicationTime();
         if (!replicationDisabledPartitions.contains(replicaId.getPartitionId()) && !replicaId.isDown() && !quarantined) {
           activeReplicasPerNode.add(remoteReplicaInfo);
         }
@@ -746,7 +746,7 @@ class ReplicaThread implements Runnable {
       RemoteReplicaInfo remoteReplicaInfo = replicasToReplicatePerNode.get(i);
       if (exchangeMetadataResponse.serverErrorCode == ServerErrorCode.No_Error) {
         if (remoteReplicaInfo.getToken().equals(exchangeMetadataResponse.remoteToken)) {
-          remoteReplicaInfo.setQuarantineTime(time.milliseconds());
+          remoteReplicaInfo.setReEnableReplicationTime(time.milliseconds() + replicationConfig.replicationQuarantineDurationMs);
         } else {
           meaningfulExchangeCount++;
         }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -311,13 +311,19 @@ class ReplicaThread implements Runnable {
         }
       }
     }
+    long sleepDurationMs;
     if (allCaughtUp) {
+      sleepDurationMs = replicationConfig.replicationThreadIdleSleepDurationMs;
+      replicationMetrics.replicaThreadIdleCount.inc();
+    } else {
+      sleepDurationMs = replicationConfig.replicationThreadThrottleSleepDurationMs;
+    }
+    if (sleepDurationMs > 0) {
       try {
-        time.sleep(replicationConfig.replicationThreadSleepDurationMs);
+        time.sleep(sleepDurationMs);
       } catch (InterruptedException e) {
         logger.error("Received interrupted exception during throttling", e);
       }
-      replicationMetrics.replicaThreadSleepCount.inc();
     }
   }
 

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -57,7 +57,6 @@ import com.github.ambry.store.Transformer;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Time;
-import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -312,7 +311,7 @@ class ReplicaThread implements Runnable {
         }
       }
     }
-    if(allCaughtUp) {
+    if (allCaughtUp) {
       try {
         time.sleep(replicationConfig.replicationThreadSleepDurationMs);
       } catch (InterruptedException e) {
@@ -422,7 +421,6 @@ class ReplicaThread implements Runnable {
               remoteNode);
       writeMessagesToLocalStoreAndAdvanceTokens(exchangeMetadataResponseList, getResponse, replicasToReplicatePerNode,
           remoteNode);
-
     } finally {
       long fixMissingStoreKeysTime = SystemTime.getInstance().milliseconds() - fixMissingStoreKeysStartTimeInMs;
       replicationMetrics.updateFixMissingStoreKeysTime(fixMissingStoreKeysTime, replicatingFromRemoteColo,
@@ -744,7 +742,8 @@ class ReplicaThread implements Runnable {
       RemoteReplicaInfo remoteReplicaInfo = replicasToReplicatePerNode.get(i);
       if (exchangeMetadataResponse.serverErrorCode == ServerErrorCode.No_Error) {
         if (remoteReplicaInfo.getToken().equals(exchangeMetadataResponse.remoteToken)) {
-          remoteReplicaInfo.setReEnableReplicationTime(time.milliseconds() + replicationConfig.replicationReplicaBackoffDurationMs);
+          remoteReplicaInfo.setReEnableReplicationTime(
+              time.milliseconds() + replicationConfig.replicationReplicaBackoffDurationMs);
           replicationMetrics.replicaSyncedBackoffCount.inc();
         }
         if (exchangeMetadataResponse.missingStoreKeys.size() > 0) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -80,7 +80,7 @@ final class RemoteReplicaInfo {
   private FindToken tokenSafeToPersist = null;
   private long totalBytesReadFromLocalStore;
   private long localLagFromRemoteStore = -1;
-  private long reEnableReplicationTime = Utils.Infinite_Time;
+  private long reEnableReplicationTime = 0;
 
   RemoteReplicaInfo(ReplicaId replicaId, ReplicaId localReplicaId, Store localStore, FindToken token,
       long tokenPersistIntervalInMs, Time time, Port port) {
@@ -110,8 +110,16 @@ final class RemoteReplicaInfo {
     return this.port;
   }
 
+  /**
+   * Gets the time re-enable replication for this replica.
+   * @return time to re-enable replication in ms.
+   */
   long getReEnableReplicationTime() { return reEnableReplicationTime; }
 
+  /**
+   * Sets the time to re-enable replication for this replica.
+   * @param reEnableReplicationTime time to re-enable replication in ms.
+   */
   void setReEnableReplicationTime(long reEnableReplicationTime) { this.reEnableReplicationTime =
       reEnableReplicationTime; }
 

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -80,7 +80,7 @@ final class RemoteReplicaInfo {
   private FindToken tokenSafeToPersist = null;
   private long totalBytesReadFromLocalStore;
   private long localLagFromRemoteStore = -1;
-  private long quarantineTime = Utils.Infinite_Time;
+  private long reEnableReplicationTime = Utils.Infinite_Time;
 
   RemoteReplicaInfo(ReplicaId replicaId, ReplicaId localReplicaId, Store localStore, FindToken token,
       long tokenPersistIntervalInMs, Time time, Port port) {
@@ -110,9 +110,10 @@ final class RemoteReplicaInfo {
     return this.port;
   }
 
-  long getQuarantineTime() { return  quarantineTime; }
+  long getReEnableReplicationTime() { return reEnableReplicationTime; }
 
-  void setQuarantineTime(long quarantineTime) { this.quarantineTime = quarantineTime; }
+  void setReEnableReplicationTime(long reEnableReplicationTime) { this.reEnableReplicationTime =
+      reEnableReplicationTime; }
 
   long getRemoteLagFromLocalInBytes() {
     if (localStore != null) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -578,7 +578,7 @@ public class ReplicationManager {
               new ReplicaThread(threadIdentity, replicasForThread, factory, clusterMap, correlationIdGenerator,
                   dataNodeId, connectionPool, replicationConfig, replicationMetrics, notification, storeKeyFactory,
                   threadSpecificKeyConverter, threadSpecificTransformer, metricRegistry, replicatingOverSsl, datacenter,
-                  responseHandler);
+                  responseHandler, SystemTime.getInstance());
           if (replicaThreadPools.containsKey(datacenter)) {
             replicaThreadPools.get(datacenter).add(replicaThread);
           } else {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -114,14 +114,17 @@ final class RemoteReplicaInfo {
    * Gets the time re-enable replication for this replica.
    * @return time to re-enable replication in ms.
    */
-  long getReEnableReplicationTime() { return reEnableReplicationTime; }
+  long getReEnableReplicationTime() {
+    return reEnableReplicationTime;
+  }
 
   /**
    * Sets the time to re-enable replication for this replica.
    * @param reEnableReplicationTime time to re-enable replication in ms.
    */
-  void setReEnableReplicationTime(long reEnableReplicationTime) { this.reEnableReplicationTime =
-      reEnableReplicationTime; }
+  void setReEnableReplicationTime(long reEnableReplicationTime) {
+    this.reEnableReplicationTime = reEnableReplicationTime;
+  }
 
   long getRemoteLagFromLocalInBytes() {
     if (localStore != null) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -80,6 +80,7 @@ final class RemoteReplicaInfo {
   private FindToken tokenSafeToPersist = null;
   private long totalBytesReadFromLocalStore;
   private long localLagFromRemoteStore = -1;
+  private long quarantineTime = Utils.Infinite_Time;
 
   RemoteReplicaInfo(ReplicaId replicaId, ReplicaId localReplicaId, Store localStore, FindToken token,
       long tokenPersistIntervalInMs, Time time, Port port) {
@@ -108,6 +109,10 @@ final class RemoteReplicaInfo {
   Port getPort() {
     return this.port;
   }
+
+  long getQuarantineTime() { return  quarantineTime; }
+
+  void setQuarantineTime(long quarantineTime) { this.quarantineTime = quarantineTime; }
 
   long getRemoteLagFromLocalInBytes() {
     if (localStore != null) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -114,7 +114,7 @@ public class ReplicationMetrics {
   public final Counter blobDeletedOnGetCount;
   public final Counter blobAuthorizationFailureCount;
   public final Counter replicaSyncedBackoffCount;
-  public final Counter replicaThreadSleepCount;
+  public final Counter replicaThreadIdleCount;
 
   public List<Gauge<Long>> replicaLagInBytes;
   private MetricRegistry registry;
@@ -213,7 +213,7 @@ public class ReplicationMetrics {
     blobAuthorizationFailureCount =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "BlobAuthorizationFailureCount"));
     replicaSyncedBackoffCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaSyncedBackoffCount"));
-    replicaThreadSleepCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaThreadSleepCount"));
+    replicaThreadIdleCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaThreadIdleCount"));
     this.registry = registry;
     this.replicaLagInBytes = new ArrayList<Gauge<Long>>();
     populateInvalidMessageMetricForReplicas(replicaIds);

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -114,7 +114,6 @@ public class ReplicationMetrics {
   public final Counter blobDeletedOnGetCount;
   public final Counter blobAuthorizationFailureCount;
   public final Histogram percentageOfMeaningfulExchange;
-  public final Histogram totalBytesReplicatedPerCycle;
 
   public List<Gauge<Long>> replicaLagInBytes;
   private MetricRegistry registry;
@@ -213,7 +212,6 @@ public class ReplicationMetrics {
     blobAuthorizationFailureCount =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "BlobAuthorizationFailureCount"));
     percentageOfMeaningfulExchange = registry.histogram(MetricRegistry.name(ReplicaThread.class, "PercentageOfMeaningfulExchange"));
-    totalBytesReplicatedPerCycle = registry.histogram(MetricRegistry.name(ReplicaThread.class, "TotalBytesReplicatedPerCycle"));
     this.registry = registry;
     this.replicaLagInBytes = new ArrayList<Gauge<Long>>();
     populateInvalidMessageMetricForReplicas(replicaIds);

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -113,6 +113,8 @@ public class ReplicationMetrics {
   public final Histogram sslIntraColoTotalReplicationTime;
   public final Counter blobDeletedOnGetCount;
   public final Counter blobAuthorizationFailureCount;
+  public final Histogram percentageOfMeaningfulExchange;
+  public final Histogram totalBytesReplicatedPerCycle;
 
   public List<Gauge<Long>> replicaLagInBytes;
   private MetricRegistry registry;
@@ -210,6 +212,8 @@ public class ReplicationMetrics {
     blobDeletedOnGetCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "BlobDeletedOnGetCount"));
     blobAuthorizationFailureCount =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "BlobAuthorizationFailureCount"));
+    percentageOfMeaningfulExchange = registry.histogram(MetricRegistry.name(ReplicaThread.class, "PercentageOfMeaningfulExchange"));
+    totalBytesReplicatedPerCycle = registry.histogram(MetricRegistry.name(ReplicaThread.class, "TotalBytesReplicatedPerCycle"));
     this.registry = registry;
     this.replicaLagInBytes = new ArrayList<Gauge<Long>>();
     populateInvalidMessageMetricForReplicas(replicaIds);

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -113,7 +113,8 @@ public class ReplicationMetrics {
   public final Histogram sslIntraColoTotalReplicationTime;
   public final Counter blobDeletedOnGetCount;
   public final Counter blobAuthorizationFailureCount;
-  public final Histogram percentageOfMeaningfulExchange;
+  public final Counter replicaQuarantineCount;
+  public final Counter replicaThreadSleepCount;
 
   public List<Gauge<Long>> replicaLagInBytes;
   private MetricRegistry registry;
@@ -211,7 +212,8 @@ public class ReplicationMetrics {
     blobDeletedOnGetCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "BlobDeletedOnGetCount"));
     blobAuthorizationFailureCount =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "BlobAuthorizationFailureCount"));
-    percentageOfMeaningfulExchange = registry.histogram(MetricRegistry.name(ReplicaThread.class, "PercentageOfMeaningfulExchange"));
+    replicaQuarantineCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaQuarantineCount"));
+    replicaThreadSleepCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaThreadSleepCount"));
     this.registry = registry;
     this.replicaLagInBytes = new ArrayList<Gauge<Long>>();
     populateInvalidMessageMetricForReplicas(replicaIds);

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -113,7 +113,7 @@ public class ReplicationMetrics {
   public final Histogram sslIntraColoTotalReplicationTime;
   public final Counter blobDeletedOnGetCount;
   public final Counter blobAuthorizationFailureCount;
-  public final Counter replicaQuarantineCount;
+  public final Counter replicaSyncedBackoffCount;
   public final Counter replicaThreadSleepCount;
 
   public List<Gauge<Long>> replicaLagInBytes;
@@ -212,7 +212,7 @@ public class ReplicationMetrics {
     blobDeletedOnGetCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "BlobDeletedOnGetCount"));
     blobAuthorizationFailureCount =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "BlobAuthorizationFailureCount"));
-    replicaQuarantineCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaQuarantineCount"));
+    replicaSyncedBackoffCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaSyncedBackoffCount"));
     replicaThreadSleepCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaThreadSleepCount"));
     this.registry = registry;
     this.replicaLagInBytes = new ArrayList<Gauge<Long>>();

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockFindTokenFactory.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockFindTokenFactory.java
@@ -55,6 +55,18 @@ class MockFindToken implements FindToken {
     return byteBuffer.array();
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MockFindToken that = (MockFindToken) o;
+    return index == that.index && bytesRead == that.bytesRead;
+  }
+
   public int getIndex() {
     return index;
   }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -810,7 +810,7 @@ public class ReplicationTest {
     verifyNoMoreMissingKeysAndExpectedMissingBufferCount(remoteHost, localHost, replicaThread, replicasToReplicate,
         idsToBeIgnoredByPartition, storeKeyConverter, expectedIndex, expectedIndex + 1, 4);
 
-    // Verify that the replica thread is throttling when replicas are synced.
+    // Verify that the replica thread sleeps when all replicas are synced.
     long currentTimeMs = time.milliseconds();
     replicaThread.replicate(new ArrayList<>(replicasToReplicate.values()));
     assertEquals("Replicas are in sync, time should be advanced by exactly replication.sleep.duration.ms",
@@ -821,12 +821,11 @@ public class ReplicationTest {
     addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 3);
     currentTimeMs = time.milliseconds();
     replicaThread.replicate(new ArrayList<>(replicasToReplicate.values()));
-    assertEquals("Replicas are no longer in sync so the replica thread shouldn't sleep",
+    assertEquals("Replicas are no longer in sync therefore the replica thread shouldn't sleep",
         currentTimeMs, time.milliseconds());
 
     // add 3 messages to the same partition in all hosts
     addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(localHost, remoteHost), 3);
-    currentTimeMs = time.milliseconds();
     replicaThread.replicate(new ArrayList<>(replicasToReplicate.values()));
     assertEquals("No missing keys but the replica thread should still not sleep since remote has new token",
         currentTimeMs, time.milliseconds());

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -833,7 +833,7 @@ public class ReplicationTest {
     long currentTimeMs = time.milliseconds();
     replicaThread.replicate(replicasToReplicateList);
     assertEquals("Replicas are in sync, replica thread should sleep by replication.thread.idle.sleep.duration.ms",
-        currentTimeMs + config.replicationThreadIdleSleepDurationMs, time.milliseconds());
+        currentTimeMs + config.replicationReplicaThreadIdleSleepDurationMs, time.milliseconds());
 
     // 2. add 3 messages to a partition in the remote host only and verify replication for all replicas should be disabled.
     PartitionId partitionId = clusterMap.getWritablePartitionIds(null).get(0);
@@ -849,11 +849,11 @@ public class ReplicationTest {
     currentTimeMs = time.milliseconds();
     replicaThread.replicate(replicasToReplicateList);
     assertEquals("Replication for all replicas should be disabled and the thread should sleep",
-        currentTimeMs + config.replicationThreadIdleSleepDurationMs, time.milliseconds());
+        currentTimeMs + config.replicationReplicaThreadIdleSleepDurationMs, time.milliseconds());
     assertMissingKeys(missingKeys, batchSize, replicaThread, remoteHost, replicasToReplicate);
 
     // 3. forward the time and run replicate and verify the replication.
-    time.sleep(config.replicationReplicaBackoffDurationMs);
+    time.sleep(config.replicationSyncedReplicaBackoffDurationMs);
     replicaThread.replicate(replicasToReplicateList);
     missingKeys = new int[replicasToReplicate.get(remoteHost.dataNodeId).size()];
     assertMissingKeys(missingKeys, batchSize, replicaThread, remoteHost, replicasToReplicate);
@@ -865,7 +865,7 @@ public class ReplicationTest {
     assertMissingKeys(missingKeys, batchSize, replicaThread, remoteHost, replicasToReplicate);
     assertEquals(
         "Replica thread should sleep exactly replication.thread.throttle.sleep.duration.ms since remote has new token",
-        currentTimeMs + config.replicationThreadThrottleSleepDurationMs, time.milliseconds());
+        currentTimeMs + config.replicationReplicaThreadThrottleSleepDurationMs, time.milliseconds());
 
     // verify that throttling on the replica thread is disabled when replication.thread.throttle.sleep.duration.ms is 0.
     Properties properties = new Properties();

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -830,7 +830,11 @@ public class ReplicationTest {
     addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 3);
     int[] missingKeys = new int[replicasToReplicate.get(remoteHost.dataNodeId).size()];
     for (int i = 0; i < missingKeys.length; i++) {
-      missingKeys[i] = replicasToReplicate.get(remoteHost.dataNodeId).get(i).getReplicaId().getPartitionId().isEqual(partitionId.toString()) ? 3 : 0;
+      missingKeys[i] = replicasToReplicate.get(remoteHost.dataNodeId)
+          .get(i)
+          .getReplicaId()
+          .getPartitionId()
+          .isEqual(partitionId.toString()) ? 3 : 0;
     }
     currentTimeMs = time.milliseconds();
     replicaThread.replicate(replicasToReplicateList);
@@ -849,8 +853,7 @@ public class ReplicationTest {
     addPutMessagesToReplicasOfPartition(partitionId, Arrays.asList(localHost, remoteHost), 3);
     replicaThread.replicate(new ArrayList<>(replicasToReplicate.values()));
     assertMissingKeys(missingKeys, batchSize, replicaThread, remoteHost, replicasToReplicate);
-    assertEquals("Replica thread should not sleep since remote has new token",
-        currentTimeMs, time.milliseconds());
+    assertEquals("Replica thread should not sleep since remote has new token", currentTimeMs, time.milliseconds());
   }
 
   /**

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -828,9 +828,9 @@ public class ReplicationTest {
 
     // 1. verify that the replica thread sleeps and replicas are temporarily disable when all replicas are synced.
     List<List<RemoteReplicaInfo>> replicasToReplicateList = new ArrayList<>(replicasToReplicate.values());
-    // replicate is called and time is moved forward to prepare the replica states for tests.
+    // replicate is called and time is moved forward to prepare the replicas for testing.
     replicaThread.replicate(replicasToReplicateList);
-    time.sleep(config.replicationSyncedReplicaBackoffDurationMs);
+    time.sleep(config.replicationSyncedReplicaBackoffDurationMs + 1);
     long currentTimeMs = time.milliseconds();
     replicaThread.replicate(replicasToReplicateList);
     for (List<RemoteReplicaInfo> replicaInfos : replicasToReplicateList) {


### PR DESCRIPTION
- This change makes the thread sleep for a configurable amount of time before running the replication cycle again when all replicas are caught up. 
- In the case when only some replicas had meaningful exchanges, replicas that did not will have their replication temporarily disabled for a configurable amount of time to reduce wasteful work.
- In addition, a configurable sleep can be inserted between every replication regardless of the replica states.
- Metrics are added for total number of times that a replica was temporarily disabled and the number of times the thread went into idle sleep.