### PR TITLE
Refactor operation tracker ctor and introduce custom percentiles

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -13,6 +13,12 @@
  */
 package com.github.ambry.config;
 
+import com.github.ambry.utils.Utils;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
 /**
  * Configuration parameters required by a {@link com.github.ambry.router.Router}.
  * <p/>
@@ -233,6 +239,15 @@ public class RouterConfig {
   public final boolean routerUseGetBlobOperationForBlobInfo;
 
   /**
+   * The custom percentiles of Histogram in operation tracker to be reported. This allows router to emit metrics of
+   * arbitrary percentiles (i.e. 97th, 93th etc). An example of this config is "0.91,0.93,0.97"(comma separated), each
+   * value should fall in {@code [0..1]}.
+   */
+  @Config("router.operation.tracker.custom.percentiles")
+  @Default("")
+  public final List<Double> routerOperationTrackerCustomPercentiles;
+
+  /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
    */
@@ -289,5 +304,9 @@ public class RouterConfig {
         verifiableProperties.getIntInRange("router.ttl.update.success.target", 2, 1, Integer.MAX_VALUE);
     routerUseGetBlobOperationForBlobInfo =
         verifiableProperties.getBoolean("router.use.get.blob.operation.for.blob.info", false);
+    List<String> customPercentiles =
+        Utils.splitString(verifiableProperties.getString("router.operation.tracker.custom.percentiles", ""), ",");
+    routerOperationTrackerCustomPercentiles =
+        Collections.unmodifiableList(customPercentiles.stream().map(Double::valueOf).collect(Collectors.toList()));
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapMetrics.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapMetrics.java
@@ -67,79 +67,24 @@ class ClusterMapMetrics {
 
     // Metrics based on HardwareLayout
 
-    this.hardwareLayoutVersion = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return getHardwareLayoutVersion();
-      }
-    };
-    this.partitionLayoutVersion = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return getPartitionLayoutVersion();
-      }
-    };
+    this.hardwareLayoutVersion = this::getHardwareLayoutVersion;
+    this.partitionLayoutVersion = this::getPartitionLayoutVersion;
     registry.register(MetricRegistry.name(ClusterMap.class, "hardwareLayoutVersion"), hardwareLayoutVersion);
     registry.register(MetricRegistry.name(ClusterMap.class, "partitionLayoutVersion"), partitionLayoutVersion);
 
-    this.datacenterCount = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countDatacenters();
-      }
-    };
-    this.dataNodeCount = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countDataNodes();
-      }
-    };
-    this.diskCount = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countDisks();
-      }
-    };
+    this.datacenterCount = this::countDatacenters;
+    this.dataNodeCount = this::countDataNodes;
+    this.diskCount = this::countDisks;
     registry.register(MetricRegistry.name(ClusterMap.class, "datacenterCount"), datacenterCount);
     registry.register(MetricRegistry.name(ClusterMap.class, "dataNodeCount"), dataNodeCount);
     registry.register(MetricRegistry.name(ClusterMap.class, "diskCount"), diskCount);
 
-    this.dataNodesHardUpCount = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countDataNodesInHardState(HardwareState.AVAILABLE);
-      }
-    };
-    this.dataNodesHardDownCount = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countDataNodesInHardState(HardwareState.UNAVAILABLE);
-      }
-    };
-    this.dataNodesUnavailableCount = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countUnavailableDataNodes();
-      }
-    };
-    this.disksHardUpCount = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countDisksInHardState(HardwareState.AVAILABLE);
-      }
-    };
-    this.disksHardDownCount = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countDisksInHardState(HardwareState.UNAVAILABLE);
-      }
-    };
-    this.disksUnavailableCount = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countUnavailableDisks();
-      }
-    };
+    this.dataNodesHardUpCount = () -> countDataNodesInHardState(HardwareState.AVAILABLE);
+    this.dataNodesHardDownCount = () -> countDataNodesInHardState(HardwareState.UNAVAILABLE);
+    this.dataNodesUnavailableCount = this::countUnavailableDataNodes;
+    this.disksHardUpCount = () -> countDisksInHardState(HardwareState.AVAILABLE);
+    this.disksHardDownCount = () -> countDisksInHardState(HardwareState.UNAVAILABLE);
+    this.disksUnavailableCount = this::countUnavailableDisks;
     registry.register(MetricRegistry.name(ClusterMap.class, "dataNodesHardUpCount"), dataNodesHardUpCount);
     registry.register(MetricRegistry.name(ClusterMap.class, "dataNodesHardDownCount"), dataNodesHardDownCount);
     registry.register(MetricRegistry.name(ClusterMap.class, "dataNodesUnavailableCount"), dataNodesUnavailableCount);
