### PR TITLE
Add support for cluster name in request URI

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
@@ -254,8 +254,6 @@ public class FrontendConfig {
    * @return the string with the leading and trailing slash remove.
    */
   private String stripLeadingAndTrailingSlash(String string) {
-    int startIndex = string.startsWith("/") ? 1 : 0;
-    int endIndex = Math.max(string.length() - (string.endsWith("/") ? 1 : 0), startIndex);
-    return string.substring(startIndex, endIndex);
+    return string.replaceAll("^/|/$", "");
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/FrontendConfig.java
@@ -15,9 +15,11 @@ package com.github.ambry.config;
 
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.router.GetBlobOptions;
-import java.util.Arrays;
+import com.github.ambry.utils.Utils;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 
 /**
@@ -101,6 +103,13 @@ public class FrontendConfig {
   @Config("frontend.path.prefixes.to.remove")
   @Default("")
   public final List<String> pathPrefixesToRemove;
+
+  /**
+   * The secure path to validate if required for certain container.
+   */
+  @Config("frontend.secure.path.prefix")
+  @Default("")
+  public final String securePathPrefix;
 
   /**
    * Specifies the blob size in bytes beyond which chunked response will be sent for a getBlob() call
@@ -192,13 +201,6 @@ public class FrontendConfig {
   @Default("20 * 1024 * 1024")
   public final long maxJsonRequestSizeBytes;
 
-  /**
-   * The secure path to validate if required for certain container.
-   */
-  @Config("frontend.secure.path.prefix")
-  @Default("")
-  public final String securePathPrefix;
-
   public FrontendConfig(VerifiableProperties verifiableProperties) {
     cacheValiditySeconds = verifiableProperties.getLong("frontend.cache.validity.seconds", 365 * 24 * 60 * 60);
     optionsValiditySeconds = verifiableProperties.getLong("frontend.options.validity.seconds", 24 * 60 * 60);
@@ -213,9 +215,13 @@ public class FrontendConfig {
     idSigningServiceFactory = verifiableProperties.getString(ID_SIGNING_SERVICE_FACTORY_KEY,
         "com.github.ambry.frontend.AmbryIdSigningServiceFactory");
     securePathPrefix = verifiableProperties.getString("frontend.secure.path.prefix", "");
-    pathPrefixesToRemove = Arrays.asList(
-        ((securePathPrefix.isEmpty() ? "" : "/" + securePathPrefix + ",") + verifiableProperties.getString(
-            "frontend.path.prefixes.to.remove", "")).split(","));
+    List<String> pathPrefixesFromConfig =
+        Utils.splitString(verifiableProperties.getString("frontend.path.prefixes.to.remove", ""), ",");
+    if (!securePathPrefix.isEmpty()) {
+      pathPrefixesFromConfig.add(securePathPrefix);
+    }
+    pathPrefixesToRemove = Collections.unmodifiableList(
+        pathPrefixesFromConfig.stream().map(this::stripLeadingAndTrailingSlash).collect(Collectors.toList()));
     chunkedGetResponseThresholdInBytes =
         verifiableProperties.getInt("frontend.chunked.get.response.threshold.in.bytes", 8192);
     allowServiceIdBasedPostRequest =
@@ -240,5 +246,16 @@ public class FrontendConfig {
         (int) TimeUnit.DAYS.toSeconds(30), 0, Integer.MAX_VALUE);
     maxJsonRequestSizeBytes =
         verifiableProperties.getLongInRange(MAX_JSON_REQUEST_SIZE_BYTES_KEY, 20 * 1024 * 1024, 0, Long.MAX_VALUE);
+  }
+
+  /**
+   * If the string starts or ends with a slash, remove them.
+   * @param string the string to strip.
+   * @return the string with the leading and trailing slash remove.
+   */
+  private String stripLeadingAndTrailingSlash(String string) {
+    int startIndex = string.startsWith("/") ? 1 : 0;
+    int endIndex = Math.max(string.length() - (string.endsWith("/") ? 1 : 0), startIndex);
+    return string.substring(startIndex, endIndex);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ServerConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ServerConfig.java
@@ -13,7 +13,7 @@
  */
 package com.github.ambry.config;
 
-import java.util.Arrays;
+import com.github.ambry.utils.Utils;
 import java.util.List;
 
 
@@ -100,6 +100,6 @@ public class ServerConfig {
     serverMessageTransformer = verifiableProperties.getString("server.message.transformer",
         "com.github.ambry.messageformat.ValidatingTransformer");
     serverStatsReportsToPublish =
-        Arrays.asList(verifiableProperties.getString("server.stats.reports.to.publish", "").split(","));
+        Utils.splitString(verifiableProperties.getString("server.stats.reports.to.publish", ""), ",");
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/VerifiableProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/VerifiableProperties.java
@@ -95,12 +95,7 @@ public class VerifiableProperties {
    * @return the integer value
    */
   public int getIntInRange(String name, int defaultVal, int start, int end) {
-    int v = 0;
-    if (containsKey(name)) {
-      v = Integer.parseInt(getProperty(name));
-    } else {
-      v = defaultVal;
-    }
+    int v = containsKey(name) ? Integer.parseInt(getProperty(name)) : defaultVal;
     if (v >= start && v <= end) {
       return v;
     } else {
@@ -110,12 +105,7 @@ public class VerifiableProperties {
   }
 
   public Short getShortInRange(String name, Short defaultVal, Short start, Short end) {
-    Short v = 0;
-    if (containsKey(name)) {
-      v = Short.parseShort(getProperty(name));
-    } else {
-      v = defaultVal;
-    }
+    Short v = containsKey(name) ? Short.parseShort(getProperty(name)) : defaultVal;
     if (v >= start && v <= end) {
       return v;
     } else {
@@ -143,12 +133,7 @@ public class VerifiableProperties {
   }
 
   public Double getDoubleInRange(String name, Double defaultVal, Double start, Double end) {
-    Double v = 0.0;
-    if (containsKey(name)) {
-      v = Double.parseDouble(getProperty(name));
-    } else {
-      v = defaultVal;
-    }
+    Double v = containsKey(name) ? Double.valueOf(Double.parseDouble(getProperty(name))) : defaultVal;
     // use big decimal for double comparison
     BigDecimal startDecimal = new BigDecimal(start);
     BigDecimal endDecimal = new BigDecimal(end);
@@ -189,12 +174,7 @@ public class VerifiableProperties {
    * @return the long value
    */
   public long getLongInRange(String name, long defaultVal, long start, long end) {
-    long v = 0;
-    if (containsKey(name)) {
-      v = Long.parseLong(getProperty(name));
-    } else {
-      return defaultVal;
-    }
+    long v = containsKey(name) ? Long.parseLong(getProperty(name)) : defaultVal;
     if (v >= start && v <= end) {
       return v;
     } else {
@@ -219,11 +199,7 @@ public class VerifiableProperties {
    * @default The default value for the property if not present
    */
   public double getDouble(String name, double defaultVal) {
-    if (containsKey(name)) {
-      return getDouble(name);
-    } else {
-      return defaultVal;
-    }
+    return containsKey(name) ? getDouble(name) : defaultVal;
   }
 
   /**
@@ -233,11 +209,10 @@ public class VerifiableProperties {
    * @return the boolean value
    */
   public boolean getBoolean(String name, boolean defaultVal) {
-    String v = "";
     if (!containsKey(name)) {
       return defaultVal;
     } else {
-      v = getProperty(name);
+      String v = getProperty(name);
       if (v.compareTo("true") == 0 || v.compareTo("false") == 0) {
         return Boolean.parseBoolean(v);
       } else {
@@ -254,11 +229,7 @@ public class VerifiableProperties {
    * Get a string property, or, if no such property is defined, return the given default value
    */
   public String getString(String name, String defaultVal) {
-    if (containsKey(name)) {
-      return getProperty(name);
-    } else {
-      return defaultVal;
-    }
+    return containsKey(name) ? getProperty(name) : defaultVal;
   }
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/rest/RequestPath.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RequestPath.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.rest;
+
+import java.util.List;
+
+
+public class RequestPath {
+  private final String prefix;
+  private final String clusterName;
+  private final String operationOrBlobId;
+  private final RestUtils.SubResource subResource;
+  private String operationOrBlobIdWithoutLeadingSlash = null;
+
+  /**
+   * Parse the request path (and additional headers in some cases). The path will match the following regex-like
+   * description:
+   * <pre>
+   * {@code {prefixToRemove}?{clusterNameSegment}?({operationOrBlobId}|{operationOrBlobId}/{subResource})}
+   * </pre>
+   * For example, something like {@code /prefixOne/clusterA/parts/of/blobId/BlobInfo}, {@code /clusterA/operation},
+   * or {@code /blobId}, among others.
+   * @param restRequest {@link RestRequest} containing metadata about the request.
+   * @param prefixesToRemove the list of prefixes that could precede the other parts of the URL. Removal of
+   *                         prefixes earlier in the list will be preferred to removal of the ones later in the list.
+   * @param clusterName the cluster name to recognize and handle when parsing the URL. Case is ignored when matching
+   *                    this path segment.
+   * @return a {@link RequestPath} object.
+   */
+  public static RequestPath parse(RestRequest restRequest, List<String> prefixesToRemove, String clusterName) {
+    String path = restRequest.getPath();
+    int offset = 0;
+
+    // remove prefix.
+    String prefixFound = "";
+    if (prefixesToRemove != null) {
+      for (String prefix : prefixesToRemove) {
+        int nextSegmentOffset = matchPathSegments(path, offset, prefix, false);
+        if (nextSegmentOffset >= 0) {
+          prefixFound = prefix;
+          offset = nextSegmentOffset;
+          break;
+        }
+      }
+    }
+
+    // check if the next path segment matches the cluster name.
+    String clusterNameFound = "";
+    if (clusterName != null) {
+      int nextSegmentOffset = matchPathSegments(path, offset, clusterName, true);
+      if (nextSegmentOffset >= 0) {
+        clusterNameFound = clusterName;
+        offset = nextSegmentOffset;
+      }
+    }
+
+    // if there are at least 2 path segments (*/*) after the current position,
+    // test if the last segment is a sub-resource
+    RestUtils.SubResource subResource = null;
+    int lastSlashOffset = path.lastIndexOf('/');
+    if (lastSlashOffset > offset) {
+      try {
+        subResource = RestUtils.SubResource.valueOf(path.substring(lastSlashOffset + 1));
+      } catch (IllegalArgumentException e) {
+        // nothing to do.
+      }
+    }
+
+    // the operationOrBlobId is the part in between the prefix/cluster and sub-resource,
+    // if these optional path segments exist.
+    String operationOrBlobId = path.substring(offset, subResource == null ? path.length() : lastSlashOffset);
+    if ((operationOrBlobId.isEmpty() || operationOrBlobId.equals("/")) && restRequest.getArgs()
+        .containsKey(RestUtils.Headers.BLOB_ID)) {
+      operationOrBlobId = restRequest.getArgs().get(RestUtils.Headers.BLOB_ID).toString();
+    }
+
+    return new RequestPath(prefixFound, clusterNameFound, operationOrBlobId, subResource);
+  }
+
+  RequestPath(String prefix, String clusterName, String operationOrBlobId, RestUtils.SubResource subResource) {
+    this.prefix = prefix;
+    this.clusterName = clusterName;
+    this.operationOrBlobId = operationOrBlobId;
+    this.subResource = subResource;
+  }
+
+  /**
+   * @return the path prefix, or an empty string if the path did not start with a recognized prefix.
+   */
+  public String getPrefix() {
+    return prefix;
+  }
+
+  /**
+   * @returno the cluster name, or an empty string if the path did not include the recognized cluster name.
+   */
+  public String getClusterName() {
+    return clusterName;
+  }
+
+  /**
+   * @return the extracted operation type or blob ID from the request.
+   * @param stripLeadingSlash {@code true} to remove the leading slash, if present.
+   */
+  public String getOperationOrBlobId(boolean stripLeadingSlash) {
+    if (stripLeadingSlash) {
+      if (operationOrBlobIdWithoutLeadingSlash == null) {
+        operationOrBlobIdWithoutLeadingSlash =
+            operationOrBlobId.startsWith("/") ? operationOrBlobId.substring(1) : operationOrBlobId;
+      }
+      return operationOrBlobIdWithoutLeadingSlash;
+    } else {
+      return operationOrBlobId;
+    }
+  }
+
+  /**
+   * @return a {@link RestUtils.SubResource}, or {@code null} if no sub-resource was found in the request path.
+   */
+  public RestUtils.SubResource getSubResource() {
+    return subResource;
+  }
+
+  /**
+   * This will check if the request path matches the specified operation. This will check that that the first one or
+   * more path segments in {@link #getOperationOrBlobId(boolean)} match the path segments in {@code operation}. For example,
+   * {@code /op} or {@code /op/sub} will match the operation {@code op}.
+   * @param operation the operation name to check the path against.
+   * @return {@code true} if this request path matches the specified operation.
+   */
+  public boolean matchesOperation(String operation) {
+    return matchPathSegments(operationOrBlobId, 0, operation, true) >= 0;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RequestPath that = (RequestPath) o;
+    return prefix.equals(that.prefix) && clusterName.equals(that.clusterName) && operationOrBlobId.equals(
+        that.operationOrBlobId) && subResource == that.subResource;
+  }
+
+  @Override
+  public String toString() {
+    return "RequestPath{" + "prefix='" + prefix + '\'' + ", clusterName='" + clusterName + '\''
+        + ", operationOrBlobId='" + operationOrBlobId + '\'' + ", subResource=" + subResource + '}';
+  }
+
+  /**
+   * A helper method to search for segments of a request path. This method checks if the region of {@code path} starting
+   * at {@code pathOffset} matches the path segments in {@code segments}. This will only consider it a match if the
+   * a new segment (following slash) or the end of the path immediately follows {@code segments}.
+   * @param path the path to match the segments against.
+   * @param pathOffset the start offset in {@code path} to match against.
+   * @param segments the segments to search for. This method will ignore any leading or trailing slashes in this string.
+   * @param ignoreCase if {@code true}, ignore case when comparing characters.
+   * @return the offset of the character following {@code segments} in {@code path},
+   *         or {@code -1} if the segments to search for were not found.
+   */
+  private static int matchPathSegments(String path, int pathOffset, String segments, boolean ignoreCase) {
+    // start the search past the leading slash, if one exists
+    pathOffset += path.startsWith("/", pathOffset) ? 1 : 0;
+    // for search purposes we strip off leading and trailing slashes from the segments to search for.
+    int segmentsStartOffset = segments.startsWith("/") ? 1 : 0;
+    int segmentsLength = Math.max(segments.length() - segmentsStartOffset - (segments.endsWith("/") ? 1 : 0), 0);
+    int nextSegmentOffset = -1;
+    if (path.regionMatches(ignoreCase, pathOffset, segments, segmentsStartOffset, segmentsLength)) {
+      int nextCharOffset = pathOffset + segmentsLength;
+      // this is only a match if the end of the path was reached or the next character is a slash (starts new segment).
+      if (nextCharOffset == path.length() || path.charAt(nextCharOffset) == '/') {
+        nextSegmentOffset = nextCharOffset;
+      }
+    }
+    return nextSegmentOffset;
+  }
+}

--- a/ambry-api/src/main/java/com.github.ambry/rest/RequestPath.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RequestPath.java
@@ -103,7 +103,7 @@ public class RequestPath {
   }
 
   /**
-   * @returno the cluster name, or an empty string if the path did not include the recognized cluster name.
+   * @return the cluster name, or an empty string if the path did not include the recognized cluster name.
    */
   public String getClusterName() {
     return clusterName;

--- a/ambry-api/src/main/java/com.github.ambry/rest/RequestPath.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RequestPath.java
@@ -55,7 +55,7 @@ public class RequestPath {
    *                         prefixes earlier in the list will be preferred to removal of the ones later in the list.
    * @param clusterName the cluster name to recognize and handle when parsing the URL. Case is ignored when matching
    *                    this path segment.
-   * @return
+   * @return a {@link RequestPath} object.
    */
   public static RequestPath parse(String path, Map<String, Object> args, List<String> prefixesToRemove,
       String clusterName) {

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestUtils.java
@@ -313,7 +313,8 @@ public class RestUtils {
      * "replicas" here means the string representation of all the replicas (i.e. host:port/path) where the blob might
      * reside.
      */
-    Replicas}
+    Replicas
+  }
 
   public static final class MultipartPost {
     public final static String BLOB_PART = "Blob";

--- a/ambry-api/src/test/java/com.github.ambry/rest/RequestPathTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/RequestPathTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.rest;
+
+import com.github.ambry.utils.UtilsTest;
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Test {@link RequestPath}.
+ */
+public class RequestPathTest {
+
+  /**
+   * Tests {@link RequestPath#getOperationOrBlobId(boolean)}.
+   */
+  @Test
+  public void testRequestPathParsing() {
+    String baseId = "expectedOpOrId";
+    String queryString = "?queryParam1=queryValue1&queryParam2=queryParam2=queryValue2";
+    String securePath = "secure-path";
+    List<String> prefixesToRemove = Arrays.asList("media", "toRemove/multipart", securePath);
+    String clusterName = "Ambry-TesT";
+    String blobId = UtilsTest.getRandomString(10);
+    String blobIdQuery = RestUtils.Headers.BLOB_ID + "=" + blobId;
+
+    Map<String, String> prefixesToTest = new HashMap<>();
+    prefixesToTest.put("", "");
+    prefixesToRemove.forEach(prefix -> prefixesToTest.put("/" + prefix, prefix));
+    Map<String, String> clusterNameSegmentsToTest = new HashMap<>();
+    clusterNameSegmentsToTest.put("", "");
+    clusterNameSegmentsToTest.put("/" + clusterName.toLowerCase(), clusterName);
+    clusterNameSegmentsToTest.put("/" + clusterName.toUpperCase(), clusterName);
+    List<String> opsOrIdsToTest = Arrays.asList("/", "/" + baseId, "/" + baseId + "/random/extra",
+        "/" + RestUtils.SIGNED_ID_PREFIX + "/" + baseId, "/media" + baseId, "/" + RestUtils.SubResource.BlobInfo);
+    // construct test cases
+    prefixesToTest.forEach((prefixToUse, expectedPrefix) -> {
+      clusterNameSegmentsToTest.forEach((clusterNameToUse, expectedClusterName) -> {
+        opsOrIdsToTest.forEach(opOrId -> {
+          String path = prefixToUse + clusterNameToUse + opOrId;
+          // the uri as is (e.g. "/expectedOp).
+          parseRequestPathAndVerify(path, prefixesToRemove, clusterName,
+              new RequestPath(expectedPrefix, expectedClusterName, opOrId, null));
+
+          // the uri with a query string (e.g. "/expectedOp?param=value").
+          parseRequestPathAndVerify(path + queryString, prefixesToRemove, clusterName,
+              new RequestPath(expectedPrefix, expectedClusterName, opOrId, null));
+          if (opOrId.length() > 1) {
+            for (RestUtils.SubResource subResource : RestUtils.SubResource.values()) {
+              String subResourceStr = "/" + subResource.name();
+              parseRequestPathAndVerify(path + subResourceStr, prefixesToRemove, clusterName,
+                  new RequestPath(expectedPrefix, expectedClusterName, opOrId, subResource));
+              parseRequestPathAndVerify(path + subResourceStr + queryString, prefixesToRemove, clusterName,
+                  new RequestPath(expectedPrefix, expectedClusterName, opOrId, subResource));
+            }
+          } else {
+            parseRequestPathAndVerify(path + "?" + blobIdQuery, prefixesToRemove, clusterName,
+                new RequestPath(expectedPrefix, expectedClusterName, blobId, null));
+            parseRequestPathAndVerify(path + queryString + "&" + blobIdQuery, prefixesToRemove, clusterName,
+                new RequestPath(expectedPrefix, expectedClusterName, blobId, null));
+          }
+        });
+      });
+    });
+  }
+
+  /**
+   * Test the behavior of {@link RequestPath#matchesOperation(String)}.
+   */
+  @Test
+  public void testOperationMatching() {
+    String operation = "opToMatch";
+    Stream.of(new RequestPath("", "", "/" + operation + "/abc/def", null),
+        new RequestPath("", "", "/" + operation, null), new RequestPath("", "", "/" + operation + "/", null))
+        .forEach(requestPath -> {
+          assertTrue("Operation should match", requestPath.matchesOperation(operation));
+          assertTrue("Operation should match", requestPath.matchesOperation("/" + operation));
+          assertTrue("Operation should match", requestPath.matchesOperation("/" + operation + "/"));
+          assertFalse("Operation should not match", requestPath.matchesOperation("notOpToMatch"));
+        });
+
+  }
+
+  /**
+   * Test the behavior of {@link RequestPath#getOperationOrBlobId(boolean)}.
+   */
+  @Test
+  public void testStripLeadingSlash() {
+    RequestPath requestPath = new RequestPath("", "", "/opToMatch/abc", null);
+    assertEquals("Should strip leading slash", "opToMatch/abc", requestPath.getOperationOrBlobId(true));
+    assertEquals("Should not strip leading slash", "/opToMatch/abc", requestPath.getOperationOrBlobId(false));
+  }
+
+  /**
+   * Form the request, call {@link RequestPath#parse}, and check the result.
+   * @param requestPath the request path to supply
+   * @param prefixesToRemove the prefix list to supply
+   * @param clusterName the cluster name to supply
+   * @param expected the expected {@link RequestPath}.
+   */
+  private void parseRequestPathAndVerify(String requestPath, List<String> prefixesToRemove, String clusterName,
+      RequestPath expected) {
+    try {
+      RestRequest restRequest = RestUtilsTest.createRestRequest(RestMethod.GET, requestPath, null);
+      RequestPath actual = RequestPath.parse(restRequest, prefixesToRemove, clusterName);
+      assertEquals(
+          "Unexpected result for testRequestPath(" + requestPath + ", " + prefixesToRemove + ", " + clusterName + ")",
+          expected, actual);
+    } catch (UnsupportedEncodingException | URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/ambry-commons/src/main/java/com.github.ambry.commons/JdkSslFactory.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/JdkSslFactory.java
@@ -54,18 +54,10 @@ public class JdkSslFactory implements SSLFactory {
     sslContext = createSSLContext(sslConfig);
 
     ArrayList<String> cipherSuitesList = Utils.splitString(sslConfig.sslCipherSuites, ",");
-    if (cipherSuitesList.size() > 0 && !(cipherSuitesList.size() == 1 && cipherSuitesList.get(0).isEmpty())) {
-      cipherSuites = cipherSuitesList.toArray(new String[cipherSuitesList.size()]);
-    } else {
-      cipherSuites = null;
-    }
+    cipherSuites = !cipherSuitesList.isEmpty() ? cipherSuitesList.toArray(new String[0]) : null;
 
     ArrayList<String> protocolsList = Utils.splitString(sslConfig.sslEnabledProtocols, ",");
-    if (protocolsList.size() > 0 && !(protocolsList.size() == 1 && protocolsList.get(0).isEmpty())) {
-      enabledProtocols = protocolsList.toArray(new String[protocolsList.size()]);
-    } else {
-      enabledProtocols = null;
-    }
+    enabledProtocols = !protocolsList.isEmpty() ? protocolsList.toArray(new String[0]) : null;
 
     this.endpointIdentification =
         !sslConfig.sslEndpointIdentificationAlgorithm.isEmpty() ? sslConfig.sslEndpointIdentificationAlgorithm : null;

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageService.java
@@ -22,6 +22,7 @@ import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.rest.BlobStorageService;
+import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
@@ -41,7 +42,7 @@ import com.github.ambry.router.RouterErrorCode;
 import com.github.ambry.router.RouterException;
 import com.github.ambry.utils.AsyncOperationTracker;
 import com.github.ambry.utils.SystemTime;
-import com.github.ambry.utils.ThrowingBiConsumer;
+import com.github.ambry.utils.ThrowingConsumer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.GregorianCalendar;
@@ -84,6 +85,7 @@ class AmbryBlobStorageService implements BlobStorageService {
   private final Logger logger = LoggerFactory.getLogger(AmbryBlobStorageService.class);
   private final String datacenterName;
   private final String hostname;
+  private final String clusterName;
   private IdConverter idConverter = null;
   private SecurityService securityService = null;
   private GetPeersHandler getPeersHandler;
@@ -111,12 +113,14 @@ class AmbryBlobStorageService implements BlobStorageService {
    * @param accountAndContainerInjector the {@link AccountAndContainerInjector} to use.
    * @param datacenterName the local datacenter name for this frontend.
    * @param hostname the hostname for this frontend.
+   * @param clusterName
    */
   AmbryBlobStorageService(FrontendConfig frontendConfig, FrontendMetrics frontendMetrics,
       RestResponseHandler responseHandler, Router router, ClusterMap clusterMap, IdConverterFactory idConverterFactory,
       SecurityServiceFactory securityServiceFactory, UrlSigningService urlSigningService,
       IdSigningService idSigningService, AccountService accountService,
-      AccountAndContainerInjector accountAndContainerInjector, String datacenterName, String hostname) {
+      AccountAndContainerInjector accountAndContainerInjector, String datacenterName, String hostname,
+      String clusterName) {
     this.frontendConfig = frontendConfig;
     this.frontendMetrics = frontendMetrics;
     this.responseHandler = responseHandler;
@@ -130,6 +134,7 @@ class AmbryBlobStorageService implements BlobStorageService {
     this.accountAndContainerInjector = accountAndContainerInjector;
     this.datacenterName = datacenterName;
     this.hostname = hostname;
+    this.clusterName = clusterName.toLowerCase();
     getReplicasHandler = new GetReplicasHandler(frontendMetrics, clusterMap);
     logger.trace("Instantiated AmbryBlobStorageService");
   }
@@ -180,20 +185,21 @@ class AmbryBlobStorageService implements BlobStorageService {
 
   @Override
   public void handleGet(final RestRequest restRequest, final RestResponseChannel restResponseChannel) {
-    ThrowingBiConsumer<String, SubResource> routingAction = (operationOrBlobId, subResource) -> {
-      if (operationOrBlobId.equalsIgnoreCase(Operations.GET_PEERS)) {
+    ThrowingConsumer<RequestPath> routingAction = requestPath -> {
+      if (requestPath.matchesOperation(Operations.GET_PEERS)) {
         getPeersHandler.handle(restRequest, restResponseChannel,
             (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
-      } else if (operationOrBlobId.equalsIgnoreCase(Operations.GET_CLUSTER_MAP_SNAPSHOT)) {
+      } else if (requestPath.matchesOperation(Operations.GET_CLUSTER_MAP_SNAPSHOT)) {
         getClusterMapSnapshotHandler.handle(restRequest, restResponseChannel,
             (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
-      } else if (operationOrBlobId.endsWith(Operations.GET_SIGNED_URL)) {
+      } else if (requestPath.matchesOperation(Operations.GET_SIGNED_URL)) {
         getSignedUrlHandler.handle(restRequest, restResponseChannel,
             (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
-      } else if (operationOrBlobId.equalsIgnoreCase(Operations.ACCOUNTS)) {
+      } else if (requestPath.matchesOperation(Operations.ACCOUNTS)) {
         getAccountsHandler.handle(restRequest, restResponseChannel,
             (result, exception) -> submitResponse(restRequest, restResponseChannel, result, exception));
       } else {
+        SubResource subResource = requestPath.getSubResource();
         GetBlobOptions options = RestUtils.buildGetBlobOptions(restRequest.getArgs(), subResource,
             RestUtils.getGetOption(restRequest, frontendConfig.defaultRouterGetOption));
         GetCallback routerCallback = new GetCallback(restRequest, restResponseChannel, subResource, options);
@@ -212,11 +218,8 @@ class AmbryBlobStorageService implements BlobStorageService {
 
   @Override
   public void handlePost(RestRequest restRequest, RestResponseChannel restResponseChannel) {
-    ThrowingBiConsumer<String, SubResource> routingAction = (operationOrBlobId, subResource) -> {
-      if (operationOrBlobId.startsWith("/")) {
-        operationOrBlobId = operationOrBlobId.substring(1);
-      }
-      if (operationOrBlobId.equalsIgnoreCase(Operations.ACCOUNTS)) {
+    ThrowingConsumer<RequestPath> routingAction = requestPath -> {
+      if (requestPath.matchesOperation(Operations.ACCOUNTS)) {
         postAccountsHandler.handle(restRequest, restResponseChannel,
             (result, exception) -> submitResponse(restRequest, restResponseChannel, null, exception));
       } else {
@@ -230,8 +233,8 @@ class AmbryBlobStorageService implements BlobStorageService {
 
   @Override
   public void handlePut(RestRequest restRequest, RestResponseChannel restResponseChannel) {
-    ThrowingBiConsumer<String, SubResource> routingAction = (operationOrBlobId, subResource) -> {
-      if (operationOrBlobId.equalsIgnoreCase(Operations.UPDATE_TTL)) {
+    ThrowingConsumer<RequestPath> routingAction = requestPath -> {
+      if (requestPath.matchesOperation(Operations.UPDATE_TTL)) {
         ttlUpdateHandler.handle(restRequest, restResponseChannel, (r, e) -> {
           if (e instanceof RouterException
               && ((RouterException) e).getErrorCode() == RouterErrorCode.BlobUpdateNotAllowed) {
@@ -244,7 +247,8 @@ class AmbryBlobStorageService implements BlobStorageService {
           submitResponse(restRequest, restResponseChannel, null, e);
         });
       } else {
-        throw new RestServiceException("Unrecognized operation: " + operationOrBlobId, RestServiceErrorCode.BadRequest);
+        throw new RestServiceException("Unrecognized operation: " + requestPath.getOperationOrBlobId(false),
+            RestServiceErrorCode.BadRequest);
       }
     };
     preProcessAndRouteRequest(restRequest, restResponseChannel, frontendMetrics.putPreProcessingMetrics, routingAction);
@@ -252,7 +256,7 @@ class AmbryBlobStorageService implements BlobStorageService {
 
   @Override
   public void handleDelete(RestRequest restRequest, RestResponseChannel restResponseChannel) {
-    ThrowingBiConsumer<String, SubResource> routingAction = (operationOrBlobId, subResource) -> {
+    ThrowingConsumer<RequestPath> routingAction = requestPath -> {
       RestRequestMetrics requestMetrics =
           restRequest.isSslUsed() ? frontendMetrics.deleteBlobSSLMetrics : frontendMetrics.deleteBlobMetrics;
       restRequest.getMetricsTracker().injectMetrics(requestMetrics);
@@ -267,7 +271,7 @@ class AmbryBlobStorageService implements BlobStorageService {
 
   @Override
   public void handleHead(RestRequest restRequest, RestResponseChannel restResponseChannel) {
-    ThrowingBiConsumer<String, SubResource> routingAction = (operationOrBlobId, subResource) -> {
+    ThrowingConsumer<RequestPath> routingAction = requestPath -> {
       RestRequestMetrics requestMetrics =
           frontendMetrics.headRequestMetricsGroup.getRestRequestMetrics(restRequest.isSslUsed(), false);
       restRequest.getMetricsTracker().injectMetrics(requestMetrics);
@@ -293,6 +297,8 @@ class AmbryBlobStorageService implements BlobStorageService {
       checkAvailable();
       // TODO: make this non blocking once all handling of indiviual methods is moved to their own classes
       securityService.preProcessRequest(restRequest).get();
+      restRequest.setArg(REQUEST_PATH,
+          RequestPath.parse(restRequest, frontendConfig.pathPrefixesToRemove, clusterName));
       long preProcessingEndTime = System.currentTimeMillis();
       frontendMetrics.optionsPreProcessingTimeInMs.update(preProcessingEndTime - processingStartTime);
 
@@ -365,24 +371,20 @@ class AmbryBlobStorageService implements BlobStorageService {
    * @param restRequest the {@link RestRequest}.
    * @param restResponseChannel the {@link RestResponseChannel}.
    * @param preProcessingMetrics metrics instance for recording pre-processing time.
-   * @param routingAction called with either an operation or blob ID as the first argument and maybe a sub-resource as
-   *                      the second argument. Used to start request handling based on operation type.
+   * @param routingAction called with the parsed {@link RequestPath} as an argument. Used to start request handling
+   *                      based on operation type.
    */
   private void preProcessAndRouteRequest(RestRequest restRequest, RestResponseChannel restResponseChannel,
-      AsyncOperationTracker.Metrics preProcessingMetrics, ThrowingBiConsumer<String, SubResource> routingAction) {
+      AsyncOperationTracker.Metrics preProcessingMetrics, ThrowingConsumer<RequestPath> routingAction) {
     handlePrechecks(restRequest, restResponseChannel);
     Callback<Void> errorCallback = (r, e) -> submitResponse(restRequest, restResponseChannel, null, e);
     try {
       logger.trace("Handling {} request - {}", restRequest.getRestMethod(), restRequest.getUri());
       checkAvailable();
       securityService.preProcessRequest(restRequest, FrontendUtils.buildCallback(preProcessingMetrics, r -> {
-        SubResource subResource = RestUtils.getBlobSubResource(restRequest);
-        String operationOrBlobId =
-            RestUtils.getOperationOrBlobIdFromUri(restRequest, subResource, frontendConfig.pathPrefixesToRemove);
-        if (operationOrBlobId.startsWith("/")) {
-          operationOrBlobId = operationOrBlobId.substring(1);
-        }
-        routingAction.accept(operationOrBlobId, subResource);
+        RequestPath requestPath = RequestPath.parse(restRequest, frontendConfig.pathPrefixesToRemove, clusterName);
+        restRequest.setArg(REQUEST_PATH, requestPath);
+        routingAction.accept(requestPath);
       }, restRequest.getUri(), logger, errorCallback));
     } catch (Exception e) {
       errorCallback.onCompletion(null, e);
@@ -611,22 +613,18 @@ class AmbryBlobStorageService implements BlobStorageService {
           logger.trace("Forwarding {} to the IdConverter/Router", restMethod);
           switch (restMethod) {
             case GET:
-              String receivedId =
-                  RestUtils.getOperationOrBlobIdFromUri(restRequest, RestUtils.getBlobSubResource(restRequest),
-                      frontendConfig.pathPrefixesToRemove);
+              String receivedId = RestUtils.getRequestPath(restRequest).getOperationOrBlobId(false);
               InboundIdConverterCallback idConverterCallback =
                   new InboundIdConverterCallback(restRequest, restResponseChannel, getCallback);
               idConverter.convert(restRequest, receivedId, idConverterCallback);
               break;
             case HEAD:
-              receivedId = RestUtils.getOperationOrBlobIdFromUri(restRequest, RestUtils.getBlobSubResource(restRequest),
-                  frontendConfig.pathPrefixesToRemove);
+              receivedId = RestUtils.getRequestPath(restRequest).getOperationOrBlobId(false);
               idConverterCallback = new InboundIdConverterCallback(restRequest, restResponseChannel, headCallback);
               idConverter.convert(restRequest, receivedId, idConverterCallback);
               break;
             case DELETE:
-              receivedId = RestUtils.getOperationOrBlobIdFromUri(restRequest, RestUtils.getBlobSubResource(restRequest),
-                  frontendConfig.pathPrefixesToRemove);
+              receivedId = RestUtils.getRequestPath(restRequest).getOperationOrBlobId(false);
               idConverterCallback = new InboundIdConverterCallback(restRequest, restResponseChannel, deleteCallback);
               idConverter.convert(restRequest, receivedId, idConverterCallback);
               break;
@@ -684,7 +682,7 @@ class AmbryBlobStorageService implements BlobStorageService {
       ReadableStreamChannel response = null;
       switch (restMethod) {
         case GET:
-          RestUtils.SubResource subResource = RestUtils.getBlobSubResource(restRequest);
+          RestUtils.SubResource subResource = RestUtils.getRequestPath(restRequest).getSubResource();
           // inject encryption metrics if need be
           if (BlobId.isEncrypted(convertedId)) {
             restRequest.getMetricsTracker()
@@ -757,8 +755,7 @@ class AmbryBlobStorageService implements BlobStorageService {
       this.operationType = operationType;
       this.operationTimeTracker = operationTimeTracker;
       this.callbackProcessingTimeTracker = callbackProcessingTimeTracker;
-      blobId = RestUtils.getOperationOrBlobIdFromUri(restRequest, RestUtils.getBlobSubResource(restRequest),
-          frontendConfig.pathPrefixesToRemove);
+      blobId = RestUtils.getRequestPath(restRequest).getOperationOrBlobId(false);
     }
 
     /**

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/AmbryBlobStorageServiceFactory.java
@@ -91,7 +91,8 @@ public class AmbryBlobStorageServiceFactory implements BlobStorageServiceFactory
               urlSigningService, idSigningService, accountAndContainerInjector);
       return new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, clusterMap,
           idConverterFactory, securityServiceFactory, urlSigningService, idSigningService, accountService,
-          accountAndContainerInjector, clusterMapConfig.clusterMapDatacenterName, clusterMapConfig.clusterMapHostName);
+          accountAndContainerInjector, clusterMapConfig.clusterMapDatacenterName, clusterMapConfig.clusterMapHostName,
+          clusterMapConfig.clusterMapClusterName);
     } catch (Exception e) {
       throw new IllegalStateException("Could not instantiate AmbryBlobStorageService", e);
     }

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
@@ -169,7 +169,7 @@ class PostBlobHandler {
      */
     private Callback<Void> securityPostProcessRequestCallback(BlobInfo blobInfo) {
       return buildCallback(frontendMetrics.postSecurityPostProcessRequestMetrics, securityCheckResult -> {
-        if (getOperation().equalsIgnoreCase(Operations.STITCH)) {
+        if (RestUtils.getRequestPath(restRequest).matchesOperation(Operations.STITCH)) {
           CopyingAsyncWritableChannel channel = new CopyingAsyncWritableChannel(frontendConfig.maxJsonRequestSizeBytes);
           restRequest.readInto(channel, fetchStitchRequestBodyCallback(channel, blobInfo));
         } else {
@@ -331,19 +331,6 @@ class PostBlobHandler {
           throw new RestServiceException("Invalid chunk upload TTL: " + chunkTtl, RestServiceErrorCode.InvalidArgs);
         }
       }
-    }
-
-    /**
-     * @return the operation parsed from the {@link RestRequest}.
-     */
-    private String getOperation() {
-      RestUtils.SubResource subResource = RestUtils.getBlobSubResource(restRequest);
-      String operation =
-          RestUtils.getOperationOrBlobIdFromUri(restRequest, subResource, frontendConfig.pathPrefixesToRemove);
-      if (operation.startsWith("/")) {
-        operation = operation.substring(1);
-      }
-      return operation;
     }
 
     /**

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -1189,7 +1189,6 @@ public class AmbryBlobStorageServiceTest {
    * @throws UnsupportedEncodingException
    * @throws URISyntaxException
    */
-
   static RestRequest createRestRequest(RestMethod restMethod, String uri, JSONObject headers, List<ByteBuffer> contents)
       throws JSONException, UnsupportedEncodingException, URISyntaxException {
     JSONObject request = new JSONObject();
@@ -2578,7 +2577,8 @@ class FrontendTestSecurityServiceFactory implements SecurityServiceFactory {
     /**
      * Works in {@link SecurityService#processResponse(RestRequest, RestResponseChannel, BlobInfo, Callback)}.
      */
-    ProcessResponse}
+    ProcessResponse
+  }
 
   /**
    * The exception to return via future/callback.
@@ -2810,7 +2810,8 @@ class FrontendTestRouter implements Router {
     GetBlob,
     PutBlob,
     StitchBlob,
-    UpdateBlobTtl}
+    UpdateBlobTtl
+  }
 
   OpType exceptionOpType = null;
   Exception exceptionToReturn = null;

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -128,6 +128,7 @@ public class AmbryBlobStorageServiceTest {
   private final IdSigningService idSigningService;
   private final String datacenterName = "Data-Center";
   private final String hostname = "localhost";
+  private final String clusterName = "ambry-test";
   private FrontendConfig frontendConfig;
   private VerifiableProperties verifiableProperties;
   private boolean shouldAllowServiceIdBasedPut = true;
@@ -758,7 +759,7 @@ public class AmbryBlobStorageServiceTest {
     ambryBlobStorageService =
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, testRouter, clusterMap,
             idConverterFactory, securityServiceFactory, urlSigningService, idSigningService, accountService,
-            accountAndContainerInjector, datacenterName, hostname);
+            accountAndContainerInjector, datacenterName, hostname, clusterName);
     ambryBlobStorageService.start();
     JSONObject headers = new JSONObject();
     String serviceId = "service-id";
@@ -780,7 +781,7 @@ public class AmbryBlobStorageServiceTest {
     ambryBlobStorageService =
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, clusterMap,
             idConverterFactory, securityServiceFactory, urlSigningService, idSigningService, accountService,
-            accountAndContainerInjector, datacenterName, hostname);
+            accountAndContainerInjector, datacenterName, hostname, clusterName);
     ambryBlobStorageService.start();
     // test good requests
     for (String datanode : TailoredPeersClusterMap.DATANODE_NAMES) {
@@ -1043,7 +1044,7 @@ public class AmbryBlobStorageServiceTest {
     ambryBlobStorageService =
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, testRouter, clusterMap,
             idConverterFactory, securityServiceFactory, urlSigningService, idSigningService, accountService,
-            accountAndContainerInjector, datacenterName, hostname);
+            accountAndContainerInjector, datacenterName, hostname, clusterName);
     ambryBlobStorageService.start();
     String blobId = new BlobId(blobIdVersion, BlobId.BlobIdType.NATIVE, (byte) -1, Account.UNKNOWN_ACCOUNT_ID,
         Container.UNKNOWN_CONTAINER_ID, clusterMap.getAllPartitionIds(null).get(0), false,
@@ -1141,25 +1142,22 @@ public class AmbryBlobStorageServiceTest {
     try {
       getBlobAndVerify(blobId, null, null, headers, content, account, signedPathRequiredContainer);
       fail("get blob should fail because secure path is missing");
-    } catch (Exception e) {
-      assertEquals("Mismatch in error code", RestServiceErrorCode.AccessDenied,
-          ((RestServiceException) e).getErrorCode());
+    } catch (RestServiceException e) {
+      assertEquals("Mismatch in error code", RestServiceErrorCode.AccessDenied, e.getErrorCode());
     }
     // test that secure path equals other prefix should fail (return AccessDenied)
     try {
       getBlobAndVerify("/media" + blobId, null, null, headers, content, account, signedPathRequiredContainer);
       fail("get blob should fail because secure path equals other prefix and doesn't match expected one");
-    } catch (Exception e) {
-      assertEquals("Mismatch in error code", RestServiceErrorCode.AccessDenied,
-          ((RestServiceException) e).getErrorCode());
+    } catch (RestServiceException e) {
+      assertEquals("Mismatch in error code", RestServiceErrorCode.AccessDenied, e.getErrorCode());
     }
     // test that incorrect path should fail (return BadRequest)
     try {
       getBlobAndVerify("/incorrect-path" + blobId, null, null, headers, content, account, signedPathRequiredContainer);
       fail("get blob should fail because secure path is incorrect");
-    } catch (Exception e) {
-      assertEquals("Mismatch in error code", RestServiceErrorCode.BadRequest,
-          ((RestServiceException) e).getErrorCode());
+    } catch (RestServiceException e) {
+      assertEquals("Mismatch in error code", RestServiceErrorCode.BadRequest, e.getErrorCode());
     }
     // test container with no validation
     setAmbryHeadersForPut(headers, TTL_SECS, false, refAccountName, contentType, ownerId, refAccountName,
@@ -1170,9 +1168,8 @@ public class AmbryBlobStorageServiceTest {
     try {
       getBlobAndVerify("/incorrect-path" + blobId, null, null, headers, content, account, noValidationContainer);
       fail("get blob should fail because there is invalid path in uri");
-    } catch (Exception e) {
-      assertEquals("Mismatch in error code", RestServiceErrorCode.BadRequest,
-          ((RestServiceException) e).getErrorCode());
+    } catch (RestServiceException e) {
+      assertEquals("Mismatch in error code", RestServiceErrorCode.BadRequest, e.getErrorCode());
     }
     // test container with no validation should succeed if URI is correct
     getBlobAndVerify(blobId, null, null, headers, content, account, noValidationContainer);
@@ -1360,7 +1357,7 @@ public class AmbryBlobStorageServiceTest {
   private AmbryBlobStorageService getAmbryBlobStorageService() {
     return new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, clusterMap,
         idConverterFactory, securityServiceFactory, urlSigningService, idSigningService, accountService,
-        accountAndContainerInjector, datacenterName, hostname);
+        accountAndContainerInjector, datacenterName, hostname, clusterName);
   }
 
   // nullInputsForFunctionsTest() helpers
@@ -1986,7 +1983,7 @@ public class AmbryBlobStorageServiceTest {
     ambryBlobStorageService =
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, router, clusterMap,
             converterFactory, securityServiceFactory, urlSigningService, idSigningService, accountService,
-            accountAndContainerInjector, datacenterName, hostname);
+            accountAndContainerInjector, datacenterName, hostname, clusterName);
     ambryBlobStorageService.start();
     RestMethod[] restMethods = {RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD};
     doExternalServicesBadInputTest(restMethods, expectedExceptionMsg, false);
@@ -2017,7 +2014,7 @@ public class AmbryBlobStorageServiceTest {
       ambryBlobStorageService =
           new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, new FrontendTestRouter(),
               clusterMap, idConverterFactory, securityFactory, urlSigningService, idSigningService, accountService,
-              accountAndContainerInjector, datacenterName, hostname);
+              accountAndContainerInjector, datacenterName, hostname, clusterName);
       ambryBlobStorageService.start();
       doExternalServicesBadInputTest(restMethods, exceptionMsg,
           mode == FrontendTestSecurityServiceFactory.Mode.ProcessResponse);
@@ -2074,7 +2071,7 @@ public class AmbryBlobStorageServiceTest {
     ambryBlobStorageService =
         new AmbryBlobStorageService(frontendConfig, frontendMetrics, responseHandler, testRouter, clusterMap,
             idConverterFactory, securityServiceFactory, urlSigningService, idSigningService, accountService,
-            accountAndContainerInjector, datacenterName, hostname);
+            accountAndContainerInjector, datacenterName, hostname, clusterName);
     ambryBlobStorageService.start();
     for (RestMethod restMethod : RestMethod.values()) {
       switch (restMethod) {
@@ -2562,10 +2559,11 @@ class FrontendTestSecurityServiceFactory implements SecurityServiceFactory {
   /**
    * Defines the API in which {@link #exceptionToThrow} and {@link #exceptionToReturn} will work.
    */
-  protected enum Mode {/**
-   * Works in {@link SecurityService#preProcessRequest(RestRequest, Callback)}.
-   */
-  PreProcessRequest,
+  protected enum Mode {
+    /**
+     * Works in {@link SecurityService#preProcessRequest(RestRequest, Callback)}.
+     */
+    PreProcessRequest,
 
     /**
      * Works in {@link SecurityService#processRequest(RestRequest, Callback)}.
@@ -2807,7 +2805,12 @@ class FrontendTestRouter implements Router {
   /**
    * Enumerates the different operation types in the router.
    */
-  enum OpType {DeleteBlob, GetBlob, PutBlob, StitchBlob, UpdateBlobTtl}
+  enum OpType {
+    DeleteBlob,
+    GetBlob,
+    PutBlob,
+    StitchBlob,
+    UpdateBlobTtl}
 
   OpType exceptionOpType = null;
   Exception exceptionToReturn = null;

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbrySecurityServiceTest.java
@@ -24,6 +24,7 @@ import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.rest.MockRestRequest;
 import com.github.ambry.rest.MockRestResponseChannel;
+import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.ResponseStatus;
 import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
@@ -73,6 +74,7 @@ public class AmbrySecurityServiceTest {
   private static final FrontendConfig FRONTEND_CONFIG = new FrontendConfig(new VerifiableProperties(new Properties()));
   private static final String SERVICE_ID = "AmbrySecurityService";
   private static final String OWNER_ID = SERVICE_ID;
+  private static final String CLUSTER_NAME = "ambry-test";
   private static final InMemAccountService ACCOUNT_SERVICE =
       new InMemAccountServiceFactory(false, true).getAccountService();
   private static final QuotaManager quotaManager = new QuotaManager(FRONTEND_CONFIG);
@@ -121,7 +123,8 @@ public class AmbrySecurityServiceTest {
   @Test
   public void preProcessRequestTest() throws Exception {
     RestMethod[] methods =
-        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS, RestMethod.PUT};
+        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS,
+            RestMethod.PUT};
     for (RestMethod restMethod : methods) {
       // add a header that is prohibited
       JSONObject headers = new JSONObject();
@@ -168,7 +171,8 @@ public class AmbrySecurityServiceTest {
 
     // without callbacks
     RestMethod[] methods =
-        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS, RestMethod.PUT};
+        new RestMethod[]{RestMethod.POST, RestMethod.GET, RestMethod.DELETE, RestMethod.HEAD, RestMethod.OPTIONS,
+            RestMethod.PUT};
     for (RestMethod restMethod : methods) {
       RestRequest restRequest = createRestRequest(restMethod, "/", null);
       securityService.preProcessRequest(restRequest).get();
@@ -432,7 +436,10 @@ public class AmbrySecurityServiceTest {
     if (headers != null) {
       request.put(MockRestRequest.HEADERS_KEY, headers);
     }
-    return new MockRestRequest(request, null);
+    RestRequest restRequest = new MockRestRequest(request, null);
+    restRequest.setArg(RestUtils.InternalKeys.REQUEST_PATH,
+        RequestPath.parse(restRequest, FRONTEND_CONFIG.pathPrefixesToRemove, CLUSTER_NAME));
+    return restRequest;
   }
 
   /**

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/PostBlobHandlerTest.java
@@ -28,6 +28,7 @@ import com.github.ambry.config.FrontendConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.rest.MockRestResponseChannel;
+import com.github.ambry.rest.RequestPath;
 import com.github.ambry.rest.RestMethod;
 import com.github.ambry.rest.RestRequest;
 import com.github.ambry.rest.RestResponseChannel;
@@ -38,7 +39,6 @@ import com.github.ambry.router.ChunkInfo;
 import com.github.ambry.router.FutureResult;
 import com.github.ambry.router.InMemoryRouter;
 import com.github.ambry.router.PutBlobOptionsBuilder;
-import com.github.ambry.router.ReadableStreamChannel;
 import com.github.ambry.router.RouterErrorCode;
 import com.github.ambry.router.RouterException;
 import com.github.ambry.utils.MockTime;
@@ -47,6 +47,8 @@ import com.github.ambry.utils.ThrowingConsumer;
 import com.github.ambry.utils.Utils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -86,6 +88,7 @@ public class PostBlobHandlerTest {
   private static final String CONTENT_TYPE = "text/plain";
   private static final String OWNER_ID = "tester";
   private static final String CONVERTED_ID = "/abcdef";
+  private static final String CLUSTER_NAME = "ambry-test";
 
   static {
     try {
@@ -282,9 +285,8 @@ public class PostBlobHandlerTest {
     JSONObject headers = new JSONObject();
     AmbryBlobStorageServiceTest.setAmbryHeadersForPut(headers, blobTtlSecs, !container.isCacheable(), SERVICE_ID,
         CONTENT_TYPE, OWNER_ID, REF_ACCOUNT.getName(), container.getName());
-    ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(1024));
-    RestRequest request = AmbryBlobStorageServiceTest.createRestRequest(RestMethod.POST, "/", headers,
-        new LinkedList<>(Arrays.asList(content, null)));
+    byte[] content = TestUtils.getRandomBytes(1024);
+    RestRequest request = getRestRequest(headers, "/", content);
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();
     FutureResult<Void> future = new FutureResult<>();
     postBlobHandler.handle(request, restResponseChannel, future::done);
@@ -316,15 +318,15 @@ public class PostBlobHandlerTest {
    * @param expectWarning {@code true} if a warning header for non compliance is expected. {@code false} otherwise.
    * @throws Exception
    */
-  private void verifySuccessResponseOnTtlEnforcement(FutureResult<Void> postFuture, ByteBuffer content,
-      long blobTtlSecs, RestResponseChannel restResponseChannel, boolean expectWarning) throws Exception {
+  private void verifySuccessResponseOnTtlEnforcement(FutureResult<Void> postFuture, byte[] content, long blobTtlSecs,
+      RestResponseChannel restResponseChannel, boolean expectWarning) throws Exception {
     postFuture.get(TIMEOUT_SECS, TimeUnit.SECONDS);
 
     String id = (String) restResponseChannel.getHeader(RestUtils.Headers.LOCATION);
     assertNotNull("There should be a blob ID returned", id);
     InMemoryRouter.InMemoryBlob blob = router.getActiveBlobs().get(id);
     assertNotNull("No blob with ID " + id, blob);
-    assertEquals("Unexpected blob content stored", content.rewind(), blob.getBlob());
+    assertEquals("Unexpected blob content stored", ByteBuffer.wrap(content), blob.getBlob());
     assertEquals("Unexpected ttl stored", blobTtlSecs, blob.getBlobProperties().getTimeToLiveInSeconds());
 
     if (expectWarning) {
@@ -362,9 +364,8 @@ public class PostBlobHandlerTest {
     if (maxUploadSize != null) {
       headers.put(RestUtils.Headers.MAX_UPLOAD_SIZE, maxUploadSize);
     }
-    ByteBuffer content = ByteBuffer.wrap(TestUtils.getRandomBytes(contentLength));
-    RestRequest request = AmbryBlobStorageServiceTest.createRestRequest(RestMethod.POST, "/", headers,
-        new LinkedList<>(Arrays.asList(content, null)));
+    byte[] content = TestUtils.getRandomBytes(contentLength);
+    RestRequest request = getRestRequest(headers, "/", content);
     long creationTimeMs = System.currentTimeMillis();
     time.setCurrentMilliseconds(creationTimeMs);
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();
@@ -386,7 +387,7 @@ public class PostBlobHandlerTest {
         assertNull("Signed id metadata should not be set on non-chunk uploads", metadata);
       }
       InMemoryRouter.InMemoryBlob blob = router.getActiveBlobs().get(idConverterFactory.lastInput);
-      assertEquals("Unexpected blob content stored", content.flip(), blob.getBlob());
+      assertEquals("Unexpected blob content stored", ByteBuffer.wrap(content), blob.getBlob());
       assertEquals("Unexpected ttl stored", blobTtlSecs, blob.getBlobProperties().getTimeToLiveInSeconds());
     } else {
       TestUtils.assertException(ExecutionException.class, () -> future.get(TIMEOUT_SECS, TimeUnit.SECONDS),
@@ -480,9 +481,7 @@ public class PostBlobHandlerTest {
     JSONObject headers = new JSONObject();
     AmbryBlobStorageServiceTest.setAmbryHeadersForPut(headers, TestUtils.TTL_SECS, !REF_CONTAINER.isCacheable(),
         SERVICE_ID, CONTENT_TYPE, OWNER_ID, REF_ACCOUNT.getName(), REF_CONTAINER.getName());
-    RestRequest request =
-        AmbryBlobStorageServiceTest.createRestRequest(RestMethod.POST, "/" + Operations.STITCH, headers,
-            new LinkedList<>(Arrays.asList(ByteBuffer.wrap(requestBody), null)));
+    RestRequest request = getRestRequest(headers, "/" + Operations.STITCH, requestBody);
     RestResponseChannel restResponseChannel = new MockRestResponseChannel();
     FutureResult<Void> future = new FutureResult<>();
     idConverterFactory.lastInput = null;
@@ -501,5 +500,14 @@ public class PostBlobHandlerTest {
       TestUtils.assertException(ExecutionException.class, () -> future.get(TIMEOUT_SECS, TimeUnit.SECONDS),
           errorChecker);
     }
+  }
+
+  private RestRequest getRestRequest(JSONObject headers, String path, byte[] requestBody)
+      throws UnsupportedEncodingException, URISyntaxException {
+    RestRequest request = AmbryBlobStorageServiceTest.createRestRequest(RestMethod.POST, path, headers,
+        new LinkedList<>(Arrays.asList(ByteBuffer.wrap(requestBody), null)));
+    request.setArg(RestUtils.InternalKeys.REQUEST_PATH,
+        RequestPath.parse(request, frontendConfig.pathPrefixesToRemove, CLUSTER_NAME));
+    return request;
   }
 }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/PostBlobHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/PostBlobHandlerTest.java
@@ -502,6 +502,14 @@ public class PostBlobHandlerTest {
     }
   }
 
+  /**
+   * Method to easily create a POST {@link RestRequest}. This will set {@link RestUtils.InternalKeys#REQUEST_PATH} to a
+   * valid {@link RequestPath} object.
+   * @param headers any associated headers as a {@link JSONObject}.
+   * @param path the path for the request.
+   * @param requestBody the body of the request.
+   * @return A {@link RestRequest} object that defines the request required by the input.
+   */
   private RestRequest getRestRequest(JSONObject headers, String path, byte[] requestBody)
       throws UnsupportedEncodingException, URISyntaxException {
     RestRequest request = AmbryBlobStorageServiceTest.createRestRequest(RestMethod.POST, path, headers,

--- a/ambry-network/src/main/java/com.github.ambry.network/SSLBlockingChannel.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/SSLBlockingChannel.java
@@ -68,14 +68,13 @@ public class SSLBlockingChannel extends BlockingChannel {
         sslSocket = (SSLSocket) sslSocketFactory.createSocket(socket, host, port, true);
 
         ArrayList<String> protocolsList = Utils.splitString(sslConfig.sslEnabledProtocols, ",");
-        if (protocolsList != null && protocolsList.size() > 0) {
+        if (!protocolsList.isEmpty()) {
           String[] enabledProtocols = protocolsList.toArray(new String[protocolsList.size()]);
           sslSocket.setEnabledProtocols(enabledProtocols);
         }
 
         ArrayList<String> cipherSuitesList = Utils.splitString(sslConfig.sslCipherSuites, ",");
-        if (cipherSuitesList != null && cipherSuitesList.size() > 0 && !(cipherSuitesList.size() == 1
-            && cipherSuitesList.get(0).equals(""))) {
+        if (!cipherSuitesList.isEmpty()) {
           String[] cipherSuites = cipherSuitesList.toArray(new String[cipherSuitesList.size()]);
           sslSocket.setEnabledCipherSuites(cipherSuites);
         }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettySslFactory.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettySslFactory.java
@@ -26,7 +26,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
-import java.util.ArrayList;
+import java.util.List;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -166,9 +166,8 @@ public class NettySslFactory implements SSLFactory {
    * @return the list of supported cipher suites, or {@code null} if the configs did not specify any
    */
   private static Iterable<String> getCipherSuites(SSLConfig config) {
-    ArrayList<String> cipherSuitesList = Utils.splitString(config.sslCipherSuites, ",");
-    return (cipherSuitesList.size() > 0 && !(cipherSuitesList.size() == 1 && cipherSuitesList.get(0).isEmpty()))
-        ? cipherSuitesList : null;
+    List<String> cipherSuitesList = Utils.splitString(config.sslCipherSuites, ",");
+    return cipherSuitesList.size() > 0 ? cipherSuitesList : null;
   }
 
   /**
@@ -176,9 +175,8 @@ public class NettySslFactory implements SSLFactory {
    * @return the list of supported cipher suites, or {@code null} if the configs did not specify any
    */
   private static String[] getEnabledProtocols(SSLConfig config) {
-    String[] enabledProtocols = config.sslEnabledProtocols.split(",");
-    return enabledProtocols.length > 0 && !(enabledProtocols.length == 1 && enabledProtocols[0].isEmpty())
-        ? enabledProtocols : null;
+    List<String> enabledProtocols = Utils.splitString(config.sslEnabledProtocols, ",");
+    return !enabledProtocols.isEmpty() ? enabledProtocols.toArray(new String[0]) : null;
   }
 
   /**

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -733,8 +733,10 @@ public class Utils {
   }
 
   /**
-   * Split the input string "data" using the delimiter and return as list of strings for the slices obtained
-   * @param data the string to split. If this string is empty, a zero element list will be returned.
+   * Split the input string "data" using the delimiter and return as list of strings for the slices obtained.
+   * This method will ignore empty segments. That is, a call like {@code splitString(",a1,,b2,c3,", ","}} will return
+   * {@code ["a1","b2","c3]}. Since this is used for reading list-style configs, this is usually the desired behavior.
+   * @param data the string to split.
    * @param delimiter the delimiter for splitting.
    * @return a mutable list of items.
    */
@@ -742,7 +744,9 @@ public class Utils {
     if (data == null) {
       throw new IllegalArgumentException("Passed in string is null ");
     }
-    return data.isEmpty() ? new ArrayList<>() : new ArrayList<>(Arrays.asList(data.split(delimiter)));
+    return Arrays.stream(data.split(delimiter))
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toCollection(ArrayList::new));
   }
 
   /**

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -734,15 +734,15 @@ public class Utils {
 
   /**
    * Split the input string "data" using the delimiter and return as list of strings for the slices obtained
-   * @param data
-   * @param delimiter
-   * @return
+   * @param data the string to split. If this string is empty, a zero element list will be returned.
+   * @param delimiter the delimiter for splitting.
+   * @return a mutable list of items.
    */
   public static ArrayList<String> splitString(String data, String delimiter) {
     if (data == null) {
       throw new IllegalArgumentException("Passed in string is null ");
     }
-    return new ArrayList<>(Arrays.asList(data.split(delimiter)));
+    return data.isEmpty() ? new ArrayList<>() : new ArrayList<>(Arrays.asList(data.split(delimiter)));
   }
 
   /**

--- a/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/UtilsTest.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -511,8 +513,8 @@ public class UtilsTest {
   @Test
   public void getTtlInSecsFromExpiryMsTest() {
     long creationTimeMs = SystemTime.getInstance().milliseconds();
-    for (long ttlInSecs : new long[]{1, 20, 1000, Integer.MAX_VALUE, Utils.Infinite_Time, -100, -(
-        TimeUnit.MILLISECONDS.toSeconds(creationTimeMs) + 1)}) {
+    for (long ttlInSecs : new long[]{1, 20, 1000, Integer.MAX_VALUE, Utils.Infinite_Time, -100,
+        -(TimeUnit.MILLISECONDS.toSeconds(creationTimeMs) + 1)}) {
       long expectedTtlSecs = ttlInSecs;
       if (ttlInSecs == Utils.Infinite_Time) {
         expectedTtlSecs = Utils.Infinite_Time;
@@ -551,6 +553,17 @@ public class UtilsTest {
     assertEquals("Wrong comparison result for finite times", 0, Utils.compareTimes(25, 25));
     assertEquals("Wrong comparison result for finite times", -1, Utils.compareTimes(24, 25));
     assertEquals("Wrong comparison result for finite times", 1, Utils.compareTimes(25, 24));
+  }
+
+  /**
+   * Tests for {@link Utils#splitString(String, String)}.
+   */
+  @Test
+  public void splitStringTest() {
+    assertEquals("Unexpected result", new ArrayList<>(Arrays.asList("a", "b", "c")), Utils.splitString("a,b,c", ","));
+    assertEquals("Empty string should return empty list", new ArrayList<>(), Utils.splitString("", ","));
+    assertEquals("Empty segments should be ignored", new ArrayList<>(Arrays.asList("a", "b-extra", "c")),
+        Utils.splitString(",a,,b-extra,c,,", ","));
   }
 
   private static final String CHARACTERS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";


### PR DESCRIPTION
To support multicluster deployments of ambry, this PR:
- adds support for including a path segment for the cluster name in the
  request URI.
- centralizes the request path parsing in
  AmbryBlobStorageService.preProcessAndRouteRequest. Instead of requiring
  string parsing in multiple places/classes, a RequestPath object as an
  internal request argument that can be referred to by components that
  need it.
- makes the checking of prefixes and operations in the path more robust
  to variations in path segments and separators.
- Also includes some fixes to make parsing comma separated list configs
  more convenient.