### PR TITLE
Set org.gradle.caching to false

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@
 #
 org.gradle.daemon=true
 org.gradle.configureondemand=true
-org.gradle.caching=true
+org.gradle.caching=false


### PR DESCRIPTION
We are seeing some build failures in dev environment since "org.gradle.caching=true" has been set in gradle.properties.

Some of the failures have been because gradle seems to cache a module if no existing files are modified in the module, and doesn't rebuild when new files are added.
We should set org.gradle.caching to false to fix this. Setting this to true doesn't buy us a lot of performance, because the compilation is fast anyways.