### PR TITLE
Fix broken builds by specifying Ubuntu trusty dist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 script:
   - ./gradlew build && ./gradlew codeCoverageReport
 sudo: required


### PR DESCRIPTION
Reference: https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766