### PR TITLE
Use Timer instead of Histgram on some metrics

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,7 +115,7 @@ public class NetworkClient implements Closeable {
       networkMetrics.networkClientException.inc();
     } finally {
       numPendingRequests.set(pendingRequests.size());
-      networkMetrics.networkClientSendAndPollTime.update(time.milliseconds() - startTime);
+      networkMetrics.networkClientSendAndPollTime.update(time.milliseconds() - startTime, TimeUnit.MILLISECONDS);
     }
     return responseInfoList;
   }
@@ -363,15 +364,17 @@ public class NetworkClient implements Closeable {
      */
     void onRequestDequeue() {
       requestDequeuedAtMs = time.milliseconds();
-      networkMetrics.networkClientRequestQueueTime.update(requestDequeuedAtMs - requestQueuedAtMs);
+      networkMetrics.networkClientRequestQueueTime.update(requestDequeuedAtMs - requestQueuedAtMs,
+          TimeUnit.MILLISECONDS);
     }
 
     /**
      * Actions to be done on receiving response for the request sent
      */
     void onResponseReceive() {
-      networkMetrics.networkClientRoundTripTime.update(time.milliseconds() - requestDequeuedAtMs);
-      networkMetrics.networkClientTotalTime.update(time.milliseconds() - requestQueuedAtMs);
+      networkMetrics.networkClientRoundTripTime.update(time.milliseconds() - requestDequeuedAtMs,
+          TimeUnit.MILLISECONDS);
+      networkMetrics.networkClientTotalTime.update(time.milliseconds() - requestQueuedAtMs, TimeUnit.MILLISECONDS);
     }
   }
 }

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkMetrics.java
@@ -18,6 +18,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -86,11 +87,11 @@ public class NetworkMetrics {
   public final Meter sslDecryptionTimeInUsPerKB;
 
   // NetworkClient metrics
-  public final Histogram networkClientSendAndPollTime;
-  public final Histogram networkClientRequestQueueTime;
-  public final Histogram networkClientRoundTripTime;
+  public final Timer networkClientSendAndPollTime;
+  public final Timer networkClientRequestQueueTime;
+  public final Timer networkClientRoundTripTime;
   // NetworkClient request queuing time plus round trip time.
-  public final Histogram networkClientTotalTime;
+  public final Timer networkClientTotalTime;
 
   public final Counter connectionCheckoutTimeoutError;
   public final Counter connectionNotAvailable;
@@ -125,10 +126,8 @@ public class NetworkMetrics {
     transmissionSendPendingTime =
         registry.histogram(MetricRegistry.name(Selector.class, "TransmissionSendPendingTime"));
     transmissionSendAllTime = registry.histogram(MetricRegistry.name(Selector.class, "TransmissionSendTime"));
-    transmissionRoundTripTime =
-        registry.histogram(MetricRegistry.name(Selector.class, "TransmissionRoundTripTime"));
-    transmissionReceiveAllTime =
-        registry.histogram(MetricRegistry.name(Selector.class, "TransmissionReceiveTime"));
+    transmissionRoundTripTime = registry.histogram(MetricRegistry.name(Selector.class, "TransmissionRoundTripTime"));
+    transmissionReceiveAllTime = registry.histogram(MetricRegistry.name(Selector.class, "TransmissionReceiveTime"));
     transmissionSendBytesRate = registry.meter(MetricRegistry.name(Selector.class, "TransmissionSendBytesRate"));
     transmissionReceiveBytesRate = registry.meter(MetricRegistry.name(Selector.class, "TransmissionReceiveBytesRate"));
     transmissionSendTime = registry.histogram(MetricRegistry.name(Selector.class, "TransmissionSendTime"));
@@ -152,12 +151,11 @@ public class NetworkMetrics {
     sslDecryptionTimeInUsPerKB = registry.meter(MetricRegistry.name(Selector.class, "SslDecryptionTimeInUsPerKB"));
 
     networkClientSendAndPollTime =
-        registry.histogram(MetricRegistry.name(NetworkClient.class, "NetworkClientSendAndPollTime"));
+        registry.timer(MetricRegistry.name(NetworkClient.class, "NetworkClientSendAndPollTime"));
     networkClientRequestQueueTime =
-        registry.histogram(MetricRegistry.name(NetworkClient.class, "NetworkClientRequestQueueTime"));
-    networkClientRoundTripTime =
-        registry.histogram(MetricRegistry.name(NetworkClient.class, "NetworkClientRoundTripTime"));
-    networkClientTotalTime = registry.histogram(MetricRegistry.name(NetworkClient.class, "NetworkClientTotalTime"));
+        registry.timer(MetricRegistry.name(NetworkClient.class, "NetworkClientRequestQueueTime"));
+    networkClientRoundTripTime = registry.timer(MetricRegistry.name(NetworkClient.class, "NetworkClientRoundTripTime"));
+    networkClientTotalTime = registry.timer(MetricRegistry.name(NetworkClient.class, "NetworkClientTotalTime"));
     connectionCheckoutTimeoutError =
         registry.counter(MetricRegistry.name(NetworkClient.class, "ConnectionCheckoutTimeoutError"));
     connectionNotAvailable = registry.counter(MetricRegistry.name(NetworkClient.class, "ConnectionNotAvailable"));

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouterMetrics.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.DiskId;
@@ -73,7 +74,7 @@ public class NonBlockingRouterMetrics {
   // Latency.
   public final Histogram putBlobOperationLatencyMs;
   public final Histogram stitchBlobOperationLatencyMs;
-  public final Histogram putChunkOperationLatencyMs;
+  public final Timer putChunkOperationLatencyMs;
   public final Histogram getBlobInfoOperationLatencyMs;
   public final Histogram getBlobOperationLatencyMs;
   public final Histogram getBlobOperationTotalTimeMs;
@@ -257,7 +258,7 @@ public class NonBlockingRouterMetrics {
     stitchBlobOperationLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(PutOperation.class, "StitchBlobOperationLatencyMs"));
     putChunkOperationLatencyMs =
-        metricRegistry.histogram(MetricRegistry.name(PutOperation.class, "PutChunkOperationLatencyMs"));
+        metricRegistry.timer(MetricRegistry.name(PutOperation.class, "PutChunkOperationLatencyMs"));
     getBlobInfoOperationLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(GetBlobInfoOperation.class, "GetBlobInfoOperationLatencyMs"));
     getBlobOperationLatencyMs =

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -54,7 +54,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -503,7 +503,7 @@ class PutOperation {
     if (chunk.chunkBlobProperties.isEncrypted()) {
       routerMetrics.putEncryptedChunkOperationLatencyMs.update(operationLatencyMs);
     } else {
-      routerMetrics.putChunkOperationLatencyMs.update(operationLatencyMs);
+      routerMetrics.putChunkOperationLatencyMs.update(operationLatencyMs, TimeUnit.MILLISECONDS);
     }
     chunk.clear();
   }


### PR DESCRIPTION
For metrics below, we want to know both latency histogram and rate. 
Timer, as a combination of Histogram and Meter, is the best choice.

networkClientSendAndPollTime
networkClientRequestQueueTime
networkClientRoundTripTime
networkClientTotalTime
putChunkOperationLatencyMs