### PR TITLE
Allow index to populate bloom filter with UUID only

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -294,9 +294,9 @@ public class StoreConfig {
   /**
    * Whether to populate bloom filter with UUID only for index segment.
    */
-  @Config("store.pure.uuid.based.bloom.filter.enabled")
+  @Config("store.uuid.based.bloom.filter.enabled")
   @Default("false")
-  public final boolean storePureUuidBasedBloomFilterEnabled;
+  public final boolean storeUuidBasedBloomFilterEnabled;
 
   /**
    * Whether to rebuild index bloom filter during startup. If true, store will cleanup existing bloom files and rebuild
@@ -369,8 +369,7 @@ public class StoreConfig {
     String storeOperationFilePermissionStr =
         verifiableProperties.getString("store.operation.file.permission", "rw-rw-r--");
     storeOperationFilePermission = PosixFilePermissions.fromString(storeOperationFilePermissionStr);
-    storePureUuidBasedBloomFilterEnabled =
-        verifiableProperties.getBoolean("store.pure.uuid.based.bloom.filter.enabled", false);
+    storeUuidBasedBloomFilterEnabled = verifiableProperties.getBoolean("store.uuid.based.bloom.filter.enabled", false);
     storeIndexRebuildBloomFilterEnabled =
         verifiableProperties.getBoolean("store.index.rebuild.bloom.filter.enabled", false);
   }

--- a/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/StoreConfig.java
@@ -291,6 +291,21 @@ public class StoreConfig {
   @Default("rw-rw-r--")
   public final Set<PosixFilePermission> storeOperationFilePermission;
 
+  /**
+   * Whether to populate bloom filter with UUID only for index segment.
+   */
+  @Config("store.pure.uuid.based.bloom.filter.enabled")
+  @Default("false")
+  public final boolean storePureUuidBasedBloomFilterEnabled;
+
+  /**
+   * Whether to rebuild index bloom filter during startup. If true, store will cleanup existing bloom files and rebuild
+   * them based on index segments when server restarts.
+   */
+  @Config("store.index.rebuild.bloom.filter.enabled")
+  @Default("false")
+  public final boolean storeIndexRebuildBloomFilterEnabled;
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -354,6 +369,10 @@ public class StoreConfig {
     String storeOperationFilePermissionStr =
         verifiableProperties.getString("store.operation.file.permission", "rw-rw-r--");
     storeOperationFilePermission = PosixFilePermissions.fromString(storeOperationFilePermissionStr);
+    storePureUuidBasedBloomFilterEnabled =
+        verifiableProperties.getBoolean("store.pure.uuid.based.bloom.filter.enabled", false);
+    storeIndexRebuildBloomFilterEnabled =
+        verifiableProperties.getBoolean("store.index.rebuild.bloom.filter.enabled", false);
   }
 }
 

