### PR TITLE
Support to pass externalAssetTag from HTTP header to NotificationSystem.

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -143,6 +143,9 @@ public class BlobProperties {
     return isEncrypted;
   }
 
+  /**
+   * @return the ExternalAssetTag of a uploaded blob. Can be null.
+   */
   public String getExternalAssetTag() {
     return externalAssetTag;
   }

--- a/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/messageformat/BlobProperties.java
@@ -32,6 +32,8 @@ public class BlobProperties {
   private final boolean isEncrypted;
   private long blobSize;
   private long timeToLiveInSeconds;
+  // Non persistent blob properties.
+  private final String externalAssetTag;
 
   /**
    * @param blobSize The size of the blob in bytes
@@ -42,7 +44,7 @@ public class BlobProperties {
    */
   public BlobProperties(long blobSize, String serviceId, short accountId, short containerId, boolean isEncrypted) {
     this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, SystemTime.getInstance().milliseconds(),
-        accountId, containerId, isEncrypted);
+        accountId, containerId, isEncrypted, null);
   }
 
   /**
@@ -55,11 +57,12 @@ public class BlobProperties {
    * @param accountId accountId of the user who owns the blob
    * @param containerId containerId of the blob
    * @param isEncrypted whether this blob is encrypted.
+   * @param externalAssetTag externalAssetTag for this blob. This is a non-persistent field.
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
-      long timeToLiveInSeconds, short accountId, short containerId, boolean isEncrypted) {
+      long timeToLiveInSeconds, short accountId, short containerId, boolean isEncrypted, String externalAssetTag) {
     this(blobSize, serviceId, ownerId, contentType, isPrivate, timeToLiveInSeconds,
-        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted);
+        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag);
   }
 
   /**
@@ -73,9 +76,11 @@ public class BlobProperties {
    * @param accountId accountId of the user who owns the blob
    * @param containerId containerId of the blob
    * @param isEncrypted whether this blob is encrypted.
+   * @param externalAssetTag externalAssetTag for this blob. This is a non-persistent field.
    */
   public BlobProperties(long blobSize, String serviceId, String ownerId, String contentType, boolean isPrivate,
-      long timeToLiveInSeconds, long creationTimeInMs, short accountId, short containerId, boolean isEncrypted) {
+      long timeToLiveInSeconds, long creationTimeInMs, short accountId, short containerId, boolean isEncrypted,
+      String externalAssetTag) {
     this.blobSize = blobSize;
     this.serviceId = serviceId;
     this.ownerId = ownerId;
@@ -86,6 +91,7 @@ public class BlobProperties {
     this.accountId = accountId;
     this.containerId = containerId;
     this.isEncrypted = isEncrypted;
+    this.externalAssetTag = externalAssetTag;
   }
 
   public long getTimeToLiveInSeconds() {
@@ -137,6 +143,10 @@ public class BlobProperties {
     return isEncrypted;
   }
 
+  public String getExternalAssetTag() {
+    return externalAssetTag;
+  }
+
   /**
    * @param timeToLiveInSeconds the new value of timeToLiveInSeconds
    */
@@ -181,6 +191,7 @@ public class BlobProperties {
     sb.append(", ").append("AccountId=").append(getAccountId());
     sb.append(", ").append("ContainerId=").append(getContainerId());
     sb.append(", ").append("IsEncrypted=").append(isEncrypted());
+    sb.append(", ").append("externalAssetTag=").append(getExternalAssetTag());
     sb.append("]");
     return sb.toString();
   }

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -178,6 +178,10 @@ public class RestUtils {
      */
     public static final String MAX_UPLOAD_SIZE = "x-ambry-max-upload-size";
     /**
+     * An externalAssetTag for this blob.
+     */
+    public static final String EXTERNAL_ASSET_TAG = "x-ambry-external-asset-tag";
+    /**
      * The blob ID requested by the URL.
      */
     public static final String BLOB_ID = "x-ambry-blob-id";
@@ -328,6 +332,7 @@ public class RestUtils {
     String serviceId = getHeader(args, Headers.SERVICE_ID, true);
     String contentType = getHeader(args, Headers.AMBRY_CONTENT_TYPE, true);
     String ownerId = getHeader(args, Headers.OWNER_ID, false);
+    String externalAssetTag = getHeader(args, Headers.EXTERNAL_ASSET_TAG, false);
 
     long ttl = Utils.Infinite_Time;
     Long ttlFromHeader = getLongHeader(args, Headers.TTL, false);
@@ -343,7 +348,7 @@ public class RestUtils {
     // based on the container properties and ACLs. For now, BlobProperties still includes this field, though.
     boolean isPrivate = !container.isCacheable();
     return new BlobProperties(-1, serviceId, ownerId, contentType, isPrivate, ttl, account.getId(), container.getId(),
-        container.isEncrypted());
+        container.isEncrypted(), externalAssetTag);
   }
 
   /**

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
@@ -42,7 +42,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -2061,7 +2061,7 @@ public class AmbryBlobStorageServiceTest {
       Account expectedAccount, Container expectedContainer) throws Exception {
     BlobProperties blobProperties =
         new BlobProperties(0, serviceId, "owner", "image/gif", isPrivate, Utils.Infinite_Time,
-            Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false);
+            Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false, null);
     ReadableStreamChannel content = new ByteBufferReadableStreamChannel(ByteBuffer.allocate(0));
     String blobId = router.putBlobWithIdVersion(blobProperties, new byte[0], content, BlobId.BLOB_ID_V1).get();
     verifyAccountAndContainerFromBlobId(blobId, expectedAccount, expectedContainer, null);

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -82,10 +82,10 @@ public class AmbrySecurityServiceTest {
   private static final BlobInfo DEFAULT_INFO;
   private static final BlobInfo UNKNOWN_INFO = new BlobInfo(
       new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, Utils.Infinite_Time, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
+          Container.UNKNOWN_CONTAINER_ID, false, null), new byte[0]);
   private static final BlobInfo UNKNOWN_INFO_ENC = new BlobInfo(
       new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, Utils.Infinite_Time, Account.UNKNOWN_ACCOUNT_ID,
-          Container.UNKNOWN_CONTAINER_ID, true), new byte[0]);
+          Container.UNKNOWN_CONTAINER_ID, true, null), new byte[0]);
   private static final FrontendTestUrlSigningServiceFactory URL_SIGNING_SERVICE_FACTORY =
       new FrontendTestUrlSigningServiceFactory();
 
@@ -106,7 +106,7 @@ public class AmbrySecurityServiceTest {
           UtilsTest.getRandomString(11));
       DEFAULT_INFO = new BlobInfo(
           new BlobProperties(Utils.getRandomLong(TestUtils.RANDOM, 1000) + 100, SERVICE_ID, OWNER_ID, "image/gif",
-              false, Utils.Infinite_Time, REF_ACCOUNT.getId(), REF_CONTAINER.getId(), false),
+              false, Utils.Infinite_Time, REF_ACCOUNT.getId(), REF_CONTAINER.getId(), false, null),
           RestUtils.buildUserMetadata(USER_METADATA));
       ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(InMemAccountService.UNKNOWN_ACCOUNT));
     } catch (Exception e) {
@@ -282,17 +282,17 @@ public class AmbrySecurityServiceTest {
     // with no owner id
     BlobInfo blobInfo = new BlobInfo(
         new BlobProperties(100, SERVICE_ID, null, "image/gif", false, Utils.Infinite_Time, REF_ACCOUNT.getId(),
-            REF_CONTAINER.getId(), false), new byte[0]);
+            REF_CONTAINER.getId(), false, null), new byte[0]);
     testHeadBlobWithVariousRanges(blobInfo);
     // with no content type
     blobInfo = new BlobInfo(
         new BlobProperties(100, SERVICE_ID, OWNER_ID, null, false, Utils.Infinite_Time, REF_ACCOUNT.getId(),
-            REF_CONTAINER.getId(), false), new byte[0]);
+            REF_CONTAINER.getId(), false, null), new byte[0]);
     testHeadBlobWithVariousRanges(blobInfo);
     // with a TTL
     blobInfo = new BlobInfo(
         new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, 10000, REF_ACCOUNT.getId(),
-            REF_CONTAINER.getId(), false), new byte[0]);
+            REF_CONTAINER.getId(), false, null), new byte[0]);
     testHeadBlobWithVariousRanges(blobInfo);
 
     // GET BlobInfo
@@ -313,29 +313,29 @@ public class AmbrySecurityServiceTest {
     // less than chunk threshold size
     blobInfo = new BlobInfo(
         new BlobProperties(FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes - 1, SERVICE_ID, OWNER_ID, "image/gif",
-            false, 10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
+            false, 10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false, null), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // == chunk threshold size
     blobInfo = new BlobInfo(
         new BlobProperties(FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes, SERVICE_ID, OWNER_ID, "image/gif", false,
-            10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
+            10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false, null), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // more than chunk threshold size
     blobInfo = new BlobInfo(
         new BlobProperties(FRONTEND_CONFIG.chunkedGetResponseThresholdInBytes * 2, SERVICE_ID, OWNER_ID, "image/gif",
-            false, 10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
+            false, 10000, Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, false, null), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // Get blob with content type null
     blobInfo = new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, null, true, 10000, Account.UNKNOWN_ACCOUNT_ID,
-        Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
+        Container.UNKNOWN_CONTAINER_ID, false, null), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // Get blob in a non-cacheable container. AmbrySecurityService should not care about the isPrivate setting.
     blobInfo = new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", false, Utils.Infinite_Time,
-        Account.UNKNOWN_ACCOUNT_ID, Container.DEFAULT_PRIVATE_CONTAINER_ID, false), new byte[0]);
+        Account.UNKNOWN_ACCOUNT_ID, Container.DEFAULT_PRIVATE_CONTAINER_ID, false, null), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // Get blob in a cacheable container. AmbrySecurityService should not care about the isPrivate setting.
     blobInfo = new BlobInfo(new BlobProperties(100, SERVICE_ID, OWNER_ID, "image/gif", true, Utils.Infinite_Time,
-        Account.UNKNOWN_ACCOUNT_ID, Container.DEFAULT_PUBLIC_CONTAINER_ID, false), new byte[0]);
+        Account.UNKNOWN_ACCOUNT_ID, Container.DEFAULT_PUBLIC_CONTAINER_ID, false, null), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // not modified response
     // > creation time (in secs).
@@ -348,7 +348,7 @@ public class AmbrySecurityServiceTest {
     // Get blob for a public blob with content type as "text/html"
     blobInfo = new BlobInfo(
         new BlobProperties(100, SERVICE_ID, OWNER_ID, "text/html", true, 10000, Account.UNKNOWN_ACCOUNT_ID,
-            Container.UNKNOWN_CONTAINER_ID, false), new byte[0]);
+            Container.UNKNOWN_CONTAINER_ID, false, null), new byte[0]);
     testGetBlobWithVariousRanges(blobInfo);
     // not modified response
     // > creation time (in secs).

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/PostBlobHandlerTest.java
@@ -433,7 +433,7 @@ public class PostBlobHandlerTest {
       byte[] content = TestUtils.getRandomBytes(chunkSize);
       BlobProperties blobProperties =
           new BlobProperties(-1, SERVICE_ID, OWNER_ID, CONTENT_TYPE, !container.isCacheable(), blobTtlSecs,
-              creationTimeMs, container.getParentAccountId(), container.getId(), container.isEncrypted());
+              creationTimeMs, container.getParentAccountId(), container.getId(), container.isEncrypted(), null);
       String blobId =
           router.putBlob(blobProperties, null, new ByteBufferReadableStreamChannel(ByteBuffer.wrap(content)),
               new PutBlobOptionsBuilder().chunkUpload(true).build()).get(TIMEOUT_SECS, TimeUnit.SECONDS);

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/TtlUpdateHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/TtlUpdateHandlerTest.java
@@ -64,7 +64,7 @@ public class TtlUpdateHandlerTest {
 
   private static final BlobProperties BLOB_PROPERTIES =
       new BlobProperties(100, SERVICE_ID, null, null, false, TTL_SECS, REF_ACCOUNT.getId(), REF_CONTAINER.getId(),
-          false);
+          false, null);
   private static final byte[] BLOB_DATA = TestUtils.getRandomBytes(100);
 
   static {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobPropertiesSerDe.java
@@ -59,7 +59,7 @@ public class BlobPropertiesSerDe {
     short containerId = version > VERSION_1 ? stream.readShort() : Container.UNKNOWN_CONTAINER_ID;
     boolean isEncrypted = version > VERSION_2 && stream.readByte() == (byte) 1;
     return new BlobProperties(blobSize, serviceId, ownerId, contentType, isPrivate, ttl, creationTime, accountId,
-        containerId, isEncrypted);
+        containerId, isEncrypted, null);
   }
 
   /**

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobPropertiesTest.java
@@ -48,8 +48,8 @@ public class BlobPropertiesTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{BlobPropertiesSerDe.VERSION_1}, {BlobPropertiesSerDe.VERSION_2},
-        {BlobPropertiesSerDe.VERSION_3}});
+    return Arrays.asList(
+        new Object[][]{{BlobPropertiesSerDe.VERSION_1}, {BlobPropertiesSerDe.VERSION_2}, {BlobPropertiesSerDe.VERSION_3}});
   }
 
   public BlobPropertiesTest(short version) {
@@ -62,6 +62,7 @@ public class BlobPropertiesTest {
     String serviceId = "ServiceId";
     String ownerId = "OwnerId";
     String contentType = "ContentType";
+    String externalAssetTag = "some-external-asset-tag";
     int timeToLiveInSeconds = 144;
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
@@ -72,92 +73,92 @@ public class BlobPropertiesTest {
     boolean encryptFlagToExpect = version == BlobPropertiesSerDe.VERSION_3 && isEncrypted;
 
     BlobProperties blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
-        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted);
+        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
     ByteBuffer serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, Utils.Infinite_Time, accountIdToExpect,
-        containerIdToExpect, encryptFlagToExpect);
+        containerIdToExpect, encryptFlagToExpect, null);
     assertTrue(blobProperties.getCreationTimeInMs() > 0);
     assertTrue(blobProperties.getCreationTimeInMs() <= System.currentTimeMillis());
 
     blobProperties = new BlobProperties(blobSize, serviceId, null, null, false, Utils.Infinite_Time,
-        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted);
+        SystemTime.getInstance().milliseconds(), accountId, containerId, isEncrypted, externalAssetTag);
     serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, Utils.Infinite_Time, accountIdToExpect,
-        containerIdToExpect, encryptFlagToExpect);
+        containerIdToExpect, encryptFlagToExpect, null);
 
     blobProperties =
         new BlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds, accountId, containerId,
-            isEncrypted);
+            isEncrypted, externalAssetTag);
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
 
     serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds,
-        accountIdToExpect, containerIdToExpect, encryptFlagToExpect);
+        accountIdToExpect, containerIdToExpect, encryptFlagToExpect, null);
     assertTrue(blobProperties.getCreationTimeInMs() > 0);
     assertTrue(blobProperties.getCreationTimeInMs() <= System.currentTimeMillis());
 
     long creationTimeMs = SystemTime.getInstance().milliseconds();
     blobProperties =
         new BlobProperties(blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds, creationTimeMs,
-            accountId, containerId, isEncrypted);
+            accountId, containerId, isEncrypted, "some-external-asset-tag");
     System.out.println(blobProperties.toString()); // Provide example of BlobProperties.toString()
     serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
 
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, timeToLiveInSeconds,
-        accountIdToExpect, containerIdToExpect, encryptFlagToExpect);
+        accountIdToExpect, containerIdToExpect, encryptFlagToExpect, null);
     assertEquals(blobProperties.getCreationTimeInMs(), creationTimeMs);
 
     long creationTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(creationTimeMs);
     // valid TTLs
-    long[] validTTLs =
-        new long[]{TimeUnit.HOURS.toSeconds(1), TimeUnit.HOURS.toSeconds(10), TimeUnit.HOURS.toSeconds(100),
-            TimeUnit.DAYS.toSeconds(1), TimeUnit.DAYS.toSeconds(10), TimeUnit.DAYS.toSeconds(100),
-            TimeUnit.DAYS.toSeconds(30 * 12), TimeUnit.DAYS.toSeconds(30 * 12 * 10),
-            Integer.MAX_VALUE - creationTimeInSecs - 1, Integer.MAX_VALUE - creationTimeInSecs,
-            Integer.MAX_VALUE - creationTimeInSecs + 1, Integer.MAX_VALUE - creationTimeInSecs + 100,
-            Integer.MAX_VALUE - creationTimeInSecs + 10000};
+    long[] validTTLs = new long[]{TimeUnit.HOURS.toSeconds(1), TimeUnit.HOURS.toSeconds(10), TimeUnit.HOURS.toSeconds(
+        100), TimeUnit.DAYS.toSeconds(1), TimeUnit.DAYS.toSeconds(10), TimeUnit.DAYS.toSeconds(
+        100), TimeUnit.DAYS.toSeconds(30 * 12), TimeUnit.DAYS.toSeconds(30 * 12 * 10),
+        Integer.MAX_VALUE - creationTimeInSecs - 1,
+        Integer.MAX_VALUE - creationTimeInSecs,
+        Integer.MAX_VALUE - creationTimeInSecs + 1,
+        Integer.MAX_VALUE - creationTimeInSecs + 100, Integer.MAX_VALUE - creationTimeInSecs + 10000};
     for (long ttl : validTTLs) {
       blobProperties =
           new BlobProperties(blobSize, serviceId, ownerId, contentType, true, ttl, creationTimeMs, accountId,
-              containerId, isEncrypted);
+              containerId, isEncrypted, null);
       serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
       blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
           new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
       verifyBlobProperties(blobProperties, blobSize, serviceId, ownerId, contentType, true, ttl, accountIdToExpect,
-          containerIdToExpect, encryptFlagToExpect);
+          containerIdToExpect, encryptFlagToExpect, null);
     }
 
     blobProperties =
         new BlobProperties(blobSize, serviceId, null, null, false, timeToLiveInSeconds, creationTimeMs, accountId,
-            containerId, isEncrypted);
+            containerId, isEncrypted, externalAssetTag);
     verifyBlobProperties(blobProperties, blobSize, serviceId, null, null, false, timeToLiveInSeconds, accountId,
-        containerId, isEncrypted);
+        containerId, isEncrypted, externalAssetTag);
     blobProperties.setTimeToLiveInSeconds(timeToLiveInSeconds + 1);
     verifyBlobProperties(blobProperties, blobSize, serviceId, null, null, false, timeToLiveInSeconds + 1, accountId,
-        containerId, isEncrypted);
+        containerId, isEncrypted, externalAssetTag);
     serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize, serviceId, "", "", false, timeToLiveInSeconds + 1, accountIdToExpect,
-        containerIdToExpect, encryptFlagToExpect);
+        containerIdToExpect, encryptFlagToExpect, null);
 
     blobProperties.setBlobSize(blobSize + 1);
     verifyBlobProperties(blobProperties, blobSize + 1, serviceId, "", "", false, timeToLiveInSeconds + 1,
-        accountIdToExpect, containerIdToExpect, encryptFlagToExpect);
+        accountIdToExpect, containerIdToExpect, encryptFlagToExpect, null);
     serializedBuffer = serializeBlobPropertiesInVersion(blobProperties);
     blobProperties = BlobPropertiesSerDe.getBlobPropertiesFromStream(
         new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
     verifyBlobProperties(blobProperties, blobSize + 1, serviceId, "", "", false, timeToLiveInSeconds + 1,
-        accountIdToExpect, containerIdToExpect, encryptFlagToExpect);
+        accountIdToExpect, containerIdToExpect, encryptFlagToExpect, null);
   }
 
   /**
@@ -222,10 +223,12 @@ public class BlobPropertiesTest {
    * @param ttlInSecs the time to live associated with the {@link BlobProperties} in secs
    * @param accountId accountId of the user who uploaded the blob
    * @param containerId containerId of the blob
-   * @param isEncrypted whether the blob is encrypted.
+   * @param isEncrypted whether the blob is encrypted
+   * @param externalAssetTag the externalAssetTag of the blob.
    */
   private void verifyBlobProperties(BlobProperties blobProperties, long blobSize, String serviceId, String ownerId,
-      String contentType, boolean isPrivate, long ttlInSecs, short accountId, short containerId, boolean isEncrypted) {
+      String contentType, boolean isPrivate, long ttlInSecs, short accountId, short containerId, boolean isEncrypted,
+      String externalAssetTag) {
     assertEquals(blobProperties.getBlobSize(), blobSize);
     assertEquals(blobProperties.getServiceId(), serviceId);
     assertEquals(blobProperties.getOwnerId(), ownerId);
@@ -235,5 +238,6 @@ public class BlobPropertiesTest {
     assertEquals("AccountId mismatch ", accountId, blobProperties.getAccountId());
     assertEquals("ContainerId mismatch ", containerId, blobProperties.getContainerId());
     assertEquals(isEncrypted, blobProperties.isEncrypted());
+    assertEquals("externalAssetTag mismatch", externalAssetTag, blobProperties.getExternalAssetTag());
   }
 }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
@@ -91,7 +91,7 @@ public class BlobStoreHardDeleteTest {
       long updateTimeMs = SystemTime.getInstance().milliseconds() + TestUtils.RANDOM.nextInt();
 
       BlobProperties blobProperties =
-          new BlobProperties(BLOB_SIZE, "test", "mem1", "img", false, 9999, accountId, containerId, true);
+          new BlobProperties(BLOB_SIZE, "test", "mem1", "img", false, 9999, accountId, containerId, true, null);
 
       MessageFormatInputStream msg0 =
           getPutMessage(keys[0], ByteBuffer.wrap(encryptionKey), blobProperties, usermetadata, blob, BLOB_SIZE,

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreRecoveryTest.java
@@ -82,7 +82,7 @@ public class BlobStoreRecoveryTest {
       // 1st message
       BlobProperties blobProperties =
           new BlobProperties(4000, "test", "mem1", "img", false, 9999, keys[0].getAccountId(), keys[0].getContainerId(),
-              true);
+              true, null);
       expectedExpirationTimeMs =
           Utils.addSecondsToEpochTime(blobProperties.getCreationTimeInMs(), blobProperties.getTimeToLiveInSeconds());
       PutMessageFormatInputStream msg1 =

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -181,12 +181,12 @@ public class MessageFormatRecordTest {
       boolean isEncrypted = TestUtils.RANDOM.nextBoolean();
       if (version == VERSION_1) {
         properties = new BlobProperties(blobSize, "id", "member", "test", true, ttl, Account.UNKNOWN_ACCOUNT_ID,
-            Container.UNKNOWN_CONTAINER_ID, isEncrypted);
+            Container.UNKNOWN_CONTAINER_ID, isEncrypted, null);
       } else {
         short accountId = Utils.getRandomShort(TestUtils.RANDOM);
         short containerId = Utils.getRandomShort(TestUtils.RANDOM);
         properties =
-            new BlobProperties(blobSize, "id", "member", "test", true, ttl, accountId, containerId, isEncrypted);
+            new BlobProperties(blobSize, "id", "member", "test", true, ttl, accountId, containerId, isEncrypted, null);
       }
       ByteBuffer stream;
       if (version == VERSION_1) {
@@ -226,7 +226,7 @@ public class MessageFormatRecordTest {
     // failure case
     BlobProperties properties =
         new BlobProperties(1000, "id", "member", "test", true, Utils.Infinite_Time, Account.UNKNOWN_ACCOUNT_ID,
-            Container.UNKNOWN_CONTAINER_ID, false);
+            Container.UNKNOWN_CONTAINER_ID, false, null);
     ByteBuffer stream = ByteBuffer.allocate(getBlobPropertiesRecordSize(properties) - 10);
     try {
       MessageFormatRecord.BlobProperties_Format_V1.serializeBlobPropertiesRecord(stream, properties);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatSendTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatSendTest.java
@@ -162,7 +162,7 @@ public class MessageFormatSendTest {
     StoreKey storeKey = new MockId("012345678910123456789012");
     BlobProperties properties =
         new BlobProperties(blob.length, serviceId, ownerId, contentType, false, 100, accountId, containerId,
-            encryptionKey != null);
+            encryptionKey != null, null);
     MessageFormatInputStream putStream;
     MessageFormatRecord.MessageHeader_Format header;
     if (putFormat.equals(PutMessageFormatInputStream.class.getSimpleName())) {
@@ -395,7 +395,7 @@ public class MessageFormatSendTest {
     for (int i = 0; i < 5; i++) {
       properties[i] =
           new BlobProperties(blob[i].length, serviceIdPrefix + i, ownerIdPrefix + i, contentTypePrefix + i, false, 100,
-              (short) (accountIdBase + i), (short) (containerIdBase + i), encryptionKeys[i] != null);
+              (short) (accountIdBase + i), (short) (containerIdBase + i), encryptionKeys[i] != null, null);
     }
 
     MessageFormatInputStream[] putStreams = new MessageFormatInputStream[5];

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -235,7 +235,7 @@ public class RequestResponseTest {
     BlobProperties blobProperties =
         new BlobProperties(blobSize, "serviceID", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM),
-            TestUtils.RANDOM.nextBoolean());
+            TestUtils.RANDOM.nextBoolean(), null);
     testPutRequest(clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata, BlobType.DataBlob, blob,
         blobSize, blobKey);
     doTest(InvalidVersionPutRequest.Put_Request_Invalid_version, clusterMap, correlationId, clientId, blobId,
@@ -245,7 +245,7 @@ public class RequestResponseTest {
     blobProperties =
         new BlobProperties(blobSize * 10, "serviceID", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM),
-            TestUtils.RANDOM.nextBoolean());
+            TestUtils.RANDOM.nextBoolean(), null);
     testPutRequest(clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata, BlobType.DataBlob, blob,
         blobSize, blobKey);
 
@@ -253,14 +253,15 @@ public class RequestResponseTest {
     blobProperties =
         new BlobProperties(blobSize * 10, "serviceID", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM),
-            TestUtils.RANDOM.nextBoolean());
+            TestUtils.RANDOM.nextBoolean(), null);
     testPutRequest(clusterMap, correlationId, clientId, blobId, blobProperties, userMetadata, BlobType.MetadataBlob,
         blob, blobSize, blobKey);
 
     // Put Request with empty user metadata.
     byte[] emptyUserMetadata = new byte[0];
     blobProperties = new BlobProperties(blobSize, "serviceID", "memberId", "contentType", false, Utils.Infinite_Time,
-        Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), TestUtils.RANDOM.nextBoolean());
+        Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), TestUtils.RANDOM.nextBoolean(),
+        null);
     testPutRequest(clusterMap, correlationId, clientId, blobId, blobProperties, emptyUserMetadata, BlobType.DataBlob,
         blob, blobSize, blobKey);
 

--- a/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
@@ -211,7 +211,7 @@ public class BlobIdTransformer implements Transformer {
           new BlobProperties(blobData.getSize(), oldProperties.getServiceId(), oldProperties.getOwnerId(),
               oldProperties.getContentType(), oldProperties.isPrivate(), oldProperties.getTimeToLiveInSeconds(),
               oldProperties.getCreationTimeInMs(), newBlobId.getAccountId(), newBlobId.getContainerId(),
-              oldProperties.isEncrypted());
+              oldProperties.isEncrypted(), null);
 
       PutMessageFormatInputStream putMessageFormatInputStream =
           new PutMessageFormatInputStream(newKey, blobEncryptionKey, newProperties, userMetaData, blobDataBytes,

--- a/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
@@ -462,7 +462,7 @@ public class BlobIdTransformerTest {
       MessageInfo messageInfo;
       BlobProperties blobProperties =
           new BlobProperties(blobStreamSize, "serviceId", "ownerId", "contentType", false, 0, 0, blobId.getAccountId(),
-              blobId.getContainerId(), hasEncryption);
+              blobId.getContainerId(), hasEncryption, null);
       if (clazz != null) {
         MessageFormatInputStream messageFormatInputStream;
         if (clazz == PutMessageFormatInputStream.class) {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -1539,7 +1539,7 @@ public class ReplicationTest {
     blobIdRandom.nextBytes(usermetadata);
     BlobProperties blobProperties =
         new BlobProperties(blobSize, "test", null, null, false, EXPIRY_TIME_MS - CONSTANT_TIME_MS, CONSTANT_TIME_MS,
-            accountId, containerId, encryptionKey != null);
+            accountId, containerId, encryptionKey != null, null);
     MessageFormatInputStream stream =
         new PutMessageFormatInputStream(id, encryptionKey == null ? null : ByteBuffer.wrap(encryptionKey),
             blobProperties, ByteBuffer.wrap(usermetadata), new ByteBufferInputStream(ByteBuffer.wrap(blob)), blobSize);

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -1095,7 +1095,8 @@ class PutOperation {
             passedInBlobProperties.getOwnerId(), passedInBlobProperties.getContentType(),
             passedInBlobProperties.isPrivate(), passedInBlobProperties.getTimeToLiveInSeconds(),
             passedInBlobProperties.getCreationTimeInMs(), passedInBlobProperties.getAccountId(),
-            passedInBlobProperties.getContainerId(), passedInBlobProperties.isEncrypted());
+            passedInBlobProperties.getContainerId(), passedInBlobProperties.isEncrypted(),
+            passedInBlobProperties.getExternalAssetTag());
         operationTracker = new SimpleOperationTracker(routerConfig.routerDatacenterName, partitionId, false, null, true,
             Integer.MAX_VALUE, routerConfig.routerPutSuccessTarget, routerConfig.routerPutRequestParallelism);
         correlationIdToChunkPutRequestInfo.clear();
@@ -1600,7 +1601,7 @@ class PutOperation {
               passedInBlobProperties.getContentType(), passedInBlobProperties.isPrivate(),
               passedInBlobProperties.getTimeToLiveInSeconds(), passedInBlobProperties.getCreationTimeInMs(),
               passedInBlobProperties.getAccountId(), passedInBlobProperties.getContainerId(),
-              passedInBlobProperties.isEncrypted());
+              passedInBlobProperties.isEncrypted(), passedInBlobProperties.getExternalAssetTag());
       if (isStitchOperation() || getNumDataChunks() > 1) {
         // values returned are in the right order as TreeMap returns them in key-order.
         List<StoreKey> orderedChunkIdList = new ArrayList<>(indexToChunkIds.values());

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -140,7 +140,7 @@ public class ChunkFillTest {
     short containerId = Utils.getRandomShort(random);
     BlobProperties putBlobProperties =
         new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time, accountId,
-            containerId, false);
+            containerId, false, null);
     Random random = new Random();
     byte[] putUserMetadata = new byte[10];
     random.nextBytes(putUserMetadata);
@@ -240,7 +240,7 @@ public class ChunkFillTest {
     short containerId = Utils.getRandomShort(random);
     BlobProperties putBlobProperties =
         new BlobProperties(blobSize, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time, accountId,
-            containerId, testEncryption);
+            containerId, testEncryption, null);
     Random random = new Random();
     byte[] putUserMetadata = new byte[10];
     random.nextBytes(putUserMetadata);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -156,7 +156,7 @@ public class GetBlobInfoOperationTest {
     short containerId = Utils.getRandomShort(random);
     blobProperties =
         new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time, accountId,
-            containerId, testEncryption);
+            containerId, testEncryption, null);
     userMetadata = new byte[BLOB_USER_METADATA_SIZE];
     random.nextBytes(userMetadata);
     putContent = new byte[BLOB_SIZE];
@@ -574,7 +574,7 @@ public class GetBlobInfoOperationTest {
     Assert.assertNull("Unexpected blob data channel in operation result",
         op.getOperationResult().getBlobResult.getBlobDataChannel());
     Assert.assertTrue("Blob properties must be the same",
-        RouterTestHelpers.haveEquivalentFields(blobProperties, blobInfo.getBlobProperties()));
+        RouterTestHelpers.arePersistedFieldsEquivalent(blobProperties, blobInfo.getBlobProperties()));
     Assert.assertEquals("Blob size should in received blobProperties should be the same as actual", BLOB_SIZE,
         blobInfo.getBlobProperties().getBlobSize());
     Assert.assertArrayEquals("User metadata must be the same", userMetadata, blobInfo.getUserMetadata());

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -230,7 +230,7 @@ public class GetBlobOperationTest {
    */
   private void doPut() throws Exception {
     blobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
-        Utils.getRandomShort(random), Utils.getRandomShort(random), testEncryption);
+        Utils.getRandomShort(random), Utils.getRandomShort(random), testEncryption, null);
     userMetadata = new byte[10];
     random.nextBytes(userMetadata);
     putContent = new byte[blobSize];
@@ -745,7 +745,7 @@ public class GetBlobOperationTest {
     random.nextBytes(putContent);
     blobProperties =
         new BlobProperties(blobSize + 20, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
-            Utils.getRandomShort(random), Utils.getRandomShort(random), testEncryption);
+            Utils.getRandomShort(random), Utils.getRandomShort(random), testEncryption, null);
     doDirectPut(BlobType.DataBlob, ByteBuffer.wrap(putContent));
     Counter sizeMismatchCounter = (testEncryption ? routerMetrics.simpleEncryptedBlobSizeMismatchCount
         : routerMetrics.simpleUnencryptedBlobSizeMismatchCount);
@@ -767,7 +767,7 @@ public class GetBlobOperationTest {
     metadataContent.flip();
     blobProperties =
         new BlobProperties(blobSize - 20, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
-            Utils.getRandomShort(random), Utils.getRandomShort(random), testEncryption);
+            Utils.getRandomShort(random), Utils.getRandomShort(random), testEncryption, null);
     doDirectPut(BlobType.MetadataBlob, metadataContent);
     startCount = routerMetrics.compositeBlobSizeMismatchCount.getCount();
     getAndAssertSuccess();
@@ -1160,7 +1160,7 @@ public class GetBlobOperationTest {
               if (!options.getBlobOptions.isRawMode()) {
                 blobInfo = result.getBlobResult.getBlobInfo();
                 Assert.assertTrue("Blob properties must be the same",
-                    RouterTestHelpers.haveEquivalentFields(blobProperties, blobInfo.getBlobProperties()));
+                    RouterTestHelpers.arePersistedFieldsEquivalent(blobProperties, blobInfo.getBlobProperties()));
                 Assert.assertEquals("Blob size should in received blobProperties should be the same as actual",
                     blobSize, blobInfo.getBlobProperties().getBlobSize());
                 Assert.assertArrayEquals("User metadata must be the same", userMetadata, blobInfo.getUserMetadata());
@@ -1172,7 +1172,7 @@ public class GetBlobOperationTest {
             case BlobInfo:
               blobInfo = result.getBlobResult.getBlobInfo();
               Assert.assertTrue("Blob properties must be the same",
-                  RouterTestHelpers.haveEquivalentFields(blobProperties, blobInfo.getBlobProperties()));
+                  RouterTestHelpers.arePersistedFieldsEquivalent(blobProperties, blobInfo.getBlobProperties()));
               Assert.assertEquals("Blob size should in received blobProperties should be the same as actual", blobSize,
                   blobInfo.getBlobProperties().getBlobSize());
               Assert.assertNull("Unexpected blob data in operation result", result.getBlobResult.getBlobDataChannel());

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -381,7 +381,7 @@ public class GetManagerTest {
    */
   private void compareBlobInfo(BlobInfo blobInfo) {
     Assert.assertTrue("Blob properties should match",
-        RouterTestHelpers.haveEquivalentFields(putBlobProperties, blobInfo.getBlobProperties()));
+        RouterTestHelpers.arePersistedFieldsEquivalent(putBlobProperties, blobInfo.getBlobProperties()));
     Assert.assertEquals("Blob size in received blobProperties should be the same as actual", blobSize,
         blobInfo.getBlobProperties().getBlobSize());
     Assert.assertArrayEquals("User metadata should match", putUserMetadata, blobInfo.getUserMetadata());
@@ -424,7 +424,7 @@ public class GetManagerTest {
   private void setOperationParams(int blobSize, GetBlobOptions options) {
     this.blobSize = blobSize;
     putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
-        Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), testEncryption);
+        Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), testEncryption, null);
     putUserMetadata = new byte[10];
     random.nextBytes(putUserMetadata);
     putContent = new byte[blobSize];

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
@@ -113,7 +113,7 @@ public class InMemoryRouter implements Router {
           new BlobProperties(blob.remaining(), blobProperties.getServiceId(), blobProperties.getOwnerId(),
               blobProperties.getContentType(), blobProperties.isPrivate(), blobProperties.getTimeToLiveInSeconds(),
               blobProperties.getCreationTimeInMs(), blobProperties.getAccountId(), blobProperties.getContainerId(),
-              blobProperties.isEncrypted());
+              blobProperties.isEncrypted(), null);
       this.userMetadata = userMetadata;
       this.blob = blob;
       this.stitchedChunks = stitchedChunks;

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -211,7 +211,7 @@ public class NonBlockingRouterTest {
    */
   private void setOperationParams(int putContentSize, long ttlSecs) {
     putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, ttlSecs,
-        Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), testEncryption);
+        Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), testEncryption, null);
     putUserMetadata = new byte[USER_METADATA_SIZE];
     random.nextBytes(putUserMetadata);
     putContent = new byte[putContentSize];
@@ -555,7 +555,7 @@ public class NonBlockingRouterTest {
         // Create a clean cluster and put another blob that immediate expires.
         setOperationParams();
         putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, 0,
-            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false);
+            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null);
         blobId =
             router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get();
         Set<String> allBlobsInServer = getBlobsInServers(mockServerLayout);
