### PR TITLE
Introduce shorter blob ID (V6)

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -262,8 +262,8 @@ public class RouterConfig {
     routerLatencyToleranceQuantile =
         verifiableProperties.getDoubleInRange("router.latency.tolerance.quantile", 0.9, 0.0, 1.0);
     routerBlobidCurrentVersion =
-        verifiableProperties.getShortFromAllowedValues("router.blobid.current.version", (short) 5,
-            new Short[]{1, 2, 3, 4, 5});
+        verifiableProperties.getShortFromAllowedValues("router.blobid.current.version", (short) 6,
+            new Short[]{1, 2, 3, 4, 5, 6});
     routerKeyManagementServiceFactory = verifiableProperties.getString("router.key.management.service.factory",
         "com.github.ambry.router.SingleKeyManagementServiceFactory");
     routerCryptoServiceFactory = verifiableProperties.getString("router.crypto.service.factory",

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -90,6 +90,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.net.ssl.SSLSession;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -490,7 +491,10 @@ public class AmbryBlobStorageServiceTest {
    */
   @Test
   public void injectionAccountAndContainerForGetHeadDeleteBlobIdTest() throws Exception {
-    for (short version : new Short[]{BlobId.BLOB_ID_V2, BlobId.BLOB_ID_V3, BlobId.BLOB_ID_V4, BlobId.BLOB_ID_V5}) {
+    List<Short> blobIdVersions = Arrays.stream(BlobId.getAllValidVersions())
+        .filter(version -> version >= BlobId.BLOB_ID_V2)
+        .collect(Collectors.toList());
+    for (short version : blobIdVersions) {
       populateAccountService();
 
       // aid=refAId, cid=refCId

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendUtilsTest.java
@@ -23,6 +23,9 @@ import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.utils.TestUtils;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.Test;
 
 import static com.github.ambry.utils.Utils.*;
@@ -54,7 +57,9 @@ public class FrontendUtilsTest {
     PartitionId referencePartitionId =
         referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     boolean referenceIsEncrypted = TestUtils.RANDOM.nextBoolean();
-    short[] versions = {BlobId.BLOB_ID_V3, BlobId.BLOB_ID_V4, BlobId.BLOB_ID_V5};
+    List<Short> versions = Arrays.stream(BlobId.getAllValidVersions())
+        .filter(version -> version >= BlobId.BLOB_ID_V3)
+        .collect(Collectors.toList());
     for (short version : versions) {
       BlobId blobId =
           new BlobId(version, referenceType, referenceDatacenterId, referenceAccountId, referenceContainerId,
@@ -62,7 +67,7 @@ public class FrontendUtilsTest {
       BlobId regeneratedBlobId = FrontendUtils.getBlobIdFromString(blobId.getID(), referenceClusterMap);
       assertEquals("BlobId mismatch", blobId, regeneratedBlobId);
       assertBlobIdFieldValues(regeneratedBlobId, referenceType, referenceDatacenterId, referenceAccountId,
-          referenceContainerId, referencePartitionId, version >= BlobId.BLOB_ID_V4 ? referenceIsEncrypted : false);
+          referenceContainerId, referencePartitionId, version >= BlobId.BLOB_ID_V4 && referenceIsEncrypted);
 
       // bad path
       try {

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -300,10 +300,13 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(4).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    // Changes in this patch: a. New header version has 4 more bytes compared to previous b. BlobProperties increased by 1 byte
-    // c. Encryption Key Record size is 114 for an encryptionKey of size 100. EncryptionKeyRecord could be null if not applicable.
+    // Changes in this patch:
+    // a. New header version has 4 more bytes compared to previous
+    // b. BlobProperties increased by 1 byte
+    // c. Encryption Key Record size is 114 for an encryptionKey of size 100.
+    //    EncryptionKeyRecord could be null if not applicable.
     // Delta: 7 * 4 (headers for 7 records) + 1*6 (BlobProperties for 6 put records) + 114*3 = 376
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198896);
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198728);
 
     getAndVerify(channel, 6);
 
@@ -335,10 +338,14 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(6).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    // changes in this patch: a. New header version has 4 more bytes compared to preivous b. BlobProperties increased by 1 byte
-    // c. Encryption Key Record size is 114 for an encryptionKey of size 100. EncryptionKeyRecord could be null if not applicable.
+    // changes in this patch:
+    // a. New header version has 4 more bytes compared to previous
+    // b. BlobProperties increased by 1 byte
+    // c. Encryption Key Record size is 114 for an encryptionKey of size 100.
+    //    EncryptionKeyRecord could be null if not applicable.
     // Delta: 6*4 (header) + 3*1 ( blob props) + 114*2 = 225 + 376 (from previous checkpoint) = 631
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 298712);
+    // TODO write explanation of how to calculate this from scratch
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 298400);
 
     getAndVerify(channel, 9);
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -300,13 +300,10 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(4).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    // Changes in this patch:
-    // a. New header version has 4 more bytes compared to previous
-    // b. BlobProperties increased by 1 byte
-    // c. Encryption Key Record size is 114 for an encryptionKey of size 100.
-    //    EncryptionKeyRecord could be null if not applicable.
-    // Delta: 7 * 4 (headers for 7 records) + 1*6 (BlobProperties for 6 put records) + 114*3 = 376
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 198728);
+    int expectedTokenValueT1 = 198728;
+    // For each future change to this offset, add to this variable and write an explanation of why the number changed.
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap,
+        expectedTokenValueT1);
 
     getAndVerify(channel, 6);
 
@@ -338,14 +335,10 @@ public class ServerHardDeleteTest {
     notificationSystem.awaitBlobDeletions(blobIdList.get(6).getID());
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
-    // changes in this patch:
-    // a. New header version has 4 more bytes compared to previous
-    // b. BlobProperties increased by 1 byte
-    // c. Encryption Key Record size is 114 for an encryptionKey of size 100.
-    //    EncryptionKeyRecord could be null if not applicable.
-    // Delta: 6*4 (header) + 3*1 ( blob props) + 114*2 = 225 + 376 (from previous checkpoint) = 631
-    // TODO write explanation of how to calculate this from scratch
-    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap, 298400);
+    int expectedTokenValueT2 = 298400;
+    // For each future change to this offset, add to this variable and write an explanation of why the number changed.
+    ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap,
+        expectedTokenValueT2);
 
     getAndVerify(channel, 9);
   }

--- a/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
@@ -17,6 +17,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +37,7 @@ import static org.junit.Assert.*;
 public class TestUtils {
   public static final long TTL_SECS = TimeUnit.DAYS.toSeconds(7);
   public static final Random RANDOM = new Random();
+  public static final List<Boolean> BOOLEAN_VALUES = Collections.unmodifiableList(Arrays.asList(true, false));
 
   /**
    * Return the number of threads currently running with a name containing the given pattern.


### PR DESCRIPTION
This introduces a new blob ID version that uses the 128 bit
representation of the UUID instead of re-encoding the less compact
string representation.

This change reduces the size of the base64 ID from 78 to 46 characters
and reduces the size of the binary representation from 58 to 34 bytes.

### Size reduction testing
Added the following snippet to `BlobIdTest::testBuildBlobId`:
```java
byte[] bytesRepr = blobId.toBytes();
String base64String = blobId.getID();
System.out.printf("V%d: bytes: %d, chars-base64: %d, str: %s\n", version, bytesRepr.length, base64String.length(),
    base64String);
```

Got the following results:
```
V1: bytes: 52, chars-base64: 70, str: AAEAAQAAAAAAAAAAAAAAJGM4ZTAzZjQ2LTlmZjgtNGU5Yy1hMTc5LWExNzQ5YmJhNDMxMw
V2: bytes: 58, chars-base64: 78, str: AAIA5DnsCjIAAQAAAAAAAAAAAAAAJGUwNzQ5YTYyLTZhYWMtNDM2MC04OGFjLTYzYmNmYTRkZTZlMw
V3: bytes: 58, chars-base64: 78, str: AAMA8i1xTc0AAQAAAAAAAAAAAAAAJDVkOTMwNjMzLWZlYmEtNDJjOS1hNDM2LWM3ZTU0ZmI2MWRhYg
V4: bytes: 58, chars-base64: 78, str: AAQF_wAUPw8AAQAAAAAAAAAAAAAAJGFjOWNhMmU2LWEzZjYtNDM5ZC1hZTFhLWY2NTI2MjE0ZDY4ZQ
V5: bytes: 58, chars-base64: 78, str: AAUU8g6yUfkAAQAAAAAAAAAAAAAAJDFlMTIxNTEwLWM3NDctNGRmZC1hYzBlLTJjZTAyMmE5MTBkMw
V6: bytes: 34, chars-base64: 46, str: AAYUlGWUF9kAAQAAAAAAAAAAfuL7CDhRT165LDYA_id7Iw
```