### PR TITLE
Add edit functionality to AccountUpdateTool

### DIFF
--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -15,7 +15,6 @@ package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.HelixStoreOperator;
-import com.github.ambry.commons.Notifier;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -80,6 +79,7 @@ public class HelixAccountServiceTest {
   private static final Map<Short, Map<Short, Container>> idToRefContainerMap = new HashMap<>();
   private final Properties helixConfigProps = new Properties();
   private final Path accountBackupDir;
+  private final MockNotifier<String> notifier;
   private VerifiableProperties vHelixConfigProps;
   private HelixPropertyStoreConfig storeConfig;
   private Account refAccount;
@@ -100,7 +100,6 @@ public class HelixAccountServiceTest {
   private short refParentAccountId;
   private AccountService accountService;
   private MockHelixAccountServiceFactory mockHelixAccountServiceFactory;
-  private Notifier<String> notifier;
 
   /**
    * Resets variables and settings, and cleans up if the store already exists.
@@ -134,6 +133,8 @@ public class HelixAccountServiceTest {
     if (accountService != null) {
       accountService.close();
     }
+    assertEquals("No TopicListeners should still be attached to Notifier", 0,
+        notifier.topicToListenersMap.getOrDefault(ACCOUNT_METADATA_CHANGE_TOPIC, Collections.emptySet()).size());
     deleteStoreIfExists();
   }
 

--- a/ambry-account/src/test/java/com/github/ambry/account/MockNotifier.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockNotifier.java
@@ -28,7 +28,7 @@ import java.util.Set;
  */
 public class MockNotifier<T> implements Notifier<T> {
 
-  private final Map<String, Set<TopicListener<T>>> topicToListenersMap = new HashMap<>();
+  final Map<String, Set<TopicListener<T>>> topicToListenersMap = new HashMap<>();
 
   @Override
   public boolean publish(String topic, T message) {

--- a/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
@@ -210,9 +210,9 @@ public class AccountUpdateToolTest {
   public void testBadJsonFile() throws Exception {
     String badJsonFile = tempDirPath + File.separator + "badJsonFile.json";
     writeStringToFile("Invalid json string", badJsonFile);
-    try {
-      new AccountUpdateTool(ZK_SERVER_ADDRESS, HELIX_STORE_ROOT_PATH, BACKUP_DIR, 2000, 2000,
-          Container.getCurrentJsonVersion()).updateAccountsFromFile(badJsonFile);
+    try (AccountService accountService = AccountUpdateTool.getHelixAccountService(ZK_SERVER_ADDRESS,
+        HELIX_STORE_ROOT_PATH, BACKUP_DIR, 2000, 2000)) {
+      new AccountUpdateTool(accountService, Container.getCurrentJsonVersion()).updateAccountsFromFile(badJsonFile);
       fail("Should have thrown.");
     } catch (Exception e) {
       // expected
@@ -230,8 +230,10 @@ public class AccountUpdateToolTest {
     String jsonFilePath = tempDirPath + File.separator + UUID.randomUUID().toString() + ".json";
     writeAccountsToFile(accounts, jsonFilePath);
     accountUpdateConsumer.reset();
-    new AccountUpdateTool(ZK_SERVER_ADDRESS, HELIX_STORE_ROOT_PATH, BACKUP_DIR, 2000, 2000,
-        containerJsonVersion).updateAccountsFromFile(jsonFilePath);
+    try (AccountService accountService = AccountUpdateTool.getHelixAccountService(ZK_SERVER_ADDRESS,
+        HELIX_STORE_ROOT_PATH, BACKUP_DIR, 2000, 2000)) {
+      new AccountUpdateTool(accountService, containerJsonVersion).updateAccountsFromFile(jsonFilePath);
+    }
     accountUpdateConsumer.awaitUpdate();
   }
 

--- a/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
@@ -14,11 +14,11 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.HelixStoreOperator;
 import com.github.ambry.commons.HelixNotifier;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.clustermap.HelixStoreOperator;
 import com.github.ambry.utils.TestUtils;
 import java.io.File;
 import java.io.IOException;
@@ -211,8 +211,8 @@ public class AccountUpdateToolTest {
     String badJsonFile = tempDirPath + File.separator + "badJsonFile.json";
     writeStringToFile("Invalid json string", badJsonFile);
     try {
-      AccountUpdateTool.updateAccount(badJsonFile, ZK_SERVER_ADDRESS, HELIX_STORE_ROOT_PATH, BACKUP_DIR, 2000, 2000,
-          Container.getCurrentJsonVersion());
+      new AccountUpdateTool(ZK_SERVER_ADDRESS, HELIX_STORE_ROOT_PATH, BACKUP_DIR, 2000, 2000,
+          Container.getCurrentJsonVersion()).updateAccountsFromFile(badJsonFile);
       fail("Should have thrown.");
     } catch (Exception e) {
       // expected
@@ -230,8 +230,8 @@ public class AccountUpdateToolTest {
     String jsonFilePath = tempDirPath + File.separator + UUID.randomUUID().toString() + ".json";
     writeAccountsToFile(accounts, jsonFilePath);
     accountUpdateConsumer.reset();
-    AccountUpdateTool.updateAccount(jsonFilePath, ZK_SERVER_ADDRESS, HELIX_STORE_ROOT_PATH, BACKUP_DIR, 2000, 2000,
-        containerJsonVersion);
+    new AccountUpdateTool(ZK_SERVER_ADDRESS, HELIX_STORE_ROOT_PATH, BACKUP_DIR, 2000, 2000,
+        containerJsonVersion).updateAccountsFromFile(jsonFilePath);
     accountUpdateConsumer.awaitUpdate();
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
@@ -14,20 +14,25 @@
 package com.github.ambry.account;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.commons.HelixNotifier;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.HelixPropertyStoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.tools.util.ToolUtils;
 import com.github.ambry.utils.Utils;
+import java.io.BufferedWriter;
+import java.io.Closeable;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
+import java.util.stream.Stream;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
-import joptsimple.OptionSpec;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -100,15 +105,18 @@ import static com.github.ambry.account.AccountUtils.*;
  *   </pre>
  * </p>
  */
-public class AccountUpdateTool {
+public class AccountUpdateTool implements Closeable {
   private static final int ZK_CLIENT_CONNECTION_TIMEOUT_MS = 5000;
   private static final int ZK_CLIENT_SESSION_TIMEOUT_MS = 20000;
   private static final String DEFAULT_LOCAL_BACKUP_DIR = "/tmp/account-update-tool-backups";
 
+  private final AccountService accountService;
+
   /**
    * @param args takes in three mandatory arguments: the path of the json file for the accounts to create/update,
-   *             the address of the {@code ZooKeeper} server, and the root path for the {@link org.apache.helix.store.HelixPropertyStore}
-   *             that will be used for storing account metadata and notifications.
+   *             the address of the {@code ZooKeeper} server, and the root path for the
+   *             {@link org.apache.helix.store.HelixPropertyStore} that will be used for storing account metadata and
+   *             notifications.
    *
    *             Also takes in an optional argument that specifies the timeout in millisecond to connect to the
    *             {@code ZooKeeper} server (default value is 5000), and the timeout in millisecond to keep a session
@@ -117,13 +125,19 @@ public class AccountUpdateTool {
   public static void main(String args[]) throws Exception {
     OptionParser parser = new OptionParser();
 
-    ArgumentAcceptingOptionSpec<String> accountJsonFilePathOpt = parser.accepts("accountJsonPath",
+    ArgumentAcceptingOptionSpec<String> accountJsonPathOpt = parser.accepts("accountJsonPath",
         "The path to the account json file. The json file must be in the form of a json array, with each"
             + "entry to be an account in its json form.")
         .withRequiredArg()
-        .describedAs("account_json_file_path")
+        .describedAs("account_json_path")
         .ofType(String.class);
 
+    ArgumentAcceptingOptionSpec<String> accountsToEditOpt = parser.accepts("accountsToEdit",
+        "The names of the accounts to edit. "
+            + "The script will open an editor where you can edit the json for these accounts.")
+        .withRequiredArg()
+        .describedAs("account_json_file_path")
+        .withValuesSeparatedBy(",");
     ArgumentAcceptingOptionSpec<String> zkServerOpt =
         parser.accepts("zkServer", "The address of ZooKeeper server. This option is required.")
             .withRequiredArg()
@@ -131,11 +145,9 @@ public class AccountUpdateTool {
             .ofType(String.class);
 
     ArgumentAcceptingOptionSpec<String> storePathOpt = parser.accepts("storePath",
-        "The root path of helix property store in the ZooKeeper. Must start with /, and must not end "
-            + "with /. It is recommended to make root path in the form of /ambry/<clustername>/helixPropertyStore. This option is required.")
-        .withRequiredArg()
-        .describedAs("helix_store_path")
-        .ofType(String.class);
+        "The root path of helix property store in the ZooKeeper. Must start with /, and must not end with /. "
+            + "It is recommended to make root path in the form of /ambry/<clustername>/helixPropertyStore. "
+            + "This option is required.").withRequiredArg().describedAs("helix_store_path").ofType(String.class);
 
     ArgumentAcceptingOptionSpec<Integer> zkConnectionTimeoutMsOpt = parser.accepts("zkConnectionTimeout",
         "Optional timeout in millisecond for connecting to the ZooKeeper server. This option is not required, "
@@ -160,12 +172,12 @@ public class AccountUpdateTool {
         .ofType(Short.class)
         .defaultsTo(Container.getCurrentJsonVersion());
 
-    ArgumentAcceptingOptionSpec<String> backupDirOpt = parser.accepts("backupDir",
-        "Optional local backup directory path. Defaults to " + DEFAULT_LOCAL_BACKUP_DIR)
-        .withRequiredArg()
-        .describedAs("backup_dir")
-        .ofType(String.class)
-        .defaultsTo(DEFAULT_LOCAL_BACKUP_DIR);
+    ArgumentAcceptingOptionSpec<String> backupDirOpt =
+        parser.accepts("backupDir", "Optional local backup directory path. Defaults to " + DEFAULT_LOCAL_BACKUP_DIR)
+            .withRequiredArg()
+            .describedAs("backup_dir")
+            .ofType(String.class)
+            .defaultsTo(DEFAULT_LOCAL_BACKUP_DIR);
 
     parser.accepts("help", "print this help message.");
 
@@ -176,20 +188,27 @@ public class AccountUpdateTool {
       parser.printHelpOn(System.out);
       System.exit(0);
     }
-    String accountJsonFilePath = options.valueOf(accountJsonFilePathOpt);
+    ToolUtils.ensureOrExit(Collections.singletonList(zkServerOpt), options, parser);
     String storePath = options.valueOf(storePathOpt);
     String zkServer = options.valueOf(zkServerOpt);
     String backupDir = options.valueOf(backupDirOpt);
     Integer zkConnectionTimeoutMs = options.valueOf(zkConnectionTimeoutMsOpt);
     Integer zkSessionTimeoutMs = options.valueOf(zkSessionTimeoutMsOpt);
     Short containerJsonVersion = options.valueOf(containerJsonVersionOpt);
-    ArrayList<OptionSpec> listOpt = new ArrayList<>();
-    listOpt.add(accountJsonFilePathOpt);
-    listOpt.add(zkServerOpt);
-    ToolUtils.ensureOrExit(listOpt, options, parser);
-    try {
-      updateAccount(accountJsonFilePath, zkServer, storePath, backupDir, zkConnectionTimeoutMs, zkSessionTimeoutMs,
-          containerJsonVersion);
+    String accountJsonPath = options.valueOf(accountJsonPathOpt);
+    List<String> accountsToEdit = options.valuesOf(accountsToEditOpt);
+    if ((accountJsonPath == null) == (accountsToEdit.isEmpty())) {
+      System.err.println("Must provide exactly one of --accountJsonPath or --accountsToEdit");
+      parser.printHelpOn(System.err);
+      System.exit(1);
+    }
+    try (AccountUpdateTool accountUpdateTool = new AccountUpdateTool(zkServer, storePath, backupDir,
+        zkConnectionTimeoutMs, zkSessionTimeoutMs, containerJsonVersion)) {
+      if (accountJsonPath != null) {
+        accountUpdateTool.updateAccountsFromFile(accountJsonPath);
+      } else {
+        accountUpdateTool.editAccounts(accountsToEdit);
+      }
     } catch (Exception e) {
       System.err.println("Updating accounts failed with exception: " + e);
       e.printStackTrace();
@@ -197,8 +216,7 @@ public class AccountUpdateTool {
   }
 
   /**
-   * Performs the updating accounts operation.
-   * @param accountJsonFilePath The path to the json file.
+   * Constructor.
    * @param zkServer The {@code ZooKeeper} server address to connect.
    * @param storePath The root path on the {@code ZooKeeper} for account data.
    * @param backupDir The path to the local backup directory.
@@ -207,37 +225,9 @@ public class AccountUpdateTool {
    * @param containerJsonVersion The {@link Container} JSON version to write in.
    * @throws Exception
    */
-  static void updateAccount(String accountJsonFilePath, String zkServer, String storePath, String backupDir,
-      int zkConnectionTimeoutMs, int zkSessionTimeoutMs, short containerJsonVersion) throws Exception {
+  AccountUpdateTool(String zkServer, String storePath, String backupDir, int zkConnectionTimeoutMs,
+      int zkSessionTimeoutMs, short containerJsonVersion) {
     Container.setCurrentJsonVersion(containerJsonVersion);
-    long startTime = System.currentTimeMillis();
-    Collection<Account> accountsToUpdate = getAccountsFromJson(accountJsonFilePath);
-    if (!hasDuplicateAccountIdOrName(accountsToUpdate)) {
-      try (AccountService accountService = getHelixAccountService(zkServer, storePath, backupDir, zkConnectionTimeoutMs,
-          zkSessionTimeoutMs)) {
-        if (accountService.updateAccounts(accountsToUpdate)) {
-          System.out.println(accountsToUpdate.size() + " accounts have been successfully created or updated, took " + (
-              System.currentTimeMillis() - startTime) + " ms");
-        } else {
-          throw new Exception("Updating accounts failed with unknown reason.");
-        }
-      }
-    } else {
-      throw new IllegalArgumentException("Duplicate id or name exists in the accounts to update");
-    }
-  }
-
-  /**
-   * Constructor.
-   * @param zkServer The {@code ZooKeeper} server address to connect.
-   * @param storePath The path for {@link org.apache.helix.store.HelixPropertyStore}, which will be used as the
-   *                  root path for both {@link HelixAccountService} and {@link HelixNotifier}.
-   * @param backupDir The path to the local backup directory.
-   * @param zkConnectionTimeoutMs The timeout in millisecond to connect to the {@code ZooKeeper} server.
-   * @param zkSessionTimeoutMs The timeout in millisecond for a session to the {@code ZooKeeper} server.
-   */
-  private static AccountService getHelixAccountService(String zkServer, String storePath, String backupDir,
-      int zkConnectionTimeoutMs, int zkSessionTimeoutMs) {
     Properties helixConfigProps = new Properties();
     helixConfigProps.setProperty(
         HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "zk.client.connection.timeout.ms",
@@ -248,18 +238,70 @@ public class AccountUpdateTool {
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "root.path", storePath);
     helixConfigProps.setProperty(HelixAccountServiceConfig.BACKUP_DIRECTORY_KEY, backupDir);
     VerifiableProperties vHelixConfigProps = new VerifiableProperties(helixConfigProps);
-    return new HelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry()).getAccountService();
+    accountService = new HelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry()).getAccountService();
+  }
+
+  /**
+   * Edit accounts in a text editor and upload them to zookeeper.
+   * @param accountNames the name of the accounts to edit.
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  void editAccounts(Collection<String> accountNames) throws IOException, InterruptedException {
+    Path accountJsonPath = Files.createTempFile("account-update-", ".json");
+    JSONArray accountsToEdit = new JSONArray();
+    accountNames.stream()
+        .map(accountName -> accountService.getAccountByName(accountName).toJson(false))
+        .forEach(accountsToEdit::put);
+    try (BufferedWriter writer = Files.newBufferedWriter(accountJsonPath)) {
+      accountsToEdit.write(writer, 2, 0);
+    }
+    ToolUtils.editFile(accountJsonPath);
+    System.out.println("The following account metadata will be uploaded:");
+    try (Stream<String> lines = Files.lines(accountJsonPath)) {
+      lines.forEach(System.out::println);
+    }
+    if (ToolUtils.yesNoPrompt("Do you want to update these accounts?")) {
+      updateAccountsFromFile(accountJsonPath.toAbsolutePath().toString());
+    } else {
+      System.out.println("Not updating any accounts");
+    }
+  }
+
+  /**
+   * Update accounts from a file containing a json array of account metadata.
+   * @param accountJsonPath the path to the file containing the account metadata to upload.
+   * @throws IOException
+   */
+  void updateAccountsFromFile(String accountJsonPath) throws IOException {
+    long startTime = System.currentTimeMillis();
+    Collection<Account> accountsToUpdate = getAccountsFromJson(accountJsonPath);
+    if (!hasDuplicateAccountIdOrName(accountsToUpdate)) {
+      if (accountService.updateAccounts(accountsToUpdate)) {
+        System.out.println(accountsToUpdate.size() + " accounts have been successfully created or updated, took " + (
+            System.currentTimeMillis() - startTime) + " ms");
+      } else {
+        throw new RuntimeException("Updating accounts failed. See log for details.");
+      }
+    } else {
+      throw new IllegalArgumentException("Duplicate id or name exists in the accounts to update");
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    accountService.close();
   }
 
   /**
    * Gets a collection of {@link Account}s from a json file.
-   * @param accountJsonFilePath The path to the json file.
+   * @param accountJsonPath The path to the json file.
    * @return The collection of {@link Account}s parsed from the given json file.
    * @throws IOException
    * @throws JSONException
    */
-  private static Collection<Account> getAccountsFromJson(String accountJsonFilePath) throws IOException, JSONException {
-    JSONArray accountArray = new JSONArray(Utils.readStringFromFile(accountJsonFilePath));
+  private static Collection<Account> getAccountsFromJson(String accountJsonPath) throws IOException, JSONException {
+    JSONArray accountArray = new JSONArray(Utils.readStringFromFile(accountJsonPath));
     Collection<Account> accounts = new ArrayList<>();
     for (int i = 0; i < accountArray.length(); i++) {
       JSONObject accountJson = accountArray.getJSONObject(i);

--- a/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
@@ -16,10 +16,12 @@ package com.github.ambry.tools.util;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Scanner;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
@@ -150,6 +152,51 @@ public final class ToolUtils {
       Properties properties = Utils.loadProps(propsFilePath);
       addClusterMapProperties(properties);
       return new VerifiableProperties(properties);
+    }
+  }
+
+  /**
+   * Open a file for editing in a terminal text editor. Wait for the editor process to finish before returning.
+   * This should only be called from scripts that are run in a terminal as it requires user input.
+   * If the {@code EDITOR} environment variable is set, that editor is used, otherwise it defaults to vim.
+   * @param filePath the file to edit.
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public static void editFile(Path filePath) throws IOException, InterruptedException {
+    if (System.console() == null) {
+      throw new IllegalStateException("Script must be run from a terminal to support opening a file in an editor");
+    }
+    String editor = System.getenv("EDITOR");
+    ProcessBuilder processBuilder =
+        new ProcessBuilder(editor != null ? editor : "vim", filePath.toAbsolutePath().toString());
+    processBuilder.redirectInput(ProcessBuilder.Redirect.INHERIT).redirectOutput(ProcessBuilder.Redirect.INHERIT);
+    Process process = processBuilder.start();
+    process.waitFor();
+  }
+
+  /**
+   * Provide a yes/no prompt to the user for interactive scripts.
+   * @param question the question to include in the prompt.
+   * @return {@code true} if the user responded with "yes" or "y", or {@code false} if the user responded with "no" or
+   *         "n".
+   */
+  public static boolean yesNoPrompt(String question) {
+    if (System.console() == null) {
+      throw new IllegalStateException("Script must be run from a terminal to support user prompts");
+    }
+    while (true) {
+      String line = System.console().readLine("%s (y[es]/n[o]): ", question);
+      switch (line.toLowerCase()) {
+        case "yes":
+        case "y":
+          return true;
+        case "no":
+        case "n":
+          return false;
+        default:
+          System.out.println("Please enter either yes, y, no, or n");
+      }
     }
   }
 }

--- a/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/util/ToolUtils.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
-import java.util.Scanner;
+import java.util.StringTokenizer;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
@@ -167,11 +167,23 @@ public final class ToolUtils {
     if (System.console() == null) {
       throw new IllegalStateException("Script must be run from a terminal to support opening a file in an editor");
     }
+
     String editor = System.getenv("EDITOR");
-    ProcessBuilder processBuilder =
-        new ProcessBuilder(editor != null ? editor : "vim", filePath.toAbsolutePath().toString());
-    processBuilder.redirectInput(ProcessBuilder.Redirect.INHERIT).redirectOutput(ProcessBuilder.Redirect.INHERIT);
-    Process process = processBuilder.start();
+    List<String> command = new ArrayList<>();
+    if (editor == null) {
+      command.add("vim");
+    } else {
+      // If the EDITOR variable contains extra arguments, we have to split the string into tokens.
+      StringTokenizer st = new StringTokenizer(editor);
+      while (st.hasMoreTokens()) {
+        command.add(st.nextToken());
+      }
+    }
+    command.add(filePath.toAbsolutePath().toString());
+
+    Process process = new ProcessBuilder(command).redirectInput(ProcessBuilder.Redirect.INHERIT)
+        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        .start();
     process.waitFor();
   }
 

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -44,11 +45,14 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.json.JSONString;
+import org.json.JSONTokener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -583,16 +587,7 @@ public class Utils {
    * @throws IOException
    */
   public static void writeStringToFile(String string, String path) throws IOException {
-    FileWriter fileWriter = null;
-    try {
-      File file = new File(path);
-      fileWriter = new FileWriter(file);
-      fileWriter.write(string);
-    } finally {
-      if (fileWriter != null) {
-        fileWriter.close();
-      }
-    }
+    Files.write(Paths.get(path), string.getBytes());
   }
 
   /**
@@ -627,30 +622,7 @@ public class Utils {
    * @throws IOException
    */
   public static String readStringFromFile(String path) throws IOException {
-    File file = new File(path);
-    byte[] encoded = new byte[(int) file.length()];
-    DataInputStream ds = null;
-    try {
-      ds = new DataInputStream(new FileInputStream(file));
-      ds.readFully(encoded);
-    } finally {
-      if (ds != null) {
-        ds.close();
-      }
-    }
-    return Charset.defaultCharset().decode(ByteBuffer.wrap(encoded)).toString();
-  }
-
-  /**
-   * Reads JSON object (in string format) from specified file.
-   *
-   * @param path file path to read
-   * @return JSONObject read from specified file
-   * @throws IOException
-   * @throws JSONException
-   */
-  public static JSONObject readJsonFromFile(String path) throws IOException, JSONException {
-    return new JSONObject(readStringFromFile(path));
+    return new String(Files.readAllBytes(Paths.get(path)));
   }
 
   /**


### PR DESCRIPTION
Add an interactive mode to AccountUpdateTool where the user provides the
names of containers to edit. The script will open the account metadata
in a text editor and then upload the edited account after the editor is
closed.

It is hard to unit test the features that require an interactive terminal, but here is an example run of the script: https://gist.github.com/cgtz/324261d337514d1af847238f0966aa24