### PR TITLE
Improve GetWritablePartitionIds Performance for PUT Requests

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -42,6 +42,14 @@ public interface ClusterMap extends AutoCloseable {
   List<? extends PartitionId> getWritablePartitionIds(String partitionClass);
 
   /**
+   * Get a writable partition chosen at random that belongs to given partitionclass.
+   * @param partitionClass the partition class whose writable partitions are required. Can be {@code null}
+   * @param partitionsToExclude list of partitions that shouldnt be considered as a possible partition returned
+   * @return chosen random partition. Can be {@code null}
+   */
+  PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude);
+
+  /**
    * Gets a list of all partitions in the cluster.  Gets a mutable shallow copy of the list of all partitions.
    * @param partitionClass the partition class whose partitions are required. Can be {@code null}
    * @return a list of all partitions belonging to the partition class (or all partitions if {@code partitionClass} is

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -47,7 +47,7 @@ public interface ClusterMap extends AutoCloseable {
    * @param partitionsToExclude list of partitions that shouldnt be considered as a possible partition returned
    * @return chosen random partition. Can be {@code null}
    */
-  PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude);
+  PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude);
 
   /**
    * Gets a list of all partitions in the cluster.  Gets a mutable shallow copy of the list of all partitions.

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -441,19 +441,6 @@ public class ClusterMapUtils {
       return selectedPartition;
     }
 
-    private boolean areEnoughLocalReplicasForPartitionUp(PartitionId partition) {
-      return getUpLocalReplicaCountForPartition(partition) == 2;
-    }
-
-    private int getUpLocalReplicaCountForPartition(PartitionId partition) {
-      int numLocalReplicasUp = 0;
-      for(ReplicaId replica : partition.getReplicaIds()) {
-        if(!replica.isDown() && replica.getDataNodeId().getDatacenterName().equals(localDatacenterName))
-          numLocalReplicasUp++;
-      }
-      return numLocalReplicasUp;
-    }
-
     /**
      * Returns the partitions belonging to the {@code partitionClass}. Returns all partitions if {@code partitionClass}
      * is {@code null}.

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -334,7 +334,6 @@ public class ClusterMapUtils {
   static class PartitionSelectionHelper {
     private Collection<? extends PartitionId> allPartitions;
     private Map<String, SortedMap<Integer, List<PartitionId>>> partitionIdsByClassAndLocalReplicaCount;
-    private String localDatacenterName;
 
     /**
      * @param allPartitions the list of all {@link PartitionId}s
@@ -353,7 +352,6 @@ public class ClusterMapUtils {
      */
     void updatePartitions(Collection<? extends PartitionId> allPartitions, String localDatacenterName) {
       this.allPartitions = allPartitions;
-      this.localDatacenterName = localDatacenterName;
       partitionIdsByClassAndLocalReplicaCount = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
       for (PartitionId partition : allPartitions) {
         String partitionClass = partition.getPartitionClass();

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -434,20 +434,18 @@ public class ClusterMapUtils {
      * @return A writable partition or {@code null} if no writable partition with given criteria found
      */
     PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
-      PartitionId selectedPartition = null;
       PartitionId anyWritablePartition = null;
       List<PartitionId> partitionsInClass = getPartitionsInClass(partitionClass, true);
 
       int workingSize = partitionsInClass.size();
-      while(workingSize > 0) {
+      while (workingSize > 0) {
         int randomIndex = ThreadLocalRandom.current().nextInt(workingSize);
         PartitionId selected = partitionsInClass.get(randomIndex);
-        if(partitionsToExclude == null || partitionsToExclude.size() == 0 || !partitionsToExclude.contains(selected)) {
+        if (partitionsToExclude == null || partitionsToExclude.size() == 0 || !partitionsToExclude.contains(selected)) {
           if (selected.getPartitionState() == PartitionState.READ_WRITE) {
             anyWritablePartition = selected;
-            if(areAllLocalReplicasForPartitionUp(selected, localDatacenterName)) {
-              selectedPartition = selected;
-              break;
+            if (areAllLocalReplicasForPartitionUp(selected, localDatacenterName)) {
+              return selected;
             }
           }
         }
@@ -456,7 +454,8 @@ public class ClusterMapUtils {
         }
         workingSize--;
       }
-      return (selectedPartition == null) ? anyWritablePartition : selectedPartition;
+      //if we are here then that means we couldn't find any partition with all local replicas up
+      return anyWritablePartition;
     }
 
     /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -122,7 +122,7 @@ class CompositeClusterManager implements ClusterMap {
    * @return A writable parition id object. Can be {@code null}
    */
   @Override
-  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+  public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
     List<? extends PartitionId> partitions = getWritablePartitionIds(partitionClass);
     partitions.removeAll(partitionsToExclude);
     return partitions.isEmpty()?null:partitions.get(ThreadLocalRandom.current().nextInt(partitions.size()));

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,6 +108,24 @@ class CompositeClusterManager implements ClusterMap {
       }
     }
     return staticWritablePartitionIds;
+  }
+
+  /**
+   * Randomly select a writable partition from a list of writable partition ids obtained from both the underlying
+   * {@link StaticClusterManager} and the underlying {@link HelixClusterManager}. This implementation can add to put
+   * latency because getWritablePartitionIds called within this method, scans all the partitions to get writable paritions.
+   * However, since {@link CompositeClusterManager} is used only during migrations, when both static and helix cluster
+   * managers co-exist, the latency can be a acceptable trade off for the extra metrics obtained from
+   * getWritablePartitionIds.
+   * @param partitionClass the partition class whose writable partitions are required. Can be {@code null}
+   * @param partitionsToExclude A list of partitions that should be excluded from consideration.
+   * @return A writable parition id object. Can be {@code null}
+   */
+  @Override
+  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+    List<? extends PartitionId> partitions = getWritablePartitionIds(partitionClass);
+    partitions.removeAll(partitionsToExclude);
+    return partitions.isEmpty()?null:partitions.get(ThreadLocalRandom.current().nextInt(partitions.size()));
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -119,13 +119,13 @@ class CompositeClusterManager implements ClusterMap {
    * getWritablePartitionIds.
    * @param partitionClass the partition class whose writable partitions are required. Can be {@code null}
    * @param partitionsToExclude A list of partitions that should be excluded from consideration.
-   * @return A writable parition id object. Can be {@code null}
+   * @return A writable partition id object. Can be {@code null}
    */
   @Override
   public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
     List<? extends PartitionId> partitions = getWritablePartitionIds(partitionClass);
     partitions.removeAll(partitionsToExclude);
-    return partitions.isEmpty()?null:partitions.get(ThreadLocalRandom.current().nextInt(partitions.size()));
+    return partitions.isEmpty() ? null : partitions.get(ThreadLocalRandom.current().nextInt(partitions.size()));
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -371,6 +371,11 @@ class HelixClusterManager implements ClusterMap {
   }
 
   @Override
+  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+    return partitionSelectionHelper.getRandomWritablePartition(partitionClass, partitionsToExclude);
+  }
+
+  @Override
   public List<PartitionId> getAllPartitionIds(String partitionClass) {
     return partitionSelectionHelper.getPartitions(partitionClass);
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -371,7 +371,7 @@ class HelixClusterManager implements ClusterMap {
   }
 
   @Override
-  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+  public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
     return partitionSelectionHelper.getRandomWritablePartition(partitionClass, partitionsToExclude);
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
@@ -125,6 +125,10 @@ class PartitionLayout {
     return partitionSelectionHelper.getWritablePartitions(partitionClass);
   }
 
+  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> toExclude) {
+    return partitionSelectionHelper.getRandomWritablePartition(partitionClass, toExclude);
+  }
+
   public long getAllocatedRawCapacityInBytes() {
     return allocatedRawCapacityInBytes;
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
@@ -125,7 +125,7 @@ class PartitionLayout {
     return partitionSelectionHelper.getWritablePartitions(partitionClass);
   }
 
-  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> toExclude) {
+  public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> toExclude) {
     return partitionSelectionHelper.getRandomWritablePartition(partitionClass, toExclude);
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -82,6 +82,11 @@ class StaticClusterManager implements ClusterMap {
   }
 
   @Override
+  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+    return partitionLayout.getRandomWritablePartition(partitionClass, partitionsToExclude);
+  }
+
+  @Override
   public List<PartitionId> getAllPartitionIds(String partitionClass) {
     return partitionLayout.getPartitions(partitionClass);
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -82,7 +82,7 @@ class StaticClusterManager implements ClusterMap {
   }
 
   @Override
-  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+  public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
     return partitionLayout.getRandomWritablePartition(partitionClass, partitionsToExclude);
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
@@ -194,7 +194,10 @@ public class ClusterMapUtilsTest {
    */
   private void assertInCollection(String message, Collection<? extends PartitionId> expected,
       PartitionId actual) {
-    assertTrue(message, expected.contains(actual));
+    if(expected != null)
+      assertTrue(message, expected.contains(actual));
+    else
+      assertEquals(message,null, expected);
   }
 
   /**
@@ -220,8 +223,44 @@ public class ClusterMapUtilsTest {
   }
 
   /**
-   * Verifies that the values returned {@link ClusterMapUtils.PartitionSelectionHelper#getWritablePartitions(String)} is
-   * correct.
+   * Verifies that the values returned for
+   * {@link ClusterMapUtils.PartitionSelectionHelper#getWritablePartitions(String)} is correct.
+   * @param psh the {@link ClusterMapUtils.PartitionSelectionHelper} instance to use.
+   * @param allPartitionIds all the partitions that are in clustermap
+   * @param classBeingTested the partition class being tested
+   * @param expectedReturnForClassBeingTested the list of partitions that can expected to be returned for
+   *                                             {@code classBeingTested}.
+   */
+  private void verifyGetWritablePartition(ClusterMapUtils.PartitionSelectionHelper psh,
+      Set<MockPartitionId> allPartitionIds, String classBeingTested,
+      Set<MockPartitionId> expectedReturnForClassBeingTested) {
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
+        psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
+        psh.getWritablePartitions(classBeingTested));
+  }
+
+  /**
+   * Verifies that the values returned for
+   * {@link ClusterMapUtils.PartitionSelectionHelper#getRandomWritablePartition(String, List)} is correct.
+   * @param psh the {@link ClusterMapUtils.PartitionSelectionHelper} instance to use.
+   * @param allPartitionIds all the partitions that are in clustermap
+   * @param classBeingTested the partition class being tested
+   * @param expectedReturnForClassBeingTested the list of partitions that can expected to be returned for
+   *                                             {@code classBeingTested}.
+   */
+  private void verifyGetRandomWritablePartition(ClusterMapUtils.PartitionSelectionHelper psh,
+      Set<MockPartitionId> allPartitionIds, String classBeingTested,
+      Set<MockPartitionId> expectedReturnForClassBeingTested) {
+    assertInCollection("Random partition returned not as expected", allPartitionIds,
+        psh.getRandomWritablePartition(null, null));
+    assertInCollection("Random partition returned not as expected", expectedReturnForClassBeingTested,
+        psh.getRandomWritablePartition(classBeingTested, null));
+  }
+
+  /**
+   * Verifies that the values returned {@link ClusterMapUtils.PartitionSelectionHelper#getWritablePartitions(String)} and
+   *  {@link ClusterMapUtils.PartitionSelectionHelper#getRandomWritablePartition(String, List)}  is correct.
    * @param psh the {@link ClusterMapUtils.PartitionSelectionHelper} instance to use.
    * @param allPartitionIds all the partitions that are in clustermap
    * @param classBeingTested the partition class being tested
@@ -238,47 +277,36 @@ public class ClusterMapUtilsTest {
       Set<MockPartitionId> expectedReturnForClassNotBeingTested) {
     Set<MockPartitionId> expectedReturnForClassBeingTested = new HashSet<>(Arrays.asList(testedPart1, testedPart2));
     // no problematic scenarios
-    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
-        psh.getWritablePartitions(null));
-    assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
-        psh.getWritablePartitions(classBeingTested));
-    assertInCollection("Random partition returned not as expected", allPartitionIds,
-        psh.getRandomWritablePartition(null, null));
-    assertInCollection("Random partition returned not as expected", expectedReturnForClassBeingTested,
-        psh.getRandomWritablePartition(classBeingTested, null));
+    verifyGetWritablePartition(psh, allPartitionIds, classBeingTested, expectedReturnForClassBeingTested);
+    verifyGetRandomWritablePartition(psh, allPartitionIds, classBeingTested, expectedReturnForClassBeingTested);
+
+    //verify excluded partitions behavior in getRandomPartition
     assertNull(psh.getRandomWritablePartition(null, new ArrayList<>(allPartitionIds)));
+
     checkCaseInsensitivityForPartitionSelectionHelper(psh, false, classBeingTested, expectedReturnForClassBeingTested);
+
     // one replica of one partition of "classBeingTested" down
     ((MockReplicaId) testedPart1.getReplicaIds().get(0)).markReplicaDownStatus(true);
     allPartitionIds.remove(testedPart1);
     expectedReturnForClassBeingTested.remove(testedPart1);
-    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
-        psh.getWritablePartitions(null));
-    assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
-        psh.getWritablePartitions(classBeingTested));
-    assertInCollection("Partitions returned not as expected", allPartitionIds,
-        psh.getRandomWritablePartition(null, null));
+    verifyGetWritablePartition(psh, allPartitionIds, classBeingTested, expectedReturnForClassBeingTested);
     //for getRandomWritablePartition one replica being down doesnt change anything unless its a local replica
     expectedReturnForClassBeingTested.add(testedPart1);
-    assertInCollection("Partitions returned not as expected", expectedReturnForClassBeingTested,
-        psh.getRandomWritablePartition(classBeingTested, null));
+    verifyGetRandomWritablePartition(psh, allPartitionIds, classBeingTested, expectedReturnForClassBeingTested);
+
     // one replica of other partition of "classBeingTested" down too
     ((MockReplicaId) testedPart2.getReplicaIds().get(0)).markReplicaDownStatus(true);
     allPartitionIds.remove(testedPart2);
     // if both have a replica down, then even though both are unhealthy, they are both returned.
     expectedReturnForClassBeingTested.add(testedPart1);
-    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
-        psh.getWritablePartitions(null));
-    assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
-        psh.getWritablePartitions(classBeingTested));
-    assertInCollection("Partitions returned not as expected", allPartitionIds,
-        psh.getRandomWritablePartition(null, null));
-    assertInCollection("Partitions returned not as expected", expectedReturnForClassBeingTested,
-        psh.getRandomWritablePartition(classBeingTested, null));
+    verifyGetWritablePartition(psh, allPartitionIds, classBeingTested, expectedReturnForClassBeingTested);
+    verifyGetRandomWritablePartition(psh, allPartitionIds, classBeingTested, expectedReturnForClassBeingTested);
+
     if (expectedReturnForClassNotBeingTested != null) {
       assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassNotBeingTested,
           psh.getWritablePartitions(classsNotBeingTested));
     }
+
     ((MockReplicaId) testedPart1.getReplicaIds().get(0)).markReplicaDownStatus(false);
     ((MockReplicaId) testedPart2.getReplicaIds().get(0)).markReplicaDownStatus(false);
     allPartitionIds.add(testedPart1);
@@ -288,30 +316,22 @@ public class ClusterMapUtilsTest {
     ((MockReplicaId) testedPart1.getReplicaIds().get(0)).setSealedState(true);
     allPartitionIds.remove(testedPart1);
     expectedReturnForClassBeingTested.remove(testedPart1);
-    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
-        psh.getWritablePartitions(null));
-    assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
-        psh.getWritablePartitions(classBeingTested));
-    assertInCollection("Partitions returned not as expected", allPartitionIds,
-        psh.getRandomWritablePartition(null, null));
-    assertInCollection("Partitions returned not as expected", expectedReturnForClassBeingTested,
-        psh.getRandomWritablePartition(classBeingTested, null));
+    verifyGetWritablePartition(psh, allPartitionIds, classBeingTested, expectedReturnForClassBeingTested);
+    verifyGetRandomWritablePartition(psh, allPartitionIds, classBeingTested, expectedReturnForClassBeingTested);
+
     // all READ_ONLY
     ((MockReplicaId) testedPart2.getReplicaIds().get(0)).setSealedState(true);
     allPartitionIds.remove(testedPart2);
     expectedReturnForClassBeingTested.remove(testedPart2);
-    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
-        psh.getWritablePartitions(null));
-    assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
-        psh.getWritablePartitions(classBeingTested));
-    assertInCollection("Partitions returned not as expected", allPartitionIds,
-        psh.getRandomWritablePartition(null, null));
-    assertNull("Partitions returned not as expected",
-        psh.getRandomWritablePartition(classBeingTested, null));
+    verifyGetWritablePartition(psh, allPartitionIds, classBeingTested, expectedReturnForClassBeingTested);
+    verifyGetRandomWritablePartition(psh, allPartitionIds, classBeingTested, null);
+
     if (expectedReturnForClassNotBeingTested != null) {
       assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassNotBeingTested,
           psh.getWritablePartitions(classsNotBeingTested));
     }
+
+    //cleanup the cluster map
     ((MockReplicaId) testedPart1.getReplicaIds().get(0)).setSealedState(false);
     ((MockReplicaId) testedPart2.getReplicaIds().get(0)).setSealedState(false);
     allPartitionIds.add(testedPart1);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
@@ -258,6 +258,8 @@ public class ClusterMapUtilsTest {
         psh.getWritablePartitions(classBeingTested));
     assertInCollection("Partitions returned not as expected", allPartitionIds,
         psh.getRandomWritablePartition(null, null));
+    //for getRandomWritablePartition one replica being down doesnt change anything unless its a local replica
+    expectedReturnForClassBeingTested.add(testedPart1);
     assertInCollection("Partitions returned not as expected", expectedReturnForClassBeingTested,
         psh.getRandomWritablePartition(classBeingTested, null));
     // one replica of other partition of "classBeingTested" down too

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.utils.UtilsTest;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -135,6 +136,12 @@ public class ClusterMapUtilsTest {
       } catch (IllegalArgumentException e) {
         // expected. Nothing to do.
       }
+      try {
+        psh.getRandomWritablePartition(UtilsTest.getRandomString(3), null);
+        fail("partition class is invalid, should have thrown");
+      } catch (IllegalArgumentException e) {
+        // expected. Nothing to do.
+      }
       verifyWritablePartitionsReturned(psh, allPartitionIds, maxReplicasAllSites, everywhere1, everywhere2,
           maxLocalOneRemote, expectedWritableForMaxLocalOneRemote);
       if (candidate1 != null && candidate2 != null) {
@@ -180,6 +187,17 @@ public class ClusterMapUtilsTest {
   }
 
   /**
+   * Asserts that element {@code actual} is equal to the one of the elements in {@code expected} collection.
+   * @param message the message to print if not found.
+   * @param expected the expected elements
+   * @param actual the actual element
+   */
+  private void assertInCollection(String message, Collection<? extends PartitionId> expected,
+      PartitionId actual) {
+    assertTrue(message, expected.contains(actual));
+  }
+
+  /**
    * Checks that the {@code partitionClass} is treated in a case insensitive way.
    * @param psh the {@link ClusterMapUtils.PartitionSelectionHelper} to use.
    * @param allPartitions if {@code true}, calls {@link ClusterMapUtils.PartitionSelectionHelper#getPartitions(String)}.
@@ -220,25 +238,41 @@ public class ClusterMapUtilsTest {
       Set<MockPartitionId> expectedReturnForClassNotBeingTested) {
     Set<MockPartitionId> expectedReturnForClassBeingTested = new HashSet<>(Arrays.asList(testedPart1, testedPart2));
     // no problematic scenarios
-    assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
+        psh.getWritablePartitions(null));
     assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
         psh.getWritablePartitions(classBeingTested));
+    assertInCollection("Random partition returned not as expected", allPartitionIds,
+        psh.getRandomWritablePartition(null, null));
+    assertInCollection("Random partition returned not as expected", expectedReturnForClassBeingTested,
+        psh.getRandomWritablePartition(classBeingTested, null));
+    assertNull(psh.getRandomWritablePartition(null, new ArrayList<>(allPartitionIds)));
     checkCaseInsensitivityForPartitionSelectionHelper(psh, false, classBeingTested, expectedReturnForClassBeingTested);
     // one replica of one partition of "classBeingTested" down
     ((MockReplicaId) testedPart1.getReplicaIds().get(0)).markReplicaDownStatus(true);
     allPartitionIds.remove(testedPart1);
     expectedReturnForClassBeingTested.remove(testedPart1);
-    assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
+        psh.getWritablePartitions(null));
     assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
         psh.getWritablePartitions(classBeingTested));
+    assertInCollection("Partitions returned not as expected", allPartitionIds,
+        psh.getRandomWritablePartition(null, null));
+    assertInCollection("Partitions returned not as expected", expectedReturnForClassBeingTested,
+        psh.getRandomWritablePartition(classBeingTested, null));
     // one replica of other partition of "classBeingTested" down too
     ((MockReplicaId) testedPart2.getReplicaIds().get(0)).markReplicaDownStatus(true);
     allPartitionIds.remove(testedPart2);
     // if both have a replica down, then even though both are unhealthy, they are both returned.
     expectedReturnForClassBeingTested.add(testedPart1);
-    assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
+        psh.getWritablePartitions(null));
     assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
         psh.getWritablePartitions(classBeingTested));
+    assertInCollection("Partitions returned not as expected", allPartitionIds,
+        psh.getRandomWritablePartition(null, null));
+    assertInCollection("Partitions returned not as expected", expectedReturnForClassBeingTested,
+        psh.getRandomWritablePartition(classBeingTested, null));
     if (expectedReturnForClassNotBeingTested != null) {
       assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassNotBeingTested,
           psh.getWritablePartitions(classsNotBeingTested));
@@ -252,16 +286,26 @@ public class ClusterMapUtilsTest {
     ((MockReplicaId) testedPart1.getReplicaIds().get(0)).setSealedState(true);
     allPartitionIds.remove(testedPart1);
     expectedReturnForClassBeingTested.remove(testedPart1);
-    assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
+        psh.getWritablePartitions(null));
     assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
         psh.getWritablePartitions(classBeingTested));
+    assertInCollection("Partitions returned not as expected", allPartitionIds,
+        psh.getRandomWritablePartition(null, null));
+    assertInCollection("Partitions returned not as expected", expectedReturnForClassBeingTested,
+        psh.getRandomWritablePartition(classBeingTested, null));
     // all READ_ONLY
     ((MockReplicaId) testedPart2.getReplicaIds().get(0)).setSealedState(true);
     allPartitionIds.remove(testedPart2);
     expectedReturnForClassBeingTested.remove(testedPart2);
-    assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
+        psh.getWritablePartitions(null));
     assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
         psh.getWritablePartitions(classBeingTested));
+    assertInCollection("Partitions returned not as expected", allPartitionIds,
+        psh.getRandomWritablePartition(null, null));
+    assertNull("Partitions returned not as expected",
+        psh.getRandomWritablePartition(classBeingTested, null));
     if (expectedReturnForClassNotBeingTested != null) {
       assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassNotBeingTested,
           psh.getWritablePartitions(classsNotBeingTested));

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
@@ -192,12 +192,12 @@ public class ClusterMapUtilsTest {
    * @param expected the expected elements
    * @param actual the actual element
    */
-  private void assertInCollection(String message, Collection<? extends PartitionId> expected,
-      PartitionId actual) {
-    if(expected != null)
+  private void assertInCollection(String message, Collection<? extends PartitionId> expected, PartitionId actual) {
+    if (expected != null) {
       assertTrue(message, expected.contains(actual));
-    else
-      assertEquals(message,null, expected);
+    } else {
+      assertEquals(message, null, expected);
+    }
   }
 
   /**
@@ -234,8 +234,7 @@ public class ClusterMapUtilsTest {
   private void verifyGetWritablePartition(ClusterMapUtils.PartitionSelectionHelper psh,
       Set<MockPartitionId> allPartitionIds, String classBeingTested,
       Set<MockPartitionId> expectedReturnForClassBeingTested) {
-    assertCollectionEquals("Partitions returned not as expected", allPartitionIds,
-        psh.getWritablePartitions(null));
+    assertCollectionEquals("Partitions returned not as expected", allPartitionIds, psh.getWritablePartitions(null));
     assertCollectionEquals("Partitions returned not as expected", expectedReturnForClassBeingTested,
         psh.getWritablePartitions(classBeingTested));
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -246,6 +246,11 @@ public class MockClusterMap implements ClusterMap {
   }
 
   @Override
+  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+    return partitionSelectionHelper.getRandomWritablePartition(partitionClass, partitionsToExclude);
+  }
+
+  @Override
   public List<PartitionId> getAllPartitionIds(String partitionClass) {
     lastRequestedPartitionClasses.add(partitionClass);
     return partitionSelectionHelper.getPartitions(partitionClass);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -246,8 +246,12 @@ public class MockClusterMap implements ClusterMap {
   }
 
   @Override
-  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
-    return partitionSelectionHelper.getRandomWritablePartition(partitionClass, partitionsToExclude);
+  public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
+    lastRequestedPartitionClasses.add(partitionClass);
+    if (!partitionsUnavailable) {
+      return partitionSelectionHelper.getRandomWritablePartition(partitionClass, partitionsToExclude);
+    }
+    return null;
   }
 
   @Override

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -154,15 +154,20 @@ public class ResponseHandlerTest {
     expectedEventTypes.put(ServerErrorCode.Disk_Unavailable,
         new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Error});
     expectedEventTypes.put(ServerErrorCode.Partition_ReadOnly,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Partition_ReadOnly, ReplicaEventType.Replica_Available});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
+            ReplicaEventType.Partition_ReadOnly, ReplicaEventType.Replica_Available});
     expectedEventTypes.put(ServerErrorCode.Replica_Unavailable,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Unavailable});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
+            ReplicaEventType.Replica_Unavailable});
     expectedEventTypes.put(ServerErrorCode.Temporarily_Disabled,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Unavailable});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
+            ReplicaEventType.Replica_Unavailable});
     expectedEventTypes.put(ServerErrorCode.Unknown_Error,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Available});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
+            ReplicaEventType.Replica_Available});
     expectedEventTypes.put(ServerErrorCode.No_Error,
-        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok, ReplicaEventType.Replica_Available});
+        new ReplicaEventType[]{ReplicaEventType.Node_Response, ReplicaEventType.Disk_Ok,
+            ReplicaEventType.Replica_Available});
     expectedEventTypes.put(NetworkClientErrorCode.NetworkError, new ReplicaEventType[]{ReplicaEventType.Node_Timeout});
     expectedEventTypes.put(NetworkClientErrorCode.ConnectionUnavailable, new ReplicaEventType[]{});
     expectedEventTypes.put(new RouterException("", RouterErrorCode.UnexpectedInternalError), new ReplicaEventType[]{});

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -65,7 +65,7 @@ public class ResponseHandlerTest {
     }
 
     @Override
-    public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+    public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
       return null;
     }
 

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -65,6 +65,11 @@ public class ResponseHandlerTest {
     }
 
     @Override
+    public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+      return null;
+    }
+
+    @Override
     public List<PartitionId> getAllPartitionIds(String partitionClass) {
       return null;
     }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
@@ -313,6 +313,11 @@ class TailoredPeersClusterMap implements ClusterMap {
   }
 
   @Override
+  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+    throw new IllegalStateException();
+  }
+
+  @Override
   public List<? extends PartitionId> getAllPartitionIds(String partitionClass) {
     throw new IllegalStateException();
   }

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
@@ -313,7 +313,7 @@ class TailoredPeersClusterMap implements ClusterMap {
   }
 
   @Override
-  public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+  public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
     throw new IllegalStateException();
   }
 

--- a/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
@@ -637,7 +637,7 @@ public class BlobIdTransformerTest {
       return null;
     }
 
-    public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+    public PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
       return null;
     }
 

--- a/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
@@ -637,6 +637,10 @@ public class BlobIdTransformerTest {
       return null;
     }
 
+    public PartitionId getRandomWritablePartition(String partitionClass, List<? extends PartitionId> partitionsToExclude) {
+      return null;
+    }
+
     public List<? extends PartitionId> getAllPartitionIds(String partitionClass) {
       return null;
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -1330,14 +1330,11 @@ class PutOperation {
      */
     protected PartitionId getPartitionForPut(String partitionClass, List<? extends PartitionId> partitionIdsToExclude)
         throws RouterException {
-      // getWritablePartitions creates and returns a new list, so it is safe to manipulate it.
-      List<? extends PartitionId> partitions = clusterMap.getWritablePartitionIds(partitionClass);
-      partitions.removeAll(partitionIdsToExclude);
-      if (partitions.isEmpty()) {
+      PartitionId selected = clusterMap.getRandomWritablePartition(partitionClass, partitionIdsToExclude);
+      if(selected == null) {
         throw new RouterException("No writable partitions of class " + partitionClass + " available.",
             RouterErrorCode.AmbryUnavailable);
       }
-      PartitionId selected = partitions.get(ThreadLocalRandom.current().nextInt(partitions.size()));
       if (!partitionClass.equals(selected.getPartitionClass())) {
         throw new IllegalStateException(
             "Selected partition's class [" + selected.getPartitionClass() + "] is not as required: " + partitionClass);

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -1331,7 +1331,7 @@ class PutOperation {
     protected PartitionId getPartitionForPut(String partitionClass, List<PartitionId> partitionIdsToExclude)
         throws RouterException {
       PartitionId selected = clusterMap.getRandomWritablePartition(partitionClass, partitionIdsToExclude);
-      if(selected == null) {
+      if (selected == null) {
         throw new RouterException("No writable partitions of class " + partitionClass + " available.",
             RouterErrorCode.AmbryUnavailable);
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -1328,7 +1328,7 @@ class PutOperation {
      * @return the chosen {@link PartitionId}
      * @throws RouterException
      */
-    protected PartitionId getPartitionForPut(String partitionClass, List<? extends PartitionId> partitionIdsToExclude)
+    protected PartitionId getPartitionForPut(String partitionClass, List<PartitionId> partitionIdsToExclude)
         throws RouterException {
       PartitionId selected = clusterMap.getRandomWritablePartition(partitionClass, partitionIdsToExclude);
       if(selected == null) {

--- a/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CryptoJobHandlerTest.java
@@ -542,7 +542,7 @@ public class CryptoJobHandlerTest {
     BlobId.BlobIdType type = TestUtils.RANDOM.nextBoolean() ? BlobId.BlobIdType.NATIVE : BlobId.BlobIdType.CRAFTED;
     return new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), type, dc, getRandomShort(TestUtils.RANDOM),
         getRandomShort(TestUtils.RANDOM),
-        referenceClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), false,
+        referenceClusterMap.getRandomWritablePartition(MockClusterMap.DEFAULT_PARTITION_CLASS, null), false,
         BlobId.BlobDataType.DATACHUNK);
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -210,7 +210,7 @@ public class GetBlobOperationTest {
     options = new GetBlobOptionsInternal(new GetBlobOptionsBuilder().build(), false, routerMetrics.ageAtGet);
     mockServerLayout = new MockServerLayout(mockClusterMap);
     replicasCount =
-        mockClusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0).getReplicaIds().size();
+        mockClusterMap.getRandomWritablePartition(MockClusterMap.DEFAULT_PARTITION_CLASS, null).getReplicaIds().size();
     responseHandler = new ResponseHandler(mockClusterMap);
     MockNetworkClientFactory networkClientFactory =
         new MockNetworkClientFactory(vprops, mockSelectorState, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterTestHelpers.java
@@ -310,7 +310,7 @@ class RouterTestHelpers {
    * @return a new blob ID with the specified {@link BlobId.BlobDataType} and a random UUID.
    */
   private static String getRandomBlobId(ClusterMap clusterMap, BlobId.BlobDataType blobDataType) {
-    PartitionId partitionId = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    PartitionId partitionId = clusterMap.getRandomWritablePartition(MockClusterMap.DEFAULT_PARTITION_CLASS, null);
     return new BlobId(BLOB_ID_VERSION, BlobId.BlobIdType.NATIVE, clusterMap.getLocalDatacenterId(),
         Account.UNKNOWN_ACCOUNT_ID, Container.UNKNOWN_CONTAINER_ID, partitionId, false, blobDataType).getID();
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterUtilsTest.java
@@ -47,7 +47,7 @@ public class RouterUtilsTest {
     } catch (Exception e) {
       fail("Should not get any exception.");
     }
-    partition = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    partition = clusterMap.getRandomWritablePartition(MockClusterMap.DEFAULT_PARTITION_CLASS, null);
     originalBlobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
         clusterMap.getLocalDatacenterId(), Utils.getRandomShort(random), Utils.getRandomShort(random), partition, false,
         BlobId.BlobDataType.DATACHUNK);


### PR DESCRIPTION
For each PUT request, instead of looping through all the partitions, and instead of checking replica states of all the partitions before selecting a random partition for put; this change gets a partition at random, and then checks if it is writable and if it’s replicas are available. The motivation for this change is present at https://docs.google.com/document/d/1DWXlUD1fxYkvVekl6tNFsxA7l_eaQrhb6-ht1rIb4G0/edit?ts=5d0ab0d1#

NOTE: For CompositeClusterManager, we need metrics for comparing HelixClusterManager state and StaticClusterManager state. Since the CompositeClusterManager is used only during migrations, this change trades-off  PUT latency during migration for the additional metrics. Hence, for HelixClusterManager, getting a writable partition for PUT involves getting all the partitions and checking each partition's replica state, before selecting a writable partition at random.