### PR TITLE
Prototype for server byte range request

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -32,6 +32,7 @@ public interface ClusterMap extends AutoCloseable {
    */
   PartitionId getPartitionIdFromStream(InputStream stream) throws IOException;
 
+
   /**
    * Gets a list of partitions that are available for writes. Gets a mutable shallow copy of the list of the partitions
    * that are available for writes

--- a/ambry-api/src/main/java/com.github.ambry/protocol/GetBlobStoreOption.java
+++ b/ambry-api/src/main/java/com.github.ambry/protocol/GetBlobStoreOption.java
@@ -1,0 +1,47 @@
+package com.github.ambry.protocol;
+
+import com.github.ambry.router.ByteRange;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+
+public class GetBlobStoreOption {
+  private ByteRange byteRange;
+  private static final short GetBlobStoreOption_V1 = 1;
+
+  private static final int Version_Size_In_Bytes = Short.BYTES;
+  private static final int ByteRange_Size_In_Bytes = Long.BYTES * 2;
+
+  public GetBlobStoreOption(DataInputStream stream) throws IOException {
+    short version = stream.readShort();
+    if (version != GetBlobStoreOption_V1) {
+      throw new IllegalArgumentException("Version " + version + " not supported in GetBlobStoreOption");
+    }
+    long startOffset = stream.readLong();
+    long endOffset = stream.readLong();
+    byteRange = ByteRange.fromOffsetRange(startOffset, endOffset);
+  }
+
+  public void writeTo(ByteBuffer buffer) {
+    buffer.putShort(GetBlobStoreOption_V1);
+    buffer.putLong(byteRange.getStartOffset());
+    buffer.putLong(byteRange.getEndOffset());
+  }
+
+  public long sizeInBytes() {
+    return Version_Size_In_Bytes + ByteRange_Size_In_Bytes;
+  }
+
+  public GetBlobStoreOption(ByteRange byteRange) {
+    this.byteRange = byteRange;
+  }
+
+  public ByteRange getByteRange() {
+    return byteRange;
+  }
+
+  public String toString() {
+    return "ByteRange:" + byteRange.getStartOffset() + "->" + byteRange.getEndOffset();
+  }
+}

--- a/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageInfo.java
@@ -32,6 +32,8 @@ public class MessageInfo {
   private final short containerId;
   private final long operationTimeMs;
 
+  private boolean isByteRangeResponse = false;
+
   /**
    * Construct an instance of MessageInfo.
    * @param key the {@link StoreKey} associated with this message.
@@ -115,6 +117,14 @@ public class MessageInfo {
     this.accountId = accountId;
     this.containerId = containerId;
     this.operationTimeMs = operationTimeMs;
+  }
+
+  public void setByteRangeResponse() {
+    isByteRangeResponse = true;
+  }
+
+  public boolean isByteRangeRespnose() {
+    return isByteRangeResponse;
   }
 
   public StoreKey getStoreKey() {

--- a/ambry-api/src/main/java/com.github.ambry/store/MessageReadSet.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageReadSet.java
@@ -13,7 +13,9 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.router.ByteRange;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 
 
@@ -63,4 +65,6 @@ public interface MessageReadSet {
    * @throws IOException
    */
   void doPrefetch(int index, long relativeOffset, long size) throws IOException;
+
+  ByteBuffer getPrefetchedData(int index);
 }

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
@@ -91,6 +91,12 @@ class CloudMessageReadSet implements MessageReadSet {
     }
   }
 
