### PR TITLE
Add support for Conscrypt SSL provider, direct buf option for index

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
@@ -90,6 +90,13 @@ public class NetworkConfig {
   @Default("-1")
   public final int selectorMaxKeyToProcess;
 
+  /**
+   * True to allocate direct buffers within the selector (for things like SSL work).
+   */
+  @Config("selector.use.direct.buffers")
+  @Default("false")
+  public final boolean selectorUseDirectBuffers;
+
   public NetworkConfig(VerifiableProperties verifiableProperties) {
 
     numIoThreads = verifiableProperties.getIntInRange("num.io.threads", 8, 1, Integer.MAX_VALUE);
@@ -106,5 +113,6 @@ public class NetworkConfig {
         verifiableProperties.getIntInRange("selector.executor.pool.size", 4, 0, Integer.MAX_VALUE);
     selectorMaxKeyToProcess =
         verifiableProperties.getIntInRange("selector.max.key.to.process", -1, -1, Integer.MAX_VALUE);
+    selectorUseDirectBuffers = verifiableProperties.getBoolean("selector.use.direct.buffers", false);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -257,7 +257,7 @@ public class StoreConfig {
    * Provides a hint for how indexes should be treated w.r.t memory
    */
   @Config(storeIndexMemStateName)
-  @Default("NOT_IN_MEM")
+  @Default("MMAP_WITHOUT_FORCE_LOAD")
   public final IndexMemState storeIndexMemState;
   public static final String storeIndexMemStateName = "store.index.mem.state";
 
@@ -343,8 +343,8 @@ public class StoreConfig {
     storeValidateAuthorization = verifiableProperties.getBoolean("store.validate.authorization", false);
     storeTtlUpdateBufferTimeSeconds =
         verifiableProperties.getIntInRange(storeTtlUpdateBufferTimeSecondsName, 60 * 60 * 24, 0, Integer.MAX_VALUE);
-    storeIndexMemState =
-        IndexMemState.valueOf(verifiableProperties.getString(storeIndexMemStateName, IndexMemState.NOT_IN_MEM.name()));
+    storeIndexMemState = IndexMemState.valueOf(
+        verifiableProperties.getString(storeIndexMemStateName, IndexMemState.MMAP_WITHOUT_FORCE_LOAD.name()));
     storeIoErrorCountToTriggerShutdown =
         verifiableProperties.getIntInRange("store.io.error.count.to.trigger.shutdown", Integer.MAX_VALUE, 1,
             Integer.MAX_VALUE);

--- a/ambry-api/src/main/java/com.github.ambry/store/IndexMemState.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/IndexMemState.java
@@ -19,17 +19,23 @@ package com.github.ambry.store;
  */
 public enum IndexMemState {
   /**
-   * Index should not be in memory
+   * Index should be read from an mmap-ed file, but not forced to reside in memory.
    */
-  NOT_IN_MEM,
+  MMAP_WITHOUT_FORCE_LOAD,
 
   /**
-   * Index should be in heap memory
+   * Index should be mmap-ed and force loaded into memory. The index should make a best effort to keep the segments in
+   * memory, but it is not guaranteed.
+   */
+  MMAP_WITH_FORCE_LOAD,
+
+  /**
+   * Index should be in heap memory.
    */
   IN_HEAP_MEM,
 
   /**
-   * If mmaped, the index should be force loaded into memory
+   * Index should be in direct (off-heap) memory.
    */
-  FORCE_LOAD_MMAP
+  IN_DIRECT_MEM
 }

--- a/ambry-commons/src/main/java/com.github.ambry.commons/JdkSslFactory.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/JdkSslFactory.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.SecureRandom;
+import java.security.Security;
 import java.util.ArrayList;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -27,6 +28,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManagerFactory;
+import org.conscrypt.Conscrypt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,8 +37,15 @@ import org.slf4j.LoggerFactory;
  * Factory to create SSLContext and SSLEngine
  */
 public class JdkSslFactory implements SSLFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(JdkSslFactory.class);
 
-  protected static final Logger logger = LoggerFactory.getLogger(JdkSslFactory.class);
+  static {
+    if (Conscrypt.isAvailable()) {
+      Security.addProvider(Conscrypt.newProvider());
+    } else {
+      LOGGER.warn("Conscrypt not available for this platform; will not be able to use OpenSSL-based engine");
+    }
+  }
 
   private final SSLContext sslContext;
   private final String[] cipherSuites;

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -617,7 +617,8 @@ public class Selector implements Selectable {
     } else if (portType == PortType.SSL) {
       try {
         transmission =
-            new SSLTransmission(sslFactory, connectionId, channel(key), key, hostname, port, time, metrics, mode);
+            new SSLTransmission(sslFactory, connectionId, channel(key), key, hostname, port, time, metrics, mode,
+                networkConfig.selectorUseDirectBuffers);
         metrics.sslTransmissionInitializationCount.inc();
       } catch (IOException e) {
         metrics.sslTransmissionInitializationErrorCount.inc();

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -360,8 +360,7 @@ public class IndexSegmentTest {
    */
   @Test
   public void memoryMapFailureTest() throws IOException, StoreException {
-    assumeTrue(version == PersistentIndex.VERSION_1 && !config.storeIndexMemState.equals(IndexMemState.IN_HEAP_MEM)
-        && !config.storeIndexMemState.equals(IndexMemState.FORCE_LOAD_MMAP));
+    assumeTrue(version == PersistentIndex.VERSION_1 && config.storeIndexMemState == IndexMemState.MMAP_WITHOUT_FORCE_LOAD);
     String logSegmentName = LogSegmentNameHelper.getName(0, 0);
     StoreKeyFactory mockStoreKeyFactory = Mockito.spy(STORE_KEY_FACTORY);
     IndexSegment indexSegment = generateIndexSegment(new Offset(logSegmentName, 0), mockStoreKeyFactory);

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -761,7 +761,8 @@ public class Utils {
    */
   public static ByteBuffer ensureCapacity(ByteBuffer existingBuffer, int newLength) {
     if (newLength > existingBuffer.capacity()) {
-      ByteBuffer newBuffer = ByteBuffer.allocate(newLength);
+      ByteBuffer newBuffer =
+          existingBuffer.isDirect() ? ByteBuffer.allocateDirect(newLength) : ByteBuffer.allocate(newLength);
       existingBuffer.flip();
       newBuffer.put(existingBuffer);
       return newBuffer;

--- a/build.gradle
+++ b/build.gradle
@@ -175,6 +175,7 @@ project(':ambry-commons') {
                 project(':ambry-clustermap'),
                 project(':ambry-messageformat'),
                 project(':ambry-utils')
+        compile "org.conscrypt:conscrypt-openjdk-uber:$conscryptVersion"
         testCompile project(':ambry-api').sourceSets.test.output
         testCompile project(':ambry-clustermap').sourceSets.test.output
         testCompile project(':ambry-utils').sourceSets.test.output

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -24,4 +24,5 @@ ext {
     jaydioVersion = "0.1"
     azureStorageVersion = "5.0.0"
     azureDocumentDbVersion = "2.1.1"
+    conscryptVersion = "2.2.1"
 }


### PR DESCRIPTION
- Conscrypt (https://github.com/google/conscrypt) is a security provider
library that leverages BoringSSL to implement a more performant
SSLEngine. This change adds support for using it as a provider in 
JdkSslFactory.
- Add an option to load IndexSegments into a direct (off-heap) ByteBuffer.
- Rename the IndexMemState values to better match their meanings.