### PR TITLE
Keep track of error occurred instances during stats aggregation

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixHealthReportAggregatorTask.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixHealthReportAggregatorTask.java
@@ -41,6 +41,7 @@ class HelixHealthReportAggregatorTask extends UserContentStore implements Task {
   private static final String RAW_VALID_SIZE_FIELD_NAME = "raw_valid_data_size";
   private static final String VALID_SIZE_FIELD_NAME = "valid_data_size";
   private static final String TIMESTAMP_FIELD_NAME = "timestamp";
+  private static final String ERROR_OCCURRED_INSTANCES_FIELD_NAME = "error_occurred_instances";
   private final HelixManager manager;
   private final HelixClusterAggregator clusterAggregator;
   private final String healthReportName;
@@ -82,6 +83,7 @@ class HelixHealthReportAggregatorTask extends UserContentStore implements Task {
       znRecord.setSimpleField(RAW_VALID_SIZE_FIELD_NAME, results.getFirst());
       znRecord.setSimpleField(VALID_SIZE_FIELD_NAME, results.getSecond());
       znRecord.setSimpleField(TIMESTAMP_FIELD_NAME, String.valueOf(SystemTime.getInstance().milliseconds()));
+      znRecord.setListField(ERROR_OCCURRED_INSTANCES_FIELD_NAME, clusterAggregator.getExceptionOccurredInstances());
       String path = String.format("/%s", resultId);
       manager.getHelixPropertyStore().set(path, znRecord, AccessOption.PERSISTENT);
       return new TaskResult(TaskResult.Status.COMPLETED, "Aggregation success");

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterAggregatorTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterAggregatorTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.*;
 public class HelixClusterAggregatorTest {
   private static final long RELEVANT_PERIOD_IN_MINUTES = 60;
   private static final long DEFAULT_TIMESTAMP = 1000;
+  private final String EXCEPTION_INSTANCE_NAME = "Exception_Instance";
   private final HelixClusterAggregator clusterAggregator;
   private final ObjectMapper mapper = new ObjectMapper();
 
@@ -64,6 +65,7 @@ public class HelixClusterAggregatorTest {
       statsWrappersJSON.put("Store_" + i, (nodeStatsJSON));
     }
     statsWrappersJSON.put("Store_" + nodeCount, emptyNodeStatsJSON);
+    statsWrappersJSON.put(EXCEPTION_INSTANCE_NAME, "");
     for (int i = 1; i < storeSnapshots.size(); i++) {
       StatsSnapshot.aggregate(storeSnapshots.get(0), storeSnapshots.get(i));
     }
@@ -93,6 +95,9 @@ public class HelixClusterAggregatorTest {
     // verify cluster wide aggregation
     StatsSnapshot actualSnapshot = mapper.readValue(results.getSecond(), StatsSnapshot.class);
     assertTrue("Mismatch in the aggregated snapshot", expectedSnapshot.equals(actualSnapshot));
+    // verify aggregator keeps track of instances where exception occurred.
+    assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
+        clusterAggregator.getExceptionOccurredInstances());
   }
 
   /**
@@ -115,6 +120,7 @@ public class HelixClusterAggregatorTest {
     statsWrappersJSON.put("Store_0", mapper.writeValueAsString(outdatedNodeStats));
     statsWrappersJSON.put("Store_1", mapper.writeValueAsString(upToDateNodeStats));
     statsWrappersJSON.put("Store_2", mapper.writeValueAsString(emptyNodeStats));
+    statsWrappersJSON.put(EXCEPTION_INSTANCE_NAME, "");
     Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON);
     StatsSnapshot expectedSnapshot = upToDateStoreSnapshots.get(0);
     // verify cluster wide aggregation with outdated node stats
@@ -124,6 +130,9 @@ public class HelixClusterAggregatorTest {
     StatsSnapshot.aggregate(expectedSnapshot, outdatedStoreSnapshots.get(0));
     StatsSnapshot rawSnapshot = mapper.readValue(results.getFirst(), StatsSnapshot.class);
     assertTrue("Mismatch in the raw aggregated snapshot", expectedSnapshot.equals(rawSnapshot));
+    // verify aggregator keeps track of instances where exception occurred.
+    assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
+        clusterAggregator.getExceptionOccurredInstances());
   }
 
   /**
@@ -144,6 +153,7 @@ public class HelixClusterAggregatorTest {
     statsWrappersJSON.put("Store_0", mapper.writeValueAsString(smallerNodeStats));
     statsWrappersJSON.put("Store_1", mapper.writeValueAsString(greaterNodeStats));
     statsWrappersJSON.put("Store_2", mapper.writeValueAsString(emptyNodeStats));
+    statsWrappersJSON.put(EXCEPTION_INSTANCE_NAME, "");
     Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON);
     StatsSnapshot expectedSnapshot = greaterStoreSnapshots.get(0);
     // verify cluster wide aggregation with different node stats
@@ -153,6 +163,9 @@ public class HelixClusterAggregatorTest {
     StatsSnapshot.aggregate(expectedSnapshot, smallerStoreSnapshots.get(0));
     StatsSnapshot rawSnapshot = mapper.readValue(results.getFirst(), StatsSnapshot.class);
     assertTrue("Mismatch in the raw aggregated snapshot", expectedSnapshot.equals(rawSnapshot));
+    // verify aggregator keeps track of instances where exception occurred.
+    assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
+        clusterAggregator.getExceptionOccurredInstances());
   }
 
   /**


### PR DESCRIPTION
Keep track of instances where error occurred during cluster wide stats aggregation. Such instances are recorded in ListField in aggregated report.

./gradlew build && ./gradlew test succeeded.