### PR TITLE
Misc minor fixes in Helix tool, ReplicationEngine and Composite Manager

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -129,7 +129,7 @@ class CompositeClusterManager implements ClusterMap {
   @Override
   public String getDatacenterName(byte id) {
     String dcName = staticClusterManager.getDatacenterName(id);
-    if (!dcName.equals(helixClusterManager.getDatacenterName(id))) {
+    if (helixClusterManager != null && !dcName.equals(helixClusterManager.getDatacenterName(id))) {
       helixClusterManagerMetrics.getDatacenterNameMismatchCount.inc();
     }
     return dcName;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -178,6 +178,8 @@ class HelixBootstrapUpgradeUtil {
       clusterMapToHelixMapper.validateAndClose();
     }
     clusterMapToHelixMapper.logSummary();
+    info("========Bootstrap or upgrade completed! (if program doesn't exit, please use Ctrl-c to terminate)========");
+    System.exit(0);
   }
 
   /**
@@ -421,7 +423,7 @@ class HelixBootstrapUpgradeUtil {
   private void updateClusterMapInHelix(boolean startValidatingClusterManager) throws IOException {
     info("Initializing admins and possibly adding cluster in Helix (if non-existent)");
     maybeAddCluster();
-    info("Initialized, starting validating cluster manager");
+    info("Validating cluster manager is {}", startValidatingClusterManager ? "ENABLED" : "DISABLED");
     if (startValidatingClusterManager) {
       startClusterManager();
     }
@@ -1006,6 +1008,13 @@ class HelixBootstrapUpgradeUtil {
       info("Existing resources dropped: {}", resourcesDropped);
     } else {
       info("========No updates were done to the cluster in Helix========");
+    }
+    if (validatingHelixClusterManager != null) {
+      info("========Validating HelixClusterManager metrics========");
+      info("Instance config change count: {}",
+          validatingHelixClusterManager.helixClusterManagerMetrics.instanceConfigChangeTriggerCount.getCount());
+      info("Instance config update ignored count: {}",
+          validatingHelixClusterManager.helixClusterManagerMetrics.ignoredUpdatesCount.getCount());
     }
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -178,8 +178,6 @@ class HelixBootstrapUpgradeUtil {
       clusterMapToHelixMapper.validateAndClose();
     }
     clusterMapToHelixMapper.logSummary();
-    info("========Bootstrap or upgrade completed! (if program doesn't exit, please use Ctrl-c to terminate)========");
-    System.exit(0);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -519,7 +519,7 @@ class HelixClusterManager implements ClusterMap {
             AmbryDataNode node = instanceNameToAmbryDataNode.get(instanceName);
             if (instanceName.equals(selfInstanceName) || instanceXid <= currentXid.get()) {
               if (node == null) {
-                logger.info("Dynamic addition of new nodes is not yet supported, ignoring InstanceConfig {}",
+                logger.trace("Dynamic addition of new nodes is not yet supported, ignoring InstanceConfig {}",
                     instanceConfig);
               } else {
                 Set<String> sealedReplicas = new HashSet<>(getSealedReplicas(instanceConfig));

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -38,11 +38,11 @@ import java.util.stream.Collectors;
 import org.I0Itec.zkclient.IZkDataListener;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixManager;
-import org.apache.helix.InstanceConfigChangeListener;
 import org.apache.helix.InstanceType;
-import org.apache.helix.LiveInstanceChangeListener;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.ZNRecord;
+import org.apache.helix.api.listeners.InstanceConfigChangeListener;
+import org.apache.helix.api.listeners.LiveInstanceChangeListener;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -531,6 +531,7 @@ class HelixClusterManager implements ClusterMap {
                     logger.trace(
                         "Ignoring instanceConfig change for partition {} on instance {} because partition override is enabled",
                         partitionId, instanceName);
+                    helixClusterManagerMetrics.ignoredUpdatesCount.inc();
                   } else {
                     replica.setSealedState(sealedReplicas.contains(partitionId));
                     replica.setStoppedState(stoppedReplicas.contains(partitionId));

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
@@ -19,26 +19,26 @@ import java.util.List;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ClusterMessagingService;
 import org.apache.helix.ConfigAccessor;
-import org.apache.helix.ControllerChangeListener;
-import org.apache.helix.CurrentStateChangeListener;
-import org.apache.helix.ExternalViewChangeListener;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerProperties;
-import org.apache.helix.IdealStateChangeListener;
-import org.apache.helix.InstanceConfigChangeListener;
 import org.apache.helix.InstanceType;
-import org.apache.helix.LiveInstanceChangeListener;
 import org.apache.helix.LiveInstanceInfoProvider;
-import org.apache.helix.MessageListener;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.PreConnectCallback;
 import org.apache.helix.PropertyKey;
-import org.apache.helix.ScopedConfigChangeListener;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.api.listeners.ClusterConfigChangeListener;
+import org.apache.helix.api.listeners.ControllerChangeListener;
+import org.apache.helix.api.listeners.CurrentStateChangeListener;
+import org.apache.helix.api.listeners.ExternalViewChangeListener;
+import org.apache.helix.api.listeners.IdealStateChangeListener;
+import org.apache.helix.api.listeners.InstanceConfigChangeListener;
+import org.apache.helix.api.listeners.LiveInstanceChangeListener;
+import org.apache.helix.api.listeners.MessageListener;
 import org.apache.helix.api.listeners.ResourceConfigChangeListener;
+import org.apache.helix.api.listeners.ScopedConfigChangeListener;
 import org.apache.helix.healthcheck.ParticipantHealthReportCollector;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.LiveInstance;
@@ -108,32 +108,21 @@ class MockHelixManager implements HelixManager {
   }
 
   @Override
-  public void addLiveInstanceChangeListener(LiveInstanceChangeListener listener) throws Exception {
-    if (beBadException != null) {
-      throw beBadException;
-    }
-    liveInstanceChangeListener = listener;
-    triggerLiveInstanceNotification(true);
+  public void addLiveInstanceChangeListener(org.apache.helix.LiveInstanceChangeListener listener) throws Exception {
+    // deprecated LiveInstanceChangeListener is no longer supported in testing
+    throw new IllegalStateException("Not implemented");
   }
 
   @Override
-  public void addInstanceConfigChangeListener(InstanceConfigChangeListener listener) throws Exception {
-    if (beBadException != null) {
-      throw beBadException;
-    }
-    instanceConfigChangeListener = listener;
-    triggerConfigChangeNotification(true);
+  public void addInstanceConfigChangeListener(org.apache.helix.InstanceConfigChangeListener listener) throws Exception {
+    // deprecated InstanceConfigChangeListener is no longer supported in testing
+    throw new IllegalStateException("Not implemented");
   }
 
   @Override
-  public void addExternalViewChangeListener(ExternalViewChangeListener listener) throws Exception {
-    if (beBadException != null) {
-      throw beBadException;
-    }
-    externalViewChangeListener = listener;
-    NotificationContext notificationContext = new NotificationContext(this);
-    notificationContext.setType(NotificationContext.Type.INIT);
-    externalViewChangeListener.onExternalViewChange(Collections.EMPTY_LIST, notificationContext);
+  public void addExternalViewChangeListener(org.apache.helix.ExternalViewChangeListener listener) throws Exception {
+    // deprecated ExternalViewChangeListener is no longer supported in testing
+    throw new IllegalStateException("Not implemented");
   }
 
   @Override
@@ -191,25 +180,27 @@ class MockHelixManager implements HelixManager {
   // Not implemented.
   //****************************
   @Override
-  public void addIdealStateChangeListener(IdealStateChangeListener listener) throws Exception {
+  public void addIdealStateChangeListener(org.apache.helix.IdealStateChangeListener listener) throws Exception {
     throw new IllegalStateException("Not implemented");
   }
 
   @Override
-  public void addIdealStateChangeListener(
-      org.apache.helix.api.listeners.IdealStateChangeListener idealStateChangeListener) throws Exception {
+  public void addIdealStateChangeListener(IdealStateChangeListener idealStateChangeListener) throws Exception {
     throw new IllegalStateException("Not implemented");
   }
 
   @Override
-  public void addLiveInstanceChangeListener(
-      org.apache.helix.api.listeners.LiveInstanceChangeListener liveInstanceChangeListener) throws Exception {
-    throw new IllegalStateException("Not implemented");
+  public void addLiveInstanceChangeListener(LiveInstanceChangeListener liveInstanceChangeListener) throws Exception {
+    if (beBadException != null) {
+      throw beBadException;
+    }
+    this.liveInstanceChangeListener = liveInstanceChangeListener;
+    triggerLiveInstanceNotification(true);
   }
 
   @Override
-  public void addConfigChangeListener(ScopedConfigChangeListener listener, HelixConfigScope.ConfigScopeProperty scope)
-      throws Exception {
+  public void addConfigChangeListener(org.apache.helix.ScopedConfigChangeListener listener,
+      HelixConfigScope.ConfigScopeProperty scope) throws Exception {
     throw new IllegalStateException("Not implemented");
   }
 
@@ -220,9 +211,13 @@ class MockHelixManager implements HelixManager {
   }
 
   @Override
-  public void addInstanceConfigChangeListener(
-      org.apache.helix.api.listeners.InstanceConfigChangeListener instanceConfigChangeListener) throws Exception {
-    throw new IllegalStateException("Not implemented");
+  public void addInstanceConfigChangeListener(InstanceConfigChangeListener instanceConfigChangeListener)
+      throws Exception {
+    if (beBadException != null) {
+      throw beBadException;
+    }
+    this.instanceConfigChangeListener = instanceConfigChangeListener;
+    triggerConfigChangeNotification(true);
   }
 
   @Override
@@ -237,65 +232,67 @@ class MockHelixManager implements HelixManager {
   }
 
   @Override
-  public void addConfigChangeListener(
-      org.apache.helix.api.listeners.ScopedConfigChangeListener scopedConfigChangeListener,
+  public void addConfigChangeListener(ScopedConfigChangeListener scopedConfigChangeListener,
       HelixConfigScope.ConfigScopeProperty configScopeProperty) throws Exception {
     throw new IllegalStateException("Not implemented");
   }
 
   @Override
-  public void addMessageListener(org.apache.helix.api.listeners.MessageListener messageListener, String s)
+  public void addMessageListener(MessageListener messageListener, String s) throws Exception {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public void addMessageListener(org.apache.helix.MessageListener listener, String instanceName) throws Exception {
+    throw new IllegalStateException("Not implemented");
+  }
+
+  @Override
+  public void addCurrentStateChangeListener(CurrentStateChangeListener currentStateChangeListener, String s, String s1)
       throws Exception {
     throw new IllegalStateException("Not implemented");
   }
 
   @Override
-  public void addMessageListener(MessageListener listener, String instanceName) throws Exception {
+  public void addCurrentStateChangeListener(org.apache.helix.CurrentStateChangeListener listener, String instanceName,
+      String sessionId) throws Exception {
     throw new IllegalStateException("Not implemented");
   }
 
   @Override
-  public void addCurrentStateChangeListener(
-      org.apache.helix.api.listeners.CurrentStateChangeListener currentStateChangeListener, String s, String s1)
+  public void addExternalViewChangeListener(ExternalViewChangeListener externalViewChangeListener) throws Exception {
+    if (beBadException != null) {
+      throw beBadException;
+    }
+    this.externalViewChangeListener = externalViewChangeListener;
+    NotificationContext notificationContext = new NotificationContext(this);
+    notificationContext.setType(NotificationContext.Type.INIT);
+    this.externalViewChangeListener.onExternalViewChange(Collections.emptyList(), notificationContext);
+  }
+
+  @Override
+  public void addTargetExternalViewChangeListener(ExternalViewChangeListener externalViewChangeListener)
       throws Exception {
     throw new IllegalStateException("Not implemented");
   }
 
   @Override
-  public void addCurrentStateChangeListener(CurrentStateChangeListener listener, String instanceName, String sessionId)
-      throws Exception {
+  public void addControllerListener(org.apache.helix.ControllerChangeListener listener) {
     throw new IllegalStateException("Not implemented");
   }
 
   @Override
-  public void addExternalViewChangeListener(
-      org.apache.helix.api.listeners.ExternalViewChangeListener externalViewChangeListener) throws Exception {
+  public void addControllerListener(ControllerChangeListener controllerChangeListener) {
     throw new IllegalStateException("Not implemented");
   }
 
   @Override
-  public void addTargetExternalViewChangeListener(
-      org.apache.helix.api.listeners.ExternalViewChangeListener externalViewChangeListener) throws Exception {
+  public void addControllerMessageListener(MessageListener messageListener) {
     throw new IllegalStateException("Not implemented");
   }
 
   @Override
-  public void addControllerListener(ControllerChangeListener listener) {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
-  public void addControllerListener(org.apache.helix.api.listeners.ControllerChangeListener controllerChangeListener) {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
-  public void addControllerMessageListener(org.apache.helix.api.listeners.MessageListener messageListener) {
-    throw new IllegalStateException("Not implemented");
-  }
-
-  @Override
-  public void addControllerMessageListener(MessageListener listener) {
+  public void addControllerMessageListener(org.apache.helix.MessageListener listener) {
     throw new IllegalStateException("Not implemented");
   }
 

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -228,6 +228,7 @@ public abstract class ReplicationEngine {
           .getHostname()
           .equals(hostName)) {
         foundRemoteReplicaInfo = remoteReplicaInfo;
+        break;
       }
     }
     // TODO: replace replicaPath.contains("vcr").

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -1840,6 +1840,7 @@ public class ReplicationTest {
                 new RemoteReplicaInfo(peerReplicaId, replicaId, store, new MockFindToken(0, 0), Long.MAX_VALUE,
                     SystemTime.getInstance(), new Port(peerReplicaId.getDataNodeId().getPort(), PortType.PLAINTEXT));
             remoteReplicaInfos.add(remoteReplicaInfo);
+            break;
           }
         }
       }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -1840,7 +1840,6 @@ public class ReplicationTest {
                 new RemoteReplicaInfo(peerReplicaId, replicaId, store, new MockFindToken(0, 0), Long.MAX_VALUE,
                     SystemTime.getInstance(), new Port(peerReplicaId.getDataNodeId().getPort(), PortType.PLAINTEXT));
             remoteReplicaInfos.add(remoteReplicaInfo);
-            break;
           }
         }
       }

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -212,6 +212,9 @@ public class HelixBootstrapUpgradeTool {
               : Integer.valueOf(options.valueOf(maxPartitionsInOneResourceOpt)), options.has(dryRun),
           options.has(forceRemove), new HelixAdminFactory(), !options.has(disableValidatingClusterManager));
     }
+    System.out.println("======== HelixBootstrapUpgradeTool completed successfully! ========");
+    System.out.println("( If program doesn't exit, please use Ctrl-c to terminate. )");
+    System.exit(0);
   }
 }
 

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -158,6 +158,9 @@ public class HelixBootstrapUpgradeTool {
     OptionSpecBuilder dryRun =
         parser.accepts("dryRun", "(Optional argument) Dry run, do not modify the cluster map in Helix.");
 
+    OptionSpecBuilder disableValidatingClusterManager = parser.accepts("disableVCM",
+        "(Optional argument) whether to disable validating cluster manager(VCM) in Helix bootstrap tool.");
+
     OptionSet options = parser.parse(args);
     String hardwareLayoutPath = options.valueOf(hardwareLayoutPathOpt);
     String partitionLayoutPath = options.valueOf(partitionLayoutPathOpt);
@@ -207,7 +210,7 @@ public class HelixBootstrapUpgradeTool {
           clusterNamePrefix, dcs,
           options.valueOf(maxPartitionsInOneResourceOpt) == null ? DEFAULT_MAX_PARTITIONS_PER_RESOURCE
               : Integer.valueOf(options.valueOf(maxPartitionsInOneResourceOpt)), options.has(dryRun),
-          options.has(forceRemove), new HelixAdminFactory(), true);
+          options.has(forceRemove), new HelixAdminFactory(), !options.has(disableValidatingClusterManager));
     }
   }
 }


### PR DESCRIPTION
1. Add null check in getDatacenterName() in CompositeClusterManager.
2. Make instance config change ignore count more accurate.
3. Ensure Helix bootstrap/upgrade tool can exit in the end.
4. Break the loop if remoteReplicaInfo is found in getRemoteReplicaInfo().