### PR TITLE
Support adding/removing store via AdminRequest

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -123,6 +123,14 @@ public interface ClusterMap extends AutoCloseable {
   JSONObject getSnapshot();
 
   /**
+   * Attempt to get new replica of certain partition that resides on given data node.
+   * @param partitionIdStr the partition id string
+   * @param dataNodeId the {@link DataNodeId} on which new replica is placed
+   * @return {@link ReplicaId} if there is a new replica satisfying given partition and data node. {@code null} otherwise.
+   */
+  ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId);
+
+  /**
    * Close the cluster map. Any cleanups should be done in this call.
    */
   @Override

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -123,12 +123,14 @@ public interface ClusterMap extends AutoCloseable {
   JSONObject getSnapshot();
 
   /**
-   * Attempt to get new replica of certain partition that resides on given data node.
+   * Attempt to get a bootstrap replica of certain partition that is supposed to be added onto specified data node.
+   * This method is designed to fetch detailed infos about bootstrap replica and create an instance of this replica. The
+   * purpose is to support dynamically adding new replica to specified data node.
    * @param partitionIdStr the partition id string
-   * @param dataNodeId the {@link DataNodeId} on which new replica is placed
+   * @param dataNodeId the {@link DataNodeId} on which bootstrap replica is placed
    * @return {@link ReplicaId} if there is a new replica satisfying given partition and data node. {@code null} otherwise.
    */
-  ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId);
+  ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId);
 
   /**
    * Close the cluster map. Any cleanups should be done in this call.

--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -27,7 +27,7 @@ public class ReplicationConfig {
   /**
    * The factory class the replication uses to create cloud token
    */
-  @Config("replication.cloudtoken.factory")
+  @Config("replication.cloud.token.factory")
   @Default("com.github.ambry.cloud.CloudFindTokenFactory")
   public final String replicationCloudTokenFactory;
 
