### PR TITLE
Ensure MessageInfo deleted flag is set correctly for deleted messages

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -98,6 +98,14 @@ public class ReplicationConfig {
   @Default("1048576")
   public final long replicationFetchSizeInBytes;
 
+  /**
+   * If true, replication Get requests asks for deleted and expired blobs as well to succeed in scenarios where blobs
+   * get deleted or expired after replication metadata exchange.
+   */
+  @Config("replication.include.all")
+  @Default("true")
+  public final boolean replicationIncludeAll;
+
   public ReplicationConfig(VerifiableProperties verifiableProperties) {
 
     replicationTokenFactory =
@@ -124,5 +132,6 @@ public class ReplicationConfig {
         verifiableProperties.getLongInRange("replication.synced.replica.backoff.duration.ms", 0, 0, Long.MAX_VALUE);
     replicationFetchSizeInBytes =
         verifiableProperties.getLongInRange("replication.fetch.size.in.bytes", 1048576, 1, Long.MAX_VALUE);
+    replicationIncludeAll = verifiableProperties.getBoolean("replication.include.all", true);
   }
 }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -720,7 +720,7 @@ class ReplicaThread implements Runnable {
     if (!partitionRequestInfoList.isEmpty()) {
       GetRequest getRequest = new GetRequest(correlationIdGenerator.incrementAndGet(),
           GetRequest.Replication_Client_Id_Prefix + dataNodeId.getHostname(), MessageFormatFlags.All,
-          partitionRequestInfoList, GetOption.Include_All);
+          partitionRequestInfoList, replicationConfig.replicationIncludeAll ? GetOption.Include_All : GetOption.None);
       long startTime = SystemTime.getInstance().milliseconds();
       try {
         connectedChannel.send(getRequest);

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -805,7 +805,7 @@ class PersistentIndex {
         Offset offset = new Offset(logSegmentName, value.getOriginalMessageOffset());
         // use the expiration time from the original value because it may have been updated
         readOptions = new BlobReadOptions(log, offset,
-            new MessageInfo(deletedBlobInfo.getStoreKey(), deletedBlobInfo.getSize(), false,
+            new MessageInfo(deletedBlobInfo.getStoreKey(), deletedBlobInfo.getSize(), true,
                 value.isFlagSet(IndexValue.Flags.Ttl_Update_Index), value.getExpiresAtMs(),
                 deletedBlobInfo.getAccountId(), deletedBlobInfo.getContainerId(),
                 deletedBlobInfo.getOperationTimeMs()));
@@ -813,7 +813,7 @@ class PersistentIndex {
         // PUT record in a different log segment.
         // use the expiration time from the original value because it may have been updated
         readOptions = new BlobReadOptions(log, putValue.getOffset(),
-            new MessageInfo(key, putValue.getSize(), false, value.isFlagSet(IndexValue.Flags.Ttl_Update_Index),
+            new MessageInfo(key, putValue.getSize(), true, value.isFlagSet(IndexValue.Flags.Ttl_Update_Index),
                 value.getExpiresAtMs(), putValue.getAccountId(), putValue.getContainerId(),
                 putValue.getOperationTimeInMs()));
       } else {

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1298,8 +1298,8 @@ public class IndexTest {
         state.index.getIndexSegments().lastEntry().getValue().getNumberOfItems(), entriesInJournal);
     // add some entries to trigger rollover.
     state.addPutEntries(1, PUT_RECORD_SIZE, Utils.Infinite_Time);
-    assertEquals("Number of entries in the journal should not have changed",
-        entriesInJournal, state.index.journal.getCurrentNumberOfEntries());
+    assertEquals("Number of entries in the journal should not have changed", entriesInJournal,
+        state.index.journal.getCurrentNumberOfEntries());
     // Reload the index and the journal size should now reflect the config change
     state.reloadIndex(true, false);
     assertEquals("Number of entries in the journal should be exactly 1", 1,
@@ -1333,6 +1333,10 @@ public class IndexTest {
       assertEquals("Size not as expected", putEntryValue.getSize(), options.getMessageInfo().getSize());
       assertEquals("ExpiresAtMs not as expected", putEntryValue.getExpiresAtMs(),
           options.getMessageInfo().getExpirationTimeInMs());
+      if (storeGetOptions.contains(StoreGetOptions.Store_Include_Deleted) && state.deletedKeys.contains(id)) {
+        assertTrue("MessageInfo for deleted messages should have deleted flag true",
+            options.getMessageInfo().isDeleted());
+      }
     } catch (StoreException e) {
       if (expectedErrorCode == null) {
         throw e;


### PR DESCRIPTION
A Get request with Include_Deleted or Include_All returns messages
that were subsequently deleted. The MessageInfo associated with these
returned values however should say that the message is deleted, which
it does not, today. Fixing that.