### PR TITLE
Supporting cluster wide stats aggregation for partition class

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/server/AmbryHealthReport.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/AmbryHealthReport.java
@@ -35,6 +35,12 @@ public interface AmbryHealthReport {
   String getReportName();
 
   /**
+   * Get the type of stats report specified in this health report. The stats report type is defined in {@link StatsReportType}
+   * @return the type of stats represented by this health report
+   */
+  StatsReportType getStatsReportType();
+
+  /**
    * Get the most recent health report in the form of a {@link Map}.
    * @return a {@link Map} of String to String containing the content of the health report
    */

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterAggregator.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterAggregator.java
@@ -14,6 +14,7 @@
 
 package com.github.ambry.clustermap;
 
+import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.server.StatsWrapper;
 import com.github.ambry.utils.Pair;
@@ -35,7 +36,7 @@ public class HelixClusterAggregator {
   private static final Logger logger = LoggerFactory.getLogger(HelixClusterAggregator.class);
   private final ObjectMapper mapper = new ObjectMapper();
   private final long relevantTimePeriodInMs;
-  private final List<String> exceptionOccurredInstances = new ArrayList<>();
+  private final Map<StatsReportType, List<String>> exceptionOccurredInstances = new HashMap<>();
 
   HelixClusterAggregator(long relevantTimePeriodInMinutes) {
     relevantTimePeriodInMs = TimeUnit.MINUTES.toMillis(relevantTimePeriodInMinutes);
@@ -46,39 +47,61 @@ public class HelixClusterAggregator {
    * aggregation with them.
    * @param statsWrappersJSON a {@link Map} of instance name to JSON string representation of {@link StatsWrapper} objects from the
    *                          node level
-   * @return a {@link Pair} of Strings whose values represents valid quota stats across all partitions.
-   * First element is the raw (sum) aggregated stats and second element is average(aggregated) stats for all replicas
+   * @param type the type of stats report to be aggregated, which is defined in {@link StatsReportType}
+   * @return a {@link Pair} of Strings whose values represents aggregated stats across all partitions.
+   * First element is the raw (sum) aggregated stats and second element is valid aggregated stats for all replicas
    * for each partition.
    * @throws IOException
    */
-  Pair<String, String> doWork(Map<String, String> statsWrappersJSON) throws IOException {
+  Pair<String, String> doWork(Map<String, String> statsWrappersJSON, StatsReportType type) throws IOException {
     StatsSnapshot partitionSnapshot = new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>());
     Map<String, Long> partitionTimestampMap = new HashMap<>();
     StatsSnapshot rawPartitionSnapshot = new StatsSnapshot(0L, new HashMap<String, StatsSnapshot>());
-    exceptionOccurredInstances.clear();
+    exceptionOccurredInstances.remove(type);
     for (Map.Entry<String, String> statsWrapperJSON : statsWrappersJSON.entrySet()) {
       if (statsWrapperJSON != null && statsWrapperJSON.getValue() != null) {
         try {
           StatsWrapper snapshotWrapper = mapper.readValue(statsWrapperJSON.getValue(), StatsWrapper.class);
           StatsWrapper snapshotWrapperCopy = mapper.readValue(statsWrapperJSON.getValue(), StatsWrapper.class);
 
-          combineRaw(rawPartitionSnapshot, snapshotWrapper);
-          combine(partitionSnapshot, snapshotWrapperCopy, statsWrapperJSON.getKey(), partitionTimestampMap);
+          combineRawStats(rawPartitionSnapshot, snapshotWrapper);
+          switch (type) {
+            case ACCOUNT_REPORT:
+              combineValidStatsByAccount(partitionSnapshot, snapshotWrapperCopy, statsWrapperJSON.getKey(),
+                  partitionTimestampMap);
+              break;
+            case PARTITION_CLASS_REPORT:
+              combineValidStatsByPartitionClass(partitionSnapshot, snapshotWrapperCopy, statsWrapperJSON.getKey(),
+                  partitionTimestampMap);
+              break;
+            default:
+              throw new IllegalArgumentException("Unrecognized stats report type: " + type);
+          }
         } catch (Exception e) {
           logger.error("Exception occurred while processing stats from {}", statsWrapperJSON.getKey(), e);
-          exceptionOccurredInstances.add(statsWrapperJSON.getKey());
+          exceptionOccurredInstances.computeIfAbsent(type, key -> new ArrayList<>()).add(statsWrapperJSON.getKey());
         }
       }
     }
     if (logger.isTraceEnabled()) {
       logger.trace("Combined raw snapshot {}", mapper.writeValueAsString(rawPartitionSnapshot));
-      logger.trace("Combined snapshot {}", mapper.writeValueAsString(partitionSnapshot));
+      logger.trace("Combined valid snapshot {}", mapper.writeValueAsString(partitionSnapshot));
     }
-    StatsSnapshot reducedRawSnapshot = reduce(rawPartitionSnapshot);
-    StatsSnapshot reducedSnapshot = reduce(partitionSnapshot);
+    StatsSnapshot reducedRawSnapshot = null;
+    StatsSnapshot reducedSnapshot = null;
+    switch (type) {
+      case ACCOUNT_REPORT:
+        reducedRawSnapshot = reduceByAccount(rawPartitionSnapshot);
+        reducedSnapshot = reduceByAccount(partitionSnapshot);
+        break;
+      case PARTITION_CLASS_REPORT:
+        reducedRawSnapshot = reduceByPartitionClass(rawPartitionSnapshot);
+        reducedSnapshot = reduceByPartitionClass(partitionSnapshot);
+        break;
+    }
     if (logger.isTraceEnabled()) {
       logger.trace("Reduced raw snapshot {}", mapper.writeValueAsString(reducedRawSnapshot));
-      logger.trace("Reduced snapshot {}", mapper.writeValueAsString(reducedSnapshot));
+      logger.trace("Reduced valid snapshot {}", mapper.writeValueAsString(reducedSnapshot));
     }
     return new Pair<>(mapper.writeValueAsString(reducedRawSnapshot), mapper.writeValueAsString(reducedSnapshot));
   }
@@ -88,7 +111,7 @@ public class HelixClusterAggregator {
    * @param rawBaseSnapshot the raw base {@link StatsSnapshot} which will contain the aggregated result
    * @param snapshotWrapper the {@link StatsSnapshot} to be added to the raw base {@link StatsSnapshot}
    */
-  private void combineRaw(StatsSnapshot rawBaseSnapshot, StatsWrapper snapshotWrapper) {
+  private void combineRawStats(StatsSnapshot rawBaseSnapshot, StatsWrapper snapshotWrapper) {
     Map<String, StatsSnapshot> partitionSnapshotMap = snapshotWrapper.getSnapshot().getSubMap();
     if (partitionSnapshotMap == null) {
       logger.info("There is no partition in given StatsSnapshot, skip aggregation on it.");
@@ -116,13 +139,47 @@ public class HelixClusterAggregator {
    *       given partition entry has a greater value.
    *    b) Timestamp of a given partition entry is one aggregation period newer (greater) than the timestamp of the
    *       base entry.
+   * The combined valid stats snapshot is represented in following format:
+   * {
+   *   value: 1000,
+   *   subMap: {
+   *     Partition[0]: {
+   *       value: 400,
+   *       subMap: {
+   *         Account[0]: {
+   *           value: 400,
+   *           subMap: {
+   *             Container[0]: {
+   *               value: 400
+   *               subMap: null
+   *             }
+   *           }
+   *         }
+   *       }
+   *     },
+   *     Partition[1]: {
+   *       value: 600,
+   *       subMap: {
+   *         Account[1]: {
+   *           value: 600,
+   *           subMap: {
+   *             Container[1]:{
+   *               value: 600,
+   *               subMap: null
+   *             }
+   *           }
+   *         }
+   *       }
+   *     }
+   *   }
+   * }
    * @param baseSnapshot the base {@link StatsSnapshot} which will contain the aggregated result
    * @param snapshotWrapper the {@link StatsSnapshot} to be aggregated to the base {@link StatsSnapshot}
    * @param instance new instance from which snapshot is being combined
    * @param partitionTimestampMap a {@link Map} of partition to timestamp to keep track the current timestamp of each
    *                              partition entry in the base {@link StatsSnapshot}
    */
-  private void combine(StatsSnapshot baseSnapshot, StatsWrapper snapshotWrapper, String instance,
+  private void combineValidStatsByAccount(StatsSnapshot baseSnapshot, StatsWrapper snapshotWrapper, String instance,
       Map<String, Long> partitionTimestampMap) {
     Map<String, StatsSnapshot> partitionSnapshotMap = snapshotWrapper.getSnapshot().getSubMap();
     if (partitionSnapshotMap == null) {
@@ -164,12 +221,132 @@ public class HelixClusterAggregator {
   }
 
   /**
+   * Aggregate the given {@link StatsSnapshot} with the base {@link StatsSnapshot} by partition class. The aggregation uses
+   * the same rules in {@link #combineValidStatsByAccount(StatsSnapshot, StatsWrapper, String, Map)}.
+   *
+   * The workflow of this method is as follows:
+   * 1. Check if basePartitionClassMap contains given partitionClass. If yes, go to step 2; If not, directly put it into basePartitionClassMap
+   *    and update partitionTimestampMap by adding all < partition, timestamp > pairs associated with given partitionClass
+   * 2. For each partition in given partitionClass, check if basePartitionMap contains it. If yes, go to step 3;
+   *    if not, put the partition into basePartitionMap and update partitionTimestampMap by adding the partition and its timestamp.
+   * 3. Compute the delta value and delta time between given partition and existing one. Update partitionClassVal and
+   *    partitionTimestampMap based on following rules:
+   *      a) if abs(delta time) is within relevantTimePeriodInMs and delta value > 0, replace existing partition with given partition.
+   *      b) if delta time > relevantTimePeriodInMs, which means given partition is newer than existing partition,
+   *         then replace existing partition with given one.
+   *      c) otherwise, ignore the partition(replica) because it is either stale or not the replica with largest value.
+   * 4. update basePartitionClassMap with up-to-date basePartitionMap and totalValueOfAllClasses.
+   * The combined snapshot is represented in following format:
+   * {
+   *   value: 1000,
+   *   subMap:{
+   *     PartitionClass_1: {
+   *       value: 400,
+   *       subMap: {
+   *         Partition[1]:{
+   *           value: 400,
+   *           subMap: {
+   *             Account[1]_Container[1]:{
+   *               value: 400,
+   *               subMap: null
+   *             }
+   *           }
+   *         }
+   *       }
+   *     },
+   *     PartitionClass_2: {
+   *       value: 600,
+   *       subMap:{
+   *         Partition[2]:{
+   *           value: 600,
+   *           subMap:{
+   *             Account[2]_Container[2]:{
+   *               value: 600,
+   *               subMap: null
+   *             }
+   *           }
+   *         }
+   *       }
+   *     }
+   *   }
+   * }
+   * @param baseSnapshot baseSnapshot the base {@link StatsSnapshot} which will contain the aggregated result
+   * @param snapshotWrapper the {@link StatsSnapshot} from each instance to be aggregated to the base {@link StatsSnapshot}
+   * @param instance new instance from which snapshot is being combined
+   * @param partitionTimestampMap a {@link Map} of partition to timestamp. It keeps track the current timestamp of each
+   *                              partition entry in the base {@link StatsSnapshot}
+   */
+  private void combineValidStatsByPartitionClass(StatsSnapshot baseSnapshot, StatsWrapper snapshotWrapper,
+      String instance, Map<String, Long> partitionTimestampMap) {
+    Map<String, StatsSnapshot> partitionClassSnapshotMap = snapshotWrapper.getSnapshot().getSubMap();
+    if (partitionClassSnapshotMap == null) {
+      logger.info("There is no partition in given StatsSnapshot, skip aggregation on it.");
+      return;
+    }
+    long totalValueOfAllClasses = baseSnapshot.getValue();
+    long snapshotTimestamp = snapshotWrapper.getHeader().getTimestamp();
+    Map<String, StatsSnapshot> basePartitionClassMap = baseSnapshot.getSubMap();
+
+    for (Map.Entry<String, StatsSnapshot> partitionClassSnapshot : partitionClassSnapshotMap.entrySet()) {
+      String partitionClassId = partitionClassSnapshot.getKey();
+      if (basePartitionClassMap.containsKey(partitionClassId)) {
+        long partitionClassVal = basePartitionClassMap.get(partitionClassId).getValue();
+        Map<String, StatsSnapshot> basePartitionMap = basePartitionClassMap.get(partitionClassId).getSubMap();
+        for (Map.Entry<String, StatsSnapshot> partitionToSnapshot : partitionClassSnapshot.getValue()
+            .getSubMap()
+            .entrySet()) {
+          String partitionId = partitionToSnapshot.getKey();
+          StatsSnapshot partitionSnapshot = partitionToSnapshot.getValue();
+          if (basePartitionMap.containsKey(partitionId)) {
+            long deltaInValue = partitionSnapshot.getValue() - basePartitionMap.get(partitionId).getValue();
+            long deltaInTimeMs = snapshotTimestamp - partitionTimestampMap.get(partitionId);
+            if (Math.abs(deltaInTimeMs) < relevantTimePeriodInMs && deltaInValue > 0) {
+              basePartitionMap.put(partitionId, partitionSnapshot);
+              partitionTimestampMap.put(partitionId, snapshotTimestamp);
+              partitionClassVal += deltaInValue;
+              totalValueOfAllClasses += deltaInValue;
+            } else if (deltaInTimeMs > relevantTimePeriodInMs) {
+              basePartitionMap.put(partitionId, partitionSnapshot);
+              partitionTimestampMap.put(partitionId, snapshotTimestamp);
+              partitionClassVal += deltaInValue;
+              totalValueOfAllClasses += deltaInValue;
+            } else {
+              logger.trace("Ignoring snapshot from {} for partition {}", instance, partitionId);
+            }
+          } else {
+            logger.trace("First partition: {} in partitionClass: {}", partitionId, partitionClassId);
+            basePartitionMap.put(partitionId, partitionSnapshot);
+            partitionTimestampMap.put(partitionId, snapshotTimestamp);
+            partitionClassVal += partitionSnapshot.getValue();
+            totalValueOfAllClasses += partitionSnapshot.getValue();
+          }
+        }
+        //update partitionClass snapshot
+        basePartitionClassMap.get(partitionClassId).setSubMap(basePartitionMap);
+        basePartitionClassMap.get(partitionClassId).setValue(partitionClassVal);
+      } else {
+        logger.trace("First entry for partitionClass {} is from {}", partitionClassId, instance);
+        basePartitionClassMap.put(partitionClassId, partitionClassSnapshot.getValue());
+        // put all partitions associated with this partitionClass into partitionTimestampMap on their first occurrence.
+        for (String partitionIdStr : partitionClassSnapshot.getValue().getSubMap().keySet()) {
+          partitionTimestampMap.put(partitionIdStr, snapshotTimestamp);
+        }
+        // add aggregated value in this partition class to totalValue
+        totalValueOfAllClasses += partitionClassSnapshot.getValue().getValue();
+      }
+    }
+    baseSnapshot.setValue(totalValueOfAllClasses);
+    baseSnapshot.setSubMap(basePartitionClassMap);
+  }
+
+  /**
    * Reduce the given {@link StatsSnapshot} whose first level mapped by partitions to a shallower {@link StatsSnapshot}
-   * by adding entries belonging to the same partition together.
+   * by adding entries belonging to the same partition together and aggregating based on account. The level of partition
+   * would be removed after reduce work completes.
    * @param statsSnapshot the {@link StatsSnapshot} to be reduced
    * @return the reduced {@link StatsSnapshot}
    */
-  private StatsSnapshot reduce(StatsSnapshot statsSnapshot) {
+  private StatsSnapshot reduceByAccount(StatsSnapshot statsSnapshot) {
     StatsSnapshot reducedSnapshot = new StatsSnapshot(0L, null);
     if (statsSnapshot.getSubMap() != null) {
       for (StatsSnapshot snapshot : statsSnapshot.getSubMap().values()) {
@@ -180,9 +357,69 @@ public class HelixClusterAggregator {
   }
 
   /**
+   * Reduce the given {@link StatsSnapshot} whose first level mapped by PartitionClass to a shallower {@link StatsSnapshot}.
+   * by adding entries belonging to each partition together and aggregating based on partition class. The partition level
+   * would be removed after reduce work completes.
+   * <pre>
+   *             Before Reduce                   |             After Reduce
+   * --------------------------------------------------------------------------------------------
+   * {                                           |        {
+   *   value: 1000,                              |          value:1000
+   *   subMap:{                                  |          subMap:{
+   *     PartitionClass_1: {                     |            PartitionClass_1: {
+   *       value: 1000,                          |              value: 1000,
+   *       subMap: {                             |              subMap: {
+   *         Partition[1]:{                      |                Account[1]_Container[1]:{
+   *           value: 400,                       |                  value: 1000,
+   *           subMap: {                         |                  subMap: null
+   *             Account[1]_Container[1]:{       |                }
+   *               value: 400,                   |              }
+   *               subMap: null                  |            }
+   *             }                               |          }
+   *           }                                 |        }
+   *         },                                  |
+   *         Partition[2]:{                      |
+   *           value: 600,                       |
+   *           subMap: {                         |
+   *             Account[1]_Container[1]:{       |
+   *               value: 600,                   |
+   *               subMap: null                  |
+   *             }                               |
+   *           }                                 |
+   *         }                                   |
+   *       }
+   *     }
+   *   }
+   * }
+   * </pre>
+   * @param statsSnapshot the {@link StatsSnapshot} to be reduced
+   * @return the reduced {@link StatsSnapshot}
+   */
+  static StatsSnapshot reduceByPartitionClass(StatsSnapshot statsSnapshot) {
+    StatsSnapshot returnSnapshot = new StatsSnapshot(statsSnapshot.getValue(), new HashMap<>());
+    Map<String, StatsSnapshot> partitionClassSnapshots = statsSnapshot.getSubMap();
+    if (partitionClassSnapshots != null) {
+      for (Map.Entry<String, StatsSnapshot> partitionClassToSnapshot : partitionClassSnapshots.entrySet()) {
+        StatsSnapshot partitionClassSnapshot = partitionClassToSnapshot.getValue();
+        StatsSnapshot reducedPartitionClassSnapshot = new StatsSnapshot(0L, null);
+        Map<String, StatsSnapshot> partitionToSnapshot = partitionClassSnapshot.getSubMap();
+        if (partitionToSnapshot != null) {
+          for (StatsSnapshot snapshot : partitionToSnapshot.values()) {
+            StatsSnapshot.aggregate(reducedPartitionClassSnapshot, snapshot);
+          }
+          returnSnapshot.getSubMap().put(partitionClassToSnapshot.getKey(), reducedPartitionClassSnapshot);
+        }
+      }
+    }
+    return returnSnapshot;
+  }
+
+  /**
+   * Get exception occurred instances for certain {@link StatsReportType}
+   * @param type the type of stats report to use.
    * @return the list of instances on which exception occurred during cluster wide stats aggregation.
    */
-  List<String> getExceptionOccurredInstances() {
-    return exceptionOccurredInstances;
+  List<String> getExceptionOccurredInstances(StatsReportType type) {
+    return exceptionOccurredInstances.get(type);
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixHealthReportAggregatorTask.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixHealthReportAggregatorTask.java
@@ -14,6 +14,7 @@
 
 package com.github.ambry.clustermap;
 
+import com.github.ambry.server.StatsReportType;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
 import java.util.HashMap;
@@ -46,6 +47,7 @@ class HelixHealthReportAggregatorTask extends UserContentStore implements Task {
   private final HelixClusterAggregator clusterAggregator;
   private final String healthReportName;
   private final String statsFieldName;
+  private final StatsReportType statsReportType;
   private static final Logger logger = LoggerFactory.getLogger(HelixHealthReportAggregatorTask.class);
 
   /**
@@ -55,13 +57,15 @@ class HelixHealthReportAggregatorTask extends UserContentStore implements Task {
    *                               outside of this period will be ignored.
    * @param healthReportName Name of the health report
    * @param statsFieldName Stats field name
+   * @param statsReportType the type of stats report
    */
   HelixHealthReportAggregatorTask(TaskCallbackContext context, long relevantTimePeriodInMs, String healthReportName,
-      String statsFieldName) {
+      String statsFieldName, StatsReportType statsReportType) {
     manager = context.getManager();
     clusterAggregator = new HelixClusterAggregator(relevantTimePeriodInMs);
     this.healthReportName = healthReportName;
     this.statsFieldName = statsFieldName;
+    this.statsReportType = statsReportType;
   }
 
   @Override
@@ -77,13 +81,14 @@ class HelixHealthReportAggregatorTask extends UserContentStore implements Task {
           statsWrappersJSON.put(instanceName, record.getRecord().getSimpleField(statsFieldName));
         }
       }
-      Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON);
+      Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON, statsReportType);
       String resultId = String.format("Aggregated_%s", healthReportName);
       ZNRecord znRecord = new ZNRecord(resultId);
       znRecord.setSimpleField(RAW_VALID_SIZE_FIELD_NAME, results.getFirst());
       znRecord.setSimpleField(VALID_SIZE_FIELD_NAME, results.getSecond());
       znRecord.setSimpleField(TIMESTAMP_FIELD_NAME, String.valueOf(SystemTime.getInstance().milliseconds()));
-      znRecord.setListField(ERROR_OCCURRED_INSTANCES_FIELD_NAME, clusterAggregator.getExceptionOccurredInstances());
+      znRecord.setListField(ERROR_OCCURRED_INSTANCES_FIELD_NAME,
+          clusterAggregator.getExceptionOccurredInstances(statsReportType));
       String path = String.format("/%s", resultId);
       manager.getHelixPropertyStore().set(path, znRecord, AccessOption.PERSISTENT);
       return new TaskResult(TaskResult.Status.COMPLETED, "Aggregation success");

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -218,7 +218,7 @@ class HelixParticipant implements ClusterParticipant {
               @Override
               public Task createNewTask(TaskCallbackContext context) {
                 return new HelixHealthReportAggregatorTask(context, healthReport.getAggregateIntervalInMinutes(),
-                    healthReport.getReportName(), healthReport.getStatsFieldName());
+                    healthReport.getReportName(), healthReport.getStatsFieldName(), healthReport.getStatsReportType());
               }
             });
       }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterAggregatorTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterAggregatorTest.java
@@ -15,13 +15,16 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.server.StatsHeader;
+import com.github.ambry.server.StatsReportType;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.server.StatsWrapper;
 import com.github.ambry.utils.Pair;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -44,37 +47,321 @@ public class HelixClusterAggregatorTest {
   }
 
   /**
-   * Basic tests to verify the cluster wide aggregation.
+   * Basic tests to verify the cluster wide raw data and valid data aggregation. The tests also verify stats aggregation
+   * for all types of stats reports.
    * @throws IOException
    */
   @Test
   public void testDoWorkBasic() throws IOException {
     int nodeCount = 3;
     Random random = new Random();
-    List<StatsSnapshot> storeSnapshots = new ArrayList<>();
-    for (int i = 3; i < 6; i++) {
-      storeSnapshots.add(generateStoreStats(i, 3, random));
-    }
-    StatsWrapper nodeStats = generateNodeStats(storeSnapshots, DEFAULT_TIMESTAMP);
-    String nodeStatsJSON = mapper.writeValueAsString(nodeStats);
-    StatsWrapper emptyNodeStats = generateNodeStats(Collections.emptyList(), DEFAULT_TIMESTAMP);
-    String emptyNodeStatsJSON = mapper.writeValueAsString(emptyNodeStats);
+    // For each type of report, create snapshots for 3 stores with 3 accounts, 4 accounts and 5 accounts respectively.
+    for (StatsReportType type : EnumSet.of(StatsReportType.ACCOUNT_REPORT, StatsReportType.PARTITION_CLASS_REPORT)) {
+      List<StatsSnapshot> storeSnapshots = new ArrayList<>();
+      for (int i = 3; i < 6; i++) {
+        storeSnapshots.add(generateStoreStats(i, 3, random, type));
+      }
+      StatsWrapper nodeStats = generateNodeStats(storeSnapshots, DEFAULT_TIMESTAMP, type);
+      String nodeStatsJSON = mapper.writeValueAsString(nodeStats);
+      StatsWrapper emptyNodeStats = generateNodeStats(Collections.emptyList(), DEFAULT_TIMESTAMP, type);
+      String emptyStatsJSON = mapper.writeValueAsString(emptyNodeStats);
 
-    Map<String, String> statsWrappersJSON = new HashMap<>();
-    for (int i = 0; i < nodeCount; i++) {
-      statsWrappersJSON.put("Store_" + i, (nodeStatsJSON));
+      Map<String, String> instanceToStatsMap = new HashMap<>();
+      // Each instance has exactly same nodeStatsJSON, the purpose is to ensure raw_data_size field and valid_data_size field
+      // have different expected aggregated report.
+      // For raw_data_size field, it simply sums up value from replicas of partition on all nodes even if they are exactly same;
+      // For valid_data_size field, it filters out the replica(s) of certain partition within valid time range and
+      // selects the replica with highest value.
+      for (int i = 0; i < nodeCount; i++) {
+        instanceToStatsMap.put("Instance_" + i, nodeStatsJSON);
+      }
+      // Add two special cases into instance-to-stats map for testing:
+      // (1) empty stats report from certain instance
+      // (2) corrupted/invalid stats report from certain instance (this is simulated by empty string)
+      instanceToStatsMap.put("Instance_" + nodeCount, emptyStatsJSON);
+      instanceToStatsMap.put(EXCEPTION_INSTANCE_NAME, "");
+
+      // 1. Aggregate all snapshots into the first snapshot in snapshots list. The intention is to get expected aggregated snapshot.
+      // 2. Then invoke clusterAggregator to do work on stats across all instances.
+      // 3. Verify both raw stats and valid stats after aggregation
+      Pair<String, String> aggregatedRawAndValidStats = null;
+      aggregatedRawAndValidStats = clusterAggregator.doWork(instanceToStatsMap, type);
+
+      StatsSnapshot expectedSnapshot = null;
+      switch (type) {
+        case ACCOUNT_REPORT:
+          // Since all nodes have exactly same statsSnapshot, aggregated snapshot of storeSnapshots list on single node is what
+          // we expect for valid data aggregation.
+          for (int i = 1; i < storeSnapshots.size(); i++) {
+            StatsSnapshot.aggregate(storeSnapshots.get(0), storeSnapshots.get(i));
+          }
+          expectedSnapshot = storeSnapshots.get(0);
+          break;
+        case PARTITION_CLASS_REPORT:
+          // Invoke reduceByPartitionClass to remove partition level and only keep the partition class and account_container entries
+          expectedSnapshot = HelixClusterAggregator.reduceByPartitionClass(nodeStats.getSnapshot());
+          break;
+      }
+
+      // Verify cluster wide raw stats aggregation
+      StatsSnapshot rawSnapshot = mapper.readValue(aggregatedRawAndValidStats.getFirst(), StatsSnapshot.class);
+      assertEquals("Mismatch in total value of " + type, nodeCount * expectedSnapshot.getValue(),
+          rawSnapshot.getValue());
+      if (type == StatsReportType.ACCOUNT_REPORT) {
+        verifyAggregatedRawStatsForAccountReport(rawSnapshot, expectedSnapshot, nodeCount);
+      } else if (type == StatsReportType.PARTITION_CLASS_REPORT) {
+        verifyAggregatedRawStatsForPartitionClassReport(rawSnapshot, expectedSnapshot, nodeCount);
+      }
+
+      // Verify cluster wide stats aggregation
+      StatsSnapshot actualSnapshot = mapper.readValue(aggregatedRawAndValidStats.getSecond(), StatsSnapshot.class);
+      assertTrue("Mismatch in the aggregated snapshot", expectedSnapshot.equals(actualSnapshot));
+      // Verify aggregator keeps track of instances where exception occurred.
+      assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
+          clusterAggregator.getExceptionOccurredInstances(type));
     }
-    statsWrappersJSON.put("Store_" + nodeCount, emptyNodeStatsJSON);
-    statsWrappersJSON.put(EXCEPTION_INSTANCE_NAME, "");
-    for (int i = 1; i < storeSnapshots.size(); i++) {
-      StatsSnapshot.aggregate(storeSnapshots.get(0), storeSnapshots.get(i));
+  }
+
+  /**
+   * Test stats aggregation with different number of stores on different nodes.
+   * Only used for partitionClass aggregation testing.
+   * @throws IOException
+   */
+  @Test
+  public void testDoWorkWithDiffNumberOfStores() throws IOException {
+    List<StatsSnapshot> storeSnapshots1 = new ArrayList<>();
+    List<StatsSnapshot> storeSnapshots2 = new ArrayList<>();
+    List<StatsSnapshot> storeSnapshots2Copy = new ArrayList<>();
+    int seed = 1111;
+    // storeSnapshots1 only has 2 store stats. storeSnapshots2 and storeSnapshots2Copy have 3 store stats each.
+    for (int i = 3; i < 6; i++) {
+      if (i < 5) {
+        storeSnapshots1.add(generateStoreStats(i, 3, new Random(seed), StatsReportType.PARTITION_CLASS_REPORT));
+      }
+      storeSnapshots2.add(generateStoreStats(i, 3, new Random(seed), StatsReportType.PARTITION_CLASS_REPORT));
+      storeSnapshots2Copy.add(generateStoreStats(i, 3, new Random(seed), StatsReportType.PARTITION_CLASS_REPORT));
     }
-    Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON);
-    StatsSnapshot expectedSnapshot = storeSnapshots.get(0);
-    // verify cluster wide raw aggregation
-    StatsSnapshot rawSnapshot = mapper.readValue(results.getFirst(), StatsSnapshot.class);
-    assertEquals("Mismatch in total value of all accounts", nodeCount * expectedSnapshot.getValue(),
-        rawSnapshot.getValue());
+    StatsWrapper nodeStatsWrapper1 =
+        generateNodeStats(storeSnapshots1, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
+    StatsWrapper nodeStatsWrapper2 =
+        generateNodeStats(storeSnapshots2, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
+    StatsWrapper nodeStatsWrapper2Copy =
+        generateNodeStats(storeSnapshots2Copy, DEFAULT_TIMESTAMP, StatsReportType.PARTITION_CLASS_REPORT);
+    Map<String, String> instanceStatsMap = new LinkedHashMap<>();
+    instanceStatsMap.put("Instance_1", mapper.writeValueAsString(nodeStatsWrapper1));
+    instanceStatsMap.put("Instance_2", mapper.writeValueAsString(nodeStatsWrapper2));
+
+    Pair<String, String> aggregatedRawAndValidStats =
+        clusterAggregator.doWork(instanceStatsMap, StatsReportType.PARTITION_CLASS_REPORT);
+
+    // verify aggregation on raw data
+    StatsSnapshot expectedRawSnapshot = new StatsSnapshot(0L, null);
+    StatsSnapshot.aggregate(expectedRawSnapshot, nodeStatsWrapper1.getSnapshot());
+    StatsSnapshot.aggregate(expectedRawSnapshot, nodeStatsWrapper2Copy.getSnapshot());
+    expectedRawSnapshot = HelixClusterAggregator.reduceByPartitionClass(expectedRawSnapshot);
+    StatsSnapshot rawSnapshot = mapper.readValue(aggregatedRawAndValidStats.getFirst(), StatsSnapshot.class);
+    assertTrue("Mismatch in the raw data aggregated snapshot", expectedRawSnapshot.equals(rawSnapshot));
+
+    // verify aggregation on valid data
+    StatsSnapshot expectedValidsnapshot =
+        HelixClusterAggregator.reduceByPartitionClass(nodeStatsWrapper2.getSnapshot());
+    StatsSnapshot validSnapshot = mapper.readValue(aggregatedRawAndValidStats.getSecond(), StatsSnapshot.class);
+    assertTrue("Mismatch in the valid data aggregated snapshot", expectedValidsnapshot.equals(validSnapshot));
+  }
+
+  /**
+   * Tests to verify cluster wide aggregation with outdated node stats.
+   * @throws IOException
+   */
+  @Test
+  public void testDoWorkWithOutdatedNode() throws IOException {
+    long seed = 1111;
+    for (StatsReportType type : EnumSet.of(StatsReportType.ACCOUNT_REPORT, StatsReportType.PARTITION_CLASS_REPORT)) {
+      List<StatsSnapshot> upToDateStoreSnapshots = new ArrayList<>();
+      List<StatsSnapshot> outdatedStoreSnapshots = new ArrayList<>();
+      upToDateStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed), type));
+      outdatedStoreSnapshots.add(generateStoreStats(6, 3, new Random(seed), type));
+      StatsWrapper upToDateNodeStats =
+          generateNodeStats(upToDateStoreSnapshots, TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES), type);
+      StatsWrapper outdatedNodeStats = generateNodeStats(outdatedStoreSnapshots, 0, type);
+      StatsWrapper emptyNodeStats =
+          generateNodeStats(Collections.emptyList(), TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES), type);
+      Map<String, String> instanceToStatsMap = new LinkedHashMap<>();
+      instanceToStatsMap.put("Instance_0", mapper.writeValueAsString(outdatedNodeStats));
+      instanceToStatsMap.put("Instance_1", mapper.writeValueAsString(upToDateNodeStats));
+      instanceToStatsMap.put("Instance_2", mapper.writeValueAsString(emptyNodeStats));
+      instanceToStatsMap.put(EXCEPTION_INSTANCE_NAME, "");
+      Pair<String, String> aggregatedRawAndValidStats = clusterAggregator.doWork(instanceToStatsMap, type);
+      StatsSnapshot expectedValidSnapshot = null;
+      StatsSnapshot expectedRawSnapshot = new StatsSnapshot(0L, new HashMap<>());
+      switch (type) {
+        case ACCOUNT_REPORT:
+          expectedValidSnapshot = upToDateStoreSnapshots.get(0);
+          StatsSnapshot.aggregate(expectedRawSnapshot, outdatedStoreSnapshots.get(0));
+          StatsSnapshot.aggregate(expectedRawSnapshot, upToDateStoreSnapshots.get(0));
+          break;
+        case PARTITION_CLASS_REPORT:
+          expectedValidSnapshot = HelixClusterAggregator.reduceByPartitionClass(upToDateNodeStats.getSnapshot());
+          StatsSnapshot.aggregate(expectedRawSnapshot, outdatedNodeStats.getSnapshot());
+          StatsSnapshot.aggregate(expectedRawSnapshot, upToDateNodeStats.getSnapshot());
+          expectedRawSnapshot = HelixClusterAggregator.reduceByPartitionClass(expectedRawSnapshot);
+          break;
+      }
+
+      // verify cluster wide aggregation on raw stats with outdated node stats
+      StatsSnapshot rawSnapshot = mapper.readValue(aggregatedRawAndValidStats.getFirst(), StatsSnapshot.class);
+      assertTrue("Mismatch in the aggregated raw snapshot", expectedRawSnapshot.equals(rawSnapshot));
+
+      // verify cluster wide aggregation on valid stats with outdated node stats
+      StatsSnapshot actualSnapshot = mapper.readValue(aggregatedRawAndValidStats.getSecond(), StatsSnapshot.class);
+      assertTrue("Mismatch in the aggregated valid snapshot", expectedValidSnapshot.equals(actualSnapshot));
+
+      // verify aggregator keeps track of instances where exception occurred.
+      assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
+          clusterAggregator.getExceptionOccurredInstances(type));
+    }
+  }
+
+  /**
+   * Tests to verify cluster aggregation with node stats that contain different partition stats.
+   * @throws IOException
+   */
+  @Test
+  public void testDoWorkWithDiffNodeStats() throws IOException {
+    long seed = 1234;
+    for (StatsReportType type : EnumSet.of(StatsReportType.ACCOUNT_REPORT, StatsReportType.PARTITION_CLASS_REPORT)) {
+      List<StatsSnapshot> greaterStoreSnapshots = new ArrayList<>();
+      List<StatsSnapshot> smallerStoreSnapshots = new ArrayList<>();
+      List<StatsSnapshot> mediumStoreSnapshots = new ArrayList<>();
+      greaterStoreSnapshots.add(generateStoreStats(6, 3, new Random(seed), type));
+      mediumStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed), type));
+      smallerStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed), type));
+      StatsWrapper greaterNodeStats = generateNodeStats(greaterStoreSnapshots, DEFAULT_TIMESTAMP, type);
+      StatsWrapper mediumNodeStats = generateNodeStats(mediumStoreSnapshots, DEFAULT_TIMESTAMP, type);
+      StatsWrapper smallerNodeStats = generateNodeStats(smallerStoreSnapshots, DEFAULT_TIMESTAMP, type);
+      StatsWrapper emptyNodeStats = generateNodeStats(Collections.emptyList(), DEFAULT_TIMESTAMP, type);
+      Map<String, String> instanceToStatsMap = new LinkedHashMap<>();
+      instanceToStatsMap.put("Instance_0", mapper.writeValueAsString(smallerNodeStats));
+      instanceToStatsMap.put("Instance_1", mapper.writeValueAsString(greaterNodeStats));
+      instanceToStatsMap.put("Instance_2", mapper.writeValueAsString(mediumNodeStats));
+      instanceToStatsMap.put("Instance_3", mapper.writeValueAsString(emptyNodeStats));
+      instanceToStatsMap.put(EXCEPTION_INSTANCE_NAME, "");
+      Pair<String, String> aggregatedRawAndValidStats = clusterAggregator.doWork(instanceToStatsMap, type);
+
+      StatsSnapshot expectedRawSnapshot = new StatsSnapshot(0L, new HashMap<>());
+      StatsSnapshot expectedValidSnapshot = null;
+      switch (type) {
+        case ACCOUNT_REPORT:
+          StatsSnapshot.aggregate(expectedRawSnapshot, smallerStoreSnapshots.get(0));
+          StatsSnapshot.aggregate(expectedRawSnapshot, mediumStoreSnapshots.get(0));
+          StatsSnapshot.aggregate(expectedRawSnapshot, greaterStoreSnapshots.get(0));
+          expectedValidSnapshot = greaterStoreSnapshots.get(0);
+          break;
+        case PARTITION_CLASS_REPORT:
+          expectedValidSnapshot = HelixClusterAggregator.reduceByPartitionClass(greaterNodeStats.getSnapshot());
+          StatsSnapshot.aggregate(expectedRawSnapshot, mediumNodeStats.getSnapshot());
+          StatsSnapshot.aggregate(expectedRawSnapshot, smallerNodeStats.getSnapshot());
+          StatsSnapshot.aggregate(expectedRawSnapshot, greaterNodeStats.getSnapshot());
+          expectedRawSnapshot = HelixClusterAggregator.reduceByPartitionClass(expectedRawSnapshot);
+          break;
+      }
+
+      // verify cluster wide aggregation on raw data with different node stats
+      StatsSnapshot rawSnapshot = mapper.readValue(aggregatedRawAndValidStats.getFirst(), StatsSnapshot.class);
+      assertTrue("Mismatch in the raw aggregated snapshot for " + type, expectedRawSnapshot.equals(rawSnapshot));
+
+      // verify cluster wide aggregation on valid data with different node stats
+      StatsSnapshot actualSnapshot = mapper.readValue(aggregatedRawAndValidStats.getSecond(), StatsSnapshot.class);
+      assertTrue("Mismatch in the valid aggregated snapshot for " + type, expectedValidSnapshot.equals(actualSnapshot));
+
+      // verify aggregator keeps track of instances where exception occurred.
+      assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
+          clusterAggregator.getExceptionOccurredInstances(type));
+    }
+  }
+
+  /**
+   * Given a {@link List} of {@link StatsSnapshot}s and a timestamp generate a {@link StatsWrapper} that would have been
+   * produced by a node.
+   * @param storeSnapshots a {@link List} of store level {@link StatsSnapshot}s.
+   * @param timestamp the timestamp to be attached to the generated {@link StatsWrapper}
+   * @param type the type of stats report to generate on this node
+   * @return the generated node level {@link StatsWrapper}
+   */
+  private StatsWrapper generateNodeStats(List<StatsSnapshot> storeSnapshots, long timestamp, StatsReportType type) {
+    long total = 0;
+    int numbOfPartitions = storeSnapshots.size();
+    Map<String, StatsSnapshot> partitionMap = new HashMap<>();
+    Map<String, StatsSnapshot> partitionClassMap = new HashMap<>();
+    String[] PARTITION_CLASS = new String[]{"PartitionClass1", "PartitionClass2"};
+    for (int i = 0; i < numbOfPartitions; i++) {
+      String partitionIdStr = "Partition[" + i + "]";
+      StatsSnapshot partitionSnapshot = storeSnapshots.get(i);
+      partitionMap.put(partitionIdStr, partitionSnapshot);
+      total += partitionSnapshot.getValue();
+      if (type == StatsReportType.PARTITION_CLASS_REPORT) {
+        String partitionClassStr = PARTITION_CLASS[i % PARTITION_CLASS.length];
+        StatsSnapshot partitionClassSnapshot =
+            partitionClassMap.getOrDefault(partitionClassStr, new StatsSnapshot(0L, new HashMap<>()));
+        partitionClassSnapshot.setValue(partitionClassSnapshot.getValue() + partitionSnapshot.getValue());
+        partitionClassSnapshot.getSubMap().put(partitionIdStr, partitionSnapshot);
+        partitionClassMap.put(partitionClassStr, partitionClassSnapshot);
+      }
+    }
+    StatsSnapshot nodeSnapshot = null;
+    if (type == StatsReportType.ACCOUNT_REPORT) {
+      nodeSnapshot = new StatsSnapshot(total, partitionMap);
+    } else if (type == StatsReportType.PARTITION_CLASS_REPORT) {
+      nodeSnapshot = new StatsSnapshot(total, partitionClassMap);
+    }
+    StatsHeader header =
+        new StatsHeader(StatsHeader.StatsDescription.QUOTA, timestamp, numbOfPartitions, numbOfPartitions,
+            Collections.emptyList());
+    return new StatsWrapper(header, nodeSnapshot);
+  }
+
+  /**
+   * Generate certain type of {@link StatsSnapshot} based on the given parameters that would have been produced by a
+   * {@link com.github.ambry.store.Store}.
+   * @param accountCount number of account entry in the {@link StatsSnapshot}
+   * @param containerCount number of container entry in the {@link StatsSnapshot}
+   * @param random the random generator to be used
+   * @param type the type of stats report to be generated for the store
+   * @return the generated store level {@link StatsSnapshot}
+   */
+  private StatsSnapshot generateStoreStats(int accountCount, int containerCount, Random random, StatsReportType type) {
+    Map<String, StatsSnapshot> subMap = new HashMap<>();
+    long totalSize = 0;
+    for (int i = 0; i < accountCount; i++) {
+      String accountIdStr = "Account[" + i + "]";
+      Map<String, StatsSnapshot> containerMap = new HashMap<>();
+      long subTotalSize = 0;
+      for (int j = 0; j < containerCount; j++) {
+        String containerIdStr = "Container[" + j + "]";
+        long validSize = random.nextInt(2501) + 500;
+        subTotalSize += validSize;
+        if (type == StatsReportType.ACCOUNT_REPORT) {
+          containerMap.put(containerIdStr, new StatsSnapshot(validSize, null));
+        } else if (type == StatsReportType.PARTITION_CLASS_REPORT) {
+          subMap.put(accountIdStr + "_" + containerIdStr, new StatsSnapshot(validSize, null));
+        }
+      }
+      totalSize += subTotalSize;
+      if (type == StatsReportType.ACCOUNT_REPORT) {
+        subMap.put(accountIdStr, new StatsSnapshot(subTotalSize, containerMap));
+      }
+    }
+    return new StatsSnapshot(totalSize, subMap);
+  }
+
+  /**
+   * Help verify the aggregated raw stats match expected stats snapshot for {@link StatsReportType#ACCOUNT_REPORT}
+   * @param rawSnapshot the raw stats snapshot after aggregation
+   * @param expectedSnapshot the expected stats snapshot
+   * @param nodeCount total number of instances involved in stats aggregation
+   */
+  private void verifyAggregatedRawStatsForAccountReport(StatsSnapshot rawSnapshot, StatsSnapshot expectedSnapshot,
+      int nodeCount) {
     Map<String, StatsSnapshot> rawAccountMap = rawSnapshot.getSubMap();
     assertEquals("Mismatch in number of accounts", expectedSnapshot.getSubMap().size(), rawAccountMap.size());
     for (Map.Entry<String, StatsSnapshot> accountEntry : expectedSnapshot.getSubMap().entrySet()) {
@@ -92,127 +379,33 @@ public class HelixClusterAggregatorTest {
             rawContainerMap.get(containerEntry.getKey()).getValue());
       }
     }
-    // verify cluster wide aggregation
-    StatsSnapshot actualSnapshot = mapper.readValue(results.getSecond(), StatsSnapshot.class);
-    assertTrue("Mismatch in the aggregated snapshot", expectedSnapshot.equals(actualSnapshot));
-    // verify aggregator keeps track of instances where exception occurred.
-    assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
-        clusterAggregator.getExceptionOccurredInstances());
   }
 
   /**
-   * Tests to verify cluster wide aggregation with outdated node stats.
-   * @throws IOException
+   * Help verify the aggregated raw stats match expected stats snapshot for {@link StatsReportType#PARTITION_CLASS_REPORT}
+   * @param rawSnapshot the raw stats snapshot after aggregation
+   * @param expectedSnapshot the expected stats snapshot
+   * @param nodeCount total number of instances involved in stats aggregation
    */
