### PR TITLE
Sending BlobInfo headers on getBlob()

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -262,12 +262,18 @@ public class RestUtils {
      * To be set if the operation knows the keep-alive behavior it prefers on error. Valid values are boolean.
      * Not authoritative, only a hint
      */
-    public final static String KEEP_ALIVE_ON_ERROR_HINT = KEY_PREFIX + "keep-alive-on-error-hint";
+    public static final String KEEP_ALIVE_ON_ERROR_HINT = KEY_PREFIX + "keep-alive-on-error-hint";
 
     /**
      * To be set to {@code true} if tracking info should be attached to frontend responses.
      */
-    public final static String SEND_TRACKING_INFO = KEY_PREFIX + "ambry-internal-keys-send-tracking-info";
+    public static final String SEND_TRACKING_INFO = KEY_PREFIX + "send-tracking-info";
+
+    /**
+     * Set to {@code true} (assumed {@code false} if absent) if the user metadata needs to be sent as the body of the
+     * response.
+     */
+    public static final String SEND_USER_METADATA_AS_RESPONSE_BODY = KEY_PREFIX + "send-user-metadata-as-response-body";
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockRestResponseChannel.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockRestResponseChannel.java
@@ -23,7 +23,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -279,13 +278,8 @@ public class MockRestResponseChannel implements RestResponseChannel {
    * @return the response headers associated with this response channel
    */
   public Map<String, Object> getResponseHeaders() {
-    if (!responseMetadata.has(RESPONSE_HEADERS_KEY)) {
-      return Collections.emptyMap();
-    }
-    JSONObject headers = responseMetadata.getJSONObject(RESPONSE_HEADERS_KEY);
-    Map<String, Object> ret = new HashMap<>();
-    headers.keySet().forEach(s -> ret.put(s, headers.get(s)));
-    return ret;
+    return responseMetadata.has(RESPONSE_HEADERS_KEY) ? responseMetadata.getJSONObject(RESPONSE_HEADERS_KEY).toMap()
+        : Collections.emptyMap();
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockRestResponseChannel.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockRestResponseChannel.java
@@ -21,9 +21,12 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -270,6 +273,19 @@ public class MockRestResponseChannel implements RestResponseChannel {
    */
   public Exception getException() {
     return exception;
+  }
+
+  /**
+   * @return the response headers associated with this response channel
+   */
+  public Map<String, Object> getResponseHeaders() {
+    if (!responseMetadata.has(RESPONSE_HEADERS_KEY)) {
+      return Collections.emptyMap();
+    }
+    JSONObject headers = responseMetadata.getJSONObject(RESPONSE_HEADERS_KEY);
+    Map<String, Object> ret = new HashMap<>();
+    headers.keySet().forEach(s -> ret.put(s, headers.get(s)));
+    return ret;
   }
 
   /**

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -856,8 +856,8 @@ class AmbryBlobStorageService implements BlobStorageService {
                   if (securityException == null) {
                     if (subResource != null) {
                       BlobInfo blobInfo = routerResult.getBlobInfo();
-                      if (RestUtils.getBooleanHeader(restRequest.getArgs(), SEND_USER_METADATA_AS_RESPONSE_BODY,
-                          false)) {
+                      if (restRequest.getArgs().containsKey(SEND_USER_METADATA_AS_RESPONSE_BODY)
+                          && (boolean) restRequest.getArgs().get(SEND_USER_METADATA_AS_RESPONSE_BODY)) {
                         restResponseChannel.setHeader(Headers.CONTENT_TYPE, "application/octet-stream");
                         restResponseChannel.setHeader(Headers.CONTENT_LENGTH, blobInfo.getUserMetadata().length);
                         response = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(blobInfo.getUserMetadata()));

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityService.java
@@ -33,7 +33,6 @@ import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.Map;
 
 import static com.github.ambry.rest.RestUtils.*;
 
@@ -340,25 +339,5 @@ class AmbrySecurityService implements SecurityService {
       restResponseChannel.setHeader(RestUtils.Headers.TARGET_CONTAINER_NAME, container.getName());
     }
     restResponseChannel.setHeader(RestUtils.Headers.PRIVATE, !container.isCacheable());
-  }
-
-  /**
-   * Sets the user metadata in the headers of the response.
-   * @param userMetadata the user metadata that needs to be sent.
-   * @param restResponseChannel the {@link RestResponseChannel} that is used for sending the response.
-   * @throws RestServiceException if there are any problems setting the header.
-   */
-  private boolean setUserMetadataHeaders(byte[] userMetadata, RestResponseChannel restResponseChannel)
-      throws RestServiceException {
-    if (userMetadata == null) {
-      return false;
-    }
-    Map<String, String> userMetadataMap = RestUtils.buildUserMetadata(userMetadata);
-    if (userMetadataMap != null) {
-      for (Map.Entry<String, String> entry : userMetadataMap.entrySet()) {
-        restResponseChannel.setHeader(entry.getKey(), entry.getValue());
-      }
-    }
-    return userMetadataMap != null;
   }
 }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -1448,6 +1448,9 @@ public class AmbryBlobStorageServiceTest {
         restRequest.getArgs().get(RestUtils.InternalKeys.TARGET_ACCOUNT_KEY));
     assertEquals("Wrong container object in RestRequest's args", expectedContainer,
         restRequest.getArgs().get(RestUtils.InternalKeys.TARGET_CONTAINER_KEY));
+    verifyBlobProperties(expectedHeaders, restResponseChannel);
+    verifyUserMetadataHeaders(expectedHeaders, restResponseChannel);
+    verifyAccountAndContainerHeaders(restResponseChannel, expectedAccount, expectedContainer);
     byte[] expectedContentArray = expectedContent.array();
     if (range != null) {
       long blobSize = expectedHeaders.getLong(RestUtils.Headers.BLOB_SIZE);
@@ -1548,7 +1551,7 @@ public class AmbryBlobStorageServiceTest {
     assertNull("Accept-Ranges should not be set", restResponseChannel.getHeader(RestUtils.Headers.ACCEPT_RANGES));
     assertNull("Content-Range header should not be set",
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_RANGE));
-    verifyBlobProperties(expectedHeaders, !expectedContainer.isCacheable(), restResponseChannel);
+    verifyBlobProperties(expectedHeaders, restResponseChannel);
     verifyUserMetadataHeaders(expectedHeaders, restResponseChannel);
     verifyAccountAndContainerHeaders(restResponseChannel, expectedAccount, expectedContainer);
   }
@@ -1588,27 +1591,24 @@ public class AmbryBlobStorageServiceTest {
     }
     assertEquals(RestUtils.Headers.CONTENT_LENGTH + " does not match expected", Long.toString(contentLength),
         restResponseChannel.getHeader(RestUtils.Headers.CONTENT_LENGTH));
-    verifyBlobProperties(expectedHeaders, !expectedContainer.isCacheable(), restResponseChannel);
+    verifyBlobProperties(expectedHeaders, restResponseChannel);
     verifyAccountAndContainerHeaders(restResponseChannel, expectedAccount, expectedContainer);
   }
 
   /**
    * Verifies blob properties from output, to that sent in during input
    * @param expectedHeaders the expected headers in the response.
-   * @param isPrivate {@code true} if the blob is expected to be private
    * @param restResponseChannel the {@link RestResponseChannel} which contains the response.
    * @throws JSONException
    */
-  private void verifyBlobProperties(JSONObject expectedHeaders, boolean isPrivate,
-      MockRestResponseChannel restResponseChannel) throws JSONException {
+  private void verifyBlobProperties(JSONObject expectedHeaders, MockRestResponseChannel restResponseChannel)
+      throws JSONException {
     assertEquals(RestUtils.Headers.BLOB_SIZE + " does not match",
         expectedHeaders.get(RestUtils.Headers.BLOB_SIZE).toString(),
         restResponseChannel.getHeader(RestUtils.Headers.BLOB_SIZE));
     assertEquals(RestUtils.Headers.SERVICE_ID + " does not match",
         expectedHeaders.getString(RestUtils.Headers.SERVICE_ID),
         restResponseChannel.getHeader(RestUtils.Headers.SERVICE_ID));
-    assertEquals(RestUtils.Headers.PRIVATE + " does not match", isPrivate,
-        Boolean.valueOf(restResponseChannel.getHeader(RestUtils.Headers.PRIVATE)));
     assertEquals(RestUtils.Headers.AMBRY_CONTENT_TYPE + " does not match",
         expectedHeaders.getString(RestUtils.Headers.AMBRY_CONTENT_TYPE),
         restResponseChannel.getHeader(RestUtils.Headers.AMBRY_CONTENT_TYPE));
@@ -1642,6 +1642,8 @@ public class AmbryBlobStorageServiceTest {
       Assert.assertEquals("Container name not as expected", expectedContainer.getName(),
           restResponseChannel.getHeader(RestUtils.Headers.TARGET_CONTAINER_NAME));
     }
+    assertEquals(RestUtils.Headers.PRIVATE + " does not match", !expectedContainer.isCacheable(),
+        Boolean.valueOf(restResponseChannel.getHeader(RestUtils.Headers.PRIVATE)));
   }
 
   /**

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -2025,7 +2025,7 @@ public class AmbryBlobStorageServiceTest {
         new BlobProperties(0, serviceId, "owner", "image/gif", isPrivate, Utils.Infinite_Time,
             Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false);
     ReadableStreamChannel content = new ByteBufferReadableStreamChannel(ByteBuffer.allocate(0));
-    String blobId = router.putBlobWithIdVersion(blobProperties, null, content, BlobId.BLOB_ID_V1).get();
+    String blobId = router.putBlobWithIdVersion(blobProperties, new byte[0], content, BlobId.BLOB_ID_V1).get();
     verifyAccountAndContainerFromBlobId(blobId, expectedAccount, expectedContainer, null);
   }
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -77,10 +77,10 @@ public class AmbrySecurityServiceTest {
   private static final BlobInfo DEFAULT_INFO;
   private static final BlobInfo UNKNOWN_INFO = new BlobInfo(
       new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, Utils.Infinite_Time, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, false), null);
+          Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
   private static final BlobInfo UNKNOWN_INFO_ENC = new BlobInfo(
       new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, Utils.Infinite_Time, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, true), null);
+          Container.UNKNOWN_CONTAINER_ID, true), new byte[0]);
   private static final FrontendTestUrlSigningServiceFactory URL_SIGNING_SERVICE_FACTORY =
       new FrontendTestUrlSigningServiceFactory();
 
@@ -244,17 +244,17 @@ public class AmbrySecurityServiceTest {
     // with no owner id
     BlobInfo blobInfo = new BlobInfo(
         new BlobProperties(100, SERVICE_ID, null, "image/gif", false, Utils.Infinite_Time, REF_ACCOUNT.getId(),
-            REF_CONTAINER.getId(), false), null);
+            REF_CONTAINER.getId(), false), new byte[0]);
     testHeadBlobWithVariousRanges(blobInfo);
     // with no content type
     blobInfo = new BlobInfo(
         new BlobProperties(100, SERVICE_ID, OWNER_ID, null, false, Utils.Infinite_Time, REF_ACCOUNT.getId(),
-            REF_CONTAINER.getId(), false), null);
+            REF_CONTAINER.getId(), false), new byte[0]);
     testHeadBlobWithVariousRanges(blobInfo);
     // with a TTL
     blobInfo = new BlobInfo(
         new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, 10000, REF_ACCOUNT.getId(),
-            REF_CONTAINER.getId(), false), null);
+            REF_CONTAINER.getId(), false), new byte[0]);
     testHeadBlobWithVariousRanges(blobInfo);
 
     // GET BlobInfo
@@ -274,30 +274,30 @@ public class AmbrySecurityServiceTest {
     // GET Blob
     // less than chunk threshold size
     blobInfo = new BlobInfo(
-        new BlobProperties(FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes - 1, SERVICE_ID, OWNER_ID,
-            "image/gif", false, 10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false), null);
+        new BlobProperties(FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes - 1, SERVICE_ID, OWNER_ID, "image/gif",
+            false, 10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // == chunk threshold size
     blobInfo = new BlobInfo(
-        new BlobProperties(FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes, SERVICE_ID, OWNER_ID,
-            "image/gif", false, 10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false), null);
+        new BlobProperties(FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes, SERVICE_ID, OWNER_ID, "image/gif", false,
+            10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // more than chunk threshold size
     blobInfo = new BlobInfo(
-        new BlobProperties(FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes * 2, SERVICE_ID, OWNER_ID,
-            "image/gif", false, 10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false), null);
+        new BlobProperties(FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes * 2, SERVICE_ID, OWNER_ID, "image/gif",
+            false, 10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // Get blob with content type null
     blobInfo = new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, null, true, 10000, Account.UNKNOWN_ACCOUNT_ID,
-        Container.UNKNOWN_CONTAINER_ID, false), null);
+        Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // Get blob in a non-cacheable container. AmbrySecurityService should not care about the isPrivate setting.
     blobInfo = new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, Utils.Infinite_Time,
-        Account.UNKNOWN_ACCOUNT_ID, Container.DEFAULT_PRIVATE_CONTAINER_ID, false), null);
+        Account.UNKNOWN_ACCOUNT_ID, Container.DEFAULT_PRIVATE_CONTAINER_ID, false), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // Get blob in a cacheable container. AmbrySecurityService should not care about the isPrivate setting.
     blobInfo = new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", true, Utils.Infinite_Time,
-        Account.UNKNOWN_ACCOUNT_ID, Container.DEFAULT_PUBLIC_CONTAINER_ID, false), null);
+        Account.UNKNOWN_ACCOUNT_ID, Container.DEFAULT_PUBLIC_CONTAINER_ID, false), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // not modified response
     // > creation time (in secs).
@@ -310,7 +310,7 @@ public class AmbrySecurityServiceTest {
     // Get blob for a public blob with content type as "text/html"
     blobInfo = new BlobInfo(
         new BlobProperties(100, SERVICE_ID, OWNER_ID, "text/html", true, 10000, Account.UNKNOWN_ACCOUNT_ID,
-            Container.UNKNOWN_CONTAINER_ID, false), null);
+            Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // not modified response
     // > creation time (in secs).
@@ -590,10 +590,10 @@ public class AmbrySecurityServiceTest {
     }
     Map<String, String> userMetadata =
         blobInfo.getUserMetadata() != null ? RestUtils.buildUserMetadata(blobInfo.getUserMetadata()) : null;
-    if (userMetadata == null) {
+    if (userMetadata == null && !(blobInfo.getUserMetadata().length == 0)) {
       Assert.assertTrue("Internal key " + RestUtils.InternalKeys.SEND_USER_METADATA_AS_RESPONSE_BODY + " should be set",
           (Boolean) restRequest.getArgs().get(RestUtils.InternalKeys.SEND_USER_METADATA_AS_RESPONSE_BODY));
-    } else {
+    } else if (!(blobInfo.getUserMetadata().length == 0)) {
       USER_METADATA.forEach((key, value) -> Assert.assertEquals("Value of " + key + " not as expected", value,
           restResponseChannel.getHeader(key)));
     }
@@ -726,7 +726,7 @@ public class AmbrySecurityServiceTest {
         accountAndContainer.getSecond());
     Map<String, String> userMetadata =
         blobInfo.getUserMetadata() != null ? RestUtils.buildUserMetadata(blobInfo.getUserMetadata()) : null;
-    if (userMetadata == null) {
+    if (blobInfo.getUserMetadata().length == 0 || userMetadata == null) {
       Assert.assertNull(
           "Internal key " + RestUtils.InternalKeys.SEND_USER_METADATA_AS_RESPONSE_BODY + " should not be set",
           restRequest.getArgs().get(RestUtils.InternalKeys.SEND_USER_METADATA_AS_RESPONSE_BODY));
@@ -766,8 +766,7 @@ public class AmbrySecurityServiceTest {
       Assert.assertTrue("Expires value should be in the future",
           RestUtils.getTimeFromDateString(restResponseChannel.getHeader(RestUtils.Headers.EXPIRES))
               > System.currentTimeMillis());
-      Assert.assertEquals("Cache-Control value not as expected",
-          "max-age=" + FRONTEND_CONFIG.cacheValiditySeconds,
+      Assert.assertEquals("Cache-Control value not as expected", "max-age=" + FRONTEND_CONFIG.cacheValiditySeconds,
           restResponseChannel.getHeader(RestUtils.Headers.CACHE_CONTROL));
       Assert.assertNull("Pragma value should not have been set",
           restResponseChannel.getHeader(RestUtils.Headers.PRAGMA));


### PR DESCRIPTION
Combining information returned in GET /BlobInfo with a GET blob
call in order to help reduce request rates