### PR TITLE
Fix gradle heap size configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ subprojects {
         testLogging {
             exceptionFormat = 'full'
         }
+        maxHeapSize = "3g"
     }
 
     task intTest(type: Test) {
@@ -86,6 +87,7 @@ subprojects {
         testLogging {
             exceptionFormat = 'full'
         }
+        maxHeapSize = "3g"
     }
 
     task allTest {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,3 @@
 version=0.1.0
 org.gradle.daemon=true
 org.gradle.configureondemand=true
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
Previously, we were increasing the heap size for the gradle daemon
but not for the test runner. This commit fixes that.