### PR TITLE
Fix to correct #1165.

### DIFF
--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
@@ -162,6 +162,7 @@ class CloudBlobStore implements Store {
       long bufferlen = bufferChanged ? -1 : size;
       cloudDestination.uploadBlob(blobId, bufferlen, blobMetadata, new ByteBufferInputStream(messageBuf));
     } else {
+      logger.trace("Blob is skipped: {}", messageInfo);
       vcrMetrics.blobUploadSkippedCount.inc();
     }
   }

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
@@ -185,10 +185,9 @@ class CloudBlobStore implements Store {
     if (messageInfo.isDeleted()) {
       return false;
     }
-    // expiration time above threshold or ttlUpdate is set. Expired blobs are blocked by ReplicaThread.
+    // expiration time above threshold. Expired blobs are blocked by ReplicaThread.
     return (messageInfo.getExpirationTimeInMs() == Utils.Infinite_Time
-        || messageInfo.getExpirationTimeInMs() - messageInfo.getOperationTimeMs() >= minTtlMillis
-        || messageInfo.isTtlUpdated());
+        || messageInfo.getExpirationTimeInMs() - messageInfo.getOperationTimeMs() >= minTtlMillis);
   }
 
   @Override

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudBlobStoreTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudBlobStoreTest.java
@@ -123,6 +123,7 @@ public class CloudBlobStoreTest {
     properties.setProperty("clustermap.cluster.name", "dev");
     properties.setProperty("clustermap.datacenter.name", "DC1");
     properties.setProperty("clustermap.host.name", "localhost");
+    properties.setProperty("clustermap.resolve.hostnames", "false");
     properties.setProperty("kms.default.container.key", TestUtils.getRandomKey(64));
   }
 
@@ -363,7 +364,8 @@ public class CloudBlobStoreTest {
         referenceTime - 2000, referenceTime - 1000);
     replicaThread.replicate(replicasToReplicateList);
     assertFalse("Blob should not exist.", latchBasedInMemoryCloudDestination.doesBlobExist(id));
-    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost));
+    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost),
+        Utils.Infinite_Time);
     replicaThread.replicate(replicasToReplicateList);
     assertTrue("Blob should exist.", latchBasedInMemoryCloudDestination.doesBlobExist(id));
 
@@ -372,7 +374,8 @@ public class CloudBlobStoreTest {
     id = blobIdList.get(1);
     addPutMessagesToReplicasOfPartition(id, accountId, containerId, partitionId, Collections.singletonList(remoteHost),
         referenceTime - 2000, referenceTime - 1000);
-    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost));
+    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost),
+        Utils.Infinite_Time);
     replicaThread.replicate(replicasToReplicateList);
     assertTrue("Blob should exist.", latchBasedInMemoryCloudDestination.doesBlobExist(id));
 
@@ -383,7 +386,8 @@ public class CloudBlobStoreTest {
         referenceTime, referenceTime + TimeUnit.DAYS.toMillis(cloudConfig.vcrMinTtlDays) - 1);
     replicaThread.replicate(replicasToReplicateList);
     assertFalse("Blob should not exist.", latchBasedInMemoryCloudDestination.doesBlobExist(id));
-    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost));
+    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost),
+        Utils.Infinite_Time);
     replicaThread.replicate(replicasToReplicateList);
     assertTrue("Blob should exist.", latchBasedInMemoryCloudDestination.doesBlobExist(id));
 
@@ -392,7 +396,8 @@ public class CloudBlobStoreTest {
     id = blobIdList.get(3);
     addPutMessagesToReplicasOfPartition(id, accountId, containerId, partitionId, Collections.singletonList(remoteHost),
         referenceTime, referenceTime + TimeUnit.DAYS.toMillis(cloudConfig.vcrMinTtlDays) - 1);
-    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost));
+    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost),
+        Utils.Infinite_Time);
     replicaThread.replicate(replicasToReplicateList);
     assertTrue("Blob should exist.", latchBasedInMemoryCloudDestination.doesBlobExist(id));
 
@@ -403,7 +408,8 @@ public class CloudBlobStoreTest {
         referenceTime, referenceTime + TimeUnit.DAYS.toMillis(cloudConfig.vcrMinTtlDays));
     replicaThread.replicate(replicasToReplicateList);
     assertTrue(latchBasedInMemoryCloudDestination.doesBlobExist(id));
-    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost));
+    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost),
+        Utils.Infinite_Time);
     replicaThread.replicate(replicasToReplicateList);
     assertTrue("Blob should exist.", latchBasedInMemoryCloudDestination.doesBlobExist(id));
 
@@ -412,7 +418,8 @@ public class CloudBlobStoreTest {
     id = blobIdList.get(5);
     addPutMessagesToReplicasOfPartition(id, accountId, containerId, partitionId, Collections.singletonList(remoteHost),
         referenceTime, referenceTime + TimeUnit.DAYS.toMillis(cloudConfig.vcrMinTtlDays));
-    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost));
+    addTtlUpdateMessagesToReplicasOfPartition(partitionId, id, Collections.singletonList(remoteHost),
+        Utils.Infinite_Time);
     replicaThread.replicate(replicasToReplicateList);
     assertTrue("Blob should exist.", latchBasedInMemoryCloudDestination.doesBlobExist(id));
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerPlaintextTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -98,8 +99,10 @@ public class ServerPlaintextTest {
   @Test
   public void endToEndCloudBackupTest() throws Exception {
     DataNodeId dataNode = plaintextCluster.getClusterMap().getDataNodeIds().get(0);
-    ServerTestUtil.endToEndCloudBackupTest(plaintextCluster, dataNode, null, null, testEncryption,
-        notificationSystem, null);
+    ServerTestUtil.endToEndCloudBackupTest(plaintextCluster, dataNode, null, null, testEncryption, notificationSystem,
+        null, Utils.Infinite_Time, false);
+    ServerTestUtil.endToEndCloudBackupTest(plaintextCluster, dataNode, null, null, testEncryption, notificationSystem,
+        null, System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1), true);
   }
 
   @Test

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerSSLTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerSSLTest.java
@@ -22,12 +22,14 @@ import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import org.junit.AfterClass;
@@ -133,7 +135,10 @@ public class ServerSSLTest {
   public void endToEndCloudBackupTest() throws Exception {
     DataNodeId dataNode = sslCluster.getClusterMap().getDataNodeIds().get(0);
     ServerTestUtil.endToEndCloudBackupTest(sslCluster, dataNode, clientSSLConfig2, clientSSLSocketFactory2,
-        testEncryption, notificationSystem, serverSSLProps);
+        testEncryption, notificationSystem, serverSSLProps, Utils.Infinite_Time, false);
+    ServerTestUtil.endToEndCloudBackupTest(sslCluster, dataNode, clientSSLConfig2, clientSSLSocketFactory2,
+        testEncryption, notificationSystem, serverSSLProps, System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1),
+        true);
   }
 
   @Test


### PR DESCRIPTION
Updated expiration time is reflacted in TtlUpdate messageInfo.
Revert CloudBlobStore#shouldUpload().
Add ttlUpdate() to endToEndCloudBackupTest.