### PR TITLE
Make router handle Replica_Unavailable properly

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -273,6 +273,7 @@ class DeleteOperation {
         updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
         break;
       case Disk_Unavailable:
+      case Replica_Unavailable:
         updateOperationState(replica, RouterErrorCode.AmbryUnavailable);
         break;
       default:

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -402,8 +402,10 @@ class GetBlobInfoOperation extends GetOperation {
         setOperationException(new RouterException("Server returned: " + errorCode, RouterErrorCode.BlobDoesNotExist));
         break;
       case Disk_Unavailable:
-        logger.trace("Disk on which the requested blob resides is not accessible");
+      case Replica_Unavailable:
+        logger.trace("Disk or replica on which the requested blob resides is not accessible");
         setOperationException(new RouterException("Server returned: " + errorCode, RouterErrorCode.AmbryUnavailable));
+        break;
       default:
         setOperationException(
             new RouterException("Server returned: " + errorCode, RouterErrorCode.UnexpectedInternalError));

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -1075,7 +1075,9 @@ class GetBlobOperation extends GetOperation {
           setChunkException(new RouterException("Server returned: " + errorCode, RouterErrorCode.BlobDoesNotExist));
           break;
         case Disk_Unavailable:
+        case Replica_Unavailable:
           setChunkException(new RouterException("Server returned: " + errorCode, RouterErrorCode.AmbryUnavailable));
+          break;
         default:
           setChunkException(
               new RouterException("Server returned: " + errorCode, RouterErrorCode.UnexpectedInternalError));

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
@@ -264,6 +264,7 @@ class TtlUpdateOperation {
         updateOperationState(replica, RouterErrorCode.BlobDoesNotExist);
         break;
       case Disk_Unavailable:
+      case Replica_Unavailable:
         updateOperationState(replica, RouterErrorCode.AmbryUnavailable);
         break;
       case Blob_Update_Not_Allowed:
@@ -310,7 +311,7 @@ class TtlUpdateOperation {
   private void checkAndMaybeComplete() {
     // operationCompleted is true if Blob_Authorization_Failure was received.
     if (operationTracker.isDone() || operationCompleted == true) {
-      if (!operationTracker.hasSucceeded() ) {
+      if (!operationTracker.hasSucceeded()) {
         setOperationException(
             new RouterException("The TtlUpdateOperation could not be completed.", resolvedRouterErrorCode));
       }

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -252,6 +252,7 @@ public class DeleteManagerTest {
     codesToSetAndTest.clear();
     codesToSetAndTest.put(ServerErrorCode.Blob_Authorization_Failure, RouterErrorCode.BlobAuthorizationFailure);
     codesToSetAndTest.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
+    codesToSetAndTest.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
     codesToSetAndTest.put(ServerErrorCode.Partition_Unknown, RouterErrorCode.UnexpectedInternalError);
     doRouterErrorCodeResolutionTest(codesToSetAndTest);
   }
@@ -265,6 +266,7 @@ public class DeleteManagerTest {
     map.put(ServerErrorCode.Blob_Expired, RouterErrorCode.BlobExpired);
     map.put(ServerErrorCode.Blob_Not_Found, RouterErrorCode.BlobDoesNotExist);
     map.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
+    map.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
     map.put(ServerErrorCode.Blob_Authorization_Failure, RouterErrorCode.BlobAuthorizationFailure);
     for (ServerErrorCode serverErrorCode : ServerErrorCode.values()) {
       if (serverErrorCode != ServerErrorCode.No_Error && serverErrorCode != ServerErrorCode.Blob_Deleted

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -403,8 +403,9 @@ public class GetBlobInfoOperationTest {
             ServerErrorCode.Blob_Authorization_Failure, ServerErrorCode.Blob_Not_Found));
     for (ServerErrorCode serverErrorCode : serverErrors) {
       mockServerLayout.getMockServers().forEach(server -> server.setServerErrorForAllRequests(serverErrorCode));
-      assertOperationFailure(serverErrorCode == ServerErrorCode.Disk_Unavailable ? RouterErrorCode.AmbryUnavailable
-          : RouterErrorCode.UnexpectedInternalError);
+      assertOperationFailure(
+          EnumSet.of(ServerErrorCode.Disk_Unavailable, ServerErrorCode.Replica_Unavailable).contains(serverErrorCode)
+              ? RouterErrorCode.AmbryUnavailable : RouterErrorCode.UnexpectedInternalError);
     }
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -496,8 +496,8 @@ public class GetBlobOperationTest {
       mockServerLayout.getMockServers().forEach(server -> server.setServerErrorForAllRequests(serverErrorCode));
       GetBlobOperation op = createOperationAndComplete(null);
       assertFailureAndCheckErrorCode(op,
-          serverErrorCode == ServerErrorCode.Disk_Unavailable ? RouterErrorCode.AmbryUnavailable
-              : RouterErrorCode.UnexpectedInternalError);
+          EnumSet.of(ServerErrorCode.Disk_Unavailable, ServerErrorCode.Replica_Unavailable).contains(serverErrorCode)
+              ? RouterErrorCode.AmbryUnavailable : RouterErrorCode.UnexpectedInternalError);
     }
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -659,6 +659,7 @@ public class NonBlockingRouterTest {
     testsAndExpected.put(ServerErrorCode.Blob_Deleted, RouterErrorCode.BlobDeleted);
     testsAndExpected.put(ServerErrorCode.Blob_Expired, RouterErrorCode.BlobExpired);
     testsAndExpected.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
+    testsAndExpected.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
     testsAndExpected.put(ServerErrorCode.Unknown_Error, RouterErrorCode.UnexpectedInternalError);
     for (Map.Entry<ServerErrorCode, RouterErrorCode> testAndExpected : testsAndExpected.entrySet()) {
       layout.getMockServers().forEach(mockServer -> mockServer.setServerErrorForAllRequests(testAndExpected.getKey()));

--- a/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
@@ -114,8 +114,7 @@ public class TtlUpdateManagerTest {
     }
     ttlUpdateManager =
         new TtlUpdateManager(clusterMap, new ResponseHandler(clusterMap), notificationSystem, accountService,
-            routerConfig, metrics,
-            time);
+            routerConfig, metrics, time);
     networkClient = networkClientFactory.getNetworkClient();
   }
 
@@ -197,6 +196,7 @@ public class TtlUpdateManagerTest {
     errorCodeMap.put(ServerErrorCode.Blob_Expired, RouterErrorCode.BlobExpired);
     errorCodeMap.put(ServerErrorCode.Blob_Not_Found, RouterErrorCode.BlobDoesNotExist);
     errorCodeMap.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
+    errorCodeMap.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
     errorCodeMap.put(ServerErrorCode.Blob_Update_Not_Allowed, RouterErrorCode.BlobUpdateNotAllowed);
     errorCodeMap.put(ServerErrorCode.Blob_Authorization_Failure, RouterErrorCode.BlobAuthorizationFailure);
     for (ServerErrorCode errorCode : ServerErrorCode.values()) {


### PR DESCRIPTION
Router should return AmbryUnavailable instead of UnexpectedInternalError
when receiving Replica_Unavailable from server.