### PR TITLE
Fix allocation failure in DiskSpaceAllocator and delete segments of removed store

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -701,11 +702,7 @@ class BlobStore implements Store {
     }
     // Step 2: if segmented, delete remaining store segments in reserve pool
     if (log.isLogSegmented()) {
-      Map<String, Map<Long, Long>> storeSegmentRequirement = new HashMap<>();
-      Map<Long, Long> segmentSizeAndNum = new HashMap<>();
-      segmentSizeAndNum.put(log.getSegmentCapacity(), log.getRemainingUnallocatedSegments());
-      storeSegmentRequirement.put(storeId, segmentSizeAndNum);
-      diskSpaceAllocator.deleteExtraSegments(storeSegmentRequirement, false);
+      diskSpaceAllocator.deleteAllSegmentsForStoreIds(Collections.singletonList(storeId));
     }
     // Step 3: delete all files in current store directory
     logger.info("Deleting store {} directory", storeId);

--- a/ambry-store/src/main/java/com.github.ambry.store/DiskSpaceAllocator.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/DiskSpaceAllocator.java
@@ -220,6 +220,9 @@ class DiskSpaceAllocator {
             } else {
               storeReserveFiles.get(storeId).add(sizeInBytes, reserveFile);
             }
+          } else {
+            logger.warn("Reserve file {} doesn't exist when adding it back to in-mem file map",
+                reserveFile.getAbsolutePath());
           }
           throw e;
         }

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -1204,6 +1204,12 @@ public class BlobStoreTest {
         : Collections.singletonList(testStore.getDiskSpaceRequirements()));
     // ensure store directory and file exist
     assertTrue("Store directory doesn't exist", storeDir.exists());
+    File storeSegmentDir = new File(reserveDir, DiskSpaceAllocator.STORE_DIR_PREFIX + storeId);
+    if (isLogSegmented) {
+      assertTrue("Store segment directory doesn't exist", storeSegmentDir.exists());
+      assertTrue("In-mem store file map should contain entry associated with test store",
+          diskAllocator.getStoreReserveFileMap().containsKey(storeId));
+    }
     // test that deletion on started store should fail
     try {
       testStore.deleteStoreFiles();
@@ -1236,7 +1242,9 @@ public class BlobStoreTest {
     assertEquals("Swap reserve dir should have one swap segment", 1,
         diskAllocator.getSwapReserveFileMap().getFileSizeSet().size());
     assertFalse("store directory shouldn't exist", storeDir.exists());
-
+    assertFalse("store segment directory shouldn't exist", storeSegmentDir.exists());
+    assertFalse("test store entry should have been removed from in-mem store file map ",
+        diskAllocator.getStoreReserveFileMap().containsKey(storeId));
     reloadStore();
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/DiskSpaceAllocatorTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/DiskSpaceAllocatorTest.java
@@ -442,11 +442,7 @@ public class DiskSpaceAllocatorTest {
     assertTrue("The number of swap segments in map is not expected",
         alloc.getSwapSegmentBySizeMap().size() == 2 && alloc.getSwapSegmentBySizeMap().get(20L) == 1L);
     // test that segments associated with storeId0 can be correctly deleted
-    Map<String, Map<Long, Long>> deleteStoreRequirement = new HashMap<>();
-    Map<Long, Long> sizeAndFileNum = new HashMap<>();
-    sizeAndFileNum.put(50L, 1L);
-    deleteStoreRequirement.put(storeId0, sizeAndFileNum);
-    alloc.deleteExtraSegments(deleteStoreRequirement, false);
+    alloc.deleteAllSegmentsForStoreIds(Collections.singletonList(storeId0));
     verifyPoolState(new ExpectedState().addStoreSeg(storeId1, 20, 3));
     // verify in-mem store reserve file map doesn't contain storeId0
     Map<String, DiskSpaceAllocator.ReserveFileMap> storeFileMap = alloc.getStoreReserveFileMap();
@@ -471,7 +467,7 @@ public class DiskSpaceAllocatorTest {
     alloc.addRequiredSegments(requirements, true);
     verifyPoolState(null);
     // test that delete segments should be no-op
-    alloc.deleteExtraSegments(requirements, false);
+    alloc.deleteAllSegmentsForStoreIds(Collections.singletonList(storeId1));
     verifyPoolState(null);
   }
 


### PR DESCRIPTION
1. During initialization, DiskSpaceAllocator deletes extra segments (both
store and swap segments). However, the code previously didn't update the
in-mem reserve file map which caused file not found exception when
checking out segment from reserve pool. This PR ensures all the deletion
operation will update in-mem data structure to avoid invalid file
reference in memory.
2. Add some code to complete store removal. Specifically, when store is
successfully removed from storage manager, blobstore should also remove
its segments from reserve pool.