### PR TITLE
Fix directory deletion failure in DiskSpaceAllocator

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/DiskSpaceAllocator.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskSpaceAllocator.java
@@ -302,9 +302,7 @@ class DiskSpaceAllocator {
         inventorySwapReserveFiles(file);
       } else {
         // if it is neither store reserved segment directory nor swap segment directory, then delete it.
-        if (!file.delete()) {
-          throw new IOException("Could not delete the following reserve file or directory: " + file.getAbsolutePath());
-        }
+        Utils.deleteFileOrDirectory(file);
       }
     }
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/DiskSpaceAllocatorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/DiskSpaceAllocatorTest.java
@@ -327,6 +327,9 @@ public class DiskSpaceAllocatorTest {
     File invalidFile = new File(reserveFileDir, DiskSpaceAllocator.RESERVE_FILE_PREFIX + UUID.randomUUID());
     assertTrue(invalidDir.mkdir());
     assertTrue(invalidFile.createNewFile());
+    // create extra file inside invalid directory to mock non-empty directory
+    File extraFile = new File(invalidDir, DiskSpaceAllocator.RESERVE_FILE_PREFIX + UUID.randomUUID());
+    assertTrue(extraFile.createNewFile());
     // instantiate DiskSpaceAllocator
     alloc = constructAllocator();
     // verify invalid directories and files no longer exist


### PR DESCRIPTION
There was bug in previous refactoring of DiskSpaceAllocator. When
cleaning up old files and directories, code misused file deletion rather
than directory deletion. This PR ensures Utils.deleteFileOrDirectory is
called in this case and extends unit test to mock non-empty directory
deletion.