### PR TITLE
Make cross-colo listening optional within Helix ClusterManager

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -170,6 +170,14 @@ public class ClusterMapConfig {
   @Default("false")
   public final boolean clusterMapEnablePartitionOverride;
 
+  /**
+   * If set to false, the Helix based cluster manager will only listen to changes to the cluster in the local colo. It
+   * will only connect to the remote ZK servers during initialization.
+   */
+  @Config("clustermap.listen.cross.colo")
+  @Default("true")
+  public final boolean clustermapListenCrossColo;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -201,5 +209,6 @@ public class ClusterMapConfig {
         verifiableProperties.getString("clustermap.default.partition.class", MAX_REPLICAS_ALL_DATACENTERS);
     clustermapCurrentXid = verifiableProperties.getLong("clustermap.current.xid", Long.MAX_VALUE);
     clusterMapEnablePartitionOverride = verifiableProperties.getBoolean("clustermap.enable.partition.override", false);
+    clustermapListenCrossColo = verifiableProperties.getBoolean("clustermap.listen.cross.colo", true);
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.I0Itec.zkclient.IZkDataListener;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixManager;
@@ -364,6 +365,15 @@ class HelixClusterManager implements ClusterMap {
       }
     }
     return null;
+  }
+
+  /**
+   * @return a map of datacenter names to {@link HelixManager}
+   */
+  Map<String, HelixManager> getHelixManagerMap() {
+    return dcToDcZkInfo.entrySet()
+        .stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().helixManager));
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -116,41 +116,42 @@ class HelixClusterManager implements ClusterMap {
         String dcName = entry.getKey();
         String zkConnectStr = entry.getValue().getZkConnectStr();
         ClusterChangeHandler clusterChangeHandler = new ClusterChangeHandler(dcName);
-        // Initialize from every datacenter in a separate thread to speed things up.
-        Utils.newThread(new Runnable() {
-          @Override
-          public void run() {
-            try {
-              HelixManager manager;
-              if (dcName.equals(clusterMapConfig.clusterMapDatacenterName)) {
-                manager = localManager;
-              } else {
-                manager =
-                    helixFactory.getZKHelixManager(clusterName, selfInstanceName, InstanceType.SPECTATOR, zkConnectStr);
-                logger.info("Connecting to Helix manager at {}", zkConnectStr);
-                manager.connect();
-                logger.info("Established connection to Helix manager at {}", zkConnectStr);
-              }
-              DcInfo dcInfo = new DcInfo(dcName, entry.getValue(), manager, clusterChangeHandler);
-              dcToDcZkInfo.put(dcName, dcInfo);
-              dcIdToDcName.put(dcInfo.dcZkInfo.getDcId(), dcName);
-
-              // The initial instance config change notification is required to populate the static cluster
-              // information, and only after that is complete do we want the live instance change notification to
-              // come in. We do not need to do anything extra to ensure this, however, since Helix provides the initial
-              // notification for a change from within the same thread that adds the listener, in the context of the add
-              // call. Therefore, when the call to add a listener returns, the initial notification will have been
-              // received and handled.
-              manager.addInstanceConfigChangeListener(clusterChangeHandler);
-              logger.info("Registered instance config change listeners for Helix manager at {}", zkConnectStr);
-              // Now register listeners to get notified on live instance change in every datacenter.
-              manager.addLiveInstanceChangeListener(clusterChangeHandler);
-              logger.info("Registered live instance change listeners for Helix manager at {}", zkConnectStr);
-            } catch (Exception e) {
-              initializationException.compareAndSet(null, e);
-            } finally {
-              initializationAttemptComplete.countDown();
+        // Initialize from every remote datacenter in a separate thread to speed things up.
+        Utils.newThread(() -> {
+          try {
+            HelixManager manager;
+            if (dcName.equals(clusterMapConfig.clusterMapDatacenterName)) {
+              manager = localManager;
+            } else {
+              manager =
+                  helixFactory.getZKHelixManager(clusterName, selfInstanceName, InstanceType.SPECTATOR, zkConnectStr);
+              logger.info("Connecting to Helix manager at {}", zkConnectStr);
+              manager.connect();
+              logger.info("Established connection to Helix manager at {}", zkConnectStr);
             }
+            DcInfo dcInfo = new DcInfo(dcName, entry.getValue(), manager, clusterChangeHandler);
+            dcToDcZkInfo.put(dcName, dcInfo);
+            dcIdToDcName.put(dcInfo.dcZkInfo.getDcId(), dcName);
+
+            // The initial instance config change notification is required to populate the static cluster
+            // information, and only after that is complete do we want the live instance change notification to
+            // come in. We do not need to do anything extra to ensure this, however, since Helix provides the initial
+            // notification for a change from within the same thread that adds the listener, in the context of the add
+            // call. Therefore, when the call to add a listener returns, the initial notification will have been
+            // received and handled.
+            manager.addInstanceConfigChangeListener(clusterChangeHandler);
+            logger.info("Registered instance config change listeners for Helix manager at {}", zkConnectStr);
+            // Now register listeners to get notified on live instance change in every datacenter.
+            manager.addLiveInstanceChangeListener(clusterChangeHandler);
+            logger.info("Registered live instance change listeners for Helix manager at {}", zkConnectStr);
+            if (!clusterMapConfig.clustermapListenCrossColo && manager != localManager) {
+              manager.disconnect();
+              logger.info("Stopped listening to cross colo ZK server {}", zkConnectStr);
+            }
+          } catch (Exception e) {
+            initializationException.compareAndSet(null, e);
+          } finally {
+            initializationAttemptComplete.countDown();
           }
         }, false).start();
       }
@@ -342,7 +343,9 @@ class HelixClusterManager implements ClusterMap {
   @Override
   public void close() {
     for (DcInfo dcInfo : dcToDcZkInfo.values()) {
-      dcInfo.helixManager.disconnect();
+      if (dcInfo.helixManager.isConnected()) {
+        dcInfo.helixManager.disconnect();
+      }
     }
     dcToDcZkInfo.clear();
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -76,6 +76,7 @@ public class HelixClusterManagerTest {
   private Map<String, Counter> counters;
   private final boolean useComposite;
   private final boolean overrideEnabled;
+  private final boolean listenCrossColo;
   private final String hardwareLayoutPath;
   private final String partitionLayoutPath;
   private static final long CURRENT_XID = 64;
@@ -98,20 +99,27 @@ public class HelixClusterManagerTest {
 
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{false, false}, {false, true}, {true, false}});
+    return Arrays.asList(
+        // @formatter:off
+        new Object[][]{{false, false, true}, {false, true, true}, {true, false, true}, {false, false, false},
+                       {false, true, false}, {true, false, false}});
+        // @formatter:on
   }
 
   /**
    * Construct the static layout files and use that to instantiate a {@link MockHelixCluster}.
    * Instantiate a {@link MockHelixManagerFactory} for use by the cluster manager.
    * @param useComposite whether or not the test are to be done for the {@link CompositeClusterManager}
-   * @param overrideEnabled whether or not the {@link ClusterMapConfig#clusterMapEnablePartitionOverride} is enabled. This config
-   *                        is only applicable for {@link HelixClusterManager}
+   * @param overrideEnabled whether or not the {@link ClusterMapConfig#clusterMapEnablePartitionOverride} is enabled.
+   *                        This config is only applicable for {@link HelixClusterManager}
+   * @param listenCrossColo whether or not listenCrossColo config in {@link ClusterMapConfig} should be set to true.
    * @throws Exception
    */
-  public HelixClusterManagerTest(boolean useComposite, boolean overrideEnabled) throws Exception {
+  public HelixClusterManagerTest(boolean useComposite, boolean overrideEnabled, boolean listenCrossColo)
+      throws Exception {
     this.useComposite = useComposite;
     this.overrideEnabled = overrideEnabled;
+    this.listenCrossColo = listenCrossColo;
     MockitoAnnotations.initMocks(this);
     String localDc = dcs[0];
     Random random = new Random();
@@ -186,6 +194,7 @@ public class HelixClusterManagerTest {
     props.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
     props.setProperty("clustermap.current.xid", Long.toString(CURRENT_XID));
     props.setProperty("clustermap.enable.partition.override", Boolean.toString(overrideEnabled));
+    props.setProperty("clustermap.listen.cross.colo", Boolean.toString(listenCrossColo));
     clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     MockHelixManagerFactory helixManagerFactory = new MockHelixManagerFactory(helixCluster, znRecord, null);
     if (useComposite) {
@@ -460,7 +469,7 @@ public class HelixClusterManagerTest {
    */
   @Test
   public void sealedReplicaChangeTest() throws Exception {
-    assumeTrue(!useComposite && !overrideEnabled);
+    assumeTrue(!useComposite && !overrideEnabled && listenCrossColo);
 
     // all instances are up initially.
     assertStateEquivalency();
@@ -499,7 +508,7 @@ public class HelixClusterManagerTest {
    */
   @Test
   public void clusterMapOverrideEnabledAndDisabledTest() throws Exception {
-    assumeTrue(!useComposite);
+    assumeTrue(!useComposite && listenCrossColo);
 
     // Get the writable partitions in OverrideMap
     Set<String> writableInOverrideMap = new HashSet<>();
@@ -593,7 +602,7 @@ public class HelixClusterManagerTest {
    */
   @Test
   public void stoppedReplicaChangeTest() {
-    assumeTrue(!useComposite && !overrideEnabled);
+    assumeTrue(!useComposite && !overrideEnabled && listenCrossColo);
 
     // all instances are up initially.
     assertStateEquivalency();
@@ -645,7 +654,7 @@ public class HelixClusterManagerTest {
    */
   @Test
   public void xidTest() throws Exception {
-    assumeTrue(!useComposite);
+    assumeTrue(!useComposite && listenCrossColo);
 
     // Close the one initialized in the constructor, as this test needs to test initialization flow as well.
     clusterManager.close();
@@ -697,6 +706,17 @@ public class HelixClusterManagerTest {
     helixCluster.triggerInstanceConfigChangeNotification();
     // Now the change should get absorbed.
     assertTrue(ignoreInstanceReplica.isDown());
+  }
+
+  @Test
+  public void listenCrossColoTest() throws Exception {
+    assumeTrue(!useComposite && listenCrossColo);
+    Counter instanceTriggerCounter =
+        ((HelixClusterManager) clusterManager).helixClusterManagerMetrics.instanceConfigChangeTriggerCount;
+    long instanceConfigChangeTriggerCount = instanceTriggerCounter.getCount();
+    helixCluster.triggerInstanceConfigChangeNotification();
+    assertEquals("Number of trigger count should be in accordance to listenCrossColo value",
+        instanceConfigChangeTriggerCount + (listenCrossColo ? dcs.length : 1), instanceTriggerCounter.getCount());
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -728,7 +728,7 @@ public class HelixClusterManagerTest {
       } else {
         assertEquals(
             "Helix cluster manager should be connected to the remote Helix managers if and only if listenCrossColo is"
-                + "set to false", listenCrossColo, entry.getValue().isConnected());
+                + "set to true", listenCrossColo, entry.getValue().isConnected());
       }
     }
     long instanceConfigChangeTriggerCount = instanceTriggerCounter.getCount();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
@@ -171,6 +171,9 @@ class MockHelixManager implements HelixManager {
   }
 
   void triggerConfigChangeNotification(boolean init) {
+    if (!isConnected) {
+      return;
+    }
     NotificationContext notificationContext = new NotificationContext(this);
     if (init) {
       notificationContext.setType(NotificationContext.Type.INIT);


### PR DESCRIPTION
Introduce listenCrossColo config in ClusterMapConfig that defaults
to true. It can be set to false when making sensitive changes to
the cluster information in ZK so that a bad change does not get
propagated across colos. This helps in safely and selectively
introducing new changes.