### PR TITLE
Introducing partition-level histogram into adaptive tracker

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -16,9 +16,7 @@ package com.github.ambry.config;
 import com.github.ambry.router.OperationTrackerScope;
 import com.github.ambry.utils.Utils;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 
@@ -252,11 +250,11 @@ public class RouterConfig {
 
   /**
    * The metric scope that is applied to operation tracker. This config specifies at which granularity router should
-   * track the latency distribution. For example, ColoWide or PartitionLevel. The valid scope is defined in
+   * track the latency distribution. For example, Datacenter or Partition. The valid scope is defined in
    * {@link OperationTrackerScope}
    */
   @Config("router.operation.tracker.metric.scope")
-  @Default("ColoWide")
+  @Default("Datacenter")
   public final OperationTrackerScope routerOperationTrackerMetricScope;
 
   /**
@@ -344,13 +342,8 @@ public class RouterConfig {
         Utils.splitString(verifiableProperties.getString("router.operation.tracker.custom.percentiles", ""), ",");
     routerOperationTrackerCustomPercentiles =
         Collections.unmodifiableList(customPercentiles.stream().map(Double::valueOf).collect(Collectors.toList()));
-    String scopeStr = verifiableProperties.getString("router.operation.tracker.metric.scope", "ColoWide");
-    Set<String> validTrackerScopes = new HashSet<>();
-    for (OperationTrackerScope scope : OperationTrackerScope.values()) {
-      validTrackerScopes.add(scope.toString());
-    }
-    routerOperationTrackerMetricScope = validTrackerScopes.contains(scopeStr) ? OperationTrackerScope.valueOf(scopeStr)
-        : OperationTrackerScope.valueOf("ColoWide");
+    String scopeStr = verifiableProperties.getString("router.operation.tracker.metric.scope", "Datacenter");
+    routerOperationTrackerMetricScope = OperationTrackerScope.valueOf(scopeStr);
     routerOperationTrackerReservoirSize =
         verifiableProperties.getIntInRange("router.operation.tracker.reservoir.size", 1028, 0, Integer.MAX_VALUE);
     routerOperationTrackerReservoirDecayFactor =

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -13,9 +13,12 @@
  */
 package com.github.ambry.config;
 
+import com.github.ambry.router.OperationTrackerScope;
 import com.github.ambry.utils.Utils;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
@@ -248,6 +251,27 @@ public class RouterConfig {
   public final List<Double> routerOperationTrackerCustomPercentiles;
 
   /**
+   *
+   */
+  @Config("router.operation.tracker.metric.scope")
+  @Default("ColoWide")
+  public final OperationTrackerScope routerOperationTrackerMetricScope;
+
+  /**
+   *
+   */
+  @Config("router.operation.tracker.reservoir.size")
+  @Default("1028")
+  public final int routerOperationTrackerReservoirSize;
+
+  /**
+   *
+   */
+  @Config("router.operation.tracker.reservoir.decay.factor")
+  @Default("0.015")
+  public final double routerOperationTrackerReservoirDecayFactor;
+
+  /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
    */
@@ -308,5 +332,16 @@ public class RouterConfig {
         Utils.splitString(verifiableProperties.getString("router.operation.tracker.custom.percentiles", ""), ",");
     routerOperationTrackerCustomPercentiles =
         Collections.unmodifiableList(customPercentiles.stream().map(Double::valueOf).collect(Collectors.toList()));
+    String scopeStr = verifiableProperties.getString("router.operation.tracker.metric.scope", "ColoWide");
+    Set<String> validTrackerScopes = new HashSet<>();
+    for (OperationTrackerScope scope : OperationTrackerScope.values()) {
+      validTrackerScopes.add(scope.toString());
+    }
+    routerOperationTrackerMetricScope = validTrackerScopes.contains(scopeStr) ? OperationTrackerScope.valueOf(scopeStr)
+        : OperationTrackerScope.valueOf("ColoWide");
+    routerOperationTrackerReservoirSize =
+        verifiableProperties.getIntInRange("router.operation.tracker.reservoir.size", 1028, 0, Integer.MAX_VALUE);
+    routerOperationTrackerReservoirDecayFactor =
+        verifiableProperties.getDouble("router.operation.tracker.reservoir.decay.factor", 0.015);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -251,25 +251,37 @@ public class RouterConfig {
   public final List<Double> routerOperationTrackerCustomPercentiles;
 
   /**
-   *
+   * The metric scope that is applied to operation tracker. This config specifies at which granularity router should
+   * track the latency distribution. For example, ColoWide or PartitionLevel. The valid scope is defined in
+   * {@link OperationTrackerScope}
    */
   @Config("router.operation.tracker.metric.scope")
   @Default("ColoWide")
   public final OperationTrackerScope routerOperationTrackerMetricScope;
 
   /**
-   *
+   * The maximum size of histogram reservoir in operation tracker. This configs specifies the max number of data points
+   * that can be kept by histogram reservoir.
    */
   @Config("router.operation.tracker.reservoir.size")
   @Default("1028")
   public final int routerOperationTrackerReservoirSize;
 
   /**
-   *
+   * The decay factor of histogram reservoir in operation tracker. This config specifies how biased histogram should be
+   * on new data.
    */
   @Config("router.operation.tracker.reservoir.decay.factor")
   @Default("0.015")
   public final double routerOperationTrackerReservoirDecayFactor;
+
+  /**
+   * The minimum required data points to populate histogram in operation tracker. If number of data points is less than
+   * this threshold, the tracker ignores statistics from histogram.
+   */
+  @Config("router.operation.tracker.min.data.points.required")
+  @Default("1000")
+  public final long routerOperationTrackerMinDataPointsRequired;
 
   /**
    * Create a RouterConfig instance.
@@ -343,5 +355,7 @@ public class RouterConfig {
         verifiableProperties.getIntInRange("router.operation.tracker.reservoir.size", 1028, 0, Integer.MAX_VALUE);
     routerOperationTrackerReservoirDecayFactor =
         verifiableProperties.getDouble("router.operation.tracker.reservoir.decay.factor", 0.015);
+    routerOperationTrackerMinDataPointsRequired =
+        verifiableProperties.getLong("router.operation.tracker.min.data.points.required", 1000L);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/router/OperationTrackerScope.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/OperationTrackerScope.java
@@ -14,7 +14,9 @@
 package com.github.ambry.router;
 
 /**
- *
+ * The metric scope applied to operation tracker. For now, the scope defines at which granularity the latency distribution
+ * should be tracked by operation tracker (i.e. ColoWide means latencies of all requests in local datacenter would be kept
+ * in a single Histogram)
  */
 public enum OperationTrackerScope {
   ColoWide, PartitionLevel

--- a/ambry-api/src/main/java/com.github.ambry/router/OperationTrackerScope.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/OperationTrackerScope.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+/**
+ *
+ */
+public enum OperationTrackerScope {
+  ColoWide, PartitionLevel
+}

--- a/ambry-api/src/main/java/com.github.ambry/router/OperationTrackerScope.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/OperationTrackerScope.java
@@ -14,10 +14,10 @@
 package com.github.ambry.router;
 
 /**
- * The metric scope applied to operation tracker. For now, the scope defines at which granularity the latency distribution
- * should be tracked by operation tracker (i.e. ColoWide means latencies of all requests in local datacenter would be kept
- * in a single Histogram)
+ * The metric scope adopted by operation tracker. For now, the scope defines at which granularity the latency distribution
+ * should be tracked by operation tracker (i.e. Datacenter means latencies of all requests in local datacenter would be
+ * kept in a single Histogram)
  */
 public enum OperationTrackerScope {
-  ColoWide, PartitionLevel
+  Datacenter, Partition
 }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -155,6 +155,14 @@ public class MockClusterMap implements ClusterMap {
     partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName);
   }
 
+  /**
+   * Creates a mock cluster map with given list of data nodes and partitions.
+   * @param enableSSLPorts whether to enable SSL port.
+   * @param datanodes the list of data nodes created in this mock cluster map.
+   * @param numMountPointsPerNode number of mount points (mocking disks) that will be created in each data node
+   * @param partitionIdList the list of partitions created in this cluster map.
+   * @param localDatacenterName the name of local datacenter.
+   */
   public MockClusterMap(boolean enableSSLPorts, List<MockDataNodeId> datanodes, int numMountPointsPerNode,
       List<PartitionId> partitionIdList, String localDatacenterName) {
     this.enableSSLPorts = enableSSLPorts;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -24,8 +24,10 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -151,6 +153,21 @@ public class MockClusterMap implements ClusterMap {
       specialPartition = null;
     }
     partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName);
+  }
+
+  public MockClusterMap(boolean enableSSLPorts, List<MockDataNodeId> datanodes, int numMountPointsPerNode,
+      List<PartitionId> partitionIdList, String localDatacenterName) {
+    this.enableSSLPorts = enableSSLPorts;
+    this.dataNodes = datanodes;
+    this.numMountPointsPerNode = numMountPointsPerNode;
+    partitions = new HashMap<>();
+    partitionIdList.forEach(p -> partitions.put(Long.valueOf(p.toPathString()), p));
+    this.localDatacenterName = localDatacenterName;
+    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName);
+    Set<String> dcNames = new HashSet<>();
+    datanodes.forEach(node -> dcNames.add(node.getDatacenterName()));
+    dataCentersInClusterMap.addAll(dcNames);
+    specialPartition = null;
   }
 
   protected ArrayList<Port> getListOfPorts(int port) {

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -87,9 +87,8 @@ class GetBlobInfoOperation extends GetOperation {
       ResponseHandler responseHandler, BlobId blobId, GetBlobOptionsInternal options,
       Callback<GetBlobResultInternal> callback, RouterCallback routerCallback, KeyManagementService kms,
       CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time, boolean isEncrypted) {
-    super(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback,
-        routerMetrics.getBlobInfoLocalColoLatencyMs, routerMetrics.getBlobInfoCrossColoLatencyMs,
-        routerMetrics.getBlobInfoPastDueCount, kms, cryptoService, cryptoJobHandler, time, isEncrypted);
+    super(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback, kms, cryptoService,
+        cryptoJobHandler, time, isEncrypted);
     this.routerCallback = routerCallback;
     operationTracker =
         getOperationTracker(blobId.getPartition(), blobId.getDatacenterId(), RouterOperation.GetBlobInfoOperation);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -135,9 +135,8 @@ class GetBlobOperation extends GetOperation {
       Callback<GetBlobResultInternal> callback, RouterCallback routerCallback, BlobIdFactory blobIdFactory,
       KeyManagementService kms, CryptoService cryptoService, CryptoJobHandler cryptoJobHandler, Time time,
       boolean isEncrypted) {
-    super(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback,
-        routerMetrics.getBlobLocalColoLatencyMs, routerMetrics.getBlobCrossColoLatencyMs,
-        routerMetrics.getBlobPastDueCount, kms, cryptoService, cryptoJobHandler, time, isEncrypted);
+    super(routerConfig, routerMetrics, clusterMap, responseHandler, blobId, options, callback, kms, cryptoService,
+        cryptoJobHandler, time, isEncrypted);
     this.routerCallback = routerCallback;
     this.blobIdFactory = blobIdFactory;
     firstChunk = new FirstGetChunk();

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -13,8 +13,6 @@
  */
 package com.github.ambry.router;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Histogram;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
@@ -53,9 +51,6 @@ abstract class GetOperation {
   protected final CryptoService cryptoService;
   protected final CryptoJobHandler cryptoJobHandler;
   protected final Time time;
-  private final Histogram localColoTracker;
-  private final Histogram crossColoTracker;
-  private final Counter pastDueCounter;
   protected volatile boolean operationCompleted = false;
   protected final AtomicReference<Exception> operationException = new AtomicReference<>();
   protected GetBlobResultInternal operationResult;
@@ -73,9 +68,6 @@ abstract class GetOperation {
    * @param blobId the {@link BlobId} of the associated blob
    * @param options the {@link GetBlobOptionsInternal} associated with this operation.
    * @param getOperationCallback the callback that is to be called when the operation completes.
-   * @param localColoTracker the {@link Histogram} that tracks intra datacenter latencies for this class of requests.
-   * @param crossColoTracker the {@link Histogram} that tracks inter datacenter latencies for this class of requests.
-   * @param pastDueCounter the {@link Counter} that tracks the number of times a request is past due.
    * @param kms {@link KeyManagementService} to assist in fetching container keys for encryption or decryption
    * @param cryptoService {@link CryptoService} to assist in encryption or decryption
    * @param cryptoJobHandler {@link CryptoJobHandler} to assist in the execution of crypto jobs
@@ -84,18 +76,14 @@ abstract class GetOperation {
    */
   GetOperation(RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics, ClusterMap clusterMap,
       ResponseHandler responseHandler, BlobId blobId, GetBlobOptionsInternal options,
-      Callback<GetBlobResultInternal> getOperationCallback, Histogram localColoTracker, Histogram crossColoTracker,
-      Counter pastDueCounter, KeyManagementService kms, CryptoService cryptoService, CryptoJobHandler cryptoJobHandler,
-      Time time, boolean isEncrypted) {
+      Callback<GetBlobResultInternal> getOperationCallback, KeyManagementService kms, CryptoService cryptoService,
+      CryptoJobHandler cryptoJobHandler, Time time, boolean isEncrypted) {
     this.routerConfig = routerConfig;
     this.routerMetrics = routerMetrics;
     this.clusterMap = clusterMap;
     this.responseHandler = responseHandler;
     this.options = options;
     this.getOperationCallback = getOperationCallback;
-    this.localColoTracker = localColoTracker;
-    this.crossColoTracker = crossColoTracker;
-    this.pastDueCounter = pastDueCounter;
     this.kms = kms;
     this.cryptoService = cryptoService;
     this.cryptoJobHandler = cryptoJobHandler;

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -250,8 +250,8 @@ abstract class GetOperation {
           new SimpleOperationTracker(routerConfig, routerOperation, partitionId, originatingDcName, true);
     } else if (trackerType.equals(AdaptiveOperationTracker.class.getSimpleName())) {
       operationTracker =
-          new AdaptiveOperationTracker(routerConfig, routerOperation, partitionId, originatingDcName, localColoTracker,
-              crossColoTracker, pastDueCounter, time);
+          new AdaptiveOperationTracker(routerConfig, routerMetrics, routerOperation, partitionId, originatingDcName,
+              time);
     } else {
       throw new IllegalArgumentException("Unrecognized tracker type: " + trackerType);
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -237,6 +237,7 @@ abstract class GetOperation {
   /**
    * Gets an {@link OperationTracker} based on the config and {@code partitionId}.
    * @param partitionId the {@link PartitionId} for which a tracker is required.
+   * @param datacenterId the id of datacenter in which the blob originated.
    * @param routerOperation The type of router operation used by tracker.
    * @return an {@link OperationTracker} based on the config and {@code partitionId}.
    */

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -23,7 +23,6 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.config.RouterConfig;
-import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
 import java.util.HashMap;
 import java.util.List;
@@ -437,6 +436,11 @@ public class NonBlockingRouterMetrics {
     }
   }
 
+  /**
+   * Initialize partition-level histogram for all partitions in cluster map.
+   * @param clusterMap the {@link ClusterMap} that contains info of all partitions.
+   * @param routerConfig the {@link RouterConfig} that specifies histogram parameters.
+   */
   private void initializePartitionToHistogramMap(ClusterMap clusterMap, RouterConfig routerConfig) {
     int reservoirSize = routerConfig.routerOperationTrackerReservoirSize;
     double decayFactor = routerConfig.routerOperationTrackerReservoirDecayFactor;
@@ -452,54 +456,14 @@ public class NonBlockingRouterMetrics {
     }
   }
 
+  /**
+   * Create a histogram with given parameters.
+   * @param reservoirSize the maximum size of reservoir in histogram
+   * @param decayFactor the decay factor used by histogram
+   * @return a configured {@link Histogram}.
+   */
   private Histogram createHistogram(int reservoirSize, double decayFactor) {
     return new Histogram(new ExponentiallyDecayingReservoir(reservoirSize, decayFactor));
-  }
-
-  Pair<Histogram, Histogram> getColoWideLatencyHistogram(RouterOperation routerOperation) {
-    Histogram localColoLatency = null;
-    Histogram crossColoLatency = null;
-    switch (routerOperation) {
-      case GetBlobOperation:
-        localColoLatency = getBlobLocalColoLatencyMs;
-        crossColoLatency = getBlobCrossColoLatencyMs;
-        break;
-      case GetBlobInfoOperation:
-        localColoLatency = getBlobInfoLocalColoLatencyMs;
-        crossColoLatency = getBlobInfoCrossColoLatencyMs;
-        break;
-    }
-    return new Pair<>(localColoLatency, crossColoLatency);
-  }
-
-  Counter getPastDueCount(RouterOperation routerOperation) {
-    Counter pastDueCounter = null;
-    switch (routerOperation) {
-      case GetBlobOperation:
-        pastDueCounter = getBlobPastDueCount;
-        break;
-      case GetBlobInfoOperation:
-        pastDueCounter = getBlobInfoPastDueCount;
-        break;
-    }
-    return pastDueCounter;
-  }
-
-  Pair<Map<PartitionId, Histogram>, Map<PartitionId, Histogram>> getPartitionToHistogramMaps(
-      RouterOperation routerOperation) {
-    Map<PartitionId, Histogram> localColoMap = null;
-    Map<PartitionId, Histogram> crossColoMap = null;
-    switch (routerOperation) {
-      case GetBlobOperation:
-        localColoMap = getBlobLocalColoPartitionToLatency;
-        crossColoMap = getBlobCrossColoPartitionToLatency;
-        break;
-      case GetBlobInfoOperation:
-        localColoMap = getBlobInfoLocalColoPartitionToLatency;
-        crossColoMap = getBlobInfoCrossColoPartitionToLatency;
-        break;
-    }
-    return new Pair<>(localColoMap, crossColoMap);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -303,9 +303,9 @@ public class GetBlobInfoOperationTest {
     assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
     AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getOperationTrackerInUse();
     Assert.assertEquals("Timed-out response shouldn't be counted into local colo latency histogram", 0,
-        tracker.getLatencyHistogram(localReplica, routerConfig).getCount());
+        tracker.getLatencyHistogram(localReplica).getCount());
     Assert.assertEquals("Timed-out response shouldn't be counted into cross colo latency histogram", 0,
-        tracker.getLatencyHistogram(remoteReplica, routerConfig).getCount());
+        tracker.getLatencyHistogram(remoteReplica).getCount());
   }
 
   /**
@@ -347,10 +347,10 @@ public class GetBlobInfoOperationTest {
     // error code should be OperationTimedOut because it precedes BlobDoesNotExist
     Assert.assertEquals(RouterErrorCode.OperationTimedOut, routerException.getErrorCode());
     Assert.assertEquals("The number of data points in local colo latency histogram is not expected", 0,
-        tracker.getLatencyHistogram(localReplica, routerConfig).getCount());
+        tracker.getLatencyHistogram(localReplica).getCount());
     // the count of data points in Histogram should be 5 because 9(total replicas) - 4(# of timed out request) = 5
     Assert.assertEquals("The number of data points in cross colo latency histogram is not expected", 5,
-        tracker.getLatencyHistogram(remoteReplica, routerConfig).getCount());
+        tracker.getLatencyHistogram(remoteReplica).getCount());
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -303,9 +303,9 @@ public class GetBlobInfoOperationTest {
     assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
     AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getOperationTrackerInUse();
     Assert.assertEquals("Timed-out response shouldn't be counted into local colo latency histogram", 0,
-        tracker.getLatencyHistogram(localReplica).getCount());
+        tracker.getLatencyHistogram(localReplica, routerConfig).getCount());
     Assert.assertEquals("Timed-out response shouldn't be counted into cross colo latency histogram", 0,
-        tracker.getLatencyHistogram(remoteReplica).getCount());
+        tracker.getLatencyHistogram(remoteReplica, routerConfig).getCount());
   }
 
   /**
@@ -347,10 +347,10 @@ public class GetBlobInfoOperationTest {
     // error code should be OperationTimedOut because it precedes BlobDoesNotExist
     Assert.assertEquals(RouterErrorCode.OperationTimedOut, routerException.getErrorCode());
     Assert.assertEquals("The number of data points in local colo latency histogram is not expected", 0,
-        tracker.getLatencyHistogram(localReplica).getCount());
+        tracker.getLatencyHistogram(localReplica, routerConfig).getCount());
     // the count of data points in Histogram should be 5 because 9(total replicas) - 4(# of timed out request) = 5
     Assert.assertEquals("The number of data points in cross colo latency histogram is not expected", 5,
-        tracker.getLatencyHistogram(remoteReplica).getCount());
+        tracker.getLatencyHistogram(remoteReplica, routerConfig).getCount());
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -290,10 +290,9 @@ public class GetBlobOperationTest {
 
   /**
    * Test {@link GetBlobOperation} instantiation and validate the get methods.
-   * @throws Exception
    */
   @Test
-  public void testInstantiation() throws Exception {
+  public void testInstantiation() {
     Callback<GetBlobResultInternal> getRouterCallback = new Callback<GetBlobResultInternal>() {
       @Override
       public void onCompletion(GetBlobResultInternal result, Exception exception) {
@@ -477,9 +476,9 @@ public class GetBlobOperationTest {
     assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
     AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getFirstChunkOperationTrackerInUse();
     Histogram localColoTracker =
-        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, true, localDcName), routerConfig);
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, true, localDcName));
     Histogram crossColoTracker =
-        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, false, localDcName), routerConfig);
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, false, localDcName));
     Assert.assertEquals("Timed-out response shouldn't be counted into local colo latency histogram", 0,
         localColoTracker.getCount());
     Assert.assertEquals("Timed-out response shouldn't be counted into cross colo latency histogram", 0,
@@ -520,9 +519,9 @@ public class GetBlobOperationTest {
     // error code should be OperationTimedOut because it precedes BlobDoesNotExist
     Assert.assertEquals(RouterErrorCode.OperationTimedOut, routerException.getErrorCode());
     Histogram localColoTracker =
-        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, true, localDcName), routerConfig);
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, true, localDcName));
     Histogram crossColoTracker =
-        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, false, localDcName), routerConfig);
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, false, localDcName));
     // the count of data points in local colo Histogram should be 1, because first 2 request timed out
     Assert.assertEquals("The number of data points in local colo latency histogram is not expected", 1,
         localColoTracker.getCount());

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -477,9 +477,9 @@ public class GetBlobOperationTest {
     assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
     AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getFirstChunkOperationTrackerInUse();
     Histogram localColoTracker =
-        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, true, localDcName));
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, true, localDcName), routerConfig);
     Histogram crossColoTracker =
