### PR TITLE
Attach tracking info to frontend responses

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
@@ -179,8 +179,7 @@ public class FrontendConfig {
         verifiableProperties.getInt("frontend.chunked.get.response.threshold.in.bytes", 8192);
     frontendAllowServiceIdBasedPostRequest =
         verifiableProperties.getBoolean("frontend.allow.service.id.based.post.request", true);
-    frontendAttachTrackingInfo =
-        verifiableProperties.getBoolean("frontend.attach.tracking.info", true);
+    frontendAttachTrackingInfo = verifiableProperties.getBoolean("frontend.attach.tracking.info", true);
     frontendUrlSignerEndpoints = verifiableProperties.getString(URL_SIGNER_ENDPOINTS, DEFAULT_ENDPOINTS_STRING);
     frontendUrlSignerDefaultMaxUploadSizeBytes =
         verifiableProperties.getLongInRange("frontend.url.signer.default.max.upload.size.bytes", 100 * 1024 * 1024, 0,

--- a/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
@@ -107,6 +107,13 @@ public class FrontendConfig {
   public final boolean frontendAllowServiceIdBasedPostRequest;
 
   /**
+   * Boolean indicator to specify if tracking information should be attached to responses.
+   */
+  @Config("frontend.attach.tracking.info")
+  @Default("true")
+  public final boolean frontendAttachTrackingInfo;
+
+  /**
    * The various endpoints for signed URLs, in JSON string.
    */
   @Config(URL_SIGNER_ENDPOINTS)
@@ -172,6 +179,8 @@ public class FrontendConfig {
         verifiableProperties.getInt("frontend.chunked.get.response.threshold.in.bytes", 8192);
     frontendAllowServiceIdBasedPostRequest =
         verifiableProperties.getBoolean("frontend.allow.service.id.based.post.request", true);
+    frontendAttachTrackingInfo =
+        verifiableProperties.getBoolean("frontend.attach.tracking.info", true);
     frontendUrlSignerEndpoints = verifiableProperties.getString(URL_SIGNER_ENDPOINTS, DEFAULT_ENDPOINTS_STRING);
     frontendUrlSignerDefaultMaxUploadSizeBytes =
         verifiableProperties.getLongInRange("frontend.url.signer.default.max.upload.size.bytes", 100 * 1024 * 1024, 0,

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -264,9 +264,9 @@ public class RestUtils {
     public final static String KEEP_ALIVE_ON_ERROR_HINT = KEY_PREFIX + "keep-alive-on-error-hint";
 
     /**
-     * To be set if tracking info should be attached to frontend responses.
+     * To be set to {@code true} if tracking info should be attached to frontend responses.
      */
-    public final static String SEND_TRACKING_INFO = "ambry-internal-keys-send-tracking-info";
+    public final static String SEND_TRACKING_INFO = KEY_PREFIX + "ambry-internal-keys-send-tracking-info";
   }
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -197,6 +197,15 @@ public class RestUtils {
      * prefix for any header to be set as user metadata for the given blob
      */
     public final static String USER_META_DATA_HEADER_PREFIX = "x-ambry-um-";
+
+    /**
+     * Response header for the name of the datacenter that the responding frontend belongs to.
+     */
+    public static final String DATACENTER_NAME = "x-ambry-datacenter";
+    /**
+     * Response header for the hostname of the responding frontend.
+     */
+    public static final String FRONTEND_NAME = "x-ambry-frontend";
   }
 
   /**
@@ -226,6 +235,11 @@ public class RestUtils {
      * Not authoritative, only a hint
      */
     public final static String KEEP_ALIVE_ON_ERROR_HINT = KEY_PREFIX + "keep-alive-on-error-hint";
+
+    /**
+     * To be set if tracking info should be attached to frontend responses.
+     */
+    public final static String SEND_TRACKING_INFO = "ambry-internal-keys-send-tracking-info";
   }
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -23,10 +23,12 @@ import com.github.ambry.router.GetBlobOptionsBuilder;
 import com.github.ambry.utils.Crc32;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -201,11 +203,36 @@ public class RestUtils {
     /**
      * Response header for the name of the datacenter that the responding frontend belongs to.
      */
+  }
+
+  public static final class TrackingHeaders {
+
+    /**
+     * Response header for the the name of the datacenter that the frontend responding belongs to.
+     */
     public static final String DATACENTER_NAME = "x-ambry-datacenter";
     /**
      * Response header for the hostname of the responding frontend.
      */
     public static final String FRONTEND_NAME = "x-ambry-frontend";
+    /**
+     * A list of all tracking headers.
+     */
+    public static final List<String> TRACKING_HEADERS;
+
+    static {
+      Field[] fields = RestUtils.TrackingHeaders.class.getDeclaredFields();
+      TRACKING_HEADERS = new ArrayList<>(fields.length);
+      try {
+        for (Field field : fields) {
+          if (field.getType() == String.class) {
+            TRACKING_HEADERS.add(field.get(null).toString());
+          }
+        }
+      } catch (IllegalAccessException e) {
+        throw new IllegalStateException("Could not get values of the tracking headers", e);
+      }
+    }
   }
 
   /**

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -364,8 +364,8 @@ class AmbryBlobStorageService implements BlobStorageService {
     try {
       if (restRequest.getArgs().containsKey(InternalKeys.SEND_TRACKING_INFO) && (Boolean) restRequest.getArgs()
           .get(InternalKeys.SEND_TRACKING_INFO)) {
-        restResponseChannel.setHeader(Headers.DATACENTER_NAME, datacenterName);
-        restResponseChannel.setHeader(Headers.FRONTEND_NAME, hostname);
+        restResponseChannel.setHeader(TrackingHeaders.DATACENTER_NAME, datacenterName);
+        restResponseChannel.setHeader(TrackingHeaders.FRONTEND_NAME, hostname);
       }
       if (exception != null && exception instanceof RouterException) {
         exception = new RestServiceException(exception,

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -362,8 +362,7 @@ class AmbryBlobStorageService implements BlobStorageService {
   void submitResponse(RestRequest restRequest, RestResponseChannel restResponseChannel,
       ReadableStreamChannel responseBody, Exception exception) {
     try {
-      if (frontendConfig.frontendAttachTrackingInfo && restRequest.getArgs()
-          .containsKey(InternalKeys.SEND_TRACKING_INFO) && (Boolean) restRequest.getArgs()
+      if (restRequest.getArgs().containsKey(InternalKeys.SEND_TRACKING_INFO) && (Boolean) restRequest.getArgs()
           .get(InternalKeys.SEND_TRACKING_INFO)) {
         restResponseChannel.setHeader(Headers.DATACENTER_NAME, datacenterName);
         restResponseChannel.setHeader(Headers.FRONTEND_NAME, hostname);

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -77,6 +77,8 @@ class AmbryBlobStorageService implements BlobStorageService {
   private final UrlSigningService urlSigningService;
   private final AccountAndContainerInjector accountAndContainerInjector;
   private final Logger logger = LoggerFactory.getLogger(AmbryBlobStorageService.class);
+  private final String datacenterName;
+  private final String hostname;
   private IdConverter idConverter = null;
   private SecurityService securityService = null;
   private GetPeersHandler getPeersHandler;
@@ -100,7 +102,7 @@ class AmbryBlobStorageService implements BlobStorageService {
   AmbryBlobStorageService(FrontendConfig frontendConfig, FrontendMetrics frontendMetrics,
       RestResponseHandler responseHandler, Router router, ClusterMap clusterMap, IdConverterFactory idConverterFactory,
       SecurityServiceFactory securityServiceFactory, UrlSigningService urlSigningService,
-      AccountAndContainerInjector accountAndContainerInjector) {
+      AccountAndContainerInjector accountAndContainerInjector, String datacenterName, String hostname) {
     this.frontendConfig = frontendConfig;
     this.frontendMetrics = frontendMetrics;
     this.responseHandler = responseHandler;
@@ -110,6 +112,8 @@ class AmbryBlobStorageService implements BlobStorageService {
     this.securityServiceFactory = securityServiceFactory;
     this.urlSigningService = urlSigningService;
     this.accountAndContainerInjector = accountAndContainerInjector;
+    this.datacenterName = datacenterName;
+    this.hostname = hostname;
     getReplicasHandler = new GetReplicasHandler(frontendMetrics, clusterMap);
     logger.trace("Instantiated AmbryBlobStorageService");
   }
@@ -358,6 +362,12 @@ class AmbryBlobStorageService implements BlobStorageService {
   void submitResponse(RestRequest restRequest, RestResponseChannel restResponseChannel,
       ReadableStreamChannel responseBody, Exception exception) {
     try {
+      if (frontendConfig.frontendAttachTrackingInfo && restRequest.getArgs()
+          .containsKey(InternalKeys.SEND_TRACKING_INFO) && (Boolean) restRequest.getArgs()
+          .get(InternalKeys.SEND_TRACKING_INFO)) {
+        restResponseChannel.setHeader(Headers.DATACENTER_NAME, datacenterName);
+        restResponseChannel.setHeader(Headers.FRONTEND_NAME, hostname);
+      }
       if (exception != null && exception instanceof RouterException) {
         exception = new RestServiceException(exception,
             RestServiceErrorCode.getRestServiceErrorCode(((RouterException) exception).getErrorCode()));

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
@@ -15,8 +15,8 @@ package com.github.ambry.frontend;
 
 import com.github.ambry.account.AccountService;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.FrontendConfig;
-import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.rest.BlobStorageService;
 import com.github.ambry.rest.BlobStorageServiceFactory;
@@ -39,6 +39,7 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
   private final FrontendMetrics frontendMetrics;
   private final VerifiableProperties verifiableProperties;
   private final ClusterMap clusterMap;
+  private final ClusterMapConfig clusterMapConfig;
   private final RestResponseHandler responseHandler;
   private final Router router;
   private final AccountService accountService;
@@ -61,6 +62,7 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
     this.responseHandler = Objects.requireNonNull(responseHandler, "Provided RestResponseHandler is null");
     this.router = Objects.requireNonNull(router, "Provided Router is null");
     this.accountService = Objects.requireNonNull(accountService, "Provided AccountService is null");
+    clusterMapConfig = new ClusterMapConfig(verifiableProperties);
     frontendConfig = new FrontendConfig(verifiableProperties);
     frontendMetrics = new FrontendMetrics(clusterMap.getMetricRegistry());
     logger.trace("Instantiated AmbryBlobStorageServiceFactory");
@@ -87,9 +89,9 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
       SecurityServiceFactory securityServiceFactory =
           Utils.getObj(frontendConfig.frontendSecurityServiceFactory, verifiableProperties, clusterMap, accountService,
               urlSigningService, accountAndContainerInjector);
-      return new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler,
-          router, clusterMap, idConverterFactory, securityServiceFactory, urlSigningService,
-          accountAndContainerInjector);
+      return new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, clusterMap,
+          idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector,
+          clusterMapConfig.clusterMapDatacenterName, clusterMapConfig.clusterMapHostName);
     } catch (Exception e) {
       throw new IllegalStateException("Could not instantiate AmbryBlobStorageService", e);
     }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -75,7 +75,9 @@ class AmbrySecurityService implements SecurityService {
         exception = e;
       }
     }
-    restRequest.setArg(InternalKeys.SEND_TRACKING_INFO, new Boolean(true));
+    if (frontendConfig.frontendAttachTrackingInfo) {
+      restRequest.setArg(InternalKeys.SEND_TRACKING_INFO, new Boolean(true));
+    }
     frontendMetrics.securityServicePreProcessRequestTimeInMs.update(System.currentTimeMillis() - startTimeMs);
     callback.onCompletion(null, exception);
   }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -75,6 +75,7 @@ class AmbrySecurityService implements SecurityService {
         exception = e;
       }
     }
+    restRequest.setArg(InternalKeys.SEND_TRACKING_INFO, new Boolean(true));
     frontendMetrics.securityServicePreProcessRequestTimeInMs.update(System.currentTimeMillis() - startTimeMs);
     callback.onCompletion(null, exception);
   }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -75,9 +75,7 @@ class AmbrySecurityService implements SecurityService {
         exception = e;
       }
     }
-    if (frontendConfig.frontendAttachTrackingInfo) {
-      restRequest.setArg(InternalKeys.SEND_TRACKING_INFO, new Boolean(true));
-    }
+    restRequest.setArg(InternalKeys.SEND_TRACKING_INFO, new Boolean(frontendConfig.frontendAttachTrackingInfo));
     frontendMetrics.securityServicePreProcessRequestTimeInMs.update(System.currentTimeMillis() - startTimeMs);
     callback.onCompletion(null, exception);
   }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
@@ -50,6 +50,9 @@ public class AmbryBlobStorageServiceFactoryTest {
     Properties properties = new Properties();
     CommonTestUtils.populateRequiredRouterProps(properties);
     properties.setProperty(FrontendConfig.URL_SIGNER_ENDPOINTS, jsonObject.toString());
+    properties.setProperty("clustermap.cluster.name", "CLuster-Name");
+    properties.setProperty("clustermap.datacenter.name", "Datacenter-Name");
+    properties.setProperty("clustermap.host.name", "localhost");
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
 
     AmbryBlobStorageServiceFactory ambryBlobStorageServiceFactory =

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactoryTest.java
@@ -50,7 +50,7 @@ public class AmbryBlobStorageServiceFactoryTest {
     Properties properties = new Properties();
     CommonTestUtils.populateRequiredRouterProps(properties);
     properties.setProperty(FrontendConfig.URL_SIGNER_ENDPOINTS, jsonObject.toString());
-    properties.setProperty("clustermap.cluster.name", "CLuster-Name");
+    properties.setProperty("clustermap.cluster.name", "Cluster-Name");
     properties.setProperty("clustermap.datacenter.name", "Datacenter-Name");
     properties.setProperty("clustermap.host.name", "localhost");
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -118,6 +118,8 @@ public class AmbryBlobStorageServiceTest {
   private final String referenceBlobIdStr;
   private final short blobIdVersion;
   private final UrlSigningService urlSigningService;
+  private final String datacenterName = "Data-Center";
+  private final String hostname = "localhost";
   private FrontendConfig frontendConfig;
   private VerifiableProperties verifiableProperties;
   private boolean shouldAllowServiceIdBasedPut = true;
@@ -722,8 +724,8 @@ public class AmbryBlobStorageServiceTest {
     FrontendTestRouter testRouter = new FrontendTestRouter();
     ambryBlobStorageService =
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, testRouter, clusterMap,
-            idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector);
-    ambryBlobStorageService.start();
+            idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector, datacenterName,
+            hostname);
     JSONObject headers = new JSONObject();
     String serviceId = "service-id";
     headers.put(RestUtils.Headers.SERVICE_ID, serviceId);
@@ -743,8 +745,8 @@ public class AmbryBlobStorageServiceTest {
     TailoredPeersClusterMap clusterMap = new TailoredPeersClusterMap();
     ambryBlobStorageService =
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, clusterMap,
-            idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector);
-    ambryBlobStorageService.start();
+            idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector, datacenterName,
+            hostname);
     // test good requests
     for (String datanode : TailoredPeersClusterMap.DATANODE_NAMES) {
       String[] parts = datanode.split(":");
@@ -920,8 +922,8 @@ public class AmbryBlobStorageServiceTest {
     testRouter.exceptionOpType = FrontendTestRouter.OpType.UpdateBlobTtl;
     ambryBlobStorageService =
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, testRouter, clusterMap,
-            idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector);
-    ambryBlobStorageService.start();
+            idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector, datacenterName,
+            hostname);
 
     String blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, (byte) -1, Account.UNKNOWN_ACCOUNT_ID,
         Container.UNKNOWN_CONTAINER_ID, clusterMap.getAllPartitionIds(null).get(0), false,
@@ -1161,7 +1163,8 @@ public class AmbryBlobStorageServiceTest {
    */
   private AmbryBlobStorageService getAmbryBlobStorageService() {
     return new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, clusterMap,
-        idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector);
+        idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector, datacenterName,
+        hostname);
   }
 
   // nullInputsForFunctionsTest() helpers
@@ -1785,7 +1788,8 @@ public class AmbryBlobStorageServiceTest {
       throws InstantiationException, JSONException {
     ambryBlobStorageService =
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, clusterMap,
-            converterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector);
+            converterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector, datacenterName,
+            hostname);
     ambryBlobStorageService.start();
     RestMethod[] restMethods = {RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD};
     doExternalServicesBadInputTest(restMethods, expectedExceptionMsg, false);
@@ -1815,7 +1819,8 @@ public class AmbryBlobStorageServiceTest {
       }
       ambryBlobStorageService =
           new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, new FrontendTestRouter(),
-              clusterMap, idConverterFactory, securityFactory, urlSigningService, accountAndContainerInjector);
+              clusterMap, idConverterFactory, securityFactory, urlSigningService, accountAndContainerInjector,
+              datacenterName, hostname);
       ambryBlobStorageService.start();
       doExternalServicesBadInputTest(restMethods, exceptionMsg,
           mode == FrontendTestSecurityServiceFactory.Mode.ProcessResponse);
