### PR TITLE
Add config for selecting PRNG algorithm in JdkSslFactory

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/SSLConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/SSLConfig.java
@@ -17,7 +17,10 @@ package com.github.ambry.config;
  * The configs for SSL
  */
 public class SSLConfig {
-  /**
+  private static final String PREFIX = "ssl.";
+  public static final String SECURE_RANDOM_ALGORITHM_KEY = PREFIX + "secure.random.algorithm";
+
+ /**
    * The SSL protocol for SSLContext
    */
   @Config("ssl.context.protocol")
@@ -44,6 +47,14 @@ public class SSLConfig {
   @Config("ssl.endpoint.identification.algorithm")
   @Default("")
   public final String sslEndpointIdentificationAlgorithm;
+
+  /**
+   * The {@code SecureRandom} PRNG algorithm to use for SSL cryptography operations. This is only honored by
+   * {@code JdkSslFactory}. {@code NettySslFactory} uses a native SSL impl and does not rely on {@code SecureRandom}.
+   */
+  @Config(SECURE_RANDOM_ALGORITHM_KEY)
+  @Default("")
+  public final String sslSecureRandomAlgorithm;
 
   /**
    * The SSL client authentication config
@@ -141,6 +152,7 @@ public class SSLConfig {
     sslContextProvider = verifiableProperties.getString("ssl.context.provider", "");
     sslEnabledProtocols = verifiableProperties.getString("ssl.enabled.protocols", "TLSv1.2");
     sslEndpointIdentificationAlgorithm = verifiableProperties.getString("ssl.endpoint.identification.algorithm", "");
+    sslSecureRandomAlgorithm = verifiableProperties.getString(SECURE_RANDOM_ALGORITHM_KEY, "");
     sslClientAuthentication = verifiableProperties.getString("ssl.client.authentication", "required");
     sslKeymanagerAlgorithm = verifiableProperties.getString("ssl.keymanager.algorithm", "");
     sslTrustmanagerAlgorithm = verifiableProperties.getString("ssl.trustmanager.algorithm", "");

--- a/ambry-api/src/main/java/com.github.ambry/config/SSLConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/SSLConfig.java
@@ -17,10 +17,8 @@ package com.github.ambry.config;
  * The configs for SSL
  */
 public class SSLConfig {
-  private static final String PREFIX = "ssl.";
-  public static final String SECURE_RANDOM_ALGORITHM_KEY = PREFIX + "secure.random.algorithm";
 
- /**
+  /**
    * The SSL protocol for SSLContext
    */
   @Config("ssl.context.protocol")
@@ -52,7 +50,7 @@ public class SSLConfig {
    * The {@code SecureRandom} PRNG algorithm to use for SSL cryptography operations. This is only honored by
    * {@code JdkSslFactory}. {@code NettySslFactory} uses a native SSL impl and does not rely on {@code SecureRandom}.
    */
-  @Config(SECURE_RANDOM_ALGORITHM_KEY)
+  @Config("ssl.secure.random.algorithm")
   @Default("")
   public final String sslSecureRandomAlgorithm;
 
@@ -152,7 +150,7 @@ public class SSLConfig {
     sslContextProvider = verifiableProperties.getString("ssl.context.provider", "");
     sslEnabledProtocols = verifiableProperties.getString("ssl.enabled.protocols", "TLSv1.2");
     sslEndpointIdentificationAlgorithm = verifiableProperties.getString("ssl.endpoint.identification.algorithm", "");
-    sslSecureRandomAlgorithm = verifiableProperties.getString(SECURE_RANDOM_ALGORITHM_KEY, "");
+    sslSecureRandomAlgorithm = verifiableProperties.getString("ssl.secure.random.algorithm", "");
     sslClientAuthentication = verifiableProperties.getString("ssl.client.authentication", "required");
     sslKeymanagerAlgorithm = verifiableProperties.getString("ssl.keymanager.algorithm", "");
     sslTrustmanagerAlgorithm = verifiableProperties.getString("ssl.trustmanager.algorithm", "");

--- a/ambry-commons/src/test/java/com.github.ambry.commons/JdkSslFactoryTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/JdkSslFactoryTest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Properties;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -51,7 +50,7 @@ public class JdkSslFactoryTest {
       } catch (NoSuchAlgorithmException e) {
         valid = false;
       }
-      props.put(SSLConfig.SECURE_RANDOM_ALGORITHM_KEY, prngAlgorithm);
+      props.put("ssl.secure.random.algorithm", prngAlgorithm);
       SSLConfig config = new SSLConfig(new VerifiableProperties(props));
       if (valid) {
         JdkSslFactory jdkSslFactory = new JdkSslFactory(config);
@@ -60,5 +59,10 @@ public class JdkSslFactoryTest {
         TestUtils.assertException(NoSuchAlgorithmException.class, () -> new JdkSslFactory(config), null);
       }
     }
+    // leaving this prop empty should use the default impl.
+    props.put("ssl.secure.random.algorithm", "");
+    SSLConfig config = new SSLConfig(new VerifiableProperties(props));
+    JdkSslFactory jdkSslFactory = new JdkSslFactory(config);
+    assertNotNull("Invalid SSLContext", jdkSslFactory.getSSLContext());
   }
 }

--- a/ambry-commons/src/test/java/com.github.ambry.commons/JdkSslFactoryTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/JdkSslFactoryTest.java
@@ -13,7 +13,17 @@
  */
 package com.github.ambry.commons;
 
+import com.github.ambry.config.SSLConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.TestUtils;
+import java.io.File;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Properties;
+import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 
 /**
@@ -28,5 +38,27 @@ public class JdkSslFactoryTest {
   @Test
   public void testSSLFactory() throws Exception {
     TestSSLUtils.testSSLFactoryImpl(JdkSslFactory.class.getName());
+
+    // test features specific to JDK impls, like the PRNG algorithm config
+    File trustStoreFile = File.createTempFile("truststore", ".jks");
+    Properties props = new Properties();
+    TestSSLUtils.addSSLProperties(props, "DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client");
+    for (String prngAlgorithm : new String[]{"NativePRNGNonBlocking", "SHA1PRNG", "Windows-PRNG", "badbadinvalid"}) {
+      // First check if the algorithm is supported by the system/jdk/security provider.
+      boolean valid = true;
+      try {
+        SecureRandom.getInstance(prngAlgorithm);
+      } catch (NoSuchAlgorithmException e) {
+        valid = false;
+      }
+      props.put(SSLConfig.SECURE_RANDOM_ALGORITHM_KEY, prngAlgorithm);
+      SSLConfig config = new SSLConfig(new VerifiableProperties(props));
+      if (valid) {
+        JdkSslFactory jdkSslFactory = new JdkSslFactory(config);
+        assertNotNull("Invalid SSLContext", jdkSslFactory.getSSLContext());
+      } else {
+        TestUtils.assertException(NoSuchAlgorithmException.class, () -> new JdkSslFactory(config), null);
+      }
+    }
   }
 }


### PR DESCRIPTION
- Add a config to allow `JdkSslFactory` to use non-default SecureRandom algorithms.
- Clean up the constructor code/unneeded members in `JdkSslFactory`

This is inspired by this [kafka PR](https://github.com/apache/kafka/pull/1747). This allows ambry users to choose from the `SecureRandom` implementations described [here](https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SecureRandom). Some of these algorithms can deliver much better performance than the `/dev/random` based default, which has a habit of running out of entropy.