### PR TITLE
Create executor pool to take over network read/write tasks.

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
@@ -77,7 +77,7 @@ public class NetworkConfig {
   public final boolean networkClientEnableConnectionReplenishment;
 
   /**
-   * The size of the pool if selector executor pool. If the value is 0, executor pool won't be used.
+   * The size of the pool if selector executor pool is employed. When size is 0, executor pool won't be used.
    */
   @Config("selector.executor.pool.size")
   @Default("4")

--- a/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
@@ -76,6 +76,13 @@ public class NetworkConfig {
   @Default("false")
   public final boolean networkClientEnableConnectionReplenishment;
 
+  /**
+   * The size of the pool if selector executor pool. If the value is 0, executor pool won't be used.
+   */
+  @Config("selector.executor.pool.size")
+  @Default("4")
+  public final int selectorExecutorPoolSize;
+
   public NetworkConfig(VerifiableProperties verifiableProperties) {
 
     numIoThreads = verifiableProperties.getIntInRange("num.io.threads", 8, 1, Integer.MAX_VALUE);
@@ -88,5 +95,7 @@ public class NetworkConfig {
     queuedMaxRequests = verifiableProperties.getIntInRange("queued.max.requests", 500, 1, Integer.MAX_VALUE);
     networkClientEnableConnectionReplenishment =
         verifiableProperties.getBoolean("network.client.enable.connection.replenishment", false);
+    selectorExecutorPoolSize =
+        verifiableProperties.getIntInRange("selector.executor.pool.size", 4, 0, Integer.MAX_VALUE);
   }
 }

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkClientFactory.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkClientFactory.java
@@ -57,7 +57,7 @@ public class NetworkClientFactory {
    * @throws IOException if the {@link Selector} could not be instantiated.
    */
   public NetworkClient getNetworkClient() throws IOException {
-    Selector selector = new Selector(networkMetrics, time, sslFactory);
+    Selector selector = new Selector(networkMetrics, time, sslFactory, networkConfig.selectorExecutorPoolSize);
     return new NetworkClient(selector, networkConfig, networkMetrics, maxConnectionsPerPortPlainText,
         maxConnectionsPerPortSsl, connectionCheckoutTimeoutMs, time);
   }

--- a/ambry-network/src/main/java/com.github.ambry.network/SSLTransmission.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/SSLTransmission.java
@@ -160,7 +160,9 @@ public class SSLTransmission extends Transmission implements ReadableByteChannel
   private boolean flush(ByteBuffer buf) throws IOException {
     int remaining = buf.remaining();
     if (remaining > 0) {
+      long start = SystemTime.getInstance().nanoseconds();
       int written = socketChannel.write(buf);
+      logger.trace("Flushed {} bytes in {} ns", written, SystemTime.getInstance().nanoseconds() - start);
       return written >= remaining;
     }
     return true;
@@ -531,13 +533,12 @@ public class SSLTransmission extends Transmission implements ReadableByteChannel
     int written = 0;
     while (src.remaining() != 0) {
       netWriteBuffer.clear();
-      long startTimeMs = SystemTime.getInstance().milliseconds();
+      long startTimeNs = SystemTime.getInstance().nanoseconds();
       SSLEngineResult wrapResult = sslEngine.wrap(src, netWriteBuffer);
-      long encryptionTimeMs = SystemTime.getInstance().milliseconds() - startTimeMs;
-      logger.trace("SSL encryption time: {} ms for {} bytes", encryptionTimeMs, wrapResult.bytesConsumed());
+      long encryptionTimeNs = SystemTime.getInstance().nanoseconds() - startTimeNs;
+      logger.trace("SSL encryption time: {} ns for {} bytes", encryptionTimeNs, wrapResult.bytesConsumed());
       if (wrapResult.bytesConsumed() > 0) {
-        metrics.sslEncryptionTimeInUsPerKB.update(
-            TimeUnit.MILLISECONDS.toMicros(encryptionTimeMs) * 1024 / wrapResult.bytesConsumed());
+        metrics.sslEncryptionTimeInUsPerKB.update(encryptionTimeNs / wrapResult.bytesConsumed());
       }
       netWriteBuffer.flip();
       //handle ssl renegotiation

--- a/ambry-network/src/main/java/com.github.ambry.network/SSLTransmission.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/SSLTransmission.java
@@ -160,9 +160,9 @@ public class SSLTransmission extends Transmission implements ReadableByteChannel
   private boolean flush(ByteBuffer buf) throws IOException {
     int remaining = buf.remaining();
     if (remaining > 0) {
-      long start = SystemTime.getInstance().nanoseconds();
+      long startNs = SystemTime.getInstance().nanoseconds();
       int written = socketChannel.write(buf);
-      logger.trace("Flushed {} bytes in {} ns", written, SystemTime.getInstance().nanoseconds() - start);
+      logger.trace("Flushed {} bytes in {} ns", written, SystemTime.getInstance().nanoseconds() - startNs);
       return written >= remaining;
     }
     return true;

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -32,6 +32,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,11 +85,12 @@ public class Selector implements Selectable {
   private final AtomicLong idGenerator;
   private final AtomicLong numActiveConnections;
   private final SSLFactory sslFactory;
+  private final ExecutorService executorPool;
 
   /**
    * Create a new selector
    */
-  public Selector(NetworkMetrics metrics, Time time, SSLFactory sslFactory) throws IOException {
+  public Selector(NetworkMetrics metrics, Time time, SSLFactory sslFactory, int executorPoolSize) throws IOException {
     this.nioSelector = java.nio.channels.Selector.open();
     this.time = time;
     this.keyMap = new HashMap<>();
@@ -99,6 +104,11 @@ public class Selector implements Selectable {
     idGenerator = new AtomicLong(0);
     numActiveConnections = new AtomicLong(0);
     unreadyConnections = new HashSet<>();
+    if (executorPoolSize > 0) {
+      executorPool = Executors.newFixedThreadPool(executorPoolSize);
+    } else {
+      executorPool = null;
+    }
     metrics.registerSelectorActiveConnections(numActiveConnections);
     metrics.registerSelectorUnreadyConnections(unreadyConnections);
   }
@@ -291,13 +301,24 @@ public class Selector implements Selectable {
    * completed I/O.
    *
    * @param timeoutMs The amount of time to wait, in milliseconds. If negative, wait indefinitely.
-   * @param sends The list of new sends to begin
+   * @param sends The list of new sends to initiate.
    *
    * @throws IOException If a send is given for which we have no existing connection or for which there is
    *         already an in-progress send
    */
   @Override
   public void poll(long timeoutMs, List<NetworkSend> sends) throws IOException {
+    if (executorPool != null) {
+      pollWithExecutorPool(timeoutMs, sends);
+    } else {
+      pollOnMainThread(timeoutMs, sends);
+    }
+  }
+
+  /**
+   * Process read/write events on current thread.
+   */
+  public void pollOnMainThread(long timeoutMs, List<NetworkSend> sends) throws IOException {
     clear();
 
     // register for write interest on any new sends
@@ -340,21 +361,26 @@ public class Selector implements Selectable {
           }
 
           if (key.isReadable() && transmission.ready()) {
-            read(key, transmission);
+            NetworkReceive networkReceive = read(key, transmission);
+            if (networkReceive == null) {
+              // Exception happened in read.
+              close(key);
+            } else if (networkReceive.getReceivedBytes().isReadComplete()) {
+              this.completedReceives.add(networkReceive);
+            }
           } else if (key.isWritable() && transmission.ready()) {
-            write(key, transmission);
+            NetworkSend networkSend = write(key, transmission);
+            if (networkSend == null) {
+              // Exception happened in write.
+              close(key);
+            } else if (networkSend.getPayload().isSendComplete()) {
+              this.completedSends.add(networkSend);
+            }
           } else if (!key.isValid()) {
             close(key);
           }
         } catch (IOException e) {
-          String socketDescription = socketDescription(channel(key));
-          if (e instanceof EOFException || e instanceof ConnectException) {
-            metrics.selectorDisconnectedErrorCount.inc();
-            logger.error("Connection {} disconnected", socketDescription, e);
-          } else {
-            metrics.selectorIOErrorCount.inc();
-            logger.warn("Error in I/O with connection to {}", socketDescription, e);
-          }
+          handleReadWriteIOException(e, key);
           close(key);
         } catch (Exception e) {
           metrics.selectorKeyOperationErrorCount.inc();
@@ -364,6 +390,114 @@ public class Selector implements Selectable {
       }
       checkUnreadyConnectionsStatus();
       this.metrics.selectorIOCount.inc();
+      this.metrics.selectorIOTime.update(time.milliseconds() - endSelect);
+    }
+    disconnected.addAll(closedConnections);
+    closedConnections.clear();
+  }
+
+  /**
+   * Use {@link ExecutorService} to process read/write events.
+   */
+  private void pollWithExecutorPool(long timeoutMs, List<NetworkSend> sends) throws IOException {
+    List<Future<NetworkSend>> completedSendsFutures = new ArrayList<>();
+    List<Future<NetworkReceive>> completedReceivesFutures = new ArrayList<>();
+    Set<SelectionKey> readWriteKeySet = new HashSet<>();
+    clear();
+
+    // register for write interest on any new sends
+    if (sends != null) {
+      for (NetworkSend networkSend : sends) {
+        send(networkSend);
+      }
+    }
+
+    // check ready keys
+    long startSelect = time.milliseconds();
+    int readyKeys = select(timeoutMs);
+    this.metrics.selectorSelectCount.inc();
+
+    if (readyKeys > 0) {
+      long endSelect = time.milliseconds();
+      this.metrics.selectorSelectTime.update(endSelect - startSelect);
+      Set<SelectionKey> keys = nioSelector.selectedKeys();
+      Iterator<SelectionKey> iter = keys.iterator();
+      while (iter.hasNext()) {
+        SelectionKey key = iter.next();
+        iter.remove();
+
+        Transmission transmission = getTransmission(key);
+        try {
+          if (key.isConnectable()) {
+            transmission.finishConnect();
+            if (transmission.ready()) {
+              connected.add(transmission.getConnectionId());
+              metrics.selectorConnectionCreated.inc();
+            } else {
+              unreadyConnections.add(transmission.getConnectionId());
+            }
+          }
+
+          /* if channel is not ready, finish prepare */
+          if (transmission.isConnected() && !transmission.ready()) {
+            transmission.prepare();
+            continue;
+          }
+
+          if (key.isReadable() && transmission.ready()) {
+            completedReceivesFutures.add(executorPool.submit(() -> read(key, transmission)));
+            readWriteKeySet.add(key);
+          } else if (key.isWritable() && transmission.ready()) {
+            completedSendsFutures.add(executorPool.submit(() -> write(key, transmission)));
+            readWriteKeySet.add(key);
+          } else if (!key.isValid()) {
+            close(key);
+          }
+        } catch (IOException e) {
+          // handles IOException from transmission.finishConnect() and transmission.prepare()
+          handleReadWriteIOException(e, key);
+          close(key);
+        } catch (Exception e) {
+          close(key);
+          metrics.selectorKeyOperationErrorCount.inc();
+          logger.error("closing key on exception remote host {}", channel(key).socket().getRemoteSocketAddress(), e);
+        }
+      }
+      for (Future<NetworkReceive> future : completedReceivesFutures) {
+        try {
+          NetworkReceive networkReceive = future.get();
+          if (networkReceive != null) {
+            readWriteKeySet.remove(keyForId(networkReceive.getConnectionId()));
+            if (networkReceive.getReceivedBytes().isReadComplete()) {
+              this.completedReceives.add(networkReceive);
+            }
+          }
+        } catch (InterruptedException | ExecutionException e) {
+          if (!(e.getCause() instanceof IOException)) {
+            logger.error("Hit unexpected exception on receive, ", e);
+          }
+        }
+      }
+      for (Future<NetworkSend> future : completedSendsFutures) {
+        try {
+          NetworkSend networkSend = future.get();
+          if (networkSend != null) {
+            readWriteKeySet.remove(keyForId(networkSend.getConnectionId()));
+            if (networkSend.getPayload().isSendComplete()) {
+              this.completedSends.add(networkSend);
+            }
+          }
+        } catch (InterruptedException | ExecutionException e) {
+          if (!(e.getCause() instanceof IOException)) {
+            logger.error("Hit unexpected exception on receive, ", e);
+          }
+        }
+      }
+      for (SelectionKey keyWithError : readWriteKeySet) {
+        close(keyWithError);
+      }
+      checkUnreadyConnectionsStatus();
+      this.metrics.selectorIOCount.inc(keys.size());
       this.metrics.selectorIOTime.update(time.milliseconds() - endSelect);
     }
     disconnected.addAll(closedConnections);
@@ -435,7 +569,6 @@ public class Selector implements Selectable {
    * @param connectionId a unique ID for this connection.
    * @param key the {@link SelectionKey} used to communicate socket events.
    * @param hostname the remote hostname for the connection, used for SSL host verification.
-   * @param hostname the remote port for the connection, used for SSL host verification.
    * @param portType used to select between a plaintext or SSL transmission.
    * @param mode for SSL transmissions, whether to operate in client or server mode.
    * @return either a {@link Transmission} or {@link SSLTransmission}.
@@ -545,17 +678,37 @@ public class Selector implements Selectable {
   }
 
   /**
-   * Process reads from ready sockets
+   * Handle read/write IOException
    */
-  private void read(SelectionKey key, Transmission transmission) throws IOException {
+  private void handleReadWriteIOException(IOException e, SelectionKey key) {
+    String socketDescription = socketDescription(channel(key));
+    if (e instanceof EOFException || e instanceof ConnectException) {
+      metrics.selectorDisconnectedErrorCount.inc();
+      logger.error("Connection {} disconnected", socketDescription, e);
+    } else {
+      metrics.selectorIOErrorCount.inc();
+      logger.warn("Error in I/O with connection to {}", socketDescription, e);
+    }
+  }
+
+  /**
+   * Process reads from ready sockets
+   * @return the {@link NetworkReceive} if no IOException during read().
+   */
+  private NetworkReceive read(SelectionKey key, Transmission transmission) throws IOException {
     long startTimeToReadInMs = time.milliseconds();
     try {
       boolean readComplete = transmission.read();
+      NetworkReceive networkReceive = transmission.getNetworkReceive();
       if (readComplete) {
-        this.completedReceives.add(transmission.getNetworkReceive());
         transmission.onReceiveComplete();
         transmission.clearReceive();
       }
+      return networkReceive;
+    } catch (IOException e) {
+      // We have key information if we log IOException here.
+      handleReadWriteIOException(e, key);
+      return null;
     } finally {
       long readTime = time.milliseconds() - startTimeToReadInMs;
       logger.trace("SocketServer time spent on read per key {} = {}", transmission.getConnectionId(), readTime);
@@ -564,19 +717,25 @@ public class Selector implements Selectable {
 
   /**
    * Process writes to ready sockets
+   * @return the {@link NetworkSend} if no IOException during write().
    */
-  private void write(SelectionKey key, Transmission transmission) throws IOException {
+  private NetworkSend write(SelectionKey key, Transmission transmission) throws IOException {
     long startTimeToWriteInMs = time.milliseconds();
     try {
       boolean sendComplete = transmission.write();
+      NetworkSend networkSend = transmission.getNetworkSend();
       if (sendComplete) {
         logger.trace("Finished writing, registering for read on connection {}", transmission.getRemoteSocketAddress());
         transmission.onSendComplete();
-        this.completedSends.add(transmission.getNetworkSend());
         metrics.sendInFlight.dec();
         transmission.clearSend();
         key.interestOps(key.interestOps() & ~SelectionKey.OP_WRITE | SelectionKey.OP_READ);
       }
+      return networkSend;
+    } catch (IOException e) {
+      // We have key information if we log IOException here.
+      handleReadWriteIOException(e, key);
+      return null;
     } finally {
       long writeTime = time.milliseconds() - startTimeToWriteInMs;
       logger.trace("SocketServer time spent on write per key {} = {}", transmission.getConnectionId(), writeTime);

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -473,9 +473,7 @@ public class Selector implements Selectable {
             }
           }
         } catch (InterruptedException | ExecutionException e) {
-          if (!(e.getCause() instanceof IOException)) {
-            logger.error("Hit unexpected exception on receive, ", e);
-          }
+          logger.error("Hit Unexpected exception on selector read, ", e);
         }
       }
       for (Future<NetworkSend> future : completedSendsFutures) {
@@ -488,7 +486,7 @@ public class Selector implements Selectable {
             }
           }
         } catch (ExecutionException | InterruptedException e) {
-          logger.error("Hit Unexpected exception on selector event processing, ", e);
+          logger.error("Hit Unexpected exception on selector write, ", e);
         }
       }
       for (SelectionKey keyWithError : readWriteKeySet) {

--- a/ambry-network/src/test/java/com.github.ambry.network/EchoServer.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/EchoServer.java
@@ -85,6 +85,7 @@ public class EchoServer extends Thread {
           @Override
           public void run() {
             try {
+              socket.setSoTimeout(3000);
               DataInputStream input = new DataInputStream(socket.getInputStream());
               DataOutputStream output = new DataOutputStream(socket.getOutputStream());
               while (socket.isConnected() && !socket.isClosed()) {

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -332,7 +332,7 @@ public class NetworkClientTest {
         .collect(Collectors.toList());
     // 1 host x 1 port x 3 connections x 100%
     int warmUpPercentage = 100;
-    AtomicInteger expectedConnectCalls = new AtomicInteger(warmUpPercentage * 3 /100);
+    AtomicInteger expectedConnectCalls = new AtomicInteger(warmUpPercentage * 3 / 100);
     Runnable checkConnectCalls = () -> Assert.assertEquals(expectedConnectCalls.get(), selector.connectCallCount());
 
     networkClient.warmUpConnections(Collections.singletonList(replicaOnSslNode.getDataNodeId()), warmUpPercentage,
@@ -647,7 +647,7 @@ class MockSelector extends Selector {
    * @throws IOException if {@link Selector} throws.
    */
   MockSelector() throws IOException {
-    super(new NetworkMetrics(new MetricRegistry()), new MockTime(), null);
+    super(new NetworkMetrics(new MetricRegistry()), new MockTime(), null, 0);
     super.close();
   }
 

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -33,11 +34,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static java.util.Arrays.*;
 import static org.junit.Assert.*;
 
 
+@RunWith(Parameterized.class)
 public class SSLSelectorTest {
 
   private static final int DEFAULT_SOCKET_BUF_SIZE = 4 * 1024;
@@ -47,7 +51,12 @@ public class SSLSelectorTest {
   private Selector selector;
   private final File trustStoreFile;
 
-  public SSLSelectorTest() throws Exception {
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][]{{0}, {2}});
+  }
+
+  public SSLSelectorTest(int poolSize) throws Exception {
     trustStoreFile = File.createTempFile("truststore", ".jks");
     SSLConfig sslConfig =
         new SSLConfig(TestSSLUtils.createSslProps("DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server"));
@@ -60,7 +69,8 @@ public class SSLSelectorTest {
     applicationBufferSize = clientSSLFactory.createSSLEngine("localhost", server.port, SSLFactory.Mode.CLIENT)
         .getSession()
         .getApplicationBufferSize();
-    selector = new Selector(new NetworkMetrics(new MetricRegistry()), SystemTime.getInstance(), clientSSLFactory);
+    selector =
+        new Selector(new NetworkMetrics(new MetricRegistry()), SystemTime.getInstance(), clientSSLFactory, poolSize);
   }
 
   @After
@@ -163,6 +173,7 @@ public class SSLSelectorTest {
     while (responseCount < conns) {
       // do the i/o
       selector.poll(0L, sends);
+      Thread.sleep(100);
 
       assertEquals("No disconnects should have occurred.", 0, selector.disconnected().size());
 
@@ -307,6 +318,7 @@ public class SSLSelectorTest {
     String connectionId =
         selector.connect(new InetSocketAddress("localhost", server.port), socketBufSize, socketBufSize, PortType.SSL);
     while (!selector.connected().contains(connectionId)) {
+      System.out.println("here");
       selector.poll(10000L);
     }
     return connectionId;
@@ -327,7 +339,7 @@ public class SSLSelectorTest {
     selector.close();
     NetworkMetrics metrics = new NetworkMetrics(new MetricRegistry());
     Time time = SystemTime.getInstance();
-    selector = new Selector(metrics, time, clientSSLFactory) {
+    selector = new Selector(metrics, time, clientSSLFactory, 0) {
       @Override
       protected Transmission createTransmission(String connectionId, SelectionKey key, String hostname, int port,
           PortType portType, SSLFactory.Mode mode) throws IOException {

--- a/ambry-router/src/test/java/com.github.ambry.router/MockSelector.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockSelector.java
@@ -55,7 +55,7 @@ class MockSelector extends Selector {
    * @throws IOException if {@link Selector} throws.
    */
   MockSelector(MockServerLayout serverLayout, AtomicReference<MockSelectorState> state, Time time) throws IOException {
-    super(new NetworkMetrics(new MetricRegistry()), time, null);
+    super(new NetworkMetrics(new MetricRegistry()), time, null, 0);
     // we don't need the actual selector, close it.
     super.close();
     this.serverLayout = serverLayout;


### PR DESCRIPTION
SSL transmission latency was high in recent performance test, especially in PUT. 
The reason is selector.poll() needs to iterate all events and do SSL encryption + network IO for each of them. This increased round trip time dramatically in the queuing system.
The change introduced an executor pool to take over event handling and selector.poll() blocks until events done.  
In the performance test, 7MB blobs were sent at 20QPS, PUT latency P95 was decreased to 380ms from 1.4kms with this change. 
