### PR TITLE
Free PutOperation references earlier

### DIFF
--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -45,7 +45,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.net.ssl.SSLSession;
 import javax.servlet.http.Cookie;

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ThreadLocalRandom;
@@ -796,6 +797,15 @@ class PutOperation {
    */
   String getServiceId() {
     return passedInBlobProperties.getServiceId();
+  }
+
+  /**
+   * This will return a view of the correlation IDs of requests that may still be in flight. This is not threadsafe
+   * and should only be called from the main event loop.
+   * @return the set of correlation IDs of requests that are still in flight.
+   */
+  Set<Integer> getInFlightCorrelationIds() {
+    return correlationIdToPutChunk.keySet();
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -805,7 +805,7 @@ class PutOperation {
    * @return the set of correlation IDs of requests that are still in flight.
    */
   Set<Integer> getInFlightCorrelationIds() {
-    return correlationIdToPutChunk.keySet();
+    return Collections.unmodifiableSet(correlationIdToPutChunk.keySet());
   }
 
   /**


### PR DESCRIPTION
This contains a couple of fixes to free references to PutOperations
earlier and to allow GC to take place:
- Since NettyMessageProcessor keeps a reference to the last NettyRequest
object sent over an HTTP connection, there can be a link to a callback
that prevents a previous PutOperation's buffer from being GCed. The
easiest way to address this is to nullify the callback reference after
it is used.
- correlationIdToPutOperation map would previously retain a reference to
a PutOperation even if the operation was fully complete. This means that
large buffers would be retained until all responses are received, even
if the server response is no longer relevant to the operation.