### PR TITLE
Allow NettyServer to use its own ssl impl

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
@@ -121,6 +121,15 @@ public class NettyConfig {
   @Default("20 * 1024 * 1024")
   public final long nettyMultipartPostMaxSizeBytes;
 
+  /**
+   * If set, use this implementation of {@link com.github.ambry.commons.SSLFactory} to use for the netty HTTP server.
+   * Otherwise, share the factory instance with the router.
+   */
+  public static final String SSL_FACTORY_KEY = "netty.server.ssl.factory";
+  @Config(SSL_FACTORY_KEY)
+  @Default("")
+  public final String nettyServerSslFactory;
+
   public NettyConfig(VerifiableProperties verifiableProperties) {
     nettyServerBossThreadCount = verifiableProperties.getInt("netty.server.boss.thread.count", 1);
     nettyServerIdleTimeSeconds = verifiableProperties.getInt("netty.server.idle.time.seconds", 60);
@@ -139,5 +148,6 @@ public class NettyConfig {
         Arrays.asList(verifiableProperties.getString("netty.server.blacklisted.query.params", "").split(",")));
     nettyMultipartPostMaxSizeBytes =
         verifiableProperties.getLongInRange("netty.multipart.post.max.size.bytes", 20 * 1024 * 1024, 0, Long.MAX_VALUE);
+    nettyServerSslFactory = verifiableProperties.getString(SSL_FACTORY_KEY, "");
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NettyConfig.java
@@ -22,6 +22,8 @@ import java.util.Set;
  * Configuration parameters required by Netty.
  */
 public class NettyConfig {
+  public static final String SSL_FACTORY_KEY = "netty.server.ssl.factory";
+
   /**
    * Number of netty boss threads.
    */
@@ -125,7 +127,6 @@ public class NettyConfig {
    * If set, use this implementation of {@link com.github.ambry.commons.SSLFactory} to use for the netty HTTP server.
    * Otherwise, share the factory instance with the router.
    */
-  public static final String SSL_FACTORY_KEY = "netty.server.ssl.factory";
   @Config(SSL_FACTORY_KEY)
   @Default("")
   public final String nettyServerSslFactory;

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -35,6 +35,7 @@ import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.rest.NettyClient;
 import com.github.ambry.rest.NettyClient.ResponseParts;
+import com.github.ambry.rest.NettySslFactory;
 import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestServer;
 import com.github.ambry.rest.RestServiceException;
@@ -522,6 +523,7 @@ public class FrontendIntegrationTest {
     properties.put("netty.server.port", Integer.toString(PLAINTEXT_SERVER_PORT));
     properties.put("netty.server.ssl.port", Integer.toString(SSL_SERVER_PORT));
     properties.put("netty.server.enable.ssl", "true");
+    properties.put(NettyConfig.SSL_FACTORY_KEY, NettySslFactory.class.getName());
     // to test that backpressure does not impede correct operation.
     properties.put("netty.server.request.buffer.watermark", "1");
     // to test that multipart requests over a certain size fail

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerFactoryTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerFactoryTest.java
@@ -17,7 +17,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.commons.TestSSLUtils;
 import com.github.ambry.config.NettyConfig;
-import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.VerifiableProperties;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
@@ -38,12 +37,6 @@ public class NettyServerFactoryTest {
   private static final PublicAccessLogger PUBLIC_ACCESS_LOGGER = new PublicAccessLogger(new String[]{}, new String[]{});
   private static final RestServerState REST_SERVER_STATE = new RestServerState("/healthCheck");
   private static final SSLFactory SSL_FACTORY = RestTestUtils.getTestSSLFactory();
-  static {
-    try {
-    } catch (Exception e) {
-      throw new IllegalStateException(e);
-    }
-  }
 
   /**
    * Checks to see that getting the default {@link NioServer} (currently {@link NettyServer}) works.

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerFactoryTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyServerFactoryTest.java
@@ -60,20 +60,20 @@ public class NettyServerFactoryTest {
   /**
    * Test that a {@link NettyServer} can be constructed by the factory.
    * @param properties the {@link Properties} to use.
-   * @param sslFactory the {@link SSLFactory} to use.
+   * @param defaultSslFactory the default {@link SSLFactory} to pass into the constructor.
    */
-  private void doGetNettyServerTest(Properties properties, SSLFactory sslFactory) throws Exception {
+  private void doGetNettyServerTest(Properties properties, SSLFactory defaultSslFactory) throws Exception {
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     NettyConfig nettyConfig = new NettyConfig(verifiableProperties);
     NettyServerFactory nettyServerFactory =
         new NettyServerFactory(verifiableProperties, new MetricRegistry(), REST_REQUEST_HANDLER, PUBLIC_ACCESS_LOGGER,
-            REST_SERVER_STATE, sslFactory);
+            REST_SERVER_STATE, defaultSslFactory);
     NioServer nioServer = nettyServerFactory.getNioServer();
     assertNotNull("No NioServer returned", nioServer);
     assertEquals("Did not receive a NettyServer instance", NettyServer.class.getCanonicalName(),
         nioServer.getClass().getCanonicalName());
     Map<Integer, ChannelInitializer<SocketChannel>> channelInitializers = nettyServerFactory.channelInitializers;
-    if (nettyConfig.nettyServerEnableSSL && sslFactory != null) {
+    if (nettyConfig.nettyServerEnableSSL && defaultSslFactory != null) {
       assertEquals("Expected two ChannelInitializers when SSLFactory is not null", 2, channelInitializers.size());
       assertNotNull("No ChannelInitializer for SSL port", channelInitializers.get(nettyConfig.nettyServerSSLPort));
     } else {

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -16,7 +16,6 @@ package com.github.ambry.store;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -18,13 +18,11 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.RandomAccessFile;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
@@ -45,14 +43,11 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.json.JSONString;
-import org.json.JSONTokener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -337,9 +332,7 @@ public class Utils {
    * @param className
    * @param <T>
    * @return
-   * @throws ClassNotFoundException
-   * @throws InstantiationException
-   * @throws IllegalAccessException
+   * @throws ReflectiveOperationException
    */
   public static <T> T getObj(String className)
       throws ClassNotFoundException, InstantiationException, IllegalAccessException {
@@ -348,19 +341,13 @@ public class Utils {
 
   /**
    * Instantiate a class instance from a given className with an arg
+   * @param <T>
    * @param className
    * @param arg
-   * @param <T>
    * @return
-   * @throws ClassNotFoundException
-   * @throws InstantiationException
-   * @throws IllegalAccessException
-   * @throws NoSuchMethodException
-   * @throws InvocationTargetException
+   * @throws ReflectiveOperationException
    */
-  public static <T> T getObj(String className, Object arg)
-      throws ClassNotFoundException, InstantiationException, IllegalAccessException, NoSuchMethodException,
-             InvocationTargetException {
+  public static <T> T getObj(String className, Object arg) throws ReflectiveOperationException {
     for (Constructor<?> ctor : Class.forName(className).getDeclaredConstructors()) {
       Class<?>[] paramTypes = ctor.getParameterTypes();
       if (paramTypes.length == 1 && checkAssignable(paramTypes[0], arg)) {
@@ -372,20 +359,14 @@ public class Utils {
 
   /**
    * Instantiate a class instance from a given className with two args
+   * @param <T>
    * @param className
    * @param arg1
    * @param arg2
-   * @param <T>
    * @return
-   * @throws ClassNotFoundException
-   * @throws InstantiationException
-   * @throws IllegalAccessException
-   * @throws NoSuchMethodException
-   * @throws InvocationTargetException
+   * @throws ReflectiveOperationException
    */
-  public static <T> T getObj(String className, Object arg1, Object arg2)
-      throws ClassNotFoundException, InstantiationException, IllegalAccessException, NoSuchMethodException,
-             InvocationTargetException {
+  public static <T> T getObj(String className, Object arg1, Object arg2) throws ReflectiveOperationException {
     for (Constructor<?> ctor : Class.forName(className).getDeclaredConstructors()) {
       Class<?>[] paramTypes = ctor.getParameterTypes();
       if (paramTypes.length == 2 && checkAssignable(paramTypes[0], arg1) && checkAssignable(paramTypes[1], arg2)) {
@@ -403,15 +384,10 @@ public class Utils {
    * @param arg3
    * @param <T>
    * @return
-   * @throws ClassNotFoundException
-   * @throws InstantiationException
-   * @throws IllegalAccessException
-   * @throws NoSuchMethodException
-   * @throws InvocationTargetException
+   * @throws ReflectiveOperationException
    */
   public static <T> T getObj(String className, Object arg1, Object arg2, Object arg3)
-      throws ClassNotFoundException, InstantiationException, IllegalAccessException, NoSuchMethodException,
-             InvocationTargetException {
+      throws ReflectiveOperationException {
     for (Constructor<?> ctor : Class.forName(className).getDeclaredConstructors()) {
       Class<?>[] paramTypes = ctor.getParameterTypes();
       if (paramTypes.length == 3 && checkAssignable(paramTypes[0], arg1) && checkAssignable(paramTypes[1], arg2)
@@ -428,15 +404,9 @@ public class Utils {
    * @param args
    * @param <T>
    * @return
-   * @throws ClassNotFoundException
-   * @throws InstantiationException
-   * @throws IllegalAccessException
-   * @throws NoSuchMethodException
-   * @throws InvocationTargetException
+   * @throws ReflectiveOperationException
    */
-  public static <T> T getObj(String className, Object... args)
-      throws ClassNotFoundException, InstantiationException, IllegalAccessException, NoSuchMethodException,
-             InvocationTargetException {
+  public static <T> T getObj(String className, Object... args) throws ReflectiveOperationException {
     for (Constructor<?> ctor : Class.forName(className).getDeclaredConstructors()) {
       Class<?>[] paramTypes = ctor.getParameterTypes();
       if (paramTypes.length == args.length) {


### PR DESCRIPTION
Previously, the Netty code was forced to use the same SSL impl as the
router. This adds a config to let NettyServer use a different SSLFactory
implementation. This can be used to leverage the performance benefits of
NettySslFactory within the HTTP server, without affecting the router,
which has some compatability issues with Netty's OpenSSL-based
SSLEngine.