### PR TITLE
Added calls to processResponse for attaching tracking info

### DIFF
--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -235,6 +235,7 @@ class AmbryBlobStorageService implements BlobStorageService {
       if (operationOrBlobId.startsWith("/")) {
         operationOrBlobId = operationOrBlobId.substring(1);
       }
+      securityService.processResponse(restRequest, restResponseChannel, null).get();
       if (operationOrBlobId.equalsIgnoreCase(Operations.UPDATE_TTL)) {
         ttlUpdateHandler.handle(restRequest, restResponseChannel, (r, e) -> {
           if (e != null && e instanceof RouterException
@@ -905,6 +906,7 @@ class AmbryBlobStorageService implements BlobStorageService {
           restResponseChannel.setHeader(RestUtils.Headers.DATE, new GregorianCalendar().getTime());
           restResponseChannel.setStatus(ResponseStatus.Accepted);
           restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, 0);
+          securityService.processResponse(restRequest, restResponseChannel, null).get();
         }
       } catch (Exception e) {
         frontendMetrics.deleteCallbackProcessingError.inc();

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -134,7 +134,8 @@ class AmbrySecurityService implements SecurityService {
         operationOrBlobId = operationOrBlobId.substring(1);
       }
       RestMethod restMethod = restRequest.getRestMethod();
-      if (blobInfo == null && !restMethod.equals(RestMethod.OPTIONS) && !restMethod.equals(RestMethod.PUT)) {
+      if (blobInfo == null && !restMethod.equals(RestMethod.OPTIONS) && !restMethod.equals(RestMethod.PUT)
+          && !restMethod.equals(RestMethod.DELETE)) {
         if (!operationOrBlobId.equals(Operations.GET_SIGNED_URL)) {
           throw new IllegalArgumentException("BlobInfo is null");
         }
@@ -186,6 +187,7 @@ class AmbrySecurityService implements SecurityService {
             break;
           case OPTIONS:
           case PUT:
+          case DELETE:
             break;
           default:
             exception = new RestServiceException("Cannot process response for request with method " + restMethod,

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -101,7 +101,8 @@ public class AmbrySecurityServiceTest {
   @Test
   public void preProcessRequestTest() throws Exception {
     RestMethod[] methods =
-        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS, RestMethod.PUT};
+        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS,
+            RestMethod.PUT};
     for (RestMethod restMethod : methods) {
       // add a header that is prohibited
       JSONObject headers = new JSONObject();
@@ -133,7 +134,8 @@ public class AmbrySecurityServiceTest {
 
     // without callbacks
     RestMethod[] methods =
-        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS, RestMethod.PUT};
+        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS,
+            RestMethod.PUT};
     for (RestMethod restMethod : methods) {
       RestRequest restRequest = createRestRequest(restMethod, "/", null);
       securityService.preProcessRequest(restRequest).get();
@@ -184,13 +186,6 @@ public class AmbrySecurityServiceTest {
     //blob info being null
     TestUtils.assertException(IllegalArgumentException.class,
         () -> securityService.processResponse(restRequest, new MockRestResponseChannel(), null).get(), null);
-
-    // for unsupported methods
-    RestMethod[] methods = {RestMethod.DELETE};
-    for (RestMethod restMethod : methods) {
-      testExceptionCasesProcessResponse(restMethod, new MockRestResponseChannel(), DEFAULT_INFO,
-          RestServiceErrorCode.InternalServerError);
-    }
 
     // OPTIONS (should be no errors)
     securityService.processResponse(createRestRequest(RestMethod.OPTIONS, "/", null), new MockRestResponseChannel(),
@@ -297,7 +292,7 @@ public class AmbrySecurityServiceTest {
 
     // security service closed
     securityService.close();
-    methods = new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD};
+    RestMethod[] methods = new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD};
     for (RestMethod restMethod : methods) {
       testExceptionCasesProcessResponse(restMethod, new MockRestResponseChannel(), blobInfo,
           RestServiceErrorCode.ServiceUnavailable);


### PR DESCRIPTION
- Added appropriate calls when handling **DELETE** and **PUT** responses in `AmbryBlobStorageService` to allow a different implementation of `AmbrySecurityService` to attach tracking related info on the response via `processResponse(...)`.
- Removed tests that expected exceptions to be thrown on **DELETE**