@@ -149,54 +94,19 @@ class ClusterMapMetrics {
 
     // Metrics based on PartitionLayout
 
-    this.partitionCount = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countPartitions();
-      }
-    };
-    this.partitionsReadWrite = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countPartitionsInState(PartitionState.READ_WRITE);
-      }
-    };
-    this.partitionsReadOnly = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return countPartitionsInState(PartitionState.READ_ONLY);
-      }
-    };
+    this.partitionCount = this::countPartitions;
+    this.partitionsReadWrite = () -> countPartitionsInState(PartitionState.READ_WRITE);
+    this.partitionsReadOnly = () -> countPartitionsInState(PartitionState.READ_ONLY);
     registry.register(MetricRegistry.name(ClusterMap.class, "numberOfPartitions"), partitionCount);
     registry.register(MetricRegistry.name(ClusterMap.class, "numberOfReadWritePartitions"), partitionsReadWrite);
     registry.register(MetricRegistry.name(ClusterMap.class, "numberOfReadOnlyPartitions"), partitionsReadOnly);
 
-    this.isMajorityReplicasDown = new Gauge<Boolean>() {
-      @Override
-      public Boolean getValue() {
-        return isMajorityOfReplicasDown();
-      }
-    };
+    this.isMajorityReplicasDown = this::isMajorityOfReplicasDown;
     registry.register(MetricRegistry.name(ClusterMap.class, "isMajorityReplicasDown"), isMajorityReplicasDown);
 
-    this.rawCapacityInBytes = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return getRawCapacity();
-      }
-    };
-    this.allocatedRawCapacityInBytes = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return getAllocatedRawCapacity();
-      }
-    };
-    this.allocatedUsableCapacityInBytes = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return getAllocatedUsableCapacity();
-      }
-    };
+    this.rawCapacityInBytes = this::getRawCapacity;
+    this.allocatedRawCapacityInBytes = this::getAllocatedRawCapacity;
+    this.allocatedUsableCapacityInBytes = this::getAllocatedUsableCapacity;
     registry.register(MetricRegistry.name(ClusterMap.class, "rawCapacityInBytes"), rawCapacityInBytes);
     registry.register(MetricRegistry.name(ClusterMap.class, "allocatedRawCapacityInBytes"),
         allocatedRawCapacityInBytes);
@@ -218,12 +128,7 @@ class ClusterMapMetrics {
 
   private void addDataNodeToStateMetrics(final DataNode dataNode) {
     final String metricName = dataNode.getHostname() + "-" + dataNode.getPort() + "-ResourceState";
-    Gauge<Long> dataNodeState = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return dataNode.getState() == HardwareState.AVAILABLE ? 1L : 0L;
-      }
-    };
+    Gauge<Long> dataNodeState = () -> dataNode.getState() == HardwareState.AVAILABLE ? 1L : 0L;
     registry.register(MetricRegistry.name(ClusterMap.class, metricName), dataNodeState);
     dataNodeStateList.add(dataNodeState);
   }
@@ -232,12 +137,7 @@ class ClusterMapMetrics {
     final String metricName =
         disk.getDataNode().getHostname() + "-" + disk.getDataNode().getPort() + "-" + disk.getMountPath()
             + "-ResourceState";
-    Gauge<Long> diskState = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return disk.getState() == HardwareState.AVAILABLE ? 1L : 0L;
-      }
-    };
+    Gauge<Long> diskState = () -> disk.getState() == HardwareState.AVAILABLE ? 1L : 0L;
     registry.register(MetricRegistry.name(ClusterMap.class, metricName), diskState);
     dataNodeStateList.add(diskState);
   }

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelConnectionPool.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelConnectionPool.java
@@ -73,32 +73,17 @@ class BlockingChannelInfo {
     this.sslSocketFactory = sslSocketFactory;
     this.sslConfig = sslConfig;
 
-    availableConnections = new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        return blockingChannelAvailableConnections.size();
-      }
-    };
+    availableConnections = blockingChannelAvailableConnections::size;
     registry.register(
         MetricRegistry.name(BlockingChannelInfo.class, host + "-" + port.getPort() + "-availableConnections"),
         availableConnections);
 
-    activeConnections = new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        return blockingChannelActiveConnections.size();
-      }
-    };
+    activeConnections = blockingChannelActiveConnections::size;
     registry.register(
         MetricRegistry.name(BlockingChannelInfo.class, host + "-" + port.getPort() + "-activeConnections"),
         activeConnections);
 
-    totalNumberOfConnections = new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        return numberOfConnections.intValue();
-      }
-    };
+    totalNumberOfConnections = numberOfConnections::intValue;
     registry.register(
         MetricRegistry.name(BlockingChannelInfo.class, host + "-" + port.getPort() + "-totalNumberOfConnections"),
         totalNumberOfConnections);