-  @Test
-  public void testDoWorkWithOutdatedNode() throws IOException {
-    long seed = 1111;
-    List<StatsSnapshot> upToDateStoreSnapshots = new ArrayList<>();
-    List<StatsSnapshot> outdatedStoreSnapshots = new ArrayList<>();
-    upToDateStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed)));
-    outdatedStoreSnapshots.add(generateStoreStats(6, 3, new Random(seed)));
-    StatsWrapper upToDateNodeStats =
-        generateNodeStats(upToDateStoreSnapshots, TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES));
-    StatsWrapper outdatedNodeStats = generateNodeStats(outdatedStoreSnapshots, 0);
-    StatsWrapper emptyNodeStats =
-        generateNodeStats(Collections.EMPTY_LIST, TimeUnit.MINUTES.toMillis(2 * RELEVANT_PERIOD_IN_MINUTES));
-    Map<String, String> statsWrappersJSON = new HashMap<>();
-    statsWrappersJSON.put("Store_0", mapper.writeValueAsString(outdatedNodeStats));
-    statsWrappersJSON.put("Store_1", mapper.writeValueAsString(upToDateNodeStats));
-    statsWrappersJSON.put("Store_2", mapper.writeValueAsString(emptyNodeStats));
-    statsWrappersJSON.put(EXCEPTION_INSTANCE_NAME, "");
-    Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON);
-    StatsSnapshot expectedSnapshot = upToDateStoreSnapshots.get(0);
-    // verify cluster wide aggregation with outdated node stats
-    StatsSnapshot actualSnapshot = mapper.readValue(results.getSecond(), StatsSnapshot.class);
-    assertTrue("Mismatch in the aggregated snapshot", expectedSnapshot.equals(actualSnapshot));
-    // verify cluster wide raw aggregation with outdated node stats
-    StatsSnapshot.aggregate(expectedSnapshot, outdatedStoreSnapshots.get(0));
-    StatsSnapshot rawSnapshot = mapper.readValue(results.getFirst(), StatsSnapshot.class);
-    assertTrue("Mismatch in the raw aggregated snapshot", expectedSnapshot.equals(rawSnapshot));
-    // verify aggregator keeps track of instances where exception occurred.
-    assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
-        clusterAggregator.getExceptionOccurredInstances());
-  }
-
-  /**
-   * Tests to verify cluster aggregation with node stats that contain different partition stats.
-   * @throws IOException
-   */
-  @Test
-  public void testDoWorkWithDiffNodeStats() throws IOException {
-    long seed = 1234;
-    List<StatsSnapshot> greaterStoreSnapshots = new ArrayList<>();
-    List<StatsSnapshot> smallerStoreSnapshots = new ArrayList<>();
-    greaterStoreSnapshots.add(generateStoreStats(6, 3, new Random(seed)));
-    smallerStoreSnapshots.add(generateStoreStats(5, 3, new Random(seed)));
-    StatsWrapper greaterNodeStats = generateNodeStats(greaterStoreSnapshots, DEFAULT_TIMESTAMP);
-    StatsWrapper smallerNodeStats = generateNodeStats(smallerStoreSnapshots, DEFAULT_TIMESTAMP);
-    StatsWrapper emptyNodeStats = generateNodeStats(Collections.EMPTY_LIST, DEFAULT_TIMESTAMP);
-    Map<String, String> statsWrappersJSON = new HashMap<>();
-    statsWrappersJSON.put("Store_0", mapper.writeValueAsString(smallerNodeStats));
-    statsWrappersJSON.put("Store_1", mapper.writeValueAsString(greaterNodeStats));
-    statsWrappersJSON.put("Store_2", mapper.writeValueAsString(emptyNodeStats));
-    statsWrappersJSON.put(EXCEPTION_INSTANCE_NAME, "");
-    Pair<String, String> results = clusterAggregator.doWork(statsWrappersJSON);
-    StatsSnapshot expectedSnapshot = greaterStoreSnapshots.get(0);
-    // verify cluster wide aggregation with different node stats
-    StatsSnapshot actualSnapshot = mapper.readValue(results.getSecond(), StatsSnapshot.class);
-    assertTrue("Mismatch in the aggregated snapshot", expectedSnapshot.equals(actualSnapshot));
-    // verify cluster wide raw aggregation with different node stats
-    StatsSnapshot.aggregate(expectedSnapshot, smallerStoreSnapshots.get(0));
-    StatsSnapshot rawSnapshot = mapper.readValue(results.getFirst(), StatsSnapshot.class);
-    assertTrue("Mismatch in the raw aggregated snapshot", expectedSnapshot.equals(rawSnapshot));
-    // verify aggregator keeps track of instances where exception occurred.
-    assertEquals("Mismatch in instances where exception occurred", Collections.singletonList(EXCEPTION_INSTANCE_NAME),
-        clusterAggregator.getExceptionOccurredInstances());
-  }
-
-  /**
-   * Given a {@link List} of {@link StatsSnapshot}s and a timestamp generate a {@link StatsWrapper} that would have been
-   * produced by a node.
-   * @param storeSnapshots a {@link List} of store level {@link StatsSnapshot}s.
-   * @param timestamp the timestamp to be attached to the generated {@link StatsWrapper}
-   * @return the generated node level {@link StatsWrapper}
-   */
-  private StatsWrapper generateNodeStats(List<StatsSnapshot> storeSnapshots, long timestamp) {
-    Map<String, StatsSnapshot> partitionMap = new HashMap<>();
-    long total = 0;
-    int numbOfPartitions = storeSnapshots.size();
-    for (int i = 0; i < numbOfPartitions; i++) {
-      StatsSnapshot partitionSnapshot = storeSnapshots.get(i);
-      partitionMap.put(String.format("partition_%d", i), partitionSnapshot);
-      total += partitionSnapshot.getValue();
-    }
-    StatsSnapshot nodeSnapshot = new StatsSnapshot(total, partitionMap);
-    StatsHeader header =
-        new StatsHeader(StatsHeader.StatsDescription.QUOTA, timestamp, numbOfPartitions, numbOfPartitions,
-            Collections.EMPTY_LIST);
-    return new StatsWrapper(header, nodeSnapshot);
-  }
-
-  /**
-   * Generate a quota {@link StatsSnapshot} based on the given parameters that would have been produced by a
-   * {@link com.github.ambry.store.Store}.
-   * @param accountCount number of account entry in the {@link StatsSnapshot}
-   * @param containerCount number of container entry in the {@link StatsSnapshot}
-   * @param random the random generator to be used
-   * @return the generated store level {@link StatsSnapshot}
-   */
-  private StatsSnapshot generateStoreStats(int accountCount, int containerCount, Random random) {
-    Map<String, StatsSnapshot> accountMap = new HashMap<>();
-    long totalSize = 0;
-    for (int i = 0; i < accountCount; i++) {
-      Map<String, StatsSnapshot> containerMap = new HashMap<>();
-      long subTotalSize = 0;
-      for (int j = 0; j < containerCount; j++) {
-        long validSize = random.nextInt(2501) + 500;
-        subTotalSize += validSize;
-        containerMap.put(String.format("containerId_%d", j), new StatsSnapshot(validSize, null));
+  private void verifyAggregatedRawStatsForPartitionClassReport(StatsSnapshot rawSnapshot,
+      StatsSnapshot expectedSnapshot, int nodeCount) {
+    assertEquals("Mismatch in number of partition classes", expectedSnapshot.getSubMap().size(),
+        rawSnapshot.getSubMap().size());
+    Map<String, StatsSnapshot> rawPartitionClassMap = rawSnapshot.getSubMap();
+    Map<String, StatsSnapshot> expectedSnapshotOnOneNode = expectedSnapshot.getSubMap();
+    for (Map.Entry<String, StatsSnapshot> partitionClassEntry : rawPartitionClassMap.entrySet()) {
+      String partitionClassId = partitionClassEntry.getKey();
+      assertEquals("Mismatch in value of partition class: " + partitionClassId,
+          nodeCount * expectedSnapshotOnOneNode.get(partitionClassId).getValue(),
+          partitionClassEntry.getValue().getValue());
+      Map<String, StatsSnapshot> nodeContainerMap = expectedSnapshotOnOneNode.get(partitionClassId).getSubMap();
+      assertEquals("Mismatch in number of containers in partition class: " + partitionClassId, nodeContainerMap.size(),
+          partitionClassEntry.getValue().getSubMap().size());
+      for (Map.Entry<String, StatsSnapshot> containerEntry : partitionClassEntry.getValue().getSubMap().entrySet()) {
+        String containerIdStr = containerEntry.getKey();
+        assertEquals("Mismatch in value of container: " + containerIdStr,
+            nodeCount * nodeContainerMap.get(containerIdStr).getValue(), containerEntry.getValue().getValue());
       }
-      totalSize += subTotalSize;
-      accountMap.put(String.format("accountId_%d", i), new StatsSnapshot(subTotalSize, containerMap));
     }
-    return new StatsSnapshot(totalSize, accountMap);
   }
 }

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryStatsReport.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryStatsReport.java
@@ -66,6 +66,11 @@ class AmbryStatsReport extends HealthReportProvider implements AmbryHealthReport
   }
 
   @Override
+  public StatsReportType getStatsReportType() {
+    return statsReportType;
+  }
+
+  @Override
   public long getAggregateIntervalInMinutes() {
     return aggregatePeriodInMinutes;
   }


### PR DESCRIPTION
1. Added methods in HelixClusterAggregator to aggregate partition class
reports.
2. Added one more test to verify aggregation with different number of
partitions on different nodes.


This PR is the 3rd part of #952 . When it is merged, we can close #952 .