### PR TITLE
Fixing the intermittent Helix tool test failure

### DIFF
--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -679,7 +679,7 @@ public class TestUtils {
       for (Datacenter dcObj : hardwareLayout.getDatacenters()) {
         dataNodes.addAll(dcObj.getDataNodes());
       }
-      return dataNodes;
+      return Collections.unmodifiableList(dataNodes);
     }
 
     public Datacenter getRandomDatacenter() {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -671,6 +671,17 @@ public class TestUtils {
       return rackAware;
     }
 
+    /**
+     * @return all existing nodes in hardware layout when this method is being invoked.
+     */
+    public List<DataNode> getAllExistingDataNodes() {
+      List<DataNode> dataNodes = new ArrayList<>();
+      for (Datacenter dcObj : hardwareLayout.getDatacenters()) {
+        dataNodes.addAll(dcObj.getDataNodes());
+      }
+      return dataNodes;
+    }
+
     public Datacenter getRandomDatacenter() {
       if (hardwareLayout.getDatacenters().size() == 0) {
         return null;

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -104,7 +104,7 @@ public class HelixBootstrapUpgradeToolTest {
 
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{"DC1"}, {"DC1, DC0"}, {"all"}});
+    return Arrays.asList(new Object[][]{{"DC1"}});
   }
 
   /**
@@ -240,6 +240,9 @@ public class HelixBootstrapUpgradeToolTest {
    */
   @Test
   public void testEverything() throws Exception {
+    // keep initial data nodes in default Hardware Layout
+    List<DataNode> nodesInDefaultHardwareLayout = testHardwareLayout.getAllExistingDataNodes();
+
     /* Test bootstrap */
     long expectedResourceCount =
         (testPartitionLayout.getPartitionLayout().getPartitionCount() - 1) / DEFAULT_MAX_PARTITIONS_PER_RESOURCE + 1;
@@ -307,7 +310,18 @@ public class HelixBootstrapUpgradeToolTest {
     }
     Disk diskForNewReplica;
     do {
-      diskForNewReplica = testHardwareLayout.getRandomDisk();
+      if (partition1.getId() < 100L) {
+        // this is to ensure that if partition1 comes from initial partitions [0, 99], we add new replica to the disk
+        // residing on the initial nodes in default hardware layout. The reason here is, if new replica was added to a
+        // new node (not initially in hardware layout), the replica size of all initial partitions would be reset when
+        // first calling writeBootstrapOrUpgrade() at the end of testing. However the new added replica stays unchanged.
+        // So when writeBootstrapOrUpgrade() is called second time, validating cluster manager in Helix tool will see
+        // inconsistent replica size of same partition and an exception will be thrown which makes test failed.
+        DataNode randomNode = nodesInDefaultHardwareLayout.get(RANDOM.nextInt(nodesInDefaultHardwareLayout.size()));
+        diskForNewReplica = randomNode.getDisks().get(RANDOM.nextInt(randomNode.getDisks().size()));
+      } else {
+        diskForNewReplica = testHardwareLayout.getRandomDisk();
+      }
     } while (partition1Nodes.contains(diskForNewReplica.getDataNode()));
 
     partition1.addReplica(new Replica(partition1, diskForNewReplica, testHardwareLayout.clusterMapConfig));

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -104,7 +104,7 @@ public class HelixBootstrapUpgradeToolTest {
 
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{"DC1"}});
+    return Arrays.asList(new Object[][]{{"DC1"}, {"DC1, DC0"}, {"all"}});
   }
 
   /**


### PR DESCRIPTION
The replica size is changed in testEverything() method. If new replica
from initial partition is added to new node disk and is not reset when
calling writeBootstrapOrUpgrade(), then the second time it is invoked,
validating cluster manager in Helix tool would see different size of
replica of same partition and fails the test.
This patch ensures that if new replica is from initial partition, the
replica is only allowed to be added to original nodes in HardwareLayout,
which would be reset by writeBootstrapOrUpgrade() and avoid inconsistent
replica size error in validating cluster manager.