--- a/ambry-api/src/main/java/com.github.ambry/store/StoreKey.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/StoreKey.java
@@ -26,6 +26,12 @@ public abstract class StoreKey implements Comparable<StoreKey> {
   public abstract byte[] toBytes();
 
   /**
+   * The byte version of UUID for this key
+   * @return A byte buffer that represents the UUID of this key
+   */
+  public abstract byte[] getUuidBytesArray();
+
+  /**
    * The size of the serialized version of the key
    * @return The size of the key
    */

--- a/ambry-api/src/test/java/com.github.ambry/store/MockId.java
+++ b/ambry-api/src/test/java/com.github.ambry/store/MockId.java
@@ -56,8 +56,7 @@ public class MockId extends StoreKey {
   @Override
   public byte[] getUuidBytesArray() {
     byte[] uuidBytes = id.getBytes();
-    ByteBuffer uuidBuf = ByteBuffer.allocate(Id_Size_In_Bytes + (short) uuidBytes.length);
-    uuidBuf.putShort((short) id.length());
+    ByteBuffer uuidBuf = ByteBuffer.allocate((short) uuidBytes.length);
     uuidBuf.put(uuidBytes);
     return uuidBuf.array();
   }

--- a/ambry-api/src/test/java/com.github.ambry/store/MockId.java
+++ b/ambry-api/src/test/java/com.github.ambry/store/MockId.java
@@ -18,6 +18,7 @@ import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.UUID;
 
 
 public class MockId extends StoreKey {
@@ -25,22 +26,30 @@ public class MockId extends StoreKey {
   private String id;
   private final short accountId;
   private final short containerId;
+  private final String uuidStr;
   private static final int Id_Size_In_Bytes = 2;
+  private static final short UUID_SIZE_FIELD_LENGTH_IN_BYTES = Integer.BYTES;
 
   public MockId(String id) {
     this(id, Utils.getRandomShort(TestUtils.RANDOM), Utils.getRandomShort(TestUtils.RANDOM));
   }
 
   public MockId(String id, short accountId, short containerId) {
+    this(id, accountId, containerId, UUID.randomUUID().toString());
+  }
+
+  public MockId(String id, short accountId, short containerId, String uuidStr) {
     this.id = id;
     this.accountId = accountId;
     this.containerId = containerId;
+    this.uuidStr = uuidStr;
   }
 
   public MockId(DataInputStream stream) throws IOException {
     id = Utils.readShortString(stream);
     accountId = stream.readShort();
     containerId = stream.readShort();
+    uuidStr = Utils.readIntString(stream);
   }
 
   @Override
@@ -50,7 +59,19 @@ public class MockId extends StoreKey {
     idBuf.put(id.getBytes());
     idBuf.putShort(accountId);
     idBuf.putShort(containerId);
+    byte[] uuidBytes = uuidStr.getBytes();
+    idBuf.putInt(uuidBytes.length);
+    idBuf.put(uuidBytes);
     return idBuf.array();
+  }
+
+  @Override
+  public byte[] getUuidBytesArray() {
+    byte[] uuidBytes = uuidStr.getBytes();
+    ByteBuffer uuidBuf = ByteBuffer.allocate(UUID_SIZE_FIELD_LENGTH_IN_BYTES + (short) uuidBytes.length);
+    uuidBuf.putInt(uuidBytes.length);
+    uuidBuf.put(uuidBytes);
+    return uuidBuf.array();
   }
 
   @Override
@@ -65,7 +86,8 @@ public class MockId extends StoreKey {
 
   @Override
   public short sizeInBytes() {
-    return (short) (Id_Size_In_Bytes + id.length() + Short.BYTES + Short.BYTES);
+    return (short) (Id_Size_In_Bytes + id.length() + Short.BYTES + Short.BYTES + UUID_SIZE_FIELD_LENGTH_IN_BYTES
+        + (short) uuidStr.getBytes().length);
   }
 
   public short getAccountId() {
@@ -87,7 +109,11 @@ public class MockId extends StoreKey {
       throw new NullPointerException();
     }
     MockId otherId = (MockId) o;
-    return id.compareTo(otherId.id);
+    int result = id.compareTo(otherId.id);
+    if (result == 0) {
+      result = uuidStr.compareTo(otherId.uuidStr);
+    }
+    return result;
   }
 
   @Override

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -195,8 +195,8 @@ public class BlobId extends StoreKey {
    * @param blobDataType The blob data type.
    * @param uuidStr The uuid that is to be used to construct this id.
    */
-  private BlobId(short version, BlobIdType type, byte datacenterId, short accountId, short containerId,
-      PartitionId partitionId, boolean isEncrypted, BlobDataType blobDataType, String uuidStr) {
+  BlobId(short version, BlobIdType type, byte datacenterId, short accountId, short containerId, PartitionId partitionId,
+      boolean isEncrypted, BlobDataType blobDataType, String uuidStr) {
     if (partitionId == null) {
       throw new IllegalArgumentException("partitionId cannot be null");
     }
@@ -490,6 +490,30 @@ public class BlobId extends StoreKey {
         break;
     }
     return idBuf.array();
+  }
+
+  @Override
+  public byte[] getUuidBytesArray() {
+    ByteBuffer uuidBuf;
+    switch (version) {
+      case BLOB_ID_V1:
+      case BLOB_ID_V2:
+      case BLOB_ID_V3:
+      case BLOB_ID_V4:
+      case BLOB_ID_V5:
+        byte[] uuidBytes = getUuid().getBytes();
+        uuidBuf = ByteBuffer.allocate(UUID_SIZE_FIELD_LENGTH_IN_BYTES + (short) uuidBytes.length);
+        uuidBuf.putInt(uuidBytes.length);
+        uuidBuf.put(uuidBytes);
+        break;
+      case BLOB_ID_V6:
+        uuidBuf = ByteBuffer.allocate(UuidSerDe.SIZE_IN_BYTES);
+        UuidSerDe.serialize(uuid, uuidBuf);
+        break;
+      default:
+        throw new IllegalArgumentException("blobId version=" + version + " not supported");
+    }
+    return uuidBuf.array();
   }
 
   @Override

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -502,8 +502,7 @@ public class BlobId extends StoreKey {
       case BLOB_ID_V4:
       case BLOB_ID_V5:
         byte[] uuidBytes = getUuid().getBytes();
-        uuidBuf = ByteBuffer.allocate(UUID_SIZE_FIELD_LENGTH_IN_BYTES + (short) uuidBytes.length);
-        uuidBuf.putInt(uuidBytes.length);
+        uuidBuf = ByteBuffer.allocate((short) uuidBytes.length);
         uuidBuf.put(uuidBytes);
         break;
       case BLOB_ID_V6:

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -394,7 +394,7 @@ class IndexSegment {
    * @return required {@link ByteBuffer} associated with the key.
    */
   private ByteBuffer getStoreKeyBytes(StoreKey key) {
-    return config.storePureUuidBasedBloomFilterEnabled ? ByteBuffer.wrap(key.getUuidBytesArray())
+    return config.storeUuidBasedBloomFilterEnabled ? ByteBuffer.wrap(key.getUuidBytesArray())
         : ByteBuffer.wrap(key.toBytes());
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -40,7 +40,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.After;
@@ -453,10 +452,9 @@ public class IndexSegmentTest {
       containerId2 = getRandomShort(random);
     } while (containerId2 == containerId1);
     String idStr = UtilsTest.getRandomString(CUSTOM_ID_SIZE);
-    String uuidStr = UUID.randomUUID().toString();
-    // generate two ids with same uuid string but different account/container.
-    MockId id1 = new MockId(idStr, accountId1, containerId1, uuidStr);
-    MockId id2 = new MockId(idStr, accountId2, containerId2, uuidStr);
+    // generate two ids with same id string but different account/container.
+    MockId id1 = new MockId(idStr, accountId1, containerId1);
+    MockId id2 = new MockId(idStr, accountId2, containerId2);
     IndexValue value1 =
         IndexValueTest.getIndexValue(1000, new Offset(logSegmentName1, 0), Utils.Infinite_Time, time.milliseconds(),
             accountId1, containerId1, version);

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexSegmentTest.java
@@ -36,9 +36,11 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
 import java.util.Properties;
+import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.After;
@@ -47,6 +49,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
+import static com.github.ambry.utils.Utils.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -360,7 +363,8 @@ public class IndexSegmentTest {
    */
   @Test
   public void memoryMapFailureTest() throws IOException, StoreException {
-    assumeTrue(version == PersistentIndex.VERSION_1 && config.storeIndexMemState == IndexMemState.MMAP_WITHOUT_FORCE_LOAD);
+    assumeTrue(
+        version == PersistentIndex.VERSION_1 && config.storeIndexMemState == IndexMemState.MMAP_WITHOUT_FORCE_LOAD);
     String logSegmentName = LogSegmentNameHelper.getName(0, 0);
     StoreKeyFactory mockStoreKeyFactory = Mockito.spy(STORE_KEY_FACTORY);
     IndexSegment indexSegment = generateIndexSegment(new Offset(logSegmentName, 0), mockStoreKeyFactory);
@@ -423,6 +427,70 @@ public class IndexSegmentTest {
     } catch (StoreException e) {
       assertEquals("Mismatch in error code", StoreErrorCodes.Index_Creation_Failure, e.getErrorCode());
     }
+  }
+
+  /**
+   * Test populating bloom filter with whole blob id and with UUID respectively.
+   * @throws Exception
+   */
+  @Test
+  public void populateBloomFilterWithUuidTest() throws Exception {
+    assumeTrue(version > PersistentIndex.VERSION_0);
+    // with default config, bloom filter will be populated by whole blob id bytes array
+    String logSegmentName1 = LogSegmentNameHelper.getName(0, 0);
+    IndexSegment indexSegment1 =
+        new IndexSegment(tempDir.getAbsolutePath(), new Offset(logSegmentName1, 0), STORE_KEY_FACTORY,
+            KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1, config,
+            metrics, time);
+    Random random = new Random();
+    short accountId1 = getRandomShort(random);
+    short containerId1 = getRandomShort(random);
+    short accountId2, containerId2;
+    do {
+      accountId2 = getRandomShort(random);
+    } while (accountId2 == accountId1);
+    do {
+      containerId2 = getRandomShort(random);
+    } while (containerId2 == containerId1);
+    String idStr = UtilsTest.getRandomString(CUSTOM_ID_SIZE);
+    String uuidStr = UUID.randomUUID().toString();
+    // generate two ids with same uuid string but different account/container.
+    MockId id1 = new MockId(idStr, accountId1, containerId1, uuidStr);
+    MockId id2 = new MockId(idStr, accountId2, containerId2, uuidStr);
+    IndexValue value1 =
+        IndexValueTest.getIndexValue(1000, new Offset(logSegmentName1, 0), Utils.Infinite_Time, time.milliseconds(),
+            accountId1, containerId1, version);
+    indexSegment1.addEntry(new IndexEntry(id1, value1), new Offset(logSegmentName1, 1000));
+    indexSegment1.writeIndexSegmentToFile(new Offset(logSegmentName1, 1000));
+    indexSegment1.seal();
+    // test that id1 can be found in index segment but id2 should be non-existent because bloom filter considers it not present
+    Set<IndexValue> findResult = indexSegment1.find(id1);
+    assertNotNull("Should have found the added key", findResult);
+    assertEquals(accountId1, findResult.iterator().next().getAccountId());
+    assertNull("Should have failed to find non existent key", indexSegment1.find(id2));
+
+    // create second index segment whose bloom filter is populated with UUID only.
+    // We add id1 into indexSegment2 and attempt to get id2 which should succeed.
+    Properties properties = new Properties();
+    properties.setProperty("store.pure.uuid.based.bloom.filter.enabled", Boolean.toString(true));
+    StoreConfig storeConfig = new StoreConfig(new VerifiableProperties(properties));
+    String logSegmentName2 = LogSegmentNameHelper.getName(1, 0);
+    IndexSegment indexSegment2 =
+        new IndexSegment(tempDir.getAbsolutePath(), new Offset(logSegmentName2, 0), STORE_KEY_FACTORY,
+            KEY_SIZE + IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1, IndexValue.INDEX_VALUE_SIZE_IN_BYTES_V1, storeConfig,
+            metrics, time);
+    indexSegment2.addEntry(new IndexEntry(id1, value1), new Offset(logSegmentName2, 1000));
+    indexSegment2.writeIndexSegmentToFile(new Offset(logSegmentName2, 1000));
+    indexSegment2.seal();
+    findResult = indexSegment2.find(id1);
+    assertNotNull("Should have found the id1", findResult);
+    // test that we are able to get id2 from indexSegment2
+    findResult = indexSegment2.find(id2);
+    assertNotNull("Should have found the id2", findResult);
+    // verify that the found entry actually has account/container associated with id1
+    IndexValue indexValue = findResult.iterator().next();
+    assertTrue("Account or container is not expected",
+        indexValue.getAccountId() == accountId1 && indexValue.getContainerId() == containerId1);
   }
 
   // helpers
@@ -1024,12 +1092,11 @@ public class IndexSegmentTest {
    * @param endOffset the expected end offset of the {@code indexSegment}
    * @param lastModifiedTimeInMs the last modified time of the index segment in ms
    * @param resetKey the resetKey of the index segment
-   * @throws IOException
    * @throws StoreException
    */
   private void verifyReadFromFile(NavigableMap<MockId, NavigableSet<IndexValue>> referenceIndex, File file,
       Offset startOffset, int numItems, int expectedSizeWritten, long endOffset, long lastModifiedTimeInMs,
-      Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey) throws IOException, StoreException {
+      Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey) throws StoreException {
     // read from file (not sealed) and verify that everything is ok
     Journal journal = new Journal(tempDir.getAbsolutePath(), Integer.MAX_VALUE, Integer.MAX_VALUE);
     IndexSegment fromDisk = createIndexSegmentFromFile(file, false, journal);
@@ -1077,13 +1144,11 @@ public class IndexSegmentTest {
    * @param endOffset the expected end offset of the {@code indexSegment}
    * @param lastModifiedTimeInMs the last modified time of the index segment in ms
    * @param resetKey the resetKey of the index segment
-   * @throws IOException
    * @throws StoreException
    */
   private void verifyAllForIndexSegmentFromFile(NavigableMap<MockId, NavigableSet<IndexValue>> referenceIndex,
       IndexSegment fromDisk, Offset startOffset, int numItems, int expectedSizeWritten, boolean sealed, long endOffset,
-      long lastModifiedTimeInMs, Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey)
-      throws StoreException, IOException {
+      long lastModifiedTimeInMs, Pair<StoreKey, PersistentIndex.IndexEntryType> resetKey) throws StoreException {
     verifyIndexSegmentDetails(fromDisk, startOffset, numItems, expectedSizeWritten, sealed, endOffset,
         lastModifiedTimeInMs, resetKey);
     verifyFind(referenceIndex, fromDisk);


### PR DESCRIPTION
Instead of using whole blob id (including accountId, containerId,
partitionId etc) to populate bloom filter, this PR allows index to
generate bloom filter based on blobId's UUID only. Thus, bloom filter
logic becomes consistent with blobId comparison which uses UUID only to
distinguish blobs. Also, it helps to cleanup some A1 Deletes(if any)
that associated with A2 Puts.