### PR TITLE
Share memory between blobdata and networking buffer

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/commons/CommonUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/commons/CommonUtils.java
@@ -15,7 +15,11 @@
 package com.github.ambry.commons;
 
 import com.github.ambry.config.HelixPropertyStoreConfig;
+import com.github.ambry.utils.ByteBufferInputStream;
+import java.io.DataInputStream;
+import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
@@ -41,5 +45,30 @@ public class CommonUtils {
         propertyStoreConfig.zkClientConnectionTimeoutMs, new ZNRecordSerializer());
     return new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(zkClient), propertyStoreConfig.rootPath,
         subscribedPaths);
+  }
+
+  /**
+   * ByteBufferDataInputStream wraps a {@link ByteBuffer} within a {@link DataInputStream}.
+   */
+  public static class ByteBufferDataInputStream extends DataInputStream {
+    private final ByteBuffer buffer;
+
+    /**
+     * The constructor to create a {@link ByteBufferDataInputStream}.
+     * @param buffer The buffer from which {@link DataInputStream} will be created upon.
+     */
+    public ByteBufferDataInputStream(ByteBuffer buffer) {
+      super(new ByteBufferInputStream(buffer));
+      Objects.requireNonNull(buffer);
+      this.buffer = buffer;
+    }
+
+    /**
+     * Return the underlying {@link ByteBuffer}.
+     * @return The underlying {@link ByteBuffer}.
+     */
+    public ByteBuffer getBuffer() {
+      return buffer;
+    }
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/commons/CommonUtils.java
+++ b/ambry-api/src/main/java/com.github.ambry/commons/CommonUtils.java
@@ -15,11 +15,7 @@
 package com.github.ambry.commons;
 
 import com.github.ambry.config.HelixPropertyStoreConfig;
-import com.github.ambry.utils.ByteBufferInputStream;
-import java.io.DataInputStream;
-import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.Objects;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
@@ -45,30 +41,5 @@ public class CommonUtils {
         propertyStoreConfig.zkClientConnectionTimeoutMs, new ZNRecordSerializer());
     return new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(zkClient), propertyStoreConfig.rootPath,
         subscribedPaths);
