### PR TITLE
Introducing node-level/disk-level histogram in adaptive tracker

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/router/OperationTrackerScope.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/OperationTrackerScope.java
@@ -19,5 +19,5 @@ package com.github.ambry.router;
  * kept in a single Histogram)
  */
 public enum OperationTrackerScope {
-  Datacenter, Partition
+  Datacenter, Partition, DataNode, Disk
 }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -214,7 +214,7 @@ public abstract class ReplicationEngine {
         persistor.write(true);
       }
     } catch (Exception e) {
-      logger.error("Error shutting down replica manager {}", e);
+      logger.error("Error shutting down replica manager", e);
       throw new ReplicationException("Error shutting down replica manager");
     }
   }


### PR DESCRIPTION
This PR introduces two more operation tracker scope: DataNode and Disk
to allow adaptive tracker to use node-level/disk-level histogram. This
provides different granularity when determining if a certain request is
past due or not. Since all operation tracker scopes are configurable, we
can tune the adaptive tracker and identify the bottleneck of serving
requests on server side.