### PR TITLE
Making TTL required true by default for containers

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/account/Container.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/Container.java
@@ -69,7 +69,7 @@ public class Container {
   static final boolean ENCRYPTED_DEFAULT_VALUE = false;
   static final boolean PREVIOUSLY_ENCRYPTED_DEFAULT_VALUE = ENCRYPTED_DEFAULT_VALUE;
   static final boolean MEDIA_SCAN_DISABLED_DEFAULT_VALUE = false;
-  static final boolean TTL_REQUIRED_DEFAULT_VALUE = false;
+  static final boolean TTL_REQUIRED_DEFAULT_VALUE = true;
   static final boolean CACHEABLE_DEFAULT_VALUE = true;
   public static final short JSON_VERSION_1 = 1;
   public static final short JSON_VERSION_2 = 2;
@@ -322,7 +322,7 @@ public class Container {
         cacheable = !metadata.getBoolean(IS_PRIVATE_KEY);
         mediaScanDisabled = MEDIA_SCAN_DISABLED_DEFAULT_VALUE;
         replicationPolicy = null;
-        ttlRequired = false;
+        ttlRequired = TTL_REQUIRED_DEFAULT_VALUE;
         break;
       case JSON_VERSION_2:
         id = (short) metadata.getInt(CONTAINER_ID_KEY);
@@ -334,7 +334,7 @@ public class Container {
         cacheable = metadata.optBoolean(CACHEABLE_KEY, CACHEABLE_DEFAULT_VALUE);
         mediaScanDisabled = metadata.optBoolean(MEDIA_SCAN_DISABLED_KEY, MEDIA_SCAN_DISABLED_DEFAULT_VALUE);
         replicationPolicy = metadata.optString(REPLICATION_POLICY_KEY, null);
-        ttlRequired = metadata.optBoolean(TTL_REQUIRED_KEY, false);
+        ttlRequired = metadata.optBoolean(TTL_REQUIRED_KEY, TTL_REQUIRED_DEFAULT_VALUE);
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + metadataVersion);
@@ -374,7 +374,7 @@ public class Container {
         this.previouslyEncrypted = PREVIOUSLY_ENCRYPTED_DEFAULT_VALUE;
         this.mediaScanDisabled = MEDIA_SCAN_DISABLED_DEFAULT_VALUE;
         this.replicationPolicy = null;
-        this.ttlRequired = false;
+        this.ttlRequired = TTL_REQUIRED_DEFAULT_VALUE;
         break;
       case JSON_VERSION_2:
         this.encrypted = encrypted;

--- a/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
@@ -160,10 +160,11 @@ public class FrontendConfig {
   @Default("28 * 24 * 60 * 60")
   public final long chunkUploadInitialChunkTtlSecs;
 
-  public static final String FAIL_TTL_REQUIRED_NOT_PROVIDED_KEY = PREFIX + "fail.ttl.required.not.provided";
-  @Config(FAIL_TTL_REQUIRED_NOT_PROVIDED_KEY)
+  public static final String FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY =
+      PREFIX + "fail.if.ttl.required.but.not.provided";
+  @Config(FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY)
   @Default("false")
-  public final boolean failTtlRequiredNotProvided;
+  public final boolean failIfTtlRequiredButNotProvided;
 
   public static final String MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY =
       PREFIX + "max.acceptable.ttl.secs.if.ttl.required";
@@ -204,7 +205,7 @@ public class FrontendConfig {
         GetOption.valueOf(verifiableProperties.getString("frontend.default.router.get.option", GetOption.None.name()));
     chunkUploadInitialChunkTtlSecs =
         verifiableProperties.getLong(CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS_KEY, TimeUnit.DAYS.toSeconds(28));
-    failTtlRequiredNotProvided = verifiableProperties.getBoolean(FAIL_TTL_REQUIRED_NOT_PROVIDED_KEY, false);
+    failIfTtlRequiredButNotProvided = verifiableProperties.getBoolean(FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY, false);
     maxAcceptableTtlSecsIfTtlRequired = verifiableProperties.getIntInRange(MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY,
         (int) TimeUnit.DAYS.toSeconds(30), 0, Integer.MAX_VALUE);
   }

--- a/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
@@ -160,6 +160,17 @@ public class FrontendConfig {
   @Default("28 * 24 * 60 * 60")
   public final long chunkUploadInitialChunkTtlSecs;
 
+  public static final String FAIL_TTL_REQUIRED_NOT_PROVIDED_KEY = PREFIX + "fail.ttl.required.not.provided";
+  @Config(FAIL_TTL_REQUIRED_NOT_PROVIDED_KEY)
+  @Default("false")
+  public final boolean failTtlRequiredNotProvided;
+
+  public static final String MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY =
+      PREFIX + "max.acceptable.ttl.secs.if.ttl.required";
+  @Config(MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY)
+  @Default("30 * 24 * 60 * 60")
+  public final int maxAcceptableTtlSecsIfTtlRequired;
+
   public FrontendConfig(VerifiableProperties verifiableProperties) {
     frontendCacheValiditySeconds = verifiableProperties.getLong("frontend.cache.validity.seconds", 365 * 24 * 60 * 60);
     frontendOptionsValiditySeconds = verifiableProperties.getLong("frontend.options.validity.seconds", 24 * 60 * 60);
@@ -193,5 +204,8 @@ public class FrontendConfig {
         GetOption.valueOf(verifiableProperties.getString("frontend.default.router.get.option", GetOption.None.name()));
     chunkUploadInitialChunkTtlSecs =
         verifiableProperties.getLong(CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS_KEY, TimeUnit.DAYS.toSeconds(28));
+    failTtlRequiredNotProvided = verifiableProperties.getBoolean(FAIL_TTL_REQUIRED_NOT_PROVIDED_KEY, false);
+    maxAcceptableTtlSecsIfTtlRequired = verifiableProperties.getIntInRange(MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY,
+        (int) TimeUnit.DAYS.toSeconds(30), 0, Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -201,8 +201,9 @@ public class RestUtils {
     public final static String USER_META_DATA_HEADER_PREFIX = "x-ambry-um-";
 
     /**
-     * Response header for the name of the datacenter that the responding frontend belongs to.
+     * Response header indicating the reason a request is non compliant.
      */
+    public final static String NON_COMPLIANCE_WARNING = "x-ambry-non-compliance-warning";
   }
 
   public static final class TrackingHeaders {
@@ -320,15 +321,6 @@ public class RestUtils {
 
     long ttl = Utils.Infinite_Time;
     Long ttlFromHeader = getLongHeader(args, Headers.TTL, false);
-    if (container.isTtlRequired()) {
-      if (ttlFromHeader == null) {
-        throw new RestServiceException("TTL(a finite time) is required in container " + container.getName(),
-            RestServiceErrorCode.MissingArgs);
-      } else if (ttlFromHeader == Utils.Infinite_Time) {
-        throw new RestServiceException("TTL(a finite time) is required in container " + container.getName(),
-            RestServiceErrorCode.InvalidArgs);
-      }
-    }
     if (ttlFromHeader != null) {
       if (ttlFromHeader < -1) {
         throw new RestServiceException(Headers.TTL + "[" + ttlFromHeader + "] is not valid (has to be >= -1)",

--- a/ambry-api/src/main/java/com.github.ambry/store/Transformer.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/Transformer.java
@@ -15,6 +15,7 @@ package com.github.ambry.store;
 
 import java.util.List;
 
+
 /**
  * An interface for a transformation function. Transformations parse the message and may modify any data in the message
  * (including keys).

--- a/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
@@ -534,7 +534,7 @@ public class AccountContainerTest {
           assertEquals("Wrong media scan disabled setting", MEDIA_SCAN_DISABLED_DEFAULT_VALUE,
               updatedContainer.isMediaScanDisabled());
           assertNull("Wrong replication policy", updatedContainer.getReplicationPolicy());
-          assertFalse("Wrong ttl required setting", updatedContainer.isTtlRequired());
+          assertEquals("Wrong ttl required setting", TTL_REQUIRED_DEFAULT_VALUE, updatedContainer.isTtlRequired());
           break;
         case Container.JSON_VERSION_2:
           assertEquals("Wrong encryption setting", updatedEncrypted, updatedContainer.isEncrypted());
@@ -785,7 +785,7 @@ public class AccountContainerTest {
         assertEquals("Wrong media scan disabled setting", MEDIA_SCAN_DISABLED_DEFAULT_VALUE,
             container.isMediaScanDisabled());
         assertNull("Wrong replication policy", container.getReplicationPolicy());
-        assertFalse("Wrong ttl required setting", container.isTtlRequired());
+        assertEquals("Wrong ttl required setting", TTL_REQUIRED_DEFAULT_VALUE, container.isTtlRequired());
         break;
       case Container.JSON_VERSION_2:
         assertEquals("Wrong encryption setting", refContainerEncryptionValues.get(index), container.isEncrypted());

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -15,7 +15,6 @@ package com.github.ambry.rest;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
-import com.github.ambry.account.ContainerBuilder;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.protocol.GetOption;
@@ -54,9 +53,6 @@ import static org.junit.Assert.*;
 public class RestUtilsTest {
   private static final Random RANDOM = new Random();
   private static final String ALPHABET = "abcdefghijklmnopqrstuvwxyz";
-  private static final Container ttlRequiredContainer =
-      new ContainerBuilder((short) 1, "ttlRequiredContainerName", Container.ContainerStatus.ACTIVE, "description",
-          (short) 1).setTtlRequired(true).build();
 
   /**
    * Tests building of {@link BlobProperties} given good input (all arguments in the number and format expected).
@@ -95,14 +91,6 @@ public class RestUtilsTest {
     headers = new JSONObject();
     setAmbryHeadersForPut(headers, "-2", serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId);
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
-    // ttl required in ttlRequired container.
-    headers = new JSONObject();
-    setAmbryHeadersForPut(headers, null, serviceId, ttlRequiredContainer, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.MissingArgs);
-    // ttl(finite time) required in ttlRequired container.
-    headers = new JSONObject();
-    setAmbryHeadersForPut(headers, "-1", serviceId, ttlRequiredContainer, contentType, ownerId);
-    verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InvalidArgs);
     // serviceId missing.
     headers = new JSONObject();
     setAmbryHeadersForPut(headers, ttl, null, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId);
@@ -139,7 +127,7 @@ public class RestUtilsTest {
     verifyBlobPropertiesConstructionFailure(headers, RestServiceErrorCode.InternalServerError);
 
     // no failures.
-    // ttl missing. Should be infinite time by default in non ttlRequired container.
+    // ttl missing. Should be infinite time by default
     // ownerId missing.
     headers = new JSONObject();
     setAmbryHeadersForPut(headers, null, serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, null);
@@ -151,9 +139,9 @@ public class RestUtilsTest {
     headers.put(RestUtils.Headers.TTL, JSONObject.NULL);
     verifyBlobPropertiesConstructionSuccess(headers);
 
-    // Post with valid ttl to ttlRequired container.
+    // Post with valid ttl
     headers = new JSONObject();
-    setAmbryHeadersForPut(headers, "100", serviceId, ttlRequiredContainer, contentType, ownerId);
+    setAmbryHeadersForPut(headers, "100", serviceId, Container.DEFAULT_PUBLIC_CONTAINER, contentType, ownerId);
     verifyBlobPropertiesConstructionSuccess(headers);
 
     // ownerId null.

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
@@ -150,8 +150,8 @@ public class FrontendMetrics {
   // AmbryBlobStorageService
   public final Counter responseSubmissionError;
   public final Counter resourceReleaseError;
-  public final Counter routerCallbackError;
   public final Counter ttlTooLargeError;
+  public final Counter ttlNotCompliantError;
   // DeleteCallback
   public final Counter deleteCallbackProcessingError;
   // HeadCallback
@@ -363,8 +363,6 @@ public class FrontendMetrics {
         metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "ResponseSubmissionError"));
     resourceReleaseError =
         metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "ResourceReleaseError"));
-    routerCallbackError =
-        metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "RouterCallbackError"));
     // DeleteCallback
     deleteCallbackProcessingError =
         metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "DeleteCallbackProcessingError"));
@@ -378,6 +376,8 @@ public class FrontendMetrics {
         MetricRegistry.name(AmbryBlobStorageService.class, "GetSecurityResponseCallbackProcessingError"));
     // PostBlobHandler
     ttlTooLargeError = metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "TtlTooLargeError"));
+    ttlNotCompliantError =
+        metricRegistry.counter(MetricRegistry.name(AmbryBlobStorageService.class, "TtlNotCompliantError"));
     // GetPeersHandler
     unknownDatanodeError = metricRegistry.counter(MetricRegistry.name(GetPeersHandler.class, "UnknownDatanodeError"));
     // GetReplicasHandler

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
@@ -212,7 +212,7 @@ class PostBlobHandler {
       } else if (container.isTtlRequired() && (blobProperties.getTimeToLiveInSeconds() == Utils.Infinite_Time
           || blobProperties.getTimeToLiveInSeconds() > frontendConfig.maxAcceptableTtlSecsIfTtlRequired)) {
         String descriptor = RestUtils.getAccountFromArgs(restRequest.getArgs()).getName() + ":" + container.getName();
-        if (frontendConfig.failTtlRequiredNotProvided) {
+        if (frontendConfig.failIfTtlRequiredButNotProvided) {
           throw new RestServiceException(
               "TTL < " + frontendConfig.maxAcceptableTtlSecsIfTtlRequired + " is required for upload to " + descriptor,
               RestServiceErrorCode.InvalidArgs);

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.frontend;
 
+import com.github.ambry.account.Container;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -203,10 +204,26 @@ class PostBlobHandler {
       long propsBuildStartTime = System.currentTimeMillis();
       accountAndContainerInjector.injectAccountAndContainerForPostRequest(restRequest);
       BlobProperties blobProperties = RestUtils.buildBlobProperties(restRequest.getArgs());
+      Container container = RestUtils.getContainerFromArgs(restRequest.getArgs());
       if (blobProperties.getTimeToLiveInSeconds() + TimeUnit.MILLISECONDS.toSeconds(
           blobProperties.getCreationTimeInMs()) > Integer.MAX_VALUE) {
         LOGGER.debug("TTL set to very large value in POST request with BlobProperties {}", blobProperties);
         frontendMetrics.ttlTooLargeError.inc();
+      } else if (container.isTtlRequired() && (blobProperties.getTimeToLiveInSeconds() == Utils.Infinite_Time
+          || blobProperties.getTimeToLiveInSeconds() > frontendConfig.maxAcceptableTtlSecsIfTtlRequired)) {
+        String descriptor = RestUtils.getAccountFromArgs(restRequest.getArgs()).getName() + ":" + container.getName();
+        if (frontendConfig.failTtlRequiredNotProvided) {
+          throw new RestServiceException(
+              "TTL < " + frontendConfig.maxAcceptableTtlSecsIfTtlRequired + " is required for upload to " + descriptor,
+              RestServiceErrorCode.InvalidArgs);
+        } else {
+          LOGGER.debug(
+              blobProperties.getServiceId() + " attempted an upload with ttl " + blobProperties.getTimeToLiveInSeconds()
+                  + " to " + descriptor);
+          frontendMetrics.ttlNotCompliantError.inc();
+          restResponseChannel.setHeader(RestUtils.Headers.NON_COMPLIANCE_WARNING,
+              "TTL < " + frontendConfig.maxAcceptableTtlSecsIfTtlRequired + " will be required for future uploads");
+        }
       }
       // inject encryption frontendMetrics if applicable
       if (blobProperties.isEncrypted()) {

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -101,8 +101,7 @@ public class AmbrySecurityServiceTest {
   @Test
   public void preProcessRequestTest() throws Exception {
     RestMethod[] methods =
-        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS,
-            RestMethod.PUT};
+        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS, RestMethod.PUT};
     for (RestMethod restMethod : methods) {
       // add a header that is prohibited
       JSONObject headers = new JSONObject();
@@ -149,8 +148,7 @@ public class AmbrySecurityServiceTest {
 
     // without callbacks
     RestMethod[] methods =
-        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS,
-            RestMethod.PUT};
+        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS, RestMethod.PUT};
     for (RestMethod restMethod : methods) {
       RestRequest restRequest = createRestRequest(restMethod, "/", null);
       securityService.preProcessRequest(restRequest).get();

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -213,8 +213,8 @@ public class FrontendIntegrationTest {
     doPostGetHeadUpdateDeleteTest(refContentSize, null, null, "unknown_service_id", false, null, null, false);
     doPostGetHeadUpdateDeleteTest(refContentSize, null, null, "unknown_service_id", true, null, null, false);
     // different sizes
-    for (int contentSize : new int[]{0, FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes - 1,
-        FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes, refContentSize}) {
+    for (int contentSize : new int[]{0, FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes
+        - 1, FRONTEND_CONFIG.frontendChunkedGetResponseThresholdInBytes, refContentSize}) {
       doPostGetHeadUpdateDeleteTest(contentSize, refAccount, publicContainer, refAccount.getName(),
           !publicContainer.isCacheable(), refAccount.getName(), publicContainer.getName(), false);
     }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/PostBlobHandlerTest.java
@@ -125,7 +125,7 @@ public class PostBlobHandlerTest {
     Properties properties = new Properties();
 
     // ttl required in container, config asks not to fail. If TTL does not conform, look for non compliance warning
-    properties.setProperty(FrontendConfig.FAIL_TTL_REQUIRED_NOT_PROVIDED_KEY, "false");
+    properties.setProperty(FrontendConfig.FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY, "false");
     initPostBlobHandler(properties);
     // ok
     doTtlRequiredEnforcementTest(REF_CONTAINER_WITH_TTL_REQUIRED, frontendConfig.maxAcceptableTtlSecsIfTtlRequired - 1);
@@ -135,7 +135,7 @@ public class PostBlobHandlerTest {
     doTtlRequiredEnforcementTest(REF_CONTAINER_WITH_TTL_REQUIRED, frontendConfig.maxAcceptableTtlSecsIfTtlRequired + 1);
 
     // ttl required in container, config asks to fail. If TTL does not conform, look for failure
-    properties.setProperty(FrontendConfig.FAIL_TTL_REQUIRED_NOT_PROVIDED_KEY, "true");
+    properties.setProperty(FrontendConfig.FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY, "true");
     initPostBlobHandler(properties);
     // ok
     doTtlRequiredEnforcementTest(REF_CONTAINER_WITH_TTL_REQUIRED, frontendConfig.maxAcceptableTtlSecsIfTtlRequired - 1);
@@ -216,7 +216,7 @@ public class PostBlobHandlerTest {
     postBlobHandler.handle(request, restResponseChannel, future::done);
     if (container.isTtlRequired() && (blobTtlSecs == Utils.Infinite_Time
         || blobTtlSecs > frontendConfig.maxAcceptableTtlSecsIfTtlRequired)) {
-      if (frontendConfig.failTtlRequiredNotProvided) {
+      if (frontendConfig.failIfTtlRequiredButNotProvided) {
         try {
           future.get(TIMEOUT_SECS, TimeUnit.SECONDS);
           fail("Post should have failed");

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/PostBlobHandlerTest.java
@@ -17,7 +17,9 @@ package com.github.ambry.frontend;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.Account;
+import com.github.ambry.account.AccountBuilder;
 import com.github.ambry.account.Container;
+import com.github.ambry.account.ContainerBuilder;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.MockClusterMap;
@@ -42,6 +44,7 @@ import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -64,8 +67,9 @@ import static org.junit.Assert.*;
  */
 public class PostBlobHandlerTest {
   private static final InMemAccountService ACCOUNT_SERVICE = new InMemAccountService(false, true);
-  private static final Account REF_ACCOUNT = ACCOUNT_SERVICE.createAndAddRandomAccount();
-  private static final Container REF_CONTAINER = REF_ACCOUNT.getContainerById(Container.DEFAULT_PRIVATE_CONTAINER_ID);
+  private static final Account REF_ACCOUNT;
+  private static final Container REF_CONTAINER;
+  private static final Container REF_CONTAINER_WITH_TTL_REQUIRED;
   private static final ClusterMap CLUSTER_MAP;
 
   private static final int TIMEOUT_SECS = 10;
@@ -80,28 +84,71 @@ public class PostBlobHandlerTest {
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }
+    Account account = ACCOUNT_SERVICE.createAndAddRandomAccount();
+    Container publicContainer = account.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
+    Container ttlRequiredContainer = new ContainerBuilder(publicContainer).setTtlRequired(true).build();
+    Account newAccount = new AccountBuilder(account).addOrUpdateContainer(ttlRequiredContainer).build();
+    if (!ACCOUNT_SERVICE.updateAccounts(Collections.singleton(newAccount))) {
+      throw new IllegalStateException("Account could not be created");
+    }
+    REF_ACCOUNT = ACCOUNT_SERVICE.getAccountById(newAccount.getId());
+    REF_CONTAINER = REF_ACCOUNT.getContainerById(Container.DEFAULT_PRIVATE_CONTAINER_ID);
+    REF_CONTAINER_WITH_TTL_REQUIRED = REF_ACCOUNT.getContainerById(Container.DEFAULT_PUBLIC_CONTAINER_ID);
   }
 
   private final MockTime time = new MockTime();
-  private final FrontendConfig frontendConfig;
+  private final FrontendMetrics metrics = new FrontendMetrics(new MetricRegistry());
   private final InMemoryRouter router;
-  private final PostBlobHandler postBlobHandler;
+  private final FrontendTestIdConverterFactory idConverterFactory;
+  private final FrontendTestSecurityServiceFactory securityServiceFactory;
+  private final AccountAndContainerInjector injector;
+  private FrontendConfig frontendConfig;
+  private PostBlobHandler postBlobHandler;
 
   public PostBlobHandlerTest() {
-    FrontendTestIdConverterFactory idConverterFactory = new FrontendTestIdConverterFactory();
-    idConverterFactory.translation = CONVERTED_ID;
+    idConverterFactory = new FrontendTestIdConverterFactory();
+    securityServiceFactory = new FrontendTestSecurityServiceFactory();
     Properties props = new Properties();
     VerifiableProperties verifiableProperties = new VerifiableProperties(props);
-    MetricRegistry metricRegistry = new MetricRegistry();
-    FrontendMetrics metrics = new FrontendMetrics(metricRegistry);
-    frontendConfig = new FrontendConfig(verifiableProperties);
-    AccountAndContainerInjector accountAndContainerInjector =
-        new AccountAndContainerInjector(ACCOUNT_SERVICE, metrics, frontendConfig);
     router = new InMemoryRouter(verifiableProperties, CLUSTER_MAP);
-    FrontendTestSecurityServiceFactory securityServiceFactory = new FrontendTestSecurityServiceFactory();
-    postBlobHandler =
-        new PostBlobHandler(securityServiceFactory.getSecurityService(), idConverterFactory.getIdConverter(), router,
-            accountAndContainerInjector, time, frontendConfig, metrics);
+    injector = new AccountAndContainerInjector(ACCOUNT_SERVICE, metrics, frontendConfig);
+    initPostBlobHandler(props);
+  }
+
+  /**
+   * Tests for different combinations of container and frontend config w.r.t TTL enforcement.
+   * @throws Exception
+   */
+  @Test
+  public void ttlRequiredEnforcementTest() throws Exception {
+    idConverterFactory.returnInputIfTranslationNull = true;
+    Properties properties = new Properties();
+
+    // ttl required in container, config asks not to fail. If TTL does not conform, look for non compliance warning
+    properties.setProperty(FrontendConfig.FAIL_TTL_REQUIRED_NOT_PROVIDED_KEY, "false");
+    initPostBlobHandler(properties);
+    // ok
+    doTtlRequiredEnforcementTest(REF_CONTAINER_WITH_TTL_REQUIRED, frontendConfig.maxAcceptableTtlSecsIfTtlRequired - 1);
+    doTtlRequiredEnforcementTest(REF_CONTAINER_WITH_TTL_REQUIRED, frontendConfig.maxAcceptableTtlSecsIfTtlRequired);
+    // not ok
+    doTtlRequiredEnforcementTest(REF_CONTAINER_WITH_TTL_REQUIRED, Utils.Infinite_Time);
+    doTtlRequiredEnforcementTest(REF_CONTAINER_WITH_TTL_REQUIRED, frontendConfig.maxAcceptableTtlSecsIfTtlRequired + 1);
+
+    // ttl required in container, config asks to fail. If TTL does not conform, look for failure
+    properties.setProperty(FrontendConfig.FAIL_TTL_REQUIRED_NOT_PROVIDED_KEY, "true");
+    initPostBlobHandler(properties);
+    // ok
+    doTtlRequiredEnforcementTest(REF_CONTAINER_WITH_TTL_REQUIRED, frontendConfig.maxAcceptableTtlSecsIfTtlRequired - 1);
+    doTtlRequiredEnforcementTest(REF_CONTAINER_WITH_TTL_REQUIRED, frontendConfig.maxAcceptableTtlSecsIfTtlRequired);
+    // not ok
+    doTtlRequiredEnforcementTest(REF_CONTAINER_WITH_TTL_REQUIRED, Utils.Infinite_Time);
+    doTtlRequiredEnforcementTest(REF_CONTAINER_WITH_TTL_REQUIRED, frontendConfig.maxAcceptableTtlSecsIfTtlRequired + 1);
+
+    // ttl not required in container, any ttl works and no exceptions or warnings
+    doTtlRequiredEnforcementTest(REF_CONTAINER, Utils.Infinite_Time);
+    doTtlRequiredEnforcementTest(REF_CONTAINER, frontendConfig.maxAcceptableTtlSecsIfTtlRequired - 1);
+    doTtlRequiredEnforcementTest(REF_CONTAINER, frontendConfig.maxAcceptableTtlSecsIfTtlRequired);
+    doTtlRequiredEnforcementTest(REF_CONTAINER, frontendConfig.maxAcceptableTtlSecsIfTtlRequired + 1);
   }
 
   /**
@@ -110,29 +157,112 @@ public class PostBlobHandlerTest {
    */
   @Test
   public void chunkUploadTest() throws Exception {
+    idConverterFactory.translation = CONVERTED_ID;
     // valid request arguments
-    doChunkUploadTest(1024, true, UUID.randomUUID().toString(), 1025,
-        frontendConfig.chunkUploadInitialChunkTtlSecs, null);
-    doChunkUploadTest(1024, true, UUID.randomUUID().toString(), 1024,
-        frontendConfig.chunkUploadInitialChunkTtlSecs, null);
+    doChunkUploadTest(1024, true, UUID.randomUUID().toString(), 1025, frontendConfig.chunkUploadInitialChunkTtlSecs,
+        null);
+    doChunkUploadTest(1024, true, UUID.randomUUID().toString(), 1024, frontendConfig.chunkUploadInitialChunkTtlSecs,
+        null);
     // blob exceeds max blob size
     doChunkUploadTest(1024, true, UUID.randomUUID().toString(), 1023, 7200,
         routerExceptionChecker(RouterErrorCode.BlobTooLarge));
     // no session header
-    doChunkUploadTest(1024, true, null, 1025, 7200,
-        restServiceExceptionChecker(RestServiceErrorCode.MissingArgs));
+    doChunkUploadTest(1024, true, null, 1025, 7200, restServiceExceptionChecker(RestServiceErrorCode.MissingArgs));
     // missing max blob size
     doChunkUploadTest(1024, true, UUID.randomUUID().toString(), null, 7200,
         restServiceExceptionChecker(RestServiceErrorCode.MissingArgs));
     // invalid TTL
     doChunkUploadTest(1024, true, UUID.randomUUID().toString(), 1025, Utils.Infinite_Time,
         restServiceExceptionChecker(RestServiceErrorCode.InvalidArgs));
-    doChunkUploadTest(1024, true, UUID.randomUUID().toString(), 1025,
-        frontendConfig.chunkUploadInitialChunkTtlSecs + 1,
+    doChunkUploadTest(1024, true, UUID.randomUUID().toString(), 1025, frontendConfig.chunkUploadInitialChunkTtlSecs + 1,
         restServiceExceptionChecker(RestServiceErrorCode.InvalidArgs));
     // ensure that the chunk upload request requirements are not enforced for non chunk uploads.
     doChunkUploadTest(1024, false, null, null, Utils.Infinite_Time, null);
   }
+
+  // helpers
+  // general
+
+  /**
+   * Initates a {@link PostBlobHandler}
+   * @param properties the properties to use to init the {@link PostBlobHandler}
+   */
+  private void initPostBlobHandler(Properties properties) {
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+    frontendConfig = new FrontendConfig(verifiableProperties);
+    postBlobHandler =
+        new PostBlobHandler(securityServiceFactory.getSecurityService(), idConverterFactory.getIdConverter(), router,
+            injector, time, frontendConfig, metrics);
+  }
+
+  // ttlRequiredEnforcementTest() helpers
+
+  /**
+   * Does the TTL required enforcement test by selecting the right verification methods based on container and frontend
+   * config
+   * @param container the {@link Container} to uplaod to
+   * @param blobTtlSecs the TTL to set for the blob
+   * @throws Exception
+   */
+  private void doTtlRequiredEnforcementTest(Container container, long blobTtlSecs) throws Exception {
+    JSONObject headers = new JSONObject();
+    AmbryBlobStorageServiceTest.setAmbryHeadersForPut(headers, blobTtlSecs, !container.isCacheable(), SERVICE_ID,
+        CONTENT_TYPE, OWNER_ID, REF_ACCOUNT.getName(), container.getName());
+    ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(1024));
+    RestRequest request = AmbryBlobStorageServiceTest.createRestRequest(RestMethod.POST, "/", headers,
+        new LinkedList<>(Arrays.asList(content, null)));
+    RestResponseChannel restResponseChannel = new MockRestResponseChannel();
+    FutureResult<ReadableStreamChannel> future = new FutureResult<>();
+    postBlobHandler.handle(request, restResponseChannel, future::done);
+    if (container.isTtlRequired() && (blobTtlSecs == Utils.Infinite_Time
+        || blobTtlSecs > frontendConfig.maxAcceptableTtlSecsIfTtlRequired)) {
+      if (frontendConfig.failTtlRequiredNotProvided) {
+        try {
+          future.get(TIMEOUT_SECS, TimeUnit.SECONDS);
+          fail("Post should have failed");
+        } catch (ExecutionException e) {
+          RestServiceException rootCause = (RestServiceException) Utils.getRootCause(e);
+          assertNotNull("Root cause should be a RestServiceException", rootCause);
+          assertEquals("Incorrect RestServiceErrorCode", RestServiceErrorCode.InvalidArgs, rootCause.getErrorCode());
+        }
+      } else {
+        verifySuccessResponseOnTtlEnforcement(future, content, blobTtlSecs, restResponseChannel, true);
+      }
+    } else {
+      verifySuccessResponseOnTtlEnforcement(future, content, blobTtlSecs, restResponseChannel, false);
+    }
+  }
+
+  /**
+   * Verifies successful put when subject to enforcement of TTL
+   * @param postFuture the {@link FutureResult} returned from the POST call
+   * @param content the content being POSTed
+   * @param blobTtlSecs the ttl of the blob (in secs)
+   * @param restResponseChannel the {@link RestResponseChannel} over which the response is expected
+   * @param expectWarning {@code true} if a warning header for non compliance is expected. {@code false} otherwise.
+   * @throws Exception
+   */
+  private void verifySuccessResponseOnTtlEnforcement(FutureResult<ReadableStreamChannel> postFuture, ByteBuffer content,
+      long blobTtlSecs, RestResponseChannel restResponseChannel, boolean expectWarning) throws Exception {
+    ReadableStreamChannel channel = postFuture.get(TIMEOUT_SECS, TimeUnit.SECONDS);
+    assertNull("No body expected for POST", channel);
+
+    String id = (String) restResponseChannel.getHeader(RestUtils.Headers.LOCATION);
+    assertNotNull("There should be a blob ID returned", id);
+    InMemoryRouter.InMemoryBlob blob = router.getActiveBlobs().get(id);
+    assertNotNull("No blob with ID " + id, blob);
+    assertEquals("Unexpected blob content stored", content.rewind(), blob.getBlob());
+    assertEquals("Unexpected ttl stored", blobTtlSecs, blob.getBlobProperties().getTimeToLiveInSeconds());
+
+    if (expectWarning) {
+      assertNotNull("There should be a non compliance warning",
+          restResponseChannel.getHeader(RestUtils.Headers.NON_COMPLIANCE_WARNING));
+    } else {
+      assertNull("There should be no warning", restResponseChannel.getHeader(RestUtils.Headers.NON_COMPLIANCE_WARNING));
+    }
+  }
+
+  // chunkUploadTest() helpers
 
   /**
    * Make a post request and verify behavior related to chunk uploads (for stitched blobs).


### PR DESCRIPTION
This change
- makes TTL required `true` by default
- introduces a config to control a TTL that is acceptable
- introduces a config to control whether to fail if conditions are not met (sends a non compliance header if configured not to fail)