### PR TITLE
Improve OperationTracker to terminate when there are two NOT_FOUND from originating DC

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -303,9 +303,9 @@ public class RouterConfig {
    * NOT_FOUND responses returned from originating dc. Notice that some of the blob ids don't have the datacenter id, it
    * will have no effect on those blobs.
    */
-  @Config("router.operation.tracker.originating.dc.notfound.enabled")
+  @Config("router.operation.tracker.terminate.on.not.found.enabled")
   @Default("false")
-  public final boolean routerOperationTrackerOriginatingDcNotFoundEnabled;
+  public final boolean routerOperationTrackerTerminateOnNotFoundEnabled;
 
   /**
    * The maximum number of inflight requests that allowed for adaptive tracker. If current number of inflight requests
@@ -427,7 +427,7 @@ public class RouterConfig {
       throw new IllegalArgumentException(
           "Operation tracker parallelism is larger than operation tracker max inflight number");
     }
-    routerOperationTrackerOriginatingDcNotFoundEnabled =
-        verifiableProperties.getBoolean("router.operation.tracker.originating.dc.notfound.enabled", false);
+    routerOperationTrackerTerminateOnNotFoundEnabled =
+        verifiableProperties.getBoolean("router.operation.tracker.terminate.on.not.found.enabled", false);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -303,8 +303,8 @@ public class RouterConfig {
    * NOT_FOUND responses returned from originating dc. Notice that some of the blob ids don't have the datacenter id, it
    * will have no effect on those blobs.
    */
-  @Config("router.operation.tracker.originatingdc.notfound.enabled")
-  @Default("true")
+  @Config("router.operation.tracker.originating.dc.notfound.enabled")
+  @Default("false")
   public final boolean routerOperationTrackerOriginatingDcNotFoundEnabled;
 
   /**
@@ -428,6 +428,6 @@ public class RouterConfig {
           "Operation tracker parallelism is larger than operation tracker max inflight number");
     }
     routerOperationTrackerOriginatingDcNotFoundEnabled =
-        verifiableProperties.getBoolean("router.operation.tracker.originatingdc.notfound.enabled", true);
+        verifiableProperties.getBoolean("router.operation.tracker.originating.dc.notfound.enabled", false);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -298,6 +298,11 @@ public class RouterConfig {
   @Default("1000")
   public final long routerOperationTrackerMinDataPointsRequired;
 
+  /**
+   * If this config is set to {@code true} the operation tracker would terminate operations when there are more than 2
+   * NOT_FOUND responses returned from originating dc. Notice that some of the blob ids don't have the datacenter id, it
+   * will have no effect on those blobs.
+   */
   @Config("router.operation.tracker.originatingdc.notfound.enabled")
   @Default("true")
   public final boolean routerOperationTrackerOriginatingDcNotFoundEnabled;

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -298,6 +298,10 @@ public class RouterConfig {
   @Default("1000")
   public final long routerOperationTrackerMinDataPointsRequired;
 
+  @Config("router.operation.tracker.originatingdc.notfound.enabled")
+  @Default("true")
+  public final boolean routerOperationTrackerOriginatingDcNotFoundEnabled;
+
   /**
    * The maximum number of inflight requests that allowed for adaptive tracker. If current number of inflight requests
    * is larger than or equal to this threshold, tracker shouldn't send out any request even though the oldest is past due.
@@ -418,5 +422,7 @@ public class RouterConfig {
       throw new IllegalArgumentException(
           "Operation tracker parallelism is larger than operation tracker max inflight number");
     }
+    routerOperationTrackerOriginatingDcNotFoundEnabled =
+        verifiableProperties.getBoolean("router.operation.tracker.originatingdc.notfound.enabled", true);
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -287,8 +287,7 @@ class DeleteOperation {
    * @param replicaId the {@link ReplicaId} associated with the failed response.
    * @param exception the {@link RouterException} associated with the failed response.
    */
-  void onErrorResponse(ReplicaId replicaId, RouterException exception) {
-    logger.info("Get exception: " + exception);
+  private void onErrorResponse(ReplicaId replicaId, RouterException exception) {
     operationTracker.onResponse(replicaId,
         TrackedRequestFinalState.fromRouterErrorCodeToFinalState(exception.getErrorCode()));
     setOperationException(exception);
@@ -308,7 +307,7 @@ class DeleteOperation {
       if (operationTracker.hasSucceeded()) {
         operationException.set(null);
       } else if (operationTracker.hasFailedOnNotFound()) {
-        operationException.set(new RouterException("", RouterErrorCode.BlobDoesNotExist));
+        operationException.set(new RouterException("Operation failed on BlobNotFound", RouterErrorCode.BlobDoesNotExist));
       }
       operationCompleted = true;
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -65,8 +65,6 @@ class DeleteOperation {
   // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable
   // failure.
   private final AtomicReference<Exception> operationException = new AtomicReference<Exception>();
-  // RouterErrorCode that is resolved from all the received ServerErrorCode for this operation.
-  private RouterErrorCode resolvedRouterErrorCode;
   // Denotes whether the operation is complete.
   private boolean operationCompleted = false;
 
@@ -177,13 +175,14 @@ class DeleteOperation {
     if (responseInfo.getError() != null) {
       logger.trace("DeleteRequest with response correlationId {} timed out for replica {} ",
           deleteRequest.getCorrelationId(), replica.getDataNodeId());
-      updateOperationState(replica, RouterErrorCode.OperationTimedOut);
+      onErrorResponse(replica, new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut));
     } else {
       if (deleteResponse == null) {
         logger.trace(
             "DeleteRequest with response correlationId {} received UnexpectedInternalError on response deserialization for replica {} ",
             deleteRequest.getCorrelationId(), replica.getDataNodeId());
-        updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
+        onErrorResponse(replica, new RouterException("Response deserialization received an unexpected error",
+            RouterErrorCode.UnexpectedInternalError));
       } else {
         // The true case below should not really happen. This means a response has been received
         // not for its original request. We will immediately fail this operation.
@@ -192,15 +191,30 @@ class DeleteOperation {
               + " is not the same as the correlation id in the associated DeleteRequest: "
               + deleteRequest.getCorrelationId());
           routerMetrics.unknownReplicaResponseError.inc();
-          setOperationException(
+          onErrorResponse(replica,
               new RouterException("Received wrong response that is not for the corresponding request.",
                   RouterErrorCode.UnexpectedInternalError));
-          updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
         } else {
-          // The status of operation tracker will be updated within the processServerError method.
-          processServerError(replica, deleteResponse.getError(), deleteResponse.getCorrelationId());
-          if (deleteResponse.getError() == ServerErrorCode.Blob_Authorization_Failure) {
-            operationCompleted = true;
+          ServerErrorCode getError = deleteResponse.getError();
+          if (getError == ServerErrorCode.No_Error || getError == ServerErrorCode.Blob_Deleted) {
+            operationTracker.onResponse(replica, TrackedRequestFinalState.SUCCESS);
+            if (RouterUtils.isRemoteReplica(routerConfig, replica)) {
+              logger.trace("Cross colo request successful for remote replica {} in {} ", replica.getDataNodeId(),
+                  replica.getDataNodeId().getDatacenterName());
+              routerMetrics.crossColoSuccessCount.inc();
+            }
+          } else {
+            logger.trace("Replica {} returned an error {} for a delete request with response correlationId : {} ",
+                replica.getDataNodeId(), getError, deleteRequest.getCorrelationId());
+            RouterErrorCode routerErrorCode = processServerError(getError);
+            if (getError == ServerErrorCode.Blob_Authorization_Failure) {
+              // this is a successful response and one that completes the operation regardless of whether the
+              // success target has been reached or not.
+              operationCompleted = true;
+            }
+            // any server error code that is not equal to ServerErrorCode.No_Error, the onErrorResponse should be invoked
+            // because the operation itself doesn't succeed although the response in some cases is successful (i.e. Blob_Deleted)
+            onErrorResponse(replica, new RouterException("Server returned: " + getError, routerErrorCode));
           }
         }
       }
@@ -237,80 +251,52 @@ class DeleteOperation {
         // Do not notify this as a failure to the response handler, as this timeout could simply be due to
         // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
         // response and the response handler will be notified accordingly.
-        updateOperationState(deleteRequestInfo.replica, RouterErrorCode.OperationTimedOut);
+        onErrorResponse(deleteRequestInfo.replica,
+            new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut));
+      } else {
+        // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
+        break;
       }
     }
   }
 
   /**
    * Processes {@link ServerErrorCode} received from {@code replica}. This method maps a {@link ServerErrorCode}
-   * to a {@link RouterErrorCode}, and then makes corresponding state update.
-   * @param replica The replica for which the ServerErrorCode was generated.
+   * to a {@link RouterErrorCode}.
    * @param serverErrorCode The ServerErrorCode received from the replica.
-   * @param correlationId the correlationId of the request
+   * @return the {@link RouterErrorCode} mapped from server error code.
    */
-  private void processServerError(ReplicaId replica, ServerErrorCode serverErrorCode, int correlationId) {
+  private RouterErrorCode processServerError(ServerErrorCode serverErrorCode) {
     switch (serverErrorCode) {
-      case No_Error:
-      case Blob_Deleted:
-        operationTracker.onResponse(replica, TrackedRequestFinalState.SUCCESS);
-        if (RouterUtils.isRemoteReplica(routerConfig, replica)) {
-          logger.trace("Cross colo request successful for remote replica {} in {} ", replica.getDataNodeId(),
-              replica.getDataNodeId().getDatacenterName());
-          routerMetrics.crossColoSuccessCount.inc();
-        }
-        break;
       case Blob_Authorization_Failure:
-        updateOperationState(replica, RouterErrorCode.BlobAuthorizationFailure);
-        break;
+        return RouterErrorCode.BlobAuthorizationFailure;
       case Blob_Expired:
-        updateOperationState(replica, RouterErrorCode.BlobExpired);
-        break;
+        return RouterErrorCode.BlobExpired;
       case Blob_Not_Found:
-        updateOperationState(replica, RouterErrorCode.BlobDoesNotExist);
-        break;
-      case Partition_Unknown:
-        updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
-        break;
+        return RouterErrorCode.BlobDoesNotExist;
       case Disk_Unavailable:
       case Replica_Unavailable:
-        updateOperationState(replica, RouterErrorCode.AmbryUnavailable);
-        break;
+        return RouterErrorCode.AmbryUnavailable;
       default:
-        updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
-        break;
-    }
-    if (serverErrorCode != ServerErrorCode.No_Error) {
-      logger.trace("Replica {} returned an error {} for a delete request with response correlationId : {} ",
-          replica.getDataNodeId(), serverErrorCode, correlationId);
+        return RouterErrorCode.UnexpectedInternalError;
     }
   }
 
   /**
-   * Updates the state of the {@code DeleteOperation}. This includes two parts: 1) resolves the
-   * {@link RouterErrorCode} depending on the precedence level of the new router error code from
-   * {@code replica} and the current {@code resolvedRouterErrorCode}. An error code with a smaller
-   * precedence level overrides an error code with a larger precedence level. 2) updates the
-   * {@code DeleteOperation} based on the {@link RouterErrorCode}, and the source {@link ReplicaId}
-   * for which the {@link RouterErrorCode} is generated.
-   * @param replica The replica for which the RouterErrorCode was generated.
-   * @param error {@link RouterErrorCode} that indicates the error for the replica.
+   * Perform the necessary actions when a request to a replica fails.
+   * @param replicaId the {@link ReplicaId} associated with the failed response.
+   * @param exception the {@link RouterException} associated with the failed response.
    */
-  private void updateOperationState(ReplicaId replica, RouterErrorCode error) {
-    if (resolvedRouterErrorCode == null) {
-      resolvedRouterErrorCode = error;
-    } else {
-      if (getPrecedenceLevel(error) < getPrecedenceLevel(resolvedRouterErrorCode)) {
-        resolvedRouterErrorCode = error;
-      }
-    }
-    operationTracker.onResponse(replica,
-        resolvedRouterErrorCode == RouterErrorCode.OperationTimedOut ? TrackedRequestFinalState.TIMED_OUT
-            : TrackedRequestFinalState.FAILURE);
-    if (error != RouterErrorCode.BlobDeleted && error != RouterErrorCode.BlobExpired) {
+  void onErrorResponse(ReplicaId replicaId, RouterException exception) {
+    logger.info("Get exception: " + exception);
+    operationTracker.onResponse(replicaId,
+        TrackedRequestFinalState.fromRouterErrorCodeToFinalState(exception.getErrorCode()));
+    setOperationException(exception);
+    if (exception.getErrorCode() != RouterErrorCode.BlobDeleted
+        && exception.getErrorCode() != RouterErrorCode.BlobExpired) {
       routerMetrics.routerRequestErrorCount.inc();
     }
-    routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId()).deleteRequestErrorCount.inc();
+    routerMetrics.getDataNodeBasedMetrics(replicaId.getDataNodeId()).deleteRequestErrorCount.inc();
   }
 
   /**
@@ -319,11 +305,28 @@ class DeleteOperation {
   private void checkAndMaybeComplete() {
     // operationCompleted is true if Blob_Authorization_Failure was received.
     if (operationTracker.isDone() || operationCompleted) {
-      if (!operationTracker.hasSucceeded()) {
-        setOperationException(
-            new RouterException("The DeleteOperation could not be completed.", resolvedRouterErrorCode));
+      if (operationTracker.hasSucceeded()) {
+        operationException.set(null);
+      } else if (operationTracker.hasFailedOnNotFound()) {
+        operationException.set(new RouterException("", RouterErrorCode.BlobDoesNotExist));
       }
       operationCompleted = true;
+    }
+  }
+
+  /**
+   * Set the exception associated with this operation.
+   * First, if current operationException is null, directly set operationException as exception;
+   * Second, if operationException exists, compare ErrorCodes of exception and existing operation Exception depending
+   * on precedence level. An ErrorCode with a smaller precedence level overrides an ErrorCode with a larger precedence
+   * level. Update the operationException if necessary.
+   * @param exception the {@link RouterException} to possibly set.
+   */
+  void setOperationException(Exception exception) {
+    if (exception instanceof RouterException) {
+      RouterUtils.replaceOperationException(operationException, (RouterException) exception, this::getPrecedenceLevel);
+    } else {
+      operationException.compareAndSet(null, exception);
     }
   }
 
@@ -408,14 +411,6 @@ class DeleteOperation {
    */
   Void getOperationResult() {
     return operationResult;
-  }
-
-  /**
-   * Sets the exception associated with this operation. When this is called, the operation has failed.
-   * @param exception the irrecoverable exception associated with this operation.
-   */
-  void setOperationException(Exception exception) {
-    operationException.set(exception);
   }
 
   long getSubmissionTimeMs() {

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -318,7 +318,7 @@ class DeleteOperation {
    * @param exception the {@link RouterException} to possibly set.
    */
   void setOperationException(RouterException exception) {
-    RouterUtils.replaceOperationException(operationException, (RouterException) exception, this::getPrecedenceLevel);
+    RouterUtils.replaceOperationException(operationException, exception, this::getPrecedenceLevel);
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -206,7 +206,7 @@ class DeleteOperation {
             }
           } else {
             logger.trace("Replica {} returned an error {} for a delete request with response correlationId : {} ",
-                replica.getDataNodeId(), getError, deleteRequest.getCorrelationId());
+                replica, getError, deleteRequest.getCorrelationId());
             RouterErrorCode routerErrorCode = processServerError(getError);
             if (getError == ServerErrorCode.Blob_Authorization_Failure) {
               // this is a successful response and one that completes the operation regardless of whether the

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -312,18 +312,13 @@ class DeleteOperation {
 
   /**
    * Set the exception associated with this operation.
-   * First, if current operationException is null, directly set operationException as exception;
-   * Second, if operationException exists, compare ErrorCodes of exception and existing operation Exception depending
+   * If operationException exists, compare ErrorCodes of exception and existing operation Exception depending
    * on precedence level. An ErrorCode with a smaller precedence level overrides an ErrorCode with a larger precedence
    * level. Update the operationException if necessary.
    * @param exception the {@link RouterException} to possibly set.
    */
-  void setOperationException(Exception exception) {
-    if (exception instanceof RouterException) {
-      RouterUtils.replaceOperationException(operationException, (RouterException) exception, this::getPrecedenceLevel);
-    } else {
-      operationException.compareAndSet(null, exception);
-    }
+  void setOperationException(RouterException exception) {
+    RouterUtils.replaceOperationException(operationException, (RouterException) exception, this::getPrecedenceLevel);
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -205,14 +205,16 @@ class GetBlobInfoOperation extends GetOperation {
     if (responseInfo.getError() != null) {
       logger.trace("GetBlobInfoRequest with response correlationId {} timed out for replica {} ", correlationId,
           getRequestInfo.replicaId.getDataNodeId());
-      onErrorResponse(getRequestInfo.replicaId, new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut));
+      onErrorResponse(getRequestInfo.replicaId,
+          new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut));
     } else {
       if (getResponse == null) {
         logger.trace(
             "GetBlobInfoRequest with response correlationId {} received an unexpected error on response deserialization from replica {} ",
             correlationId, getRequestInfo.replicaId.getDataNodeId());
-        onErrorResponse(getRequestInfo.replicaId, new RouterException("Response deserialization received an unexpected error",
-            RouterErrorCode.UnexpectedInternalError));
+        onErrorResponse(getRequestInfo.replicaId,
+            new RouterException("Response deserialization received an unexpected error",
+                RouterErrorCode.UnexpectedInternalError));
       } else {
         if (getResponse.getCorrelationId() != correlationId) {
           // The NetworkClient associates a response with a request based on the fact that only one request is sent
@@ -237,8 +239,9 @@ class GetBlobInfoOperation extends GetOperation {
                 "GetBlobInfoRequest with response correlationId {} response deserialization failed for replica {} ",
                 correlationId, getRequestInfo.replicaId.getDataNodeId());
             routerMetrics.responseDeserializationErrorCount.inc();
-            onErrorResponse(getRequestInfo.replicaId, new RouterException("Response deserialization received an unexpected error", e,
-                RouterErrorCode.UnexpectedInternalError));
+            onErrorResponse(getRequestInfo.replicaId,
+                new RouterException("Response deserialization received an unexpected error", e,
+                    RouterErrorCode.UnexpectedInternalError));
           }
         }
       }
@@ -304,7 +307,7 @@ class GetBlobInfoOperation extends GetOperation {
     } else {
       logger.trace("Replica {} returned an error {} for a GetBlobInfoRequest with response correlationId : {} ",
           getRequestInfo.replicaId.getDataNodeId(), getError, getResponse.getCorrelationId());
-      onErrorResponse(getRequestInfo.replicaId, new RouterException("", processServerError(getError)));
+      onErrorResponse(getRequestInfo.replicaId, new RouterException("Server returned", processServerError(getError)));
     }
   }
 
@@ -314,7 +317,6 @@ class GetBlobInfoOperation extends GetOperation {
    * @param exception the {@link RouterException} associated with the failed response.
    */
   private void onErrorResponse(ReplicaId replicaId, RouterException exception) {
-    logger.info("DC: " + replicaId.getDataNodeId().getDatacenterName() + " exception: " + exception);
     operationTracker.onResponse(replicaId,
         TrackedRequestFinalState.fromRouterErrorCodeToFinalState(exception.getErrorCode()));
     setOperationException(exception);
@@ -417,7 +419,8 @@ class GetBlobInfoOperation extends GetOperation {
       if (progressTracker.hasSucceeded()) {
         operationException.set(null);
       } else if (operationTracker.hasFailedOnNotFound()) {
-        operationException.set(new RouterException("", RouterErrorCode.BlobDoesNotExist));
+        operationException.set(new RouterException("GetBlobInfoOperation failed because of BlobNotFound",
+            RouterErrorCode.BlobDoesNotExist));
       }
       operationCompleted = true;
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -313,7 +313,7 @@ class GetBlobInfoOperation extends GetOperation {
    * @param replicaId the {@link ReplicaId} associated with the failed response.
    * @param exception the {@link RouterException} associated with the failed response.
    */
-  void onErrorResponse(ReplicaId replicaId, RouterException exception) {
+  private void onErrorResponse(ReplicaId replicaId, RouterException exception) {
     logger.info("DC: " + replicaId.getDataNodeId().getDatacenterName() + " exception: " + exception);
     operationTracker.onResponse(replicaId,
         TrackedRequestFinalState.fromRouterErrorCodeToFinalState(exception.getErrorCode()));

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -135,13 +135,12 @@ class GetBlobInfoOperation extends GetOperation {
     while (inFlightRequestsIterator.hasNext()) {
       Map.Entry<Integer, GetRequestInfo> entry = inFlightRequestsIterator.next();
       if (time.milliseconds() - entry.getValue().startTimeMs > routerConfig.routerRequestTimeoutMs) {
-        onErrorResponse(entry.getValue().replicaId, RouterErrorCode.OperationTimedOut);
         logger.trace("GetBlobInfoRequest with correlationId {} in flight has expired for replica {} ", entry.getKey(),
             entry.getValue().replicaId.getDataNodeId());
         // Do not notify this as a failure to the response handler, as this timeout could simply be due to
         // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
         // response and the response handler will be notified accordingly.
-        setOperationException(
+        onErrorResponse(entry.getValue().replicaId,
             new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut));
         inFlightRequestsIterator.remove();
       } else {
@@ -206,16 +205,14 @@ class GetBlobInfoOperation extends GetOperation {
     if (responseInfo.getError() != null) {
       logger.trace("GetBlobInfoRequest with response correlationId {} timed out for replica {} ", correlationId,
           getRequestInfo.replicaId.getDataNodeId());
-      setOperationException(new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut));
-      onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.OperationTimedOut);
+      onErrorResponse(getRequestInfo.replicaId, new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut));
     } else {
       if (getResponse == null) {
         logger.trace(
             "GetBlobInfoRequest with response correlationId {} received an unexpected error on response deserialization from replica {} ",
             correlationId, getRequestInfo.replicaId.getDataNodeId());
-        setOperationException(new RouterException("Response deserialization received an unexpected error",
+        onErrorResponse(getRequestInfo.replicaId, new RouterException("Response deserialization received an unexpected error",
             RouterErrorCode.UnexpectedInternalError));
-        onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.UnexpectedInternalError);
       } else {
         if (getResponse.getCorrelationId() != correlationId) {
           // The NetworkClient associates a response with a request based on the fact that only one request is sent
@@ -225,11 +222,10 @@ class GetBlobInfoOperation extends GetOperation {
           routerMetrics.unknownReplicaResponseError.inc();
           logger.trace("GetBlobInfoRequest with response correlationId {} mismatch from response {} for replica {} ",
               correlationId, getResponse.getCorrelationId(), getRequestInfo.replicaId.getDataNodeId());
-          setOperationException(new RouterException(
+          onErrorResponse(getRequestInfo.replicaId, new RouterException(
               "The correlation id in the GetResponse " + getResponse.getCorrelationId()
                   + "is not the same as the correlation id in the associated GetRequest: " + correlationId,
               RouterErrorCode.UnexpectedInternalError));
-          onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.UnexpectedInternalError);
           // we do not notify the ResponseHandler responsible for failure detection as this is an unexpected error.
         } else {
           try {
@@ -241,9 +237,8 @@ class GetBlobInfoOperation extends GetOperation {
                 "GetBlobInfoRequest with response correlationId {} response deserialization failed for replica {} ",
                 correlationId, getRequestInfo.replicaId.getDataNodeId());
             routerMetrics.responseDeserializationErrorCount.inc();
-            setOperationException(new RouterException("Response deserialization received an unexpected error", e,
+            onErrorResponse(getRequestInfo.replicaId, new RouterException("Response deserialization received an unexpected error", e,
                 RouterErrorCode.UnexpectedInternalError));
-            onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.UnexpectedInternalError);
           }
         }
       }
@@ -265,10 +260,9 @@ class GetBlobInfoOperation extends GetOperation {
       int partitionsInResponse = getResponse.getPartitionResponseInfoList().size();
       // Each get request issued by the router is for a single blob.
       if (partitionsInResponse != 1) {
-        setOperationException(new RouterException(
+        onErrorResponse(getRequestInfo.replicaId, new RouterException(
             "Unexpected number of partition responses, expected: 1, " + "received: " + partitionsInResponse,
             RouterErrorCode.UnexpectedInternalError));
-        onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.UnexpectedInternalError);
         // Again, no need to notify the responseHandler.
       } else {
         getError = getResponse.getPartitionResponseInfoList().get(0).getErrorCode();
@@ -276,10 +270,9 @@ class GetBlobInfoOperation extends GetOperation {
           PartitionResponseInfo partitionResponseInfo = getResponse.getPartitionResponseInfoList().get(0);
           int msgsInResponse = partitionResponseInfo.getMessageInfoList().size();
           if (msgsInResponse != 1) {
-            setOperationException(new RouterException(
+            onErrorResponse(getRequestInfo.replicaId, new RouterException(
                 "Unexpected number of messages in a partition response, expected: 1, " + "received: " + msgsInResponse,
                 RouterErrorCode.UnexpectedInternalError));
-            onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.UnexpectedInternalError);
           } else {
             MessageMetadata messageMetadata = partitionResponseInfo.getMessageMetadataList().get(0);
             MessageInfo messageInfo = partitionResponseInfo.getMessageInfoList().get(0);
@@ -304,25 +297,27 @@ class GetBlobInfoOperation extends GetOperation {
           }
           // any server error code that is not equal to ServerErrorCode.No_Error, the onErrorResponse should be invoked
           // because the operation itself doesn't succeed although the response in some cases is successful (i.e. Blob_Deleted)
-          onErrorResponse(getRequestInfo.replicaId, routerErrorCode);
+          onErrorResponse(getRequestInfo.replicaId,
+              new RouterException("Server returned: " + getError, routerErrorCode));
         }
       }
     } else {
       logger.trace("Replica {} returned an error {} for a GetBlobInfoRequest with response correlationId : {} ",
           getRequestInfo.replicaId.getDataNodeId(), getError, getResponse.getCorrelationId());
-      onErrorResponse(getRequestInfo.replicaId, processServerError(getError));
+      onErrorResponse(getRequestInfo.replicaId, new RouterException("", processServerError(getError)));
     }
   }
 
   /**
    * Perform the necessary actions when a request to a replica fails.
    * @param replicaId the {@link ReplicaId} associated with the failed response.
-   * @param routerErrorCode the {@link RouterErrorCode} associated with the failed response.
+   * @param exception the {@link RouterException} associated with the failed response.
    */
-  void onErrorResponse(ReplicaId replicaId, RouterErrorCode routerErrorCode) {
+  void onErrorResponse(ReplicaId replicaId, RouterException exception) {
+    logger.info("DC: " + replicaId.getDataNodeId().getDatacenterName() + " exception: " + exception);
     operationTracker.onResponse(replicaId,
-        routerErrorCode == RouterErrorCode.OperationTimedOut ? TrackedRequestFinalState.TIMED_OUT
-            : TrackedRequestFinalState.FAILURE);
+        TrackedRequestFinalState.fromRouterErrorCodeToFinalState(exception.getErrorCode()));
+    setOperationException(exception);
     routerMetrics.routerRequestErrorCount.inc();
     routerMetrics.getDataNodeBasedMetrics(replicaId.getDataNodeId()).getBlobInfoRequestErrorCount.inc();
   }
@@ -411,7 +406,6 @@ class GetBlobInfoOperation extends GetOperation {
       default:
         resolvedRouterErrorCode = RouterErrorCode.UnexpectedInternalError;
     }
-    setOperationException(new RouterException("Server returned: " + errorCode, resolvedRouterErrorCode));
     return resolvedRouterErrorCode;
   }
 
@@ -422,6 +416,8 @@ class GetBlobInfoOperation extends GetOperation {
     if (progressTracker.isDone()) {
       if (progressTracker.hasSucceeded()) {
         operationException.set(null);
+      } else if (operationTracker.hasFailedOnNotFound()) {
+        operationException.set(new RouterException("", RouterErrorCode.BlobDoesNotExist));
       }
       operationCompleted = true;
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -68,8 +68,7 @@ import org.slf4j.LoggerFactory;
  * determined after the first chunk is fetched, based on whether the first chunk turns out to be a metadata chunk or
  * a data chunk.
  *
- * As soon as the first data chunk is fetched (which could be the first chunk in the case of simple blobs and the
- * second chunk fetched in the case of composite blobs), the operation callback is invoked (and the future is marked
+ * As soon as the first data chunk is fetched, the operation callback is invoked (and the future is marked
  * as done) so that the caller can start reading in data. The rest of the chunks are asynchronously fetched and
  * buffered up to the maximum that can be buffered. When fetched chunks are consumed by the caller, subsequent chunks
  * become eligible to be fetched.

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -699,7 +699,8 @@ class GetBlobOperation extends GetOperation {
         if (progressTracker.hasSucceeded() && !retainChunkExceptionOnSuccess) {
           chunkException = null;
         } else if (chunkOperationTracker.hasFailedOnNotFound()) {
-          chunkException = new RouterException("", RouterErrorCode.BlobDoesNotExist);
+          chunkException =
+              new RouterException("Get Chunk failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist);
         }
         chunkCompleted = true;
       }
@@ -803,7 +804,8 @@ class GetBlobOperation extends GetOperation {
             }
           }
         }
-      } checkAndMaybeComplete();
+      }
+      checkAndMaybeComplete();
     }
 
     /**
@@ -908,7 +910,7 @@ class GetBlobOperation extends GetOperation {
         logger.trace("Replica {} returned an error {} for a GetBlobRequest with response correlationId : {} ",
             getRequestInfo.replicaId.getDataNodeId(), getError, getResponse.getCorrelationId());
         // process and set the most relevant exception.
-        onErrorResponse(getRequestInfo.replicaId, new RouterException("", processServerError(getError)));
+        onErrorResponse(getRequestInfo.replicaId, new RouterException("Server returned", processServerError(getError)));
       }
     }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -647,13 +647,13 @@ class GetBlobOperation extends GetOperation {
       while (inFlightRequestsIterator.hasNext()) {
         Map.Entry<Integer, GetRequestInfo> entry = inFlightRequestsIterator.next();
         if (time.milliseconds() - entry.getValue().startTimeMs > routerConfig.routerRequestTimeoutMs) {
-          onErrorResponse(entry.getValue().replicaId, RouterErrorCode.OperationTimedOut);
           logger.trace("GetBlobRequest with correlationId {} in flight has expired for replica {} ", entry.getKey(),
               entry.getValue().replicaId.getDataNodeId());
           // Do not notify this as a failure to the response handler, as this timeout could simply be due to
           // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
           // response and the response handler will be notified accordingly.
-          chunkException = new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut);
+          onErrorResponse(entry.getValue().replicaId,
+              new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut));
           inFlightRequestsIterator.remove();
         } else {
           // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
@@ -698,6 +698,8 @@ class GetBlobOperation extends GetOperation {
       if (progressTracker.isDone()) {
         if (progressTracker.hasSucceeded() && !retainChunkExceptionOnSuccess) {
           chunkException = null;
+        } else if (chunkOperationTracker.hasFailedOnNotFound()) {
+          chunkException = new RouterException("", RouterErrorCode.BlobDoesNotExist);
         }
         chunkCompleted = true;
       }
@@ -761,16 +763,16 @@ class GetBlobOperation extends GetOperation {
         // the latency histogram in adaptive operation tracker should not be updated.
         logger.trace("GetBlobRequest with response correlationId {} timed out for replica {} ", correlationId,
             getRequestInfo.replicaId.getDataNodeId());
-        chunkException = new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut);
-        onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.OperationTimedOut);
+        onErrorResponse(getRequestInfo.replicaId,
+            new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut));
       } else {
         if (getResponse == null) {
           logger.trace(
               "GetBlobRequest with response correlationId {} received an unexpected error on response deserialization from replica {} ",
               correlationId, getRequestInfo.replicaId.getDataNodeId());
-          chunkException = new RouterException("Response deserialization received an unexpected error",
-              RouterErrorCode.UnexpectedInternalError);
-          onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.UnexpectedInternalError);
+          onErrorResponse(getRequestInfo.replicaId,
+              new RouterException("Response deserialization received an unexpected error",
+                  RouterErrorCode.UnexpectedInternalError));
         } else {
           if (getResponse.getCorrelationId() != correlationId) {
             // The NetworkClient associates a response with a request based on the fact that only one request is sent
@@ -780,11 +782,10 @@ class GetBlobOperation extends GetOperation {
             logger.trace("GetBlobRequest with response correlationId {} mismatch from response {} for replica {} ",
                 correlationId, getResponse.getCorrelationId(), getRequestInfo.replicaId.getDataNodeId());
             routerMetrics.unknownReplicaResponseError.inc();
-            chunkException = new RouterException(
+            onErrorResponse(getRequestInfo.replicaId, new RouterException(
                 "The correlation id in the GetResponse " + getResponse.getCorrelationId()
                     + " is not the same as the correlation id in the associated GetRequest: " + correlationId,
-                RouterErrorCode.UnexpectedInternalError);
-            onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.UnexpectedInternalError);
+                RouterErrorCode.UnexpectedInternalError));
             // we do not notify the ResponseHandler responsible for failure detection as this is an unexpected error.
           } else {
             try {
@@ -796,14 +797,13 @@ class GetBlobOperation extends GetOperation {
                   "GetBlobRequest with response correlationId {} response deserialization failed for replica {} ",
                   correlationId, getRequestInfo.replicaId.getDataNodeId());
               routerMetrics.responseDeserializationErrorCount.inc();
-              chunkException = new RouterException("Response deserialization received an unexpected error", e,
-                  RouterErrorCode.UnexpectedInternalError);
-              onErrorResponse(getRequestInfo.replicaId, RouterErrorCode.UnexpectedInternalError);
+              onErrorResponse(getRequestInfo.replicaId,
+                  new RouterException("Response deserialization received an unexpected error", e,
+                      RouterErrorCode.UnexpectedInternalError));
             }
           }
         }
-      }
-      checkAndMaybeComplete();
+      } checkAndMaybeComplete();
     }
 
     /**
@@ -865,18 +865,18 @@ class GetBlobOperation extends GetOperation {
         int partitionsInResponse = getResponse.getPartitionResponseInfoList().size();
         // Each get request issued by the router is for a single blob.
         if (partitionsInResponse != 1) {
-          chunkException = new RouterException(
+          onErrorResponse(getRequestInfo.replicaId, new RouterException(
               "Unexpected number of partition responses, expected: 1, " + "received: " + partitionsInResponse,
-              RouterErrorCode.UnexpectedInternalError);
+              RouterErrorCode.UnexpectedInternalError));
         } else {
           getError = getResponse.getPartitionResponseInfoList().get(0).getErrorCode();
           if (getError == ServerErrorCode.No_Error) {
             PartitionResponseInfo partitionResponseInfo = getResponse.getPartitionResponseInfoList().get(0);
             int objectsInPartitionResponse = partitionResponseInfo.getMessageInfoList().size();
             if (objectsInPartitionResponse != 1) {
-              chunkException = new RouterException(
+              onErrorResponse(getRequestInfo.replicaId, new RouterException(
                   "Unexpected number of messages in a partition response, expected: 1, " + "received: "
-                      + objectsInPartitionResponse, RouterErrorCode.UnexpectedInternalError);
+                      + objectsInPartitionResponse, RouterErrorCode.UnexpectedInternalError));
             } else {
               MessageMetadata messageMetadata = partitionResponseInfo.getMessageMetadataList().get(0);
               MessageInfo messageInfo = partitionResponseInfo.getMessageInfoList().get(0);
@@ -896,29 +896,31 @@ class GetBlobOperation extends GetOperation {
               // this is a successful response and one that completes the operation regardless of whether the
               // success target has been reached or not.
               chunkCompleted = true;
+              chunkException = new RouterException("Server returned: " + getError, routerErrorCode);
             }
             // any server error code that is not equal to ServerErrorCode.No_Error, the onErrorResponse should be invoked
             // because the operation itself doesn't succeed although the response in some cases is successful (i.e. Blob_Deleted)
-            onErrorResponse(getRequestInfo.replicaId, routerErrorCode);
+            onErrorResponse(getRequestInfo.replicaId,
+                new RouterException("Server returned: " + getError, routerErrorCode));
           }
         }
       } else {
         logger.trace("Replica {} returned an error {} for a GetBlobRequest with response correlationId : {} ",
             getRequestInfo.replicaId.getDataNodeId(), getError, getResponse.getCorrelationId());
         // process and set the most relevant exception.
-        onErrorResponse(getRequestInfo.replicaId, processServerError(getError));
+        onErrorResponse(getRequestInfo.replicaId, new RouterException("", processServerError(getError)));
       }
     }
 
     /**
      * Perform the necessary actions when a request to a replica fails.
      * @param replicaId the {@link ReplicaId} associated with the failed response.
-     * @param routerErrorCode the {@link RouterErrorCode} associated with the failed response.
+     * @param exception the {@link RouterException} associated with the failed response.
      */
-    void onErrorResponse(ReplicaId replicaId, RouterErrorCode routerErrorCode) {
+    void onErrorResponse(ReplicaId replicaId, RouterException exception) {
       chunkOperationTracker.onResponse(replicaId,
-          routerErrorCode == RouterErrorCode.OperationTimedOut ? TrackedRequestFinalState.TIMED_OUT
-              : TrackedRequestFinalState.FAILURE);
+          TrackedRequestFinalState.fromRouterErrorCodeToFinalState(exception.getErrorCode()));
+      setChunkException(exception);
       routerMetrics.routerRequestErrorCount.inc();
       routerMetrics.getDataNodeBasedMetrics(replicaId.getDataNodeId()).getRequestErrorCount.inc();
     }
@@ -931,22 +933,19 @@ class GetBlobOperation extends GetOperation {
      * @return the {@link RouterErrorCode} mapped from input server error code.
      */
     RouterErrorCode processServerError(ServerErrorCode errorCode) {
-      RouterErrorCode resolvedRouterErrorCode = RouterErrorCode.UnexpectedInternalError;
-      setChunkException(new RouterException("Server returned: " + errorCode, resolvedRouterErrorCode));
-      return resolvedRouterErrorCode;
+      return RouterErrorCode.UnexpectedInternalError;
     }
 
     /**
      * Set the exception associated with this chunk operation.
-     * A {@link ServerErrorCode#Blob_Deleted} or {@link ServerErrorCode#Blob_Expired} error overrides any other
-     * previously received exception.
+     * First, if the current chunkException is null, directly set it as provided exception;
+     * Second, if the chunkException exists but the precedence level of the provided exception's error code is smaller
+     * than the precedence level of the chunkException's error code, then update the chunkException.
      * @param exception the {@link RouterException} to possibly set.
      */
     void setChunkException(RouterException exception) {
-      if (chunkException == null || exception.getErrorCode() == RouterErrorCode.BlobDeleted
-          || exception.getErrorCode() == RouterErrorCode.BlobExpired
-          || exception.getErrorCode() == RouterErrorCode.BlobAuthorizationFailure
-          || exception.getErrorCode() == RouterErrorCode.RangeNotSatisfiable) {
+      if (chunkException == null || getPrecedenceLevel(exception.getErrorCode()) < getPrecedenceLevel(
+          chunkException.getErrorCode())) {
         chunkException = exception;
       }
     }
@@ -1208,7 +1207,6 @@ class GetBlobOperation extends GetOperation {
         default:
           resolvedRouterErrorCode = RouterErrorCode.UnexpectedInternalError;
       }
-      setChunkException(new RouterException("Server returned: " + errorCode, resolvedRouterErrorCode));
       return resolvedRouterErrorCode;
     }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -917,7 +917,7 @@ class GetBlobOperation extends GetOperation {
      * @param replicaId the {@link ReplicaId} associated with the failed response.
      * @param exception the {@link RouterException} associated with the failed response.
      */
-    void onErrorResponse(ReplicaId replicaId, RouterException exception) {
+    private void onErrorResponse(ReplicaId replicaId, RouterException exception) {
       chunkOperationTracker.onResponse(replicaId,
           TrackedRequestFinalState.fromRouterErrorCodeToFinalState(exception.getErrorCode()));
       setChunkException(exception);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -184,7 +184,7 @@ abstract class GetOperation {
    * @param routerErrorCode The {@link RouterErrorCode} for which to get its precedence level.
    * @return The precedence level of the {@link RouterErrorCode}.
    */
-  private int getPrecedenceLevel(RouterErrorCode routerErrorCode) {
+  protected int getPrecedenceLevel(RouterErrorCode routerErrorCode) {
     switch (routerErrorCode) {
       case BlobAuthorizationFailure:
         return 1;

--- a/ambry-router/src/main/java/com.github.ambry.router/OperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/OperationTracker.java
@@ -54,6 +54,14 @@ interface OperationTracker {
   boolean hasSucceeded();
 
   /**
+   * Return {@code true} only if the number of NOT_FOUND responses from originating DC pass the threshold.
+   * It also means hasSucceeded would return {@code false}.
+   *
+   * @return {@code true} if the operation failed because of {@link TrackedRequestFinalState#NOT_FOUND}.
+   */
+  boolean hasFailedOnNotFound();
+
+  /**
    * Determines if an operation has completed (either succeeded or failed).
    *
    * @return {@code true} if the operation has completed.

--- a/ambry-router/src/main/java/com.github.ambry.router/OperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/OperationTracker.java
@@ -54,7 +54,7 @@ interface OperationTracker {
   boolean hasSucceeded();
 
   /**
-   * Return {@code true} only if the number of NOT_FOUND responses from originating DC pass the threshold.
+   * Return {@code true} only if the number of NOT_FOUND responses from originating DC passes the threshold.
    * It also means hasSucceeded would return {@code false}.
    *
    * @return {@code true} if the operation failed because of {@link TrackedRequestFinalState#NOT_FOUND}.
@@ -69,10 +69,11 @@ interface OperationTracker {
   boolean isDone();
 
   /**
-   * Accounts for successful, failed or timed-out response from a replica. Must invoke this method
-   * if a successful/failed/timed-out response is received for a replica.
+   * Accounts for all type of response from a replica. Must invoke this method if a
+   * successful/failed/timed-out/notfound response is received for a replica. Note
+   * that not callers should not pass more than one state from the same replica.
    * @param replicaId ReplicaId associated with this response.
-   * @param trackedRequestFinalState The final state of a single request being tracked (SUCCESS, FAILURE or TIMED_OUT).
+   * @param trackedRequestFinalState The final state of a single request being tracked (SUCCESS, FAILURE, TIMED_OUT or NOT_FOUND).
    */
   void onResponse(ReplicaId replicaId, TrackedRequestFinalState trackedRequestFinalState);
 

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -1436,7 +1436,7 @@ class PutOperation {
      * Perform the necessary actions when a request to a replica fails.
      * @param replicaId the {@link ReplicaId} associated with the failed response.
      */
-    void onErrorResponse(ReplicaId replicaId) {
+    private void onErrorResponse(ReplicaId replicaId) {
       operationTracker.onResponse(replicaId, TrackedRequestFinalState.FAILURE);
       routerMetrics.routerRequestErrorCount.inc();
       routerMetrics.getDataNodeBasedMetrics(replicaId.getDataNodeId()).putRequestErrorCount.inc();

--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -190,10 +190,7 @@ class SimpleOperationTracker implements OperationTracker {
           generateErrorMessage(partitionId, examinedReplicas, replicaPool, backupReplicasToCheck, downReplicasToCheck));
     }
     if (routerConfig.routerOperationTrackerOriginatingDcNotFoundEnabled && numReplicasInOriginatingDc > 0) {
-      int minTarget = Collections.min(
-          Arrays.asList(routerConfig.routerPutSuccessTarget, routerConfig.routerDeleteSuccessTarget,
-              routerConfig.routerTtlUpdateSuccessTarget));
-      this.originatingDcNotFoundFailureThreshold = Math.max(numReplicasInOriginatingDc - minTarget + 1, 0);
+      this.originatingDcNotFoundFailureThreshold = Math.max(numReplicasInOriginatingDc - routerConfig.routerPutSuccessTarget + 1, 0);
     }
     this.otIterator = new OpTrackerIterator();
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -189,7 +189,7 @@ class SimpleOperationTracker implements OperationTracker {
       throw new IllegalArgumentException(
           generateErrorMessage(partitionId, examinedReplicas, replicaPool, backupReplicasToCheck, downReplicasToCheck));
     }
-    if (routerConfig.routerOperationTrackerOriginatingDcNotFoundEnabled && numReplicasInOriginatingDc > 0) {
+    if (routerConfig.routerOperationTrackerTerminateOnNotFoundEnabled && numReplicasInOriginatingDc > 0) {
       this.originatingDcNotFoundFailureThreshold = Math.max(numReplicasInOriginatingDc - routerConfig.routerPutSuccessTarget + 1, 0);
     }
     this.otIterator = new OpTrackerIterator();

--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -219,7 +219,7 @@ class SimpleOperationTracker implements OperationTracker {
     } else {
       failedCount++;
       // NOT_FOUND is a special error. When tracker sees more than 2 NOT_FOUND from the originating DC, we can
-      // be sure the operation will ends up with a NOT_FOUND error.
+      // be sure the operation will end up with a NOT_FOUND error.
       if (trackedRequestFinalState == TrackedRequestFinalState.NOT_FOUND && replicaId.getDataNodeId()
           .getDatacenterName()
           .equals(originatingDcName)) {

--- a/ambry-router/src/main/java/com.github.ambry.router/TrackedRequestFinalState.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TrackedRequestFinalState.java
@@ -19,5 +19,16 @@ package com.github.ambry.router;
  * consumed by operation tracker to change success/failure counter and determine whether to update Histograms.
  */
 public enum TrackedRequestFinalState {
-  SUCCESS, FAILURE, TIMED_OUT
+  SUCCESS, FAILURE, TIMED_OUT, NOT_FOUND;
+
+  public static TrackedRequestFinalState fromRouterErrorCodeToFinalState(RouterErrorCode code) {
+    switch(code){
+      case OperationTimedOut:
+        return TIMED_OUT;
+      case BlobDoesNotExist:
+        return NOT_FOUND;
+      default:
+        return FAILURE;
+    }
+  }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/TrackedRequestFinalState.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TrackedRequestFinalState.java
@@ -21,6 +21,11 @@ package com.github.ambry.router;
 public enum TrackedRequestFinalState {
   SUCCESS, FAILURE, TIMED_OUT, NOT_FOUND;
 
+  /**
+   *  Return the corresponding {@link TrackedRequestFinalState}  for the given {@link RouterErrorCode}.
+   * @param code The {@link RouterErrorCode} to handle.
+   * @return The corresponding {@link TrackedRequestFinalState}.
+   */
   public static TrackedRequestFinalState fromRouterErrorCodeToFinalState(RouterErrorCode code) {
     switch(code){
       case OperationTimedOut:

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
@@ -284,7 +284,7 @@ class TtlUpdateOperation {
    * @param replicaId the {@link ReplicaId} associated with the failed response.
    * @param exception the {@link RouterException} associated with the failed response.
    */
-  void onErrorResponse(ReplicaId replicaId, RouterException exception) {
+  private void onErrorResponse(ReplicaId replicaId, RouterException exception) {
     operationTracker.onResponse(replicaId,
         TrackedRequestFinalState.fromRouterErrorCodeToFinalState(exception.getErrorCode()));
     setOperationException(exception);

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
@@ -314,18 +314,13 @@ class TtlUpdateOperation {
 
   /**
    * Set the exception associated with this operation.
-   * First, if current operationException is null, directly set operationException as exception;
-   * Second, if operationException exists, compare ErrorCodes of exception and existing operation Exception depending
+   * If operationException exists, compare ErrorCodes of exception and existing operation Exception depending
    * on precedence level. An ErrorCode with a smaller precedence level overrides an ErrorCode with a larger precedence
    * level. Update the operationException if necessary.
    * @param exception the {@link RouterException} to possibly set.
    */
   void setOperationException(Exception exception) {
-    if (exception instanceof RouterException) {
-      RouterUtils.replaceOperationException(operationException, (RouterException) exception, this::getPrecedenceLevel);
-    } else {
-      operationException.compareAndSet(null, exception);
-    }
+    RouterUtils.replaceOperationException(operationException, (RouterException) exception, this::getPrecedenceLevel);
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
@@ -197,8 +197,8 @@ class TtlUpdateOperation {
               routerMetrics.crossColoSuccessCount.inc();
             }
           } else {
-              LOGGER.debug("Replica {} returned an error {} for a Ttl update request with response correlationId : {} ",
-                  replica.getDataNodeId(), getError, ttlUpdateResponse.getCorrelationId());
+            LOGGER.debug("Replica {} returned an error {} for a Ttl update request with response correlationId : {} ",
+                replica.getDataNodeId(), getError, ttlUpdateResponse.getCorrelationId());
             RouterErrorCode routerErrorCode = processServerError(getError);
             if (ttlUpdateResponse.getError() == ServerErrorCode.Blob_Authorization_Failure) {
               // this is a successful response and one that completes the operation regardless of whether the
@@ -304,7 +304,8 @@ class TtlUpdateOperation {
       if (operationTracker.hasSucceeded()) {
         operationException.set(null);
       } else if (operationTracker.hasFailedOnNotFound()) {
-        operationException.set(new RouterException("", RouterErrorCode.BlobDoesNotExist));
+        operationException.set(
+            new RouterException("TtlUpdateOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
       }
       operationCompleted = true;
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
@@ -319,8 +319,8 @@ class TtlUpdateOperation {
    * level. Update the operationException if necessary.
    * @param exception the {@link RouterException} to possibly set.
    */
-  void setOperationException(Exception exception) {
-    RouterUtils.replaceOperationException(operationException, (RouterException) exception, this::getPrecedenceLevel);
+  void setOperationException(RouterException exception) {
+    RouterUtils.replaceOperationException(operationException, exception, this::getPrecedenceLevel);
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
@@ -28,6 +28,7 @@ import com.github.ambry.utils.Time;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +52,7 @@ class TtlUpdateOperation {
   // The operation tracker that tracks the state of this operation.
   private final OperationTracker operationTracker;
   // A map used to find inflight requests using a correlation id.
-  private final Map<Integer, TtlUpdateRequestInfo> ttlUpdateRequestInfos = new HashMap<>();
+  private final Map<Integer, TtlUpdateRequestInfo> ttlUpdateRequestInfos = new TreeMap<>();
   // The result of this operation to be set into FutureResult.
   private final Void operationResult = null;
   // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateOperation.java
@@ -168,13 +168,14 @@ class TtlUpdateOperation {
     if (responseInfo.getError() != null) {
       LOGGER.debug("TtlUpdateRequest with response correlationId {} timed out for replica {} ",
           ttlUpdateRequest.getCorrelationId(), replica.getDataNodeId());
-      updateOperationState(replica, RouterErrorCode.OperationTimedOut);
+      onErrorResponse(replica, new RouterException("Operation timed out", RouterErrorCode.OperationTimedOut));
     } else {
       if (ttlUpdateResponse == null) {
         LOGGER.debug(
             "TtlUpdateRequest with response correlationId {} received UnexpectedInternalError on response deserialization for replica {} ",
             ttlUpdateRequest.getCorrelationId(), replica.getDataNodeId());
-        updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
+        onErrorResponse(replica, new RouterException("Response deserialization received an unexpected error",
+            RouterErrorCode.UnexpectedInternalError));
       } else {
         // The true case below should not really happen. This means a response has been received
         // not for its original request. We will immediately fail this operation.
@@ -183,15 +184,30 @@ class TtlUpdateOperation {
               + " is not the same as the correlation id in the associated TtlUpdateRequest: "
               + ttlUpdateRequest.getCorrelationId());
           routerMetrics.unknownReplicaResponseError.inc();
-          setOperationException(
+          onErrorResponse(replica,
               new RouterException("Received wrong response that is not for the corresponding request.",
                   RouterErrorCode.UnexpectedInternalError));
-          updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
         } else {
-          // The status of operation tracker will be updated within the processServerError method.
-          processServerError(replica, ttlUpdateResponse.getError(), ttlUpdateResponse.getCorrelationId());
-          if (ttlUpdateResponse.getError() == ServerErrorCode.Blob_Authorization_Failure) {
-            operationCompleted = true;
+          ServerErrorCode getError = ttlUpdateResponse.getError();
+          if (getError == ServerErrorCode.No_Error || getError == ServerErrorCode.Blob_Already_Updated) {
+            operationTracker.onResponse(replica, TrackedRequestFinalState.SUCCESS);
+            if (RouterUtils.isRemoteReplica(routerConfig, replica)) {
+              LOGGER.trace("Cross colo request successful for remote replica {} in {} ", replica.getDataNodeId(),
+                  replica.getDataNodeId().getDatacenterName());
+              routerMetrics.crossColoSuccessCount.inc();
+            }
+          } else {
+              LOGGER.debug("Replica {} returned an error {} for a Ttl update request with response correlationId : {} ",
+                  replica.getDataNodeId(), getError, ttlUpdateResponse.getCorrelationId());
+            RouterErrorCode routerErrorCode = processServerError(getError);
+            if (ttlUpdateResponse.getError() == ServerErrorCode.Blob_Authorization_Failure) {
+              // this is a successful response and one that completes the operation regardless of whether the
+              // success target has been reached or not.
+              operationCompleted = true;
+            }
+            // any server error code that is not equal to ServerErrorCode.No_Error, the onErrorResponse should be invoked
+            // because the operation itself doesn't succeed although the response in some cases is successful (i.e. Blob_Deleted)
+            onErrorResponse(replica, new RouterException("Server returned: " + getError, routerErrorCode));
           }
         }
       }
@@ -228,83 +244,55 @@ class TtlUpdateOperation {
         // Do not notify this as a failure to the response handler, as this timeout could simply be due to
         // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
         // response and the response handler will be notified accordingly.
-        updateOperationState(ttlUpdateRequestInfo.replica, RouterErrorCode.OperationTimedOut);
+        onErrorResponse(ttlUpdateRequestInfo.replica,
+            new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut));
+      } else {
+        // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
+        break;
       }
     }
   }
 
   /**
    * Processes {@link ServerErrorCode} received from {@code replica}. This method maps a {@link ServerErrorCode}
-   * to a {@link RouterErrorCode}, and then makes corresponding state update.
-   * @param replica The replica for which the ServerErrorCode was generated.
+   * to a {@link RouterErrorCode}
    * @param serverErrorCode The ServerErrorCode received from the replica.
-   * @param correlationId the correlationId of the request
+   * @return the {@link RouterErrorCode} mapped from server error code.
    */
-  private void processServerError(ReplicaId replica, ServerErrorCode serverErrorCode, int correlationId) {
+  private RouterErrorCode processServerError(ServerErrorCode serverErrorCode) {
     switch (serverErrorCode) {
-      case No_Error:
-      case Blob_Already_Updated:
-        operationTracker.onResponse(replica, TrackedRequestFinalState.SUCCESS);
-        if (RouterUtils.isRemoteReplica(routerConfig, replica)) {
-          LOGGER.trace("Cross colo request successful for remote replica {} in {} ", replica.getDataNodeId(),
-              replica.getDataNodeId().getDatacenterName());
-          routerMetrics.crossColoSuccessCount.inc();
-        }
-        break;
       case Blob_Authorization_Failure:
-        updateOperationState(replica, RouterErrorCode.BlobAuthorizationFailure);
-        break;
+        return RouterErrorCode.BlobAuthorizationFailure;
       case Blob_Deleted:
-        updateOperationState(replica, RouterErrorCode.BlobDeleted);
-        break;
+        return RouterErrorCode.BlobDeleted;
       case Blob_Expired:
-        updateOperationState(replica, RouterErrorCode.BlobExpired);
-        break;
+        return RouterErrorCode.BlobExpired;
       case Blob_Not_Found:
-        updateOperationState(replica, RouterErrorCode.BlobDoesNotExist);
-        break;
+        return RouterErrorCode.BlobDoesNotExist;
       case Disk_Unavailable:
       case Replica_Unavailable:
-        updateOperationState(replica, RouterErrorCode.AmbryUnavailable);
-        break;
+        return RouterErrorCode.AmbryUnavailable;
       case Blob_Update_Not_Allowed:
-        updateOperationState(replica, RouterErrorCode.BlobUpdateNotAllowed);
-        break;
+        return RouterErrorCode.BlobUpdateNotAllowed;
       default:
-        updateOperationState(replica, RouterErrorCode.UnexpectedInternalError);
-        break;
-    }
-    if (serverErrorCode != ServerErrorCode.No_Error) {
-      LOGGER.debug("Replica {} returned an error {} for a Ttl update request with response correlationId : {} ",
-          replica.getDataNodeId(), serverErrorCode, correlationId);
+        return RouterErrorCode.UnexpectedInternalError;
     }
   }
 
   /**
-   * Updates the state of the {@link TtlUpdateOperation}. This includes two parts: 1) resolves the
-   * {@link RouterErrorCode} depending on the precedence level of the new router error code from
-   * {@code replica} and the current {@code resolvedRouterErrorCode}. An error code with a smaller
-   * precedence level overrides an error code with a larger precedence level. 2) updates the
-   * {@link TtlUpdateOperation} based on the {@link RouterErrorCode}, and the source {@link ReplicaId}
-   * for which the {@link RouterErrorCode} is generated.
-   * @param replica The replica for which the RouterErrorCode was generated.
-   * @param error {@link RouterErrorCode} that indicates the error for the replica.
+   * Perform the necessary actions when a request to a replica fails.
+   * @param replicaId the {@link ReplicaId} associated with the failed response.
+   * @param exception the {@link RouterException} associated with the failed response.
    */
-  private void updateOperationState(ReplicaId replica, RouterErrorCode error) {
-    if (resolvedRouterErrorCode == null) {
-      resolvedRouterErrorCode = error;
-    } else {
-      if (getPrecedenceLevel(error) < getPrecedenceLevel(resolvedRouterErrorCode)) {
-        resolvedRouterErrorCode = error;
-      }
-    }
-    operationTracker.onResponse(replica,
-        resolvedRouterErrorCode == RouterErrorCode.OperationTimedOut ? TrackedRequestFinalState.TIMED_OUT
-            : TrackedRequestFinalState.FAILURE);
-    if (error != RouterErrorCode.BlobDeleted && error != RouterErrorCode.BlobExpired) {
+  void onErrorResponse(ReplicaId replicaId, RouterException exception) {
+    operationTracker.onResponse(replicaId,
+        TrackedRequestFinalState.fromRouterErrorCodeToFinalState(exception.getErrorCode()));
+    setOperationException(exception);
+    if (exception.getErrorCode() != RouterErrorCode.BlobDeleted
+        && exception.getErrorCode() != RouterErrorCode.BlobExpired) {
       routerMetrics.routerRequestErrorCount.inc();
     }
-    routerMetrics.getDataNodeBasedMetrics(replica.getDataNodeId()).ttlUpdateRequestErrorCount.inc();
+    routerMetrics.getDataNodeBasedMetrics(replicaId.getDataNodeId()).ttlUpdateRequestErrorCount.inc();
   }
 
   /**
@@ -313,11 +301,28 @@ class TtlUpdateOperation {
   private void checkAndMaybeComplete() {
     // operationCompleted is true if Blob_Authorization_Failure was received.
     if (operationTracker.isDone() || operationCompleted) {
-      if (!operationTracker.hasSucceeded()) {
-        setOperationException(
-            new RouterException("The TtlUpdateOperation could not be completed.", resolvedRouterErrorCode));
+      if (operationTracker.hasSucceeded()) {
+        operationException.set(null);
+      } else if (operationTracker.hasFailedOnNotFound()) {
+        operationException.set(new RouterException("", RouterErrorCode.BlobDoesNotExist));
       }
       operationCompleted = true;
+    }
+  }
+
+  /**
+   * Set the exception associated with this operation.
+   * First, if current operationException is null, directly set operationException as exception;
+   * Second, if operationException exists, compare ErrorCodes of exception and existing operation Exception depending
+   * on precedence level. An ErrorCode with a smaller precedence level overrides an ErrorCode with a larger precedence
+   * level. Update the operationException if necessary.
+   * @param exception the {@link RouterException} to possibly set.
+   */
+  void setOperationException(Exception exception) {
+    if (exception instanceof RouterException) {
+      RouterUtils.replaceOperationException(operationException, (RouterException) exception, this::getPrecedenceLevel);
+    } else {
+      operationException.compareAndSet(null, exception);
     }
   }
 
@@ -406,14 +411,6 @@ class TtlUpdateOperation {
    */
   Void getOperationResult() {
     return operationResult;
-  }
-
-  /**
-   * Sets the exception associated with this operation. When this is called, the operation has failed.
-   * @param exception the irrecoverable exception associated with this operation.
-   */
-  void setOperationException(Exception exception) {
-    operationException.set(exception);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -466,8 +466,11 @@ public class DeleteManagerTest {
         });
   }
 
+  /**
+   * Test the case  when getting NOT_FOUND error from origin DC while termination on NOT_FOUND is enabled.
+   */
   @Test
-  public void testOriginatingDcNotFoundError() throws Exception {
+  public void testOriginDcNotFoundError() throws Exception {
     assertCloseCleanup(router);
     Properties props = getNonBlockingRouterProperties();
     props.setProperty("router.delete.request.parallelism", "1");

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -241,12 +241,6 @@ public class DeleteManagerTest {
    */
   @Test
   public void routerErrorCodeResolutionTest() throws Exception {
-    // create a blobId with a random datacenter id. Setting this would disable originatingDc NotFound error.
-    blobId =
-        new BlobId(BlobId.BLOB_ID_V6, BlobId.BlobIdType.NATIVE, ClusterMapUtils.UNKNOWN_DATACENTER_ID,
-            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), partition, false,
-            BlobId.BlobDataType.DATACHUNK);
-    blobIdString = blobId.getID();
     LinkedHashMap<ServerErrorCode, RouterErrorCode> codesToSetAndTest = new LinkedHashMap<>();
     // test 4 codes
     codesToSetAndTest.put(ServerErrorCode.Blob_Authorization_Failure, RouterErrorCode.BlobAuthorizationFailure);
@@ -262,13 +256,6 @@ public class DeleteManagerTest {
     codesToSetAndTest.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
     codesToSetAndTest.put(ServerErrorCode.Partition_Unknown, RouterErrorCode.UnexpectedInternalError);
     doRouterErrorCodeResolutionTest(codesToSetAndTest);
-
-    // create a blobId with a random datacenter id. Setting this would disable originatingDc NotFound error.
-    blobId =
-        new BlobId(BlobId.BLOB_ID_V6, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
-            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), partition, false,
-            BlobId.BlobDataType.DATACHUNK);
-    blobIdString = blobId.getID();
   }
 
   /**
@@ -474,17 +461,16 @@ public class DeleteManagerTest {
     assertCloseCleanup(router);
     Properties props = getNonBlockingRouterProperties();
     props.setProperty("router.delete.request.parallelism", "1");
-    props.setProperty("router.operation.tracker.terminate.on.not.found.enabled",  "true");
+    props.setProperty("router.operation.tracker.terminate.on.not.found.enabled", "true");
     VerifiableProperties vProps = new VerifiableProperties(props);
     RouterConfig routerConfig = new RouterConfig(vProps);
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(clusterMap, routerConfig),
         new MockNetworkClientFactory(vProps, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, serverLayout, mockTime), new LoggingNotificationSystem(), clusterMap, null, null, null,
         new InMemAccountService(false, true), mockTime, MockClusterMap.DEFAULT_PARTITION_CLASS);
-    blobId =
-        new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE, (byte)0,
-            Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), partition, false,
-            BlobId.BlobDataType.DATACHUNK);
+    blobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE, (byte) 0,
+        Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), partition, false,
+        BlobId.BlobDataType.DATACHUNK);
     blobIdString = blobId.getID();
     ServerErrorCode[] serverErrorCodes = new ServerErrorCode[9];
     Arrays.fill(serverErrorCodes, ServerErrorCode.No_Error);

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -471,6 +471,7 @@ public class DeleteManagerTest {
     assertCloseCleanup(router);
     Properties props = getNonBlockingRouterProperties();
     props.setProperty("router.delete.request.parallelism", "1");
+    props.setProperty("router.operation.tracker.originating.dc.notfound.enabled",  "true");
     VerifiableProperties vProps = new VerifiableProperties(props);
     RouterConfig routerConfig = new RouterConfig(vProps);
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(clusterMap, routerConfig),

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -471,7 +471,7 @@ public class DeleteManagerTest {
     assertCloseCleanup(router);
     Properties props = getNonBlockingRouterProperties();
     props.setProperty("router.delete.request.parallelism", "1");
-    props.setProperty("router.operation.tracker.originating.dc.notfound.enabled",  "true");
+    props.setProperty("router.operation.tracker.terminate.on.not.found.enabled",  "true");
     VerifiableProperties vProps = new VerifiableProperties(props);
     RouterConfig routerConfig = new RouterConfig(vProps);
     router = new NonBlockingRouter(routerConfig, new NonBlockingRouterMetrics(clusterMap, routerConfig),

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -783,6 +783,7 @@ public class GetBlobInfoOperationTest {
     properties.setProperty("router.get.operation.tracker.type", operationTrackerType);
     properties.setProperty("router.request.timeout.ms", Integer.toString(20));
     properties.setProperty("router.operation.tracker.exclude.timeout.enabled", Boolean.toString(excludeTimeout));
+    properties.setProperty("router.operation.tracker.originating.dc.notfound.enabled", "true");
     return properties;
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -383,11 +383,11 @@ public class GetBlobInfoOperationTest {
   }
 
   /**
-   * Test the case where originating replicas return Blob_Not_found and the rest returns IO_Error.
+   * Test the case where origin replicas return Blob_Not_found and the rest returns IO_Error.
    * @throws Exception
    */
   @Test
-  public void testIOErrorAndBlobNotFoundOriginatingNotFound() throws Exception {
+  public void testIOErrorAndBlobNotFoundInOriginDc() throws Exception {
     assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
     correlationIdToGetOperation.clear();
 
@@ -400,7 +400,7 @@ public class GetBlobInfoOperationTest {
 
     for (MockServer server : mockServerLayout.getMockServers()) {
       if (server.getDataCenter().equals(oldLocal)) {
-        // for originating DC, always return Blob_Not_Found;
+        // for origin DC, always return Blob_Not_Found;
         server.setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
       } else {
         // otherwise, return IO_Error.
@@ -430,11 +430,11 @@ public class GetBlobInfoOperationTest {
 
 
   /**
-   * Test the case where originating replicas return Blob_Not_found and the rest times out.
+   * Test the case where origin replicas return Blob_Not_found and the rest times out.
    * @throws Exception
    */
   @Test
-  public void testTimeoutAndBlobNotFoundOriginatingNotFound() throws Exception {
+  public void testTimeoutAndBlobNotFoundInOriginDc() throws Exception {
     assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
     correlationIdToGetOperation.clear();
 
@@ -448,7 +448,7 @@ public class GetBlobInfoOperationTest {
 
     for (MockServer server : mockServerLayout.getMockServers()) {
       if (server.getDataCenter().equals(oldLocal)) {
-        // for originating DC, always return Blob_Not_Found;
+        // for origin DC, always return Blob_Not_Found;
         server.setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
       } else {
         // Randomly set something here, it will not be used.
@@ -524,7 +524,7 @@ public class GetBlobInfoOperationTest {
     mockServerLayout.getMockServers()
         .forEach(server -> server.setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found));
     assertOperationFailure(RouterErrorCode.BlobDoesNotExist);
-    // Blob is created by putBlob function so the local datacenter will be the originating datecenter.
+    // Blob is created by putBlob function so the local datacenter will be the origin datecenter.
     // Thus only need two Blob_Not_Found to terminate the operation.
     Assert.assertEquals("Must have attempted sending requests to all replicas", 2,
         correlationIdToGetOperation.size());

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -783,7 +783,7 @@ public class GetBlobInfoOperationTest {
     properties.setProperty("router.get.operation.tracker.type", operationTrackerType);
     properties.setProperty("router.request.timeout.ms", Integer.toString(20));
     properties.setProperty("router.operation.tracker.exclude.timeout.enabled", Boolean.toString(excludeTimeout));
-    properties.setProperty("router.operation.tracker.originating.dc.notfound.enabled", "true");
+    properties.setProperty("router.operation.tracker.terminate.on.not.found.enabled", "true");
     return properties;
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -394,7 +394,7 @@ public class GetBlobInfoOperationTest {
     // Pick a remote DC as the new local DC.
     String newLocal = "DC1";
     String oldLocal = localDcName;
-    Properties props = getNonBlockingRouterProperties();
+    Properties props = getNonBlockingRouterProperties(true);
     props.setProperty("router.datacenter.name", newLocal);
     routerConfig = new RouterConfig(new VerifiableProperties(props));
 
@@ -423,7 +423,7 @@ public class GetBlobInfoOperationTest {
     Assert.assertEquals("The number of data points in remote colo latency histogram is not expected", 2,
         tracker.getLatencyHistogram(localReplica).getCount());
 
-    props = getNonBlockingRouterProperties();
+    props = getNonBlockingRouterProperties(true);
     props.setProperty("router.datacenter.name", oldLocal);
     routerConfig = new RouterConfig(new VerifiableProperties(props));
   }
@@ -441,9 +441,10 @@ public class GetBlobInfoOperationTest {
     // Pick a remote DC as the new local DC.
     String newLocal = "DC1";
     String oldLocal = localDcName;
-    Properties props = getNonBlockingRouterProperties();
+    Properties props = getNonBlockingRouterProperties(true);
     props.setProperty("router.datacenter.name", newLocal);
     props.setProperty("router.get.request.parallelism", "3");
+    props.setProperty("router.operation.tracker.max.inflight.requests", "3");
     routerConfig = new RouterConfig(new VerifiableProperties(props));
 
     for (MockServer server : mockServerLayout.getMockServers()) {
@@ -474,9 +475,10 @@ public class GetBlobInfoOperationTest {
     // error code should be OperationTimedOut because it precedes BlobDoesNotExist
     Assert.assertEquals(RouterErrorCode.BlobDoesNotExist, routerException.getErrorCode());
 
-    props = getNonBlockingRouterProperties();
+    props = getNonBlockingRouterProperties(true);
     props.setProperty("router.datacenter.name", oldLocal);
     props.setProperty("router.get.request.parallelism", Integer.toString(requestParallelism));
+    props.setProperty("router.operation.tracker.max.inflight.requests", "2");
     routerConfig = new RouterConfig(new VerifiableProperties(props));
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -1563,6 +1563,7 @@ public class GetBlobOperationTest {
     properties.setProperty("router.get.operation.tracker.type", operationTrackerType);
     properties.setProperty("router.request.timeout.ms", Integer.toString(20));
     properties.setProperty("router.operation.tracker.exclude.timeout.enabled", Boolean.toString(excludeTimeout));
+    properties.setProperty("router.operation.tracker.originating.dc.notfound.enabled", "true");
     return properties;
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -559,11 +559,11 @@ public class GetBlobOperationTest {
   }
 
   /**
-   * Test the case where originating replicas return Blob_Not_found and the rest times out.
+   * Test the case where origin replicas return Blob_Not_found and the rest times out.
    * @throws Exception
    */
   @Test
-  public void testTimeoutAndBlobNotFoundOriginatingNotFound() throws Exception {
+  public void testTimeoutAndBlobNotFoundInOriginDc() throws Exception {
     assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
     doPut();
 
@@ -646,7 +646,7 @@ public class GetBlobOperationTest {
           @Override
           public void testAndAssert(RouterErrorCode expectedError) throws Exception {
             GetBlobOperation op = createOperationAndComplete(null);
-            // Local dc is the originating DC, only two NOT_FOUND would terminate the operation.
+            // Local dc is the origin DC, only two NOT_FOUND would terminate the operation.
             Assert.assertEquals("Must have attempted sending requests to all replicas", 2,
                 correlationIdToGetOperation.size());
             assertFailureAndCheckErrorCode(op, expectedError);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -1563,7 +1563,7 @@ public class GetBlobOperationTest {
     properties.setProperty("router.get.operation.tracker.type", operationTrackerType);
     properties.setProperty("router.request.timeout.ms", Integer.toString(20));
     properties.setProperty("router.operation.tracker.exclude.timeout.enabled", Boolean.toString(excludeTimeout));
-    properties.setProperty("router.operation.tracker.originating.dc.notfound.enabled", "true");
+    properties.setProperty("router.operation.tracker.terminate.on.not.found.enabled", "true");
     return properties;
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -519,7 +519,7 @@ public class GetBlobOperationTest {
    * @throws Exception
    */
   @Test
-  public void testRequestTimeoutAndBlobNotFound() throws Exception {
+  public void testRequestTimeoutAndBlobNotFoundLocalTimeout() throws Exception {
     assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
     doPut();
     GetBlobOperation op = createOperation(routerConfig, null);
@@ -556,6 +556,54 @@ public class GetBlobOperationTest {
     // the count of data points in cross colo Histogram should be 6 because all remote replicas respond with proper error code
     Assert.assertEquals("The number of data points in cross colo latency histogram is not expected", 6,
         crossColoTracker.getCount());
+  }
+
+  /**
+   * Test the case where originating replicas return Blob_Not_found and the rest times out.
+   * @throws Exception
+   */
+  @Test
+  public void testTimeoutAndBlobNotFoundOriginatingNotFound() throws Exception {
+    assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
+    doPut();
+
+    // Pick a remote DC as the new local DC.
+    String newLocal = "DC1";
+    String oldLocal = localDcName;
+    Properties props = getDefaultNonBlockingRouterProperties();
+    props.setProperty("router.datacenter.name", newLocal);
+    props.setProperty("router.get.request.parallelism", "3");
+    routerConfig = new RouterConfig(new VerifiableProperties(props));
+
+    GetBlobOperation op = createOperation(null);
+    AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getFirstChunkOperationTrackerInUse();
+    correlationIdToGetOperation.clear();
+    for (MockServer server : mockServerLayout.getMockServers()) {
+      server.setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+    }
+    op.poll(requestRegistrationCallback);
+    time.sleep(routerConfig.routerRequestTimeoutMs + 1);
+
+    // 3 requests have been sent out and all of them timed out. Nest, complete operation on remaining replicas
+    // The request should have response from all remote replicas.
+    while (!op.isOperationComplete()) {
+      op.poll(requestRegistrationCallback);
+      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.requestListToFill);
+      for (ResponseInfo responseInfo : responses) {
+        GetResponse getResponse = responseInfo.getError() == null ? GetResponse.readFrom(
+            new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap) : null;
+        op.handleResponse(responseInfo, getResponse);
+      }
+    }
+
+    RouterException routerException = (RouterException) op.getOperationException();
+    // error code should be OperationTimedOut because it precedes BlobDoesNotExist
+    Assert.assertEquals(RouterErrorCode.BlobDoesNotExist, routerException.getErrorCode());
+
+    props = getDefaultNonBlockingRouterProperties();
+    props.setProperty("router.datacenter.name", oldLocal);
+    props.setProperty("router.get.request.parallelism", "2");
+    routerConfig = new RouterConfig(new VerifiableProperties(props));
   }
 
   /**
@@ -598,7 +646,8 @@ public class GetBlobOperationTest {
           @Override
           public void testAndAssert(RouterErrorCode expectedError) throws Exception {
             GetBlobOperation op = createOperationAndComplete(null);
-            Assert.assertEquals("Must have attempted sending requests to all replicas", replicasCount,
+            // Local dc is the originating DC, only two NOT_FOUND would terminate the operation.
+            Assert.assertEquals("Must have attempted sending requests to all replicas", 2,
                 correlationIdToGetOperation.size());
             assertFailureAndCheckErrorCode(op, expectedError);
           }
@@ -619,7 +668,7 @@ public class GetBlobOperationTest {
     serverErrorToRouterError.put(ServerErrorCode.Blob_Authorization_Failure, RouterErrorCode.BlobAuthorizationFailure);
     for (Map.Entry<ServerErrorCode, RouterErrorCode> entry : serverErrorToRouterError.entrySet()) {
       Map<ServerErrorCode, Integer> errorCounts = new HashMap<>();
-      errorCounts.put(ServerErrorCode.Blob_Not_Found, replicasCount - 1);
+      errorCounts.put(ServerErrorCode.Replica_Unavailable, replicasCount - 1);
       errorCounts.put(entry.getKey(), 1);
       testWithErrorCodes(errorCounts, mockServerLayout, entry.getValue(), getErrorCodeChecker);
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -570,12 +570,13 @@ public class GetBlobOperationTest {
     // Pick a remote DC as the new local DC.
     String newLocal = "DC1";
     String oldLocal = localDcName;
-    Properties props = getDefaultNonBlockingRouterProperties();
+    Properties props = getDefaultNonBlockingRouterProperties(true);
     props.setProperty("router.datacenter.name", newLocal);
     props.setProperty("router.get.request.parallelism", "3");
+    props.setProperty("router.operation.tracker.max.inflight.requests", "3");
     routerConfig = new RouterConfig(new VerifiableProperties(props));
 
-    GetBlobOperation op = createOperation(null);
+    GetBlobOperation op = createOperation(routerConfig, null);
     AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getFirstChunkOperationTrackerInUse();
     correlationIdToGetOperation.clear();
     for (MockServer server : mockServerLayout.getMockServers()) {
@@ -600,9 +601,10 @@ public class GetBlobOperationTest {
     // error code should be OperationTimedOut because it precedes BlobDoesNotExist
     Assert.assertEquals(RouterErrorCode.BlobDoesNotExist, routerException.getErrorCode());
 
-    props = getDefaultNonBlockingRouterProperties();
+    props = getDefaultNonBlockingRouterProperties(true);
     props.setProperty("router.datacenter.name", oldLocal);
     props.setProperty("router.get.request.parallelism", "2");
+    props.setProperty("router.operation.tracker.max.inflight.requests", "2");
     routerConfig = new RouterConfig(new VerifiableProperties(props));
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
@@ -435,7 +435,7 @@ public class OperationTrackerTest {
    * Test the case when NotFound Error should be disabled since the cross colo is disabled.
    */
   @Test
-  public void originatingDcNotFoundColoDisableTest() {
+  public void blobNotFoundInOriginDcAndCrossColoDisabledTest() {
     initialize();
     originatingDcName = datanodes.get(datanodes.size() - 1).getDatacenterName();
     OperationTracker ot = getOperationTracker(false, 1, 3, false, Integer.MAX_VALUE);
@@ -453,10 +453,10 @@ public class OperationTrackerTest {
   }
 
   /**
-   * Test the case when NotFound Error should be disabled since the originating DC is unknown.
+   * Test the case when NotFound Error should be disabled since the origin DC is unknown.
    */
   @Test
-  public void originatingDcNotFoundUnknownOriginatingDcTest() {
+  public void originDcNotFoundUnknownOriginDcTest() {
     initialize();
     originatingDcName = null;
     OperationTracker ot = getOperationTracker(true, 1, 12, false, Integer.MAX_VALUE);
@@ -476,7 +476,7 @@ public class OperationTrackerTest {
    * Test the case when NotFound Error triggered.
    */
   @Test
-  public void originatingDcNotFoundTriggeredTest() {
+  public void originDcNotFoundTriggeredTest() {
     initialize();
     originatingDcName = datanodes.get(datanodes.size() - 1).getDatacenterName();
     OperationTracker ot = getOperationTracker(true, 2, 3, true, Integer.MAX_VALUE);

--- a/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
@@ -629,6 +629,7 @@ public class OperationTrackerTest {
     props.setProperty("router.get.replicas.required", Integer.toString(replicasRequired));
     props.setProperty("router.latency.tolerance.quantile", Double.toString(QUANTILE));
     props.setProperty("router.operation.tracker.max.inflight.requests", Integer.toString(parallelism));
+    props.setProperty("router.operation.tracker.originating.dc.notfound.enabled", "true");
     RouterConfig routerConfig = new RouterConfig(new VerifiableProperties(props));
     NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
     OperationTracker tracker;

--- a/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
@@ -629,7 +629,7 @@ public class OperationTrackerTest {
     props.setProperty("router.get.replicas.required", Integer.toString(replicasRequired));
     props.setProperty("router.latency.tolerance.quantile", Double.toString(QUANTILE));
     props.setProperty("router.operation.tracker.max.inflight.requests", Integer.toString(parallelism));
-    props.setProperty("router.operation.tracker.originating.dc.notfound.enabled", "true");
+    props.setProperty("router.operation.tracker.terminate.on.not.found.enabled", "true");
     RouterConfig routerConfig = new RouterConfig(new VerifiableProperties(props));
     NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
     OperationTracker tracker;

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -54,20 +54,8 @@ public class PutOperationTest {
   private final Time time;
   private final Map<Integer, PutOperation> correlationIdToPutOperation = new TreeMap<>();
   private final MockServer mockServer = new MockServer(mockClusterMap, "");
-
-  private class PutTestRequestRegistrationCallbackImpl implements RequestRegistrationCallback<PutOperation> {
-    private List<RequestInfo> requestListToFill;
-
-    @Override
-    public void registerRequestToSend(PutOperation putOperation, RequestInfo requestInfo) {
-      requestListToFill.add(requestInfo);
-      correlationIdToPutOperation.put(((RequestOrResponse) requestInfo.getRequest()).getCorrelationId(), putOperation);
-    }
-  }
-
   private final PutTestRequestRegistrationCallbackImpl requestRegistrationCallback =
       new PutTestRequestRegistrationCallbackImpl();
-
   private final int chunkSize = 10;
   private final int requestParallelism = 3;
   private final int successTarget = 1;
@@ -290,6 +278,16 @@ public class PutOperationTest {
   private ResponseInfo getResponseInfo(RequestInfo requestInfo) throws IOException {
     NetworkReceive networkReceive = new NetworkReceive(null, mockServer.send(requestInfo.getRequest()), time);
     return new ResponseInfo(requestInfo, null, networkReceive.getReceivedBytes().getPayload());
+  }
+
+  private class PutTestRequestRegistrationCallbackImpl implements RequestRegistrationCallback<PutOperation> {
+    private List<RequestInfo> requestListToFill;
+
+    @Override
+    public void registerRequestToSend(PutOperation putOperation, RequestInfo requestInfo) {
+      requestListToFill.add(requestInfo);
+      correlationIdToPutOperation.put(((RequestOrResponse) requestInfo.getRequest()).getCorrelationId(), putOperation);
+    }
   }
 }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
@@ -17,7 +17,9 @@ import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.account.Container;
 import com.github.ambry.account.InMemAccountService;
+import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.commons.ResponseHandler;
@@ -194,17 +196,16 @@ public class TtlUpdateManagerTest {
     Map<ServerErrorCode, RouterErrorCode> errorCodeMap = new HashMap<>();
     errorCodeMap.put(ServerErrorCode.Blob_Deleted, RouterErrorCode.BlobDeleted);
     errorCodeMap.put(ServerErrorCode.Blob_Expired, RouterErrorCode.BlobExpired);
-    errorCodeMap.put(ServerErrorCode.Blob_Not_Found, RouterErrorCode.BlobDoesNotExist);
     errorCodeMap.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
     errorCodeMap.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
     errorCodeMap.put(ServerErrorCode.Blob_Update_Not_Allowed, RouterErrorCode.BlobUpdateNotAllowed);
     errorCodeMap.put(ServerErrorCode.Blob_Authorization_Failure, RouterErrorCode.BlobAuthorizationFailure);
     for (ServerErrorCode errorCode : ServerErrorCode.values()) {
-      if (errorCode == ServerErrorCode.No_Error || errorCode == ServerErrorCode.Blob_Already_Updated) {
+      if (errorCode == ServerErrorCode.No_Error || errorCode == ServerErrorCode.Blob_Already_Updated  || errorCode == ServerErrorCode.Blob_Not_Found) {
         continue;
       }
       ArrayList<ServerErrorCode> serverErrorCodes =
-          new ArrayList<>(Collections.nCopies(serverCount, ServerErrorCode.Blob_Not_Found));
+          new ArrayList<>(Collections.nCopies(serverCount, ServerErrorCode.IO_Error));
       // has to be repeated because the op tracker returns failure if it sees 8/9 failures and the success target is 2
       serverErrorCodes.set(3, errorCode);
       serverErrorCodes.set(5, errorCode);
@@ -454,7 +455,7 @@ public class TtlUpdateManagerTest {
       throw new IllegalStateException("Cannot run test because there aren't enough servers for the given codes");
     }
     List<ServerErrorCode> serverErrorCodes =
-        new ArrayList<>(Collections.nCopies(serverCount, ServerErrorCode.Blob_Not_Found));
+        new ArrayList<>(Collections.nCopies(serverCount, ServerErrorCode.IO_Error));
     List<RouterErrorCode> expected = new ArrayList<>(codesToSetAndTest.size());
     // fill in the array with all the error codes that need resolution and knock them off one by one
     // has to be repeated because the op tracker returns failure if it sees 8/9 failures and the success target is 2
@@ -465,15 +466,15 @@ public class TtlUpdateManagerTest {
       expected.add(entry.getValue());
       serverIdx += 2;
     }
-    expected.add(RouterErrorCode.BlobDoesNotExist);
+    expected.add(RouterErrorCode.UnexpectedInternalError);
     for (int i = 0; i < expected.size(); i++) {
       List<ServerErrorCode> shuffled = new ArrayList<>(serverErrorCodes);
       Collections.shuffle(shuffled);
       setServerErrorCodes(shuffled, serverLayout);
       executeOpAndVerify(blobIds, expected.get(i), false, true, true, false);
       if (i * 2 + 1 < serverErrorCodes.size()) {
-        serverErrorCodes.set(i * 2, ServerErrorCode.Blob_Not_Found);
-        serverErrorCodes.set(i * 2 + 1, ServerErrorCode.Blob_Not_Found);
+        serverErrorCodes.set(i * 2, ServerErrorCode.IO_Error);
+        serverErrorCodes.set(i * 2 + 1, ServerErrorCode.IO_Error);
       }
     }
     serverLayout.getMockServers().forEach(MockServer::resetServerErrors);

--- a/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
@@ -71,11 +71,6 @@ public class TtlUpdateManagerTest {
   private static final int BLOBS_COUNT = 5;
   private static final String UPDATE_SERVICE_ID = "update-service-id";
   private static final String LOCAL_DC = "DC1";
-
-  static {
-    TestUtils.RANDOM.nextBytes(PUT_CONTENT);
-  }
-
   private final NonBlockingRouter router;
   private final TtlUpdateManager ttlUpdateManager;
   private final NetworkClient networkClient;
@@ -296,9 +291,6 @@ public class TtlUpdateManagerTest {
     }
   }
 
-  // helpers
-  // general
-
   /**
    * Executes a ttl update operations and verifies results
    * @param ids the collection of ids to ttl update
@@ -342,6 +334,9 @@ public class TtlUpdateManagerTest {
       assertTtl(router, ids, expectedTtlSecs);
     }
   }
+
+  // helpers
+  // general
 
   /**
    * Sends all the requests that the {@code manager} may have ready
@@ -411,8 +406,6 @@ public class TtlUpdateManagerTest {
     return properties;
   }
 
-  // fixedCountSuccessfulResponseTest() helpers
-
   /**
    * Does the fixed count successful response test by setting the appropriate number of successful responses
    * @param successfulResponsesCount the number of successful responses
@@ -440,7 +433,7 @@ public class TtlUpdateManagerTest {
     serverLayout.getMockServers().forEach(MockServer::resetServerErrors);
   }
 
-  // routerErrorCodeResolutionTest() helpers
+  // fixedCountSuccessfulResponseTest() helpers
 
   /**
    * Runs the router code resolution test based on the input
@@ -478,6 +471,12 @@ public class TtlUpdateManagerTest {
     }
     serverLayout.getMockServers().forEach(MockServer::resetServerErrors);
     assertTtl(router, blobIds, TTL_SECS);
+  }
+
+  // routerErrorCodeResolutionTest() helpers
+
+  static {
+    TestUtils.RANDOM.nextBytes(PUT_CONTENT);
   }
 }
 


### PR DESCRIPTION
NOT_FOUND will be treated as a special error code for OperationTracker.

When there are two NOT_FOUND responses from originating dc, operation tracker would terminate the operation (including GetBlob, GetBlobInfo, DeleteBlob and TtlUpdate). The reason we choose to terminate at two, is because all the mutation operations would require two success responses and we have three replicas. So N + M > R.