### PR TITLE
Introducing Ambry partition state model and update Helix tool

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -13,11 +13,15 @@
  */
 package com.github.ambry.config;
 
+import org.apache.helix.model.LeaderStandbySMD;
+
+
 /**
  * The configs for resource state.
  */
 public class ClusterMapConfig {
-
+  public static final String DEFAULT_STATE_MODEL_DEF = LeaderStandbySMD.name;
+  public static final String AMBRY_STATE_MODEL_DEF = "AmbryLeaderStandby";
   private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
 
   /**
@@ -178,6 +182,10 @@ public class ClusterMapConfig {
   @Default("true")
   public final boolean clustermapListenCrossColo;
 
+  @Config("clustermap.state.model.definition")
+  @Default(DEFAULT_STATE_MODEL_DEF)
+  public final String clustermapStateModelDefinition;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -210,5 +218,11 @@ public class ClusterMapConfig {
     clustermapCurrentXid = verifiableProperties.getLong("clustermap.current.xid", Long.MAX_VALUE);
     clusterMapEnablePartitionOverride = verifiableProperties.getBoolean("clustermap.enable.partition.override", false);
     clustermapListenCrossColo = verifiableProperties.getBoolean("clustermap.listen.cross.colo", true);
+    clustermapStateModelDefinition =
+        verifiableProperties.getString("clustermap.state.model.definition", DEFAULT_STATE_MODEL_DEF);
+    if (!clustermapStateModelDefinition.equals(DEFAULT_STATE_MODEL_DEF) && !clustermapStateModelDefinition.equals(
+        AMBRY_STATE_MODEL_DEF)) {
+      throw new IllegalArgumentException("Unsupported state model definition: " + clustermapStateModelDefinition);
+    }
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDefaultStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDefaultStateModel.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import org.apache.helix.NotificationContext;
+import org.apache.helix.model.Message;
+import org.apache.helix.participant.statemachine.StateModel;
+import org.apache.helix.participant.statemachine.StateModelInfo;
+import org.apache.helix.participant.statemachine.StateModelParser;
+import org.apache.helix.participant.statemachine.Transition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A default {@link StateModel} to use when the Ambry participants (datanodes) register to Helix. The methods are callbacks
+ * that get called within a participant whenever partition's state changes in Helix. For now these are no-ops.
+ *
+ * In the critical path of puts and gets, there are no leader replicas in Ambry. Every replica can serve reads and
+ * writes. However, going forward, it is useful to have one of the replicas chosen as a LEADER for purposes such as
+ * replication.
+ */
+@StateModelInfo(initialState = "OFFLINE", states = {"LEADER", "STANDBY"})
+public class AmbryDefaultStateModel extends StateModel {
+  private Logger logger = LoggerFactory.getLogger(getClass());
+
+  AmbryDefaultStateModel() {
+    StateModelParser parser = new StateModelParser();
+    _currentState = parser.getInitialState(AmbryDefaultStateModel.class);
+  }
+
+  @Transition(to = "STANDBY", from = "OFFLINE")
+  public void onBecomeStandbyFromOffline(Message message, NotificationContext context) {
+    logger.info("Partition {} in resource {} is becoming STANDBY from OFFLINE", message.getPartitionName(),
+        message.getResourceName());
+  }
+
+  @Transition(to = "LEADER", from = "STANDBY")
+  public void onBecomeLeaderFromStandby(Message message, NotificationContext context) {
+    logger.info("Partition {} in resource {} is becoming LEADER from STANDBY", message.getPartitionName(),
+        message.getResourceName());
+  }
+
+  @Transition(to = "STANDBY", from = "LEADER")
+  public void onBecomeStandbyFromLeader(Message message, NotificationContext context) {
+    logger.info("Partition {} in resource {} is becoming STANDBY from LEADER", message.getPartitionName(),
+        message.getResourceName());
+  }
+
+  @Transition(to = "OFFLINE", from = "STANDBY")
+  public void onBecomeOfflineFromStandby(Message message, NotificationContext context) {
+    logger.info("Partition {} in resource {} is becoming OFFLINE from STANDBY", message.getPartitionName(),
+        message.getResourceName());
+  }
+
+  @Transition(to = "OFFLINE", from = "LEADER")
+  public void onBecomeOfflineFromLeader(Message message, NotificationContext context) {
+    logger.info("Partition {} in resource {} is becoming OFFLINE from LEADER", message.getPartitionName(),
+        message.getResourceName());
+  }
+
+  @Override
+  public void reset() {
+    // no op
+  }
+}
+

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryHelixState.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryHelixState.java
@@ -13,6 +13,50 @@
  */
 package com.github.ambry.clustermap;
 
+/**
+ * The states of ambry replica that are managed by Helix controller.
+ * Ambry router makes decision based on these states when routing requests.
+ */
 public enum AmbryHelixState {
-  OFFLINE, BOOTSTRAP, STANDBY, LEADER, INACTIVE, ERROR, DROPPED
+  /**
+   * Initial state of replica when starting up.
+   * Router should not send any request to replica in this state.
+   */
+  OFFLINE,
+
+  /**
+   * Bootstrap state is an intermediate state between OFFLINE and STANDBY.
+   * This state allows replica to do some bootstrap work like checking replication lag and catching up with peers.
+   * GET, DELETE, TTLUpdate can be routed to replica in this state.
+   */
+  BOOTSTRAP,
+
+  /**
+   * The state in which replica is fully functioning. That is, it can receive all types of requests.
+   */
+  STANDBY,
+
+  /**
+   * The state in which replica is fully functioning. For replicas from same partition in same DC, at most one is in
+   * LEADER state. Currently we don't distinguish LEADER from STANDBY and they both can receive all types of requests.
+   * In the future, we may leverage LEADER replica to perform cross-dc replication.
+   */
+  LEADER,
+
+  /**
+   * Inactive is an intermediate state between OFFLINE and STANDBY.
+   * This state allows replica to do some decommission work like making sure its peers have caught up with it.
+   * Only GET request is allowed to be routed to inactive replica.
+   */
+  INACTIVE,
+
+  /**
+   * When replica behaves unexpectedly and Helix makes replica in this state.
+   */
+  ERROR,
+
+  /**
+   * End state of a replica that is decommissioned.
+   */
+  DROPPED
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryHelixState.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryHelixState.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+public enum AmbryHelixState {
+  OFFLINE, BOOTSTRAP, STANDBY, LEADER, INACTIVE, ERROR, DROPPED
+}

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
@@ -26,10 +26,14 @@ import org.slf4j.LoggerFactory;
 @StateModelInfo(initialState = "OFFLINE", states = {"BOOTSTRAP", "LEADER", "STANDBY", "INACTIVE"})
 public class AmbryPartitionStateModel extends StateModel {
   private Logger logger = LoggerFactory.getLogger(getClass());
+  private final String resourceName;
+  private final String partitionName;
 
-  AmbryPartitionStateModel() {
+  AmbryPartitionStateModel(String resourceName, String partitionName) {
+    this.resourceName = resourceName;
+    this.partitionName = partitionName;
     StateModelParser parser = new StateModelParser();
-    _currentState = parser.getInitialState(AmbryDefaultStateModel.class);
+    _currentState = parser.getInitialState(DefaultLeaderStandbyStateModel.class);
   }
 
   @Transition(to = "BOOTSTRAP", from = "OFFLINE")
@@ -74,8 +78,14 @@ public class AmbryPartitionStateModel extends StateModel {
         message.getResourceName());
   }
 
+  @Transition(to = "DROPPED", from = "ERROR")
+  public void onBecomeDroppedFromError(Message message, NotificationContext context) {
+    logger.info("Partition {} in resource {} is becoming DROPPED from ERROR", message.getPartitionName(),
+        message.getResourceName());
+  }
+
   @Override
   public void reset() {
-    // no op
+    logger.info("Reset method invoked. Partition {} un resource {} is reset to OFFLINE", partitionName, resourceName);
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelDefinition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelDefinition.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import org.apache.helix.HelixDefinedState;
+import org.apache.helix.model.StateModelDefinition;
+
+
+/**
+ * Define state model employed by Ambry.
+ * Helix allows user to define custom state model which means Ambry is able to introduce custom states and define the
+ * transition logic among these states. This class presents replica states, valid transitions and priorities that would
+ * be used by Helix to manage Ambry partitions
+ */
+public class AmbryStateModelDefinition {
+  public static final String AMBRY_LEADER_STANDBY_MODEL = "AmbryLeaderStandby";
+
+  private static final String UPPER_BOUND_REPLICATION_FACTOR = "R";
+
+  public static StateModelDefinition getDefinition() {
+
+    StateModelDefinition.Builder builder = new StateModelDefinition.Builder(AMBRY_LEADER_STANDBY_MODEL);
+    // Init state
+    builder.initialState(AmbryHelixState.OFFLINE.name());
+
+    /*
+     * States and their priority which are managed by Helix controller.
+     *
+     * The implication is that transition to a state which has a higher number is
+     * considered a "downward" transition by Helix. Downward transitions are not
+     * throttled.
+     */
+    builder.addState(AmbryHelixState.LEADER.name(), 0);
+    builder.addState(AmbryHelixState.STANDBY.name(), 1);
+    builder.addState(AmbryHelixState.BOOTSTRAP.name(), 2);
+    builder.addState(AmbryHelixState.INACTIVE.name(), 2);
+    builder.addState(AmbryHelixState.OFFLINE.name(), 3);
+    // HelixDefinedState adds two additional states: ERROR and DROPPED. The priority is Integer.MAX_VALUE
+    for (HelixDefinedState state : HelixDefinedState.values()) {
+      builder.addState(state.name());
+    }
+
+    // Add valid transitions between the states.
+    builder.addTransition(AmbryHelixState.OFFLINE.name(), AmbryHelixState.BOOTSTRAP.name(), 3);
+    builder.addTransition(AmbryHelixState.BOOTSTRAP.name(), AmbryHelixState.STANDBY.name(), 2);
+    builder.addTransition(AmbryHelixState.STANDBY.name(), AmbryHelixState.LEADER.name(), 1);
+    builder.addTransition(AmbryHelixState.LEADER.name(), AmbryHelixState.STANDBY.name(), 0);
+    builder.addTransition(AmbryHelixState.STANDBY.name(), AmbryHelixState.INACTIVE.name(), 2);
+    builder.addTransition(AmbryHelixState.INACTIVE.name(), AmbryHelixState.OFFLINE.name(), 3);
+    builder.addTransition(AmbryHelixState.OFFLINE.name(), HelixDefinedState.DROPPED.name());
+
+    // States constraints
+    /*
+     * Static constraint: number of leader replica for certain partition shouldn't exceed 1 at any time.
+     */
+    builder.upperBound(AmbryHelixState.LEADER.name(), 1);
+    /*
+     * Dynamic constraint: R means it should be derived based on the replication factor for the cluster
+     * this allows a different replication factor for each resource without having to define a new state model.
+     */
+    builder.dynamicUpperBound(AmbryHelixState.STANDBY.name(), UPPER_BOUND_REPLICATION_FACTOR);
+
+    return builder.build();
+  }
+}

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelDefinition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelDefinition.java
@@ -21,7 +21,15 @@ import org.apache.helix.model.StateModelDefinition;
  * Define state model employed by Ambry.
  * Helix allows user to define custom state model which means Ambry is able to introduce custom states and define the
  * transition logic among these states. This class presents replica states, valid transitions and priorities that would
- * be used by Helix to manage Ambry partitions
+ * be used by Helix to manage Ambry partitions. Specifically, we add two custom states into new state model: BOOTSTRAP
+ * and INACTIVE. The valid transitions among states are depicted as follows:
+ *
+ *                  <--- INACTIVE <----
+ *                 |                   |
+ * DROPPED <--- OFFLINE              STANDBY  <----> LEADER
+ *                 |                   |
+ *                  ---> BOOTSTRAP --->
+ *
  */
 public class AmbryStateModelDefinition {
   public static final String AMBRY_LEADER_STANDBY_MODEL = "AmbryLeaderStandby";

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelDefinition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelDefinition.java
@@ -31,12 +31,12 @@ import org.apache.helix.model.StateModelDefinition;
  *                  ---> BOOTSTRAP --->
  *
  */
-public class AmbryStateModelDefinition {
-  public static final String AMBRY_LEADER_STANDBY_MODEL = "AmbryLeaderStandby";
+class AmbryStateModelDefinition {
+  static final String AMBRY_LEADER_STANDBY_MODEL = "AmbryLeaderStandby";
 
   private static final String UPPER_BOUND_REPLICATION_FACTOR = "R";
 
-  public static StateModelDefinition getDefinition() {
+  static StateModelDefinition getDefinition() {
 
     StateModelDefinition.Builder builder = new StateModelDefinition.Builder(AMBRY_LEADER_STANDBY_MODEL);
     // Init state

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
@@ -13,25 +13,38 @@
  */
 package com.github.ambry.clustermap;
 
+import com.github.ambry.config.ClusterMapConfig;
 import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
 
 
 /**
- * A factory for creating {@link AmbryStateModel}
+ * A factory for creating {@link AmbryDefaultStateModel}
  */
 class AmbryStateModelFactory extends StateModelFactory<StateModel> {
+  private final String ambryStateModelDef;
+
+  AmbryStateModelFactory(ClusterMapConfig clusterMapConfig) {
+    ambryStateModelDef = clusterMapConfig.clustermapStateModelDefinition;
+  }
 
   /**
-   * Create and return an instance of {@link AmbryStateModel}
+   * Create and return an instance of {@link AmbryDefaultStateModel}
    * @param resourceName the resource name for which this state model is being created.
    * @param partitionName the partition name for which this state model is being created.
-   *
-   * @return an instance of {@link AmbryStateModel}.
+   * @return an instance of {@link AmbryDefaultStateModel}.
    */
   @Override
   public StateModel createNewStateModel(String resourceName, String partitionName) {
-    return new AmbryStateModel();
+    StateModel stateModelToReturn;
+    switch (ambryStateModelDef) {
+      case AmbryStateModelDefinition.AMBRY_LEADER_STANDBY_MODEL:
+        stateModelToReturn = new AmbryPartitionStateModel();
+        break;
+      default:
+        stateModelToReturn = new AmbryDefaultStateModel();
+    }
+    return stateModelToReturn;
   }
 }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
@@ -13,36 +13,39 @@
  */
 package com.github.ambry.clustermap;
 
-import com.github.ambry.config.ClusterMapConfig;
+import org.apache.helix.model.LeaderStandbySMD;
 import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
 
 
 /**
- * A factory for creating {@link AmbryDefaultStateModel}
+ * A factory for creating {@link DefaultLeaderStandbyStateModel}
  */
 class AmbryStateModelFactory extends StateModelFactory<StateModel> {
   private final String ambryStateModelDef;
 
-  AmbryStateModelFactory(ClusterMapConfig clusterMapConfig) {
-    ambryStateModelDef = clusterMapConfig.clustermapStateModelDefinition;
+  AmbryStateModelFactory(String stateModelDef) {
+    ambryStateModelDef = stateModelDef;
   }
 
   /**
-   * Create and return an instance of {@link AmbryDefaultStateModel}
+   * Create and return an instance of {@link DefaultLeaderStandbyStateModel}
    * @param resourceName the resource name for which this state model is being created.
    * @param partitionName the partition name for which this state model is being created.
-   * @return an instance of {@link AmbryDefaultStateModel}.
+   * @return an instance of {@link DefaultLeaderStandbyStateModel}.
    */
   @Override
   public StateModel createNewStateModel(String resourceName, String partitionName) {
     StateModel stateModelToReturn;
     switch (ambryStateModelDef) {
       case AmbryStateModelDefinition.AMBRY_LEADER_STANDBY_MODEL:
-        stateModelToReturn = new AmbryPartitionStateModel();
+        stateModelToReturn = new AmbryPartitionStateModel(resourceName, partitionName);
+        break;
+      case LeaderStandbySMD.name:
+        stateModelToReturn = new DefaultLeaderStandbyStateModel();
         break;
       default:
-        stateModelToReturn = new AmbryDefaultStateModel();
+        throw new IllegalArgumentException("Unsupported state model definition: " + ambryStateModelDef);
     }
     return stateModelToReturn;
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
@@ -19,7 +19,7 @@ import org.apache.helix.participant.statemachine.StateModelFactory;
 
 
 /**
- * A factory for creating {@link DefaultLeaderStandbyStateModel}
+ * A factory for creating {@link StateModel}.
  */
 class AmbryStateModelFactory extends StateModelFactory<StateModel> {
   private final String ambryStateModelDef;
@@ -29,10 +29,10 @@ class AmbryStateModelFactory extends StateModelFactory<StateModel> {
   }
 
   /**
-   * Create and return an instance of {@link DefaultLeaderStandbyStateModel}
+   * Create and return an instance of {@link StateModel} based on given definition
    * @param resourceName the resource name for which this state model is being created.
    * @param partitionName the partition name for which this state model is being created.
-   * @return an instance of {@link DefaultLeaderStandbyStateModel}.
+   * @return an instance of {@link StateModel}.
    */
   @Override
   public StateModel createNewStateModel(String resourceName, String partitionName) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DefaultLeaderStandbyStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DefaultLeaderStandbyStateModel.java
@@ -24,20 +24,21 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * A default {@link StateModel} to use when the Ambry participants (datanodes) register to Helix. The methods are callbacks
- * that get called within a participant whenever partition's state changes in Helix. For now these are no-ops.
+ * A default LeaderStandby {@link StateModel} to use when the Ambry participants (datanodes) register to Helix. The
+ * methods are callbacks that get called within a participant whenever partition's state changes in Helix. For now
+ * these are no-ops.
  *
  * In the critical path of puts and gets, there are no leader replicas in Ambry. Every replica can serve reads and
  * writes. However, going forward, it is useful to have one of the replicas chosen as a LEADER for purposes such as
  * replication.
  */
 @StateModelInfo(initialState = "OFFLINE", states = {"LEADER", "STANDBY"})
-public class AmbryDefaultStateModel extends StateModel {
+public class DefaultLeaderStandbyStateModel extends StateModel {
   private Logger logger = LoggerFactory.getLogger(getClass());
 
-  AmbryDefaultStateModel() {
+  DefaultLeaderStandbyStateModel() {
     StateModelParser parser = new StateModelParser();
-    _currentState = parser.getInitialState(AmbryDefaultStateModel.class);
+    _currentState = parser.getInitialState(DefaultLeaderStandbyStateModel.class);
   }
 
   @Transition(to = "STANDBY", from = "OFFLINE")

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -195,15 +195,16 @@ class HelixBootstrapUpgradeUtil {
    * @param dcs the comma-separated list of datacenters that needs to be upgraded/bootstrapped.
    * @param maxPartitionsInOneResource the maximum number of Ambry partitions to group under a single Helix resource.
    * @param helixAdminFactory the {@link HelixAdminFactory} to use to instantiate {@link HelixAdmin}
+   * @param stateModelDef the state model definition to use in Ambry cluster.
    * @throws IOException if there is an error reading a file.
    * @throws JSONException if there is an error parsing the JSON content in any of the files.
    */
   static void uploadClusterConfigs(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
-      String clusterNamePrefix, String dcs, int maxPartitionsInOneResource, HelixAdminFactory helixAdminFactory)
-      throws Exception {
+      String clusterNamePrefix, String dcs, int maxPartitionsInOneResource, HelixAdminFactory helixAdminFactory,
+      String stateModelDef) throws Exception {
     HelixBootstrapUpgradeUtil clusterMapToHelixMapper =
         new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
-            maxPartitionsInOneResource, false, false, helixAdminFactory, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
+            maxPartitionsInOneResource, false, false, helixAdminFactory, stateModelDef);
     Map<String, Map<String, String>> partitionOverrideInfos =
         clusterMapToHelixMapper.generatePartitionOverrideFromAllDCs();
     info("Uploading partition override to HelixPropertyStore based on override json file.");
@@ -234,14 +235,16 @@ class HelixBootstrapUpgradeUtil {
    *                          will give the cluster name in Helix to bootstrap or upgrade.
    * @param dcs the comma-separated list of datacenters that needs to be upgraded/bootstrapped.
    * @param helixAdminFactory the {@link HelixAdminFactory} to use to instantiate {@link HelixAdmin}
+   * @param stateModelDef the state model definition to use in Ambry cluster.
    * @throws IOException if there is an error reading a file.
    * @throws JSONException if there is an error parsing the JSON content in any of the files.
    */
   static void validate(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
-      String clusterNamePrefix, String dcs, HelixAdminFactory helixAdminFactory) throws Exception {
+      String clusterNamePrefix, String dcs, HelixAdminFactory helixAdminFactory, String stateModelDef)
+      throws Exception {
     HelixBootstrapUpgradeUtil clusterMapToHelixMapper =
         new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs, 0,
-            false, false, helixAdminFactory, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
+            false, false, helixAdminFactory, stateModelDef);
     clusterMapToHelixMapper.validateAndClose();
     clusterMapToHelixMapper.logSummary();
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -93,7 +93,7 @@ class HelixParticipant implements ClusterParticipant {
         clusterMapConfig.clustermapStateModelDefinition);
     StateMachineEngine stateMachineEngine = manager.getStateMachineEngine();
     stateMachineEngine.registerStateModelFactory(clusterMapConfig.clustermapStateModelDefinition,
-        new AmbryStateModelFactory(clusterMapConfig));
+        new AmbryStateModelFactory(clusterMapConfig.clustermapStateModelDefinition));
     registerHealthReportTasks(stateMachineEngine, ambryHealthReports);
     try {
       synchronized (helixAdministrationLock) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -28,7 +28,6 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
 import org.apache.helix.healthcheck.HealthReportProvider;
 import org.apache.helix.model.InstanceConfig;
-import org.apache.helix.model.LeaderStandbySMD;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskCallbackContext;
@@ -49,6 +48,7 @@ class HelixParticipant implements ClusterParticipant {
   private final String zkConnectStr;
   private final HelixFactory helixFactory;
   private final Object helixAdministrationLock = new Object();
+  private final ClusterMapConfig clusterMapConfig;
   private HelixManager manager;
   private String instanceName;
   private HelixAdmin helixAdmin;
@@ -60,6 +60,7 @@ class HelixParticipant implements ClusterParticipant {
    * @throws IOException if there is an error in parsing the JSON serialized ZK connect string config.
    */
   HelixParticipant(ClusterMapConfig clusterMapConfig, HelixFactory helixFactory) throws IOException {
+    this.clusterMapConfig = clusterMapConfig;
     clusterName = clusterMapConfig.clusterMapClusterName;
     instanceName =
         ClusterMapUtils.getInstanceName(clusterMapConfig.clusterMapHostName, clusterMapConfig.clusterMapPort);
@@ -88,9 +89,11 @@ class HelixParticipant implements ClusterParticipant {
    */
   @Override
   public void participate(List<AmbryHealthReport> ambryHealthReports) throws IOException {
-    logger.info("Initiating the participation");
+    logger.info("Initiating the participation. The specified state model is {}",
+        clusterMapConfig.clustermapStateModelDefinition);
     StateMachineEngine stateMachineEngine = manager.getStateMachineEngine();
-    stateMachineEngine.registerStateModelFactory(LeaderStandbySMD.name, new AmbryStateModelFactory());
+    stateMachineEngine.registerStateModelFactory(clusterMapConfig.clustermapStateModelDefinition,
+        new AmbryStateModelFactory(clusterMapConfig));
     registerHealthReportTasks(stateMachineEngine, ambryHealthReports);
     try {
       synchronized (helixAdministrationLock) {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.VerifiableProperties;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import org.apache.helix.participant.statemachine.StateModel;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Test for {@link AmbryStateModelFactory}
+ */
+@RunWith(Parameterized.class)
+public class AmbryStateModelFactoryTest {
+  private final ClusterMapConfig clustermapConfig;
+
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(
+        new Object[][]{{ClusterMapConfig.DEFAULT_STATE_MODEL_DEF}, {ClusterMapConfig.AMBRY_STATE_MODEL_DEF}});
+  }
+
+  public AmbryStateModelFactoryTest(String stateModelDef) {
+    Properties props = new Properties();
+    props.setProperty("clustermap.host.name", "localhost");
+    props.setProperty("clustermap.port", "2200");
+    props.setProperty("clustermap.cluster.name", "AmbryStateModelFactoryTest");
+    props.setProperty("clustermap.state.model.definition", stateModelDef);
+    props.setProperty("clustermap.datacenter.name", "DC0");
+    clustermapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+  }
+
+  @Test
+  public void testDifferentStateModelDefs() {
+    AmbryStateModelFactory factory = new AmbryStateModelFactory(clustermapConfig);
+    StateModel stateModel = factory.createNewStateModel("0", "1");
+    if ((clustermapConfig.clustermapStateModelDefinition).equals(ClusterMapConfig.DEFAULT_STATE_MODEL_DEF)) {
+      assertTrue("Unexpected state model def", stateModel instanceof AmbryDefaultStateModel);
+    } else {
+      assertTrue("Unexpected state model def", stateModel instanceof AmbryPartitionStateModel);
+    }
+  }
+}

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.clustermap;
 
+import com.github.ambry.config.ClusterMapConfig;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -48,7 +49,7 @@ public class MockHelixCluster {
     this.partitionLayoutPath = partitionLayoutPath;
     this.zkLayoutPath = zkLayoutPath;
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        "all", 3, false, false, helixAdminFactory, false);
+        "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
     this.clusterName = clusterName;
   }
 
@@ -59,7 +60,7 @@ public class MockHelixCluster {
    */
   void upgradeWithNewHardwareLayout(String hardwareLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        "all", 3, false, false, helixAdminFactory, false);
+        "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
     triggerInstanceConfigChangeNotification();
   }
 
@@ -70,7 +71,7 @@ public class MockHelixCluster {
    */
   void upgradeWithNewPartitionLayout(String partitionLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        "all", 3, false, false, helixAdminFactory, false);
+        "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
     triggerInstanceConfigChangeNotification();
   }
 

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -178,7 +178,7 @@ public class HelixBootstrapUpgradeToolTest {
       try {
         HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
             CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(),
-            true);
+            true, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
         fail("Should have thrown IllegalArgumentException as a zk host is missing for one of the dcs");
       } catch (IllegalArgumentException e) {
         // OK
@@ -356,7 +356,7 @@ public class HelixBootstrapUpgradeToolTest {
     // This updates and verifies that the information in Helix is consistent with the one in the static cluster map.
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, forceRemove, new HelixAdminFactory(),
-        true);
+        true, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
     verifyResourceCount(testHardwareLayout.getHardwareLayout(), expectedResourceCount);
   }
 

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -420,7 +420,8 @@ public class HelixBootstrapUpgradeToolTest {
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
     HelixBootstrapUpgradeUtil.uploadClusterConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-        CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory());
+        CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory(),
+        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
     // Check writable partitions in each datacenter
     for (ZkInfo zkInfo : dcsToZkInfo.values()) {
       HelixPropertyStore<ZNRecord> propertyStore =

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -207,7 +207,7 @@ public class HelixBootstrapUpgradeTool {
       expectedOpts.add(dcsNameOpt);
       ToolUtils.ensureExactOrExit(expectedOpts, options.specs(), parser);
       HelixBootstrapUpgradeUtil.validate(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
-          new HelixAdminFactory());
+          new HelixAdminFactory(), stateModelDef);
     } else if (options.has(uploadConfig)) {
       ArrayList<OptionSpec<?>> expectedOpts = new ArrayList<>();
       expectedOpts.add(uploadConfig);
@@ -218,7 +218,7 @@ public class HelixBootstrapUpgradeTool {
       expectedOpts.add(dcsNameOpt);
       ToolUtils.ensureExactOrExit(expectedOpts, options.specs(), parser);
       HelixBootstrapUpgradeUtil.uploadClusterConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-          clusterNamePrefix, dcs, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory());
+          clusterNamePrefix, dcs, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory(), stateModelDef);
     } else if (options.has(addStateModel)) {
       listOpt.add(stateModelDefinitionOpt);
       ToolUtils.ensureOrExit(listOpt, options, parser);


### PR DESCRIPTION
1. Introduce new state model that incorporates BOOTSTRAP and INACTIVE
states.
2. Add clustermap config that allows participant to choose which state
model to use. Previous LeadStandby Model is default option.
3. Update Helix bootstrap tool to supporting specifying state model when
creating new cluster or adding new state model to existing cluster.