### PR TITLE
Preserve CRCs in messages when they are transformed during replication

### DIFF
--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PartitionResponseInfo.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PartitionResponseInfo.java
@@ -104,6 +104,9 @@ public class PartitionResponseInfo {
     sb.append("PartitionId=").append(partitionId);
     sb.append(" ServerErrorCode=").append(errorCode);
     sb.append(" MessageInfoAndMetadataListSize=").append(messageInfoAndMetadataListSize);
+    if (errorCode == ServerErrorCode.No_Error) {
+      sb.append(" MessageInfoList=").append(messageInfoAndMetadataListSerde.getMessageInfoList());
+    }
     sb.append("]");
     return sb.toString();
   }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PartitionResponseInfo.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PartitionResponseInfo.java
@@ -104,9 +104,6 @@ public class PartitionResponseInfo {
     sb.append("PartitionId=").append(partitionId);
     sb.append(" ServerErrorCode=").append(errorCode);
     sb.append(" MessageInfoAndMetadataListSize=").append(messageInfoAndMetadataListSize);
-    if (errorCode == ServerErrorCode.No_Error) {
-      sb.append(" MessageInfoList=").append(messageInfoAndMetadataListSerde.getMessageInfoList());
-    }
     sb.append("]");
     return sb.toString();
   }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
@@ -158,13 +158,14 @@ public class BlobIdTransformer implements Transformer {
       PutMessageFormatInputStream putMessageFormatInputStream =
           new PutMessageFormatInputStream(newKey, blobEncryptionKey, newProperties, userMetaData, blobData.getStream(),
               blobData.getSize(), blobData.getBlobType());
-      // Reuse the CRC if present in the oldMessageInfo. This is important to ensure that messages that are received via
-      // replication are sent to the store with proper CRCs (which the store needs to detect duplicate messages).
-      // As an additional guard, here the CRC is only reused if the key's ID in string form is the same after conversion.
-      Long crc = oldMessageInfo.getStoreKey().getID().equals(newKey.getID()) ? oldMessageInfo.getCrc() : null;
+      // Reuse the original CRC if present in the oldMessageInfo. This is important to ensure that messages that are
+      // received via replication are sent to the store with proper CRCs (which the store needs to detect duplicate
+      // messages). As an additional guard, here the original CRC is only reused if the key's ID in string form is the
+      // same after conversion.
+      Long originalCrc = oldMessageInfo.getStoreKey().getID().equals(newKey.getID()) ? oldMessageInfo.getCrc() : null;
       MessageInfo info =
           new MessageInfo(newKey, putMessageFormatInputStream.getSize(), false, oldMessageInfo.isTtlUpdated(),
-              oldMessageInfo.getExpirationTimeInMs(), crc, newProperties.getAccountId(),
+              oldMessageInfo.getExpirationTimeInMs(), originalCrc, newProperties.getAccountId(),
               newProperties.getContainerId(), oldMessageInfo.getOperationTimeMs());
       return new Message(info, putMessageFormatInputStream);
     } else {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
@@ -158,10 +158,14 @@ public class BlobIdTransformer implements Transformer {
       PutMessageFormatInputStream putMessageFormatInputStream =
           new PutMessageFormatInputStream(newKey, blobEncryptionKey, newProperties, userMetaData, blobData.getStream(),
               blobData.getSize(), blobData.getBlobType());
+      // Reuse the CRC if present in the oldMessageInfo. This is important to ensure that messages that are received via
+      // replication are sent to the store with proper CRCs (which the store needs to detect duplicate messages).
+      // As an additional guard, here the CRC is only reused if the key's ID in string form is the same after conversion.
+      Long crc = oldMessageInfo.getStoreKey().getID().equals(newKey.getID()) ? oldMessageInfo.getCrc() : null;
       MessageInfo info =
           new MessageInfo(newKey, putMessageFormatInputStream.getSize(), false, oldMessageInfo.isTtlUpdated(),
-              oldMessageInfo.getExpirationTimeInMs(), newProperties.getAccountId(), newProperties.getContainerId(),
-              oldMessageInfo.getOperationTimeMs());
+              oldMessageInfo.getExpirationTimeInMs(), crc, newProperties.getAccountId(),
+              newProperties.getContainerId(), oldMessageInfo.getOperationTimeMs());
       return new Message(info, putMessageFormatInputStream);
     } else {
       throw new IllegalArgumentException("Only 'put' records are valid");

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -294,6 +294,8 @@ class BlobStore implements Store {
           existingIdenticalEntries++;
           metrics.identicalPutAttemptCount.inc();
         } else {
+          logger.trace("COLLISION: For key {} in WriteSet with crc {}, index already has the key with journal crc {}",
+              info.getStoreKey(), info.getCrc(), index.journal.getCrcOfKey(info.getStoreKey()));
           return MessageWriteSetStateInStore.COLLIDING;
         }
       }


### PR DESCRIPTION
This is important to ensure that the store identifies duplicates
correctly (and thus avoid false Blob_Already_Exists errors)