### PR TITLE
Fix NullPointerException and 'no more capacity' issues in blob store

### DIFF
--- a/ambry-api/src/test/java/com.github.ambry/store/MockWrite.java
+++ b/ambry-api/src/test/java/com.github.ambry/store/MockWrite.java
@@ -16,6 +16,7 @@ package com.github.ambry.store;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
+import java.util.Objects;
 
 
 /**
@@ -53,8 +54,8 @@ public class MockWrite implements Write {
     } catch (IOException e) {
       // The IOException message may vary in different java versions. As code evolves, we may need to update IO_ERROR_STR
       // in StoreException (based on java version that is being employed) to correctly capture disk I/O related errors.
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException(errorCode.toString() + " while writing into store", e, errorCode);
     }
     buf.limit(savedLimit);

--- a/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.github.ambry.replication.ReplicationTest.*;
@@ -123,8 +124,9 @@ class InMemoryStore implements Store {
           sizeRead += channel.read(buf);
         }
       } catch (IOException e) {
-        StoreErrorCodes errorCode = e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-            : StoreErrorCodes.Unknown_Error;
+        StoreErrorCodes errorCode =
+            Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+                : StoreErrorCodes.Unknown_Error;
         throw new StoreException(errorCode.toString() + " while writing into dummy log", e, errorCode);
       }
       buf.flip();

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -62,7 +62,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
@@ -1129,8 +1128,8 @@ public class ReplicationTest {
     Time time = new MockTime();
     MockFindToken token1 = new MockFindToken(0, 0);
     RemoteReplicaInfo remoteReplicaInfo = new RemoteReplicaInfo(new MockReplicaId(), new MockReplicaId(),
-        new InMemoryStore(null, Collections.emptyList(), Collections.emptyList(), null), token1, tokenPersistInterval, time,
-        new Port(5000, PortType.PLAINTEXT));
+        new InMemoryStore(null, Collections.emptyList(), Collections.emptyList(), null), token1, tokenPersistInterval,
+        time, new Port(5000, PortType.PLAINTEXT));
 
     // The equality check is for the reference, which is fine.
     // Initially, the current token and the token to persist are the same.

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -62,6 +62,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -234,8 +235,8 @@ public class HardDeleter implements Runnable {
       }
     } catch (IOException e) {
       metrics.hardDeleteExceptionsCount.inc();
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException(errorCode.toString() + " occurred while performing hard delete ", e, errorCode);
     }
       /* Now that all the blobs in the range were successfully hard deleted, the next time hard deletes can be resumed
@@ -540,8 +541,8 @@ public class HardDeleter implements Runnable {
       fileStream.getChannel().force(true);
       tempFile.renameTo(actual);
     } catch (IOException e) {
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException(
           errorCode.toString() + " while persisting cleanup tokens to disk " + tempFile.getAbsoluteFile(), errorCode);
     } finally {
@@ -621,8 +622,8 @@ public class HardDeleter implements Runnable {
         diskIOScheduler.getSlice(HARD_DELETE_CLEANUP_JOB_NAME, HARD_DELETE_CLEANUP_JOB_NAME, logWriteInfo.size);
       }
     } catch (IOException e) {
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException(errorCode.toString() + " while performing hard delete ", e, errorCode);
     }
     logger.trace("Performed hard deletes from {} to {} for {}", startToken, endToken, dataDir);

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -41,6 +41,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -400,8 +401,8 @@ class IndexSegment {
       stream.writeLong(crcValue);
       stream.close();
     } catch (IOException e) {
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException(errorCode.toString() + " while trying to persist bloom filter", e, errorCode);
     }
   }
@@ -448,12 +449,12 @@ class IndexSegment {
       mmap.position(firstKeyRelativeOffset + index * persistedEntrySize);
       storeKey = factory.getStoreKey(new DataInputStream(new ByteBufferInputStream(mmap)));
     } catch (InternalError e) {
-      throw e.getMessage().equals(StoreException.INTERNAL_ERROR_STR) ? new StoreException(
+      throw Objects.equals(e.getMessage(), StoreException.INTERNAL_ERROR_STR) ? new StoreException(
           "Internal error occurred due to unsafe memory access", e, StoreErrorCodes.IOError)
           : new StoreException("Unknown internal error while trying to get store key", e,
               StoreErrorCodes.Unknown_Error);
     } catch (IOException e) {
-      throw e.getMessage().equals(StoreException.IO_ERROR_STR) ? new StoreException(
+      throw Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? new StoreException(
           "IO error while trying to get store key", e, StoreErrorCodes.IOError)
           : new StoreException("Unknown IO error while trying to get store key", e, StoreErrorCodes.Unknown_Error);
     } catch (Throwable t) {
@@ -700,8 +701,9 @@ class IndexSegment {
         // swap temp file with the original file
         temp.renameTo(getFile());
       } catch (IOException e) {
-        StoreErrorCodes errorCode = e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-            : StoreErrorCodes.Unknown_Error;
+        StoreErrorCodes errorCode =
+            Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+                : StoreErrorCodes.Unknown_Error;
         throw new StoreException(
             "IndexSegment : " + indexFile.getAbsolutePath() + " encountered " + errorCode.toString()
                 + " while persisting index to disk", e, errorCode);
@@ -794,8 +796,8 @@ class IndexSegment {
     } catch (FileNotFoundException e) {
       throw new StoreException("File not found while mapping the segment of index", e, StoreErrorCodes.File_Not_Found);
     } catch (IOException e) {
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException(errorCode.toString() + " while mapping the segment of index", e, errorCode);
     } finally {
       rwLock.writeLock().unlock();
@@ -906,8 +908,8 @@ class IndexSegment {
             StoreErrorCodes.Index_Creation_Failure);
       }
     } catch (IOException e) {
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException("IndexSegment : " + indexFile.getAbsolutePath() + " encountered " + errorCode.toString()
           + " while reading from file ", e, errorCode);
     }

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -135,8 +136,8 @@ class LogSegment implements Read, Write {
     } catch (FileNotFoundException e) {
       throw new StoreException("File not found while creating log segment", e, StoreErrorCodes.File_Not_Found);
     } catch (IOException e) {
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException(errorCode.toString() + " while creating log segment", e, errorCode);
     }
   }
@@ -164,8 +165,8 @@ class LogSegment implements Read, Write {
     } catch (ClosedChannelException e) {
       throw new StoreException("Channel closed while writing into the log segment", e, StoreErrorCodes.Channel_Closed);
     } catch (IOException e) {
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException(errorCode.toString() + " while writing into the log segment", e, errorCode);
     }
     endOffset.addAndGet(bytesWritten);
@@ -209,8 +210,9 @@ class LogSegment implements Read, Write {
           bytesWritten += fileChannel.write(byteBufferForAppend, endOffset.get() + bytesWritten);
         }
       } catch (IOException e) {
-        StoreErrorCodes errorCode = e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-            : StoreErrorCodes.Unknown_Error;
+        StoreErrorCodes errorCode =
+            Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+                : StoreErrorCodes.Unknown_Error;
         throw new StoreException(errorCode.toString() + " while writing into the log segment", e, errorCode);
       }
     }
@@ -239,8 +241,8 @@ class LogSegment implements Read, Write {
       directFile.write(byteArray, offset, length);
       endOffset.addAndGet(length);
     } catch (IOException e) {
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException(errorCode.toString() + " while writing into segment via direct IO", e, errorCode);
     }
     return length;
@@ -422,8 +424,8 @@ class LogSegment implements Read, Write {
       fileChannel.position(endOffset);
       this.endOffset.set(endOffset);
     } catch (IOException e) {
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException(errorCode.toString() + " while setting end offset of segment", e, errorCode);
     }
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.NavigableSet;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
@@ -828,8 +829,8 @@ class PersistentIndex {
             + "]", StoreErrorCodes.ID_Deleted);
       }
     } catch (IOException e) {
-      StoreErrorCodes errorCode =
-          e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+          : StoreErrorCodes.Unknown_Error;
       throw new StoreException(errorCode.toString() + " when reading delete blob info from the log " + dataDir, e,
           errorCode);
     }
@@ -1661,8 +1662,9 @@ class PersistentIndex {
       } catch (FileNotFoundException e) {
         throw new StoreException("File not found while writing index to file", e, StoreErrorCodes.File_Not_Found);
       } catch (IOException e) {
-        StoreErrorCodes errorCode = e.getMessage().equals(StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-            : StoreErrorCodes.Unknown_Error;
+        StoreErrorCodes errorCode =
+            Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
+                : StoreErrorCodes.Unknown_Error;
         throw new StoreException(errorCode.toString() + " while persisting index to disk", e, errorCode);
       } finally {
         context.stop();

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -691,8 +691,8 @@ public class BlobStoreTest {
     MockId mockId = put(1, PUT_RECORD_SIZE, Utils.Infinite_Time).get(0);
     short[] accountIds =
         {-1, Utils.getRandomShort(TestUtils.RANDOM), -1, mockId.getAccountId(), Utils.getRandomShort(TestUtils.RANDOM)};
-    short[] containerIds = {-1, -1, Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(
-        TestUtils.RANDOM), mockId.getContainerId()};
+    short[] containerIds = {-1, -1, Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM),
+        mockId.getContainerId()};
     for (int i = 0; i < accountIds.length; i++) {
       verifyDeleteFailure(new MockId(mockId.getID(), accountIds[i], containerIds[i]),
           StoreErrorCodes.Authorization_Failure);
@@ -723,8 +723,8 @@ public class BlobStoreTest {
     MockId mockId = put(1, PUT_RECORD_SIZE, Utils.Infinite_Time).get(0);
     short[] accountIds =
         {-1, Utils.getRandomShort(TestUtils.RANDOM), -1, mockId.getAccountId(), Utils.getRandomShort(TestUtils.RANDOM)};
-    short[] containerIds = {-1, -1, Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(
-        TestUtils.RANDOM), mockId.getContainerId()};
+    short[] containerIds = {-1, -1, Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM),
+        mockId.getContainerId()};
     for (int i = 0; i < accountIds.length; i++) {
       verifyGetFailure(new MockId(mockId.getID(), accountIds[i], containerIds[i]),
           StoreErrorCodes.Authorization_Failure);
@@ -1099,6 +1099,17 @@ public class BlobStoreTest {
       fail("should throw exception");
     } catch (StoreException e) {
       assertEquals("Mismatch in error code", StoreErrorCodes.IOError, e.getErrorCode());
+    }
+    assertEquals("Mismatch in error count", 2, testStore2.getErrorCount().get());
+
+    // test that when InternalError's error message is null, the error code should be Unknown_Error and store error count
+    // stays unchanged.
+    doThrow(new InternalError()).when(mockStoreKeyFactory).getStoreKey(any(DataInputStream.class));
+    try {
+      testStore2.get(Collections.singletonList(id2), EnumSet.noneOf(StoreGetOptions.class));
+      fail("should throw exception");
+    } catch (StoreException e) {
+      assertEquals("Mismatch in error code", StoreErrorCodes.Unknown_Error, e.getErrorCode());
     }
     assertEquals("Mismatch in error count", 2, testStore2.getErrorCount().get());
 

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -49,7 +49,7 @@ import org.mockito.Mockito;
 
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 
@@ -387,6 +387,14 @@ public class IndexSegmentTest {
       fail("should fail");
     } catch (StoreException e) {
       assertEquals("Mismatch in error code", StoreErrorCodes.IOError, e.getErrorCode());
+    }
+    // test that when IOException's error message is null, the error code should be Unknown_Error
+    doThrow(new IOException()).when(mockStoreKeyFactory).getStoreKey(any(DataInputStream.class));
+    try {
+      indexSegment.seal();
+      fail("should fail");
+    } catch (StoreException e) {
+      assertEquals("Mismatch in error code", StoreErrorCodes.Unknown_Error, e.getErrorCode());
     }
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -211,6 +211,11 @@ public class IndexTest {
         .getMessageInfo(any(Read.class), anyLong(), any(StoreKeyFactory.class));
     verifyBlobReadOptions(state.deletedKeyWithPutInSameSegment, EnumSet.of(StoreGetOptions.Store_Include_Deleted),
         StoreErrorCodes.IOError);
+    // test that when IOException's error message is null, the error code should be Unknown_Error
+    doThrow(new IOException()).when(mockHardDelete)
+        .getMessageInfo(any(Read.class), anyLong(), any(StoreKeyFactory.class));
+    verifyBlobReadOptions(state.deletedKeyWithPutInSameSegment, EnumSet.of(StoreGetOptions.Store_Include_Deleted),
+        StoreErrorCodes.Unknown_Error);
   }
 
   /**
@@ -1168,6 +1173,14 @@ public class IndexTest {
       fail("Should have thrown exception due to I/O error");
     } catch (StoreException e) {
       assertEquals("StoreException error code mismatch ", StoreErrorCodes.IOError, e.getErrorCode());
+    }
+    // test that when IOException's error message is null, the error code should be Unknown_Error
+    try {
+      doThrow(new IOException()).when(mockLog).flush();
+      state.index.close();
+      fail("Should have thrown exception due to I/O error");
+    } catch (StoreException e) {
+      assertEquals("StoreException error code mismatch ", StoreErrorCodes.Unknown_Error, e.getErrorCode());
     }
     Mockito.reset(mockLog);
   }


### PR DESCRIPTION
1. NPE occurs when error message of captured IOException is null. In
this case, we should use Objects.equals to compare error string.
2. 'no more capacity' issue occurs when new log segment creation failed,
however, the code didn't restore the counter of remainingUnallocatedSegments.
This patch will catch such failure and restore counter as well as clean
up the allocated file.

This pr will address #1167 