### PR TITLE
Pass IdSigningService into SecurityServiceFactory

### DIFF
--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
@@ -88,7 +88,7 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
           new AccountAndContainerInjector(accountService, frontendMetrics, frontendConfig);
       SecurityServiceFactory securityServiceFactory =
           Utils.getObj(frontendConfig.securityServiceFactory, verifiableProperties, clusterMap, accountService,
-              urlSigningService, accountAndContainerInjector);
+              urlSigningService, idSigningService, accountAndContainerInjector);
       return new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, clusterMap,
           idConverterFactory, securityServiceFactory, urlSigningService, idSigningService, accountAndContainerInjector,
           clusterMapConfig.clusterMapDatacenterName, clusterMapConfig.clusterMapHostName);

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbrySecurityServiceFactory.java
@@ -31,7 +31,7 @@ public class AmbrySecurityServiceFactory implements SecurityServiceFactory {
   private final UrlSigningService urlSigningService;
 
   public AmbrySecurityServiceFactory(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
-      AccountService accountService, UrlSigningService urlSigningService,
+      AccountService accountService, UrlSigningService urlSigningService, IdSigningService idSigningService,
       AccountAndContainerInjector accountAndContainerInjector) {
     frontendConfig = new FrontendConfig(verifiableProperties);
     frontendMetrics = new FrontendMetrics(clusterMap.getMetricRegistry());

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -154,8 +154,9 @@ public class AmbryBlobStorageServiceTest {
         frontendConfig.chunkUploadInitialChunkTtlSecs, 4 * 1024 * 1024, SystemTime.getInstance());
     idSigningService = new AmbryIdSigningService();
     idConverterFactory = new AmbryIdConverterFactory(verifiableProperties, metricRegistry, idSigningService);
-    securityServiceFactory = new AmbrySecurityServiceFactory(verifiableProperties, clusterMap, null, urlSigningService,
-        accountAndContainerInjector);
+    securityServiceFactory =
+        new AmbrySecurityServiceFactory(verifiableProperties, clusterMap, null, urlSigningService, idSigningService,
+            accountAndContainerInjector);
     accountService.clear();
     accountService.updateAccounts(Collections.singleton(InMemAccountService.UNKNOWN_ACCOUNT));
     refAccount = accountService.createAndAddRandomAccount();

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceFactoryTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceFactoryTest.java
@@ -33,7 +33,7 @@ public class AmbrySecurityServiceFactoryTest {
   public void getAmbrySecurityServiceFactoryTest() throws Exception {
     SecurityService securityService =
         new AmbrySecurityServiceFactory(new VerifiableProperties(new Properties()), new MockClusterMap(), null, null,
-            null).getSecurityService();
+            null, null).getSecurityService();
     Assert.assertNotNull(securityService);
   }
 }


### PR DESCRIPTION
Allow SecurityService implementations to leverage IdSigningService, if
they need to.