@@ -720,7 +720,7 @@ public class NonBlockingRouterTest {
         GetBlobResult getBlobResult = router.getBlob(stitchedBlobId, new GetBlobOptionsBuilder().build())
             .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         assertTrue("Blob properties must be the same",
-            RouterTestHelpers.haveEquivalentFields(putBlobProperties, getBlobResult.getBlobInfo().getBlobProperties()));
+            RouterTestHelpers.arePersistedFieldsEquivalent(putBlobProperties, getBlobResult.getBlobInfo().getBlobProperties()));
         assertEquals("Unexpected blob size", expectedContent.length,
             getBlobResult.getBlobInfo().getBlobProperties().getBlobSize());
         assertArrayEquals("User metadata must be the same", putUserMetadata,

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -94,7 +94,7 @@ public class PutOperationTest {
     int numChunks = NonBlockingRouter.MAX_IN_MEM_CHUNKS + 1;
     BlobProperties blobProperties =
         new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
-            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false);
+            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null);
     byte[] userMetadata = new byte[10];
     byte[] content = new byte[chunkSize * numChunks];
     random.nextBytes(content);
@@ -202,7 +202,7 @@ public class PutOperationTest {
     int numChunks = NonBlockingRouter.MAX_IN_MEM_CHUNKS + 1;
     BlobProperties blobProperties =
         new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
-            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false);
+            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null);
     byte[] userMetadata = new byte[10];
     byte[] content = new byte[chunkSize * numChunks];
     random.nextBytes(content);
