### PR TITLE
Getbloberror

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -490,8 +490,10 @@ class GetBlobOperation extends GetOperation {
     protected boolean retainChunkExceptionOnSuccess;
     // the index of the current chunk in the overall blob.
     protected int chunkIndex;
-    // the most relevant exception encountered for the current chunk.
+    // the most relevant exception encountered for the current chunk. It will be derived from the chunkExceptionForReplica.
     protected RouterException chunkException;
+    // map of the ReplicaId to RouterException associated with each ReplicaId.
+    protected Map<ReplicaId, RouterException> chunkExceptionForReplica;
     // For a GetChunk, responses may be handled multiple times. Regardless of the successTarget,
     // the actual body of the response is deserialized only once.
     protected boolean successfullyDeserialized;
@@ -550,6 +552,7 @@ class GetBlobOperation extends GetOperation {
       chunkBlobId = null;
       chunkIndex = -1;
       chunkException = null;
+      chunkExceptionForReplica = null;
       successfullyDeserialized = false;
       progressTracker = null;
       decryptCallbackResultInfo = null;
@@ -641,13 +644,13 @@ class GetBlobOperation extends GetOperation {
       while (inFlightRequestsIterator.hasNext()) {
         Map.Entry<Integer, GetRequestInfo> entry = inFlightRequestsIterator.next();
         if (time.milliseconds() - entry.getValue().startTimeMs > routerConfig.routerRequestTimeoutMs) {
-          onErrorResponse(entry.getValue().replicaId, RouterErrorCode.OperationTimedOut);
+          onErrorResponse(entry.getValue().replicaId,
+              new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut));
           logger.trace("GetBlobRequest with correlationId {} in flight has expired for replica {} ", entry.getKey(),
               entry.getValue().replicaId.getDataNodeId());
           // Do not notify this as a failure to the response handler, as this timeout could simply be due to
           // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
           // response and the response handler will be notified accordingly.
-          chunkException = new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut);
           inFlightRequestsIterator.remove();
         } else {
           // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
@@ -692,11 +695,13 @@ class GetBlobOperation extends GetOperation {
       if (progressTracker.isDone()) {
         if (progressTracker.hasSucceeded() && !retainChunkExceptionOnSuccess) {
           chunkException = null;
+        } else {
+          maybeDeriveChunkException();
         }
         chunkCompleted = true;
       }
       if (chunkCompleted) {
-        setOperationException(chunkException);
+        setOperationException(getChunkException());
         state = ChunkState.Complete;
       }
     }
@@ -755,16 +760,16 @@ class GetBlobOperation extends GetOperation {
         // the latency histogram in adaptive operation tracker should not be updated.
         logger.trace("GetBlobRequest with response correlationId {} timed out for replica {} ", correlationId,
             getRequestInfo.replicaId.getDataNodeId());
-        chunkException = new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut);
-        onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.OperationTimedOut);
+        onErrorResponse(getRequestInfo.replicaId,
+            new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut));
       } else {
         if (getResponse == null) {
           logger.trace(
               "GetBlobRequest with response correlationId {} received an unexpected error on response deserialization from replica {} ",
               correlationId, getRequestInfo.replicaId.getDataNodeId());
-          chunkException = new RouterException("Response deserialization received an unexpected error",
-              RouterErrorCode.UnexpectedInternalError);
-          onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.UnexpectedInternalError);
+          onErrorResponse(getRequestInfo.replicaId,
+              new RouterException("Response deserialization received an unexpected error",
+                  RouterErrorCode.UnexpectedInternalError));
         } else {
           if (getResponse.getCorrelationId() != correlationId) {
             // The NetworkClient associates a response with a request based on the fact that only one request is sent
@@ -774,11 +779,10 @@ class GetBlobOperation extends GetOperation {
             logger.trace("GetBlobRequest with response correlationId {} mismatch from response {} for replica {} ",
                 correlationId, getResponse.getCorrelationId(), getRequestInfo.replicaId.getDataNodeId());
             routerMetrics.unknownReplicaResponseError.inc();
-            chunkException = new RouterException(
+            onErrorResponse(getRequestInfo.replicaId, new RouterException(
                 "The correlation id in the GetResponse " + getResponse.getCorrelationId()
                     + " is not the same as the correlation id in the associated GetRequest: " + correlationId,
-                RouterErrorCode.UnexpectedInternalError);
-            onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.UnexpectedInternalError);
+                RouterErrorCode.UnexpectedInternalError));
             // we do not notify the ResponseHandler responsible for failure detection as this is an unexpected error.
           } else {
             try {
@@ -790,9 +794,9 @@ class GetBlobOperation extends GetOperation {
                   "GetBlobRequest with response correlationId {} response deserialization failed for replica {} ",
                   correlationId, getRequestInfo.replicaId.getDataNodeId());
               routerMetrics.responseDeserializationErrorCount.inc();
-              chunkException = new RouterException("Response deserialization received an unexpected error", e,
-                  RouterErrorCode.UnexpectedInternalError);
-              onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.UnexpectedInternalError);
+              onErrorResponse(getRequestInfo.replicaId,
+                  new RouterException("Response deserialization received an unexpected error", e,
+                      RouterErrorCode.UnexpectedInternalError));
             }
           }
         }