@@ -240,8 +225,7 @@ class BlockingChannelInfo {
   }
 
   /**
-   * Returns the number of connections with this BlockingChannelInfo
-   * @return
+   * @return the number of connections with this BlockingChannelInfo
    */
   public int getNumberOfConnections() {
     return this.numberOfConnections.intValue();
@@ -310,40 +294,29 @@ public final class BlockingChannelConnectionPool implements ConnectionPool {
     connectionDestroyTime =
         registry.timer(MetricRegistry.name(BlockingChannelConnectionPool.class, "connectionDestroyTime"));
 
-    totalNumberOfNodesConnectedTo = new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        int noOfNodesConnectedTo = 0;
-        for (BlockingChannelInfo blockingChannelInfo : connections.values()) {
-          if (blockingChannelInfo.getNumberOfConnections() > 0) {
-            noOfNodesConnectedTo++;
-          }
+    totalNumberOfNodesConnectedTo = () -> {
+      int noOfNodesConnectedTo = 0;
+      for (BlockingChannelInfo blockingChannelInfo : connections.values()) {
+        if (blockingChannelInfo.getNumberOfConnections() > 0) {
+          noOfNodesConnectedTo++;
         }
-        return noOfNodesConnectedTo;
       }
+      return noOfNodesConnectedTo;
     };
     registry.register(MetricRegistry.name(BlockingChannelConnectionPool.class, "totalNumberOfNodesConnectedTo"),
         totalNumberOfNodesConnectedTo);
 
-    totalNumberOfConnections = new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        int noOfConnections = 0;
-        for (BlockingChannelInfo blockingChannelInfo : connections.values()) {
-          noOfConnections += blockingChannelInfo.getNumberOfConnections();
-        }
-        return noOfConnections;
+    totalNumberOfConnections = () -> {
+      int noOfConnections = 0;
+      for (BlockingChannelInfo blockingChannelInfo : connections.values()) {
+        noOfConnections += blockingChannelInfo.getNumberOfConnections();
       }
+      return noOfConnections;
     };
     registry.register(MetricRegistry.name(BlockingChannelConnectionPool.class, "totalNumberOfConnections"),
         totalNumberOfConnections);
     requestsWaitingToCheckoutConnectionCount = new AtomicInteger(0);
-    requestsWaitingToCheckoutConnection = new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        return requestsWaitingToCheckoutConnectionCount.get();
-      }
-    };
+    requestsWaitingToCheckoutConnection = requestsWaitingToCheckoutConnectionCount::get;
     registry.register(MetricRegistry.name(BlockingChannelConnectionPool.class, "requestsWaitingToCheckoutConnection"),
         requestsWaitingToCheckoutConnection);
     sslSocketFactoryClientInitializationCount = registry.counter(

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -351,12 +351,7 @@ public class ReplicationMetrics {
    */
   void trackLiveThreadsCount(final Map<String, List<ReplicaThread>> replicaThreadPools, String localDatacenter) {
     for (final String datacenter : replicaThreadPools.keySet()) {
-      Gauge<Integer> liveThreadsPerDatacenter = new Gauge<Integer>() {
-        @Override
-        public Integer getValue() {
-          return getLiveThreads(replicaThreadPools.get(datacenter));
-        }
-      };
+      Gauge<Integer> liveThreadsPerDatacenter = () -> getLiveThreads(replicaThreadPools.get(datacenter));
       if (localDatacenter.equals(datacenter)) {
         registry.register(MetricRegistry.name(ReplicaThread.class, "NumberOfIntra-Colo-ReplicaThreads"),
             liveThreadsPerDatacenter);
@@ -382,12 +377,7 @@ public class ReplicationMetrics {
     DataNodeId dataNodeId = replicaId.getDataNodeId();
     final String metricName =
         dataNodeId.getHostname() + "-" + dataNodeId.getPort() + "-" + replicaId.getPartitionId() + "-replicaLagInBytes";
-    Gauge<Long> replicaLag = new Gauge<Long>() {
-      @Override
-      public Long getValue() {
-        return remoteReplicaInfo.getRemoteLagFromLocalInBytes();
-      }
-    };
+    Gauge<Long> replicaLag = remoteReplicaInfo::getRemoteLagFromLocalInBytes;
     registry.register(MetricRegistry.name(ReplicationMetrics.class, metricName), replicaLag);
     replicaLagInBytes.add(replicaLag);
   }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/AsyncRequestResponseHandlerFactory.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/AsyncRequestResponseHandlerFactory.java
@@ -251,12 +251,7 @@ class RequestResponseHandlerMetrics {
    */
   public void registerRequestWorker(final AsyncRequestWorker asyncRequestWorker) {
     int pos = asyncRequestWorkerIndex.getAndIncrement();
-    Gauge<Integer> gauge = new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        return asyncRequestWorker.getRequestQueueSize();
-      }
-    };
+    Gauge<Integer> gauge = asyncRequestWorker::getRequestQueueSize;
     metricRegistry.register(MetricRegistry.name(AsyncRequestWorker.class, pos + "-RequestQueueSize"), gauge);
   }
 
@@ -265,30 +260,15 @@ class RequestResponseHandlerMetrics {
    * @param asyncRequestResponseHandler the {@link AsyncRequestResponseHandler} whose key metrics have to be tracked.
    */
   public void trackAsyncRequestResponseHandler(final AsyncRequestResponseHandler asyncRequestResponseHandler) {
-    Gauge<Integer> totalRequestQueueSize = new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        return asyncRequestResponseHandler.getRequestQueueSize();
-      }
-    };
+    Gauge<Integer> totalRequestQueueSize = asyncRequestResponseHandler::getRequestQueueSize;
     metricRegistry.register(MetricRegistry.name(AsyncRequestResponseHandler.class, "TotalRequestQueueSize"),
         totalRequestQueueSize);
 
-    Gauge<Integer> totalResponseSetSize = new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        return asyncRequestResponseHandler.getResponseSetSize();
-      }
-    };
+    Gauge<Integer> totalResponseSetSize = asyncRequestResponseHandler::getResponseSetSize;
     metricRegistry.register(MetricRegistry.name(AsyncRequestResponseHandler.class, "TotalResponseSetSize"),
         totalResponseSetSize);
 
-    Gauge<Integer> asyncHandlerWorkersAlive = new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        return asyncRequestResponseHandler.getWorkersAlive();
-      }
-    };
+    Gauge<Integer> asyncHandlerWorkersAlive = asyncRequestResponseHandler::getWorkersAlive;
     metricRegistry.register(MetricRegistry.name(AsyncRequestResponseHandler.class, "AsyncHandlerWorkersAlive"),
         asyncHandlerWorkersAlive);
   }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/RestServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/RestServer.java
