### PR TITLE
Adding bootstrap functionality to Journal

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/Journal.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Journal.java
@@ -54,7 +54,7 @@ class Journal {
   private final AtomicInteger currentNumberOfEntries;
   private final String dataDir;
   private final Logger logger = LoggerFactory.getLogger(getClass());
-  private boolean bootstrap;
+  private boolean isBootstrapMode = false;
 
   /**
    * The journal that holds the most recent entries in a store sorted by offset of the blob on disk
@@ -65,7 +65,6 @@ class Journal {
   Journal(String dataDir, int maxEntriesToJournal, int maxEntriesToReturn) {
     journal = new ConcurrentSkipListMap<>();
     recentCrcs = new ConcurrentHashMap<>();
-    bootstrap = false;
     this.maxEntriesToJournal = maxEntriesToJournal;
     this.maxEntriesToReturn = maxEntriesToReturn;
     this.currentNumberOfEntries = new AtomicInteger(0);
@@ -83,7 +82,7 @@ class Journal {
       throw new IllegalArgumentException("Invalid arguments passed to add to the journal");
     }
     if (maxEntriesToJournal > 0) {
-      if (!bootstrap && currentNumberOfEntries.get() >= maxEntriesToJournal) {
+      if (!isBootstrapMode && currentNumberOfEntries.get() >= maxEntriesToJournal) {
         Map.Entry<Offset, StoreKey> earliestEntry = journal.firstEntry();
         journal.remove(earliestEntry.getKey());
         recentCrcs.remove(earliestEntry.getValue());
@@ -193,14 +192,14 @@ class Journal {
    * Puts the {@link Journal} into bootstrap mode to ignore the {@code maxEntriesToJournal} constraint temporarily.
    */
   void startBootstrap() {
-    bootstrap = true;
+    isBootstrapMode = true;
   }
 
   /**
    * Signals the {@link Journal} is done bootstrapping and will start to honor {@code maxEntriesToJournal}.
    */
   void finishBootstrap() {
-    bootstrap = false;
+    isBootstrapMode = false;
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/Journal.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Journal.java
@@ -54,6 +54,7 @@ class Journal {
   private final AtomicInteger currentNumberOfEntries;
   private final String dataDir;
   private final Logger logger = LoggerFactory.getLogger(getClass());
+  private boolean bootstrap;
 
   /**
    * The journal that holds the most recent entries in a store sorted by offset of the blob on disk
@@ -64,6 +65,7 @@ class Journal {
   Journal(String dataDir, int maxEntriesToJournal, int maxEntriesToReturn) {
     journal = new ConcurrentSkipListMap<>();
     recentCrcs = new ConcurrentHashMap<>();
+    bootstrap = false;
     this.maxEntriesToJournal = maxEntriesToJournal;
     this.maxEntriesToReturn = maxEntriesToReturn;
     this.currentNumberOfEntries = new AtomicInteger(0);
@@ -81,7 +83,7 @@ class Journal {
       throw new IllegalArgumentException("Invalid arguments passed to add to the journal");
     }
     if (maxEntriesToJournal > 0) {
-      if (currentNumberOfEntries.get() == maxEntriesToJournal) {
+      if (!bootstrap && currentNumberOfEntries.get() >= maxEntriesToJournal) {
         Map.Entry<Offset, StoreKey> earliestEntry = journal.firstEntry();
         journal.remove(earliestEntry.getKey());
         recentCrcs.remove(earliestEntry.getValue());
@@ -188,9 +190,24 @@ class Journal {
   }
 
   /**
-   * @return the maximum number of entries to journal.
+   * Puts the {@link Journal} into bootstrap mode to ignore the {@code maxEntriesToJournal} constraint temporarily.
    */
-  int getMaxEntriesToJournal() {
-    return maxEntriesToJournal;
+  void startBootstrap() {
+    bootstrap = true;
   }
+
+  /**
+   * Signals the {@link Journal} is done bootstrapping and will start to honor {@code maxEntriesToJournal}.
+   */
+  void finishBootstrap() {
+    bootstrap = false;
+  }
+
+  /**
+   * @return the number of entries that is currently in the {@link Journal}.
+   */
+  int getCurrentNumberOfEntries() {
+    return currentNumberOfEntries.get();
+  }
+
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/Journal.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Journal.java
@@ -186,4 +186,11 @@ class Journal {
   StoreKey getKeyAtOffset(Offset offset) {
     return journal.get(offset);
   }
+
+  /**
+   * @return the maximum number of entries to journal.
+   */
+  int getMaxEntriesToJournal() {
+    return maxEntriesToJournal;
+  }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/Journal.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Journal.java
@@ -54,7 +54,7 @@ class Journal {
   private final AtomicInteger currentNumberOfEntries;
   private final String dataDir;
   private final Logger logger = LoggerFactory.getLogger(getClass());
-  private boolean isBootstrapMode = false;
+  private boolean inBootstrapMode = false;
 
   /**
    * The journal that holds the most recent entries in a store sorted by offset of the blob on disk
@@ -82,7 +82,7 @@ class Journal {
       throw new IllegalArgumentException("Invalid arguments passed to add to the journal");
     }
     if (maxEntriesToJournal > 0) {
-      if (!isBootstrapMode && currentNumberOfEntries.get() >= maxEntriesToJournal) {
+      if (!inBootstrapMode && currentNumberOfEntries.get() >= maxEntriesToJournal) {
         Map.Entry<Offset, StoreKey> earliestEntry = journal.firstEntry();
         journal.remove(earliestEntry.getKey());
         recentCrcs.remove(earliestEntry.getValue());
@@ -192,14 +192,14 @@ class Journal {
    * Puts the {@link Journal} into bootstrap mode to ignore the {@code maxEntriesToJournal} constraint temporarily.
    */
   void startBootstrap() {
-    isBootstrapMode = true;
+    inBootstrapMode = true;
   }
 
   /**
    * Signals the {@link Journal} is done bootstrapping and will start to honor {@code maxEntriesToJournal}.
    */
   void finishBootstrap() {
-    isBootstrapMode = false;
+    inBootstrapMode = false;
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -186,7 +186,7 @@ class PersistentIndex {
 
     List<File> indexFiles = getAllIndexSegmentFiles();
     try {
-      this.journal.startBootstrap();
+      journal.startBootstrap();
       for (int i = 0; i < indexFiles.size(); i++) {
         // We map all the index segments except the most recent index segment.
         // The recent index segment would go through recovery after they have been
@@ -209,7 +209,7 @@ class PersistentIndex {
       setEndOffsets();
       log.setActiveSegment(getCurrentEndOffset().getName());
       logEndOffsetOnStartup = log.getEndOffset();
-      this.journal.finishBootstrap();
+      journal.finishBootstrap();
 
       if (hardDelete != null) {
         // After recovering the last messages, and setting the log end offset, let the hard delete thread do its recovery.

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -209,10 +209,12 @@ class PersistentIndex {
       log.setActiveSegment(getCurrentEndOffset().getName());
       logEndOffsetOnStartup = log.getEndOffset();
 
-      // Validate store.index.max.number.of.inmem.elements to prevent incorrect Journal size
+      // Validate the max Journal size
       if (!getIndexSegments().isEmpty() &&
-          config.storeIndexMaxNumberOfInmemElements < getIndexSegments().lastEntry().getValue().getNumberOfItems()) {
-        throw new StoreException("store.index.max.number.of.inmem.elements is less than the number of entries in the last index segment",
+          this.journal.getMaxEntriesToJournal() < getIndexSegments().lastEntry().getValue().getNumberOfItems()) {
+        throw new StoreException("max journal size of " + this.journal.getMaxEntriesToJournal() +
+            " is less than the number of entries in the last index segment of " +
+            getIndexSegments().lastEntry().getValue().getNumberOfItems(),
             StoreErrorCodes.Illegal_Index_State);
       }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -186,6 +186,7 @@ class PersistentIndex {
 
     List<File> indexFiles = getAllIndexSegmentFiles();
     try {
+      this.journal.startBootstrap();
       for (int i = 0; i < indexFiles.size(); i++) {
         // We map all the index segments except the most recent index segment.
         // The recent index segment would go through recovery after they have been
@@ -208,15 +209,7 @@ class PersistentIndex {
       setEndOffsets();
       log.setActiveSegment(getCurrentEndOffset().getName());
       logEndOffsetOnStartup = log.getEndOffset();
-
-      // Validate the max Journal size
-      if (!getIndexSegments().isEmpty() &&
-          this.journal.getMaxEntriesToJournal() < getIndexSegments().lastEntry().getValue().getNumberOfItems()) {
-        throw new StoreException("max journal size of " + this.journal.getMaxEntriesToJournal() +
-            " is less than the number of entries in the last index segment of " +
-            getIndexSegments().lastEntry().getValue().getNumberOfItems(),
-            StoreErrorCodes.Illegal_Index_State);
-      }
+      this.journal.finishBootstrap();
 
       if (hardDelete != null) {
         // After recovering the last messages, and setting the log end offset, let the hard delete thread do its recovery.

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -209,6 +209,13 @@ class PersistentIndex {
       log.setActiveSegment(getCurrentEndOffset().getName());
       logEndOffsetOnStartup = log.getEndOffset();
 
+      // Validate store.index.max.number.of.inmem.elements to prevent incorrect Journal size
+      if (!getIndexSegments().isEmpty() &&
+          config.storeIndexMaxNumberOfInmemElements < getIndexSegments().lastEntry().getValue().getNumberOfItems()) {
+        throw new StoreException("store.index.max.number.of.inmem.elements is less than the number of entries in the last index segment",
+            StoreErrorCodes.Illegal_Index_State);
+      }
+
       if (hardDelete != null) {
         // After recovering the last messages, and setting the log end offset, let the hard delete thread do its recovery.
         // NOTE: It is safe to do the hard delete recovery after the regular recovery because we ensure that hard deletes

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1295,10 +1295,9 @@ public class IndexTest {
     state.reloadIndex(true, false);
     int entriesInJournal = state.index.journal.getCurrentNumberOfEntries();
     assertEquals("Number of entries in the journal should be equal to the number of elements in the last index segment",
-        state.index.getIndexSegments().lastEntry().getValue().getNumberOfItems(),
-        state.index.journal.getCurrentNumberOfEntries());
+        state.index.getIndexSegments().lastEntry().getValue().getNumberOfItems(), entriesInJournal);
     // add some entries to trigger rollover.
-    state.addPutEntries(3, PUT_RECORD_SIZE, Utils.Infinite_Time);
+    state.addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);
     assertEquals("Number of entries in the journal should not have changed",
         entriesInJournal, state.index.journal.getCurrentNumberOfEntries());
     // Reload the index and the journal size should now reflect the config change

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -536,7 +536,6 @@ public class IndexTest {
     final AtomicReference<Offset> logEndOffset = new AtomicReference<>(state.log.getEndOffset());
     state.appendToLog(ITERATIONS);
 
-
     final Set<IndexEntry> entriesAdded = Collections.newSetFromMap(new ConcurrentHashMap<IndexEntry, Boolean>());
     Runnable adder = new Runnable() {
       @Override


### PR DESCRIPTION
- This change adds a bootstrap state to Journal that temporarily ignores the max journal size
constraint while operating in bootstrap mode. This is done to prevent incorrect max journal size when reducing the max number of in mem elements to something much lower than the number of entries in the last index segment. 

Fixes #765.