### PR TITLE
Changing impl of keeping sealed index segs in mem

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.config;
 
+import com.github.ambry.store.IndexMemState;
+
+
 /**
  * The configs for the store
  */
@@ -248,12 +251,12 @@ public class StoreConfig {
   public static final String storeTtlUpdateBufferTimeSecondsName = "store.ttl.update.buffer.time.seconds";
 
   /**
-   * Specifies whether all index segments should be kept in memory (as opposed to a specific subset).
+   * Provides a hint for how indexes should be treated w.r.t memory
    */
-  @Config(storeKeepIndexInMemoryName)
+  @Config(storeIndexMemStateName)
   @Default("false")
-  public final boolean storeKeepIndexInMemory;
-  public static final String storeKeepIndexInMemoryName = "store.keep.index.in.memory";
+  public final IndexMemState storeIndexMemState;
+  public static final String storeIndexMemStateName = "store.index.mem.state";
 
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
@@ -307,7 +310,8 @@ public class StoreConfig {
     storeValidateAuthorization = verifiableProperties.getBoolean("store.validate.authorization", false);
     storeTtlUpdateBufferTimeSeconds =
         verifiableProperties.getIntInRange(storeTtlUpdateBufferTimeSecondsName, 60 * 60 * 24, 0, Integer.MAX_VALUE);
-    storeKeepIndexInMemory = verifiableProperties.getBoolean(storeKeepIndexInMemoryName, false);
+    storeIndexMemState =
+        IndexMemState.valueOf(verifiableProperties.getString(storeIndexMemStateName, IndexMemState.NOT_IN_MEM.name()));
   }
 }
 

--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -254,7 +254,7 @@ public class StoreConfig {
    * Provides a hint for how indexes should be treated w.r.t memory
    */
   @Config(storeIndexMemStateName)
-  @Default("false")
+  @Default("NOT_IN_MEM")
   public final IndexMemState storeIndexMemState;
   public static final String storeIndexMemStateName = "store.index.mem.state";
 

--- a/ambry-api/src/main/java/com.github.ambry/store/IndexMemState.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/IndexMemState.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.store;
+
+/**
+ * Values for different ways in which the index of a {@link Store} can be maintained. The values are hints for the
+ * actual implementations which can choose to respect or ignore the hints.
+ */
+public enum IndexMemState {
+  /**
+   * Index should not be in memory
+   */
+  NOT_IN_MEM,
+
+  /**
+   * Index should be in heap memory
+   */
+  IN_HEAP_MEM,
+
+  /**
+   * If mmaped, the index should be force loaded into memory
+   */
+  FORCE_LOAD_MMAP
+}

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -83,8 +83,9 @@ public class IndexSegmentTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(
-        new Object[][]{{PersistentIndex.VERSION_0, true}, {PersistentIndex.VERSION_0, false}, {PersistentIndex.VERSION_1, true}, {PersistentIndex.VERSION_1, false}, {PersistentIndex.VERSION_2, true}, {PersistentIndex.VERSION_2, false}});
+    return Arrays.asList(new Object[][]{{PersistentIndex.VERSION_0, true}, {PersistentIndex.VERSION_0, false},
+        {PersistentIndex.VERSION_1, true}, {PersistentIndex.VERSION_1, false}, {PersistentIndex.VERSION_2, true},
+        {PersistentIndex.VERSION_2, false}});
   }
 
   /**
@@ -961,20 +962,18 @@ public class IndexSegmentTest {
     // journal should not contain any entries
     assertNull("Journal should not have any entries", journal.getFirstOffset());
 
-    if (!config.storeKeepIndexInMemory) {
-      // test bloom file recreation
-      // delete the bloom file
-      assertTrue("File could not be deleted", bloomFile.delete());
+    // test bloom file recreation
+    // delete the bloom file
+    assertTrue("File could not be deleted", bloomFile.delete());
 
-      // read from file (sealed) again and verify that everything is ok
-      journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
-      fromDisk = createIndexSegmentFromFile(file, true, journal);
-      assertTrue("Bloom file does not exist", bloomFile.exists());
-      verifyAllForIndexSegmentFromFile(referenceIndex, fromDisk, startOffset, numItems, expectedSizeWritten, true,
-          endOffset, lastModifiedTimeInMs, resetKey);
-      // journal should not contain any entries
-      assertNull("Journal should not have any entries", journal.getFirstOffset());
-    }
+    // read from file (sealed) again and verify that everything is ok
+    journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
+    fromDisk = createIndexSegmentFromFile(file, true, journal);
+    assertTrue("Bloom file does not exist", bloomFile.exists());
+    verifyAllForIndexSegmentFromFile(referenceIndex, fromDisk, startOffset, numItems, expectedSizeWritten, true,
+        endOffset, lastModifiedTimeInMs, resetKey);
+    // journal should not contain any entries
+    assertNull("Journal should not have any entries", journal.getFirstOffset());
   }
 
   /**


### PR DESCRIPTION
After a discussion with @cgtz, impl has been changed to hold the serialized version of sealed index segments in memory instead of converting into a hash map.
This brings the benefit of reducing the memory footprint and making it more predictable but removes the ability to mutate sealed index  segments if required in the future
