### PR TITLE
Make replication GetRequest fetch deleted and expired blobs

### DIFF
--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageSievingInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageSievingInputStream.java
@@ -51,6 +51,8 @@ public class MessageSievingInputStream extends InputStream {
   public final Histogram batchMessageSieveTime;
   public final Counter messageSievingCorruptMessagesDiscardedCount;
   public final Counter messageSievingDeprecatedMessagesDiscardedCount;
+  public final Counter messageSievingDeletedMessagesDiscardedCount;
+  public final Counter messageSievingExpiredMessagesDiscardedCount;
 
   /**
    * @param inStream The stream from which bytes need to be read. If the underlying stream is SocketInputStream, it needs
@@ -63,16 +65,18 @@ public class MessageSievingInputStream extends InputStream {
       List<Transformer> transformers, MetricRegistry metricRegistry) throws IOException {
     this.logger = LoggerFactory.getLogger(getClass());
     this.transformers = transformers;
-    singleMessageSieveTime = metricRegistry.histogram(
-        MetricRegistry.name(MessageSievingInputStream.class, "SingleMessageSieveTime"));
-    batchMessageSieveTime = metricRegistry.histogram(
-        MetricRegistry.name(MessageSievingInputStream.class, "BatchMessageSieveTime"));
+    singleMessageSieveTime =
+        metricRegistry.histogram(MetricRegistry.name(MessageSievingInputStream.class, "SingleMessageSieveTime"));
+    batchMessageSieveTime =
+        metricRegistry.histogram(MetricRegistry.name(MessageSievingInputStream.class, "BatchMessageSieveTime"));
     messageSievingCorruptMessagesDiscardedCount = metricRegistry.counter(
-        MetricRegistry.name(MessageSievingInputStream.class,
-            "MessageSievingCorruptMessagesDiscardedCount"));
+        MetricRegistry.name(MessageSievingInputStream.class, "MessageSievingCorruptMessagesDiscardedCount"));
     messageSievingDeprecatedMessagesDiscardedCount = metricRegistry.counter(
-        MetricRegistry.name(MessageSievingInputStream.class,
-            "MessageSievingDeprecatedMessagesDiscardedCount"));
+        MetricRegistry.name(MessageSievingInputStream.class, "MessageSievingDeprecatedMessagesDiscardedCount"));
+    messageSievingDeletedMessagesDiscardedCount = metricRegistry.counter(
+        MetricRegistry.name(MessageSievingInputStream.class, "MessageSievingDeletedMessagesDiscardedCount"));
+    messageSievingExpiredMessagesDiscardedCount = metricRegistry.counter(
+        MetricRegistry.name(MessageSievingInputStream.class, "MessageSievingExpiredMessagesDiscardedCount"));
     sievedStreamSize = 0;
     hasInvalidMessages = false;
     hasDeprecatedMessages = false;
@@ -102,7 +106,15 @@ public class MessageSievingInputStream extends InputStream {
       // @todo: (say, due to corruption). This can help avoid a copy.
       Message msg = new Message(msgInfo, new ByteArrayInputStream(Utils.readBytesFromStream(inStream, msgSize)));
       logger.trace("Read stream for message info " + msgInfo + "  into memory");
-      sieve(msg, msgStreamList, bytesRead);
+      if (msg.getMessageInfo().isDeleted()) {
+        messageSievingDeletedMessagesDiscardedCount.inc();
+        logger.trace("Skipping message with key {}, because it is deleted.", msg.getMessageInfo().getStoreKey());
+      } else if (msg.getMessageInfo().isExpired()) {
+        messageSievingExpiredMessagesDiscardedCount.inc();
+        logger.trace("Skipping message with key {}, because it has expired.", msg.getMessageInfo().getStoreKey());
+      } else {
+        validateAndTransform(msg, msgStreamList, bytesRead);
+      }
       bytesRead += msgSize;
     }
     if (bytesRead != totalMessageListSize) {
@@ -179,7 +191,7 @@ public class MessageSievingInputStream extends InputStream {
    * @param msgOffset the offset of the message in the stream.
    * @throws IOException if an exception was encountered reading or writing bytes to/from streams.
    */
-  private void sieve(Message inMsg, List<InputStream> msgStreamList, int msgOffset) throws IOException {
+  private void validateAndTransform(Message inMsg, List<InputStream> msgStreamList, int msgOffset) throws IOException {
     if (transformers == null || transformers.isEmpty()) {
       // Write the message without any transformations.
       sievedMessageInfoList.add(inMsg.getMessageInfo());

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -720,7 +720,7 @@ class ReplicaThread implements Runnable {
     if (!partitionRequestInfoList.isEmpty()) {
       GetRequest getRequest = new GetRequest(correlationIdGenerator.incrementAndGet(),
           GetRequest.Replication_Client_Id_Prefix + dataNodeId.getHostname(), MessageFormatFlags.All,
-          partitionRequestInfoList, GetOption.None);
+          partitionRequestInfoList, GetOption.Include_All);
       long startTime = SystemTime.getInstance().milliseconds();
       try {
         connectedChannel.send(getRequest);
@@ -801,7 +801,8 @@ class ReplicaThread implements Runnable {
               }
               messageInfoList = validMessageDetectionInputStream.getValidMessageInfoList();
               if (messageInfoList.size() == 0) {
-                logger.error("MessageInfoList is of size 0 as all messages are invalidated or deprecated");
+                logger.error(
+                    "MessageInfoList is of size 0 as all messages are invalidated, deprecated, deleted or expired.");
               } else {
                 writeset = new MessageFormatWriteSet(validMessageDetectionInputStream, messageInfoList, false);
                 remoteReplicaInfo.getLocalStore().put(writeset);

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -675,6 +675,11 @@ public class ReplicationTest {
     }
   }
 
+  /**
+   * Test the case where a blob gets deleted after a replication metadata exchange completes and identifies the blob as
+   * a candidate. The subsequent GetRequest should succeed as Replication makes a Include_All call, and
+   * fixMissingStoreKeys() should succeed without exceptions. The blob should not be put locally.
+   */
   @Test
   public void testDeletionAfterMetadataExchange() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -747,13 +747,13 @@ public class ReplicationTest {
         replicaThread.exchangeMetadata(new MockConnection(remoteHost, batchSize),
             replicasToReplicate.get(remoteHost.dataNodeId));
 
-    Assert.assertEquals(
+    Assert.assertEquals("Actual keys in Exchange Metadata Response different from expected",
         idsToExpectByPartition.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()),
         responses.stream().map(k -> k.missingStoreKeys).flatMap(Collection::stream).collect(Collectors.toSet()));
 
     // Now delete a message in the remote before doing the Get requests (for every partition). Remove these keys from
     // expected key set. Even though they are requested, they should not go into the local store. However, this cycle
-    // of replication must be successful
+    // of replication must be successful.
     for (PartitionId partitionId : partitionIds) {
       Iterator<StoreKey> iter = idsToExpectByPartition.get(partitionId).iterator();
       iter.next();
@@ -766,7 +766,117 @@ public class ReplicationTest {
         replicasToReplicate.get(remoteHost.dataNodeId), responses);
 
     Assert.assertEquals(idsToExpectByPartition.keySet(), localHost.infosByPartition.keySet());
-    Assert.assertEquals(
+    Assert.assertEquals("Actual keys in Exchange Metadata Response different from expected",
+        idsToExpectByPartition.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()),
+        localHost.infosByPartition.values()
+            .stream()
+            .flatMap(Collection::stream)
+            .map(MessageInfo::getStoreKey)
+            .collect(Collectors.toSet()));
+  }
+
+  /**
+   * Test the case where a blob expires after a replication metadata exchange completes and identifies the blob as
+   * a candidate. The subsequent GetRequest should succeed as Replication makes a Include_All call, and
+   * fixMissingStoreKeys() should succeed without exceptions. The blob should not be put locally.
+   */
+  @Test
+  public void testExpiryAfterMetadataExchange() throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    Pair<Host, Host> localAndRemoteHosts = getLocalAndRemoteHosts(clusterMap);
+    Host localHost = localAndRemoteHosts.getFirst();
+    Host remoteHost = localAndRemoteHosts.getSecond();
+    MockStoreKeyConverterFactory storeKeyConverterFactory = new MockStoreKeyConverterFactory(null, null);
+    storeKeyConverterFactory.setConversionMap(new HashMap<>());
+    storeKeyConverterFactory.setReturnInputIfAbsent(true);
+    MockStoreKeyConverterFactory.MockStoreKeyConverter storeKeyConverter =
+        storeKeyConverterFactory.getStoreKeyConverter();
+
+    short blobIdVersion = CommonTestUtils.getCurrentBlobIdVersion();
+    List<PartitionId> partitionIds = clusterMap.getWritablePartitionIds(null);
+    Map<PartitionId, Set<StoreKey>> idsToExpectByPartition = new HashMap<>();
+    for (int i = 0; i < partitionIds.size(); i++) {
+      PartitionId partitionId = partitionIds.get(i);
+
+      // add 5 messages to remote host only.
+      Set<StoreKey> expectedIds =
+          new HashSet<>(addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 5));
+
+      short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+      short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+      boolean toEncrypt = TestUtils.RANDOM.nextBoolean();
+
+      // add an expired message to the remote host only
+      StoreKey id =
+          new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId,
+              containerId, partitionId, toEncrypt, BlobId.BlobDataType.DATACHUNK);
+      Pair<ByteBuffer, MessageInfo> putMsgInfo = getPutMessage(id, accountId, containerId, toEncrypt);
+      remoteHost.addMessage(partitionId,
+          new MessageInfo(id, putMsgInfo.getFirst().remaining(), 1, accountId, containerId,
+              putMsgInfo.getSecond().getOperationTimeMs()), putMsgInfo.getFirst());
+
+      // add 3 messages to the remote host only
+      expectedIds.addAll(addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 3));
+
+      // delete the very first blob in the remote host only (and delete it from expected list)
+      Iterator<StoreKey> iter = expectedIds.iterator();
+      addDeleteMessagesToReplicasOfPartition(partitionId, iter.next(), Collections.singletonList(remoteHost));
+      iter.remove();
+
+      // PUT and DELETE a blob in the remote host only
+      id = addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 1).get(0);
+      addDeleteMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost));
+
+      idsToExpectByPartition.put(partitionId, expectedIds);
+    }
+
+    // do the exchange metadata.
+
+    StoreKeyFactory storeKeyFactory = new BlobIdFactory(clusterMap);
+    Transformer transformer = new BlobIdTransformer(storeKeyFactory, storeKeyConverter);
+    int batchSize = 400;
+    Pair<Map<DataNodeId, List<RemoteReplicaInfo>>, ReplicaThread> replicasAndThread =
+        getRemoteReplicasAndReplicaThread(batchSize, clusterMap, localHost, remoteHost, storeKeyConverter, transformer,
+            null);
+    Map<DataNodeId, List<RemoteReplicaInfo>> replicasToReplicate = replicasAndThread.getFirst();
+    ReplicaThread replicaThread = replicasAndThread.getSecond();
+
+    // Do the replica metadata exchange.
+    List<ReplicaThread.ExchangeMetadataResponse> responses =
+        replicaThread.exchangeMetadata(new MockConnection(remoteHost, batchSize),
+            replicasToReplicate.get(remoteHost.dataNodeId));
+
+    Assert.assertEquals("Actual keys in Exchange Metadata Response different from expected",
+        idsToExpectByPartition.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()),
+        responses.stream().map(k -> k.missingStoreKeys).flatMap(Collection::stream).collect(Collectors.toSet()));
+
+    // Now expire a message in the remote before doing the Get requests (for every partition). Remove these keys from
+    // expected key set. Even though they are requested, they should not go into the local store. However, this cycle
+    // of replication must be successful.
+    PartitionId partitionId = idsToExpectByPartition.keySet().iterator().next();
+    Iterator<StoreKey> keySet = idsToExpectByPartition.get(partitionId).iterator();
+    StoreKey keyToExpire = keySet.next();
+    keySet.remove();
+    MessageInfo msgInfoToExpire = null;
+
+    for (MessageInfo info : remoteHost.infosByPartition.get(partitionId)) {
+      if (info.getStoreKey().equals(keyToExpire)) {
+        msgInfoToExpire = info;
+        break;
+      }
+    }
+
+    int i = remoteHost.infosByPartition.get(partitionId).indexOf(msgInfoToExpire);
+    remoteHost.infosByPartition.get(partitionId)
+        .set(i, new MessageInfo(msgInfoToExpire.getStoreKey(), msgInfoToExpire.getSize(), msgInfoToExpire.isDeleted(),
+            msgInfoToExpire.isTtlUpdated(), 1, msgInfoToExpire.getAccountId(), msgInfoToExpire.getContainerId(),
+            msgInfoToExpire.getOperationTimeMs()));
+
+    replicaThread.fixMissingStoreKeys(new MockConnection(remoteHost, batchSize),
+        replicasToReplicate.get(remoteHost.dataNodeId), responses);
+
+    Assert.assertEquals(idsToExpectByPartition.keySet(), localHost.infosByPartition.keySet());
+    Assert.assertEquals("Actual keys in Exchange Metadata Response different from expected",
         idsToExpectByPartition.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()),
         localHost.infosByPartition.values()
             .stream()