@@ -1871,8 +1876,8 @@ public class AmbryBlobStorageServiceTest {
   private void doRouterExceptionPipelineTest(FrontendTestRouter testRouter, String exceptionMsg) throws Exception {
     ambryBlobStorageService =
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, testRouter, clusterMap,
-            idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector);
-    ambryBlobStorageService.start();
+            idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector, datacenterName,
+            hostname);
     for (RestMethod restMethod : RestMethod.values()) {
       switch (restMethod) {
         case HEAD:

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -345,8 +345,7 @@ public class AmbryBlobStorageServiceTest {
       restRequest = createRestRequest(RestMethod.GET, "/", null, null);
       restResponseChannel = new MockRestResponseChannel();
       ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, null);
-      assertTrue("Response header should not contain tracking info",
-          restResponseChannel.getHeader(header) == null);
+      assertTrue("Response header should not contain tracking info", restResponseChannel.getHeader(header) == null);
     }
     restRequest = createRestRequest(RestMethod.GET, "/", null, null);
     restRequest.setArg(RestUtils.InternalKeys.SEND_TRACKING_INFO, new Boolean(true));

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -745,6 +745,7 @@ public class AmbryBlobStorageServiceTest {
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, testRouter, clusterMap,
             idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector, datacenterName,
             hostname);
+    ambryBlobStorageService.start();
     JSONObject headers = new JSONObject();
     String serviceId = "service-id";
     headers.put(RestUtils.Headers.SERVICE_ID, serviceId);
@@ -766,6 +767,7 @@ public class AmbryBlobStorageServiceTest {
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, clusterMap,
             idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector, datacenterName,
             hostname);
+    ambryBlobStorageService.start();
     // test good requests
     for (String datanode : TailoredPeersClusterMap.DATANODE_NAMES) {
       String[] parts = datanode.split(":");
@@ -943,7 +945,7 @@ public class AmbryBlobStorageServiceTest {
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, testRouter, clusterMap,
             idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector, datacenterName,
             hostname);
-
+    ambryBlobStorageService.start();
     String blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, (byte) -1, Account.UNKNOWN_ACCOUNT_ID,
         Container.UNKNOWN_CONTAINER_ID, clusterMap.getAllPartitionIds(null).get(0), false,
         BlobId.BlobDataType.DATACHUNK).getID();
@@ -1897,6 +1899,7 @@ public class AmbryBlobStorageServiceTest {
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, testRouter, clusterMap,
             idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector, datacenterName,
             hostname);
+    ambryBlobStorageService.start();
     for (RestMethod restMethod : RestMethod.values()) {
       switch (restMethod) {
         case HEAD:

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -337,6 +337,23 @@ public class AmbryBlobStorageServiceTest {
     } finally {
       responseHandler.start();
     }
+
+    // verify tracking infos are attached accordingly.
+    RestRequest restRequest = createRestRequest(RestMethod.GET, "/", null, null);
+    MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
+    ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, null);
+    assertTrue("Response header should not contain tracking info",
+        restResponseChannel.getHeader(RestUtils.Headers.DATACENTER_NAME) == null);
+    assertTrue("Response header should not contain tracking info",
+        restResponseChannel.getHeader(RestUtils.Headers.FRONTEND_NAME) == null);
+    restRequest = createRestRequest(RestMethod.GET, "/", null, null);
+    restRequest.setArg(RestUtils.InternalKeys.SEND_TRACKING_INFO, new Boolean(true));
+    restResponseChannel = new MockRestResponseChannel();
+    ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, null);
+    assertEquals("Unexpected or missing tracking info", datacenterName,
+        restResponseChannel.getHeader(RestUtils.Headers.DATACENTER_NAME));
+    assertEquals("Unexpected or missing tracking info", hostname,
+        restResponseChannel.getHeader(RestUtils.Headers.FRONTEND_NAME));
   }
 
   /**

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -339,21 +339,23 @@ public class AmbryBlobStorageServiceTest {
     }
 
     // verify tracking infos are attached accordingly.
-    RestRequest restRequest = createRestRequest(RestMethod.GET, "/", null, null);
-    MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, null);
-    assertTrue("Response header should not contain tracking info",
-        restResponseChannel.getHeader(RestUtils.Headers.DATACENTER_NAME) == null);
-    assertTrue("Response header should not contain tracking info",
-        restResponseChannel.getHeader(RestUtils.Headers.FRONTEND_NAME) == null);
+    RestRequest restRequest;
+    MockRestResponseChannel restResponseChannel;
+    for (String header : RestUtils.TrackingHeaders.TRACKING_HEADERS) {
+      restRequest = createRestRequest(RestMethod.GET, "/", null, null);
+      restResponseChannel = new MockRestResponseChannel();
+      ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, null);
+      assertTrue("Response header should not contain tracking info",
+          restResponseChannel.getHeader(header) == null);
+    }
     restRequest = createRestRequest(RestMethod.GET, "/", null, null);
     restRequest.setArg(RestUtils.InternalKeys.SEND_TRACKING_INFO, new Boolean(true));
     restResponseChannel = new MockRestResponseChannel();
     ambryBlobStorageService.submitResponse(restRequest, restResponseChannel, null, null);
     assertEquals("Unexpected or missing tracking info", datacenterName,
-        restResponseChannel.getHeader(RestUtils.Headers.DATACENTER_NAME));
+        restResponseChannel.getHeader(RestUtils.TrackingHeaders.DATACENTER_NAME));
     assertEquals("Unexpected or missing tracking info", hostname,
-        restResponseChannel.getHeader(RestUtils.Headers.FRONTEND_NAME));
+        restResponseChannel.getHeader(RestUtils.TrackingHeaders.FRONTEND_NAME));
   }
 
   /**

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -248,6 +248,7 @@ public class FrontendIntegrationTest {
     assertEquals("Unexpected response status", HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, response.status());
     assertTrue("No Date header", response.headers().getTimeMillis(HttpHeaderNames.DATE, -1) != -1);
     assertFalse("Channel should not be active", HttpUtil.isKeepAlive(response));
+    verifyTrackingHeaders(response);
   }
 
   /*
@@ -263,6 +264,7 @@ public class FrontendIntegrationTest {
     ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
     HttpResponse response = getHttpResponse(responseParts);
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
+    verifyTrackingHeaders(response);
     final String expectedResponseBody = "GOOD";
     ByteBuffer content = getContent(responseParts.queue, expectedResponseBody.length());
     assertEquals("GET content does not match original content", expectedResponseBody, new String(content.array()));
@@ -288,6 +290,7 @@ public class FrontendIntegrationTest {
       ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
       HttpResponse response = getHttpResponse(responseParts);
       assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
+      verifyTrackingHeaders(response);
       ByteBuffer content = getContent(responseParts.queue, HttpUtil.getContentLength(response));
       JSONObject responseJson = new JSONObject(new String(content.array()));
       String returnedReplicasStr = responseJson.get(GetReplicasHandler.REPLICAS_KEY).toString().replace("\"", "");
@@ -321,6 +324,7 @@ public class FrontendIntegrationTest {
     FullHttpRequest httpRequest = buildRequest(HttpMethod.GET, Operations.GET_SIGNED_URL, headers, null);
     ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
     HttpResponse response = getHttpResponse(responseParts);
+    verifyTrackingHeaders(response);
     assertNotNull("There should be a response from the server", response);
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
     String signedPostUrl = response.headers().get(RestUtils.Headers.SIGNED_URL);
@@ -349,6 +353,7 @@ public class FrontendIntegrationTest {
     responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
     response = getHttpResponse(responseParts);
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
+    verifyTrackingHeaders(response);
     String signedGetUrl = response.headers().get(RestUtils.Headers.SIGNED_URL);
     assertNotNull("Did not get a signed GET URL", signedGetUrl);
     discardContent(responseParts.queue, 1);
@@ -387,6 +392,7 @@ public class FrontendIntegrationTest {
     ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
     HttpResponse response = getHttpResponse(responseParts);
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
+    verifyTrackingHeaders(response);
     String signedPostUrl = response.headers().get(RestUtils.Headers.SIGNED_URL);
     assertNotNull("Did not get a signed POST URL", signedPostUrl);
     discardContent(responseParts.queue, 1);
@@ -782,6 +788,7 @@ public class FrontendIntegrationTest {
     assertNull(RestUtils.Headers.BLOB_SIZE + " should have been null ",
         response.headers().get(RestUtils.Headers.BLOB_SIZE));
     assertNull("Content-Type should have been null", response.headers().get(RestUtils.Headers.CONTENT_TYPE));
+    verifyTrackingHeaders(response);
     verifyCacheHeaders(isPrivate, response);
     assertNoContent(responseParts.queue);
   }
@@ -806,6 +813,7 @@ public class FrontendIntegrationTest {
     ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
     HttpResponse response = getHttpResponse(responseParts);
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
+    verifyTrackingHeaders(response);
     checkCommonGetHeadHeaders(response.headers());
     verifyUserMetadata(expectedHeaders, response, usermetadata, responseParts.queue);
     assertTrue("Channel should be active", HttpUtil.isKeepAlive(response));
@@ -835,6 +843,7 @@ public class FrontendIntegrationTest {
     HttpResponse response = getHttpResponse(responseParts);
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
     checkCommonGetHeadHeaders(response.headers());
+    verifyTrackingHeaders(response);
     verifyBlobProperties(expectedHeaders, isPrivate, response);
     verifyAccountAndContainerHeaders(accountName, containerName, response);
     verifyUserMetadata(expectedHeaders, response, usermetadata, responseParts.queue);

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -1175,8 +1175,8 @@ public class FrontendIntegrationTest {
    */
   private void verifyTrackingHeaders(HttpResponse response) {
     Assert.assertEquals("Unexpected or missing tracking header for datacenter name", DATA_CENTER_NAME,
-        response.headers().get(RestUtils.Headers.DATACENTER_NAME));
+        response.headers().get(RestUtils.TrackingHeaders.DATACENTER_NAME));
     Assert.assertEquals("Unexpected or missing tracking header for hostname", HOST_NAME,
-        response.headers().get(RestUtils.Headers.FRONTEND_NAME));
+        response.headers().get(RestUtils.TrackingHeaders.FRONTEND_NAME));
   }
 }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -248,7 +248,6 @@ public class FrontendIntegrationTest {
     assertEquals("Unexpected response status", HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, response.status());
     assertTrue("No Date header", response.headers().getTimeMillis(HttpHeaderNames.DATE, -1) != -1);
     assertFalse("Channel should not be active", HttpUtil.isKeepAlive(response));
-    verifyTrackingHeaders(response);
   }
 
   /*
@@ -264,7 +263,6 @@ public class FrontendIntegrationTest {
     ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
     HttpResponse response = getHttpResponse(responseParts);
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
-    verifyTrackingHeaders(response);
     final String expectedResponseBody = "GOOD";
     ByteBuffer content = getContent(responseParts.queue, expectedResponseBody.length());
     assertEquals("GET content does not match original content", expectedResponseBody, new String(content.array()));

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -541,6 +541,9 @@ public class FrontendIntegrationTest {
     TestSSLUtils.addSSLProperties(properties, "", SSLFactory.Mode.SERVER, trustStoreFile, "frontend");
     // add key for singleKeyManagementService
     properties.put("kms.default.container.key", TestUtils.getRandomKey(32));
+    properties.setProperty("clustermap.cluster.name", "CLuster-Name");
+    properties.setProperty("clustermap.datacenter.name", "Datacenter-Name");
+    properties.setProperty("clustermap.host.name", "localhost");
     return new VerifiableProperties(properties);
   }
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -32,7 +32,6 @@ import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.protocol.GetOption;
-import com.github.ambry.protocol.Response;
 import com.github.ambry.rest.NettyClient;
 import com.github.ambry.rest.NettyClient.ResponseParts;
 import com.github.ambry.rest.RestMethod;
@@ -1172,7 +1171,7 @@ public class FrontendIntegrationTest {
 
   /**
    * Verify the tracking headers were attached to the response properly.
-   * @param response the {@link Response} to be verified.
+   * @param response the {@link HttpResponse} to be verified.
    */
   private void verifyTrackingHeaders(HttpResponse response) {
     Assert.assertEquals("Unexpected or missing tracking header for datacenter name", DATA_CENTER_NAME,

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -428,13 +428,10 @@ class NettyResponseChannel implements RestResponseChannel {
    * @param targetResponse the target response that the tracking headers will be copied over.
    */
   private void copyTrackingHeaders(HttpResponse sourceResponse, HttpResponse targetResponse) {
-    if (sourceResponse.headers().contains(RestUtils.Headers.DATACENTER_NAME)) {
-      targetResponse.headers()
-          .set(RestUtils.Headers.DATACENTER_NAME, sourceResponse.headers().get(RestUtils.Headers.DATACENTER_NAME));
-    }
-    if (sourceResponse.headers().contains(RestUtils.Headers.FRONTEND_NAME)) {
-      targetResponse.headers()
-          .set(RestUtils.Headers.FRONTEND_NAME, sourceResponse.headers().get(RestUtils.Headers.FRONTEND_NAME));
+    for (String header : RestUtils.TrackingHeaders.TRACKING_HEADERS) {
+      if (sourceResponse.headers().contains(header)) {
+        targetResponse.headers().set(header, sourceResponse.headers().get(header));
+      }
     }
   }
 

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -417,8 +417,25 @@ class NettyResponseChannel implements RestResponseChannel {
       logger.warn("Response is {} but there is no value for {}", ResponseStatus.MethodNotAllowed,
           HttpHeaderNames.ALLOW);
     }
+    copyTrackingHeaders(responseMetadata, response);
     HttpUtil.setKeepAlive(response, shouldKeepAlive(status));
     return response;
+  }
+
+  /**
+   * Copy tracking headers (if any) from sourceResponse to targetResponse.
+   * @param sourceResponse the source response with the tracking headers.
+   * @param targetResponse the target response that the tracking headers will be copied over.
+   */
+  private void copyTrackingHeaders(HttpResponse sourceResponse, HttpResponse targetResponse) {
+    if (sourceResponse.headers().contains(RestUtils.Headers.DATACENTER_NAME)) {
+      targetResponse.headers()
+          .set(RestUtils.Headers.DATACENTER_NAME, sourceResponse.headers().get(RestUtils.Headers.DATACENTER_NAME));
+    }
+    if (sourceResponse.headers().contains(RestUtils.Headers.FRONTEND_NAME)) {
+      targetResponse.headers()
+          .set(RestUtils.Headers.FRONTEND_NAME, sourceResponse.headers().get(RestUtils.Headers.FRONTEND_NAME));
+    }
   }
 
   /**

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -461,6 +461,40 @@ public class NettyResponseChannelTest {
   }
 
   /**
+   * Tests that tracking headers are copied over correctly for error responses.
+   */
+  @Test
+  public void errorResponseTrackingHeadersTest() {
+    EmbeddedChannel channel = createEmbeddedChannel();
+    for (boolean shouldTrackingHeadersExist : new boolean[]{true, false}) {
+      TestingUri uri;
+      HttpHeaders httpHeaders;
+      HttpResponse response;
+      for (RestServiceErrorCode errorCode : RestServiceErrorCode.values()) {
+        httpHeaders = new DefaultHttpHeaders();
+        if (shouldTrackingHeadersExist) {
+          addTrackingHeaders(httpHeaders);
+        }
+        uri = shouldTrackingHeadersExist ? TestingUri.CopyHeadersAndOnResponseCompleteWithRestException
+            : TestingUri.OnResponseCompleteWithRestException;
+        httpHeaders.set(MockNettyMessageProcessor.REST_SERVICE_ERROR_CODE_HEADER_NAME, errorCode);
+        channel.writeInbound(RestTestUtils.createRequest(HttpMethod.HEAD, uri.toString(), httpHeaders));
+        response = channel.readOutbound();
+        verifyTrackingHeaders(response, shouldTrackingHeadersExist);
+      }
+      httpHeaders = new DefaultHttpHeaders();
+      if (shouldTrackingHeadersExist) {
+        addTrackingHeaders(httpHeaders);
+      }
+      uri = shouldTrackingHeadersExist ? TestingUri.CopyHeadersAndOnResponseCompleteWithNonRestException
+          : TestingUri.OnResponseCompleteWithNonRestException;
+      channel.writeInbound(RestTestUtils.createRequest(HttpMethod.HEAD, uri.toString(), httpHeaders));
+      response = channel.readOutbound();
+      verifyTrackingHeaders(response, shouldTrackingHeadersExist);
+    }
+  }
+
+  /**
    * Tests keep-alive for different HTTP methods and error statuses.
    */
   @Test
@@ -836,6 +870,31 @@ public class NettyResponseChannelTest {
     }
     return channel;
   }
+
+  /**
+   * Add tracking headers to the {@link HttpHeaders}
+   * @param httpHeaders the {@link HttpHeaders} to be added with tracking headers
+   */
+  private void addTrackingHeaders(HttpHeaders httpHeaders) {
+    for (String header : RestUtils.TrackingHeaders.TRACKING_HEADERS) {
+      httpHeaders.set(header, header);
+    }
+  }
+
+  /**
+   * Verify tracking headers exist in the response when they are suppose to be and vice versa.
+   * @param response the {@link HttpResponse} that will have its headers checked.
+   * @param shouldTrackingHeadersExist the boolean indicating are tracking headers expected.
+   */
+  private void verifyTrackingHeaders(HttpResponse response, boolean shouldTrackingHeadersExist) {
+    for (String header : RestUtils.TrackingHeaders.TRACKING_HEADERS) {
+      if (shouldTrackingHeadersExist) {
+        assertEquals("Unexpected tracking header", header, response.headers().get(header));
+      } else {
+        assertFalse("Response should not contain any tracking headers", response.headers().contains(header));
+      }
+    }
+  }
 }
 
 /**
@@ -880,6 +939,12 @@ enum TestingUri {
    * immediately with a {@link RuntimeException} as {@code cause}. The exception message is the URI string.
    */
   OnResponseCompleteWithNonRestException, /**
+   * When this request is received tracking headers are copied over and then behaviors of OnResponseCompleteWithRestException is applied.
+   */
+  CopyHeadersAndOnResponseCompleteWithRestException, /**
+   * When this request is received tracking headers are copied over and then behaviors of OnResponseCompleteWithNonRestException is applied.
+   */
+  CopyHeadersAndOnResponseCompleteWithNonRestException, /**
    * When this request is received, {@link RestResponseChannel#onResponseComplete(Exception)} is called
    * immediately with an {@link IOException} with message {@link Utils#CLIENT_RESET_EXCEPTION_MSG}.
    */
@@ -1069,6 +1134,29 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
             restResponseChannel.getStatus());
         assertFalse("Request channel is not closed", request.isOpen());
         break;
