### PR TITLE
Misc changes for adaptive operation tracker

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -407,7 +407,7 @@ public class RouterConfig {
     routerOperationTrackerMinDataPointsRequired =
         verifiableProperties.getLong("router.operation.tracker.min.data.points.required", 1000L);
     routerOperationTrackerMaxInflightRequests =
-        verifiableProperties.getIntInRange("router.adaptive.tracker.max.inflight.requests", 2, 1, Integer.MAX_VALUE);
+        verifiableProperties.getIntInRange("router.operation.tracker.max.inflight.requests", 2, 1, Integer.MAX_VALUE);
     routerOperationTrackerExcludeTimeoutEnabled =
         verifiableProperties.getBoolean("router.operation.tracker.exclude.timeout.enabled", false);
     routerOperationTrackerHistogramDumpEnabled =

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -298,18 +298,31 @@ public class RouterConfig {
   @Default("1000")
   public final long routerOperationTrackerMinDataPointsRequired;
 
+  /**
+   * The maximum number of inflight requests that allowed for adaptive tracker. If current number of inflight requests
+   * is larger than or equal to this threshold, tracker shouldn't send out any request even though the oldest is past due.
+   */
   @Config("router.adaptive.tracker.max.inflight.requests")
   @Default("2")
   public final int routerAdaptiveTrackerMaxInflightRequests;
 
+  /**
+   * Indicates whether to enable excluding timed out requests in Histogram reservoir.
+   */
   @Config("router.operation.tracker.exclude.timeout.enabled")
   @Default("false")
   public final boolean routerOperationTrackerExcludeTimeoutEnabled;
 
+  /**
+   * Indicates whether to dump resource-level histogram to log file.
+   */
   @Config("router.operation.tracker.histogram.dump.enabled")
   @Default("false")
   public final boolean routerOperationTrackerHistogramDumpEnabled;
 
+  /**
+   * The period of dumping resource-level histogram (if enabled).
+   */
   @Config("router.operation.tracker.histogram.dump.period")
   @Default("600")
   public final long routerOperationTrackerHistogramDumpPeriod;

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -298,6 +298,22 @@ public class RouterConfig {
   @Default("1000")
   public final long routerOperationTrackerMinDataPointsRequired;
 
+  @Config("router.adaptive.tracker.max.inflight.requests")
+  @Default("2")
+  public final int routerAdaptiveTrackerMaxInflightRequests;
+
+  @Config("router.operation.tracker.exclude.timeout.enabled")
+  @Default("false")
+  public final boolean routerOperationTrackerExcludeTimeoutEnabled;
+
+  @Config("router.operation.tracker.histogram.dump.enabled")
+  @Default("false")
+  public final boolean routerOperationTrackerHistogramDumpEnabled;
+
+  @Config("router.operation.tracker.histogram.dump.period")
+  @Default("600")
+  public final long routerOperationTrackerHistogramDumpPeriod;
+
   /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
@@ -371,5 +387,13 @@ public class RouterConfig {
         verifiableProperties.getDouble("router.operation.tracker.reservoir.decay.factor", 0.015);
     routerOperationTrackerMinDataPointsRequired =
         verifiableProperties.getLong("router.operation.tracker.min.data.points.required", 1000L);
+    routerAdaptiveTrackerMaxInflightRequests =
+        verifiableProperties.getIntInRange("router.adaptive.tracker.max.inflight.requests", 2, 1, Integer.MAX_VALUE);
+    routerOperationTrackerExcludeTimeoutEnabled =
+        verifiableProperties.getBoolean("router.operation.tracker.exclude.timeout.enabled", false);
+    routerOperationTrackerHistogramDumpEnabled =
+        verifiableProperties.getBoolean("router.operation.tracker.histogram.dump.enabled", false);
+    routerOperationTrackerHistogramDumpPeriod =
+        verifiableProperties.getLongInRange("router.operation.tracker.histogram.dump.period", 600L, 1L, Long.MAX_VALUE);
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/AdaptiveOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/AdaptiveOperationTracker.java
@@ -84,7 +84,7 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
       localDcResourceToHistogram = getResourceToLatencyMap(routerOperation, true);
       crossDcResourceToHistogram = getResourceToLatencyMap(routerOperation, false);
     }
-    if (parallelism > routerConfig.routerAdaptiveTrackerMaxInflightRequests) {
+    if (parallelism > routerConfig.routerOperationTrackerMaxInflightRequests) {
       throw new IllegalArgumentException(
           "Operation tracker parallelism is larger than adaptive tracker max inflight number");
     }
@@ -224,8 +224,15 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
 
     @Override
     public boolean hasNext() {
-      return replicaIterator.hasNext() && (inflightCount < parallelism || (
-          inflightCount < routerConfig.routerAdaptiveTrackerMaxInflightRequests && isOldestRequestPastDue()));
+      if (replicaIterator.hasNext()) {
+        if (inflightCount < parallelism) {
+          return true;
+        }
+        if (inflightCount < routerConfig.routerOperationTrackerMaxInflightRequests && isOldestRequestPastDue()) {
+          return true;
+        }
+      }
+      return false;
     }
 
     @Override

--- a/ambry-router/src/main/java/com.github.ambry.router/AdaptiveOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/AdaptiveOperationTracker.java
@@ -224,8 +224,8 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
 
     @Override
     public boolean hasNext() {
-      return replicaIterator.hasNext() && (inflightCount < parallelism || (isOldestRequestPastDue()
-          && inflightCount < routerConfig.routerAdaptiveTrackerMaxInflightRequests));
+      return replicaIterator.hasNext() && (inflightCount < parallelism || (
+          inflightCount < routerConfig.routerAdaptiveTrackerMaxInflightRequests && isOldestRequestPastDue()));
     }
 
     @Override

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -410,6 +410,8 @@ class NonBlockingRouter implements Router {
     if (cryptoJobHandler != null) {
       cryptoJobHandler.close();
     }
+    // close router metrics
+    routerMetrics.close();
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -199,11 +199,11 @@ public class NonBlockingRouterMetrics {
   public final CryptoJobMetrics decryptJobMetrics;
 
   // Resource to latency histogram map. Here resource can be DataNode, Partition, Disk, Replica etc.
-  Map<Resource, Histogram> getBlobLocalDcResourceToLatency;
-  Map<Resource, Histogram> getBlobCrossDcResourceToLatency;
+  Map<Resource, Histogram> getBlobLocalDcResourceToLatency = new HashMap<>();
+  Map<Resource, Histogram> getBlobCrossDcResourceToLatency = new HashMap<>();
 
-  Map<Resource, Histogram> getBlobInfoLocalDcResourceToLatency;
-  Map<Resource, Histogram> getBlobInfoCrossDcResourceToLatency;
+  Map<Resource, Histogram> getBlobInfoLocalDcResourceToLatency = new HashMap<>();
+  Map<Resource, Histogram> getBlobInfoCrossDcResourceToLatency = new HashMap<>();
 
   // Map that stores dataNode-level metrics.
   private final Map<DataNodeId, NodeLevelMetrics> dataNodeToMetrics;
@@ -487,10 +487,6 @@ public class NonBlockingRouterMetrics {
     int reservoirSize = routerConfig.routerOperationTrackerReservoirSize;
     double decayFactor = routerConfig.routerOperationTrackerReservoirDecayFactor;
     String localDatacenterName = clusterMap.getDatacenterName(clusterMap.getLocalDatacenterId());
-    getBlobLocalDcResourceToLatency = new HashMap<>();
-    getBlobInfoLocalDcResourceToLatency = new HashMap<>();
-    getBlobCrossDcResourceToLatency = new HashMap<>();
-    getBlobInfoCrossDcResourceToLatency = new HashMap<>();
     switch (routerConfig.routerOperationTrackerMetricScope) {
       case Partition:
         for (PartitionId partitionId : clusterMap.getAllPartitionIds(null)) {

--- a/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
@@ -184,7 +184,7 @@ public class AdaptiveOperationTrackerTest {
     sendRequests(ot, 0);
     // push it over the edge
     time.sleep(5);
-    // should only send one request because (inflight num + 1) == routerConfig.routerAdaptiveTrackerMaxInflightRequests
+    // should only send one request because (inflight num + 1) == routerConfig.routerOperationTrackerMaxInflightRequests
     sendRequests(ot, 1);
     // 0-3-0-0; 3-0-0-0
     // mark one request TIMED_OUT

--- a/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
@@ -701,7 +701,7 @@ public class AdaptiveOperationTrackerTest {
     props.setProperty("router.get.replicas.required", Integer.toString(Integer.MAX_VALUE));
     props.setProperty("router.latency.tolerance.quantile", Double.toString(QUANTILE));
     props.setProperty("router.operation.tracker.metric.scope", trackerScope.toString());
-    props.setProperty("router.adaptive.tracker.max.inflight.requests", Integer.toString(maxInflightNum));
+    props.setProperty("router.operation.tracker.max.inflight.requests", Integer.toString(maxInflightNum));
     props.setProperty("router.operation.tracker.exclude.timeout.enabled", Boolean.toString(excludeTimeout));
     if (customPercentiles != null) {
       props.setProperty("router.operation.tracker.custom.percentiles", customPercentiles);

--- a/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
@@ -646,14 +646,14 @@ public class AdaptiveOperationTrackerTest {
     tracker.onResponse(partitionAndInflightReplicas.get(mockPartition).poll(), TrackedRequestFinalState.SUCCESS);
     assertTrue("Operation should have succeeded", tracker.hasSucceeded());
     // test that no other resource-level metrics have been instantiated.
-    assertNull("Partition histogram in RouterMetrics should be null",
-        routerMetrics.getBlobInfoLocalDcResourceToLatency);
-    assertNull("Partition histogram in RouterMetrics should be null",
-        routerMetrics.getBlobInfoCrossDcResourceToLatency);
-    assertNull("Partition histogram in OperationTracker should be null",
-        tracker.getResourceToLatencyMap(RouterOperation.GetBlobInfoOperation, true));
-    assertNull("Partition histogram in OperationTracker should be null",
-        tracker.getResourceToLatencyMap(RouterOperation.GetBlobInfoOperation, false));
+    assertTrue("Partition histogram in RouterMetrics should be empty",
+        routerMetrics.getBlobInfoLocalDcResourceToLatency.isEmpty());
+    assertTrue("Partition histogram in RouterMetrics should be empty",
+        routerMetrics.getBlobInfoCrossDcResourceToLatency.isEmpty());
+    assertTrue("Partition histogram in OperationTracker should be empty",
+        tracker.getResourceToLatencyMap(RouterOperation.GetBlobInfoOperation, true).isEmpty());
+    assertTrue("Partition histogram in OperationTracker should be empty",
+        tracker.getResourceToLatencyMap(RouterOperation.GetBlobInfoOperation, false).isEmpty());
     // extra test: invalid router operation
     try {
       tracker.getResourceToLatencyMap(RouterOperation.PutOperation, true);

--- a/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/AdaptiveOperationTrackerTest.java
@@ -123,7 +123,7 @@ public class AdaptiveOperationTrackerTest {
     double localColoCutoff = localColoTracker.getSnapshot().getValue(QUANTILE);
     double crossColoCutoff = crossColoTracker.getSnapshot().getValue(QUANTILE);
 
-    OperationTracker ot = getOperationTracker(createRouterConfig(true, REPLICA_COUNT, 2, null), mockPartition);
+    OperationTracker ot = getOperationTracker(createRouterConfig(true, REPLICA_COUNT, 2, 6, null, true), mockPartition);
     // 3-0-0-0; 3-0-0-0
     sendRequests(ot, 2);
     // 1-2-0-0; 3-0-0-0
@@ -165,6 +165,53 @@ public class AdaptiveOperationTrackerTest {
   }
 
   /**
+   * Test that the max number of inflight requests should not exceed configured number.
+   * @throws InterruptedException
+   */
+  @Test
+  public void clampMaxInflightRequestsTest() throws InterruptedException {
+    primeTracker(localColoTracker, MIN_DATA_POINTS_REQUIRED, LOCAL_COLO_LATENCY_RANGE);
+    primeTracker(crossColoTracker, MIN_DATA_POINTS_REQUIRED, CROSS_COLO_LATENCY_RANGE);
+    double localColoCutoff = localColoTracker.getSnapshot().getValue(QUANTILE);
+    double crossColoCutoff = crossColoTracker.getSnapshot().getValue(QUANTILE);
+    // set max inflight number = 2 and excludeTimeout = false in this test
+    OperationTracker ot = getOperationTracker(createRouterConfig(true, 3, 2, 3, null, false), mockPartition);
+    // 3-0-0-0; 3-0-0-0
+    sendRequests(ot, 2);
+    // 1-2-0-0; 3-0-0-0
+    // sleep for less than the cutoff
+    time.sleep((long) localColoCutoff - 2);
+    sendRequests(ot, 0);
+    // push it over the edge
+    time.sleep(5);
+    // should only send one request because (inflight num + 1) == routerConfig.routerAdaptiveTrackerMaxInflightRequests
+    sendRequests(ot, 1);
+    // 0-3-0-0; 3-0-0-0
+    // mark one request TIMED_OUT
+    ot.onResponse(partitionAndInflightReplicas.get(mockPartition).poll(), TrackedRequestFinalState.TIMED_OUT);
+    // should send out 1 request
+    sendRequests(ot, 1);
+    // 0-2-0-1; 2-1-0-0
+
+    // mark one request FAILURE
+    ot.onResponse(partitionAndInflightReplicas.get(mockPartition).poll(), TrackedRequestFinalState.FAILURE);
+    time.sleep((long) (crossColoCutoff - localColoCutoff) + 2);
+
+    // should send out 1 request
+    sendRequests(ot, 1);
+    // 0-1-0-2; 1-2-0-0
+
+    // mark 3 inflight requests SUCCESS
+    while (!partitionAndInflightReplicas.get(mockPartition).isEmpty()) {
+      assertFalse("Operation should not be done", ot.isDone());
+      ot.onResponse(partitionAndInflightReplicas.get(mockPartition).poll(), TrackedRequestFinalState.SUCCESS);
+    }
+    assertTrue("Operation should have succeeded", ot.hasSucceeded());
+    // past due counter should be 3 (note that pastDueCounter is updated only when Iterator.remove() is called)
+    assertEquals("Past due counter is not expected", 3, pastDueCounter.getCount());
+  }
+
+  /**
    * Tests that adaptive tracker uses separate partition-level histogram to determine if inflight requests are past due.
    * @throws Exception
    */
@@ -179,7 +226,7 @@ public class AdaptiveOperationTrackerTest {
     MockClusterMap clusterMap =
         new MockClusterMap(false, datanodes, 3, Arrays.asList(mockPartition1, mockPartition2), localDcName);
     trackerScope = OperationTrackerScope.Partition;
-    RouterConfig routerConfig = createRouterConfig(true, 2, 1, null);
+    RouterConfig routerConfig = createRouterConfig(true, 2, 1, 6, null, true);
     NonBlockingRouterMetrics originalMetrics = routerMetrics;
     routerMetrics = new NonBlockingRouterMetrics(clusterMap, routerConfig);
     Counter pastDueCount = routerMetrics.getBlobPastDueCount;
@@ -279,7 +326,7 @@ public class AdaptiveOperationTrackerTest {
     MockClusterMap clusterMap =
         new MockClusterMap(false, datanodes, 3, Arrays.asList(mockPartition1, mockPartition2), localDcName);
     trackerScope = OperationTrackerScope.DataNode;
-    RouterConfig routerConfig = createRouterConfig(true, 1, 1, null);
+    RouterConfig routerConfig = createRouterConfig(true, 1, 1, 6, null, true);
     NonBlockingRouterMetrics originalMetrics = routerMetrics;
     routerMetrics = new NonBlockingRouterMetrics(clusterMap, routerConfig);
     Counter pastDueCount = routerMetrics.getBlobPastDueCount;
@@ -371,7 +418,7 @@ public class AdaptiveOperationTrackerTest {
     MockClusterMap clusterMap =
         new MockClusterMap(false, datanodes, 2, Arrays.asList(mockPartition1, mockPartition2), localDcName);
     trackerScope = OperationTrackerScope.Disk;
-    RouterConfig routerConfig = createRouterConfig(true, 1, 1, null);
+    RouterConfig routerConfig = createRouterConfig(true, 1, 1, 6, null, true);
     NonBlockingRouterMetrics originalMetrics = routerMetrics;
     routerMetrics = new NonBlockingRouterMetrics(clusterMap, routerConfig);
     Counter pastDueCount = routerMetrics.getBlobPastDueCount;
@@ -471,7 +518,7 @@ public class AdaptiveOperationTrackerTest {
     primeTracker(crossColoTracker, MIN_DATA_POINTS_REQUIRED, CROSS_COLO_LATENCY_RANGE);
     double localColoCutoff = localColoTracker.getSnapshot().getValue(QUANTILE);
 
-    OperationTracker ot = getOperationTracker(createRouterConfig(false, 1, 1, null), mockPartition);
+    OperationTracker ot = getOperationTracker(createRouterConfig(false, 1, 1, 6, null, true), mockPartition);
     // 3-0-0-0
     sendRequests(ot, 1);
     // 2-1-0-0
@@ -503,7 +550,7 @@ public class AdaptiveOperationTrackerTest {
     primeTracker(crossColoTracker, MIN_DATA_POINTS_REQUIRED, CROSS_COLO_LATENCY_RANGE);
     double localColoCutoff = localColoTracker.getSnapshot().getValue(1);
 
-    OperationTracker ot = getOperationTracker(createRouterConfig(false, 1, 1, null), mockPartition);
+    OperationTracker ot = getOperationTracker(createRouterConfig(false, 1, 1, 6, null, true), mockPartition);
     // 3-0-0-0
     sendRequests(ot, 1);
     // 2-1-0-0
@@ -549,7 +596,7 @@ public class AdaptiveOperationTrackerTest {
     assertTrue("No gauges should be created because custom percentile is not set", gauges.isEmpty());
     // test that dedicated gauges are correctly created for custom percentiles.
     String customPercentiles = "0.91,0.97";
-    RouterConfig routerConfig = createRouterConfig(false, 1, 1, customPercentiles);
+    RouterConfig routerConfig = createRouterConfig(false, 1, 1, 6, customPercentiles, true);
     String[] percentileArray = customPercentiles.split(",");
     Arrays.sort(percentileArray);
     List<String> sortedPercentiles =
@@ -636,12 +683,14 @@ public class AdaptiveOperationTrackerTest {
    * @param crossColoEnabled {@code true} if cross colo needs to be enabled. {@code false} otherwise.
    * @param successTarget the number of successful responses required for the operation to succeed.
    * @param parallelism the number of parallel requests that can be in flight.
+   * @param maxInflightNum the maximum number of inflight requests for adaptive tracker.
    * @param customPercentiles the custom percentiles to be reported. Percentiles are specified in a comma-separated
    *                          string, i.e "0.94,0.96,0.97".
+   * @param excludeTimeout whether to exclude timed out requests in Histogram.
    * @return an instance of {@link RouterConfig}
    */
   private RouterConfig createRouterConfig(boolean crossColoEnabled, int successTarget, int parallelism,
-      String customPercentiles) {
+      int maxInflightNum, String customPercentiles, boolean excludeTimeout) {
     Properties props = new Properties();
     props.setProperty("router.hostname", "localhost");
     props.setProperty("router.datacenter.name", localDcName);
@@ -652,6 +701,8 @@ public class AdaptiveOperationTrackerTest {
     props.setProperty("router.get.replicas.required", Integer.toString(Integer.MAX_VALUE));
     props.setProperty("router.latency.tolerance.quantile", Double.toString(QUANTILE));
     props.setProperty("router.operation.tracker.metric.scope", trackerScope.toString());
+    props.setProperty("router.adaptive.tracker.max.inflight.requests", Integer.toString(maxInflightNum));
+    props.setProperty("router.operation.tracker.exclude.timeout.enabled", Boolean.toString(excludeTimeout));
     if (customPercentiles != null) {
       props.setProperty("router.operation.tracker.custom.percentiles", customPercentiles);
     }
@@ -708,7 +759,7 @@ public class AdaptiveOperationTrackerTest {
   private void doTrackerUpdateTest(boolean succeedRequests) throws InterruptedException {
     long timeIncrement = 10;
     OperationTracker ot =
-        getOperationTracker(createRouterConfig(true, REPLICA_COUNT, REPLICA_COUNT, null), mockPartition);
+        getOperationTracker(createRouterConfig(true, REPLICA_COUNT, REPLICA_COUNT, 6, null, true), mockPartition);
     // 3-0-0-0; 3-0-0-0
     sendRequests(ot, REPLICA_COUNT);
     // 0-3-0-0; 0-3-0-0

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -308,6 +308,9 @@ public class GetBlobInfoOperationTest {
         tracker.getLatencyHistogram(remoteReplica).getCount());
   }
 
+  /**
+   * Test that timed out requests are allowed to update Histogram by default.
+   */
   @Test
   public void testTimeoutRequestUpdateHistogramByDefault() {
     NonBlockingRouter.currentOperationsCount.incrementAndGet();

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -485,6 +485,10 @@ public class GetBlobOperationTest {
         crossColoTracker.getCount());
   }
 
+  /**
+   * Test that timed out requests are allowed to update Histogram by default.
+   * @throws Exception
+   */
   @Test
   public void testTimeoutRequestUpdateHistogramByDefault() throws Exception {
     doPut();

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -81,7 +81,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static com.github.ambry.router.GetBlobOptions.*;
 import static com.github.ambry.router.PutManagerTest.*;
 import static com.github.ambry.router.RouterTestHelpers.*;
 import static org.junit.Assume.*;
@@ -201,7 +200,7 @@ public class GetBlobOperationTest {
     // a blob size that is greater than the maxChunkSize and is not a multiple of it. Will result in a composite blob.
     blobSize = maxChunkSize * random.nextInt(10) + random.nextInt(maxChunkSize - 1) + 1;
     mockSelectorState.set(MockSelectorState.Good);
-    VerifiableProperties vprops = new VerifiableProperties(getDefaultNonBlockingRouterProperties());
+    VerifiableProperties vprops = new VerifiableProperties(getDefaultNonBlockingRouterProperties(true));
     routerConfig = new RouterConfig(vprops);
     mockClusterMap = new MockClusterMap();
     localDcName = mockClusterMap.getDatacenterName(mockClusterMap.getLocalDatacenterId());
@@ -316,7 +315,7 @@ public class GetBlobOperationTest {
     Assert.assertEquals("Blob ids must match", blobIdStr, op.getBlobIdStr());
 
     // test the case where the tracker type is bad
-    Properties properties = getDefaultNonBlockingRouterProperties();
+    Properties properties = getDefaultNonBlockingRouterProperties(true);
     properties.setProperty("router.get.operation.tracker.type", "NonExistentTracker");
     RouterConfig badConfig = new RouterConfig(new VerifiableProperties(properties));
     try {
@@ -461,7 +460,7 @@ public class GetBlobOperationTest {
   @Test
   public void testRouterRequestTimeoutAllFailure() throws Exception {
     doPut();
-    GetBlobOperation op = createOperation(null);
+    GetBlobOperation op = createOperation(routerConfig, null);
     op.poll(requestRegistrationCallback);
     while (!op.isOperationComplete()) {
       time.sleep(routerConfig.routerRequestTimeoutMs + 1);
@@ -473,7 +472,7 @@ public class GetBlobOperationTest {
         correlationIdToGetOperation.size());
     assertFailureAndCheckErrorCode(op, RouterErrorCode.OperationTimedOut);
 
-    // test that timed out response won't update latency histogram
+    // test that timed out response won't update latency histogram if exclude timeout is enabled.
     assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
     AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getFirstChunkOperationTrackerInUse();
     Histogram localColoTracker =
@@ -486,6 +485,30 @@ public class GetBlobOperationTest {
         crossColoTracker.getCount());
   }
 
+  @Test
+  public void testTimeoutRequestUpdateHistogramByDefault() throws Exception {
+    doPut();
+    VerifiableProperties vprops = new VerifiableProperties(getDefaultNonBlockingRouterProperties(false));
+    RouterConfig routerConfig = new RouterConfig(vprops);
+    GetBlobOperation op = createOperation(routerConfig, null);
+    op.poll(requestRegistrationCallback);
+    while (!op.isOperationComplete()) {
+      time.sleep(routerConfig.routerRequestTimeoutMs + 1);
+      op.poll(requestRegistrationCallback);
+    }
+    Assert.assertEquals("Must have attempted sending requests to all replicas", replicasCount,
+        correlationIdToGetOperation.size());
+    Assert.assertEquals(RouterErrorCode.OperationTimedOut,
+        ((RouterException) op.getOperationException()).getErrorCode());
+    assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
+    AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getFirstChunkOperationTrackerInUse();
+
+    Assert.assertEquals("Number of data points in local colo latency histogram is not expected", 3,
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, true, localDcName)).getCount());
+    Assert.assertEquals("Number of data points in cross colo latency histogram is not expected", 6,
+        tracker.getLatencyHistogram(RouterTestHelpers.getAnyReplica(blobId, false, localDcName)).getCount());
+  }
+
   /**
    * Test the case where 2 local replicas timed out. The remaining one local replica and rest remote replicas respond
    * with Blob_Not_Found.
@@ -495,7 +518,7 @@ public class GetBlobOperationTest {
   public void testRequestTimeoutAndBlobNotFound() throws Exception {
     assumeTrue(operationTrackerType.equals(AdaptiveOperationTracker.class.getSimpleName()));
     doPut();
-    GetBlobOperation op = createOperation(null);
+    GetBlobOperation op = createOperation(routerConfig, null);
     AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getFirstChunkOperationTrackerInUse();
     correlationIdToGetOperation.clear();
     for (MockServer server : mockServerLayout.getMockServers()) {
@@ -538,7 +561,7 @@ public class GetBlobOperationTest {
   @Test
   public void testNetworkClientTimeoutAllFailure() throws Exception {
     doPut();
-    GetBlobOperation op = createOperation(null);
+    GetBlobOperation op = createOperation(routerConfig, null);
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
       for (RequestInfo requestInfo : requestRegistrationCallback.requestListToFill) {
@@ -639,17 +662,17 @@ public class GetBlobOperationTest {
     String dcWherePutHappened = routerConfig.routerDatacenterName;
 
     // test requests coming in from local dc as well as cross-colo.
-    Properties props = getDefaultNonBlockingRouterProperties();
+    Properties props = getDefaultNonBlockingRouterProperties(true);
     props.setProperty("router.datacenter.name", "DC1");
     routerConfig = new RouterConfig(new VerifiableProperties(props));
     doTestSuccessInThePresenceOfVariousErrors(dcWherePutHappened);
 
-    props = getDefaultNonBlockingRouterProperties();
+    props = getDefaultNonBlockingRouterProperties(true);
     props.setProperty("router.datacenter.name", "DC2");
     routerConfig = new RouterConfig(new VerifiableProperties(props));
     doTestSuccessInThePresenceOfVariousErrors(dcWherePutHappened);
 
-    props = getDefaultNonBlockingRouterProperties();
+    props = getDefaultNonBlockingRouterProperties(true);
     props.setProperty("router.datacenter.name", "DC3");
     routerConfig = new RouterConfig(new VerifiableProperties(props));
     doTestSuccessInThePresenceOfVariousErrors(dcWherePutHappened);
@@ -960,7 +983,7 @@ public class GetBlobOperationTest {
   @Test
   public void testSetOperationException() throws Exception {
     doPut();
-    GetBlobOperation op = createOperation(null);
+    GetBlobOperation op = createOperation(routerConfig, null);
     RouterErrorCode[] routerErrorCodes = new RouterErrorCode[8];
     routerErrorCodes[0] = RouterErrorCode.BlobDoesNotExist;
     routerErrorCodes[1] = RouterErrorCode.OperationTimedOut;
@@ -1297,7 +1320,7 @@ public class GetBlobOperationTest {
    * @throws Exception
    */
   private GetBlobOperation createOperationAndComplete(Callback<GetBlobResultInternal> callback) throws Exception {
-    GetBlobOperation op = createOperation(callback);
+    GetBlobOperation op = createOperation(routerConfig, callback);
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
       List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.requestListToFill);
@@ -1312,11 +1335,11 @@ public class GetBlobOperationTest {
 
   /**
    * Create a getBlob operation with the specified callback
+   * @param routerConfig the routerConfig used to instantiate GetBlobOperation.
    * @param callback the callback to run after completion of the operation, or {@code null} if no callback.
    * @return the operation
-   * @throws Exception
    */
-  private GetBlobOperation createOperation(Callback<GetBlobResultInternal> callback) throws Exception {
+  private GetBlobOperation createOperation(RouterConfig routerConfig, Callback<GetBlobResultInternal> callback) {
     NonBlockingRouter.currentOperationsCount.incrementAndGet();
     GetBlobOperation op =
         new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, callback,
@@ -1472,9 +1495,10 @@ public class GetBlobOperationTest {
 
   /**
    * Get the default {@link Properties} for the {@link NonBlockingRouter}.
+   * @param excludeTimeout whether to exclude timed out request in Histogram.
    * @return the constructed {@link Properties}
    */
-  private Properties getDefaultNonBlockingRouterProperties() {
+  private Properties getDefaultNonBlockingRouterProperties(boolean excludeTimeout) {
     Properties properties = new Properties();
     properties.setProperty("router.hostname", "localhost");
     properties.setProperty("router.datacenter.name", "DC3");
@@ -1485,6 +1509,7 @@ public class GetBlobOperationTest {
     properties.setProperty("router.get.success.target", Integer.toString(1));
     properties.setProperty("router.get.operation.tracker.type", operationTrackerType);
     properties.setProperty("router.request.timeout.ms", Integer.toString(20));
+    properties.setProperty("router.operation.tracker.exclude.timeout.enabled", Boolean.toString(excludeTimeout));
     return properties;
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
@@ -555,7 +555,7 @@ public class OperationTrackerTest {
         Boolean.toString(includeNonOriginatingDcReplicas));
     props.setProperty("router.get.replicas.required", Integer.toString(replicasRequired));
     props.setProperty("router.latency.tolerance.quantile", Double.toString(QUANTILE));
-    props.setProperty("router.adaptive.tracker.max.inflight.requests", Integer.toString(parallelism));
+    props.setProperty("router.operation.tracker.max.inflight.requests", Integer.toString(parallelism));
     RouterConfig routerConfig = new RouterConfig(new VerifiableProperties(props));
     NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
     OperationTracker tracker;

--- a/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
@@ -555,6 +555,7 @@ public class OperationTrackerTest {
         Boolean.toString(includeNonOriginatingDcReplicas));
     props.setProperty("router.get.replicas.required", Integer.toString(replicasRequired));
     props.setProperty("router.latency.tolerance.quantile", Double.toString(QUANTILE));
+    props.setProperty("router.adaptive.tracker.max.inflight.requests", Integer.toString(parallelism));
     RouterConfig routerConfig = new RouterConfig(new VerifiableProperties(props));
     NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
     OperationTracker tracker;


### PR DESCRIPTION
1. add log info to record which type of adaptive tracker is used
2. enforce max number of inlight requests for adaptive tracker
3. make excluding timedout request configurable
4. support periodically dumping resource-level histogram to log file