@@ -134,7 +134,7 @@ public class ReplicationConfig {
   /**
    * The version of metadata request to be used for replication.
    */
-  @Config("replication.metadatarequest.version")
+  @Config("replication.metadata.request.version")
   @Default("1")
   public final short replicaMetadataRequestVersion;
 
@@ -142,7 +142,7 @@ public class ReplicationConfig {
 
     replicationStoreTokenFactory =
         verifiableProperties.getString("replication.token.factory", "com.github.ambry.store.StoreFindTokenFactory");
-    replicationCloudTokenFactory = verifiableProperties.getString("replication.cloudtoken.factory",
+    replicationCloudTokenFactory = verifiableProperties.getString("replication.cloud.token.factory",
         "com.github.ambry.cloud.CloudFindTokenFactory");
     replicationNumOfIntraDCReplicaThreads =
         verifiableProperties.getInt("replication.no.of.intra.dc.replica.threads", 1);
@@ -172,6 +172,6 @@ public class ReplicationConfig {
     replicationTrackPerPartitionLagFromRemote =
         verifiableProperties.getBoolean("replication.track.per.partition.lag.from.remote", false);
     replicaMetadataRequestVersion =
-        verifiableProperties.getShortInRange("replication.metadatarequest.version", (short) 1, (short) 1, (short) 2);
+        verifiableProperties.getShortInRange("replication.metadata.request.version", (short) 1, (short) 1, (short) 2);
   }
 }

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudTokenPersistor.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudTokenPersistor.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +50,7 @@ public class CloudTokenPersistor extends ReplicaTokenPersistor {
    * @param clusterMap the {@link ClusterMap} to deserialize tokens.
    * @param tokenHelper the {@link FindTokenHelper} to deserialize tokens.
    */
-  public CloudTokenPersistor(String replicaTokenFileName, Map<String, List<PartitionInfo>> partitionGroupedByMountPath,
+  public CloudTokenPersistor(String replicaTokenFileName, Map<String, Set<PartitionInfo>> partitionGroupedByMountPath,
       ReplicationMetrics replicationMetrics, ClusterMap clusterMap, FindTokenHelper tokenHelper,
       CloudDestination cloudDestination) {
     super(partitionGroupedByMountPath, replicationMetrics, clusterMap, tokenHelper);

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
@@ -42,7 +42,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -175,12 +174,9 @@ public class VcrReplicationManager extends ReplicationEngine {
       }
       PartitionInfo partitionInfo = new PartitionInfo(remoteReplicaInfos, partitionId, store, cloudReplica);
       partitionToPartitionInfo.put(partitionId, partitionInfo);
-      mountPathToPartitionInfos.compute(cloudReplica.getMountPath(), (key, value) -> {
-        // For CloudBackupManager, at most one PartitionInfo in the list.
-        Set<PartitionInfo> retSet = (value == null) ? ConcurrentHashMap.newKeySet() : value;
-        retSet.add(partitionInfo);
-        return retSet;
-      });
+      // For CloudBackupManager, at most one PartitionInfo in the set.
+      mountPathToPartitionInfos.computeIfAbsent(cloudReplica.getMountPath(), key -> ConcurrentHashMap.newKeySet())
+          .add(partitionInfo);
       partitionStoreMap.put(partitionId.toPathString(), store);
     } else {
       try {

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
@@ -42,6 +42,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.helix.InstanceType;
@@ -175,9 +177,9 @@ public class VcrReplicationManager extends ReplicationEngine {
       partitionToPartitionInfo.put(partitionId, partitionInfo);
       mountPathToPartitionInfos.compute(cloudReplica.getMountPath(), (key, value) -> {
         // For CloudBackupManager, at most one PartitionInfo in the list.
-        List<PartitionInfo> retList = (value == null) ? new ArrayList<>() : value;
-        retList.add(partitionInfo);
-        return retList;
+        Set<PartitionInfo> retSet = (value == null) ? ConcurrentHashMap.newKeySet() : value;
+        retSet.add(partitionInfo);
+        return retSet;
       });
       partitionStoreMap.put(partitionId.toPathString(), store);
     } else {

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrRequests.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrRequests.java
@@ -53,7 +53,7 @@ public class VcrRequests extends AmbryRequests {
       NotificationSystem notification, ReplicationEngine replicationEngine, StoreKeyFactory storageKeyFactory,
       boolean enableDataPrefetch, StoreKeyConverterFactory storeKeyConverterFactory) {
     super(storeManager, requestResponseChannel, clusterMap, currentNode, registry, serverMetrics, findTokenHelper,
-        notification, replicationEngine, storageKeyFactory, enableDataPrefetch, storeKeyConverterFactory);
+        notification, replicationEngine, storageKeyFactory, enableDataPrefetch, storeKeyConverterFactory, null);
   }
 
   @Override

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudTokenPersistorTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudTokenPersistorTest.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -52,7 +54,7 @@ public class CloudTokenPersistorTest {
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     ClusterMap clusterMap = new MockClusterMap();
     DataNodeId dataNodeId = new CloudDataNode(cloudConfig, clusterMapConfig);
-    Map<String, List<PartitionInfo>> mountPathToPartitionInfoList = new HashMap<>();
+    Map<String, Set<PartitionInfo>> mountPathToPartitionInfoList = new HashMap<>();
     BlobIdFactory blobIdFactory = new BlobIdFactory(clusterMap);
     StoreFindTokenFactory factory = new StoreFindTokenFactory(blobIdFactory);
     PartitionId partitionId = clusterMap.getAllPartitionIds(null).get(0);
@@ -70,7 +72,7 @@ public class CloudTokenPersistorTest {
       replicaTokenInfos.add(new RemoteReplicaInfo.ReplicaTokenInfo(remoteReplicaInfo));
     }
     PartitionInfo partitionInfo = new PartitionInfo(remoteReplicas, partitionId, null, cloudReplicaId);
-    mountPathToPartitionInfoList.computeIfAbsent(cloudReplicaId.getMountPath(), key -> new ArrayList<>())
+    mountPathToPartitionInfoList.computeIfAbsent(cloudReplicaId.getMountPath(), key -> ConcurrentHashMap.newKeySet())
         .add(partitionInfo);
 
     LatchBasedInMemoryCloudDestination cloudDestination =

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -288,6 +288,11 @@ class CompositeClusterManager implements ClusterMap {
   }
 
   @Override
+  public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+    return helixClusterManager.getNewReplica(partitionIdStr, dataNodeId);
+  }
+
+  @Override
   public void close() {
     staticClusterManager.close();
     if (helixClusterManager != null) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -288,8 +288,8 @@ class CompositeClusterManager implements ClusterMap {
   }
 
   @Override
-  public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
-    return helixClusterManager.getNewReplica(partitionIdStr, dataNodeId);
+  public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
+    return helixClusterManager.getBootstrapReplica(partitionIdStr, dataNodeId);
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -87,6 +88,7 @@ class HelixClusterManager implements ClusterMap {
   final HelixClusterManagerMetrics helixClusterManagerMetrics;
   private final PartitionSelectionHelper partitionSelectionHelper;
   private final Map<String, Map<String, String>> partitionOverrideInfoMap = new HashMap<>();
+  private ZkHelixPropertyStore<ZNRecord> helixPropertyStoreInLocalDc = null;
   // The current xid currently does not change after instantiation. This can change in the future, allowing the cluster
   // manager to dynamically incorporate newer changes in the cluster. This variable is atomic so that the gauge metric
   // reflects the current value.
@@ -216,13 +218,13 @@ class HelixClusterManager implements ClusterMap {
     DcZkInfo dcZkInfo = dataCenterToZkAddress.get(clusterMapConfig.clusterMapDatacenterName);
     String zkConnectStr = dcZkInfo.getZkConnectStr();
     HelixManager manager;
-    ZkHelixPropertyStore<ZNRecord> helixPropertyStore;
     manager = helixFactory.getZKHelixManager(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectStr);
     logger.info("Connecting to Helix manager in local zookeeper at {}", zkConnectStr);
     manager.connect();
     logger.info("Established connection to Helix manager in local zookeeper at {}", zkConnectStr);
-    helixPropertyStore = manager.getHelixPropertyStore();
-    logger.info("HelixPropertyStore from local datacenter {} is: {}", dcZkInfo.getDcName(), helixPropertyStore);
+    helixPropertyStoreInLocalDc = manager.getHelixPropertyStore();
+    logger.info("HelixPropertyStore from local datacenter {} is: {}", dcZkInfo.getDcName(),
+        helixPropertyStoreInLocalDc);
     IZkDataListener dataListener = new IZkDataListener() {
       @Override
       public void handleDataChange(String dataPath, Object data) {
@@ -235,10 +237,9 @@ class HelixClusterManager implements ClusterMap {
       }
     };
     logger.info("Subscribing data listener to HelixPropertyStore.");
-    helixPropertyStore.subscribeDataChanges(ClusterMapUtils.PARTITION_OVERRIDE_ZNODE_PATH, dataListener);
-    logger.info("Getting ZNRecord from HelixPropertyStore");
-    ZNRecord zNRecord =
-        helixPropertyStore.get(ClusterMapUtils.PARTITION_OVERRIDE_ZNODE_PATH, null, AccessOption.PERSISTENT);
+    helixPropertyStoreInLocalDc.subscribeDataChanges(PARTITION_OVERRIDE_ZNODE_PATH, dataListener);
+    logger.info("Getting PartitionOverride ZNRecord from HelixPropertyStore");
+    ZNRecord zNRecord = helixPropertyStoreInLocalDc.get(PARTITION_OVERRIDE_ZNODE_PATH, null, AccessOption.PERSISTENT);
     if (clusterMapConfig.clusterMapEnablePartitionOverride) {
       if (zNRecord != null) {
         partitionOverrideInfoMap.putAll(zNRecord.getMapFields());
@@ -379,6 +380,55 @@ class HelixClusterManager implements ClusterMap {
   @Override
   public List<PartitionId> getAllPartitionIds(String partitionClass) {
     return partitionSelectionHelper.getPartitions(partitionClass);
+  }
+
+  @Override
+  public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+    ReplicaId newReplica = null;
+    logger.info("Getting ReplicaAddition ZNRecord from HelixPropertyStore in local DC.");
+    ZNRecord zNRecord = helixPropertyStoreInLocalDc.get(REPLICA_ADDITION_ZNODE_PATH, null, AccessOption.PERSISTENT);
+    if (zNRecord != null) {
+      String instanceName = getInstanceName(dataNodeId.getHostname(), dataNodeId.getPort());
+      Map<String, Map<String, String>> partitionToReplicas = zNRecord.getMapFields();
+      Map<String, String> replicaInfos = partitionToReplicas.get(partitionIdStr);
+      if (replicaInfos != null && replicaInfos.containsKey(instanceName)) {
+        long replicaCapacity = Long.valueOf(replicaInfos.get(REPLICAS_CAPACITY_STR));
+        String partitionClass = replicaInfos.get(PARTITION_CLASS_STR);
+        AmbryPartition mappedPartition = partitionNameToAmbryPartition.get(partitionIdStr);
+        if (mappedPartition == null) {
+          logger.info("Partition {} is currently not present in cluster map, creating a new partition.",
+              partitionIdStr);
+          mappedPartition =
+              new AmbryPartition(Long.valueOf(partitionIdStr), partitionClass, helixClusterManagerCallback);
+        }
+        // Check if data or disk is in current cluster map, if not, set newReplica to null.
+        AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instanceName);
+        String mountPathFromHelix = replicaInfos.get(instanceName);
+        Set<AmbryDisk> disks = dataNode != null ? ambryDataNodeToAmbryDisks.get(dataNode) : null;
+        Optional<AmbryDisk> potentialDisk =
+            disks != null ? disks.stream().filter(d -> d.getMountPath().equals(mountPathFromHelix)).findAny()
+                : Optional.empty();
+        if (dataNode != null && potentialDisk.isPresent()) {
+          try {
+            newReplica =
+                new AmbryReplica(clusterMapConfig, mappedPartition, potentialDisk.get(), true, replicaCapacity, false);
+          } catch (Exception e) {
+            logger.error("Failed to create new replica for partition {} on {} due to exception: ", partitionIdStr,
+                instanceName, e);
+            newReplica = null;
+          }
+        } else {
+          logger.error(
+              "Either datanode or disk that associated with new replica is not found in cluster map. Cannot create new replica.");
+        }
+      } else {
+        logger.warn("Partition {} or replica on host {} is not found in replica info map", partitionIdStr,
+            instanceName);
+      }
+    } else {
+      logger.warn("ZNRecord from HelixPropertyStore is NULL, partition to replicaInfo map doesn't exist.");
+    }
+    return newReplica;
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -382,51 +382,72 @@ class HelixClusterManager implements ClusterMap {
     return partitionSelectionHelper.getPartitions(partitionClass);
   }
 
+  /**
+   * {@inheritDoc}
+   * To create bootstrap replica, {@link HelixClusterManager} needs to fetch replica info (i.e. capacity, mount path)
+   * from Helix PropertyStore. This method looks up the ZNode in local datacenter and does some validation. Right now,
+   * {@link HelixClusterManager} supports getting bootstrap replica of new partition but it doesn't support getting replica
+   * residing on hosts that are not present in clustermap.
+   * The ZNRecord of REPLICA_ADDITION_ZNODE has following format in mapFields.
+   * <p/>
+   * "mapFields": {
+   *     "1": {
+   *         "replicaCapacityInBytes": 107374182400,
+   *         "partitionClass": "max-replicas-all-datacenters",
+   *         "localhost1_17088": "/tmp/c/1",
+   *         "localhost2_17088": "/tmp/d/1"
+   *     },
+   *     "2": {
+   *         "replicaCapacityInBytes": 107374182400,
+   *         "partitionClass": "max-replicas-all-datacenters",
+   *         "localhost3_17088": "/tmp/e/1"
+   *     }
+   * }
+   * In above example, two bootstrap replicas of partition[1] will be added to localhost1 and localhost2 respectively.
+   * The host name is followed by mount path on which the bootstrap replica should be placed.
+   */
   @Override
-  public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+  public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
     ReplicaId newReplica = null;
     logger.info("Getting ReplicaAddition ZNRecord from HelixPropertyStore in local DC.");
     ZNRecord zNRecord = helixPropertyStoreInLocalDc.get(REPLICA_ADDITION_ZNODE_PATH, null, AccessOption.PERSISTENT);
-    if (zNRecord != null) {
-      String instanceName = getInstanceName(dataNodeId.getHostname(), dataNodeId.getPort());
-      Map<String, Map<String, String>> partitionToReplicas = zNRecord.getMapFields();
-      Map<String, String> replicaInfos = partitionToReplicas.get(partitionIdStr);
-      if (replicaInfos != null && replicaInfos.containsKey(instanceName)) {
-        long replicaCapacity = Long.valueOf(replicaInfos.get(REPLICAS_CAPACITY_STR));
-        String partitionClass = replicaInfos.get(PARTITION_CLASS_STR);
-        AmbryPartition mappedPartition = partitionNameToAmbryPartition.get(partitionIdStr);
-        if (mappedPartition == null) {
-          logger.info("Partition {} is currently not present in cluster map, creating a new partition.",
-              partitionIdStr);
-          mappedPartition =
-              new AmbryPartition(Long.valueOf(partitionIdStr), partitionClass, helixClusterManagerCallback);
-        }
-        // Check if data node or disk is in current cluster map, if not, set newReplica to null.
-        AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instanceName);
-        String mountPathFromHelix = replicaInfos.get(instanceName);
-        Set<AmbryDisk> disks = dataNode != null ? ambryDataNodeToAmbryDisks.get(dataNode) : null;
-        Optional<AmbryDisk> potentialDisk =
-            disks != null ? disks.stream().filter(d -> d.getMountPath().equals(mountPathFromHelix)).findAny()
-                : Optional.empty();
-        if (dataNode != null && potentialDisk.isPresent()) {
-          try {
-            newReplica =
-                new AmbryReplica(clusterMapConfig, mappedPartition, potentialDisk.get(), true, replicaCapacity, false);
-          } catch (Exception e) {
-            logger.error("Failed to create new replica for partition {} on {} due to exception: ", partitionIdStr,
-                instanceName, e);
-            newReplica = null;
-          }
-        } else {
-          logger.error(
-              "Either datanode or disk that associated with new replica is not found in cluster map. Cannot create new replica.");
-        }
-      } else {
-        logger.warn("Partition {} or replica on host {} is not found in replica info map", partitionIdStr,
-            instanceName);
+    if (zNRecord == null) {
+      logger.warn("ZNRecord from HelixPropertyStore is NULL, partition to replicaInfo map doesn't exist.");
+      return null;
+    }
+    String instanceName = getInstanceName(dataNodeId.getHostname(), dataNodeId.getPort());
+    Map<String, Map<String, String>> partitionToReplicas = zNRecord.getMapFields();
+    Map<String, String> replicaInfos = partitionToReplicas.get(partitionIdStr);
+    if (replicaInfos == null || !replicaInfos.containsKey(instanceName)) {
+      logger.warn("Partition {} or replica on host {} is not found in replica info map", partitionIdStr, instanceName);
+      return null;
+    }
+    long replicaCapacity = Long.parseLong(replicaInfos.get(REPLICAS_CAPACITY_STR));
+    String partitionClass = replicaInfos.get(PARTITION_CLASS_STR);
+    AmbryPartition mappedPartition = partitionNameToAmbryPartition.get(partitionIdStr);
+    if (mappedPartition == null) {
+      logger.info("Partition {} is currently not present in cluster map, creating a new partition.", partitionIdStr);
+      mappedPartition = new AmbryPartition(Long.parseLong(partitionIdStr), partitionClass, helixClusterManagerCallback);
+    }
+    // Check if data node or disk is in current cluster map, if not, set newReplica to null.
+    AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instanceName);
+    String mountPathFromHelix = replicaInfos.get(instanceName);
+    Set<AmbryDisk> disks = dataNode != null ? ambryDataNodeToAmbryDisks.get(dataNode) : null;
+    Optional<AmbryDisk> potentialDisk =
+        disks != null ? disks.stream().filter(d -> d.getMountPath().equals(mountPathFromHelix)).findAny()
+            : Optional.empty();
+    if (potentialDisk.isPresent()) {
+      try {
+        newReplica =
+            new AmbryReplica(clusterMapConfig, mappedPartition, potentialDisk.get(), true, replicaCapacity, false);
+      } catch (Exception e) {
+        logger.error("Failed to create new replica for partition {} on {} due to exception: ", partitionIdStr,
+            instanceName, e);
+        newReplica = null;
       }
     } else {
-      logger.warn("ZNRecord from HelixPropertyStore is NULL, partition to replicaInfo map doesn't exist.");
+      logger.error(
+          "Either datanode or disk that associated with new replica is not found in cluster map. Cannot create new replica.");
     }
     return newReplica;
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -389,7 +389,7 @@ class HelixClusterManager implements ClusterMap {
    * {@link HelixClusterManager} supports getting bootstrap replica of new partition but it doesn't support getting replica
    * residing on hosts that are not present in clustermap.
    * The ZNRecord of REPLICA_ADDITION_ZNODE has following format in mapFields.
-   * <p/>
+   * <pre>
    * "mapFields": {
    *     "1": {
    *         "replicaCapacityInBytes": 107374182400,
@@ -403,6 +403,7 @@ class HelixClusterManager implements ClusterMap {
    *         "localhost3_17088": "/tmp/e/1"
    *     }
    * }
+   * </pre>
    * In above example, two bootstrap replicas of partition[1] will be added to localhost1 and localhost2 respectively.
    * The host name is followed by mount path on which the bootstrap replica should be placed.
    */

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -408,7 +408,7 @@ class HelixClusterManager implements ClusterMap {
    */
   @Override
   public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
-    ReplicaId newReplica = null;
+    ReplicaId bootstrapReplica = null;
     logger.info("Getting ReplicaAddition ZNRecord from HelixPropertyStore in local DC.");
     ZNRecord zNRecord = helixPropertyStoreInLocalDc.get(REPLICA_ADDITION_ZNODE_PATH, null, AccessOption.PERSISTENT);
     if (zNRecord == null) {
@@ -429,7 +429,7 @@ class HelixClusterManager implements ClusterMap {
       logger.info("Partition {} is currently not present in cluster map, creating a new partition.", partitionIdStr);
       mappedPartition = new AmbryPartition(Long.parseLong(partitionIdStr), partitionClass, helixClusterManagerCallback);
     }
-    // Check if data node or disk is in current cluster map, if not, set newReplica to null.
+    // Check if data node or disk is in current cluster map, if not, set bootstrapReplica to null.
     AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instanceName);
     String mountPathFromHelix = replicaInfos.get(instanceName);
     Set<AmbryDisk> disks = dataNode != null ? ambryDataNodeToAmbryDisks.get(dataNode) : null;
@@ -438,18 +438,18 @@ class HelixClusterManager implements ClusterMap {
             : Optional.empty();
     if (potentialDisk.isPresent()) {
       try {
-        newReplica =
+        bootstrapReplica =
             new AmbryReplica(clusterMapConfig, mappedPartition, potentialDisk.get(), true, replicaCapacity, false);
       } catch (Exception e) {
-        logger.error("Failed to create new replica for partition {} on {} due to exception: ", partitionIdStr,
+        logger.error("Failed to create bootstrap replica for partition {} on {} due to exception: ", partitionIdStr,
             instanceName, e);
-        newReplica = null;
+        bootstrapReplica = null;
       }
     } else {
       logger.error(
-          "Either datanode or disk that associated with new replica is not found in cluster map. Cannot create new replica.");
+          "Either datanode or disk that associated with bootstrap replica is not found in cluster map. Cannot create the replica.");
     }
-    return newReplica;
+    return bootstrapReplica;
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -401,7 +401,7 @@ class HelixClusterManager implements ClusterMap {
           mappedPartition =
               new AmbryPartition(Long.valueOf(partitionIdStr), partitionClass, helixClusterManagerCallback);
         }
-        // Check if data or disk is in current cluster map, if not, set newReplica to null.
+        // Check if data node or disk is in current cluster map, if not, set newReplica to null.
         AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instanceName);
         String mountPathFromHelix = replicaInfos.get(instanceName);
         Set<AmbryDisk> disks = dataNode != null ? ambryDataNodeToAmbryDisks.get(dataNode) : null;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -534,9 +534,9 @@ class StaticClusterManager implements ClusterMap {
   }
 
   @Override
-  public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+  public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
     throw new UnsupportedOperationException(
-        "Adding new replica is currently not supported in static cluster manager. Return null here");
+        "Adding new replica is currently not supported in static cluster manager.");
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -534,6 +534,12 @@ class StaticClusterManager implements ClusterMap {
   }
 
   @Override
+  public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+    throw new UnsupportedOperationException(
+        "Adding new replica is currently not supported in static cluster manager. Return null here");
+  }
+
+  @Override
   public void close() {
     // No-op.
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -48,6 +48,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
@@ -87,6 +88,7 @@ public class HelixClusterManagerTest {
 
   // for verifying getPartitions() and getWritablePartitions()
   private static final String SPECIAL_PARTITION_CLASS = "specialPartitionClass";
+  private static final String NEW_PARTITION_ID_STR = "100";
   private final PartitionRangeCheckParams defaultRw;
   private final PartitionRangeCheckParams specialRw;
   private final PartitionRangeCheckParams defaultRo;
@@ -127,7 +129,7 @@ public class HelixClusterManagerTest {
     int port = 2200;
     byte dcId = (byte) 0;
     for (String dcName : dcs) {
-      dcsToZkInfo.put(dcName, new com.github.ambry.utils.TestUtils.ZkInfo(tempDirPath, dcName, dcId++, port++, false));
+      dcsToZkInfo.put(dcName, new com.github.ambry.utils.TestUtils.ZkInfo(tempDirPath, dcName, dcId++, port++, true));
     }
     hardwareLayoutPath = tempDirPath + File.separator + "hardwareLayoutTest.json";
     partitionLayoutPath = tempDirPath + File.separator + "partitionLayoutTest.json";
@@ -135,7 +137,6 @@ public class HelixClusterManagerTest {
     JSONObject zkJson = constructZkLayoutJSON(dcsToZkInfo.values());
     testHardwareLayout = constructInitialHardwareLayoutJSON(clusterNameStatic);
     testPartitionLayout = constructInitialPartitionLayoutJSON(testHardwareLayout, 3, localDc);
-
     // for getPartitions() and getWritablePartitions() tests
     assertTrue("There should be more than 1 replica per partition in each DC for some of these tests to work",
         testPartitionLayout.replicaCountPerDc > 1);
@@ -172,7 +173,7 @@ public class HelixClusterManagerTest {
       partitionOverrideMap.computeIfAbsent(String.valueOf(i), k -> new HashMap<>())
           .put(ClusterMapUtils.PARTITION_STATE, ClusterMapUtils.READ_ONLY_STR);
     }
-    znRecord = new ZNRecord(ClusterMapUtils.PARTITION_OVERRIDE_STR);
+    znRecord = new ZNRecord(PARTITION_OVERRIDE_STR);
     znRecord.setMapFields(partitionOverrideMap);
 
     helixCluster =
@@ -198,7 +199,9 @@ public class HelixClusterManagerTest {
     props.setProperty("clustermap.enable.partition.override", Boolean.toString(overrideEnabled));
     props.setProperty("clustermap.listen.cross.colo", Boolean.toString(listenCrossColo));
     clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
-    MockHelixManagerFactory helixManagerFactory = new MockHelixManagerFactory(helixCluster, znRecord, null);
+    Map<String, ZNRecord> znRecordMap = new HashMap<>();
+    znRecordMap.put(PARTITION_OVERRIDE_ZNODE_PATH, znRecord);
+    MockHelixManagerFactory helixManagerFactory = new MockHelixManagerFactory(helixCluster, znRecordMap, null);
     if (useComposite) {
       StaticClusterAgentsFactory staticClusterAgentsFactory =
           new StaticClusterAgentsFactory(clusterMapConfig, hardwareLayoutPath, partitionLayoutPath);
@@ -218,6 +221,9 @@ public class HelixClusterManagerTest {
   public void after() {
     if (clusterManager != null) {
       clusterManager.close();
+    }
+    for (com.github.ambry.utils.TestUtils.ZkInfo zkInfo : dcsToZkInfo.values()) {
+      zkInfo.shutdown();
     }
   }
 
@@ -294,6 +300,9 @@ public class HelixClusterManagerTest {
   @Test
   public void emptyPartitionOverrideTest() throws Exception {
     assumeTrue(overrideEnabled);
+    // Close the one initialized in the constructor, as this test needs to test fetching override map from property store as well.
+    // Otherwise, the ZNRecord still exists and HelixClusterManager will populate override map based on ZNRecord.
+    clusterManager.close();
     metricRegistry = new MetricRegistry();
     // create a MockHelixManagerFactory
     ClusterMap clusterManagerWithEmptyRecord = new HelixClusterManager(clusterMapConfig, selfInstanceName,
@@ -310,6 +319,115 @@ public class HelixClusterManagerTest {
       writableInCluster = helixCluster.getAllWritablePartitions();
     }
     assertEquals("Mismatch in writable partitions during initialization", writableInCluster, writableInClusterManager);
+  }
+
+  /**
+   * Test HelixClusterManager can get a new replica with given partitionId, hostname and port number.
+   * @throws Exception
+   */
+  @Test
+  public void getNewReplicaTest() throws Exception {
+    assumeTrue(!useComposite);
+    clusterManager.close();
+    metricRegistry = new MetricRegistry();
+    // 1. test the case where ZNRecord is NULL in Helix PropertyStore
+    HelixClusterManager helixClusterManager =
+        new HelixClusterManager(clusterMapConfig, hostname, new MockHelixManagerFactory(helixCluster, null, null),
+            metricRegistry);
+    PartitionId partitionOfNewReplica = helixClusterManager.getAllPartitionIds(null).get(0);
+    DataNode dataNodeOfNewReplica = testHardwareLayout.getAllExistingDataNodes().get(0);
+    assertNull("New replica should be null because no replica infos ZNRecord in Helix",
+        helixClusterManager.getNewReplica(partitionOfNewReplica.toPathString(), dataNodeOfNewReplica));
+    helixClusterManager.close();
+
+    // Prepare new replica info map in Helix property store. We use the first partition and first data node in HardwareLayout
+    // and PartitionLayout to build the replica info map of an existing partition. Also, we place a new partition on last
+    // data node in HardwareLayout. The format should be as follows.
+    // {
+    //   "0":{
+    //       "partitionClass" : "defaultPartitionClass"
+    //       "replicaCapacityInBytes" : "107374182400"
+    //       "localhost_18088" : "/mnt0"
+    //   }
+    //   "100":{
+    //       "partitionClass" : "defaultPartitionClass"
+    //       "replicaCapacityInBytes" : "107374182400"
+    //       "localhost_18099" : "/mnt5"
+    //       "localhost_18088" : "/mnt10"
+    //       "newhost_001"     : "/mnt0"
+    //   }
+    // }
+    Map<String, Map<String, String>> partitionToReplicaInfosMap = new HashMap<>();
+    // new replica of existing partition
+    Map<String, String> newReplicaInfos1 = new HashMap<>();
+    newReplicaInfos1.put(PARTITION_CLASS_STR, DEFAULT_PARTITION_CLASS);
+    newReplicaInfos1.put(REPLICAS_CAPACITY_STR, String.valueOf(TestPartitionLayout.defaultReplicaCapacityInBytes));
+    newReplicaInfos1.put(dataNodeOfNewReplica.getHostname() + "_" + dataNodeOfNewReplica.getPort(),
+        dataNodeOfNewReplica.getDisks().get(0).getMountPath());
+    partitionToReplicaInfosMap.put(partitionOfNewReplica.toPathString(), newReplicaInfos1);
+    // new replica of a new partition
+    Map<String, String> newReplicaInfos2 = new HashMap<>();
+    newReplicaInfos2.put(PARTITION_CLASS_STR, DEFAULT_PARTITION_CLASS);
+    newReplicaInfos2.put(REPLICAS_CAPACITY_STR, String.valueOf(TestPartitionLayout.defaultReplicaCapacityInBytes));
+    DataNode dataNodeOfNewPartition =
+        testHardwareLayout.getAllExistingDataNodes().get(testHardwareLayout.getDataNodeCount() - 1);
+    int diskNum = dataNodeOfNewPartition.getDisks().size();
+    newReplicaInfos2.put(dataNodeOfNewPartition.getHostname() + "_" + dataNodeOfNewPartition.getPort(),
+        dataNodeOfNewPartition.getDisks().get(diskNum - 1).getMountPath());
+    // add two fake entries (fake disk and fake host)
+    newReplicaInfos2.put(getInstanceName(dataNodeOfNewReplica.getHostname(), dataNodeOfNewReplica.getPort()), "/mnt10");
+    newReplicaInfos2.put("newhost_100", "/mnt0");
+    partitionToReplicaInfosMap.put(NEW_PARTITION_ID_STR, newReplicaInfos2);
+    // fake node that doesn't exist in current clustermap
+    DataNodeId fakeNode = Mockito.mock(DataNode.class);
+    Mockito.when(fakeNode.getHostname()).thenReturn("new_host");
+    Mockito.when(fakeNode.getPort()).thenReturn(100);
+    // set ZNRecord
+    ZNRecord replicaInfosZNRecord = new ZNRecord(REPLICA_ADDITION_STR);
+    replicaInfosZNRecord.setMapFields(partitionToReplicaInfosMap);
+    // populate znRecordMap
+    Map<String, ZNRecord> znRecordMap = new HashMap<>();
+    znRecordMap.put(REPLICA_ADDITION_ZNODE_PATH, replicaInfosZNRecord);
+    // create a new cluster manager
+    metricRegistry = new MetricRegistry();
+    helixClusterManager = new HelixClusterManager(clusterMapConfig, hostname,
+        new MockHelixManagerFactory(helixCluster, znRecordMap, null), metricRegistry);
+
+    // 2. test that no partition or no host is found in helix property store that associates with new replica
+    // select a partition that doesn't equal to partitionOfNewReplica dataNodeOfNewReplica
+    PartitionId partitionForTest;
+    Random random = new Random();
+    List<PartitionId> partitionsInClusterManager = helixClusterManager.getAllPartitionIds(null);
+    do {
+      partitionForTest = partitionsInClusterManager.get(random.nextInt(partitionsInClusterManager.size()));
+    } while (partitionForTest == partitionOfNewReplica);
+    assertNull("New replica should be null because given partition id is not in Helix property store",
+        helixClusterManager.getNewReplica(partitionForTest.toPathString(), dataNodeOfNewReplica));
+    // select partitionOfNewReplica but a random node that doesn't equal to
+    DataNode dataNodeForTest;
+    List<DataNode> dataNodesInHardwareLayout = testHardwareLayout.getAllExistingDataNodes();
+    do {
+      dataNodeForTest = dataNodesInHardwareLayout.get(random.nextInt(dataNodesInHardwareLayout.size()));
+    } while (dataNodeForTest == dataNodeOfNewReplica);
+    assertNull("New replica should be null because hostname is not found in replica info map",
+        helixClusterManager.getNewReplica(partitionOfNewReplica.toPathString(), dataNodeForTest));
+
+    // 3. test that new replica is from a new partition which doesn't exist in current cluster yet. (Mock adding new partition case)
+    //    3.1 test new partition on host that is not present in current clustermap
+    assertNull("New replica should be null because host is not present in clustermap",
+        helixClusterManager.getNewReplica(NEW_PARTITION_ID_STR, fakeNode));
+    //    3.2 test new partition on disk that doesn't exist
+    assertNull("New replica should be null because disk doesn't exist",
+        helixClusterManager.getNewReplica(NEW_PARTITION_ID_STR, dataNodeOfNewReplica));
+    //    3.3 test replica is created for new partition
+    assertNotNull("New replica should be created successfully",
+        helixClusterManager.getNewReplica(NEW_PARTITION_ID_STR, dataNodeOfNewPartition));
+
+    // 4. test that new replica of existing partition is successfully created based on infos from Helix property store.
+    assertNotNull("New replica should be created successfully",
+        helixClusterManager.getNewReplica(partitionOfNewReplica.toPathString(), dataNodeOfNewReplica));
+
+    helixClusterManager.close();
   }
 
   /**
@@ -584,7 +702,9 @@ public class HelixClusterManagerTest {
       Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
       helixCluster.upgradeWithNewPartitionLayout(partitionLayoutPath);
       clusterManager.close();
-      MockHelixManagerFactory helixManagerFactory = new MockHelixManagerFactory(helixCluster, znRecord, null);
+      Map<String, ZNRecord> znRecordMap = new HashMap<>();
+      znRecordMap.put(PARTITION_OVERRIDE_ZNODE_PATH, znRecord);
+      MockHelixManagerFactory helixManagerFactory = new MockHelixManagerFactory(helixCluster, znRecordMap, null);
       HelixClusterManager clusterManager =
           new HelixClusterManager(clusterMapConfig, selfInstanceName, helixManagerFactory, new MetricRegistry());
       // Ensure the new RW partition is added
@@ -1037,18 +1157,19 @@ public class HelixClusterManagerTest {
   private static class MockHelixManagerFactory extends HelixFactory {
     private final MockHelixCluster helixCluster;
     private final Exception beBadException;
-    private final ZNRecord znRecord;
+    private final Map<String, ZNRecord> znRecordMap;
 
     /**
      * Construct this factory
      * @param helixCluster the {@link MockHelixCluster} that this factory's manager will be associated with.
-     * @param znRecord the {@link ZNRecord} that will be used to set HelixPropertyStore by this factory's manager.
+     * @param znRecordMap A map that maps ZNode path to corresponding {@link ZNRecord} that will be used in HelixPropertyStore.
      * @param beBadException the {@link Exception} that the Helix Manager constructed by this factory will throw.
      */
-    MockHelixManagerFactory(MockHelixCluster helixCluster, ZNRecord znRecord, Exception beBadException) {
+    MockHelixManagerFactory(MockHelixCluster helixCluster, Map<String, ZNRecord> znRecordMap,
+        Exception beBadException) {
       this.helixCluster = helixCluster;
       this.beBadException = beBadException;
-      this.znRecord = znRecord;
+      this.znRecordMap = znRecordMap;
     }
 
     /**
@@ -1061,7 +1182,7 @@ public class HelixClusterManagerTest {
      */
     HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddr) {
       if (helixCluster.getZkAddrs().contains(zkAddr)) {
-        return new MockHelixManager(instanceName, instanceType, zkAddr, helixCluster, znRecord, beBadException);
+        return new MockHelixManager(instanceName, instanceType, zkAddr, helixCluster, znRecordMap, beBadException);
       } else {
         throw new IllegalArgumentException("Invalid ZkAddr");
       }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -337,7 +337,7 @@ public class HelixClusterManagerTest {
     PartitionId partitionOfNewReplica = helixClusterManager.getAllPartitionIds(null).get(0);
     DataNode dataNodeOfNewReplica = testHardwareLayout.getAllExistingDataNodes().get(0);
     assertNull("New replica should be null because no replica infos ZNRecord in Helix",
-        helixClusterManager.getNewReplica(partitionOfNewReplica.toPathString(), dataNodeOfNewReplica));
+        helixClusterManager.getBootstrapReplica(partitionOfNewReplica.toPathString(), dataNodeOfNewReplica));
     helixClusterManager.close();
 
     // Prepare new replica info map in Helix property store. We use the first partition and first data node in HardwareLayout
@@ -402,7 +402,7 @@ public class HelixClusterManagerTest {
       partitionForTest = partitionsInClusterManager.get(random.nextInt(partitionsInClusterManager.size()));
     } while (partitionForTest.toString().equals(partitionOfNewReplica.toString()));
     assertNull("New replica should be null because given partition id is not in Helix property store",
-        helixClusterManager.getNewReplica(partitionForTest.toPathString(), dataNodeOfNewReplica));
+        helixClusterManager.getBootstrapReplica(partitionForTest.toPathString(), dataNodeOfNewReplica));
     // select partitionOfNewReplica but a random node that doesn't equal to
     DataNode dataNodeForTest;
     List<DataNode> dataNodesInHardwareLayout = testHardwareLayout.getAllExistingDataNodes();
@@ -410,22 +410,22 @@ public class HelixClusterManagerTest {
       dataNodeForTest = dataNodesInHardwareLayout.get(random.nextInt(dataNodesInHardwareLayout.size()));
     } while (dataNodeForTest == dataNodeOfNewReplica);
     assertNull("New replica should be null because hostname is not found in replica info map",
-        helixClusterManager.getNewReplica(partitionOfNewReplica.toPathString(), dataNodeForTest));
+        helixClusterManager.getBootstrapReplica(partitionOfNewReplica.toPathString(), dataNodeForTest));
 
     // 3. test that new replica is from a new partition which doesn't exist in current cluster yet. (Mock adding new partition case)
     //    3.1 test new partition on host that is not present in current clustermap
     assertNull("New replica should be null because host is not present in clustermap",
-        helixClusterManager.getNewReplica(NEW_PARTITION_ID_STR, fakeNode));
+        helixClusterManager.getBootstrapReplica(NEW_PARTITION_ID_STR, fakeNode));
     //    3.2 test new partition on disk that doesn't exist
     assertNull("New replica should be null because disk doesn't exist",
-        helixClusterManager.getNewReplica(NEW_PARTITION_ID_STR, dataNodeOfNewReplica));
+        helixClusterManager.getBootstrapReplica(NEW_PARTITION_ID_STR, dataNodeOfNewReplica));
     //    3.3 test replica is created for new partition
     assertNotNull("New replica should be created successfully",
-        helixClusterManager.getNewReplica(NEW_PARTITION_ID_STR, dataNodeOfNewPartition));
+        helixClusterManager.getBootstrapReplica(NEW_PARTITION_ID_STR, dataNodeOfNewPartition));
 
     // 4. test that new replica of existing partition is successfully created based on infos from Helix property store.
     assertNotNull("New replica should be created successfully",
-        helixClusterManager.getNewReplica(partitionOfNewReplica.toPathString(), dataNodeOfNewReplica));
+        helixClusterManager.getBootstrapReplica(partitionOfNewReplica.toPathString(), dataNodeOfNewReplica));
 
     helixClusterManager.close();
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -18,9 +18,9 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.TestUtils.*;
 import com.github.ambry.commons.ResponseHandler;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
@@ -393,14 +393,14 @@ public class HelixClusterManagerTest {
     helixClusterManager = new HelixClusterManager(clusterMapConfig, hostname,
         new MockHelixManagerFactory(helixCluster, znRecordMap, null), metricRegistry);
 
-    // 2. test that no partition or no host is found in helix property store that associates with new replica
-    // select a partition that doesn't equal to partitionOfNewReplica dataNodeOfNewReplica
+    // 2. test that cases: 1) partition is not found  2) host is not found in helix property store that associates with new replica
+    // select a partition that doesn't equal to partitionOfNewReplica
     PartitionId partitionForTest;
     Random random = new Random();
     List<PartitionId> partitionsInClusterManager = helixClusterManager.getAllPartitionIds(null);
     do {
       partitionForTest = partitionsInClusterManager.get(random.nextInt(partitionsInClusterManager.size()));
-    } while (partitionForTest == partitionOfNewReplica);
+    } while (partitionForTest.toString().equals(partitionOfNewReplica.toString()));
     assertNull("New replica should be null because given partition id is not in Helix property store",
         helixClusterManager.getNewReplica(partitionForTest.toPathString(), dataNodeOfNewReplica));
     // select partitionOfNewReplica but a random node that doesn't equal to

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -504,7 +504,7 @@ public class MockClusterMap implements ClusterMap {
   }
 
   @Override
-  public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+  public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
     ReplicaId newReplica = null;
     PartitionId partition = partitions.get(Long.valueOf(partitionIdStr));
     for (ReplicaId replicaId : partition.getReplicaIds()) {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.json.JSONArray;
@@ -277,6 +278,19 @@ public class MockClusterMap implements ClusterMap {
   }
 
   /**
+   * Create a new partition and add it to mock clustermap.
+   * @param dataNodes the replicas of new partition should be placed on the given data nodes only.
+   * @return new {@link PartitionId}
+   */
+  public PartitionId createNewPartition(List<MockDataNodeId> dataNodes) {
+    int mountPathIndexToUse = (new Random()).nextInt(this.dataNodes.get(0).getMountPaths().size());
+    PartitionId partitionId =
+        new MockPartitionId(partitions.size(), DEFAULT_PARTITION_CLASS, dataNodes, mountPathIndexToUse);
+    partitions.put((long) partitions.size(), partitionId);
+    return partitionId;
+  }
+
+  /**
    * Return if ssl ports are enabled in this cluster.
    */
   public boolean isSslPortsEnabled() {
@@ -351,8 +365,7 @@ public class MockClusterMap implements ClusterMap {
     for (PartitionId partitionId : partitions.values()) {
       List<? extends ReplicaId> replicaIds = partitionId.getReplicaIds();
       for (ReplicaId replicaId : replicaIds) {
-        if (replicaId.getDataNodeId().getHostname().compareTo(dataNodeId.getHostname()) == 0
-            && replicaId.getDataNodeId().getPort() == dataNodeId.getPort()) {
+        if (replicaId.getDataNodeId().compareTo(dataNodeId) == 0) {
           replicaIdsToReturn.add(replicaId);
         }
       }
@@ -488,6 +501,19 @@ public class MockClusterMap implements ClusterMap {
     partitions.values().forEach(partitionId -> partitionsJsonArray.put(partitionId.getSnapshot()));
     snapshot.put(PARTITIONS, partitionsJsonArray);
     return snapshot;
+  }
+
+  @Override
+  public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+    ReplicaId newReplica = null;
+    PartitionId partition = partitions.get(Long.valueOf(partitionIdStr));
+    for (ReplicaId replicaId : partition.getReplicaIds()) {
+      if (replicaId.getDataNodeId().compareTo(dataNodeId) == 0) {
+        newReplica = replicaId;
+        break;
+      }
+    }
+    return newReplica;
   }
 
   @Override

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -122,7 +122,7 @@ public class ResponseHandlerTest {
     }
 
     @Override
-    public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+    public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
       return null;
     }
 

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -122,6 +122,11 @@ public class ResponseHandlerTest {
     }
 
     @Override
+    public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+      return null;
+    }
+
+    @Override
     public void close() {
     }
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
@@ -389,7 +389,7 @@ class TailoredPeersClusterMap implements ClusterMap {
   }
 
   @Override
-  public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+  public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
     return null;
   }
 

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
@@ -388,6 +388,11 @@ class TailoredPeersClusterMap implements ClusterMap {
 
   }
 
+  @Override
+  public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+    return null;
+  }
+
   Set<String> getPeers(String datanode) {
     return peerMap.get(datanode);
   }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/BlobStoreControlAction.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/BlobStoreControlAction.java
@@ -14,10 +14,10 @@
 package com.github.ambry.protocol;
 
 /**
- * Enum of types of BlobStore control request.
+ * Enum of actions of BlobStore control.
  * The order of these enums should not be changed since their relative position goes into the serialized form of
  * requests.
  */
-public enum BlobStoreControlRequestType {
+public enum BlobStoreControlAction {
   StopStore, StartStore, AddStore, RemoveStore
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/BlobStoreControlRequestType.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/BlobStoreControlRequestType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.protocol;
+
+/**
+ * Enum of types of BlobStore control request.
+ * The order of these enums should not be changed since their relative position goes into the serialized form of
+ * requests.
+ */
+public enum BlobStoreControlRequestType {
+  StopStore, StartStore, AddStore, RemoveStore
+}

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -672,7 +672,7 @@ public class RequestResponseTest {
    */
   @Test
   public void blobStoreControlAdminRequestTest() throws IOException {
-    for (BlobStoreControlRequestType requestType : EnumSet.allOf(BlobStoreControlRequestType.class)) {
+    for (BlobStoreControlAction requestType : EnumSet.allOf(BlobStoreControlAction.class)) {
       doBlobStoreControlAdminRequestTest(requestType);
     }
   }
@@ -743,7 +743,7 @@ public class RequestResponseTest {
    * @param storeControlRequestType the type of store control request specified in {@link BlobStoreControlAdminRequest}.
    * @throws IOException
    */
-  private void doBlobStoreControlAdminRequestTest(BlobStoreControlRequestType storeControlRequestType)
+  private void doBlobStoreControlAdminRequestTest(BlobStoreControlAction storeControlRequestType)
       throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
     PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
@@ -764,10 +764,10 @@ public class RequestResponseTest {
     Assert.assertEquals("Num caught up per partition not as set", numCaughtUpPerPartition,
         deserializedBlobStoreControlRequest.getNumReplicasCaughtUpPerPartition());
     Assert.assertEquals("Control request type is not expected", storeControlRequestType,
-        deserializedBlobStoreControlRequest.getControlRequestType());
+        deserializedBlobStoreControlRequest.getStoreControlAction());
     // test toString method
     String correctString = "BlobStoreControlAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId
-        + ", ControlRequestType=" + deserializedBlobStoreControlRequest.getControlRequestType()
+        + ", ControlRequestType=" + deserializedBlobStoreControlRequest.getStoreControlAction()
         + ", NumReplicasCaughtUpPerPartition="
         + deserializedBlobStoreControlRequest.getNumReplicasCaughtUpPerPartition() + ", PartitionId="
         + deserializedBlobStoreControlRequest.getPartitionId() + "]";

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -743,8 +743,7 @@ public class RequestResponseTest {
    * @param storeControlRequestType the type of store control request specified in {@link BlobStoreControlAdminRequest}.
    * @throws IOException
    */
-  private void doBlobStoreControlAdminRequestTest(BlobStoreControlAction storeControlRequestType)
-      throws IOException {
+  private void doBlobStoreControlAdminRequestTest(BlobStoreControlAction storeControlRequestType) throws IOException {
     MockClusterMap clusterMap = new MockClusterMap();
     PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
     int correlationId = 1234;
@@ -767,7 +766,7 @@ public class RequestResponseTest {
         deserializedBlobStoreControlRequest.getStoreControlAction());
     // test toString method
     String correctString = "BlobStoreControlAdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId
-        + ", ControlRequestType=" + deserializedBlobStoreControlRequest.getStoreControlAction()
+        + ", BlobStoreControlAction=" + deserializedBlobStoreControlRequest.getStoreControlAction()
         + ", NumReplicasCaughtUpPerPartition="
         + deserializedBlobStoreControlRequest.getNumReplicasCaughtUpPerPartition() + ", PartitionId="
         + deserializedBlobStoreControlRequest.getPartitionId() + "]";

--- a/ambry-replication/src/main/java/com.github.ambry.replication/DiskTokenPersistor.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/DiskTokenPersistor.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +44,7 @@ public class DiskTokenPersistor extends ReplicaTokenPersistor {
    * @param clusterMap the {@link ClusterMap} to deserialize tokens.
    * @param tokenHelper the {@link FindTokenHelper} to deserialize tokens.
    */
-  public DiskTokenPersistor(String replicaTokenFileName, Map<String, List<PartitionInfo>> partitionGroupedByMountPath,
+  public DiskTokenPersistor(String replicaTokenFileName, Map<String, Set<PartitionInfo>> partitionGroupedByMountPath,
       ReplicationMetrics replicationMetrics, ClusterMap clusterMap, FindTokenHelper tokenHelper) {
     super(partitionGroupedByMountPath, replicationMetrics, clusterMap, tokenHelper);
     this.replicaTokenFileName = replicaTokenFileName;

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaTokenPersistor.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaTokenPersistor.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,11 +42,11 @@ import static com.github.ambry.replication.RemoteReplicaInfo.*;
 public abstract class ReplicaTokenPersistor implements Runnable {
 
   private static final Logger logger = LoggerFactory.getLogger(DiskTokenPersistor.class);
-  protected final Map<String, List<PartitionInfo>> partitionGroupedByMountPath;
+  protected final Map<String, Set<PartitionInfo>> partitionGroupedByMountPath;
   protected final ReplicationMetrics replicationMetrics;
   protected final ReplicaTokenSerde replicaTokenSerde;
 
-  public ReplicaTokenPersistor(Map<String, List<PartitionInfo>> partitionGroupedByMountPath,
+  public ReplicaTokenPersistor(Map<String, Set<PartitionInfo>> partitionGroupedByMountPath,
       ReplicationMetrics replicationMetrics, ClusterMap clusterMap, FindTokenHelper findTokenHelper) {
     this.partitionGroupedByMountPath = partitionGroupedByMountPath;
     this.replicationMetrics = replicationMetrics;

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -72,7 +73,7 @@ public abstract class ReplicationEngine {
   protected final FindTokenHelper tokenHelper;
   protected final Logger logger = LoggerFactory.getLogger(getClass());
   protected final Map<PartitionId, PartitionInfo> partitionToPartitionInfo;
-  protected final Map<String, List<PartitionInfo>> mountPathToPartitionInfos;
+  protected final Map<String, Set<PartitionInfo>> mountPathToPartitionInfos;
   protected ReplicaTokenPersistor persistor = null;
 
   protected static final short Replication_Delay_Multiplier = 5;

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -194,7 +194,7 @@ public abstract class ReplicationEngine {
   }
 
   /**
-   * Shutsdown the replication manager. Shutsdown the individual replica threads and
+   * Shuts down the replication manager. Shuts down the individual replica threads and
    * then persists all the replica tokens
    * @throws ReplicationException
    */
@@ -224,7 +224,7 @@ public abstract class ReplicationEngine {
   protected void removeRemoteReplicaInfoFromReplicaThread(List<RemoteReplicaInfo> remoteReplicaInfos) {
     for (RemoteReplicaInfo remoteReplicaInfo : remoteReplicaInfos) {
       // Thread safe with addRemoteReplicaInfoToReplicaThread.
-      // For ReplicationManger, this method is not used.
+      // For ReplicationManger, for same thread, removeRemoteReplicaInfo() ensures lock is held by only one thread at any time.
       // For CloudBackUpManager with HelixVcrCluster, Helix requires acknowledgement before next message for the same
       // resource, which means methods in HelixVcrStateModel will be executed sequentially for same partition.
       // So do listener actions in addPartition() and removePartition().

--- a/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
@@ -681,6 +681,11 @@ public class BlobIdTransformerTest {
       return null;
     }
 
+    @Override
+    public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+      return null;
+    }
+
     public void close() {
     }
   }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
@@ -682,7 +682,7 @@ public class BlobIdTransformerTest {
     }
 
     @Override
-    public ReplicaId getNewReplica(String partitionIdStr, DataNodeId dataNodeId) {
+    public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
       return null;
     }
 

--- a/ambry-replication/src/test/java/com.github.ambry.replication/DiskTokenPersistorTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/DiskTokenPersistorTest.java
@@ -77,8 +77,7 @@ public class DiskTokenPersistorTest {
     mountPathToPartitionInfoList.computeIfAbsent(replicaId.getMountPath(), key -> new ArrayList<>()).add(partitionInfo);
 
     Properties replicationProperties = new Properties();
-    replicationProperties.setProperty("replication.cloudtoken.factory",
-        MockFindToken.MockFindTokenFactory.class.getName());
+    replicationProperties.setProperty("replication.cloud.token.factory", MockFindTokenFactory.class.getName());
     ReplicationConfig replicationConfig = new ReplicationConfig(new VerifiableProperties(replicationProperties));
     findTokenHelper = new FindTokenHelper(blobIdFactory, replicationConfig);
   }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/DiskTokenPersistorTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/DiskTokenPersistorTest.java
@@ -34,6 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,7 +45,7 @@ import org.junit.Test;
  * Test for {@link DiskTokenPersistor}.
  */
 public class DiskTokenPersistorTest {
-  private static Map<String, List<PartitionInfo>> mountPathToPartitionInfoList;
+  private static Map<String, Set<PartitionInfo>> mountPathToPartitionInfoList;
   private static ClusterMap clusterMap;
   private static ReplicaId replicaId;
   private static List<RemoteReplicaInfo.ReplicaTokenInfo> replicaTokenInfos;
@@ -74,7 +76,8 @@ public class DiskTokenPersistorTest {
       replicaTokenInfos.add(new RemoteReplicaInfo.ReplicaTokenInfo(remoteReplicaInfo));
     }
     PartitionInfo partitionInfo = new PartitionInfo(remoteReplicas, partitionId, null, replicaId);
-    mountPathToPartitionInfoList.computeIfAbsent(replicaId.getMountPath(), key -> new ArrayList<>()).add(partitionInfo);
+    mountPathToPartitionInfoList.computeIfAbsent(replicaId.getMountPath(), key -> ConcurrentHashMap.newKeySet())
+        .add(partitionInfo);
 
     Properties replicationProperties = new Properties();
     replicationProperties.setProperty("replication.cloud.token.factory", MockFindTokenFactory.class.getName());

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockFindToken.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockFindToken.java
@@ -77,17 +77,4 @@ public class MockFindToken implements FindToken {
   public long getBytesRead() {
     return this.bytesRead;
   }
-
-  public static class MockFindTokenFactory implements FindTokenFactory {
-
-    @Override
-    public FindToken getFindToken(DataInputStream stream) throws IOException {
-      return new MockFindToken(stream);
-    }
-
-    @Override
-    public FindToken getNewFindToken() {
-      return new MockFindToken(0, 0);
-    }
-  }
 }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockFindTokenFactory.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockFindTokenFactory.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.github.ambry.replication;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+
+public class MockFindTokenFactory implements FindTokenFactory {
+  @Override
+  public FindToken getFindToken(DataInputStream stream) throws IOException {
+    return new MockFindToken(stream);
+  }
+
+  @Override
+  public FindToken getNewFindToken() {
+    return new MockFindToken(0, 0);
+  }
+}

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockFindTokenHelper.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockFindTokenHelper.java
@@ -26,6 +26,6 @@ public class MockFindTokenHelper extends FindTokenHelper {
 
   @Override
   public FindTokenFactory getFindTokenFactoryFromReplicaType(ReplicaType replicaType) {
-    return new MockFindToken.MockFindTokenFactory();
+    return new MockFindTokenFactory();
   }
 }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
@@ -28,6 +28,7 @@ import java.io.DataInputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -141,7 +142,7 @@ public class MockReplicationManager extends ReplicationManager {
   /**
    * @return mountPathToPartitionInfos map
    */
-  Map<String, List<PartitionInfo>> getMountPathToPartitionInfosMap() {
+  Map<String, Set<PartitionInfo>> getMountPathToPartitionInfosMap() {
     return mountPathToPartitionInfos;
   }
 

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.replication;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.ReplicationConfig;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.store.StorageManager;
+import com.github.ambry.store.StoreKey;
+import com.github.ambry.store.StoreKeyConverterFactory;
+import com.github.ambry.store.StoreKeyFactory;
+import java.io.DataInputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * An extension of {@link ReplicationManager} to help with testing.
+ */
+public class MockReplicationManager extends ReplicationManager {
+  // General variables
+  public RuntimeException exceptionToThrow = null;
+  // Variables for controlling and examining the values provided to controlReplicationForPartitions()
+  public Boolean controlReplicationReturnVal;
+  public Collection<PartitionId> idsVal;
+  public List<String> originsVal;
+  public Boolean enableVal;
+  // Variables for controlling getRemoteReplicaLagFromLocalInBytes()
+  // the key is partitionId:hostname:replicaPath
+  public Map<String, Long> lagOverrides = null;
+
+  /**
+   * Static construction helper
+   * @param verifiableProperties the {@link VerifiableProperties} to use for config.
+   * @param storageManager the {@link StorageManager} to use.
+   * @param clusterMap the {@link ClusterMap} to use.
+   * @param dataNodeId the {@link DataNodeId} to use.
+   * @param storeKeyConverterFactory the {@link StoreKeyConverterFactory} to use.
+   * @return an instance of {@link MockReplicationManager}
+   * @throws ReplicationException
+   */
+  public static MockReplicationManager getReplicationManager(VerifiableProperties verifiableProperties,
+      StorageManager storageManager, ClusterMap clusterMap, DataNodeId dataNodeId,
+      StoreKeyConverterFactory storeKeyConverterFactory) throws ReplicationException {
+    ReplicationConfig replicationConfig = new ReplicationConfig(verifiableProperties);
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    StoreConfig storeConfig = new StoreConfig(verifiableProperties);
+    return new MockReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap,
+        dataNodeId, storeKeyConverterFactory);
+  }
+
+  MockReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
+      StoreConfig storeConfig, StorageManager storageManager, ClusterMap clusterMap, DataNodeId dataNodeId,
+      StoreKeyConverterFactory storeKeyConverterFactory) throws ReplicationException {
+    super(replicationConfig, clusterMapConfig, storeConfig, storageManager, new StoreKeyFactory() {
+          @Override
+          public StoreKey getStoreKey(DataInputStream stream) {
+            return null;
+          }
+
+          @Override
+          public StoreKey getStoreKey(String input) {
+            return null;
+          }
+        }, clusterMap, null, dataNodeId, null, clusterMap.getMetricRegistry(), null, storeKeyConverterFactory,
+        BlobIdTransformer.class.getName());
+    reset();
+  }
+
+  @Override
+  public boolean controlReplicationForPartitions(Collection<PartitionId> ids, List<String> origins, boolean enable) {
+    failIfRequired();
+    if (controlReplicationReturnVal == null) {
+      throw new IllegalStateException("Return val not set. Don't know what to return");
+    }
+    idsVal = ids;
+    originsVal = origins;
+    enableVal = enable;
+    return controlReplicationReturnVal;
+  }
+
+  @Override
+  public long getRemoteReplicaLagFromLocalInBytes(PartitionId partitionId, String hostName, String replicaPath) {
+    failIfRequired();
+    long lag;
+    String key = getPartitionLagKey(partitionId, hostName, replicaPath);
+    if (lagOverrides == null || !lagOverrides.containsKey(key)) {
+      lag = super.getRemoteReplicaLagFromLocalInBytes(partitionId, hostName, replicaPath);
+    } else {
+      lag = lagOverrides.get(key);
+    }
+    return lag;
+  }
+
+  /**
+   * Resets all state
+   */
+  public void reset() {
+    exceptionToThrow = null;
+    controlReplicationReturnVal = null;
+    idsVal = null;
+    originsVal = null;
+    enableVal = null;
+    lagOverrides = null;
+  }
+
+  /**
+   * Gets the key for the lag override in {@code lagOverrides} using the given parameters.
+   * @param partitionId the {@link PartitionId} whose replica {@code hostname} is.
+   * @param hostname the hostname of the replica whose lag override key is required.
+   * @param replicaPath the replica path of the replica whose lag override key is required.
+   * @return
+   */
+  public static String getPartitionLagKey(PartitionId partitionId, String hostname, String replicaPath) {
+    return partitionId.toString() + ":" + hostname + ":" + replicaPath;
+  }
+
+  /**
+   * @return partitionToPartitionInfo map
+   */
+  Map<PartitionId, PartitionInfo> getPartitionToPartitionInfoMap() {
+    return partitionToPartitionInfo;
+  }
+
+  /**
+   * @return mountPathToPartitionInfos map
+   */
+  Map<String, List<PartitionInfo>> getMountPathToPartitionInfosMap() {
+    return mountPathToPartitionInfos;
+  }
+
+  /**
+   * Throws a {@link RuntimeException} if the {@link MockReplicationManager} is required to.
+   */
+  private void failIfRequired() {
+    if (exceptionToThrow != null) {
+      throw exceptionToThrow;
+    }
+  }
+}

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -64,6 +64,7 @@ import com.github.ambry.protocol.AdminRequest;
 import com.github.ambry.protocol.AdminRequestOrResponseType;
 import com.github.ambry.protocol.AdminResponse;
 import com.github.ambry.protocol.BlobStoreControlAdminRequest;
+import com.github.ambry.protocol.BlobStoreControlRequestType;
 import com.github.ambry.protocol.DeleteRequest;
 import com.github.ambry.protocol.DeleteResponse;
 import com.github.ambry.protocol.GetOption;
@@ -400,7 +401,8 @@ final class ServerTestUtil {
       System.out.println("Begin to stop a BlobStore");
       AdminRequest adminRequest =
           new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionIds.get(0), 1, "clientid2");
-      BlobStoreControlAdminRequest controlRequest = new BlobStoreControlAdminRequest((short) 0, false, adminRequest);
+      BlobStoreControlAdminRequest controlRequest =
+          new BlobStoreControlAdminRequest((short) 0, BlobStoreControlRequestType.StopStore, adminRequest);
       channel.send(controlRequest);
       stream = channel.receive().getInputStream();
       AdminResponse adminResponse = AdminResponse.readFrom(new DataInputStream(stream));
@@ -441,7 +443,8 @@ final class ServerTestUtil {
       // start the store via AdminRequest
       System.out.println("Begin to restart the BlobStore");
       adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionIds.get(0), 1, "clientid2");
-      controlRequest = new BlobStoreControlAdminRequest((short) 0, true, adminRequest);
+      controlRequest =
+          new BlobStoreControlAdminRequest((short) 0, BlobStoreControlRequestType.StartStore, adminRequest);
       channel.send(controlRequest);
       stream = channel.receive().getInputStream();
       adminResponse = AdminResponse.readFrom(new DataInputStream(stream));
@@ -1341,7 +1344,8 @@ final class ServerTestUtil {
     System.out.println("Begin to stop a BlobStore");
     AdminRequest adminRequest =
         new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionId, 1, "clientid2");
-    BlobStoreControlAdminRequest controlRequest = new BlobStoreControlAdminRequest((short) 0, false, adminRequest);
+    BlobStoreControlAdminRequest controlRequest =
+        new BlobStoreControlAdminRequest((short) 0, BlobStoreControlRequestType.StopStore, adminRequest);
     channel.send(controlRequest);
     InputStream stream = channel.receive().getInputStream();
     AdminResponse adminResponse = AdminResponse.readFrom(new DataInputStream(stream));
@@ -1386,7 +1390,7 @@ final class ServerTestUtil {
     // start the store via AdminRequest
     System.out.println("Begin to restart the BlobStore");
     adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionId, 1, "clientId");
-    controlRequest = new BlobStoreControlAdminRequest((short) 0, true, adminRequest);
+    controlRequest = new BlobStoreControlAdminRequest((short) 0, BlobStoreControlRequestType.StartStore, adminRequest);
     channel.send(controlRequest);
     stream = channel.receive().getInputStream();
     adminResponse = AdminResponse.readFrom(new DataInputStream(stream));

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -64,7 +64,7 @@ import com.github.ambry.protocol.AdminRequest;
 import com.github.ambry.protocol.AdminRequestOrResponseType;
 import com.github.ambry.protocol.AdminResponse;
 import com.github.ambry.protocol.BlobStoreControlAdminRequest;
-import com.github.ambry.protocol.BlobStoreControlRequestType;
+import com.github.ambry.protocol.BlobStoreControlAction;
 import com.github.ambry.protocol.DeleteRequest;
 import com.github.ambry.protocol.DeleteResponse;
 import com.github.ambry.protocol.GetOption;
@@ -402,7 +402,7 @@ final class ServerTestUtil {
       AdminRequest adminRequest =
           new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionIds.get(0), 1, "clientid2");
       BlobStoreControlAdminRequest controlRequest =
-          new BlobStoreControlAdminRequest((short) 0, BlobStoreControlRequestType.StopStore, adminRequest);
+          new BlobStoreControlAdminRequest((short) 0, BlobStoreControlAction.StopStore, adminRequest);
       channel.send(controlRequest);
       stream = channel.receive().getInputStream();
       AdminResponse adminResponse = AdminResponse.readFrom(new DataInputStream(stream));
@@ -444,7 +444,7 @@ final class ServerTestUtil {
       System.out.println("Begin to restart the BlobStore");
       adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionIds.get(0), 1, "clientid2");
       controlRequest =
-          new BlobStoreControlAdminRequest((short) 0, BlobStoreControlRequestType.StartStore, adminRequest);
+          new BlobStoreControlAdminRequest((short) 0, BlobStoreControlAction.StartStore, adminRequest);
       channel.send(controlRequest);
       stream = channel.receive().getInputStream();
       adminResponse = AdminResponse.readFrom(new DataInputStream(stream));
@@ -1345,7 +1345,7 @@ final class ServerTestUtil {
     AdminRequest adminRequest =
         new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionId, 1, "clientid2");
     BlobStoreControlAdminRequest controlRequest =
-        new BlobStoreControlAdminRequest((short) 0, BlobStoreControlRequestType.StopStore, adminRequest);
+        new BlobStoreControlAdminRequest((short) 0, BlobStoreControlAction.StopStore, adminRequest);
     channel.send(controlRequest);
     InputStream stream = channel.receive().getInputStream();
     AdminResponse adminResponse = AdminResponse.readFrom(new DataInputStream(stream));
@@ -1390,7 +1390,7 @@ final class ServerTestUtil {
     // start the store via AdminRequest
     System.out.println("Begin to restart the BlobStore");
     adminRequest = new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionId, 1, "clientId");
-    controlRequest = new BlobStoreControlAdminRequest((short) 0, BlobStoreControlRequestType.StartStore, adminRequest);
+    controlRequest = new BlobStoreControlAdminRequest((short) 0, BlobStoreControlAction.StartStore, adminRequest);
     channel.send(controlRequest);
     stream = channel.receive().getInputStream();
     adminResponse = AdminResponse.readFrom(new DataInputStream(stream));

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
@@ -57,7 +57,7 @@ public class VcrRecoveryTest {
   public void cloudRecoveryTest() throws Exception {
     String dcName = "DC1";
     Properties recoveryProperties = new Properties();
-    recoveryProperties.setProperty("replication.metadatarequest.version", "2");
+    recoveryProperties.setProperty("replication.metadata.request.version", "2");
 
     // create vcr node
     Port vcrClusterMapPort = new Port(12310, PortType.PLAINTEXT);

--- a/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
@@ -26,6 +26,7 @@ import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -133,7 +134,7 @@ class StatsManager {
    */
   void collectAndAggregate(StatsSnapshot aggregatedSnapshot, PartitionId partitionId,
       List<PartitionId> unreachablePartitions) {
-    Store store = storageManager.getStore(partitionId);
+    Store store = storageManager.getStore(partitionId, false);
     if (store == null) {
       unreachablePartitions.add(partitionId);
     } else {
@@ -158,7 +159,7 @@ class StatsManager {
   StatsSnapshot fetchSnapshot(PartitionId partitionId, List<PartitionId> unreachablePartitions,
       StatsReportType reportType) {
     StatsSnapshot statsSnapshot = null;
-    Store store = storageManager.getStore(partitionId);
+    Store store = storageManager.getStore(partitionId, false);
     if (store == null) {
       unreachablePartitions.add(partitionId);
     } else {
@@ -355,5 +356,9 @@ class StatsManager {
       }
     }
     return unreachableStores;
+  }
+
+  Map<PartitionId, ReplicaId> getPartitionToReplicaMap() {
+    return Collections.unmodifiableMap(partitionToReplicaMap);
   }
 }

--- a/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
@@ -26,7 +26,6 @@ import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -356,9 +355,5 @@ class StatsManager {
       }
     }
     return unreachableStores;
-  }
-
-  Map<PartitionId, ReplicaId> getPartitionToReplicaMap() {
-    return Collections.unmodifiableMap(partitionToReplicaMap);
   }
 }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -13,11 +13,10 @@
  */
 package com.github.ambry.server;
 
-import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.PartitionId;
@@ -29,9 +28,10 @@ import com.github.ambry.commons.CommonTestUtils;
 import com.github.ambry.commons.ErrorMapping;
 import com.github.ambry.commons.ServerMetrics;
 import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.DiskManagerConfig;
 import com.github.ambry.config.ReplicationConfig;
-import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.StatsManagerConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.BlobType;
@@ -46,6 +46,7 @@ import com.github.ambry.protocol.AdminRequest;
 import com.github.ambry.protocol.AdminRequestOrResponseType;
 import com.github.ambry.protocol.AdminResponse;
 import com.github.ambry.protocol.BlobStoreControlAdminRequest;
+import com.github.ambry.protocol.BlobStoreControlRequestType;
 import com.github.ambry.protocol.CatchupStatusAdminRequest;
 import com.github.ambry.protocol.CatchupStatusAdminResponse;
 import com.github.ambry.protocol.DeleteRequest;
@@ -65,43 +66,32 @@ import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.protocol.RequestOrResponseType;
 import com.github.ambry.protocol.Response;
 import com.github.ambry.protocol.TtlUpdateRequest;
-import com.github.ambry.replication.BlobIdTransformer;
-import com.github.ambry.replication.FindToken;
 import com.github.ambry.replication.FindTokenHelper;
 import com.github.ambry.replication.MockFindTokenHelper;
+import com.github.ambry.replication.MockReplicationManager;
 import com.github.ambry.replication.ReplicationException;
 import com.github.ambry.replication.ReplicationManager;
-import com.github.ambry.store.FindInfo;
+import com.github.ambry.store.BlobStore;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MessageInfoTest;
-import com.github.ambry.store.MessageReadSet;
 import com.github.ambry.store.MessageWriteSet;
 import com.github.ambry.store.MockStoreKeyConverterFactory;
 import com.github.ambry.store.MockWrite;
-import com.github.ambry.store.StorageManager;
 import com.github.ambry.store.Store;
 import com.github.ambry.store.StoreErrorCodes;
 import com.github.ambry.store.StoreException;
-import com.github.ambry.store.StoreGetOptions;
-import com.github.ambry.store.StoreInfo;
 import com.github.ambry.store.StoreKey;
-import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
-import com.github.ambry.store.StoreStats;
 import com.github.ambry.utils.ByteBufferChannel;
 import com.github.ambry.utils.ByteBufferInputStream;
-import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -113,8 +103,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import static com.github.ambry.clustermap.MockClusterMap.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -127,6 +120,7 @@ public class AmbryRequestsTest {
   private final DataNodeId dataNodeId;
   private final MockStorageManager storageManager;
   private final MockReplicationManager replicationManager;
+  private final MockStatsManager statsManager;
   private final AmbryRequests ambryRequests;
   private final MockRequestResponseChannel requestResponseChannel = new MockRequestResponseChannel();
   private final Set<StoreKey> validKeysInStore = new HashSet<>();
@@ -146,6 +140,7 @@ public class AmbryRequestsTest {
     properties.setProperty("replication.no.of.inter.dc.replica.threads", "1");
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     replicationConfig = new ReplicationConfig(verifiableProperties);
+    StatsManagerConfig statsManagerConfig = new StatsManagerConfig(verifiableProperties);
     dataNodeId = clusterMap.getDataNodeIds().get(0);
     StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
     findTokenHelper = new MockFindTokenHelper(storeKeyFactory, replicationConfig);
@@ -155,11 +150,14 @@ public class AmbryRequestsTest {
     replicationManager =
         MockReplicationManager.getReplicationManager(verifiableProperties, storageManager, clusterMap, dataNodeId,
             storeKeyConverterFactory);
+    statsManager =
+        new MockStatsManager(storageManager, clusterMap.getReplicaIds(dataNodeId), clusterMap.getMetricRegistry(),
+            statsManagerConfig);
     ServerMetrics serverMetrics =
         new ServerMetrics(clusterMap.getMetricRegistry(), AmbryRequests.class, AmbryServer.class);
     ambryRequests = new AmbryRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,
         clusterMap.getMetricRegistry(), serverMetrics, findTokenHelper, null, replicationManager, null, false,
-        storeKeyConverterFactory);
+        storeKeyConverterFactory, statsManager);
     storageManager.start();
   }
 
@@ -178,8 +176,7 @@ public class AmbryRequestsTest {
    */
   @Test
   public void scheduleCompactionSuccessTest() throws InterruptedException, IOException {
-    List<? extends PartitionId> partitionIds =
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
+    List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS);
     for (PartitionId id : partitionIds) {
       doScheduleCompactionTest(id, ServerErrorCode.No_Error);
       assertEquals("Partition scheduled for compaction not as expected", id,
@@ -197,7 +194,7 @@ public class AmbryRequestsTest {
     // partitionId not specified
     doScheduleCompactionTest(null, ServerErrorCode.Bad_Request);
 
-    PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
     // store is not started - Replica_Unavailable
     storageManager.returnNullStore = true;
     doScheduleCompactionTest(id, ServerErrorCode.Replica_Unavailable);
@@ -242,8 +239,7 @@ public class AmbryRequestsTest {
         {RequestOrResponseType.PutRequest, RequestOrResponseType.DeleteRequest, RequestOrResponseType.GetRequest,
             RequestOrResponseType.ReplicaMetadataRequest, RequestOrResponseType.TtlUpdateRequest};
     for (RequestOrResponseType requestType : requestOrResponseTypes) {
-      List<? extends PartitionId> partitionIds =
-          clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
+      List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS);
       for (PartitionId id : partitionIds) {
         doRequestControlRequestTest(requestType, id);
       }
@@ -269,8 +265,7 @@ public class AmbryRequestsTest {
    */
   @Test
   public void controlReplicationSuccessTest() throws InterruptedException, IOException {
-    List<? extends PartitionId> partitionIds =
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS);
+    List<? extends PartitionId> partitionIds = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS);
     for (PartitionId id : partitionIds) {
       doControlReplicationTest(id, ServerErrorCode.No_Error);
     }
@@ -286,12 +281,11 @@ public class AmbryRequestsTest {
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = false;
     sendAndVerifyReplicationControlRequest(Collections.EMPTY_LIST, false,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0), ServerErrorCode.Bad_Request);
+        clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0), ServerErrorCode.Bad_Request);
     replicationManager.reset();
     replicationManager.exceptionToThrow = new IllegalStateException();
     sendAndVerifyReplicationControlRequest(Collections.EMPTY_LIST, false,
-        clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0),
-        ServerErrorCode.Unknown_Error);
+        clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0), ServerErrorCode.Unknown_Error);
     // PartitionUnknown is hard to simulate without betraying knowledge of the internals of MockClusterMap.
   }
 
@@ -386,7 +380,7 @@ public class AmbryRequestsTest {
    * @throws IOException
    */
   @Test
-  public void controlBlobStoreSuccessTest() throws InterruptedException, IOException {
+  public void controlBlobStoreSuccessTest() throws Exception {
     List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     PartitionId id = partitionIds.get(0);
     List<? extends ReplicaId> replicaIds = id.getReplicaIds();
@@ -397,17 +391,19 @@ public class AmbryRequestsTest {
     replicationManager.controlReplicationReturnVal = true;
     generateLagOverrides(0, acceptableLagInBytes);
     // stop BlobStore
-    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.No_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StopStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.No_Error);
     // verify APIs are called in the process of stopping BlobStore
     assertEquals("Compaction on store should be disabled after stopping the BlobStore", false,
         storageManager.compactionEnableVal);
     assertEquals("Partition disabled for compaction not as expected", id,
         storageManager.compactionControlledPartitionId);
-    assertEquals("Origins list should be empty", true, replicationManager.originsVal.isEmpty());
+    assertTrue("Origins list should be empty", replicationManager.originsVal.isEmpty());
     assertEquals("Replication on given BlobStore should be disabled", false, replicationManager.enableVal);
     assertEquals("Partition shutdown not as expected", id, storageManager.shutdownPartitionId);
     // start BlobStore
-    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.No_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StartStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.No_Error);
     // verify APIs are called in the process of starting BlobStore
     assertEquals("Partition started not as expected", id, storageManager.startedPartitionId);
     assertEquals("Replication on given BlobStore should be enabled", true, replicationManager.enableVal);
@@ -415,6 +411,81 @@ public class AmbryRequestsTest {
         storageManager.compactionControlledPartitionId);
     assertEquals("Compaction on store should be enabled after starting the BlobStore", true,
         storageManager.compactionEnableVal);
+    // add BlobStore (create a new partition and add one of its replicas to server)
+    PartitionId newPartition = clusterMap.createNewPartition(clusterMap.getDataNodes());
+    sendAndVerifyStoreControlRequest(newPartition, BlobStoreControlRequestType.AddStore,
+        numReplicasCaughtUpPerPartition, ServerErrorCode.No_Error);
+    // remove BlobStore (remove previously added store)
+    BlobStore mockStore = Mockito.mock(BlobStore.class);
+    storageManager.overrideStoreToReturn = mockStore;
+    doNothing().when(mockStore).deleteStoreFiles();
+    sendAndVerifyStoreControlRequest(newPartition, BlobStoreControlRequestType.RemoveStore,
+        numReplicasCaughtUpPerPartition, ServerErrorCode.No_Error);
+    storageManager.overrideStoreToReturn = null;
+  }
+
+  @Test
+  public void addBlobStoreFailureTest() throws Exception {
+    // create newPartition1 that no replica sits on current node.
+    List<MockDataNodeId> dataNodes = clusterMap.getDataNodes()
+        .stream()
+        .filter(node -> !node.getHostname().equals(dataNodeId.getHostname()) && node.getPort() != dataNodeId.getPort())
+        .collect(Collectors.toList());
+    PartitionId newPartition1 = clusterMap.createNewPartition(dataNodes);
+    // test that getting new replica from cluster map fails
+    sendAndVerifyStoreControlRequest(newPartition1, BlobStoreControlRequestType.AddStore, (short) 0,
+        ServerErrorCode.Replica_Unavailable);
+
+    // create newPartition2 that has one replica on current node
+    PartitionId newPartition2 = clusterMap.createNewPartition(clusterMap.getDataNodes());
+    // test that adding store into StorageManager fails
+    storageManager.returnValueOfAddBlobStore = false;
+    sendAndVerifyStoreControlRequest(newPartition2, BlobStoreControlRequestType.AddStore, (short) 0,
+        ServerErrorCode.Unknown_Error);
+    storageManager.returnValueOfAddBlobStore = true;
+
+    // test that adding replica into ReplicationManager fails (we first add replica into ReplicationManager to trigger failure)
+    ReplicaId replicaToAdd =
+        clusterMap.getNewReplica(newPartition2.toPathString(), dataNodeId);
+    replicationManager.addReplica(replicaToAdd);
+    sendAndVerifyStoreControlRequest(newPartition2, BlobStoreControlRequestType.AddStore, (short) 0,
+        ServerErrorCode.Unknown_Error);
+    assertTrue("Remove replica from replication manager should succeed.",
+        replicationManager.removeReplica(replicaToAdd));
+
+    // test that adding replica into StatsManager fails
+    statsManager.returnValOfAddReplica = false;
+    sendAndVerifyStoreControlRequest(newPartition2, BlobStoreControlRequestType.AddStore, (short) 0,
+        ServerErrorCode.Unknown_Error);
+    statsManager.returnValOfAddReplica = true;
+  }
+
+  @Test
+  public void removeBlobStoreFailureTest() throws Exception {
+    // first, create new partition but don't add to current node
+    PartitionId newPartition = clusterMap.createNewPartition(clusterMap.getDataNodes());
+    // test store removal failure because store doesn't exist
+    sendAndVerifyStoreControlRequest(newPartition, BlobStoreControlRequestType.RemoveStore, (short) 0,
+        ServerErrorCode.Partition_Unknown);
+    // add store on current node for store removal testing
+    sendAndVerifyStoreControlRequest(newPartition, BlobStoreControlRequestType.AddStore, (short) 0,
+        ServerErrorCode.No_Error);
+    // mock exception in StorageManager
+    storageManager.returnValueOfRemoveBlobStore = false;
+    sendAndVerifyStoreControlRequest(newPartition, BlobStoreControlRequestType.RemoveStore, (short) 0,
+        ServerErrorCode.Unknown_Error);
+    storageManager.returnValueOfRemoveBlobStore = true;
+    // mock exception when deleting files of removed store
+    BlobStore mockStore = Mockito.mock(BlobStore.class);
+    storageManager.overrideStoreToReturn = mockStore;
+    doThrow(new IOException()).when(mockStore).deleteStoreFiles();
+    sendAndVerifyStoreControlRequest(newPartition, BlobStoreControlRequestType.RemoveStore, (short) 0,
+        ServerErrorCode.Unknown_Error);
+    // test store removal success case
+    doNothing().when(mockStore).deleteStoreFiles();
+    sendAndVerifyStoreControlRequest(newPartition, BlobStoreControlRequestType.RemoveStore, (short) 0,
+        ServerErrorCode.No_Error);
+    storageManager.overrideStoreToReturn = null;
   }
 
   /**
@@ -429,23 +500,28 @@ public class AmbryRequestsTest {
     short numReplicasCaughtUpPerPartition = 3;
     // test start BlobStore failure
     storageManager.returnValueOfStartingBlobStore = false;
-    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StartStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Unknown_Error);
     storageManager.returnValueOfStartingBlobStore = true;
     // test start BlobStore with runtime exception
     storageManager.exceptionToThrowOnStartingBlobStore = new IllegalStateException();
-    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StartStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Unknown_Error);
     storageManager.exceptionToThrowOnStartingBlobStore = null;
     // test enable replication failure
     replicationManager.controlReplicationReturnVal = false;
-    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StartStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Unknown_Error);
     replicationManager.controlReplicationReturnVal = true;
     // test enable compaction failure
     storageManager.returnValueOfControllingCompaction = false;
-    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StartStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Unknown_Error);
     storageManager.returnValueOfControllingCompaction = true;
     // test enable compaction with runtime exception
     storageManager.exceptionToThrowOnControllingCompaction = new IllegalStateException();
-    sendAndVerifyStoreControlRequest(id, true, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StartStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Unknown_Error);
     storageManager.exceptionToThrowOnControllingCompaction = null;
   }
 
@@ -460,48 +536,58 @@ public class AmbryRequestsTest {
     PartitionId id = partitionIds.get(0);
     short numReplicasCaughtUpPerPartition = 3;
     // test partition unknown
-    sendAndVerifyStoreControlRequest(null, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Bad_Request);
+    sendAndVerifyStoreControlRequest(null, BlobStoreControlRequestType.StopStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Bad_Request);
     // test validate request failure - Replica_Unavailable
     storageManager.returnNullStore = true;
-    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Replica_Unavailable);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StopStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Replica_Unavailable);
     storageManager.returnNullStore = false;
     // test validate request failure - Disk_Unavailable
     storageManager.shutdown();
     storageManager.returnNullStore = true;
-    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Disk_Unavailable);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StopStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Disk_Unavailable);
     storageManager.returnNullStore = false;
     storageManager.start();
     // test invalid numReplicasCaughtUpPerPartition
     numReplicasCaughtUpPerPartition = -1;
-    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Bad_Request);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StopStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Bad_Request);
     numReplicasCaughtUpPerPartition = 3;
     // test disable compaction failure
     storageManager.returnValueOfControllingCompaction = false;
-    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StopStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Unknown_Error);
     storageManager.returnValueOfControllingCompaction = true;
     // test disable compaction with runtime exception
     storageManager.exceptionToThrowOnControllingCompaction = new IllegalStateException();
-    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StopStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Unknown_Error);
     storageManager.exceptionToThrowOnControllingCompaction = null;
     // test disable replication failure
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = false;
-    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StopStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Unknown_Error);
     // test peers catchup failure
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = true;
     // all replicas of this partition > acceptableLag
     generateLagOverrides(1, 1);
-    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Retry_After_Backoff);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StopStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Retry_After_Backoff);
     // test shutdown BlobStore failure
     replicationManager.reset();
     replicationManager.controlReplicationReturnVal = true;
     storageManager.returnValueOfShutdownBlobStore = false;
     generateLagOverrides(0, 0);
-    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StopStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Unknown_Error);
     // test shutdown BlobStore with runtime exception
     storageManager.exceptionToThrowOnShuttingDownBlobStore = new IllegalStateException();
-    sendAndVerifyStoreControlRequest(id, false, numReplicasCaughtUpPerPartition, ServerErrorCode.Unknown_Error);
+    sendAndVerifyStoreControlRequest(id, BlobStoreControlRequestType.StopStore, numReplicasCaughtUpPerPartition,
+        ServerErrorCode.Unknown_Error);
     storageManager.exceptionToThrowOnShuttingDownBlobStore = null;
   }
 
@@ -577,8 +663,7 @@ public class AmbryRequestsTest {
    */
   @Test
   public void ttlUpdateTest() throws InterruptedException, IOException, MessageFormatException, StoreException {
-    MockPartitionId id =
-        (MockPartitionId) clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    MockPartitionId id = (MockPartitionId) clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
     int correlationId = TestUtils.RANDOM.nextInt();
     String clientId = UtilsTest.getRandomString(10);
     BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
@@ -683,21 +768,21 @@ public class AmbryRequestsTest {
    * Sends and verifies that a {@link AdminRequestOrResponseType#BlobStoreControl} request received the error code
    * expected.
    * @param partitionId the {@link PartitionId} to send the request for. Can be {@code null}.
-   * @param enable {@code true} if BlobStore needs to be started. {@code false} otherwise.
+   * @param storeControlRequestType type of control operation that will be performed on certain store.
    * @param numReplicasCaughtUpPerPartition the number of peer replicas which have caught up with this store before proceeding.
    * @param expectedServerErrorCode the {@link ServerErrorCode} expected in the response.
    * @throws InterruptedException
    * @throws IOException
    */
-  private void sendAndVerifyStoreControlRequest(PartitionId partitionId, boolean enable,
-      short numReplicasCaughtUpPerPartition, ServerErrorCode expectedServerErrorCode)
-      throws InterruptedException, IOException {
+  private void sendAndVerifyStoreControlRequest(PartitionId partitionId,
+      BlobStoreControlRequestType storeControlRequestType, short numReplicasCaughtUpPerPartition,
+      ServerErrorCode expectedServerErrorCode) throws InterruptedException, IOException {
     int correlationId = TestUtils.RANDOM.nextInt();
     String clientId = UtilsTest.getRandomString(10);
     AdminRequest adminRequest =
         new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionId, correlationId, clientId);
     BlobStoreControlAdminRequest blobStoreControlAdminRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, enable, adminRequest);
+        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, storeControlRequestType, adminRequest);
     Response response = sendRequestGetResponse(blobStoreControlAdminRequest, expectedServerErrorCode);
     assertTrue("Response not of type AdminResponse", response instanceof AdminResponse);
   }
@@ -1079,7 +1164,7 @@ public class AmbryRequestsTest {
    * @throws IOException
    */
   private void miscTtlUpdateFailuresTest() throws InterruptedException, IOException {
-    PartitionId id = clusterMap.getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS).get(0);
+    PartitionId id = clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
     // store exceptions
     for (StoreErrorCodes code : StoreErrorCodes.values()) {
       MockStorageManager.storeException = new StoreException("expected", code);
@@ -1203,443 +1288,6 @@ public class AmbryRequestsTest {
     public void sendResponse(Send payloadToSend, Request originalRequest, ServerNetworkResponseMetrics metrics) {
       lastResponse = payloadToSend;
       lastOriginalRequest = originalRequest;
-    }
-  }
-
-  /**
-   * An extension of {@link StorageManager} to help with tests.
-   */
-  private static class MockStorageManager extends StorageManager {
-
-    /**
-     * The operation received at the store.
-     */
-    static RequestOrResponseType operationReceived = null;
-
-    /**
-     * The {@link MessageWriteSet} received at the store (only for put, delete and ttl update)
-     */
-    static MessageWriteSet messageWriteSetReceived = null;
-
-    /**
-     * The IDs received at the store (only for get)
-     */
-    static List<? extends StoreKey> idsReceived = null;
-
-    /**
-     * The {@link StoreGetOptions} received at the store (only for get)
-     */
-    static EnumSet<StoreGetOptions> storeGetOptionsReceived;
-
-    /**
-     * The {@link FindToken} received at the store (only for findEntriesSince())
-     */
-    static FindToken tokenReceived = null;
-
-    /**
-     * The maxTotalSizeOfEntries received at the store (only for findEntriesSince())
-     */
-    static Long maxTotalSizeOfEntriesReceived = null;
-
-    /**
-     * StoreException to throw when an API is invoked
-     */
-    static StoreException storeException = null;
-
-    /**
-     * RuntimeException to throw when an API is invoked. Will be preferred over {@link #storeException}.
-     */
-    static RuntimeException runtimeException = null;
-
-    /**
-     * An empty {@link Store} implementation.
-     */
-    private Store store = new Store() {
-      boolean started;
-
-      @Override
-      public void start() throws StoreException {
-        throwExceptionIfRequired();
-        started = true;
-      }
-
-      @Override
-      public StoreInfo get(List<? extends StoreKey> ids, EnumSet<StoreGetOptions> storeGetOptions)
-          throws StoreException {
-        operationReceived = RequestOrResponseType.GetRequest;
-        idsReceived = ids;
-        storeGetOptionsReceived = storeGetOptions;
-        throwExceptionIfRequired();
-        checkValidityOfIds(ids);
-        return new StoreInfo(new MessageReadSet() {
-          @Override
-          public long writeTo(int index, WritableByteChannel channel, long relativeOffset, long maxSize) {
-            return 0;
-          }
-
-          @Override
-          public int count() {
-            return 0;
-          }
-
-          @Override
-          public long sizeInBytes(int index) {
-            return 0;
-          }
-
-          @Override
-          public StoreKey getKeyAt(int index) {
-            return null;
-          }
-
-          @Override
-          public void doPrefetch(int index, long relativeOffset, long size) {
-          }
-        }, Collections.emptyList());
-      }
-
-      @Override
-      public void put(MessageWriteSet messageSetToWrite) throws StoreException {
-        operationReceived = RequestOrResponseType.PutRequest;
-        messageWriteSetReceived = messageSetToWrite;
-        throwExceptionIfRequired();
-      }
-
-      @Override
-      public void delete(MessageWriteSet messageSetToDelete) throws StoreException {
-        operationReceived = RequestOrResponseType.DeleteRequest;
-        messageWriteSetReceived = messageSetToDelete;
-        throwExceptionIfRequired();
-        checkValidityOfIds(
-            messageSetToDelete.getMessageSetInfo().stream().map(MessageInfo::getStoreKey).collect(Collectors.toList()));
-      }
-
-      @Override
-      public void updateTtl(MessageWriteSet messageSetToUpdate) throws StoreException {
-        operationReceived = RequestOrResponseType.TtlUpdateRequest;
-        messageWriteSetReceived = messageSetToUpdate;
-        throwExceptionIfRequired();
-        checkValidityOfIds(
-            messageSetToUpdate.getMessageSetInfo().stream().map(MessageInfo::getStoreKey).collect(Collectors.toList()));
-      }
-
-      @Override
-      public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries) throws StoreException {
-        operationReceived = RequestOrResponseType.ReplicaMetadataRequest;
-        tokenReceived = token;
-        maxTotalSizeOfEntriesReceived = maxTotalSizeOfEntries;
-        throwExceptionIfRequired();
-        return new FindInfo(Collections.emptyList(),
-            findTokenHelper.getFindTokenFactoryFromReplicaType(ReplicaType.DISK_BACKED).getNewFindToken());
-      }
-
-      @Override
-      public Set<StoreKey> findMissingKeys(List<StoreKey> keys) {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public StoreStats getStoreStats() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean isKeyDeleted(StoreKey key) {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public long getSizeInBytes() {
-        return 0;
-      }
-
-      @Override
-      public boolean isEmpty() {
-        return false;
-      }
-
-      @Override
-      public boolean isStarted() {
-        return started;
-      }
-
-      public void shutdown() throws StoreException {
-        throwExceptionIfRequired();
-        started = false;
-      }
-
-      /**
-       * Throws a {@link RuntimeException} or {@link StoreException} if so configured
-       * @throws StoreException
-       */
-      private void throwExceptionIfRequired() throws StoreException {
-        if (runtimeException != null) {
-          throw runtimeException;
-        }
-        if (storeException != null) {
-          throw storeException;
-        }
-      }
-
-      /**
-       * Checks the validity of the {@code ids}
-       * @param ids the {@link StoreKey}s to check
-       * @throws StoreException if the key is not valid
-       */
-      private void checkValidityOfIds(Collection<? extends StoreKey> ids) throws StoreException {
-        for (StoreKey id : ids) {
-          if (!validKeysInStore.contains(id)) {
-            throw new StoreException("Not a valid key.", StoreErrorCodes.ID_Not_Found);
-          }
-        }
-      }
-    };
-
-    private static final VerifiableProperties VPROPS = new VerifiableProperties(new Properties());
-
-    /**
-     * if {@code true}, a {@code null} {@link Store} is returned on a call to {@link #getStore(PartitionId)}. Otherwise
-     * {@link #store} is returned.
-     */
-    boolean returnNullStore = false;
-    /**
-     * If non-null, the given exception is thrown when {@link #scheduleNextForCompaction(PartitionId)} is called.
-     */
-    RuntimeException exceptionToThrowOnSchedulingCompaction = null;
-    /**
-     * If non-null, the given exception is thrown when {@link #controlCompactionForBlobStore(PartitionId, boolean)} is called.
-     */
-    RuntimeException exceptionToThrowOnControllingCompaction = null;
-    /**
-     * If non-null, the given exception is thrown when {@link #shutdownBlobStore(PartitionId)} is called.
-     */
-    RuntimeException exceptionToThrowOnShuttingDownBlobStore = null;
-    /**
-     * If non-null, the given exception is thrown when {@link #startBlobStore(PartitionId)} is called.
-     */
-    RuntimeException exceptionToThrowOnStartingBlobStore = null;
-    /**
-     * The return value for a call to {@link #scheduleNextForCompaction(PartitionId)}.
-     */
-    boolean returnValueOfSchedulingCompaction = true;
-    /**
-     * The return value for a call to {@link #controlCompactionForBlobStore(PartitionId, boolean)}.
-     */
-    boolean returnValueOfControllingCompaction = true;
-    /**
-     * The return value for a call to {@link #shutdownBlobStore(PartitionId)}.
-     */
-    boolean returnValueOfShutdownBlobStore = true;
-    /**
-     * The return value for a call to {@link #startBlobStore(PartitionId)}.
-     */
-    boolean returnValueOfStartingBlobStore = true;
-    /**
-     * The {@link PartitionId} that was provided in the call to {@link #scheduleNextForCompaction(PartitionId)}
-     */
-    PartitionId compactionScheduledPartitionId = null;
-    /**
-     * The {@link PartitionId} that was provided in the call to {@link #controlCompactionForBlobStore(PartitionId, boolean)}
-     */
-    PartitionId compactionControlledPartitionId = null;
-    /**
-     * The {@link boolean} that was provided in the call to {@link #controlCompactionForBlobStore(PartitionId, boolean)}
-     */
-    Boolean compactionEnableVal = null;
-    /**
-     * The {@link PartitionId} that was provided in the call to {@link #shutdownBlobStore(PartitionId)}
-     */
-    PartitionId shutdownPartitionId = null;
-    /**
-     * The {@link PartitionId} that was provided in the call to {@link #startBlobStore(PartitionId)}
-     */
-    PartitionId startedPartitionId = null;
-
-    private final Set<StoreKey> validKeysInStore;
-
-    private final FindTokenHelper findTokenHelper;
-
-    MockStorageManager(Set<StoreKey> validKeysInStore, List<? extends ReplicaId> replicas,
-        FindTokenHelper findTokenHelper) throws StoreException {
-      super(new StoreConfig(VPROPS), new DiskManagerConfig(VPROPS), Utils.newScheduler(1, true), new MetricRegistry(),
-          replicas, null, null, null, null, new MockTime());
-      this.validKeysInStore = validKeysInStore;
-      this.findTokenHelper = findTokenHelper;
-    }
-
-    @Override
-    public Store getStore(PartitionId id) {
-      return returnNullStore ? null : store;
-    }
-
-    @Override
-    public boolean scheduleNextForCompaction(PartitionId id) {
-      if (exceptionToThrowOnSchedulingCompaction != null) {
-        throw exceptionToThrowOnSchedulingCompaction;
-      }
-      compactionScheduledPartitionId = id;
-      return returnValueOfSchedulingCompaction;
-    }
-
-    @Override
-    public boolean controlCompactionForBlobStore(PartitionId id, boolean enabled) {
-      if (exceptionToThrowOnControllingCompaction != null) {
-        throw exceptionToThrowOnControllingCompaction;
-      }
-      compactionControlledPartitionId = id;
-      compactionEnableVal = enabled;
-      return returnValueOfControllingCompaction;
-    }
-
-    @Override
-    public boolean shutdownBlobStore(PartitionId id) {
-      if (exceptionToThrowOnShuttingDownBlobStore != null) {
-        throw exceptionToThrowOnShuttingDownBlobStore;
-      }
-      shutdownPartitionId = id;
-      return returnValueOfShutdownBlobStore;
-    }
-
-    @Override
-    public boolean startBlobStore(PartitionId id) {
-      if (exceptionToThrowOnStartingBlobStore != null) {
-        throw exceptionToThrowOnStartingBlobStore;
-      }
-      startedPartitionId = id;
-      return returnValueOfStartingBlobStore;
-    }
-
-    /**
-     * Resets variables associated with the {@link Store} impl
-     */
-    void resetStore() {
-      operationReceived = null;
-      messageWriteSetReceived = null;
-      idsReceived = null;
-      storeGetOptionsReceived = null;
-      tokenReceived = null;
-      maxTotalSizeOfEntriesReceived = null;
-    }
-  }
-
-  /**
-   * An extension of {@link ReplicationManager} to help with testing.
-   */
-  private static class MockReplicationManager extends ReplicationManager {
-    // General variables
-    RuntimeException exceptionToThrow = null;
-    // Variables for controlling and examining the values provided to controlReplicationForPartitions()
-    Boolean controlReplicationReturnVal;
-    Collection<PartitionId> idsVal;
-    List<String> originsVal;
-    Boolean enableVal;
-    // Variables for controlling getRemoteReplicaLagFromLocalInBytes()
-    // the key is partitionId:hostname:replicaPath
-    Map<String, Long> lagOverrides = null;
-
-    /**
-     * Static construction helper
-     * @param verifiableProperties the {@link VerifiableProperties} to use for config.
-     * @param storageManager the {@link StorageManager} to use.
-     * @param clusterMap the {@link ClusterMap} to use.
-     * @param dataNodeId the {@link DataNodeId} to use.
-     * @param storeKeyConverterFactory the {@link StoreKeyConverterFactory} to use.
-     * @return an instance of {@link MockReplicationManager}
-     * @throws ReplicationException
-     */
-    static MockReplicationManager getReplicationManager(VerifiableProperties verifiableProperties,
-        StorageManager storageManager, ClusterMap clusterMap, DataNodeId dataNodeId,
-        StoreKeyConverterFactory storeKeyConverterFactory) throws ReplicationException {
-      ReplicationConfig replicationConfig = new ReplicationConfig(verifiableProperties);
-      ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
-      StoreConfig storeConfig = new StoreConfig(verifiableProperties);
-      return new MockReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap,
-          dataNodeId, storeKeyConverterFactory);
-    }
-
-    /**
-     * Constructor for MockReplicationManager.
-     * @param replicationConfig the config for replication.
-     * @param clusterMapConfig the config for clustermap.
-     * @param storeConfig the config for the store.
-     * @param storageManager the {@link StorageManager} to use.
-     * @param clusterMap the {@link ClusterMap} to use.
-     * @param dataNodeId the {@link DataNodeId} to use.
-     * @throws ReplicationException
-     */
-    MockReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
-        StoreConfig storeConfig, StorageManager storageManager, ClusterMap clusterMap, DataNodeId dataNodeId,
-        StoreKeyConverterFactory storeKeyConverterFactory) throws ReplicationException {
-      super(replicationConfig, clusterMapConfig, storeConfig, storageManager, new StoreKeyFactory() {
-            @Override
-            public StoreKey getStoreKey(DataInputStream stream) {
-              return null;
-            }
-
-            @Override
-            public StoreKey getStoreKey(String input) {
-              return null;
-            }
-          }, clusterMap, null, dataNodeId, null, clusterMap.getMetricRegistry(), null, storeKeyConverterFactory,
-          BlobIdTransformer.class.getName());
-      reset();
-    }
-
-    @Override
-    public boolean controlReplicationForPartitions(Collection<PartitionId> ids, List<String> origins, boolean enable) {
-      failIfRequired();
-      if (controlReplicationReturnVal == null) {
-        throw new IllegalStateException("Return val not set. Don't know what to return");
-      }
-      idsVal = ids;
-      originsVal = origins;
-      enableVal = enable;
-      return controlReplicationReturnVal;
-    }
-
-    @Override
-    public long getRemoteReplicaLagFromLocalInBytes(PartitionId partitionId, String hostName, String replicaPath) {
-      failIfRequired();
-      long lag;
-      String key = getPartitionLagKey(partitionId, hostName, replicaPath);
-      if (lagOverrides == null || !lagOverrides.containsKey(key)) {
-        lag = super.getRemoteReplicaLagFromLocalInBytes(partitionId, hostName, replicaPath);
-      } else {
-        lag = lagOverrides.get(key);
-      }
-      return lag;
-    }
-
-    /**
-     * Resets all state
-     */
-    void reset() {
-      exceptionToThrow = null;
-      controlReplicationReturnVal = null;
-      idsVal = null;
-      originsVal = null;
-      enableVal = null;
-      lagOverrides = null;
-    }
-
-    /**
-     * Gets the key for the lag override in {@code lagOverrides} using the given parameters.
-     * @param partitionId the {@link PartitionId} whose replica {@code hostname} is.
-     * @param hostname the hostname of the replica whose lag override key is required.
-     * @param replicaPath the replica path of the replica whose lag override key is required.
-     * @return
-     */
-    static String getPartitionLagKey(PartitionId partitionId, String hostname, String replicaPath) {
-      return partitionId.toString() + ":" + hostname + ":" + replicaPath;
-    }
-
-    /**
-     * Throws a {@link RuntimeException} if the {@link MockReplicationManager} is required to.
-     */
-    private void failIfRequired() {
-      if (exceptionToThrow != null) {
-        throw exceptionToThrow;
-      }
     }
   }
 }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryStatsReportTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryStatsReportTest.java
@@ -38,8 +38,8 @@ public class AmbryStatsReportTest {
   public void testAmbryStatsReport() throws StoreException {
     StatsManagerConfig config = new StatsManagerConfig(new VerifiableProperties(new Properties()));
     StatsManager testStatsManager =
-        new StatsManager(new StatsManagerTest.MockStorageManager(Collections.emptyMap()), Collections.emptyList(),
-            new MetricRegistry(), config, new MockTime());
+        new StatsManager(new MockStorageManager(Collections.emptyMap()), Collections.emptyList(), new MetricRegistry(),
+            config, new MockTime());
     // test account stats report
     AmbryStatsReport ambryStatsReport =
         new AmbryStatsReport(testStatsManager, AGGREGATE_INTERVAL_MINS, StatsReportType.ACCOUNT_REPORT);

--- a/ambry-server/src/test/java/com.github.ambry.server/MockStatsManager.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/MockStatsManager.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.server;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.config.StatsManagerConfig;
+import com.github.ambry.store.StorageManager;
+import com.github.ambry.utils.MockTime;
+import java.util.List;
+
+
+/**
+ * An extension of {@link StatsManager} to help with tests.
+ */
+class MockStatsManager extends StatsManager {
+  boolean returnValOfAddReplica = true;
+
+  MockStatsManager(StorageManager storageManager, List<? extends ReplicaId> replicaIds, MetricRegistry metricRegistry,
+      StatsManagerConfig statsManagerConfig) {
+    super(storageManager, replicaIds, metricRegistry, statsManagerConfig, new MockTime());
+  }
+
+  @Override
+  boolean addReplica(ReplicaId id) {
+    return returnValOfAddReplica;
+  }
+}

--- a/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.server;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaType;
+import com.github.ambry.config.DiskManagerConfig;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.protocol.RequestOrResponseType;
+import com.github.ambry.replication.FindToken;
+import com.github.ambry.replication.FindTokenHelper;
+import com.github.ambry.store.FindInfo;
+import com.github.ambry.store.MessageInfo;
+import com.github.ambry.store.MessageReadSet;
+import com.github.ambry.store.MessageWriteSet;
+import com.github.ambry.store.StorageManager;
+import com.github.ambry.store.Store;
+import com.github.ambry.store.StoreErrorCodes;
+import com.github.ambry.store.StoreException;
+import com.github.ambry.store.StoreGetOptions;
+import com.github.ambry.store.StoreInfo;
+import com.github.ambry.store.StoreKey;
+import com.github.ambry.store.StoreStats;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Utils;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+
+
+/**
+ * An extension of {@link StorageManager} to help with tests.
+ */
+class MockStorageManager extends StorageManager {
+
+  /**
+   * The operation received at the store.
+   */
+  static RequestOrResponseType operationReceived = null;
+  /**
+   * The {@link MessageWriteSet} received at the store (only for put, delete and ttl update)
+   */
+  static MessageWriteSet messageWriteSetReceived = null;
+  /**
+   * The IDs received at the store (only for get)
+   */
+  static List<? extends StoreKey> idsReceived = null;
+  /**
+   * The {@link StoreGetOptions} received at the store (only for get)
+   */
+  static EnumSet<StoreGetOptions> storeGetOptionsReceived;
+  /**
+   * The {@link FindToken} received at the store (only for findEntriesSince())
+   */
+  static FindToken tokenReceived = null;
+  /**
+   * The maxTotalSizeOfEntries received at the store (only for findEntriesSince())
+   */
+  static Long maxTotalSizeOfEntriesReceived = null;
+  /**
+   * StoreException to throw when an API is invoked
+   */
+  static StoreException storeException = null;
+  /**
+   * RuntimeException to throw when an API is invoked. Will be preferred over {@link #storeException}.
+   */
+  static RuntimeException runtimeException = null;
+
+  /**
+   * An empty {@link Store} implementation.
+   */
+  private Store store = new Store() {
+    boolean started;
+
+    @Override
+    public void start() throws StoreException {
+      throwExceptionIfRequired();
+      started = true;
+    }
+
+    @Override
+    public StoreInfo get(List<? extends StoreKey> ids, EnumSet<StoreGetOptions> storeGetOptions) throws StoreException {
+      operationReceived = RequestOrResponseType.GetRequest;
+      idsReceived = ids;
+      storeGetOptionsReceived = storeGetOptions;
+      throwExceptionIfRequired();
+      checkValidityOfIds(ids);
+      return new StoreInfo(new MessageReadSet() {
+        @Override
+        public long writeTo(int index, WritableByteChannel channel, long relativeOffset, long maxSize) {
+          return 0;
+        }
+
+        @Override
+        public int count() {
+          return 0;
+        }
+
+        @Override
+        public long sizeInBytes(int index) {
+          return 0;
+        }
+
+        @Override
+        public StoreKey getKeyAt(int index) {
+          return null;
+        }
+
+        @Override
+        public void doPrefetch(int index, long relativeOffset, long size) {
+        }
+      }, Collections.emptyList());
+    }
+
+    @Override
+    public void put(MessageWriteSet messageSetToWrite) throws StoreException {
+      operationReceived = RequestOrResponseType.PutRequest;
+      messageWriteSetReceived = messageSetToWrite;
+      throwExceptionIfRequired();
+    }
+
+    @Override
+    public void delete(MessageWriteSet messageSetToDelete) throws StoreException {
+      operationReceived = RequestOrResponseType.DeleteRequest;
+      messageWriteSetReceived = messageSetToDelete;
+      throwExceptionIfRequired();
+      checkValidityOfIds(
+          messageSetToDelete.getMessageSetInfo().stream().map(MessageInfo::getStoreKey).collect(Collectors.toList()));
+    }
+
+    @Override
+    public void updateTtl(MessageWriteSet messageSetToUpdate) throws StoreException {
+      operationReceived = RequestOrResponseType.TtlUpdateRequest;
+      messageWriteSetReceived = messageSetToUpdate;
+      throwExceptionIfRequired();
+      checkValidityOfIds(
+          messageSetToUpdate.getMessageSetInfo().stream().map(MessageInfo::getStoreKey).collect(Collectors.toList()));
+    }
+
+    @Override
+    public FindInfo findEntriesSince(FindToken token, long maxTotalSizeOfEntries) throws StoreException {
+      operationReceived = RequestOrResponseType.ReplicaMetadataRequest;
+      tokenReceived = token;
+      maxTotalSizeOfEntriesReceived = maxTotalSizeOfEntries;
+      throwExceptionIfRequired();
+      return new FindInfo(Collections.emptyList(),
+          findTokenHelper.getFindTokenFactoryFromReplicaType(ReplicaType.DISK_BACKED).getNewFindToken());
+    }
+
+    @Override
+    public Set<StoreKey> findMissingKeys(List<StoreKey> keys) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public StoreStats getStoreStats() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isKeyDeleted(StoreKey key) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getSizeInBytes() {
+      return 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public boolean isStarted() {
+      return started;
+    }
+
+    public void shutdown() throws StoreException {
+      throwExceptionIfRequired();
+      started = false;
+    }
+
+    /**
+     * Throws a {@link RuntimeException} or {@link StoreException} if so configured
+     * @throws StoreException
+     */
+    private void throwExceptionIfRequired() throws StoreException {
+      if (runtimeException != null) {
+        throw runtimeException;
+      }
+      if (storeException != null) {
+        throw storeException;
+      }
+    }
+
+    /**
+     * Checks the validity of the {@code ids}
+     * @param ids the {@link StoreKey}s to check
+     * @throws StoreException if the key is not valid
+     */
+    private void checkValidityOfIds(Collection<? extends StoreKey> ids) throws StoreException {
+      for (StoreKey id : ids) {
+        if (!validKeysInStore.contains(id)) {
+          throw new StoreException("Not a valid key.", StoreErrorCodes.ID_Not_Found);
+        }
+      }
+    }
+  };
+
+  private static final VerifiableProperties VPROPS = new VerifiableProperties(new Properties());
+  /**
+   * if {@code true}, a {@code null} {@link Store} is returned on a call to {@link StorageManager#getStore(PartitionId, boolean)}. Otherwise
+   * {@link #store} is returned.
+   */
+  boolean returnNullStore = false;
+  /**
+   * if not null, return this when getStore() method is called.
+   */
+  Store overrideStoreToReturn = null;
+  /**
+   * If non-null, the given exception is thrown when {@link #scheduleNextForCompaction(PartitionId)} is called.
+   */
+  RuntimeException exceptionToThrowOnSchedulingCompaction = null;
+  /**
+   * If non-null, the given exception is thrown when {@link #controlCompactionForBlobStore(PartitionId, boolean)} is called.
+   */
+  RuntimeException exceptionToThrowOnControllingCompaction = null;
+  /**
+   * If non-null, the given exception is thrown when {@link #shutdownBlobStore(PartitionId)} is called.
+   */
+  RuntimeException exceptionToThrowOnShuttingDownBlobStore = null;
+  /**
+   * If non-null, the given exception is thrown when {@link #startBlobStore(PartitionId)} is called.
+   */
+  RuntimeException exceptionToThrowOnStartingBlobStore = null;
+  /**
+   * The return value for a call to {@link #scheduleNextForCompaction(PartitionId)}.
+   */
+  boolean returnValueOfSchedulingCompaction = true;
+  /**
+   * The return value for a call to {@link #controlCompactionForBlobStore(PartitionId, boolean)}.
+   */
+  boolean returnValueOfControllingCompaction = true;
+  /**
+   * The return value for a call to {@link #shutdownBlobStore(PartitionId)}.
+   */
+  boolean returnValueOfShutdownBlobStore = true;
+  /**
+   * The return value for a call to {@link #startBlobStore(PartitionId)}.
+   */
+  boolean returnValueOfStartingBlobStore = true;
+  /**
+   * The return value for a call to {@link #addBlobStore(ReplicaId)}.
+   */
+  boolean returnValueOfAddBlobStore = true;
+  /**
+   * The return value for a call to {@link #removeBlobStore(PartitionId)}.
+   */
+  boolean returnValueOfRemoveBlobStore = true;
+  /**
+   * The {@link PartitionId} that was provided in the call to {@link #scheduleNextForCompaction(PartitionId)}
+   */
+  PartitionId compactionScheduledPartitionId = null;
+  /**
+   * The {@link PartitionId} that was provided in the call to {@link #controlCompactionForBlobStore(PartitionId, boolean)}
+   */
+  PartitionId compactionControlledPartitionId = null;
+  /**
+   * The {@link boolean} that was provided in the call to {@link #controlCompactionForBlobStore(PartitionId, boolean)}
+   */
+  Boolean compactionEnableVal = null;
+  /**
+   * The {@link PartitionId} that was provided in the call to {@link #shutdownBlobStore(PartitionId)}
+   */
+  PartitionId shutdownPartitionId = null;
+  /**
+   * The {@link PartitionId} that was provided in the call to {@link #startBlobStore(PartitionId)}
+   */
+  PartitionId startedPartitionId = null;
+  PartitionId addedPartitionId = null;
+  CountDownLatch waitOperationCountdown = new CountDownLatch(0);
+  boolean firstCall = true;
+  List<PartitionId> unreachablePartitions = new ArrayList<>();
+
+  private Set<StoreKey> validKeysInStore = new HashSet<>();
+  private FindTokenHelper findTokenHelper = new FindTokenHelper();
+  private Map<PartitionId, Store> storeMap = null;
+
+  MockStorageManager(Set<StoreKey> validKeysInStore, List<? extends ReplicaId> replicas,
+      FindTokenHelper findTokenHelper) throws StoreException {
+    super(new StoreConfig(VPROPS), new DiskManagerConfig(VPROPS), Utils.newScheduler(1, true), new MetricRegistry(),
+        replicas, null, null, null, null, new MockTime());
+    this.validKeysInStore = validKeysInStore;
+    this.findTokenHelper = findTokenHelper;
+  }
+
+  MockStorageManager(Map<PartitionId, Store> map) throws StoreException {
+    super(new StoreConfig(VPROPS), new DiskManagerConfig(VPROPS), null, new MetricRegistry(), new ArrayList<>(), null,
+        null, null, null, SystemTime.getInstance());
+    storeMap = map;
+  }
+
+  @Override
+  public Store getStore(PartitionId id, boolean skipStateCheck) {
+    if (!firstCall) {
+      try {
+        waitOperationCountdown.await();
+      } catch (InterruptedException e) {
+        throw new IllegalStateException("CountDown await was interrupted", e);
+      }
+    }
+    firstCall = false;
+    Store storeToReturn;
+    if (storeMap != null) {
+      storeToReturn = storeMap.get(id);
+      if (storeToReturn == null) {
+        unreachablePartitions.add(id);
+      }
+    } else if (overrideStoreToReturn != null) {
+      storeToReturn = overrideStoreToReturn;
+    } else {
+      storeToReturn = returnNullStore ? null : store;
+    }
+    return storeToReturn;
+  }
+
+  @Override
+  public boolean scheduleNextForCompaction(PartitionId id) {
+    if (exceptionToThrowOnSchedulingCompaction != null) {
+      throw exceptionToThrowOnSchedulingCompaction;
+    }
+    compactionScheduledPartitionId = id;
+    return returnValueOfSchedulingCompaction;
+  }
+
+  @Override
+  public boolean controlCompactionForBlobStore(PartitionId id, boolean enabled) {
+    if (exceptionToThrowOnControllingCompaction != null) {
+      throw exceptionToThrowOnControllingCompaction;
+    }
+    compactionControlledPartitionId = id;
+    compactionEnableVal = enabled;
+    return returnValueOfControllingCompaction;
+  }
+
+  @Override
+  public boolean shutdownBlobStore(PartitionId id) {
+    if (exceptionToThrowOnShuttingDownBlobStore != null) {
+      throw exceptionToThrowOnShuttingDownBlobStore;
+    }
+    shutdownPartitionId = id;
+    return returnValueOfShutdownBlobStore;
+  }
+
+  @Override
+  public boolean startBlobStore(PartitionId id) {
+    if (exceptionToThrowOnStartingBlobStore != null) {
+      throw exceptionToThrowOnStartingBlobStore;
+    }
+    startedPartitionId = id;
+    return returnValueOfStartingBlobStore;
+  }
+
+  @Override
+  public boolean addBlobStore(ReplicaId id) {
+    addedPartitionId = id.getPartitionId();
+    return returnValueOfAddBlobStore;
+  }
+
+  @Override
+  public boolean removeBlobStore(PartitionId id) {
+    return returnValueOfRemoveBlobStore;
+  }
+
+  /**
+   * Resets variables associated with the {@link Store} impl
+   */
+  void resetStore() {
+    operationReceived = null;
+    messageWriteSetReceived = null;
+    idsReceived = null;
+    storeGetOptionsReceived = null;
+    tokenReceived = null;
+    maxTotalSizeOfEntriesReceived = null;
+  }
+}

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 /**
  * The blob store that controls the log and index
  */
-class BlobStore implements Store {
+public class BlobStore implements Store {
   static final String SEPARATOR = "_";
   private final static String LockFile = ".lock";
 

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -43,8 +43,8 @@ import org.slf4j.LoggerFactory;
  * {@link DiskManager}
  */
 public class StorageManager implements StoreManager {
-  private final ConcurrentMap<PartitionId, DiskManager> partitionToDiskManager = new ConcurrentHashMap<>();
-  private final ConcurrentMap<DiskId, DiskManager> diskToDiskManager = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<PartitionId, DiskManager> partitionToDiskManager = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<DiskId, DiskManager> diskToDiskManager = new ConcurrentHashMap<>();
   private final StorageManagerMetrics metrics;
   private final Time time;
   private final StoreConfig storeConfig;

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -161,8 +161,18 @@ public class StorageManager implements StoreManager {
 
   @Override
   public Store getStore(PartitionId id) {
+    return getStore(id, false);
+  }
+
+  /**
+   * @param id the {@link PartitionId} to find the store for.
+   * @param skipStateCheck whether to skip checking state of the store. if true, it also returns store that is not started yet.
+   * @return the {@link Store} corresponding to the given {@link PartitionId}, or {@code null} if no store was found for
+   *         that partition, or that store was not started.
+   */
+  public Store getStore(PartitionId id, boolean skipStateCheck) {
     DiskManager diskManager = partitionToDiskManager.get(id);
-    return diskManager != null ? diskManager.getStore(id) : null;
+    return diskManager != null ? diskManager.getStore(id, skipStateCheck) : null;
   }
 
   @Override
@@ -247,6 +257,7 @@ public class StorageManager implements StoreManager {
   @Override
   public boolean addBlobStore(ReplicaId replica) {
     if (partitionToDiskManager.containsKey(replica.getPartitionId())) {
+      logger.info("{} already exists in storage manager, rejecting adding store request", replica.getPartitionId());
       return false;
     }
     DiskManager diskManager = diskToDiskManager.computeIfAbsent(replica.getDiskId(), disk -> {
@@ -289,7 +300,7 @@ public class StorageManager implements StoreManager {
     DiskManager diskManager = partitionToDiskManager.get(id);
     if (diskManager == null) {
       logger.info("Store {} is not found in storage manager", id);
-      return true;
+      return false;
     }
     if (!diskManager.removeBlobStore(id)) {
       logger.error("Fail to remove store {} from disk manager", id);

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
@@ -43,6 +43,7 @@ import com.github.ambry.protocol.AdminRequest;
 import com.github.ambry.protocol.AdminRequestOrResponseType;
 import com.github.ambry.protocol.AdminResponse;
 import com.github.ambry.protocol.BlobStoreControlAdminRequest;
+import com.github.ambry.protocol.BlobStoreControlRequestType;
 import com.github.ambry.protocol.CatchupStatusAdminRequest;
 import com.github.ambry.protocol.CatchupStatusAdminResponse;
 import com.github.ambry.protocol.GetOption;
@@ -221,6 +222,10 @@ public class ServerAdminTool implements Closeable {
     @Default("Short.MAX_VALUE")
     final short numReplicasCaughtUpPerPartition;
 
+    @Config("store.control.request.type")
+    @Default("StartStore")
+    final BlobStoreControlRequestType storeControlRequestType;
+
     /**
      * Path of the file where the data from certain operations will output. For example, the blob from GetBlob and the
      * user metadata from GetUserMetadata will be written into this file.
@@ -250,6 +255,8 @@ public class ServerAdminTool implements Closeable {
       numReplicasCaughtUpPerPartition =
           verifiableProperties.getShortInRange("num.replicas.caught.up.per.partition", Short.MAX_VALUE, (short) 1,
               Short.MAX_VALUE);
+      storeControlRequestType =
+          BlobStoreControlRequestType.valueOf(verifiableProperties.getString("store.control.request.type"));
       dataOutputFilePath = verifiableProperties.getString("data.output.file.path", "/tmp/ambryResult.out");
     }
   }
@@ -394,7 +401,7 @@ public class ServerAdminTool implements Closeable {
           for (String partitionIdStr : config.partitionIds) {
             PartitionId partitionId = getPartitionIdFromStr(partitionIdStr, clusterMap);
             sendBlobStoreControlRequest(serverAdminTool, dataNodeId, partitionId,
-                config.numReplicasCaughtUpPerPartition, config.enableState);
+                config.numReplicasCaughtUpPerPartition, config.storeControlRequestType);
           }
         } else {
           LOGGER.error("There were no partitions provided to be controlled (Start/Stop)");
@@ -501,22 +508,22 @@ public class ServerAdminTool implements Closeable {
    * @param dataNodeId the {@link DataNodeId} to send the request to.
    * @param partitionId the partition id  on which the operation will take place. Can be {@code null}.
    * @param numReplicasCaughtUpPerPartition the minimum number of peers should catch up with the partition.
-   * @param enable the enable (or disable) status required for BlobStore control.
+   * @param storeControlRequestType the type of control operation that will performed on certain store.
    * @throws IOException
    * @throws TimeoutException
    */
   private static void sendBlobStoreControlRequest(ServerAdminTool serverAdminTool, DataNodeId dataNodeId,
-      PartitionId partitionId, short numReplicasCaughtUpPerPartition, boolean enable)
-      throws IOException, TimeoutException {
+      PartitionId partitionId, short numReplicasCaughtUpPerPartition,
+      BlobStoreControlRequestType storeControlRequestType) throws IOException, TimeoutException {
     ServerErrorCode errorCode =
-        serverAdminTool.controlBlobStore(dataNodeId, partitionId, numReplicasCaughtUpPerPartition, enable);
+        serverAdminTool.controlBlobStore(dataNodeId, partitionId, numReplicasCaughtUpPerPartition,
+            storeControlRequestType);
     if (errorCode == ServerErrorCode.No_Error) {
-      LOGGER.info("Enable state of controlling BlobStore from has been set to {} for {} on {}", enable, partitionId,
+      LOGGER.info("{} control request has been performed for {} on {}", storeControlRequestType, partitionId,
           dataNodeId);
     } else {
-      LOGGER.error(
-          "From {}, received server error code {} for request to set enable state {} for controlling BlobStore for {}",
-          dataNodeId, errorCode, enable, partitionId);
+      LOGGER.error("From {}, received server error code {} for {} request that performed on {}", dataNodeId, errorCode,
+          storeControlRequestType, partitionId);
     }
   }
 
@@ -688,18 +695,19 @@ public class ServerAdminTool implements Closeable {
    * @param partitionId the {@link PartitionId} to start or stop.
    * @param numReplicasCaughtUpPerPartition the minimum number of peers should catch up with partition if the store is
    *                                        being stopped
-   * @param enable the enable (or disable) status required for BlobStore control.
+   * @param storeControlRequestType the type of control operation that will performed on certain store.
    * @return the {@link ServerErrorCode} that is returned.
    * @throws IOException
    * @throws TimeoutException
    */
   private ServerErrorCode controlBlobStore(DataNodeId dataNodeId, PartitionId partitionId,
-      short numReplicasCaughtUpPerPartition, boolean enable) throws IOException, TimeoutException {
+      short numReplicasCaughtUpPerPartition, BlobStoreControlRequestType storeControlRequestType)
+      throws IOException, TimeoutException {
     AdminRequest adminRequest =
         new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionId, correlationId.incrementAndGet(),
             CLIENT_ID);
     BlobStoreControlAdminRequest controlRequest =
-        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, enable, adminRequest);
+        new BlobStoreControlAdminRequest(numReplicasCaughtUpPerPartition, storeControlRequestType, adminRequest);
     ByteBuffer responseBytes = sendRequestGetResponse(dataNodeId, partitionId, controlRequest);
     AdminResponse adminResponse = AdminResponse.readFrom(new DataInputStream(new ByteBufferInputStream(responseBytes)));
     return adminResponse.getError();

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
@@ -43,7 +43,7 @@ import com.github.ambry.protocol.AdminRequest;
 import com.github.ambry.protocol.AdminRequestOrResponseType;
 import com.github.ambry.protocol.AdminResponse;
 import com.github.ambry.protocol.BlobStoreControlAdminRequest;
-import com.github.ambry.protocol.BlobStoreControlRequestType;
+import com.github.ambry.protocol.BlobStoreControlAction;
 import com.github.ambry.protocol.CatchupStatusAdminRequest;
 import com.github.ambry.protocol.CatchupStatusAdminResponse;
 import com.github.ambry.protocol.GetOption;
@@ -224,7 +224,7 @@ public class ServerAdminTool implements Closeable {
 
     @Config("store.control.request.type")
     @Default("StartStore")
-    final BlobStoreControlRequestType storeControlRequestType;
+    final BlobStoreControlAction storeControlRequestType;
 
     /**
      * Path of the file where the data from certain operations will output. For example, the blob from GetBlob and the
@@ -256,7 +256,7 @@ public class ServerAdminTool implements Closeable {
           verifiableProperties.getShortInRange("num.replicas.caught.up.per.partition", Short.MAX_VALUE, (short) 1,
               Short.MAX_VALUE);
       storeControlRequestType =
-          BlobStoreControlRequestType.valueOf(verifiableProperties.getString("store.control.request.type"));
+          BlobStoreControlAction.valueOf(verifiableProperties.getString("store.control.request.type"));
       dataOutputFilePath = verifiableProperties.getString("data.output.file.path", "/tmp/ambryResult.out");
     }
   }
@@ -514,7 +514,7 @@ public class ServerAdminTool implements Closeable {
    */
   private static void sendBlobStoreControlRequest(ServerAdminTool serverAdminTool, DataNodeId dataNodeId,
       PartitionId partitionId, short numReplicasCaughtUpPerPartition,
-      BlobStoreControlRequestType storeControlRequestType) throws IOException, TimeoutException {
+      BlobStoreControlAction storeControlRequestType) throws IOException, TimeoutException {
     ServerErrorCode errorCode =
         serverAdminTool.controlBlobStore(dataNodeId, partitionId, numReplicasCaughtUpPerPartition,
             storeControlRequestType);
@@ -701,7 +701,7 @@ public class ServerAdminTool implements Closeable {
    * @throws TimeoutException
    */
   private ServerErrorCode controlBlobStore(DataNodeId dataNodeId, PartitionId partitionId,
-      short numReplicasCaughtUpPerPartition, BlobStoreControlRequestType storeControlRequestType)
+      short numReplicasCaughtUpPerPartition, BlobStoreControlAction storeControlRequestType)
       throws IOException, TimeoutException {
     AdminRequest adminRequest =
         new AdminRequest(AdminRequestOrResponseType.BlobStoreControl, partitionId, correlationId.incrementAndGet(),


### PR DESCRIPTION
1. Refactored store control admin request to support adding/removing store.
2. Changes made in replication manager to support adding/removing replica
3. Added method in clustermap that allows caller to get detailed info of new replica from Helix PropertyStore. 
4. Changed removeBlobStore in StorageManager to return the store if it is successfully removed.
5. Moved MockStorageManager to a separate file which can be re-used by other tests.  