### PR TITLE
Support for raw mode in GetBlobOptions

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptions.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptions.java
@@ -43,6 +43,9 @@ public class GetBlobOptions {
     if (rawMode && range != null) {
       throw new IllegalArgumentException("Raw mode and range cannot be used together");
     }
+    if (rawMode && operationType != OperationType.All) {
+      throw new IllegalArgumentException("Raw mode can be used only with OperationType.ALL");
+    }
     this.operationType = operationType;
     this.getOption = getOption;
     this.range = range;

--- a/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptions.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptions.java
@@ -26,10 +26,8 @@ public class GetBlobOptions {
   private final OperationType operationType;
   private final GetOption getOption;
   private final ByteRange range;
-
   // Flag indicating whether to return the raw blob payload without deserialization.
-  // If blob was stored encrypted, decryption will be skipped, otherwise the router will encrypt the blob and associated chunks.
-  private boolean rawMode = false;
+  private final boolean rawMode;
 
   /**
    * Construct a {@link GetBlobOptions} object that represents any options associated with a getBlob request.
@@ -37,27 +35,20 @@ public class GetBlobOptions {
    * @param getOption the {@link GetOption} associated with the request.
    * @param range a {@link ByteRange} for this get request. This can be null, if the entire blob is desired.
    */
-  GetBlobOptions(OperationType operationType, GetOption getOption, ByteRange range) {
+  GetBlobOptions(OperationType operationType, GetOption getOption, ByteRange range, boolean rawMode) {
     if (operationType == null || getOption == null) {
       throw new IllegalArgumentException("operationType and getOption must be defined");
+    }
+    if (rawMode && range != null) {
+      throw new IllegalArgumentException("Raw mode and range cannot be used together");
     }
     this.operationType = operationType;
     this.getOption = getOption;
     this.range = range;
+    this.rawMode = rawMode;
   }
 
-  /**
-   * Sets the rawMode flag of the {@link GetBlobOptions} object.
-   * If rawMode is true, the returned {@link GetBlobResult} will contain the raw (unserialized) blob payload in the
-   * data channel and null blobInfo.  This option cannot be used in conjunction with a byte range.
-   * @param rawMode the new value of rawMode flag.
-   * @return this object.
-   */
   public GetBlobOptions setRawMode(boolean rawMode) {
-    if (rawMode && range != null) {
-      throw new IllegalArgumentException("Raw mode and range cannot be used together");
-    }
-    this.rawMode = rawMode;
     return this;
   }
 

--- a/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptions.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptions.java
@@ -27,6 +27,10 @@ public class GetBlobOptions {
   private final GetOption getOption;
   private final ByteRange range;
 
+  // Flag indicating whether to return the raw blob payload without deserialization.
+  // If blob was stored encrypted, decryption will be skipped, otherwise the router will encrypt the blob and associated chunks.
+  private boolean rawMode = false;
+
   /**
    * Construct a {@link GetBlobOptions} object that represents any options associated with a getBlob request.
    * @param operationType the {@link OperationType} for this request. This must be non-null.
@@ -40,6 +44,28 @@ public class GetBlobOptions {
     this.operationType = operationType;
     this.getOption = getOption;
     this.range = range;
+  }
+
+  /**
+   * Sets the rawMode flag of the {@link GetBlobOptions} object.
+   * If rawMode is true, the returned {@link GetBlobResult} will contain the raw (unserialized) blob payload in the
+   * data channel and null blobInfo.  This option cannot be used in conjunction with a byte range.
+   * @param rawMode the new value of rawMode flag.
+   * @return this object.
+   */
+  public GetBlobOptions setRawMode(boolean rawMode) {
+    if (rawMode && range != null) {
+      throw new IllegalArgumentException("Raw mode and range cannot be used together");
+    }
+    this.rawMode = rawMode;
+    return this;
+  }
+
+  /**
+   * @return The value of the rawMode flag.
+   */
+  public boolean isRawMode() {
+    return rawMode;
   }
 
   /**
@@ -65,7 +91,8 @@ public class GetBlobOptions {
 
   @Override
   public String toString() {
-    return "GetBlobOptions{operationType=" + operationType + ", getOption=" + getOption + ", range=" + range + '}';
+    return "GetBlobOptions{operationType=" + operationType + ", getOption=" + getOption + ", range=" + range
+        + ", rawMode=" + rawMode + '}';
   }
 
   @Override
@@ -85,6 +112,9 @@ public class GetBlobOptions {
     if (getOption != that.getOption) {
       return false;
     }
+    if (rawMode != that.rawMode) {
+      return false;
+    }
     return !(range != null ? !range.equals(that.range) : that.range != null);
   }
 
@@ -93,6 +123,7 @@ public class GetBlobOptions {
     int result = operationType.hashCode();
     result = 31 * result + getOption.hashCode();
     result = 31 * result + (range != null ? range.hashCode() : 0);
+    result = 31 * result + Boolean.hashCode(rawMode);
     return result;
   }
 

--- a/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptions.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptions.java
@@ -34,6 +34,7 @@ public class GetBlobOptions {
    * @param operationType the {@link OperationType} for this request. This must be non-null.
    * @param getOption the {@link GetOption} associated with the request.
    * @param range a {@link ByteRange} for this get request. This can be null, if the entire blob is desired.
+   * @param rawMode a system flag indicating that the raw bytes should be returned.
    */
   GetBlobOptions(OperationType operationType, GetOption getOption, ByteRange range, boolean rawMode) {
     if (operationType == null || getOption == null) {
@@ -46,10 +47,6 @@ public class GetBlobOptions {
     this.getOption = getOption;
     this.range = range;
     this.rawMode = rawMode;
-  }
-
-  public GetBlobOptions setRawMode(boolean rawMode) {
-    return this;
   }
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptionsBuilder.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptionsBuilder.java
@@ -55,7 +55,9 @@ public class GetBlobOptionsBuilder {
   }
 
   /**
-   * @param rawMode the raw mode for this get request.
+   * @param rawMode the raw mode flag for this get request.
+   * If rawMode is true, the returned {@link GetBlobResult} will contain the raw (unserialized) blob payload in the
+   * data channel and null blobInfo.  This option cannot be used in conjunction with a byte range.
    * @return this builder
    */
   public GetBlobOptionsBuilder rawMode(boolean rawMode) {
@@ -67,6 +69,6 @@ public class GetBlobOptionsBuilder {
    * @return the {@link GetBlobOptions} built.
    */
   public GetBlobOptions build() {
-    return new GetBlobOptions(operationType, getOption, range).setRawMode(rawMode);
+    return new GetBlobOptions(operationType, getOption, range, rawMode);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptionsBuilder.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/GetBlobOptionsBuilder.java
@@ -25,6 +25,7 @@ public class GetBlobOptionsBuilder {
   private GetBlobOptions.OperationType operationType = GetBlobOptions.OperationType.All;
   private GetOption getOption = GetOption.None;
   private ByteRange range = null;
+  private boolean rawMode = false;
 
   /**
    * @param operationType the {@link GetBlobOptions.OperationType} for this request.
@@ -54,9 +55,18 @@ public class GetBlobOptionsBuilder {
   }
 
   /**
+   * @param rawMode the raw mode for this get request.
+   * @return this builder
+   */
+  public GetBlobOptionsBuilder rawMode(boolean rawMode) {
+    this.rawMode = rawMode;
+    return this;
+  }
+
+  /**
    * @return the {@link GetBlobOptions} built.
    */
   public GetBlobOptions build() {
-    return new GetBlobOptions(operationType, getOption, range);
+    return new GetBlobOptions(operationType, getOption, range).setRawMode(rawMode);
   }
 }

--- a/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
@@ -63,6 +63,7 @@ public class GetBlobOptionsTest {
     assertEquals("GetOption from options not as expected.", GetOption.Include_All, options.getGetOption());
   }
 
+  /** Test the rawMode option */
   @Test
   public void testRawModeOption() {
     GetBlobOptions options =
@@ -70,6 +71,9 @@ public class GetBlobOptionsTest {
     assertEquals("RawMode from options not as expected.", true, options.isRawMode());
   }
 
+  /**
+   * Test that using rawMode and range together fails.
+   */
   @Test(expected = IllegalArgumentException.class)
   public void testRawModeWithRange() {
     GetBlobOptions options = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)

--- a/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
@@ -63,6 +63,21 @@ public class GetBlobOptionsTest {
     assertEquals("GetOption from options not as expected.", GetOption.Include_All, options.getGetOption());
   }
 
+  @Test
+  public void testRawModeOption() {
+    GetBlobOptions options =
+        new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).rawMode(true).build();
+    assertEquals("RawMode from options not as expected.", true, options.isRawMode());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRawModeWithRange() {
+    GetBlobOptions options = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
+        .range(ByteRange.fromOffsetRange(0, 1))
+        .rawMode(true)
+        .build();
+  }
+
   /**
    * Test toString, equals, and hashCode methods.
    */
@@ -75,21 +90,40 @@ public class GetBlobOptionsTest {
     GetBlobOptions b = new GetBlobOptionsBuilder().operationType(type).getOption(getOption).range(byteRange).build();
     assertEquals("GetBlobOptions should be equal", a, b);
     assertEquals("GetBlobOptions hashcodes should be equal", a.hashCode(), b.hashCode());
-    assertEquals("toString output not as expected",
-        "GetBlobOptions{operationType=" + type + ", getOption=" + getOption + ", range=" + byteRange.toString() + "}",
-        a.toString());
+    assertEquals("GetBlobOptions toString should be equal", a.toString(), b.toString());
 
-    b = new GetBlobOptionsBuilder().operationType(type)
-        .getOption(getOption)
-        .range(ByteRange.fromOffsetRange(2, 7))
-        .build();
-    assertThat("GetBlobOptions should not be equal.", a, not(b));
+    // Change OperationType
     b = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
         .getOption(getOption)
         .range(byteRange)
         .build();
-    assertThat("GetBlobOptions should not be equal.", a, not(b));
+    assertObjectsAreDistinct(a, b);
+
+    // Change GetOption
     b = new GetBlobOptionsBuilder().operationType(type).getOption(GetOption.Include_All).range(byteRange).build();
+    assertObjectsAreDistinct(a, b);
+
+    // Change range
+    b = new GetBlobOptionsBuilder().operationType(type)
+        .getOption(getOption)
+        .range(ByteRange.fromOffsetRange(2, 7))
+        .build();
+    assertObjectsAreDistinct(a, b);
+
+    // Change rawMode (need to omit range)
+    a = new GetBlobOptionsBuilder().operationType(type).getOption(getOption).build();
+    b = new GetBlobOptionsBuilder().operationType(type).getOption(getOption).rawMode(true).build();
+    assertObjectsAreDistinct(a, b);
+  }
+
+  /**
+   * Verify that two instances of GetBlobOptions are not equal and have distinct hashcodes and toStrings.
+   * @param a first instance
+   * @param b second instance
+   */
+  private static void assertObjectsAreDistinct(GetBlobOptions a, GetBlobOptions b) {
     assertThat("GetBlobOptions should not be equal.", a, not(b));
+    assertThat("GetBlobOptions hashcodes should not be equal", a.hashCode(), not(b.hashCode()));
+    assertThat("GetBlobOptions toString should not be equal", a.toString(), not(b.toString()));
   }
 }

--- a/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
@@ -15,6 +15,7 @@
 package com.github.ambry.router;
 
 import com.github.ambry.protocol.GetOption;
+import com.github.ambry.utils.TestUtils;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -73,13 +74,14 @@ public class GetBlobOptionsTest {
 
   /**
    * Test that using rawMode and range together fails.
+   * @throws Exception
    */
-  @Test(expected = IllegalArgumentException.class)
-  public void testRawModeWithRange() {
-    GetBlobOptions options = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
+  @Test
+  public void testRawModeWithRange() throws Exception {
+    GetBlobOptionsBuilder options = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
         .range(ByteRange.fromOffsetRange(0, 1))
-        .rawMode(true)
-        .build();
+        .rawMode(true);
+    TestUtils.assertException(IllegalArgumentException.class, () -> options.build(), null);
   }
 
   /**
@@ -121,13 +123,14 @@ public class GetBlobOptionsTest {
   }
 
   /**
-   * Verify that two instances of GetBlobOptions are not equal and have distinct hashcodes and toStrings.
+   * Verify that two instances of GetBlobOptions are not equal and have distinct toStrings.
    * @param a first instance
    * @param b second instance
    */
   private static void assertObjectsAreDistinct(GetBlobOptions a, GetBlobOptions b) {
     assertThat("GetBlobOptions should not be equal.", a, not(b));
-    assertThat("GetBlobOptions hashcodes should not be equal", a.hashCode(), not(b.hashCode()));
+    // Don't compare hashcodes since collisions are possible.
+    // assertThat("GetBlobOptions hashcodes should not be equal", a.hashCode(), not(b.hashCode()));
     assertThat("GetBlobOptions toString should not be equal", a.toString(), not(b.toString()));
   }
 }

--- a/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
@@ -67,20 +67,30 @@ public class GetBlobOptionsTest {
   /** Test the rawMode option */
   @Test
   public void testRawModeOption() {
-    GetBlobOptions options =
-        new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).rawMode(true).build();
-    assertEquals("RawMode from options not as expected.", true, options.isRawMode());
+    for (Boolean boolVal : TestUtils.BOOLEAN_VALUES) {
+      GetBlobOptions options =
+          new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All).rawMode(boolVal).build();
+      assertEquals("RawMode from options not as expected.", boolVal, options.isRawMode());
+    }
   }
 
   /**
-   * Test that using rawMode and range together fails.
+   * Test rawMode with invalid combinations.
    * @throws Exception
    */
   @Test
-  public void testRawModeWithRange() throws Exception {
+  public void testRawModeWithInvalidCombinations() throws Exception {
+    // Test that using rawMode and range together fails.
     GetBlobOptionsBuilder options = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
         .range(ByteRange.fromOffsetRange(0, 1))
         .rawMode(true);
+    TestUtils.assertException(IllegalArgumentException.class, () -> options.build(), null);
+
+    // Test that using rawMode fails with OperationType other than ALL.
+    options.range(null);
+    options.operationType(GetBlobOptions.OperationType.BlobInfo);
+    TestUtils.assertException(IllegalArgumentException.class, () -> options.build(), null);
+    options.operationType(GetBlobOptions.OperationType.Data);
     TestUtils.assertException(IllegalArgumentException.class, () -> options.build(), null);
   }
 
@@ -117,8 +127,11 @@ public class GetBlobOptionsTest {
     assertObjectsAreDistinct(a, b);
 
     // Change rawMode (need to omit range)
-    a = new GetBlobOptionsBuilder().operationType(type).getOption(getOption).build();
-    b = new GetBlobOptionsBuilder().operationType(type).getOption(getOption).rawMode(true).build();
+    a = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All).getOption(getOption).build();
+    b = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
+        .getOption(getOption)
+        .rawMode(true)
+        .build();
     assertObjectsAreDistinct(a, b);
   }
 
@@ -129,8 +142,7 @@ public class GetBlobOptionsTest {
    */
   private static void assertObjectsAreDistinct(GetBlobOptions a, GetBlobOptions b) {
     assertThat("GetBlobOptions should not be equal.", a, not(b));
-    // Don't compare hashcodes since collisions are possible.
-    // assertThat("GetBlobOptions hashcodes should not be equal", a.hashCode(), not(b.hashCode()));
     assertThat("GetBlobOptions toString should not be equal", a.toString(), not(b.toString()));
+    // Note: don't compare hashcodes since collisions are possible.
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -348,7 +348,7 @@ class GetBlobInfoOperation extends GetOperation {
               null);
     } else {
       // submit decrypt job
-      progressTracker.initializeDecryptionTracker();
+      progressTracker.initializeCryptoJobTracker(CryptoJobType.DECRYPTION);
       logger.trace("Submitting decrypt job for {}", blobId);
       decryptJobMetricsTracker.onJobSubmission();
       long startTimeMs = System.currentTimeMillis();
@@ -363,14 +363,14 @@ class GetBlobInfoOperation extends GetOperation {
               operationResult = new GetBlobResultInternal(
                   new GetBlobResult(new BlobInfo(serverBlobProperties, result.getDecryptedUserMetadata().array()),
                       null), null);
-              progressTracker.setDecryptionSuccess();
+              progressTracker.setCryptoJobSuccess();
             } else {
               decryptJobMetricsTracker.incrementOperationError();
               logger.trace("Exception {} thrown on decryption for {}", exception, blobId);
               setOperationException(
                   new RouterException("Exception thrown on decrypting the content for " + blobId, exception,
                       RouterErrorCode.UnexpectedInternalError));
-              progressTracker.setDecryptionFailed();
+              progressTracker.setCryptoJobFailed();
             }
             decryptJobMetricsTracker.onJobResultProcessingComplete();
             routerCallback.onPollReady();

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -813,7 +813,7 @@ class GetBlobOperation extends GetOperation {
         return true;
       } else {
         // encryptionKey == null && needEncryption
-        // TODO: defer this til later
+        // TODO: encrypt buffer if caller wants it
         /*
         logger.trace("Submitting encrypt job for {}", blobDesc);
         long startTimeMs = System.currentTimeMillis();
@@ -1089,7 +1089,6 @@ class GetBlobOperation extends GetOperation {
         ByteBuffer rawPayloadBuffer = null;
         boolean rawMode = options.getBlobOptions.isRawMode();
         if (rawMode) {
-          // Note: currently only works for simple blobs
           byte[] payloadBytes = new byte[payload.available()];
           payload.read(payloadBytes);
           payload = new ByteArrayInputStream(payloadBytes);
@@ -1119,7 +1118,9 @@ class GetBlobOperation extends GetOperation {
         chunkIndexToBuffer = new TreeMap<>();
         if (blobType == BlobType.MetadataBlob) {
           if (rawMode) {
-            setOperationException(new IllegalStateException("Only simple blobs supported in raw mode"));
+            // Send the list of chunk Ids
+            chunkIndexToBuffer.put(0, blobData.getStream().getByteBuffer());
+            numChunksRetrieved = 1;
           } else {
             handleMetadataBlob(blobData, userMetadata, encryptionKey);
           }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -456,7 +456,7 @@ class GetBlobOperation extends GetOperation {
           routerMetrics.compositeBlobGetCount.inc();
         }
       } else {
-        // TODO: how to track these counts in raw mode?
+        routerMetrics.rawBlobGetCount.inc();
       }
     }
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -779,6 +779,14 @@ class GetBlobOperation extends GetOperation {
       checkAndMaybeComplete();
     }
 
+    /**
+     * Launch a crypto job as needed.
+     * @param dataBuffer to buffer to encrypt or decrypt.
+     * @param userMetadata userMetadata of the blob.
+     * @param encryptionKey encryption key for the blob. Could be null for non encrypted blob.
+     * @param isSimple {@code true} for simple blob, {@code false} for data chunk.
+     * @return {@code true} if a crypto job was launched, otherwise {@code false}.
+     */
     protected boolean maybeLaunchCryptoJob(ByteBuffer dataBuffer, byte[] userMetadata, ByteBuffer encryptionKey,
         boolean isSimple) {
       //

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -349,10 +349,11 @@ class NonBlockingRouter implements Router {
     };
     currentOperationsCount.incrementAndGet();
     currentBackgroundOperationsCount.incrementAndGet();
-    GetBlobOptionsInternal options =
-        new GetBlobOptionsInternal(new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.Include_All, null),
-            true, routerMetrics.ageAtDelete);
-    backgroundDeleter.getBlob(blobIdStr, options, callback);
+    GetBlobOptions options = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
+        .getOption(GetOption.Include_All)
+        .build();
+    GetBlobOptionsInternal optionsInternal = new GetBlobOptionsInternal(options, true, routerMetrics.ageAtDelete);
+    backgroundDeleter.getBlob(blobIdStr, optionsInternal, callback);
   }
 
   /**
@@ -700,11 +701,13 @@ class NonBlockingRouter implements Router {
           }
         };
 
-        GetBlobOptionsInternal options =
-            new GetBlobOptionsInternal(new GetBlobOptions(GetBlobOptions.OperationType.All, GetOption.None, null), true,
-                routerMetrics.ageAtTtlUpdate);
+        GetBlobOptions options = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
+            .getOption(GetOption.None)
+            .build();
+        GetBlobOptionsInternal optionsInternal =
+            new GetBlobOptionsInternal(options, true, routerMetrics.ageAtTtlUpdate);
         try {
-          getBlob(blobIdStr, options, internalCallback);
+          getBlob(blobIdStr, optionsInternal, internalCallback);
         } catch (RouterException e) {
           completeUpdateBlobTtlOperation(e, futureResult, callback);
         }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -158,6 +158,7 @@ public class NonBlockingRouterMetrics {
   public final Counter simpleBlobGetCount;
   public final Counter compositeBlobPutCount;
   public final Counter compositeBlobGetCount;
+  public final Counter rawBlobGetCount;
 
   // AdaptiveOperationTracker metrics
   public final Histogram getBlobLocalColoLatencyMs;
@@ -373,6 +374,7 @@ public class NonBlockingRouterMetrics {
     compositeBlobPutCount = metricRegistry.counter(MetricRegistry.name(PutManager.class, "CompositeBlobPutCount"));
     compositeBlobGetCount = metricRegistry.counter(MetricRegistry.name(GetManager.class, "CompositeBlobGetCount"));
     skippedGetBlobCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "SkippedGetBlobCount"));
+    rawBlobGetCount = metricRegistry.counter(MetricRegistry.name(GetManager.class, "RawBlobGetCount"));
 
     // Track metrics at the DataNode level.
     dataNodeToMetrics = new HashMap<>();

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -348,11 +348,9 @@ public class GetBlobOperationTest {
     }
   }
 
-  // TODO: test get blob with raw mode
-  // Simple encrypted blob should succeed, others should fail
-
   /**
    * Test gets of simple blob in raw mode.
+   * TODO: also test composite blob
    */
   @Test
   public void testSimpleBlobRawMode() throws Exception {
@@ -362,7 +360,6 @@ public class GetBlobOperationTest {
         new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All).rawMode(true).build(), false,
         routerMetrics.ageAtGet);
     if (testEncryption) {
-      // will fail to match result
       getAndAssertSuccess();
     } else {
       GetBlobOperation op = createOperationAndComplete(null);
@@ -1189,7 +1186,6 @@ public class GetBlobOperationTest {
     // Ensure that a ChannelClosed exception is not set when the ReadableStreamChannel is closed correctly.
     Assert.assertNull("Callback operation exception should be null", op.getOperationException());
     if (options.getBlobOptions.getOperationType() != GetBlobOptions.OperationType.BlobInfo && !options.getBlobOptions.isRawMode()) {
-      // TODO: look at failing the "raw" operation if a range is set
       int sizeWritten = blobSize;
       if (options.getBlobOptions.getRange() != null) {
         ByteRange range = options.getBlobOptions.getRange().toResolvedByteRange(blobSize);
@@ -1277,8 +1273,8 @@ public class GetBlobOperationTest {
             putContentBuf = getBlobBufferFromServer(server);
             break;
           }
-          Assert.assertNotNull("Did not find server with blob: " + blobIdStr, putContentBuf);
         }
+        Assert.assertNotNull("Did not find server with blob: " + blobIdStr, putContentBuf);
       } else {
         putContentBuf = ByteBuffer.wrap(putContent);
         // If a range is set, compare the result against the specified byte range.


### PR DESCRIPTION
Also renamed ProgressTracker.DecryptionTracker to CryptoTracker to allow both encryption and decryption to be used during GET requests.
Note: only simple encrypted blobs supported now, other cases will be handled in follow up.