### PR TITLE
[stitched uploads] Support stitch API in frontend

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
@@ -28,12 +28,17 @@ public class FrontendConfig {
 
   // Property keys
   public static final String URL_SIGNER_ENDPOINTS = PREFIX + "url.signer.endpoints";
+  public static final String CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS_KEY = PREFIX + "chunk.upload.initial.chunk.ttl.secs";
+  public static final String FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY =
+      PREFIX + "fail.if.ttl.required.but.not.provided";
+  public static final String MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY =
+      PREFIX + "max.acceptable.ttl.secs.if.ttl.required";
+  public static final String MAX_STITCH_REQUEST_SIZE_BYTES_KEY = PREFIX + "max.stitch.request.size.bytes";
 
+  // Default values
   private static final String DEFAULT_ENDPOINT = "http://localhost:1174";
-
   private static final String DEFAULT_ENDPOINTS_STRING =
       "{\"POST\": \"" + DEFAULT_ENDPOINT + "\", \"GET\": \"" + DEFAULT_ENDPOINT + "\"}";
-
   /**
    * Cache validity in seconds for non-private blobs for GET.
    */
@@ -155,22 +160,24 @@ public class FrontendConfig {
   /**
    * The blob TTL in seconds to use for data chunks uploaded in a stitched upload session.
    */
-  public static final String CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS_KEY = PREFIX + "chunk.upload.initial.chunk.ttl.secs";
   @Config(CHUNK_UPLOAD_INITIAL_CHUNK_TTL_SECS_KEY)
   @Default("28 * 24 * 60 * 60")
   public final long chunkUploadInitialChunkTtlSecs;
 
-  public static final String FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY =
-      PREFIX + "fail.if.ttl.required.but.not.provided";
   @Config(FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY)
   @Default("false")
   public final boolean failIfTtlRequiredButNotProvided;
 
-  public static final String MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY =
-      PREFIX + "max.acceptable.ttl.secs.if.ttl.required";
   @Config(MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY)
   @Default("30 * 24 * 60 * 60")
   public final int maxAcceptableTtlSecsIfTtlRequired;
+
+  /**
+   * The maximum size in bytes for the JSON body of a "POST /stitch" request.
+   */
+  @Config(MAX_STITCH_REQUEST_SIZE_BYTES_KEY)
+  @Default("20 * 1024 * 1024")
+  public final long maxStitchRequestSizeBytes;
 
   public FrontendConfig(VerifiableProperties verifiableProperties) {
     cacheValiditySeconds = verifiableProperties.getLong("frontend.cache.validity.seconds", 365 * 24 * 60 * 60);
@@ -208,5 +215,7 @@ public class FrontendConfig {
     failIfTtlRequiredButNotProvided = verifiableProperties.getBoolean(FAIL_IF_TTL_REQUIRED_BUT_NOT_PROVIDED_KEY, false);
     maxAcceptableTtlSecsIfTtlRequired = verifiableProperties.getIntInRange(MAX_ACCEPTABLE_TTL_SECS_IF_TTL_REQUIRED_KEY,
         (int) TimeUnit.DAYS.toSeconds(30), 0, Integer.MAX_VALUE);
+    maxStitchRequestSizeBytes =
+        verifiableProperties.getLongInRange(MAX_STITCH_REQUEST_SIZE_BYTES_KEY, 20 * 1024 * 1024, 0, Long.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/frontend/IdSigningService.java
+++ b/ambry-api/src/main/java/com.github.ambry/frontend/IdSigningService.java
@@ -37,6 +37,8 @@ public interface IdSigningService {
   String getSignedId(String blobId, Map<String, String> metadata) throws RestServiceException;
 
   /**
+   * Implementations of this method should transparently handle any valid ID prefixes or suffixes
+   * (leading slashes, etc.) that may be added by an {@link IdConverter}.
    * @param id the input ID to check.
    * @return {@code true} if the ID is signed. {@code false} otherwise
    */
@@ -44,7 +46,8 @@ public interface IdSigningService {
 
   /**
    * Verify that the signed ID has not been tampered with and extract the blob ID and additional metadata from the
-   * signed ID.
+   * signed ID. Implementations of this method should transparently handle any valid ID prefixes or suffixes
+   * (leading slashes, etc.) that may be added by an {@link IdConverter}.
    * @return a {@link Pair} that contains the blob ID and additional metadata parsed from the signed ID.
    * @throws RestServiceException if there are problems verifying or parsing the ID.
    */

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -662,7 +662,7 @@ public class RestUtils {
    * @throws RestServiceException if exception occurs during parsing the arg.
    */
   public static boolean isChunkUpload(Map<String, Object> args) throws RestServiceException {
-    return getHeader(args, Headers.CHUNK_UPLOAD, false) != null;
+    return getBooleanHeader(args, Headers.CHUNK_UPLOAD, false);
   }
 
   /**
@@ -691,7 +691,7 @@ public class RestUtils {
    *                                    {@code args} or if there is more than one value for {@code header} in
    *                                    {@code args}.
    */
-  public static String getHeader(Map<String, Object> args, String header, boolean required)
+  public static String getHeader(Map<String, ?> args, String header, boolean required)
       throws RestServiceException {
     String value = null;
     if (args.containsKey(header)) {
@@ -719,7 +719,7 @@ public class RestUtils {
    * @throws RestServiceException same as cases of {@link #getHeader(Map, String, boolean)} and if the value cannot be
    *                              converted to a {@link Long}.
    */
-  public static Long getLongHeader(Map<String, Object> args, String header, boolean required)
+  public static Long getLongHeader(Map<String, ?> args, String header, boolean required)
       throws RestServiceException {
     // if getHeader() is no longer called, tests for this function have to be changed.
     String value = getHeader(args, header, required);

--- a/ambry-api/src/main/java/com.github.ambry/router/ChunkInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/ChunkInfo.java
@@ -14,6 +14,9 @@
 
 package com.github.ambry.router;
 
+import java.util.Objects;
+
+
 /**
  * Represents a data chunk to be stitched by a {@link Router#stitchBlob} call.
  */
@@ -28,7 +31,7 @@ public class ChunkInfo {
    * @param expirationTimeInMs the expiration time of the chunk in milliseconds.
    */
   public ChunkInfo(String blobId, long chunkSizeInBytes, long expirationTimeInMs) {
-    this.blobId = blobId;
+    this.blobId = Objects.requireNonNull(blobId, "blobId cannot be null");
     this.chunkSizeInBytes = chunkSizeInBytes;
     this.expirationTimeInMs = expirationTimeInMs;
   }
@@ -58,5 +61,23 @@ public class ChunkInfo {
   public String toString() {
     return "ChunkInfo{" + "blobId='" + blobId + '\'' + ", chunkSizeInBytes=" + chunkSizeInBytes
         + ", expirationTimeInMs=" + expirationTimeInMs + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ChunkInfo chunkInfo = (ChunkInfo) o;
+    return chunkSizeInBytes == chunkInfo.chunkSizeInBytes && expirationTimeInMs == chunkInfo.expirationTimeInMs
+        && Objects.equals(blobId, chunkInfo.blobId);
+  }
+
+  @Override
+  public int hashCode() {
+    return blobId.hashCode();
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/router/ChunkInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/ChunkInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.router;
+
+/**
+ * Represents a data chunk to be stitched by a {@link Router#stitchBlob} call.
+ */
+public class ChunkInfo {
+  private final String blobId;
+  private final long chunkSizeInBytes;
+  private final long expirationTimeInMs;
+
+  /**
+   * @param blobId the blob ID for the chunk.
+   * @param chunkSizeInBytes the size of the chunk content in bytes.
+   * @param expirationTimeInMs the expiration time of the chunk in milliseconds.
+   */
+  public ChunkInfo(String blobId, long chunkSizeInBytes, long expirationTimeInMs) {
+    this.blobId = blobId;
+    this.chunkSizeInBytes = chunkSizeInBytes;
+    this.expirationTimeInMs = expirationTimeInMs;
+  }
+
+  /**
+   * @return the blob ID for the chunk.
+   */
+  public String getBlobId() {
+    return blobId;
+  }
+
+  /**
+   * @return the size of the chunk content in bytes.
+   */
+  public long getChunkSizeInBytes() {
+    return chunkSizeInBytes;
+  }
+
+  /**
+   * @return the expiration time of the chunk in milliseconds.
+   */
+  public long getExpirationTimeInMs() {
+    return expirationTimeInMs;
+  }
+
+  @Override
+  public String toString() {
+    return "ChunkInfo{" + "blobId='" + blobId + '\'' + ", chunkSizeInBytes=" + chunkSizeInBytes
+        + ", expirationTimeInMs=" + expirationTimeInMs + '}';
+  }
+}

--- a/ambry-api/src/main/java/com.github.ambry/router/PutBlobOptions.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/PutBlobOptions.java
@@ -20,6 +20,7 @@ package com.github.ambry.router;
  * @todo honor these options within the router impl
  */
 public class PutBlobOptions {
+  public static final PutBlobOptions DEFAULT = new PutBlobOptionsBuilder().build();
   private final boolean chunkUpload;
   private final long maxUploadSize;
 

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -76,6 +76,7 @@ class AmbryBlobStorageService implements BlobStorageService {
   private final FrontendMetrics frontendMetrics;
   private final GetReplicasHandler getReplicasHandler;
   private final UrlSigningService urlSigningService;
+  private final IdSigningService idSigningService;
   private final AccountAndContainerInjector accountAndContainerInjector;
   private final Logger logger = LoggerFactory.getLogger(AmbryBlobStorageService.class);
   private final String datacenterName;
@@ -99,11 +100,16 @@ class AmbryBlobStorageService implements BlobStorageService {
    * @param idConverterFactory the {@link IdConverterFactory} to use to get an {@link IdConverter} instance.
    * @param securityServiceFactory the {@link SecurityServiceFactory} to use to get an {@link SecurityService} instance.
    * @param urlSigningService the {@link UrlSigningService} used to sign URLs.
+   * @param idSigningService the {@link IdSigningService} used to sign and verify IDs.
+   * @param accountAndContainerInjector the {@link AccountAndContainerInjector} to use.
+   * @param datacenterName the local datacenter name for this frontend.
+   * @param hostname the hostname for this frontend.
    */
   AmbryBlobStorageService(FrontendConfig frontendConfig, FrontendMetrics frontendMetrics,
       RestResponseHandler responseHandler, Router router, ClusterMap clusterMap, IdConverterFactory idConverterFactory,
       SecurityServiceFactory securityServiceFactory, UrlSigningService urlSigningService,
-      AccountAndContainerInjector accountAndContainerInjector, String datacenterName, String hostname) {
+      IdSigningService idSigningService, AccountAndContainerInjector accountAndContainerInjector, String datacenterName,
+      String hostname) {
     this.frontendConfig = frontendConfig;
     this.frontendMetrics = frontendMetrics;
     this.responseHandler = responseHandler;
@@ -112,6 +118,7 @@ class AmbryBlobStorageService implements BlobStorageService {
     this.idConverterFactory = idConverterFactory;
     this.securityServiceFactory = securityServiceFactory;
     this.urlSigningService = urlSigningService;
+    this.idSigningService = idSigningService;
     this.accountAndContainerInjector = accountAndContainerInjector;
     this.datacenterName = datacenterName;
     this.hostname = hostname;
@@ -129,8 +136,8 @@ class AmbryBlobStorageService implements BlobStorageService {
         new GetSignedUrlHandler(urlSigningService, securityService, idConverter, accountAndContainerInjector,
             frontendMetrics, clusterMap);
     postBlobHandler =
-        new PostBlobHandler(securityService, idConverter, router, accountAndContainerInjector, SystemTime.getInstance(),
-            frontendConfig, frontendMetrics);
+        new PostBlobHandler(securityService, idConverter, idSigningService, router, accountAndContainerInjector,
+            SystemTime.getInstance(), frontendConfig, frontendMetrics);
     ttlUpdateHandler =
         new TtlUpdateHandler(router, securityService, idConverter, accountAndContainerInjector, frontendMetrics,
             clusterMap);

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
@@ -90,7 +90,7 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
           Utils.getObj(frontendConfig.securityServiceFactory, verifiableProperties, clusterMap, accountService,
               urlSigningService, accountAndContainerInjector);
       return new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, clusterMap,
-          idConverterFactory, securityServiceFactory, urlSigningService, accountAndContainerInjector,
+          idConverterFactory, securityServiceFactory, urlSigningService, idSigningService, accountAndContainerInjector,
           clusterMapConfig.clusterMapDatacenterName, clusterMapConfig.clusterMapHostName);
     } catch (Exception e) {
       throw new IllegalStateException("Could not instantiate AmbryBlobStorageService", e);

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryIdSigningService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryIdSigningService.java
@@ -43,7 +43,8 @@ public class AmbryIdSigningService implements IdSigningService {
 
   @Override
   public boolean isIdSigned(String id) {
-    return id.startsWith(SIGNED_ID_PREFIX);
+    int searchStart = id.startsWith("/") ? 1 : 0;
+    return id.startsWith(SIGNED_ID_PREFIX, searchStart);
   }
 
   @Override
@@ -52,7 +53,8 @@ public class AmbryIdSigningService implements IdSigningService {
       throw new RestServiceException("Expected ID to be signed: " + signedId, RestServiceErrorCode.InternalServerError);
     }
     try {
-      String base64String = signedId.substring(SIGNED_ID_PREFIX.length());
+      int startIndex = SIGNED_ID_PREFIX.length() + (signedId.startsWith("/") ? 1 : 0);
+      String base64String = signedId.substring(startIndex);
       String jsonString = new String(Base64.decodeBase64(base64String), StandardCharsets.UTF_8);
       return SignedIdSerDe.fromJson(jsonString);
     } catch (Exception e) {

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/FrontendMetrics.java
@@ -63,6 +63,8 @@ public class FrontendMetrics {
   public final AsyncOperationTracker.Metrics postSecurityPreProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics postSecurityProcessRequestMetrics;
   public final AsyncOperationTracker.Metrics postSecurityPostProcessRequestMetrics;
+  public final AsyncOperationTracker.Metrics postReadStitchRequestMetrics;
+  public final AsyncOperationTracker.Metrics postRouterStitchBlobMetrics;
   public final AsyncOperationTracker.Metrics postRouterPutBlobMetrics;
   public final AsyncOperationTracker.Metrics postIdConversionMetrics;
   public final AsyncOperationTracker.Metrics postSecurityProcessResponseMetrics;
@@ -223,6 +225,10 @@ public class FrontendMetrics {
         new AsyncOperationTracker.Metrics(PostBlobHandler.class, "postSecurityProcessRequest", metricRegistry);
     postSecurityPostProcessRequestMetrics =
         new AsyncOperationTracker.Metrics(PostBlobHandler.class, "postSecurityPostProcessRequest", metricRegistry);
+    postReadStitchRequestMetrics =
+        new AsyncOperationTracker.Metrics(PostBlobHandler.class, "postReadStitchRequest", metricRegistry);
+    postRouterStitchBlobMetrics =
+        new AsyncOperationTracker.Metrics(PostBlobHandler.class, "postRouterStitchBlob", metricRegistry);
     postRouterPutBlobMetrics =
         new AsyncOperationTracker.Metrics(PostBlobHandler.class, "postRouterPutBlob", metricRegistry);
     postIdConversionMetrics =

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/Operations.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/Operations.java
@@ -20,4 +20,5 @@ public class Operations {
   public static final String GET_PEERS = "peers";
   public static final String GET_SIGNED_URL = "signedUrl";
   public static final String UPDATE_TTL = "updateTtl";
+  public static final String STITCH = "stitch";
 }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
@@ -14,6 +14,8 @@
 package com.github.ambry.frontend;
 
 import com.github.ambry.account.Container;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.commons.CopyingAsyncWritableChannel;
 import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
@@ -23,15 +25,27 @@ import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.Callback;
+import com.github.ambry.router.ChunkInfo;
 import com.github.ambry.router.PutBlobOptions;
 import com.github.ambry.router.PutBlobOptionsBuilder;
 import com.github.ambry.router.ReadableStreamChannel;
 import com.github.ambry.router.Router;
+import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +53,26 @@ import static com.github.ambry.frontend.FrontendUtils.*;
 
 
 /**
- * Handler for post blob requests.
+ * Handler for post blob requests. The following request types are handled by {@link PostBlobHandler}:
+ * <h2>Direct uploads</h2>
+ * Direct upload requests treat the body of the request as the content to upload to Ambry. The request path should be
+ * "/". In these requests, the blob properties and user metadata are supplied as headers. See
+ * {@link RestUtils#buildBlobProperties(Map)} and {@link RestUtils#buildBlobProperties(Map)} for more details.
+ * <h2>Stitched uploads</h2>
+ * Stitched upload requests allow clients to stitch together previously uploaded data chunks into a single logical blob.
+ * The request path should be "/stitch" ({@link Operations#STITCH}). This request accepts the same headers as direct
+ * upload requests for supplying the blob properties and user metadata of the stitched blob, but, instead of the actual
+ * blob content, accepts a UTF-8 JSON object that includes the signed IDs for the chunks to stitch.
+ * <h3>Request body format</h3>
+ * The body of the request should be a JSON object that contains an array field with the key,
+ * {@link #SIGNED_CHUNK_IDS_KEY}. Each element of the array should be a signed ID produced by an
+ * {@link IdSigningService} implementation representing a data chunk to be stitched together. The order of the IDs in
+ * the array will be the order in which the data chunks are stitched. For example:
+ * <pre><code>
+ * {
+ *   "signedChunkIds": ["/signedId/id1", "/signedId/id2", "..."]
+ * }
+ * </code></pre>
  */
 class PostBlobHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostBlobHandler.class);
@@ -47,9 +80,11 @@ class PostBlobHandler {
    * Key to represent the time at which a blob will expire in ms. Used within the metadata map in signed IDs.
    */
   static final String EXPIRATION_TIME_MS_KEY = "et";
+  static final String SIGNED_CHUNK_IDS_KEY = "signedChunkIds";
 
   private final SecurityService securityService;
   private final IdConverter idConverter;
+  private final IdSigningService idSigningService;
   private final Router router;
   private final AccountAndContainerInjector accountAndContainerInjector;
   private final Time time;
@@ -60,17 +95,19 @@ class PostBlobHandler {
    * Constructs a handler for handling requests for signed URLs.
    * @param securityService the {@link SecurityService} to use.
    * @param idConverter the {@link IdConverter} to use.
+   * @param idSigningService the {@link IdSigningService} to use.
    * @param router the {@link Router} to use.
    * @param accountAndContainerInjector helper to resolve account and container for a given request.
    * @param time the {@link Time} instance to use.
    * @param frontendConfig the {@link FrontendConfig} to use.
    * @param frontendMetrics {@link FrontendMetrics} instance where metrics should be recorded.
    */
-  PostBlobHandler(SecurityService securityService, IdConverter idConverter, Router router,
-      AccountAndContainerInjector accountAndContainerInjector, Time time, FrontendConfig frontendConfig,
+  PostBlobHandler(SecurityService securityService, IdConverter idConverter, IdSigningService idSigningService,
+      Router router, AccountAndContainerInjector accountAndContainerInjector, Time time, FrontendConfig frontendConfig,
       FrontendMetrics frontendMetrics) {
     this.securityService = securityService;
     this.idConverter = idConverter;
+    this.idSigningService = idSigningService;
     this.router = router;
     this.accountAndContainerInjector = accountAndContainerInjector;
     this.time = time;
@@ -94,6 +131,7 @@ class PostBlobHandler {
    */
   private class CallbackChain {
     private final RestRequest restRequest;
+    private final String uri;
     private final RestResponseChannel restResponseChannel;
     private final Callback<ReadableStreamChannel> finalCallback;
 
@@ -107,6 +145,7 @@ class PostBlobHandler {
       this.restRequest = restRequest;
       this.restResponseChannel = restResponseChannel;
       this.finalCallback = finalCallback;
+      this.uri = restRequest.getUri();
     }
 
     /**
@@ -130,7 +169,7 @@ class PostBlobHandler {
         BlobInfo blobInfo = getBlobInfoFromRequest();
         checkUploadRequirements(blobInfo.getBlobProperties());
         securityService.processRequest(restRequest, securityProcessRequestCallback(blobInfo));
-      }, restRequest.getUri(), LOGGER, finalCallback);
+      }, uri, LOGGER, finalCallback);
     }
 
     /**
@@ -142,7 +181,7 @@ class PostBlobHandler {
     private Callback<Void> securityProcessRequestCallback(BlobInfo blobInfo) {
       return buildCallback(frontendMetrics.postSecurityProcessRequestMetrics,
           securityCheckResult -> securityService.postProcessRequest(restRequest,
-              securityPostProcessRequestCallback(blobInfo)), restRequest.getUri(), LOGGER, finalCallback);
+              securityPostProcessRequestCallback(blobInfo)), uri, LOGGER, finalCallback);
     }
 
     /**
@@ -153,10 +192,41 @@ class PostBlobHandler {
      */
     private Callback<Void> securityPostProcessRequestCallback(BlobInfo blobInfo) {
       return buildCallback(frontendMetrics.postSecurityPostProcessRequestMetrics, securityCheckResult -> {
-        PutBlobOptions options = getPutBlobOptionsFromRequest();
-        router.putBlob(blobInfo.getBlobProperties(), blobInfo.getUserMetadata(), restRequest, options,
-            routerPutBlobCallback(blobInfo));
-      }, restRequest.getUri(), LOGGER, finalCallback);
+        if (getOperation().equalsIgnoreCase(Operations.STITCH)) {
+          CopyingAsyncWritableChannel channel =
+              new CopyingAsyncWritableChannel(frontendConfig.maxStitchRequestSizeBytes);
+          restRequest.readInto(channel, fetchStitchRequestBodyCallback(channel, blobInfo));
+        } else {
+          PutBlobOptions options = getPutBlobOptionsFromRequest();
+          router.putBlob(blobInfo.getBlobProperties(), blobInfo.getUserMetadata(), restRequest, options,
+              routerPutBlobCallback(blobInfo));
+        }
+      }, uri, LOGGER, finalCallback);
+    }
+
+    /**
+     * After reading the body of the stitch request
+     * @param channel
+     * @param blobInfo
+     * @return
+     */
+    private Callback<Long> fetchStitchRequestBodyCallback(CopyingAsyncWritableChannel channel, BlobInfo blobInfo) {
+      return buildCallback(frontendMetrics.postReadStitchRequestMetrics,
+          bytesRead -> router.stitchBlob(blobInfo.getBlobProperties(), blobInfo.getUserMetadata(),
+              getChunksToStitch(blobInfo.getBlobProperties(), readJsonFromChannel(channel)),
+              routerStitchBlobCallback(blobInfo)), uri, LOGGER, finalCallback);
+    }
+
+    /**
+     * After {@link Router#putBlob} finishes, call {@link IdConverter#convert} to convert the returned ID into a format
+     * that will be returned in the "Location" header.
+     * @param blobInfo the {@link BlobInfo} to make the router call with.
+     * @return a {@link Callback} to be used with {@link Router#putBlob}.
+     */
+    private Callback<String> routerStitchBlobCallback(BlobInfo blobInfo) {
+      return buildCallback(frontendMetrics.postRouterStitchBlobMetrics,
+          blobId -> idConverter.convert(restRequest, blobId, idConverterCallback(blobInfo)), uri, LOGGER,
+          finalCallback);
     }
 
     /**
@@ -169,7 +239,7 @@ class PostBlobHandler {
       return buildCallback(frontendMetrics.postRouterPutBlobMetrics, blobId -> {
         setSignedIdMetadataIfRequired(blobInfo.getBlobProperties());
         idConverter.convert(restRequest, blobId, idConverterCallback(blobInfo));
-      }, restRequest.getUri(), LOGGER, finalCallback);
+      }, uri, LOGGER, finalCallback);
     }
 
     /**
@@ -182,7 +252,7 @@ class PostBlobHandler {
       return buildCallback(frontendMetrics.postIdConversionMetrics, convertedBlobId -> {
         restResponseChannel.setHeader(RestUtils.Headers.LOCATION, convertedBlobId);
         securityService.processResponse(restRequest, restResponseChannel, blobInfo, securityProcessResponseCallback());
-      }, restRequest.getUri(), LOGGER, finalCallback);
+      }, uri, LOGGER, finalCallback);
     }
 
     /**
@@ -191,7 +261,7 @@ class PostBlobHandler {
      */
     private Callback<Void> securityProcessResponseCallback() {
       return buildCallback(frontendMetrics.postSecurityProcessResponseMetrics,
-          securityCheckResult -> finalCallback.onCompletion(null, null), restRequest.getUri(), LOGGER, finalCallback);
+          securityCheckResult -> finalCallback.onCompletion(null, null), uri, LOGGER, finalCallback);
     }
 
     /**
@@ -284,6 +354,118 @@ class PostBlobHandler {
         if (chunkTtl <= 0 || chunkTtl > frontendConfig.chunkUploadInitialChunkTtlSecs) {
           throw new RestServiceException("Invalid chunk upload TTL: " + chunkTtl, RestServiceErrorCode.InvalidArgs);
         }
+      }
+    }
+
+    /**
+     * @return the operation parsed from the {@link RestRequest}.
+     */
+    private String getOperation() {
+      RestUtils.SubResource subResource = RestUtils.getBlobSubResource(restRequest);
+      String operation =
+          RestUtils.getOperationOrBlobIdFromUri(restRequest, subResource, frontendConfig.pathPrefixesToRemove);
+      if (operation.startsWith("/")) {
+        operation = operation.substring(1);
+      }
+      return operation;
+    }
+
+    /**
+     * Parse and verify the signed chunk IDs in the body of a stitch request.
+     * @param stitchedBlobProperties the {@link BlobProperties} for the final stitched blob.
+     * @param stitchRequestJson the {@link JSONObject} from the stitch request body.
+     * @return a list of chunks to stitch that can be provided to the router.
+     * @throws RestServiceException
+     */
+    List<ChunkInfo> getChunksToStitch(BlobProperties stitchedBlobProperties, JSONObject stitchRequestJson)
+        throws RestServiceException {
+      JSONArray signedChunkIds = stitchRequestJson.optJSONArray(SIGNED_CHUNK_IDS_KEY);
+      if (signedChunkIds == null || signedChunkIds.length() < 1) {
+        throw new RestServiceException("Must provide at least one ID in stitch request",
+            RestServiceErrorCode.MissingArgs);
+      }
+      List<ChunkInfo> chunksToStitch = new ArrayList<>(signedChunkIds.length());
+      String expectedSession = null;
+      for (Object signedChunkIdObj : signedChunkIds) {
+        String signedChunkId = signedChunkIdObj.toString();
+        if (!idSigningService.isIdSigned(signedChunkId)) {
+          throw new RestServiceException("All chunks IDs must be signed: " + signedChunkId,
+              RestServiceErrorCode.BadRequest);
+        }
+        Pair<String, Map<String, String>> idAndMetadata = idSigningService.parseSignedId(signedChunkId);
+        String blobId = idAndMetadata.getFirst();
+        Map<String, String> metadata = idAndMetadata.getSecond();
+
+        expectedSession = verifyChunkUploadSession(metadata, expectedSession);
+        @SuppressWarnings("ConstantConditions")
+        long chunkSizeBytes = RestUtils.getLongHeader(metadata, RestUtils.Headers.BLOB_SIZE, true);
+        // Expiration time is sent to the router, but not verified in this handler. The router is responsible for making
+        // checks related to internal ambry requirements, like making sure that the chunks do not expire before the
+        // metadata blob.
+        @SuppressWarnings("ConstantConditions")
+        long expirationTimeMs = RestUtils.getLongHeader(metadata, EXPIRATION_TIME_MS_KEY, true);
+        verifyChunkAccountAndContainer(blobId, stitchedBlobProperties);
+
+        chunksToStitch.add(new ChunkInfo(blobId, chunkSizeBytes, expirationTimeMs));
+      }
+      return chunksToStitch;
+    }
+
+    /**
+     * Verify that the session ID in the chunk metadata matches the expected session.
+     * @param chunkMetadata the metadata map parsed from a signed chunk ID.
+     * @param expectedSession the session that the chunk should match. This can be null for the first chunk (where any
+     *                        session ID is valid).
+     * @return this chunk's session ID
+     * @throws RestServiceException if the chunk has a null session ID or it does not match the expected value.
+     */
+    private String verifyChunkUploadSession(Map<String, String> chunkMetadata, String expectedSession)
+        throws RestServiceException {
+      String chunkSession = RestUtils.getHeader(chunkMetadata, RestUtils.Headers.SESSION, true);
+      if (expectedSession != null && !expectedSession.equals(chunkSession)) {
+        throw new RestServiceException("Session IDs differ for chunks in a stitch request",
+            RestServiceErrorCode.BadRequest);
+      }
+      return chunkSession;
+    }
+
+    /**
+     * Check that the account and container IDs encoded in a chunk's blob ID matches those in the properties for the
+     * stitched blob.
+     * @param chunkBlobId the blob ID for the chunk.
+     * @param stitchedBlobProperties the {@link BlobProperties} for the stitched blob.
+     * @throws RestServiceException if the account or container ID does not match.
+     */
+    private void verifyChunkAccountAndContainer(String chunkBlobId, BlobProperties stitchedBlobProperties)
+        throws RestServiceException {
+      Pair<Short, Short> accountAndContainer;
+      try {
+        accountAndContainer = BlobId.getAccountAndContainerIds(chunkBlobId);
+      } catch (Exception e) {
+        throw new RestServiceException("Invalid blob ID in signed chunk ID", RestServiceErrorCode.BadRequest);
+      }
+      if (stitchedBlobProperties.getAccountId() != accountAndContainer.getFirst()
+          || stitchedBlobProperties.getContainerId() != accountAndContainer.getSecond()) {
+        throw new RestServiceException("Account and container for chunk: (" + accountAndContainer.getFirst() + ", "
+            + accountAndContainer.getSecond() + ") does not match account and container for stitched blob: ("
+            + stitchedBlobProperties.getAccountId() + ", " + stitchedBlobProperties.getContainerId() + ")",
+            RestServiceErrorCode.BadRequest);
+      }
+    }
+
+    /**
+     * Parse a {@link JSONObject} from the data in {@code channel}. This assumes that the data is UTF-8 encoded.
+     * @param channel the {@link CopyingAsyncWritableChannel} that contains the JSON data.
+     * @return a {@link JSONObject}.
+     * @throws IOException if closing the {@link InputStream} fails.
+     * @throws RestServiceException if JSON parsing fails.
+     */
+    private JSONObject readJsonFromChannel(CopyingAsyncWritableChannel channel)
+        throws IOException, RestServiceException {
+      try (InputStream inputStream = channel.getContentAsInputStream()) {
+        return new JSONObject(new JSONTokener(new InputStreamReader(inputStream, StandardCharsets.UTF_8)));
+      } catch (JSONException e) {
+        throw new RestServiceException("Invalid stitch request body", e, RestServiceErrorCode.BadRequest);
       }
     }
   }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -49,6 +49,7 @@ import com.github.ambry.rest.RestUtilsTest;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.ByteRange;
 import com.github.ambry.router.Callback;
+import com.github.ambry.router.ChunkInfo;
 import com.github.ambry.router.FutureResult;
 import com.github.ambry.router.GetBlobOptions;
 import com.github.ambry.router.GetBlobResult;
@@ -2634,7 +2635,7 @@ class FrontendTestRouter implements Router {
    * Enumerates the different operation types in the router.
    */
   enum OpType {
-    DeleteBlob, GetBlob, PutBlob, UpdateBlobTtl
+    DeleteBlob, GetBlob, PutBlob, StitchBlob, UpdateBlobTtl
   }
 
   OpType exceptionOpType = null;
@@ -2668,6 +2669,12 @@ class FrontendTestRouter implements Router {
   public Future<String> putBlob(BlobProperties blobProperties, byte[] usermetadata, ReadableStreamChannel channel,
       PutBlobOptions options, Callback<String> callback) {
     return completeOperation(UtilsTest.getRandomString(10), callback, OpType.PutBlob);
+  }
+
+  @Override
+  public Future<String> stitchBlob(BlobProperties blobProperties, byte[] userMetadata, List<ChunkInfo> chunksToStitch,
+      Callback<String> callback) {
+    return completeOperation(UtilsTest.getRandomString(10), callback, OpType.StitchBlob);
   }
 
   @Override

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryIdSigningServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryIdSigningServiceTest.java
@@ -52,9 +52,12 @@ public class AmbryIdSigningServiceTest {
     Map<String, String> metadata = Stream.of("a", "b", "c").collect(Collectors.toMap(s -> "key-" + s, s -> "val-" + s));
     assertFalse("Original blob should not be considered signed", idSigningService.isIdSigned(blobId));
     String signedId = idSigningService.getSignedId(blobId, metadata);
-    Pair<String, Map<String, String>> idAndMetadata = idSigningService.parseSignedId(signedId);
-    assertEquals("Unexpected blob ID from parseSignedId()", blobId, idAndMetadata.getFirst());
-    assertEquals("Unexpected metadata from parseSignedId()", metadata, idAndMetadata.getSecond());
+    for (String id : new String[]{signedId, "/" + signedId}) {
+      assertTrue("ID should be considered signed", idSigningService.isIdSigned(id));
+      Pair<String, Map<String, String>> idAndMetadata = idSigningService.parseSignedId(id);
+      assertEquals("Unexpected blob ID from parseSignedId()", blobId, idAndMetadata.getFirst());
+      assertEquals("Unexpected metadata from parseSignedId()", metadata, idAndMetadata.getSecond());
+    }
 
     TestUtils.assertException(RestServiceException.class, () -> idSigningService.getSignedId(null, null),
         errorCodeChecker(RestServiceErrorCode.InternalServerError));

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
@@ -18,6 +18,7 @@ import com.github.ambry.account.Container;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.router.Callback;
+import com.github.ambry.router.ChunkInfo;
 import com.github.ambry.router.FutureResult;
 import com.github.ambry.router.GetBlobOptions;
 import com.github.ambry.router.GetBlobResult;
@@ -26,6 +27,7 @@ import com.github.ambry.router.ReadableStreamChannel;
 import com.github.ambry.router.Router;
 import com.github.ambry.router.RouterErrorCode;
 import com.github.ambry.router.RouterException;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Future;
 import org.slf4j.Logger;
@@ -132,6 +134,12 @@ class PerfRouter implements Router {
       });
     }
     return futureResult;
+  }
+
+  @Override
+  public Future<String> stitchBlob(BlobProperties blobProperties, byte[] userMetadata, List<ChunkInfo> chunksToStitch,
+      Callback<String> callback) {
+    throw new UnsupportedOperationException("Only in full PR");
   }
 
   /**


### PR DESCRIPTION
Add support to PostBlobHandler to support "POST /stitch" requests. This
API takes a JSON body containing a list of signed IDs that represent
data chunks, parses this list, and calls the Router.stitchBlob method to
generate a new composite blob.

### Notes for reviewers
The first commit provides a subset of the router changes in #1081 to make this PR easier to review before that one is merged. I will rebase on top of the router changes before merging this. To view only the frontend-relevant changes, ignore the changes in the first commit on this branch.