### PR TITLE
Fix size calculation in serializeString

### DIFF
--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataRequestInfo.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/ReplicaMetadataRequestInfo.java
@@ -21,6 +21,7 @@ import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,10 +63,8 @@ public class ReplicaMetadataRequestInfo {
   }
 
   public void writeTo(ByteBuffer buffer) {
-    buffer.putInt(hostName.getBytes().length);
-    buffer.put(hostName.getBytes());
-    buffer.putInt(replicaPath.getBytes().length);
-    buffer.put(replicaPath.getBytes());
+    Utils.serializeString(buffer, hostName, Charset.defaultCharset());
+    Utils.serializeString(buffer, replicaPath, Charset.defaultCharset());
     buffer.put(partitionId.getBytes());
     buffer.put(token.toBytes());
   }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestOrResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestOrResponse.java
@@ -14,7 +14,9 @@
 package com.github.ambry.protocol;
 
 import com.github.ambry.network.Send;
+import com.github.ambry.utils.Utils;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,8 +70,7 @@ public abstract class RequestOrResponse implements Send {
     bufferToSend.putShort((short) type.ordinal());
     bufferToSend.putShort(versionId);
     bufferToSend.putInt(correlationId);
-    bufferToSend.putInt(clientId.length());
-    bufferToSend.put(clientId.getBytes());
+    Utils.serializeString(bufferToSend, clientId, Charset.defaultCharset());
   }
 
   public long sizeInBytes() {

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreDescriptorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreDescriptorTest.java
@@ -14,11 +14,13 @@
 package com.github.ambry.store;
 
 import com.github.ambry.utils.CrcOutputStream;
+import com.github.ambry.utils.Utils;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.UUID;
 import org.junit.Test;
 
@@ -94,8 +96,7 @@ public class StoreDescriptorTest {
     byte[] toBytes = new byte[size];
     ByteBuffer byteBuffer = ByteBuffer.wrap(toBytes);
     byteBuffer.putShort(version);
-    byteBuffer.putInt(incarnationIdUUID.toString().getBytes().length);
-    byteBuffer.put(incarnationIdUUID.toString().getBytes());
+    Utils.serializeString(byteBuffer, incarnationIdUUID.toString(), Charset.defaultCharset());
     byteBuffer.flip();
     return byteBuffer.array();
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreFindTokenTest.java
@@ -259,11 +259,7 @@ public class StoreFindTokenTest {
         // add version
         bufWrap.putShort(StoreFindToken.VERSION_0);
         // add sessionId
-        byte[] sessionIdBytes = sessionId == null ? null : sessionId.toString().getBytes();
-        bufWrap.putInt(sessionIdBytes == null ? 0 : sessionIdBytes.length);
-        if (sessionIdBytes != null) {
-          bufWrap.put(sessionIdBytes);
-        }
+        Utils.serializeNullableString(bufWrap, sessionId == null ? null : sessionId.toString());
         long logOffset = -1;
         long indexStartOffset = -1;
         StoreFindToken.Type type = token.getType();
@@ -294,11 +290,7 @@ public class StoreFindTokenTest {
         // add version
         bufWrap.putShort(StoreFindToken.VERSION_1);
         // add sessionId
-        sessionIdBytes = (sessionId == null) ? null : sessionId.toString().getBytes();
-        bufWrap.putInt(sessionIdBytes == null ? 0 : sessionIdBytes.length);
-        if (sessionIdBytes != null) {
-          bufWrap.put(sessionIdBytes);
-        }
+        Utils.serializeNullableString(bufWrap, sessionId == null ? null : sessionId.toString());
         // add type
         type = token.getType();
         bufWrap.putShort((byte) type.ordinal());

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -535,7 +535,7 @@ public class Utils {
   }
 
   /**
-   * Serializes a nullable string into byte buffer
+   * Serializes a nullable string into byte buffer using the default charset.
    *
    * @param outputBuffer The output buffer to serialize the value to
    * @param value The value to serialize
@@ -544,8 +544,7 @@ public class Utils {
     if (value == null) {
       outputBuffer.putInt(0);
     } else {
-      outputBuffer.putInt(value.length());
-      outputBuffer.put(value.getBytes());
+      serializeString(outputBuffer, value, Charset.defaultCharset());
     }
   }
 
@@ -556,8 +555,9 @@ public class Utils {
    * @param charset {@link Charset} to be used to encode
    */
   public static void serializeString(ByteBuffer outputBuffer, String value, Charset charset) {
-    outputBuffer.putInt(value.length());
-    outputBuffer.put(value.getBytes(charset));
+    byte[] valueArray = value.getBytes(charset);
+    outputBuffer.putInt(valueArray.length);
+    outputBuffer.put(valueArray);
   }
 
   /**


### PR DESCRIPTION
For certain combinations of encoding and input string, String::length
returns the wrong size for the buffer that follows. One example is
encoding a String with multi-codepoint unicode characters (e.g. emoji)
into ASCII. In this case, the encoder will replace the multi-codepoint
characters with a single "?" character. This prevents such records
from being successfully deserialized.