### PR TITLE
Allow tests to run when Conscrypt not available

### DIFF
--- a/ambry-commons/src/main/java/com.github.ambry.commons/JdkSslFactory.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/JdkSslFactory.java
@@ -43,8 +43,9 @@ public class JdkSslFactory implements SSLFactory {
     try {
       Conscrypt.checkAvailability();
       Security.addProvider(Conscrypt.newProvider());
-    } catch (Exception e) {
-      LOGGER.warn("Conscrypt not available for this platform; will not be able to use OpenSSL-based engine", e);
+    } catch (Throwable t) {
+      // catching a throwable since Conscrypt.checkAvailability can throw an UnsatisfiedLinkError
+      LOGGER.warn("Conscrypt not available for this platform; will not be able to use OpenSSL-based engine", t);
     }
   }
 

--- a/ambry-commons/src/test/java/com.github.ambry.commons/TestSSLUtils.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/TestSSLUtils.java
@@ -54,12 +54,13 @@ import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;
 import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
 import org.bouncycastle.operator.bc.BcRSAContentSignerBuilder;
+import org.conscrypt.Conscrypt;
 import org.junit.Assert;
 
 
 public class TestSSLUtils {
   private final static String SSL_CONTEXT_PROTOCOL = "TLS";
-  private final static String SSL_CONTEXT_PROVIDER = "Conscrypt";
+  private final static String SSL_CONTEXT_PROVIDER = Conscrypt.isAvailable() ? "Conscrypt" : "SunJSSE";
   private final static String TLS_V1_2_PROTOCOL = "TLSv1.2";
   private static final String SSL_V2_HELLO_PROTOCOL = "SSLv2Hello";
   private final static String ENDPOINT_IDENTIFICATION_ALGORITHM = "HTTPS";

--- a/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SSLSelectorTest.java
@@ -27,12 +27,15 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
+import java.security.Security;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
+import org.conscrypt.Conscrypt;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,7 +60,12 @@ public class SSLSelectorTest {
   @Parameterized.Parameters
   public static List<Object[]> data() {
     List<Object[]> params = new ArrayList<>();
-    for (String provider : new String[]{"Conscrypt", "SunJSSE"}) {
+    List<String> supportedProviders = new ArrayList<>();
+    supportedProviders.add("SunJSSE");
+    if (Conscrypt.isAvailable()) {
+      supportedProviders.add("Conscrypt");
+    }
+    for (String provider : supportedProviders) {
       for (int poolSize : new int[]{0, 2}) {
         for (boolean useDirectBuffers : TestUtils.BOOLEAN_VALUES) {
           params.add(new Object[]{provider, poolSize, useDirectBuffers});


### PR DESCRIPTION
- Check Conscrypt availability before running tests with it to allow
   tests to run on machines with glibc < 2.14.
- Catch Throwable when checking Conscrypt availability
