### PR TITLE
Avoid returning 416 when range end past blob

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -18,6 +18,7 @@ import com.github.ambry.account.Container;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.router.ByteRange;
+import com.github.ambry.router.ByteRanges;
 import com.github.ambry.router.GetBlobOptions;
 import com.github.ambry.router.GetBlobOptionsBuilder;
 import com.github.ambry.utils.Crc32;
@@ -515,7 +516,7 @@ public class RestUtils {
    * @return a {@link Pair} containing the content range header value and the content length in bytes.
    */
   public static Pair<String, Long> buildContentRangeAndLength(ByteRange range, long blobSize)
-      throws RestServiceException{
+      throws RestServiceException {
     try {
       range = range.toResolvedByteRange(blobSize);
     } catch (IllegalArgumentException e) {
@@ -876,11 +877,11 @@ public class RestUtils {
       String startOffsetStr = rangeHeaderValue.substring(BYTE_RANGE_PREFIX.length(), hyphenIndex);
       String endOffsetStr = rangeHeaderValue.substring(hyphenIndex + 1);
       if (startOffsetStr.isEmpty()) {
-        range = ByteRange.fromLastNBytes(Long.parseLong(endOffsetStr));
+        range = ByteRanges.fromLastNBytes(Long.parseLong(endOffsetStr));
       } else if (endOffsetStr.isEmpty()) {
-        range = ByteRange.fromStartOffset(Long.parseLong(startOffsetStr));
+        range = ByteRanges.fromStartOffset(Long.parseLong(startOffsetStr));
       } else {
-        range = ByteRange.fromOffsetRange(Long.parseLong(startOffsetStr), Long.parseLong(endOffsetStr));
+        range = ByteRanges.fromOffsetRange(Long.parseLong(startOffsetStr), Long.parseLong(endOffsetStr));
       }
     } catch (Exception e) {
       throw new RestServiceException(

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -515,7 +515,7 @@ public class RestUtils {
    * @return a {@link Pair} containing the content range header value and the content length in bytes.
    */
   public static Pair<String, Long> buildContentRangeAndLength(ByteRange range, long blobSize)
-      throws RestServiceException {
+      throws RestServiceException{
     try {
       range = range.toResolvedByteRange(blobSize);
     } catch (IllegalArgumentException e) {

--- a/ambry-api/src/main/java/com.github.ambry/router/ByteRange.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/ByteRange.java
@@ -31,7 +31,7 @@ public abstract class ByteRange {
       throw new IllegalArgumentException(
           "Invalid range offsets provided for ByteRange; startOffset=" + startOffset + ", endOffset=" + endOffset);
     }
-    return new OffsetRange(startOffset, endOffset);
+    return new ClosedRange(startOffset, endOffset);
   }
 
   /**
@@ -44,7 +44,7 @@ public abstract class ByteRange {
     if (startOffset < 0) {
       throw new IllegalArgumentException("Invalid range offsets provided for ByteRange; startOffset=" + startOffset);
     }
-    return new FromStartOffset(startOffset);
+    return new OpenRange(startOffset);
   }
 
   /**
@@ -57,7 +57,13 @@ public abstract class ByteRange {
     if (lastNBytes < 0) {
       throw new IllegalArgumentException("Invalid range offsets provided for ByteRange; lastNBytes=" + lastNBytes);
     }
-    return new LastNBytes(lastNBytes);
+    return new SuffixRange(lastNBytes);
+  }
+
+  /**
+   * All implementations should be defined in this class.
+   */
+  private ByteRange() {
   }
 
   // Implement the following methods if they are supported for the range type.
@@ -142,14 +148,14 @@ public abstract class ByteRange {
   /**
    * A range from a start offset to an end offset.
    */
-  private static class OffsetRange extends ByteRange {
+  private static class ClosedRange extends ByteRange {
     private long startOffset;
     private long endOffset;
 
     /**
      * @see ByteRange#fromOffsetRange(long, long)
      */
-    private OffsetRange(long startOffset, long endOffset) {
+    private ClosedRange(long startOffset, long endOffset) {
       this.startOffset = startOffset;
       this.endOffset = endOffset;
     }
@@ -179,7 +185,7 @@ public abstract class ByteRange {
       if (getStartOffset() >= totalSize) {
         throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
       }
-      return new OffsetRange(getStartOffset(), Math.min(getEndOffset(), totalSize - 1));
+      return new ClosedRange(getStartOffset(), Math.min(getEndOffset(), totalSize - 1));
     }
 
     @Override
@@ -195,7 +201,7 @@ public abstract class ByteRange {
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      OffsetRange that = (OffsetRange) o;
+      ClosedRange that = (ClosedRange) o;
       return startOffset == that.startOffset && endOffset == that.endOffset;
     }
 
@@ -208,13 +214,13 @@ public abstract class ByteRange {
   /**
    * A range from a start offset to the end of an object.
    */
-  private static class FromStartOffset extends ByteRange {
+  private static class OpenRange extends ByteRange {
     private long startOffset;
 
     /**
      * @see ByteRange#fromStartOffset(long)
      */
-    private FromStartOffset(long startOffset) {
+    private OpenRange(long startOffset) {
       this.startOffset = startOffset;
     }
 
@@ -233,7 +239,7 @@ public abstract class ByteRange {
       if (getStartOffset() >= totalSize) {
         throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
       }
-      return new OffsetRange(getStartOffset(), totalSize - 1);
+      return new ClosedRange(getStartOffset(), totalSize - 1);
     }
 
     @Override
@@ -249,7 +255,7 @@ public abstract class ByteRange {
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      FromStartOffset that = (FromStartOffset) o;
+      OpenRange that = (OpenRange) o;
       return startOffset == that.startOffset;
     }
 
@@ -262,13 +268,13 @@ public abstract class ByteRange {
   /**
    * A range that represents the last N bytes of an object.
    */
-  private static class LastNBytes extends ByteRange {
+  private static class SuffixRange extends ByteRange {
     private long lastNBytes;
 
     /**
      * @see ByteRange#fromLastNBytes(long)
      */
-    private LastNBytes(long lastNBytes) {
+    private SuffixRange(long lastNBytes) {
       this.lastNBytes = lastNBytes;
     }
 
@@ -292,7 +298,7 @@ public abstract class ByteRange {
       if (totalSize < 0) {
         throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
       }
-      return new OffsetRange(Math.max(totalSize - getLastNBytes(), 0), totalSize - 1);
+      return new ClosedRange(Math.max(totalSize - getLastNBytes(), 0), totalSize - 1);
     }
 
     @Override
@@ -308,7 +314,7 @@ public abstract class ByteRange {
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      LastNBytes that = (LastNBytes) o;
+      SuffixRange that = (SuffixRange) o;
       return lastNBytes == that.lastNBytes;
     }
 

--- a/ambry-api/src/main/java/com.github.ambry/router/ByteRange.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/ByteRange.java
@@ -29,7 +29,7 @@ public abstract class ByteRange {
    */
   @Deprecated
   public static ByteRange fromOffsetRange(long startOffset, long endOffset) {
-    return ByteRange.fromOffsetRange(startOffset, endOffset);
+    return ByteRanges.fromOffsetRange(startOffset, endOffset);
   }
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/router/ByteRange.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/ByteRange.java
@@ -21,49 +21,45 @@ public abstract class ByteRange {
 
   /**
    * Construct a range from a start offset to an end offset.
+   * @deprecated Please use {@link ByteRanges#fromOffsetRange} instead.
    * @param startOffset the (inclusive) start byte offset.
    * @param endOffset the (inclusive) end byte offset.
    * @return A {@link ByteRange} with the specified offsets.
    * @throws IllegalArgumentException if the start offset is less than 0, or the end offset is less than the start.
    */
+  @Deprecated
   public static ByteRange fromOffsetRange(long startOffset, long endOffset) {
-    if (startOffset < 0 || endOffset < startOffset) {
-      throw new IllegalArgumentException(
-          "Invalid range offsets provided for ByteRange; startOffset=" + startOffset + ", endOffset=" + endOffset);
-    }
-    return new ClosedRange(startOffset, endOffset);
+    return ByteRange.fromOffsetRange(startOffset, endOffset);
   }
 
   /**
    * Construct a range from a start offset to the end of an object.
+   * @deprecated Please use {@link ByteRanges#fromStartOffset} instead.
    * @param startOffset The (inclusive) start byte offset.
    * @return A {@link ByteRange} with the specified start offset.
    * @throws IllegalArgumentException if the start offset is less than 0
    */
+  @Deprecated
   public static ByteRange fromStartOffset(long startOffset) {
-    if (startOffset < 0) {
-      throw new IllegalArgumentException("Invalid range offsets provided for ByteRange; startOffset=" + startOffset);
-    }
-    return new OpenRange(startOffset);
+    return ByteRanges.fromStartOffset(startOffset);
   }
 
   /**
    * Construct a range that represents the last N bytes of an object.
+   * @deprecated Please use {@link ByteRanges#fromLastNBytes} instead.
    * @param lastNBytes the number of bytes to read from the end of an object.
    * @return A {@link ByteRange} representing the last N bytes of an objects.
    * @throws IllegalArgumentException if the number of bytes to read is less than or equal to 0.
    */
+  @Deprecated
   public static ByteRange fromLastNBytes(long lastNBytes) {
-    if (lastNBytes < 0) {
-      throw new IllegalArgumentException("Invalid range offsets provided for ByteRange; lastNBytes=" + lastNBytes);
-    }
-    return new SuffixRange(lastNBytes);
+    return ByteRanges.fromLastNBytes(lastNBytes);
   }
 
   /**
-   * All implementations should be defined in this class.
+   * All implementations should be defined within this package.
    */
-  private ByteRange() {
+  ByteRange() {
   }
 
   // Implement the following methods if they are supported for the range type.
@@ -143,184 +139,5 @@ public abstract class ByteRange {
      * If this range specifies a start and end offset to read between.
      */
     OFFSET_RANGE
-  }
-
-  /**
-   * A range from a start offset to an end offset.
-   */
-  private static class ClosedRange extends ByteRange {
-    private long startOffset;
-    private long endOffset;
-
-    /**
-     * @see ByteRange#fromOffsetRange(long, long)
-     */
-    private ClosedRange(long startOffset, long endOffset) {
-      this.startOffset = startOffset;
-      this.endOffset = endOffset;
-    }
-
-    @Override
-    public long getStartOffset() {
-      return startOffset;
-    }
-
-    @Override
-    public long getEndOffset() {
-      return endOffset;
-    }
-
-    @Override
-    public long getRangeSize() {
-      return getEndOffset() - getStartOffset() + 1;
-    }
-
-    @Override
-    public ByteRangeType getType() {
-      return ByteRangeType.OFFSET_RANGE;
-    }
-
-    @Override
-    public ByteRange toResolvedByteRange(long totalSize) {
-      if (getStartOffset() >= totalSize) {
-        throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
-      }
-      return new ClosedRange(getStartOffset(), Math.min(getEndOffset(), totalSize - 1));
-    }
-
-    @Override
-    public String toString() {
-      return "ByteRange{startOffset=" + startOffset + ", endOffset=" + endOffset + '}';
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      ClosedRange that = (ClosedRange) o;
-      return startOffset == that.startOffset && endOffset == that.endOffset;
-    }
-
-    @Override
-    public int hashCode() {
-      return 31 * Long.hashCode(startOffset) + Long.hashCode(endOffset);
-    }
-  }
-
-  /**
-   * A range from a start offset to the end of an object.
-   */
-  private static class OpenRange extends ByteRange {
-    private long startOffset;
-
-    /**
-     * @see ByteRange#fromStartOffset(long)
-     */
-    private OpenRange(long startOffset) {
-      this.startOffset = startOffset;
-    }
-
-    @Override
-    public long getStartOffset() {
-      return startOffset;
-    }
-
-    @Override
-    public ByteRangeType getType() {
-      return ByteRangeType.FROM_START_OFFSET;
-    }
-
-    @Override
-    public ByteRange toResolvedByteRange(long totalSize) {
-      if (getStartOffset() >= totalSize) {
-        throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
-      }
-      return new ClosedRange(getStartOffset(), totalSize - 1);
-    }
-
-    @Override
-    public String toString() {
-      return "ByteRange{startOffset=" + startOffset + '}';
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      OpenRange that = (OpenRange) o;
-      return startOffset == that.startOffset;
-    }
-
-    @Override
-    public int hashCode() {
-      return Long.hashCode(startOffset);
-    }
-  }
-
-  /**
-   * A range that represents the last N bytes of an object.
-   */
-  private static class SuffixRange extends ByteRange {
-    private long lastNBytes;
-
-    /**
-     * @see ByteRange#fromLastNBytes(long)
-     */
-    private SuffixRange(long lastNBytes) {
-      this.lastNBytes = lastNBytes;
-    }
-
-    @Override
-    public long getLastNBytes() {
-      return lastNBytes;
-    }
-
-    @Override
-    public long getRangeSize() {
-      return lastNBytes;
-    }
-
-    @Override
-    public ByteRangeType getType() {
-      return ByteRangeType.LAST_N_BYTES;
-    }
-
-    @Override
-    public ByteRange toResolvedByteRange(long totalSize) {
-      if (totalSize < 0) {
-        throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
-      }
-      return new ClosedRange(Math.max(totalSize - getLastNBytes(), 0), totalSize - 1);
-    }
-
-    @Override
-    public String toString() {
-      return "ByteRange{lastNBytes=" + lastNBytes + '}';
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      SuffixRange that = (SuffixRange) o;
-      return lastNBytes == that.lastNBytes;
-    }
-
-    @Override
-    public int hashCode() {
-      return Long.hashCode(lastNBytes);
-    }
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/router/ByteRanges.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/ByteRanges.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.router;
+
+public class ByteRanges {
+
+  /**
+   * Construct a range from a start offset to an end offset.
+   * @param startOffset the (inclusive) start byte offset.
+   * @param endOffset the (inclusive) end byte offset.
+   * @return A {@link ByteRange} with the specified offsets.
+   * @throws IllegalArgumentException if the start offset is less than 0, or the end offset is less than the start.
+   */
+  public static ByteRange fromOffsetRange(long startOffset, long endOffset) {
+    if (startOffset < 0 || endOffset < startOffset) {
+      throw new IllegalArgumentException(
+          "Invalid range offsets provided for ByteRange; startOffset=" + startOffset + ", endOffset=" + endOffset);
+    }
+    return new ClosedRange(startOffset, endOffset);
+  }
+
+  /**
+   * Construct a range from a start offset to the end of an object.
+   * @param startOffset The (inclusive) start byte offset.
+   * @return A {@link ByteRange} with the specified start offset.
+   * @throws IllegalArgumentException if the start offset is less than 0
+   */
+  public static ByteRange fromStartOffset(long startOffset) {
+    if (startOffset < 0) {
+      throw new IllegalArgumentException("Invalid range offsets provided for ByteRange; startOffset=" + startOffset);
+    }
+    return new OpenRange(startOffset);
+  }
+
+  /**
+   * Construct a range that represents the last N bytes of an object.
+   * @param lastNBytes the number of bytes to read from the end of an object.
+   * @return A {@link ByteRange} representing the last N bytes of an objects.
+   * @throws IllegalArgumentException if the number of bytes to read is less than or equal to 0.
+   */
+  public static ByteRange fromLastNBytes(long lastNBytes) {
+    if (lastNBytes < 0) {
+      throw new IllegalArgumentException("Invalid range offsets provided for ByteRange; lastNBytes=" + lastNBytes);
+    }
+    return new SuffixRange(lastNBytes);
+  }
+
+  /**
+   * Only static methods in this class.
+   */
+  private ByteRanges() {
+  }
+
+  /**
+   * A range from a start offset to an end offset.
+   */
+  private static class ClosedRange extends ByteRange {
+    private long startOffset;
+    private long endOffset;
+
+    /**
+     * @see ByteRanges#fromOffsetRange(long, long)
+     */
+    private ClosedRange(long startOffset, long endOffset) {
+      this.startOffset = startOffset;
+      this.endOffset = endOffset;
+    }
+
+    @Override
+    public long getStartOffset() {
+      return startOffset;
+    }
+
+    @Override
+    public long getEndOffset() {
+      return endOffset;
+    }
+
+    @Override
+    public long getRangeSize() {
+      return getEndOffset() - getStartOffset() + 1;
+    }
+
+    @Override
+    public ByteRangeType getType() {
+      return ByteRangeType.OFFSET_RANGE;
+    }
+
+    @Override
+    public ByteRange toResolvedByteRange(long totalSize) {
+      if (getStartOffset() >= totalSize) {
+        throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
+      }
+      return new ClosedRange(getStartOffset(), Math.min(getEndOffset(), totalSize - 1));
+    }
+
+    @Override
+    public String toString() {
+      return "ByteRange{startOffset=" + startOffset + ", endOffset=" + endOffset + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ClosedRange that = (ClosedRange) o;
+      return startOffset == that.startOffset && endOffset == that.endOffset;
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * Long.hashCode(startOffset) + Long.hashCode(endOffset);
+    }
+  }
+
+  /**
+   * A range from a start offset to the end of an object.
+   */
+  private static class OpenRange extends ByteRange {
+    private long startOffset;
+
+    /**
+     * @see ByteRanges#fromStartOffset(long)
+     */
+    private OpenRange(long startOffset) {
+      this.startOffset = startOffset;
+    }
+
+    @Override
+    public long getStartOffset() {
+      return startOffset;
+    }
+
+    @Override
+    public ByteRangeType getType() {
+      return ByteRangeType.FROM_START_OFFSET;
+    }
+
+    @Override
+    public ByteRange toResolvedByteRange(long totalSize) {
+      if (getStartOffset() >= totalSize) {
+        throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
+      }
+      return new ClosedRange(getStartOffset(), totalSize - 1);
+    }
+
+    @Override
+    public String toString() {
+      return "ByteRange{startOffset=" + startOffset + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      OpenRange that = (OpenRange) o;
+      return startOffset == that.startOffset;
+    }
+
+    @Override
+    public int hashCode() {
+      return Long.hashCode(startOffset);
+    }
+  }
+
+  /**
+   * A range that represents the last N bytes of an object.
+   */
+  private static class SuffixRange extends ByteRange {
+    private long lastNBytes;
+
+    /**
+     * @see ByteRanges#fromLastNBytes(long)
+     */
+    private SuffixRange(long lastNBytes) {
+      this.lastNBytes = lastNBytes;
+    }
+
+    @Override
+    public long getLastNBytes() {
+      return lastNBytes;
+    }
+
+    @Override
+    public long getRangeSize() {
+      return lastNBytes;
+    }
+
+    @Override
+    public ByteRangeType getType() {
+      return ByteRangeType.LAST_N_BYTES;
+    }
+
+    @Override
+    public ByteRange toResolvedByteRange(long totalSize) {
+      if (totalSize < 0) {
+        throw new IllegalArgumentException("Invalid totalSize: " + totalSize + " for range: " + this);
+      }
+      return new ClosedRange(Math.max(totalSize - getLastNBytes(), 0), totalSize - 1);
+    }
+
+    @Override
+    public String toString() {
+      return "ByteRange{lastNBytes=" + lastNBytes + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      SuffixRange that = (SuffixRange) o;
+      return lastNBytes == that.lastNBytes;
+    }
+
+    @Override
+    public int hashCode() {
+      return Long.hashCode(lastNBytes);
+    }
+  }
+}

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -673,15 +673,16 @@ public class RestUtilsTest {
   public void buildContentRangeAndLengthTest() throws RestServiceException {
     // good cases
     doBuildContentRangeAndLengthTest(ByteRange.fromOffsetRange(4, 8), 12, "bytes 4-8/12", 5, true);
+    doBuildContentRangeAndLengthTest(ByteRange.fromOffsetRange(4, 12), 12, "bytes 4-11/12", 8, true);
+    doBuildContentRangeAndLengthTest(ByteRange.fromOffsetRange(4, 15), 12, "bytes 4-11/12", 8, true);
     doBuildContentRangeAndLengthTest(ByteRange.fromStartOffset(14), 17, "bytes 14-16/17", 3, true);
     doBuildContentRangeAndLengthTest(ByteRange.fromLastNBytes(12), 17, "bytes 5-16/17", 12, true);
     doBuildContentRangeAndLengthTest(ByteRange.fromLastNBytes(17), 17, "bytes 0-16/17", 17, true);
+    doBuildContentRangeAndLengthTest(ByteRange.fromLastNBytes(13), 12, "bytes 0-11/12", 12, true);
     // bad cases
-    doBuildContentRangeAndLengthTest(ByteRange.fromOffsetRange(4, 12), 12, null, -1, false);
-    doBuildContentRangeAndLengthTest(ByteRange.fromOffsetRange(4, 15), 12, null, -1, false);
+    doBuildContentRangeAndLengthTest(ByteRange.fromOffsetRange(4, 12), 4, null, -1, false);
     doBuildContentRangeAndLengthTest(ByteRange.fromStartOffset(12), 12, null, -1, false);
     doBuildContentRangeAndLengthTest(ByteRange.fromStartOffset(15), 12, null, -1, false);
-    doBuildContentRangeAndLengthTest(ByteRange.fromLastNBytes(13), 12, null, -1, false);
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RestUtilsTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.router.ByteRange;
+import com.github.ambry.router.ByteRanges;
 import com.github.ambry.router.GetBlobOptions;
 import com.github.ambry.utils.Crc32;
 import com.github.ambry.utils.Pair;
@@ -650,12 +651,12 @@ public class RestUtilsTest {
     // no range
     doBuildGetBlobOptionsTest(null, null, true, true);
     // valid ranges
-    doBuildGetBlobOptionsTest("bytes=0-7", ByteRange.fromOffsetRange(0, 7), true, false);
-    doBuildGetBlobOptionsTest("bytes=234-56679090", ByteRange.fromOffsetRange(234, 56679090), true, false);
-    doBuildGetBlobOptionsTest("bytes=1-", ByteRange.fromStartOffset(1), true, false);
-    doBuildGetBlobOptionsTest("bytes=12345678-", ByteRange.fromStartOffset(12345678), true, false);
-    doBuildGetBlobOptionsTest("bytes=-8", ByteRange.fromLastNBytes(8), true, false);
-    doBuildGetBlobOptionsTest("bytes=-123456789", ByteRange.fromLastNBytes(123456789), true, false);
+    doBuildGetBlobOptionsTest("bytes=0-7", ByteRanges.fromOffsetRange(0, 7), true, false);
+    doBuildGetBlobOptionsTest("bytes=234-56679090", ByteRanges.fromOffsetRange(234, 56679090), true, false);
+    doBuildGetBlobOptionsTest("bytes=1-", ByteRanges.fromStartOffset(1), true, false);
+    doBuildGetBlobOptionsTest("bytes=12345678-", ByteRanges.fromStartOffset(12345678), true, false);
+    doBuildGetBlobOptionsTest("bytes=-8", ByteRanges.fromLastNBytes(8), true, false);
+    doBuildGetBlobOptionsTest("bytes=-123456789", ByteRanges.fromLastNBytes(123456789), true, false);
     // bad ranges
     String[] badRanges =
         {"bytes=0-abcd", "bytes=0as23-44444444", "bytes=22-7777777777777777777777777777777777777777777", "bytes=22--53",
@@ -672,17 +673,17 @@ public class RestUtilsTest {
   @Test
   public void buildContentRangeAndLengthTest() throws RestServiceException {
     // good cases
-    doBuildContentRangeAndLengthTest(ByteRange.fromOffsetRange(4, 8), 12, "bytes 4-8/12", 5, true);
-    doBuildContentRangeAndLengthTest(ByteRange.fromOffsetRange(4, 12), 12, "bytes 4-11/12", 8, true);
-    doBuildContentRangeAndLengthTest(ByteRange.fromOffsetRange(4, 15), 12, "bytes 4-11/12", 8, true);
-    doBuildContentRangeAndLengthTest(ByteRange.fromStartOffset(14), 17, "bytes 14-16/17", 3, true);
-    doBuildContentRangeAndLengthTest(ByteRange.fromLastNBytes(12), 17, "bytes 5-16/17", 12, true);
-    doBuildContentRangeAndLengthTest(ByteRange.fromLastNBytes(17), 17, "bytes 0-16/17", 17, true);
-    doBuildContentRangeAndLengthTest(ByteRange.fromLastNBytes(13), 12, "bytes 0-11/12", 12, true);
+    doBuildContentRangeAndLengthTest(ByteRanges.fromOffsetRange(4, 8), 12, "bytes 4-8/12", 5, true);
+    doBuildContentRangeAndLengthTest(ByteRanges.fromOffsetRange(4, 12), 12, "bytes 4-11/12", 8, true);
+    doBuildContentRangeAndLengthTest(ByteRanges.fromOffsetRange(4, 15), 12, "bytes 4-11/12", 8, true);
+    doBuildContentRangeAndLengthTest(ByteRanges.fromStartOffset(14), 17, "bytes 14-16/17", 3, true);
+    doBuildContentRangeAndLengthTest(ByteRanges.fromLastNBytes(12), 17, "bytes 5-16/17", 12, true);
+    doBuildContentRangeAndLengthTest(ByteRanges.fromLastNBytes(17), 17, "bytes 0-16/17", 17, true);
+    doBuildContentRangeAndLengthTest(ByteRanges.fromLastNBytes(13), 12, "bytes 0-11/12", 12, true);
     // bad cases
-    doBuildContentRangeAndLengthTest(ByteRange.fromOffsetRange(4, 12), 4, null, -1, false);
-    doBuildContentRangeAndLengthTest(ByteRange.fromStartOffset(12), 12, null, -1, false);
-    doBuildContentRangeAndLengthTest(ByteRange.fromStartOffset(15), 12, null, -1, false);
+    doBuildContentRangeAndLengthTest(ByteRanges.fromOffsetRange(4, 12), 4, null, -1, false);
+    doBuildContentRangeAndLengthTest(ByteRanges.fromStartOffset(12), 12, null, -1, false);
+    doBuildContentRangeAndLengthTest(ByteRanges.fromStartOffset(15), 12, null, -1, false);
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/router/ByteRangeTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/ByteRangeTest.java
@@ -85,14 +85,15 @@ public class ByteRangeTest {
 
     // -20 (last 20 bytes)
     range = ByteRange.fromLastNBytes(20);
-    assertRangeResolutionFailure(range, 0);
     assertRangeResolutionFailure(range, -1);
+    assertRangeResolutionSuccess(range, 0, 0, -1);
+    assertRangeResolutionSuccess(range, 19, 0, 18);
     assertRangeResolutionSuccess(range, 20, 0, 19);
     assertRangeResolutionSuccess(range, 30, 10, 29);
 
     // 22-44 (bytes 22 through 44, inclusive)
     range = ByteRange.fromOffsetRange(22, 44);
-    assertRangeResolutionFailure(range, 44);
+    assertRangeResolutionSuccess(range, 44, 22, 43);
     assertRangeResolutionSuccess(range, 45, 22, 44);
 
     // {MAX_LONG-50}- (bytes after/including MAX_LONG-50)
@@ -117,14 +118,14 @@ public class ByteRangeTest {
     ByteRange b = ByteRange.fromLastNBytes(4);
     assertEquals("ByteRanges should be equal", a, b);
     assertEquals("ByteRange hashcodes should be equal", a.hashCode(), b.hashCode());
-    assertEquals("toString output not as expected", "ByteRange{type=LAST_N_BYTES, lastNBytes=4}", a.toString());
+    assertEquals("toString output not as expected", "ByteRange{lastNBytes=4}", a.toString());
 
     a = ByteRange.fromOffsetRange(2, 5);
     assertFalse("ByteRanges should not be equal", a.equals(b));
     b = ByteRange.fromOffsetRange(2, 5);
     assertEquals("ByteRanges should be equal", a, b);
     assertEquals("ByteRange hashcodes should be equal", a.hashCode(), b.hashCode());
-    assertEquals("toString output not as expected", "ByteRange{type=OFFSET_RANGE, startOffset=2, endOffset=5}",
+    assertEquals("toString output not as expected", "ByteRange{startOffset=2, endOffset=5}",
         a.toString());
 
     a = ByteRange.fromStartOffset(7);
@@ -132,7 +133,7 @@ public class ByteRangeTest {
     b = ByteRange.fromStartOffset(7);
     assertEquals("ByteRanges should be equal", a, b);
     assertEquals("ByteRange hashcodes should be equal", a.hashCode(), b.hashCode());
-    assertEquals("toString output not as expected", "ByteRange{type=FROM_START_OFFSET, startOffset=7}", a.toString());
+    assertEquals("toString output not as expected", "ByteRange{startOffset=7}", a.toString());
   }
 
   /**

--- a/ambry-api/src/test/java/com.github.ambry/router/ByteRangeTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/ByteRangeTest.java
@@ -65,26 +65,26 @@ public class ByteRangeTest {
   @Test
   public void testResolvedByteRange() throws Exception {
     // 0-0 (0th byte)
-    ByteRange range = ByteRange.fromOffsetRange(0, 0);
+    ByteRange range = ByteRanges.fromOffsetRange(0, 0);
     assertRangeResolutionFailure(range, 0);
     assertRangeResolutionFailure(range, -1);
     assertRangeResolutionSuccess(range, 2, 0, 0);
 
     // 0- (bytes after/including 0)
-    range = ByteRange.fromStartOffset(0);
+    range = ByteRanges.fromStartOffset(0);
     assertRangeResolutionFailure(range, 0);
     assertRangeResolutionFailure(range, -1);
     assertRangeResolutionSuccess(range, 20, 0, 19);
 
     // 15- (bytes after/including 15)
-    range = ByteRange.fromStartOffset(15);
+    range = ByteRanges.fromStartOffset(15);
     assertRangeResolutionFailure(range, 15);
     assertRangeResolutionFailure(range, -1);
     assertRangeResolutionSuccess(range, 20, 15, 19);
     assertRangeResolutionSuccess(range, 16, 15, 15);
 
     // -20 (last 20 bytes)
-    range = ByteRange.fromLastNBytes(20);
+    range = ByteRanges.fromLastNBytes(20);
     assertRangeResolutionFailure(range, -1);
     assertRangeResolutionSuccess(range, 0, 0, -1);
     assertRangeResolutionSuccess(range, 19, 0, 18);
@@ -92,19 +92,19 @@ public class ByteRangeTest {
     assertRangeResolutionSuccess(range, 30, 10, 29);
 
     // 22-44 (bytes 22 through 44, inclusive)
-    range = ByteRange.fromOffsetRange(22, 44);
+    range = ByteRanges.fromOffsetRange(22, 44);
     assertRangeResolutionSuccess(range, 44, 22, 43);
     assertRangeResolutionSuccess(range, 45, 22, 44);
 
     // {MAX_LONG-50}- (bytes after/including MAX_LONG-50)
-    range = ByteRange.fromStartOffset(Long.MAX_VALUE - 50);
+    range = ByteRanges.fromStartOffset(Long.MAX_VALUE - 50);
     assertRangeResolutionFailure(range, 0);
     assertRangeResolutionFailure(range, -1);
     assertRangeResolutionFailure(range, 20);
     assertRangeResolutionSuccess(range, Long.MAX_VALUE, Long.MAX_VALUE - 50, Long.MAX_VALUE - 1);
 
     // Last 0 bytes
-    range = ByteRange.fromLastNBytes(0);
+    range = ByteRanges.fromLastNBytes(0);
     assertRangeResolutionSuccess(range, 0, 0, -1);
     assertRangeResolutionSuccess(range, 20, 20, 19);
   }
@@ -114,23 +114,23 @@ public class ByteRangeTest {
    */
   @Test
   public void testToStringEqualsAndHashcode() {
-    ByteRange a = ByteRange.fromLastNBytes(4);
-    ByteRange b = ByteRange.fromLastNBytes(4);
+    ByteRange a = ByteRanges.fromLastNBytes(4);
+    ByteRange b = ByteRanges.fromLastNBytes(4);
     assertEquals("ByteRanges should be equal", a, b);
     assertEquals("ByteRange hashcodes should be equal", a.hashCode(), b.hashCode());
     assertEquals("toString output not as expected", "ByteRange{lastNBytes=4}", a.toString());
 
-    a = ByteRange.fromOffsetRange(2, 5);
+    a = ByteRanges.fromOffsetRange(2, 5);
     assertFalse("ByteRanges should not be equal", a.equals(b));
-    b = ByteRange.fromOffsetRange(2, 5);
+    b = ByteRanges.fromOffsetRange(2, 5);
     assertEquals("ByteRanges should be equal", a, b);
     assertEquals("ByteRange hashcodes should be equal", a.hashCode(), b.hashCode());
     assertEquals("toString output not as expected", "ByteRange{startOffset=2, endOffset=5}",
         a.toString());
 
-    a = ByteRange.fromStartOffset(7);
+    a = ByteRanges.fromStartOffset(7);
     assertFalse("ByteRanges should not be equal", a.equals(b));
-    b = ByteRange.fromStartOffset(7);
+    b = ByteRanges.fromStartOffset(7);
     assertEquals("ByteRanges should be equal", a, b);
     assertEquals("ByteRange hashcodes should be equal", a.hashCode(), b.hashCode());
     assertEquals("toString output not as expected", "ByteRange{startOffset=7}", a.toString());
@@ -146,7 +146,7 @@ public class ByteRangeTest {
   private void testByteRangeCreationOffsetRange(long startOffset, long endOffset, boolean expectSuccess)
       throws Exception {
     if (expectSuccess) {
-      ByteRange byteRange = ByteRange.fromOffsetRange(startOffset, endOffset);
+      ByteRange byteRange = ByteRanges.fromOffsetRange(startOffset, endOffset);
       assertEquals("Wrong range type", ByteRange.ByteRangeType.OFFSET_RANGE, byteRange.getType());
       assertEquals("Wrong startOffset", startOffset, byteRange.getStartOffset());
       assertEquals("Wrong endOffset", endOffset, byteRange.getEndOffset());
@@ -157,7 +157,7 @@ public class ByteRangeTest {
       }
     } else {
       try {
-        ByteRange.fromOffsetRange(startOffset, endOffset);
+        ByteRanges.fromOffsetRange(startOffset, endOffset);
         fail(String.format("Range creation should not have succeeded with range [%d, %d]", startOffset, endOffset));
       } catch (IllegalArgumentException expected) {
       }
@@ -172,7 +172,7 @@ public class ByteRangeTest {
    */
   private void testByteRangeCreationFromStartOffset(long startOffset, boolean expectSuccess) throws Exception {
     if (expectSuccess) {
-      ByteRange byteRange = ByteRange.fromStartOffset(startOffset);
+      ByteRange byteRange = ByteRanges.fromStartOffset(startOffset);
       assertEquals("Wrong range type", ByteRange.ByteRangeType.FROM_START_OFFSET, byteRange.getType());
       assertEquals("Wrong startOffset", startOffset, byteRange.getStartOffset());
       try {
@@ -183,7 +183,7 @@ public class ByteRangeTest {
       }
     } else {
       try {
-        ByteRange.fromStartOffset(startOffset);
+        ByteRanges.fromStartOffset(startOffset);
         fail("Range creation should not have succeeded with range from " + startOffset);
       } catch (IllegalArgumentException expected) {
       }
@@ -199,7 +199,7 @@ public class ByteRangeTest {
    */
   private void testByteRangeCreationLastNBytes(long lastNBytes, boolean expectSuccess) throws Exception {
     if (expectSuccess) {
-      ByteRange byteRange = ByteRange.fromLastNBytes(lastNBytes);
+      ByteRange byteRange = ByteRanges.fromLastNBytes(lastNBytes);
       assertEquals("Wrong range type", ByteRange.ByteRangeType.LAST_N_BYTES, byteRange.getType());
       assertEquals("Wrong lastNBytes", lastNBytes, byteRange.getLastNBytes());
       try {
@@ -210,7 +210,7 @@ public class ByteRangeTest {
       }
     } else {
       try {
-        ByteRange.fromLastNBytes(lastNBytes);
+        ByteRanges.fromLastNBytes(lastNBytes);
         fail("Range creation should not have succeeded with range of last " + lastNBytes + " bytes");
       } catch (IllegalArgumentException expected) {
       }

--- a/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/router/GetBlobOptionsTest.java
@@ -34,9 +34,9 @@ public class GetBlobOptionsTest {
   public void testRangeOption() throws Exception {
     long startOffset = 1;
     long endOffset = 2;
-    ByteRange range = ByteRange.fromOffsetRange(startOffset, endOffset);
+    ByteRange range = ByteRanges.fromOffsetRange(startOffset, endOffset);
     GetBlobOptions options = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
-        .range(ByteRange.fromOffsetRange(startOffset, endOffset))
+        .range(ByteRanges.fromOffsetRange(startOffset, endOffset))
         .build();
     assertEquals("Range from options not as expected.", range, options.getRange());
   }
@@ -82,7 +82,7 @@ public class GetBlobOptionsTest {
   public void testRawModeWithInvalidCombinations() throws Exception {
     // Test that using rawMode and range together fails.
     GetBlobOptionsBuilder options = new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
-        .range(ByteRange.fromOffsetRange(0, 1))
+        .range(ByteRanges.fromOffsetRange(0, 1))
         .rawMode(true);
     TestUtils.assertException(IllegalArgumentException.class, () -> options.build(), null);
 
@@ -99,7 +99,7 @@ public class GetBlobOptionsTest {
    */
   @Test
   public void testToStringEqualsAndHashcode() {
-    ByteRange byteRange = ByteRange.fromLastNBytes(4);
+    ByteRange byteRange = ByteRanges.fromLastNBytes(4);
     GetOption getOption = GetOption.None;
     GetBlobOptions.OperationType type = GetBlobOptions.OperationType.Data;
     GetBlobOptions a = new GetBlobOptionsBuilder().operationType(type).getOption(getOption).range(byteRange).build();
@@ -122,7 +122,7 @@ public class GetBlobOptionsTest {
     // Change range
     b = new GetBlobOptionsBuilder().operationType(type)
         .getOption(getOption)
-        .range(ByteRange.fromOffsetRange(2, 7))
+        .range(ByteRanges.fromOffsetRange(2, 7))
         .build();
     assertOptionsAreDistinct(a, b);
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -49,6 +49,7 @@ import com.github.ambry.rest.RestUtils;
 import com.github.ambry.rest.RestUtilsTest;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.ByteRange;
+import com.github.ambry.router.ByteRanges;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.ChunkInfo;
 import com.github.ambry.router.FutureResult;
@@ -1323,17 +1324,17 @@ public class AmbryBlobStorageServiceTest {
     getHeadAndVerify(blobId, null, null, headers, expectedAccount, expectedContainer);
     getHeadAndVerify(blobId, null, GetOption.None, headers, expectedAccount, expectedContainer);
 
-    ByteRange range = ByteRange.fromStartOffset(ThreadLocalRandom.current().nextLong(CONTENT_LENGTH));
+    ByteRange range = ByteRanges.fromStartOffset(ThreadLocalRandom.current().nextLong(CONTENT_LENGTH));
     getBlobAndVerify(blobId, range, null, headers, content, expectedAccount, expectedContainer);
     getHeadAndVerify(blobId, range, null, headers, expectedAccount, expectedContainer);
 
-    range = ByteRange.fromLastNBytes(ThreadLocalRandom.current().nextLong(CONTENT_LENGTH + 1));
+    range = ByteRanges.fromLastNBytes(ThreadLocalRandom.current().nextLong(CONTENT_LENGTH + 1));
     getBlobAndVerify(blobId, range, null, headers, content, expectedAccount, expectedContainer);
     getHeadAndVerify(blobId, range, null, headers, expectedAccount, expectedContainer);
 
     long random1 = ThreadLocalRandom.current().nextLong(CONTENT_LENGTH);
     long random2 = ThreadLocalRandom.current().nextLong(CONTENT_LENGTH);
-    range = ByteRange.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2));
+    range = ByteRanges.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2));
     getBlobAndVerify(blobId, range, null, headers, content, expectedAccount, expectedContainer);
     getHeadAndVerify(blobId, range, null, headers, expectedAccount, expectedContainer);
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -33,6 +33,7 @@ import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestTestUtils;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.ByteRange;
+import com.github.ambry.router.ByteRanges;
 import com.github.ambry.router.Callback;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.TestUtils;
@@ -483,19 +484,19 @@ public class AmbrySecurityServiceTest {
     long blobSize = blobInfo.getBlobProperties().getBlobSize();
     testGetBlob(blobInfo, null);
 
-    testGetBlob(blobInfo, ByteRange.fromLastNBytes(0));
+    testGetBlob(blobInfo, ByteRanges.fromLastNBytes(0));
     if (blobSize > 0) {
-      testGetBlob(blobInfo, ByteRange.fromStartOffset(0));
-      testGetBlob(blobInfo, ByteRange.fromStartOffset(ThreadLocalRandom.current().nextLong(1, blobSize - 1)));
-      testGetBlob(blobInfo, ByteRange.fromStartOffset(blobSize - 1));
+      testGetBlob(blobInfo, ByteRanges.fromStartOffset(0));
+      testGetBlob(blobInfo, ByteRanges.fromStartOffset(ThreadLocalRandom.current().nextLong(1, blobSize - 1)));
+      testGetBlob(blobInfo, ByteRanges.fromStartOffset(blobSize - 1));
 
       long random1 = ThreadLocalRandom.current().nextLong(blobSize);
       long random2 = ThreadLocalRandom.current().nextLong(blobSize);
-      testGetBlob(blobInfo, ByteRange.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2)));
-      testGetBlob(blobInfo, ByteRange.fromLastNBytes(blobSize));
+      testGetBlob(blobInfo, ByteRanges.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2)));
+      testGetBlob(blobInfo, ByteRanges.fromLastNBytes(blobSize));
     }
     if (blobSize > 1) {
-      testGetBlob(blobInfo, ByteRange.fromLastNBytes(ThreadLocalRandom.current().nextLong(1, blobSize)));
+      testGetBlob(blobInfo, ByteRanges.fromLastNBytes(ThreadLocalRandom.current().nextLong(1, blobSize)));
     }
   }
 
@@ -559,20 +560,20 @@ public class AmbrySecurityServiceTest {
     long blobSize = blobInfo.getBlobProperties().getBlobSize();
     testHeadBlob(blobInfo, null);
 
-    testHeadBlob(blobInfo, ByteRange.fromLastNBytes(0));
+    testHeadBlob(blobInfo, ByteRanges.fromLastNBytes(0));
     if (blobSize > 0) {
-      testHeadBlob(blobInfo, ByteRange.fromStartOffset(0));
-      testHeadBlob(blobInfo, ByteRange.fromStartOffset(ThreadLocalRandom.current().nextLong(1, blobSize - 1)));
-      testHeadBlob(blobInfo, ByteRange.fromStartOffset(blobSize - 1));
+      testHeadBlob(blobInfo, ByteRanges.fromStartOffset(0));
+      testHeadBlob(blobInfo, ByteRanges.fromStartOffset(ThreadLocalRandom.current().nextLong(1, blobSize - 1)));
+      testHeadBlob(blobInfo, ByteRanges.fromStartOffset(blobSize - 1));
 
       long random1 = ThreadLocalRandom.current().nextLong(blobSize);
       long random2 = ThreadLocalRandom.current().nextLong(blobSize);
-      testHeadBlob(blobInfo, ByteRange.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2)));
+      testHeadBlob(blobInfo, ByteRanges.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2)));
 
-      testHeadBlob(blobInfo, ByteRange.fromLastNBytes(blobSize));
+      testHeadBlob(blobInfo, ByteRanges.fromLastNBytes(blobSize));
     }
     if (blobSize > 1) {
-      testHeadBlob(blobInfo, ByteRange.fromLastNBytes(ThreadLocalRandom.current().nextLong(1, blobSize)));
+      testHeadBlob(blobInfo, ByteRanges.fromLastNBytes(ThreadLocalRandom.current().nextLong(1, blobSize)));
     }
   }
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -42,6 +42,7 @@ import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.rest.RestTestUtils;
 import com.github.ambry.rest.RestUtils;
 import com.github.ambry.router.ByteRange;
+import com.github.ambry.router.ByteRanges;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
@@ -579,16 +580,16 @@ public class FrontendIntegrationTest {
     getBlobAndVerify(blobId, null, GetOption.None, headers, isPrivate, content, expectedAccountName,
         expectedContainerName);
     getHeadAndVerify(blobId, null, GetOption.None, headers, isPrivate, expectedAccountName, expectedContainerName);
-    ByteRange range = ByteRange.fromLastNBytes(ThreadLocalRandom.current().nextLong(content.capacity() + 1));
+    ByteRange range = ByteRanges.fromLastNBytes(ThreadLocalRandom.current().nextLong(content.capacity() + 1));
     getBlobAndVerify(blobId, range, null, headers, isPrivate, content, expectedAccountName, expectedContainerName);
     getHeadAndVerify(blobId, range, null, headers, isPrivate, expectedAccountName, expectedContainerName);
     if (contentSize > 0) {
-      range = ByteRange.fromStartOffset(ThreadLocalRandom.current().nextLong(content.capacity()));
+      range = ByteRanges.fromStartOffset(ThreadLocalRandom.current().nextLong(content.capacity()));
       getBlobAndVerify(blobId, range, null, headers, isPrivate, content, expectedAccountName, expectedContainerName);
       getHeadAndVerify(blobId, range, null, headers, isPrivate, expectedAccountName, expectedContainerName);
       long random1 = ThreadLocalRandom.current().nextLong(content.capacity());
       long random2 = ThreadLocalRandom.current().nextLong(content.capacity());
-      range = ByteRange.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2));
+      range = ByteRanges.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2));
       getBlobAndVerify(blobId, range, null, headers, isPrivate, content, expectedAccountName, expectedContainerName);
       getHeadAndVerify(blobId, range, null, headers, isPrivate, expectedAccountName, expectedContainerName);
     }
@@ -1278,11 +1279,11 @@ public class FrontendIntegrationTest {
         account.getName(), container.getName(), null);
     List<ByteRange> ranges = new ArrayList<>();
     ranges.add(null);
-    ranges.add(ByteRange.fromLastNBytes(ThreadLocalRandom.current().nextLong(fullContentArray.length + 1)));
-    ranges.add(ByteRange.fromStartOffset(ThreadLocalRandom.current().nextLong(fullContentArray.length)));
+    ranges.add(ByteRanges.fromLastNBytes(ThreadLocalRandom.current().nextLong(fullContentArray.length + 1)));
+    ranges.add(ByteRanges.fromStartOffset(ThreadLocalRandom.current().nextLong(fullContentArray.length)));
     long random1 = ThreadLocalRandom.current().nextLong(fullContentArray.length);
     long random2 = ThreadLocalRandom.current().nextLong(fullContentArray.length);
-    ranges.add(ByteRange.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2)));
+    ranges.add(ByteRanges.fromOffsetRange(Math.min(random1, random2), Math.max(random1, random2)));
     for (ByteRange range : ranges) {
       getBlobAndVerify(stitchedBlobId, range, GetOption.None, expectedGetHeaders, !container.isCacheable(),
           ByteBuffer.wrap(fullContentArray), account.getName(), container.getName());

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -813,10 +813,10 @@ public class GetBlobOperationTest {
     testRangeRequestFromStartOffset(random.nextInt(blobSize), true);
     // Last n bytes of the blob
     testRangeRequestLastNBytes(random.nextInt(blobSize) + 1, true);
-    // Last blobSize + 1 bytes (should not succeed)
-    testRangeRequestLastNBytes(blobSize + 1, false);
-    // Range over the end of the blob (should not succeed)
-    testRangeRequestOffsetRange(random.nextInt(blobSize), blobSize + 5, false);
+    // Last blobSize + 1 bytes
+    testRangeRequestLastNBytes(blobSize + 1, true);
+    // Range over the end of the blob
+    testRangeRequestOffsetRange(random.nextInt(blobSize), blobSize + 5, true);
     // Ranges that start past the end of the blob (should not succeed)
     testRangeRequestFromStartOffset(blobSize, false);
     testRangeRequestOffsetRange(blobSize, blobSize + 20, false);
@@ -850,10 +850,10 @@ public class GetBlobOperationTest {
     testRangeRequestFromStartOffset(random.nextInt(blobSize), true);
     // Last n bytes of the blob
     testRangeRequestLastNBytes(random.nextInt(blobSize) + 1, true);
-    // Last blobSize + 1 bytes (should not succeed)
-    testRangeRequestLastNBytes(blobSize + 1, false);
-    // Range over the end of the blob (should not succeed)
-    testRangeRequestOffsetRange(random.nextInt(blobSize), blobSize + 5, false);
+    // Last blobSize + 1 bytes
+    testRangeRequestLastNBytes(blobSize + 1, true);
+    // Range over the end of the blob
+    testRangeRequestOffsetRange(random.nextInt(blobSize), blobSize + 5, true);
     // Ranges that start past the end of the blob (should not succeed)
     testRangeRequestFromStartOffset(blobSize, false);
     testRangeRequestOffsetRange(blobSize, blobSize + 20, false);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -1030,7 +1030,7 @@ public class GetBlobOperationTest {
       throws Exception {
     doPut();
     options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
-        .range(ByteRange.fromOffsetRange(startOffset, endOffset))
+        .range(ByteRanges.fromOffsetRange(startOffset, endOffset))
         .build(), false, routerMetrics.ageAtGet);
     getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
   }
@@ -1045,7 +1045,7 @@ public class GetBlobOperationTest {
   private void testRangeRequestFromStartOffset(long startOffset, boolean rangeSatisfiable) throws Exception {
     doPut();
     options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
-        .range(ByteRange.fromStartOffset(startOffset))
+        .range(ByteRanges.fromStartOffset(startOffset))
         .build(), false, routerMetrics.ageAtGet);
     getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
   }
@@ -1060,7 +1060,7 @@ public class GetBlobOperationTest {
   private void testRangeRequestLastNBytes(long lastNBytes, boolean rangeSatisfiable) throws Exception {
     doPut();
     options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.All)
-        .range(ByteRange.fromLastNBytes(lastNBytes))
+        .range(ByteRanges.fromLastNBytes(lastNBytes))
         .build(), false, routerMetrics.ageAtGet);
     getErrorCodeChecker.testAndAssert(rangeSatisfiable ? null : RouterErrorCode.RangeNotSatisfiable);
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -143,7 +143,7 @@ public class GetManagerTest {
   @Test
   public void testRangeRequest() throws Exception {
     testGetSuccess(chunkSize * 6 + 11, new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.Data)
-        .range(ByteRange.fromOffsetRange(chunkSize * 2 + 3, chunkSize * 5 + 4))
+        .range(ByteRanges.fromOffsetRange(chunkSize * 2 + 3, chunkSize * 5 + 4))
         .build());
   }
 


### PR DESCRIPTION
The original implementation of ByteRange.toResolvedByteRange was
stricter than the RFC called for and required that the end of the range
be less than the blob size. This change allows ranges where the end
offset or suffix length is greater than the blob size to be served.

Per rfc7233:
   A client can limit the number of bytes requested without knowing the
   size of the selected representation.  If the last-byte-pos value is
   absent, or if the value is greater than or equal to the current
   length of the representation data, the byte range is interpreted as
   the remainder of the representation
and
   If the selected representation is shorter than the specified
   suffix-length, the entire representation is used.

This change also refactors the implementation of ByteRange to use
inheritance instead of switch statements.