### PR TITLE
Minor fixes in IOException catch and metrics registry

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/store/StoreException.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/StoreException.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.store;
 
+import java.util.Objects;
+
+
 public class StoreException extends Exception {
   public static final String INTERNAL_ERROR_STR =
       "a fault occurred in a recent unsafe memory access operation in compiled Java code";
@@ -37,5 +40,15 @@ public class StoreException extends Exception {
 
   public StoreErrorCodes getErrorCode() {
     return this.error;
+  }
+
+  /**
+   * Resolve the error code from {@link Throwable}. This is to determine if exception is related to real disk I/O issue.
+   * @param t the {@link Throwable} to check
+   * @return the {@link StoreErrorCodes} based on the error message in exception/error.
+   */
+  public static StoreErrorCodes resolveErrorCode(Throwable t) {
+    return Objects.equals(t.getMessage(), StoreException.IO_ERROR_STR) || Objects.equals(t.getMessage(),
+        StoreException.INTERNAL_ERROR_STR) ? StoreErrorCodes.IOError : StoreErrorCodes.Unknown_Error;
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/store/StoreException.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/StoreException.java
@@ -17,9 +17,9 @@ import java.util.Objects;
 
 
 public class StoreException extends Exception {
-  public static final String INTERNAL_ERROR_STR =
+  static final String INTERNAL_ERROR_STR =
       "a fault occurred in a recent unsafe memory access operation in compiled Java code";
-  public static final String IO_ERROR_STR = "Input/output error";
+  static final String IO_ERROR_STR = "Input/output error";
   private static final long serialVersionUID = 1;
   private final StoreErrorCodes error;
 

--- a/ambry-api/src/test/java/com.github.ambry/store/MockWrite.java
+++ b/ambry-api/src/test/java/com.github.ambry/store/MockWrite.java
@@ -16,7 +16,6 @@ package com.github.ambry.store;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
-import java.util.Objects;
 
 
 /**
@@ -54,8 +53,7 @@ public class MockWrite implements Write {
     } catch (IOException e) {
       // The IOException message may vary in different java versions. As code evolves, we may need to update IO_ERROR_STR
       // in StoreException (based on java version that is being employed) to correctly capture disk I/O related errors.
-      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-          : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
       throw new StoreException(errorCode.toString() + " while writing into store", e, errorCode);
     }
     buf.limit(savedLimit);

--- a/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import static com.github.ambry.replication.ReplicationTest.*;
@@ -124,9 +123,7 @@ class InMemoryStore implements Store {
           sizeRead += channel.read(buf);
         }
       } catch (IOException e) {
-        StoreErrorCodes errorCode =
-            Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-                : StoreErrorCodes.Unknown_Error;
+        StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
         throw new StoreException(errorCode.toString() + " while writing into dummy log", e, errorCode);
       }
       buf.flip();

--- a/ambry-router/src/main/java/com.github.ambry.router/AdaptiveOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/AdaptiveOperationTracker.java
@@ -66,7 +66,7 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
    */
   AdaptiveOperationTracker(RouterConfig routerConfig, RouterOperation routerOperation, PartitionId partitionId,
       String originatingDcName, Histogram localColoTracker, Histogram crossColoTracker, Counter pastDueCounter,
-      NonBlockingRouterMetrics routerMetrics, Time time) {
+      Time time) {
     super(routerConfig, routerOperation, partitionId, originatingDcName, true);
     this.time = time;
     this.localColoTracker = localColoTracker;
@@ -74,23 +74,6 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
     this.pastDueCounter = pastDueCounter;
     this.quantile = routerConfig.routerLatencyToleranceQuantile;
     this.otIterator = new OpTrackerIterator();
-    Class operationClass = null;
-    switch (routerOperation) {
-      case GetBlobOperation:
-        operationClass = GetBlobOperation.class;
-        break;
-      case GetBlobInfoOperation:
-        operationClass = GetBlobInfoOperation.class;
-        break;
-      default:
-        throw new IllegalArgumentException(routerOperation + " is not supported in AdaptiveOperationTracker");
-    }
-    routerMetrics.registerCustomPercentiles(operationClass, "LocalColoLatencyMs", localColoTracker,
-        routerConfig.routerOperationTrackerCustomPercentiles);
-    if (crossColoTracker != null) {
-      routerMetrics.registerCustomPercentiles(operationClass, "CrossColoLatencyMs", crossColoTracker,
-          routerConfig.routerOperationTrackerCustomPercentiles);
-    }
   }
 
   @Override

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -251,7 +251,7 @@ abstract class GetOperation {
     } else if (trackerType.equals(AdaptiveOperationTracker.class.getSimpleName())) {
       operationTracker =
           new AdaptiveOperationTracker(routerConfig, routerOperation, partitionId, originatingDcName, localColoTracker,
-              crossColoTracker, pastDueCounter, routerMetrics, time);
+              crossColoTracker, pastDueCounter, time);
     } else {
       throw new IllegalArgumentException("Unrecognized tracker type: " + trackerType);
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterFactory.java
@@ -83,7 +83,7 @@ public class NonBlockingRouterFactory implements RouterFactory {
     this.notificationSystem = notificationSystem;
     this.accountService = accountService;
     MetricRegistry registry = clusterMap.getMetricRegistry();
-    routerMetrics = new NonBlockingRouterMetrics(clusterMap);
+    routerMetrics = new NonBlockingRouterMetrics(clusterMap, routerConfig);
     networkConfig = new NetworkConfig(verifiableProperties);
     networkMetrics = new NetworkMetrics(registry);
     time = SystemTime.getInstance();

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -135,7 +135,7 @@ public class ChunkFillTest {
     VerifiableProperties vProps = getNonBlockingRouterProperties();
     MockClusterMap mockClusterMap = new MockClusterMap();
     RouterConfig routerConfig = new RouterConfig(vProps);
-    NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
+    NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
     short accountId = Utils.getRandomShort(random);
     short containerId = Utils.getRandomShort(random);
     BlobProperties putBlobProperties =
@@ -234,7 +234,7 @@ public class ChunkFillTest {
     VerifiableProperties vProps = getNonBlockingRouterProperties();
     MockClusterMap mockClusterMap = new MockClusterMap();
     RouterConfig routerConfig = new RouterConfig(vProps);
-    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
+    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
     ResponseHandler responseHandler = new ResponseHandler(mockClusterMap);
     short accountId = Utils.getRandomShort(random);
     short containerId = Utils.getRandomShort(random);

--- a/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
@@ -69,7 +69,7 @@ public class CryptoJobHandlerTest {
     cryptoService = new GCMCryptoServiceFactory(verifiableProperties, REGISTRY).getCryptoService();
     cryptoJobHandler = new CryptoJobHandler(DEFAULT_THREAD_COUNT);
     referenceClusterMap = new MockClusterMap();
-    routerMetrics = new NonBlockingRouterMetrics(referenceClusterMap);
+    routerMetrics = new NonBlockingRouterMetrics(referenceClusterMap, null);
   }
 
   @After

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -99,7 +99,7 @@ public class DeleteManagerTest {
     clusterMap = new MockClusterMap();
     serverLayout = new MockServerLayout(clusterMap);
     RouterConfig routerConfig = new RouterConfig(vProps);
-    router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(clusterMap),
+    router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(clusterMap, routerConfig),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), new LoggingNotificationSystem(), clusterMap, null, null, null,
         new InMemAccountService(false, true), mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
@@ -360,7 +360,8 @@ public class DeleteManagerTest {
     Properties props = getNonBlockingRouterProperties();
     props.setProperty("router.delete.request.parallelism", "3");
     VerifiableProperties vProps = new VerifiableProperties(props);
-    router = new NonBlockingRouter(new RouterConfig(vProps), new NonBlockingRouterMetrics(clusterMap),
+    RouterConfig routerConfig = new RouterConfig(vProps);
+    router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(clusterMap, routerConfig),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), new LoggingNotificationSystem(), clusterMap, null, null, null,
         new InMemAccountService(false, true), mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -135,7 +135,7 @@ public class GetBlobInfoOperationTest {
     VerifiableProperties vprops = new VerifiableProperties(getNonBlockingRouterProperties());
     routerConfig = new RouterConfig(vprops);
     mockClusterMap = new MockClusterMap();
-    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
+    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
     options = new GetBlobOptionsInternal(
         new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.BlobInfo).build(), false,
         routerMetrics.ageAtGet);
@@ -149,7 +149,7 @@ public class GetBlobInfoOperationTest {
       kmsSingleKey = TestUtils.getRandomKey(SingleKeyManagementServiceTest.DEFAULT_KEY_SIZE_CHARS);
       instantiateCryptoComponents(vprops);
     }
-    router = new NonBlockingRouter(new RouterConfig(vprops), new NonBlockingRouterMetrics(mockClusterMap),
+    router = new NonBlockingRouter(new RouterConfig(vprops), new NonBlockingRouterMetrics(mockClusterMap, routerConfig),
         networkClientFactory, new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService, cryptoJobHandler,
         new InMemAccountService(false, true), time, MockClusterMap.DEFAULT_PARTITION_CLASS);
     short accountId = Utils.getRandomShort(random);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -178,8 +178,9 @@ public class GetBlobOperationTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(
-        new Object[][]{{SimpleOperationTracker.class.getSimpleName(), false}, {AdaptiveOperationTracker.class.getSimpleName(), false}, {AdaptiveOperationTracker.class.getSimpleName(), true}});
+    return Arrays.asList(new Object[][]{{SimpleOperationTracker.class.getSimpleName(), false},
+        {AdaptiveOperationTracker.class.getSimpleName(), false},
+        {AdaptiveOperationTracker.class.getSimpleName(), true}});
   }
 
   /**
@@ -200,7 +201,7 @@ public class GetBlobOperationTest {
     routerConfig = new RouterConfig(vprops);
     mockClusterMap = new MockClusterMap();
     blobIdFactory = new BlobIdFactory(mockClusterMap);
-    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
+    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
     options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().build(), false, routerMetrics.ageAtGet);
     mockServerLayout = new MockServerLayout(mockClusterMap);
     replicasCount =
@@ -215,8 +216,8 @@ public class GetBlobOperationTest {
       cryptoService = new MockCryptoService(new CryptoServiceConfig(vprops));
       cryptoJobHandler = new CryptoJobHandler(CryptoJobHandlerTest.DEFAULT_THREAD_COUNT);
     }
-    router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap), networkClientFactory,
-        new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService, cryptoJobHandler,
+    router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap, routerConfig),
+        networkClientFactory, new LoggingNotificationSystem(), mockClusterMap, kms, cryptoService, cryptoJobHandler,
         new InMemAccountService(false, true), time, MockClusterMap.DEFAULT_PARTITION_CLASS);
     mockNetworkClient = networkClientFactory.getMockNetworkClient();
     routerCallback = new RouterCallback(mockNetworkClient, new ArrayList<BackgroundDeleteRequest>());
@@ -1218,7 +1219,8 @@ public class GetBlobOperationTest {
     }
     // Ensure that a ChannelClosed exception is not set when the ReadableStreamChannel is closed correctly.
     Assert.assertNull("Callback operation exception should be null", op.getOperationException());
-    if (options.getBlobOptions.getOperationType() != GetBlobOptions.OperationType.BlobInfo && !options.getBlobOptions.isRawMode()) {
+    if (options.getBlobOptions.getOperationType() != GetBlobOptions.OperationType.BlobInfo
+        && !options.getBlobOptions.isRawMode()) {
       int sizeWritten = blobSize;
       if (options.getBlobOptions.getRange() != null) {
         ByteRange range = options.getBlobOptions.getRange().toResolvedByteRange(blobSize);
@@ -1348,8 +1350,8 @@ public class GetBlobOperationTest {
   private ByteBuffer getBlobBuffer() throws IOException {
     // Find server with the blob
     for (ReplicaId replicaId : blobId.getPartition().getReplicaIds()) {
-      MockServer server = mockServerLayout.getMockServer(replicaId.getDataNodeId().getHostname(),
-          replicaId.getDataNodeId().getPort());
+      MockServer server =
+          mockServerLayout.getMockServer(replicaId.getDataNodeId().getHostname(), replicaId.getDataNodeId().getPort());
       if (server.getBlobs().containsKey(blobId.getID())) {
         return getBlobBufferFromServer(server);
       }
@@ -1365,8 +1367,9 @@ public class GetBlobOperationTest {
   private ByteBuffer getBlobBufferFromServer(MockServer server) throws IOException {
     PartitionRequestInfo requestInfo =
         new PartitionRequestInfo(blobId.getPartition(), Collections.singletonList(blobId));
-    GetRequest getRequest = new GetRequest(1, "assertBlobReadSuccess", MessageFormatFlags.All,
-        Collections.singletonList(requestInfo), GetOption.None);
+    GetRequest getRequest =
+        new GetRequest(1, "assertBlobReadSuccess", MessageFormatFlags.All, Collections.singletonList(requestInfo),
+            GetOption.None);
     GetResponse getResponse = server.makeGetResponse(getRequest, ServerErrorCode.No_Error);
 
     // simulating server sending response over the wire

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -408,7 +408,7 @@ public class GetManagerTest {
     properties.setProperty("router.put.success.target", Integer.toString(successTarget));
     VerifiableProperties vProps = new VerifiableProperties(properties);
     routerConfig = new RouterConfig(vProps);
-    router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap),
+    router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap, routerConfig),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), new LoggingNotificationSystem(), mockClusterMap, kms,
         cryptoService, cryptoJobHandler, new InMemAccountService(false, true), mockTime,

--- a/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
@@ -16,7 +16,6 @@ package com.github.ambry.router;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.MockReplicaId;
@@ -76,7 +75,6 @@ public class OperationTrackerTest {
   private final Set<ReplicaId> repetitionTracker = new HashSet<>();
 
   // for AdaptiveOperationTracker
-  private final NonBlockingRouterMetrics routerMetrics;
   private final Time time = new MockTime();
   private final MetricRegistry registry = new MetricRegistry();
   private final Histogram localColoTracker = registry.histogram("LocalColoTracker");
@@ -95,13 +93,8 @@ public class OperationTrackerTest {
   /**
    * @param operationTrackerType the type of {@link OperationTracker} that needs to be used in tests
    */
-  public OperationTrackerTest(String operationTrackerType) throws Exception {
+  public OperationTrackerTest(String operationTrackerType) {
     this.operationTrackerType = operationTrackerType;
-    if (operationTrackerType.equals(ADAPTIVE_OP_TRACKER)) {
-      routerMetrics = new NonBlockingRouterMetrics(new MockClusterMap());
-    } else {
-      routerMetrics = null;
-    }
   }
 
   /**
@@ -499,7 +492,7 @@ public class OperationTrackerTest {
           try {
             operationTracker =
                 new AdaptiveOperationTracker(routerConfig, entry.getKey(), mockPartition, originatingDcName,
-                    localColoTracker, crossColoTracker, pastDueCounter, routerMetrics, time);
+                    localColoTracker, crossColoTracker, pastDueCounter, time);
           } catch (IllegalArgumentException e) {
             assertTrue("Get operation shouldn't throw any exception in adaptive tracker",
                 entry.getKey() != RouterOperation.GetBlobOperation
@@ -571,8 +564,7 @@ public class OperationTrackerTest {
         break;
       case ADAPTIVE_OP_TRACKER:
         tracker = new AdaptiveOperationTracker(routerConfig, RouterOperation.GetBlobOperation, mockPartition,
-            originatingDcName, localColoTracker, crossColoEnabled ? crossColoTracker : null, pastDueCounter,
-            routerMetrics, time);
+            originatingDcName, localColoTracker, crossColoEnabled ? crossColoTracker : null, pastDueCounter, time);
         break;
       default:
         throw new IllegalArgumentException("Unrecognized operation tracker type - " + operationTrackerType);

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -884,7 +884,7 @@ public class PutManagerTest {
     if (testEncryption && instantiateEncryptionCast) {
       setupEncryptionCast(vProps);
     }
-    metrics = new NonBlockingRouterMetrics(mockClusterMap);
+    metrics = new NonBlockingRouterMetrics(mockClusterMap, null);
     router = new NonBlockingRouter(new RouterConfig(vProps), metrics,
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, mockServerLayout, mockTime), notificationSystem, mockClusterMap, kms, cryptoService,

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -50,7 +50,7 @@ import org.junit.Test;
 public class PutOperationTest {
   private final RouterConfig routerConfig;
   private final MockClusterMap mockClusterMap = new MockClusterMap();
-  private final NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap);
+  private final NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, null);
   private final Time time;
   private final Map<Integer, PutOperation> correlationIdToPutOperation = new TreeMap<>();
   private final MockServer mockServer = new MockServer(mockClusterMap, "");

--- a/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
@@ -97,7 +97,7 @@ public class TtlUpdateManagerTest {
     VerifiableProperties vProps =
         new VerifiableProperties(getNonBlockingRouterProperties(DEFAULT_SUCCESS_TARGET, DEFAULT_PARALLELISM));
     RouterConfig routerConfig = new RouterConfig(vProps);
-    NonBlockingRouterMetrics metrics = new NonBlockingRouterMetrics(clusterMap);
+    NonBlockingRouterMetrics metrics = new NonBlockingRouterMetrics(clusterMap, null);
     MockNetworkClientFactory networkClientFactory =
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, time);

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -235,8 +234,7 @@ public class HardDeleter implements Runnable {
       }
     } catch (IOException e) {
       metrics.hardDeleteExceptionsCount.inc();
-      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-          : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
       throw new StoreException(errorCode.toString() + " occurred while performing hard delete ", e, errorCode);
     }
       /* Now that all the blobs in the range were successfully hard deleted, the next time hard deletes can be resumed
@@ -541,8 +539,7 @@ public class HardDeleter implements Runnable {
       fileStream.getChannel().force(true);
       tempFile.renameTo(actual);
     } catch (IOException e) {
-      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-          : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
       throw new StoreException(
           errorCode.toString() + " while persisting cleanup tokens to disk " + tempFile.getAbsoluteFile(), errorCode);
     } finally {
@@ -622,8 +619,7 @@ public class HardDeleter implements Runnable {
         diskIOScheduler.getSlice(HARD_DELETE_CLEANUP_JOB_NAME, HARD_DELETE_CLEANUP_JOB_NAME, logWriteInfo.size);
       }
     } catch (IOException e) {
-      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-          : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
       throw new StoreException(errorCode.toString() + " while performing hard delete ", e, errorCode);
     }
     logger.trace("Performed hard deletes from {} to {} for {}", startToken, endToken, dataDir);

--- a/ambry-store/src/main/java/com.github.ambry.store/Log.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Log.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -392,9 +391,7 @@ class Log implements Write {
       try {
         diskSpaceAllocator.allocate(segmentFile, size);
       } catch (IOException e) {
-        StoreErrorCodes errorCode =
-            Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-                : StoreErrorCodes.Unknown_Error;
+        StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
         throw new StoreException(errorCode.toString() + " while allocating the file", e, errorCode);
       }
     }
@@ -412,8 +409,7 @@ class Log implements Write {
       logSegment.close();
       diskSpaceAllocator.free(segmentFile, logSegment.getCapacityInBytes());
     } catch (IOException e) {
-      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-          : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
       throw new StoreException(errorCode.toString() + " while freeing log segment", e, errorCode);
     }
   }
@@ -470,17 +466,15 @@ class Log implements Write {
           new LogSegment(segmentNameAndFilename.getFirst(), newSegmentFile, segmentCapacity, metrics, true);
       segmentsByName.put(segmentNameAndFilename.getFirst(), newSegment);
     } catch (StoreException e) {
-      logger.error("Failed to create new log segment {} with store exception: ", segmentNameAndFilename.getFirst(), e);
       try {
         diskSpaceAllocator.free(newSegmentFile, segmentCapacity);
         remainingUnallocatedSegments.incrementAndGet();
+        throw e;
       } catch (IOException exception) {
-        StoreErrorCodes errorCode =
-            Objects.equals(exception.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-                : StoreErrorCodes.Unknown_Error;
+        StoreErrorCodes errorCode = StoreException.resolveErrorCode(exception);
         throw new StoreException(
-            errorCode.toString() + " while freeing log segment " + segmentNameAndFilename.getFirst(), exception,
-            errorCode);
+            e.getMessage() + " And then " + errorCode.toString() + " occurred while freeing the log segment "
+                + segmentNameAndFilename.getFirst(), exception, errorCode);
       } finally {
         metrics.overflowWriteError.inc();
       }

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -104,7 +104,8 @@ class LogSegment implements Read, Write {
    */
   LogSegment(String name, File file, StoreMetrics metrics) throws StoreException {
     if (!file.exists() || !file.isFile()) {
-      throw new IllegalArgumentException(file.getAbsolutePath() + " does not exist or is not a file");
+      throw new StoreException(file.getAbsolutePath() + " does not exist or is not a file",
+          StoreErrorCodes.File_Not_Found);
     }
     // TODO: just because the file exists, it does not mean the headers have been written into it. LogSegment should
     // TODO: be able to handle this situation.

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -72,7 +72,8 @@ class LogSegment implements Read, Write {
   LogSegment(String name, File file, long capacityInBytes, StoreMetrics metrics, boolean writeHeader)
       throws StoreException {
     if (!file.exists() || !file.isFile()) {
-      throw new IllegalArgumentException(file.getAbsolutePath() + " does not exist or is not a file");
+      throw new StoreException(file.getAbsolutePath() + " does not exist or is not a file",
+          StoreErrorCodes.File_Not_Found);
     }
     this.file = file;
     this.name = name;

--- a/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/LogSegment.java
@@ -26,7 +26,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -136,8 +135,7 @@ class LogSegment implements Read, Write {
     } catch (FileNotFoundException e) {
       throw new StoreException("File not found while creating log segment", e, StoreErrorCodes.File_Not_Found);
     } catch (IOException e) {
-      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-          : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
       throw new StoreException(errorCode.toString() + " while creating log segment", e, errorCode);
     }
   }
@@ -165,8 +163,7 @@ class LogSegment implements Read, Write {
     } catch (ClosedChannelException e) {
       throw new StoreException("Channel closed while writing into the log segment", e, StoreErrorCodes.Channel_Closed);
     } catch (IOException e) {
-      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-          : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
       throw new StoreException(errorCode.toString() + " while writing into the log segment", e, errorCode);
     }
     endOffset.addAndGet(bytesWritten);
@@ -210,9 +207,7 @@ class LogSegment implements Read, Write {
           bytesWritten += fileChannel.write(byteBufferForAppend, endOffset.get() + bytesWritten);
         }
       } catch (IOException e) {
-        StoreErrorCodes errorCode =
-            Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-                : StoreErrorCodes.Unknown_Error;
+        StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
         throw new StoreException(errorCode.toString() + " while writing into the log segment", e, errorCode);
       }
     }
@@ -228,7 +223,7 @@ class LogSegment implements Read, Write {
    * @param offset The offset in the byteArray to start with.
    * @param length The amount of data in bytes to use from the byteArray.
    * @throws IllegalArgumentException if there is not enough space for data of size {@code length}.
-   * @throws IOException if data could not be written to the file because of I/O errors
+   * @throws StoreException if data could not be written to the file because of I/O errors
    */
   int appendFromDirectly(byte[] byteArray, int offset, int length) throws StoreException {
     if (!fileChannel.isOpen()) {
@@ -241,8 +236,7 @@ class LogSegment implements Read, Write {
       directFile.write(byteArray, offset, length);
       endOffset.addAndGet(length);
     } catch (IOException e) {
-      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-          : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
       throw new StoreException(errorCode.toString() + " while writing into segment via direct IO", e, errorCode);
     }
     return length;
@@ -424,8 +418,7 @@ class LogSegment implements Read, Write {
       fileChannel.position(endOffset);
       this.endOffset.set(endOffset);
     } catch (IOException e) {
-      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-          : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
       throw new StoreException(errorCode.toString() + " while setting end offset of segment", e, errorCode);
     }
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.NavigableSet;
-import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
@@ -829,8 +828,7 @@ class PersistentIndex {
             + "]", StoreErrorCodes.ID_Deleted);
       }
     } catch (IOException e) {
-      StoreErrorCodes errorCode = Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-          : StoreErrorCodes.Unknown_Error;
+      StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
       throw new StoreException(errorCode.toString() + " when reading delete blob info from the log " + dataDir, e,
           errorCode);
     }
@@ -1662,9 +1660,7 @@ class PersistentIndex {
       } catch (FileNotFoundException e) {
         throw new StoreException("File not found while writing index to file", e, StoreErrorCodes.File_Not_Found);
       } catch (IOException e) {
-        StoreErrorCodes errorCode =
-            Objects.equals(e.getMessage(), StoreException.IO_ERROR_STR) ? StoreErrorCodes.IOError
-                : StoreErrorCodes.Unknown_Error;
+        StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
         throw new StoreException(errorCode.toString() + " while persisting index to disk", e, errorCode);
       } finally {
         context.stop();

--- a/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/LogSegmentTest.java
@@ -444,14 +444,14 @@ public class LogSegmentTest {
     try {
       new LogSegment(name, file, STANDARD_SEGMENT_SIZE, metrics, true);
       fail("Construction should have failed because the backing file does not exist");
-    } catch (IllegalArgumentException e) {
+    } catch (StoreException e) {
       // expected. Nothing to do.
     }
 
     try {
       new LogSegment(name, file, metrics);
       fail("Construction should have failed because the backing file does not exist");
-    } catch (IllegalArgumentException e) {
+    } catch (StoreException e) {
       // expected. Nothing to do.
     }
 
@@ -461,7 +461,7 @@ public class LogSegmentTest {
     try {
       new LogSegment(name, file, STANDARD_SEGMENT_SIZE, metrics, true);
       fail("Construction should have failed because the backing file does not exist");
-    } catch (IllegalArgumentException e) {
+    } catch (StoreException e) {
       // expected. Nothing to do.
     }
 
@@ -470,7 +470,7 @@ public class LogSegmentTest {
     try {
       new LogSegment(name, file, metrics);
       fail("Construction should have failed because the backing file does not exist");
-    } catch (IllegalArgumentException e) {
+    } catch (StoreException e) {
       // expected. Nothing to do.
     }
 


### PR DESCRIPTION
1. When log segment instantiation encounters IOException, no matter
freeing log segment succeeds or not, ensure that store exception is
correctly thrown in ensureCapacity method.
2. Register the custom percentile metrics during RouterMetrics
initialization rather than register them every time adaptive tracker is
created. This will avoid unnecessary overhead.