### PR TITLE
AccountService's RouterStore wait for cross colo replication before reading blob from server.

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/AccountMetadataStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/AccountMetadataStore.java
@@ -66,9 +66,10 @@ abstract class AccountMetadataStore {
    * Fetch the {@link Account} metadata from the given ZNRecord. It should return null when there is no {@link Account}
    * ever created before. Subclass can assume the {@link ZNRecord} passed in this function is not null;
    * @param record The {@link ZNRecord} fetched from {@code znRecordPath}.
+   * @param isCalledFromListener True is this function is invoked in the {@link TopicListener}.
    * @return {@link Account} metadata in a map.
    */
-  abstract Map<String, String> fetchAccountMetadataFromZNRecord(ZNRecord record);
+  abstract Map<String, String> fetchAccountMetadataFromZNRecord(ZNRecord record, boolean isCalledFromListener);
 
   /**
    * Create new {@link ZKUpdater} that will be used to update the accounts.
@@ -80,9 +81,10 @@ abstract class AccountMetadataStore {
   /**
    * fetchAccountMetadata would fetch the latest full set of {@link Account} metadata from the store. It returns null
    * when there is no {@link Account} created.
+   * @param isCalledFromListener True is this function is invoked in the {@link TopicListener}.
    * @return {@link Account} metadata in a map.
    */
-  Map<String, String> fetchAccountMetadata() {
+  Map<String, String> fetchAccountMetadata(boolean isCalledFromListener) {
     long startTimeMs = System.currentTimeMillis();
     logger.trace("Start reading ZNRecord from path={}", znRecordPath);
     Stat stat = new Stat();
@@ -93,7 +95,7 @@ abstract class AccountMetadataStore {
       logger.info("The ZNRecord to read does not exist on path={}", znRecordPath);
       return null;
     }
-    Map<String, String> newAccountMap = fetchAccountMetadataFromZNRecord(znRecord);
+    Map<String, String> newAccountMap = fetchAccountMetadataFromZNRecord(znRecord, isCalledFromListener);
     if (newAccountMap != null) {
       backupFileManager.persistAccountMap(newAccountMap, stat);
     }

--- a/ambry-account/src/main/java/com/github/ambry/account/LegacyMetadataStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/LegacyMetadataStore.java
@@ -51,7 +51,7 @@ class LegacyMetadataStore extends AccountMetadataStore {
   }
 
   @Override
-  Map<String, String> fetchAccountMetadataFromZNRecord(ZNRecord record) {
+  Map<String, String> fetchAccountMetadataFromZNRecord(ZNRecord record, boolean isCalledFromListener) {
     Map<String, String> result = record.getMapField(ACCOUNT_METADATA_MAP_KEY);
     if (result == null) {
       logger.info("ZNRecord={} to read on path={} does not have a simple map with key={}", record,

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -881,8 +881,8 @@ public class HelixAccountServiceTest {
     HelixAccountService helixAccountService = (HelixAccountService) accountService;
     RouterStore routerStore =
         new RouterStore(helixAccountService.getAccountServiceMetrics(), helixAccountService.getBackupFileManager(),
-            helixStore, new AtomicReference<>(mockRouter), false, TOTAL_NUMBER_OF_VERSION_TO_KEEP);
-    Map<String, String> accountMap = routerStore.fetchAccountMetadata();
+            helixStore, new AtomicReference<>(mockRouter), new HelixAccountServiceConfig(vHelixConfigProps), false);
+    Map<String, String> accountMap = routerStore.fetchAccountMetadata(true);
     assertNotNull("Accounts should be backfilled to new znode", accountMap);
     assertAccountMapEquals(accountService.getAllAccounts(), accountMap);
   }

--- a/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.account;
 
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.ReadableStreamChannelInputStream;
 import com.github.ambry.messageformat.BlobInfo;
@@ -67,6 +68,11 @@ public class MockRouter implements Router {
     byte[] getData() {
       return data;
     }
+  }
+
+  @Override
+  public ClusterMap getClusterMap() {
+    return null;
   }
 
   @Override

--- a/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
@@ -84,6 +84,7 @@ public class RouterStoreTest {
     Properties properties = new Properties();
     properties.setProperty(HelixAccountServiceConfig.BACKUP_DIRECTORY_KEY, accountBackupDir.toString());
     properties.setProperty(HelixAccountServiceConfig.ZK_CLIENT_CONNECT_STRING_KEY, "1000");
+    properties.setProperty(HelixAccountServiceConfig.TOTAL_NUMBER_OF_VERSION_TO_KEEP, String.valueOf(TOTAL_NUMBER_OF_VERSION_TO_KEEP));
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     config = new HelixAccountServiceConfig(verifiableProperties);
     backup = new BackupFileManager(accountServiceMetrics, config);
@@ -114,8 +115,7 @@ public class RouterStoreTest {
   @Test
   public void testUpdateAndFetch() throws Exception {
     RouterStore store =
-        new RouterStore(accountServiceMetrics, backup, helixStore, new AtomicReference<>(router), forBackfill,
-            TOTAL_NUMBER_OF_VERSION_TO_KEEP);
+        new RouterStore(accountServiceMetrics, backup, helixStore, new AtomicReference<>(router), config, forBackfill);
     Map<Short, Account> idToRefAccountMap = new HashMap<>();
     Map<Short, Map<Short, Container>> idtoRefContainerMap = new HashMap<>();
     Set<Short> accountIDSet = new HashSet<>();
@@ -144,8 +144,7 @@ public class RouterStoreTest {
   @Test
   public void testSizeLimitInList() throws Exception {
     RouterStore store =
-        new RouterStore(accountServiceMetrics, backup, helixStore, new AtomicReference<>(router), forBackfill,
-            TOTAL_NUMBER_OF_VERSION_TO_KEEP);
+        new RouterStore(accountServiceMetrics, backup, helixStore, new AtomicReference<>(router), config, forBackfill);
 
     Map<Short, Account> idToRefAccountMap = new HashMap<>();
     Map<Short, Map<Short, Container>> idtoRefContainerMap = new HashMap<>();
@@ -203,7 +202,7 @@ public class RouterStoreTest {
   }
 
   /**
-   * call {@link RouterStore#updateAccounts(Collection)} to update {@link Account} metadata then call {@link RouterStore#fetchAccountMetadata()}
+   * call {@link RouterStore#updateAccounts(Collection)} to update {@link Account} metadata then call {@link RouterStore#fetchAccountMetadata(boolean)}
    * to fetch the {@link Account} metadata back and compare them. Also it fetches the {@link Account} metadata directly from ambry-server
    * and compare them.
    * @param store The {@link RouterStore}.
@@ -218,7 +217,7 @@ public class RouterStoreTest {
     assertTrue("Update accounts failed at router store", succeeded);
 
     // verify that fetchAccountMetadata can fetch the accounts we just updated.
-    Map<String, String> accountMap = store.fetchAccountMetadata();
+    Map<String, String> accountMap = store.fetchAccountMetadata(true);
     assertAccountsEqual(accountMap, allAccounts);
 
     List<RouterStore.BlobIDAndVersion> blobIDAndVersions = getBlobIDAndVersionInHelix(count);

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -137,10 +137,6 @@ public class HelixAccountServiceConfig {
     enableServeFromBackup = verifiableProperties.getBoolean(ENABLE_SERVE_FROM_BACKUP, false);
     totalNumberOfVersionToKeep =
         verifiableProperties.getIntInRange(TOTAL_NUMBER_OF_VERSION_TO_KEEP, 100, 1, Integer.MAX_VALUE);
-    int waitTime = verifiableProperties.getIntInRange(WAIT_TIME_FOR_CROSS_COLO_REPLICATION_MS, -1, -1, Integer.MAX_VALUE);
-    if (!useNewZNodePath) {
-      waitTime = -1;
-    }
-    waitTimeForCrossColoReplicationMs = waitTime;
+    waitTimeForCrossColoReplicationMs = verifiableProperties.getIntInRange(WAIT_TIME_FOR_CROSS_COLO_REPLICATION_MS, -1, -1, Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/HelixAccountServiceConfig.java
@@ -32,6 +32,7 @@ public class HelixAccountServiceConfig {
   public static final String ENABLE_SERVE_FROM_BACKUP = HELIX_ACCOUNT_SERVICE_PREFIX + "enable.serve.from.backup";
   public static final String TOTAL_NUMBER_OF_VERSION_TO_KEEP =
       HELIX_ACCOUNT_SERVICE_PREFIX + "total.number.of.version.to.keep";
+  public static final String WAIT_TIME_FOR_CROSS_COLO_REPLICATION_MS = HELIX_ACCOUNT_SERVICE_PREFIX + "wait.time.for.cross.colo.replication.ms";
 
   /**
    * The ZooKeeper server address. This config is required when using {@code HelixAccountService}.
@@ -110,6 +111,15 @@ public class HelixAccountServiceConfig {
   @Default("100")
   public final int totalNumberOfVersionToKeep;
 
+  /**
+   * The duration to wait for cross colo replication. The reason to wait for this duration is to avoid the cross colo
+   * read as much as possible. A negative value indicates AccountService will not wait for replication. Please set the
+   * duration to at least 90 percentile of cross colo replication latency.
+   */
+  @Config(WAIT_TIME_FOR_CROSS_COLO_REPLICATION_MS)
+  @Default("-1")
+  public final int waitTimeForCrossColoReplicationMs;
+
   public HelixAccountServiceConfig(VerifiableProperties verifiableProperties) {
     zkClientConnectString = verifiableProperties.getString(ZK_CLIENT_CONNECT_STRING_KEY);
     updaterPollingIntervalMs =
@@ -127,5 +137,10 @@ public class HelixAccountServiceConfig {
     enableServeFromBackup = verifiableProperties.getBoolean(ENABLE_SERVE_FROM_BACKUP, false);
     totalNumberOfVersionToKeep =
         verifiableProperties.getIntInRange(TOTAL_NUMBER_OF_VERSION_TO_KEEP, 100, 1, Integer.MAX_VALUE);
+    int waitTime = verifiableProperties.getIntInRange(WAIT_TIME_FOR_CROSS_COLO_REPLICATION_MS, -1, -1, Integer.MAX_VALUE);
+    if (!useNewZNodePath) {
+      waitTime = -1;
+    }
+    waitTimeForCrossColoReplicationMs = waitTime;
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/router/Router.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/Router.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.Utils;
@@ -26,6 +27,12 @@ import java.util.concurrent.Future;
  * The router interface for Ambry that helps to interact with Ambry server.
  */
 public interface Router extends Closeable {
+
+  /**
+   * Return {@link ClusterMap} instance if it exists within this router. Otherwise, return null;
+   * @return The {@link ClusterMap}.
+   */
+  ClusterMap getClusterMap();
 
   /**
    * Requests for the blob (info, data, or both) asynchronously and invokes the {@link Callback} when the request

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/AmbryBlobStorageServiceTest.java
@@ -2820,6 +2820,11 @@ class FrontendTestRouter implements Router {
   String ttlUpdateServiceId = null;
 
   @Override
+  public ClusterMap getClusterMap() {
+    return null;
+  }
+
+  @Override
   public Future<GetBlobResult> getBlob(String blobId, GetBlobOptions options, Callback<GetBlobResult> callback) {
     GetBlobResult result;
     switch (options.getOperationType()) {

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -126,6 +126,11 @@ class NonBlockingRouter implements Router {
     return ocList.get(ThreadLocalRandom.current().nextInt(ocCount));
   }
 
+  @Override
+  public ClusterMap getClusterMap() {
+    return clusterMap;
+  }
+
   /**
    * Requests for the blob data asynchronously with user-set {@link GetBlobOptions} and invokes the {@link Callback}
    * when the request completes.

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
@@ -98,6 +98,11 @@ public class InMemoryRouter implements Router {
     this(verifiableProperties, null, clusterMap);
   }
 
+  @Override
+  public ClusterMap getClusterMap() {
+    return clusterMap;
+  }
+
   /**
    * Representation of a blob in memory. Contains blob properties, user metadata and blob data.
    */

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/PerfRouter.java
@@ -15,6 +15,7 @@ package com.github.ambry.tools.perf.rest;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.messageformat.BlobInfo;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.router.Callback;
@@ -71,6 +72,11 @@ class PerfRouter implements Router {
     chunk = new byte[perfConfig.perfRouterChunkSize];
     random.nextBytes(chunk);
     logger.trace("Instantiated PerfRouter");
+  }
+
+  @Override
+  public ClusterMap getClusterMap() {
+    return null;
   }
 
   @Override


### PR DESCRIPTION
When there is an update to account metadata, a new blob will be created and the blob id will be broadcasted to all the frontends across all the colos in the same fabric group. Since blob id is broadcasted through zookeeper and zookeeper is much faster than ambry server's replication, most of the time, ambry-frontend would read the new blob from remote colo, which results in lots of cross-colo read.

This PR is trying to mitigate this problem. It will wait for a while before reading the new blob in ambry-frontend. The wait duration should equal to 95 percentile of cross colo replication. In this way, most of the time, ambry-frontend would read the new blob from local colo.