### PR TITLE
Make Bootstrap tool use Helix Cluster Manager for validation

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -155,7 +155,7 @@ class HelixBootstrapUpgradeUtil {
    * @param dryRun if true, perform a dry run; do not update anything in Helix.
    * @param forceRemove if true, removes any hosts from Helix not present in the json files.
    * @param helixAdminFactory the {@link HelixAdminFactory} to use to instantiate {@link HelixAdmin}
-   * @param startValidatingClusterManager whether validation should include staring up a {@link HelixClusterManager}
+   * @param startValidatingClusterManager whether validation should include starting up a {@link HelixClusterManager}
    * @throws IOException if there is an error reading a file.
    * @throws JSONException if there is an error parsing the JSON content in any of the files.
    */
@@ -698,7 +698,7 @@ class HelixBootstrapUpgradeUtil {
   /**
    * Initialize a map of dataCenter to HelixAdmin based on the given zk Connect Strings.
    */
-  private void maybeAddCluster() throws IOException {
+  private void maybeAddCluster() {
     for (Map.Entry<String, HelixAdmin> entry : adminForDc.entrySet()) {
       // Add a cluster entry in every DC
       String dcName = entry.getKey();
@@ -711,6 +711,10 @@ class HelixBootstrapUpgradeUtil {
     }
   }
 
+  /**
+   * Start the Helix Cluster Manager to be used for validation.
+   * @throws IOException if there was an error instantiating the cluster manager.
+   */
   private void startClusterManager() throws IOException {
     Properties props = new Properties();
     props.setProperty("clustermap.host.name", "localhost");
@@ -735,7 +739,7 @@ class HelixBootstrapUpgradeUtil {
    * Validate that the information in Helix is consistent with the information in the static clustermap; and close
    * all the admin connections to ZK hosts.
    */
-  private void validateAndClose() throws Exception {
+  private void validateAndClose() {
     try {
       info("Validating static and Helix cluster maps");
       verifyEquivalencyWithStaticClusterMap(staticClusterMap.hardwareLayout, staticClusterMap.partitionLayout);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -48,7 +48,7 @@ public class MockHelixCluster {
     this.partitionLayoutPath = partitionLayoutPath;
     this.zkLayoutPath = zkLayoutPath;
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        "all", 3, false, false, helixAdminFactory);
+        "all", 3, false, false, helixAdminFactory, false);
     this.clusterName = clusterName;
   }
 
@@ -59,7 +59,7 @@ public class MockHelixCluster {
    */
   void upgradeWithNewHardwareLayout(String hardwareLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        "all", 3, false, false, helixAdminFactory);
+        "all", 3, false, false, helixAdminFactory, false);
     triggerInstanceConfigChangeNotification();
   }
 
@@ -70,7 +70,7 @@ public class MockHelixCluster {
    */
   void upgradeWithNewPartitionLayout(String partitionLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        "all", 3, false, false, helixAdminFactory);
+        "all", 3, false, false, helixAdminFactory, false);
     triggerInstanceConfigChangeNotification();
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -207,7 +207,7 @@ public class HelixBootstrapUpgradeTool {
           clusterNamePrefix, dcs,
           options.valueOf(maxPartitionsInOneResourceOpt) == null ? DEFAULT_MAX_PARTITIONS_PER_RESOURCE
               : Integer.valueOf(options.valueOf(maxPartitionsInOneResourceOpt)), options.has(dryRun),
-          options.has(forceRemove), new HelixAdminFactory());
+          options.has(forceRemove), new HelixAdminFactory(), true);
     }
   }
 }


### PR DESCRIPTION
Instantiate a Helix cluster manager within the bootstrap tool to listen
on the changes that it makes itself. This cluster manager's state will
be checked during validation. If there are other errors that can cause
errors such as Out of Memory in the Helix client, then those can be
immediately detected because the tool itself will be affected.
