### PR TITLE
Adding a method (and impls) to get a snapshot of the ClusterMap

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.MetricRegistry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import org.json.JSONObject;
 
 
 /**
@@ -105,6 +106,12 @@ public interface ClusterMap extends AutoCloseable {
    * Performs the required action for a replica related event.
    */
   void onReplicaEvent(ReplicaId replicaId, ReplicaEventType event);
+
+  /**
+   * @return a snapshot which includes information that the implementation considers relevant. Must necessarily contain
+   * information about nodes, partitions and replicas from each datacenter
+   */
+  JSONObject getSnapshot();
 
   /**
    * Close the cluster map. Any cleanups should be done in this call.

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMapSnapshotConstants.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMapSnapshotConstants.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+/**
+ * List of constants that an implementation of {@link ClusterMap#getSnapshot()} may use
+ */
+public class ClusterMapSnapshotConstants {
+
+  // general
+  // keys
+  public static final String TIMESTAMP_MS = "timeStampMs";
+  public static final String IMPLEMENTATION = "implementation";
+  public static final String CLUSTER_NAME = "clusterName";
+  public static final String DATACENTERS = "datacenters";
+  public static final String PARTITIONS = "partitions";
+  public static final String CAPACITY_BYTES = "capacityBytes";
+  public static final String LIVENESS = "liveness";
+  // values
+  public static final String UP = "up";
+  public static final String DOWN = "down";
+  public static final String NODE_DOWN = "nodeDown";
+  public static final String DISK_DOWN = "diskDown";
+  public static final String SOFT_DOWN = "softDown";
+
+  // datacenters
+  public static final String DATACENTER_NAME = "name";
+  public static final String DATACENTER_ID = "id";
+  public static final String DATACENTER_NODES = "datanodes";
+
+  // datanodes
+  public static final String DATA_NODE_HOSTNAME = "hostname";
+  public static final String DATA_NODE_PORTS = "ports";
+  public static final String DATA_NODE_PORT_CONNECT_TO = "portToConnectTo";
+  public static final String DATA_NODE_DATACENTER = "dc";
+  public static final String DATA_NODE_SSL_ENABLED_DATACENTERS = "sslEnabledDcs";
+  public static final String DATA_NODE_RACK_ID = "rackId";
+  public static final String DATA_NODE_XID = "xid";
+  public static final String DATA_NODE_DISKS = "disks";
+
+  // disks
+  public static final String DISK_NODE = "node";
+  public static final String DISK_MOUNT_PATH = "mountPath";
+
+  // partitions
+  public static final String PARTITION_ID = "id";
+  public static final String PARTITION_CLASS = "class";
+  public static final String PARTITION_WRITE_STATE = "writeState";
+  public static final String PARTITION_REPLICAS = "replicas";
+
+  // replicas
+  // keys
+  public static final String REPLICA_WRITE_STATE = "state";
+  public static final String REPLICA_PATH = "path";
+  public static final String REPLICA_NODE = "node";
+  public static final String REPLICA_PARTITION = "partition";
+  public static final String REPLICA_DISK = "disk";
+  // values
+  public static final String REPLICA_STOPPED = "stopped";
+}

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/DataNodeId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/DataNodeId.java
@@ -14,6 +14,7 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.network.Port;
+import org.json.JSONObject;
 
 
 /**
@@ -83,4 +84,9 @@ public interface DataNodeId extends Resource, Comparable<DataNodeId> {
    * @return the xid associated with this node.
    */
   long getXid();
+
+  /**
+   * @return a snapshot which includes information that the implementation considers relevant.
+   */
+  JSONObject getSnapshot();
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/DataNodeId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/DataNodeId.java
@@ -14,7 +14,6 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.network.Port;
-import org.json.JSONObject;
 
 
 /**
@@ -84,9 +83,4 @@ public interface DataNodeId extends Resource, Comparable<DataNodeId> {
    * @return the xid associated with this node.
    */
   long getXid();
