### PR TITLE
Revert "Shutdown request handler before network server in ambry server (#1206)"

### DIFF
--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
@@ -221,11 +221,11 @@ public class AmbryServer {
       if (statsManager != null) {
         statsManager.shutdown();
       }
-      if (requestHandlerPool != null) {
-        requestHandlerPool.shutdown();
-      }
       if (networkServer != null) {
         networkServer.shutdown();
+      }
+      if (requestHandlerPool != null) {
+        requestHandlerPool.shutdown();
       }
       if (replicationManager != null) {
         replicationManager.shutdown();


### PR DESCRIPTION
This reverts commit 063ca5ee6a91536a57352ad65f4484c7f19cb7e0.
We have some suspicions that the frontend may not be able to deal with
this nicely if it is in the middle of writing to a socket.