### PR TITLE
Make server detect Disk_Unavailable correctly

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaId.java
@@ -76,6 +76,11 @@ public interface ReplicaId {
   void markDiskDown();
 
   /**
+   * Marks the disk as up if at least one store on disk is available.
+   */
+  void markDiskUp();
+
+  /**
    * Returns true if the replica is down
    */
   boolean isDown();

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaId.java
@@ -71,6 +71,11 @@ public interface ReplicaId {
   DiskId getDiskId();
 
   /**
+   * Marks the disk as down if all stores on disk are unavailable.
+   */
+  void markDiskDown();
+
+  /**
    * Returns true if the replica is down
    */
   boolean isDown();

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
@@ -127,8 +127,13 @@ class AmbryReplica implements ReplicaId, Resource {
   }
 
   @Override
-  public void markDiskDown(){
+  public void markDiskDown() {
     disk.onDiskError();
+  }
+
+  @Override
+  public void markDiskUp() {
+    disk.onDiskOk();
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
@@ -126,6 +126,11 @@ class AmbryReplica implements ReplicaId, Resource {
     return "Replica[" + getDataNodeId().getHostname() + ":" + getDataNodeId().getPort() + ":" + getReplicaPath() + "]";
   }
 
+  @Override
+  public void markDiskDown(){
+    disk.onDiskError();
+  }
+
   /**
    * Take actions, if any, when this replica is unavailable.
    */

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
@@ -100,6 +100,11 @@ class Replica implements ReplicaId {
     return partition.getPartitionState().equals(PartitionState.READ_ONLY);
   }
 
+  @Override
+  public void markDiskDown() {
+    disk.onDiskError();
+  }
+
   Partition getPartition() {
     return partition;
   }
@@ -117,7 +122,7 @@ class Replica implements ReplicaId {
   void setStoppedState(boolean isStopped) {
     this.isStopped = isStopped;
   }
-  
+
   protected void validatePartition() {
     if (partition == null) {
       throw new IllegalStateException("Partition cannot be null.");

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
@@ -105,6 +105,11 @@ class Replica implements ReplicaId {
     disk.onDiskError();
   }
 
+  @Override
+  public void markDiskUp() {
+    disk.onDiskOk();
+  }
+
   Partition getPartition() {
     return partition;
   }
@@ -117,10 +122,6 @@ class Replica implements ReplicaId {
       }
     }
     return peers;
-  }
-
-  void setStoppedState(boolean isStopped) {
-    this.isStopped = isStopped;
   }
 
   protected void validatePartition() {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
@@ -118,6 +118,11 @@ public class MockReplicaId implements ReplicaId {
     diskId.onDiskError();
   }
 
+  @Override
+  public void markDiskUp() {
+    diskId.onDiskOk();
+  }
+
   public void cleanup() {
     File replicaDir = new File(replicaPath);
     File[] replicaDirFiles = replicaDir.listFiles();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
@@ -113,6 +113,11 @@ public class MockReplicaId implements ReplicaId {
     return "Mount Path " + mountPath + " Replica Path " + replicaPath;
   }
 
+  @Override
+  public void markDiskDown() {
+    diskId.onDiskError();
+  }
+
   public void cleanup() {
     File replicaDir = new File(replicaPath);
     File[] replicaDirFiles = replicaDir.listFiles();

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -1106,7 +1106,7 @@ public class AmbryRequests implements RequestAPI {
       if (storageManager.getStore(partition) == null) {
         if (localReplica != null) {
           // check stores on the disk
-          if (storageManager.isDiskUnavailable(localReplica.getDiskId())) {
+          if (!storageManager.isDiskAvailable(localReplica.getDiskId())) {
             metrics.diskUnavailableError.inc();
             localReplica.markDiskDown();
             return ServerErrorCode.Disk_Unavailable;

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -87,7 +87,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -109,7 +109,7 @@ public class AmbryRequests implements RequestAPI {
   private Logger publicAccessLogger = LoggerFactory.getLogger("PublicAccessLogger");
   private final ClusterMap clusterMap;
   private final DataNodeId currentNode;
-  private final Collection<PartitionId> partitionsInCurrentNode;
+  private final Map<PartitionId, ReplicaId> localPartitionToReplicaMap;
   private final ServerMetrics metrics;
   private final MessageFormatMetrics messageFormatMetrics;
   private final FindTokenFactory findTokenFactory;
@@ -144,11 +144,11 @@ public class AmbryRequests implements RequestAPI {
       requestsDisableInfo.put(requestType, Collections.newSetFromMap(new ConcurrentHashMap<>()));
     }
 
-    Set<PartitionId> partitionIds = new HashSet<>();
+    Map<PartitionId, ReplicaId> partitionToReplica = new HashMap<>();
     for (ReplicaId replicaId : clusterMap.getReplicaIds(currentNode)) {
-      partitionIds.add(replicaId.getPartitionId());
+      partitionToReplica.put(replicaId.getPartitionId(), replicaId);
     }
-    partitionsInCurrentNode = Collections.unmodifiableSet(partitionIds);
+    localPartitionToReplicaMap = Collections.unmodifiableMap(partitionToReplica);
   }
 
   public void handleRequests(Request request) throws InterruptedException {
@@ -806,7 +806,7 @@ public class AmbryRequests implements RequestAPI {
         error = validateRequest(controlRequest.getPartitionId(), RequestOrResponseType.AdminRequest, false);
         partitionIds = Collections.singletonList(controlRequest.getPartitionId());
       } else {
-        partitionIds = partitionsInCurrentNode;
+        partitionIds = localPartitionToReplicaMap.keySet();
       }
       if (!error.equals(ServerErrorCode.Partition_Unknown)) {
         controlRequestForPartitions(EnumSet.of(toControl), partitionIds, controlRequest.shouldEnable());
@@ -836,7 +836,7 @@ public class AmbryRequests implements RequestAPI {
       error = validateRequest(replControlRequest.getPartitionId(), RequestOrResponseType.AdminRequest, false);
       partitionIds = Collections.singletonList(replControlRequest.getPartitionId());
     } else {
-      partitionIds = partitionsInCurrentNode;
+      partitionIds = localPartitionToReplicaMap.keySet();
     }
     if (!error.equals(ServerErrorCode.Partition_Unknown)) {
       if (replicationManager.controlReplicationForPartitions(partitionIds, replControlRequest.getOrigins(),
@@ -873,7 +873,7 @@ public class AmbryRequests implements RequestAPI {
         error = validateRequest(catchupStatusRequest.getPartitionId(), RequestOrResponseType.AdminRequest, false);
         partitionIds = Collections.singletonList(catchupStatusRequest.getPartitionId());
       } else {
-        partitionIds = partitionsInCurrentNode;
+        partitionIds = localPartitionToReplicaMap.keySet();
       }
       if (!error.equals(ServerErrorCode.Partition_Unknown)) {
         error = ServerErrorCode.No_Error;
@@ -1097,7 +1097,7 @@ public class AmbryRequests implements RequestAPI {
     }
     if (!skipPartitionAndDiskAvailableCheck) {
       // 2. ensure the disk for the partition/replica is available
-      ReplicaId localReplica = storageManager.getLocalReplica(partition);
+      ReplicaId localReplica = localPartitionToReplicaMap.get(partition);
       if (localReplica != null && localReplica.getDiskId().getState() == HardwareState.UNAVAILABLE) {
         metrics.diskUnavailableError.inc();
         return ServerErrorCode.Disk_Unavailable;
@@ -1106,7 +1106,7 @@ public class AmbryRequests implements RequestAPI {
       if (storageManager.getStore(partition) == null) {
         if (localReplica != null) {
           // check stores on the disk
-          if (storageManager.isDiskUnavailable(storageManager.getDiskManager(partition))) {
+          if (storageManager.isDiskUnavailable(localReplica.getDiskId())) {
             metrics.diskUnavailableError.inc();
             localReplica.markDiskDown();
             return ServerErrorCode.Disk_Unavailable;

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -160,9 +160,7 @@ public class AmbryRequestsTest {
    */
   @After
   public void after() throws InterruptedException {
-    if (storageManager != null) {
-      storageManager.shutdown();
-    }
+    storageManager.shutdown();
   }
 
   /**

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -17,7 +17,9 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.HardwareState;
 import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockDiskId;
 import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.PartitionId;
@@ -108,6 +110,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.junit.After;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -129,9 +132,8 @@ public class AmbryRequestsTest {
   private final Map<StoreKey, StoreKey> conversionMap = new HashMap<>();
   private final MockStoreKeyConverterFactory storeKeyConverterFactory;
 
-  public AmbryRequestsTest() throws IOException, ReplicationException, StoreException {
+  public AmbryRequestsTest() throws IOException, ReplicationException, StoreException, InterruptedException {
     clusterMap = new MockClusterMap();
-    storageManager = new MockStorageManager(validKeysInStore);
     Properties properties = new Properties();
     properties.setProperty("clustermap.cluster.name", "test");
     properties.setProperty("clustermap.datacenter.name", "DC1");
@@ -141,6 +143,7 @@ public class AmbryRequestsTest {
     properties.setProperty("replication.no.of.inter.dc.replica.threads", "0");
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     dataNodeId = clusterMap.getDataNodeIds().get(0);
+    storageManager = new MockStorageManager(validKeysInStore, clusterMap.getReplicaIds(dataNodeId));
     storeKeyConverterFactory = new MockStoreKeyConverterFactory(null, null);
     storeKeyConverterFactory.setConversionMap(conversionMap);
     replicationManager =
@@ -149,6 +152,17 @@ public class AmbryRequestsTest {
     ambryRequests = new AmbryRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
         clusterMap.getMetricRegistry(), FIND_TOKEN_FACTORY, null, replicationManager, null, false,
         storeKeyConverterFactory);
+    storageManager.start();
+  }
+
+  /**
+   * Close the storageManager created.
+   */
+  @After
+  public void after() throws InterruptedException {
+    if (storageManager != null) {
+      storageManager.shutdown();
+    }
   }
 
   /**
@@ -178,11 +192,18 @@ public class AmbryRequestsTest {
     doScheduleCompactionTest(null, ServerErrorCode.Bad_Request);
 
     PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
-
     // store is not started - Replica_Unavailable
     storageManager.returnNullStore = true;
     doScheduleCompactionTest(id, ServerErrorCode.Replica_Unavailable);
     storageManager.returnNullStore = false;
+
+    // all stores are shutdown - Disk_Unavailable. This is simulated by shutting down the storage manager.
+    storageManager.shutdown();
+    storageManager.returnNullStore = true;
+    doScheduleCompactionTest(id, ServerErrorCode.Disk_Unavailable);
+    storageManager.returnNullStore = false;
+    storageManager.start();
+
     // PartitionUnknown is hard to simulate without betraying knowledge of the internals of MockClusterMap.
 
     // disk unavailable
@@ -369,12 +390,7 @@ public class AmbryRequestsTest {
     replicationManager.controlReplicationReturnVal = true;
     generateLagOverrides(0, acceptableLagInBytes);
     // stop BlobStore
-    AdminRequest adminRequest =
-        new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    BlobStoreControlAdminRequest stopBlobStoreAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
-    Response response = sendRequestGetResponse(stopBlobStoreAdminRequest, ServerErrorCode.No_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.No_Error);
     // verify APIs are called in the process of stopping BlobStore
     assertEquals("Compaction on store should be disabled after stopping the BlobStore", false,
         storageManager.compactionEnableVal);
@@ -384,11 +400,7 @@ public class AmbryRequestsTest {
     assertEquals("Replication on given BlobStore should be disabled", false, replicationManager.enableVal);
     assertEquals("Partition shutdown not as expected", id, storageManager.shutdownPartitionId);
     // start BlobStore
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    BlobStoreControlAdminRequest startBlobStoreAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, true, adminRequest);
-    response = sendRequestGetResponse(startBlobStoreAdminRequest, ServerErrorCode.No_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.No_Error);
     // verify APIs are called in the process of starting BlobStore
     assertEquals("Partition started not as expected", id, storageManager.startedPartitionId);
     assertEquals("Replication on given BlobStore should be enabled", true, replicationManager.enableVal);
@@ -411,45 +423,24 @@ public class AmbryRequestsTest {
     String clientId = UtilsTest.getRandomString(10);
     short numReplicasCaughtUpPerPartition = 3;
     // test start BlobStore failure
-    AdminRequest adminRequest =
-        new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    BlobStoreControlAdminRequest blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, true, adminRequest);
     storageManager.returnValueOfStartingBlobStore = false;
-    Response response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
     storageManager.returnValueOfStartingBlobStore = true;
     // test start BlobStore with runtime exception
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, true, adminRequest);
     storageManager.exceptionToThrowOnStartingBlobStore = new IllegalStateException();
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
     storageManager.exceptionToThrowOnStartingBlobStore = null;
     // test enable replication failure
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, true, adminRequest);
     replicationManager.controlReplicationReturnVal = false;
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
     replicationManager.controlReplicationReturnVal = true;
     // test enable compaction failure
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, true, adminRequest);
     storageManager.returnValueOfControllingCompaction = false;
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
     storageManager.returnValueOfControllingCompaction = true;
     // test enable compaction with runtime exception
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, true, adminRequest);
     storageManager.exceptionToThrowOnControllingCompaction = new IllegalStateException();
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
     storageManager.exceptionToThrowOnControllingCompaction = null;
   }
 
@@ -462,83 +453,51 @@ public class AmbryRequestsTest {
   public void stopBlobStoreFailureTest() throws InterruptedException, IOException {
     List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     PartitionId id = partitionIds.get(0);
-    int correlationId = TestUtils.RANDOM.nextInt();
-    String clientId = UtilsTest.getRandomString(10);
     short numReplicasCaughtUpPerPartition = 3;
     // test partition unknown
-    AdminRequest adminRequest =
-        new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, null, correlationId, clientId);
-    BlobStoreControlAdminRequest blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
-    Response response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Bad_Request);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
-    // test validate request failure
+    sendAndVerifyStoreControlRequest(null, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Bad_Request);
+    // test validate request failure - Replica_Unavailable
     storageManager.returnNullStore = true;
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Replica_Unavailable);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Replica_Unavailable);
     storageManager.returnNullStore = false;
+    // test validate request failure - Disk_Unavailable
+    storageManager.shutdown();
+    storageManager.returnNullStore = true;
+    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Disk_Unavailable);
+    storageManager.returnNullStore = false;
+    storageManager.start();
+    ((MockDiskId) findReplica(id).getDiskId()).setDiskState(HardwareState.AVAILABLE, true);
     // test invalid numReplicasCaughtUpPerPartition
     numReplicasCaughtUpPerPartition = -1;
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Bad_Request);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Bad_Request);
     numReplicasCaughtUpPerPartition = 3;
     // test disable compaction failure
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     storageManager.returnValueOfControllingCompaction = false;
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
     storageManager.returnValueOfControllingCompaction = true;
     // test disable compaction with runtime exception
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
     storageManager.exceptionToThrowOnControllingCompaction = new IllegalStateException();
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
     storageManager.exceptionToThrowOnControllingCompaction = null;
     // test disable replication failure
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = false;
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
     // test peers catchup failure
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = true;
     // all replicas of this partition > acceptableLag
     generateLagOverrides(1, 1);
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Retry_After_Backoff);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Retry_After_Backoff);
     // test shutdown BlobStore failure
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = true;
     storageManager.returnValueOfShutdownBlobStore = false;
     generateLagOverrides(0, 0);
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
     // test shutdown BlobStore with runtime exception
     storageManager.exceptionToThrowOnShuttingDownBlobStore = new IllegalStateException();
-    adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, id, correlationId, clientId);
-    blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, false, adminRequest);
-    response = sendRequestGetResponse(blobStoreControlAdminRequest, ServerErrorCode.Unknown_Error);
-    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
+    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
     storageManager.exceptionToThrowOnShuttingDownBlobStore = null;
   }
 
@@ -696,6 +655,29 @@ public class AmbryRequestsTest {
         assertEquals("Error code does not match expected", expectedErrorCode, info.getError());
       }
     }
+  }
+
+  /**
+   * Sends and verifies that a {@link AdminRequestOrResponseType#BlobStoreControl} request received the error code
+   * expected.
+   * @param partitionId the {@link PartitionId} to send the request for. Can be {@code null}.
+   * @param enable {@code true} if BlobStore needs to be started. {@code false} otherwise.
+   * @param numReplicasCaughtUpPerPartition the number of peer replicas which have caught up with this store before proceeding.
+   * @param expectedServerErrorCode the {@link ServerErrorCode} expected in the response.
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  private void sendAndVerifyStoreControlRequest(PartitionId partitionId, boolean enable,
+      short numReplicasCaughtUpPerPartition, ServerErrorCode expectedServerErrorCode)
+      throws InterruptedException, IOException {
+    int correlationId = TestUtils.RANDOM.nextInt();
+    String clientId = UtilsTest.getRandomString(10);
+    AdminRequest adminRequest =
+        new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionId, correlationId, clientId);
+    BlobStoreControlAdminRequest blobStoreControlAdminRequest =
+        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, enable, adminRequest);
+    Response response = sendRequestGetResponse(blobStoreControlAdminRequest, expectedServerErrorCode);
+    assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
   }
 
   /**
@@ -1087,7 +1069,6 @@ public class AmbryRequestsTest {
     sendAndVerifyOperationRequest(RequestOrResponseType.TtlUpdateRequest, Collections.singletonList(id),
         ServerErrorCode.Unknown_Error, true);
     MockStorageManager.runtimeException = null;
-
     // store is not started/is stopped/otherwise unavailable - Replica_Unavailable
     storageManager.returnNullStore = true;
     sendAndVerifyOperationRequest(RequestOrResponseType.TtlUpdateRequest, Collections.singletonList(id),
@@ -1101,7 +1082,6 @@ public class AmbryRequestsTest {
     sendAndVerifyOperationRequest(RequestOrResponseType.TtlUpdateRequest, Collections.singletonList(id),
         ServerErrorCode.Disk_Unavailable, false);
     clusterMap.onReplicaEvent(replicaId, ReplicaEventType.Disk_Ok);
-
     // request disabled is checked in request control tests
   }
 
@@ -1444,9 +1424,9 @@ public class AmbryRequestsTest {
 
     private final Set<StoreKey> validKeysInStore;
 
-    MockStorageManager(Set<StoreKey> validKeysInStore) throws StoreException {
+    MockStorageManager(Set<StoreKey> validKeysInStore, List<? extends ReplicaId> replicas) throws StoreException {
       super(new StoreConfig(VPROPS), new DiskManagerConfig(VPROPS), Utils.newScheduler(1, true), new MetricRegistry(),
-          Collections.emptyList(), null, null, null, null, new MockTime());
+          replicas, null, null, null, null, new MockTime());
       this.validKeysInStore = validKeysInStore;
     }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -220,6 +220,9 @@ class BlobStore implements Store {
                 taskScheduler, diskIOScheduler, metrics);
         checkCapacityAndUpdateReplicaStatusDelegate();
         logger.trace("The store {} is successfully started", storeId);
+        if (replicaId != null) {
+          replicaId.markDiskUp();
+        }
         started = true;
       } catch (Exception e) {
         metrics.storeStartFailure.inc();

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -220,10 +220,10 @@ class BlobStore implements Store {
                 taskScheduler, diskIOScheduler, metrics);
         checkCapacityAndUpdateReplicaStatusDelegate();
         logger.trace("The store {} is successfully started", storeId);
+        started = true;
         if (replicaId != null) {
           replicaId.markDiskUp();
         }
-        started = true;
       } catch (Exception e) {
         metrics.storeStartFailure.inc();
         throw new StoreException("Error while starting store for dir " + dataDir, e,

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -218,7 +218,7 @@ class BlobStore implements Store {
             new BlobStoreStats(storeId, index, config.storeStatsBucketCount, bucketSpanInMs, logSegmentForecastOffsetMs,
                 queueProcessingPeriodInMs, config.storeStatsWaitTimeoutInSecs, time, longLivedTaskScheduler,
                 taskScheduler, diskIOScheduler, metrics);
-        checkCapacityAndUpdateReplicaStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
+        checkCapacityAndUpdateReplicaStatusDelegate();
         logger.trace("The store {} is successfully started", storeId);
         started = true;
       } catch (Exception e) {
@@ -310,10 +310,8 @@ class BlobStore implements Store {
   /**
    * Checks the used capacity of the store against the configured percentage thresholds to see if the store
    * should be read-only or read-write
-   * @param totalCapacity total capacity of the store in bytes
-   * @param usedCapacity total used capacity of the store in bytes
    */
-  private void checkCapacityAndUpdateReplicaStatusDelegate(long totalCapacity, long usedCapacity) {
+  private void checkCapacityAndUpdateReplicaStatusDelegate() {
     if (replicaStatusDelegate != null) {
       logger.debug("The current used capacity is {} bytes on store {}", index.getLogUsedCapacity(),
           replicaId.getPartitionId());
@@ -385,7 +383,7 @@ class BlobStore implements Store {
               blobStoreStats.handleNewPutEntry(newEntry.getValue());
             }
             logger.trace("Store : {} message set written to index ", dataDir);
-            checkCapacityAndUpdateReplicaStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
+            checkCapacityAndUpdateReplicaStatusDelegate();
           }
         }
       }
@@ -705,7 +703,7 @@ class BlobStore implements Store {
   void compact(CompactionDetails details, ByteBuffer bundleReadBuffer) throws IOException, StoreException {
     checkStarted();
     compactor.compact(details, bundleReadBuffer);
-    checkCapacityAndUpdateReplicaStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
+    checkCapacityAndUpdateReplicaStatusDelegate();
     logger.trace("One cycle of compaction is completed on the store {}", storeId);
   }
 
@@ -719,7 +717,7 @@ class BlobStore implements Store {
     if (CompactionLog.isCompactionInProgress(dataDir, storeId)) {
       logger.info("Resuming compaction of {}", this);
       compactor.resumeCompaction(bundleReadBuffer);
-      checkCapacityAndUpdateReplicaStatusDelegate(log.getCapacityInBytes(), index.getLogUsedCapacity());
+      checkCapacityAndUpdateReplicaStatusDelegate();
     }
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
@@ -236,14 +236,6 @@ class DiskManager {
   }
 
   /**
-   * @param id the {@link PartitionId} used to find the local replica.
-   * @return the local {@link ReplicaId} associated with the given {@link PartitionId}.
-   */
-  ReplicaId getLocalReplica(PartitionId id) {
-    return partitionToReplicaMap.get(id);
-  }
-
-  /**
    * Schedules the {@link PartitionId} {@code id} for compaction next.
    * @param id the {@link PartitionId} of the {@link BlobStore} to compact.
    * @return {@code true} if the scheduling was successful. {@code false} if not.

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
@@ -235,6 +235,10 @@ class DiskManager {
     return disk;
   }
 
+  ReplicaId getLocalReplica(PartitionId id){
+    return partitionToReplicaMap.get(id);
+  }
+
   /**
    * Schedules the {@link PartitionId} {@code id} for compaction next.
    * @param id the {@link PartitionId} of the {@link BlobStore} to compact.
@@ -365,5 +369,14 @@ class DiskManager {
       throw new StoreException("Mount path does not exist: " + mountPath + " ; cannot start stores on this disk",
           StoreErrorCodes.Initialization_Error);
     }
+  }
+
+  boolean areAllStoresDown() {
+    for (BlobStore store : stores.values()) {
+      if (store.isStarted()) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskManager.java
@@ -235,7 +235,11 @@ class DiskManager {
     return disk;
   }
 
-  ReplicaId getLocalReplica(PartitionId id){
+  /**
+   * @param id the {@link PartitionId} used to find the local replica.
+   * @return the local {@link ReplicaId} associated with the given {@link PartitionId}.
+   */
+  ReplicaId getLocalReplica(PartitionId id) {
     return partitionToReplicaMap.get(id);
   }
 
@@ -371,6 +375,10 @@ class DiskManager {
     }
   }
 
+  /**
+   * Check if all stores on this disk are down.
+   * @return {@code true} if all stores are down. {@code false} at least one store is up.
+   */
   boolean areAllStoresDown() {
     for (BlobStore store : stores.values()) {
       if (store.isStarted()) {

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -158,13 +158,13 @@ public class StorageManager {
   }
 
   /**
-   * Check if a certain disk is unavailable.
+   * Check if a certain disk is available.
    * @param disk the {@link DiskId} to check.
-   * @return {@code true} if the disk is unavailable. {@code false} if not.
+   * @return {@code true} if the disk is available. {@code false} if not.
    */
-  public boolean isDiskUnavailable(DiskId disk) {
+  public boolean isDiskAvailable(DiskId disk) {
     DiskManager diskManager = diskToDiskManager.get(disk);
-    return diskManager == null || diskManager.areAllStoresDown();
+    return diskManager != null && !diskManager.areAllStoresDown();
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -153,8 +153,17 @@ public class StorageManager {
    * @return the {@link DiskManager} corresponding to the given {@link PartitionId}, or {@code null} if no DiskManager was found for
    *         that partition
    */
-  DiskManager getDiskManager(PartitionId id) {
+  public DiskManager getDiskManager(PartitionId id) {
     return partitionToDiskManager.get(id);
+  }
+
+  public boolean isDiskUnavailable(DiskManager diskManager) {
+    return diskManager.areAllStoresDown();
+  }
+
+  public ReplicaId getLocalReplica(PartitionId id) {
+    DiskManager diskManager = partitionToDiskManager.get(id);
+    return diskManager != null ? diskManager.getLocalReplica(id) : null;
   }
 
   /**
@@ -203,6 +212,7 @@ public class StorageManager {
       for (Thread shutdownThread : shutdownThreads) {
         shutdownThread.join();
       }
+      metrics.deregisterCompactionThreadsTracker();
       logger.info("Shutting down storage manager complete");
     } finally {
       metrics.storageManagerShutdownTimeMs.update(time.milliseconds() - startTimeMs);

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -157,10 +157,19 @@ public class StorageManager {
     return partitionToDiskManager.get(id);
   }
 
+  /**
+   * Check if a certain disk is unavailable.
+   * @param diskManager the {@link DiskManager} to check.
+   * @return {@code true} if the disk is unavailable. {@code false} if not.
+   */
   public boolean isDiskUnavailable(DiskManager diskManager) {
     return diskManager.areAllStoresDown();
   }
 
+  /**
+   * @param id the {@link PartitionId} used to find the local replica.
+   * @return the {@link ReplicaId} corresponding to the given {@link PartitionId}, or {@code null} if no replica was found.
+   */
   public ReplicaId getLocalReplica(PartitionId id) {
     DiskManager diskManager = partitionToDiskManager.get(id);
     return diskManager != null ? diskManager.getLocalReplica(id) : null;

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManagerMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManagerMetrics.java
@@ -106,6 +106,14 @@ public class StorageManagerMetrics {
   }
 
   /**
+   * Deregister the Metrics related to the compaction thread.
+   */
+  void deregisterCompactionThreadsTracker() {
+    registry.remove(MetricRegistry.name(StorageManager.class, "CompactionThreadsAlive"));
+    registry.remove(MetricRegistry.name(StorageManager.class, "CompactionHealth"));
+  }
+
+  /**
    * Marks the beginning of a compaction.
    * @param incrementUniqueCompactionsCount {@code true} if this is a new compaction and not the resume of a suspended
    *                                                    one. {@code false otherwise}

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -205,13 +205,12 @@ public class StoreMetrics {
   /**
    * Deregister the IndexGauges for given {@code store}.
    * @param storeId the {@link BlobStore} for which the IndexGauges should be deregistered.
-   * @return {@code true} if deregistration was successful. {@code false} if not.
    */
-  private boolean deregisterIndexGauges(String storeId) {
+  private void deregisterIndexGauges(String storeId) {
     String prefix = storeId + SEPERATOR;
-    return registry.remove(MetricRegistry.name(Log.class, prefix + "CurrentCapacityUsed")) && registry.remove(
-        MetricRegistry.name(Log.class, prefix + "PercentageUsedCapacity")) && registry.remove(
-        MetricRegistry.name(Log.class, prefix + "CurrentSegmentCount"));
+    registry.remove(MetricRegistry.name(Log.class, prefix + "CurrentCapacityUsed"));
+    registry.remove(MetricRegistry.name(Log.class, prefix + "PercentageUsedCapacity"));
+    registry.remove(MetricRegistry.name(Log.class, prefix + "CurrentSegmentCount"));
   }
 
   void initializeHardDeleteMetric(String storeId, final HardDeleter hardDeleter, final PersistentIndex index) {
@@ -236,14 +235,13 @@ public class StoreMetrics {
   /**
    * Deregister the HardDeleteMetric for given {@code store}.
    * @param storeId the {@link BlobStore} for which the HardDeleteMetric should be deregistered.
-   * @return {@code true} if deregistration was successful. {@code false} if not.
    */
-  private boolean deregisterHardDeleteMetric(String storeId) {
+  private void deregisterHardDeleteMetric(String storeId) {
     String prefix = storeId + SEPERATOR;
-    return registry.remove(MetricRegistry.name(PersistentIndex.class, prefix + "CurrentHardDeleteProgress")) && registry
-        .remove(MetricRegistry.name(Log.class, prefix + "PercentageHardDeleteCompleted")) && registry.remove(
-        MetricRegistry.name(PersistentIndex.class, prefix + "HardDeleteThreadRunning")) && registry.remove(
-        MetricRegistry.name(PersistentIndex.class, prefix + "HardDeleteCaughtUp"));
+    registry.remove(MetricRegistry.name(PersistentIndex.class, prefix + "CurrentHardDeleteProgress"));
+    registry.remove(MetricRegistry.name(Log.class, prefix + "PercentageHardDeleteCompleted"));
+    registry.remove(MetricRegistry.name(PersistentIndex.class, prefix + "HardDeleteThreadRunning"));
+    registry.remove(MetricRegistry.name(PersistentIndex.class, prefix + "HardDeleteCaughtUp"));
   }
 
   void initializeCompactorGauges(String storeId, final AtomicBoolean compactionInProgress) {
@@ -256,19 +254,19 @@ public class StoreMetrics {
   /**
    * Deregister the CompactorGauges for given {@code store}.
    * @param storeId the {@link BlobStore} for which the CompactorGauges should be deregistered.
-   * @return {@code true} if deregistration was successful. {@code false} if not.
    */
-  private boolean deregisterCompactorGauges(String storeId) {
+  private void deregisterCompactorGauges(String storeId) {
     String prefix = storeId + SEPERATOR;
-    return registry.remove(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionInProgress"));
+    registry.remove(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionInProgress"));
   }
 
   /**
    * Deregister the Metrics related to the given {@code store}.
    * @param storeId the {@link BlobStore} for which some Metrics should be deregistered.
-   * @return {@code true} if deregistration was successful. {@code false} if not.
    */
-  boolean deregisterMetrics(String storeId) {
-    return deregisterIndexGauges(storeId) && deregisterHardDeleteMetric(storeId) && deregisterCompactorGauges(storeId);
+  void deregisterMetrics(String storeId) {
+    deregisterIndexGauges(storeId);
+    deregisterHardDeleteMetric(storeId);
+    deregisterCompactorGauges(storeId);
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -348,7 +348,7 @@ public class StorageManagerTest {
    * Tests that{@link StorageManager} can correctly determine if disk is unavailable based on states of all stores.
    */
   @Test
-  public void isDiskUnavailableTest() throws Exception {
+  public void isDiskAvailableTest() throws Exception {
     MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     Map<DiskId, List<ReplicaId>> diskToReplicas = new HashMap<>();
@@ -365,7 +365,7 @@ public class StorageManagerTest {
     }
     // verify all disks are still available because at least one store on them is up
     for (List<ReplicaId> replicasOnDisk : diskToReplicas.values()) {
-      assertFalse("Disk should be available", storageManager.isDiskUnavailable(replicasOnDisk.get(0).getDiskId()));
+      assertTrue("Disk should be available", storageManager.isDiskAvailable(replicasOnDisk.get(0).getDiskId()));
     }
 
     // now, shutdown the last store on each disk
@@ -374,7 +374,7 @@ public class StorageManagerTest {
     }
     // verify all disks are unavailable because all stores are down
     for (List<ReplicaId> replicasOnDisk : diskToReplicas.values()) {
-      assertTrue("Disk should be unavailable", storageManager.isDiskUnavailable(replicasOnDisk.get(0).getDiskId()));
+      assertFalse("Disk should be unavailable", storageManager.isDiskAvailable(replicasOnDisk.get(0).getDiskId()));
     }
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -201,10 +201,10 @@ public class StorageManagerTest {
   }
 
   /**
-   * Test get DiskManager and get local replica with given {@link PartitionId}.
+   * Test get DiskManager with given {@link PartitionId}.
    */
   @Test
-  public void getDiskManagerAndLocalReplicaTest() throws Exception {
+  public void getDiskManagerTest() throws Exception {
     MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
@@ -218,13 +218,11 @@ public class StorageManagerTest {
     for (ReplicaId replica : replicas) {
       id = replica.getPartitionId();
       assertNotNull("DiskManager should not be null for valid partition", storageManager.getDiskManager(id));
-      assertNotNull("Local replica should not be null for valid partition", storageManager.getLocalReplica(id));
     }
     // test invalid partition
     ReplicaId replica = invalidPartitionReplicas.get(0);
     id = replica.getPartitionId();
     assertNull("DiskManager should be null for invalid partition", storageManager.getDiskManager(id));
-    assertNull("Local replica should be null for invalid partition", storageManager.getLocalReplica(id));
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
   }
 
@@ -359,26 +357,24 @@ public class StorageManagerTest {
     for (ReplicaId replica : replicas) {
       diskToReplicas.computeIfAbsent(replica.getDiskId(), disk -> new ArrayList<>()).add(replica);
     }
-    List<DiskManager> diskManagers = new ArrayList<>();
     // for each disk, shutdown all the stores except for the last one
-    for(List<ReplicaId> replicasOnDisk : diskToReplicas.values()){
-      for(int i = 0; i < replicasOnDisk.size() - 1; ++i){
+    for (List<ReplicaId> replicasOnDisk : diskToReplicas.values()) {
+      for (int i = 0; i < replicasOnDisk.size() - 1; ++i) {
         storageManager.getStore(replicasOnDisk.get(i).getPartitionId()).shutdown();
       }
-      diskManagers.add(storageManager.getDiskManager(replicasOnDisk.get(0).getPartitionId()));
     }
     // verify all disks are still available because at least one store on them is up
-    for(DiskManager diskManager : diskManagers){
-      assertFalse("Disk should be available", storageManager.isDiskUnavailable(diskManager));
+    for (List<ReplicaId> replicasOnDisk : diskToReplicas.values()) {
+      assertFalse("Disk should be available", storageManager.isDiskUnavailable(replicasOnDisk.get(0).getDiskId()));
     }
 
     // now, shutdown the last store on each disk
-    for(List<ReplicaId> replicasOnDisk : diskToReplicas.values()){
+    for (List<ReplicaId> replicasOnDisk : diskToReplicas.values()) {
       storageManager.getStore(replicasOnDisk.get(replicasOnDisk.size() - 1).getPartitionId()).shutdown();
     }
     // verify all disks are unavailable because all stores are down
-    for(DiskManager diskManager : diskManagers){
-      assertTrue("Disk should be unavailable", storageManager.isDiskUnavailable(diskManager));
+    for (List<ReplicaId> replicasOnDisk : diskToReplicas.values()) {
+      assertTrue("Disk should be unavailable", storageManager.isDiskUnavailable(replicasOnDisk.get(0).getDiskId()));
     }
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -201,10 +201,10 @@ public class StorageManagerTest {
   }
 
   /**
-   * Test get DiskManager with given {@link PartitionId}.
+   * Test get DiskManager and get local replica with given {@link PartitionId}.
    */
   @Test
-  public void getDiskManagerTest() throws Exception {
+  public void getDiskManagerAndLocalReplicaTest() throws Exception {
     MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
     List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
     List<MockDataNodeId> dataNodes = new ArrayList<>();
@@ -217,12 +217,14 @@ public class StorageManagerTest {
     storageManager.start();
     for (ReplicaId replica : replicas) {
       id = replica.getPartitionId();
-      assertNotNull("DiskManager should not be null for valid replica", storageManager.getDiskManager(id));
+      assertNotNull("DiskManager should not be null for valid partition", storageManager.getDiskManager(id));
+      assertNotNull("Local replica should not be null for valid partition", storageManager.getLocalReplica(id));
     }
     // test invalid partition
     ReplicaId replica = invalidPartitionReplicas.get(0);
     id = replica.getPartitionId();
-    assertNull("DiskManager should be null for invalid replica", storageManager.getDiskManager(id));
+    assertNull("DiskManager should be null for invalid partition", storageManager.getDiskManager(id));
+    assertNull("Local replica should be null for invalid partition", storageManager.getLocalReplica(id));
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
   }
 
@@ -340,6 +342,43 @@ public class StorageManagerTest {
     // make sure replicaStatusDelegate is invoked 3 times and each time the input replica list conforms with stores on particular disk
     for (List<ReplicaId> replicasPerDisk : diskToReplicas.values()) {
       verify(replicaStatusDelegateSpy, times(1)).unmarkStopped(replicasPerDisk);
+    }
+    shutdownAndAssertStoresInaccessible(storageManager, replicas);
+  }
+
+  /**
+   * Tests that{@link StorageManager} can correctly determine if disk is unavailable based on states of all stores.
+   */
+  @Test
+  public void isDiskUnavailableTest() throws Exception {
+    MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
+    List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
+    Map<DiskId, List<ReplicaId>> diskToReplicas = new HashMap<>();
+    StorageManager storageManager = createStorageManager(replicas, metricRegistry, null);
+    storageManager.start();
+    for (ReplicaId replica : replicas) {
+      diskToReplicas.computeIfAbsent(replica.getDiskId(), disk -> new ArrayList<>()).add(replica);
+    }
+    List<DiskManager> diskManagers = new ArrayList<>();
+    // for each disk, shutdown all the stores except for the last one
+    for(List<ReplicaId> replicasOnDisk : diskToReplicas.values()){
+      for(int i = 0; i < replicasOnDisk.size() - 1; ++i){
+        storageManager.getStore(replicasOnDisk.get(i).getPartitionId()).shutdown();
+      }
+      diskManagers.add(storageManager.getDiskManager(replicasOnDisk.get(0).getPartitionId()));
+    }
+    // verify all disks are still available because at least one store on them is up
+    for(DiskManager diskManager : diskManagers){
+      assertFalse("Disk should be available", storageManager.isDiskUnavailable(diskManager));
+    }
+
+    // now, shutdown the last store on each disk
+    for(List<ReplicaId> replicasOnDisk : diskToReplicas.values()){
+      storageManager.getStore(replicasOnDisk.get(replicasOnDisk.size() - 1).getPartitionId()).shutdown();
+    }
+    // verify all disks are unavailable because all stores are down
+    for(DiskManager diskManager : diskManagers){
+      assertTrue("Disk should be unavailable", storageManager.isDiskUnavailable(diskManager));
     }
     shutdownAndAssertStoresInaccessible(storageManager, replicas);
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
@@ -109,6 +109,11 @@ class StoreTestUtils {
       return isSealed;
     }
 
+    @Override
+    public void markDiskDown() {
+      // Null OK
+    }
+
     public void setSealedState(boolean isSealed) {
       this.isSealed = isSealed;
     }

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
@@ -114,6 +114,11 @@ class StoreTestUtils {
       // Null OK
     }
 
+    @Override
+    public void markDiskUp() {
+      // Null OK
+    }
+
     public void setSealedState(boolean isSealed) {
       this.isSealed = isSealed;
     }


### PR DESCRIPTION
Current code has an issue that server cannot detect its own unavailable disks. To address it, when store is unavailable, server will check all stores on the same disk to determine disk state. If at least one store is available then disk is up, otherwise, mark disk as down.

./gradlew build && ./gradlew test succeeded.