+  @Override
+  public ByteBuffer getPrefetchedData(int index) {
+    validateIndex(index);
+    return blobReadInfoList.get(index).getPrefetchedBuffer();
+  }
+
   /**
    * Validate that the index is withing the bounds of {@code blobReadInfoList}
    * @param index The index to be verified

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -610,7 +610,7 @@ public class MessageFormatRecord {
    *  user metadata   - The offset at which the user metadata record is located relative to this message. This exist
    *  relative offset   only when blob property record and blob record exist
    *
-   *  blob metadata   - The offset at which the blob record is located relative to this message. This exist only when
+   *  blob            - The offset at which the blob record is located relative to this message. This exist only when
    *  relative offset   blob property record and user metadata record exist
    *
    *  crc             - The crc of the message header

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
@@ -305,6 +305,11 @@ public class BlobStoreHardDeleteTest {
       public void doPrefetch(int index, long relativeOffset, long size) {
         return;
       }
+
+      @Override
+      public ByteBuffer getPrefetchedData(int index) {
+        return null;
+      }
     }
   }
 

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/GetResponse.java
@@ -42,6 +42,7 @@ public class GetResponse extends Response {
   static final short GET_RESPONSE_VERSION_V_3 = 3;
   static final short GET_RESPONSE_VERSION_V_4 = 4;
   static final short GET_RESPONSE_VERSION_V_5 = 5;
+  static final short GET_RESPONSE_VERSION_V_6 = 6;
 
   static short CURRENT_VERSION = GET_RESPONSE_VERSION_V_5;
 

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/MessageInfoAndMetdataListSerde.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/MessageInfoAndMetdataListSerde.java
@@ -41,6 +41,7 @@ class MessageInfoAndMetadataListSerde {
   static final short VERSION_3 = 3;
   static final short VERSION_4 = 4;
   static final short VERSION_5 = 5;
+  static final short VERSION_6 = 6;
 
   static final short AUTO_VERSION = VERSION_5;
 
@@ -116,6 +117,10 @@ class MessageInfoAndMetadataListSerde {
         // operationTime
         size += Long.BYTES;
       }
+      if (version >= VERSION_6) {
+        // isByteRangeResponse
+        size += 1;
+      }
       if (version > VERSION_3) {
         // whether message metadata is present.
         size += Byte.BYTES;
@@ -146,7 +151,7 @@ class MessageInfoAndMetadataListSerde {
         outputBuffer.putLong(messageInfo.getSize());
         outputBuffer.putLong(messageInfo.getExpirationTimeInMs());
         outputBuffer.put(messageInfo.isDeleted() ? UPDATED : (byte) ~UPDATED);
-        if (version < VERSION_1 || version > VERSION_5) {
+        if (version < VERSION_1 || version > VERSION_6) {
           throw new IllegalArgumentException("Unknown version in MessageInfoList " + version);
         }
         if (version >= VERSION_5) {
@@ -165,6 +170,9 @@ class MessageInfoAndMetadataListSerde {
           outputBuffer.putShort(messageInfo.getAccountId());
           outputBuffer.putShort(messageInfo.getContainerId());
           outputBuffer.putLong(messageInfo.getOperationTimeMs());
+        }
+        if (version >= VERSION_6) {
+          outputBuffer.put(messageInfo.isByteRangeRespnose() ? UPDATED : (byte)~UPDATED);
         }
         if (version > VERSION_3) {
           if (messageMetadata != null) {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
@@ -91,6 +91,11 @@ class InMemoryStore implements Store {
     public void doPrefetch(int index, long relativeOffset, long size) {
 
     }
+
+    @Override
+    public ByteBuffer getPrefetchedData(int index) {
+      return buffers.get(index);
+    }
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobInfoOperation.java
@@ -159,7 +159,7 @@ class GetBlobInfoOperation extends GetOperation {
       ReplicaId replicaId = replicaIterator.next();
       String hostname = replicaId.getDataNodeId().getHostname();
       Port port = replicaId.getDataNodeId().getPortToConnectTo();
-      GetRequest getRequest = createGetRequest(blobId, getOperationFlag(), options.getBlobOptions.getGetOption());
+      GetRequest getRequest = createGetRequest(blobId, getOperationFlag(), options.getBlobOptions.getGetOption(), null);
       RequestInfo request = new RequestInfo(hostname, port, getRequest, replicaId);
       int correlationId = getRequest.getCorrelationId();
       correlationIdToGetRequestInfo.put(correlationId, new GetRequestInfo(replicaId, time.milliseconds()));

--- a/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetOperation.java
@@ -22,6 +22,7 @@ import com.github.ambry.config.RouterConfig;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.MessageFormatFlags;
 import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.protocol.GetBlobStoreOption;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.protocol.GetRequest;
 import com.github.ambry.protocol.GetResponse;
@@ -30,7 +31,9 @@ import com.github.ambry.store.MessageInfo;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -214,12 +217,20 @@ abstract class GetOperation {
    * @param flag The {@link MessageFormatFlags} to be set with the GetRequest.
    * @return the created GetRequest.
    */
-  protected GetRequest createGetRequest(BlobId blobId, MessageFormatFlags flag, GetOption getOption) {
+  protected GetRequest createGetRequest(BlobId blobId, MessageFormatFlags flag, GetOption getOption, GetBlobStoreOption getBlobStoreOption) {
     List<BlobId> blobIds = Collections.singletonList(blobId);
     List<PartitionRequestInfo> partitionRequestInfoList =
         Collections.singletonList(new PartitionRequestInfo(blobId.getPartition(), blobIds));
-    return new GetRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname, flag,
-        partitionRequestInfoList, getOption);
+    logger.info("GetBlobStoreOption for blobId " + blobId.toString() + " is " + getBlobStoreOption);
+    if (getBlobStoreOption == null) {
+      return new GetRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
+          flag, partitionRequestInfoList, getOption);
+    } else {
+      Map<BlobId, GetBlobStoreOption> getBlobStoreOptions = new HashMap<>();
+      getBlobStoreOptions.put(blobId, getBlobStoreOption);
+      return new GetRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
+          flag, partitionRequestInfoList, getOption, getBlobStoreOptions);
+    }
   }
 
   /**

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryRequestsTest.java
@@ -1292,6 +1292,11 @@ public class AmbryRequestsTest {
           @Override
           public void doPrefetch(int index, long relativeOffset, long size) {
           }
+
+          @Override
+          public ByteBuffer getPrefetchedData(int index) {
+            return null;
+          }
         }, Collections.emptyList());
       }
 


### PR DESCRIPTION
Adding ByteRange information for GetRequest as a map.
Adding IsByteRangeResponse in the MessageInfo in GetResponse.
Only enable ByteRange response when the prefetch is enabled, and the blob type is data blob, and it's not encrypted.