### PR TITLE
Adding metrics and logging for replica thread throttling

### DIFF
--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -323,7 +323,7 @@ class ReplicaThread implements Runnable {
       try {
         long currentTime = time.milliseconds();
         time.sleep(sleepDurationMs);
-        logger.trace("Replica thread slep for {} ms", time.milliseconds() - currentTime);
+        logger.trace("Replica thread: {} slept for {} ms", threadName, time.milliseconds() - currentTime);
       } catch (InterruptedException e) {
         logger.error("Received interrupted exception during throttling", e);
       }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -115,6 +115,7 @@ public class ReplicationMetrics {
   public final Counter blobAuthorizationFailureCount;
   public final Counter replicaSyncedBackoffCount;
   public final Counter replicaThreadIdleCount;
+  public final Counter replicaThreadThrottleCount;
 
   public List<Gauge<Long>> replicaLagInBytes;
   private MetricRegistry registry;
@@ -214,6 +215,7 @@ public class ReplicationMetrics {
         registry.counter(MetricRegistry.name(ReplicaThread.class, "BlobAuthorizationFailureCount"));
     replicaSyncedBackoffCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaSyncedBackoffCount"));
     replicaThreadIdleCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaThreadIdleCount"));
+    replicaThreadThrottleCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaThreadThrottleCount"));
     this.registry = registry;
     this.replicaLagInBytes = new ArrayList<Gauge<Long>>();
     populateInvalidMessageMetricForReplicas(replicaIds);


### PR DESCRIPTION
- Added metrics to track sleep triggered from different sources separately.
- `replicaThreadIdleCount` will now only be incremented when idle sleep is enabled (when the config `replicationReplicaThreadIdleSleepDurationMs` > 0).
- Sleep time will also be logged.