-  }
-
-  /**
-   * ByteBufferDataInputStream wraps a {@link ByteBuffer} within a {@link DataInputStream}.
-   */
-  public static class ByteBufferDataInputStream extends DataInputStream {
-    private final ByteBuffer buffer;
-
-    /**
-     * The constructor to create a {@link ByteBufferDataInputStream}.
-     * @param buffer The buffer from which {@link DataInputStream} will be created upon.
-     */
-    public ByteBufferDataInputStream(ByteBuffer buffer) {
-      super(new ByteBufferInputStream(buffer));
-      Objects.requireNonNull(buffer);
-      this.buffer = buffer;
-    }
-
-    /**
-     * Return the underlying {@link ByteBuffer}.
-     * @return The underlying {@link ByteBuffer}.
-     */
-    public ByteBuffer getBuffer() {
-      return buffer;
-    }
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -364,6 +364,10 @@ public class RouterConfig {
   @Default("4")
   public final int routerMaxInMemGetChunks;
 
+  @Config("router.get.blob.operation.share.memory")
+  @Default("false")
+  public final boolean routerGetBlobOperationShareMemory;
+
   /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
@@ -456,5 +460,6 @@ public class RouterConfig {
         Integer.MAX_VALUE / routerMaxPutChunkSizeBytes);
     routerMaxInMemGetChunks = verifiableProperties.getIntInRange("router.max.in.mem.get.chunks", 4, 1,
         Integer.MAX_VALUE / routerMaxPutChunkSizeBytes);
+    routerGetBlobOperationShareMemory = verifiableProperties.getBoolean("router.get.blob.operation.shared.memory", false);
   }
 }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -1645,7 +1645,7 @@ public class MessageFormatRecord {
    * @return The {@link ByteBufferInputStream}
    * @throws IOException Unexpected IO errors.
    */
-  static ByteBufferInputStream getByteBufferInputStreamForBlobRecord(CrcInputStream crcStream, int dataSize)
+  static ByteBufferInputStream getByteBufferInputStreamForBlobRecord(CrcInputStream crcStream, long dataSize)
       throws IOException {
     ByteBufferInputStream output;
     InputStream inputStream = crcStream.getUnderlyingInputStream();
@@ -1654,16 +1654,16 @@ public class MessageFormatRecord {
       int startIndex = byteBuffer.position();
       int oldLimit = byteBuffer.limit();
 
-      byteBuffer.limit(startIndex + dataSize);
+      byteBuffer.limit(startIndex + (int) dataSize);
       ByteBuffer dataBuffer = byteBuffer.slice();
-      crcStream.update(dataBuffer.duplicate());
+      crcStream.updateCrc(dataBuffer.duplicate());
 
       output = new ByteBufferInputStream(dataBuffer);
       byteBuffer.limit(oldLimit);
       // Change the byte buffer's position as if the data is fetched.
-      byteBuffer.position(startIndex+dataSize);
+      byteBuffer.position(startIndex + (int) dataSize);
     } else {
-      output = new ByteBufferInputStream(crcStream, dataSize);
+      output = new ByteBufferInputStream(crcStream, (int) dataSize);
     }
     return output;
   }
@@ -1703,7 +1703,7 @@ public class MessageFormatRecord {
       if (dataSize > Integer.MAX_VALUE) {
         throw new IOException("We only support data of max size == MAX_INT. Error while reading blob from store");
       }
-      ByteBufferInputStream output = getByteBufferInputStreamForBlobRecord(crcStream, (int) dataSize);
+      ByteBufferInputStream output = getByteBufferInputStreamForBlobRecord(crcStream, dataSize);
       long crc = crcStream.getValue();
       long streamCrc = dataStream.readLong();
       if (crc != streamCrc) {
@@ -1761,7 +1761,7 @@ public class MessageFormatRecord {
       if (dataSize > Integer.MAX_VALUE) {
         throw new IOException("We only support data of max size == MAX_INT. Error while reading blob from store");
       }
-      ByteBufferInputStream output = getByteBufferInputStreamForBlobRecord(crcStream, (int) dataSize);
+      ByteBufferInputStream output = getByteBufferInputStreamForBlobRecord(crcStream, dataSize);
       long crc = crcStream.getValue();
       long streamCrc = dataStream.readLong();
       if (crc != streamCrc) {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -1659,9 +1659,9 @@ public class MessageFormatRecord {
       crcStream.update(dataBuffer.duplicate());
 
       output = new ByteBufferInputStream(dataBuffer);
-      // resume the byteBuffer for future use.
-      byteBuffer.position(startIndex+dataSize);
       byteBuffer.limit(oldLimit);
+      // Change the byte buffer's position as if the data is fetched.
+      byteBuffer.position(startIndex+dataSize);
     } else {
       output = new ByteBufferInputStream(crcStream, dataSize);
     }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -1645,7 +1645,7 @@ public class MessageFormatRecord {
    * @return The {@link ByteBufferInputStream}
    * @throws IOException Unexpected IO errors.
    */
-  private static ByteBufferInputStream getByteBufferInputStreamForBlobRecord(CrcInputStream crcStream, int dataSize)
+  static ByteBufferInputStream getByteBufferInputStreamForBlobRecord(CrcInputStream crcStream, int dataSize)
       throws IOException {
     ByteBufferInputStream output = null;
     InputStream inputStream = crcStream.getUnderlyingInputStream();

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -15,18 +15,24 @@ package com.github.ambry.messageformat;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
+import com.github.ambry.commons.CommonUtils;
 import com.github.ambry.store.MockId;
 import com.github.ambry.store.MockIdFactory;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
 import com.github.ambry.utils.ByteBufferInputStream;
+import com.github.ambry.utils.ByteBufferOutputStream;
 import com.github.ambry.utils.Crc32;
+import com.github.ambry.utils.CrcInputStream;
+import com.github.ambry.utils.CrcOutputStream;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
+import java.io.DataInput;
 import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -35,6 +41,7 @@ import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Assert;
 import org.junit.Test;
+import sun.util.resources.ga.LocaleNames_ga;
 
 import static com.github.ambry.account.Account.*;
 import static com.github.ambry.account.Container.*;
@@ -652,6 +659,56 @@ public class MessageFormatRecordTest {
       fail("Failed to detect corruption of blob record");
     } catch (MessageFormatException e) {
       Assert.assertEquals("Error code mismatch", MessageFormatErrorCodes.Data_Corrupt, e.getErrorCode());
+    }
+  }
+
+  @Test
+  public void testBlobDataShareMemory() throws Exception {
+    int blobSize = 1000;
+    // The first 8 bytes are the size of blob, the next 1000 bytes are the blob content, the next 8 bytes are the crc
+    // value, and we do this twice.
+    int bufferSize = (Long.SIZE / Byte.SIZE + blobSize + Long.SIZE / Byte.SIZE) * 2;
+    byte[] firstRandomBytes = new byte[blobSize];
+    byte[] secondRandomBytes = new byte[blobSize];
+    new Random().nextBytes(firstRandomBytes);
+    new Random().nextBytes(secondRandomBytes);
+
+    ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
+    ByteBufferOutputStream bbos = new ByteBufferOutputStream(buffer);
+
+    // Fill the buffer
+    byte[] arrayToFill = firstRandomBytes;
+    while (arrayToFill != null) {
+      CrcOutputStream crcStream = new CrcOutputStream(bbos);
+      DataOutputStream dos = new DataOutputStream(crcStream);
+      dos.writeLong((long) blobSize);
+      dos.write(arrayToFill);
+      buffer.putLong(crcStream.getValue());
+      if (arrayToFill == firstRandomBytes) {
+        arrayToFill = secondRandomBytes;
+      } else {
+        arrayToFill = null;
+      }
+    }
+
+    buffer.flip();
+    byte[] expectedArray = firstRandomBytes;
+    while (expectedArray != null) {
+      CrcInputStream cis = new CrcInputStream(new CommonUtils.ByteBufferDataInputStream(buffer));
+      DataInputStream dis = new DataInputStream(cis);
+      long dataSize = dis.readLong();
+      assertEquals((long) dataSize, blobSize);
+      ByteBufferInputStream obtained = getByteBufferInputStreamForBlobRecord(cis, (int) dataSize);
+      byte[] obtainedArray = new byte[blobSize];
+      obtained.read(obtainedArray);
+      assertArrayEquals(obtainedArray, expectedArray);
+      long crcRead = buffer.getLong();
+      assertEquals(crcRead, cis.getValue());
+      if (expectedArray == firstRandomBytes) {
+        expectedArray = secondRandomBytes;
+      } else {
+        expectedArray = null;
+      }
     }
   }
 

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -33,6 +33,7 @@ import com.github.ambry.utils.UtilsTest;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -697,6 +698,7 @@ public class MessageFormatRecordTest {
       long dataSize = dis.readLong();
       assertEquals((long) dataSize, blobSize);
       ByteBufferInputStream obtained = getByteBufferInputStreamForBlobRecord(cis, (int) dataSize);
+      assertEquals(getByteArrayFromByteBuffer(buffer), getByteArrayFromByteBuffer(obtained.getByteBuffer()));
       byte[] obtainedArray = new byte[blobSize];
       obtained.read(obtainedArray);
       assertArrayEquals(obtainedArray, expectedArray);
@@ -708,6 +710,16 @@ public class MessageFormatRecordTest {
         expectedArray = null;
       }
     }
+  }
+
+  private byte[] getByteArrayFromByteBuffer(ByteBuffer buffer) throws Exception {
+    assertFalse(buffer.isDirect());
+    if (buffer.hasArray()) {
+      return buffer.array();
+    }
+    Field arrayField = ByteBuffer.class.getDeclaredField("hb");
+    arrayField.setAccessible(true);
+    return (byte[])arrayField.get(buffer);
   }
 
   /**

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -698,6 +698,7 @@ public class MessageFormatRecordTest {
       long dataSize = dis.readLong();
       assertEquals((long) dataSize, blobSize);
       ByteBufferInputStream obtained = getByteBufferInputStreamForBlobRecord(cis, (int) dataSize);
+      // Make sure these two ByteBuffers actually share the underlying memory.
       assertEquals(getByteArrayFromByteBuffer(buffer), getByteArrayFromByteBuffer(obtained.getByteBuffer()));
       byte[] obtainedArray = new byte[blobSize];
       obtained.read(obtainedArray);
@@ -712,6 +713,13 @@ public class MessageFormatRecordTest {
     }
   }
 
+  /**
+   * Return the internal byte array of the given {@link ByteBuffer}. It only works when the {@link ByteBuffer} is not
+   * a direct {@link ByteBuffer}.
+   * @param buffer The {@link ByteBuffer}.
+   * @return The internal byte array.
+   * @throws Exception Any unexpected error.
+   */
   private byte[] getByteArrayFromByteBuffer(ByteBuffer buffer) throws Exception {
     assertFalse(buffer.isDirect());
     if (buffer.hasArray()) {
@@ -719,7 +727,7 @@ public class MessageFormatRecordTest {
     }
     Field arrayField = ByteBuffer.class.getDeclaredField("hb");
     arrayField.setAccessible(true);
-    return (byte[])arrayField.get(buffer);
+    return (byte[]) arrayField.get(buffer);
   }
 
   /**

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -15,11 +15,11 @@ package com.github.ambry.messageformat;
 
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
-import com.github.ambry.commons.CommonUtils;
 import com.github.ambry.store.MockId;
 import com.github.ambry.store.MockIdFactory;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
+import com.github.ambry.utils.ByteBufferDataInputStream;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.ByteBufferOutputStream;
 import com.github.ambry.utils.Crc32;
@@ -30,7 +30,6 @@ import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
-import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -41,7 +40,6 @@ import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Assert;
 import org.junit.Test;
-import sun.util.resources.ga.LocaleNames_ga;
 
 import static com.github.ambry.account.Account.*;
 import static com.github.ambry.account.Container.*;
@@ -694,7 +692,7 @@ public class MessageFormatRecordTest {
     buffer.flip();
     byte[] expectedArray = firstRandomBytes;
     while (expectedArray != null) {
-      CrcInputStream cis = new CrcInputStream(new CommonUtils.ByteBufferDataInputStream(buffer));
+      CrcInputStream cis = new CrcInputStream(new ByteBufferDataInputStream(buffer));
       DataInputStream dis = new DataInputStream(cis);
       long dataSize = dis.readLong();
       assertEquals((long) dataSize, blobSize);

--- a/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DeleteManager.java
@@ -142,7 +142,7 @@ class DeleteManager {
     long startTime = time.milliseconds();
     DeleteResponse deleteResponse =
         RouterUtils.extractResponseAndNotifyResponseHandler(responseHandler, routerMetrics, responseInfo,
-            DeleteResponse::readFrom, DeleteResponse::getError);
+            DeleteResponse::readFrom, DeleteResponse::getError, false);
     RequestInfo routerRequestInfo = responseInfo.getRequestInfo();
     int correlationId = ((DeleteRequest) routerRequestInfo.getRequest()).getCorrelationId();
     DeleteOperation deleteOperation = correlationIdToDeleteOperation.remove(correlationId);

--- a/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetManager.java
@@ -217,7 +217,7 @@ class GetManager {
                 serverError = response.getPartitionResponseInfoList().get(0).getErrorCode();
               }
               return serverError;
-            });
+            }, routerConfig.routerGetBlobOperationShareMemory);
     RequestInfo routerRequestInfo = responseInfo.getRequestInfo();
     GetRequest getRequest = (GetRequest) routerRequestInfo.getRequest();
     GetOperation getOperation = correlationIdToGetOperation.remove(getRequest.getCorrelationId());

--- a/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutManager.java
@@ -220,7 +220,7 @@ class PutManager {
     long startTime = time.milliseconds();
     PutResponse putResponse =
         RouterUtils.extractResponseAndNotifyResponseHandler(responseHandler, routerMetrics, responseInfo,
-            PutResponse::readFrom, PutResponse::getError);
+            PutResponse::readFrom, PutResponse::getError, false);
     RequestInfo routerRequestInfo = responseInfo.getRequestInfo();
     int correlationId = ((PutRequest) routerRequestInfo.getRequest()).getCorrelationId();
     // Get the PutOperation that generated the request.

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -1,16 +1,16 @@
 /**
- * Copyright 2016 LinkedIn Corp. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- */
+* Copyright 2016 LinkedIn Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 package com.github.ambry.router;
 
 import com.github.ambry.account.Account;
@@ -27,6 +27,7 @@ import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.protocol.Response;
 import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.utils.ByteBufferDataInputStream;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
@@ -193,12 +194,8 @@ class RouterUtils {
     NetworkClientErrorCode networkClientErrorCode = responseInfo.getError();
     if (networkClientErrorCode == null) {
       try {
-        DataInputStream dis = null;
-        if (shareMemory) {
-          dis = new CommonUtils.ByteBufferDataInputStream(responseInfo.getResponse());
-        } else {
-          dis = new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse()));
-        }
+        DataInputStream dis = shareMemory ? new ByteBufferDataInputStream(responseInfo.getResponse())
+            : new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse()));
         response = deserializer.readFrom(dis);
         responseHandler.onEvent(replicaId, errorExtractor.apply(response));
       } catch (Exception e) {

--- a/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/RouterUtils.java
@@ -20,7 +20,6 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
-import com.github.ambry.commons.CommonUtils;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.network.NetworkClientErrorCode;

--- a/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateManager.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TtlUpdateManager.java
@@ -155,7 +155,7 @@ class TtlUpdateManager {
     long startTime = time.milliseconds();
     TtlUpdateResponse ttlUpdateResponse =
         RouterUtils.extractResponseAndNotifyResponseHandler(responseHandler, routerMetrics, responseInfo,
-            TtlUpdateResponse::readFrom, TtlUpdateResponse::getError);
+            TtlUpdateResponse::readFrom, TtlUpdateResponse::getError, false);
     RequestInfo routerRequestInfo = responseInfo.getRequestInfo();
     int correlationId = ((TtlUpdateRequest) routerRequestInfo.getRequest()).getCorrelationId();
     TtlUpdateOperation ttlUpdateOperation = correlationIdToTtlUpdateOperation.remove(correlationId);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -23,6 +23,7 @@ import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.BlobIdFactory;
 import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
+import com.github.ambry.commons.CommonUtils;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.CryptoServiceConfig;
@@ -82,6 +83,7 @@ import org.junit.runners.Parameterized;
 
 import static com.github.ambry.router.PutManagerTest.*;
 import static com.github.ambry.router.RouterTestHelpers.*;
+import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
 
@@ -1369,8 +1371,13 @@ public class GetBlobOperationTest {
       op.poll(requestRegistrationCallback);
       List<ResponseInfo> responses = sendAndWaitForResponses(requestRegistrationCallback.getRequestsToSend());
       for (ResponseInfo responseInfo : responses) {
-        GetResponse getResponse = responseInfo.getError() == null ? GetResponse.readFrom(
-            new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse())), mockClusterMap) : null;
+        DataInputStream dis = null;
+        if (routerConfig.routerGetBlobOperationShareMemory) {
+          dis = new CommonUtils.ByteBufferDataInputStream(responseInfo.getResponse());
+        } else {
+          dis = new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse()));
+        }
+        GetResponse getResponse = responseInfo.getError() == null ? GetResponse.readFrom(dis, mockClusterMap) : null;
         op.handleResponse(responseInfo, getResponse);
       }
     }
@@ -1555,6 +1562,7 @@ public class GetBlobOperationTest {
     properties.setProperty("router.request.timeout.ms", Integer.toString(20));
     properties.setProperty("router.operation.tracker.exclude.timeout.enabled", Boolean.toString(excludeTimeout));
     properties.setProperty("router.operation.tracker.terminate.on.not.found.enabled", "true");
+    properties.setProperty("router.get.blob.operation.share.memory", "true");
     return properties;
   }
 }

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -23,7 +23,6 @@ import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.BlobIdFactory;
 import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