@@ -2014,10 +2124,12 @@ public class ReplicationTest {
         for (PartitionRequestInfo requestInfo : getRequest.getPartitionInfoList()) {
           List<MessageInfo> infosForPartition = infosToReturn.get(requestInfo.getPartition());
           PartitionResponseInfo partitionResponseInfo;
-          // To keep things simple, this mock class only checks for the Deleted case (and not the Expired case).
-          if (getRequest.getGetOption().equals(GetOption.None) && infosForPartition.stream()
-              .anyMatch(MessageInfo::isDeleted)) {
+          if (!getRequest.getGetOption().equals(GetOption.Include_All) && !getRequest.getGetOption()
+              .equals(GetOption.Include_Deleted_Blobs) && infosForPartition.stream().anyMatch(MessageInfo::isDeleted)) {
             partitionResponseInfo = new PartitionResponseInfo(requestInfo.getPartition(), ServerErrorCode.Blob_Deleted);
+          } else if (!getRequest.getGetOption().equals(GetOption.Include_All) && !getRequest.getGetOption()
+              .equals(GetOption.Include_Expired_Blobs) && infosForPartition.stream().anyMatch(MessageInfo::isExpired)) {
+            partitionResponseInfo = new PartitionResponseInfo(requestInfo.getPartition(), ServerErrorCode.Blob_Expired);
           } else {
             partitionResponseInfo =
                 new PartitionResponseInfo(requestInfo.getPartition(), infosToReturn.get(requestInfo.getPartition()),


### PR DESCRIPTION
If a blob that is identified as a candidate blob to fetch after
replication metadata exchange gets deleted or expired before the
subsequent batch Get request, then that Get Request fails (with
Blob_Deleted or Blob_Expired error). This ends up wasting a
replication cycle. Instead, pass in Include_All in the batch
Get Request and drop any blobs that got deleted or expired between
the metadata exchange and the Get request at the receiving side
(as part of the sieving and transformation).