@@ -136,12 +136,7 @@ public class RestServer {
       accountServiceCloseTimeInMs =
           metricRegistry.histogram(MetricRegistry.name(RestServer.class, "AccountServiceCloseTimeInMs"));
 
-      Gauge<Integer> restServerStatus = new Gauge<Integer>() {
-        @Override
-        public Integer getValue() {
-          return restServerState.isServiceUp() ? 1 : 0;
-        }
-      };
+      Gauge<Integer> restServerStatus = () -> restServerState.isServiceUp() ? 1 : 0;
       metricRegistry.register(MetricRegistry.name(RestServer.class, "RestServerState"), restServerStatus);
     }
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/AdaptiveOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/AdaptiveOperationTracker.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.config.RouterConfig;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Time;
 import java.util.HashMap;
@@ -39,7 +40,6 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
   static final long MIN_DATA_POINTS_REQUIRED = 1000;
 
   private final Time time;
-  private final String datacenterName;
   private final double quantile;
   private final Histogram localColoTracker;
   private final Histogram crossColoTracker;
@@ -55,34 +55,30 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
 
   /**
    * Constructs an {@link AdaptiveOperationTracker}
-   * @param datacenterName The datacenter where the router is located.
+   * @param operationClass The operation class in which operation tracker is used.
    * @param partitionId The partition on which the operation is performed.
-   * @param crossColoEnabled {@code true} if requests can be sent to remote replicas, {@code false}
-   *                                otherwise.
    * @param originatingDcName name of the cross colo DC whose replicas should be tried first.
-   * @param includeNonOriginatingDcReplicas if take the option to include remote non originating DC replicas.
-   * @param replicasRequired The number of replicas required for the operation.
-   * @param successTarget The number of successful responses required to succeed the operation.
-   * @param parallelism The maximum number of inflight requests at any point of time.
-   * @param time the {@link Time} instance to use.
    * @param localColoTracker the {@link Histogram} that tracks intra datacenter latencies for this class of requests.
    * @param crossColoTracker the {@link Histogram} that tracks inter datacenter latencies for this class of requests.
    * @param pastDueCounter the {@link Counter} that tracks the number of times a request is past due.
-   * @param quantile the quantile cutoff to use for when evaluating requests against the trackers.
+   * @param time the {@link Time} instance to use.
    */