@@ -859,18 +863,18 @@ class GetBlobOperation extends GetOperation {
         int partitionsInResponse = getResponse.getPartitionResponseInfoList().size();
         // Each get request issued by the router is for a single blob.
         if (partitionsInResponse != 1) {
-          chunkException = new RouterException(
+          onErrorResponse(getRequestInfo.replicaId, new RouterException(
               "Unexpected number of partition responses, expected: 1, " + "received: " + partitionsInResponse,
-              RouterErrorCode.UnexpectedInternalError);
+              RouterErrorCode.UnexpectedInternalError));
         } else {
           getError = getResponse.getPartitionResponseInfoList().get(0).getErrorCode();
           if (getError == ServerErrorCode.No_Error) {
             PartitionResponseInfo partitionResponseInfo = getResponse.getPartitionResponseInfoList().get(0);
             int objectsInPartitionResponse = partitionResponseInfo.getMessageInfoList().size();
             if (objectsInPartitionResponse != 1) {
-              chunkException = new RouterException(
+              onErrorResponse(getRequestInfo.replicaId, new RouterException(
                   "Unexpected number of messages in a partition response, expected: 1, " + "received: "
-                      + objectsInPartitionResponse, RouterErrorCode.UnexpectedInternalError);
+                      + objectsInPartitionResponse, RouterErrorCode.UnexpectedInternalError));
             } else {
               MessageMetadata messageMetadata = partitionResponseInfo.getMessageMetadataList().get(0);
               MessageInfo messageInfo = partitionResponseInfo.getMessageInfoList().get(0);
@@ -887,31 +891,35 @@ class GetBlobOperation extends GetOperation {
             RouterErrorCode routerErrorCode = processServerError(getError);
             if (getError == ServerErrorCode.Blob_Deleted || getError == ServerErrorCode.Blob_Expired
                 || getError == ServerErrorCode.Blob_Authorization_Failure) {
+              setChunkException(new RouterException("Server returned: " + getError, routerErrorCode));
               // this is a successful response and one that completes the operation regardless of whether the
               // success target has been reached or not.
               chunkCompleted = true;
             }
             // any server error code that is not equal to ServerErrorCode.No_Error, the onErrorResponse should be invoked
             // because the operation itself doesn't succeed although the response in some cases is successful (i.e. Blob_Deleted)
-            onErrorResponse(getRequestInfo.replicaId, routerErrorCode);
+            onErrorResponse(getRequestInfo.replicaId,
+                new RouterException("Server returned: " + getError, routerErrorCode));
           }
         }
       } else {
         logger.trace("Replica {} returned an error {} for a GetBlobRequest with response correlationId : {} ",
             getRequestInfo.replicaId.getDataNodeId(), getError, getResponse.getCorrelationId());
         // process and set the most relevant exception.
-        onErrorResponse(getRequestInfo.replicaId, processServerError(getError));
+        onErrorResponse(getRequestInfo.replicaId,
+            new RouterException("Server returned: " + getError, processServerError(getError)));
       }
     }
 
     /**
      * Perform the necessary actions when a request to a replica fails.
      * @param replicaId the {@link ReplicaId} associated with the failed response.
-     * @param routerErrorCode the {@link RouterErrorCode} associated with the failed response.
+     * @param exception the {@link RouterException} associated with the failed response.
      */
-    void onErrorResponse(ReplicaId replicaId, RouterErrorCode routerErrorCode) {
+    void onErrorResponse(ReplicaId replicaId, RouterException exception) {
+      addChunkException(replicaId, exception);
       chunkOperationTracker.onResponse(replicaId,
-          routerErrorCode == RouterErrorCode.OperationTimedOut ? TrackedRequestFinalState.TIMED_OUT
+          exception.getErrorCode() == RouterErrorCode.OperationTimedOut ? TrackedRequestFinalState.TIMED_OUT
               : TrackedRequestFinalState.FAILURE);
       routerMetrics.routerRequestErrorCount.inc();
       routerMetrics.getDataNodeBasedMetrics(replicaId.getDataNodeId()).getRequestErrorCount.inc();
@@ -925,23 +933,61 @@ class GetBlobOperation extends GetOperation {
      * @return the {@link RouterErrorCode} mapped from input server error code.
      */
     RouterErrorCode processServerError(ServerErrorCode errorCode) {
-      RouterErrorCode resolvedRouterErrorCode = RouterErrorCode.UnexpectedInternalError;
-      setChunkException(new RouterException("Server returned: " + errorCode, resolvedRouterErrorCode));
-      return resolvedRouterErrorCode;
+      return RouterErrorCode.UnexpectedInternalError;
     }
 
     /**
      * Set the exception associated with this chunk operation.
-     * A {@link ServerErrorCode#Blob_Deleted} or {@link ServerErrorCode#Blob_Expired} error overrides any other
-     * previously received exception.
      * @param exception the {@link RouterException} to possibly set.
      */
     void setChunkException(RouterException exception) {
-      if (chunkException == null || exception.getErrorCode() == RouterErrorCode.BlobDeleted
-          || exception.getErrorCode() == RouterErrorCode.BlobExpired
-          || exception.getErrorCode() == RouterErrorCode.BlobAuthorizationFailure
-          || exception.getErrorCode() == RouterErrorCode.RangeNotSatisfiable) {
-        chunkException = exception;
+      chunkException = exception;
+    }
+
+    /**
+     * add the exception associated with this chunk operation.
+     * @param replicaId the {@link ReplicaId} associated with this exception.
+     * @param exception the {@link RouterException} to possibly set.
+     */
+    void addChunkException(ReplicaId replicaId, RouterException exception) {
+      if (this.chunkExceptionForReplica == null) {
+        this.chunkExceptionForReplica = new HashMap<>();
+      }
+      this.chunkExceptionForReplica.put(replicaId, exception);
+    }
+
+    private void maybeDeriveChunkException() {
+      if (chunkException != null || chunkExceptionForReplica.size() == 0) {
+        return;
+      }
+      // Iterate through the map to get the majority of the exception based on the error code.
+      RouterException majority = null;
+      int counter = 0;
+      for (RouterException e : chunkExceptionForReplica.values()) {
+        if (counter == 0) {
+          majority = e;
+          counter = 1;
+        } else if (majority.getErrorCode() == e.getErrorCode()) {
+          counter++;
+        } else {
+          counter--;
+        }
+      }
+      counter = 0;
+      for (RouterException e : chunkExceptionForReplica.values()) {
+        if (majority.getErrorCode() == e.getErrorCode()) {
+          counter++;
+        }
+      }
+      chunkException = counter > chunkExceptionForReplica.size()/2 ? majority : null;
+      // if there is no majority, then rely on precedence level.
+      if (chunkException == null) {
+        for (RouterException e : chunkExceptionForReplica.values()) {
+          if (chunkException == null
+              || getPrecedenceLevel(chunkException.getErrorCode()) > getPrecedenceLevel(e.getErrorCode())) {
+            chunkException = e;
+          }
+        }
       }
     }
 
@@ -1198,7 +1244,6 @@ class GetBlobOperation extends GetOperation {
         default:
           resolvedRouterErrorCode = RouterErrorCode.UnexpectedInternalError;
       }
-      setChunkException(new RouterException("Server returned: " + errorCode, resolvedRouterErrorCode));
       return resolvedRouterErrorCode;
     }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -184,7 +184,7 @@ abstract class GetOperation {
    * @param routerErrorCode The {@link RouterErrorCode} for which to get its precedence level.
    * @return The precedence level of the {@link RouterErrorCode}.
    */
-  private int getPrecedenceLevel(RouterErrorCode routerErrorCode) {
+  protected int getPrecedenceLevel(RouterErrorCode routerErrorCode) {
     switch (routerErrorCode) {
       case BlobAuthorizationFailure:
         return 1;

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -491,7 +491,7 @@ public class GetBlobOperationTest {
    * @throws Exception
    */
   @Test
-  public void testRequestTimeoutAndBlobNotFound() throws Exception {
+  public void testRequestTimeoutAndBlobNotFoundMajorityNotFound() throws Exception {
     assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
     doPut();
     GetBlobOperation op = createOperation(null);
@@ -517,7 +517,7 @@ public class GetBlobOperationTest {
 
     RouterException routerException = (RouterException) op.getOperationException();
     // error code should be OperationTimedOut because it precedes BlobDoesNotExist
-    Assert.assertEquals(RouterErrorCode.OperationTimedOut, routerException.getErrorCode());
+    Assert.assertEquals(RouterErrorCode.BlobDoesNotExist, routerException.getErrorCode());
     Histogram localColoTracker =
         tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, true, localDcName));
     Histogram crossColoTracker =
@@ -528,6 +528,43 @@ public class GetBlobOperationTest {
     // the count of data points in cross colo Histogram should be 6 because all remote replicas respond with proper error code
     Assert.assertEquals("The number of data points in cross colo latency histogram is not expected", 6,
         crossColoTracker.getCount());
+  }
+
+  /**
+   * Test the case where 2 local replicas respond with Blob_Not_Found. The remaining one local replica and rest remote
+   * replicas time out due to network error.
+   * @throws Exception
+   */
+  @Test
+  public void testRequestTimeoutAndBlobNotFoundMajorityTimeout() throws Exception {
+    assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
+    doPut();
+    GetBlobOperation op = createOperation(null);
+    AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getFirstChunkOperationTrackerInUse();
+    correlationIdToGetOperation.clear();
+    for (MockServer server : mockServerLayout.getMockServers()) {
+      server.setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    }
+
+    int blobNotFoundCounter = 0;
+    while (!op.isOperationComplete()) {
+      op.poll(requestRegistrationCallback);
+      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.requestListToFill);
+      for (ResponseInfo responseInfo : responses) {
+        GetResponse getResponse = null;
+        if (blobNotFoundCounter < 2) {
+          getResponse = responseInfo.getError() == null ? GetResponse.readFrom(new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap) : null;
+          blobNotFoundCounter ++;
+        } else {
+          responseInfo = new ResponseInfo(responseInfo.getRequestInfo(), NetworkClientErrorCode.NetworkError, null);
+        }
+        op.handleResponse(responseInfo, getResponse);
+      }
+    }
+
+    RouterException routerException = (RouterException) op.getOperationException();
+    // error code should be OperationTimedOut because it precedes BlobDoesNotExist
+    Assert.assertEquals(RouterErrorCode.OperationTimedOut, routerException.getErrorCode());
   }
 
   /**


### PR DESCRIPTION
Aggregate router exceptions at GetChunk operation based on the count of each exception. The majority will be returned. If there is no majority, then fall back to use precedence level function.

Next step, do the same thing for GetBlobIdOperation.