### PR TITLE
Adding a container config for a whitelist of content types

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/account/Container.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/Container.java
@@ -264,7 +264,7 @@ public class Container {
           UNKNOWN_CONTAINER_DESCRIPTION, UNKNOWN_CONTAINER_ENCRYPTED_SETTING,
           UNKNOWN_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, UNKNOWN_CONTAINER_CACHEABLE_SETTING,
           UNKNOWN_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, UNKNOWN_CONTAINER_TTL_REQUIRED_SETTING,
-          Collections.emptySet(), UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID);
+          CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE, UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID);
 
   /**
    * A container defined specifically for the blobs put without specifying target container but isPrivate flag is
@@ -278,7 +278,7 @@ public class Container {
           DEFAULT_PUBLIC_CONTAINER_DESCRIPTION, DEFAULT_PUBLIC_CONTAINER_ENCRYPTED_SETTING,
           DEFAULT_PUBLIC_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, DEFAULT_PUBLIC_CONTAINER_CACHEABLE_SETTING,
           DEFAULT_PUBLIC_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, DEFAULT_PUBLIC_CONTAINER_TTL_REQUIRED_SETTING,
-          Collections.emptySet(), DEFAULT_PUBLIC_CONTAINER_PARENT_ACCOUNT_ID);
+          CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE, DEFAULT_PUBLIC_CONTAINER_PARENT_ACCOUNT_ID);
 
   /**
    * A container defined specifically for the blobs put without specifying target container but isPrivate flag is
@@ -292,7 +292,7 @@ public class Container {
           DEFAULT_PRIVATE_CONTAINER_DESCRIPTION, DEFAULT_PRIVATE_CONTAINER_ENCRYPTED_SETTING,
           DEFAULT_PRIVATE_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, DEFAULT_PRIVATE_CONTAINER_CACHEABLE_SETTING,
           DEFAULT_PRIVATE_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, DEFAULT_PRIVATE_CONTAINER_TTL_REQUIRED_SETTING,
-          Collections.emptySet(), DEFAULT_PRIVATE_CONTAINER_PARENT_ACCOUNT_ID);
+          CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE, DEFAULT_PRIVATE_CONTAINER_PARENT_ACCOUNT_ID);
 
   // container field variables
   private final short id;
@@ -348,10 +348,8 @@ public class Container {
             metadata.optJSONArray(CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD);
         if (contentTypeWhitelistForFilenamesOnDownloadJson != null) {
           contentTypeWhitelistForFilenamesOnDownload = new HashSet<>();
-          for (int i = 0; i < contentTypeWhitelistForFilenamesOnDownloadJson.length(); i++) {
-            contentTypeWhitelistForFilenamesOnDownload.add(
-                contentTypeWhitelistForFilenamesOnDownloadJson.get(i).toString());
-          }
+          contentTypeWhitelistForFilenamesOnDownloadJson.forEach(
+              contentType -> contentTypeWhitelistForFilenamesOnDownload.add(contentType.toString()));
         } else {
           contentTypeWhitelistForFilenamesOnDownload = CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
         }
@@ -472,9 +470,13 @@ public class Container {
         metadata.put(MEDIA_SCAN_DISABLED_KEY, mediaScanDisabled);
         metadata.putOpt(REPLICATION_POLICY_KEY, replicationPolicy);
         metadata.put(TTL_REQUIRED_KEY, ttlRequired);
-        JSONArray contentTypeWhitelistForFilenamesOnDownloadJson = new JSONArray();
-        contentTypeWhitelistForFilenamesOnDownload.forEach(contentTypeWhitelistForFilenamesOnDownloadJson::put);
-        metadata.put(CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD, contentTypeWhitelistForFilenamesOnDownloadJson);
+        if (contentTypeWhitelistForFilenamesOnDownload != null
+            && !contentTypeWhitelistForFilenamesOnDownload.isEmpty()) {
+          JSONArray contentTypeWhitelistForFilenamesOnDownloadJson = new JSONArray();
+          contentTypeWhitelistForFilenamesOnDownload.forEach(contentTypeWhitelistForFilenamesOnDownloadJson::put);
+          metadata.put(CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD,
+              contentTypeWhitelistForFilenamesOnDownloadJson);
+        }
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + currentJsonVersion);

--- a/ambry-api/src/main/java/com.github.ambry/account/Container.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/Container.java
@@ -13,7 +13,11 @@
  */
 package com.github.ambry.account;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -65,12 +69,15 @@ public class Container {
   static final String MEDIA_SCAN_DISABLED_KEY = "mediaScanDisabled";
   static final String REPLICATION_POLICY_KEY = "replicationPolicy";
   static final String TTL_REQUIRED_KEY = "ttlRequired";
+  static final String CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD = "contentTypeWhitelistForFilenamesOnDownload";
   static final String PARENT_ACCOUNT_ID_KEY = "parentAccountId";
   static final boolean ENCRYPTED_DEFAULT_VALUE = false;
   static final boolean PREVIOUSLY_ENCRYPTED_DEFAULT_VALUE = ENCRYPTED_DEFAULT_VALUE;
   static final boolean MEDIA_SCAN_DISABLED_DEFAULT_VALUE = false;
   static final boolean TTL_REQUIRED_DEFAULT_VALUE = true;
   static final boolean CACHEABLE_DEFAULT_VALUE = true;
+  static final Set<String> CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE = Collections.emptySet();
+
   public static final short JSON_VERSION_1 = 1;
   public static final short JSON_VERSION_2 = 2;
 
@@ -257,7 +264,7 @@ public class Container {
           UNKNOWN_CONTAINER_DESCRIPTION, UNKNOWN_CONTAINER_ENCRYPTED_SETTING,
           UNKNOWN_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, UNKNOWN_CONTAINER_CACHEABLE_SETTING,
           UNKNOWN_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, UNKNOWN_CONTAINER_TTL_REQUIRED_SETTING,
-          UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID);
+          Collections.emptySet(), UNKNOWN_CONTAINER_PARENT_ACCOUNT_ID);
 
   /**
    * A container defined specifically for the blobs put without specifying target container but isPrivate flag is
@@ -271,7 +278,7 @@ public class Container {
           DEFAULT_PUBLIC_CONTAINER_DESCRIPTION, DEFAULT_PUBLIC_CONTAINER_ENCRYPTED_SETTING,
           DEFAULT_PUBLIC_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, DEFAULT_PUBLIC_CONTAINER_CACHEABLE_SETTING,
           DEFAULT_PUBLIC_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, DEFAULT_PUBLIC_CONTAINER_TTL_REQUIRED_SETTING,
-          DEFAULT_PUBLIC_CONTAINER_PARENT_ACCOUNT_ID);
+          Collections.emptySet(), DEFAULT_PUBLIC_CONTAINER_PARENT_ACCOUNT_ID);
 
   /**
    * A container defined specifically for the blobs put without specifying target container but isPrivate flag is
@@ -285,7 +292,7 @@ public class Container {
           DEFAULT_PRIVATE_CONTAINER_DESCRIPTION, DEFAULT_PRIVATE_CONTAINER_ENCRYPTED_SETTING,
           DEFAULT_PRIVATE_CONTAINER_PREVIOUSLY_ENCRYPTED_SETTING, DEFAULT_PRIVATE_CONTAINER_CACHEABLE_SETTING,
           DEFAULT_PRIVATE_CONTAINER_MEDIA_SCAN_DISABLED_SETTING, null, DEFAULT_PRIVATE_CONTAINER_TTL_REQUIRED_SETTING,
-          DEFAULT_PRIVATE_CONTAINER_PARENT_ACCOUNT_ID);
+          Collections.emptySet(), DEFAULT_PRIVATE_CONTAINER_PARENT_ACCOUNT_ID);
 
   // container field variables
   private final short id;
@@ -298,6 +305,7 @@ public class Container {
   private final boolean mediaScanDisabled;
   private final String replicationPolicy;
   private final boolean ttlRequired;
+  private final Set<String> contentTypeWhitelistForFilenamesOnDownload;
   private final short parentAccountId;
 
   /**
@@ -323,6 +331,7 @@ public class Container {
         mediaScanDisabled = MEDIA_SCAN_DISABLED_DEFAULT_VALUE;
         replicationPolicy = null;
         ttlRequired = TTL_REQUIRED_DEFAULT_VALUE;
+        contentTypeWhitelistForFilenamesOnDownload = CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
         break;
       case JSON_VERSION_2:
         id = (short) metadata.getInt(CONTAINER_ID_KEY);
@@ -335,6 +344,17 @@ public class Container {
         mediaScanDisabled = metadata.optBoolean(MEDIA_SCAN_DISABLED_KEY, MEDIA_SCAN_DISABLED_DEFAULT_VALUE);
         replicationPolicy = metadata.optString(REPLICATION_POLICY_KEY, null);
         ttlRequired = metadata.optBoolean(TTL_REQUIRED_KEY, TTL_REQUIRED_DEFAULT_VALUE);
+        JSONArray contentTypeWhitelistForFilenamesOnDownloadJson =
+            metadata.optJSONArray(CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD);
+        if (contentTypeWhitelistForFilenamesOnDownloadJson != null) {
+          contentTypeWhitelistForFilenamesOnDownload = new HashSet<>();
+          for (int i = 0; i < contentTypeWhitelistForFilenamesOnDownloadJson.length(); i++) {
+            contentTypeWhitelistForFilenamesOnDownload.add(
+                contentTypeWhitelistForFilenamesOnDownloadJson.get(i).toString());
+          }
+        } else {
+          contentTypeWhitelistForFilenamesOnDownload = CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
+        }
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + metadataVersion);
@@ -356,11 +376,13 @@ public class Container {
    * @param mediaScanDisabled {@code true} if media scanning for content in this container should be disabled.
    * @param replicationPolicy the replication policy to use. If {@code null}, the cluster's default will be used.
    * @param ttlRequired {@code true} if ttl is required on content created in this container.
+   * @param contentTypeWhitelistForFilenamesOnDownload the set of content types for which the filename can be sent on
+   *                                                   download
    * @param parentAccountId The id of the parent {@link Account} of this container.
    */
   Container(short id, String name, ContainerStatus status, String description, boolean encrypted,
       boolean previouslyEncrypted, boolean cacheable, boolean mediaScanDisabled, String replicationPolicy,
-      boolean ttlRequired, short parentAccountId) {
+      boolean ttlRequired, Set<String> contentTypeWhitelistForFilenamesOnDownload, short parentAccountId) {
     checkPreconditions(name, status, encrypted, previouslyEncrypted);
     this.id = id;
     this.name = name;
@@ -375,6 +397,8 @@ public class Container {
         this.mediaScanDisabled = MEDIA_SCAN_DISABLED_DEFAULT_VALUE;
         this.replicationPolicy = null;
         this.ttlRequired = TTL_REQUIRED_DEFAULT_VALUE;
+        this.contentTypeWhitelistForFilenamesOnDownload =
+            CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
         break;
       case JSON_VERSION_2:
         this.encrypted = encrypted;
@@ -382,6 +406,9 @@ public class Container {
         this.mediaScanDisabled = mediaScanDisabled;
         this.replicationPolicy = replicationPolicy;
         this.ttlRequired = ttlRequired;
+        this.contentTypeWhitelistForFilenamesOnDownload =
+            contentTypeWhitelistForFilenamesOnDownload == null ? Collections.emptySet()
+                : contentTypeWhitelistForFilenamesOnDownload;
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + currentJsonVersion);
@@ -445,6 +472,9 @@ public class Container {
         metadata.put(MEDIA_SCAN_DISABLED_KEY, mediaScanDisabled);
         metadata.putOpt(REPLICATION_POLICY_KEY, replicationPolicy);
         metadata.put(TTL_REQUIRED_KEY, ttlRequired);
+        JSONArray contentTypeWhitelistForFilenamesOnDownloadJson = new JSONArray();
+        contentTypeWhitelistForFilenamesOnDownload.forEach(contentTypeWhitelistForFilenamesOnDownloadJson::put);
+        metadata.put(CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD, contentTypeWhitelistForFilenamesOnDownloadJson);
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + currentJsonVersion);
@@ -529,6 +559,13 @@ public class Container {
   }
 
   /**
+   * @return the set of content types for which the filename can be sent on download
+   */
+  public Set<String> getContentTypeWhitelistForFilenamesOnDownload() {
+    return contentTypeWhitelistForFilenamesOnDownload;
+  }
+
+  /**
    * Gets the if of the {@link Account} that owns this container.
    * @return The id of the parent {@link Account} of this container.
    */
@@ -560,7 +597,8 @@ public class Container {
         && mediaScanDisabled == container.mediaScanDisabled && parentAccountId == container.parentAccountId
         && Objects.equals(name, container.name) && status == container.status && Objects.equals(description,
         container.description) && Objects.equals(replicationPolicy, container.replicationPolicy)
-        && ttlRequired == container.ttlRequired;
+        && ttlRequired == container.ttlRequired && Objects.equals(contentTypeWhitelistForFilenamesOnDownload,
+        container.contentTypeWhitelistForFilenamesOnDownload);
   }
 
   @Override

--- a/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
+++ b/ambry-api/src/main/java/com.github.ambry/account/ContainerBuilder.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.account;
 
+import java.util.Set;
+
 import static com.github.ambry.account.Container.*;
 
 
@@ -37,6 +39,8 @@ public class ContainerBuilder {
   private boolean mediaScanDisabled = MEDIA_SCAN_DISABLED_DEFAULT_VALUE;
   private String replicationPolicy = null;
   private boolean ttlRequired = TTL_REQUIRED_DEFAULT_VALUE;
+  private Set<String> contentTypeWhitelistForFilenamesOnDownload =
+      CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE;
 
   /**
    * Constructor. This will allow building a new {@link Container} from an existing {@link Container}. The builder will
@@ -59,6 +63,7 @@ public class ContainerBuilder {
     replicationPolicy = origin.getReplicationPolicy();
     ttlRequired = origin.isTtlRequired();
     parentAccountId = origin.getParentAccountId();
+    contentTypeWhitelistForFilenamesOnDownload = origin.getContentTypeWhitelistForFilenamesOnDownload();
   }
 
   /**
@@ -180,10 +185,22 @@ public class ContainerBuilder {
   /**
    * Sets the replication policy desired by the {@link Container}.
    * @param replicationPolicy the replication policy desired by the container
-   * @return
+   * @return This builder.
    */
   public ContainerBuilder setReplicationPolicy(String replicationPolicy) {
     this.replicationPolicy = replicationPolicy;
+    return this;
+  }
+
+  /**
+   * Sets the whitelist for the content types for which filenames can be sent on download
+   * @param contentTypeWhitelistForFilenamesOnDownload the whitelist for the content types for which filenames can be
+   *                                                   sent on download
+   * @return This builder.
+   */
+  public ContainerBuilder setContentTypeWhitelistForFilenamesOnDownload(
+      Set<String> contentTypeWhitelistForFilenamesOnDownload) {
+    this.contentTypeWhitelistForFilenamesOnDownload = contentTypeWhitelistForFilenamesOnDownload;
     return this;
   }
 
@@ -195,6 +212,6 @@ public class ContainerBuilder {
    */
   public Container build() {
     return new Container(id, name, status, description, encrypted, previouslyEncrypted || encrypted, cacheable,
-        mediaScanDisabled, replicationPolicy, ttlRequired, parentAccountId);
+        mediaScanDisabled, replicationPolicy, ttlRequired, contentTypeWhitelistForFilenamesOnDownload, parentAccountId);
   }
 }

--- a/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
@@ -19,11 +19,14 @@ import com.github.ambry.utils.UtilsTest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -62,6 +65,7 @@ public class AccountContainerTest {
   private List<Boolean> refContainerMediaScanDisabledValues;
   private List<String> refContainerReplicationPolicyValues;
   private List<Boolean> refContainerTtlRequiredValues;
+  private List<Set<String>> refContainerContentTypeWhitelistForFilenamesOnDownloadValues;
   private List<JSONObject> containerJsonList;
   private List<Container> refContainers;
 
@@ -97,10 +101,9 @@ public class AccountContainerTest {
 
   /**
    * Tests constructing an {@link Account} from Json metadata.
-   * @throws Exception Any unexpected exceptions.
    */
   @Test
-  public void testConstructAccountFromJson() throws Exception {
+  public void testConstructAccountFromJson() {
     assertAccountAgainstReference(Account.fromJson(refAccountJson), true, true);
   }
 
@@ -129,6 +132,8 @@ public class AccountContainerTest {
             .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
             .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
             .setTtlRequired(refContainerTtlRequiredValues.get(0))
+            .setContentTypeWhitelistForFilenamesOnDownload(
+                refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(0))
             .build());
     // second container with (id=1, name="0")
     containers.add(
@@ -139,6 +144,8 @@ public class AccountContainerTest {
             .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
             .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
             .setTtlRequired(refContainerTtlRequiredValues.get(0))
+            .setContentTypeWhitelistForFilenamesOnDownload(
+                refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(0))
             .build());
     createAccountWithBadContainersAndFail(containers, IllegalStateException.class);
   }
@@ -158,6 +165,8 @@ public class AccountContainerTest {
             .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
             .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
             .setTtlRequired(refContainerTtlRequiredValues.get(0))
+            .setContentTypeWhitelistForFilenamesOnDownload(
+                refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(0))
             .build());
     // second container with (id=0, name="1")
     containers.add(
@@ -168,6 +177,8 @@ public class AccountContainerTest {
             .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
             .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
             .setTtlRequired(refContainerTtlRequiredValues.get(0))
+            .setContentTypeWhitelistForFilenamesOnDownload(
+                refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(0))
             .build());
     createAccountWithBadContainersAndFail(containers, IllegalStateException.class);
   }
@@ -187,6 +198,8 @@ public class AccountContainerTest {
             .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
             .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
             .setTtlRequired(refContainerTtlRequiredValues.get(0))
+            .setContentTypeWhitelistForFilenamesOnDownload(
+                refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(0))
             .build());
     // second container with (id=1, name="0")
     containers.add(
@@ -197,6 +210,8 @@ public class AccountContainerTest {
             .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
             .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
             .setTtlRequired(refContainerTtlRequiredValues.get(0))
+            .setContentTypeWhitelistForFilenamesOnDownload(
+                refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(0))
             .build());
     // third container with (id=10, name="10")
     containers.add(new ContainerBuilder((short) 10, "10", refContainerStatuses.get(0), refContainerDescriptions.get(0),
@@ -206,6 +221,8 @@ public class AccountContainerTest {
         .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
         .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
         .setTtlRequired(refContainerTtlRequiredValues.get(0))
+        .setContentTypeWhitelistForFilenamesOnDownload(
+            refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(0))
         .build());
     // second container with (id=10, name="11")
     containers.add(new ContainerBuilder((short) 10, "11", refContainerStatuses.get(0), refContainerDescriptions.get(0),
@@ -215,6 +232,8 @@ public class AccountContainerTest {
         .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
         .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
         .setTtlRequired(refContainerTtlRequiredValues.get(0))
+        .setContentTypeWhitelistForFilenamesOnDownload(
+            refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(0))
         .build());
     createAccountWithBadContainersAndFail(containers, IllegalStateException.class);
   }
@@ -244,6 +263,8 @@ public class AccountContainerTest {
         .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
         .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
         .setTtlRequired(refContainerTtlRequiredValues.get(0))
+        .setContentTypeWhitelistForFilenamesOnDownload(
+            refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(0))
         .build());
     createAccountWithBadContainersAndFail(containers, IllegalStateException.class);
   }
@@ -357,7 +378,9 @@ public class AccountContainerTest {
               .setCacheable(refContainerCachingValues.get(i))
               .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(i))
               .setReplicationPolicy(refContainerReplicationPolicyValues.get(i))
-              .setTtlRequired(refContainerTtlRequiredValues.get(i));
+              .setTtlRequired(refContainerTtlRequiredValues.get(i))
+              .setContentTypeWhitelistForFilenamesOnDownload(
+                  refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(i));
       Container containerFromBuilder = containerBuilder.build();
       assertContainer(containerFromBuilder, i);
 
@@ -505,6 +528,11 @@ public class AccountContainerTest {
       boolean updatedMediaScanDisabled = !container.isMediaScanDisabled();
       String updatedReplicationPolicy = container.getReplicationPolicy() + "---updated";
       boolean updatedTtlRequired = !container.isTtlRequired();
+      Set<String> updatedContentTypeWhitelistForFilenamesOnDownloadValues =
+          container.getContentTypeWhitelistForFilenamesOnDownload()
+              .stream()
+              .map(contentType -> contentType + "--updated")
+              .collect(Collectors.toSet());
 
       containerBuilder.setId(updatedContainerId)
           .setName(updatedContainerName)
@@ -514,7 +542,8 @@ public class AccountContainerTest {
           .setCacheable(updatedCacheable)
           .setMediaScanDisabled(updatedMediaScanDisabled)
           .setReplicationPolicy(updatedReplicationPolicy)
-          .setTtlRequired(updatedTtlRequired);
+          .setTtlRequired(updatedTtlRequired)
+          .setContentTypeWhitelistForFilenamesOnDownload(updatedContentTypeWhitelistForFilenamesOnDownloadValues);
       accountBuilder.addOrUpdateContainer(containerBuilder.build());
 
       // build account and assert
@@ -535,6 +564,9 @@ public class AccountContainerTest {
               updatedContainer.isMediaScanDisabled());
           assertNull("Wrong replication policy", updatedContainer.getReplicationPolicy());
           assertEquals("Wrong ttl required setting", TTL_REQUIRED_DEFAULT_VALUE, updatedContainer.isTtlRequired());
+          assertEquals("Wrong content type whitelist for filenames on download value",
+              CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD_DEFAULT_VALUE,
+              updatedContainer.getContentTypeWhitelistForFilenamesOnDownload());
           break;
         case Container.JSON_VERSION_2:
           assertEquals("Wrong encryption setting", updatedEncrypted, updatedContainer.isEncrypted());
@@ -544,6 +576,9 @@ public class AccountContainerTest {
               updatedContainer.isMediaScanDisabled());
           assertEquals("Wrong replication policy", updatedReplicationPolicy, updatedContainer.getReplicationPolicy());
           assertEquals("Wrong ttl required setting", updatedTtlRequired, updatedContainer.isTtlRequired());
+          assertEquals("Wrong content type whitelist for filenames on download value",
+              updatedContentTypeWhitelistForFilenamesOnDownloadValues,
+              updatedContainer.getContentTypeWhitelistForFilenamesOnDownload());
           break;
         default:
           throw new IllegalStateException("Unsupported version: " + Container.getCurrentJsonVersion());
@@ -580,7 +615,9 @@ public class AccountContainerTest {
             .setCacheable(refContainerCachingValues.get(0))
             .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
             .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
-            .setTtlRequired(refContainerTtlRequiredValues.get(0));
+            .setTtlRequired(refContainerTtlRequiredValues.get(0))
+            .setContentTypeWhitelistForFilenamesOnDownload(
+                refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(0));
     Container container = containerBuilder.build();
     accountBuilder.removeContainer(container);
     accountBuilder.removeContainer(null);
@@ -670,10 +707,9 @@ public class AccountContainerTest {
 
   /**
    * Tests {@link Account#equals(Object)} that checks equality of {@link Container}s.
-   * @throws Exception
    */
   @Test
-  public void testAccountEqual() throws Exception {
+  public void testAccountEqual() {
     // Check two accounts with same fields but no containers.
     Account accountNoContainer = new AccountBuilder(refAccountId, refAccountName, refAccountStatus).build();
     Account accountNoContainerDuplicate = new AccountBuilder(refAccountId, refAccountName, refAccountStatus).build();
@@ -697,6 +733,8 @@ public class AccountContainerTest {
             .setMediaScanDisabled(refContainerMediaScanDisabledValues.get(0))
             .setReplicationPolicy(refContainerReplicationPolicyValues.get(0))
             .setTtlRequired(refContainerTtlRequiredValues.get(0))
+            .setContentTypeWhitelistForFilenamesOnDownload(
+                refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(0))
             .build();
     refContainers.remove(0);
     refContainers.add(updatedContainer);
@@ -796,6 +834,12 @@ public class AccountContainerTest {
         assertEquals("Wrong replication policy", refContainerReplicationPolicyValues.get(index),
             container.getReplicationPolicy());
         assertEquals("Wrong ttl required setting", refContainerTtlRequiredValues.get(index), container.isTtlRequired());
+        Set<String> expectedContentTypeWhitelistForFilenamesOnDownloadValue =
+            refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(index) == null ? Collections.emptySet()
+                : refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(index);
+        assertEquals("Wrong content types whitelisted for filename on download",
+            expectedContentTypeWhitelistForFilenamesOnDownloadValue,
+            container.getContentTypeWhitelistForFilenamesOnDownload());
         break;
       default:
         throw new IllegalStateException("Unsupported version: " + Container.getCurrentJsonVersion());
@@ -863,7 +907,7 @@ public class AccountContainerTest {
       boolean previouslyEncrypted, Class<? extends Exception> exceptionClass) throws Exception {
     TestUtils.assertException(exceptionClass, () -> {
       new Container((short) 0, name, status, "description", encrypted, previouslyEncrypted, false, false, null, false,
-          (short) 0);
+          Collections.emptySet(), (short) 0);
     }, null);
   }
 
@@ -882,6 +926,7 @@ public class AccountContainerTest {
     refContainerMediaScanDisabledValues = new ArrayList<>();
     refContainerReplicationPolicyValues = new ArrayList<>();
     refContainerTtlRequiredValues = new ArrayList<>();
+    refContainerContentTypeWhitelistForFilenamesOnDownloadValues = new ArrayList<>();
     containerJsonList = new ArrayList<>();
     refContainers = new ArrayList<>();
     Set<Short> containerIdSet = new HashSet<>();
@@ -909,13 +954,31 @@ public class AccountContainerTest {
         refContainerReplicationPolicyValues.add(null);
       }
       refContainerTtlRequiredValues.add(random.nextBoolean());
+      if (i == 0) {
+        refContainerContentTypeWhitelistForFilenamesOnDownloadValues.add(null);
+      } else if (i == 1) {
+        refContainerContentTypeWhitelistForFilenamesOnDownloadValues.add(Collections.emptySet());
+      } else {
+        refContainerContentTypeWhitelistForFilenamesOnDownloadValues.add(
+            getRandomContentTypeWhitelistForFilenamesOnDownload());
+      }
       refContainers.add(new Container(refContainerIds.get(i), refContainerNames.get(i), refContainerStatuses.get(i),
           refContainerDescriptions.get(i), refContainerEncryptionValues.get(i),
           refContainerPreviousEncryptionValues.get(i), refContainerCachingValues.get(i),
           refContainerMediaScanDisabledValues.get(i), refContainerReplicationPolicyValues.get(i),
-          refContainerTtlRequiredValues.get(i), refAccountId));
+          refContainerTtlRequiredValues.get(i), refContainerContentTypeWhitelistForFilenamesOnDownloadValues.get(i),
+          refAccountId));
       containerJsonList.add(buildContainerJson(refContainers.get(i)));
     }
+  }
+
+  /**
+   * @return a random set of strings
+   */
+  private Set<String> getRandomContentTypeWhitelistForFilenamesOnDownload() {
+    Set<String> toRet = new HashSet<>();
+    IntStream.range(0, random.nextInt(10) + 1).boxed().forEach(i -> toRet.add(UtilsTest.getRandomString(10)));
+    return toRet;
   }
 
   /**
@@ -947,6 +1010,8 @@ public class AccountContainerTest {
         containerJson.put(MEDIA_SCAN_DISABLED_KEY, container.isMediaScanDisabled());
         containerJson.putOpt(REPLICATION_POLICY_KEY, container.getReplicationPolicy());
         containerJson.put(TTL_REQUIRED_KEY, container.isTtlRequired());
+        containerJson.put(CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD,
+            container.getContentTypeWhitelistForFilenamesOnDownload());
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + Container.getCurrentJsonVersion());

--- a/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/account/AccountContainerTest.java
@@ -1010,8 +1010,11 @@ public class AccountContainerTest {
         containerJson.put(MEDIA_SCAN_DISABLED_KEY, container.isMediaScanDisabled());
         containerJson.putOpt(REPLICATION_POLICY_KEY, container.getReplicationPolicy());
         containerJson.put(TTL_REQUIRED_KEY, container.isTtlRequired());
-        containerJson.put(CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD,
-            container.getContentTypeWhitelistForFilenamesOnDownload());
+        if (container.getContentTypeWhitelistForFilenamesOnDownload() != null
+            && !container.getContentTypeWhitelistForFilenamesOnDownload().isEmpty()) {
+          containerJson.put(CONTENT_TYPE_WHITELIST_FOR_FILENAMES_ON_DOWNLOAD,
+              container.getContentTypeWhitelistForFilenamesOnDownload());
+        }
         break;
       default:
         throw new IllegalStateException("Unsupported container json version=" + Container.getCurrentJsonVersion());


### PR DESCRIPTION
The whitelist will serve as an advisory on the content types that are cleared for sending filename in the headers during download