### PR TITLE
Minor fixes for store removal

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -149,16 +149,16 @@ class HelixParticipant implements ClusterParticipant {
     }
     boolean setStoppedResult;
     synchronized (helixAdministrationLock) {
-      logger.trace("Getting stopped replicas from instanceConfig");
+      logger.info("Getting stopped replicas from instanceConfig");
       List<String> stoppedListInHelix = getStoppedReplicas();
       Set<String> stoppedSet = new HashSet<>(stoppedListInHelix);
       boolean stoppedSetUpdated =
           markStop ? stoppedSet.addAll(replicasToUpdate) : stoppedSet.removeAll(replicasToUpdate);
       if (stoppedSetUpdated) {
-        logger.trace("Updating the stopped list in Helix InstanceConfig");
+        logger.info("Updating the stopped list in Helix InstanceConfig");
         setStoppedResult = setStoppedReplicas(new ArrayList<>(stoppedSet));
       } else {
-        logger.trace("No replicas should be added or removed, no need to update the stopped list");
+        logger.info("No replicas should be added or removed, no need to update the stopped list");
         setStoppedResult = true;
       }
     }

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
@@ -563,6 +563,7 @@ public class AmbryServerRequests extends AmbryRequests {
       ((BlobStore) store).deleteStoreFiles();
       ReplicaStatusDelegate replicaStatusDelegate = ((BlobStore) store).getReplicaStatusDelegate();
       // Remove this store from sealed and stopped list (if present)
+      logger.info("Removing store from sealed and stopped list(if present)");
       replicaStatusDelegate.unseal(replicaId);
       replicaStatusDelegate.unmarkStopped(Collections.singletonList(replicaId));
       localPartitionToReplicaMap.remove(partitionId);

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
@@ -130,8 +130,8 @@ public class AmbryServerRequests extends AmbryRequests {
   protected ConcurrentHashMap<PartitionId, ReplicaId> createLocalPartitionToReplicaMap() {
     List<? extends ReplicaId> localReplicaIds = clusterMap.getReplicaIds(currentNode);
     return localReplicaIds.stream()
-        .collect(Collectors.toMap(ReplicaId::getPartitionId, Function.identity(), (o1, o2) -> {
-          // This a merge function that handles collisions between values associated with the same key.
+        .collect(Collectors.toMap(ReplicaId::getPartitionId, Function.identity(), (v1, v2) -> {
+          // This is a merge function that handles collisions between values associated with the same key.
           // In the context of ambry server, this means two replicas are associated with same partition on current node
           // For now, we treat it as an illegal case and throw an exception here.
           throw new IllegalStateException("Found two replicas from same partition on local node!");
@@ -562,7 +562,7 @@ public class AmbryServerRequests extends AmbryRequests {
     if (storeManager.removeBlobStore(partitionId) && store != null) {
       ((BlobStore) store).deleteStoreFiles();
       ReplicaStatusDelegate replicaStatusDelegate = ((BlobStore) store).getReplicaStatusDelegate();
-      // Remove this store from sealed and stopped list (if present)
+      // Remove store from sealed and stopped list (if present)
       logger.info("Removing store from sealed and stopped list(if present)");
       replicaStatusDelegate.unseal(replicaId);
       replicaStatusDelegate.unmarkStopped(Collections.singletonList(replicaId));

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -703,7 +703,9 @@ public class BlobStore implements Store {
     }
     // Step 2: if segmented, delete remaining store segments in reserve pool
     if (log.isLogSegmented()) {
-      diskSpaceAllocator.deleteAllSegmentsForStoreIds(Collections.singletonList(storeId));
+      logger.info("Deleting remaining segments associated with store {} in reserve pool", storeId);
+      diskSpaceAllocator.deleteAllSegmentsForStoreIds(
+          Collections.singletonList(replicaId.getPartitionId().toPathString()));
     }
     // Step 3: delete all files in current store directory
     logger.info("Deleting store {} directory", storeId);
@@ -713,7 +715,14 @@ public class BlobStore implements Store {
     } catch (Exception e) {
       throw new IOException("Couldn't delete store directory " + dataDir, e);
     }
-    logger.info("All files of store {} deleted", storeId);
+    logger.info("All files of store {} are deleted", storeId);
+  }
+
+  /**
+   * @return {@link ReplicaStatusDelegate} associated with this store
+   */
+  public ReplicaStatusDelegate getReplicaStatusDelegate() {
+    return replicaStatusDelegate;
   }
 
   @Override

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/ServerAdminTool.java
@@ -41,8 +41,8 @@ import com.github.ambry.network.SendWithCorrelationId;
 import com.github.ambry.protocol.AdminRequest;
 import com.github.ambry.protocol.AdminRequestOrResponseType;
 import com.github.ambry.protocol.AdminResponse;
-import com.github.ambry.protocol.BlobStoreControlAdminRequest;
 import com.github.ambry.protocol.BlobStoreControlAction;
+import com.github.ambry.protocol.BlobStoreControlAdminRequest;
 import com.github.ambry.protocol.CatchupStatusAdminRequest;
 import com.github.ambry.protocol.CatchupStatusAdminResponse;
 import com.github.ambry.protocol.GetOption;
@@ -253,7 +253,7 @@ public class ServerAdminTool implements Closeable {
       origins = verifiableProperties.getString("replication.origins", "").split(",");
       acceptableLagInBytes = verifiableProperties.getLongInRange("acceptable.lag.in.bytes", 0, 0, Long.MAX_VALUE);
       numReplicasCaughtUpPerPartition =
-          verifiableProperties.getShortInRange("num.replicas.caught.up.per.partition", Short.MAX_VALUE, (short) 1,
+          verifiableProperties.getShortInRange("num.replicas.caught.up.per.partition", Short.MAX_VALUE, (short) 0,
               Short.MAX_VALUE);
       storeControlRequestType =
           BlobStoreControlAction.valueOf(verifiableProperties.getString("store.control.request.type"));
@@ -413,6 +413,8 @@ public class ServerAdminTool implements Closeable {
     serverAdminTool.close();
     outputFileStream.close();
     clusterMap.close();
+    System.out.println("Server admin tool is safely closed");
+    System.exit(0);
   }
 
   /**
@@ -513,8 +515,8 @@ public class ServerAdminTool implements Closeable {
    * @throws TimeoutException
    */
   private static void sendBlobStoreControlRequest(ServerAdminTool serverAdminTool, DataNodeId dataNodeId,
-      PartitionId partitionId, short numReplicasCaughtUpPerPartition,
-      BlobStoreControlAction storeControlRequestType) throws IOException, TimeoutException {
+      PartitionId partitionId, short numReplicasCaughtUpPerPartition, BlobStoreControlAction storeControlRequestType)
+      throws IOException, TimeoutException {
     ServerErrorCode errorCode =
         serverAdminTool.controlBlobStore(dataNodeId, partitionId, numReplicasCaughtUpPerPartition,
             storeControlRequestType);


### PR DESCRIPTION
1. Changed localPartitionToReplicaMap to ConcurrentHashMap to support adding/removing replica dynamically.
2. Enabled server to delete removed store entry in sealed/stopped list (The list is stored in InstanceConfig).
3. Fixed issue that store didn't delete remaining segments in reserved pool.
4. Fixed the bug that DiskSpaceAllocator didn't update in-mem data structure when deleting whole store reserve directory.