### PR TITLE
HelixAccountService backfill to new zookeeper path

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -414,6 +414,22 @@ class HelixAccountService implements AccountService {
       throw new IllegalStateException("Router not initialized.");
     }
   }
+
+  /**
+   * Return {@link AccountServiceMetrics}.
+   * @return {@link AccountServiceMetrics}
+   */
+  AccountServiceMetrics getAccountServiceMetrics() {
+    return accountServiceMetrics;
+  }
+
+  /**
+   * Return {@link LocalBackup}.
+   * @return {@link LocalBackup}
+   */
+  LocalBackup getBackup() {
+    return backup;
+  }
 }
 
 /**

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -349,8 +349,9 @@ public class HelixAccountService implements AccountService {
   }
 
   /**
-   * Maybe backfill the newly updated {@link Account} metadata to new zookeeper node. This function doesn't guarantee
-   * the success of the operation. It gives up whenever there is failure or exception and wait for next update.
+   * Backfill the newly updated {@link Account} metadata to new zookeeper node based on the configuration. This function
+   * doesn't guarantee the success of the operation. It gives up whenever there is failure or exception and wait for
+   * next update.
    */
   private void maybeBackFillToNewStore() {
     if (!config.backFillAccountsToNewZNode) {

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -85,7 +85,7 @@ import static com.github.ambry.utils.Utils.*;
  *   cannot exceed 1MB before the transition.
  * </p>
  */
-class HelixAccountService implements AccountService {
+public class HelixAccountService implements AccountService {
   static final String ACCOUNT_METADATA_CHANGE_TOPIC = "account_metadata_change_topic";
   static final String FULL_ACCOUNT_METADATA_CHANGE_MESSAGE = "full_account_metadata_change";
 

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -157,7 +157,7 @@ public class HelixAccountService implements AccountService {
   public void setupRouter(final Router router) throws IllegalStateException {
     if (!this.router.compareAndSet(null, router)) {
       throw new IllegalStateException("Router already initialized");
-    } else if (config.useNewZNodePath){
+    } else if (config.useNewZNodePath) {
       initialFetchAndSchedule();
     }
   }
@@ -353,12 +353,12 @@ public class HelixAccountService implements AccountService {
    * the success of the operation. It gives up whenever there is failure or exception and wait for next update.
    */
   private void maybeBackFillToNewStore() {
-    if (!config.backFillAccountsToNewZNode)  {
+    if (!config.backFillAccountsToNewZNode) {
       return;
     }
-    logger.trace("starting backfilling the new state to new store");
-    if (backFillStore.updateAccounts( accountInfoMapRef.get().getAccounts())) {
-      logger.trace("Finish backfilling the new state to new store");
+    logger.info("Starting backfilling the new state to new store");
+    if (backFillStore.updateAccounts(accountInfoMapRef.get().getAccounts())) {
+      logger.info("Finish backfilling the new state to new store");
     } else {
       logger.error("Fail to backfill the new state to new store, just skip this one");
     }

--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -285,7 +285,8 @@ class RouterStore extends AccountMetadataStore {
         try {
           accountMap.put(String.valueOf(account.getId()), account.toJson(true).toString());
         } catch (Exception e) {
-          errorMessage = "Updating accounts failed because unexpected exception occurred when updating accountId=" + account.getId() + " accountName=" + account.getName();
+          errorMessage = "Updating accounts failed because unexpected exception occurred when updating accountId="
+              + account.getId() + " accountName=" + account.getName();
           // Do not depend on Helix to log, so log the error message here.
           logger.error(errorMessage, e);
           throw new IllegalStateException(errorMessage, e);

--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -233,7 +233,7 @@ class RouterStore extends AccountMetadataStore {
 
           // Start Step 2:
           if (!forBackFill) {
-            // if this is for backfill, then just don't read account metadata from blob
+            // if this is not for backfill, then just read account metadata from blob
             accountMap = readAccountMetadataFromBlobID(blobIDAndVersion.blobID);
           } else {
             accountMap = new HashMap<>();

--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -276,7 +276,7 @@ class RouterStore extends AccountMetadataStore {
           // Throw exception, so that helixStore can capture and terminate the update operation
           errorMessage = "Updating accounts failed because one account to update conflicts with existing accounts";
           logger.error(errorMessage);
-          throw new IllegalArgumentException(errorMessage);
+          throw new IllegalStateException(errorMessage);
         }
       }
 
@@ -342,11 +342,20 @@ class RouterStore extends AccountMetadataStore {
     private static final String BLOBID_KEY = "blob_id";
     private static final String VERSION_KEY = "version";
 
+    /**
+     * Constructor to create a {@link BlobIDAndVersion}.
+     * @param blobID The blob id.
+     * @param version The version associated with this blob id.
+     */
     BlobIDAndVersion(String blobID, int version) {
       this.blobID = blobID;
       this.version = version;
     }
 
+    /**
+     * Return a string in json format of this object.
+     * @return A string in json format of this object.
+     */
     public String toJson() {
       JSONObject object = new JSONObject();
       object.put(BLOBID_KEY, blobID);
@@ -354,14 +363,28 @@ class RouterStore extends AccountMetadataStore {
       return object.toString();
     }
 
+    /**
+     * Return version number.
+     * @return Version number.
+     */
     public int getVersion() {
       return version;
     }
 
+    /**
+     * Return blob id.
+     * @return Blob id.
+     */
     public String getBlobID() {
       return blobID;
     }
 
+    /**
+     * Deserialize a string that carries a json object to an {@link BlobIDAndVersion}.
+     * @param json The string that carries a json object.
+     * @return A {@link BlobIDAndVersion} object.
+     * @throws JSONException If parsing the string to {@link JSONObject} fails.
+     */
     static BlobIDAndVersion fromJson(String json) throws JSONException {
       JSONObject object = new JSONObject(json);
       String blobID = object.getString(BLOBID_KEY);

--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -232,12 +232,8 @@ class RouterStore extends AccountMetadataStore {
           newVersion = blobIDAndVersion.version + 1;
 
           // Start Step 2:
-          if (!forBackFill) {
-            // if this is not for backfill, then just read account metadata from blob
-            accountMap = readAccountMetadataFromBlobID(blobIDAndVersion.blobID);
-          } else {
-            accountMap = new HashMap<>();
-          }
+          // if this is not for backfill, then just read account metadata from blob
+          accountMap = (!forBackFill) ? readAccountMetadataFromBlobID(blobIDAndVersion.blobID) : new HashMap<>();
           // make this list mutable
           accountBlobIDs = new ArrayList<>(accountBlobIDs);
         } catch (JSONException e) {

--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -251,6 +251,7 @@ class RouterStore extends AccountMetadataStore {
           throw new IllegalStateException(errorMessage, e);
         }
       }
+      // This ZNRecord doesn't exist when first time we update this ZNRecord, thus accountMap will be null.
       if (accountMap == null) {
         accountMap = new HashMap<>();
         accountBlobIDs = new ArrayList<>();
@@ -277,8 +278,6 @@ class RouterStore extends AccountMetadataStore {
           logger.error(errorMessage);
           throw new IllegalArgumentException(errorMessage);
         }
-      } else {
-        accountMap.clear();
       }
 
       for (Account account : this.accounts) {

--- a/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/AccountTestUtils.java
@@ -96,7 +96,7 @@ class AccountTestUtils {
    * @throws Exception
    */
   static void generateRefAccounts(Map<Short, Account> idToRefAccountMap,
-      Map<Short, Map<Short, Container>> idToRefContainerMap, Set accountIdSet, int accountCount,
+      Map<Short, Map<Short, Container>> idToRefContainerMap, Set<Short> accountIdSet, int accountCount,
       int containerCountPerAccount) throws Exception {
     idToRefAccountMap.clear();
     idToRefContainerMap.clear();

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.helix.AccessOption;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.HelixPropertyStore;
 import org.json.JSONArray;
@@ -51,6 +52,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -60,9 +62,10 @@ import static com.github.ambry.account.AccountTestUtils.*;
 import static com.github.ambry.account.Container.*;
 import static com.github.ambry.account.HelixAccountService.*;
 import static com.github.ambry.utils.TestUtils.*;
-import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
@@ -119,6 +122,17 @@ public class HelixAccountServiceTest {
    */
   public HelixAccountServiceTest(boolean useNewZNodePath) throws Exception {
     this.useNewZNodePath = useNewZNodePath;
+    accountBackupDir = Paths.get(TestUtils.getTempDir("account-backup")).toAbsolutePath();
+    notifier = new MockNotifier<>();
+    mockRouter = new MockRouter();
+    setup();
+    deleteStoreIfExists();
+    generateReferenceAccountsAndContainers();
+  }
+
+  @Before
+  public void setup() {
+    helixConfigProps.clear();
     helixConfigProps.setProperty(
         HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "zk.client.connection.timeout.ms",
         String.valueOf(ZK_CLIENT_CONNECTION_TIMEOUT_MS));
@@ -126,17 +140,12 @@ public class HelixAccountServiceTest {
         String.valueOf(ZK_CLIENT_SESSION_TIMEOUT_MS));
     helixConfigProps.setProperty(HelixAccountServiceConfig.ZK_CLIENT_CONNECT_STRING_KEY, ZK_CONNECT_STRING);
     helixConfigProps.setProperty(HelixPropertyStoreConfig.HELIX_PROPERTY_STORE_PREFIX + "root.path", STORE_ROOT_PATH);
-    accountBackupDir = Paths.get(TestUtils.getTempDir("account-backup")).toAbsolutePath();
     helixConfigProps.setProperty(HelixAccountServiceConfig.BACKUP_DIRECTORY_KEY, accountBackupDir.toString());
     helixConfigProps.setProperty(HelixAccountServiceConfig.USE_NEW_ZNODE_PATH, String.valueOf(useNewZNodePath));
     vHelixConfigProps = new VerifiableProperties(helixConfigProps);
     storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
-    notifier = new MockNotifier<>();
-    mockRouter = new MockRouter();
     mockHelixAccountServiceFactory =
         new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier, null, mockRouter);
-    deleteStoreIfExists();
-    generateReferenceAccountsAndContainers();
   }
 
   /**
@@ -441,8 +450,8 @@ public class HelixAccountServiceTest {
     } catch (NullPointerException e) {
       // expected
     }
-    accountService =
-        new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), null, null, mockRouter).getAccountService();
+    accountService = new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), null, null, mockRouter)
+        .getAccountService();
     accountService.close();
     accountService = mockHelixAccountServiceFactory.getAccountService();
     try {
@@ -736,7 +745,8 @@ public class HelixAccountServiceTest {
     storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
     String updaterThreadPrefix = UUID.randomUUID().toString();
     MockHelixAccountServiceFactory mockHelixAccountServiceFactory =
-        new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier, updaterThreadPrefix, mockRouter);
+        new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier, updaterThreadPrefix,
+            mockRouter);
     accountService = mockHelixAccountServiceFactory.getAccountService();
     CountDownLatch latch = new CountDownLatch(1);
     mockHelixAccountServiceFactory.getHelixStore(ZK_CONNECT_STRING, storeConfig).setReadLatch(latch);
@@ -756,7 +766,8 @@ public class HelixAccountServiceTest {
     storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
     String updaterThreadPrefix = UUID.randomUUID().toString();
     MockHelixAccountServiceFactory mockHelixAccountServiceFactory =
-        new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier, updaterThreadPrefix, mockRouter);
+        new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier, updaterThreadPrefix,
+            mockRouter);
     accountService = mockHelixAccountServiceFactory.getAccountService();
     assertEquals("Wrong number of thread for account updater.", 0, numThreadsByThisName(updaterThreadPrefix));
   }
@@ -774,9 +785,74 @@ public class HelixAccountServiceTest {
     storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
     String updaterThreadPrefix = UUID.randomUUID().toString();
     MockHelixAccountServiceFactory mockHelixAccountServiceFactory =
-        new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier, updaterThreadPrefix, mockRouter);
+        new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier, updaterThreadPrefix,
+            mockRouter);
     accountService = mockHelixAccountServiceFactory.getAccountService();
     updateAccountsAndAssertAccountExistence(Collections.singleton(refAccount), 1, true);
+  }
+
+  /**
+   * Tests disabling account updates. By setting the {@link HelixAccountServiceConfig#UPDATE_DISABLED} to be true, all the
+   * account update request should be rejected.
+   */
+  @Test
+  public void testUpdateDisabled() {
+    helixConfigProps.setProperty(HelixAccountServiceConfig.UPDATE_DISABLED, "true");
+    vHelixConfigProps = new VerifiableProperties(helixConfigProps);
+    storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
+    String updaterThreadPrefix = UUID.randomUUID().toString();
+    MockHelixAccountServiceFactory mockHelixAccountServiceFactory =
+        new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier, updaterThreadPrefix,
+            mockRouter);
+    accountService = mockHelixAccountServiceFactory.getAccountService();
+
+    // add a new account
+    Account newAccountWithoutContainer = new AccountBuilder(refAccountId, refAccountName, refAccountStatus).build();
+    List<Account> accountsToUpdate = Collections.singletonList(newAccountWithoutContainer);
+    assertFalse("Update accounts should be disabled", accountService.updateAccounts(accountsToUpdate));
+  }
+
+  /**
+   * Tests enabling backfilling for new znode path. While {@link HelixAccountService} is still using old znode path, it should
+   * forward the new {@link Account} metadata to new znode path.
+   */
+  @Test
+  public void testFillAccountsToNewZNode() {
+    if (useNewZNodePath) {
+      return;
+    }
+    helixConfigProps.put(HelixAccountServiceConfig.FILL_ACCOUNTS_TO_NEW_ZNODE, "true");
+    vHelixConfigProps = new VerifiableProperties(helixConfigProps);
+    storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
+    String updaterThreadPrefix = UUID.randomUUID().toString();
+    MockHelixAccountServiceFactory mockHelixAccountServiceFactory =
+        new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier, updaterThreadPrefix,
+            mockRouter);
+    accountService = mockHelixAccountServiceFactory.getAccountService();
+    ((HelixAccountService) accountService).setupRouter(mockRouter);
+
+    // update accounts and then make sure the blob ids are stored in the helixStore
+    Account newAccountWithoutContainer = new AccountBuilder(refAccountId, refAccountName, refAccountStatus).build();
+    List<Account> accountsToUpdate = Collections.singletonList(newAccountWithoutContainer);
+    boolean hasUpdateAccountSucceed = accountService.updateAccounts(accountsToUpdate);
+    assertTrue("Wrong update return status", hasUpdateAccountSucceed);
+    assertAccountsInAccountService(accountsToUpdate, 1, accountService);
+    HelixPropertyStore<ZNRecord> helixStore =
+        mockHelixAccountServiceFactory.getHelixStore(ZK_CONNECT_STRING, storeConfig);
+    ZNRecord record = helixStore.get(RouterStore.ACCOUNT_METADATA_BLOB_IDS_PATH, null, AccessOption.PERSISTENT);
+    assertNotNull("Backfill should create ZNRecord", record);
+    List<String> blobIDAndVersions = record.getListField(RouterStore.ACCOUNT_METADATA_BLOB_IDS_LIST_KEY);
+    assertNotNull("Blob ids are missing from ZNRecord", blobIDAndVersions);
+    assertEquals("Number of blobs mismatch", 1, blobIDAndVersions.size());
+    RouterStore.BlobIDAndVersion blobIDAndVersion = null;
+    for (String json : blobIDAndVersions) {
+      RouterStore.BlobIDAndVersion current = RouterStore.BlobIDAndVersion.fromJson(json);
+      if (current.getVersion() == 1) {
+        blobIDAndVersion = current;
+        break;
+      }
+    }
+    assertNotNull("Version 1 expected", blobIDAndVersion);
   }
 
   /**
@@ -843,7 +919,8 @@ public class HelixAccountServiceTest {
             .max(Comparator.naturalOrder())
             .get();
         checkBackupFile(expectedOldState, oldStateBackup);
-        String newStateFilename = oldStateBackup.getFileName().toString().replace(LocalBackup.OLD_STATE_SUFFIX, LocalBackup.NEW_STATE_SUFFIX);
+        String newStateFilename =
+            oldStateBackup.getFileName().toString().replace(LocalBackup.OLD_STATE_SUFFIX, LocalBackup.NEW_STATE_SUFFIX);
         Path newStateBackup = oldStateBackup.getParent().resolve(newStateFilename);
         checkBackupFile(accountService.getAllAccounts(), newStateBackup);
       } else {

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -821,7 +821,7 @@ public class HelixAccountServiceTest {
     if (useNewZNodePath) {
       return;
     }
-    helixConfigProps.put(HelixAccountServiceConfig.FILL_ACCOUNTS_TO_NEW_ZNODE, "true");
+    helixConfigProps.put(HelixAccountServiceConfig.BACKFILL_ACCOUNTS_TO_NEW_ZNODE, "true");
     vHelixConfigProps = new VerifiableProperties(helixConfigProps);
     storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
     String updaterThreadPrefix = UUID.randomUUID().toString();

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -63,6 +63,7 @@ import static com.github.ambry.account.Container.*;
 import static com.github.ambry.account.HelixAccountService.*;
 import static com.github.ambry.utils.TestUtils.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -818,9 +819,7 @@ public class HelixAccountServiceTest {
    */
   @Test
   public void testFillAccountsToNewZNode() throws Exception {
-    if (useNewZNodePath) {
-      return;
-    }
+    assumeTrue(!useNewZNodePath);
     helixConfigProps.put(HelixAccountServiceConfig.BACKFILL_ACCOUNTS_TO_NEW_ZNODE, "true");
     vHelixConfigProps = new VerifiableProperties(helixConfigProps);
     storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
@@ -957,6 +956,7 @@ public class HelixAccountServiceTest {
   private void assertAccountMapEquals(Collection<Account> expectedAccounts, Map<String, String> accountMap)
       throws Exception {
     Set<Account> expectedAccountSet = new HashSet<>(expectedAccounts);
+    assertEquals("Number of accounts mismatch", expectedAccountSet.size(), accountMap.size());
     for (String accountJsonString : accountMap.values()) {
       JSONObject accountJson = new JSONObject(accountJsonString);
       Account account = Account.fromJson(accountJson);

--- a/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/InMemoryUnknownAccountServiceTest.java
@@ -32,8 +32,7 @@ import static org.junit.Assert.*;
  */
 public class InMemoryUnknownAccountServiceTest {
   private static final Random random = new Random();
-  private AccountService accountService =
-      new InMemoryUnknownAccountServiceFactory(null, null).getAccountService();
+  private AccountService accountService = new InMemoryUnknownAccountServiceFactory(null, null).getAccountService();
 
   /**
    * Cleans up if the store already exists.

--- a/ambry-account/src/test/java/com/github/ambry/account/MockHelixAccountServiceFactory.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockHelixAccountServiceFactory.java
@@ -45,8 +45,9 @@ public class MockHelixAccountServiceFactory extends HelixAccountServiceFactory {
    */
   public MockHelixAccountServiceFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
       Notifier<String> notifier, String updaterThreadPrefix, Router router) {
-    super(new HelixPropertyStoreConfig(verifiableProperties), new HelixAccountServiceConfig(verifiableProperties), new AccountServiceMetrics(metricRegistry), notifier);
-    HelixAccountServiceConfig config =  new HelixAccountServiceConfig(verifiableProperties);
+    super(new HelixPropertyStoreConfig(verifiableProperties), new HelixAccountServiceConfig(verifiableProperties),
+        new AccountServiceMetrics(metricRegistry), notifier);
+    HelixAccountServiceConfig config = new HelixAccountServiceConfig(verifiableProperties);
     this.updaterThreadPrefix = updaterThreadPrefix;
     this.router = router;
     this.useNewZNodePath = config.useNewZNodePath;
@@ -57,8 +58,9 @@ public class MockHelixAccountServiceFactory extends HelixAccountServiceFactory {
     try {
       ScheduledExecutorService scheduler =
           accountServiceConfig.updaterPollingIntervalMs > 0 ? Utils.newScheduler(1, updaterThreadPrefix, false) : null;
-      HelixAccountService accountService = new HelixAccountService(getHelixStore(accountServiceConfig.zkClientConnectString, storeConfig),
-          accountServiceMetrics, notifier, scheduler, accountServiceConfig);
+      HelixAccountService accountService =
+          new HelixAccountService(getHelixStore(accountServiceConfig.zkClientConnectString, storeConfig),
+              accountServiceMetrics, notifier, scheduler, accountServiceConfig);
       if (useNewZNodePath) {
         accountService.setupRouter(router);
       }

--- a/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
@@ -44,12 +44,13 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 public class MockRouter implements Router {
   private final static Logger logger = LoggerFactory.getLogger(MockRouter.class);
   private static final Random random = TestUtils.RANDOM;
 
   private final Lock lock = new ReentrantLock();
-  private Map<String, BlobInfoAndData>  allBlobs = new HashMap<>();
+  private Map<String, BlobInfoAndData> allBlobs = new HashMap<>();
 
   private class BlobInfoAndData {
     private final BlobInfo info;
@@ -105,10 +106,10 @@ public class MockRouter implements Router {
       long size = channel.getSize();
       try {
         InputStream input = new ReadableStreamChannelInputStream(channel);
-        byte[] bytes = Utils.readBytesFromStream(input, (int)size);
+        byte[] bytes = Utils.readBytesFromStream(input, (int) size);
         BlobInfoAndData blob = new BlobInfoAndData(new BlobInfo(blobProperties, userMetadata), bytes);
         String id = null;
-        for(;;) {
+        for (; ; ) {
           id = UtilsTest.getRandomString(10);
           if (allBlobs.putIfAbsent(id, blob) == null) {
             break;
@@ -119,7 +120,7 @@ public class MockRouter implements Router {
           callback.onCompletion(id, null);
         }
         return future;
-      } catch  (Exception e) {
+      } catch (Exception e) {
         logger.error("Failed to put blob", e);
         future.done(null, e);
         if (callback != null) {

--- a/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
@@ -109,7 +109,7 @@ public class MockRouter implements Router {
         byte[] bytes = Utils.readBytesFromStream(input, (int) size);
         BlobInfoAndData blob = new BlobInfoAndData(new BlobInfo(blobProperties, userMetadata), bytes);
         String id = null;
-        for (; ; ) {
+        while (true) {
           id = UtilsTest.getRandomString(10);
           if (allBlobs.putIfAbsent(id, blob) == null) {
             break;

--- a/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.account;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.HelixStoreOperator;
+import com.github.ambry.clustermap.MockHelixPropertyStore;
+import com.github.ambry.config.HelixAccountServiceConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.TestUtils;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+
+/**
+ * Unit test for {@link RouterStore}
+ */
+@RunWith(Parameterized.class)
+public class RouterStoreTest {
+  private final AccountServiceMetrics accountServiceMetrics;
+  private final LocalBackup backup;
+  private final Path accountBackupDir;
+  private final HelixAccountServiceConfig config;
+  private final MockHelixPropertyStore<ZNRecord> helixStore;
+  private final MockRouter router;
+  private final boolean forBackfill;
+
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][]{{false}, {true}});
+  }
+
+  /**
+   * Construct a unit test for {@link RouterStore}.
+   * @param forBackfill True if RouterStore should be created for backfilling.
+   * @throws IOException Any I/O error.
+   */
+  public RouterStoreTest(boolean forBackfill) throws IOException {
+    this.forBackfill = forBackfill;
+    accountBackupDir = Paths.get(TestUtils.getTempDir("account-backup")).toAbsolutePath();
+    accountServiceMetrics = new AccountServiceMetrics(new MetricRegistry());
+    Properties properties = new Properties();
+    properties.setProperty(HelixAccountServiceConfig.BACKUP_DIRECTORY_KEY, accountBackupDir.toString());
+    properties.setProperty(HelixAccountServiceConfig.ZK_CLIENT_CONNECT_STRING_KEY, "1000");
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+    config = new HelixAccountServiceConfig(verifiableProperties);
+    backup = new LocalBackup(accountServiceMetrics, config);
+    helixStore = new MockHelixPropertyStore<>();
+    router = new MockRouter();
+  }
+
+  /**
+   * cleanup after each test case.
+   * @throws Exception Any unexpected exception.
+   */
+  @After
+  public void cleanUp() throws Exception {
+    HelixStoreOperator operator = new HelixStoreOperator(helixStore);
+    if (operator.exist("/")) {
+      operator.delete("/");
+    }
+    if (Files.exists(accountBackupDir)) {
+      Files.walk(accountBackupDir).map(Path::toFile).forEach(File::delete);
+      Files.deleteIfExists(accountBackupDir);
+    }
+  }
+
+  /**
+   * Test basic operations of the {@link RouterStore}, update and fetch {@link Account} metadata.
+   * @throws Exception Any unexpected Exception
+   */
+  @Test
+  public void testUpdateAndFetch() throws Exception {
+    RouterStore store =
+        new RouterStore(accountServiceMetrics, backup, helixStore, new AtomicReference<>(router), forBackfill);
+    Map<Short, Account> idToRefAccountMap = new HashMap<>();
+    Map<Short, Map<Short, Container>> idtoRefContainerMap = new HashMap<>();
+    Set<Short> accountIDSet = new HashSet<>();
+    // generate an new account and test update and fetch on this account
+    AccountTestUtils.generateRefAccounts(idToRefAccountMap, idtoRefContainerMap, accountIDSet, 1, 1);
+    assertUpdateAndFetch(store, idToRefAccountMap, idToRefAccountMap, 1);
+
+    // generate another new account and test update and fetch on this account
+    Map<Short, Account> anotherIdToRefAccountMap = new HashMap<>();
+    AccountTestUtils.generateRefAccounts(anotherIdToRefAccountMap, idtoRefContainerMap, accountIDSet, 1, 1);
+    if (!forBackfill) {
+      for (Map.Entry<Short, Account> entry : anotherIdToRefAccountMap.entrySet()) {
+        idToRefAccountMap.put(entry.getKey(), entry.getValue());
+      }
+    } else {
+      idToRefAccountMap = anotherIdToRefAccountMap;
+    }
+    // the version should be 2 now
+    assertUpdateAndFetch(store, idToRefAccountMap, anotherIdToRefAccountMap, 2);
+  }
+
+  /**
+   * call {@link RouterStore#updateAccounts(Collection)} to update {@link Account} metadata then call {@link RouterStore#fetchAccountMetadata()}
+   * to fetch the {@link Account} metadata back and compare them. Also it fetches the {@link Account} metadata directly from ambry-server
+   * and compare them.
+   * @param store The {@link RouterStore}.
+   * @param allAccounts The whole set of {@link Account} metadata after update.
+   * @param accountsToUpdate The {@link Account} to update
+   * @param version The expected version of blob id to fetch {@link Account} metadata from ambry-server.
+   */
+  private void assertUpdateAndFetch(RouterStore store, Map<Short, Account> allAccounts,
+      Map<Short, Account> accountsToUpdate, int version) {
+    // verify that updateAccount works again
+    boolean succeeded = store.updateAccounts(accountsToUpdate.values());
+    assertTrue("Update accounts failed at router store", succeeded);
+
+    // verify that fetchAccountMetadata can fetch the accounts we just updated.
+    Map<String, String> accountMap = store.fetchAccountMetadata();
+    assertAccountsEqual(accountMap, allAccounts);
+
+    // Verify that ZNRecord contains the right data.
+    ZNRecord record = helixStore.get(RouterStore.ACCOUNT_METADATA_BLOB_IDS_PATH, null, AccessOption.PERSISTENT);
+    assertNotNull("ZNRecord missing after update", record);
+    List<String> blobIDAndVersions = record.getListField(RouterStore.ACCOUNT_METADATA_BLOB_IDS_LIST_KEY);
+    assertNotNull("Blob ids are missing from ZNRecord", blobIDAndVersions);
+    // version also equals to the number of blobs
+    assertEquals("Number of blobs mismatch", version, blobIDAndVersions.size());
+
+    RouterStore.BlobIDAndVersion blobIDAndVersion = null;
+    for (String json : blobIDAndVersions) {
+      RouterStore.BlobIDAndVersion current = RouterStore.BlobIDAndVersion.fromJson(json);
+      if (current.getVersion() == version) {
+        blobIDAndVersion = current;
+        break;
+      }
+    }
+    assertNotNull("Version " + version + " expected", blobIDAndVersion);
+    accountMap = store.readAccountMetadataFromBlobID(blobIDAndVersion.getBlobID());
+    assertAccountsEqual(accountMap, allAccounts);
+  }
+
+  /**
+   * Compare the account map in json string with the account map from id to account.
+   * @param accountMap The account map ini json string.
+   * @param accounts The account map from id to account.
+   */
+  private void assertAccountsEqual(Map<String, String> accountMap, Map<Short, Account> accounts) {
+    AccountInfoMap accountInfoMap = new AccountInfoMap(accountServiceMetrics, accountMap);
+    Collection<Account> obtainedAccounts = accountInfoMap.getAccounts();
+
+    assertEquals("Account size doesn't match", obtainedAccounts.size(), accounts.size());
+    for (Account obtainedAccount : obtainedAccounts) {
+      Account expectedAccount = accounts.get(obtainedAccount.getId());
+      assertEquals("Account mismatched", expectedAccount, obtainedAccount);
+    }
+  }
+}

--- a/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.clustermap.MockHelixPropertyStore;
 import com.github.ambry.config.HelixAccountServiceConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -93,8 +94,7 @@ public class RouterStoreTest {
       operator.delete("/");
     }
     if (Files.exists(accountBackupDir)) {
-      Files.walk(accountBackupDir).map(Path::toFile).forEach(File::delete);
-      Files.deleteIfExists(accountBackupDir);
+      Utils.deleteFileOrDirectory(accountBackupDir.toFile());
     }
   }
 

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -26,7 +26,7 @@ public class HelixAccountServiceConfig {
   public static final String ZK_CLIENT_CONNECT_STRING_KEY = HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string";
   public static final String USE_NEW_ZNODE_PATH = HELIX_ACCOUNT_SERVICE_PREFIX + "use.new.znode.path";
   public static final String UPDATE_DISABLED =  HELIX_ACCOUNT_SERVICE_PREFIX + "update.disabled";
-  public static final String FILL_ACCOUNTS_TO_NEW_ZNODE = HELIX_ACCOUNT_SERVICE_PREFIX + "fill.accounts.to.new.znode";
+  public static final String BACKFILL_ACCOUNTS_TO_NEW_ZNODE = HELIX_ACCOUNT_SERVICE_PREFIX + "backfill.accounts.to.new.znode";
 
 
   /**
@@ -77,9 +77,9 @@ public class HelixAccountServiceConfig {
    * change message. This option can't be true with useNewZNodePath at the same time. It should only be enabled while
    * using the old znode path. And there should only be one machine enabling this option.
    */
-  @Config(FILL_ACCOUNTS_TO_NEW_ZNODE)
+  @Config(BACKFILL_ACCOUNTS_TO_NEW_ZNODE)
   @Default("false")
-  public final boolean fillAccountsToNewZNode;
+  public final boolean backFillAccountsToNewZNode;
 
   public HelixAccountServiceConfig(VerifiableProperties verifiableProperties) {
     zkClientConnectString = verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY);
@@ -90,10 +90,10 @@ public class HelixAccountServiceConfig {
     backupDir = verifiableProperties.getString(BACKUP_DIRECTORY_KEY, "");
     useNewZNodePath = verifiableProperties.getBoolean(USE_NEW_ZNODE_PATH, false);
     updateDisabled = verifiableProperties.getBoolean(UPDATE_DISABLED, false);
-    fillAccountsToNewZNode = verifiableProperties.getBoolean(FILL_ACCOUNTS_TO_NEW_ZNODE, false);
+    backFillAccountsToNewZNode = verifiableProperties.getBoolean(BACKFILL_ACCOUNTS_TO_NEW_ZNODE, false);
 
-    if (fillAccountsToNewZNode && useNewZNodePath) {
-      throw new IllegalStateException("useNewZNodePath and fillAccountsToNewZNode can't be true at the same time.");
+    if (backFillAccountsToNewZNode && useNewZNodePath) {
+      throw new IllegalStateException("useNewZNodePath and backFillAccountsToNewZNode can't be true at the same time.");
     }
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -24,7 +24,9 @@ public class HelixAccountServiceConfig {
       HELIX_ACCOUNT_SERVICE_PREFIX + "updater.shut.down.timeout.ms";
   public static final String BACKUP_DIRECTORY_KEY = HELIX_ACCOUNT_SERVICE_PREFIX + "backup.dir";
   public static final String ZK_CLIENT_CONNECT_STRING_KEY = HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string";
-  public static final String USE_NEW_ZNODE_PATH =  HELIX_ACCOUNT_SERVICE_PREFIX + "use.new.znode.path";
+  public static final String USE_NEW_ZNODE_PATH = HELIX_ACCOUNT_SERVICE_PREFIX + "use.new.znode.path";
+  public static final String UPDATE_DISABLED =  HELIX_ACCOUNT_SERVICE_PREFIX + "update.disabled";
+  public static final String FILL_ACCOUNTS_TO_NEW_ZNODE = HELIX_ACCOUNT_SERVICE_PREFIX + "fill.accounts.to.new.znode";
 
 
   /**
@@ -63,6 +65,22 @@ public class HelixAccountServiceConfig {
   @Default("false")
   public final boolean useNewZNodePath;
 
+  /**
+   * If true, HelixAccountService would reject all the requests to update accounts.
+   */
+  @Config(UPDATE_DISABLED)
+  @Default("false")
+  public final boolean updateDisabled;
+
+  /**
+   * If true, HelixAccountService would persist account metadata to ambry-server upon receiving the account metadata
+   * change message. This option can't be true with useNewZNodePath at the same time. It should only be enabled while
+   * using the old znode path. And there should only be one machine enabling this option.
+   */
+  @Config(FILL_ACCOUNTS_TO_NEW_ZNODE)
+  @Default("false")
+  public final boolean fillAccountsToNewZNode;
+
   public HelixAccountServiceConfig(VerifiableProperties verifiableProperties) {
     zkClientConnectString = verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY);
     updaterPollingIntervalMs =
@@ -71,5 +89,11 @@ public class HelixAccountServiceConfig {
         verifiableProperties.getIntInRange(UPDATER_SHUT_DOWN_TIMEOUT_MS_KEY, 60 * 1000, 1, Integer.MAX_VALUE);
     backupDir = verifiableProperties.getString(BACKUP_DIRECTORY_KEY, "");
     useNewZNodePath = verifiableProperties.getBoolean(USE_NEW_ZNODE_PATH, false);
+    updateDisabled = verifiableProperties.getBoolean(UPDATE_DISABLED, false);
+    fillAccountsToNewZNode = verifiableProperties.getBoolean(FILL_ACCOUNTS_TO_NEW_ZNODE, false);
+
+    if (fillAccountsToNewZNode && useNewZNodePath) {
+      throw new IllegalStateException("useNewZNodePath and fillAccountsToNewZNode can't be true at the same time.");
+    }
   }
 }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/RestServer.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/RestServer.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.account.AccountServiceFactory;
+import com.github.ambry.account.HelixAccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.config.RestServerConfig;
@@ -170,6 +171,12 @@ public class RestServer {
         Utils.getObj(restServerConfig.restServerRouterFactory, verifiableProperties, clusterMap, notificationSystem,
             sslFactory, accountService);
     router = routerFactory.getRouter();
+
+
+    // setup the router for the account service
+    if (accountService instanceof HelixAccountService) {
+      ((HelixAccountService)accountService).setupRouter(router);
+    }
 
     RestResponseHandlerFactory restResponseHandlerFactory =
         Utils.getObj(restServerConfig.restServerResponseHandlerFactory,

--- a/build.gradle
+++ b/build.gradle
@@ -295,6 +295,7 @@ project(':ambry-protocol') {
 project(':ambry-rest') {
     dependencies {
         compile project(':ambry-api'),
+                project(':ambry-account'),
                 project(':ambry-utils'),
                 project(':ambry-commons')
         compile "com.codahale.metrics:metrics-core:$metricsVersion"


### PR DESCRIPTION
This PR started the implementation to safely transition HelixAccountService from old ZNode path to new ZNode path. 
1. Introduce a new configuration option to disable all the requests to update accounts
2.Introduce a new configuration option to backfill any new updates to the new ZNode path.