### PR TITLE
Granular (colo-level) update support in the Helix tool

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -117,7 +117,7 @@ public class ClusterMapUtils {
    * @return a map of dcName -> DcInfo.
    * @throws JSONException if there is an error parsing the JSON.
    */
-  public static Map<String, DcZkInfo> parseDcJsonAndPopulateDcInfo(String dcInfoJsonString) throws JSONException {
+  static Map<String, DcZkInfo> parseDcJsonAndPopulateDcInfo(String dcInfoJsonString) throws JSONException {
     Map<String, DcZkInfo> dataCenterToZkAddress = new HashMap<>();
     JSONObject root = new JSONObject(dcInfoJsonString);
     JSONArray all = root.getJSONArray(ZKINFO_STR);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -342,8 +342,9 @@ class HelixBootstrapUpgradeUtil {
     Properties storeProps = new Properties();
     storeProps.setProperty("helix.property.store.root.path", "/" + clusterName);
     HelixPropertyStoreConfig propertyStoreConfig = new HelixPropertyStoreConfig(new VerifiableProperties(storeProps));
-    info("Setting partition override for all datacenters.");
+    info("Setting partition override for specified datacenters.");
     for (Map.Entry<String, ClusterMapUtils.DcZkInfo> entry : dataCenterToZkAddress.entrySet()) {
+      info("Setting partition override for {}.", entry.getKey());
       HelixPropertyStore<ZNRecord> helixPropertyStore =
           CommonUtils.createHelixPropertyStore(entry.getValue().getZkConnectStr(), propertyStoreConfig, null);
       ZNRecord znRecord = new ZNRecord(ClusterMapUtils.ZNODE_NAME);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -47,8 +47,8 @@ public class MockHelixCluster {
     this.hardwareLayoutPath = hardwareLayoutPath;
     this.partitionLayoutPath = partitionLayoutPath;
     this.zkLayoutPath = zkLayoutPath;
-    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName, 3,
-        false, false, helixAdminFactory);
+    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
+        "all", 3, false, false, helixAdminFactory);
     this.clusterName = clusterName;
   }
 
@@ -58,8 +58,8 @@ public class MockHelixCluster {
    * @throws Exception
    */
   void upgradeWithNewHardwareLayout(String hardwareLayoutPath) throws Exception {
-    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName, 3,
-        false, false, helixAdminFactory);
+    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
+        "all", 3, false, false, helixAdminFactory);
     triggerInstanceConfigChangeNotification();
   }
 
@@ -69,8 +69,8 @@ public class MockHelixCluster {
    * @throws Exception
    */
   void upgradeWithNewPartitionLayout(String partitionLayoutPath) throws Exception {
-    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName, 3,
-        false, false, helixAdminFactory);
+    HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
+        "all", 3, false, false, helixAdminFactory);
     triggerInstanceConfigChangeNotification();
   }
 

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -163,6 +163,7 @@ public class HelixBootstrapUpgradeToolTest {
    */
   @Test
   public void testIncompleteZKHostInfo() throws Exception {
+    assumeTrue(dcStr.equalsIgnoreCase("all"));
     if (testHardwareLayout.getDatacenterCount() > 1) {
       JSONObject partialZkJson =
           constructZkLayoutJSON(Collections.singleton(dcsToZkInfo.entrySet().iterator().next().getValue()));

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -37,6 +37,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.store.HelixPropertyStore;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -56,7 +57,6 @@ import static org.junit.Assume.*;
 public class HelixBootstrapUpgradeToolTest {
   private static String tempDirPath;
   private static final Map<String, ZkInfo> dcsToZkInfo = new HashMap<>();
-  private static final Map<String, HelixPropertyStore<ZNRecord>> dcsToPropertyStore = new HashMap<>();
   private static final String dcs[] = new String[]{"DC0", "DC1"};
   private static final byte ids[] = new byte[]{(byte) 0, (byte) 1};
   private final String hardwareLayoutPath;
@@ -91,6 +91,14 @@ public class HelixBootstrapUpgradeToolTest {
     int port = 2200;
     for (int i = 0; i < dcs.length; i++) {
       dcsToZkInfo.put(dcs[i], new ZkInfo(tempDirPath, dcs[i], ids[i], port++, true));
+    }
+  }
+
+  @After
+  public void clear() {
+    for (ZkInfo zkInfo : dcsToZkInfo.values()) {
+      ZKHelixAdmin admin = new ZKHelixAdmin("localhost:" + zkInfo.getPort());
+      admin.dropCluster(CLUSTER_NAME_PREFIX + CLUSTER_NAME_IN_STATIC_CLUSTER_MAP);
     }
   }
 

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -163,7 +163,6 @@ public class HelixBootstrapUpgradeToolTest {
    */
   @Test
   public void testIncompleteZKHostInfo() throws Exception {
-    assumeTrue(dcStr.equalsIgnoreCase("all") || dcStr.replaceAll("\\p{Space}", "").split(",").length == dcs.length);
     if (testHardwareLayout.getDatacenterCount() > 1) {
       JSONObject partialZkJson =
           constructZkLayoutJSON(Collections.singleton(dcsToZkInfo.entrySet().iterator().next().getValue()));

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -146,6 +146,7 @@ public class HelixBootstrapUpgradeTool {
         "The comma-separated datacenters (colos) to update. If updates to every datacenter is intended, use '--dcs all'")
         .withRequiredArg()
         .describedAs("datacenters")
+        .required()
         .ofType(String.class);
 
     ArgumentAcceptingOptionSpec<String> maxPartitionsInOneResourceOpt = parser.accepts("maxPartitionsInOneResource",

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -142,6 +142,12 @@ public class HelixBootstrapUpgradeTool {
             .describedAs("cluster_name")
             .ofType(String.class);
 
+    ArgumentAcceptingOptionSpec<String> dcsNameOpt = parser.accepts("dcs",
+        "The comma-separated datacenters (colos) to update. If updates to every datacenter is intended, use '--dcs all'")
+        .withRequiredArg()
+        .describedAs("datacenters")
+        .ofType(String.class);
+
     ArgumentAcceptingOptionSpec<String> maxPartitionsInOneResourceOpt = parser.accepts("maxPartitionsInOneResource",
         "(Optional argument) The maximum number of partitions that should be grouped under a Helix resource")
         .withRequiredArg()
@@ -157,18 +163,21 @@ public class HelixBootstrapUpgradeTool {
     String zkLayoutPath = options.valueOf(zkLayoutPathOpt);
     String clusterNamePrefix = options.valueOf(clusterNamePrefixOpt);
     String clusterName = options.valueOf(clusterNameOpt);
+    String dcs = options.valueOf(dcsNameOpt);
     ArrayList<OptionSpec> listOpt = new ArrayList<>();
     listOpt.add(hardwareLayoutPathOpt);
     listOpt.add(partitionLayoutPathOpt);
     listOpt.add(zkLayoutPathOpt);
     listOpt.add(clusterNamePrefixOpt);
+    listOpt.add(dcsNameOpt);
     if (options.has(dropClusterOpt)) {
       ArrayList<OptionSpec<?>> expectedOpts = new ArrayList<>();
       expectedOpts.add(dropClusterOpt);
       expectedOpts.add(clusterNameOpt);
       expectedOpts.add(zkLayoutPathOpt);
+      expectedOpts.add(dcsNameOpt);
       ToolUtils.ensureExactOrExit(expectedOpts, options.specs(), parser);
-      HelixBootstrapUpgradeUtil.dropCluster(zkLayoutPath, clusterName, new HelixAdminFactory());
+      HelixBootstrapUpgradeUtil.dropCluster(zkLayoutPath, clusterName, dcs, new HelixAdminFactory());
     } else if (options.has(validateOnly)) {
       ArrayList<OptionSpec<?>> expectedOpts = new ArrayList<>();
       expectedOpts.add(validateOnly);
@@ -176,8 +185,9 @@ public class HelixBootstrapUpgradeTool {
       expectedOpts.add(zkLayoutPathOpt);
       expectedOpts.add(hardwareLayoutPathOpt);
       expectedOpts.add(partitionLayoutPathOpt);
+      expectedOpts.add(dcsNameOpt);
       ToolUtils.ensureExactOrExit(expectedOpts, options.specs(), parser);
-      HelixBootstrapUpgradeUtil.validate(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix,
+      HelixBootstrapUpgradeUtil.validate(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
           new HelixAdminFactory());
     } else if (options.has(uploadConfig)) {
       ArrayList<OptionSpec<?>> expectedOpts = new ArrayList<>();
@@ -186,13 +196,14 @@ public class HelixBootstrapUpgradeTool {
       expectedOpts.add(hardwareLayoutPathOpt);
       expectedOpts.add(partitionLayoutPathOpt);
       expectedOpts.add(clusterNamePrefixOpt);
+      expectedOpts.add(dcsNameOpt);
       ToolUtils.ensureExactOrExit(expectedOpts, options.specs(), parser);
       HelixBootstrapUpgradeUtil.uploadClusterConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-          clusterNamePrefix, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory());
+          clusterNamePrefix, dcs, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory());
     } else {
       ToolUtils.ensureOrExit(listOpt, options, parser);
       HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-          clusterNamePrefix,
+          clusterNamePrefix, dcs,
           options.valueOf(maxPartitionsInOneResourceOpt) == null ? DEFAULT_MAX_PARTITIONS_PER_RESOURCE
               : Integer.valueOf(options.valueOf(maxPartitionsInOneResourceOpt)), options.has(dryRun),
           options.has(forceRemove), new HelixAdminFactory());


### PR DESCRIPTION
Add a "dcs" argument that takes a comma-separated list of dcs that
need to be affected in a given run. This provides an option to update
selectively and limit the effect of a bad change (when used along with
the listenCrossColo config within the HelixClusterManager).