-        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, false, localDcName));
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, false, localDcName), routerConfig);
     Assert.assertEquals("Timed-out response shouldn't be counted into local colo latency histogram", 0,
         localColoTracker.getCount());
     Assert.assertEquals("Timed-out response shouldn't be counted into cross colo latency histogram", 0,
@@ -520,9 +520,9 @@ public class GetBlobOperationTest {
     // error code should be OperationTimedOut because it precedes BlobDoesNotExist
     Assert.assertEquals(RouterErrorCode.OperationTimedOut, routerException.getErrorCode());
     Histogram localColoTracker =
-        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, true, localDcName));
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, true, localDcName), routerConfig);
     Histogram crossColoTracker =
-        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, false, localDcName));
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, false, localDcName), routerConfig);
     // the count of data points in local colo Histogram should be 1, because first 2 request timed out
     Assert.assertEquals("The number of data points in local colo latency histogram is not expected", 1,
         localColoTracker.getCount());

--- a/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
@@ -13,9 +13,6 @@
  */
 package com.github.ambry.router;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.MockPartitionId;
@@ -78,10 +75,6 @@ public class OperationTrackerTest {
 
   // for AdaptiveOperationTracker
   private final Time time = new MockTime();
-  private final MetricRegistry registry = new MetricRegistry();
-  private final Histogram localColoTracker = registry.histogram("LocalColoTracker");
-  private final Histogram crossColoTracker = registry.histogram("CrossColoTracker");
-  private final Counter pastDueCounter = registry.counter("PastDueCounter");
 
   /**
    * Running for both {@link SimpleOperationTracker} and {@link AdaptiveOperationTracker}


### PR DESCRIPTION
1. Introduced partition-level histograms that keep track of latency of
requests against each partition separately.
2. Introduced OperationTrackerScope that allows user to choose either
ColoWide or PartitionLevel histogram in adaptive tracker.
3. Make reservoir size and decay factor configurable in Histogram.