### PR TITLE
Enable shipkit release publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
 dist: trusty
-script:
-  - ./gradlew build codeCoverageReport
 sudo: required
 jdk:
   - oraclejdk8
@@ -17,5 +15,15 @@ addons:
     packages:
       - oracle-java8-installer
       - oracle-java8-unlimited-jce-policy
+jobs:
+  include:
+    - stage: test
+      script: "./gradlew -s --scan build codeCoverageReport"
+    - stage: deploy
+      script: "./gradlew -s build && ./gradlew ciPerformRelease"
+stages:
+  - test
+  - name: deploy
+    if: branch = master AND type = push
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     - stage: deploy
       script: "./gradlew -s build && ./gradlew ciPerformRelease"
 stages:
-  - test
+  - name: test
   - name: deploy
     if: branch = master AND type = push
 after_success:

--- a/build.gradle
+++ b/build.gradle
@@ -428,9 +428,9 @@ task codeCoverageReport(type: JacocoReport) {
 }
 codeCoverageReport.dependsOn subprojects*.allTest
 
-buildScan {
-    // auto accept TOS
-    termsOfServiceUrl = "https://gradle.com/terms-of-service"
-    termsOfServiceAgree = "yes"
+if (hasProperty('buildScan')) {
+    buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+    }
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ subprojects {
     javadoc {
         // TODO audit and fix our javadocs so that we don't need this setting
         // This is mainly for cases where param/throws tags don't have descriptions
+        // Previously, javadocs weren't being compiled, but now shipkit automatically enables this build step
         failOnError = false
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@ buildscript {
     apply from: file('gradle/buildscript.gradle'), to: buildscript
 }
 
+plugins {
+    id 'org.shipkit.java' version '2.2.5'
+}
+
 apply from: file('gradle/license.gradle')
 apply from: file('gradle/environment.gradle')
 apply from: file("gradle/dependency-versions.gradle")
@@ -104,6 +108,12 @@ subprojects {
 
     artifacts {
         archives testJar
+    }
+
+    javadoc {
+        // TODO audit and fix our javadocs so that we don't need this setting
+        // This is mainly for cases where param/throws tags don't have descriptions
+        failOnError = false
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -426,6 +426,11 @@ task codeCoverageReport(type: JacocoReport) {
         csv.enabled true
     }
 }
-
 codeCoverageReport.dependsOn subprojects*.allTest
+
+buildScan {
+    // auto accept TOS
+    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
+}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,5 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied.
 #
-version=0.1.0
 org.gradle.daemon=true
 org.gradle.configureondemand=true

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -14,6 +14,7 @@ shipkit {
     gitHub.repository = "linkedin/ambry"
 
     //Reference: https://github.com/mockito/shipkit/blob/master/docs/getting-started.md#production-configuration
+    // This is okay to check in since it only grants read access via API to public github repos
     gitHub.readOnlyAuthToken = "b1c2f54fbaaba080269d0176c88ab6488d8c61ef"
 
     //Reference: https://github.com/mockito/shipkit/blob/master/docs/getting-started.md#write-token
@@ -25,14 +26,14 @@ allprojects {
         //Bintray configuration is handled by JFrog Bintray Gradle Plugin
         //For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
         bintray {
+            user = System.getenv("BINTRAY_USER")
             key = System.getenv("BINTRAY_API_KEY")
 
             pkg {
                 repo = 'maven'
-                user = 'cgtz'
                 userOrg = 'linkedin'
                 name = 'ambry'
-                licenses = ['MIT']
+                licenses = ['Apache-2.0']
                 labels = ['blob storage']
             }
         }

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 LinkedIn Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.
+
+// Configuration for automatically publishing to bintray
+// Reference: https://github.com/mockito/shipkit/blob/master/docs/getting-started.md
+shipkit {
+    gitHub.repository = "linkedin/ambry"
+
+    //Reference: https://github.com/mockito/shipkit/blob/master/docs/getting-started.md#production-configuration
+    gitHub.readOnlyAuthToken = "b1c2f54fbaaba080269d0176c88ab6488d8c61ef"
+
+    //Reference: https://github.com/mockito/shipkit/blob/master/docs/getting-started.md#write-token
+    gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")
+}
+
+allprojects {
+    plugins.withId("org.shipkit.bintray") {
+        //Bintray configuration is handled by JFrog Bintray Gradle Plugin
+        //For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
+        bintray {
+            key = System.getenv("BINTRAY_API_KEY")
+
+            pkg {
+                repo = 'maven'
+                user = 'cgtz'
+                userOrg = 'linkedin'
+                name = 'ambry'
+                licenses = ['MIT']
+                labels = ['blob storage']
+            }
+        }
+    }
+}

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -15,7 +15,7 @@ shipkit {
 
     //Reference: https://github.com/mockito/shipkit/blob/master/docs/getting-started.md#production-configuration
     // This is okay to check in since it only grants read access via API to public github repos
-    gitHub.readOnlyAuthToken = "b1c2f54fbaaba080269d0176c88ab6488d8c61ef"
+    gitHub.readOnlyAuthToken = "9ad754b8745e20d90734ff7be8889c93a3bca81e"
 
     //Reference: https://github.com/mockito/shipkit/blob/master/docs/getting-started.md#write-token
     gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,3 @@
+#Version of the produced binaries. This file is intended to be checked-in.
+#It will be automatically bumped by release automation.
+version=0.3.0


### PR DESCRIPTION
- Set up the shipkit (https://github.com/mockito/shipkit/blob/master/docs/getting-started.md) gradle plugin for publishing releases to bintray.
- Configure travis to automaticly generate github releases and maven artifacts when PRs are merged to the master branch.

Tested locally using `./gradlew testRelease`
I have set up travis-ci environment variables to use my bintray/github account/api keys.