### PR TITLE
WIP: Add additional queue choices/request dropping to SocketServer

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.config;
 
+import com.github.ambry.network.RequestQueueType;
+
+
 /**
  * The configs for network layer
  */
@@ -31,6 +34,20 @@ public class NetworkConfig {
   @Config("queued.max.requests")
   @Default("500")
   public final int queuedMaxRequests;
+
+  /**
+   * The type of queue to use to hold requests waiting to be processed.
+   */
+  @Config("request.queue.type")
+  @Default("BASIC_FIFO")
+  public final RequestQueueType requestQueueType;
+
+  /**
+   * The maximum time in milliseconds a request is allowed to spend in the queue waiting to be processed.
+   */
+  @Config("request.queue.timeout.ms")
+  @Default("Integer.MAX_VALUE")
+  public final int requestQueueTimeoutMs;
 
   /**
    * The port to listen and accept connections on
@@ -93,6 +110,10 @@ public class NetworkConfig {
     socketRequestMaxBytes =
         verifiableProperties.getIntInRange("socket.request.max.bytes", 100 * 1024 * 1024, 1, Integer.MAX_VALUE);
     queuedMaxRequests = verifiableProperties.getIntInRange("queued.max.requests", 500, 1, Integer.MAX_VALUE);
+    requestQueueType =
+        verifiableProperties.getEnum("request.queue.type", RequestQueueType.class, RequestQueueType.BASIC_FIFO);
+    requestQueueTimeoutMs =
+        verifiableProperties.getIntInRange("request.queue.timeout.ms", Integer.MAX_VALUE, 0, Integer.MAX_VALUE);
     networkClientEnableConnectionReplenishment =
         verifiableProperties.getBoolean("network.client.enable.connection.replenishment", false);
     selectorExecutorPoolSize =

--- a/ambry-api/src/main/java/com.github.ambry/config/VerifiableProperties.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/VerifiableProperties.java
@@ -243,6 +243,19 @@ public class VerifiableProperties {
     }
   }
 
+  /**
+   * Read an enum value from the properties instance.
+   * @param name the property name.
+   * @param enumClass the {@link Class} of the enum.
+   * @param defaultVal the default value to use if the property is not found
+   * @param <E> the enum type.
+   * @return the enum value.
+   */
+  public <E extends Enum<E>> E getEnum(String name, Class<E> enumClass, E defaultVal) {
+    String v = getString(name, defaultVal.name());
+    return Enum.valueOf(enumClass, v);
+  }
+
   public void verify() {
     logger.info("Verifying properties");
     Enumeration keys = props.propertyNames();

--- a/ambry-api/src/main/java/com.github.ambry/network/RequestBundle.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/RequestBundle.java
@@ -1,0 +1,30 @@
+package com.github.ambry.network;
+
+import java.util.Collection;
+import java.util.Collections;
+
+
+public class RequestBundle {
+  private final Request requestToServe;
+  private final Collection<Request> requestsToDrop;
+
+  RequestBundle(Request requestToServe, Collection<Request> requestsToDrop) {
+    this.requestToServe = requestToServe;
+    this.requestsToDrop = requestsToDrop;
+  }
+
+  /**
+   * @return a request that the request handler should serve. Can be null if there are no pending requests that have
+   * not timed out.
+   */
+  public Request getRequestToServe() {
+    return requestToServe;
+  }
+
+  /**
+   * @return requests that have spent too long in the queue and should be dropped by the request handler.
+   */
+  public Collection<Request> getRequestsToDrop() {
+    return requestsToDrop;
+  }
+}

--- a/ambry-api/src/main/java/com.github.ambry/network/RequestQueueType.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/RequestQueueType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.network;
+
+public enum RequestQueueType {
+  BASIC_FIFO,
+  ADAPTIVE_LIFO_CO_DEL
+}

--- a/ambry-api/src/main/java/com.github.ambry/network/RequestResponseChannel.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/RequestResponseChannel.java
@@ -28,32 +28,29 @@ public interface RequestResponseChannel {
    * @param metrics The set of metrics tracked at the network layer
    * @throws InterruptedException
    */
-  public void sendResponse(Send payloadToSend, Request originalRequest, ServerNetworkResponseMetrics metrics)
+  void sendResponse(Send payloadToSend, Request originalRequest, ServerNetworkResponseMetrics metrics)
       throws InterruptedException;
 
   /**
    * Receives the request from the channel
-   * @return The request that was queued by the network layer into the channel
-   * @throws InterruptedException
+   * @return A bundle of requests that were queued by the network layer into the channel. The bundle may include 0 or 1
+   *         requests to handle, and 0 or more requests that should be dropped.
+   * @throws InterruptedException if the thread was interrupted.
    */
-  public Request receiveRequest() throws InterruptedException;
+  RequestBundle receiveRequest() throws InterruptedException;
+
 
   /**
    * Sends a request over the network. The request gets queued by the channel.
    * @param request The request to be queued by the channel
    * @throws InterruptedException
    */
-  public void sendRequest(Request request) throws InterruptedException;
+  void sendRequest(Request request) throws InterruptedException;
 
   /**
    * Closes the connection on which the original request came
    * @param request The request whose connection needs to be closed
    * @throws InterruptedException
    */
-  public void closeConnection(Request request) throws InterruptedException;
-
-  /**
-   * Shuts down the request response channel
-   */
-  public void shutdown();
+  void closeConnection(Request request) throws InterruptedException;
 }

--- a/ambry-network/src/main/java/com.github.ambry.network/AdaptiveLifoCoDelRequestQueue.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/AdaptiveLifoCoDelRequestQueue.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.network;
+
+import com.github.ambry.utils.Time;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
+/**
+ * Adaptive LIFO blocking queue utilizing CoDel algorithm to prevent queue overloading. This queue is based on
+ *  (and borrows most of its code from) {@code AdaptiveLifoCoDelCallQueue} in HBase.
+ *
+ * @see <a href="http://queue.acm.org/detail.cfm?id=2839461">Fail at Scale paper</a>
+ * @see <a href="https://github.com/apache/hbase/blob/master/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/AdaptiveLifoCoDelCallQueue.java">HBase implementation</a>
+ */
+public class AdaptiveLifoCoDelRequestQueue implements RequestQueue {
+  private final Time time;
+  private final LinkedBlockingDeque<Request> deque;
+
+  // so we can calculate actual threshold to switch to LIFO under load
+  private final int maxCapacity;
+  // if queue if full more than that percent, we switch to LIFO mode.
+  // Values are in the range of 0.7, 0.8 etc (0-1.0).
+  private final double lifoThreshold;
+  // Both are in milliseconds
+  private final int coDelTargetDelayMs;
+  private final int coDelIntervalMs;
+  // minimal delay observed during the interval
+  private volatile long minDelayMs;
+  // the moment when current interval ends
+  private volatile long intervalTimeMs;
+  // switch to ensure only one threads does interval cutoffs
+  private final AtomicBoolean resetDelay = new AtomicBoolean(true);
+  // if we're in this mode, "long" calls are getting dropped
+  private final AtomicBoolean isOverloaded = new AtomicBoolean(false);
+
+  /**
+   *
+   * @param capacity the max capacity of the queue.
+   * @param lifoThreshold
+   * @param coDelTargetDelayMs
+   * @param coDelIntervalMs
+   * @param time
+   */
+  AdaptiveLifoCoDelRequestQueue(int capacity, double lifoThreshold, int coDelTargetDelayMs, int coDelIntervalMs,
+      Time time) {
+    this.maxCapacity = capacity;
+    this.coDelTargetDelayMs = coDelTargetDelayMs;
+    this.coDelIntervalMs = coDelIntervalMs;
+    this.lifoThreshold = lifoThreshold;
+    this.time = time;
+
+    deque = new LinkedBlockingDeque<>(capacity);
+    intervalTimeMs = time.milliseconds();
+  }
+
+  /**
+   * Behaves as {@link LinkedBlockingQueue#take()}, except it will silently
+   * skip all calls which it thinks should be dropped.
+   *
+   * @return the head of this queue
+   * @throws InterruptedException if interrupted while waiting
+   */
+  @Override
+  public RequestBundle take() throws InterruptedException {
+    Request requestToServe = null;
+    List<Request> requestsToDrop = new ArrayList<>();
+    while (true) {
+      Request nextRequest;
+      if (((double) deque.size() / this.maxCapacity) > lifoThreshold) {
+        nextRequest = deque.pollLast();
+      } else {
+        nextRequest = deque.pollFirst();
+      }
+      if (nextRequest == null) {
+        break;
+      }
+      if (needToDrop(nextRequest)) {
+        requestsToDrop.add(nextRequest);
+      } else {
+        requestToServe = nextRequest;
+        break;
+      }
+    }
+    // If there are no requests to drop and no requests to serve currently in the queue, block until a new request comes
+    // so we can give the consumer something to do.
+    if (requestToServe == null && requestsToDrop.isEmpty()) {
+      requestToServe = deque.take();
+    }
+    return new RequestBundle(requestToServe, requestsToDrop);
+  }
+
+  @Override
+  public boolean offer(Request request) {
+    return deque.offer(request);
+  }
+
+  @Override
+  public int size() {
+    return deque.size();
+  }
+
+  @Override
+  public String toString() {
+    return deque.toString();
+  }
+
+  /**
+   * @param request to validate
+   * @return true if this call needs to be skipped based on call timestamp
+   *   and internal queue state (deemed overloaded).
+   */
+  private boolean needToDrop(Request request) {
+    long currentTimeMs = time.milliseconds();
+    long callDelayMs = currentTimeMs - request.getStartTimeInMs();
+
+    long localMinDelayMs = this.minDelayMs;
+
+    // Try and determine if we should reset
+    // the delay time and determine overload
+    if (currentTimeMs > intervalTimeMs && resetDelay.compareAndSet(false, true)) {
+      intervalTimeMs = currentTimeMs + coDelIntervalMs;
+
+      isOverloaded.set(localMinDelayMs > coDelTargetDelayMs);
+    }
+
+    // If it looks like we should reset the delay
+    // time do it only once on one thread
+    if (resetDelay.compareAndSet(true, false)) {
+      minDelayMs = callDelayMs;
+      // we just reset the delay dunno about how this will work
+      return false;
+    } else if (callDelayMs < localMinDelayMs) {
+      minDelayMs = callDelayMs;
+    }
+
+    return isOverloaded.get() && callDelayMs > 2 * coDelTargetDelayMs;
+  }
+}
+

--- a/ambry-network/src/main/java/com.github.ambry.network/FifoRequestQueue.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/FifoRequestQueue.java
@@ -1,0 +1,60 @@
+package com.github.ambry.network;
+
+import com.github.ambry.utils.Time;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+
+public class FifoRequestQueue implements RequestQueue {
+  private final int timeout;
+  private final Time time;
+  private final BlockingQueue<Request> queue;
+
+  FifoRequestQueue(int capacity, int timeout, Time time) {
+    this.timeout = timeout;
+    this.time = time;
+    queue = new ArrayBlockingQueue<>(capacity);
+  }
+
+  @Override
+  public boolean offer(Request request) {
+    return queue.offer(request);
+  }
+
+  @Override
+  public RequestBundle take() throws InterruptedException {
+    Request requestToServe = null;
+    List<Request> requestsToDrop = new ArrayList<>();
+    Request nextRequest;
+    while ((nextRequest = queue.poll()) != null) {
+      if (needToDrop(nextRequest)) {
+        requestsToDrop.add(nextRequest);
+      } else {
+        requestToServe = nextRequest;
+        break;
+      }
+    }
+    // If there are no requests to drop and no requests to serve currently in the queue, block until a new request comes
+    // so we can give the consumer something to do.
+    if (requestToServe == null && requestsToDrop.isEmpty()) {
+      requestToServe = queue.take();
+    }
+    return new RequestBundle(requestToServe, requestsToDrop);
+  }
+
+  @Override
+  public int size() {
+    return queue.size();
+  }
+
+  @Override
+  public String toString() {
+    return queue.toString();
+  }
+
+  private boolean needToDrop(Request request) {
+    return time.milliseconds() - request.getStartTimeInMs() > timeout;
+  }
+}

--- a/ambry-network/src/main/java/com.github.ambry.network/RequestQueue.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/RequestQueue.java
@@ -1,0 +1,9 @@
+package com.github.ambry.network;
+
+interface RequestQueue {
+  boolean offer(Request request);
+
+  RequestBundle take() throws InterruptedException;
+
+  int size();
+}

--- a/ambry-network/src/main/java/com.github.ambry.network/SocketServerRequest.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/SocketServerRequest.java
@@ -1,0 +1,43 @@
+package com.github.ambry.network;
+
+import com.github.ambry.utils.SystemTime;
+import java.io.InputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The request at the network layer
+ */
+class SocketServerRequest implements Request {
+  private static final Logger logger = LoggerFactory.getLogger(SocketServerRequest.class);
+  private final int processor;
+  private final String connectionId;
+  private final InputStream input;
+  private final long startTimeInMs;
+
+  SocketServerRequest(int processor, String connectionId, InputStream input) {
+    this.processor = processor;
+    this.connectionId = connectionId;
+    this.input = input;
+    this.startTimeInMs = SystemTime.getInstance().milliseconds();
+    logger.trace("Processor {} received request : {}", processor, connectionId);
+  }
+
+  @Override
+  public InputStream getInputStream() {
+    return input;
+  }
+
+  @Override
+  public long getStartTimeInMs() {
+    return startTimeInMs;
+  }
+
+  int getProcessor() {
+    return processor;
+  }
+
+  String getConnectionId() {
+    return connectionId;
+  }
+}

--- a/ambry-network/src/main/java/com.github.ambry.network/SocketServerResponse.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/SocketServerResponse.java
@@ -1,0 +1,51 @@
+package com.github.ambry.network;
+
+import com.github.ambry.utils.SystemTime;
+
+
+/**
+ * The response at the network layer
+ */
+class SocketServerResponse implements Response {
+
+  private final int processor;
+  private final Request request;
+  private final Send output;
+  private final ServerNetworkResponseMetrics metrics;
+  private long startQueueTimeInMs;
+
+  SocketServerResponse(Request request, Send output, ServerNetworkResponseMetrics metrics) {
+    this.request = request;
+    this.output = output;
+    this.processor = ((SocketServerRequest) request).getProcessor();
+    this.metrics = metrics;
+  }
+
+  @Override
+  public Send getPayload() {
+    return output;
+  }
+
+  @Override
+  public Request getRequest() {
+    return request;
+  }
+
+  int getProcessor() {
+    return processor;
+  }
+
+  void onEnqueueIntoResponseQueue() {
+    this.startQueueTimeInMs = SystemTime.getInstance().milliseconds();
+  }
+
+  void onDequeueFromResponseQueue() {
+    if (metrics != null) {
+      metrics.updateQueueTime(SystemTime.getInstance().milliseconds() - startQueueTimeInMs);
+    }
+  }
+
+  ServerNetworkResponseMetrics getMetrics() {
+    return metrics;
+  }
+}

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -153,7 +153,12 @@ public class AmbryRequests implements RequestAPI {
     localPartitionToReplicaMap = Collections.unmodifiableMap(partitionToReplica);
   }
 
-  public void handleRequests(Request request) throws InterruptedException {
+  /**
+   * @param request the {@link Request} to parse and handle.
+   * @param drop if the request should be dropped (just send an error response immediately)
+   * @throws InterruptedException
+   */
+  public void handleRequests(Request request, boolean drop) throws InterruptedException {
     try {
       DataInputStream stream = new DataInputStream(request.getInputStream());
       RequestOrResponseType type = RequestOrResponseType.values()[stream.readShort()];

--- a/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/ServerMetrics.java
@@ -28,11 +28,7 @@ public class ServerMetrics {
   public static final long mediumBlob = 1 * 1024 * 1024; // up to and including 1MB
   // largeBlob is everything larger than mediumBlob
 
-  public final Histogram putBlobRequestQueueTimeInMs;
-  public final Histogram putBlobProcessingTimeInMs;
-  public final Histogram putBlobResponseQueueTimeInMs;
-  public final Histogram putBlobSendTimeInMs;
-  public final Histogram putBlobTotalTimeInMs;
+  final RequestMetrics putBlobMetrics;
 
   public final Histogram putSmallBlobProcessingTimeInMs;
   public final Histogram putSmallBlobSendTimeInMs;
@@ -46,11 +42,7 @@ public class ServerMetrics {
   public final Histogram putLargeBlobSendTimeInMs;
   public final Histogram putLargeBlobTotalTimeInMs;
 
-  public final Histogram getBlobRequestQueueTimeInMs;
-  public final Histogram getBlobProcessingTimeInMs;
-  public final Histogram getBlobResponseQueueTimeInMs;
-  public final Histogram getBlobSendTimeInMs;
-  public final Histogram getBlobTotalTimeInMs;
+  final RequestMetrics getBlobMetrics;
 
   public final Histogram getSmallBlobProcessingTimeInMs;
   public final Histogram getSmallBlobSendTimeInMs;
@@ -64,55 +56,24 @@ public class ServerMetrics {
   public final Histogram getLargeBlobSendTimeInMs;
   public final Histogram getLargeBlobTotalTimeInMs;
 
-  public final Histogram getBlobPropertiesRequestQueueTimeInMs;
-  public final Histogram getBlobPropertiesProcessingTimeInMs;
-  public final Histogram getBlobPropertiesResponseQueueTimeInMs;
-  public final Histogram getBlobPropertiesSendTimeInMs;
-  public final Histogram getBlobPropertiesTotalTimeInMs;
+  final RequestMetrics getBlobPropertiesMetrics;
 
-  public final Histogram getBlobUserMetadataRequestQueueTimeInMs;
-  public final Histogram getBlobUserMetadataProcessingTimeInMs;
-  public final Histogram getBlobUserMetadataResponseQueueTimeInMs;
-  public final Histogram getBlobUserMetadataSendTimeInMs;
-  public final Histogram getBlobUserMetadataTotalTimeInMs;
+  final RequestMetrics getBlobUserMetadataMetrics;
 
-  public final Histogram getBlobAllRequestQueueTimeInMs;
-  public final Histogram getBlobAllProcessingTimeInMs;
-  public final Histogram getBlobAllResponseQueueTimeInMs;
-  public final Histogram getBlobAllSendTimeInMs;
-  public final Histogram getBlobAllTotalTimeInMs;
+  final RequestMetrics getBlobAllMetrics;
 
-  public final Histogram getBlobAllByReplicaRequestQueueTimeInMs;
-  public final Histogram getBlobAllByReplicaProcessingTimeInMs;
-  public final Histogram getBlobAllByReplicaResponseQueueTimeInMs;
-  public final Histogram getBlobAllByReplicaSendTimeInMs;
-  public final Histogram getBlobAllByReplicaTotalTimeInMs;
+  final RequestMetrics getBlobAllByReplicaMetrics;
 
-  public final Histogram getBlobInfoRequestQueueTimeInMs;
-  public final Histogram getBlobInfoProcessingTimeInMs;
-  public final Histogram getBlobInfoResponseQueueTimeInMs;
-  public final Histogram getBlobInfoSendTimeInMs;
-  public final Histogram getBlobInfoTotalTimeInMs;
+  final RequestMetrics getBlobInfoMetrics;
 
-  public final Histogram deleteBlobRequestQueueTimeInMs;
-  public final Histogram deleteBlobProcessingTimeInMs;
-  public final Histogram deleteBlobResponseQueueTimeInMs;
-  public final Histogram deleteBlobSendTimeInMs;
-  public final Histogram deleteBlobTotalTimeInMs;
+  final RequestMetrics deleteBlobMetrics;
 
-  public final Histogram updateBlobTtlRequestQueueTimeInMs;
-  public final Histogram updateBlobTtlProcessingTimeInMs;
-  public final Histogram updateBlobTtlResponseQueueTimeInMs;
-  public final Histogram updateBlobTtlSendTimeInMs;
-  public final Histogram updateBlobTtlTotalTimeInMs;
+  final RequestMetrics updateBlobTtlMetrics;
 
-  public final Histogram replicaMetadataRequestQueueTimeInMs;
-  public final Histogram replicaMetadataRequestProcessingTimeInMs;
-  public final Histogram replicaMetadataResponseQueueTimeInMs;
-  public final Histogram replicaMetadataSendTimeInMs;
-  public final Histogram replicaMetadataTotalTimeInMs;
+  final RequestMetrics replicaMetadataRequestMetrics;
   public final Histogram replicaMetadataTotalSizeOfMessages;
 
+  final RequestMetrics triggerCompactionRequ;
   public final Histogram triggerCompactionRequestQueueTimeInMs;
   public final Histogram triggerCompactionRequestProcessingTimeInMs;
   public final Histogram triggerCompactionResponseQueueTimeInMs;
@@ -504,6 +465,35 @@ public class ServerMetrics {
       putMediumBlobProcessingTimeInMs.update(processingTime);
     } else {
       putLargeBlobProcessingTimeInMs.update(processingTime);
+    }
+  }
+
+  /**
+   * Metrics emitted for each type of request.
+   */
+  static class RequestMetrics {
+    final Histogram requestQueueTimeInMs;
+    final Histogram processingTimeInMs;
+    final Histogram responseQueueTimeInMs;
+    final Histogram sendTimeInMs;
+    final Histogram totalTimeInMs;
+
+    /**
+     * @param prefix A prefix that describes the type of request these metrics are for.
+     * @param registry The {@link MetricRegistry} to use.
+     */
+    RequestMetrics(String prefix, MetricRegistry registry) {
+
+      requestQueueTimeInMs =
+          registry.histogram(MetricRegistry.name(AmbryRequests.class, prefix + "RequestQueueTime"));
+      processingTimeInMs =
+          registry.histogram(MetricRegistry.name(AmbryRequests.class, prefix + "ProcessingTime"));
+      responseQueueTimeInMs =
+          registry.histogram(MetricRegistry.name(AmbryRequests.class, prefix + "ResponseQueueTime"));
+      sendTimeInMs =
+          registry.histogram(MetricRegistry.name(AmbryRequests.class, prefix + "SendTime"));
+      totalTimeInMs =
+          registry.histogram(MetricRegistry.name(AmbryRequests.class, prefix + "TotalTime"));
     }
   }
 }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -29,6 +29,7 @@ import com.github.ambry.commons.CommonTestUtils;
 import com.github.ambry.commons.ServerErrorCode;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.DiskManagerConfig;
+import com.github.ambry.config.NetworkConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -616,7 +617,7 @@ public class AmbryRequestsTest {
   // general
 
   /**
-   * Calls {@link AmbryRequests#handleRequests(Request)} with {@code request} and returns the {@link Response} received.
+   * Calls {@link AmbryRequests#handleRequests} with {@code request} and returns the {@link Response} received.
    * @param request the {@link Request} to process
    * @param expectedServerErrorCode the expected {@link ServerErrorCode} in the server response.
    * @return the {@link Response} received.
@@ -626,7 +627,7 @@ public class AmbryRequestsTest {
   private Response sendRequestGetResponse(RequestOrResponse request, ServerErrorCode expectedServerErrorCode)
       throws InterruptedException, IOException {
     Request mockRequest = MockRequest.fromRequest(request);
-    ambryRequests.handleRequests(mockRequest);
+    ambryRequests.handleRequests(mockRequest, false);
     assertEquals("Request accompanying response does not match original request", mockRequest,
         requestResponseChannel.lastOriginalRequest);
     assertNotNull("Response not sent", requestResponseChannel.lastResponse);
@@ -1193,7 +1194,7 @@ public class AmbryRequestsTest {
     Send lastResponse = null;
 
     MockRequestResponseChannel() {
-      super(1, 1);
+      super(new NetworkConfig(new VerifiableProperties(new Properties())));
     }
 
     @Override


### PR DESCRIPTION
- Add support for dropping requests that have exceeded a queueing
  timeout to SocketServer/RequestHandler.
- Add an implementation of the Adaptive LIFO controlled delay queue described in
  https://queue.acm.org/detail.cfm?id=2839461 that supports request
  dropping. Based on an HBase java implementation.

This is WIP:
- The request dropping logic is a little messy right now and involves an extra queue, but I might 
   make some changes to fold it into the main queue 
- Need to add some extra configs for the AdaptiveLifoCodelRequestQueue tuning parameters.
- Need to add tests