### PR TITLE
Fix a bug to make failure on reading blob fails account service update

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -237,6 +237,10 @@ class RouterStore extends AccountMetadataStore {
           // If this is not for backfill, then just read account metadata from blob, otherwise, initialize it with
           // an empty map and fill it up with the accountMap passed to constructor.
           accountMap = (!forBackFill) ? readAccountMetadataFromBlobID(blobIDAndVersion.blobID) : new HashMap<>();
+          if (accountMap == null) {
+            logAndThrowIllegalStateException("Fail to read account metadata from blob id " + blobIDAndVersion.blobID,
+                null);
+          }
         } catch (JSONException e) {
           accountServiceMetrics.remoteDataCorruptionErrorCount.inc();
           logAndThrowIllegalStateException(

--- a/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
@@ -168,14 +168,21 @@ public class MockRouter implements Router {
     throw new UnsupportedOperationException("updateBlobTtl is not supported by this mock");
   }
 
-  @Override
-  public void close() throws IOException {
-    // close will remove all the blobs
+  /**
+   * clear would remove all the blob in the map.
+   */
+  public void clear() {
     lock.lock();
     try {
       allBlobs.clear();
     } finally {
       lock.unlock();
     }
+  }
+
+  @Override
+  public void close() throws IOException {
+    // close will remove all the blobs
+    clear();
   }
 }

--- a/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
@@ -161,8 +161,7 @@ public class RouterStoreTest {
     for (Map.Entry<Short, Account> entry : anotherIdToRefAccountMap.entrySet()) {
       idToRefAccountMap.put(entry.getKey(), entry.getValue());
     }
-    boolean succeeded = store.updateAccounts(anotherIdToRefAccountMap.values());
-    assertFalse("Update account should fail on read error", succeeded);
+    assertFalse("Update account should fail on read error", store.updateAccounts(anotherIdToRefAccountMap.values()));
   }
 
   /**

--- a/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
@@ -47,10 +47,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
 
 /**
@@ -135,6 +133,36 @@ public class RouterStoreTest {
     }
     // the version should be 2 now
     assertUpdateAndFetch(store, idToRefAccountMap, anotherIdToRefAccountMap, 2, 2);
+  }
+
+  /**
+   * Test update when there is an read error from router. Update should fail.
+   * @throws Exception Any error.
+   */
+  @Test
+  public void testUpdateFailureOnReadFromRouter() throws Exception {
+    assumeTrue(!forBackfill);
+    RouterStore store =
+        new RouterStore(accountServiceMetrics, backup, helixStore, new AtomicReference<>(router), forBackfill,
+            TOTAL_NUMBER_OF_VERSION_TO_KEEP);
+    Map<Short, Account> idToRefAccountMap = new HashMap<>();
+    Map<Short, Map<Short, Container>> idtoRefContainerMap = new HashMap<>();
+    Set<Short> accountIDSet = new HashSet<>();
+    // generate an new account and test update and fetch on this account
+    AccountTestUtils.generateRefAccounts(idToRefAccountMap, idtoRefContainerMap, accountIDSet, 1, 1);
+    assertUpdateAndFetch(store, idToRefAccountMap, idToRefAccountMap, 1, 1);
+
+    // Now clear the router
+    router.close();
+
+    // generate another new account and test update and fetch on this account
+    Map<Short, Account> anotherIdToRefAccountMap = new HashMap<>();
+    AccountTestUtils.generateRefAccounts(anotherIdToRefAccountMap, idtoRefContainerMap, accountIDSet, 1, 1);
+    for (Map.Entry<Short, Account> entry : anotherIdToRefAccountMap.entrySet()) {
+      idToRefAccountMap.put(entry.getKey(), entry.getValue());
+    }
+    boolean succeeded = store.updateAccounts(anotherIdToRefAccountMap.values());
+    assertFalse("Update account should fail on read error", succeeded);
   }
 
   /**

--- a/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/RouterStoreTest.java
@@ -152,8 +152,8 @@ public class RouterStoreTest {
     AccountTestUtils.generateRefAccounts(idToRefAccountMap, idtoRefContainerMap, accountIDSet, 1, 1);
     assertUpdateAndFetch(store, idToRefAccountMap, idToRefAccountMap, 1, 1);
 
-    // Now clear the router
-    router.close();
+    // Now clear the router to remove the blob so next time when reading blob, it will remove an exception.
+    router.clear();
 
     // generate another new account and test update and fetch on this account
     Map<Short, Account> anotherIdToRefAccountMap = new HashMap<>();


### PR DESCRIPTION
When reading blob fails, the account service update should also fail. This pr would fix this bug.