### PR TITLE
Close connections on router request timeouts

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -105,6 +105,13 @@ public class RouterConfig {
   public final int routerRequestTimeoutMs;
 
   /**
+   * {@code true} if the router should tell the network layer about requests that have timed out. The network client
+   * can choose how to drop these requests.
+   */
+  @Config("router.drop.request.on.timeout")
+  public final boolean routerDropRequestOnTimeout;
+
+  /**
    * The max chunk size to be used for put operations.
    */
   @Config("router.max.put.chunk.size.bytes")
@@ -377,6 +384,7 @@ public class RouterConfig {
     routerConnectionCheckoutTimeoutMs =
         verifiableProperties.getIntInRange("router.connection.checkout.timeout.ms", 1000, 1, 5000);
     routerRequestTimeoutMs = verifiableProperties.getIntInRange("router.request.timeout.ms", 2000, 1, 10000);
+    routerDropRequestOnTimeout = verifiableProperties.getBoolean("router.drop.requests.on.timeout", false);
     routerMaxPutChunkSizeBytes =
         verifiableProperties.getIntInRange("router.max.put.chunk.size.bytes", 4 * 1024 * 1024, 1, Integer.MAX_VALUE);
     routerPutRequestParallelism =

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -109,6 +109,7 @@ public class RouterConfig {
    * can choose how to drop these requests.
    */
   @Config("router.drop.request.on.timeout")
+  @Default("false")
   public final boolean routerDropRequestOnTimeout;
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/network/SendWithCorrelationId.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/SendWithCorrelationId.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.network;
+
+/**
+ * Most {@link Send}s include a correlation ID that is used to associate a request/response pair. This can be used to
+ * indicate that a correlation ID is required.
+ */
+public interface SendWithCorrelationId extends Send {
+
+  /**
+   * @return the correlation id for the {@link Send} (a process-unique identifier for a request).
+   */
+  int getCorrelationId();
+}

--- a/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/NetworkClient.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The NetworkClient provides a method for sending a list of requests in the form of {@link Send} to a host:port,
- * and receive responses for sent requests. Requests that come in via {@link #sendAndPoll(List, int)} call,
+ * and receive responses for sent requests. Requests that come in via {@link #sendAndPoll(List, List, int)} call,
  * that could not be immediately sent is queued and an attempt will be made in subsequent invocations of the call (or
  * until they time out).
  * (Note: We will empirically determine whether, rather than queueing a request,
@@ -50,6 +50,7 @@ public class NetworkClient implements Closeable {
   private final Time time;
   private final LinkedList<RequestMetadata> pendingRequests;
   private final HashMap<String, RequestMetadata> connectionIdToRequestInFlight;
+  private final HashMap<Integer, String> correlationIdToConnectionId;
   private final HashMap<String, RequestMetadata> pendingConnectionsToAssociatedRequests;
   private final AtomicLong numPendingRequests;
   private final int checkoutTimeoutMs;
@@ -78,6 +79,7 @@ public class NetworkClient implements Closeable {
     pendingRequests = new LinkedList<>();
     numPendingRequests = new AtomicLong(0);
     connectionIdToRequestInFlight = new HashMap<>();
+    correlationIdToConnectionId = new HashMap<>();
     pendingConnectionsToAssociatedRequests = new HashMap<>();
     networkMetrics.registerNetworkClientPendingConnections(numPendingRequests);
   }
@@ -86,27 +88,38 @@ public class NetworkClient implements Closeable {
    * Attempt to send the given requests and poll for responses from the network via the associated selector. Any
    * requests that could not be sent out will be added to a queue. Every time this method is called, it will first
    * attempt sending the requests in the queue (or time them out) and then attempt sending the newly added requests.
-   * @param requestInfos the list of {@link RequestInfo} representing the requests that need to be sent out. This
+   * @param requestsToSend the list of {@link RequestInfo} representing the requests that need to be sent out. This
    *                     could be empty.
+   * @param requestsToDrop the list of correlation IDs representing the requests that can be dropped by
+   *                       closing the connection.
    * @param pollTimeoutMs the poll timeout.
    * @return a list of {@link ResponseInfo} representing the responses received for any requests that were sent out
    * so far.
    * @throws IllegalStateException if the NetworkClient is closed.
    */
-  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestInfos, int pollTimeoutMs) {
+  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestsToSend, List<Integer> requestsToDrop,
+      int pollTimeoutMs) {
     if (closed || !selector.isOpen()) {
       throw new IllegalStateException("The NetworkClient is closed.");
     }
     long startTime = time.milliseconds();
     List<ResponseInfo> responseInfoList = new ArrayList<>();
     try {
-      for (RequestInfo requestInfo : requestInfos) {
+      for (RequestInfo requestInfo : requestsToSend) {
         pendingRequests.add(new RequestMetadata(requestInfo));
       }
       List<NetworkSend> sends = prepareSends(responseInfoList);
       if (networkConfig.networkClientEnableConnectionReplenishment) {
         int connectionsInitiated = connectionTracker.replenishConnections(this::connect);
         networkMetrics.connectionReplenished.inc(connectionsInitiated);
+      }
+      for (Integer correlationId : requestsToDrop) {
+        String connectionId = correlationIdToConnectionId.get(correlationId);
+        if (connectionId != null) {
+          // we do not need to mutate any of the bookkeeping data structures since that will be handled when dealing
+          // with the disconnected list in handleSelectorEvents()
+          selector.close(connectionId);
+        }
       }
       selector.poll(pollTimeoutMs, sends);
       handleSelectorEvents(responseInfoList);
@@ -185,6 +198,7 @@ public class NetworkClient implements Closeable {
           logger.trace("Connection checkout succeeded for {}:{} with connectionId {} ", host, port, connId);
           sends.add(new NetworkSend(connId, requestMetadata.requestInfo.getRequest(), null, time));
           connectionIdToRequestInFlight.put(connId, requestMetadata);
+          correlationIdToConnectionId.put(requestMetadata.requestInfo.getRequest().getCorrelationId(), connId);
           iter.remove();
           requestMetadata.onRequestDequeue();
         }
@@ -287,6 +301,7 @@ public class NetworkClient implements Closeable {
         requestMetadata = connectionIdToRequestInFlight.remove(connId);
         if (requestMetadata != null) {
           logger.trace("ConnectionId {} with request in flight disconnected", connId);
+          correlationIdToConnectionId.remove(requestMetadata.requestInfo.getRequest().getCorrelationId());
           responseInfoList.add(
               new ResponseInfo(requestMetadata.requestInfo, NetworkClientErrorCode.NetworkError, null));
         } else {
@@ -308,6 +323,7 @@ public class NetworkClient implements Closeable {
           connId);
       connectionTracker.checkInConnection(connId);
       RequestMetadata requestMetadata = connectionIdToRequestInFlight.remove(connId);
+      correlationIdToConnectionId.remove(requestMetadata.requestInfo.getRequest().getCorrelationId());
       responseInfoList.add(new ResponseInfo(requestMetadata.requestInfo, null, recv.getReceivedBytes().getPayload()));
       requestMetadata.onResponseReceive();
     }
@@ -324,7 +340,7 @@ public class NetworkClient implements Closeable {
   }
 
   /**
-   * Wake up the NetworkClient if it is within a {@link #sendAndPoll(List, int)} sleep. This wakes
+   * Wake up the NetworkClient if it is within a {@link #sendAndPoll(List, List, int)} sleep. This wakes
    * up the {@link Selector}, which in turn wakes up the {@link java.nio.channels.Selector}.
    * <br>
    * @see java.nio.channels.Selector#wakeup()

--- a/ambry-network/src/main/java/com.github.ambry.network/RequestInfo.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/RequestInfo.java
@@ -67,4 +67,10 @@ public class RequestInfo {
   public ReplicaId getReplicaId() {
     return replicaId;
   }
+
+  @Override
+  public String toString() {
+    return "RequestInfo{" + "host='" + host + '\'' + ", port=" + port + ", request=" + request + ", replicaId="
+        + replicaId + '}';
+  }
 }

--- a/ambry-network/src/main/java/com.github.ambry.network/RequestInfo.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/RequestInfo.java
@@ -23,7 +23,7 @@ import com.github.ambry.clustermap.ReplicaId;
 public class RequestInfo {
   private final String host;
   private final Port port;
-  private final Send request;
+  private final SendWithCorrelationId request;
   private final ReplicaId replicaId;
 
   /**
@@ -33,7 +33,7 @@ public class RequestInfo {
    * @param request the data to be sent.
    * @param replicaId the {@link ReplicaId} associated with this request
    */
-  public RequestInfo(String host, Port port, Send request, ReplicaId replicaId) {
+  public RequestInfo(String host, Port port, SendWithCorrelationId request, ReplicaId replicaId) {
     this.host = host;
     this.port = port;
     this.request = request;
@@ -57,7 +57,7 @@ public class RequestInfo {
   /**
    * @return the request in the form of {@link Send} associated with this object.
    */
-  public Send getRequest() {
+  public SendWithCorrelationId getRequest() {
     return request;
   }
 

--- a/ambry-network/src/main/java/com.github.ambry.network/ResponseInfo.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/ResponseInfo.java
@@ -73,4 +73,10 @@ public class ResponseInfo {
   public DataNodeId getDataNode() {
     return dataNode;
   }
+
+  @Override
+  public String toString() {
+    return "ResponseInfo{" + "requestInfo=" + requestInfo + ", error=" + error + ", response=" + response
+        + ", dataNode=" + dataNode + '}';
+  }
 }

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -27,6 +27,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -155,7 +156,7 @@ public class NetworkClientTest {
     int responseCount = 0;
 
     do {
-      responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+      responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
       requestInfoList.clear();
       for (ResponseInfo responseInfo : responseInfoList) {
         MockSend send = (MockSend) responseInfo.getRequestInfo().getRequest();
@@ -171,7 +172,7 @@ public class NetworkClientTest {
     } while (requestCount > responseCount);
     Assert.assertEquals("Should receive only as many responses as there were requests", requestCount, responseCount);
 
-    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     requestInfoList.clear();
     Assert.assertEquals("No responses are expected at this time", 0, responseInfoList.size());
   }
@@ -188,7 +189,7 @@ public class NetworkClientTest {
     int requestCount = requestInfoList.size();
     int responseCount = 0;
 
-    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     requestInfoList.clear();
     // The first sendAndPoll() initiates the connections. So, after the selector poll, new connections
     // would have been established, but no new responses or disconnects, so the NetworkClient should not have been
@@ -198,7 +199,7 @@ public class NetworkClientTest {
     time.sleep(CHECKOUT_TIMEOUT_MS + 1);
 
     do {
-      responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+      responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
       requestInfoList.clear();
       for (ResponseInfo responseInfo : responseInfoList) {
         NetworkClientErrorCode error = responseInfo.getError();
@@ -210,7 +211,7 @@ public class NetworkClientTest {
         responseCount++;
       }
     } while (requestCount > responseCount);
-    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     requestInfoList.clear();
     Assert.assertEquals("No responses are expected at this time", 0, responseInfoList.size());
   }
@@ -230,7 +231,7 @@ public class NetworkClientTest {
     // set beBad so that requests end up failing due to "network error".
     selector.setState(MockSelectorState.DisconnectOnSend);
     do {
-      responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+      responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
       requestInfoList.clear();
       for (ResponseInfo responseInfo : responseInfoList) {
         NetworkClientErrorCode error = responseInfo.getError();
@@ -242,7 +243,7 @@ public class NetworkClientTest {
         responseCount++;
       }
     } while (requestCount > responseCount);
-    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     requestInfoList.clear();
     Assert.assertEquals("No responses are expected at this time", 0, responseInfoList.size());
     selector.setState(MockSelectorState.Good);
@@ -256,7 +257,7 @@ public class NetworkClientTest {
     List<RequestInfo> requestInfoList = new ArrayList<>();
     // test that IllegalStateException would be thrown if replica is not specified in RequestInfo
     requestInfoList.add(new RequestInfo(sslHost, sslPort, new MockSend(-1), null));
-    networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     Assert.assertEquals("NetworkClientException should increase because replica is null in request", 1,
         networkMetrics.networkClientException.getCount());
     requestInfoList.clear();
@@ -265,7 +266,7 @@ public class NetworkClientTest {
     requestInfoList.add(new RequestInfo(sslHost, sslPort, new MockSend(4), replicaOnSslNode));
     selector.setState(MockSelectorState.ThrowExceptionOnConnect);
     try {
-      networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+      networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     } catch (Exception e) {
       Assert.fail("If selector throws on connect, sendAndPoll() should not throw");
     }
@@ -286,33 +287,33 @@ public class NetworkClientTest {
     selector.setState(MockSelectorState.IdlePoll);
     Assert.assertEquals(0, selector.connectCallCount());
     // this sendAndPoll() should initiate a connect().
-    List<ResponseInfo> responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(),
-        POLL_TIMEOUT_MS);
+    List<ResponseInfo> responseInfoList =
+        networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     // At this time a single connection would have been initiated for the above request.
     Assert.assertEquals(1, selector.connectCallCount());
     Assert.assertEquals(0, responseInfoList.size());
     requestInfoList.clear();
 
     // Subsequent calls to sendAndPoll() should not initiate any connections.
-    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     Assert.assertEquals(1, selector.connectCallCount());
     Assert.assertEquals(0, responseInfoList.size());
 
     // Another connection should get initialized if a new request comes in for the same destination.
     requestInfoList.add(new RequestInfo(sslHost, sslPort, new MockSend(1), replicaOnSslNode));
-    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     Assert.assertEquals(2, selector.connectCallCount());
     Assert.assertEquals(0, responseInfoList.size());
     requestInfoList.clear();
 
     // Subsequent calls to sendAndPoll() should not initiate any more connections.
-    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     Assert.assertEquals(2, selector.connectCallCount());
     Assert.assertEquals(0, responseInfoList.size());
 
     // Once connect failure kicks in, the pending requests should be failed immediately.
     selector.setState(MockSelectorState.FailConnectionInitiationOnPoll);
-    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     Assert.assertEquals(2, selector.connectCallCount());
     Assert.assertEquals(2, responseInfoList.size());
     Assert.assertEquals(NetworkClientErrorCode.NetworkError, responseInfoList.get(0).getError());
@@ -321,7 +322,7 @@ public class NetworkClientTest {
   }
 
   /**
-   * Test that connections get replenished in {@link NetworkClient#sendAndPoll(List, List, int)} to maintain the minimum
+   * Test that connections get replenished in {@link NetworkClient#sendAndPoll(List, Set, int)} to maintain the minimum
    * number of active connections.
    */
   @Test
@@ -342,29 +343,67 @@ public class NetworkClientTest {
 
     selector.setState(MockSelectorState.Good);
     // this sendAndPoll() should use one of the pre-warmed connections
-    List<ResponseInfo> responseInfoList = networkClient.sendAndPoll(requestGen.apply(3), Collections.emptyList(),
-        POLL_TIMEOUT_MS);
+    List<ResponseInfo> responseInfoList =
+        networkClient.sendAndPoll(requestGen.apply(3), Collections.emptySet(), POLL_TIMEOUT_MS);
     checkConnectCalls.run();
     Assert.assertEquals(3, responseInfoList.size());
 
     // this sendAndPoll() should disconnect two of the pre-warmed connections
     selector.setState(MockSelectorState.DisconnectOnSend);
-    responseInfoList = networkClient.sendAndPoll(requestGen.apply(2), Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestGen.apply(2), Collections.emptySet(), POLL_TIMEOUT_MS);
     checkConnectCalls.run();
     Assert.assertEquals(2, responseInfoList.size());
 
     // the two connections lost in the previous sendAndPoll should be replenished
     selector.setState(MockSelectorState.Good);
-    responseInfoList = networkClient.sendAndPoll(requestGen.apply(1), Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestGen.apply(1), Collections.emptySet(), POLL_TIMEOUT_MS);
     expectedConnectCalls.addAndGet(2);
     checkConnectCalls.run();
     Assert.assertEquals(1, responseInfoList.size());
 
     // this call should use the existing connections in the pool
     selector.setState(MockSelectorState.Good);
-    responseInfoList = networkClient.sendAndPoll(requestGen.apply(3), Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestGen.apply(3), Collections.emptySet(), POLL_TIMEOUT_MS);
     checkConnectCalls.run();
     Assert.assertEquals(3, responseInfoList.size());
+  }
+
+  /**
+   * Test dropping of requests by closing
+   */
+  @Test
+  public void testRequestDropping() {
+    AtomicInteger nextCorrelationId = new AtomicInteger(1);
+    Function<Integer, List<RequestInfo>> requestGen = numRequests -> IntStream.range(0, numRequests)
+        .mapToObj(
+            i -> new RequestInfo(sslHost, sslPort, new MockSend(nextCorrelationId.getAndIncrement()), replicaOnSslNode))
+        .collect(Collectors.toList());
+    List<ResponseInfo> responseInfoList;
+
+    responseInfoList = networkClient.sendAndPoll(requestGen.apply(3), Collections.emptySet(), POLL_TIMEOUT_MS);
+    Assert.assertEquals("No responses expected in first poll.", 0, responseInfoList.size());
+
+    responseInfoList =
+        networkClient.sendAndPoll(Collections.emptyList(), new HashSet<>(Arrays.asList(2, 3)), POLL_TIMEOUT_MS);
+    for (ResponseInfo responseInfo : responseInfoList) {
+      MockSend send = (MockSend) responseInfo.getRequestInfo().getRequest();
+      if (send.getCorrelationId() == 1) {
+        NetworkClientErrorCode error = responseInfo.getError();
+        ByteBuffer response = responseInfo.getResponse();
+        Assert.assertNull("Should not have encountered an error", error);
+        Assert.assertNotNull("Should receive a valid response", response);
+        int correlationIdInRequest = send.getCorrelationId();
+        int correlationIdInResponse = response.getInt();
+        Assert.assertEquals("Received response for the wrong request", correlationIdInRequest, correlationIdInResponse);
+      } else {
+        Assert.assertEquals("Expected disconnect", NetworkClientErrorCode.NetworkError, responseInfo.getError());
+        Assert.assertNull("Should not receive a response", responseInfo.getResponse());
+      }
+    }
+    Assert.assertEquals("Should receive only as many responses as there were requests", 3, responseInfoList.size());
+
+    responseInfoList = networkClient.sendAndPoll(Collections.emptyList(), Collections.emptySet(), POLL_TIMEOUT_MS);
+    Assert.assertEquals("No responses are expected at this time", 0, responseInfoList.size());
   }
 
   /**
@@ -385,14 +424,14 @@ public class NetworkClientTest {
     List<RequestInfo> requestInfoList = new ArrayList<>();
     requestInfoList.add(new RequestInfo(sslHost, sslPort, new MockSend(2), replicaOnSslNode));
     requestInfoList.add(new RequestInfo(sslHost, sslPort, new MockSend(3), replicaOnSslNode));
-    List<ResponseInfo> responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(),
-        POLL_TIMEOUT_MS);
+    List<ResponseInfo> responseInfoList =
+        networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     requestInfoList.clear();
     Assert.assertEquals(2, selector.connectCallCount());
     Assert.assertEquals(0, responseInfoList.size());
 
     // Invoke sendAndPoll() again, the Connection C1 will get disconnected
-    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     // Verify that no more connection is initiated in network client
     Assert.assertEquals(2, selector.connectCallCount());
     // There should be 2 responses, one is success from Request R1, another is from Connection C1 timeout.
@@ -407,12 +446,12 @@ public class NetworkClientTest {
     responseInfoList.clear();
 
     // Invoke sendAndPoll() again, Request R2 will get sent via Connection C2
-    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     Assert.assertEquals(2, selector.connectCallCount());
     Assert.assertEquals(1, responseInfoList.size());
     Assert.assertNull(responseInfoList.get(0).getError());
     // Verify the correlation Id of Request R2
-    Assert.assertEquals(3, ((MockSend) responseInfoList.get(0).getRequestInfo().getRequest()).getCorrelationId());
+    Assert.assertEquals(3, responseInfoList.get(0).getRequestInfo().getRequest().getCorrelationId());
     responseInfoList.clear();
     selector.setState(MockSelectorState.Good);
   }
@@ -427,15 +466,15 @@ public class NetworkClientTest {
     List<RequestInfo> requestInfoList = new ArrayList<>();
     selector.setState(MockSelectorState.IdlePoll);
     requestInfoList.add(new RequestInfo(sslHost, sslPort, new MockSend(4), replicaOnSslNode));
-    List<ResponseInfo> responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(),
-        POLL_TIMEOUT_MS);
+    List<ResponseInfo> responseInfoList =
+        networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     Assert.assertEquals(0, responseInfoList.size());
     requestInfoList.clear();
     // now make the selector return any attempted connections as disconnections.
     selector.setState(MockSelectorState.FailConnectionInitiationOnPoll);
     // increment the time so that the request times out in the next cycle.
     time.sleep(2000);
-    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+    responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     // the size of responseInfoList should be 2 because first response comes from dropping request in the queue that
     // waits too long. (This response would be handled by corresponding manager, i.e PutManager, GetManager, etc); second
     // response comes from underlying connection timeout in nioSelector (usually due to remote node is down). This response
@@ -459,7 +498,7 @@ public class NetworkClientTest {
     requestInfoList.add(new RequestInfo(sslHost, sslPort, new MockSend(4), replicaOnSslNode));
     selector.setState(MockSelectorState.ThrowExceptionOnPoll);
     try {
-      networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+      networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
     } catch (Exception e) {
       Assert.fail("If selector throws on poll, sendAndPoll() should not throw.");
     }
@@ -484,7 +523,7 @@ public class NetworkClientTest {
     List<RequestInfo> requestInfoList = new ArrayList<RequestInfo>();
     networkClient.close();
     try {
-      networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), POLL_TIMEOUT_MS);
+      networkClient.sendAndPoll(requestInfoList, Collections.emptySet(), POLL_TIMEOUT_MS);
       Assert.fail("Polling after close should throw");
     } catch (IllegalStateException e) {
     }
@@ -638,6 +677,7 @@ class MockSelector extends Selector {
   private List<String> connected = new ArrayList<>();
   private List<String> nextConnected = new ArrayList<>();
   private List<String> disconnected = new ArrayList<>();
+  private final List<String> closedConnections = new ArrayList<>();
   private final List<String> delayedFailFreshList = new ArrayList<>();
   private final List<String> delayedFailPassedList = new ArrayList<>();
   private List<NetworkSend> sends = new ArrayList<>();
@@ -725,19 +765,21 @@ class MockSelector extends Selector {
     delayedFailPassedList.clear();
     delayedFailPassedList.addAll(delayedFailFreshList);
     delayedFailFreshList.clear();
+    disconnected.addAll(closedConnections);
     this.sends = sends;
     if (sends != null) {
       for (NetworkSend send : sends) {
         MockSend mockSend = (MockSend) send.getPayload();
         if (state == MockSelectorState.DisconnectOnSend) {
           disconnected.add(send.getConnectionId());
-        } else {
+        } else if (!closedConnections.contains(send.getConnectionId())) {
           receives.add(
               new NetworkReceive(send.getConnectionId(), new MockBoundedByteBufferReceive(mockSend.getCorrelationId()),
                   new MockTime()));
         }
       }
     }
+    closedConnections.clear();
   }
 
   /**
@@ -818,7 +860,7 @@ class MockSelector extends Selector {
   @Override
   public void close(String conn) {
     if (connectionIds.contains(conn)) {
-      disconnected.add(conn);
+      closedConnections.add(conn);
     }
   }
 

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestOrResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestOrResponse.java
@@ -14,6 +14,7 @@
 package com.github.ambry.protocol;
 
 import com.github.ambry.network.Send;
+import com.github.ambry.network.SendWithCorrelationId;
 import com.github.ambry.utils.Utils;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -24,7 +25,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Request Response for serialization and de-serialization
  */
-public abstract class RequestOrResponse implements Send {
+public abstract class RequestOrResponse implements SendWithCorrelationId {
   protected final RequestOrResponseType type;
   protected final int correlationId;
   protected short versionId;
@@ -50,6 +51,7 @@ public abstract class RequestOrResponse implements Send {
     return type;
   }
 
+  @Override
   public int getCorrelationId() {
     return correlationId;
   }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestOrResponse.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/RequestOrResponse.java
@@ -13,7 +13,6 @@
  */
 package com.github.ambry.protocol;
 
-import com.github.ambry.network.Send;
 import com.github.ambry.network.SendWithCorrelationId;
 import com.github.ambry.utils.Utils;
 import java.nio.ByteBuffer;

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -26,7 +26,6 @@ import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.protocol.DeleteRequest;
 import com.github.ambry.protocol.DeleteResponse;
-import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Time;
 import java.util.HashMap;
@@ -55,22 +54,7 @@ class DeleteManager {
 
   private static final Logger logger = LoggerFactory.getLogger(DeleteManager.class);
 
-  /**
-   * Used by a {@link DeleteOperation} to associate a {@code CorrelationId} to a {@link DeleteOperation}.
-   */
-  private class DeleteRequestRegistrationCallbackImpl implements RequestRegistrationCallback<DeleteOperation> {
-    private List<RequestInfo> requestListToFill;
-
-    @Override
-    public void registerRequestToSend(DeleteOperation deleteOperation, RequestInfo requestInfo) {
-      requestListToFill.add(requestInfo);
-      correlationIdToDeleteOperation.put(((RequestOrResponse) requestInfo.getRequest()).getCorrelationId(),
-          deleteOperation);
-    }
-  }
-
-  private final DeleteRequestRegistrationCallbackImpl requestRegistrationCallback =
-      new DeleteRequestRegistrationCallbackImpl();
+  private final RequestRegistrationCallback<DeleteOperation> requestRegistrationCallback;
 
   /**
    * Creates a DeleteManager.
@@ -96,6 +80,7 @@ class DeleteManager {
     this.time = time;
     deleteOperations = ConcurrentHashMap.newKeySet();
     correlationIdToDeleteOperation = new HashMap<>();
+    requestRegistrationCallback = new RequestRegistrationCallback<>(correlationIdToDeleteOperation);
   }
 
   /**
@@ -122,11 +107,13 @@ class DeleteManager {
   /**
    * Polls all delete operations and populates a list of {@link RequestInfo} to be sent to data nodes in order to
    * complete delete operations.
-   * @param requestListToFill list to be filled with the requests created.
+   * @param requestsToSend list to be filled with the requests created.
+   * @param requestsToDrop list to be filled with the requests to drop.
    */
-  public void poll(List<RequestInfo> requestListToFill) {
+  public void poll(List<RequestInfo> requestsToSend, List<Integer> requestsToDrop) {
     long startTime = time.milliseconds();
-    requestRegistrationCallback.requestListToFill = requestListToFill;
+    requestRegistrationCallback.setRequestsToSend(requestsToSend);
+    requestRegistrationCallback.setRequestsToDrop(requestsToDrop);
     for (DeleteOperation op : deleteOperations) {
       boolean exceptionEncountered = false;
       try {

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -110,7 +110,7 @@ class DeleteManager {
    * @param requestsToSend list to be filled with the requests created.
    * @param requestsToDrop list to be filled with the requests to drop.
    */
-  public void poll(List<RequestInfo> requestsToSend, List<Integer> requestsToDrop) {
+  public void poll(List<RequestInfo> requestsToSend, Set<Integer> requestsToDrop) {
     long startTime = time.milliseconds();
     requestRegistrationCallback.setRequestsToSend(requestsToSend);
     requestRegistrationCallback.setRequestsToDrop(requestsToDrop);

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteOperation.java
@@ -17,13 +17,13 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ResponseHandler;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.DeleteRequest;
 import com.github.ambry.protocol.DeleteResponse;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.Time;
 import java.util.Iterator;
 import java.util.Map;
@@ -108,7 +108,7 @@ class DeleteOperation {
    *                            that gets created as part of this poll operation.
    */
   void poll(RequestRegistrationCallback<DeleteOperation> requestRegistrationCallback) {
-    cleanupExpiredInflightRequests();
+    cleanupExpiredInflightRequests(requestRegistrationCallback);
     checkAndMaybeComplete();
     if (!isOperationComplete()) {
       fetchRequests(requestRegistrationCallback);
@@ -237,21 +237,25 @@ class DeleteOperation {
   /**
    * Goes through the inflight request list of this {@code DeleteOperation} and remove those that
    * have been timed out.
+   * @param requestRegistrationCallback The callback to use to notify the networking layer of dropped requests.
    */
-  private void cleanupExpiredInflightRequests() {
+  private void cleanupExpiredInflightRequests(
+      RequestRegistrationCallback<DeleteOperation> requestRegistrationCallback) {
     Iterator<Map.Entry<Integer, DeleteRequestInfo>> itr = deleteRequestInfos.entrySet().iterator();
     while (itr.hasNext()) {
-      Map.Entry<Integer, DeleteRequestInfo> deleteRequestInfoEntry = itr.next();
-      DeleteRequestInfo deleteRequestInfo = deleteRequestInfoEntry.getValue();
+      Map.Entry<Integer, DeleteRequestInfo> entry = itr.next();
+      int correlationId = entry.getKey();
+      DeleteRequestInfo deleteRequestInfo = entry.getValue();
       if (time.milliseconds() - deleteRequestInfo.startTimeMs > routerConfig.routerRequestTimeoutMs) {
         itr.remove();
-        logger.trace("Delete Request with correlationid {} in flight has expired for replica {} ",
-            deleteRequestInfoEntry.getKey(), deleteRequestInfo.replica.getDataNodeId());
+        logger.trace("Delete Request with correlationId {} in flight has expired for replica {} ", correlationId,
+            deleteRequestInfo.replica.getDataNodeId());
         // Do not notify this as a failure to the response handler, as this timeout could simply be due to
         // connection unavailability. If there is indeed a network error, the NetworkClient will provide an error
         // response and the response handler will be notified accordingly.
         onErrorResponse(deleteRequestInfo.replica,
-            new RouterException("Timed out waiting for a response", RouterErrorCode.OperationTimedOut));
+            RouterUtils.buildTimeoutException(correlationId, deleteRequestInfo.replica.getDataNodeId(), blobId));
+        requestRegistrationCallback.registerRequestToDrop(correlationId);
       } else {
         // the entries are ordered by correlation id and time. Break on the first request that has not timed out.
         break;
@@ -303,7 +307,8 @@ class DeleteOperation {
       if (operationTracker.hasSucceeded()) {
         operationException.set(null);
       } else if (operationTracker.hasFailedOnNotFound()) {
-        operationException.set(new RouterException("DeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
+        operationException.set(
+            new RouterException("DeleteOperation failed because of BlobNotFound", RouterErrorCode.BlobDoesNotExist));
       }
       operationCompleted = true;
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -185,7 +185,7 @@ class GetManager {
    * @param requestsToSend list to be filled with the requests created
    * @param requestsToDrop list to be filled with the requests to drop.
    */
-  void poll(List<RequestInfo> requestsToSend, List<Integer> requestsToDrop) {
+  void poll(List<RequestInfo> requestsToSend, Set<Integer> requestsToDrop) {
     long startTime = time.milliseconds();
     requestRegistrationCallback.setRequestsToSend(requestsToSend);
     requestRegistrationCallback.setRequestsToDrop(requestsToDrop);

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -192,7 +192,7 @@ class PutManager {
    * @param requestsToSend list to be filled with the requests created
    * @param requestsToDrop list to be filled with the requests to drop.
    */
-  void poll(List<RequestInfo> requestsToSend, List<Integer> requestsToDrop) {
+  void poll(List<RequestInfo> requestsToSend, Set<Integer> requestsToDrop) {
     long startTime = time.milliseconds();
     requestRegistrationCallback.setRequestsToSend(requestsToSend);
     requestRegistrationCallback.setRequestsToDrop(requestsToDrop);

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -26,7 +26,6 @@ import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.protocol.PutRequest;
 import com.github.ambry.protocol.PutResponse;
-import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.util.HashMap;
@@ -73,20 +72,9 @@ class PutManager {
   private final NonBlockingRouterMetrics routerMetrics;
   private final String defaultPartitionClass;
 
-  private class PutRequestRegistrationCallbackImpl implements RequestRegistrationCallback<PutOperation> {
-    private List<RequestInfo> requestListToFill;
-
-    @Override
-    public void registerRequestToSend(PutOperation putOperation, RequestInfo requestInfo) {
-      requestListToFill.add(requestInfo);
-      correlationIdToPutOperation.put(((RequestOrResponse) requestInfo.getRequest()).getCorrelationId(), putOperation);
-    }
-  }
-
   // A single callback as this will never get called concurrently. The list of request to fill will be set as
   // appropriate before the callback is passed on to the PutOperations, every time.
-  private final PutRequestRegistrationCallbackImpl requestRegistrationCallback =
-      new PutRequestRegistrationCallbackImpl();
+  private final RequestRegistrationCallback<PutOperation> requestRegistrationCallback;
 
   /**
    * Create a PutManager
@@ -134,6 +122,7 @@ class PutManager {
     this.time = time;
     putOperations = ConcurrentHashMap.newKeySet();
     correlationIdToPutOperation = new HashMap<>();
+    requestRegistrationCallback = new RequestRegistrationCallback<>(correlationIdToPutOperation);
     chunkFillerThread = Utils.newThread("ChunkFillerThread-" + suffix, new ChunkFiller(), true);
     chunkFillerThread.start();
     routerMetrics.initializePutManagerMetrics(chunkFillerThread);
@@ -200,11 +189,13 @@ class PutManager {
    * RequestResponseHandler thread in the {@link NonBlockingRouter} ({@link #handleResponse} gets called only if a
    * response is received for a put operation), any error handling or operation completion and cleanup also usually
    * gets done in the context of this method.
-   * @param requestListToFill list to be filled with the requests created
+   * @param requestsToSend list to be filled with the requests created
+   * @param requestsToDrop list to be filled with the requests to drop.
    */
-  void poll(List<RequestInfo> requestListToFill) {
+  void poll(List<RequestInfo> requestsToSend, List<Integer> requestsToDrop) {
     long startTime = time.milliseconds();
-    requestRegistrationCallback.requestListToFill = requestListToFill;
+    requestRegistrationCallback.setRequestsToSend(requestsToSend);
+    requestRegistrationCallback.setRequestsToDrop(requestsToDrop);
     for (PutOperation op : putOperations) {
       try {
         op.poll(requestRegistrationCallback);

--- a/ambry-router/src/main/java/com.github.ambry.router/RequestRegistrationCallback.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RequestRegistrationCallback.java
@@ -16,6 +16,7 @@ package com.github.ambry.router;
 import com.github.ambry.network.RequestInfo;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -28,7 +29,7 @@ import java.util.Map;
 class RequestRegistrationCallback<T> {
   private final Map<Integer, T> correlationIdToOperation;
   private List<RequestInfo> requestsToSend = null;
-  private List<Integer> requestsToDrop = null;
+  private Set<Integer> requestsToDrop = null;
 
   /**
    * @param correlationIdToOperation used to keep a mapping from correlation ID to the operation that the request
@@ -48,7 +49,7 @@ class RequestRegistrationCallback<T> {
   /**
    * @return the list where the correlation IDs of requests to drop are added.
    */
-  List<Integer> getRequestsToDrop() {
+  Set<Integer> getRequestsToDrop() {
     return requestsToDrop;
   }
 
@@ -62,7 +63,7 @@ class RequestRegistrationCallback<T> {
   /**
    * @param requestsToDrop the list to add the correlation IDs of requests to drop to.
    */
-  void setRequestsToDrop(List<Integer> requestsToDrop) {
+  void setRequestsToDrop(Set<Integer> requestsToDrop) {
     this.requestsToDrop = requestsToDrop;
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterCallback.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterCallback.java
@@ -41,7 +41,7 @@ class RouterCallback {
    * Called by the operation managers when a poll-eligible event occurs for any operation. A poll-eligible event is any
    * event that occurs asynchronously to the RequestResponseHandler thread such that there is a high chance of
    * meaningful work getting done when the operation is subsequently polled. When the callback is invoked, the
-   * RequestResponseHandler thread which could be sleeping in a {@link NetworkClient#sendAndPoll(List, int)} is woken up
+   * RequestResponseHandler thread which could be sleeping in a {@link NetworkClient#sendAndPoll(List, List, int)} is woken up
    * so that the operations can be polled without additional delays. For example, when a chunk gets filled by the
    * ChunkFillerThread within the {@link PutManager}, this callback is invoked so that the RequestResponseHandler
    * immediately polls the operation to send out the request for the chunk.

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterCallback.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterCallback.java
@@ -41,7 +41,7 @@ class RouterCallback {
    * Called by the operation managers when a poll-eligible event occurs for any operation. A poll-eligible event is any
    * event that occurs asynchronously to the RequestResponseHandler thread such that there is a high chance of
    * meaningful work getting done when the operation is subsequently polled. When the callback is invoked, the
-   * RequestResponseHandler thread which could be sleeping in a {@link NetworkClient#sendAndPoll(List, List, int)} is woken up
+   * RequestResponseHandler thread which could be sleeping in a {@link NetworkClient#sendAndPoll(List, java.util.Set, int)} is woken up
    * so that the operations can be polled without additional delays. For example, when a chunk gets filled by the
    * ChunkFillerThread within the {@link PutManager}, this callback is invoked so that the RequestResponseHandler
    * immediately polls the operation to send out the request for the chunk.

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -21,11 +21,11 @@ import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ResponseHandler;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.Response;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
@@ -140,8 +140,11 @@ class RouterUtils {
    * @return a {@link RouterException} with the {@link RouterErrorCode#OperationTimedOut} error code.
    */
   static RouterException buildTimeoutException(int correlationId, DataNodeId dataNode, BlobId blobId) {
-    return new RouterException("Timed out waiting for a response. correlationId=" + correlationId + ", dataNode=" + dataNode + ", blobId=" + blobId, RouterErrorCode.OperationTimedOut);
+    return new RouterException(
+        "Timed out waiting for a response. correlationId=" + correlationId + ", dataNode=" + dataNode + ", blobId="
+            + blobId, RouterErrorCode.OperationTimedOut);
   }
+
   /**
    * Atomically replace the exception for an operation depending on the precedence of the new exception.
    * First, if the current operationException is null, directly set operationException as exception;

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -17,6 +17,7 @@ import com.github.ambry.account.Account;
 import com.github.ambry.account.AccountService;
 import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ResponseHandler;
@@ -132,6 +133,15 @@ class RouterUtils {
     return new Pair<>(account, container);
   }
 
+  /**
+   * @param correlationId correlation ID for the request that timed out
+   * @param dataNode the node that the request was made to.
+   * @param blobId the blob ID of the request.
+   * @return a {@link RouterException} with the {@link RouterErrorCode#OperationTimedOut} error code.
+   */
+  static RouterException buildTimeoutException(int correlationId, DataNodeId dataNode, BlobId blobId) {
+    return new RouterException("Timed out waiting for a response. correlationId=" + correlationId + ", dataNode=" + dataNode + ", blobId=" + blobId, RouterErrorCode.OperationTimedOut);
+  }
   /**
    * Atomically replace the exception for an operation depending on the precedence of the new exception.
    * First, if the current operationException is null, directly set operationException as exception;

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateManager.java
@@ -123,7 +123,7 @@ class TtlUpdateManager {
    * @param requestsToSend list to be filled with the requests created.
    * @param requestsToDrop list to be filled with the requests to drop.
    */
-  void poll(List<RequestInfo> requestsToSend, List<Integer> requestsToDrop) {
+  void poll(List<RequestInfo> requestsToSend, Set<Integer> requestsToDrop) {
     long startTime = time.milliseconds();
     requestRegistrationCallback.setRequestsToSend(requestsToSend);
     requestRegistrationCallback.setRequestsToDrop(requestsToDrop);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -732,11 +732,11 @@ public class GetBlobInfoOperationTest {
   private List<ResponseInfo> sendAndWaitForResponses(List<RequestInfo> requestList) {
     int sendCount = requestList.size();
     Collections.shuffle(requestList);
-    List<ResponseInfo> responseList = new ArrayList<>(networkClient.sendAndPoll(requestList, Collections.emptyList(),
-        100));
+    List<ResponseInfo> responseList =
+        new ArrayList<>(networkClient.sendAndPoll(requestList, Collections.emptySet(), 100));
     requestList.clear();
     while (responseList.size() < sendCount) {
-      responseList.addAll(networkClient.sendAndPoll(requestList, Collections.emptyList(), 100));
+      responseList.addAll(networkClient.sendAndPoll(requestList, Collections.emptySet(), 100));
     }
     return responseList;
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobInfoOperationTest.java
@@ -21,7 +21,6 @@ import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.commons.ResponseHandler;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.CryptoServiceConfig;
 import com.github.ambry.config.KMSConfig;
 import com.github.ambry.config.RouterConfig;
@@ -33,7 +32,7 @@ import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.GetResponse;
-import com.github.ambry.protocol.RequestOrResponse;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.TestUtils;
@@ -97,8 +96,8 @@ public class GetBlobInfoOperationTest {
   private final byte[] putContent;
   private final boolean testEncryption;
   private final String operationTrackerType;
-  private final GetTestRequestRegistrationCallbackImpl requestRegistrationCallback =
-      new GetTestRequestRegistrationCallbackImpl();
+  private final RequestRegistrationCallback<GetOperation> requestRegistrationCallback =
+      new RequestRegistrationCallback<>(correlationIdToGetOperation);
   private final GetBlobOptionsInternal options;
   private String kmsSingleKey;
   private MockKeyManagementService kms = null;
@@ -107,16 +106,6 @@ public class GetBlobInfoOperationTest {
   private ReplicaId localReplica;
   private ReplicaId remoteReplica;
   private String localDcName;
-
-  private class GetTestRequestRegistrationCallbackImpl implements RequestRegistrationCallback<GetOperation> {
-    private List<RequestInfo> requestListToFill;
-
-    @Override
-    public void registerRequestToSend(GetOperation getOperation, RequestInfo requestInfo) {
-      requestListToFill.add(requestInfo);
-      correlationIdToGetOperation.put(((RequestOrResponse) requestInfo.getRequest()).getCorrelationId(), getOperation);
-    }
-  }
 
   /**
    * Running for both {@link SimpleOperationTracker} and {@link AdaptiveOperationTracker}, with and without encryption
@@ -247,7 +236,7 @@ public class GetBlobInfoOperationTest {
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, null,
             routerCallback, kms, cryptoService, cryptoJobHandler, time, false);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
-    requestRegistrationCallback.requestListToFill = requestListToFill;
+    requestRegistrationCallback.setRequestsToSend(requestListToFill);
     op.poll(requestRegistrationCallback);
     Assert.assertEquals("There should only be as many requests at this point as requestParallelism", requestParallelism,
         correlationIdToGetOperation.size());
@@ -284,7 +273,7 @@ public class GetBlobInfoOperationTest {
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, null,
             routerCallback, kms, cryptoService, cryptoJobHandler, time, false);
-    requestRegistrationCallback.requestListToFill = new ArrayList<>();
+    requestRegistrationCallback.setRequestsToSend(new ArrayList<>());
     op.poll(requestRegistrationCallback);
     int count = 0;
     while (!op.isOperationComplete()) {
@@ -319,7 +308,7 @@ public class GetBlobInfoOperationTest {
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, null,
             routerCallback, kms, cryptoService, cryptoJobHandler, time, false);
-    requestRegistrationCallback.requestListToFill = new ArrayList<>();
+    requestRegistrationCallback.setRequestsToSend(new ArrayList<>());
     op.poll(requestRegistrationCallback);
     while (!op.isOperationComplete()) {
       time.sleep(routerConfig.routerRequestTimeoutMs + 1);
@@ -355,7 +344,7 @@ public class GetBlobInfoOperationTest {
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, null,
             routerCallback, kms, cryptoService, cryptoJobHandler, time, false);
-    requestRegistrationCallback.requestListToFill = new ArrayList<>();
+    requestRegistrationCallback.setRequestsToSend(new ArrayList<>());
     AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getOperationTrackerInUse();
 
     op.poll(requestRegistrationCallback);
@@ -412,7 +401,7 @@ public class GetBlobInfoOperationTest {
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, null,
             routerCallback, kms, cryptoService, cryptoJobHandler, time, false);
-    requestRegistrationCallback.requestListToFill = new ArrayList<>();
+    requestRegistrationCallback.setRequestsToSend(new ArrayList<>());
     AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getOperationTrackerInUse();
 
     completeOp(op);
@@ -427,7 +416,6 @@ public class GetBlobInfoOperationTest {
     props.setProperty("router.datacenter.name", oldLocal);
     routerConfig = new RouterConfig(new VerifiableProperties(props));
   }
-
 
   /**
    * Test the case where origin replicas return Blob_Not_found and the rest times out.
@@ -461,7 +449,7 @@ public class GetBlobInfoOperationTest {
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, null,
             routerCallback, kms, cryptoService, cryptoJobHandler, time, false);
-    requestRegistrationCallback.requestListToFill = new ArrayList<>();
+    requestRegistrationCallback.setRequestsToSend(new ArrayList<>());
     AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getOperationTrackerInUse();
 
     // First three requests would come from local datacenter and they will all time out.
@@ -493,7 +481,7 @@ public class GetBlobInfoOperationTest {
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, null,
             routerCallback, kms, cryptoService, cryptoJobHandler, time, false);
     ArrayList<RequestInfo> requestListToFill = new ArrayList<>();
-    requestRegistrationCallback.requestListToFill = requestListToFill;
+    requestRegistrationCallback.setRequestsToSend(requestListToFill);
 
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
@@ -528,8 +516,7 @@ public class GetBlobInfoOperationTest {
     assertOperationFailure(RouterErrorCode.BlobDoesNotExist);
     // Blob is created by putBlob function so the local datacenter will be the origin datecenter.
     // Thus only need two Blob_Not_Found to terminate the operation.
-    Assert.assertEquals("Must have attempted sending requests to all replicas", 2,
-        correlationIdToGetOperation.size());
+    Assert.assertEquals("Must have attempted sending requests to all replicas", 2, correlationIdToGetOperation.size());
   }
 
   /**
@@ -671,7 +658,7 @@ public class GetBlobInfoOperationTest {
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, null,
             routerCallback, kms, cryptoService, cryptoJobHandler, time, false);
-    requestRegistrationCallback.requestListToFill = new ArrayList<>();
+    requestRegistrationCallback.setRequestsToSend(new ArrayList<>());
 
     ArrayList<MockServer> mockServers = new ArrayList<>(mockServerLayout.getMockServers());
     // set the status to various server level or partition level errors (not Blob_Deleted or Blob_Expired).
@@ -707,7 +694,7 @@ public class GetBlobInfoOperationTest {
     GetBlobInfoOperation op =
         new GetBlobInfoOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, null,
             routerCallback, kms, cryptoService, cryptoJobHandler, time, false);
-    requestRegistrationCallback.requestListToFill = new ArrayList<>();
+    requestRegistrationCallback.setRequestsToSend(new ArrayList<>());
     op.poll(requestRegistrationCallback);
     Assert.assertEquals("There should only be as many requests at this point as requestParallelism", requestParallelism,
         correlationIdToGetOperation.size());
@@ -724,7 +711,7 @@ public class GetBlobInfoOperationTest {
   private void completeOp(GetBlobInfoOperation op) throws IOException {
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
-      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.requestListToFill);
+      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.getRequestsToSend());
       for (ResponseInfo responseInfo : responses) {
         GetResponse getResponse = responseInfo.getError() == null ? GetResponse.readFrom(
             new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap) : null;
@@ -745,10 +732,11 @@ public class GetBlobInfoOperationTest {
   private List<ResponseInfo> sendAndWaitForResponses(List<RequestInfo> requestList) {
     int sendCount = requestList.size();
     Collections.shuffle(requestList);
-    List<ResponseInfo> responseList = new ArrayList<>(networkClient.sendAndPoll(requestList, 100));
+    List<ResponseInfo> responseList = new ArrayList<>(networkClient.sendAndPoll(requestList, Collections.emptyList(),
+        100));
     requestList.clear();
     while (responseList.size() < sendCount) {
-      responseList.addAll(networkClient.sendAndPoll(requestList, 100));
+      responseList.addAll(networkClient.sendAndPoll(requestList, Collections.emptyList(), 100));
     }
     return responseList;
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -1529,10 +1529,10 @@ public class GetBlobOperationTest {
     // Shuffle the replicas to introduce randomness in the order in which responses arrive.
     Collections.shuffle(requestList);
     List<ResponseInfo> responseList = new ArrayList<>();
-    responseList.addAll(mockNetworkClient.sendAndPoll(requestList, Collections.emptyList(), 100));
+    responseList.addAll(mockNetworkClient.sendAndPoll(requestList, Collections.emptySet(), 100));
     requestList.clear();
     while (responseList.size() < sendCount) {
-      responseList.addAll(mockNetworkClient.sendAndPoll(requestList, Collections.emptyList(), 100));
+      responseList.addAll(mockNetworkClient.sendAndPoll(requestList, Collections.emptySet(), 100));
     }
     return responseList;
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -25,7 +25,6 @@ import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.commons.ResponseHandler;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.CryptoServiceConfig;
 import com.github.ambry.config.KMSConfig;
 import com.github.ambry.config.RouterConfig;
@@ -47,8 +46,8 @@ import com.github.ambry.protocol.GetRequest;
 import com.github.ambry.protocol.GetResponse;
 import com.github.ambry.protocol.PartitionRequestInfo;
 import com.github.ambry.protocol.PutRequest;
-import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.router.RouterTestHelpers.*;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferChannel;
 import com.github.ambry.utils.ByteBufferInputStream;
@@ -137,18 +136,8 @@ public class GetBlobOperationTest {
   // Options which are passed into GetBlobOperations
   private GetBlobOptionsInternal options;
 
-  private final GetTestRequestRegistrationCallbackImpl requestRegistrationCallback =
-      new GetTestRequestRegistrationCallbackImpl();
-
-  private class GetTestRequestRegistrationCallbackImpl implements RequestRegistrationCallback<GetOperation> {
-    List<RequestInfo> requestListToFill;
-
-    @Override
-    public void registerRequestToSend(GetOperation getOperation, RequestInfo requestInfo) {
-      requestListToFill.add(requestInfo);
-      correlationIdToGetOperation.put(((RequestOrResponse) requestInfo.getRequest()).getCorrelationId(), getOperation);
-    }
-  }
+  private final RequestRegistrationCallback<GetOperation> requestRegistrationCallback =
+      new RequestRegistrationCallback<>(correlationIdToGetOperation);
 
   /**
    * A checker that either asserts that a get operation succeeds or returns the specified error code.
@@ -535,7 +524,7 @@ public class GetBlobOperationTest {
     // The request should have response from one local replica and all remote replicas.
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
-      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.requestListToFill);
+      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.getRequestsToSend());
       for (ResponseInfo responseInfo : responses) {
         GetResponse getResponse = responseInfo.getError() == null ? GetResponse.readFrom(
             new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap) : null;
@@ -589,7 +578,7 @@ public class GetBlobOperationTest {
     // The request should have response from all remote replicas.
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
-      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.requestListToFill);
+      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.getRequestsToSend());
       for (ResponseInfo responseInfo : responses) {
         GetResponse getResponse = responseInfo.getError() == null ? GetResponse.readFrom(
             new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap) : null;
@@ -618,14 +607,14 @@ public class GetBlobOperationTest {
     GetBlobOperation op = createOperation(routerConfig, null);
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
-      for (RequestInfo requestInfo : requestRegistrationCallback.requestListToFill) {
+      for (RequestInfo requestInfo : requestRegistrationCallback.getRequestsToSend()) {
         ResponseInfo fakeResponse = new ResponseInfo(requestInfo, NetworkClientErrorCode.NetworkError, null);
         op.handleResponse(fakeResponse, null);
         if (op.isOperationComplete()) {
           break;
         }
       }
-      requestRegistrationCallback.requestListToFill.clear();
+      requestRegistrationCallback.getRequestsToSend().clear();
     }
 
     // At this time requests would have been created for all replicas, as none of them were delivered,
@@ -1378,7 +1367,7 @@ public class GetBlobOperationTest {
     GetBlobOperation op = createOperation(routerConfig, callback);
     while (!op.isOperationComplete()) {
       op.poll(requestRegistrationCallback);
-      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.requestListToFill);
+      List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.getRequestsToSend());
       for (ResponseInfo responseInfo : responses) {
         GetResponse getResponse = responseInfo.getError() == null ? GetResponse.readFrom(
             new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap) : null;
@@ -1399,7 +1388,7 @@ public class GetBlobOperationTest {
     GetBlobOperation op =
         new GetBlobOperation(routerConfig, routerMetrics, mockClusterMap, responseHandler, blobId, options, callback,
             routerCallback, blobIdFactory, kms, cryptoService, cryptoJobHandler, time, false);
-    requestRegistrationCallback.requestListToFill = new ArrayList<>();
+    requestRegistrationCallback.setRequestsToSend(new ArrayList<>());
     return op;
   }
 
@@ -1540,10 +1529,10 @@ public class GetBlobOperationTest {
     // Shuffle the replicas to introduce randomness in the order in which responses arrive.
     Collections.shuffle(requestList);
     List<ResponseInfo> responseList = new ArrayList<>();
-    responseList.addAll(mockNetworkClient.sendAndPoll(requestList, 100));
+    responseList.addAll(mockNetworkClient.sendAndPoll(requestList, Collections.emptyList(), 100));
     requestList.clear();
     while (responseList.size() < sendCount) {
-      responseList.addAll(mockNetworkClient.sendAndPoll(requestList, 100));
+      responseList.addAll(mockNetworkClient.sendAndPoll(requestList, Collections.emptyList(), 100));
     }
     return responseList;
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
@@ -66,9 +66,10 @@ class MockNetworkClient extends NetworkClient {
    * {@inheritDoc}
    */
   @Override
-  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestInfos, int pollTimeoutMs) {
+  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestsToSend, List<Integer> requestsToDrop,
+      int pollTimeoutMs) {
     processedResponseCount = responseCount;
-    List<ResponseInfo> responseInfoList = super.sendAndPoll(requestInfos, pollTimeoutMs);
+    List<ResponseInfo> responseInfoList = super.sendAndPoll(requestsToSend, requestsToDrop, pollTimeoutMs);
     responseCount += responseInfoList.size();
     return responseInfoList;
   }
@@ -85,7 +86,7 @@ class MockNetworkClient extends NetworkClient {
 
   /**
    * Get the number of responses received by the client before the current
-   * {@link MockNetworkClient#sendAndPoll(List, int)} call.
+   * {@link NetworkClient#sendAndPoll(List, List, int)} call.
    * @return the number of processed responses.
    */
   int getProcessedResponseCount() {

--- a/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
@@ -25,6 +25,7 @@ import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Time;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 
 /**
@@ -66,7 +67,7 @@ class MockNetworkClient extends NetworkClient {
    * {@inheritDoc}
    */
   @Override
-  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestsToSend, List<Integer> requestsToDrop,
+  public List<ResponseInfo> sendAndPoll(List<RequestInfo> requestsToSend, Set<Integer> requestsToDrop,
       int pollTimeoutMs) {
     processedResponseCount = responseCount;
     List<ResponseInfo> responseInfoList = super.sendAndPoll(requestsToSend, requestsToDrop, pollTimeoutMs);
@@ -86,7 +87,7 @@ class MockNetworkClient extends NetworkClient {
 
   /**
    * Get the number of responses received by the client before the current
-   * {@link NetworkClient#sendAndPoll(List, List, int)} call.
+   * {@link NetworkClient#sendAndPoll(List, Set, int)} call.
    * @return the number of processed responses.
    */
   int getProcessedResponseCount() {

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -991,7 +991,7 @@ public class NonBlockingRouterTest {
     FutureResult futureResult = opHelper.submitOperation(blobId);
     int requestParallelism = opHelper.requestParallelism;
     List<RequestInfo> allRequests = new ArrayList<>();
-    List<Integer> allDropped = new ArrayList<>();
+    Set<Integer> allDropped = new HashSet<>();
     long loopStartTimeMs = SystemTime.getInstance().milliseconds();
     while (allRequests.size() < requestParallelism) {
       if (loopStartTimeMs + AWAIT_TIMEOUT_MS < SystemTime.getInstance().milliseconds()) {
@@ -1013,7 +1013,7 @@ public class NonBlockingRouterTest {
           if (loopStartTimeMs + AWAIT_TIMEOUT_MS < SystemTime.getInstance().milliseconds()) {
             Assert.fail("Waited too long for the response.");
           }
-          responseInfoList = networkClient.sendAndPoll(requestInfoListToSend, Collections.emptyList(), 10);
+          responseInfoList = networkClient.sendAndPoll(requestInfoListToSend, Collections.emptySet(), 10);
           requestInfoListToSend.clear();
         } while (responseInfoList.size() == 0);
         responseInfo = responseInfoList.get(0);
@@ -1060,7 +1060,7 @@ public class NonBlockingRouterTest {
     invalidResponse.set(false);
     FutureResult futureResult = opHelper.submitOperation(blobId);
     List<RequestInfo> allRequests = new ArrayList<>();
-    List<Integer> allDropped = new ArrayList<>();
+    Set<Integer> allDropped = new HashSet<>();
     long loopStartTimeMs = SystemTime.getInstance().milliseconds();
     while (!futureResult.isDone()) {
       if (loopStartTimeMs + AWAIT_TIMEOUT_MS < SystemTime.getInstance().milliseconds()) {
@@ -1093,7 +1093,7 @@ public class NonBlockingRouterTest {
     FutureResult futureResult = opHelper.submitOperation(blobId);
     int requestParallelism = opHelper.requestParallelism;
     List<RequestInfo> allRequests = new ArrayList<>();
-    List<Integer> allDropped = new ArrayList<>();
+    Set<Integer> allDropped = new HashSet<>();
     long loopStartTimeMs = SystemTime.getInstance().milliseconds();
     while (allRequests.size() < requestParallelism) {
       if (loopStartTimeMs + AWAIT_TIMEOUT_MS < SystemTime.getInstance().milliseconds()) {
@@ -1107,7 +1107,7 @@ public class NonBlockingRouterTest {
       if (loopStartTimeMs + AWAIT_TIMEOUT_MS < SystemTime.getInstance().milliseconds()) {
         Assert.fail("Waited too long for the response.");
       }
-      responseInfoList.addAll(networkClient.sendAndPoll(allRequests, Collections.emptyList(), 10));
+      responseInfoList.addAll(networkClient.sendAndPoll(allRequests, allDropped, 10));
       allRequests.clear();
     } while (responseInfoList.size() < requestParallelism);
     // corrupt the first response.
@@ -1265,7 +1265,7 @@ public class NonBlockingRouterTest {
      * @param requestsToSend the list of {@link RequestInfo} to send to pass into the poll call.
      * @param requestsToDrop the list of correlation IDs to drop to pass into the poll call.
      */
-    void pollOpManager(List<RequestInfo> requestsToSend, List<Integer> requestsToDrop) {
+    void pollOpManager(List<RequestInfo> requestsToSend, Set<Integer> requestsToDrop) {
       switch (opType) {
         case PUT:
           putManager.poll(requestsToSend, requestsToDrop);
@@ -1287,7 +1287,7 @@ public class NonBlockingRouterTest {
     private void awaitOpCompletionOrTimeOut(FutureResult futureResult) throws InterruptedException {
       int timer = 0;
       List<RequestInfo> allRequests = new ArrayList<>();
-      List<Integer> allDropped = new ArrayList<>();
+      Set<Integer> allDropped = new HashSet<>();
       while (timer < AWAIT_TIMEOUT_MS / 2 && !futureResult.completed()) {
         pollOpManager(allRequests, allDropped);
         Thread.sleep(50);

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -24,7 +24,6 @@ import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.commons.ResponseHandler;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.CryptoServiceConfig;
 import com.github.ambry.config.KMSConfig;
 import com.github.ambry.config.RouterConfig;
@@ -38,6 +37,7 @@ import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.protocol.RequestOrResponseType;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
@@ -991,12 +991,13 @@ public class NonBlockingRouterTest {
     FutureResult futureResult = opHelper.submitOperation(blobId);
     int requestParallelism = opHelper.requestParallelism;
     List<RequestInfo> allRequests = new ArrayList<>();
+    List<Integer> allDropped = new ArrayList<>();
     long loopStartTimeMs = SystemTime.getInstance().milliseconds();
     while (allRequests.size() < requestParallelism) {
       if (loopStartTimeMs + AWAIT_TIMEOUT_MS < SystemTime.getInstance().milliseconds()) {
         Assert.fail("Waited too long for requests.");
       }
-      opHelper.pollOpManager(allRequests);
+      opHelper.pollOpManager(allRequests, allDropped);
     }
     ReplicaId replicaIdToFail = indexToFail == -1 ? null : allRequests.get(indexToFail).getReplicaId();
     for (RequestInfo requestInfo : allRequests) {
@@ -1012,7 +1013,7 @@ public class NonBlockingRouterTest {
           if (loopStartTimeMs + AWAIT_TIMEOUT_MS < SystemTime.getInstance().milliseconds()) {
             Assert.fail("Waited too long for the response.");
           }
-          responseInfoList = networkClient.sendAndPoll(requestInfoListToSend, 10);
+          responseInfoList = networkClient.sendAndPoll(requestInfoListToSend, Collections.emptyList(), 10);
           requestInfoListToSend.clear();
         } while (responseInfoList.size() == 0);
         responseInfo = responseInfoList.get(0);
@@ -1024,9 +1025,10 @@ public class NonBlockingRouterTest {
     if (testEncryption) {
       opHelper.awaitOpCompletionOrTimeOut(futureResult);
     } else {
-      opHelper.pollOpManager(allRequests);
+      opHelper.pollOpManager(allRequests, allDropped);
     }
     futureResult.get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    Assert.assertEquals(0, allDropped.size());
     if (indexToFail == -1) {
       Assert.assertEquals("Successful notification should have arrived for replicas that were up",
           opHelper.requestParallelism, successfulResponseCount.get());
@@ -1058,18 +1060,24 @@ public class NonBlockingRouterTest {
     invalidResponse.set(false);
     FutureResult futureResult = opHelper.submitOperation(blobId);
     List<RequestInfo> allRequests = new ArrayList<>();
+    List<Integer> allDropped = new ArrayList<>();
     long loopStartTimeMs = SystemTime.getInstance().milliseconds();
     while (!futureResult.isDone()) {
       if (loopStartTimeMs + AWAIT_TIMEOUT_MS < SystemTime.getInstance().milliseconds()) {
         Assert.fail("Waited too long for requests.");
       }
-      opHelper.pollOpManager(allRequests);
+      opHelper.pollOpManager(allRequests, allDropped);
       mockTime.sleep(REQUEST_TIMEOUT_MS + 1);
     }
+    System.out.println(allDropped);
     Assert.assertEquals("Successful notification should not have arrived for replicas that were up", 0,
         successfulResponseCount.get());
     Assert.assertEquals("Failure detector should not have been notified", 0, failedReplicaIds.size());
     Assert.assertFalse("There should be no notifications of any other kind", invalidResponse.get());
+    Set<Integer> allCorrelationIds = allRequests.stream()
+        .map(requestInfo -> requestInfo.getRequest().getCorrelationId())
+        .collect(Collectors.toSet());
+    Assert.assertEquals("Timed out requests should be dropped", allCorrelationIds, new HashSet<>(allDropped));
   }
 
   /**
@@ -1085,12 +1093,13 @@ public class NonBlockingRouterTest {
     FutureResult futureResult = opHelper.submitOperation(blobId);
     int requestParallelism = opHelper.requestParallelism;
     List<RequestInfo> allRequests = new ArrayList<>();
+    List<Integer> allDropped = new ArrayList<>();
     long loopStartTimeMs = SystemTime.getInstance().milliseconds();
     while (allRequests.size() < requestParallelism) {
       if (loopStartTimeMs + AWAIT_TIMEOUT_MS < SystemTime.getInstance().milliseconds()) {
         Assert.fail("Waited too long for requests.");
       }
-      opHelper.pollOpManager(allRequests);
+      opHelper.pollOpManager(allRequests, allDropped);
     }
     List<ResponseInfo> responseInfoList = new ArrayList<>();
     loopStartTimeMs = SystemTime.getInstance().milliseconds();
@@ -1098,7 +1107,7 @@ public class NonBlockingRouterTest {
       if (loopStartTimeMs + AWAIT_TIMEOUT_MS < SystemTime.getInstance().milliseconds()) {
         Assert.fail("Waited too long for the response.");
       }
-      responseInfoList.addAll(networkClient.sendAndPoll(allRequests, 10));
+      responseInfoList.addAll(networkClient.sendAndPoll(allRequests, Collections.emptyList(), 10));
       allRequests.clear();
     } while (responseInfoList.size() < requestParallelism);
     // corrupt the first response.
@@ -1112,7 +1121,7 @@ public class NonBlockingRouterTest {
     if (testEncryption) {
       opHelper.awaitOpCompletionOrTimeOut(futureResult);
     } else {
-      opHelper.pollOpManager(allRequests);
+      opHelper.pollOpManager(allRequests, allDropped);
     }
     try {
       futureResult.get(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -1253,18 +1262,19 @@ public class NonBlockingRouterTest {
 
     /**
      * Poll the associated operation manager.
-     * @param requestInfos the list of {@link RequestInfo} to pass in the poll call.
+     * @param requestsToSend the list of {@link RequestInfo} to send to pass into the poll call.
+     * @param requestsToDrop the list of correlation IDs to drop to pass into the poll call.
      */
-    void pollOpManager(List<RequestInfo> requestInfos) {
+    void pollOpManager(List<RequestInfo> requestsToSend, List<Integer> requestsToDrop) {
       switch (opType) {
         case PUT:
-          putManager.poll(requestInfos);
+          putManager.poll(requestsToSend, requestsToDrop);
           break;
         case GET:
-          getManager.poll(requestInfos);
+          getManager.poll(requestsToSend, requestsToDrop);
           break;
         case DELETE:
-          deleteManager.poll(requestInfos);
+          deleteManager.poll(requestsToSend, requestsToDrop);
           break;
       }
     }
@@ -1277,11 +1287,13 @@ public class NonBlockingRouterTest {
     private void awaitOpCompletionOrTimeOut(FutureResult futureResult) throws InterruptedException {
       int timer = 0;
       List<RequestInfo> allRequests = new ArrayList<>();
+      List<Integer> allDropped = new ArrayList<>();
       while (timer < AWAIT_TIMEOUT_MS / 2 && !futureResult.completed()) {
-        pollOpManager(allRequests);
+        pollOpManager(allRequests, allDropped);
         Thread.sleep(50);
         timer += 50;
         allRequests.clear();
+        allDropped.clear();
       }
     }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutOperationTest.java
@@ -26,7 +26,6 @@ import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.PutRequest;
 import com.github.ambry.protocol.PutResponse;
-import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.utils.ByteBufferChannel;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
@@ -54,8 +53,8 @@ public class PutOperationTest {
   private final Time time;
   private final Map<Integer, PutOperation> correlationIdToPutOperation = new TreeMap<>();
   private final MockServer mockServer = new MockServer(mockClusterMap, "");
-  private final PutTestRequestRegistrationCallbackImpl requestRegistrationCallback =
-      new PutTestRequestRegistrationCallbackImpl();
+  private final RequestRegistrationCallback<PutOperation> requestRegistrationCallback =
+      new RequestRegistrationCallback<>(correlationIdToPutOperation);
   private final int chunkSize = 10;
   private final int requestParallelism = 3;
   private final int successTarget = 1;
@@ -96,7 +95,7 @@ public class PutOperationTest {
             MockClusterMap.DEFAULT_PARTITION_CLASS);
     op.startOperation();
     List<RequestInfo> requestInfos = new ArrayList<>();
-    requestRegistrationCallback.requestListToFill = requestInfos;
+    requestRegistrationCallback.setRequestsToSend(requestInfos);
     // Since this channel is in memory, one call to fill chunks would end up filling the maximum number of PutChunks.
     op.fillChunks();
     Assert.assertTrue("ReadyForPollCallback should have been invoked as chunks were fully filled",
@@ -278,16 +277,6 @@ public class PutOperationTest {
   private ResponseInfo getResponseInfo(RequestInfo requestInfo) throws IOException {
     NetworkReceive networkReceive = new NetworkReceive(null, mockServer.send(requestInfo.getRequest()), time);
     return new ResponseInfo(requestInfo, null, networkReceive.getReceivedBytes().getPayload());
-  }
-
-  private class PutTestRequestRegistrationCallbackImpl implements RequestRegistrationCallback<PutOperation> {
-    private List<RequestInfo> requestListToFill;
-
-    @Override
-    public void registerRequestToSend(PutOperation putOperation, RequestInfo requestInfo) {
-      requestListToFill.add(requestInfo);
-      correlationIdToPutOperation.put(((RequestOrResponse) requestInfo.getRequest()).getCorrelationId(), putOperation);
-    }
   }
 }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
@@ -349,14 +349,15 @@ public class TtlUpdateManagerTest {
   private void sendRequestsGetResponses(FutureResult<Void> futureResult, TtlUpdateManager manager, boolean advanceTime,
       boolean ignoreUnrecognizedRequests) {
     List<RequestInfo> requestInfoList = new ArrayList<>();
+    List<Integer> requestsToDrop = new ArrayList<>();
     Set<RequestInfo> requestAcks = new HashSet<>();
     List<RequestInfo> referenceRequestInfos = new ArrayList<>();
     while (!futureResult.isDone()) {
-      manager.poll(requestInfoList);
+      manager.poll(requestInfoList, requestsToDrop);
       referenceRequestInfos.addAll(requestInfoList);
       List<ResponseInfo> responseInfoList = new ArrayList<>();
       try {
-        responseInfoList = networkClient.sendAndPoll(requestInfoList, AWAIT_TIMEOUT_MS);
+        responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), AWAIT_TIMEOUT_MS);
       } catch (RuntimeException | Error e) {
         if (!advanceTime) {
           throw e;

--- a/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/TtlUpdateManagerTest.java
@@ -21,7 +21,6 @@ import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.commons.ResponseHandler;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
@@ -30,6 +29,7 @@ import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.protocol.RequestOrResponseType;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
@@ -349,7 +349,7 @@ public class TtlUpdateManagerTest {
   private void sendRequestsGetResponses(FutureResult<Void> futureResult, TtlUpdateManager manager, boolean advanceTime,
       boolean ignoreUnrecognizedRequests) {
     List<RequestInfo> requestInfoList = new ArrayList<>();
-    List<Integer> requestsToDrop = new ArrayList<>();
+    Set<Integer> requestsToDrop = new HashSet<>();
     Set<RequestInfo> requestAcks = new HashSet<>();
     List<RequestInfo> referenceRequestInfos = new ArrayList<>();
     while (!futureResult.isDone()) {
@@ -357,7 +357,7 @@ public class TtlUpdateManagerTest {
       referenceRequestInfos.addAll(requestInfoList);
       List<ResponseInfo> responseInfoList = new ArrayList<>();
       try {
-        responseInfoList = networkClient.sendAndPoll(requestInfoList, Collections.emptyList(), AWAIT_TIMEOUT_MS);
+        responseInfoList = networkClient.sendAndPoll(requestInfoList, requestsToDrop, AWAIT_TIMEOUT_MS);
       } catch (RuntimeException | Error e) {
         if (!advanceTime) {
           throw e;

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
@@ -793,8 +793,8 @@ public class ServerAdminTool implements Closeable {
       if (time.milliseconds() - startTimeMs > OPERATION_TIMEOUT_MS) {
         throw new TimeoutException(identifier + ": Operation did not complete within " + OPERATION_TIMEOUT_MS + " ms");
       }
-      List<ResponseInfo> responseInfos = networkClient.sendAndPoll(requestInfos, Collections.emptyList(),
-          POLL_TIMEOUT_MS);
+      List<ResponseInfo> responseInfos =
+          networkClient.sendAndPoll(requestInfos, Collections.emptySet(), POLL_TIMEOUT_MS);
       if (responseInfos.size() > 1) {
         // May need to relax this check because response list may contain more than 1 response
         throw new IllegalStateException("Received more than one response even though a single request was sent");

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
@@ -20,7 +20,6 @@ import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.SSLFactory;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.Config;
 import com.github.ambry.config.Default;
@@ -38,7 +37,7 @@ import com.github.ambry.network.NetworkMetrics;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
-import com.github.ambry.network.Send;
+import com.github.ambry.network.SendWithCorrelationId;
 import com.github.ambry.protocol.AdminRequest;
 import com.github.ambry.protocol.AdminRequestOrResponseType;
 import com.github.ambry.protocol.AdminResponse;
@@ -53,6 +52,7 @@ import com.github.ambry.protocol.PartitionRequestInfo;
 import com.github.ambry.protocol.ReplicationControlAdminRequest;
 import com.github.ambry.protocol.RequestControlAdminRequest;
 import com.github.ambry.protocol.RequestOrResponseType;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.tools.util.ToolUtils;
 import com.github.ambry.utils.ByteBufferInputStream;
@@ -779,8 +779,8 @@ public class ServerAdminTool implements Closeable {
    * @return the response as a {@link ByteBuffer} if the response was successfully received. {@code null} otherwise.
    * @throws TimeoutException
    */
-  private ByteBuffer sendRequestGetResponse(DataNodeId dataNodeId, PartitionId partitionId, Send request)
-      throws TimeoutException {
+  private ByteBuffer sendRequestGetResponse(DataNodeId dataNodeId, PartitionId partitionId,
+      SendWithCorrelationId request) throws TimeoutException {
     ReplicaId replicaId = getReplicaFromNode(dataNodeId, partitionId);
     String hostname = dataNodeId.getHostname();
     Port port = dataNodeId.getPortToConnectTo();
@@ -793,7 +793,8 @@ public class ServerAdminTool implements Closeable {
       if (time.milliseconds() - startTimeMs > OPERATION_TIMEOUT_MS) {
         throw new TimeoutException(identifier + ": Operation did not complete within " + OPERATION_TIMEOUT_MS + " ms");
       }
-      List<ResponseInfo> responseInfos = networkClient.sendAndPoll(requestInfos, POLL_TIMEOUT_MS);
+      List<ResponseInfo> responseInfos = networkClient.sendAndPoll(requestInfos, Collections.emptyList(),
+          POLL_TIMEOUT_MS);
       if (responseInfos.size() > 1) {
         // May need to relax this check because response list may contain more than 1 response
         throw new IllegalStateException("Received more than one response even though a single request was sent");


### PR DESCRIPTION
This change provides a way for the router to indicate to the
NetworkClient that a request should be dropped (currently implemented by
closing the connection that the request was sent over). Allowing the
NetworkClient to kill unhealthy connections and reinit them should
prevent the connection pool from being unnecessarily occupied by failed
requests that the router no longer cares about.

This change requires informing the NetworkClient about request
correlation IDs so that there is a key to drop a request by (as the
rest of the router does not know about connection IDs).

---
I still need to add some additional test cases, but I'm putting this up for review so reviewers can get a gist of the prod code changes.