-
-  /**
-   * @return a snapshot which includes information that the implementation considers relevant.
-   */
-  JSONObject getSnapshot();
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/DiskId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/DiskId.java
@@ -13,9 +13,6 @@
  */
 package com.github.ambry.clustermap;
 
-import org.json.JSONObject;
-
-
 /**
  * A DiskId stores {@link ReplicaId}s. Each DiskId is hosted on one specific {@link DataNodeId}. Each DiskId is uniquely
  * identified by its DataNodeId and mount path (the path to this Disk's device on its DataNode).
@@ -42,9 +39,4 @@ public interface DiskId extends Resource {
    * @return the raw capacity in bytes
    */
   long getRawCapacityInBytes();
-
-  /**
-   * @return a snapshot which includes information that the implementation considers relevant.
-   */
-  JSONObject getSnapshot();
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/DiskId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/DiskId.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.clustermap;
 
+import org.json.JSONObject;
+
+
 /**
  * A DiskId stores {@link ReplicaId}s. Each DiskId is hosted on one specific {@link DataNodeId}. Each DiskId is uniquely
  * identified by its DataNodeId and mount path (the path to this Disk's device on its DataNode).
@@ -39,4 +42,9 @@ public interface DiskId extends Resource {
    * @return the raw capacity in bytes
    */
   long getRawCapacityInBytes();
+
+  /**
+   * @return a snapshot which includes information that the implementation considers relevant.
+   */
+  JSONObject getSnapshot();
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionId.java
@@ -14,6 +14,7 @@
 package com.github.ambry.clustermap;
 
 import java.util.List;
+import org.json.JSONObject;
 
 
 /**
@@ -65,4 +66,9 @@ public interface PartitionId extends Resource, Comparable<PartitionId> {
    * @return the partition class that this partition belongs to
    */
   String getPartitionClass();
+
+  /**
+   * @return a snapshot which includes information that the implementation considers relevant.
+   */
+  JSONObject getSnapshot();
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionId.java
@@ -14,7 +14,6 @@
 package com.github.ambry.clustermap;
 
 import java.util.List;
-import org.json.JSONObject;
 
 
 /**
@@ -66,9 +65,4 @@ public interface PartitionId extends Resource, Comparable<PartitionId> {
    * @return the partition class that this partition belongs to
    */
   String getPartitionClass();
-
-  /**
-   * @return a snapshot which includes information that the implementation considers relevant.
-   */
-  JSONObject getSnapshot();
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaId.java
@@ -14,6 +14,7 @@
 package com.github.ambry.clustermap;
 
 import java.util.List;
+import org.json.JSONObject;
 
 
 /**
@@ -89,4 +90,9 @@ public interface ReplicaId {
    * @return true if this replica is in sealed state.
    */
   boolean isSealed();
+
+  /**
+   * @return a snapshot which includes information that the implementation considers relevant.
+   */
+  JSONObject getSnapshot();
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaId.java
@@ -21,7 +21,7 @@ import org.json.JSONObject;
  * A ReplicaId is part of some {@link PartitionId}. The durable state of a ReplicaId is stored in a specific path
  * ("replica path") on a specific device (identified by its "mount path") on a {@link DataNodeId}.
  */
