### PR TITLE
Adding tests to verify replication with different versions of BlobId behaves correctly

### DIFF
--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -909,7 +909,7 @@ public class ReplicationTest {
     // For simplicity, we use A1 to denote Version_2 blobId, A2 to denote Version_5 blobId.
     // For example, A1P means Version_2 PUT message, A2D means Version_5 DELETE message, etc.
     short VERSION_2 = 2;
-    short VERSION_5 = CommonTestUtils.getCurrentBlobIdVersion();
+    short VERSION_5 = 5;
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     boolean toEncrypt = TestUtils.RANDOM.nextBoolean();

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -914,13 +914,13 @@ public class ReplicationTest {
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     boolean toEncrypt = TestUtils.RANDOM.nextBoolean();
 
-    Map<String, String> testCasesAndResults = new HashMap<>();
-    testCasesAndResults.put("A1P A1D A2P", "");
-    testCasesAndResults.put("A1P A2D", "A2P");
-    testCasesAndResults.put("A1P A2P A1D", "");
-    testCasesAndResults.put("A1P A2P", "A2P");
-    testCasesAndResults.put("A1P A2P A1D A2D", "");
-    testCasesAndResults.put("A2P A2D A1P", "A2P");  // this case should not happen in practice
+    Map<String, String> testCasesAndExpectedResults = new HashMap<>();
+    testCasesAndExpectedResults.put("A1P A1D A2P", "");
+    testCasesAndExpectedResults.put("A1P A2D", "A2P");
+    testCasesAndExpectedResults.put("A1P A2P A1D", "");
+    testCasesAndExpectedResults.put("A1P A2P", "A2P");
+    testCasesAndExpectedResults.put("A1P A2P A1D A2D", "");
+    testCasesAndExpectedResults.put("A2P A2D A1P", "A2P");
     StoreKey blobIdV2 =
         new BlobId(VERSION_2, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID, accountId, containerId,
             partitionId, toEncrypt, BlobId.BlobDataType.DATACHUNK);
@@ -950,7 +950,7 @@ public class ReplicationTest {
       }
     }
 
-    for (Map.Entry<String, String> caseAndResult : testCasesAndResults.entrySet()) {
+    for (Map.Entry<String, String> caseAndResult : testCasesAndExpectedResults.entrySet()) {
       // Set up different combinations of PUT, DELETE messages on remote host
       String[] messages = caseAndResult.getKey().split(" ");
       for (String message : messages) {

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreKeyConverterImplNoOp.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreKeyConverterImplNoOp.java
@@ -14,8 +14,6 @@
 
 package com.github.ambry.store;
 
-import com.github.ambry.store.StoreKey;
-import com.github.ambry.store.StoreKeyConverter;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
This PR added test to mock a scenario where replication with different versions of BlobId on local and remote hosts. The intention is to ensure that different combinations of BlobIds as well as messages are transformed and replicated as expected.

No code changes in production code, only for testing. 