### PR TITLE
HelixAccountService: limit the number of versions in the list

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -128,13 +128,15 @@ public class HelixAccountService implements AccountService {
     this.backupFileManager = new BackupFileManager(this.accountServiceMetrics, config);
     AccountMetadataStore backFillStore = null;
     if (config.useNewZNodePath) {
-      accountMetadataStore = new RouterStore(this.accountServiceMetrics, backupFileManager, helixStore, router, false, config.maxNumberOfVersionsToSave);
+      accountMetadataStore = new RouterStore(this.accountServiceMetrics, backupFileManager, helixStore, router, false,
+          config.totalNumberOfVersionToKeep);
       // postpone initializeFetchAndSchedule to setupRouter function.
     } else {
       accountMetadataStore = new LegacyMetadataStore(this.accountServiceMetrics, backupFileManager, helixStore);
       initialFetchAndSchedule();
       if (config.backFillAccountsToNewZNode) {
-        backFillStore = new RouterStore(this.accountServiceMetrics, backupFileManager, helixStore, router, true, config.maxNumberOfVersionsToSave);
+        backFillStore = new RouterStore(this.accountServiceMetrics, backupFileManager, helixStore, router, true,
+            config.totalNumberOfVersionToKeep);
       }
     }
     this.backFillStore = backFillStore;

--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -128,13 +128,13 @@ public class HelixAccountService implements AccountService {
     this.backupFileManager = new BackupFileManager(this.accountServiceMetrics, config);
     AccountMetadataStore backFillStore = null;
     if (config.useNewZNodePath) {
-      accountMetadataStore = new RouterStore(this.accountServiceMetrics, backupFileManager, helixStore, router, false);
+      accountMetadataStore = new RouterStore(this.accountServiceMetrics, backupFileManager, helixStore, router, false, config.maxNumberOfVersionsToSave);
       // postpone initializeFetchAndSchedule to setupRouter function.
     } else {
       accountMetadataStore = new LegacyMetadataStore(this.accountServiceMetrics, backupFileManager, helixStore);
       initialFetchAndSchedule();
       if (config.backFillAccountsToNewZNode) {
-        backFillStore = new RouterStore(this.accountServiceMetrics, backupFileManager, helixStore, router, true);
+        backFillStore = new RouterStore(this.accountServiceMetrics, backupFileManager, helixStore, router, true, config.maxNumberOfVersionsToSave);
       }
     }
     this.backFillStore = backFillStore;

--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -317,7 +317,7 @@ class RouterStore extends AccountMetadataStore {
           // Block this execution? or maybe wait for a while then get out?
           router.get().deleteBlob(newBlobID, SERVICE_ID).get();
         } catch (Exception e) {
-          logger.error("Failed to delete blob={} because of {}", newBlobID, e);
+          logger.error("Failed to delete blob=" + newBlobID, e);
           accountServiceMetrics.accountDeletesToAmbryServerErrorCount.inc();
         }
       }
@@ -330,7 +330,7 @@ class RouterStore extends AccountMetadataStore {
             // Block this execution? or maybe wait for a while then get out?
             router.get().deleteBlob(blobID, SERVICE_ID).get();
           } catch (Exception e) {
-            logger.error("Failed to delete blob={} because of {}", blobID, e);
+            logger.error("Failed to delete blob=" + blobID, e);
             accountServiceMetrics.accountDeletesToAmbryServerErrorCount.inc();
           }
         }

--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -299,7 +299,6 @@ class RouterStore extends AccountMetadataStore {
               + " to delete");
           oldBlobIDsToDelete.add(blobIDAndVersion.getBlobID());
         }
-        // Clear json string list since it's not sorted.
         blobIDAndVersionsJson = blobIDAndVersions.stream().map(BlobIDAndVersion::toJson).collect(Collectors.toList());
       }
 
@@ -322,7 +321,7 @@ class RouterStore extends AccountMetadataStore {
           accountServiceMetrics.accountDeletesToAmbryServerErrorCount.inc();
         }
       }
