### PR TITLE
Create ZkServerWrapper to speed up test.

### DIFF
--- a/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
@@ -232,7 +232,7 @@ public class TestUtils {
   /**
    * A wrapper class to start and shutdown {@link ZooKeeperServer}.
    * We maintain this class because {@link org.I0Itec.zkclient.ZkServer} calls NetworkUtil.getLocalHostNames()
-   * which takes time in Max OS.
+   * which takes time in Mac OS.
    */
   static class ZkServerWrapper {
     private static final Logger logger = LoggerFactory.getLogger(ZkServerWrapper.class);

--- a/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
@@ -230,9 +230,11 @@ public class TestUtils {
   }
 
   /**
-   * A wrapper class to start and shutdown {@link ZooKeeperServer}.
-   * We maintain this class because {@link org.I0Itec.zkclient.ZkServer} calls NetworkUtil.getLocalHostNames()
-   * which takes time in Mac OS.
+   * A wrapper class to start and shutdown {@link ZooKeeperServer}. The code is from {@link org.I0Itec.zkclient.ZkServer}.
+   * We maintain this class to speed up tests because function calls to NetworkUtil.getLocalHostNames() in
+   * {@link org.I0Itec.zkclient.ZkServer} takes time in Mac OS.
+   * {@link org.I0Itec.zkclient.ZkServer} calls NetworkUtil.getLocalHostNames() to log and make sure "localhost" is in
+   * the list of NetworkUtil.getLocalHostNames(), which are not necessary in tests.
    */
   static class ZkServerWrapper {
     private static final Logger logger = LoggerFactory.getLogger(ZkServerWrapper.class);

--- a/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/TestUtils.java
@@ -231,6 +231,8 @@ public class TestUtils {
 
   /**
    * A wrapper class to start and shutdown {@link ZooKeeperServer}.
+   * We maintain this class because {@link org.I0Itec.zkclient.ZkServer} calls NetworkUtil.getLocalHostNames()
+   * which takes time in Max OS.
    */
   static class ZkServerWrapper {
     private static final Logger logger = LoggerFactory.getLogger(ZkServerWrapper.class);


### PR DESCRIPTION
Create ZkServerWrapper to replace ZKServer. 
In Mac, NetworkUtil.getLocalHostNames() in ZKServer is time-consuming.
