### PR TITLE
Two harmless changes for test and perf tuning.

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -230,7 +230,7 @@ public class RouterConfig {
     routerScalingUnitMaxConnectionsPerPortPlainText =
         verifiableProperties.getIntInRange("router.scaling.unit.max.connections.per.port.plain.text", 5, 1, 20);
     routerScalingUnitMaxConnectionsPerPortSsl =
-        verifiableProperties.getIntInRange("router.scaling.unit.max.connections.per.port.ssl", 2, 1, 20);
+        verifiableProperties.getIntInRange("router.scaling.unit.max.connections.per.port.ssl", 2, 1, 100);
     routerConnectionsWarmUpPercentagePerPort =
         verifiableProperties.getIntInRange("router.connections.warm.up.percentage.per.port", 25, 0, 100);
     routerConnectionsWarmUpTimeoutMs =

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
@@ -66,7 +66,7 @@ public class MockPartitionId implements PartitionId {
 
   @Override
   public List<ReplicaId> getReplicaIds() {
-    return replicaIds;
+    return new ArrayList<>(replicaIds);
   }
 
   @Override


### PR DESCRIPTION
1. Increase upper limit of  `routerScalingUnitMaxConnectionsPerPortSsl` in config. 
2. A fix that can potentially fix #1063.