### PR TITLE
Cancel scheduled persistor task when shutting down BlobStore

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -115,7 +115,7 @@ class PersistentIndex {
   private volatile ConcurrentSkipListMap<Offset, IndexSegment> inFluxIndexSegments = validIndexSegments;
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final IndexPersistor persistor = new IndexPersistor();
-  private ScheduledFuture<?> persistorTask = null;
+  private final ScheduledFuture<?> persistorTask;
 
   /**
    * Creates a new persistent index
@@ -232,6 +232,8 @@ class PersistentIndex {
         persistorTask = scheduler.scheduleAtFixedRate(persistor,
             config.storeDataFlushDelaySeconds + new Random().nextInt(Time.SecsPerMin),
             config.storeDataFlushIntervalSeconds, TimeUnit.SECONDS);
+      } else {
+        persistorTask = null;
       }
       if (hardDelete != null && config.storeEnableHardDelete) {
         logger.info("Index : " + datadir + " Starting hard delete thread ");

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -1604,7 +1604,7 @@ class PersistentIndex {
     }
   }
 
-  private class IndexPersistor implements Runnable {
+  class IndexPersistor implements Runnable {
 
     /**
      * Writes all the individual index segments to disk. It flushes the log before starting the

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -1331,10 +1331,10 @@ class PersistentIndex {
   void close() throws StoreException {
     long startTimeInMs = time.milliseconds();
     try {
-      persistor.write();
       if (persistorTask != null) {
         persistorTask.cancel(false);
       }
+      persistor.write();
       if (hardDeleter != null) {
         try {
           hardDeleter.shutdown();

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
@@ -481,7 +481,7 @@ public class BlobStoreCompactorTest {
   public void interspersedDeletedAndExpiredBlobsTest() throws Exception {
     refreshState(false, false);
     state.properties.put("store.index.max.number.of.inmem.elements", Integer.toString(5));
-    state.initIndex();
+    state.initIndex(null);
 
     int numFinalSegmentsCount = 3;
     long expiryTimeMs = getInvalidationTime(numFinalSegmentsCount + 1);
@@ -1263,7 +1263,7 @@ public class BlobStoreCompactorTest {
     state.reloadLog(false);
     // use the "real" log, index and disk IO schedulers this time.
     compactor = getCompactor(state.log, DISK_IO_SCHEDULER);
-    state.initIndex();
+    state.initIndex(null);
     compactor.initialize(state.index);
     assertEquals("Wrong number of swap segments in use",
         tempDir.list(BlobStoreCompactor.TEMP_LOG_SEGMENTS_FILTER).length, compactor.getSwapSegmentsInUse());

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1255,7 +1255,7 @@ public class IndexTest {
     mockScheduler.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
     mockScheduler.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
     state.initIndex(mockScheduler);
-    Thread.sleep(1);
+    Thread.sleep(10);
     // verify that the persistor task is successfully scheduled
     assertEquals("The number of scheduled persistor task should be 1 after initialization", 1,
         ((ThreadPoolExecutor) state.scheduler).getQueue().size());

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -1277,7 +1277,7 @@ public class IndexTest {
     state.initIndex(mockScheduler);
     // verify that the persistor task is successfully scheduled
     assertTrue("The persistor task wasn't invoked within the expected time",
-        mockPersistor.invokeCountDown.await(SCHEDULER_PERIOD_MS, TimeUnit.MILLISECONDS));
+        mockPersistor.invokeCountDown.await(2 * SCHEDULER_PERIOD_MS, TimeUnit.MILLISECONDS));
     state.index.close();
     mockPersistor.invokeCountDown = new CountDownLatch(1);
     // verify that the persisitor task is canceled after index closed and is never invoked again.

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -45,8 +45,8 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1255,22 +1255,25 @@ public class IndexTest {
     // re-initialize index by using mock scheduler (the intention is to speed up testing by using shorter period)
     ScheduledThreadPoolExecutor scheduler = (ScheduledThreadPoolExecutor) Utils.newScheduler(1, false);
     ScheduledThreadPoolExecutor mockScheduler = Mockito.spy(scheduler);
-
+    AtomicReference<ScheduledFuture> persistorTask = new AtomicReference<>();
+    MockIndexPersistor mockPersistor = new MockIndexPersistor();
+    mockPersistor.invokeCountDown = new CountDownLatch(1);
     doAnswer(invocation -> {
       Object[] args = invocation.getArguments();
-      return mockScheduler.scheduleAtFixedRate((Runnable) args[0], 0, 100, TimeUnit.MILLISECONDS);
+      persistorTask.set(mockScheduler.scheduleAtFixedRate(mockPersistor, 0, 50, TimeUnit.MILLISECONDS));
+      return persistorTask.get();
     }).when(mockScheduler)
         .scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.SECONDS.getClass()));
     state.initIndex(mockScheduler);
-    Thread.sleep(10);
     // verify that the persistor task is successfully scheduled
-    assertEquals("The number of scheduled persistor task should be 1 after initialization", 1,
-        ((ThreadPoolExecutor) state.scheduler).getQueue().size());
+    assertTrue("The persistor task wasn't invoked within the expected time",
+        mockPersistor.invokeCountDown.await(10, TimeUnit.MILLISECONDS));
     state.index.close();
-    Thread.sleep(150);
-    // verify that the persisitor task is canceled after index closed.
-    assertEquals("The number of scheduled persistor task should be 0 after index closed", 0,
-        ((ThreadPoolExecutor) state.scheduler).getQueue().size());
+    mockPersistor.invokeCountDown = new CountDownLatch(1);
+    // verify that the persisitor task is canceled after index closed and is never invoked again.
+    assertTrue("The persistor task should be canceled after index closed", persistorTask.get().isCancelled());
+    assertFalse("The persistor task should not be invoked again",
+        mockPersistor.invokeCountDown.await(60, TimeUnit.MILLISECONDS));
   }
 
   /**
@@ -2702,6 +2705,18 @@ public class IndexTest {
       assertEquals("AccountId mismatch for " + entry.getKey(), expectedValue.getAccountId(), value.getAccountId());
       assertEquals("ContainerId mismatch for " + entry.getKey(), expectedValue.getContainerId(),
           value.getContainerId());
+    }
+  }
+
+  /**
+   * An implementation of mock persistor to help with tests.
+   */
+  private class MockIndexPersistor implements Runnable {
+    CountDownLatch invokeCountDown;
+
+    @Override
+    public void run() {
+      invokeCountDown.countDown();
     }
   }
 }

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -910,7 +910,7 @@ public class Utils {
    * A thread factory to use for {@link ScheduledExecutorService}s instantiated using
    * {@link #newScheduler(int, String, boolean)}.
    */
-  public static class SchedulerThreadFactory implements ThreadFactory {
+  private static class SchedulerThreadFactory implements ThreadFactory {
     private final AtomicInteger schedulerThreadId = new AtomicInteger(0);
     private final String threadNamePrefix;
     private final boolean isDaemon;
@@ -920,7 +920,7 @@ public class Utils {
      * @param threadNamePrefix the prefix string for threads in this scheduler's thread pool.
      * @param isDaemon {@code true} if the created threads should be daemon threads.
      */
-    public SchedulerThreadFactory(String threadNamePrefix, boolean isDaemon) {
+    SchedulerThreadFactory(String threadNamePrefix, boolean isDaemon) {
       this.threadNamePrefix = threadNamePrefix;
       this.isDaemon = isDaemon;
     }

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -910,7 +910,7 @@ public class Utils {
    * A thread factory to use for {@link ScheduledExecutorService}s instantiated using
    * {@link #newScheduler(int, String, boolean)}.
    */
-  private static class SchedulerThreadFactory implements ThreadFactory {
+  public static class SchedulerThreadFactory implements ThreadFactory {
     private final AtomicInteger schedulerThreadId = new AtomicInteger(0);
     private final String threadNamePrefix;
     private final boolean isDaemon;
@@ -920,7 +920,7 @@ public class Utils {
      * @param threadNamePrefix the prefix string for threads in this scheduler's thread pool.
      * @param isDaemon {@code true} if the created threads should be daemon threads.
      */
-    SchedulerThreadFactory(String threadNamePrefix, boolean isDaemon) {
+    public SchedulerThreadFactory(String threadNamePrefix, boolean isDaemon) {
       this.threadNamePrefix = threadNamePrefix;
       this.isDaemon = isDaemon;
     }


### PR DESCRIPTION
Currently, when shutting down a blobstore, the PersistentIndex doesn't
explicitly cancel the background persistor. Since stopping blobstore is
introduced and store might be shutdown while the node/disk is still
up. In this case, persistor of shutdown store still keeps writing into
file periodically, which causes ClosedChannelException.

This PR makes PersistentIndex cancel the background persistor explicitly
and ensures that no persistor task is running after index closed.