### PR TITLE
Vcrrequest init error fix

### DIFF
--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
@@ -110,7 +110,7 @@ class CloudBlobStore implements Store {
   }
 
   @Override
-  public void start() throws StoreException {
+  public void start() {
     started = true;
   }
 

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudStorageManager.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudStorageManager.java
@@ -113,5 +113,6 @@ public class CloudStorageManager implements StoreManager {
         value -> new CloudBlobStore(properties, partitionId, cloudDestination, clusterMap, vcrMetrics));
     // cloud blob store start is idempotent
     partitionToStore.get(partitionId).start();
+    logger.info("Cloudblobstore started for partition {}", partitionId);
   }
 }

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrRequests.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrRequests.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.ServerMetrics;
 import com.github.ambry.network.Request;
 import com.github.ambry.network.RequestResponseChannel;
@@ -31,6 +32,9 @@ import com.github.ambry.store.Store;
 import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,14 +78,21 @@ public class VcrRequests extends AmbryRequests {
       metrics.badRequestError.inc();
       return ServerErrorCode.Bad_Request;
     }
-
-    // 2. check if partition is handled by this vcr node
-    return skipPartitionAvailableCheck ? ServerErrorCode.No_Error
-        : storeManager.checkLocalPartitionStatus(partition, null);
+    return ServerErrorCode.No_Error;
   }
 
   @Override
   protected long getRemoteReplicaLag(Store store, long totalBytesRead) {
     return -1;
+  }
+
+  @Override
+  protected Map<PartitionId, ReplicaId> createLocalPartitionToReplicaMap() {
+    List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
+    Map<PartitionId, ReplicaId> partitionToReplica = new HashMap<>();
+    for (PartitionId partitionId : partitionIds) {
+      partitionToReplica.put(partitionId, new CloudReplica(partitionId, currentNode));
+    }
+    return partitionToReplica;
   }
 }

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrRequests.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrRequests.java
@@ -88,6 +88,7 @@ public class VcrRequests extends AmbryRequests {
 
   @Override
   protected Map<PartitionId, ReplicaId> createLocalPartitionToReplicaMap() {
+    //Vcr should be able to handle requests for all partitions
     List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     Map<PartitionId, ReplicaId> partitionToReplica = new HashMap<>();
     for (PartitionId partitionId : partitionIds) {

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrRequests.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrRequests.java
@@ -32,9 +32,10 @@ import com.github.ambry.store.Store;
 import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,10 +91,7 @@ public class VcrRequests extends AmbryRequests {
   protected Map<PartitionId, ReplicaId> createLocalPartitionToReplicaMap() {
     //Vcr should be able to handle requests for all partitions
     List<? extends PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
-    Map<PartitionId, ReplicaId> partitionToReplica = new HashMap<>();
-    for (PartitionId partitionId : partitionIds) {
-      partitionToReplica.put(partitionId, new CloudReplica(partitionId, currentNode));
-    }
-    return partitionToReplica;
+    return partitionIds.stream()
+        .collect(Collectors.toMap(Function.identity(), partitionId -> new CloudReplica(partitionId, currentNode)));
   }
 }

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudStorageManagerTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudStorageManagerTest.java
@@ -22,6 +22,7 @@ import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.store.Store;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Properties;
@@ -123,17 +124,23 @@ public class CloudStorageManagerTest {
     PartitionId partitionId = mockReplicaId.getPartitionId();
 
     //try get for a partition that doesn't exist
-    Assert.assertNull(cloudStorageManager.getStore(partitionId));
+    Store store = cloudStorageManager.getStore(partitionId);
+    Assert.assertNotNull(store);
+    Assert.assertTrue(store.isStarted());
 
     //add and start a replica to the store
     Assert.assertTrue(cloudStorageManager.addBlobStore(mockReplicaId));
 
     //try get for an added replica
-    Assert.assertNotNull(cloudStorageManager.getStore(partitionId));
+    store = cloudStorageManager.getStore(partitionId);
+    Assert.assertNotNull(store);
+    Assert.assertTrue(store.isStarted());
 
     //try get for a removed replica
     Assert.assertTrue(cloudStorageManager.removeBlobStore(partitionId));
-    Assert.assertNull(cloudStorageManager.getStore(partitionId));
+    store = cloudStorageManager.getStore(partitionId);
+    Assert.assertNotNull(store);
+    Assert.assertTrue(store.isStarted());
   }
 
   /**
@@ -148,7 +155,7 @@ public class CloudStorageManagerTest {
 
     //try checkLocalPartitionStatus for a partition that doesn't exist
     Assert.assertEquals(cloudStorageManager.checkLocalPartitionStatus(partitionId, new MockReplicaId()),
-        ServerErrorCode.Partition_Unknown);
+        ServerErrorCode.No_Error);
 
     //add and start a replica to the store
     Assert.assertTrue(cloudStorageManager.addBlobStore(mockReplicaId));
@@ -162,12 +169,12 @@ public class CloudStorageManagerTest {
 
     //try checkLocalPartitionStatus for a stopped replica (stopped blob store)
     Assert.assertEquals(cloudStorageManager.checkLocalPartitionStatus(partitionId, mockReplicaId),
-        ServerErrorCode.Replica_Unavailable);
+        ServerErrorCode.No_Error);
 
     //try checkLocalPartitionStatus for a removed replica
     Assert.assertTrue(cloudStorageManager.removeBlobStore(partitionId));
     Assert.assertEquals(cloudStorageManager.checkLocalPartitionStatus(partitionId, new MockReplicaId()),
-        ServerErrorCode.Partition_Unknown);
+        ServerErrorCode.No_Error);
   }
 
   /**

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -88,11 +88,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -186,12 +186,8 @@ public class AmbryRequests implements RequestAPI {
    * @return list of {@link ReplicaId}s on current node.
    */
   protected Map<PartitionId, ReplicaId> createLocalPartitionToReplicaMap() {
-    Map<PartitionId, ReplicaId> partitionToReplica = new HashMap<>();
     List<? extends ReplicaId> localReplicaIds = clusterMap.getReplicaIds(currentNode);
-    for (ReplicaId replicaId : localReplicaIds) {
-      partitionToReplica.put(replicaId.getPartitionId(), replicaId);
-    }
-    return partitionToReplica;
+    return localReplicaIds.stream().collect(Collectors.toMap(ReplicaId::getPartitionId, Function.identity()));
   }
 
   public void handlePutRequest(Request request) throws IOException, InterruptedException {

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryRequests.java
@@ -108,7 +108,7 @@ public class AmbryRequests implements RequestAPI {
   protected final RequestResponseChannel requestResponseChannel;
   private Logger publicAccessLogger = LoggerFactory.getLogger("PublicAccessLogger");
   protected final ClusterMap clusterMap;
-  private final DataNodeId currentNode;
+  protected final DataNodeId currentNode;
   private final Map<PartitionId, ReplicaId> localPartitionToReplicaMap;
   protected final ServerMetrics metrics;
   private final MessageFormatMetrics messageFormatMetrics;
@@ -146,11 +146,7 @@ public class AmbryRequests implements RequestAPI {
       requestsDisableInfo.put(requestType, Collections.newSetFromMap(new ConcurrentHashMap<>()));
     }
 
-    Map<PartitionId, ReplicaId> partitionToReplica = new HashMap<>();
-    for (ReplicaId replicaId : clusterMap.getReplicaIds(currentNode)) {
-      partitionToReplica.put(replicaId.getPartitionId(), replicaId);
-    }
-    localPartitionToReplicaMap = Collections.unmodifiableMap(partitionToReplica);
+    localPartitionToReplicaMap = Collections.unmodifiableMap(createLocalPartitionToReplicaMap());
   }
 
   public void handleRequests(Request request) throws InterruptedException {
@@ -183,6 +179,19 @@ public class AmbryRequests implements RequestAPI {
       logger.error("Error while handling request " + request + " closing connection", e);
       requestResponseChannel.closeConnection(request);
     }
+  }
+
+  /**
+   * Get the list of replicas on current node.
+   * @return list of {@link ReplicaId}s on current node.
+   */
+  protected Map<PartitionId, ReplicaId> createLocalPartitionToReplicaMap() {
+    Map<PartitionId, ReplicaId> partitionToReplica = new HashMap<>();
+    List<? extends ReplicaId> localReplicaIds = clusterMap.getReplicaIds(currentNode);
+    for (ReplicaId replicaId : localReplicaIds) {
+      partitionToReplica.put(replicaId.getPartitionId(), replicaId);
+    }
+    return partitionToReplica;
   }
 
   public void handlePutRequest(Request request) throws IOException, InterruptedException {


### PR DESCRIPTION
This PR fixes a bug that was encountered while testing recovery. Vcr was trying to get local replicas map using the "getReplicaIds" API in HelixClusterManager. But this API has a check for being called only in a AmbryDataNode. 
As a fix this PR overrides the get local replicas functionality in VcrRequests. Also Vcr nodes should be able to handle requests for all partitions. The overridden get local replicas functionality exhibits this behavior too.