### PR TITLE
Ignore dynamic fields when comparing InstanceConfigs

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -156,7 +156,7 @@ public class ClusterMapConfig {
    * The current xid for this cluster manager. Any changes beyond this xid will be ignored by the cluster manager.
    */
   @Config("clustermap.current.xid")
-  @Default("Long.MAX")
+  @Default("Long.MAX_VALUE")
   public final Long clustermapCurrentXid;
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -142,16 +142,19 @@ public class ClusterMapUtils {
   }
 
   /**
-   * Get the list of sealed replicas on a given instance.
+   * Get the list of sealed replicas on a given instance. This is guaranteed to return a non-null list. It would return
+   * an empty list if there are no sealed replicas or if the field itself is absent for this instance.
    * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
    * @return the list of sealed replicas.
    */
   static List<String> getSealedReplicas(InstanceConfig instanceConfig) {
-    return instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
+    List<String> sealedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
+    return sealedReplicas == null ? Collections.emptyList() : sealedReplicas;
   }
 
   /**
-   * Get the list of stopped replicas on a given instance.
+   * Get the list of stopped replicas on a given instance. This is guaranteed to return a non-null list. It would return
+   * an empty list if there are no stopped replicas or if the field itself is absent for this instance.
    * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
    * @return the list of stopped replicas.
    */

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -59,6 +59,7 @@ public class ClusterMapUtils {
   static final String DATACENTER_ID_STR = "id";
   static final String SCHEMA_VERSION_STR = "schemaVersion";
   static final String XID_STR = "xid";
+  static final long DEFAULT_XID = Long.MIN_VALUE;
   static final int MIN_PORT = 1025;
   static final int MAX_PORT = 65535;
   static final long MIN_REPLICA_CAPACITY_IN_BYTES = 1024 * 1024 * 1024L;
@@ -195,7 +196,7 @@ public class ClusterMapUtils {
    */
   static long getXid(InstanceConfig instanceConfig) {
     String xid = instanceConfig.getRecord().getSimpleField(XID_STR);
-    return xid == null ? Long.MIN_VALUE : Long.valueOf(xid);
+    return xid == null ? DEFAULT_XID : Long.valueOf(xid);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DataNode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DataNode.java
@@ -86,7 +86,7 @@ class DataNode implements DataNodeId {
     this.ports.put(PortType.PLAINTEXT, new Port(portNum, PortType.PLAINTEXT));
     populatePorts(jsonObject);
     this.rackId = jsonObject.optString("rackId", null);
-    this.xid = jsonObject.optLong("xid", Long.MIN_VALUE);
+    this.xid = jsonObject.optLong("xid", ClusterMapUtils.DEFAULT_XID);
 
     validate();
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -505,6 +505,9 @@ class HelixBootstrapUpgradeUtil {
           ArrayList<String> newInstances = new ArrayList<>(instanceSetInStatic);
           Collections.shuffle(newInstances);
           resourceIs.setPreferenceList(partitionName, newInstances);
+          // Existing resources may not have ANY_LIVEINSTANCE set as the numReplicas (which allows for different replication
+          // for different partitions under the same resource). So set it here.
+          resourceIs.setReplicas(ResourceConfig.ResourceConfigConstants.ANY_LIVEINSTANCE.toString());
           resourceModified = true;
         }
       }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -508,7 +508,7 @@ class HelixBootstrapUpgradeUtil {
           resourceModified = true;
         }
       }
-      if (resourceModified) {
+      if (!dryRun && resourceModified) {
         if (resourceIs.getPartitionSet().isEmpty()) {
           dcAdmin.dropResource(clusterName, resourceName);
           resourcesDropped++;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -419,13 +419,7 @@ class HelixBootstrapUpgradeUtil {
       InstanceConfig instanceConfigInHelix = dcAdmin.getInstanceConfig(clusterName, instanceName);
       InstanceConfig instanceConfigFromStatic =
           createInstanceConfigFromStaticInfo(dcToInstanceNameToDataNodeId.get(dcName).get(instanceName),
-              partitionsToInstancesInDc);
-      // Note about the following check: This compares ZNode data for exact equality, which suffices for now.
-      // However, in the future, this needs to discount comparisons for certain things that are dynamically set by
-      // instances (and hence will have outdated information in the static map). Such as
-      // 1. RO/RW status of replicas.
-      // 2. Replica availability (for which support has not yet been added).
-      // 3. xid.
+              partitionsToInstancesInDc, instanceToDiskReplicasMap, instanceConfigInHelix);
       if (!instanceConfigFromStatic.getRecord().equals(instanceConfigInHelix.getRecord())) {
         info("Instance {} already present in Helix, but InstanceConfig has changed, updating. Remaining instances: {}",
             instanceName, --totalInstances);
@@ -445,7 +439,7 @@ class HelixBootstrapUpgradeUtil {
     for (String instanceName : instancesInStatic) {
       InstanceConfig instanceConfigFromStatic =
           createInstanceConfigFromStaticInfo(dcToInstanceNameToDataNodeId.get(dcName).get(instanceName),
-              partitionsToInstancesInDc);
+              partitionsToInstancesInDc, instanceToDiskReplicasMap, null);
       info("Instance {} is new, adding to Helix. Remaining instances: {}", instanceName, --totalInstances);
       if (!dryRun) {
         dcAdmin.addInstance(clusterName, instanceConfigFromStatic);
@@ -570,10 +564,16 @@ class HelixBootstrapUpgradeUtil {
    * Create an {@link InstanceConfig} for the given node from the static cluster information.
    * @param node the {@link DataNodeId}
    * @param partitionToInstances the map of partitions to instances that will be populated for this instance.
+   * @param instanceToDiskReplicasMap the map of instances to the map of disk to set of replicas.
+   * @param referenceInstanceConfig the InstanceConfig used to set the fields that are not derived from the json files.
+   *                                These are the SEALED state and STOPPED_REPLICAS configurations. If this field is null,
+   *                                then these fields are derived from the json files. This can happen if this is a newly
+   *                                added node.
    * @return the constructed {@link InstanceConfig}
    */
-  private InstanceConfig createInstanceConfigFromStaticInfo(DataNodeId node,
-      Map<String, Set<String>> partitionToInstances) {
+  static InstanceConfig createInstanceConfigFromStaticInfo(DataNodeId node,
+      Map<String, Set<String>> partitionToInstances,
+      Map<String, Map<DiskId, SortedSet<Replica>>> instanceToDiskReplicasMap, InstanceConfig referenceInstanceConfig) {
     String instanceName = getInstanceName(node);
     InstanceConfig instanceConfig = new InstanceConfig(instanceName);
     instanceConfig.setHostName(node.getHostname());
@@ -583,12 +583,16 @@ class HelixBootstrapUpgradeUtil {
     }
     instanceConfig.getRecord().setSimpleField(ClusterMapUtils.DATACENTER_STR, node.getDatacenterName());
     instanceConfig.getRecord().setSimpleField(ClusterMapUtils.RACKID_STR, node.getRackId());
-    instanceConfig.getRecord().setSimpleField(ClusterMapUtils.XID_STR, Long.toString(node.getXid()));
+    long xid = node.getXid();
+    if (xid != ClusterMapUtils.DEFAULT_XID) {
+      // Set the XID only if it is not the default, in order to avoid unnecessary updates.
+      instanceConfig.getRecord().setSimpleField(ClusterMapUtils.XID_STR, Long.toString(node.getXid()));
+    }
     instanceConfig.getRecord()
         .setSimpleField(ClusterMapUtils.SCHEMA_VERSION_STR, Integer.toString(ClusterMapUtils.CURRENT_SCHEMA_VERSION));
 
     List<String> sealedPartitionsList = new ArrayList<>();
-
+    List<String> stoppedReplicasList = new ArrayList<>();
     if (instanceToDiskReplicasMap.containsKey(instanceName)) {
       Map<String, Map<String, String>> diskInfos = new HashMap<>();
       for (HashMap.Entry<DiskId, SortedSet<Replica>> diskToReplicas : instanceToDiskReplicasMap.get(instanceName)
@@ -607,7 +611,7 @@ class HelixBootstrapUpgradeUtil {
               .append(ClusterMapUtils.REPLICAS_STR_SEPARATOR)
               .append(replica.getPartition().getPartitionClass())
               .append(ClusterMapUtils.REPLICAS_DELIM_STR);
-          if (replica.isSealed()) {
+          if (referenceInstanceConfig == null && replica.isSealed()) {
             sealedPartitionsList.add(Long.toString(replica.getPartition().getId()));
           }
           partitionToInstances.computeIfAbsent(Long.toString(replica.getPartition().getId()), k -> new HashSet<>())
@@ -621,8 +625,14 @@ class HelixBootstrapUpgradeUtil {
       }
       instanceConfig.getRecord().setMapFields(diskInfos);
     }
+
+    // Set the fields that need to be preserved from the referenceInstanceConfig.
+    if (referenceInstanceConfig != null) {
+      sealedPartitionsList = referenceInstanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
+      stoppedReplicasList = referenceInstanceConfig.getRecord().getListField(ClusterMapUtils.STOPPED_REPLICAS_STR);
+    }
     instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, sealedPartitionsList);
-    instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, new ArrayList<>());
+    instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, stoppedReplicasList);
     return instanceConfig;
   }
 
@@ -768,19 +778,13 @@ class HelixBootstrapUpgradeUtil {
       ensureOrThrow(
           Objects.equals(dataNode.getRackId(), instanceConfig.getRecord().getSimpleField(ClusterMapUtils.RACKID_STR)),
           "Rack Id mismatch for instance " + instanceName);
-      ensureOrThrow(
-          Objects.equals(Long.toString(dataNode.getXid()), instanceConfig.getRecord().getSimpleField(ClusterMapUtils.XID_STR)),
-          "Xid mismatch for instance " + instanceName);
-      Set<String> sealedReplicasInHelix =
-          new HashSet<>(instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR));
-      Set<String> sealedReplicasInClusterMap = new HashSet<>();
-      for (Replica replica : staticClusterMap.getReplicas(dataNodeId)) {
-        if (replica.getPartition().partitionState.equals(PartitionState.READ_ONLY)) {
-          sealedReplicasInClusterMap.add(Long.toString(replica.getPartition().getId()));
-        }
+
+      String xidInHelix = instanceConfig.getRecord().getSimpleField(ClusterMapUtils.XID_STR);
+      if (xidInHelix == null) {
+        xidInHelix = Long.toString(ClusterMapUtils.DEFAULT_XID);
       }
-      ensureOrThrow(sealedReplicasInClusterMap.equals(sealedReplicasInHelix),
-          "Sealed replicas info mismatch for " + "instance " + instanceName);
+      ensureOrThrow(Objects.equals(Long.toString(dataNode.getXid()), xidInHelix),
+          "Xid mismatch for instance " + instanceName);
     }
     if (expectMoreInHelixDuringValidate) {
       ensureOrThrow(allInstancesInHelix.equals(instancesNotForceRemovedByDc.get(dc.getName())),

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -631,8 +631,8 @@ class HelixBootstrapUpgradeUtil {
 
     // Set the fields that need to be preserved from the referenceInstanceConfig.
     if (referenceInstanceConfig != null) {
-      sealedPartitionsList = referenceInstanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
-      stoppedReplicasList = referenceInstanceConfig.getRecord().getListField(ClusterMapUtils.STOPPED_REPLICAS_STR);
+      sealedPartitionsList = ClusterMapUtils.getSealedReplicas(referenceInstanceConfig);
+      stoppedReplicasList = ClusterMapUtils.getStoppedReplicas(referenceInstanceConfig);
     }
     instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, sealedPartitionsList);
     instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, stoppedReplicasList);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -117,10 +117,7 @@ class HelixParticipant implements ClusterParticipant {
           "HelixParticipant only works with the AmbryReplica implementation of ReplicaId");
     }
     synchronized (helixAdministrationLock) {
-      List<String> sealedReplicas = getSealedReplicas();
-      if (sealedReplicas == null) {
-        sealedReplicas = new ArrayList<>();
-      }
+      List<String> sealedReplicas = new ArrayList<>(getSealedReplicas());
       String partitionId = replicaId.getPartitionId().toPathString();
       boolean success = true;
       if (!isSealed && sealedReplicas.contains(partitionId)) {
@@ -178,7 +175,7 @@ class HelixParticipant implements ClusterParticipant {
 
   /**
    * Get the list of sealed replicas from the HelixAdmin.
-   * @return list of sealed replicas from HelixAdmin
+   * @return list of sealed replicas from HelixAdmin.
    */
   @Override
   public List<String> getSealedReplicas() {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
@@ -100,15 +100,15 @@ public class HelixParticipantTest {
     String instanceName = ClusterMapUtils.getInstanceName(hostname, port);
     HelixParticipant helixParticipant =
         new HelixParticipant(new ClusterMapConfig(new VerifiableProperties(props)), helixManagerFactory);
-    helixParticipant.participate(Collections.EMPTY_LIST);
+    helixParticipant.participate(Collections.emptyList());
     HelixManager helixManager = helixManagerFactory.getZKHelixManager(null, null, null, null);
     HelixAdmin helixAdmin = helixManager.getClusterManagmentTool();
     InstanceConfig instanceConfig = new InstanceConfig("someInstanceId");
     helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
 
-    //Make sure the current sealedReplicas list is null
+    //Make sure the current sealedReplicas list is empty
     List<String> sealedReplicas = helixParticipant.getSealedReplicas();
-    assertNull("sealedReplicas is not null", sealedReplicas);
+    assertEquals("sealedReplicas should be empty", Collections.emptyList(), sealedReplicas);
 
     String listName = "sealedReplicas";
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
@@ -192,18 +192,18 @@ public class HelixParticipantTest {
     HelixParticipant helixParticipantDummy =
         new HelixParticipant(new ClusterMapConfig(new VerifiableProperties(propsDummy)), helixManagerFactory);
     HelixParticipant helixParticipantSpy = Mockito.spy(helixParticipant);
-    helixParticipant.participate(Collections.EMPTY_LIST);
-    helixParticipantDummy.participate(Collections.EMPTY_LIST);
-    helixParticipantSpy.participate(Collections.EMPTY_LIST);
+    helixParticipant.participate(Collections.emptyList());
+    helixParticipantDummy.participate(Collections.emptyList());
+    helixParticipantSpy.participate(Collections.emptyList());
     HelixManager helixManager = helixManagerFactory.getZKHelixManager(null, null, null, null);
     HelixAdmin helixAdmin = helixManager.getClusterManagmentTool();
     InstanceConfig instanceConfig = new InstanceConfig("testInstanceId");
     helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
     helixAdmin.setInstanceConfig(clusterName, instanceNameDummy, null);
 
-    //Make sure the current stoppedReplicas list is null
+    //Make sure the current stoppedReplicas list is non-null and empty
     List<String> stoppedReplicas = helixParticipant.getStoppedReplicas();
-    assertTrue("stoppedReplicas list should be empty", stoppedReplicas.isEmpty());
+    assertEquals("stoppedReplicas list should be empty", Collections.emptyList(), stoppedReplicas);
 
     String listName = "stoppedReplicas list";
 
@@ -275,7 +275,7 @@ public class HelixParticipantTest {
     helixManagerFactory.helixManager.beBad = true;
     HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, helixManagerFactory);
     try {
-      helixParticipant.participate(Collections.EMPTY_LIST);
+      helixParticipant.participate(Collections.emptyList());
       fail("Participation should have failed");
     } catch (IOException e) {
       // OK
@@ -310,7 +310,7 @@ public class HelixParticipantTest {
   public void testHelixParticipant() throws Exception {
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     HelixParticipant participant = new HelixParticipant(clusterMapConfig, helixManagerFactory);
-    participant.participate(Collections.EMPTY_LIST);
+    participant.participate(Collections.emptyList());
     MockHelixManager helixManager = helixManagerFactory.helixManager;
     assertTrue(helixManager.isConnected());
     assertEquals(LeaderStandbySMD.name, helixManager.stateModelDef);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -184,7 +184,8 @@ public class TestUtils {
       int numRacks, HardwareState hardwareState, JSONArray disks) throws JSONException {
     JSONArray jsonArray = new JSONArray();
     for (int i = 0; i < dataNodeCount; ++i) {
-      jsonArray.put(getJsonDataNode(hostname, basePort + i, sslPort + i, i % numRacks, DEFAULT_XID, hardwareState, disks));
+      jsonArray.put(
+          getJsonDataNode(hostname, basePort + i, sslPort + i, i % numRacks, DEFAULT_XID, hardwareState, disks));
     }
     return jsonArray;
   }
@@ -481,6 +482,8 @@ public class TestUtils {
 
     private HardwareLayout hardwareLayout;
 
+    ClusterMapConfig clusterMapConfig;
+
     protected JSONArray getDisks() throws JSONException {
       return getJsonArrayDisks(diskCount, "/mnt", HardwareState.AVAILABLE, diskCapacityInBytes);
     }
@@ -540,8 +543,9 @@ public class TestUtils {
       properties.setProperty("clustermap.cluster.name", "test");
       properties.setProperty("clustermap.datacenter.name", "dc1");
       properties.setProperty("clustermap.host.name", "localhost");
-      this.hardwareLayout = new HardwareLayout(getJsonHardwareLayout(clusterName, getDatacenters(true)),
-          new ClusterMapConfig(new VerifiableProperties(properties)));
+      clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(properties));
+      this.hardwareLayout =
+          new HardwareLayout(getJsonHardwareLayout(clusterName, getDatacenters(true)), clusterMapConfig);
     }
 
     void addNewDataNodes(int i) throws JSONException {

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -153,8 +153,12 @@ public class HelixBootstrapUpgradeToolTest {
     // Assert that sealed list being different does not affect equality
     List<String> sealedList = Arrays.asList("5", "10");
     referenceInstanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, sealedList);
+    // set the field to null. The created InstanceConfig should not have null fields.
+    referenceInstanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, null);
     instanceConfig = HelixBootstrapUpgradeUtil.createInstanceConfigFromStaticInfo(dataNode, partitionToInstances,
         Collections.emptyMap(), referenceInstanceConfig);
+    // Stopped replicas should be an empty list and not null, so set that in referenceInstanceConfig for comparison.
+    referenceInstanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, Collections.emptyList());
     assertEquals(instanceConfig.getRecord(), referenceInstanceConfig.getRecord());
 
     // Assert that stopped list being different does not affect equality


### PR DESCRIPTION
When comparing InstanceConfig generated from json files with what
exists in Helix in order to determine if an update is necessary,
ignore the dynamic fields such as sealed lists and stopped lists,
since those are from now on Helix-only fields.