### PR TITLE
Upload new replicas infos onto Helix PropertyStore

### DIFF
--- a/ambry-api/src/test/java/com.github.ambry/commons/CommonUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/commons/CommonUtilsTest.java
@@ -73,8 +73,9 @@ public class CommonUtilsTest {
 
     // Ensure the HelixPropertyStore works correctly
     List<String> list = Arrays.asList("first", "second", "third");
-    String path = propertyStoreConfig.rootPath + ClusterMapUtils.PROPERTYSTORE_ZNODE_PATH;
-    ZNRecord znRecord = new ZNRecord(ClusterMapUtils.ZNODE_NAME);
+    String path = propertyStoreConfig.rootPath + ClusterMapUtils.PROPERTYSTORE_ZNODE_PATH
+        + ClusterMapUtils.PARTITION_OVERRIDE_STR;
+    ZNRecord znRecord = new ZNRecord(ClusterMapUtils.PARTITION_OVERRIDE_STR);
     znRecord.setListField("AmbryList", list);
     if (!propertyStore.set(path, znRecord, AccessOption.PERSISTENT)) {
       fail("Failed to set HelixPropertyStore");

--- a/ambry-api/src/test/java/com.github.ambry/commons/CommonUtilsTest.java
+++ b/ambry-api/src/test/java/com.github.ambry/commons/CommonUtilsTest.java
@@ -40,7 +40,7 @@ public class CommonUtilsTest {
   @Test
   public void createHelixPropertyStoreTest() throws IOException {
     Properties storeProps = new Properties();
-    storeProps.setProperty("helix.property.store.root.path", "/Ambry-Test");
+    storeProps.setProperty("helix.property.store.root.path", "/Ambry-Test/" + ClusterMapUtils.PROPERTYSTORE_STR);
     HelixPropertyStoreConfig propertyStoreConfig = new HelixPropertyStoreConfig(new VerifiableProperties(storeProps));
     String tempDirPath = getTempDir("clusterMapUtils-");
     ZkInfo zkInfo = new ZkInfo(tempDirPath, "DC1", (byte) 0, 2200, true);
@@ -73,8 +73,7 @@ public class CommonUtilsTest {
 
     // Ensure the HelixPropertyStore works correctly
     List<String> list = Arrays.asList("first", "second", "third");
-    String path = propertyStoreConfig.rootPath + ClusterMapUtils.PROPERTYSTORE_ZNODE_PATH
-        + ClusterMapUtils.PARTITION_OVERRIDE_STR;
+    String path = propertyStoreConfig.rootPath + ClusterMapUtils.PARTITION_OVERRIDE_ZNODE_PATH;
     ZNRecord znRecord = new ZNRecord(ClusterMapUtils.PARTITION_OVERRIDE_STR);
     znRecord.setListField("AmbryList", list);
     if (!propertyStore.set(path, znRecord, AccessOption.PERSISTENT)) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
@@ -86,6 +86,6 @@ public class AmbryPartitionStateModel extends StateModel {
 
   @Override
   public void reset() {
-    logger.info("Reset method invoked. Partition {} un resource {} is reset to OFFLINE", partitionName, resourceName);
+    logger.info("Reset method invoked. Partition {} in resource {} is reset to OFFLINE", partitionName, resourceName);
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -43,9 +43,14 @@ public class ClusterMapUtils {
   public static final byte UNKNOWN_DATACENTER_ID = -1;
   public static final String PARTITION_OVERRIDE_STR = "PartitionOverride";
   public static final String REPLICA_ADDITION_STR = "ReplicaAddition";
+  public static final String PROPERTYSTORE_STR = "PROPERTYSTORE";
+  // Following two ZNode paths are the path to ZNode that stores some admin configs. Partition override config is used
+  // to administratively override partition from frontend's point of view. Replica addition config is used to specify
+  // detailed new replica infos (capacity, mount path, etc) which will be added to target server.
+  // Note that, root path in Helix is "/ClusterName/PROPERTYSTORE", so the full path is (use partition override as example)
+  // "/ClusterName/PROPERTYSTORE/AdminConfigs/PartitionOverride"
   public static final String PARTITION_OVERRIDE_ZNODE_PATH = "/AdminConfigs/" + PARTITION_OVERRIDE_STR;
   public static final String REPLICA_ADDITION_ZNODE_PATH = "/AdminConfigs/" + REPLICA_ADDITION_STR;
-  public static final String PROPERTYSTORE_ZNODE_PATH = "/PROPERTYSTORE/AdminConfigs/";
   static final String DISK_CAPACITY_STR = "capacityInBytes";
   static final String DISK_STATE = "diskState";
   static final String PARTITION_STATE = "state";

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -41,15 +41,19 @@ import org.slf4j.LoggerFactory;
 public class ClusterMapUtils {
   // datacenterId == UNKNOWN_DATACENTER_ID indicate datacenterId is not available at the time when this blobId is formed.
   public static final byte UNKNOWN_DATACENTER_ID = -1;
-  public static final String ZNODE_NAME = "PartitionOverride";
-  public static final String ZNODE_PATH = "/ClusterConfigs/" + ZNODE_NAME;
-  public static final String PROPERTYSTORE_ZNODE_PATH = "/PROPERTYSTORE/ClusterConfigs/" + ZNODE_NAME;
+  public static final String PARTITION_OVERRIDE_STR = "PartitionOverride";
+  public static final String REPLICA_ADDITION_STR = "ReplicaAddition";
+  public static final String PARTITION_OVERRIDE_ZNODE_PATH = "/AdminConfigs/" + PARTITION_OVERRIDE_STR;
+  public static final String REPLICA_ADDITION_ZNODE_PATH = "/AdminConfigs/" + REPLICA_ADDITION_STR;
+  public static final String PROPERTYSTORE_ZNODE_PATH = "/PROPERTYSTORE/AdminConfigs/";
   static final String DISK_CAPACITY_STR = "capacityInBytes";
   static final String DISK_STATE = "diskState";
   static final String PARTITION_STATE = "state";
+  static final String PARTITION_CLASS_STR = "partitionClass";
   static final String REPLICAS_STR = "Replicas";
   static final String REPLICAS_DELIM_STR = ",";
   static final String REPLICAS_STR_SEPARATOR = ":";
+  static final String REPLICAS_CAPACITY_STR = "replicaCapacityInBytes";
   static final String SSLPORT_STR = "sslPort";
   static final String RACKID_STR = "rackId";
   static final String SEALED_STR = "SEALED";
@@ -432,7 +436,7 @@ public class ClusterMapUtils {
         if (partitionsToExclude == null || partitionsToExclude.size() == 0 || !partitionsToExclude.contains(selected)) {
           if (selected.getPartitionState() == PartitionState.READ_WRITE) {
             anyWritablePartition = selected;
-            if(areEnoughReplicasForPartitionUp(selected)) {
+            if (areEnoughReplicasForPartitionUp(selected)) {
               return selected;
             }
           }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -114,7 +114,6 @@ class HelixBootstrapUpgradeUtil {
   private HelixClusterManager validatingHelixClusterManager;
   private static final Logger logger = LoggerFactory.getLogger("Helix bootstrap tool");
   private static final String ALL = "all";
-  //private static final String
 
   /**
    * Parse the dc string argument and return a map of dc -> DcZkInfo for every datacenter that is enabled.

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -286,7 +286,7 @@ class HelixBootstrapUpgradeUtil {
         break;
       default:
         throw new IllegalArgumentException(
-            "Unrecognized admin config type: " + adminType + ". Current supported types are "
+            "Unrecognized admin config type: " + adminType + ". Current supported types are: "
                 + ClusterMapUtils.PARTITION_OVERRIDE_STR + ", " + ClusterMapUtils.REPLICA_ADDITION_STR);
     }
     info("Upload cluster configs completed.");

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -688,6 +688,7 @@ class HelixBootstrapUpgradeUtil {
         info("Resource {} has different state model {}. Updating it with {}", resourceName,
             resourceIs.getStateModelDefRef(), stateModelDef);
         resourceIs.setStateModelDefRef(stateModelDef);
+        resourceModified = true;
       }
       resourceIs.setNumPartitions(resourceIs.getPartitionSet().size());
       if (resourceModified) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -235,9 +235,10 @@ class HelixClusterManager implements ClusterMap {
       }
     };
     logger.info("Subscribing data listener to HelixPropertyStore.");
-    helixPropertyStore.subscribeDataChanges(ClusterMapUtils.ZNODE_PATH, dataListener);
+    helixPropertyStore.subscribeDataChanges(ClusterMapUtils.PARTITION_OVERRIDE_ZNODE_PATH, dataListener);
     logger.info("Getting ZNRecord from HelixPropertyStore");
-    ZNRecord zNRecord = helixPropertyStore.get(ClusterMapUtils.ZNODE_PATH, null, AccessOption.PERSISTENT);
+    ZNRecord zNRecord =
+        helixPropertyStore.get(ClusterMapUtils.PARTITION_OVERRIDE_ZNODE_PATH, null, AccessOption.PERSISTENT);
     if (clusterMapConfig.clusterMapEnablePartitionOverride) {
       if (zNRecord != null) {
         partitionOverrideInfoMap.putAll(zNRecord.getMapFields());

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -170,7 +170,7 @@ public class HelixClusterManagerTest {
       partitionOverrideMap.computeIfAbsent(String.valueOf(i), k -> new HashMap<>())
           .put(ClusterMapUtils.PARTITION_STATE, ClusterMapUtils.READ_ONLY_STR);
     }
-    znRecord = new ZNRecord(ClusterMapUtils.ZNODE_NAME);
+    znRecord = new ZNRecord(ClusterMapUtils.PARTITION_OVERRIDE_STR);
     znRecord.setMapFields(partitionOverrideMap);
 
     helixCluster =

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
@@ -90,8 +90,8 @@ class MockHelixManager implements HelixManager {
     this.beBadException = beBadException;
 
     MockitoAnnotations.initMocks(this);
-    Mockito.when(helixPropertyStore.get(eq(ClusterMapUtils.ZNODE_PATH), eq(null), eq(AccessOption.PERSISTENT)))
-        .thenReturn(record);
+    Mockito.when(helixPropertyStore.get(eq(ClusterMapUtils.PARTITION_OVERRIDE_ZNODE_PATH), eq(null),
+        eq(AccessOption.PERSISTENT))).thenReturn(record);
   }
 
   @Override

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -57,8 +57,8 @@ import static org.junit.Assume.*;
 public class HelixBootstrapUpgradeToolTest {
   private static String tempDirPath;
   private static final Map<String, ZkInfo> dcsToZkInfo = new HashMap<>();
-  private static final String dcs[] = new String[]{"DC0", "DC1"};
-  private static final byte ids[] = new byte[]{(byte) 0, (byte) 1};
+  private static final String[] dcs = new String[]{"DC0", "DC1"};
+  private static final byte[] ids = new byte[]{(byte) 0, (byte) 1};
   private final String hardwareLayoutPath;
   private final String partitionLayoutPath;
   private final String zkLayoutPath;
@@ -388,6 +388,80 @@ public class HelixBootstrapUpgradeToolTest {
   }
 
   /**
+   * Test that new replicas can be correctly extracted from the diff between static clustermap and clustermap in Helix.
+   * Also test that new added replica infos are correct (i.e. partition class, replica size, data node and mount path)
+   * @throws Exception
+   */
+  @Test
+  public void testReplicaAdditionConfigUpload() throws Exception {
+    // Test bootstrap
+    long expectedResourceCount =
+        (testPartitionLayout.getPartitionLayout().getPartitionCount() - 1) / DEFAULT_MAX_PARTITIONS_PER_RESOURCE + 1;
+    writeBootstrapOrUpgrade(expectedResourceCount, false);
+
+    // Now, change the replica count for two partitions.
+    Partition partition1 = (Partition) testPartitionLayout.getPartitionLayout()
+        .getPartitions(null)
+        .get(RANDOM.nextInt(testPartitionLayout.getPartitionCount()));
+    Partition partition2 = (Partition) testPartitionLayout.getPartitionLayout()
+        .getPartitions(null)
+        .get(RANDOM.nextInt(testPartitionLayout.getPartitionCount()));
+
+    // Add a new replica for partition1. Find a disk on a data node that does not already have a replica for partition1.
+    HashSet<DataNodeId> partition1Nodes = new HashSet<>();
+    for (Replica replica : partition1.getReplicas()) {
+      partition1Nodes.add(replica.getDataNodeId());
+    }
+    Disk diskForNewReplica;
+    do {
+      diskForNewReplica = testHardwareLayout.getRandomDisk();
+    } while (partition1Nodes.contains(diskForNewReplica.getDataNode()));
+    // Add new replica into partition1
+    partition1.addReplica(new Replica(partition1, diskForNewReplica, testHardwareLayout.clusterMapConfig));
+    String dcNameForNewReplica = diskForNewReplica.getDataNode().getDatacenterName();
+    // Remove a replica from partition2.
+    partition2.getReplicas().remove(0);
+
+    Utils.writeJsonObjectToFile(zkJson, zkLayoutPath);
+    Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
+    Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
+    HelixBootstrapUpgradeUtil.uploadClusterAdminConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
+        CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory(),
+        new String[]{ClusterMapUtils.REPLICA_ADDITION_STR});
+
+    for (ZkInfo zkInfo : dcsToZkInfo.values()) {
+      HelixPropertyStore<ZNRecord> propertyStore =
+          CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig,
+              Collections.singletonList(propertyStoreConfig.rootPath));
+      String getPath = ClusterMapUtils.PROPERTYSTORE_ZNODE_PATH + ClusterMapUtils.REPLICA_ADDITION_STR;
+      ZNRecord zNRecord = propertyStore.get(getPath, null, AccessOption.PERSISTENT);
+      if (!activeDcSet.contains(zkInfo.getDcName())) {
+        // if data center is not enabled, no admin config should be uploaded to Helix.
+        assertNull(zNRecord);
+      } else if (!zkInfo.getDcName().equals(dcNameForNewReplica)) {
+        // if data center doesn't equal to
+        Map<String, Map<String, String>> replicaAddition = zNRecord.getMapFields();
+        assertTrue(replicaAddition.isEmpty());
+      } else {
+        assertNotNull(zNRecord);
+        Map<String, Map<String, String>> replicaAddition = zNRecord.getMapFields();
+        assertEquals("There should be only one partition in new replica map", 1, replicaAddition.size());
+        assertNotNull("Partition id in new replica map is not expected",
+            replicaAddition.get(partition1.toPathString()));
+        Map<String, String> newReplicaMap = replicaAddition.get(partition1.toPathString());
+        assertEquals("Partition class is not expected", partition1.getPartitionClass(),
+            newReplicaMap.get(ClusterMapUtils.PARTITION_CLASS_STR));
+        assertEquals("Replica capacity is not expected", String.valueOf(partition1.getReplicaCapacityInBytes()),
+            newReplicaMap.get(ClusterMapUtils.REPLICAS_CAPACITY_STR));
+        String instanceName =
+            diskForNewReplica.getDataNode().getHostname() + "_" + diskForNewReplica.getDataNode().getPort();
+        assertTrue("Instance name doesn't exist", newReplicaMap.containsKey(instanceName));
+        assertEquals("Mount path is not expected", diskForNewReplica.getMountPath(), newReplicaMap.get(instanceName));
+      }
+    }
+  }
+
+  /**
    * Write the layout files out from the constructed in-memory hardware and partition layouts; use the bootstrap tool
    * to update the contents in Helix; verify that the information is consistent between the two.
    * @param expectedResourceCount number of resources expected in Helix for this cluster in each datacenter.
@@ -419,15 +493,15 @@ public class HelixBootstrapUpgradeToolTest {
     Utils.writeJsonObjectToFile(zkJson, zkLayoutPath);
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
-    HelixBootstrapUpgradeUtil.uploadClusterConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
+    HelixBootstrapUpgradeUtil.uploadClusterAdminConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory(),
-        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
+        new String[]{ClusterMapUtils.PARTITION_OVERRIDE_STR});
     // Check writable partitions in each datacenter
     for (ZkInfo zkInfo : dcsToZkInfo.values()) {
       HelixPropertyStore<ZNRecord> propertyStore =
           CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig,
               Collections.singletonList(propertyStoreConfig.rootPath));
-      String getPath = ClusterMapUtils.PROPERTYSTORE_ZNODE_PATH;
+      String getPath = ClusterMapUtils.PROPERTYSTORE_ZNODE_PATH + ClusterMapUtils.PARTITION_OVERRIDE_STR;
       ZNRecord zNRecord = propertyStore.get(getPath, null, AccessOption.PERSISTENT);
       if (!activeDcSet.contains(zkInfo.getDcName())) {
         assertNull(zNRecord);

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -69,7 +69,8 @@ public class HelixBootstrapUpgradeToolTest {
   private TestPartitionLayout testPartitionLayout;
   private static final String CLUSTER_NAME_IN_STATIC_CLUSTER_MAP = "ToolTestStatic";
   private static final String CLUSTER_NAME_PREFIX = "Ambry-";
-  private static final String ROOT_PATH = "/" + CLUSTER_NAME_PREFIX + CLUSTER_NAME_IN_STATIC_CLUSTER_MAP;
+  private static final String ROOT_PATH =
+      "/" + CLUSTER_NAME_PREFIX + CLUSTER_NAME_IN_STATIC_CLUSTER_MAP + "/" + ClusterMapUtils.PROPERTYSTORE_STR;
   private static HelixPropertyStoreConfig propertyStoreConfig;
 
   /**
@@ -443,7 +444,7 @@ public class HelixBootstrapUpgradeToolTest {
       HelixPropertyStore<ZNRecord> propertyStore =
           CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig,
               Collections.singletonList(propertyStoreConfig.rootPath));
-      String getPath = ClusterMapUtils.PROPERTYSTORE_ZNODE_PATH + ClusterMapUtils.REPLICA_ADDITION_STR;
+      String getPath = ClusterMapUtils.REPLICA_ADDITION_ZNODE_PATH;
       ZNRecord zNRecord = propertyStore.get(getPath, null, AccessOption.PERSISTENT);
       if (!activeDcSet.contains(zkInfo.getDcName())) {
         // if data center is not enabled, no admin config should be uploaded to Helix.
@@ -511,7 +512,7 @@ public class HelixBootstrapUpgradeToolTest {
       HelixPropertyStore<ZNRecord> propertyStore =
           CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig,
               Collections.singletonList(propertyStoreConfig.rootPath));
-      String getPath = ClusterMapUtils.PROPERTYSTORE_ZNODE_PATH + ClusterMapUtils.PARTITION_OVERRIDE_STR;
+      String getPath = ClusterMapUtils.PARTITION_OVERRIDE_ZNODE_PATH;
       ZNRecord zNRecord = propertyStore.get(getPath, null, AccessOption.PERSISTENT);
       if (!activeDcSet.contains(zkInfo.getDcName())) {
         assertNull(zNRecord);

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -425,10 +425,20 @@ public class HelixBootstrapUpgradeToolTest {
     Utils.writeJsonObjectToFile(zkJson, zkLayoutPath);
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
+    // test invalid admin type
+    try {
+      HelixBootstrapUpgradeUtil.uploadClusterAdminConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
+          CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory(),
+          new String[]{"invalid_admin_type"});
+      fail("should fail because of invalid admin type");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    // upload replica addition admin config
     HelixBootstrapUpgradeUtil.uploadClusterAdminConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory(),
         new String[]{ClusterMapUtils.REPLICA_ADDITION_STR});
-
+    // verify replica addition znode in Helix PropertyStore
     for (ZkInfo zkInfo : dcsToZkInfo.values()) {
       HelixPropertyStore<ZNRecord> propertyStore =
           CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig,


### PR DESCRIPTION
This PR supports uploading infos of new replicas onto Helix
PropertyStore. This is part of move replica which specifies the location
of new replicas and their size, partition class etc. The Helix bootstrap
upgrade tool will extract diff between static clustermap and clustermap
in Helix. The diff is used to generate a map of new added replicas and
then upload it to Helix.