+      case CopyHeadersAndOnResponseCompleteWithRestException:
+        copyTrackingHeaders(httpRequest);
+        errorCodeStr = (String) request.getArgs().get(REST_SERVICE_ERROR_CODE_HEADER_NAME);
+        includeExceptionMessageInResponse =
+            request.getArgs().containsKey(INCLUDE_EXCEPTION_MESSAGE_IN_RESPONSE_HEADER_NAME);
+        errorCode = RestServiceErrorCode.valueOf(errorCodeStr);
+        if (errorCode == RestServiceErrorCode.NotAllowed) {
+          restResponseChannel.setHeader(RestUtils.Headers.ALLOW, METHOD_NOT_ALLOWED_ALLOW_HEADER_VALUE);
+        }
+        restResponseChannel.onResponseComplete(
+            new RestServiceException(errorCodeStr, errorCode, includeExceptionMessageInResponse));
+        assertEquals("ResponseStatus does not reflect error", ResponseStatus.getResponseStatus(errorCode),
+            restResponseChannel.getStatus());
+        assertFalse("Request channel is not closed", request.isOpen());
+        break;
+      case CopyHeadersAndOnResponseCompleteWithNonRestException:
+        copyTrackingHeaders(httpRequest);
+        restResponseChannel.onResponseComplete(
+            new RuntimeException(TestingUri.OnResponseCompleteWithNonRestException.toString()));
+        assertEquals("ResponseStatus does not reflect error", ResponseStatus.InternalServerError,
+            restResponseChannel.getStatus());
+        assertFalse("Request channel is not closed", request.isOpen());
+        break;
       case OnResponseCompleteWithEarlyClientTermination:
         restResponseChannel.onResponseComplete(Utils.convertToClientTerminationException(new Exception()));
         assertEquals("ResponseStatus does not reflect error", ResponseStatus.InternalServerError,
@@ -1234,6 +1322,16 @@ class MockNettyMessageProcessor extends SimpleChannelInboundHandler<HttpObject> 
     restResponseChannel.setHeader(CUSTOM_HEADER_NAME, httpRequest.headers().get(CUSTOM_HEADER_NAME));
     assertEquals("Value of [" + CUSTOM_HEADER_NAME + "] differs from what was set",
         httpRequest.headers().get(CUSTOM_HEADER_NAME), restResponseChannel.getHeader(CUSTOM_HEADER_NAME));
+  }
+
+  /**
+   * Copies tracking headers from request to response.
+   * @param httpRequest the {@link HttpRequest} to copy headers from.
+   */
+  private void copyTrackingHeaders(HttpRequest httpRequest) throws RestServiceException {
+    for (String header : RestUtils.TrackingHeaders.TRACKING_HEADERS) {
+      restResponseChannel.setHeader(header, httpRequest.headers().get(header));
+    }
   }
 
   /**


### PR DESCRIPTION
- Added the configs and logic to attach tracking info to response headers regarding to the responding frontend.
- At the moment only two pieces of information is attached to responses for tracking purpose.
  - `x-ambry-datacenter` name of the datacenter that the responding frontend belongs to.
  - `x-ambry-frontend` hostname of the responding frontend.

