### PR TITLE
Stitched blobs support different sized component blobs

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -194,6 +194,13 @@ public class RouterConfig {
   public final short routerBlobidCurrentVersion;
 
   /**
+   * The version to use for new metadata blobs.
+   */
+  @Config("router.metadata.content.version")
+  @Default("2")
+  public final short routerMetadataContentVersion;
+
+  /**
    * The KeyManagementServiceFactory that will be used to fetch {@link com.github.ambry.router.KeyManagementService}
    */
   @Config("router.key.management.service.factory")
@@ -292,6 +299,8 @@ public class RouterConfig {
     routerBlobidCurrentVersion =
         verifiableProperties.getShortFromAllowedValues("router.blobid.current.version", (short) 6,
             new Short[]{1, 2, 3, 4, 5, 6});
+    routerMetadataContentVersion =
+        verifiableProperties.getShortFromAllowedValues("router.metadata.content.version", (short) 2, new Short[]{2, 3});
     routerKeyManagementServiceFactory =
         verifiableProperties.getString("router.key.management.service.factory", DEFAULT_KMS_FACTORY);
     routerCryptoServiceFactory =

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/CompositeBlobInfo.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/CompositeBlobInfo.java
@@ -15,6 +15,9 @@
 package com.github.ambry.messageformat;
 
 import com.github.ambry.store.StoreKey;
+import com.github.ambry.utils.Pair;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -23,9 +26,41 @@ import java.util.List;
  * total composite blob size, and a list of keys for the blob's data chunks.
  */
 public class CompositeBlobInfo {
+
+  /**
+   * POJO class for holding a store key, the size of the data content it refers to,
+   * and the offset of the data in the larger composite blob
+   */
+  public static class StoreKeyAndSizeAndOffset {
+    private final StoreKey storeKey;
+    private final long offset;
+    private final long size;
+
+    public StoreKeyAndSizeAndOffset(StoreKey storeKey, long offset, long size) {
+      this.storeKey = storeKey;
+      this.offset = offset;
+      this.size = size;
+    }
+
+    public StoreKey getStoreKey() {
+      return storeKey;
+    }
+
+    public long getOffset() {
+      return offset;
+    }
+
+    public long getSize() {
+      return size;
+    }
+  }
+
+
   private final int chunkSize;
   private final long totalSize;
   private final List<StoreKey> keys;
+  private final List<Long> offsets = new ArrayList<>();
+  private final List<StoreKeyAndSizeAndOffset> keysAndSizesAndOffsets = new ArrayList<>();
 
   /**
    * Construct a {@link CompositeBlobInfo} object.
@@ -37,6 +72,49 @@ public class CompositeBlobInfo {
     this.chunkSize = chunkSize;
     this.totalSize = totalSize;
     this.keys = keys;
+    long last = 0;
+    for (StoreKey key : keys) {
+      offsets.add(last);
+      keysAndSizesAndOffsets.add(new StoreKeyAndSizeAndOffset(key, last, Math.min(chunkSize, totalSize - last)));
+      last += chunkSize;
+    }
+  }
+
+  /**
+   * Construct a {@link CompositeBlobInfo} object.
+   * @param keysAndContentSizes
+   */
+  public CompositeBlobInfo(List<Pair<StoreKey,Long>> keysAndContentSizes) {
+    this.chunkSize = -1;
+    this.keys = new ArrayList<>();
+    long last = 0;
+    for (Pair<StoreKey,Long> keyAndContentSize : keysAndContentSizes) {
+      StoreKey key = keyAndContentSize.getFirst();
+      keys.add(key);
+      offsets.add(last);
+      keysAndSizesAndOffsets.add(new StoreKeyAndSizeAndOffset(key, last, keyAndContentSize.getSecond()));
+      last += keyAndContentSize.getSecond();
+    }
+    this.totalSize = last;
+  }
+
+  public List<StoreKeyAndSizeAndOffset> getStoreKeysInByteRange(long start, long end) {
+    if (end < start || start < 0L || end >= totalSize) {
+      throw new IllegalArgumentException("Bad input parameters, start="+start+" end="+end+" totalSize="+totalSize);
+    }
+    int idx = Collections.binarySearch(offsets, start);
+    //binarySearch returns -(insertion point) - 1 if not an exact match, which points to the index of
+    //the first element greater than the key, or list.size() if all elements in the list are
+    // less than the specified key.
+    if (idx < 0) {
+      idx = -idx-2; //points to element with offset closest to but less than 'start'
+    }
+    List<StoreKeyAndSizeAndOffset> ans = new ArrayList<>();
+    while(idx < keys.size() && offsets.get(idx) <= end) {
+      ans.add(keysAndSizesAndOffsets.get(idx));
+      idx++;
+    }
+    return ans;
   }
 
   /**
@@ -61,5 +139,9 @@ public class CompositeBlobInfo {
    */
   public List<StoreKey> getKeys() {
     return keys;
+  }
+
+  public List<StoreKeyAndSizeAndOffset> getKeysAndSizesAndOffsets() {
+    return keysAndSizesAndOffsets;
   }
 }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/CompositeBlobInfo.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/CompositeBlobInfo.java
@@ -55,7 +55,6 @@ public class CompositeBlobInfo {
     }
   }
 
-
   private final int chunkSize;
   private final long totalSize;
   private final List<StoreKey> keys;
@@ -84,11 +83,11 @@ public class CompositeBlobInfo {
    * Construct a {@link CompositeBlobInfo} object.
    * @param keysAndContentSizes
    */
-  public CompositeBlobInfo(List<Pair<StoreKey,Long>> keysAndContentSizes) {
+  public CompositeBlobInfo(List<Pair<StoreKey, Long>> keysAndContentSizes) {
     this.chunkSize = -1;
     this.keys = new ArrayList<>();
     long last = 0;
-    for (Pair<StoreKey,Long> keyAndContentSize : keysAndContentSizes) {
+    for (Pair<StoreKey, Long> keyAndContentSize : keysAndContentSizes) {
       StoreKey key = keyAndContentSize.getFirst();
       keys.add(key);
       offsets.add(last);
@@ -108,17 +107,18 @@ public class CompositeBlobInfo {
    */
   public List<StoreKeyAndSizeAndOffset> getStoreKeysInByteRange(long start, long end) {
     if (end < start || start < 0L || end >= totalSize) {
-      throw new IllegalArgumentException("Bad input parameters, start="+start+" end="+end+" totalSize="+totalSize);
+      throw new IllegalArgumentException(
+          "Bad input parameters, start=" + start + " end=" + end + " totalSize=" + totalSize);
     }
     int idx = Collections.binarySearch(offsets, start);
     //binarySearch returns -(insertion point) - 1 if not an exact match, which points to the index of
     //the first element greater than the key, or list.size() if all elements in the list are
     // less than the specified key.
     if (idx < 0) {
-      idx = -idx-2; //points to element with offset closest to but less than 'start'
+      idx = -idx - 2; //points to element with offset closest to but less than 'start'
     }
     List<StoreKeyAndSizeAndOffset> ans = new ArrayList<>();
-    while(idx < keys.size() && offsets.get(idx) <= end) {
+    while (idx < keys.size() && offsets.get(idx) <= end) {
       ans.add(keysAndSizesAndOffsets.get(idx));
       idx++;
     }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/CompositeBlobInfo.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/CompositeBlobInfo.java
@@ -98,6 +98,14 @@ public class CompositeBlobInfo {
     this.totalSize = last;
   }
 
+  /**
+   * Returns the keys (along with their data content size and offset relative to the total
+   * composite blob) of the chunks related to the given byte range of the entire composite
+   * blob
+   * @param start inclusive starting byte index
+   * @param end inclusive ending byte index
+   * @return
+   */
   public List<StoreKeyAndSizeAndOffset> getStoreKeysInByteRange(long start, long end) {
     if (end < start || start < 0L || end >= totalSize) {
       throw new IllegalArgumentException("Bad input parameters, start="+start+" end="+end+" totalSize="+totalSize);
@@ -141,6 +149,11 @@ public class CompositeBlobInfo {
     return keys;
   }
 
+  /**
+   * Get the list of keys for the composite blob's data chunks, along with the
+   * key's data content size and offset relative to the total composite blob
+   * @return A list of {@link StoreKeyAndSizeAndOffset}
+   */
   public List<StoreKeyAndSizeAndOffset> getKeysAndSizesAndOffsets() {
     return keysAndSizesAndOffsets;
   }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/CompositeBlobInfo.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/CompositeBlobInfo.java
@@ -19,6 +19,7 @@ import com.github.ambry.utils.Pair;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -170,5 +171,21 @@ public class CompositeBlobInfo {
     public long getSize() {
       return size;
     }
+
+    @Override
+    public boolean equals(Object that) {
+      if (that instanceof ChunkMetadata) {
+        ChunkMetadata thatCM = (ChunkMetadata) that;
+        return storeKey.equals(thatCM.storeKey) && offset == thatCM.offset && size == thatCM.size;
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(storeKey, offset, size);
+    }
   }
+
+
 }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -1459,7 +1459,7 @@ public class MessageFormatRecord {
      * @throws MessageFormatException
      */
     public static CompositeBlobInfo deserializeMetadataContentRecord(DataInputStream stream,
-        StoreKeyFactory storeKeyFactory) throws IOException, MessageFormatException {
+        StoreKeyFactory storeKeyFactory) throws IOException {
       List<StoreKey> keys = new ArrayList<StoreKey>();
       int chunkSize = stream.readInt();
       long totalSize = stream.readLong();

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -18,6 +18,7 @@ import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Crc32;
 import com.github.ambry.utils.CrcInputStream;
+import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -54,6 +55,7 @@ public class MessageFormatRecord {
   public static final short Blob_Version_V1 = 1;
   public static final short Blob_Version_V2 = 2;
   public static final short Metadata_Content_Version_V2 = 2;
+  public static final short Metadata_Content_Version_V3 = 3;
   public static final int Message_Header_Invalid_Relative_Offset = -1;
 
   static short headerVersionToUse = Message_Header_Version_V2;
@@ -1467,6 +1469,87 @@ public class MessageFormatRecord {
         keys.add(storeKey);
       }
       return new CompositeBlobInfo(chunkSize, totalSize, keys);
+    }
+  }
+
+  /**
+   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   * |         |              |            |            |          |            |            |          |
+   * | version |  total size  | # of keys  |  size of   |   key1   |  size of   |    key2    |  ......  |
+   * |(2 bytes)|  (8 bytes)   | (4 bytes)  | key1 blob  |          | key2 blob  |            |  ......  |
+   * |         |              |            | (8 bytes)  |          | (8 bytes)  |            |          |
+   *  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   *  version           - The version of the metadata content record
+   *
+   *  total size        - total size of the object this metadata describes.
+   *
+   *  # of keys         - number of keys in the metadata blob
+   *
+   *  size of key1 blob - size of the data referenced by key1
+   *
+   *  key1              - first key to be part of metadata blob
+   *
+   *  size of key2 blob - size of the data referenced by key2
+   *
+   *  key2              - second key to be part of metadata blob
+   *
+   */
+  public static class Metadata_Content_Format_V3 {
+    private static final int NUM_OF_KEYS_FIELD_SIZE_IN_BYTES = 4;
+    private static final int SIZE_OF_BLOB_FIELD_IN_BYTES = 4;
+    private static final int TOTAL_SIZE_FIELD_SIZE_IN_BYTES = 8;
+
+    /**
+     * Get the total size of the metadata content record.
+     * @param keySize The size of each key in bytes.
+     * @param numberOfKeys The total number of keys.
+     * @return The total size in bytes.
+     */
+    public static int getMetadataContentSize(int keySize, int numberOfKeys) {
+      return Version_Field_Size_In_Bytes + TOTAL_SIZE_FIELD_SIZE_IN_BYTES + NUM_OF_KEYS_FIELD_SIZE_IN_BYTES + (
+          numberOfKeys * keySize * SIZE_OF_BLOB_FIELD_IN_BYTES);
+    }
+
+    /**
+     * Serialize a metadata content record.
+     * @param outputBuffer
+     * @param totalSize
+     * @param keysAndContentSizes
+     */
+    public static void serializeMetadataContentRecord(ByteBuffer outputBuffer, long totalSize,
+        List<Pair<StoreKey, Long>> keysAndContentSizes) {
+      int keySize = keysAndContentSizes.get(0).getFirst().sizeInBytes();
+      outputBuffer.putShort(Metadata_Content_Version_V3);
+      outputBuffer.putLong(totalSize);
+      outputBuffer.putInt(keysAndContentSizes.size());
+
+      for (Pair<StoreKey, Long> keyAndContentSize : keysAndContentSizes) {
+        if (keyAndContentSize.getFirst().sizeInBytes() != keySize) {
+          throw new IllegalArgumentException("Keys are not of same size");
+        }
+        outputBuffer.putLong(keyAndContentSize.getSecond());
+        outputBuffer.put(keyAndContentSize.getFirst().toBytes());
+      }
+    }
+
+    /**
+     * Deserialize a metadata content record from a stream.
+     * @param stream The stream to read the serialized record from.
+     * @param storeKeyFactory The factory to use for parsing keys in the serialized metadata content record.
+     * @return A {@link CompositeBlobInfo} object with the chunk size and list of keys from the record.
+     * @throws IOException
+     */
+    public static CompositeBlobInfo deserializeMetadataContentRecord(DataInputStream stream,
+        StoreKeyFactory storeKeyFactory) throws IOException {
+      List<Pair<StoreKey, Long>> keysAndContentSizes = new ArrayList<>();
+      stream.readLong(); //total size
+      int numberOfKeys = stream.readInt();
+      for (int i = 0; i < numberOfKeys; i++) {
+        long contentSize = stream.readLong();
+        StoreKey storeKey = storeKeyFactory.getStoreKey(stream);
+        keysAndContentSizes.add(new Pair<>(storeKey, contentSize));
+      }
+      return new CompositeBlobInfo(keysAndContentSizes);
     }
   }
 }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MetadataContentSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MetadataContentSerDe.java
@@ -21,12 +21,14 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 /**
  * A class to serialize and deserialize MetadataContent which forms the content of a Metadata Blob.
  */
 public class MetadataContentSerDe {
+
   /**
    * Serialize the input list of keys that form the metadata content.
    * @param chunkSize the size of the intermediate data chunks for the object this metadata describes.

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MetadataContentSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MetadataContentSerDe.java
@@ -43,6 +43,12 @@ public class MetadataContentSerDe {
     return outputBuf;
   }
 
+  /**
+   * Serialize the input list of keys with data content sizes that form the metadata content.
+   * @param totalSize the total size of the object this metadata describes.
+   * @param keysAndContentSizes the input list of keys and related data content sizes that form the metadata content.
+   * @return a ByteBuffer containing the serialized output.
+   */
   public static ByteBuffer serializeMetadataContentV3(long totalSize, List<Pair<StoreKey, Long>> keysAndContentSizes) {
     int bufSize =
         MessageFormatRecord.Metadata_Content_Format_V3.getMetadataContentSize(keysAndContentSizes.get(0).getFirst().sizeInBytes(), keysAndContentSizes.size());

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MetadataContentSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MetadataContentSerDe.java
@@ -16,6 +16,7 @@ package com.github.ambry.messageformat;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.Pair;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -42,6 +43,15 @@ public class MetadataContentSerDe {
     return outputBuf;
   }
 
+  public static ByteBuffer serializeMetadataContentV3(long totalSize, List<Pair<StoreKey, Long>> keysAndContentSizes) {
+    int bufSize =
+        MessageFormatRecord.Metadata_Content_Format_V3.getMetadataContentSize(keysAndContentSizes.get(0).getFirst().sizeInBytes(), keysAndContentSizes.size());
+    ByteBuffer outputBuf = ByteBuffer.allocate(bufSize);
+    MessageFormatRecord.Metadata_Content_Format_V3.serializeMetadataContentRecord(outputBuf, totalSize,
+        keysAndContentSizes);
+    return outputBuf;
+  }
+
   /**
    * Deserialize the serialized metadata content in the input ByteBuffer using the given {@link StoreKeyFactory} as a
    * reference.
@@ -57,6 +67,9 @@ public class MetadataContentSerDe {
     switch (version) {
       case MessageFormatRecord.Metadata_Content_Version_V2:
         return MessageFormatRecord.Metadata_Content_Format_V2.deserializeMetadataContentRecord(
+            new DataInputStream(new ByteBufferInputStream(buf)), storeKeyFactory);
+      case MessageFormatRecord.Metadata_Content_Version_V3:
+        return MessageFormatRecord.Metadata_Content_Format_V3.deserializeMetadataContentRecord(
             new DataInputStream(new ByteBufferInputStream(buf)), storeKeyFactory);
       default:
         throw new MessageFormatException("Unknown version encountered for MetadataContent: " + version,

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MetadataContentSerDe.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MetadataContentSerDe.java
@@ -34,7 +34,7 @@ public class MetadataContentSerDe {
    * @param keys the input list of keys that form the metadata content.
    * @return a ByteBuffer containing the serialized output.
    */
-  public static ByteBuffer serializeMetadataContent(int chunkSize, long totalSize, List<StoreKey> keys) {
+  public static ByteBuffer serializeMetadataContentV2(int chunkSize, long totalSize, List<StoreKey> keys) {
     int bufSize =
         MessageFormatRecord.Metadata_Content_Format_V2.getMetadataContentSize(keys.get(0).sizeInBytes(), keys.size());
     ByteBuffer outputBuf = ByteBuffer.allocate(bufSize);
@@ -50,8 +50,8 @@ public class MetadataContentSerDe {
    * @return a ByteBuffer containing the serialized output.
    */
   public static ByteBuffer serializeMetadataContentV3(long totalSize, List<Pair<StoreKey, Long>> keysAndContentSizes) {
-    int bufSize =
-        MessageFormatRecord.Metadata_Content_Format_V3.getMetadataContentSize(keysAndContentSizes.get(0).getFirst().sizeInBytes(), keysAndContentSizes.size());
+    int bufSize = MessageFormatRecord.Metadata_Content_Format_V3.getMetadataContentSize(
+        keysAndContentSizes.get(0).getFirst().sizeInBytes(), keysAndContentSizes.size());
     ByteBuffer outputBuf = ByteBuffer.allocate(bufSize);
     MessageFormatRecord.Metadata_Content_Format_V3.serializeMetadataContentRecord(outputBuf, totalSize,
         keysAndContentSizes);

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/CompositeBlobInfoTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/CompositeBlobInfoTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package com.github.ambry.messageformat;
 
 import com.github.ambry.store.MockId;

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/CompositeBlobInfoTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/CompositeBlobInfoTest.java
@@ -68,15 +68,83 @@ public class CompositeBlobInfoTest {
     //total size given as input
     assertInvalidGetStoreKeysInByteRange(totalSize, totalSize, compositeBlobInfo);
     //total size and total size + 1 given as input
-    assertInvalidGetStoreKeysInByteRange(totalSize, totalSize+1, compositeBlobInfo);
+    assertInvalidGetStoreKeysInByteRange(totalSize, totalSize + 1, compositeBlobInfo);
     //negative number given as input
-    assertInvalidGetStoreKeysInByteRange(-1, totalSize-1, compositeBlobInfo);
+    assertInvalidGetStoreKeysInByteRange(-1, totalSize - 1, compositeBlobInfo);
     //start bigger than end
-    assertInvalidGetStoreKeysInByteRange(totalSize-1, 0, compositeBlobInfo);
+    assertInvalidGetStoreKeysInByteRange(totalSize - 1, 0, compositeBlobInfo);
     //start bigger than end, one byte
     assertInvalidGetStoreKeysInByteRange(1, 0, compositeBlobInfo);
     //total range but end equal to total size
     assertInvalidGetStoreKeysInByteRange(0, totalSize, compositeBlobInfo);
+  }
+
+  /**
+   * Tests that invalid inputs to the V3 {@link CompositeBlobInfo} ctor don't work
+   */
+  @Test
+  public void testCreateInvalidCompositeBlob() {
+    //tests null input
+    invalidV3CompositeBlobInfoCtor(null);
+    //tests empty input
+    List<Pair<StoreKey, Long>> keysAndContentSizes = new ArrayList<>();
+    invalidV3CompositeBlobInfoCtor(keysAndContentSizes);
+    //tests attempt creation of compositeBlobInfo with 0 length blob
+    keysAndContentSizes = createKeysAndContentSizes(60, 1, 1000000, 100);
+    keysAndContentSizes.add(new Pair<>(new MockId(UtilsTest.getRandomString(60)), 0L));
+    invalidV3CompositeBlobInfoCtor(keysAndContentSizes);
+  }
+
+  /**
+   * Tests various kinds of inputs for the V2 {@link CompositeBlobInfo}
+   */
+  @Test
+  public void testV2CompositeBlobInfoCtor() {
+    List<StoreKey> keys = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      keys.add(new MockId(UtilsTest.getRandomString(60)));
+    }
+    //creates 1 10 byte blob, so not enough keys
+    invalidV2CompositeBlobInfoCtor(100, 10, keys);
+    //creates 9 100 byte blobs, so too many keys
+    invalidV2CompositeBlobInfoCtor(100, 900, keys);
+    //creates 9 100 byte blobs and 1 1 byte blob
+    validV2CompositeBlobInfoCtor(100, 901, keys);
+    //creates 10 100 byte blobs
+    validV2CompositeBlobInfoCtor(100, 1000, keys);
+    //creates 10 100 byte blobs and 1 1 byte blob, so not enough keys
+    invalidV2CompositeBlobInfoCtor(100, 1001, keys);
+    //rest are a mix of negative and 0 values for chunkSize and totalSize, all invalid
+    invalidV2CompositeBlobInfoCtor(0, 0, keys);
+    invalidV2CompositeBlobInfoCtor(1, 0, keys);
+    invalidV2CompositeBlobInfoCtor(0, 1, keys);
+    invalidV2CompositeBlobInfoCtor(-1, 1, keys);
+    invalidV2CompositeBlobInfoCtor(-1, -1, keys);
+    invalidV2CompositeBlobInfoCtor(1, -1, keys);
+  }
+
+  private void validV2CompositeBlobInfoCtor(int chunkSize, long totalSize, List<StoreKey> keys) {
+    new CompositeBlobInfo(chunkSize, totalSize, keys);
+  }
+
+  private void invalidV2CompositeBlobInfoCtor(int chunkSize, long totalSize, List<StoreKey> keys) {
+    try {
+      new CompositeBlobInfo(chunkSize, totalSize, keys);
+    } catch (IllegalArgumentException e) {
+      //expected
+      return;
+    }
+    fail();
+  }
+
+  private void invalidV3CompositeBlobInfoCtor(List<Pair<StoreKey, Long>> keysAndContentSizes) {
+    try {
+      new CompositeBlobInfo(keysAndContentSizes);
+    } catch (IllegalArgumentException e) {
+      //expected
+      return;
+    }
+    fail();
   }
 
   /**

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/CompositeBlobInfoTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/CompositeBlobInfoTest.java
@@ -1,0 +1,141 @@
+package com.github.ambry.messageformat;
+
+import com.github.ambry.store.MockId;
+import com.github.ambry.store.StoreKey;
+import com.github.ambry.utils.Pair;
+import com.github.ambry.utils.UtilsTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class CompositeBlobInfoTest {
+
+  /**
+   * Tests various valid inputs for {@link CompositeBlobInfo#getStoreKeysInByteRange(long, long)}
+   */
+  @Test
+  public void testValidGetStoreKeysInByteRange() {
+    List<Pair<StoreKey, Long>> keysAndContentSizes = createKeysAndContentSizes(60, 1, 1000000, 100);
+    CompositeBlobInfo compositeBlobInfo = new CompositeBlobInfo(keysAndContentSizes);
+    long totalSize = compositeBlobInfo.getTotalSize();
+    //total byte range
+    assertGetStoreKeysInByteRange(0, totalSize - 1, compositeBlobInfo, keysAndContentSizes);
+    //last byte
+    assertGetStoreKeysInByteRange(totalSize - 1, totalSize - 1, compositeBlobInfo, keysAndContentSizes);
+    //first byte
+    assertGetStoreKeysInByteRange(0, 0, compositeBlobInfo, keysAndContentSizes);
+    //first half
+    assertGetStoreKeysInByteRange(0, (totalSize - 1) / 2, compositeBlobInfo, keysAndContentSizes);
+    //second half
+    assertGetStoreKeysInByteRange((totalSize - 1) / 2, (totalSize - 1), compositeBlobInfo, keysAndContentSizes);
+    //middle third of bytes
+    assertGetStoreKeysInByteRange((totalSize - 1) / 3, 2 * (totalSize - 1) / 3, compositeBlobInfo, keysAndContentSizes);
+    //byte in the middle
+    assertGetStoreKeysInByteRange((totalSize - 1) / 2, (totalSize - 1) / 2, compositeBlobInfo, keysAndContentSizes);
+    //two bytes in the middle
+    assertGetStoreKeysInByteRange((totalSize - 1) / 2, (totalSize - 1) / 2 + 1, compositeBlobInfo, keysAndContentSizes);
+    //total range minus first and last byte
+    assertGetStoreKeysInByteRange(1, totalSize - 2, compositeBlobInfo, keysAndContentSizes);
+  }
+
+  /**
+   * Tests various invalid inputs for {@link CompositeBlobInfo#getStoreKeysInByteRange(long, long)}
+   */
+  @Test
+  public void testInvalidGetStoreKeysInByteRange() {
+    List<Pair<StoreKey, Long>> keysAndContentSizes = createKeysAndContentSizes(60, 1, 1000000, 100);
+    CompositeBlobInfo compositeBlobInfo = new CompositeBlobInfo(keysAndContentSizes);
+    long totalSize = compositeBlobInfo.getTotalSize();
+    //total size given as input
+    assertInvalidGetStoreKeysInByteRange(totalSize, totalSize, compositeBlobInfo);
+    //total size and total size + 1 given as input
+    assertInvalidGetStoreKeysInByteRange(totalSize, totalSize+1, compositeBlobInfo);
+    //negative number given as input
+    assertInvalidGetStoreKeysInByteRange(-1, totalSize-1, compositeBlobInfo);
+    //start bigger than end
+    assertInvalidGetStoreKeysInByteRange(totalSize-1, 0, compositeBlobInfo);
+    //start bigger than end, one byte
+    assertInvalidGetStoreKeysInByteRange(1, 0, compositeBlobInfo);
+    //total range but end equal to total size
+    assertInvalidGetStoreKeysInByteRange(0, totalSize, compositeBlobInfo);
+  }
+
+  /**
+   * Creates a list of pairs of StoreKeys and content sizes, where each pair is of a random size
+   * @param keySize size of the actual store key
+   * @param lowerBound the smallest random content size value allowed
+   * @param higherBound the largest random content size value allowed
+   * @param numKeys number of keys to populate the list
+   * @return a list of pairs of StoreKeys and content sizes, where each pair is of a random size
+   */
+  private List<Pair<StoreKey, Long>> createKeysAndContentSizes(int keySize, int lowerBound, int higherBound,
+      int numKeys) {
+    List<Pair<StoreKey, Long>> keysAndContentSizes = new ArrayList<>();
+    Random rand = new Random();
+    for (int i = 0; i < numKeys; i++) {
+      keysAndContentSizes.add(new Pair<>(new MockId(UtilsTest.getRandomString(keySize)),
+          (long) rand.nextInt(higherBound - lowerBound) + lowerBound));
+    }
+    return keysAndContentSizes;
+  }
+
+  /*
+  Naive O(n) algorithm to test the actual method (which should be O(ln(n))), linearly scans list for
+  chunks with bytes that lie between start and end (both inclusive)
+   */
+  private List<CompositeBlobInfo.ChunkMetadata> getChunkMetadataForRange(long start, long end,
+      List<Pair<StoreKey, Long>> keysAndContentSizes) {
+    Objects.nonNull(keysAndContentSizes);
+    long totalSize = 0;
+    for (Pair<StoreKey, Long> keyAndContentSize : keysAndContentSizes) {
+      totalSize += keyAndContentSize.getSecond();
+    }
+    if (end < start || start < 0L || end >= totalSize) {
+      throw new IllegalArgumentException(
+          "Bad input parameters, start=" + start + " end=" + end + " totalSize=" + totalSize);
+    }
+    List<CompositeBlobInfo.ChunkMetadata> ans = new ArrayList<>();
+    long seenSoFar = -1;
+    int idx = 0;
+    while (seenSoFar < end) {
+      Pair<StoreKey, Long> keyAndContentSize = keysAndContentSizes.get(idx++);
+      seenSoFar += keyAndContentSize.getSecond();
+      if (seenSoFar >= start) {
+        ans.add(new CompositeBlobInfo.ChunkMetadata(keyAndContentSize.getFirst(),
+            seenSoFar - keyAndContentSize.getSecond() + 1, keyAndContentSize.getSecond()));
+      }
+    }
+    return ans;
+  }
+
+  private void assertInvalidGetStoreKeysInByteRange(long start, long end, CompositeBlobInfo compositeBlobInfo) {
+    try {
+      compositeBlobInfo.getStoreKeysInByteRange(start, end);
+    } catch (IllegalArgumentException e) {
+      //expected
+      return;
+    }
+    fail();
+  }
+
+  private void assertGetStoreKeysInByteRange(long start, long end, CompositeBlobInfo compositeBlobInfo,
+      List<Pair<StoreKey, Long>> keysAndContentSizes) {
+    assertEqualChunkMetadataLists(getChunkMetadataForRange(start, end, keysAndContentSizes),
+        compositeBlobInfo.getStoreKeysInByteRange(start, end));
+  }
+
+  private void assertEqualChunkMetadataLists(List<CompositeBlobInfo.ChunkMetadata> expected,
+      List<CompositeBlobInfo.ChunkMetadata> actual) {
+    assertNotNull("Actual shouldn't be null", actual);
+    assertNotNull("Expected shouldn't be null", expected);
+    assertEquals("Different list sizes", expected.size(), actual.size());
+    for (int i = 0; i < actual.size(); i++) {
+      assertEquals("Actual chunkMetadata is different than expected chunkMetadata", actual.get(i), expected.get(i));
+    }
+  }
+}

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -490,9 +490,8 @@ public class MessageFormatRecordTest {
     CompositeBlobInfo compositeBlobInfo = deserializeMetadataContentV3(metadataContent, new MockIdFactory());
     Assert.assertEquals("Total size doesn't match", total, compositeBlobInfo.getTotalSize());
     Assert.assertEquals("List of keys dont match", keys, compositeBlobInfo.getKeys());
-    List<CompositeBlobInfo.StoreKeyAndSizeAndOffset> list = compositeBlobInfo.getKeysAndSizesAndOffsets();
-    Assert.assertEquals("StoreKeyAndSizeAndOffset and input list have different sizes", list.size(),
-        keysAndContentSizes.size());
+    List<CompositeBlobInfo.ChunkMetadata> list = compositeBlobInfo.getChunkMetadataList();
+    Assert.assertEquals("ChunkMetadata and input list have different sizes", list.size(), keysAndContentSizes.size());
     long sum = 0;
     for (int i = 0; i < list.size(); i++) {
       Assert.assertEquals(keysAndContentSizes.get(i).getFirst(), list.get(i).getStoreKey());
@@ -707,9 +706,8 @@ public class MessageFormatRecordTest {
     CompositeBlobInfo compositeBlobInfo = deserializeMetadataContentV3(metadataContent, new MockIdFactory());
     Assert.assertEquals("Total size doesn't match", total, compositeBlobInfo.getTotalSize());
     Assert.assertEquals("List of keys dont match", keys, compositeBlobInfo.getKeys());
-    List<CompositeBlobInfo.StoreKeyAndSizeAndOffset> list = compositeBlobInfo.getKeysAndSizesAndOffsets();
-    Assert.assertEquals("StoreKeyAndSizeAndOffset and input list have different sizes", list.size(),
-        keysAndContentSizes.size());
+    List<CompositeBlobInfo.ChunkMetadata> list = compositeBlobInfo.getChunkMetadataList();
+    Assert.assertEquals("ChunkMetadata and input list have different sizes", list.size(), keysAndContentSizes.size());
     long sum = 0;
     for (int i = 0; i < list.size(); i++) {
       Assert.assertEquals(keysAndContentSizes.get(i).getFirst(), list.get(i).getStoreKey());

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -564,7 +564,7 @@ public class MessageFormatRecordTest {
   }
 
   private CompositeBlobInfo deserializeMetadataContentV3(ByteBuffer metadataContent, StoreKeyFactory storeKeyFactory)
-      throws MessageFormatException, IOException {
+      throws IOException {
     ByteBufferInputStream byteBufferInputStream = new ByteBufferInputStream(metadataContent);
     DataInputStream inputStream = new DataInputStream(byteBufferInputStream);
     short metadataContentVersion = inputStream.readShort();

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -21,6 +21,7 @@ import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Crc32;
+import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
@@ -473,13 +474,58 @@ public class MessageFormatRecordTest {
   }
 
   @Test
+  public void testMetadataContentRecordV3() throws IOException, MessageFormatException {
+    // Test Metadata Blob V3
+    int numKeys = 5;
+    List<StoreKey> keys = getKeys(60, numKeys);
+    List<Pair<StoreKey,Long>> keysAndContentSizes = new ArrayList<>();
+    long total = 0;
+    for (int i = 0; i < numKeys; i++) {
+      long randNum = ThreadLocalRandom.current().nextLong(1, 10000000);
+      total += randNum;
+      keysAndContentSizes.add(new Pair<>(keys.get(i), randNum));
+    }
+
+    ByteBuffer metadataContent = getSerializedMetadataContentV3(total, keysAndContentSizes);
+    CompositeBlobInfo compositeBlobInfo = deserializeMetadataContentV3(metadataContent, new MockIdFactory());
+    Assert.assertEquals("Total size doesn't match", total, compositeBlobInfo.getTotalSize());
+    Assert.assertEquals("List of keys dont match", keys, compositeBlobInfo.getKeys());
+    List<CompositeBlobInfo.StoreKeyAndSizeAndOffset> list = compositeBlobInfo.getKeysAndSizesAndOffsets();
+    Assert.assertEquals("StoreKeyAndSizeAndOffset and input list have different sizes", list.size(), keysAndContentSizes.size());
+    long sum = 0;
+    for (int i = 0; i < list.size(); i++) {
+      Assert.assertEquals(keysAndContentSizes.get(i).getFirst(), list.get(i).getStoreKey());
+      Assert.assertEquals((long)keysAndContentSizes.get(i).getSecond(), list.get(i).getSize());
+      Assert.assertEquals(sum, list.get(i).getOffset());
+      sum += list.get(i).getSize();
+    }
+  }
+
+  @Test
   public void testInvalidMetadataContentV2Fields() {
     List<StoreKey> keys = getKeys(60, 5);
     int[] chunkSizes = {0, 5, 10, 10};
     long[] totalSizes = {5, -10, 10 * keys.size() - 10, 10 * keys.size() + 1};
     for (int n = 0; n < chunkSizes.length; n++) {
       try {
-        MetadataContentSerDe.serializeMetadataContent(chunkSizes[n], totalSizes[n], keys);
+        MetadataContentSerDe.serializeMetadataContentV2(chunkSizes[n], totalSizes[n], keys);
+        fail("Should have failed to serialize");
+      } catch (IllegalArgumentException ignored) {
+      }
+    }
+  }
+
+  @Test
+  public void testInvalidMetadataContentV3Fields() {
+    List<StoreKey> keys = getKeys(60, 2);
+    int[][] chunkSizes = {{0,0}, {2,3}, {5,5}, {5,5}};
+    long[] totalSizes = {5, -10, 10 * keys.size() - 9, 10 * keys.size() + 1};
+    for (int n = 0; n < chunkSizes.length; n++) {
+      try {
+        List<Pair<StoreKey, Long>> keyAndContentSizes = new ArrayList<>();
+        keyAndContentSizes.add(new Pair<>(keys.get(0), (long)chunkSizes[n][0]));
+        keyAndContentSizes.add(new Pair<>(keys.get(1), (long)chunkSizes[n][1]));
+        MetadataContentSerDe.serializeMetadataContentV3(totalSizes[n], keyAndContentSizes);
         fail("Should have failed to serialize");
       } catch (IllegalArgumentException ignored) {
       }
@@ -504,6 +550,27 @@ public class MessageFormatRecordTest {
     Assert.assertEquals("Metadata Content Version mismatch ", MessageFormatRecord.Metadata_Content_Version_V2,
         metadataContentVersion);
     return MessageFormatRecord.Metadata_Content_Format_V2.deserializeMetadataContentRecord(inputStream,
+        storeKeyFactory);
+  }
+
+  private ByteBuffer getSerializedMetadataContentV3(long totalSize, List<Pair<StoreKey, Long>> keysAndContentSizes) {
+    int size =
+        MessageFormatRecord.Metadata_Content_Format_V3.getMetadataContentSize(keysAndContentSizes.get(0).getFirst().sizeInBytes(), keysAndContentSizes.size());
+    ByteBuffer metadataContent = ByteBuffer.allocate(size);
+    MessageFormatRecord.Metadata_Content_Format_V3.serializeMetadataContentRecord(metadataContent, totalSize,
+        keysAndContentSizes);
+    metadataContent.flip();
+    return metadataContent;
+  }
+
+  private CompositeBlobInfo deserializeMetadataContentV3(ByteBuffer metadataContent, StoreKeyFactory storeKeyFactory)
+      throws MessageFormatException, IOException {
+    ByteBufferInputStream byteBufferInputStream = new ByteBufferInputStream(metadataContent);
+    DataInputStream inputStream = new DataInputStream(byteBufferInputStream);
+    short metadataContentVersion = inputStream.readShort();
+    Assert.assertEquals("Metadata Content Version mismatch ", MessageFormatRecord.Metadata_Content_Version_V3,
+        metadataContentVersion);
+    return MessageFormatRecord.Metadata_Content_Format_V3.deserializeMetadataContentRecord(inputStream,
         storeKeyFactory);
   }
 
@@ -609,6 +676,43 @@ public class MessageFormatRecordTest {
       Assert.assertEquals("List of keys dont match", keys, compositeBlobInfo.getKeys());
 
       testBlobCorruption(blob, blobSize, metadataContentSize);
+    }
+  }
+
+  @Test
+  public void testBlobRecordWithMetadataContentV3() throws IOException, MessageFormatException {
+    int numKeys = 5;
+    List<StoreKey> keys = getKeys(60, numKeys);
+    List<Pair<StoreKey,Long>> keysAndContentSizes = new ArrayList<>();
+    long total = 0;
+    for (int i = 0; i < numKeys; i++) {
+      long randNum = ThreadLocalRandom.current().nextLong(1, 10000000);
+      total += randNum;
+      keysAndContentSizes.add(new Pair<>(keys.get(i), randNum));
+    }
+
+    ByteBuffer metadataContent = getSerializedMetadataContentV3(total, keysAndContentSizes);
+    int metadataContentSize = MessageFormatRecord.Metadata_Content_Format_V3.getMetadataContentSize(keys.get(0).sizeInBytes(), keys.size());
+    long blobSize = MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(metadataContentSize);
+    ByteBuffer blob = ByteBuffer.allocate((int) blobSize);
+    BlobData blobData = getBlobRecordV2(metadataContentSize, BlobType.MetadataBlob, metadataContent, blob);
+    Assert.assertEquals(metadataContentSize, blobData.getSize());
+    byte[] verify = new byte[metadataContentSize];
+    blobData.getStream().read(verify);
+    Assert.assertArrayEquals("Metadata content mismatch", metadataContent.array(), verify);
+
+    metadataContent.rewind();
+    CompositeBlobInfo compositeBlobInfo = deserializeMetadataContentV3(metadataContent, new MockIdFactory());
+    Assert.assertEquals("Total size doesn't match", total, compositeBlobInfo.getTotalSize());
+    Assert.assertEquals("List of keys dont match", keys, compositeBlobInfo.getKeys());
+    List<CompositeBlobInfo.StoreKeyAndSizeAndOffset> list = compositeBlobInfo.getKeysAndSizesAndOffsets();
+    Assert.assertEquals("StoreKeyAndSizeAndOffset and input list have different sizes", list.size(), keysAndContentSizes.size());
+    long sum = 0;
+    for (int i = 0; i < list.size(); i++) {
+      Assert.assertEquals(keysAndContentSizes.get(i).getFirst(), list.get(i).getStoreKey());
+      Assert.assertEquals((long)keysAndContentSizes.get(i).getSecond(), list.get(i).getSize());
+      Assert.assertEquals(sum, list.get(i).getOffset());
+      sum += list.get(i).getSize();
     }
   }
 

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -478,7 +478,7 @@ public class MessageFormatRecordTest {
     // Test Metadata Blob V3
     int numKeys = 5;
     List<StoreKey> keys = getKeys(60, numKeys);
-    List<Pair<StoreKey,Long>> keysAndContentSizes = new ArrayList<>();
+    List<Pair<StoreKey, Long>> keysAndContentSizes = new ArrayList<>();
     long total = 0;
     for (int i = 0; i < numKeys; i++) {
       long randNum = ThreadLocalRandom.current().nextLong(1, 10000000);
@@ -491,11 +491,12 @@ public class MessageFormatRecordTest {
     Assert.assertEquals("Total size doesn't match", total, compositeBlobInfo.getTotalSize());
     Assert.assertEquals("List of keys dont match", keys, compositeBlobInfo.getKeys());
     List<CompositeBlobInfo.StoreKeyAndSizeAndOffset> list = compositeBlobInfo.getKeysAndSizesAndOffsets();
-    Assert.assertEquals("StoreKeyAndSizeAndOffset and input list have different sizes", list.size(), keysAndContentSizes.size());
+    Assert.assertEquals("StoreKeyAndSizeAndOffset and input list have different sizes", list.size(),
+        keysAndContentSizes.size());
     long sum = 0;
     for (int i = 0; i < list.size(); i++) {
       Assert.assertEquals(keysAndContentSizes.get(i).getFirst(), list.get(i).getStoreKey());
-      Assert.assertEquals((long)keysAndContentSizes.get(i).getSecond(), list.get(i).getSize());
+      Assert.assertEquals((long) keysAndContentSizes.get(i).getSecond(), list.get(i).getSize());
       Assert.assertEquals(sum, list.get(i).getOffset());
       sum += list.get(i).getSize();
     }
@@ -518,13 +519,13 @@ public class MessageFormatRecordTest {
   @Test
   public void testInvalidMetadataContentV3Fields() {
     List<StoreKey> keys = getKeys(60, 2);
-    int[][] chunkSizes = {{0,0}, {2,3}, {5,5}, {5,5}};
+    int[][] chunkSizes = {{0, 0}, {2, 3}, {5, 5}, {5, 5}};
     long[] totalSizes = {5, -10, 10 * keys.size() - 9, 10 * keys.size() + 1};
     for (int n = 0; n < chunkSizes.length; n++) {
       try {
         List<Pair<StoreKey, Long>> keyAndContentSizes = new ArrayList<>();
-        keyAndContentSizes.add(new Pair<>(keys.get(0), (long)chunkSizes[n][0]));
-        keyAndContentSizes.add(new Pair<>(keys.get(1), (long)chunkSizes[n][1]));
+        keyAndContentSizes.add(new Pair<>(keys.get(0), (long) chunkSizes[n][0]));
+        keyAndContentSizes.add(new Pair<>(keys.get(1), (long) chunkSizes[n][1]));
         MetadataContentSerDe.serializeMetadataContentV3(totalSizes[n], keyAndContentSizes);
         fail("Should have failed to serialize");
       } catch (IllegalArgumentException ignored) {
@@ -554,8 +555,8 @@ public class MessageFormatRecordTest {
   }
 
   private ByteBuffer getSerializedMetadataContentV3(long totalSize, List<Pair<StoreKey, Long>> keysAndContentSizes) {
-    int size =
-        MessageFormatRecord.Metadata_Content_Format_V3.getMetadataContentSize(keysAndContentSizes.get(0).getFirst().sizeInBytes(), keysAndContentSizes.size());
+    int size = MessageFormatRecord.Metadata_Content_Format_V3.getMetadataContentSize(
+        keysAndContentSizes.get(0).getFirst().sizeInBytes(), keysAndContentSizes.size());
     ByteBuffer metadataContent = ByteBuffer.allocate(size);
     MessageFormatRecord.Metadata_Content_Format_V3.serializeMetadataContentRecord(metadataContent, totalSize,
         keysAndContentSizes);
@@ -683,7 +684,7 @@ public class MessageFormatRecordTest {
   public void testBlobRecordWithMetadataContentV3() throws IOException, MessageFormatException {
     int numKeys = 5;
     List<StoreKey> keys = getKeys(60, numKeys);
-    List<Pair<StoreKey,Long>> keysAndContentSizes = new ArrayList<>();
+    List<Pair<StoreKey, Long>> keysAndContentSizes = new ArrayList<>();
     long total = 0;
     for (int i = 0; i < numKeys; i++) {
       long randNum = ThreadLocalRandom.current().nextLong(1, 10000000);
@@ -692,7 +693,8 @@ public class MessageFormatRecordTest {
     }
 
     ByteBuffer metadataContent = getSerializedMetadataContentV3(total, keysAndContentSizes);
-    int metadataContentSize = MessageFormatRecord.Metadata_Content_Format_V3.getMetadataContentSize(keys.get(0).sizeInBytes(), keys.size());
+    int metadataContentSize =
+        MessageFormatRecord.Metadata_Content_Format_V3.getMetadataContentSize(keys.get(0).sizeInBytes(), keys.size());
     long blobSize = MessageFormatRecord.Blob_Format_V2.getBlobRecordSize(metadataContentSize);
     ByteBuffer blob = ByteBuffer.allocate((int) blobSize);
     BlobData blobData = getBlobRecordV2(metadataContentSize, BlobType.MetadataBlob, metadataContent, blob);
@@ -706,11 +708,12 @@ public class MessageFormatRecordTest {
     Assert.assertEquals("Total size doesn't match", total, compositeBlobInfo.getTotalSize());
     Assert.assertEquals("List of keys dont match", keys, compositeBlobInfo.getKeys());
     List<CompositeBlobInfo.StoreKeyAndSizeAndOffset> list = compositeBlobInfo.getKeysAndSizesAndOffsets();
-    Assert.assertEquals("StoreKeyAndSizeAndOffset and input list have different sizes", list.size(), keysAndContentSizes.size());
+    Assert.assertEquals("StoreKeyAndSizeAndOffset and input list have different sizes", list.size(),
+        keysAndContentSizes.size());
     long sum = 0;
     for (int i = 0; i < list.size(); i++) {
       Assert.assertEquals(keysAndContentSizes.get(i).getFirst(), list.get(i).getStoreKey());
-      Assert.assertEquals((long)keysAndContentSizes.get(i).getSecond(), list.get(i).getSize());
+      Assert.assertEquals((long) keysAndContentSizes.get(i).getSecond(), list.get(i).getSize());
       Assert.assertEquals(sum, list.get(i).getOffset());
       sum += list.get(i).getSize();
     }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
@@ -31,6 +31,7 @@ import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.store.TransformationOutput;
 import com.github.ambry.store.Transformer;
 import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.Pair;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -202,8 +203,22 @@ public class BlobIdTransformer implements Transformer {
           }
           newKeys.add(newDataChunkKey);
         }
-        ByteBuffer metadataContent = MetadataContentSerDe.serializeMetadataContentV2(compositeBlobInfo.getChunkSize(),
-            compositeBlobInfo.getTotalSize(), newKeys);
+        ByteBuffer metadataContent;
+        if (compositeBlobInfo.getMetadataContentVersion() == Metadata_Content_Version_V2) {
+          metadataContent = MetadataContentSerDe.serializeMetadataContentV2(compositeBlobInfo.getChunkSize(),
+              compositeBlobInfo.getTotalSize(), newKeys);
+        } else if (compositeBlobInfo.getMetadataContentVersion() == Metadata_Content_Version_V3) {
+          List<Pair<StoreKey, Long>> keyAndSizeList = new ArrayList<>();
+          List<CompositeBlobInfo.ChunkMetadata> chunkMetadataList = compositeBlobInfo.getChunkMetadataList();
+          for (int i = 0; i < newKeys.size(); i++) {
+            keyAndSizeList.add(new Pair<>(newKeys.get(i), chunkMetadataList.get(i).getSize()));
+          }
+          metadataContent =
+              MetadataContentSerDe.serializeMetadataContentV3(compositeBlobInfo.getTotalSize(), keyAndSizeList);
+        } else {
+          throw new IllegalStateException("Unexpected metadata content version from composite blob: "
+              + compositeBlobInfo.getMetadataContentVersion());
+        }
         blobPropertiesSize = compositeBlobInfo.getTotalSize();
         metadataContent.flip();
         blobDataBytes = new ByteBufferInputStream(metadataContent);

--- a/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
@@ -202,7 +202,7 @@ public class BlobIdTransformer implements Transformer {
           }
           newKeys.add(newDataChunkKey);
         }
-        ByteBuffer metadataContent = MetadataContentSerDe.serializeMetadataContent(compositeBlobInfo.getChunkSize(),
+        ByteBuffer metadataContent = MetadataContentSerDe.serializeMetadataContentV2(compositeBlobInfo.getChunkSize(),
             compositeBlobInfo.getTotalSize(), newKeys);
         blobPropertiesSize = compositeBlobInfo.getTotalSize();
         metadataContent.flip();

--- a/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
@@ -27,6 +27,7 @@ import com.github.ambry.messageformat.BlobType;
 import com.github.ambry.messageformat.DeleteMessageFormatInputStream;
 import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatInputStream;
+import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.messageformat.MetadataContentSerDe;
 import com.github.ambry.messageformat.PutMessageFormatBlobV1InputStream;
 import com.github.ambry.messageformat.PutMessageFormatInputStream;
@@ -73,6 +74,7 @@ public class BlobIdTransformerTest {
   private static final int USER_META_DATA_SIZE = 64;
   private static final int COMPOSITE_BLOB_SIZE = 8000000;
   private static final int COMPOSITE_BLOB_DATA_CHUNK_SIZE = 4000000;
+  private static short metadataContentVersion = MessageFormatRecord.Metadata_Content_Version_V3;
 
   public static final Pair<String, String> BLOB_ID_PAIR_VERSION_1_CONVERTED =
       new Pair<>("AAEAAQAAAAAAAAAhAAAAJDkwNTUwOTJhLTc3ZTAtNDI4NC1iY2IxLTc2MDZlYTAzNWM4OQ",
@@ -155,15 +157,23 @@ public class BlobIdTransformerTest {
    */
   @Test
   public void testMetaDataBlobOperation() throws IOException, MessageFormatException {
-    InputAndExpected inputAndExpected =
-        new InputAndExpected(BLOB_ID_VERSION_1_METADATA_CONVERTED, VALID_MESSAGE_FORMAT_INPUT_STREAM_IMPLS[0], false,
-            new String[]{BLOB_ID_VERSION_1_DATACHUNK_0_CONVERTED.getFirst(),
-                BLOB_ID_VERSION_1_DATACHUNK_1_CONVERTED.getFirst()},
-            new String[]{BLOB_ID_VERSION_1_DATACHUNK_0_CONVERTED.getSecond(),
-                BLOB_ID_VERSION_1_DATACHUNK_1_CONVERTED.getSecond()});
-    TransformationOutput output = transformer.transform(inputAndExpected.getInput());
-    assertNull("output exception should be null", output.getException());
-    verifyOutput(output.getMsg(), inputAndExpected.getExpected());
+    for (int i = 0; i < 2; i++) {
+      //ensure we test both metadata content versions
+      if (i == 0) {
+        metadataContentVersion = MessageFormatRecord.Metadata_Content_Version_V2;
+      } else {
+        metadataContentVersion = MessageFormatRecord.Metadata_Content_Version_V3;
+      }
+      InputAndExpected inputAndExpected =
+          new InputAndExpected(BLOB_ID_VERSION_1_METADATA_CONVERTED, VALID_MESSAGE_FORMAT_INPUT_STREAM_IMPLS[0], false,
+              new String[]{BLOB_ID_VERSION_1_DATACHUNK_0_CONVERTED.getFirst(),
+                  BLOB_ID_VERSION_1_DATACHUNK_1_CONVERTED.getFirst()},
+              new String[]{BLOB_ID_VERSION_1_DATACHUNK_0_CONVERTED.getSecond(),
+                  BLOB_ID_VERSION_1_DATACHUNK_1_CONVERTED.getSecond()});
+      TransformationOutput output = transformer.transform(inputAndExpected.getInput());
+      assertNull("output exception should be null", output.getException());
+      verifyOutput(output.getMsg(), inputAndExpected.getExpected());
+    }
   }
 
   /**
@@ -560,8 +570,28 @@ public class BlobIdTransformerTest {
       for (String datachunkId : datachunkIds) {
         storeKeys.add(blobIdFactory.getStoreKey(datachunkId));
       }
-      ByteBuffer output =
-          MetadataContentSerDe.serializeMetadataContentV2(COMPOSITE_BLOB_DATA_CHUNK_SIZE, COMPOSITE_BLOB_SIZE, storeKeys);
+      ByteBuffer output;
+      switch (metadataContentVersion) {
+        case MessageFormatRecord.Metadata_Content_Version_V2:
+          output = MetadataContentSerDe.serializeMetadataContentV2(COMPOSITE_BLOB_DATA_CHUNK_SIZE, COMPOSITE_BLOB_SIZE,
+              storeKeys);
+          break;
+        case MessageFormatRecord.Metadata_Content_Version_V3:
+          int totalLeft = COMPOSITE_BLOB_SIZE;
+          List<Pair<StoreKey, Long>> keyAndSizeList = new ArrayList<>();
+          int i = 0;
+          while (totalLeft >= COMPOSITE_BLOB_DATA_CHUNK_SIZE) {
+            keyAndSizeList.add(new Pair<>(storeKeys.get(i++), (long) COMPOSITE_BLOB_DATA_CHUNK_SIZE));
+            totalLeft -= COMPOSITE_BLOB_DATA_CHUNK_SIZE;
+          }
+          if (totalLeft > 0) {
+            keyAndSizeList.add(new Pair<>(storeKeys.get(i), (long) totalLeft));
+          }
+          output = MetadataContentSerDe.serializeMetadataContentV3(COMPOSITE_BLOB_SIZE, keyAndSizeList);
+          break;
+        default:
+          throw new IllegalStateException("Unexpected metadata content version: " + metadataContentVersion);
+      }
       output.flip();
       return output;
     }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
@@ -561,7 +561,7 @@ public class BlobIdTransformerTest {
         storeKeys.add(blobIdFactory.getStoreKey(datachunkId));
       }
       ByteBuffer output =
-          MetadataContentSerDe.serializeMetadataContent(COMPOSITE_BLOB_DATA_CHUNK_SIZE, COMPOSITE_BLOB_SIZE, storeKeys);
+          MetadataContentSerDe.serializeMetadataContentV2(COMPOSITE_BLOB_DATA_CHUNK_SIZE, COMPOSITE_BLOB_SIZE, storeKeys);
       output.flip();
       return output;
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -943,8 +943,9 @@ class GetBlobOperation extends GetOperation {
         buf.position(0);
         buf.limit(0);
       } else {
-        long startOffsetInThisChunk = Math.max(resolvedByteRange.getStartOffset() - offset, 0);
-        long endOffsetInThisChunkExclusive = Math.min(resolvedByteRange.getEndOffset() - offset + 1, chunkSize);
+        long startOffsetInThisChunk = chunkIndex == 0 ? resolvedByteRange.getStartOffset() - offset : 0;
+        long endOffsetInThisChunkExclusive =
+            chunkIndex == (numChunksTotal - 1) ? resolvedByteRange.getEndOffset() - offset + 1 : chunkSize;
         buf.position((int) startOffsetInThisChunk);
         buf.limit((int) endOffsetInThisChunkExclusive);
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -990,7 +990,7 @@ class GetBlobOperation extends GetOperation {
 
     // refers to the blob type.
     private BlobType blobType;
-    private List<CompositeBlobInfo.ChunkMetadata> keysAndSizesAndOffsets;
+    private List<CompositeBlobInfo.ChunkMetadata> chunkMetadataList;
     private BlobProperties serverBlobProperties;
 
     /**
@@ -1194,13 +1194,13 @@ class GetBlobOperation extends GetOperation {
       compositeBlobInfo =
           MetadataContentSerDe.deserializeMetadataContentRecord(serializedMetadataContent, blobIdFactory);
       totalSize = compositeBlobInfo.getTotalSize();
-      keysAndSizesAndOffsets = compositeBlobInfo.getChunkMetadataList();
+      chunkMetadataList = compositeBlobInfo.getChunkMetadataList();
       boolean rangeResolutionFailure = false;
       try {
         if (options.getBlobOptions.getRange() != null) {
           resolvedByteRange = options.getBlobOptions.getRange().toResolvedByteRange(totalSize);
           // Get only the chunks within the range.
-          keysAndSizesAndOffsets = compositeBlobInfo.getStoreKeysInByteRange(resolvedByteRange.getStartOffset(),
+          chunkMetadataList = compositeBlobInfo.getStoreKeysInByteRange(resolvedByteRange.getStartOffset(),
               resolvedByteRange.getEndOffset());
         }
       } catch (IllegalArgumentException e) {
@@ -1243,9 +1243,9 @@ class GetBlobOperation extends GetOperation {
         numChunksTotal = 0;
         dataChunks = null;
       } else {
-        chunkIdIterator = keysAndSizesAndOffsets.listIterator();
-        numChunksTotal = keysAndSizesAndOffsets.size();
-        dataChunks = new GetChunk[Math.min(keysAndSizesAndOffsets.size(), NonBlockingRouter.MAX_IN_MEM_CHUNKS)];
+        chunkIdIterator = chunkMetadataList.listIterator();
+        numChunksTotal = chunkMetadataList.size();
+        dataChunks = new GetChunk[Math.min(chunkMetadataList.size(), NonBlockingRouter.MAX_IN_MEM_CHUNKS)];
         for (int i = 0; i < dataChunks.length; i++) {
           int idx = chunkIdIterator.nextIndex();
           CompositeBlobInfo.ChunkMetadata keyAndOffset = chunkIdIterator.next();

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -1606,8 +1606,7 @@ class PutOperation {
               passedInBlobProperties.isEncrypted(), passedInBlobProperties.getExternalAssetTag());
       if (isStitchOperation() || getNumDataChunks() > 1) {
         // values returned are in the right order as TreeMap returns them in key-order.
-        List<Pair<StoreKey, Long>> orderedChunkIdList = indexToChunkIds.values().stream().collect(
-            Collectors.toList());
+        List<Pair<StoreKey, Long>> orderedChunkIdList = indexToChunkIds.values().stream().collect(Collectors.toList());
 
         buf = MetadataContentSerDe.serializeMetadataContentV3(getBlobSize(), orderedChunkIdList);
         onFillComplete(false);
@@ -1623,8 +1622,7 @@ class PutOperation {
      * @return a list of all of the successfully put chunk ids associated with this blob
      */
     List<StoreKey> getSuccessfullyPutChunkIds() {
-      return indexToChunkIds.values().stream().map(b -> b.getFirst()).collect(
-          Collectors.toList());
+      return indexToChunkIds.values().stream().map(b -> b.getFirst()).collect(Collectors.toList());
     }
 
     /**

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -339,7 +339,9 @@ class PutOperation {
           RouterErrorCode.InvalidPutArgument);
     }
     long totalSize = 0;
-    long intermediateChunkSize = routerConfig.routerMaxPutChunkSizeBytes;
+    long intermediateChunkSize =
+        routerConfig.routerMetadataContentVersion == MessageFormatRecord.Metadata_Content_Version_V2
+            ? chunksToStitch.get(0).getChunkSizeInBytes() : routerConfig.routerMaxPutChunkSizeBytes;
     metadataPutChunk.setIntermediateChunkSize(intermediateChunkSize);
     for (ListIterator<ChunkInfo> iter = chunksToStitch.listIterator(); iter.hasNext(); ) {
       int chunkIndex = iter.nextIndex();
@@ -366,7 +368,9 @@ class PutOperation {
     long chunkSize = chunkInfo.getChunkSizeInBytes();
     long chunkExpirationTimeInMs = chunkInfo.getExpirationTimeInMs();
 
-    if (chunkSize == 0 || chunkSize > intermediateChunkSize) {
+    if (chunkSize == 0 || chunkSize > intermediateChunkSize || (
+        routerConfig.routerMetadataContentVersion == MessageFormatRecord.Metadata_Content_Version_V2 && !lastChunk
+            && chunkSize < intermediateChunkSize)) {
       throw new RouterException(
           "Invalid chunkSize for " + (lastChunk ? "last" : "intermediate") + " chunk: " + chunkSize
               + "; intermediateChunkSize: " + intermediateChunkSize, RouterErrorCode.InvalidPutArgument);

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -1612,12 +1612,11 @@ class PutOperation {
               passedInBlobProperties.isEncrypted(), passedInBlobProperties.getExternalAssetTag());
       if (isStitchOperation() || getNumDataChunks() > 1) {
         // values returned are in the right order as TreeMap returns them in key-order.
-        List<Pair<StoreKey, Long>> orderedChunkIdList = new ArrayList<>(indexToChunkIdsAndChunkSizes.values());
-
         if (routerConfig.routerMetadataContentVersion == MessageFormatRecord.Metadata_Content_Version_V2) {
           buf = MetadataContentSerDe.serializeMetadataContentV2(intermediateChunkSize, getBlobSize(),
               getSuccessfullyPutChunkIds());
         } else if (routerConfig.routerMetadataContentVersion == MessageFormatRecord.Metadata_Content_Version_V3) {
+          List<Pair<StoreKey, Long>> orderedChunkIdList = new ArrayList<>(indexToChunkIdsAndChunkSizes.values());
           buf = MetadataContentSerDe.serializeMetadataContentV3(getBlobSize(), orderedChunkIdList);
         } else {
           throw new IllegalStateException(

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -858,8 +858,6 @@ public class GetBlobOperationTest {
     // Ranges that start past the end of the blob (should not succeed)
     testRangeRequestFromStartOffset(blobSize, false);
     testRangeRequestOffsetRange(blobSize, blobSize + 20, false);
-    // 0 byte range
-    testRangeRequestLastNBytes(0, true);
     // 1 byte ranges
     testRangeRequestOffsetRange(0, 0, true);
     testRangeRequestOffsetRange(blobSize - 1, blobSize - 1, true);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -764,7 +764,7 @@ public class GetBlobOperationTest {
       storeKeys.add(blobId);
     }
     blobSize = maxChunkSize * numChunks;
-    ByteBuffer metadataContent = MetadataContentSerDe.serializeMetadataContent(maxChunkSize, blobSize, storeKeys);
+    ByteBuffer metadataContent = MetadataContentSerDe.serializeMetadataContentV2(maxChunkSize, blobSize, storeKeys);
     metadataContent.flip();
     blobProperties =
         new BlobProperties(blobSize - 20, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -860,11 +860,12 @@ public class GetBlobOperationTest {
     testRangeRequestOffsetRange(blobSize, blobSize + 20, false);
     // 1 byte ranges
     testRangeRequestOffsetRange(0, 0, true);
+    testRangeRequestOffsetRange(blobSize/2, blobSize/2, true);
     testRangeRequestOffsetRange(blobSize - 1, blobSize - 1, true);
     testRangeRequestFromStartOffset(blobSize - 1, true);
     testRangeRequestLastNBytes(1, true);
 
-    blobSize = maxChunkSize * 2 + random.nextInt(maxChunkSize);
+    blobSize = maxChunkSize * 2 + random.nextInt(maxChunkSize) + 1;
     // Single start chunk
     testRangeRequestOffsetRange(0, maxChunkSize - 1, true);
     // Single intermediate chunk

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -186,18 +186,20 @@ public class GetManagerTest {
 
 
   /**
-   * Test a get request.
+   * Test a get request on a stitched blob.
    * @param blobSize the size of the blob to put/get.
    * @param options the {@link GetBlobOptions} for the get request.
    */
   private void testGetSuccessStitch(int blobSize, GetBlobOptions options) throws Exception {
     router = getNonBlockingRouter();
     ByteBuffer byteBuffer = ByteBuffer.allocate(blobSize);
+    //Divide blob into 10 chunks to be stitched
     int chunkSize = blobSize / 10;
     List<String> stitchBlobsIds = new ArrayList<>();
     List<ChunkInfo> chunkInfos = new ArrayList<>();
     int curBlobSize = blobSize;
     for (int i = 0; i < 10; i++) {
+      //Give each chunk a different size
       int curChunkSize = Math.min(curBlobSize, chunkSize+i*5);
       setOperationParams(curChunkSize, options);
       byteBuffer.put(putContent);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -162,9 +162,10 @@ public class GetManagerTest {
    */
   @Test
   public void testRangeRequestStitch() throws Exception {
-    testGetSuccessStitch(chunkSize * 6 + 11, new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.Data)
-        .range(ByteRanges.fromOffsetRange(chunkSize * 2 + 3, chunkSize * 5 + 4))
-        .build());
+    testGetSuccessStitch(chunkSize * 6 + 11,
+        new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.Data)
+            .range(ByteRanges.fromOffsetRange(chunkSize * 2 + 3, chunkSize * 5 + 4))
+            .build());
   }
 
   /**
@@ -184,7 +185,6 @@ public class GetManagerTest {
     router.close();
   }
 
-
   /**
    * Test a get request on a stitched blob.
    * @param blobSize the size of the blob to put/get.
@@ -200,11 +200,12 @@ public class GetManagerTest {
     int curBlobSize = blobSize;
     for (int i = 0; i < 10; i++) {
       //Give each chunk a different size
-      int curChunkSize = Math.min(curBlobSize, chunkSize+i*5);
+      int curChunkSize = Math.min(curBlobSize, chunkSize + i * 5);
       setOperationParams(curChunkSize, options);
       byteBuffer.put(putContent);
       curBlobSize -= curChunkSize;
-      stitchBlobsIds.add(router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get());
+      stitchBlobsIds.add(
+          router.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build()).get());
       chunkInfos.add(new ChunkInfo(stitchBlobsIds.get(i), curChunkSize, -1L));
     }
     setOperationParams(blobSize, options);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -23,6 +23,7 @@ import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
@@ -55,6 +56,7 @@ public class GetManagerTest {
   private final AtomicReference<MockSelectorState> mockSelectorState = new AtomicReference<MockSelectorState>();
   private NonBlockingRouter router;
   private final boolean testEncryption;
+  private final int metadataContentVersion;
   private KeyManagementService kms = null;
   private CryptoService cryptoService = null;
   private CryptoJobHandler cryptoJobHandler = null;
@@ -74,20 +76,24 @@ public class GetManagerTest {
   private static final int CHECKOUT_TIMEOUT_MS = 1000;
 
   /**
-   * Running for both regular and encrypted blobs
-   * @return an array with both {@code false} and {@code true}.
+   * Running for both regular and encrypted blobs, and versions 2 and 3 of MetadataContent
+   * @return an array with all four different choices
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{{false}, {true}});
+    return Arrays.asList(new Object[][]{{false, MessageFormatRecord.Metadata_Content_Version_V2},
+        {false, MessageFormatRecord.Metadata_Content_Version_V3},
+        {true, MessageFormatRecord.Metadata_Content_Version_V2},
+        {true, MessageFormatRecord.Metadata_Content_Version_V3}});
   }
 
   /**
    * Pre-initialization common to all tests.
    * @param testEncryption {@code true} if blobs need to be tested w/ encryption. {@code false} otherwise
    */
-  public GetManagerTest(boolean testEncryption) throws Exception {
+  public GetManagerTest(boolean testEncryption, int metadataContentVersion) throws Exception {
     this.testEncryption = testEncryption;
+    this.metadataContentVersion = metadataContentVersion;
     // random chunkSize in the range [1, 1 MB]
     chunkSize = random.nextInt(1024 * 1024) + 1;
     requestParallelism = 3;
@@ -141,8 +147,13 @@ public class GetManagerTest {
    * @throws Exception
    */
   @Test
-  public void testCompositeBlobGetSuccessStitch() throws Exception {
-    testGetSuccessStitch(chunkSize * 6 + 11, new GetBlobOptionsBuilder().build());
+  public void testCompositeBlobGetSuccessStitchDifferentSizedBlobs() throws Exception {
+    if (metadataContentVersion > 2) {
+      testGetSuccessStitch(chunkSize * 6 + 11, new GetBlobOptionsBuilder().build());
+    } else {
+      router = getNonBlockingRouter();
+      router.close();
+    }
   }
 
   /**
@@ -161,11 +172,16 @@ public class GetManagerTest {
    * @throws Exception
    */
   @Test
-  public void testRangeRequestStitch() throws Exception {
-    testGetSuccessStitch(chunkSize * 6 + 11,
-        new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.Data)
-            .range(ByteRanges.fromOffsetRange(chunkSize * 2 + 3, chunkSize * 5 + 4))
-            .build());
+  public void testRangeRequestStitchDifferentSizedBlobs() throws Exception {
+    if (metadataContentVersion > 2) {
+      testGetSuccessStitch(chunkSize * 6 + 11,
+          new GetBlobOptionsBuilder().operationType(GetBlobOptions.OperationType.Data)
+              .range(ByteRanges.fromOffsetRange(chunkSize * 2 + 3, chunkSize * 5 + 4))
+              .build());
+    } else {
+      router = getNonBlockingRouter();
+      router.close();
+    }
   }
 
   /**
@@ -460,7 +476,7 @@ public class GetManagerTest {
     properties.setProperty("router.max.put.chunk.size.bytes", Integer.toString(chunkSize));
     properties.setProperty("router.put.request.parallelism", Integer.toString(requestParallelism));
     properties.setProperty("router.put.success.target", Integer.toString(successTarget));
-    properties.setProperty("router.metadata.content.version", "3");
+    properties.setProperty("router.metadata.content.version", String.valueOf(metadataContentVersion));
     VerifiableProperties vProps = new VerifiableProperties(properties);
     routerConfig = new RouterConfig(vProps);
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap, routerConfig),

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -460,6 +460,7 @@ public class GetManagerTest {
     properties.setProperty("router.max.put.chunk.size.bytes", Integer.toString(chunkSize));
     properties.setProperty("router.put.request.parallelism", Integer.toString(requestParallelism));
     properties.setProperty("router.put.success.target", Integer.toString(successTarget));
+    properties.setProperty("router.metadata.content.version", "3");
     VerifiableProperties vProps = new VerifiableProperties(properties);
     routerConfig = new RouterConfig(vProps);
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(mockClusterMap, routerConfig),

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -880,6 +880,7 @@ public class PutManagerTest {
     properties.setProperty("router.max.put.chunk.size.bytes", Integer.toString(chunkSize));
     properties.setProperty("router.put.request.parallelism", Integer.toString(requestParallelism));
     properties.setProperty("router.put.success.target", Integer.toString(successTarget));
+    properties.setProperty("router.metadata.content.version", "3");
     VerifiableProperties vProps = new VerifiableProperties(properties);
     if (testEncryption && instantiateEncryptionCast) {
       setupEncryptionCast(vProps);

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -287,13 +287,12 @@ public class PutManagerTest {
     }
 
     // intermediate chunk sizes do not match
-    runTest.accept(
-        RouterTestHelpers.buildChunkList(mockClusterMap, BlobDataType.DATACHUNK, Utils.Infinite_Time,
-            LongStream.of(200, 10, 200)));
+    runTest.accept(RouterTestHelpers.buildChunkList(mockClusterMap, BlobDataType.DATACHUNK, Utils.Infinite_Time,
+        LongStream.of(200, 10, 200)));
 
     // last chunk larger than intermediate chunks
     runTest.accept(RouterTestHelpers.buildChunkList(mockClusterMap, BlobDataType.DATACHUNK, Utils.Infinite_Time,
-            LongStream.of(200, 201)));
+        LongStream.of(200, 201)));
   }
 
   /**


### PR DESCRIPTION
Changed stitched blobs to work with blobs with different data content sizes.

Note: Still need to add serializeMetadataContentV3 into BlobIdTransformer, but regular stitched blob operation changes are ready to be looked at