### PR TITLE
Add chunk ID to get exceptions, add max in-mem chunks config

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -343,11 +343,18 @@ public class RouterConfig {
   public final long routerOperationTrackerHistogramDumpPeriod;
 
   /**
-   * The max number of chunks per GetBlobOperation or PutOperation that may be buffered in memory.
+   * The max number of chunks per PutOperation that may be buffered in memory.
    */
-  @Config("router.max.in.mem.chunks")
+  @Config("router.max.in.mem.put.chunks")
   @Default("4")
-  public final int routerMaxInMemChunks;
+  public final int routerMaxInMemPutChunks;
+
+  /**
+   * The max number of chunks per GetBlobOperation that may be buffered in memory.
+   */
+  @Config("router.max.in.mem.get.chunks")
+  @Default("4")
+  public final int routerMaxInMemGetChunks;
 
   /**
    * Create a RouterConfig instance.
@@ -436,6 +443,9 @@ public class RouterConfig {
     }
     routerOperationTrackerTerminateOnNotFoundEnabled =
         verifiableProperties.getBoolean("router.operation.tracker.terminate.on.not.found.enabled", false);
-    routerMaxInMemChunks = verifiableProperties.getIntInRange("router.max.in.mem.chunks", 4, 1, Integer.MAX_VALUE);
+    routerMaxInMemPutChunks = verifiableProperties.getIntInRange("router.max.in.mem.put.chunks", 4, 1,
+        Integer.MAX_VALUE / routerMaxPutChunkSizeBytes);
+    routerMaxInMemGetChunks = verifiableProperties.getIntInRange("router.max.in.mem.get.chunks", 4, 1,
+        Integer.MAX_VALUE / routerMaxPutChunkSizeBytes);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -343,6 +343,13 @@ public class RouterConfig {
   public final long routerOperationTrackerHistogramDumpPeriod;
 
   /**
+   * The max number of chunks per GetBlobOperation or PutOperation that may be buffered in memory.
+   */
+  @Config("router.max.in.mem.chunks")
+  @Default("4")
+  public final int routerMaxInMemChunks;
+
+  /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
    */
@@ -429,5 +436,6 @@ public class RouterConfig {
     }
     routerOperationTrackerTerminateOnNotFoundEnabled =
         verifiableProperties.getBoolean("router.operation.tracker.terminate.on.not.found.enabled", false);
+    routerMaxInMemChunks = verifiableProperties.getIntInRange("router.max.in.mem.chunks", 4, 1, Integer.MAX_VALUE);
   }
 }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -278,7 +278,7 @@ class GetBlobOperation extends GetOperation {
             }
             if (dataChunk.isInProgress() || (dataChunk.isReady()
                 && numChunksRetrieved - blobDataChannel.getNumChunksWrittenOut()
-                < routerConfig.routerMaxInMemChunks)) {
+                < routerConfig.routerMaxInMemGetChunks)) {
               dataChunk.poll(requestRegistrationCallback);
               if (dataChunk.isComplete()) {
                 onChunkOperationComplete(dataChunk);
@@ -1305,7 +1305,7 @@ class GetBlobOperation extends GetOperation {
       } else {
         chunkIdIterator = chunkMetadataList.listIterator();
         numChunksTotal = chunkMetadataList.size();
-        dataChunks = new GetChunk[Math.min(chunkMetadataList.size(), routerConfig.routerMaxInMemChunks)];
+        dataChunks = new GetChunk[Math.min(chunkMetadataList.size(), routerConfig.routerMaxInMemGetChunks)];
         for (int i = 0; i < dataChunks.length; i++) {
           int idx = chunkIdIterator.nextIndex();
           CompositeBlobInfo.ChunkMetadata keyAndOffset = chunkIdIterator.next();

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -72,7 +72,6 @@ class NonBlockingRouter implements Router {
   private static final Logger logger = LoggerFactory.getLogger(NonBlockingRouter.class);
   static final AtomicInteger currentOperationsCount = new AtomicInteger(0);
   private final AtomicInteger currentBackgroundOperationsCount = new AtomicInteger(0);
-  static final int MAX_IN_MEM_CHUNKS = 4;
   static final int SHUTDOWN_WAIT_MS = 10 * Time.MsPerSec;
   static final AtomicInteger correlationIdGenerator = new AtomicInteger(0);
 

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -685,7 +685,7 @@ class PutOperation {
         break;
       }
     }
-    if (chunkToReturn == null && putChunks.size() < NonBlockingRouter.MAX_IN_MEM_CHUNKS) {
+    if (chunkToReturn == null && putChunks.size() < routerConfig.routerMaxInMemChunks) {
       chunkToReturn = new PutChunk();
       putChunks.add(chunkToReturn);
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -685,7 +685,7 @@ class PutOperation {
         break;
       }
     }
-    if (chunkToReturn == null && putChunks.size() < routerConfig.routerMaxInMemChunks) {
+    if (chunkToReturn == null && putChunks.size() < routerConfig.routerMaxInMemPutChunks) {
       chunkToReturn = new PutChunk();
       putChunks.add(chunkToReturn);
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -273,7 +273,7 @@ public class ChunkFillTest {
     int chunksLeftToBeFilled = numChunks;
     do {
       if (testEncryption) {
-        int chunksPerBatch = Math.min(NonBlockingRouter.MAX_IN_MEM_CHUNKS, chunksLeftToBeFilled);
+        int chunksPerBatch = Math.min(routerConfig.routerMaxInMemChunks, chunksLeftToBeFilled);
         CountDownLatch onPollLatch = new CountDownLatch(chunksPerBatch);
         routerCallback.setOnPollLatch(onPollLatch);
         op.fillChunks();

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -273,7 +273,7 @@ public class ChunkFillTest {
     int chunksLeftToBeFilled = numChunks;
     do {
       if (testEncryption) {
-        int chunksPerBatch = Math.min(routerConfig.routerMaxInMemChunks, chunksLeftToBeFilled);
+        int chunksPerBatch = Math.min(routerConfig.routerMaxInMemPutChunks, chunksLeftToBeFilled);
         CountDownLatch onPollLatch = new CountDownLatch(chunksPerBatch);
         routerCallback.setOnPollLatch(onPollLatch);
         op.fillChunks();

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -79,7 +79,7 @@ public class PutOperationTest {
    */
   @Test
   public void testSendIncomplete() throws Exception {
-    int numChunks = NonBlockingRouter.MAX_IN_MEM_CHUNKS + 1;
+    int numChunks = routerConfig.routerMaxInMemChunks + 1;
     BlobProperties blobProperties =
         new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null);
@@ -103,7 +103,7 @@ public class PutOperationTest {
         mockNetworkClient.getAndClearWokenUpStatus());
     // A poll should therefore return requestParallelism number of requests from each chunk
     op.poll(requestRegistrationCallback);
-    Assert.assertEquals(NonBlockingRouter.MAX_IN_MEM_CHUNKS * requestParallelism, requestInfos.size());
+    Assert.assertEquals(routerConfig.routerMaxInMemChunks * requestParallelism, requestInfos.size());
 
     // There are MAX_IN_MEM_CHUNKS + 1 data chunks for this blob (and a metadata chunk).
     // Once the first chunk is completely sent out, the first PutChunk will be reused. What the test verifies is that
@@ -187,7 +187,7 @@ public class PutOperationTest {
    */
   @Test
   public void testSetOperationExceptionAndComplete() throws Exception {
-    int numChunks = NonBlockingRouter.MAX_IN_MEM_CHUNKS + 1;
+    int numChunks = routerConfig.routerMaxInMemChunks + 1;
     BlobProperties blobProperties =
         new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null);

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -79,7 +79,7 @@ public class PutOperationTest {
    */
   @Test
   public void testSendIncomplete() throws Exception {
-    int numChunks = routerConfig.routerMaxInMemChunks + 1;
+    int numChunks = routerConfig.routerMaxInMemPutChunks + 1;
     BlobProperties blobProperties =
         new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null);
@@ -103,9 +103,9 @@ public class PutOperationTest {
         mockNetworkClient.getAndClearWokenUpStatus());
     // A poll should therefore return requestParallelism number of requests from each chunk
     op.poll(requestRegistrationCallback);
-    Assert.assertEquals(routerConfig.routerMaxInMemChunks * requestParallelism, requestInfos.size());
+    Assert.assertEquals(routerConfig.routerMaxInMemPutChunks * requestParallelism, requestInfos.size());
 
-    // There are MAX_IN_MEM_CHUNKS + 1 data chunks for this blob (and a metadata chunk).
+    // There are routerMaxInMemPutChunks + 1 data chunks for this blob (and a metadata chunk).
     // Once the first chunk is completely sent out, the first PutChunk will be reused. What the test verifies is that
     // the buffer of the first PutChunk does not get reused. It does this as follows:
     // For the first chunk,
@@ -187,7 +187,7 @@ public class PutOperationTest {
    */
   @Test
   public void testSetOperationExceptionAndComplete() throws Exception {
-    int numChunks = routerConfig.routerMaxInMemChunks + 1;
+    int numChunks = routerConfig.routerMaxInMemPutChunks + 1;
     BlobProperties blobProperties =
         new BlobProperties(-1, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM), false, null);


### PR DESCRIPTION
Add the chunk ID to the exception messages for any exceptions that
occur when fetching a data chunk in GetBlobOperation.
    
Add config for the max number of data chunks to keep in memory for
a single PutOperations or GetBlobOperation. This also determines
the max number of chunk requests that may be in flight to a server
node in a single operation.
