### PR TITLE
Provide option to use GetBlobOperation for BlobInfo

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -220,6 +220,16 @@ public class RouterConfig {
   public final int routerTtlUpdateSuccessTarget;
 
   /**
+   * If this config is set to {@code true} the router will use {@code GetBlobOperation} instead of
+   * {@code GetBlobInfoOperation} for {@code getBlobInfo} calls. This allows the router to correct some blob size
+   * corruptions that may have arisen from using older versions of {@code BlobIdTransformer} with the downside of
+   * requiring more data to be fetched from storage. For most ambry deployments this is not necessary.
+   */
+  @Config("router.use.get.blob.operation.for.blob.info")
+  @Default("false")
+  public final boolean routerUseGetBlobOperationForBlobInfo;
+
+  /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
    */
@@ -274,5 +284,7 @@ public class RouterConfig {
         verifiableProperties.getIntInRange("router.ttl.update.request.parallelism", 3, 1, Integer.MAX_VALUE);
     routerTtlUpdateSuccessTarget =
         verifiableProperties.getIntInRange("router.ttl.update.success.target", 2, 1, Integer.MAX_VALUE);
+    routerUseGetBlobOperationForBlobInfo =
+        verifiableProperties.getBoolean("router.use.get.blob.operation.for.blob.info", false);
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -135,9 +135,17 @@ class GetManager {
       routerMetrics.getBlobNotOriginateLocalOperationRate.mark();
     }
     trackGetBlobRateMetrics(options.getBlobOptions, isEncrypted);
-    getOperation =
-        new GetBlobOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback,
-            routerCallback, blobIdFactory, kms, cryptoService, cryptoJobHandler, time, isEncrypted);
+
+    if (!routerConfig.routerUseGetBlobOperationForBlobInfo
+        && options.getBlobOptions.getOperationType() == GetBlobOptions.OperationType.BlobInfo) {
+      getOperation =
+          new GetBlobInfoOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback,
+              routerCallback, kms, cryptoService, cryptoJobHandler, time, isEncrypted);
+    } else {
+      getOperation =
+          new GetBlobOperation(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback,
+              routerCallback, blobIdFactory, kms, cryptoService, cryptoJobHandler, time, isEncrypted);
+    }
     getOperations.add(getOperation);
   }
 


### PR DESCRIPTION
This allows for ambry operators to choose to use GetBlobInfoOperation,
instead of being required to use GetBlobOperation. GetBlobInfoOperation
requires less content to be fetched from storage and suffices for most
deployments that do not have encrypted or composite blobs with corrupted
size fields.