### PR TITLE
Misc fixes in cluster manager, replication and compaction manager

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/store/Store.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/Store.java
@@ -104,6 +104,11 @@ public interface Store {
   boolean isEmpty();
 
   /**
+   * @return true if the store is started
+   */
+  boolean isStarted();
+
+  /**
    * Shuts down the store
    */
   void shutdown() throws StoreException;

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
@@ -354,6 +354,11 @@ class CloudBlobStore implements Store {
     started = false;
   }
 
+  @Override
+  public boolean isStarted() {
+    return started;
+  }
+
   private void checkStarted() throws StoreException {
     if (!started) {
       throw new StoreException("Store not started", StoreErrorCodes.Store_Not_Started);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -454,6 +454,7 @@ class HelixClusterManager implements ClusterMap {
             try {
               initializeInstances(configs);
             } catch (Exception e) {
+              logger.error("Exception occurred when initializing instances in {}: ", dcName, e);
               initializationFailureMap.putIfAbsent(dcName, e);
             }
             instanceConfigInitialized.set(true);

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -95,7 +95,7 @@ public class ReplicationManager extends ReplicationEngine {
         retrieveReplicaTokensAndPersistIfNecessary(mountPath);
       }
       if (replicaThreadPoolByDc.size() == 0) {
-        logger.warn("Number of Datacenters to replicate from is 0, not starting any replica threads");
+        logger.warn("Number of data centers to replicate from is 0, not starting any replica threads");
         return;
       }
       // valid for replication manager.

--- a/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
@@ -148,6 +148,7 @@ class InMemoryStore implements Store {
   private final DummyLog log;
   final List<MessageInfo> messageInfos;
   final PartitionId id;
+  private boolean started;
 
   InMemoryStore(PartitionId id, List<MessageInfo> messageInfos, List<ByteBuffer> buffers,
       ReplicationTest.StoreEventListener listener) {
@@ -158,10 +159,12 @@ class InMemoryStore implements Store {
     log = new DummyLog(buffers);
     this.listener = listener;
     this.id = id;
+    started = true;
   }
 
   @Override
   public void start() throws StoreException {
+    started = true;
   }
 
   @Override
@@ -309,5 +312,11 @@ class InMemoryStore implements Store {
 
   @Override
   public void shutdown() throws StoreException {
+    started = false;
+  }
+
+  @Override
+  public boolean isStarted() {
+    return started;
   }
 }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockHost.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockHost.java
@@ -37,8 +37,8 @@ import java.util.function.Function;
  * Representation of a host. Contains all the data for all partitions.
  */
 public class MockHost {
+  final Map<PartitionId, InMemoryStore> storesByPartition = new HashMap<>();
   private final ClusterMap clusterMap;
-  private final Map<PartitionId, InMemoryStore> storesByPartition = new HashMap<>();
 
   public final DataNodeId dataNodeId;
   final Map<PartitionId, List<MessageInfo>> infosByPartition = new HashMap<>();
@@ -73,11 +73,11 @@ public class MockHost {
       for (ReplicaId peerReplicaId : replicaId.getPeerReplicaIds()) {
         if (peerReplicaId.getDataNodeId().equals(remoteHost.dataNodeId)) {
           PartitionId partitionId = replicaId.getPartitionId();
-          InMemoryStore store = storesByPartition.computeIfAbsent(partitionId, partitionId1 -> new InMemoryStore(partitionId,
-              infosByPartition.computeIfAbsent(partitionId1,
+          InMemoryStore store = storesByPartition.computeIfAbsent(partitionId,
+              partitionId1 -> new InMemoryStore(partitionId, infosByPartition.computeIfAbsent(partitionId1,
                   (Function<PartitionId, List<MessageInfo>>) partitionId2 -> new ArrayList<>()),
-              buffersByPartition.computeIfAbsent(partitionId1,
-                  (Function<PartitionId, List<ByteBuffer>>) partitionId22 -> new ArrayList<>()), listener));
+                  buffersByPartition.computeIfAbsent(partitionId1,
+                      (Function<PartitionId, List<ByteBuffer>>) partitionId22 -> new ArrayList<>()), listener));
           RemoteReplicaInfo remoteReplicaInfo =
               new RemoteReplicaInfo(peerReplicaId, replicaId, store, new MockFindToken(0, 0), Long.MAX_VALUE,
                   SystemTime.getInstance(), new Port(peerReplicaId.getDataNodeId().getPort(), PortType.PLAINTEXT));

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -932,25 +932,25 @@ public class NonBlockingRouterMetrics {
       for (Map.Entry<Resource, Histogram> resourceToHistogram : getBlobLocalDcResourceToLatency.entrySet()) {
         Resource resource = resourceToHistogram.getKey();
         Histogram histogram = resourceToHistogram.getValue();
-        logger.info("{} GetBlob local DC latency histogram {}th percentile in ms: {}", resource.toString(),
+        logger.debug("{} GetBlob local DC latency histogram {}th percentile in ms: {}", resource.toString(),
             quantile * 100, histogram.getSnapshot().getValue(quantile));
       }
       for (Map.Entry<Resource, Histogram> resourceToHistogram : getBlobCrossDcResourceToLatency.entrySet()) {
         Resource resource = resourceToHistogram.getKey();
         Histogram histogram = resourceToHistogram.getValue();
-        logger.info("{} GetBlob cross DC latency histogram {}th percentile in ms: {}", resource.toString(),
+        logger.trace("{} GetBlob cross DC latency histogram {}th percentile in ms: {}", resource.toString(),
             quantile * 100, histogram.getSnapshot().getValue(quantile));
       }
       for (Map.Entry<Resource, Histogram> resourceToHistogram : getBlobInfoLocalDcResourceToLatency.entrySet()) {
         Resource resource = resourceToHistogram.getKey();
         Histogram histogram = resourceToHistogram.getValue();
-        logger.info("{} GetBlobInfo local DC latency histogram {}th percentile in ms: {}", resource.toString(),
+        logger.debug("{} GetBlobInfo local DC latency histogram {}th percentile in ms: {}", resource.toString(),
             quantile * 100, histogram.getSnapshot().getValue(quantile));
       }
       for (Map.Entry<Resource, Histogram> resourceToHistogram : getBlobInfoCrossDcResourceToLatency.entrySet()) {
         Resource resource = resourceToHistogram.getKey();
         Histogram histogram = resourceToHistogram.getValue();
-        logger.info("{} GetBlobInfo cross DC latency histogram {}th percentile in ms: {}", resource.toString(),
+        logger.trace("{} GetBlobInfo cross DC latency histogram {}th percentile in ms: {}", resource.toString(),
             quantile * 100, histogram.getSnapshot().getValue(quantile));
       }
     }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -1245,10 +1245,12 @@ public class AmbryRequestsTest {
      * An empty {@link Store} implementation.
      */
     private Store store = new Store() {
+      boolean started;
 
       @Override
       public void start() throws StoreException {
         throwExceptionIfRequired();
+        started = true;
       }
 
       @Override
@@ -1317,7 +1319,7 @@ public class AmbryRequestsTest {
         tokenReceived = token;
         maxTotalSizeOfEntriesReceived = maxTotalSizeOfEntries;
         throwExceptionIfRequired();
-        return new FindInfo(Collections.EMPTY_LIST, FIND_TOKEN_FACTORY.getNewFindToken());
+        return new FindInfo(Collections.emptyList(), FIND_TOKEN_FACTORY.getNewFindToken());
       }
 
       @Override
@@ -1345,8 +1347,14 @@ public class AmbryRequestsTest {
         return false;
       }
 
+      @Override
+      public boolean isStarted() {
+        return started;
+      }
+
       public void shutdown() throws StoreException {
         throwExceptionIfRequired();
+        started = false;
       }
 
       /**

--- a/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
@@ -634,6 +634,11 @@ public class StatsManagerTest {
     public void shutdown() throws StoreException {
       throw new IllegalStateException("Not implemented");
     }
+
+    @Override
+    public boolean isStarted() {
+      throw new IllegalStateException("Not implemented");
+    }
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -761,7 +761,8 @@ class BlobStore implements Store {
   /**
    * @return {@code true} if this store has been started successfully.
    */
-  boolean isStarted() {
+  @Override
+  public boolean isStarted() {
     return started;
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import org.junit.After;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -56,6 +57,17 @@ public class CompactionManagerTest {
     blobStore = new MockBlobStore(config, metrics, time, null);
     compactionManager = new CompactionManager(MOUNT_PATH, config, Collections.singleton(blobStore),
         new StorageManagerMetrics(metricRegistry), time);
+  }
+
+  /**
+   * clean up threads created in compaction manager
+   */
+  @After
+  public void cleanup() {
+    if (compactionManager != null) {
+      compactionManager.disable();
+      compactionManager.awaitTermination();
+    }
   }
 
   /**
@@ -204,6 +216,7 @@ public class CompactionManagerTest {
     for (int i = 0; i < numStores; i++) {
       MockBlobStore store = new MockBlobStore(config, metrics, time, compactCallsCountdown, null);
       store.details = generateRandomCompactionDetails(2);
+      store.storeId = String.valueOf(i);
       if (i == 0) {
         // one store should not be started
         store.started = false;
@@ -216,22 +229,32 @@ public class CompactionManagerTest {
       }
       stores.add(store);
     }
+    // This CountDownLatch is to ensure that current test thread won't advance until the exception thrown on compact()
+    // is caught and processed. (Mainly to address race condition that store 3 is the last store being checked for
+    // compaction. The compact() method is called but exception hasn't been captured. At this point of time, cpu switches
+    // back to this test thread and checks scheduleNextForCompaction() on each store. Since exception of store 3 hasn't
+    // been captured, store 3 is not in storesToSkip set and assert fails)
+    CountDownLatch compactStopCountdown = new CountDownLatch(numStores + 2);
+    MockStorageManagerMetrics mockMetrics = new MockStorageManagerMetrics(metricRegistry);
+    mockMetrics.compactStopCountdown = compactStopCountdown;
     // using real time here so that compaction is not scheduled more than once for a store during the test unless
     // asked for.
-    compactionManager = new CompactionManager(MOUNT_PATH, config, stores, new StorageManagerMetrics(metricRegistry),
-        SystemTime.getInstance());
+    compactionManager = new CompactionManager(MOUNT_PATH, config, stores, mockMetrics, SystemTime.getInstance());
     // disable the third blobstore for compaction before starting the CompactionExecutor thread
     MockBlobStore controlCompactionTestStore = (MockBlobStore) stores.get(2);
     compactionManager.controlCompactionForBlobStore(controlCompactionTestStore, false);
     // add a new blobstore into compaction manager but not started yet.
     MockBlobStore newAddedStore =
         new MockBlobStore(config, metrics, time, compactCallsCountdown, generateRandomCompactionDetails(2));
+    newAddedStore.storeId = "newStore";
     compactionManager.addBlobStore(newAddedStore);
     compactionManager.enable();
     assertNotNull("Compaction thread should be created",
         TestUtils.getThreadByThisName(CompactionManager.THREAD_NAME_PREFIX));
     assertTrue("Compaction calls did not come within the expected time",
         compactCallsCountdown.await(1, TimeUnit.SECONDS));
+    assertTrue("Compaction stop latch didn't count down to 0 within expected time",
+        compactStopCountdown.await(1, TimeUnit.SECONDS));
     for (int i = 0; i < numStores; i++) {
       MockBlobStore store = (MockBlobStore) stores.get(i);
       if (store.callOrderException != null) {
@@ -253,23 +276,22 @@ public class CompactionManagerTest {
     for (BlobStore store : stores) {
       ((MockBlobStore) store).compactCalled = false;
     }
-
-    // stores that are not started or failed on resumeCompaction() and compact() cannot be scheduled for compaction
+    // stores that are not started, disabled or failed on resumeCompaction() and compact() cannot be scheduled for compaction
     for (int i = 0; i < numStores; i++) {
       MockBlobStore store = (MockBlobStore) stores.get(i);
       if (i < 4) {
-        assertFalse("Should not schedule compaction", compactionManager.scheduleNextForCompaction(store));
-        assertFalse("compact() should not have been called", store.compactCalled);
+        assertFalse("Should not schedule compaction for " + store, compactionManager.scheduleNextForCompaction(store));
+        assertFalse("compact() should not have been called on " + store, store.compactCalled);
       } else {
         store.compactCallsCountdown = new CountDownLatch(1);
         assertFalse("compactCalled should be reset", store.compactCalled);
-        assertTrue("Should schedule compaction", compactionManager.scheduleNextForCompaction(store));
+        assertTrue("Should schedule compaction for " + store, compactionManager.scheduleNextForCompaction(store));
         assertTrue("Compaction call did not come within the expected time",
             store.compactCallsCountdown.await(1, TimeUnit.SECONDS));
         if (store.callOrderException != null) {
           throw store.callOrderException;
         }
-        assertTrue("compact() should have been called", store.compactCalled);
+        assertTrue("compact() should have been called on " + store, store.compactCalled);
       }
     }
 
@@ -476,6 +498,7 @@ public class CompactionManagerTest {
   private class MockBlobStore extends BlobStore {
     CountDownLatch compactCallsCountdown;
     CompactionDetails details;
+    String storeId = "defaultId";
 
     boolean resumeCompactionCalled = false;
     boolean compactCalled = false;
@@ -534,6 +557,28 @@ public class CompactionManagerTest {
     @Override
     public boolean isStarted() {
       return started;
+    }
+
+    @Override
+    public String toString() {
+      return "StoreId: " + storeId;
+    }
+  }
+
+  /**
+   * A mock {@link StorageManagerMetrics} that guarantees compaction as well as exception during compaction is completely
+   * processed before switching to test thread.
+   */
+  private class MockStorageManagerMetrics extends StorageManagerMetrics {
+    CountDownLatch compactStopCountdown;
+
+    MockStorageManagerMetrics(MetricRegistry metricRegistry) {
+      super(metricRegistry);
+    }
+
+    @Override
+    void markCompactionStop() {
+      compactStopCountdown.countDown();
     }
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionManagerTest.java
@@ -234,8 +234,12 @@ public class CompactionManagerTest {
     // compaction. The compact() method is called but exception hasn't been captured. At this point of time, cpu switches
     // back to this test thread and checks scheduleNextForCompaction() on each store. Since exception of store 3 hasn't
     // been captured, store 3 is not in storesToSkip set and assert fails)
-    CountDownLatch compactStopCountdown = new CountDownLatch(numStores + 2);
     MockStorageManagerMetrics mockMetrics = new MockStorageManagerMetrics(metricRegistry);
+    // The reason to set latch count = numStore + 2 is, stores[1 - 4] plus new added will be checked if resume compaction
+    // (store 0 won't be checked because it is not started). So markCompactionStop() is called on 4 + 1 stores when checking
+    // whether to resume compaction. After that only store 3 and store 4 are eligible to perform compact() and call
+    // markCompactionStop() twice.
+    CountDownLatch compactStopCountdown = new CountDownLatch(4 + 1 + 2);
     mockMetrics.compactStopCountdown = compactStopCountdown;
     // using real time here so that compaction is not scheduled more than once for a store during the test unless
     // asked for.


### PR DESCRIPTION
1. Set DEBUG and TRACE log level in Histogram dumper
2. Fixed race condition in compaction manager test
3. Printed out remote dc exception during helix cluster manager
initialization (previously it was swallowed and hard to debug)
4. Moved partition lag update operatio to exchange metadata method in
replication manager
5. Paused replication on store that is not started. Replication can
resume if store is restarted.