@@ -249,7 +249,7 @@ public class PutOperationTest {
   public void testStitchErrorDataChunkHandling() throws Exception {
     BlobProperties blobProperties =
         new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
-            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false);
+            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null);
     byte[] userMetadata = new byte[10];
     FutureResult<String> future = new FutureResult<>();
     MockNetworkClient mockNetworkClient = new MockNetworkClient();

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
@@ -53,10 +53,10 @@ class RouterTestHelpers {
   private static final short BLOB_ID_VERSION = CommonTestUtils.getCurrentBlobIdVersion();
 
   /**
-   * Test whether two {@link BlobProperties} have the same fields
-   * @return true if the fields are equivalent in the two {@link BlobProperties}
+   * Test whether persistent properties in two {@link BlobProperties} are same.
+   * @return true if the persistent properties are equivalent in the two {@link BlobProperties}
    */
-  static boolean haveEquivalentFields(BlobProperties a, BlobProperties b) {
+  static boolean arePersistedFieldsEquivalent(BlobProperties a, BlobProperties b) {
     return a.getServiceId().equals(b.getServiceId()) && a.getOwnerId().equals(b.getOwnerId()) && a.getContentType()
         .equals(b.getContentType()) && a.isPrivate() == b.isPrivate()
         && a.getTimeToLiveInSeconds() == b.getTimeToLiveInSeconds()
@@ -226,8 +226,8 @@ class RouterTestHelpers {
    * @throws Exception
    */
   static void assertTtl(Router router, Collection<String> blobIds, long expectedTtlSecs) throws Exception {
-    GetBlobOptions options[] = {new GetBlobOptionsBuilder().build(),
-        new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build()};
+    GetBlobOptions options[] = {new GetBlobOptionsBuilder().build(), new GetBlobOptionsBuilder().operationType(
+        GetBlobOptions.OperationType.BlobInfo).build()};
     for (String blobId : blobIds) {
       for (GetBlobOptions option : options) {
         GetBlobResult result = router.getBlob(blobId, option).get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);

--- a/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
@@ -107,7 +107,7 @@ public class TtlUpdateManagerTest {
     for (int i = 0; i < BLOBS_COUNT; i++) {
       ReadableStreamChannel putChannel = new ByteBufferReadableStreamChannel(ByteBuffer.wrap(PUT_CONTENT));
       BlobProperties putBlobProperties = new BlobProperties(-1, "serviceId", "memberId", "contentType", false, TTL_SECS,
-          Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false);
+          Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null);
       String blobId = router.putBlob(putBlobProperties, new byte[0], putChannel, new PutBlobOptionsBuilder().build())
           .get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
       blobIds.add(blobId);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/RouterServerTestFramework.java
@@ -170,7 +170,7 @@ class RouterServerTestFramework {
     short containerId = container == null ? Utils.getRandomShort(TestUtils.RANDOM) : container.getId();
     BlobProperties properties =
         new BlobProperties(blobSize, "serviceid1", null, null, false, TestUtils.TTL_SECS, accountId, containerId,
-            testEncryption);
+            testEncryption, null);
     OperationChain opChain = new OperationChain(chainId, properties, userMetadata, data, operations);
     continueChain(opChain);
     return opChain;

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -252,12 +252,12 @@ public class ServerHardDeleteTest {
         Utils.getRandomShort(TestUtils.RANDOM), true));
     properties.add(
         new BlobProperties(31873, "serviceid1", "ownerid", "jpeg", false, 0, Utils.getRandomShort(TestUtils.RANDOM),
-            Utils.getRandomShort(TestUtils.RANDOM), false));
+            Utils.getRandomShort(TestUtils.RANDOM), false, null));
     properties.add(new BlobProperties(31874, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
         Utils.getRandomShort(TestUtils.RANDOM), true));
     properties.add(
         new BlobProperties(31875, "serviceid1", "ownerid", "jpeg", false, 0, Utils.getRandomShort(TestUtils.RANDOM),
-            Utils.getRandomShort(TestUtils.RANDOM), false));
+            Utils.getRandomShort(TestUtils.RANDOM), false, null));
     properties.add(new BlobProperties(31876, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),
         Utils.getRandomShort(TestUtils.RANDOM), true));
     properties.add(new BlobProperties(31877, "serviceid1", Utils.getRandomShort(TestUtils.RANDOM),

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -165,7 +165,7 @@ final class ServerTestUtil {
       // put blob 2 with an expiry time and apply TTL update later
       BlobProperties propertiesForTtlUpdate =
           new BlobProperties(31870, "serviceid1", "ownerid", "image/png", false, TestUtils.TTL_SECS, accountId,
-              containerId, testEncryption);
+              containerId, testEncryption, null);
       long ttlUpdateBlobExpiryTimeMs = getExpiryTimeMs(propertiesForTtlUpdate);
       PutRequest putRequest2 =
           new PutRequest(1, "client1", blobId2, propertiesForTtlUpdate, ByteBuffer.wrap(usermetadata),
@@ -187,7 +187,8 @@ final class ServerTestUtil {
 
       // put blob 4 that is expired
       BlobProperties propertiesExpired =
-          new BlobProperties(31870, "serviceid1", "ownerid", "jpeg", false, 0, accountId, containerId, testEncryption);
+          new BlobProperties(31870, "serviceid1", "ownerid", "jpeg", false, 0, accountId, containerId, testEncryption,
+              null);
       PutRequest putRequest4 =
           new PutRequest(1, "client1", blobId4, propertiesExpired, ByteBuffer.wrap(usermetadata), ByteBuffer.wrap(data),
               properties.getBlobSize(), BlobType.DataBlob, testEncryption ? ByteBuffer.wrap(encryptionKey) : null);
@@ -553,7 +554,8 @@ final class ServerTestUtil {
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);
     BlobProperties properties =
-        new BlobProperties(100, "serviceid1", null, null, false, TestUtils.TTL_SECS, accountId, containerId, false);
+        new BlobProperties(100, "serviceid1", null, null, false, TestUtils.TTL_SECS, accountId, containerId, false,
+            null);
     long expectedExpiryTimeMs = getExpiryTimeMs(properties);
     TestUtils.RANDOM.nextBytes(usermetadata);
     TestUtils.RANDOM.nextBytes(data);
@@ -1174,7 +1176,7 @@ final class ServerTestUtil {
       int size = new Random().nextInt(5000);
       final BlobProperties properties =
           new BlobProperties(size, "service1", "owner id check", "image/jpeg", false, TestUtils.TTL_SECS, accountId,
-              containerId, false);
+              containerId, false, null);
       final byte[] metadata = new byte[new Random().nextInt(1000)];
       final byte[] blob = new byte[size];
       TestUtils.RANDOM.nextBytes(metadata);
@@ -1360,7 +1362,7 @@ final class ServerTestUtil {
         short containerId = Utils.getRandomShort(TestUtils.RANDOM);
         propertyList.add(
             new BlobProperties(1000, "serviceid1", null, null, false, TestUtils.TTL_SECS, accountId, containerId,
-                testEncryption));
+                testEncryption, null));
         blobIdList.add(new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
             clusterMap.getLocalDatacenterId(), accountId, containerId, partition, false,
             BlobId.BlobDataType.DATACHUNK));


### PR DESCRIPTION
Add support to pass externalAssetTag from HTTP header to NotificationSystem. 
The String is pass through `BlobProperties`. 