-  AdaptiveOperationTracker(String datacenterName, PartitionId partitionId, boolean crossColoEnabled,
-      String originatingDcName, boolean includeNonOriginatingDcReplicas, int replicasRequired, int successTarget,
-      int parallelism, Time time, Histogram localColoTracker, Histogram crossColoTracker, Counter pastDueCounter,
-      double quantile) {
-    super(datacenterName, partitionId, crossColoEnabled, originatingDcName, includeNonOriginatingDcReplicas,
-        replicasRequired, successTarget, parallelism, true);
-    this.datacenterName = datacenterName;
+  AdaptiveOperationTracker(RouterConfig routerConfig, Class operationClass, PartitionId partitionId,
+      String originatingDcName, Histogram localColoTracker, Histogram crossColoTracker, Counter pastDueCounter,
+      NonBlockingRouterMetrics routerMetrics, Time time) {
+    super(routerConfig, operationClass, partitionId, originatingDcName, true);
     this.time = time;
     this.localColoTracker = localColoTracker;
     this.crossColoTracker = crossColoTracker;
     this.pastDueCounter = pastDueCounter;
-    this.quantile = quantile;
+    this.quantile = routerConfig.routerLatencyToleranceQuantile;
     this.otIterator = new OpTrackerIterator();
+    routerMetrics.registerCustomPercentiles(operationClass, "LocalColoLatencyMs", localColoTracker,
+        routerConfig.routerOperationTrackerCustomPercentiles);
+    if (crossColoTracker != null) {
+      routerMetrics.registerCustomPercentiles(operationClass, "CrossColoLatencyMs", crossColoTracker,
+          routerConfig.routerOperationTrackerCustomPercentiles);
+    }
   }
 
   @Override

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -99,8 +99,8 @@ class DeleteOperation {
     byte blobDcId = blobId.getDatacenterId();
     String originatingDcName = clusterMap.getDatacenterName(blobDcId);
     this.operationTracker =
-        new SimpleOperationTracker(routerConfig, DeleteOperation.class, blobId.getPartition(), originatingDcName,
-            false);
+        new SimpleOperationTracker(routerConfig, RouterOperation.DeleteOperation, blobId.getPartition(),
+            originatingDcName, false);
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -99,9 +99,8 @@ class DeleteOperation {
     byte blobDcId = blobId.getDatacenterId();
     String originatingDcName = clusterMap.getDatacenterName(blobDcId);
     this.operationTracker =
-        new SimpleOperationTracker(routerConfig.routerDatacenterName, blobId.getPartition(), true, originatingDcName,
-            true, Integer.MAX_VALUE, routerConfig.routerDeleteSuccessTarget,
-            routerConfig.routerDeleteRequestParallelism, false);
+        new SimpleOperationTracker(routerConfig, DeleteOperation.class, blobId.getPartition(), originatingDcName,
+            false);
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -91,7 +91,7 @@ class GetBlobInfoOperation extends GetOperation {
         routerMetrics.getBlobInfoLocalColoLatencyMs, routerMetrics.getBlobInfoCrossColoLatencyMs,
         routerMetrics.getBlobInfoPastDueCount, kms, cryptoService, cryptoJobHandler, time, isEncrypted);
     this.routerCallback = routerCallback;
-    operationTracker = getOperationTracker(blobId.getPartition(), blobId.getDatacenterId());
+    operationTracker = getOperationTracker(blobId.getPartition(), blobId.getDatacenterId(), GetBlobInfoOperation.class);
     progressTracker = new ProgressTracker(operationTracker);
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -91,7 +91,8 @@ class GetBlobInfoOperation extends GetOperation {
         routerMetrics.getBlobInfoLocalColoLatencyMs, routerMetrics.getBlobInfoCrossColoLatencyMs,
         routerMetrics.getBlobInfoPastDueCount, kms, cryptoService, cryptoJobHandler, time, isEncrypted);
     this.routerCallback = routerCallback;
-    operationTracker = getOperationTracker(blobId.getPartition(), blobId.getDatacenterId(), GetBlobInfoOperation.class);
+    operationTracker =
+        getOperationTracker(blobId.getPartition(), blobId.getDatacenterId(), RouterOperation.GetBlobInfoOperation);
     progressTracker = new ProgressTracker(operationTracker);
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -557,8 +557,8 @@ class GetBlobOperation extends GetOperation {
     void initialize(int index, BlobId id) {
       chunkIndex = index;
       chunkBlobId = id;
-      chunkOperationTracker =
-          getOperationTracker(chunkBlobId.getPartition(), chunkBlobId.getDatacenterId(), GetBlobOperation.class);
+      chunkOperationTracker = getOperationTracker(chunkBlobId.getPartition(), chunkBlobId.getDatacenterId(),
+          RouterOperation.GetBlobOperation);
       progressTracker = new ProgressTracker(chunkOperationTracker);
       state = ChunkState.Ready;
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -557,7 +557,8 @@ class GetBlobOperation extends GetOperation {
     void initialize(int index, BlobId id) {
       chunkIndex = index;
       chunkBlobId = id;
-      chunkOperationTracker = getOperationTracker(chunkBlobId.getPartition(), chunkBlobId.getDatacenterId());
+      chunkOperationTracker =
+          getOperationTracker(chunkBlobId.getPartition(), chunkBlobId.getDatacenterId(), GetBlobOperation.class);
       progressTracker = new ProgressTracker(chunkOperationTracker);
       state = ChunkState.Ready;
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -237,18 +237,20 @@ abstract class GetOperation {
   /**
    * Gets an {@link OperationTracker} based on the config and {@code partitionId}.
    * @param partitionId the {@link PartitionId} for which a tracker is required.
-   * @param operationClass The operation class in which operation tracker is used.
+   * @param routerOperation The type of router operation used by tracker.
    * @return an {@link OperationTracker} based on the config and {@code partitionId}.
    */
-  protected OperationTracker getOperationTracker(PartitionId partitionId, byte datacenterId, Class operationClass) {
+  protected OperationTracker getOperationTracker(PartitionId partitionId, byte datacenterId,
+      RouterOperation routerOperation) {
     OperationTracker operationTracker;
     String trackerType = routerConfig.routerGetOperationTrackerType;
     String originatingDcName = clusterMap.getDatacenterName(datacenterId);
     if (trackerType.equals(SimpleOperationTracker.class.getSimpleName())) {
-      operationTracker = new SimpleOperationTracker(routerConfig, operationClass, partitionId, originatingDcName, true);
+      operationTracker =
+          new SimpleOperationTracker(routerConfig, routerOperation, partitionId, originatingDcName, true);
     } else if (trackerType.equals(AdaptiveOperationTracker.class.getSimpleName())) {
       operationTracker =
-          new AdaptiveOperationTracker(routerConfig, operationClass, partitionId, originatingDcName, localColoTracker,
+          new AdaptiveOperationTracker(routerConfig, routerOperation, partitionId, originatingDcName, localColoTracker,
               crossColoTracker, pastDueCounter, routerMetrics, time);
     } else {
       throw new IllegalArgumentException("Unrecognized tracker type: " + trackerType);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -237,7 +237,7 @@ abstract class GetOperation {
   /**
    * Gets an {@link OperationTracker} based on the config and {@code partitionId}.
    * @param partitionId the {@link PartitionId} for which a tracker is required.
-   * @param operationClass
+   * @param operationClass The operation class in which operation tracker is used.
    * @return an {@link OperationTracker} based on the config and {@code partitionId}.
    */
   protected OperationTracker getOperationTracker(PartitionId partitionId, byte datacenterId, Class operationClass) {

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -452,22 +452,15 @@ public class NonBlockingRouterMetrics {
    * Initializes a {@link Gauge} metric to monitor the number of running
    * {@link com.github.ambry.router.NonBlockingRouter.OperationController} of a {@link NonBlockingRouter}.
    * @param currentOperationsCount The counter of {@link com.github.ambry.router.NonBlockingRouter.OperationController}.
+   * @param currentBackgroundOperationsCount The counter of background operations submitted to the router that are not
+   *                                         yet completed.
    */
   public void initializeNumActiveOperationsMetrics(final AtomicInteger currentOperationsCount,
       final AtomicInteger currentBackgroundOperationsCount) {
-    metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "NumActiveOperations"), new Gauge<Integer>() {
-      @Override
-      public Integer getValue() {
-        return currentOperationsCount.get();
-      }
-    });
+    metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "NumActiveOperations"),
+        (Gauge<Integer>) currentOperationsCount::get);
     metricRegistry.register(MetricRegistry.name(NonBlockingRouter.class, "NumActiveBackgroundOperations"),
-        new Gauge<Integer>() {
-          @Override
-          public Integer getValue() {
-            return currentBackgroundOperationsCount.get();
-          }
-        });
+        (Gauge<Integer>) currentBackgroundOperationsCount::get);
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -1097,8 +1097,7 @@ class PutOperation {
             passedInBlobProperties.getCreationTimeInMs(), passedInBlobProperties.getAccountId(),
             passedInBlobProperties.getContainerId(), passedInBlobProperties.isEncrypted(),
             passedInBlobProperties.getExternalAssetTag());
-        operationTracker = new SimpleOperationTracker(routerConfig.routerDatacenterName, partitionId, false, null, true,
-            Integer.MAX_VALUE, routerConfig.routerPutSuccessTarget, routerConfig.routerPutRequestParallelism);
+        operationTracker = new SimpleOperationTracker(routerConfig, PutOperation.class, partitionId, null, true);
         correlationIdToChunkPutRequestInfo.clear();
         state = ChunkState.Ready;
       } catch (RouterException e) {

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -1097,7 +1097,8 @@ class PutOperation {
             passedInBlobProperties.getCreationTimeInMs(), passedInBlobProperties.getAccountId(),
             passedInBlobProperties.getContainerId(), passedInBlobProperties.isEncrypted(),
             passedInBlobProperties.getExternalAssetTag());
-        operationTracker = new SimpleOperationTracker(routerConfig, PutOperation.class, partitionId, null, true);
+        operationTracker =
+            new SimpleOperationTracker(routerConfig, RouterOperation.PutOperation, partitionId, null, true);
         correlationIdToChunkPutRequestInfo.clear();
         state = ChunkState.Ready;
       } catch (RouterException e) {

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterOperation.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+public enum RouterOperation {
+  GetBlobOperation, GetBlobInfoOperation, PutOperation, DeleteOperation, TtlUpdateOperation
+}

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
@@ -90,8 +90,8 @@ class TtlUpdateOperation {
     byte blobDcId = blobId.getDatacenterId();
     String originatingDcName = clusterMap.getDatacenterName(blobDcId);
     this.operationTracker =
-        new SimpleOperationTracker(routerConfig, TtlUpdateOperation.class, blobId.getPartition(), originatingDcName,
-            false);
+        new SimpleOperationTracker(routerConfig, RouterOperation.TtlUpdateOperation, blobId.getPartition(),
+            originatingDcName, false);
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
@@ -90,9 +90,8 @@ class TtlUpdateOperation {
     byte blobDcId = blobId.getDatacenterId();
     String originatingDcName = clusterMap.getDatacenterName(blobDcId);
     this.operationTracker =
-        new SimpleOperationTracker(routerConfig.routerDatacenterName, blobId.getPartition(), true, originatingDcName,
-            true, Integer.MAX_VALUE, routerConfig.routerTtlUpdateSuccessTarget,
-            routerConfig.routerTtlUpdateRequestParallelism, false);
+        new SimpleOperationTracker(routerConfig, TtlUpdateOperation.class, blobId.getPartition(), originatingDcName,
+            false);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
@@ -308,8 +308,8 @@ public class AdaptiveOperationTrackerTest {
       props.setProperty("router.operation.tracker.custom.percentiles", customPercentiles);
     }
     RouterConfig routerConfig = new RouterConfig(new VerifiableProperties(props));
-    return new AdaptiveOperationTracker(routerConfig, GetOperation.class, mockPartition, null, localColoTracker,
-        crossColoEnabled ? crossColoTracker : null, pastDueCounter, routerMetrics, time);
+    return new AdaptiveOperationTracker(routerConfig, RouterOperation.GetBlobOperation, mockPartition, null,
+        localColoTracker, crossColoEnabled ? crossColoTracker : null, pastDueCounter, routerMetrics, time);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
@@ -14,12 +14,18 @@
 package com.github.ambry.router;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.config.RouterConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.utils.MockTime;
@@ -34,7 +40,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.stream.Collectors;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -68,21 +77,22 @@ public class AdaptiveOperationTrackerTest {
   private final Histogram localColoTracker = registry.histogram("LocalColoTracker");
   private final Histogram crossColoTracker = registry.histogram("CrossColoTracker");
   private final Counter pastDueCounter = registry.counter("PastDueCounter");
+  private NonBlockingRouterMetrics routerMetrics;
 
   /**
    * Constructor that sets up state.
    */
-  public AdaptiveOperationTrackerTest() {
+  public AdaptiveOperationTrackerTest() throws Exception {
     List<Port> portList = Collections.singletonList(new Port(PORT, PortType.PLAINTEXT));
     List<String> mountPaths = Collections.singletonList("mockMountPath");
-    datanodes = new ArrayList<>(Arrays.asList(
-        new MockDataNodeId[]{new MockDataNodeId(portList, mountPaths, "dc-0"), new MockDataNodeId(portList, mountPaths,
-            "dc-1")}));
+    datanodes = new ArrayList<>(Arrays.asList(new MockDataNodeId(portList, mountPaths, "dc-0"),
+        new MockDataNodeId(portList, mountPaths, "dc-1")));
     localDcName = datanodes.get(0).getDatacenterName();
     mockPartition = new MockPartitionId();
     for (int i = 0; i < REPLICA_COUNT; i++) {
       mockPartition.replicaIds.add(new MockReplicaId(PORT, mockPartition, datanodes.get(i % datanodes.size()), 0));
     }
+    routerMetrics = new NonBlockingRouterMetrics(new MockClusterMap());
   }
 
   /**
@@ -96,7 +106,7 @@ public class AdaptiveOperationTrackerTest {
     double localColoCutoff = localColoTracker.getSnapshot().getValue(QUANTILE);
     double crossColoCutoff = crossColoTracker.getSnapshot().getValue(QUANTILE);
 
-    OperationTracker ot = getOperationTracker(true, REPLICA_COUNT, 2);
+    OperationTracker ot = getOperationTracker(true, REPLICA_COUNT, 2, null);
     // 3-0-0-0; 3-0-0-0
     sendRequests(ot, 2);
     // 1-2-0-0; 3-0-0-0
@@ -167,7 +177,7 @@ public class AdaptiveOperationTrackerTest {
     primeTracker(crossColoTracker, AdaptiveOperationTracker.MIN_DATA_POINTS_REQUIRED, CROSS_COLO_LATENCY_RANGE);
     double localColoCutoff = localColoTracker.getSnapshot().getValue(QUANTILE);
 
-    OperationTracker ot = getOperationTracker(false, 1, 1);
+    OperationTracker ot = getOperationTracker(false, 1, 1, null);
     // 3-0-0-0
     sendRequests(ot, 1);
     // 2-1-0-0
@@ -199,9 +209,7 @@ public class AdaptiveOperationTrackerTest {
     primeTracker(crossColoTracker, AdaptiveOperationTracker.MIN_DATA_POINTS_REQUIRED, CROSS_COLO_LATENCY_RANGE);
     double localColoCutoff = localColoTracker.getSnapshot().getValue(1);
 
-    OperationTracker ot =
-        new AdaptiveOperationTracker(localDcName, mockPartition, false, null, true, Integer.MAX_VALUE, 1, 1, time,
-            localColoTracker, null, pastDueCounter, 1);
+    OperationTracker ot = getOperationTracker(false, 1, 1, null);
     // 3-0-0-0
     sendRequests(ot, 1);
     // 2-1-0-0
@@ -229,6 +237,49 @@ public class AdaptiveOperationTrackerTest {
     assertEquals("Past due counter is inconsistent", 1, pastDueCounter.getCount());
   }
 
+  /**
+   * Test that adaptive operation track can correctly register custom percentiles. An example of metric name is:
+   * "com.github.ambry.router.GetOperation.LocalColoLatencyMs.91.0.thPercentile"
+   * @throws Exception
+   */
+  @Test
+  public void customPercentilesMetricsRegistryTest() throws Exception {
+    // test that if custom percentile is not set, no corresponding metrics would be generated.
+    getOperationTracker(true, 1, 1, null);
+    MetricRegistry metricRegistry = routerMetrics.getMetricRegistry();
+    MetricFilter filter = new MetricFilter() {
+      @Override
+      public boolean matches(String name, Metric metric) {
+        return name.endsWith("thPercentile");
+      }
+    };
+    SortedMap<String, Gauge> gauges = metricRegistry.getGauges(filter);
+    assertTrue("No gauges should be created because custom percentile is not set", gauges.isEmpty());
+    // test that dedicated gauges are correctly created for custom percentiles.
+    String customPercentiles = "0.91,0.97";
+    String[] percentileArray = customPercentiles.split(",");
+    Arrays.sort(percentileArray);
+    List<String> sortedPercentiles =
+        Arrays.stream(percentileArray).map(p -> String.valueOf(Double.valueOf(p) * 100)).collect(Collectors.toList());
+    getOperationTracker(false, 1, 1, customPercentiles);
+    gauges = metricRegistry.getGauges(filter);
+    // Note that crossColoEnabled is false, the number of gauges should equal to number of given percentiles
+    assertEquals("The number of custom percentile gauge doesn't match", sortedPercentiles.size(), gauges.size());
+    Iterator mapItor = gauges.keySet().iterator();
+    Iterator<String> listItor = sortedPercentiles.iterator();
+    while (listItor.hasNext()) {
+      String gaugeName = (String) mapItor.next();
+      String percentileStr = listItor.next();
+      assertTrue("The gauge name doesn't match", gaugeName.endsWith(percentileStr + ".thPercentile"));
+    }
+    // reset router metrics to clean up registered metrics
+    routerMetrics = new NonBlockingRouterMetrics(new MockClusterMap());
+    metricRegistry = routerMetrics.getMetricRegistry();
+    getOperationTracker(true, 1, 1, customPercentiles);
+    gauges = metricRegistry.getGauges(filter);
+    assertEquals("The number of custom percentile gauge doesn't match", sortedPercentiles.size() * 2, gauges.size());
+  }
+
   // helpers
 
   // general
@@ -238,12 +289,27 @@ public class AdaptiveOperationTrackerTest {
    * @param crossColoEnabled {@code true} if cross colo needs to be enabled. {@code false} otherwise.
    * @param successTarget the number of successful responses required for the operation to succeed.
    * @param parallelism the number of parallel requests that can be in flight.
+   * @param customPercentiles the custom percentiles to be reported. Percentiles are specified in a comma-separated
+   *                          string, i.e "0.94,0.96,0.97".
    * @return an instance of {@link AdaptiveOperationTracker} with the given parameters.
    */
-  private OperationTracker getOperationTracker(boolean crossColoEnabled, int successTarget, int parallelism) {
-    return new AdaptiveOperationTracker(localDcName, mockPartition, crossColoEnabled, null, true, Integer.MAX_VALUE,
-        successTarget, parallelism, time, localColoTracker, crossColoEnabled ? crossColoTracker : null, pastDueCounter,
-        QUANTILE);
+  private OperationTracker getOperationTracker(boolean crossColoEnabled, int successTarget, int parallelism,
+      String customPercentiles) {
+    Properties props = new Properties();
+    props.setProperty("router.hostname", "localhost");
+    props.setProperty("router.datacenter.name", localDcName);
+    props.setProperty("router.get.cross.dc.enabled", Boolean.toString(crossColoEnabled));
+    props.setProperty("router.get.success.target", Integer.toString(successTarget));
+    props.setProperty("router.get.request.parallelism", Integer.toString(parallelism));
+    props.setProperty("router.get.include.non.originating.dc.replicas", "true");
+    props.setProperty("router.get.replicas.required", Integer.toString(Integer.MAX_VALUE));
+    props.setProperty("router.latency.tolerance.quantile", Double.toString(QUANTILE));
+    if (customPercentiles != null) {
+      props.setProperty("router.operation.tracker.custom.percentiles", customPercentiles);
+    }
+    RouterConfig routerConfig = new RouterConfig(new VerifiableProperties(props));
+    return new AdaptiveOperationTracker(routerConfig, GetOperation.class, mockPartition, null, localColoTracker,
+        crossColoEnabled ? crossColoTracker : null, pastDueCounter, routerMetrics, time);
   }
 
   /**
@@ -289,7 +355,7 @@ public class AdaptiveOperationTrackerTest {
    */
   private void doTrackerUpdateTest(boolean succeedRequests) throws InterruptedException {
     long timeIncrement = 10;
-    OperationTracker ot = getOperationTracker(true, REPLICA_COUNT, REPLICA_COUNT);
+    OperationTracker ot = getOperationTracker(true, REPLICA_COUNT, REPLICA_COUNT, null);
     // 3-0-0-0; 3-0-0-0
     sendRequests(ot, REPLICA_COUNT);
     // 0-3-0-0; 0-3-0-0

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -120,8 +120,8 @@ public class GetBlobInfoOperationTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(
-        new Object[][]{{SimpleOperationTracker.class.getSimpleName(), false}, {SimpleOperationTracker.class.getSimpleName(), true}, {AdaptiveOperationTracker.class.getSimpleName(), false}});
+    return Arrays.asList(new Object[][]{{SimpleOperationTracker.class.getSimpleName(), false},
+        {SimpleOperationTracker.class.getSimpleName(), true}, {AdaptiveOperationTracker.class.getSimpleName(), false}});
   }
 
   /**
@@ -212,7 +212,6 @@ public class GetBlobInfoOperationTest {
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options,
             getOperationCallback, routerCallback, kms, cryptoService, cryptoJobHandler, time, false);
-
     Assert.assertEquals("Callback must match", getOperationCallback, op.getCallback());
     Assert.assertEquals("Blob ids must match", blobId.getID(), op.getBlobIdStr());
 


### PR DESCRIPTION
1. refactor ctor of both simple and adaptive operation tracker by
passing the router config and operation class. This allows operation
tracker itself to populate its parameters based on type of operation
class.
2. introduce custom percentiles of latency Histogram in adaptive
operation tracker. The percentiles are configurable and on-demand. User
can define arbitrary quantile like 91th percentile to better eveluate
the latency distribution.