### PR TITLE
Support dynamically removing store from storage manager

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -705,7 +705,7 @@ class BlobStore implements Store {
     try {
       Utils.deleteFileOrDirectory(storeDir);
     } catch (Exception e) {
-      throw new IOException("Couldn't delete store directory " + dataDir);
+      throw new IOException("Couldn't delete store directory " + dataDir, e);
     }
     logger.info("All files of store {} deleted", storeId);
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -22,11 +22,8 @@ import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -697,18 +694,16 @@ class BlobStore implements Store {
     }
     // step1: return occupied swap segments (if any) to reserve pool
     String[] swapSegmentsInUse = compactor.getSwapSegmentsInUse();
-    if (swapSegmentsInUse.length > 0) {
-      for (String fileName : swapSegmentsInUse) {
-        logger.trace("Returning swap segment {} to reserve pool", fileName);
-        File swapSegmentTempFile = new File(dataDir, fileName);
-        diskSpaceAllocator.free(swapSegmentTempFile, config.storeSegmentSizeInBytes, storeId, true);
-      }
+    for (String fileName : swapSegmentsInUse) {
+      logger.info("Returning swap segment {} to reserve pool", fileName);
+      File swapSegmentTempFile = new File(dataDir, fileName);
+      diskSpaceAllocator.free(swapSegmentTempFile, config.storeSegmentSizeInBytes, storeId, true);
     }
     // step2: delete all files
     logger.info("Deleting store {} directory", storeId);
     File storeDir = new File(dataDir);
     try {
-      Files.walk(storeDir.toPath()).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+      Utils.deleteFileOrDirectory(storeDir);
     } catch (Exception e) {
       throw new IOException("Couldn't delete store directory " + dataDir);
     }

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -688,18 +688,18 @@ class BlobStore implements Store {
    * files/dirs associated with this store. This method is invoked by transition in AmbryStateModel (OFFLINE -> DROPPED)
    */
   public void deleteStoreFiles() throws StoreException, IOException {
-    // step0: ensure the store has been shut down
+    // Step 0: ensure the store has been shut down
     if (started) {
       throw new IllegalStateException("Store is still started. Deleting store files is not allowed.");
     }
-    // step1: return occupied swap segments (if any) to reserve pool
+    // Step 1: return occupied swap segments (if any) to reserve pool
     String[] swapSegmentsInUse = compactor.getSwapSegmentsInUse();
     for (String fileName : swapSegmentsInUse) {
       logger.info("Returning swap segment {} to reserve pool", fileName);
       File swapSegmentTempFile = new File(dataDir, fileName);
       diskSpaceAllocator.free(swapSegmentTempFile, config.storeSegmentSizeInBytes, storeId, true);
     }
-    // step2: delete all files
+    // Step 2: delete all files
     logger.info("Deleting store {} directory", storeId);
     File storeDir = new File(dataDir);
     try {

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStoreCompactor.java
@@ -253,16 +253,15 @@ class BlobStoreCompactor {
   }
 
   /**
-   * @return the number of temporary log segment files this compactor is currently using.
+   * @return an array of temporary log segment files this compactor is currently using.
    */
-  int getSwapSegmentsInUse() throws StoreException {
-    // TODO: use this method to return swap segment to pool when removing store
+  String[] getSwapSegmentsInUse() throws StoreException {
     String[] tempSegments = dataDir.list(TEMP_LOG_SEGMENTS_FILTER);
     if (tempSegments == null) {
       throw new StoreException("Error occurred while listing files in data dir:" + dataDir.getAbsolutePath(),
           StoreErrorCodes.IOError);
     }
-    return tempSegments.length;
+    return tempSegments;
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -390,6 +390,10 @@ class CompactionManager {
       }
     }
 
+    /**
+     * Remove store from compaction executor.
+     * @param store the {@link BlobStore} to remove
+     */
     void removeBlobStore(BlobStore store) {
       lock.lock();
       try {
@@ -404,6 +408,9 @@ class CompactionManager {
       }
     }
 
+    /**
+     * @return a list of stores on which compaction is disabled.
+     */
     Set<BlobStore> getStoresDisabledCompaction() {
       return storesDisabledCompaction;
     }

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -160,20 +160,17 @@ class CompactionManager {
    * @return {@code true} if store is removed successfully. {@code false} if not.
    */
   boolean removeBlobStore(BlobStore store) {
-    boolean result;
     if (compactionExecutor == null) {
       stores.remove(store);
-      result = true;
+      return true;
     } else if (!compactionExecutor.getStoresDisabledCompaction().contains(store)) {
-      logger.error("Fail to remove store ({}) from compaction manager because compaction of it is still enabled",
+      logger.error("Fail to remove store ({}) from compaction manager because compaction is still enabled on it",
           store);
-      result = false;
-    } else {
-      // stores.remove(store) is invoked within compactionExecutor.removeBlobStore() because it requires lock
-      compactionExecutor.removeBlobStore(store);
-      result = true;
+      return false;
     }
-    return result;
+    // stores.remove(store) is invoked within compactionExecutor.removeBlobStore() because it requires lock
+    compactionExecutor.removeBlobStore(store);
+    return true;
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -155,9 +155,9 @@ class CompactionManager {
   }
 
   /**
-   *
-   * @param store
-   * @return
+   * Remove store from compaction manager.
+   * @param store the {@link BlobStore} to remove
+   * @return {@code true} if store is removed successfully. {@code false} if not.
    */
   boolean removeBlobStore(BlobStore store) {
     boolean result;
@@ -166,12 +166,13 @@ class CompactionManager {
       result = true;
     } else {
       if (!compactionExecutor.getStoresDisabledCompaction().contains(store)) {
-        logger.error("Fail to remove store ({}) from compaction manager because compaction on it is still enabled",
+        logger.error("Fail to remove store ({}) from compaction manager because compaction of it is still enabled",
             store);
         result = false;
       } else {
         // stores.remove(store) is invoked within compactionExecutor.removeBlobStore() because it requires lock
-        result = compactionExecutor.removeBlobStore(store);
+        compactionExecutor.removeBlobStore(store);
+        result = true;
       }
     }
     return result;
@@ -389,7 +390,7 @@ class CompactionManager {
       }
     }
 
-    boolean removeBlobStore(BlobStore store) {
+    void removeBlobStore(BlobStore store) {
       lock.lock();
       try {
         stores.remove(store);
@@ -401,7 +402,6 @@ class CompactionManager {
       } finally {
         lock.unlock();
       }
-      return true;
     }
 
     Set<BlobStore> getStoresDisabledCompaction() {

--- a/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/CompactionManager.java
@@ -164,16 +164,14 @@ class CompactionManager {
     if (compactionExecutor == null) {
       stores.remove(store);
       result = true;
+    } else if (!compactionExecutor.getStoresDisabledCompaction().contains(store)) {
+      logger.error("Fail to remove store ({}) from compaction manager because compaction of it is still enabled",
+          store);
+      result = false;
     } else {
-      if (!compactionExecutor.getStoresDisabledCompaction().contains(store)) {
-        logger.error("Fail to remove store ({}) from compaction manager because compaction of it is still enabled",
-            store);
-        result = false;
-      } else {
-        // stores.remove(store) is invoked within compactionExecutor.removeBlobStore() because it requires lock
-        compactionExecutor.removeBlobStore(store);
-        result = true;
-      }
+      // stores.remove(store) is invoked within compactionExecutor.removeBlobStore() because it requires lock
+      compactionExecutor.removeBlobStore(store);
+      result = true;
     }
     return result;
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -209,7 +209,6 @@ public class StorageManager {
 
   /**
    * Shutdown the {@link DiskManager}s for the disks on this node.
-   * @throws StoreException
    * @throws InterruptedException
    */
   public void shutdown() throws InterruptedException {

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -292,7 +292,7 @@ public class StorageManager {
   /**
    * Remove store from storage manager.
    * @param id the {@link PartitionId} associated with store
-   * @return {@code ture} if removal succeeds. {@code false} otherwise.
+   * @return {@code true} if removal succeeds. {@code false} otherwise.
    */
   public boolean removeBlobStore(PartitionId id) {
     DiskManager diskManager = partitionToDiskManager.get(id);

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -289,6 +289,11 @@ public class StorageManager {
     return diskManager != null && diskManager.shutdownBlobStore(id);
   }
 
+  /**
+   * Remove store from storage manager.
+   * @param id the {@link PartitionId} associated with store
+   * @return {@code ture} if removal succeeds. {@code false} otherwise.
+   */
   public boolean removeBlobStore(PartitionId id) {
     DiskManager diskManager = partitionToDiskManager.get(id);
     if (diskManager == null) {

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -290,6 +290,21 @@ public class StorageManager {
     return diskManager != null && diskManager.shutdownBlobStore(id);
   }
 
+  public boolean removeBlobStore(PartitionId id) {
+    DiskManager diskManager = partitionToDiskManager.get(id);
+    if (diskManager == null) {
+      logger.info("Store {} is not found in storage manager", id);
+      return true;
+    }
+    if (!diskManager.removeBlobStore(id)) {
+      logger.error("Fail to remove store {} from disk manager", id);
+      return false;
+    }
+    partitionToDiskManager.remove(id);
+    logger.info("Store {} is successfully removed from storage manager", id);
+    return true;
+  }
+
   /**
    * Set BlobStore Stopped state with given {@link PartitionId} {@code id}.
    * @param partitionIds a list {@link PartitionId} of the {@link Store} whose stopped state should be set.

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManagerMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManagerMetrics.java
@@ -112,6 +112,7 @@ public class StorageManagerMetrics {
    * Deregister the Metrics related to the compaction thread.
    */
   void deregisterCompactionThreadsTracker() {
+    registry.remove(MetricRegistry.name(CompactionManager.class, "CompactionsInProgress"));
     registry.remove(MetricRegistry.name(StorageManager.class, "CompactionThreadsAlive"));
     registry.remove(MetricRegistry.name(StorageManager.class, "CompactionHealth"));
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -219,6 +219,8 @@ public class StoreMetrics {
     registry.remove(MetricRegistry.name(Log.class, prefix + "CurrentCapacityUsed"));
     registry.remove(MetricRegistry.name(Log.class, prefix + "PercentageUsedCapacity"));
     registry.remove(MetricRegistry.name(Log.class, prefix + "CurrentSegmentCount"));
+    registry.remove(MetricRegistry.name(Log.class, "ByteBufferForAppendTotalCount"));
+    registry.remove(MetricRegistry.name(Log.class, "UnderCompaction" + SEPERATOR + "ByteBufferForAppendTotalCount"));
   }
 
   void initializeHardDeleteMetric(String storeId, final HardDeleter hardDeleter, final PersistentIndex index) {

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Metrics for store operations
  */
 public class StoreMetrics {
-  private static final String SEPERATOR = ".";
+  private static final String SEPARATOR = ".";
 
   public final Timer getResponse;
   public final Timer putResponse;
@@ -102,7 +102,7 @@ public class StoreMetrics {
 
   public StoreMetrics(String prefix, MetricRegistry registry) {
     this.registry = registry;
-    String name = !prefix.isEmpty() ? prefix + SEPERATOR : "";
+    String name = !prefix.isEmpty() ? prefix + SEPARATOR : "";
     getResponse = registry.timer(MetricRegistry.name(BlobStore.class, name + "StoreGetResponse"));
     putResponse = registry.timer(MetricRegistry.name(BlobStore.class, name + "StorePutResponse"));
     deleteResponse = registry.timer(MetricRegistry.name(BlobStore.class, name + "StoreDeleteResponse"));
@@ -201,7 +201,7 @@ public class StoreMetrics {
   }
 
   void initializeIndexGauges(String storeId, final PersistentIndex index, final long capacityInBytes) {
-    String prefix = storeId + SEPERATOR;
+    String prefix = storeId + SEPARATOR;
     Gauge<Long> currentCapacityUsed = index::getLogUsedCapacity;
     registry.register(MetricRegistry.name(Log.class, prefix + "CurrentCapacityUsed"), currentCapacityUsed);
     Gauge<Double> percentageUsedCapacity = () -> ((double) index.getLogUsedCapacity() / capacityInBytes) * 100;
@@ -215,16 +215,16 @@ public class StoreMetrics {
    * @param storeId the {@link BlobStore} for which the IndexGauges should be deregistered.
    */
   private void deregisterIndexGauges(String storeId) {
-    String prefix = storeId + SEPERATOR;
+    String prefix = storeId + SEPARATOR;
     registry.remove(MetricRegistry.name(Log.class, prefix + "CurrentCapacityUsed"));
     registry.remove(MetricRegistry.name(Log.class, prefix + "PercentageUsedCapacity"));
     registry.remove(MetricRegistry.name(Log.class, prefix + "CurrentSegmentCount"));
     registry.remove(MetricRegistry.name(Log.class, "ByteBufferForAppendTotalCount"));
-    registry.remove(MetricRegistry.name(Log.class, "UnderCompaction" + SEPERATOR + "ByteBufferForAppendTotalCount"));
+    registry.remove(MetricRegistry.name(Log.class, "UnderCompaction" + SEPARATOR + "ByteBufferForAppendTotalCount"));
   }
 
   void initializeHardDeleteMetric(String storeId, final HardDeleter hardDeleter, final PersistentIndex index) {
-    String prefix = storeId + SEPERATOR;
+    String prefix = storeId + SEPARATOR;
     Gauge<Long> currentHardDeleteProgress = hardDeleter::getProgress;
     registry.register(MetricRegistry.name(PersistentIndex.class, prefix + "CurrentHardDeleteProgress"),
         currentHardDeleteProgress);
@@ -247,7 +247,7 @@ public class StoreMetrics {
    * @param storeId the {@link BlobStore} for which the HardDeleteMetric should be deregistered.
    */
   private void deregisterHardDeleteMetric(String storeId) {
-    String prefix = storeId + SEPERATOR;
+    String prefix = storeId + SEPARATOR;
     registry.remove(MetricRegistry.name(PersistentIndex.class, prefix + "CurrentHardDeleteProgress"));
     registry.remove(MetricRegistry.name(Log.class, prefix + "PercentageHardDeleteCompleted"));
     registry.remove(MetricRegistry.name(PersistentIndex.class, prefix + "HardDeleteThreadRunning"));
@@ -255,7 +255,7 @@ public class StoreMetrics {
   }
 
   void initializeCompactorGauges(String storeId, final AtomicBoolean compactionInProgress) {
-    String prefix = storeId + SEPERATOR;
+    String prefix = storeId + SEPARATOR;
     Gauge<Long> compactionInProgressGauge = () -> compactionInProgress.get() ? 1L : 0L;
     registry.register(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionInProgress"),
         compactionInProgressGauge);
@@ -266,7 +266,7 @@ public class StoreMetrics {
    * @param storeId the {@link BlobStore} for which the CompactorGauges should be deregistered.
    */
   private void deregisterCompactorGauges(String storeId) {
-    String prefix = storeId + SEPERATOR;
+    String prefix = storeId + SEPARATOR;
     registry.remove(MetricRegistry.name(BlobStoreCompactor.class, prefix + "CompactionInProgress"));
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreCompactorTest.java
@@ -229,7 +229,7 @@ public class BlobStoreCompactorTest {
     compactor = getCompactor(state.log, DISK_IO_SCHEDULER);
     compactor.initialize(state.index);
     assertFalse("Compaction should not be in progress", CompactionLog.isCompactionInProgress(tempDirStr, STORE_ID));
-    assertEquals("Temp log segment should not be found", 0, compactor.getSwapSegmentsInUse());
+    assertEquals("Temp log segment should not be found", 0, compactor.getSwapSegmentsInUse().length);
     try {
       compactor.resumeCompaction(bundleReadBuffer);
       fail("Should have failed because there is no compaction in progress");
@@ -1213,7 +1213,7 @@ public class BlobStoreCompactorTest {
     }
 
     assertFalse("No compaction should be in progress", CompactionLog.isCompactionInProgress(tempDirStr, STORE_ID));
-    assertEquals("Swap segments should not be found", 0, compactor.getSwapSegmentsInUse());
+    assertEquals("Swap segments should not be found", 0, compactor.getSwapSegmentsInUse().length);
     long logSegmentSizeAfterCompaction = getSumOfLogSegmentEndOffsets();
     long logSegmentCountAfterCompaction = state.index.getLogSegmentCount();
     long indexSegmentCountAfterCompaction = state.index.getIndexSegments().size();
@@ -1290,7 +1290,7 @@ public class BlobStoreCompactorTest {
     state.initIndex(null);
     compactor.initialize(state.index);
     assertEquals("Wrong number of swap segments in use",
-        tempDir.list(BlobStoreCompactor.TEMP_LOG_SEGMENTS_FILTER).length, compactor.getSwapSegmentsInUse());
+        tempDir.list(BlobStoreCompactor.TEMP_LOG_SEGMENTS_FILTER).length, compactor.getSwapSegmentsInUse().length);
     try {
       if (CompactionLog.isCompactionInProgress(tempDirStr, STORE_ID)) {
         compactor.resumeCompaction(bundleReadBuffer);

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -57,7 +57,6 @@ import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.*;
 import static org.mockito.Mockito.*;
 
 
@@ -1187,7 +1186,6 @@ public class BlobStoreTest {
    */
   @Test
   public void deleteStoreFilesTest() throws Exception {
-    assumeTrue(isLogSegmented);
     store.shutdown();
     // create test store directory
     File storeDir = StoreTestUtils.createTempDirectory("store-" + storeId);
@@ -1197,12 +1195,13 @@ public class BlobStoreTest {
     StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
     MetricRegistry registry = new MetricRegistry();
     StoreMetrics metrics = new StoreMetrics(registry);
-    //createBlobStore(getMockReplicaId(storeDir.getAbsolutePath()));
     BlobStore testStore =
         new BlobStore(getMockReplicaId(storeDir.getAbsolutePath()), config, scheduler, storeStatsScheduler,
             diskIOScheduler, diskAllocator, metrics, metrics, STORE_KEY_FACTORY, recovery, hardDelete, null, time);
     testStore.start();
-    diskAllocator.initializePool(Collections.singletonList(testStore.getDiskSpaceRequirements()));
+    DiskSpaceRequirements diskSpaceRequirements = testStore.getDiskSpaceRequirements();
+    diskAllocator.initializePool(diskSpaceRequirements == null ? Collections.emptyList()
+        : Collections.singletonList(testStore.getDiskSpaceRequirements()));
     // ensure store directory and file exist
     assertTrue("Store directory doesn't exist", storeDir.exists());
     // test that deletion on started store should fail

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -57,6 +57,7 @@ import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 import static org.mockito.Mockito.*;
 
 
@@ -262,7 +263,7 @@ public class BlobStoreTest {
    */
   public BlobStoreTest(boolean isLogSegmented) throws InterruptedException, IOException, StoreException {
     this.isLogSegmented = isLogSegmented;
-    tempDir = StoreTestUtils.createTempDirectory("storeDir-" + UtilsTest.getRandomString(10));
+    tempDir = StoreTestUtils.createTempDirectory("storeDir-" + storeId);
     tempDirStr = tempDir.getAbsolutePath();
     StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
     long bufferTimeMs = TimeUnit.SECONDS.toMillis(config.storeTtlUpdateBufferTimeSeconds);
@@ -1176,6 +1177,66 @@ public class BlobStoreTest {
     // verify error count keeps track of StoreException and shut down store properly
     assertEquals("Mismatch in triggered shutdown counter", 1, metrics.storeIoErrorTriggeredShutdownCount.getCount());
     assertFalse("Store should shutdown because error count exceeded threshold", testStore2.isStarted());
+
+    reloadStore();
+  }
+
+  /**
+   * Test both success and failure cases when deleting store files.
+   * @throws Exception
+   */
+  @Test
+  public void deleteStoreFilesTest() throws Exception {
+    assumeTrue(isLogSegmented);
+    store.shutdown();
+    // create test store directory
+    File storeDir = StoreTestUtils.createTempDirectory("store-" + storeId);
+    File reserveDir = StoreTestUtils.createTempDirectory("reserve-pool");
+    DiskSpaceAllocator diskAllocator =
+        new DiskSpaceAllocator(true, reserveDir, 0, new StorageManagerMetrics(new MetricRegistry()));
+    StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
+    MetricRegistry registry = new MetricRegistry();
+    StoreMetrics metrics = new StoreMetrics(registry);
+    //createBlobStore(getMockReplicaId(storeDir.getAbsolutePath()));
+    BlobStore testStore =
+        new BlobStore(getMockReplicaId(storeDir.getAbsolutePath()), config, scheduler, storeStatsScheduler,
+            diskIOScheduler, diskAllocator, metrics, metrics, STORE_KEY_FACTORY, recovery, hardDelete, null, time);
+    testStore.start();
+    diskAllocator.initializePool(Collections.singletonList(testStore.getDiskSpaceRequirements()));
+    // ensure store directory and file exist
+    assertTrue("Store directory doesn't exist", storeDir.exists());
+    // test that deletion on started store should fail
+    try {
+      testStore.deleteStoreFiles();
+    } catch (IllegalStateException e) {
+      //expected
+    }
+    // create a unreadable dir in store dir to induce deletion failure
+    File invalidDir = new File(storeDir, "invalidDir");
+    assertTrue("Couldn't create dir within store dir", invalidDir.mkdir());
+    assertTrue("Could not make unreadable", invalidDir.setReadable(false));
+    testStore.shutdown();
+    try {
+      testStore.deleteStoreFiles();
+      fail("should fail because one invalid dir is unreadable");
+    } catch (Exception e) {
+      // expected
+    }
+    assertTrue("store directory should exist because deletion failed", storeDir.exists());
+    // reset permission to allow deletion to succeed.
+    assertTrue("Could not make readable", invalidDir.setReadable(true));
+
+    // put a swap segment into store dir
+    File tempFile = File.createTempFile("sample-swap",
+        LogSegmentNameHelper.SUFFIX + BlobStoreCompactor.TEMP_LOG_SEGMENT_NAME_SUFFIX, storeDir);
+    // test success case (swap segment is returned and store dir is correctly deleted)
+    assertEquals("Swap reserve dir should be empty initially", 0,
+        diskAllocator.getSwapReserveFileMap().getFileSizeSet().size());
+    testStore.deleteStoreFiles();
+    assertFalse("swap segment still exists", tempFile.exists());
+    assertEquals("Swap reserve dir should have one swap segment", 1,
+        diskAllocator.getSwapReserveFileMap().getFileSizeSet().size());
+    assertFalse("store directory shouldn't exist", storeDir.exists());
 
     reloadStore();
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -324,6 +324,49 @@ public class StorageManagerTest {
   }
 
   /**
+   * Test remove blob store with given {@link PartitionId}
+   * @throws Exception
+   */
+  @Test
+  public void removeBlobStoreTest() throws Exception {
+    MockDataNodeId dataNode = clusterMap.getDataNodes().get(0);
+    List<ReplicaId> replicas = clusterMap.getReplicaIds(dataNode);
+    List<MockDataNodeId> dataNodes = new ArrayList<>();
+    dataNodes.add(dataNode);
+    MockPartitionId invalidPartition =
+        new MockPartitionId(Long.MAX_VALUE, MockClusterMap.DEFAULT_PARTITION_CLASS, dataNodes, 0);
+    StorageManager storageManager = createStorageManager(replicas, metricRegistry, null);
+    storageManager.start();
+    // shut down replica[1] ~ replica[size - 2]. The replica[0] will be used to test removing store that disk is not running
+    // Replica[1] will be used to test removing a started store. Replica[2] will be used to test a store with compaction enabled
+    System.out.println("size = " + replicas.size());
+    for (int i = 3; i < replicas.size(); i++) {
+      ReplicaId replica = replicas.get(i);
+      PartitionId id = replica.getPartitionId();
+      assertTrue("Disable compaction should succeed", storageManager.controlCompactionForBlobStore(id, false));
+      assertTrue("Shutdown should succeed on given store", storageManager.shutdownBlobStore(id));
+      assertTrue("Removing store should succeed", storageManager.removeBlobStore(id));
+      assertNull("The store should not exist", storageManager.getStore(id));
+    }
+    // test remove store that compaction is still enabled on it, even though it is shutdown
+    PartitionId id = replicas.get(2).getPartitionId();
+    assertTrue("Shutdown should succeed on given store", storageManager.shutdownBlobStore(id));
+    assertFalse("Removing store should fail because compaction is enabled on this store",
+        storageManager.removeBlobStore(id));
+    // test remove store that is still started
+    id = replicas.get(1).getPartitionId();
+    assertFalse("Removing store should fail because store is still started", storageManager.removeBlobStore(id));
+    // test remove store that the disk manager is not running
+    id = replicas.get(0).getPartitionId();
+    storageManager.getDiskManager(id).shutdown();
+    assertFalse("Removing store should fail because disk mananager is not running", storageManager.removeBlobStore(id));
+    // test a store that doesn't exceed
+    assertTrue("Removing not-found store should be considered success",
+        storageManager.removeBlobStore(invalidPartition));
+    shutdownAndAssertStoresInaccessible(storageManager, replicas);
+  }
+
+  /**
    * Test set stopped state of blobstore with given list of {@link PartitionId} in failure cases.
    */
   @Test

--- a/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StoreTestUtils.java
@@ -66,6 +66,7 @@ class StoreTestUtils {
       this.filePath = filePath;
       partitionId = mock(PartitionId.class);
       when(partitionId.toString()).thenReturn(storeId);
+      when(partitionId.toPathString()).thenReturn(storeId);
     }
 
     @Override


### PR DESCRIPTION
1. Given partition id, remove the corresponding store from storage
manager, disk manager and compaction manager.
2. Support deleting allocated files of store and returning swap
segments to reserver pool if necessary.