### PR TITLE
Fixes for shipkit plugin usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ branches:
   except:
     - /^v\d/
 script:
-  - ./gradlew -s --scan build codeCoverageReport && ./gradlew -s --scan ciPerformRelease
+  - ./gradlew -s --scan build codeCoverageReport && ./gradlew -s -i --scan ciPerformRelease
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,10 @@ buildscript {
 }
 
 plugins {
-    id 'org.shipkit.java' version '2.2.5'
+    id 'org.shipkit.java' version '2.2.5' apply false
+}
+if (!project.hasProperty('disableShipkit')) {
+    apply plugin: 'org.shipkit.java'
 }
 
 apply from: file('gradle/license.gradle')

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -35,6 +35,12 @@ allprojects {
                 name = 'ambry'
                 licenses = ['Apache-2.0']
                 labels = ['blob storage']
+                version {
+                    // disable upload to maven central
+                    mavenCentralSync {
+                        sync = false
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
- Enable INFO logging when releasing from travis
- Disable maven central sync, which we aren't currently set up to use.
- Add option to disable applying shipkit plugin (some internal systems
  apply additional plugins that conflict)

Tested by building with/without option and inspecting the output of `./gradlew tasks` and `./gradlew -PdisableShipkit tasks`