### PR TITLE
Add off switch for replenishConnections and honor datanode health

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
@@ -68,6 +68,14 @@ public class NetworkConfig {
   @Default("104857600")
   public final int socketRequestMaxBytes;
 
+  /**
+   * Whether the client should attempt to replenish connections when the number of connections to a host drops below
+   * a minimum number of active connections.
+   */
+  @Config("network.client.enable.connection.replenishment")
+  @Default("false")
+  public final boolean networkClientEnableConnectionReplenishment;
+
   public NetworkConfig(VerifiableProperties verifiableProperties) {
 
     numIoThreads = verifiableProperties.getIntInRange("num.io.threads", 8, 1, Integer.MAX_VALUE);
@@ -78,5 +86,7 @@ public class NetworkConfig {
     socketRequestMaxBytes =
         verifiableProperties.getIntInRange("socket.request.max.bytes", 100 * 1024 * 1024, 1, Integer.MAX_VALUE);
     queuedMaxRequests = verifiableProperties.getIntInRange("queued.max.requests", 500, 1, Integer.MAX_VALUE);
+    networkClientEnableConnectionReplenishment =
+        verifiableProperties.getBoolean("network.client.enable.connection.replenishment", false);
   }
 }

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
@@ -106,8 +106,10 @@ public class NetworkClient implements Closeable {
         pendingRequests.add(new RequestMetadata(time.milliseconds(), requestInfo, clientNetworkRequestMetrics));
       }
       List<NetworkSend> sends = prepareSends(responseInfoList);
-      int connectionsInitiated = connectionTracker.replenishConnections(this::connect);
-      networkMetrics.connectionReplenished.inc(connectionsInitiated);
+      if (networkConfig.networkClientEnableConnectionReplenishment) {
+        int connectionsInitiated = connectionTracker.replenishConnections(this::connect);
+        networkMetrics.connectionReplenished.inc(connectionsInitiated);
+      }
       selector.poll(pollTimeoutMs, sends);
       handleSelectorEvents(responseInfoList);
     } catch (Exception e) {

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -81,6 +81,7 @@ public class NetworkClientTest {
 
   public NetworkClientTest() throws IOException {
     Properties props = new Properties();
+    props.setProperty("network.client.enable.connection.replenishment", "true");
     VerifiableProperties vprops = new VerifiableProperties(props);
     NetworkConfig networkConfig = new NetworkConfig(vprops);
     selector = new MockSelector();


### PR DESCRIPTION
Make connection replenishment configurable and off by default.
Avoid trying to initiate connections with nodes detected as down.