### PR TITLE
Separating unconditional throttle cfg b/w inter & intra dc replica threads

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -60,21 +60,30 @@ public class ReplicationConfig {
   public final int replicationTokenFlushDelaySeconds;
 
   /**
-   * The time to sleep between replication cycles to throttle the replica thread
+   * The time (in ms) to sleep between replication cycles to throttle the replica thread in case the thread handles
+   * intra datacenter replicas
    */
-  @Config("replication.replica.thread.throttle.sleep.duration.ms")
+  @Config("replication.intra.replica.thread.throttle.sleep.duration.ms")
   @Default("0")
-  public final long replicationReplicaThreadThrottleSleepDurationMs;
+  public final long replicationIntraReplicaThreadThrottleSleepDurationMs;
 
   /**
-   * The time to sleep between replication cycles when the replica thread is not doing any useful work
+   * The time (in ms) to sleep between replication cycles to throttle the replica thread in case the thread handles
+   * inter datacenter replicas
+   */
+  @Config("replication.inter.replica.thread.throttle.sleep.duration.ms")
+  @Default("0")
+  public final long replicationInterReplicaThreadThrottleSleepDurationMs;
+
+  /**
+   * The time (in ms) to sleep between replication cycles when the replica thread is not doing any useful work
    */
   @Config("replication.replica.thread.idle.sleep.duration.ms")
   @Default("0")
   public final long replicationReplicaThreadIdleSleepDurationMs;
 
   /**
-   * The time to temporarily disable replication for a replica in order to reduce wasteful network calls
+   * The time (in ms) to temporarily disable replication for a replica in order to reduce wasteful network calls
    */
   @Config("replication.synced.replica.backoff.duration.ms")
   @Default("0")
@@ -103,12 +112,14 @@ public class ReplicationConfig {
         verifiableProperties.getIntInRange("replication.token.flush.interval.seconds", 300, 5, Integer.MAX_VALUE);
     replicationTokenFlushDelaySeconds =
         verifiableProperties.getIntInRange("replication.token.flush.delay.seconds", 5, 1, Integer.MAX_VALUE);
-    replicationReplicaThreadThrottleSleepDurationMs =
-        verifiableProperties.getLongInRange("replication.replica.thread.throttle.sleep.duration.ms", 0, 0,
+    replicationIntraReplicaThreadThrottleSleepDurationMs =
+        verifiableProperties.getLongInRange("replication.intra.replica.thread.throttle.sleep.duration.ms", 0, 0,
+            Long.MAX_VALUE);
+    replicationInterReplicaThreadThrottleSleepDurationMs =
+        verifiableProperties.getLongInRange("replication.inter.replica.thread.throttle.sleep.duration.ms", 0, 0,
             Long.MAX_VALUE);
     replicationReplicaThreadIdleSleepDurationMs =
-        verifiableProperties.getLongInRange("replication.replica.thread.idle.sleep.duration.ms", 0, 0,
-            Long.MAX_VALUE);
+        verifiableProperties.getLongInRange("replication.replica.thread.idle.sleep.duration.ms", 0, 0, Long.MAX_VALUE);
     replicationSyncedReplicaBackoffDurationMs =
         verifiableProperties.getLongInRange("replication.synced.replica.backoff.duration.ms", 0, 0, Long.MAX_VALUE);
     replicationFetchSizeInBytes =

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.replication;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.github.ambry.clustermap.ClusterMap;
@@ -104,9 +105,12 @@ class ReplicaThread implements Runnable {
   private final boolean replicatingOverSsl;
   private final String datacenterName;
   private final long threadThrottleDurationMs;
+  private final Time time;
+  private final Counter throttleCount;
+  private final Counter syncedBackOffCount;
+  private final Counter idleCount;
   private final ReentrantLock lock = new ReentrantLock();
   private final Condition pauseCondition = lock.newCondition();
-  private final Time time;
 
   private volatile boolean allDisabled = false;
 
@@ -142,9 +146,17 @@ class ReplicaThread implements Runnable {
       }
     }
     allReplicatedPartitions = Collections.unmodifiableSet(partitions);
-    threadThrottleDurationMs =
-        replicatingFromRemoteColo ? replicationConfig.replicationInterReplicaThreadThrottleSleepDurationMs
-            : replicationConfig.replicationIntraReplicaThreadThrottleSleepDurationMs;
+    if (replicatingFromRemoteColo) {
+      threadThrottleDurationMs = replicationConfig.replicationInterReplicaThreadThrottleSleepDurationMs;
+      syncedBackOffCount = replicationMetrics.interColoReplicaSyncedBackoffCount;
+      idleCount = replicationMetrics.interColoReplicaThreadIdleCount;
+      throttleCount = replicationMetrics.interColoReplicaThreadThrottleCount;
+    } else {
+      threadThrottleDurationMs = replicationConfig.replicationIntraReplicaThreadThrottleSleepDurationMs;
+      syncedBackOffCount = replicationMetrics.intraColoReplicaSyncedBackoffCount;
+      idleCount = replicationMetrics.intraColoReplicaThreadIdleCount;
+      throttleCount = replicationMetrics.intraColoReplicaThreadThrottleCount;
+    }
   }
 
   /**
@@ -316,10 +328,10 @@ class ReplicaThread implements Runnable {
     long sleepDurationMs = 0;
     if (allCaughtUp && replicationConfig.replicationReplicaThreadIdleSleepDurationMs > 0) {
       sleepDurationMs = replicationConfig.replicationReplicaThreadIdleSleepDurationMs;
-      replicationMetrics.replicaThreadIdleCount.inc();
+      idleCount.inc();
     } else if (threadThrottleDurationMs > 0) {
       sleepDurationMs = threadThrottleDurationMs;
-      replicationMetrics.replicaThreadThrottleCount.inc();
+      throttleCount.inc();
     }
 
     if (sleepDurationMs > 0) {
@@ -756,7 +768,7 @@ class ReplicaThread implements Runnable {
         if (remoteReplicaInfo.getToken().equals(exchangeMetadataResponse.remoteToken)) {
           remoteReplicaInfo.setReEnableReplicationTime(
               time.milliseconds() + replicationConfig.replicationSyncedReplicaBackoffDurationMs);
-          replicationMetrics.replicaSyncedBackoffCount.inc();
+          syncedBackOffCount.inc();
         }
         if (exchangeMetadataResponse.missingStoreKeys.size() > 0) {
           PartitionResponseInfo partitionResponseInfo =

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -593,7 +593,7 @@ public class ReplicationManager {
               Utils.getObj(transformerClassName, storeKeyFactory, threadSpecificKeyConverter);
           ReplicaThread replicaThread =
               new ReplicaThread(threadIdentity, replicasForThread, factory, clusterMap, correlationIdGenerator,
-                  dataNodeId, connectionPool, replicationConfig, replicationMetrics, notification, storeKeyFactory,
+                  dataNodeId, connectionPool, replicationConfig, replicationMetrics, notification,
                   threadSpecificKeyConverter, threadSpecificTransformer, metricRegistry, replicatingOverSsl, datacenter,
                   responseHandler, SystemTime.getInstance());
           if (replicaThreadPools.containsKey(datacenter)) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -113,9 +113,12 @@ public class ReplicationMetrics {
   public final Histogram sslIntraColoTotalReplicationTime;
   public final Counter blobDeletedOnGetCount;
   public final Counter blobAuthorizationFailureCount;
-  public final Counter replicaSyncedBackoffCount;
-  public final Counter replicaThreadIdleCount;
-  public final Counter replicaThreadThrottleCount;
+  public final Counter intraColoReplicaSyncedBackoffCount;
+  public final Counter interColoReplicaSyncedBackoffCount;
+  public final Counter intraColoReplicaThreadIdleCount;
+  public final Counter interColoReplicaThreadIdleCount;
+  public final Counter intraColoReplicaThreadThrottleCount;
+  public final Counter interColoReplicaThreadThrottleCount;
 
   public List<Gauge<Long>> replicaLagInBytes;
   private MetricRegistry registry;
@@ -213,9 +216,18 @@ public class ReplicationMetrics {
     blobDeletedOnGetCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "BlobDeletedOnGetCount"));
     blobAuthorizationFailureCount =
         registry.counter(MetricRegistry.name(ReplicaThread.class, "BlobAuthorizationFailureCount"));
-    replicaSyncedBackoffCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaSyncedBackoffCount"));
-    replicaThreadIdleCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaThreadIdleCount"));
-    replicaThreadThrottleCount = registry.counter(MetricRegistry.name(ReplicaThread.class, "ReplicaThreadThrottleCount"));
+    intraColoReplicaSyncedBackoffCount =
+        registry.counter(MetricRegistry.name(ReplicaThread.class, "IntraColoReplicaSyncedBackoffCount"));
+    interColoReplicaSyncedBackoffCount =
+        registry.counter(MetricRegistry.name(ReplicaThread.class, "InterColoReplicaSyncedBackoffCount"));
+    intraColoReplicaThreadIdleCount =
+        registry.counter(MetricRegistry.name(ReplicaThread.class, "IntraColoReplicaThreadIdleCount"));
+    interColoReplicaThreadIdleCount =
+        registry.counter(MetricRegistry.name(ReplicaThread.class, "InterColoReplicaThreadIdleCount"));
+    intraColoReplicaThreadThrottleCount =
+        registry.counter(MetricRegistry.name(ReplicaThread.class, "IntraColoReplicaThreadThrottleCount"));
+    interColoReplicaThreadThrottleCount =
+        registry.counter(MetricRegistry.name(ReplicaThread.class, "InterColoReplicaThreadThrottleCount"));
     this.registry = registry;
     this.replicaLagInBytes = new ArrayList<Gauge<Long>>();
     populateInvalidMessageMetricForReplicas(replicaIds);
@@ -401,7 +413,7 @@ public class ReplicationMetrics {
     }
   }
 
-  public void populateInvalidMessageMetricForReplicas(List<? extends ReplicaId> replicaIds) {
+  private void populateInvalidMessageMetricForReplicas(List<? extends ReplicaId> replicaIds) {
     for (ReplicaId replicaId : replicaIds) {
       PartitionId partitionId = replicaId.getPartitionId();
       if (!partitionIdToInvalidMessageStreamErrorCounter.containsKey(partitionId)) {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -881,9 +881,10 @@ public class ReplicationTest {
     assertEquals("Replica thread should sleep exactly " + expectedThrottleDurationMs + " since remote has new token",
         currentTimeMs + expectedThrottleDurationMs, time.milliseconds());
 
-    // verify that throttling on the replica thread is disabled when replication.thread.throttle.sleep.duration.ms is 0.
+    // verify that throttling on the replica thread is disabled when relevant configs are 0.
     Properties properties = new Properties();
-    properties.setProperty("replication.thread.throttle.sleep.duration.ms", "0");
+    properties.setProperty("replication.intra.replica.thread.throttle.sleep.duration.ms", "0");
+    properties.setProperty("replication.inter.replica.thread.throttle.sleep.duration.ms", "0");
     config = new ReplicationConfig(new VerifiableProperties(properties));
     replicasAndThread =
         getRemoteReplicasAndReplicaThread(batchSize, clusterMap, localHost, remoteHost, storeKeyConverter, transformer,


### PR DESCRIPTION
Fixes #1055
Also removes a superfluous arg in the `ReplicaThread` constructor

Setting values for inter > intra also allows for a coarse way of preferring local replication over remote