### PR TITLE
Add post blob size

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequest.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequest.java
@@ -142,6 +142,16 @@ public interface RestRequest extends ReadableStreamChannel {
   long getBytesReceived();
 
   /**
+   * Gets the number of bytes read as part of the blob data at this point in time. After the request has been fully read,
+   * this can be used to determine the full blob size in bytes. The result of this method is only valid for requests
+   * that have blob data in them.
+   * @return the current number of blob bytes read from the request body.
+   */
+  default long getBlobBytesReceived() {
+    return 0;
+  }
+
+  /**
    * @return {@code true} if SSL was used for this request (i.e. the request has an associated {@link SSLSession})
    */
   default boolean isSslUsed() {

--- a/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequest.java
+++ b/ambry-api/src/test/java/com.github.ambry/rest/MockRestRequest.java
@@ -256,6 +256,11 @@ public class MockRestRequest implements RestRequest {
   }
 
   @Override
+  public long getBlobBytesReceived() {
+    return bytesReceived.get();
+  }
+
+  @Override
   public boolean isOpen() {
     onEventComplete(Event.IsOpen);
     return channelOpen.get();

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
@@ -364,7 +364,7 @@ class PostBlobHandler {
         @SuppressWarnings("ConstantConditions")
         long chunkSizeBytes = RestUtils.getLongHeader(metadata, RestUtils.Headers.BLOB_SIZE, true);
 
-        totalStitchedBlobSize = totalStitchedBlobSize + chunkSizeBytes;
+        totalStitchedBlobSize += chunkSizeBytes;
         // Expiration time is sent to the router, but not verified in this handler. The router is responsible for making
         // checks related to internal ambry requirements, like making sure that the chunks do not expire before the
         // metadata blob.

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
@@ -304,7 +304,7 @@ class PostBlobHandler {
     private void setSignedIdMetadataAndBlobSize(BlobProperties blobProperties) throws RestServiceException {
       if (RestUtils.isChunkUpload(restRequest.getArgs())) {
         Map<String, String> metadata = new HashMap<>(2);
-        metadata.put(RestUtils.Headers.BLOB_SIZE, Long.toString(restRequest.getBytesReceived()));
+        metadata.put(RestUtils.Headers.BLOB_SIZE, Long.toString(restRequest.getBlobBytesReceived()));
         metadata.put(RestUtils.Headers.SESSION,
             RestUtils.getHeader(restRequest.getArgs(), RestUtils.Headers.SESSION, true));
         metadata.put(EXPIRATION_TIME_MS_KEY,
@@ -312,7 +312,7 @@ class PostBlobHandler {
         restRequest.setArg(RestUtils.InternalKeys.SIGNED_ID_METADATA_KEY, metadata);
       }
       //the actual blob size is the number of bytes read
-      restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, restRequest.getBytesReceived());
+      restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, restRequest.getBlobBytesReceived());
     }
 
     /**

--- a/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com.github.ambry.frontend/PostBlobHandler.java
@@ -310,8 +310,6 @@ class PostBlobHandler {
         metadata.put(EXPIRATION_TIME_MS_KEY,
             Long.toString(Utils.addSecondsToEpochTime(time.milliseconds(), blobProperties.getTimeToLiveInSeconds())));
         restRequest.setArg(RestUtils.InternalKeys.SIGNED_ID_METADATA_KEY, metadata);
-      } else {
-        restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, restRequest.getBytesReceived());
       }
       //the actual blob size is the number of bytes read
       restResponseChannel.setHeader(RestUtils.Headers.BLOB_SIZE, restRequest.getBytesReceived());

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -80,7 +80,7 @@ class NettyRequest implements RestRequest {
   private final RestMethod restMethod;
   private final RestRequestMetricsTracker restRequestMetricsTracker = new RestRequestMetricsTracker();
   private final AtomicBoolean channelOpen = new AtomicBoolean(true);
-  private final AtomicLong bytesReceived = new AtomicLong(0);
+  protected final AtomicLong bytesReceived = new AtomicLong(0);
   private final AtomicLong bytesBuffered = new AtomicLong(0);
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final RecvByteBufAllocator recvByteBufAllocator = new DefaultMaxBytesRecvByteBufAllocator();
@@ -388,6 +388,11 @@ class NettyRequest implements RestRequest {
 
   @Override
   public long getBytesReceived() {
+    return bytesReceived.get();
+  }
+
+  @Override
+  public long getBlobBytesReceived() {
     return bytesReceived.get();
   }
 


### PR DESCRIPTION
This change add the "x-ambry-blob-size" for POST requests. For stitched requests, the value of "x-ambry-blob-size" will be the sum of all the chunk sizes.

TESTS
------
STITCHED POST
---------------------
ankuagra-mn1:ambry ankuagra$  curl -i  -H "x-ambry-service-id : stitcher" -H "x-ambry-content-type : image/jpg" -H "x-ambry-ttl : 241920"  http://localhost:1174/stitch --data-binary "@newstitchrequest.json"
HTTP/1.1 201 Created
x-ambry-blob-size: 1094
Location: /AAYIAf__AAAAAQAAAAAAAAAAOlvQuJeVRPa8WwvcWthBJg
Date: Tue, 11 Jun 2019 18:15:22 GMT
Content-Length: 0
x-ambry-creation-time: Tue, 11 Jun 2019 18:15:22 GMT
x-ambry-datacenter: Datacenter
x-ambry-frontend: localhost


CHUNK POST
----------------
ankuagra-mn1:ambry ankuagra$ curl -i   -H "x-ambry-content-type : image/jpg" -H "x-ambry-um-description : Demonstration Image" "http://localhost:1174/?x-ambry-ttl=2419200&x-ambry-service-id=CUrlUpload&x-ambry-owner-id=ankuagra&x-ambry-chunk-upload=true&x-ambry-url-type=POST&x-ambry-session=4c461710-8eba-4d1a-89e8-c3ca7e64758a&x-ambry-max-upload-size=4194304&et=1560277137" --data-binary "@newstitchrequest.json"
HTTP/1.1 201 Created
x-ambry-blob-size: 547
Location: /signedId/eyJtZXRhZGF0YSI6eyJ4LWFtYnJ5LWJsb2Itc2l6ZSI6IjU0NyIsIngtYW1icnktc2Vzc2lvbiI6IjRjNDYxNzEwLThlYmEtNGQxYS04OWU4LWMzY2E3ZTY0NzU4YSIsImV0IjoiMTU2MjY5NjA1OTY4NyJ9LCJibG9iSWQiOiJBQVlRQWZfX0FBQUFBUUFBQUFBQUFBQUE5b1I3Q3I5dlRQV1d5V3Axa0pHTVRnIn0
Date: Tue, 11 Jun 2019 18:14:19 GMT
Content-Length: 0
x-ambry-creation-time: Tue, 11 Jun 2019 18:14:19 GMT
x-ambry-datacenter: Datacenter
x-ambry-frontend: localhost

REGULAR BLOB POST
----------------------
ankuagra-mn1:ambry ankuagra$  curl -i  -H "x-ambry-service-id : stitcher" -H "x-ambry-content-type : image/jpg" -H "x-ambry-ttl : 241920"  http://localhost:1174 --data-binary "@newstitchrequest.json"
HTTP/1.1 201 Created
x-ambry-blob-size: 547
Location: /AAYQAf__AAAAAQAAAAAAAAAApfaGG3oAR72iRFAJ5DOSOQ
Date: Tue, 11 Jun 2019 18:17:03 GMT
Content-Length: 0
x-ambry-creation-time: Tue, 11 Jun 2019 18:17:03 GMT
x-ambry-datacenter: Datacenter
x-ambry-frontend: localhost


LARGE BLOB SIZE (MULTIPLE CHUNKS)
------------------
ankuagra-mn1:ambry ankuagra$  curl -i  -H "x-ambry-service-id : stitcher" -H "x-ambry-content-type : image/jpg" -H "x-ambry-ttl : 241920"  http://localhost:1174 --data-binary "@ambry.jar"
HTTP/1.1 201 Created
x-ambry-blob-size: 201514644
Location: /AAYIAf__AAAAAQAAAAAAAAAAm48zgmy2Q4u87KtzDNIbGQ
Date: Tue, 11 Jun 2019 18:17:45 GMT
Content-Length: 0
x-ambry-creation-time: Tue, 11 Jun 2019 18:17:43 GMT
x-ambry-datacenter: Datacenter
x-ambry-frontend: localhost