-      // Notice this logic might end up with the dangling blob, when the process crashes before the for loop.
+      // Notice this logic might end up with the dangling blobs, when the process crashes before the for loop.
       // But since the frequency to update account metadata is pretty rare, it won't be a big problem.
       if (isUpdateSucceeded && oldBlobIDsToDelete != null) {
         for (String blobID : oldBlobIDsToDelete) {

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -86,7 +86,7 @@ public class HelixAccountServiceTest {
   private static final String BAD_ACCOUNT_METADATA_STRING = "badAccountMetadataString";
   private static final int NUM_REF_ACCOUNT = 10;
   private static final int NUM_CONTAINER_PER_ACCOUNT = 4;
-  private static final int MAX_NUMBER_OF_VERSIONS_TO_SAVE = 100;
+  private static final int TOTAL_NUMBER_OF_VERSION_TO_KEEP = 100;
   private static final Map<Short, Account> idToRefAccountMap = new HashMap<>();
   private static final Map<Short, Map<Short, Container>> idToRefContainerMap = new HashMap<>();
   private final Properties helixConfigProps = new Properties();
@@ -881,7 +881,7 @@ public class HelixAccountServiceTest {
     HelixAccountService helixAccountService = (HelixAccountService) accountService;
     RouterStore routerStore =
         new RouterStore(helixAccountService.getAccountServiceMetrics(), helixAccountService.getBackupFileManager(),
-            helixStore, new AtomicReference<>(mockRouter), false, MAX_NUMBER_OF_VERSIONS_TO_SAVE);
+            helixStore, new AtomicReference<>(mockRouter), false, TOTAL_NUMBER_OF_VERSION_TO_KEEP);
     Map<String, String> accountMap = routerStore.fetchAccountMetadata();
     assertNotNull("Accounts should be backfilled to new znode", accountMap);
     assertAccountMapEquals(accountService.getAllAccounts(), accountMap);

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -86,6 +86,7 @@ public class HelixAccountServiceTest {
   private static final String BAD_ACCOUNT_METADATA_STRING = "badAccountMetadataString";
   private static final int NUM_REF_ACCOUNT = 10;
   private static final int NUM_CONTAINER_PER_ACCOUNT = 4;
+  private static final int MAX_NUMBER_OF_VERSIONS_TO_SAVE = 100;
   private static final Map<Short, Account> idToRefAccountMap = new HashMap<>();
   private static final Map<Short, Map<Short, Container>> idToRefContainerMap = new HashMap<>();
   private final Properties helixConfigProps = new Properties();
@@ -880,7 +881,7 @@ public class HelixAccountServiceTest {
     HelixAccountService helixAccountService = (HelixAccountService) accountService;
     RouterStore routerStore =
         new RouterStore(helixAccountService.getAccountServiceMetrics(), helixAccountService.getBackupFileManager(),
-            helixStore, new AtomicReference<>(mockRouter), false);
+            helixStore, new AtomicReference<>(mockRouter), false, MAX_NUMBER_OF_VERSIONS_TO_SAVE);
     Map<String, String> accountMap = routerStore.fetchAccountMetadata();
     assertNotNull("Accounts should be backfilled to new znode", accountMap);
     assertAccountMapEquals(accountService.getAllAccounts(), accountMap);

--- a/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -77,7 +76,7 @@ public class MockRouter implements Router {
       BlobInfoAndData blob = allBlobs.get(blobId);
       FutureResult<GetBlobResult> future = new FutureResult<>();
       if (blob == null) {
-        Exception e = new ExecutionException(new RouterException("NotFound", RouterErrorCode.BlobDoesNotExist));
+        Exception e = new RouterException("NotFound", RouterErrorCode.BlobDoesNotExist);
         future.done(null, e);
         if (callback != null) {
           callback.onCompletion(null, e);
@@ -146,7 +145,7 @@ public class MockRouter implements Router {
       FutureResult<Void> future = new FutureResult<>();
       BlobInfoAndData blob = allBlobs.get(blobId);
       if (blob == null) {
-        Exception e = new ExecutionException(new RouterException("NotFound", RouterErrorCode.BlobDoesNotExist));
+        Exception e = new RouterException("NotFound", RouterErrorCode.BlobDoesNotExist);
         future.done(null, e);
         if (callback != null) {
           callback.onCompletion(null, e);
@@ -171,6 +170,12 @@ public class MockRouter implements Router {
 
   @Override
   public void close() throws IOException {
-    return;
+    // close will remove all the blobs
+    lock.lock();
+    try {
+      allBlobs.clear();
+    } finally {
+      lock.unlock();
+    }
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -29,6 +29,7 @@ public class HelixAccountServiceConfig {
   public static final String UPDATE_DISABLED =  HELIX_ACCOUNT_SERVICE_PREFIX + "update.disabled";
   public static final String BACKFILL_ACCOUNTS_TO_NEW_ZNODE = HELIX_ACCOUNT_SERVICE_PREFIX + "backfill.accounts.to.new.znode";
   public static final String ENABLE_SERVE_FROM_BACKUP  = HELIX_ACCOUNT_SERVICE_PREFIX + "enable.serve.from.backup";
+  public static final String MAX_NUMBER_OF_VERSION_TO_SAVE = HELIX_ACCOUNT_SERVICE_PREFIX + "max.number.of.version.to.save";
 
   /**
    * The ZooKeeper server address. This config is required when using {@code HelixAccountService}.
@@ -98,6 +99,15 @@ public class HelixAccountServiceConfig {
   @Default("false")
   public final boolean enableServeFromBackup;
 
+  /**
+   * Maximum number of previous versions to save in the system. Every update account http request would generate a new
+   * version. And when the number of versions surpasses this number, HelixAccountService will purge the oldest one to
+   * make room for the new one.
+   */
+  @Config(MAX_NUMBER_OF_VERSION_TO_SAVE)
+  @Default("100")
+  public final int maxNumberOfVersionToSave;
+
   public HelixAccountServiceConfig(VerifiableProperties verifiableProperties) {
     zkClientConnectString = verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY);
     updaterPollingIntervalMs =
@@ -114,5 +124,6 @@ public class HelixAccountServiceConfig {
     }
 
     enableServeFromBackup = verifiableProperties.getBoolean(ENABLE_SERVE_FROM_BACKUP, false);
+    maxNumberOfVersionToSave = verifiableProperties.getIntInRange(MAX_NUMBER_OF_VERSION_TO_SAVE, 100, 1, Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -29,7 +29,7 @@ public class HelixAccountServiceConfig {
   public static final String UPDATE_DISABLED =  HELIX_ACCOUNT_SERVICE_PREFIX + "update.disabled";
   public static final String BACKFILL_ACCOUNTS_TO_NEW_ZNODE = HELIX_ACCOUNT_SERVICE_PREFIX + "backfill.accounts.to.new.znode";
   public static final String ENABLE_SERVE_FROM_BACKUP  = HELIX_ACCOUNT_SERVICE_PREFIX + "enable.serve.from.backup";
-  public static final String MAX_NUMBER_OF_VERSION_TO_SAVE = HELIX_ACCOUNT_SERVICE_PREFIX + "max.number.of.version.to.save";
+  public static final String TOTAL_NUMBER_OF_VERSION_TO_KEEP = HELIX_ACCOUNT_SERVICE_PREFIX + "total.number.of.version.to.keep";
 
   /**
    * The ZooKeeper server address. This config is required when using {@code HelixAccountService}.
@@ -100,13 +100,13 @@ public class HelixAccountServiceConfig {
   public final boolean enableServeFromBackup;
 
   /**
-   * Maximum number of previous versions to save in the system. Every update account http request would generate a new
-   * version. And when the number of versions surpasses this number, HelixAccountService will purge the oldest one to
-   * make room for the new one.
+   * Total number of previous versions of account metadata to keep in the system. Every update account http request would
+   * generate a new version. And when the number of versions surpasses this number, HelixAccountService will purge the
+   * oldest one to make room for the new one.
    */
-  @Config(MAX_NUMBER_OF_VERSION_TO_SAVE)
+  @Config(TOTAL_NUMBER_OF_VERSION_TO_KEEP)
   @Default("100")
-  public final int maxNumberOfVersionToSave;
+  public final int totalNumberOfVersionToKeep;
 
   public HelixAccountServiceConfig(VerifiableProperties verifiableProperties) {
     zkClientConnectString = verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY);
@@ -122,8 +122,7 @@ public class HelixAccountServiceConfig {
     if (backFillAccountsToNewZNode && useNewZNodePath) {
       throw new IllegalStateException("useNewZNodePath and backFillAccountsToNewZNode can't be true at the same time.");
     }
-
     enableServeFromBackup = verifiableProperties.getBoolean(ENABLE_SERVE_FROM_BACKUP, false);
-    maxNumberOfVersionToSave = verifiableProperties.getIntInRange(MAX_NUMBER_OF_VERSION_TO_SAVE, 100, 1, Integer.MAX_VALUE);
+    totalNumberOfVersionToKeep = verifiableProperties.getIntInRange(TOTAL_NUMBER_OF_VERSION_TO_KEEP, 100, 1, Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -26,10 +26,12 @@ public class HelixAccountServiceConfig {
   public static final String MAX_BACKUP_FILE_COUNT = HELIX_ACCOUNT_SERVICE_PREFIX + "max.backup.file.count";
   public static final String ZK_CLIENT_CONNECT_STRING_KEY = HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string";
   public static final String USE_NEW_ZNODE_PATH = HELIX_ACCOUNT_SERVICE_PREFIX + "use.new.znode.path";
-  public static final String UPDATE_DISABLED =  HELIX_ACCOUNT_SERVICE_PREFIX + "update.disabled";
-  public static final String BACKFILL_ACCOUNTS_TO_NEW_ZNODE = HELIX_ACCOUNT_SERVICE_PREFIX + "backfill.accounts.to.new.znode";
-  public static final String ENABLE_SERVE_FROM_BACKUP  = HELIX_ACCOUNT_SERVICE_PREFIX + "enable.serve.from.backup";
-  public static final String TOTAL_NUMBER_OF_VERSION_TO_KEEP = HELIX_ACCOUNT_SERVICE_PREFIX + "total.number.of.version.to.keep";
+  public static final String UPDATE_DISABLED = HELIX_ACCOUNT_SERVICE_PREFIX + "update.disabled";
+  public static final String BACKFILL_ACCOUNTS_TO_NEW_ZNODE =
+      HELIX_ACCOUNT_SERVICE_PREFIX + "backfill.accounts.to.new.znode";
+  public static final String ENABLE_SERVE_FROM_BACKUP = HELIX_ACCOUNT_SERVICE_PREFIX + "enable.serve.from.backup";
+  public static final String TOTAL_NUMBER_OF_VERSION_TO_KEEP =
+      HELIX_ACCOUNT_SERVICE_PREFIX + "total.number.of.version.to.keep";
 
   /**
    * The ZooKeeper server address. This config is required when using {@code HelixAccountService}.
@@ -123,6 +125,7 @@ public class HelixAccountServiceConfig {
       throw new IllegalStateException("useNewZNodePath and backFillAccountsToNewZNode can't be true at the same time.");
     }
     enableServeFromBackup = verifiableProperties.getBoolean(ENABLE_SERVE_FROM_BACKUP, false);
-    totalNumberOfVersionToKeep = verifiableProperties.getIntInRange(TOTAL_NUMBER_OF_VERSION_TO_KEEP, 100, 1, Integer.MAX_VALUE);
+    totalNumberOfVersionToKeep =
+        verifiableProperties.getIntInRange(TOTAL_NUMBER_OF_VERSION_TO_KEEP, 100, 1, Integer.MAX_VALUE);
   }
 }


### PR DESCRIPTION
Enforcing a upper bound on how many versions of account metadata to save in the ambry-server.