### PR TITLE
Add frontend to server request rate metrics.

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -135,7 +135,9 @@ class DeleteOperation {
         logger.trace("Making request with correlationId {} to a remote replica {} in {} ",
             deleteRequest.getCorrelationId(), replica.getDataNodeId(), replica.getDataNodeId().getDatacenterName());
         routerMetrics.crossColoRequestCount.inc();
+        routerMetrics.deleteBlobCrossColoRequestRate.mark();
       } else {
+        routerMetrics.deleteBlobLocalColoRequestRate.mark();
         logger.trace("Making request with correlationId {} to a local replica {} ", deleteRequest.getCorrelationId(),
             replica.getDataNodeId());
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -170,7 +170,9 @@ class GetBlobInfoOperation extends GetOperation {
         logger.trace("Making request with correlationId {} to a remote replica {} in {} ", correlationId,
             replicaId.getDataNodeId(), replicaId.getDataNodeId().getDatacenterName());
         routerMetrics.crossColoRequestCount.inc();
+        routerMetrics.getBlobInfoCrossColoRequestRate.mark();
       } else {
+        routerMetrics.getBlobInfoLocalColoRequestRate.mark();
         logger.trace("Making request with correlationId {} to a local replica {} ", correlationId,
             replicaId.getDataNodeId());
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -636,7 +636,9 @@ class GetBlobOperation extends GetOperation {
           logger.trace("Making request with correlationId {} to a remote replica {} in {} ", correlationId,
               replicaId.getDataNodeId(), replicaId.getDataNodeId().getDatacenterName());
           routerMetrics.crossColoRequestCount.inc();
+          routerMetrics.getBlobCrossColoRequestRate.mark();
         } else {
+          routerMetrics.getBlobLocalColoRequestRate.mark();
           logger.trace("Making request with correlationId {} to a local replica {}", correlationId,
               replicaId.getDataNodeId());
         }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -52,6 +52,19 @@ public class NonBlockingRouterMetrics {
   public final Meter deleteBlobNotOriginateLocalOperationRate;
   public final Meter ttlUpdateBlobNotOriginateLocalOperationRate;
 
+  // Request to data nodes rate.
+  public final Meter putBlobLocalColoRequestRate;
+  public final Meter getBlobInfoLocalColoRequestRate;
+  public final Meter getBlobLocalColoRequestRate;
+  public final Meter deleteBlobLocalColoRequestRate;
+  public final Meter updateBlobTtlLocalColoRequestRate;
+
+  public final Meter putBlobCrossColoRequestRate;
+  public final Meter getBlobInfoCrossColoRequestRate;
+  public final Meter getBlobCrossColoRequestRate;
+  public final Meter deleteBlobCrossColoRequestRate;
+  public final Meter updateBlobTtlCrossColoRequestRate;
+
   // Latency.
   public final Histogram putBlobOperationLatencyMs;
   public final Histogram putChunkOperationLatencyMs;
@@ -202,6 +215,28 @@ public class NonBlockingRouterMetrics {
         metricRegistry.meter(MetricRegistry.name(DeleteOperation.class, "DeleteBlobNotOriginateLocalOperationRate"));
     ttlUpdateBlobNotOriginateLocalOperationRate = metricRegistry.meter(
         MetricRegistry.name(TtlUpdateOperation.class, "TtlUpdateBlobNotOriginateLocalOperationRate"));
+
+    // Request to data nodes rate.
+    putBlobLocalColoRequestRate =
+        metricRegistry.meter(MetricRegistry.name(PutOperation.class, "putBlobLocalColoRequestRate"));
+    putBlobCrossColoRequestRate =
+        metricRegistry.meter(MetricRegistry.name(PutOperation.class, "putBlobCrossColoRequestRate"));
+    getBlobInfoLocalColoRequestRate =
+        metricRegistry.meter(MetricRegistry.name(GetBlobInfoOperation.class, "getBlobInfoLocalColoRequestRate"));
+    getBlobInfoCrossColoRequestRate =
+        metricRegistry.meter(MetricRegistry.name(GetBlobInfoOperation.class, "getBlobInfoCrossColoRequestRate"));
+    getBlobLocalColoRequestRate =
+        metricRegistry.meter(MetricRegistry.name(GetBlobOperation.class, "getBlobLocalColoRequestRate"));
+    getBlobCrossColoRequestRate =
+        metricRegistry.meter(MetricRegistry.name(GetBlobOperation.class, "getBlobCrossColoRequestRate"));
+    deleteBlobLocalColoRequestRate =
+        metricRegistry.meter(MetricRegistry.name(DeleteOperation.class, "deleteBlobLocalColoRequestRate"));
+    deleteBlobCrossColoRequestRate =
+        metricRegistry.meter(MetricRegistry.name(DeleteOperation.class, "deleteBlobCrossColoRequestRate"));
+    updateBlobTtlLocalColoRequestRate =
+        metricRegistry.meter(MetricRegistry.name(TtlUpdateOperation.class, "updateBlobTtlLocalColoRequestRate"));
+    updateBlobTtlCrossColoRequestRate =
+        metricRegistry.meter(MetricRegistry.name(TtlUpdateOperation.class, "updateBlobTtlCrossColoRequestRate"));
 
     // Latency.
     putBlobOperationLatencyMs =

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
@@ -129,7 +129,9 @@ class TtlUpdateOperation {
         LOGGER.trace("Making request with correlationId {} to a remote replica {} in {} ",
             ttlUpdateRequest.getCorrelationId(), replica.getDataNodeId(), replica.getDataNodeId().getDatacenterName());
         routerMetrics.crossColoRequestCount.inc();
+        routerMetrics.updateBlobTtlCrossColoRequestRate.mark();
       } else {
+        routerMetrics.updateBlobTtlLocalColoRequestRate.mark();
         LOGGER.trace("Making request with correlationId {} to a local replica {} ", ttlUpdateRequest.getCorrelationId(),
             replica.getDataNodeId());
       }


### PR DESCRIPTION
To tune `AdaptiveOperationTracker`, we need to know:
1. Request rate from frontend request to local/remote servers.
2. The re-request time threshold. 

This PR is to address 1. 
A ticket has been sent to ask if possible to get 2 by manipulating graphs.  