### PR TITLE
Reducing logging size + metrics for size tracking for metadata response

### DIFF
--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponseInfo.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponseInfo.java
@@ -140,14 +140,13 @@ public class ReplicaMetadataResponseInfo {
     sb.append(partitionId);
     sb.append(" ServerErrorCode=").append(errorCode);
     if (errorCode == ServerErrorCode.No_Error) {
-      int size = messageInfoAndMetadataListSerde.getMessageInfoList().size();
+      List<MessageInfo> messageInfos = messageInfoAndMetadataListSerde.getMessageInfoList();
+      int size = messageInfos.size();
       sb.append(" Token=").append(token);
       sb.append(" MessageInfoListSize=").append(size);
       sb.append(" MessagesTotalSize=").append(totalSizeOfAllMessages);
-      sb.append(" MessageInfoListFirstId=")
-          .append(messageInfoAndMetadataListSerde.getMessageInfoList().get(0).getStoreKey());
-      sb.append(" MessageInfoListLastId=")
-          .append(messageInfoAndMetadataListSerde.getMessageInfoList().get(size - 1).getStoreKey());
+      sb.append(" MessageInfoListFirstId=").append(messageInfos.get(0).getStoreKey());
+      sb.append(" MessageInfoListLastId=").append(messageInfos.get(size - 1).getStoreKey());
       sb.append(" RemoteReplicaLagInBytes=").append(remoteReplicaLagInBytes);
     }
     return sb.toString();

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponseInfo.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataResponseInfo.java
@@ -37,6 +37,8 @@ public class ReplicaMetadataResponseInfo {
   private final PartitionId partitionId;
   private final ServerErrorCode errorCode;
 
+  private long totalSizeOfAllMessages = 0;
+
   private static final int Error_Size_InBytes = 2;
   private static final int Remote_Replica_Lag_Size_In_Bytes = 8;
 
@@ -53,6 +55,7 @@ public class ReplicaMetadataResponseInfo {
     messageInfoListSize = messageInfoAndMetadataListSerde.getMessageInfoAndMetadataListSize();
     this.token = findToken;
     this.errorCode = ServerErrorCode.No_Error;
+    messageInfoList.forEach(info -> totalSizeOfAllMessages += info.getSize());
   }
 
   public ReplicaMetadataResponseInfo(PartitionId partitionId, ServerErrorCode errorCode) {
@@ -124,14 +127,27 @@ public class ReplicaMetadataResponseInfo {
         + +partitionId.getBytes().length + Error_Size_InBytes;
   }
 
+  /**
+   * @return the cumulative size of all the messages represented by this response. 0 if the response signifies an error
+   */
+  public long getTotalSizeOfAllMessages() {
+    return totalSizeOfAllMessages;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append(partitionId);
     sb.append(" ServerErrorCode=").append(errorCode);
     if (errorCode == ServerErrorCode.No_Error) {
+      int size = messageInfoAndMetadataListSerde.getMessageInfoList().size();
       sb.append(" Token=").append(token);
-      sb.append(" MessageInfoList=").append(messageInfoAndMetadataListSerde.getMessageInfoList());
+      sb.append(" MessageInfoListSize=").append(size);
+      sb.append(" MessagesTotalSize=").append(totalSizeOfAllMessages);
+      sb.append(" MessageInfoListFirstId=")
+          .append(messageInfoAndMetadataListSerde.getMessageInfoList().get(0).getStoreKey());
+      sb.append(" MessageInfoListLastId=")
+          .append(messageInfoAndMetadataListSerde.getMessageInfoList().get(size - 1).getStoreKey());
       sb.append(" RemoteReplicaLagInBytes=").append(remoteReplicaLagInBytes);
     }
     return sb.toString();

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -433,12 +433,14 @@ public class RequestResponseTest {
     }
 
     long operationTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
-    MessageInfo messageInfo = new MessageInfo(id1, 1000, accountId, containerId, operationTimeMs);
+    int size = 1000;
+    MessageInfo messageInfo = new MessageInfo(id1, size, accountId, containerId, operationTimeMs);
     List<MessageInfo> messageInfoList = new ArrayList<MessageInfo>();
     messageInfoList.add(messageInfo);
     ReplicaMetadataResponseInfo responseInfo = new ReplicaMetadataResponseInfo(
         clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), new MockFindToken(0, 1000),
         messageInfoList, 1000);
+    Assert.assertEquals("Total size of messages not as expected", size, responseInfo.getTotalSizeOfAllMessages());
     List<ReplicaMetadataResponseInfo> replicaMetadataResponseInfoList = new ArrayList<ReplicaMetadataResponseInfo>();
     replicaMetadataResponseInfoList.add(responseInfo);
     ReplicaMetadataResponse response =
@@ -452,9 +454,11 @@ public class RequestResponseTest {
         deserializedReplicaMetadataResponse.getReplicaMetadataResponseInfoList().size());
     Assert.assertEquals("MsgInfo list size in ReplicaMetadataResponse mismatch ", 1,
         deserializedReplicaMetadataResponse.getReplicaMetadataResponseInfoList().get(0).getMessageInfoList().size());
+    Assert.assertEquals("Total size of messages not as expected", size,
+        deserializedReplicaMetadataResponse.getReplicaMetadataResponseInfoList().get(0).getTotalSizeOfAllMessages());
     MessageInfo msgInfo =
         deserializedReplicaMetadataResponse.getReplicaMetadataResponseInfoList().get(0).getMessageInfoList().get(0);
-    Assert.assertEquals("MsgInfo size mismatch ", 1000, msgInfo.getSize());
+    Assert.assertEquals("MsgInfo size mismatch ", size, msgInfo.getSize());
     Assert.assertEquals("MsgInfo key mismatch ", id1, msgInfo.getStoreKey());
     Assert.assertEquals("MsgInfo expiration value mismatch ", Utils.Infinite_Time, msgInfo.getExpirationTimeInMs());
     if (ReplicaMetadataResponse.getCurrentVersion() >= ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_3) {

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -625,7 +625,7 @@ public class AmbryRequests implements RequestAPI {
               metrics.replicationResponseMessageSizeTooHigh.inc();
             }
             replicaMetadataResponseList.add(replicaMetadataResponseInfo);
-            metrics.replicaMetadataTotalSizeOfMessages.update(replicaMetadataResponseInfo.getRemoteReplicaLagInBytes());
+            metrics.replicaMetadataTotalSizeOfMessages.update(replicaMetadataResponseInfo.getTotalSizeOfAllMessages());
           } catch (StoreException e) {
             logger.error(
                 "Store exception on a replica metadata request with error code " + e.getErrorCode() + " for partition "

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -111,6 +111,7 @@ public class ServerMetrics {
   public final Histogram replicaMetadataResponseQueueTimeInMs;
   public final Histogram replicaMetadataSendTimeInMs;
   public final Histogram replicaMetadataTotalTimeInMs;
+  public final Histogram replicaMetadataTotalSizeOfMessages;
 
   public final Histogram triggerCompactionRequestQueueTimeInMs;
   public final Histogram triggerCompactionRequestProcessingTimeInMs;
@@ -197,6 +198,7 @@ public class ServerMetrics {
   public final Counter ttlUpdateAuthorizationFailure;
   public final Counter ttlAlreadyUpdatedError;
   public final Counter ttlUpdateRejectedError;
+  public final Counter replicationResponseMessageSizeTooHigh;
 
   public ServerMetrics(MetricRegistry registry) {
     putBlobRequestQueueTimeInMs =
@@ -324,6 +326,8 @@ public class ServerMetrics {
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "ReplicaMetadataSendTime"));
     replicaMetadataTotalTimeInMs =
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "ReplicaMetadataTotalTime"));
+    replicaMetadataTotalSizeOfMessages =
+        registry.histogram(MetricRegistry.name(AmbryRequests.class, "ReplicaMetadataTotalSizeOfMessages"));
 
     triggerCompactionRequestQueueTimeInMs =
         registry.histogram(MetricRegistry.name(AmbryRequests.class, "TriggerCompactionRequestQueueTimeInMs"));
@@ -447,6 +451,8 @@ public class ServerMetrics {
         registry.counter(MetricRegistry.name(AmbryRequests.class, "TtlUpdateAuthorizationFailure"));
     ttlAlreadyUpdatedError = registry.counter(MetricRegistry.name(AmbryRequests.class, "TtlAlreadyUpdatedError"));
     ttlUpdateRejectedError = registry.counter(MetricRegistry.name(AmbryRequests.class, "TtlUpdateRejectedError"));
+    replicationResponseMessageSizeTooHigh =
+        registry.counter(MetricRegistry.name(AmbryRequests.class, "ReplicationResponseMessageSizeTooHigh"));
   }
 
   /**


### PR DESCRIPTION
1. Condensed the logging in `ReplicaMetadataResponseInfo` in order to re-enable public access logging
2. Re-enabled public access logging
3. Added metrics to track the size of the messages returned in the `ReplicaMetadataResponse`

Helps debug #1048