### PR TITLE
Disable signing of build artifacts

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -36,6 +36,10 @@ allprojects {
                 licenses = ['Apache-2.0']
                 labels = ['blob storage']
                 version {
+                    // disable gpg signing to speed up publishing
+                    gpg {
+                      sign = false
+                    }
                     // disable upload to maven central
                     mavenCentralSync {
                         sync = false


### PR DESCRIPTION
By default signing artifacts with the bintray public key is enabled.
However, this seems to add about 30 minutes to the :bintrayPublish task,
which is too long for travis-ci builds.

Signed artifacts are not required unless consumers of the libraries are
interested in verifying the signature.