### PR TITLE
Fix server startup failure due to invalid stats type

### DIFF
--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
@@ -50,7 +50,9 @@ import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -174,10 +176,18 @@ public class AmbryServer {
       }
 
       List<AmbryHealthReport> ambryHealthReports = new ArrayList<>();
+      Set<String> validStatsTypes = new HashSet<>();
+      for (StatsReportType type : StatsReportType.values()) {
+        validStatsTypes.add(type.toString());
+      }
       if (serverConfig.serverStatsPublishHealthReportEnabled) {
-        serverConfig.serverStatsReportsToPublish.forEach(e -> ambryHealthReports.add(
-            new AmbryStatsReport(statsManager, serverConfig.serverQuotaStatsAggregateIntervalInMinutes,
-                StatsReportType.valueOf(e))));
+        serverConfig.serverStatsReportsToPublish.forEach(e -> {
+          if (validStatsTypes.contains(e)) {
+            ambryHealthReports.add(
+                new AmbryStatsReport(statsManager, serverConfig.serverQuotaStatsAggregateIntervalInMinutes,
+                    StatsReportType.valueOf(e)));
+          }
+        });
       }
 
       clusterParticipant.participate(ambryHealthReports);

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryStatsReportTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryStatsReportTest.java
@@ -19,8 +19,13 @@ import com.github.ambry.config.StatsManagerConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.store.StoreException;
 import com.github.ambry.utils.MockTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -50,5 +55,31 @@ public class AmbryStatsReportTest {
         ambryStatsReport.getAggregateIntervalInMinutes());
     assertEquals("Mismatch in report name", "PartitionClassReport", ambryStatsReport.getReportName());
     assertEquals("Mismatch in stats field name", "PartitionClassStats", ambryStatsReport.getStatsFieldName());
+  }
+
+  @Test
+  public void testStatsToPublishConfig() {
+    // use the same logic/code in AmbryServer to test that server only accepts valid stats types and won't fail on startup.
+    Set<String> validStatsTypes = new HashSet<>();
+    for (StatsReportType type : StatsReportType.values()) {
+      validStatsTypes.add(type.toString());
+    }
+    List<String> acceptedStatsTypes = new ArrayList<>();
+    String statsReportsToPublishStr = "";
+    List<String> statsReportsTypes = Arrays.asList(statsReportsToPublishStr.split(","));
+    statsReportsTypes.forEach(e -> {
+      if (validStatsTypes.contains(e)) {
+        acceptedStatsTypes.add(e);
+      }
+    });
+    assertTrue("The accepted stats type list should be empty", acceptedStatsTypes.isEmpty());
+    statsReportsToPublishStr = "ACCOUNT_REPORT";
+    statsReportsTypes = Arrays.asList(statsReportsToPublishStr.split(","));
+    statsReportsTypes.forEach(e -> {
+      if (validStatsTypes.contains(e)) {
+        acceptedStatsTypes.add(e);
+      }
+    });
+    assertEquals("Mismatch in the size of accepted stats type list", 1, acceptedStatsTypes.size());
   }
 }


### PR DESCRIPTION
Enum valueOf method would throw IllegalArgumentException if the input
stats type doesn't exist, which causes server startup failure. This patch
adds check for stats type in config before instantiating AmbryStatsReport.