-public interface ReplicaId {
+public interface ReplicaId extends Resource {
   /**
    * Gets the PartitionId of which this ReplicaId is a member.
    *
@@ -90,9 +90,4 @@ public interface ReplicaId {
    * @return true if this replica is in sealed state.
    */
   boolean isSealed();
-
-  /**
-   * @return a snapshot which includes information that the implementation considers relevant.
-   */
-  JSONObject getSnapshot();
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/Resource.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/Resource.java
@@ -13,9 +13,16 @@
  */
 package com.github.ambry.clustermap;
 
+import org.json.JSONObject;
+
+
 /**
- * A Resource represents a {@link DiskId}, {@link DataNodeId} or a {@link PartitionId}
+ * A Resource represents a {@link DiskId}, {@link DataNodeId}, a {@link PartitionId} or a {@link ReplicaId}
  */
 
 public interface Resource {
+  /**
+   * @return a snapshot which includes information that the implementation considers relevant.
+   */
+  JSONObject getSnapshot();
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
@@ -21,6 +21,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 
 
 /**
@@ -108,6 +112,18 @@ class AmbryPartition implements PartitionId {
   @Override
   public String getPartitionClass() {
     return partitionClass;
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    JSONObject snapshot = new JSONObject();
+    snapshot.put(PARTITION_ID, toPathString());
+    snapshot.put(PARTITION_WRITE_STATE, getPartitionState().name());
+    snapshot.put(PARTITION_CLASS, getPartitionClass());
+    JSONArray replicas = new JSONArray();
+    getReplicaIds().forEach(replica -> replicas.put(replica.getSnapshot()));
+    snapshot.put(PARTITION_REPLICAS, replicas);
+    return snapshot;
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
@@ -18,7 +18,9 @@ import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import org.json.JSONObject;
 
+import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
 
 
@@ -101,6 +103,32 @@ class AmbryReplica implements ReplicaId, Resource {
   @Override
   public boolean isSealed() {
     return isSealed;
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    JSONObject snapshot = new JSONObject();
+    DataNodeId dataNodeId = getDataNodeId();
+    snapshot.put(REPLICA_NODE, dataNodeId.getHostname() + ":" + dataNodeId.getPort());
+    snapshot.put(REPLICA_PARTITION, getPartitionId().toPathString());
+    snapshot.put(REPLICA_DISK, getDiskId().getMountPath());
+    snapshot.put(REPLICA_PATH, getReplicaPath());
+    snapshot.put(CAPACITY_BYTES, getCapacityInBytes());
+    snapshot.put(REPLICA_WRITE_STATE, isSealed() ? PartitionState.READ_ONLY.name() : PartitionState.READ_WRITE.name());
+    String replicaLiveness = UP;
+    if (dataNodeId.getState() == HardwareState.UNAVAILABLE) {
+      replicaLiveness = NODE_DOWN;
+    } else if (disk.getState() == HardwareState.UNAVAILABLE) {
+      replicaLiveness = DISK_DOWN;
+    } else if (isStopped) {
+      replicaLiveness = REPLICA_STOPPED;
+    } else if (resourceStatePolicy.isHardDown()) {
+      replicaLiveness = DOWN;
+    } else if (resourceStatePolicy.isDown()) {
+      replicaLiveness = SOFT_DOWN;
+    }
+    snapshot.put(LIVENESS, replicaLiveness);
+    return snapshot;
   }
 
   void setSealedState(boolean isSealed) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplica.java
@@ -27,7 +27,7 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
 /**
  * {@link ReplicaId} implementation to use within dynamic cluster managers.
  */
-class AmbryReplica implements ReplicaId, Resource {
+class AmbryReplica implements ReplicaId {
   private final AmbryPartition partition;
   private final AmbryDisk disk;
   private final long capacityBytes;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.clustermap;
 
+import java.util.Collection;
 import java.util.List;
 
 
@@ -34,4 +35,11 @@ interface ClusterManagerCallback {
    * @return the counter for the sealed state change for partitions.
    */
   long getSealedStateChangeCounter();
+
+  /**
+   * Get the list of {@link AmbryDisk}s (all or assoicated with a particular {@link AmbryDataNode}.
+   * @param dataNode if disks of a particular data node is required, {@code null} for all disks.
+   * @return a collection of all the disks in this datacenter.
+   */
+  Collection<AmbryDisk> getDisks(AmbryDataNode dataNode);
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.json.JSONObject;
 
 
 /**
@@ -233,6 +234,13 @@ class CompositeClusterManager implements ClusterMap {
               replicaId.getDataNodeId().getPort(), replicaId.getPartitionId().toString());
       helixClusterManager.onReplicaEvent(ambryReplica, event);
     }
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    // returns the snapshot of the clustermap that will actually be used i.e. static. It is not required or correct to
+    // expect the snapshots from static and helix to match
+    return staticClusterManager.getSnapshot();
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -335,7 +335,7 @@ class HelixClusterManager implements ClusterMap {
       data.put(DATACENTER_NAME, dcName);
       data.put(DATACENTER_ID, dcId);
       JSONArray datanodesInDc = new JSONArray();
-      dcToNodes.get(dcName).forEach(mockDataNodeId -> datanodesInDc.put(mockDataNodeId.getSnapshot()));
+      dcToNodes.get(dcName).forEach(node -> datanodesInDc.put(node.getSnapshot()));
       data.put(DATACENTER_NODES, datanodesInDc);
       datacentersJsonArray.put(data);
     });

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -15,6 +15,7 @@ package com.github.ambry.clustermap;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,9 +46,12 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
 
 
@@ -63,6 +67,7 @@ class HelixClusterManager implements ClusterMap {
   private final MetricRegistry metricRegistry;
   private final ClusterMapConfig clusterMapConfig;
   private final ConcurrentHashMap<String, DcInfo> dcToDcZkInfo = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Set<AmbryDataNode>> dcToNodes = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<Byte, String> dcIdToDcName = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, AmbryPartition> partitionNameToAmbryPartition = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, AmbryDataNode> instanceNameToAmbryDataNode = new ConcurrentHashMap<>();
@@ -319,6 +324,29 @@ class HelixClusterManager implements ClusterMap {
   }
 
   @Override
+  public JSONObject getSnapshot() {
+    JSONObject snapshot = new JSONObject();
+    snapshot.put(IMPLEMENTATION, HelixClusterManager.class.getName());
+    snapshot.put(CLUSTER_NAME, clusterName);
+    snapshot.put(TIMESTAMP_MS, SystemTime.getInstance().milliseconds());
+    JSONArray datacentersJsonArray = new JSONArray();
+    dcIdToDcName.forEach((dcId, dcName) -> {
+      JSONObject data = new JSONObject();
+      data.put(DATACENTER_NAME, dcName);
+      data.put(DATACENTER_ID, dcId);
+      JSONArray datanodesInDc = new JSONArray();
+      dcToNodes.get(dcName).forEach(mockDataNodeId -> datanodesInDc.put(mockDataNodeId.getSnapshot()));
+      data.put(DATACENTER_NODES, datanodesInDc);
+      datacentersJsonArray.put(data);
+    });
+    snapshot.put(DATACENTERS, datacentersJsonArray);
+    JSONArray partitionsJsonArray = new JSONArray();
+    getAllPartitionIds(null).forEach(partitionId -> partitionsJsonArray.put(partitionId.getSnapshot()));
+    snapshot.put(PARTITIONS, partitionsJsonArray);
+    return snapshot;
+  }
+
+  @Override
   public PartitionId getPartitionIdFromStream(InputStream stream) throws IOException {
     byte[] partitionBytes = AmbryPartition.readPartitionBytesFromStream(stream);
     AmbryPartition partition = partitionMap.get(ByteBuffer.wrap(partitionBytes));
@@ -434,9 +462,10 @@ class HelixClusterManager implements ClusterMap {
               AmbryDataNode datanode =
                   new AmbryDataNode(getDcName(instanceConfig), clusterMapConfig, instanceConfig.getHostName(),
                       Integer.valueOf(instanceConfig.getPort()), getRackId(instanceConfig),
-                      getSslPortStr(instanceConfig), instanceXid);
+                      getSslPortStr(instanceConfig), instanceXid, helixClusterManagerCallback);
               initializeDisksAndReplicasOnNode(datanode, instanceConfig);
               instanceNameToAmbryDataNode.put(instanceName, datanode);
+              dcToNodes.computeIfAbsent(datanode.getDatacenterName(), s -> new HashSet<>()).add(datanode);
               allInstances.add(instanceName);
             } else {
               logger.info(
@@ -711,10 +740,11 @@ class HelixClusterManager implements ClusterMap {
       return count;
     }
 
-    /**
-     * @return a collection of all the disks in this datacenter.
-     */
-    Collection<AmbryDisk> getDisks() {
+    @Override
+    public Collection<AmbryDisk> getDisks(AmbryDataNode dataNode) {
+      if (dataNode != null) {
+        return ambryDataNodeToAmbryDisks.get(dataNode);
+      }
       List<AmbryDisk> disksToReturn = new ArrayList<>();
       for (Set<AmbryDisk> disks : ambryDataNodeToAmbryDisks.values()) {
         disksToReturn.addAll(disks);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
@@ -75,8 +75,7 @@ class HelixClusterManagerMetrics {
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getReplicaIdsMismatchCount"));
     getDataNodeIdsMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getDataNodeIdsMismatchCount"));
-    ignoredUpdatesCount =
-        registry.counter(MetricRegistry.name(HelixClusterManager.class, "ignoredUpdatesCount"));
+    ignoredUpdatesCount = registry.counter(MetricRegistry.name(HelixClusterManager.class, "ignoredUpdatesCount"));
   }
 
   void initializeInstantiationMetric(final boolean instantiated) {
@@ -87,8 +86,7 @@ class HelixClusterManagerMetrics {
 
   void initializeXidMetric(final AtomicLong currentXid) {
     helixClusterManagerCurrentXid = currentXid::get;
-    registry.register(MetricRegistry.name(HelixClusterManager.class, "currentXid"),
-        helixClusterManagerCurrentXid);
+    registry.register(MetricRegistry.name(HelixClusterManager.class, "currentXid"), helixClusterManagerCurrentXid);
   }
 
   /**
@@ -126,7 +124,7 @@ class HelixClusterManagerMetrics {
     Gauge<Long> diskDownCount = clusterMapCallback::getDownDisksCount;
     registry.register(MetricRegistry.name(HelixClusterManager.class, "diskDownCount"), diskDownCount);
 
-    for (final AmbryDisk disk : clusterMapCallback.getDisks()) {
+    for (final AmbryDisk disk : clusterMapCallback.getDisks(null)) {
       final String metricName =
           disk.getDataNode().getHostname() + "-" + disk.getDataNode().getPort() + "-" + disk.getMountPath()
               + "-DiskResourceState";

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
@@ -26,6 +26,7 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
 
 
@@ -136,6 +137,18 @@ class Partition implements PartitionId {
   @Override
   public String getPartitionClass() {
     return partitionClass;
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    JSONObject snapshot = new JSONObject();
+    snapshot.put(PARTITION_ID, toPathString());
+    snapshot.put(PARTITION_WRITE_STATE, getPartitionState().name());
+    snapshot.put(PARTITION_CLASS, getPartitionClass());
+    JSONArray replicasJsonArray = new JSONArray();
+    getReplicaIds().forEach(replica -> replicasJsonArray.put(replica.getSnapshot()));
+    snapshot.put(PARTITION_REPLICAS, replicasJsonArray);
+    return snapshot;
   }
 
   // For constructing new Partition

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
@@ -33,7 +33,7 @@ import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
  * its {@link Disk}. Note that this induces a constraint that a Partition can never have more than one Replica on a
  * given Disk. This ensures that a Partition does not have Replicas that share fates.
  */
-class Replica implements ReplicaId, Resource {
+class Replica implements ReplicaId {
   private final Partition partition;
   private Disk disk;
   private volatile boolean isStopped = false;
@@ -127,6 +127,8 @@ class Replica implements ReplicaId, Resource {
       replicaLiveness = NODE_DOWN;
     } else if (disk.getState() == HardwareState.UNAVAILABLE) {
       replicaLiveness = DISK_DOWN;
+    } else if (resourceStatePolicy.isDown()) {
+      replicaLiveness = SOFT_DOWN;
     } else if (isStopped) {
       replicaLiveness = REPLICA_STOPPED;
     }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Replica.java
@@ -23,6 +23,8 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
+
 
 /**
  * An implementation of {@link ReplicaId} to be used within the {@link StaticClusterManager}.
@@ -108,6 +110,28 @@ class Replica implements ReplicaId, Resource {
   @Override
   public boolean isSealed() {
     return partition.getPartitionState().equals(PartitionState.READ_ONLY);
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    JSONObject snapshot = new JSONObject();
+    DataNodeId dataNodeId = getDataNodeId();
+    snapshot.put(REPLICA_NODE, dataNodeId.getHostname() + ":" + dataNodeId.getPort());
+    snapshot.put(REPLICA_PARTITION, getPartitionId().toPathString());
+    snapshot.put(REPLICA_DISK, getDiskId().getMountPath());
+    snapshot.put(REPLICA_PATH, getReplicaPath());
+    snapshot.put(CAPACITY_BYTES, getCapacityInBytes());
+    snapshot.put(REPLICA_WRITE_STATE, isSealed() ? PartitionState.READ_ONLY.name() : PartitionState.READ_WRITE.name());
+    String replicaLiveness = UP;
+    if (dataNodeId.getState() == HardwareState.UNAVAILABLE) {
+      replicaLiveness = NODE_DOWN;
+    } else if (disk.getState() == HardwareState.UNAVAILABLE) {
+      replicaLiveness = DISK_DOWN;
+    } else if (isStopped) {
+      replicaLiveness = REPLICA_STOPPED;
+    }
+    snapshot.put(LIVENESS, replicaLiveness);
+    return snapshot;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -520,7 +520,7 @@ class StaticClusterManager implements ClusterMap {
       data.put(DATACENTER_NAME, dc.getName());
       data.put(DATACENTER_ID, dc.getId());
       JSONArray datanodesInDc = new JSONArray();
-      dc.getDataNodes().forEach(mockDataNodeId -> datanodesInDc.put(mockDataNodeId.getSnapshot()));
+      dc.getDataNodes().forEach(node -> datanodesInDc.put(node.getSnapshot()));
       data.put(DATACENTER_NODES, datanodesInDc);
       datacentersJsonArray.put(data);
     });

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -14,6 +14,7 @@
 package com.github.ambry.clustermap;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.utils.SystemTime;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -24,10 +25,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 import static com.github.ambry.utils.Utils.*;
 
 
@@ -502,6 +506,29 @@ class StaticClusterManager implements ClusterMap {
         ((Replica) replicaId).onReplicaResponse();
         break;
     }
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    JSONObject snapshot = new JSONObject();
+    snapshot.put(IMPLEMENTATION, StaticClusterManager.class.getName());
+    snapshot.put(CLUSTER_NAME, partitionLayout.getClusterName());
+    snapshot.put(TIMESTAMP_MS, SystemTime.getInstance().milliseconds());
+    JSONArray datacentersJsonArray = new JSONArray();
+    hardwareLayout.getDatacenters().forEach(dc -> {
+      JSONObject data = new JSONObject();
+      data.put(DATACENTER_NAME, dc.getName());
+      data.put(DATACENTER_ID, dc.getId());
+      JSONArray datanodesInDc = new JSONArray();
+      dc.getDataNodes().forEach(mockDataNodeId -> datanodesInDc.put(mockDataNodeId.getSnapshot()));
+      data.put(DATACENTER_NODES, datanodesInDc);
+      datacentersJsonArray.put(data);
+    });
+    snapshot.put(DATACENTERS, datacentersJsonArray);
+    JSONArray partitionsJsonArray = new JSONArray();
+    getAllPartitionIds(null).forEach(partitionId -> partitionsJsonArray.put(partitionId.getSnapshot()));
+    snapshot.put(PARTITIONS, partitionsJsonArray);
+    return snapshot;
   }
 
   @Override

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DataNodeTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DataNodeTest.java
@@ -108,8 +108,8 @@ public class DataNodeTest {
     assertEquals(dataNode, new TestDataNode("datacenter", dataNode.toJSONObject(), clusterMapConfig));
 
     // Test with defined rackId
-    jsonObject =
-        TestUtils.getJsonDataNode(TestUtils.getLocalHost(), 6666, 7666, 42, TestUtils.DEFAULT_XID, HardwareState.AVAILABLE, getDisks());
+    jsonObject = TestUtils.getJsonDataNode(TestUtils.getLocalHost(), 6666, 7666, 42, TestUtils.DEFAULT_XID,
+        HardwareState.AVAILABLE, getDisks());
     dataNode = new TestDataNode("datacenter", jsonObject, clusterMapConfig);
     assertEquals("42", dataNode.getRackId());
     assertEquals(TestUtils.DEFAULT_XID, dataNode.getXid());

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/FixedBackoffResourceStatePolicyTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/FixedBackoffResourceStatePolicyTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.utils.MockTime;
+import org.json.JSONObject;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -34,8 +35,7 @@ public class FixedBackoffResourceStatePolicyTest {
     assertTrue("Test initialization error, FAILURE_COUNT_THRESHOLD is too low", FAILURE_COUNT_THRESHOLD >= 2);
     assertTrue("Test initialization error, RETRY_BACKOFF_MS is too low", RETRY_BACKOFF_MS >= 2);
     time = new MockTime();
-    resource = new Resource() {
-    };
+    resource = () -> null;
     policy = new FixedBackoffResourceStatePolicy(resource, false, FAILURE_COUNT_THRESHOLD, RETRY_BACKOFF_MS, time);
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
@@ -38,8 +38,8 @@ public class MockClusterAgentsFactory implements ClusterAgentsFactory {
   @Override
   public MockClusterMap getClusterMap() throws IOException {
     if (mockClusterMap == null) {
-      mockClusterMap = new MockClusterMap(enableSslPorts, numNodes, numMountPointsPerNode, numStoresPerMountPoint,
-          false);
+      mockClusterMap =
+          new MockClusterMap(enableSslPorts, numNodes, numMountPointsPerNode, numStoresPerMountPoint, false);
     }
     return mockClusterMap;
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDataNodeId.java
@@ -19,6 +19,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 
 
 public class MockDataNodeId implements DataNodeId {
@@ -122,6 +126,24 @@ public class MockDataNodeId implements DataNodeId {
   @Override
   public long getXid() {
     return Long.MIN_VALUE;
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    JSONObject snapshot = new JSONObject();
+    snapshot.put(DATA_NODE_HOSTNAME, getHostname());
+    snapshot.put(DATA_NODE_DATACENTER, getDatacenterName());
+    snapshot.put(DATA_NODE_SSL_ENABLED_DATACENTERS, new JSONArray(sslEnabledDataCenters));
+    JSONObject portsJson = new JSONObject();
+    ports.forEach((portType, port) -> portsJson.put(port.getPortType().name(), port.getPort()));
+    portsJson.put(DATA_NODE_PORT_CONNECT_TO, getPortToConnectTo().getPort());
+    snapshot.put(DATA_NODE_PORTS, portsJson);
+    snapshot.put(DATA_NODE_XID, getXid());
+    snapshot.put(LIVENESS, getState() == HardwareState.UNAVAILABLE ? DOWN : UP);
+    JSONArray disksJson = new JSONArray();
+    mountPaths.forEach(mountPath -> disksJson.put(new MockDiskId(this, mountPath).getSnapshot()));
+    snapshot.put(DATA_NODE_DISKS, disksJson);
+    return snapshot;
   }
 
   public List<String> getMountPaths() {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDiskId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockDiskId.java
@@ -13,6 +13,11 @@
  */
 package com.github.ambry.clustermap;
 
+import org.json.JSONObject;
+
+import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
+
+
 public class MockDiskId implements DiskId {
   String mountPath;
   MockDataNodeId dataNode;
@@ -37,6 +42,16 @@ public class MockDiskId implements DiskId {
   @Override
   public long getRawCapacityInBytes() {
     return 100000;
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    JSONObject snapshot = new JSONObject();
+    snapshot.put(DISK_NODE, dataNode.getHostname() + ":" + dataNode.getPort());
+    snapshot.put(DISK_MOUNT_PATH, mountPath);
+    snapshot.put(LIVENESS, dataNode.getState() == HardwareState.UNAVAILABLE ? NODE_DOWN
+        : state == HardwareState.UNAVAILABLE ? DISK_DOWN : UP);
+    return snapshot;
   }
 
   public synchronized void onDiskError() {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
@@ -16,6 +16,10 @@ package com.github.ambry.clustermap;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 
 
 /**
@@ -131,6 +135,20 @@ public class MockPartitionId implements PartitionId {
   @Override
   public String getPartitionClass() {
     return partitionClass;
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    JSONObject snapshot = new JSONObject();
+    snapshot.put(PARTITION_ID, partition);
+    snapshot.put(PARTITION_WRITE_STATE, partitionState.name());
+    snapshot.put(PARTITION_CLASS, partitionClass);
+    JSONArray replicas = new JSONArray();
+    for (ReplicaId replicaId : replicaIds) {
+      replicas.put(replicaId.getSnapshot());
+    }
+    snapshot.put(PARTITION_REPLICAS, replicas);
+    return snapshot;
   }
 
   public void cleanUp() {

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -110,6 +111,11 @@ public class ResponseHandlerTest {
     }
 
     @Override
+    public JSONObject getSnapshot() {
+      return null;
+    }
+
+    @Override
     public void close() {
     }
 
@@ -143,20 +149,15 @@ public class ResponseHandlerTest {
     expectedEventTypes.put(ServerErrorCode.Disk_Unavailable,
         new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Error});
     expectedEventTypes.put(ServerErrorCode.Partition_ReadOnly,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
-            ReplicaEventType.Partition_ReadOnly, ReplicaEventType.Replica_Available});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Partition_ReadOnly, ReplicaEventType.Replica_Available});
     expectedEventTypes.put(ServerErrorCode.Replica_Unavailable,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
-            ReplicaEventType.Replica_Unavailable});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Unavailable});
     expectedEventTypes.put(ServerErrorCode.Temporarily_Disabled,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
-            ReplicaEventType.Replica_Unavailable});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Unavailable});
     expectedEventTypes.put(ServerErrorCode.Unknown_Error,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
-            ReplicaEventType.Replica_Available});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Available});
     expectedEventTypes.put(ServerErrorCode.No_Error,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
-            ReplicaEventType.Replica_Available});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Available});
     expectedEventTypes.put(NetworkClientErrorCode.NetworkError, new ReplicaEventType[]{ReplicaEventType.Node_Timeout});
     expectedEventTypes.put(NetworkClientErrorCode.ConnectionUnavailable, new ReplicaEventType[]{});
     expectedEventTypes.put(new RouterException("", RouterErrorCode.UnexpectedInternalError), new ReplicaEventType[]{});

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
@@ -374,6 +374,11 @@ class TailoredPeersClusterMap implements ClusterMap {
   }
 
   @Override
+  public JSONObject getSnapshot() {
+    return null;
+  }
+
+  @Override
   public void close() {
 
   }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockReadingClusterMap.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockReadingClusterMap.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
+import org.json.JSONObject;
 
 
 /**
@@ -90,6 +91,11 @@ public class MockReadingClusterMap implements ClusterMap {
   }
 
   public void onReplicaEvent(ReplicaId replicaId, ReplicaEventType replicaEventType) {
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    return null;
   }
 
   public void close() {

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
+import org.json.JSONObject;
 
 import static org.mockito.Mockito.*;
 
@@ -107,6 +108,11 @@ class StoreTestUtils {
     @Override
     public boolean isSealed() {
       return isSealed;
+    }
+
+    @Override
+    public JSONObject getSnapshot() {
+      return new JSONObject();
     }
 
     @Override

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
@@ -112,7 +112,7 @@ class StoreTestUtils {
 
     @Override
     public JSONObject getSnapshot() {
-      return new JSONObject();
+      return null;
     }
 
     @Override


### PR DESCRIPTION
Added method and impls to get a snapshot of the state of the `ClusterMap` at the time a request was made. This will help with debugging unexpected cluster states.

Will add support in frontend and server to fetch this data via http/custom requests.

Will add tests in a follow up PR