-import com.github.ambry.commons.CommonUtils;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.CryptoServiceConfig;
@@ -51,6 +50,7 @@ import com.github.ambry.router.RouterTestHelpers.*;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferChannel;
+import com.github.ambry.utils.ByteBufferDataInputStream;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.TestUtils;
@@ -1373,7 +1373,7 @@ public class GetBlobOperationTest {
       for (ResponseInfo responseInfo : responses) {
         DataInputStream dis = null;
         if (routerConfig.routerGetBlobOperationShareMemory) {
-          dis = new CommonUtils.ByteBufferDataInputStream(responseInfo.getResponse());
+          dis = new ByteBufferDataInputStream(responseInfo.getResponse());
         } else {
           dis = new DataInputStream(new ByteBufferInputStream(responseInfo.getResponse()));
         }

--- a/ambry-utils/src/main/java/com.github.ambry.utils/ByteBufferDataInputStream.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/ByteBufferDataInputStream.java
@@ -1,0 +1,31 @@
+package com.github.ambry.utils;
+
+import java.io.DataInputStream;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+
+/**
+ * ByteBufferDataInputStream wraps a {@link ByteBuffer} within a {@link DataInputStream}.
+ */
+public class ByteBufferDataInputStream extends DataInputStream {
+  private final ByteBuffer buffer;
+
+  /**
+   * The constructor to create a {@link ByteBufferDataInputStream}.
+   * @param buffer The buffer from which {@link DataInputStream} will be created upon.
+   */
+  public ByteBufferDataInputStream(ByteBuffer buffer) {
+    super(new ByteBufferInputStream(buffer));
+    Objects.requireNonNull(buffer);
+    this.buffer = buffer;
+  }
+
+  /**
+   * Return the underlying {@link ByteBuffer}.
+   * @return The underlying {@link ByteBuffer}.
+   */
+  public ByteBuffer getBuffer() {
+    return buffer;
+  }
+}

--- a/ambry-utils/src/main/java/com.github.ambry.utils/ByteBufferDataInputStream.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/ByteBufferDataInputStream.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package com.github.ambry.utils;
 
 import java.io.DataInputStream;

--- a/ambry-utils/src/main/java/com.github.ambry.utils/CrcInputStream.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/CrcInputStream.java
@@ -15,6 +15,7 @@ package com.github.ambry.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +58,10 @@ public class CrcInputStream extends InputStream {
     int ret = stream.read(b, off, len);
     crc.update(b, off, ret);
     return ret;
+  }
+
+  public void update(ByteBuffer buffer) throws IOException {
+    crc.update(buffer);
   }
 
   @Override

--- a/ambry-utils/src/main/java/com.github.ambry.utils/CrcInputStream.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/CrcInputStream.java
@@ -60,7 +60,12 @@ public class CrcInputStream extends InputStream {
     return ret;
   }
 
-  public void update(ByteBuffer buffer) throws IOException {
+  /**
+   * update crc with the all the data reading from given buffer.
+   * @param buffer The buffer to update the crc value.
+   * @throws IOException any I/O error.
+   */
+  public void updateCrc(ByteBuffer buffer) throws IOException {
     crc.update(buffer);
   }
 

--- a/ambry-utils/src/main/java/com.github.ambry.utils/CrcInputStream.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/CrcInputStream.java
@@ -74,4 +74,12 @@ public class CrcInputStream extends InputStream {
   public long getValue() {
     return crc.getValue();
   }
+
+  /**
+   * Return underlying {@link InputStream}
+   * @return Underlying {@link InputStream}
+   */
+  public InputStream getUnderlyingInputStream() {
+    return stream;
+  }
 }


### PR DESCRIPTION
For GetResponse, buffer at networking layer holds all the blob content and we are not sharing the buffer with the BlobData in the router, this would roughly double the memory footprint for GetResponse.

This PR is trying to share the memory between these two object and reduce the memory usage.