### PR TITLE
CloudReplicationConfig for containers

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/account/CloudReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/CloudReplicationConfig.java
@@ -27,8 +27,8 @@ import org.json.JSONObject;
  * </p>
  *  <pre><code>
  *  {
- *    "destinationType": "AZURE",
- *    "configSpec": "Encrypted config spec for cloud service account",
+ *    "cloudDestinationType": "AZURE",
+ *    "cloudConfigSpec": "Encrypted config spec for cloud service account",
  *    "cloudContainerName": "My container name"
  *  }
  *  </code></pre>
@@ -124,19 +124,55 @@ public class CloudReplicationConfig {
     // optional
     private String cloudContainerName;
 
-    public Builder(CloudReplicationConfig config) {
-      this.destinationType = config.destinationType;
-      this.configSpec = config.configSpec;
-      this.cloudContainerName = config.cloudContainerName;
+    /**
+     * Constructor to build a new {@link CloudReplicationConfig} from an existing {@link CloudReplicationConfig}.
+     * The builder will include all the information of the existing {@link CloudReplicationConfig}.
+     * This constructor should be used when modifying an existing config.
+     * @param origin The {@link CloudReplicationConfig} to build from.
+     */
+    public Builder(CloudReplicationConfig origin) {
+      this.destinationType = origin.destinationType;
+      this.configSpec = origin.configSpec;
+      this.cloudContainerName = origin.cloudContainerName;
     }
 
+    /**
+     * Constructor for a {@link CloudReplicationConfig} taking individual arguments.
+     * @param destinationType The destination type of the {@link CloudReplicationConfig} to build.
+     * @param configSpec The configuration spec of the {@link CloudReplicationConfig} to build.
+     */
     public Builder(String destinationType, String configSpec) {
       this.destinationType = destinationType;
       this.configSpec = configSpec;
     }
 
-    public Builder setCloudContainerName(String containerName) {
-      this.cloudContainerName = containerName;
+    /**
+     * Sets the destination type of the {@link CloudReplicationConfig} to build.
+     * @param destinationType The destination type to set.
+     * @return This builder.
+     */
+    public Builder setDestinationType(String destinationType) {
+      this.destinationType = destinationType;
+      return this;
+    }
+
+    /**
+     * Sets the configuration spec of the {@link CloudReplicationConfig} to build.
+     * @param configSpec The configuration spec to set.
+     * @return This builder.
+     */
+    public Builder setConfigSpec(String configSpec) {
+      this.configSpec = configSpec;
+      return this;
+    }
+
+    /**
+     * Sets the cloud container name of the {@link CloudReplicationConfig} to build.
+     * @param cloudContainerName The cloud container name to set.
+     * @return This builder.
+     */
+    public Builder setCloudContainerName(String cloudContainerName) {
+      this.cloudContainerName = cloudContainerName;
       return this;
     }
 

--- a/ambry-api/src/main/java/com.github.ambry/account/CloudReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/CloudReplicationConfig.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.account;
+
+import java.util.Objects;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * <p>
+ * A representation of configuration for replicating an Ambry container to a cloud destination.
+ * An Ambry container can have zero or more replication configs.
+ * </p>
+ * <p>
+ *   CloudReplicationConfig is serialized into {@link JSONObject} in the following format:
+ * </p>
+ *  <pre><code>
+ *  {
+ *    "destinationType": "AZURE",
+ *    "configSpec": "Encrypted config spec for cloud service account",
+ *    "cloudContainerName": "My container name"
+ *  }
+ *  </code></pre>
+ *  <p>
+ *    A CloudReplicationConfig object is immutable. To update a container, use {@link CloudReplicationConfig.Builder}.
+ *  </p>
+ */
+public class CloudReplicationConfig {
+
+  static final String CLOUD_DEST_TYPE_KEY = "cloudDestinationType";
+  static final String CLOUD_CONFIG_SPEC_KEY = "cloudConfigSpec";
+  static final String CLOUD_CONTAINER_NAME_KEY = "cloudContainerName";
+
+  private String destinationType;
+  // encrypted config string
+  private String configSpec;
+  private String cloudContainerName;
+
+  private CloudReplicationConfig(String destinationType, String configSpec, String cloudContainerName) {
+    this.destinationType = destinationType;
+    this.configSpec = configSpec;
+    this.cloudContainerName = cloudContainerName;
+  }
+
+  /**
+   * @return the cloud destination type
+   */
+  public String getDestinationType() {
+    return destinationType;
+  }
+
+  /**
+   * @return the cloud configuration spec
+   */
+  public String getConfigSpec() {
+    return configSpec;
+  }
+
+  /**
+   * @return the cloud container name (optional property)
+   */
+  public String getCloudContainerName() {
+    return cloudContainerName;
+  }
+
+  /**
+   * Constructing a {@link CloudReplicationConfig} object from JSON metadata.
+   * @param metadata The metadata in JSON.
+   * @throws JSONException If fails to parse metadata.
+   */
+  CloudReplicationConfig(JSONObject metadata) throws JSONException {
+    destinationType = metadata.getString(CLOUD_DEST_TYPE_KEY);
+    configSpec = metadata.getString(CLOUD_CONFIG_SPEC_KEY);
+    cloudContainerName = metadata.optString(CLOUD_CONTAINER_NAME_KEY, null);
+  }
+
+  /**
+   * @return The metadata of the replication config.
+   * @throws JSONException If fails to compose metadata.
+   */
+  public JSONObject toJson() throws JSONException {
+    JSONObject metadata = new JSONObject();
+    metadata.putOpt(CLOUD_DEST_TYPE_KEY, destinationType);
+    metadata.putOpt(CLOUD_CONFIG_SPEC_KEY, configSpec);
+    metadata.putOpt(CLOUD_CONTAINER_NAME_KEY, cloudContainerName);
+    return metadata;
+  }
+
+  @Override
+  public int hashCode() {
+    return (destinationType + configSpec + cloudContainerName).hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof CloudReplicationConfig)) {
+      return false;
+    }
+    CloudReplicationConfig oconfig = (CloudReplicationConfig) o;
+    return (Objects.equals(destinationType, oconfig.destinationType)
+        && Objects.equals(configSpec, oconfig.configSpec)
+        && Objects.equals(cloudContainerName, oconfig.cloudContainerName));
+  }
+
+  /**
+   * Builder used to construct instances of {@link CloudReplicationConfig}
+   */
+  public static class Builder {
+    // required
+    private String destinationType;
+    private String configSpec;
+
+    // optional
+    private String cloudContainerName;
+
+    public Builder(CloudReplicationConfig config) {
+      this.destinationType = config.destinationType;
+      this.configSpec = config.configSpec;
+      this.cloudContainerName = config.cloudContainerName;
+    }
+
+    public Builder(String destinationType, String configSpec) {
+      this.destinationType = destinationType;
+      this.configSpec = configSpec;
+    }
+
+    public Builder setCloudContainerName(String containerName) {
+      this.cloudContainerName = containerName;
+      return this;
+    }
+
+    /**
+     * @return the {@link CloudReplicationConfig} built from specified properties.
+     */
+    public CloudReplicationConfig build() {
+      return new CloudReplicationConfig(destinationType, configSpec, cloudContainerName);
+    }
+  }
+}

--- a/ambry-api/src/main/java/com.github.ambry/account/Container.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/Container.java
@@ -561,6 +561,9 @@ public class Container {
     return parentAccountId;
   }
 
+  /**
+   * @return the cloud replication configs for this container.
+   */
   public List<CloudReplicationConfig> getCloudReplicationConfigs() {
     return cloudConfigs;
   }

--- a/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.account;
 
+import java.util.List;
+
 import static com.github.ambry.account.Container.*;
 
 
@@ -37,6 +39,7 @@ public class ContainerBuilder {
   private boolean mediaScanDisabled = MEDIA_SCAN_DISABLED_DEFAULT_VALUE;
   private String replicationPolicy = null;
   private boolean ttlRequired = TTL_REQUIRED_DEFAULT_VALUE;
+  private List<CloudReplicationConfig> cloudConfigs;
 
   /**
    * Constructor. This will allow building a new {@link Container} from an existing {@link Container}. The builder will
@@ -59,6 +62,7 @@ public class ContainerBuilder {
     replicationPolicy = origin.getReplicationPolicy();
     ttlRequired = origin.isTtlRequired();
     parentAccountId = origin.getParentAccountId();
+    cloudConfigs = origin.getCloudReplicationConfigs();
   }
 
   /**
@@ -187,6 +191,11 @@ public class ContainerBuilder {
     return this;
   }
 
+  public ContainerBuilder setCloudConfigs(List<CloudReplicationConfig> cloudConfigs) {
+    this.cloudConfigs = cloudConfigs;
+    return this;
+  }
+
   /**
    * Builds a {@link Container} object. {@code id}, {@code name}, {@code status}, {@code isPrivate}, and
    * {@code parentAccountId} are required before build.
@@ -195,6 +204,6 @@ public class ContainerBuilder {
    */
   public Container build() {
     return new Container(id, name, status, description, encrypted, previouslyEncrypted || encrypted, cacheable,
-        mediaScanDisabled, replicationPolicy, ttlRequired, parentAccountId);
+        mediaScanDisabled, replicationPolicy, ttlRequired, parentAccountId, cloudConfigs);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
@@ -191,6 +191,11 @@ public class ContainerBuilder {
     return this;
   }
 
+  /**
+   * Sets the cloud replication configurations for the {@link Container}.
+   * @param cloudConfigs the list of cloud replication configs.
+   * @return This builder.
+   */
   public ContainerBuilder setCloudConfigs(List<CloudReplicationConfig> cloudConfigs) {
     this.cloudConfigs = cloudConfigs;
     return this;

--- a/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
@@ -67,8 +67,6 @@ public class AccountContainerTest {
   private List<JSONObject> containerJsonList;
   private List<Container> refContainers;
 
-  private CloudReplicationConfig[] refCloudConfigs;
-
   /**
    * Run this test for all versions of the container schema.
    * @return the constructor arguments to use.
@@ -105,7 +103,6 @@ public class AccountContainerTest {
    */
   @Test
   public void testConstructAccountFromJson() throws Exception {
-    System.out.println(refAccountJson);
     assertAccountAgainstReference(Account.fromJson(refAccountJson), true, true);
   }
 
@@ -363,7 +360,7 @@ public class AccountContainerTest {
               .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(i))
               .setReplicationPolicy(refContainerReplicationPolicyValues.get(i))
               .setTtlRequired(refContainerTtlRequiredValues.get(i))
-              .setCloudConfigs(refContainerCloudReplicationConfigValues);
+              .setCloudConfigs(Collections.singletonList(refContainerCloudReplicationConfigValues.get(i)));
       Container containerFromBuilder = containerBuilder.build();
       assertContainer(containerFromBuilder, i);
 
@@ -512,8 +509,12 @@ public class AccountContainerTest {
       String updatedReplicationPolicy = container.getReplicationPolicy() + "---updated";
       boolean updatedTtlRequired = !container.isTtlRequired();
       List<CloudReplicationConfig> updatedCloudConfigList = new ArrayList<>();
-      updatedCloudConfigList.add(refCloudConfigs[0]);
-      updatedCloudConfigList.add(refCloudConfigs[1]);
+      if (container.getCloudReplicationConfigs() != null) {
+        updatedCloudConfigList.add(
+            new CloudReplicationConfig.Builder(container.getCloudReplicationConfigs().get(0)).setConfigSpec(
+                "updated spec" + 1).build());
+      }
+      updatedCloudConfigList.add(new CloudReplicationConfig.Builder("AWS", "updated spec" + i).build());
 
       containerBuilder.setId(updatedContainerId)
           .setName(updatedContainerName)
@@ -923,20 +924,16 @@ public class AccountContainerTest {
       }
       refContainerTtlRequiredValues.add(random.nextBoolean());
 
-      // @formatter:off
-      refCloudConfigs = new CloudReplicationConfig[] {
-          new CloudReplicationConfig.Builder("AZURE", "spec 1").setCloudContainerName("c1").build(),
-          new CloudReplicationConfig.Builder("AZURE", "spec 2").setCloudContainerName("c2").build(),
-          new CloudReplicationConfig.Builder("AZURE", "spec 3").setCloudContainerName("c3").build()
-      };
-      // @formatter:on
+      CloudReplicationConfig cloudConfig =
+          new CloudReplicationConfig.Builder("AZURE", "spec" + i).setCloudContainerName("ctr" + i).build();
+      refContainerCloudReplicationConfigValues.add(cloudConfig);
 
-      refContainerCloudReplicationConfigValues = Collections.singletonList(refCloudConfigs[0]);
       refContainers.add(new Container(refContainerIds.get(i), refContainerNames.get(i), refContainerStatuses.get(i),
           refContainerDescriptions.get(i), refContainerEncryptionValues.get(i),
           refContainerPreviousEncryptionValues.get(i), refContainerCachingValues.get(i),
           refContainerMediaScanDisabledValues.get(i), refContainerReplicationPolicyValues.get(i),
-          refContainerTtlRequiredValues.get(i), refAccountId, refContainerCloudReplicationConfigValues));
+          refContainerTtlRequiredValues.get(i), refAccountId,
+          Collections.singletonList(refContainerCloudReplicationConfigValues.get(i))));
       containerJsonList.add(refContainers.get(i).toJson());
     }
   }


### PR DESCRIPTION
Adding an optional container config property which is a list of metadata describing how blobs in the container should be replicated to a cloud storage service.