### PR TITLE
[stitched uploads] Implement Router.stitchBlob()

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/router/Router.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/Router.java
@@ -134,14 +134,14 @@ public interface Router extends Closeable {
    * the new blob on a successful response.
    * @param blobProperties The properties of the blob. Note that the size specified in the properties is ignored. The
    *                       channel is consumed fully, and the size of the blob is the number of bytes read from it.
-   * @param usermetadata Optional user metadata about the blob. This can be null.
+   * @param userMetadata Optional user metadata about the blob. This can be null.
    * @param channel The {@link ReadableStreamChannel} that contains the content of the blob.
    * @param options The {@link PutBlobOptions} associated with the request. This cannot be null.
    * @return A future that would contain the BlobId eventually.
    */
-  default Future<String> putBlob(BlobProperties blobProperties, byte[] usermetadata, ReadableStreamChannel channel,
+  default Future<String> putBlob(BlobProperties blobProperties, byte[] userMetadata, ReadableStreamChannel channel,
       PutBlobOptions options) {
-    return putBlob(blobProperties, usermetadata, channel, options, null);
+    return putBlob(blobProperties, userMetadata, channel, options, null);
   }
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/router/RouterErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/RouterErrorCode.java
@@ -23,24 +23,34 @@ public enum RouterErrorCode {
    * operation. An operation that changes the state of an existing blob (delete) may have partially completed and so may
    * eventually complete in the future.
    */
-  AmbryUnavailable, /**
+  AmbryUnavailable,
+
+  /**
    * Caller passed in an invalid blob id and so operation could not be attempted. May occur for
    * {@link Router#getBlob(String, GetBlobOptions)}, {@link Router#deleteBlob(String, String)} (and their variants) operations.
    */
-  InvalidBlobId, /**
+  InvalidBlobId,
+
+  /**
    * Caller passed in an illegal argument for
    * {@link Router#putBlob(com.github.ambry.messageformat.BlobProperties, byte[], ReadableStreamChannel, PutBlobOptions)}
    * operation (and its variant).
    */
-  InvalidPutArgument, /**
+  InvalidPutArgument,
+
+  /**
    * Operation did not complete within specified time out. The caller should retry the operation. An operation that
    * changes the state of an existing blob (delete) may have partially completed and so may eventually complete in the
    * future.
    */
-  OperationTimedOut, /**
+  OperationTimedOut,
+
+  /**
    * Thrown when an operation is attempted after the {@link Router} is closed.
    */
-  RouterClosed, /**
+  RouterClosed,
+
+  /**
    * Router experienced an unexpected internal error. The caller should retry the operation. An operation that
    * changes the state of an existing blob (delete) may have partially completed and so may eventually complete in the
    * future.
@@ -51,34 +61,51 @@ public enum RouterErrorCode {
   /**
    * Blob is too large. Cannot store blob of such size.
    */
-  BlobTooLarge, /**
+  BlobTooLarge,
+
+  /**
    * Unexpected error reading from the input channel for puts.
    */
-  BadInputChannel, /**
+  BadInputChannel,
+
+  /**
    * Insufficient capacity available in Ambry for object to be stored.
    */
   InsufficientCapacity,
 
   // Errors on read path. May occur for getBlobInfo, getBlob or deleteBlob operations.
+
   /**
    * Blob has been deleted and so cannot be retrieved.
    */
-  BlobDeleted, /**
+  BlobDeleted,
+
+  /**
    * No Blob could be found for specified blob id.
    */
-  BlobDoesNotExist, /**
+  BlobDoesNotExist,
+
+  /**
    * TTL of Blob has expired and so Blob cannot be retrieved.
    */
-  BlobExpired, /**
+  BlobExpired,
+
+  /**
    * The range offsets provided for a getBlob operation are invalid for the specified blob.
    */
-  RangeNotSatisfiable, /**
+  RangeNotSatisfiable,
+
+  /**
    * The channel returned to the user in a getBlob operation has been closed before operation completion.
    */
-  ChannelClosed, /**
+  ChannelClosed,
+
+  /**
    * The update has been rejected
    */
-  BlobUpdateNotAllowed, /**
+  BlobUpdateNotAllowed,
+
+  /**
    * ContainerId or AccountId from blobId doesn't match these in store server.
    */
   BlobAuthorizationFailure

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryUrlSigningService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryUrlSigningService.java
@@ -59,8 +59,8 @@ public class AmbryUrlSigningService implements UrlSigningService {
    * @param defaultMaxUploadSize the default max size of upload from signed POST URLs if the request does not customize
    *                             it.
    * @param maxUrlTtlSecs the maximum ttl of signed URLs. If the request specifies a higher TTL, it will be lowered
-   * @param  chunkUploadInitialChunkTtlSecs the preconfigured blob TTL for chunks of a stitched upload. These chunks
-   *                                        will be made permanent once the blob is stitched together.
+   * @param chunkUploadInitialChunkTtlSecs the preconfigured blob TTL for chunks of a stitched upload. These chunks
+   *                                       will be made permanent once the blob is stitched together.
    * @param chunkUploadMaxChunkSize the preconfigured max size for chunks of a stitched upload.
    * @param time the {@link Time} instance to use.
    */

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
@@ -202,7 +202,7 @@ public class NetworkClient implements Closeable {
   public int warmUpConnections(List<DataNodeId> dataNodeIds, int connectionWarmUpPercentagePerDataNode,
       long timeForWarmUp) {
     int expectedConnections = 0;
-    logger.info("Connections warm up start.");
+    logger.info("Connection warm up start.");
     if (dataNodeIds.size() == 0) {
       return 0;
     }
@@ -242,8 +242,8 @@ public class NetworkClient implements Closeable {
         break;
       }
     }
-    logger.info("Connections warm up done. Tried: {} Success: {} Failed: {} Time elapsed: {}ms", expectedConnections,
-        successfulConnections, failedConnections, System.currentTimeMillis() - startTime);
+    logger.info("Connection warm up done. Tried: {}, Succeeded: {}, Failed: {}, Time elapsed: {} ms",
+        expectedConnections, successfulConnections, failedConnections, System.currentTimeMillis() - startTime);
 
     return successfulConnections;
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -183,25 +183,9 @@ abstract class GetOperation {
    */
   void setOperationException(Exception exception) {
     if (exception instanceof RouterException) {
-      RouterErrorCode routerErrorCode = ((RouterException) exception).getErrorCode();
-      if (operationException.get() == null) {
-        operationException.set(exception);
-      } else {
-        Integer currentOperationExceptionLevel = null;
-        if (operationException.get() instanceof RouterException) {
-          currentOperationExceptionLevel =
-              getPrecedenceLevel(((RouterException) operationException.get()).getErrorCode());
-        } else {
-          currentOperationExceptionLevel = getPrecedenceLevel(RouterErrorCode.UnexpectedInternalError);
-        }
-        if (getPrecedenceLevel(routerErrorCode) < currentOperationExceptionLevel) {
-          operationException.set(exception);
-        }
-      }
+      RouterUtils.replaceOperationException(operationException, (RouterException) exception, this::getPrecedenceLevel);
     } else {
-      if (operationException.get() == null) {
-        operationException.set(exception);
-      }
+      operationException.compareAndSet(null, exception);
     }
   }
 
@@ -212,7 +196,7 @@ abstract class GetOperation {
    * @param routerErrorCode The {@link RouterErrorCode} for which to get its precedence level.
    * @return The precedence level of the {@link RouterErrorCode}.
    */
-  private Integer getPrecedenceLevel(RouterErrorCode routerErrorCode) {
+  private int getPrecedenceLevel(RouterErrorCode routerErrorCode) {
     switch (routerErrorCode) {
       case BlobAuthorizationFailure:
         return 1;

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -216,7 +216,7 @@ class NonBlockingRouter implements Router {
   public Future<String> stitchBlob(BlobProperties blobProperties, byte[] userMetadata, List<ChunkInfo> chunksToStitch,
       Callback<String> callback) {
     if (blobProperties == null || chunksToStitch == null) {
-      throw new IllegalArgumentException("blobProperties or channel must not be null");
+      throw new IllegalArgumentException("blobProperties or chunksToStitch must not be null");
     }
     if (userMetadata == null) {
       userMetadata = new byte[0];
@@ -747,8 +747,7 @@ class NonBlockingRouter implements Router {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
       routerMetrics.operationDequeuingRate.mark();
-      routerMetrics.onPutBlobError(routerException, blobProperties != null && blobProperties.isEncrypted(),
-          stitchOperation);
+      routerMetrics.onPutBlobError(routerException, blobProperties.isEncrypted(), stitchOperation);
       completeOperation(futureResult, callback, null, routerException);
       // Close so that any existing operations are also disposed off.
       close();

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -201,7 +201,7 @@ class NonBlockingRouter implements Router {
     routerMetrics.operationQueuingRate.mark();
     FutureResult<String> futureResult = new FutureResult<>();
     if (isOpen.get()) {
-      getOperationController().putBlob(blobProperties, userMetadata, channel, futureResult, callback);
+      getOperationController().putBlob(blobProperties, userMetadata, channel, options, futureResult, callback);
     } else {
       RouterException routerException =
           new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
@@ -215,7 +215,30 @@ class NonBlockingRouter implements Router {
   @Override
   public Future<String> stitchBlob(BlobProperties blobProperties, byte[] userMetadata, List<ChunkInfo> chunksToStitch,
       Callback<String> callback) {
-    throw new UnsupportedOperationException("Implemented in full router PR");
+    if (blobProperties == null || chunksToStitch == null) {
+      throw new IllegalArgumentException("blobProperties or channel must not be null");
+    }
+    if (userMetadata == null) {
+      userMetadata = new byte[0];
+    }
+    currentOperationsCount.incrementAndGet();
+    if (blobProperties.isEncrypted()) {
+      routerMetrics.putEncryptedBlobOperationRate.mark();
+    } else {
+      routerMetrics.putBlobOperationRate.mark();
+    }
+    routerMetrics.operationQueuingRate.mark();
+    FutureResult<String> futureResult = new FutureResult<>();
+    if (isOpen.get()) {
+      getOperationController().stitchBlob(blobProperties, userMetadata, chunksToStitch, futureResult, callback);
+    } else {
+      RouterException routerException =
+          new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
+      routerMetrics.operationDequeuingRate.mark();
+      routerMetrics.onPutBlobError(routerException, blobProperties.isEncrypted());
+      completeOperation(futureResult, callback, null, routerException);
+    }
+    return futureResult;
   }
 
   /**
@@ -459,7 +482,7 @@ class NonBlockingRouter implements Router {
    * Completes a router operation by invoking the {@code callback} and setting the {@code futureResult} with
    * {@code operationResult} (if any) and {@code exception} (if any).
    * @param <T> the type of the operation result, which depends on the kind of operation.
-   * @param futureResult the {@link FutureResult} that needs to be set.
+   * @param futureResult the {@link FutureResult} that needs to be set. Can be null.
    * @param callback that {@link Callback} that needs to be invoked. Can be null.
    * @param operationResult the result of the operation (if any).
    * @param exception {@link Exception} encountered while performing the operation (if any).
@@ -488,7 +511,7 @@ class NonBlockingRouter implements Router {
    * @param blobId the blobId to check.
    * @return boolean indicating whether the blob may be metadata.
    */
-  private static final boolean isMaybeMetadataBlob(String blobId) {
+  private static boolean isMaybeMetadataBlob(String blobId) {
     try {
       BlobId.BlobDataType dataType = BlobId.getBlobDataType(blobId);
       return (dataType == null || dataType == BlobId.BlobDataType.METADATA);
@@ -570,21 +593,38 @@ class NonBlockingRouter implements Router {
      * @param blobProperties The properties of the blob.
      * @param userMetadata Optional user metadata about the blob. This can be null.
      * @param channel The {@link ReadableStreamChannel} that contains the content of the blob.
+     * @param options The {@link PutBlobOptions} associated with the request. This cannot be null.
      * @param futureResult A future that would contain the BlobId eventually.
      * @param callback The {@link Callback} which will be invoked on the completion of the request .
      */
     protected void putBlob(BlobProperties blobProperties, byte[] userMetadata, ReadableStreamChannel channel,
+        PutBlobOptions options, FutureResult<String> futureResult, Callback<String> callback) {
+      if (!putManager.isOpen()) {
+        handlePutManagerClosed(blobProperties, futureResult, callback);
+      } else {
+        putManager.submitPutBlobOperation(blobProperties, userMetadata, channel, options, futureResult, callback);
+        routerCallback.onPollReady();
+      }
+    }
+
+    /**
+     * Requests for a new metadata blob to be put asynchronously and invokes the {@link Callback} when the request
+     * completes. This metadata blob will contain references to the chunks provided as an argument. The blob ID returned
+     * by this operation can be used to fetch the chunks as if they were a single blob.
+     * @param blobProperties The properties of the blob. Note that the size specified in the properties is ignored. The
+     *                       channel is consumed fully, and the size of the blob is the number of bytes read from it.
+     * @param userMetadata Optional user metadata about the blob. This can be null.
+     * @param chunksToStitch the list of data chunks to stitch together. The router will treat the metadata in the
+     *                       {@link ChunkInfo} object as a source of truth, so the caller should ensure that these
+     *                       fields are set accurately.
+     * @param callback The {@link Callback} which will be invoked on the completion of the request .
+     */
+    protected void stitchBlob(BlobProperties blobProperties, byte[] userMetadata, List<ChunkInfo> chunksToStitch,
         FutureResult<String> futureResult, Callback<String> callback) {
       if (!putManager.isOpen()) {
-        RouterException routerException =
-            new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
-        routerMetrics.operationDequeuingRate.mark();
-        routerMetrics.onPutBlobError(routerException, blobProperties != null && blobProperties.isEncrypted());
-        completeOperation(futureResult, callback, null, routerException);
-        // Close so that any existing operations are also disposed off.
-        close();
+        handlePutManagerClosed(blobProperties, futureResult, callback);
       } else {
-        putManager.submitPutBlobOperation(blobProperties, userMetadata, channel, futureResult, callback);
+        putManager.submitStitchBlobOperation(blobProperties, userMetadata, chunksToStitch, futureResult, callback);
         routerCallback.onPollReady();
       }
     }
@@ -692,6 +732,24 @@ class NonBlockingRouter implements Router {
         currentOperationsCount.addAndGet(1 - blobIdStrs.size());
         completeUpdateBlobTtlOperation(e, futureResult, callback);
       }
+    }
+
+    /**
+     * To be called if a put/stitch call is made while {@link PutManager} is closed. It will complete the operation
+     * with an exception and close the router.
+     * @param blobProperties the {@link BlobProperties} for the put call.
+     * @param futureResult A future to be completed by this method
+     * @param callback The {@link Callback} which will be invoked by this method.
+     */
+    private void handlePutManagerClosed(BlobProperties blobProperties, FutureResult<String> futureResult,
+        Callback<String> callback) {
+      RouterException routerException =
+          new RouterException("Cannot accept operation because Router is closed", RouterErrorCode.RouterClosed);
+      routerMetrics.operationDequeuingRate.mark();
+      routerMetrics.onPutBlobError(routerException, blobProperties != null && blobProperties.isEncrypted());
+      completeOperation(futureResult, callback, null, routerException);
+      // Close so that any existing operations are also disposed off.
+      close();
     }
 
     /**
@@ -826,7 +884,7 @@ class NonBlockingRouter implements Router {
      */
     @Override
     protected void putBlob(BlobProperties blobProperties, byte[] userMetadata, ReadableStreamChannel channel,
-        FutureResult<String> futureResult, Callback<String> callback) {
+        PutBlobOptions options, FutureResult<String> futureResult, Callback<String> callback) {
       RouterException routerException = new RouterException("Illegal attempt to put blob through BackgroundDeleter",
           RouterErrorCode.UnexpectedInternalError);
       routerMetrics.operationDequeuingRate.mark();

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -515,7 +515,7 @@ public class NonBlockingRouterMetrics {
   /**
    * Update appropriate metrics on a putBlob operation related error.
    * @param e the {@link Exception} associated with the error.
-   * @param encryptionEnabled {@code true} if encrpytion was enabled for this operation. {@code false} otherwise
+   * @param encryptionEnabled {@code true} if encryption was enabled for this operation. {@code false} otherwise
    * @param stitchOperation {@code true} if this is a stitch operation.
    */
   void onPutBlobError(Exception e, boolean encryptionEnabled, boolean stitchOperation) {

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.router;
 
-import com.codahale.metrics.Histogram;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.account.Container;
@@ -302,15 +301,13 @@ class PutManager {
     }
     routerMetrics.operationDequeuingRate.mark();
     long operationLatencyMs = time.milliseconds() - op.getSubmissionTimeMs();
-    Histogram latencyMetric;
     if (op.isStitchOperation()) {
-      latencyMetric = op.isEncryptionEnabled() ? routerMetrics.stitchEncryptedBlobOperationLatencyMs
-          : routerMetrics.stitchBlobOperationLatencyMs;
+      (op.isEncryptionEnabled() ? routerMetrics.stitchEncryptedBlobOperationLatencyMs
+          : routerMetrics.stitchBlobOperationLatencyMs).update(operationLatencyMs);
     } else {
-      latencyMetric = op.isEncryptionEnabled() ? routerMetrics.putEncryptedBlobOperationLatencyMs
-          : routerMetrics.putBlobOperationLatencyMs;
+      (op.isEncryptionEnabled() ? routerMetrics.putEncryptedBlobOperationLatencyMs
+          : routerMetrics.putBlobOperationLatencyMs).update(operationLatencyMs);
     }
-    latencyMetric.update(operationLatencyMs);
     NonBlockingRouter.completeOperation(op.getFuture(), op.getCallback(), blobId, e);
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -164,7 +164,7 @@ class PutManager {
   }
 
   /**
-   * Submit a put blob operation to be processed asynchronously.
+   * Submit a stitch blob operation to be processed asynchronously.
    * @param blobProperties the blobProperties associated with the blob being put.
    * @param userMetaData the userMetaData associated with the blob being put.
    * @param chunksToStitch the list of chunks to stitch together.

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -815,7 +815,7 @@ class PutOperation {
   /**
    * @return {@code true} if this is a blob stitching operation instead of a standard upload.
    */
-  private boolean isStitchOperation() {
+  boolean isStitchOperation() {
     return chunksToStitch != null;
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -402,16 +402,15 @@ class PutOperation {
    */
   void maybeNotifyForBlobCreation() {
     if (isOperationComplete()) {
-      boolean composite = isComposite();
       // only notify for data chunk creation on direct uploads.
-      if (composite && !isStitchOperation()) {
+      if (isComposite() && !isStitchOperation()) {
         metadataPutChunk.maybeNotifyForFirstChunkCreation();
       }
       if (blobId != null) {
         Pair<Account, Container> accountContainer =
             RouterUtils.getAccountContainer(accountService, getBlobProperties().getAccountId(),
                 getBlobProperties().getContainerId());
-        NotificationBlobType blobType = composite ? NotificationBlobType.Composite
+        NotificationBlobType blobType = isComposite() ? NotificationBlobType.Composite
             : options.isChunkUpload() ? NotificationBlobType.DataChunk : NotificationBlobType.Simple;
         notificationSystem.onBlobCreated(getBlobIdString(), getBlobProperties(), accountContainer.getFirst(),
             accountContainer.getSecond(), blobType);

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -364,9 +364,10 @@ class PutOperation {
     long chunkSize = chunkInfo.getChunkSizeInBytes();
     long chunkExpirationTimeInMs = chunkInfo.getExpirationTimeInMs();
 
-    if (chunkSize == 0 || (lastChunk ? chunkSize > intermediateChunkSize : chunkSize != intermediateChunkSize)) {
-      throw new RouterException("Invalid chunkSize: " + chunkSize + "; intermediateChunkSize: " + intermediateChunkSize,
-          RouterErrorCode.InvalidPutArgument);
+    if (chunkSize == 0 || chunkSize > intermediateChunkSize || (!lastChunk && chunkSize < intermediateChunkSize)) {
+      throw new RouterException(
+          "Invalid chunkSize for " + (lastChunk ? "last" : "intermediate") + " chunk: " + chunkSize
+              + "; intermediateChunkSize: " + intermediateChunkSize, RouterErrorCode.InvalidPutArgument);
     }
 
     long metadataExpirationTimeInMs = Utils.addSecondsToEpochTime(passedInBlobProperties.getCreationTimeInMs(),
@@ -812,7 +813,6 @@ class PutOperation {
     boolean operationFailed = blobId == null || getOperationException() != null;
     return operationFailed || metadataPutChunk.indexToChunkIds.size() > 1 || isStitchOperation();
   }
-
 
   /**
    * @return {@code true} if this is a blob stitching operation instead of a standard upload.

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -137,7 +137,6 @@ class RouterUtils {
    */
   static void replaceOperationException(AtomicReference<Exception> operationExceptionRef, RouterException exception,
       ToIntFunction<RouterErrorCode> precedenceLevelFn) {
-    RouterErrorCode routerErrorCode = exception.getErrorCode();
     Exception currentException;
     Exception newException;
     do {
@@ -148,7 +147,8 @@ class RouterUtils {
         int currentPrecedence = precedenceLevelFn.applyAsInt(
             currentException instanceof RouterException ? ((RouterException) currentException).getErrorCode()
                 : RouterErrorCode.UnexpectedInternalError);
-        newException = precedenceLevelFn.applyAsInt(routerErrorCode) < currentPrecedence ? exception : currentException;
+        newException =
+            precedenceLevelFn.applyAsInt(exception.getErrorCode()) < currentPrecedence ? exception : currentException;
       }
     } while (!operationExceptionRef.compareAndSet(currentException, newException));
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -136,7 +136,6 @@ public class ChunkFillTest {
     MockClusterMap mockClusterMap = new MockClusterMap();
     RouterConfig routerConfig = new RouterConfig(vProps);
     NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
-    ResponseHandler responseHandler = new ResponseHandler(mockClusterMap);
     short accountId = Utils.getRandomShort(random);
     short containerId = Utils.getRandomShort(random);
     BlobProperties putBlobProperties =
@@ -150,11 +149,11 @@ public class ChunkFillTest {
     MockTime time = new MockTime();
     MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);
     PutOperation op =
-        new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
-            new InMemAccountService(true, false), putUserMetadata, putChannel, futureResult, null,
-            new RouterCallback(networkClientFactory.getNetworkClient(), new ArrayList<BackgroundDeleteRequest>()), null,
+        PutOperation.forUpload(routerConfig, routerMetrics, mockClusterMap, new LoggingNotificationSystem(),
+            new InMemAccountService(true, false), putUserMetadata, putChannel, new PutBlobOptionsBuilder().build(),
+            futureResult, null, new RouterCallback(networkClientFactory.getNetworkClient(), new ArrayList<>()), null,
             null, null, null, new MockTime(), putBlobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
-    op.startReadingFromChannel();
+    op.startOperation();
     numChunks = RouterUtils.getNumChunksForBlobAndChunkSize(blobSize, chunkSize);
     // largeBlobSize is not a multiple of chunkSize
     int expectedNumChunks = (int) (blobSize / chunkSize + 1);
@@ -260,10 +259,11 @@ public class ChunkFillTest {
     MockRouterCallback routerCallback =
         new MockRouterCallback(networkClientFactory.getNetworkClient(), Collections.EMPTY_LIST);
     PutOperation op =
-        new PutOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, new LoggingNotificationSystem(),
-            new InMemAccountService(true, false), putUserMetadata, putChannel, futureResult, null, routerCallback, null,
-            kms, cryptoService, cryptoJobHandler, time, putBlobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
-    op.startReadingFromChannel();
+        PutOperation.forUpload(routerConfig, routerMetrics, mockClusterMap, new LoggingNotificationSystem(),
+            new InMemAccountService(true, false), putUserMetadata, putChannel, new PutBlobOptionsBuilder().build(),
+            futureResult, null, routerCallback, null, kms, cryptoService, cryptoJobHandler, time, putBlobProperties,
+            MockClusterMap.DEFAULT_PARTITION_CLASS);
+    op.startOperation();
     numChunks = RouterUtils.getNumChunksForBlobAndChunkSize(blobSize, chunkSize);
     compositeBuffers = new ByteBuffer[numChunks];
     compositeEncryptionKeys = new ByteBuffer[numChunks];

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -150,9 +150,9 @@ public class ChunkFillTest {
     MockNetworkClientFactory networkClientFactory = new MockNetworkClientFactory(vProps, null, 0, 0, 0, null, time);
     PutOperation op =
         PutOperation.forUpload(routerConfig, routerMetrics, mockClusterMap, new LoggingNotificationSystem(),
-            new InMemAccountService(true, false), putUserMetadata, putChannel, new PutBlobOptionsBuilder().build(),
-            futureResult, null, new RouterCallback(networkClientFactory.getNetworkClient(), new ArrayList<>()), null,
-            null, null, null, new MockTime(), putBlobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
+            new InMemAccountService(true, false), putUserMetadata, putChannel, PutBlobOptions.DEFAULT, futureResult,
+            null, new RouterCallback(networkClientFactory.getNetworkClient(), new ArrayList<>()), null, null, null,
+            null, new MockTime(), putBlobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
     op.startOperation();
     numChunks = RouterUtils.getNumChunksForBlobAndChunkSize(blobSize, chunkSize);
     // largeBlobSize is not a multiple of chunkSize
@@ -260,8 +260,8 @@ public class ChunkFillTest {
         new MockRouterCallback(networkClientFactory.getNetworkClient(), Collections.EMPTY_LIST);
     PutOperation op =
         PutOperation.forUpload(routerConfig, routerMetrics, mockClusterMap, new LoggingNotificationSystem(),
-            new InMemAccountService(true, false), putUserMetadata, putChannel, new PutBlobOptionsBuilder().build(),
-            futureResult, null, routerCallback, null, kms, cryptoService, cryptoJobHandler, time, putBlobProperties,
+            new InMemAccountService(true, false), putUserMetadata, putChannel, PutBlobOptions.DEFAULT, futureResult,
+            null, routerCallback, null, kms, cryptoService, cryptoJobHandler, time, putBlobProperties,
             MockClusterMap.DEFAULT_PARTITION_CLASS);
     op.startOperation();
     numChunks = RouterUtils.getNumChunksForBlobAndChunkSize(blobSize, chunkSize);

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
@@ -319,8 +319,7 @@ public class InMemoryRouter implements Router {
       ReadableStreamChannel channel, Short blobIdVersion) {
     FutureResult<String> futureResult = new FutureResult<>();
     PostData postData =
-        new PostData(blobProperties, usermetadata, channel, null, new PutBlobOptionsBuilder().build(), null,
-            futureResult);
+        new PostData(blobProperties, usermetadata, channel, null, PutBlobOptions.DEFAULT, null, futureResult);
     operationPool.submit(new InMemoryBlobPoster(postData, blobs, notificationSystem, clusterMap, blobIdVersion));
     return futureResult;
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -91,6 +91,7 @@ public class NonBlockingRouterTest {
   private static final int DELETE_REQUEST_PARALLELISM = 3;
   private static final int DELETE_SUCCESS_TARGET = 2;
   private static final int PUT_CONTENT_SIZE = 1000;
+  private static final int USER_METADATA_SIZE = 10;
   private int maxPutChunkSize = PUT_CONTENT_SIZE;
   private final Random random = new Random();
   private NonBlockingRouter router;
@@ -211,7 +212,7 @@ public class NonBlockingRouterTest {
   private void setOperationParams(int putContentSize, long ttlSecs) {
     putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, ttlSecs,
         Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), testEncryption);
-    putUserMetadata = new byte[10];
+    putUserMetadata = new byte[USER_METADATA_SIZE];
     random.nextBytes(putUserMetadata);
     putContent = new byte[putContentSize];
     random.nextBytes(putContent);
@@ -254,8 +255,7 @@ public class NonBlockingRouterTest {
     List<String> blobIds = new ArrayList<>();
     for (int i = 0; i < 2; i++) {
       setOperationParams();
-      String blobId =
-          router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
+      String blobId = router.putBlob(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT).get();
       blobIds.add(blobId);
     }
     setOperationParams();
@@ -1203,8 +1203,8 @@ public class NonBlockingRouterTest {
         case PUT:
           futureResult = new FutureResult<String>();
           ReadableStreamChannel putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(putContent));
-          putManager.submitPutBlobOperation(putBlobProperties, putUserMetadata, putChannel,
-              new PutBlobOptionsBuilder().build(), futureResult, null);
+          putManager.submitPutBlobOperation(putBlobProperties, putUserMetadata, putChannel, PutBlobOptions.DEFAULT,
+              futureResult, null);
           break;
         case GET:
           final FutureResult<GetBlobResultInternal> getFutureResult = new FutureResult<>();

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -721,6 +721,8 @@ public class NonBlockingRouterTest {
             .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         assertTrue("Blob properties must be the same",
             RouterTestHelpers.haveEquivalentFields(putBlobProperties, getBlobResult.getBlobInfo().getBlobProperties()));
+        assertEquals("Unexpected blob size", expectedContent.length,
+            getBlobResult.getBlobInfo().getBlobProperties().getBlobSize());
         assertArrayEquals("User metadata must be the same", putUserMetadata,
             getBlobResult.getBlobInfo().getUserMetadata());
         RouterTestHelpers.compareContent(expectedContent, null, getBlobResult.getBlobDataChannel());

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -103,9 +103,9 @@ public class PutOperationTest {
     MockNetworkClient mockNetworkClient = new MockNetworkClient();
     PutOperation op =
         PutOperation.forUpload(routerConfig, routerMetrics, mockClusterMap, new LoggingNotificationSystem(),
-            new InMemAccountService(true, false), userMetadata, channel, new PutBlobOptionsBuilder().build(), future,
-            null, new RouterCallback(mockNetworkClient, new ArrayList<>()), null, null, null, null, time,
-            blobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
+            new InMemAccountService(true, false), userMetadata, channel, PutBlobOptions.DEFAULT, future, null,
+            new RouterCallback(mockNetworkClient, new ArrayList<>()), null, null, null, null, time, blobProperties,
+            MockClusterMap.DEFAULT_PARTITION_CLASS);
     op.startOperation();
     List<RequestInfo> requestInfos = new ArrayList<>();
     requestRegistrationCallback.requestListToFill = requestInfos;
@@ -211,9 +211,9 @@ public class PutOperationTest {
     MockNetworkClient mockNetworkClient = new MockNetworkClient();
     PutOperation op =
         PutOperation.forUpload(routerConfig, routerMetrics, mockClusterMap, new LoggingNotificationSystem(),
-            new InMemAccountService(true, false), userMetadata, channel, new PutBlobOptionsBuilder().build(), future,
-            null, new RouterCallback(mockNetworkClient, new ArrayList<>()), null, null, null, null, time,
-            blobProperties, MockClusterMap.DEFAULT_PARTITION_CLASS);
+            new InMemAccountService(true, false), userMetadata, channel, PutBlobOptions.DEFAULT, future, null,
+            new RouterCallback(mockNetworkClient, new ArrayList<>()), null, null, null, null, time, blobProperties,
+            MockClusterMap.DEFAULT_PARTITION_CLASS);
     RouterErrorCode[] routerErrorCodes = new RouterErrorCode[5];
     routerErrorCodes[0] = RouterErrorCode.OperationTimedOut;
     routerErrorCodes[1] = RouterErrorCode.UnexpectedInternalError;

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
@@ -242,7 +242,7 @@ class RouterTestHelpers {
 
   /**
    * @param totalSize the total size of the composite blob.
-   * @param maxChunkSize the size to use for intermediate data chunks.j
+   * @param maxChunkSize the size to use for intermediate data chunks.
    * @return a {@link LongStream} that returns valid chunk sizes that conform to {@code totalSize} and
    *         {@code maxChunkSize}
    */

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
@@ -104,7 +104,7 @@ class PerfRouter implements Router {
    * @param blobProperties The properties of the blob.
    * @param usermetadata Optional user metadata about the blob. This can be null.
    * @param channel The {@link ReadableStreamChannel} that contains the content of the blob.
-   * @param options
+   * @param options the {@link PutBlobOptions} for the blob.
    * @param callback the {@link Callback} to invoke on operation completion.
    * @return a {@link Future} that will contain a (dummy) blob id.
    */
@@ -137,7 +137,7 @@ class PerfRouter implements Router {
   }
 
   @Override
-  public Future<String> stitchBlob(BlobProperties blobProperties, byte[] usermetadata, List<ChunkInfo> chunksToStitch,
+  public Future<String> stitchBlob(BlobProperties blobProperties, byte[] userMetadata, List<ChunkInfo> chunksToStitch,
       Callback<String> callback) {
     logger.trace("Received stitchBlob call");
     final FutureResult<String> futureResult = new FutureResult<>();

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
@@ -137,9 +137,16 @@ class PerfRouter implements Router {
   }
 
   @Override
-  public Future<String> stitchBlob(BlobProperties blobProperties, byte[] userMetadata, List<ChunkInfo> chunksToStitch,
+  public Future<String> stitchBlob(BlobProperties blobProperties, byte[] usermetadata, List<ChunkInfo> chunksToStitch,
       Callback<String> callback) {
-    throw new UnsupportedOperationException("Only in full PR");
+    logger.trace("Received stitchBlob call");
+    final FutureResult<String> futureResult = new FutureResult<>();
+    if (!routerOpen) {
+      completeOperation(futureResult, callback, null, ROUTER_CLOSED_EXCEPTION);
+    } else {
+      completeOperation(futureResult, callback, BLOB_ID, null);
+    }
+    return futureResult;
   }
 
   /**

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -36,7 +36,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -36,6 +36,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
@@ -873,6 +874,25 @@ public class Utils {
   public static long getTtlInSecsFromExpiryMs(long expiresAtMs, long creationTimeMs) {
     return expiresAtMs == Utils.Infinite_Time ? Utils.Infinite_Time
         : Math.max(0, TimeUnit.MILLISECONDS.toSeconds(expiresAtMs - creationTimeMs));
+  }
+
+  /**
+   * Compare two times or durations, accounting for the {@link Utils#Infinite_Time} constant.
+   * @param time1 the first time.
+   * @param time2 the second time.
+   * @return -1 if {@code time1} is earlier than {@code time2}, 0 if the times are equal, and 1 if {@code time1} is
+   *         later than {@code time2}. {@link Utils#Infinite_Time} is considered greater than any other time.
+   */
+  public static int compareTimes(long time1, long time2) {
+    if (time1 == time2) {
+      return 0;
+    } else if (time1 == Utils.Infinite_Time) {
+      return 1;
+    } else if (time2 == Utils.Infinite_Time) {
+      return -1;
+    } else {
+      return Long.compare(time1, time2);
+    }
   }
 
   /**

--- a/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
@@ -522,6 +522,22 @@ public class UtilsTest {
     assertFalse("String should not be declared empty", Utils.isNullOrEmpty(getRandomString(10)));
   }
 
+  /**
+   * Tests for {@link Utils#compareTimes(long, long)}.
+   */
+  @Test
+  public void compareTimesTest() {
+    assertEquals("Infinite_Time should be equal to Infinite_Time", 0,
+        Utils.compareTimes(Utils.Infinite_Time, Utils.Infinite_Time));
+    assertEquals("Infinite_Time should be greater than any finite time.", 1,
+        Utils.compareTimes(Utils.Infinite_Time, Long.MAX_VALUE));
+    assertEquals("Any finite time should be less than any Infinite_Time.", -1,
+        Utils.compareTimes(Long.MAX_VALUE, Utils.Infinite_Time));
+    assertEquals("Wrong comparison result for finite times", 0, Utils.compareTimes(25, 25));
+    assertEquals("Wrong comparison result for finite times", -1, Utils.compareTimes(24, 25));
+    assertEquals("Wrong comparison result for finite times", 1, Utils.compareTimes(25, 24));
+  }
+
   private static final String CHARACTERS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
   static Random random = new Random();
 


### PR DESCRIPTION
Add support for stitching blobs to the router. The main change is to
allow PutOperation to take in a list of chunk IDs (+ metadata) and
upload a freestanding metadata chunk. The caller of the stitchBlob
method is responsible for ensuring that the metadata in the ChunkInfo
object is correct.

For now, this will rely on the existing metadata format which requires
that all intermediate chunks are the same size. Future changes to this
format will allow for stitching chunks of arbitrary size.

### Notes for reviewers
The number of lines in this PR got to be a bit large because of boilerplate. The main interface changes are in the `Router` and `ChunkInfo` classes. The main implementation changes are inside of the `PutOperation` class. The changes in `NonBlockingRouter` and `PutManager` are mostly about getting the stitchBlob arguments to `PutOperation`.