### PR TITLE
Recovery fixes

### DIFF
--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
@@ -135,8 +135,7 @@ class CloudBlobStore implements Store {
       for (BlobId blobId : blobIdList) {
         CloudBlobMetadata blobMetadata = cloudBlobMetadataListMap.get(blobId.getID());
         MessageInfo messageInfo = new MessageInfo(blobId, blobMetadata.getSize(), blobMetadata.getExpirationTime(),
-            (short) blobMetadata.getAccountId(), (short) blobMetadata.getContainerId(),
-            getOperationTime(blobMetadata, currentTimeStamp));
+            (short) blobMetadata.getAccountId(), (short) blobMetadata.getContainerId(), getOperationTime(blobMetadata));
         messageInfos.add(messageInfo);
         blobReadInfos.add(new CloudMessageReadSet.BlobReadInfo(blobMetadata, blobId));
       }
@@ -195,7 +194,7 @@ class CloudBlobStore implements Store {
    * @param metadata blob metadata from which to derive operation time.
    * @return operation time.
    */
-  private long getOperationTime(CloudBlobMetadata metadata, long currentTimeStamp) {
+  private long getOperationTime(CloudBlobMetadata metadata) {
     if (isBlobDeleted(metadata)) {
       return metadata.getDeletionTime();
     }

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
@@ -198,8 +198,6 @@ class CloudBlobStore implements Store {
   private long getOperationTime(CloudBlobMetadata metadata, long currentTimeStamp) {
     if (isBlobDeleted(metadata)) {
       return metadata.getDeletionTime();
-    } else if (isBlobExpired(metadata, currentTimeStamp)) {
-      return metadata.getExpirationTime();
     }
     return (metadata.getCreationTime() == Utils.Infinite_Time) ? metadata.getUploadTime() : metadata.getCreationTime();
   }

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
@@ -52,6 +52,9 @@ class CloudMessageReadSet implements MessageReadSet {
       if (blobReadInfo.isPrefetched()) {
         ByteBuffer outputBuffer = blobReadInfo.getPrefetchedBuffer();
         outputBuffer.flip();
+        long sizeToRead = Math.min(maxSize, blobReadInfo.getBlobSize() - relativeOffset);
+        outputBuffer.limit((int) (relativeOffset + sizeToRead));
+        outputBuffer.position((int) (relativeOffset));
         written = channel.write(outputBuffer);
       } else {
         blobReadInfo.downloadBlob(blobStore, Channels.newOutputStream(channel));
@@ -127,7 +130,9 @@ class CloudMessageReadSet implements MessageReadSet {
       // However, if in future, if very large size of blobs are allowed, then prefetching logic should be changed.
       prefetchedBuffer = ByteBuffer.allocate((int) blobMetadata.getSize());
       ByteBufferOutputStream outputStream = new ByteBufferOutputStream(prefetchedBuffer);
+
       blobStore.downloadBlob(blobMetadata, blobId, outputStream);
+
       isPrefetched = true;
     }
 

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
@@ -130,9 +130,7 @@ class CloudMessageReadSet implements MessageReadSet {
       // However, if in future, if very large size of blobs are allowed, then prefetching logic should be changed.
       prefetchedBuffer = ByteBuffer.allocate((int) blobMetadata.getSize());
       ByteBufferOutputStream outputStream = new ByteBufferOutputStream(prefetchedBuffer);
-
       blobStore.downloadBlob(blobMetadata, blobId, outputStream);
-
       isPrefetched = true;
     }
 

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
@@ -51,7 +51,6 @@ class CloudMessageReadSet implements MessageReadSet {
     try {
       if (blobReadInfo.isPrefetched()) {
         ByteBuffer outputBuffer = blobReadInfo.getPrefetchedBuffer();
-        outputBuffer.flip();
         long sizeToRead = Math.min(maxSize, blobReadInfo.getBlobSize() - relativeOffset);
         outputBuffer.limit((int) (relativeOffset + sizeToRead));
         outputBuffer.position((int) (relativeOffset));

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
@@ -197,7 +197,7 @@ public class VcrRecoveryTest {
       assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
           partitionResponseInfo.getErrorCode());
       for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
-        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 270, messageInfo.getSize());
+        assertEquals(blobIdToSizeMap.get((BlobId) messageInfo.getStoreKey()) + 270, messageInfo.getSize());
       }
     }
   }
@@ -256,7 +256,7 @@ public class VcrRecoveryTest {
     byte[] userMetadata = new byte[userMetaDataSize];
     TestUtils.RANDOM.nextBytes(userMetadata);
     Map<BlobId, Integer> blobIdToSizeMap = new HashMap<>();
-    int blobSize = FOUR_MB_SZ;
+    int blobSize = FOUR_MB_SZ; // Currently ambry supports max size of 4MB for blobs.
     for (BlobId blobId : blobIds) {
       byte[] data = new byte[blobSize];
       BlobProperties blobProperties =

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
@@ -24,20 +24,38 @@ import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.CommonTestUtils;
+import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
+import com.github.ambry.messageformat.MessageFormatFlags;
+import com.github.ambry.messageformat.PutMessageFormatInputStream;
+import com.github.ambry.network.BlockingChannel;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.protocol.GetOption;
+import com.github.ambry.protocol.GetRequest;
+import com.github.ambry.protocol.GetResponse;
+import com.github.ambry.protocol.PartitionRequestInfo;
+import com.github.ambry.protocol.PartitionResponseInfo;
+import com.github.ambry.store.MessageInfo;
+import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.HelixControllerManager;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
-import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -47,6 +65,142 @@ import static org.junit.Assert.*;
  * Test for recovery from cloud node to disk based data node.
  */
 public class VcrRecoveryTest {
+  private Properties recoveryProperties;
+  private MockCluster recoveryCluster;
+  private Port recoveryNodePort;
+  private MockDataNodeId recoveryNode;
+  private VcrServer vcrServer;
+  private HelixControllerManager helixControllerManager;
+  private TestUtils.ZkInfo zkInfo;
+  private PartitionId partitionId;
+  private LatchBasedInMemoryCloudDestination latchBasedInMemoryCloudDestination;
+  private List<BlobId> blobIds;
+  final private short accountId = Utils.getRandomShort(TestUtils.RANDOM);
+  final private short containerId = Utils.getRandomShort(TestUtils.RANDOM);
+  final private static int FOUR_MB_SZ = 4194304;
+
+  /**
+   * Create a cluster with a vcr node and a recovery (ambry data) node.
+   * @throws Exception on {@link Exception}
+   */
+  @Before
+  public void setup() throws Exception {
+    String dcName = "DC1";
+    String vcrMountPath = "/vcr/1";
+    recoveryProperties = new Properties();
+    recoveryProperties.setProperty("replication.metadata.request.version", "2");
+
+    // create vcr node
+    List<Port> vcrPortList = new ArrayList<>(2);
+    Port vcrClusterMapPort = new Port(12310, PortType.PLAINTEXT);
+    Port vcrSslPort = new Port(12410, PortType.SSL);
+    vcrPortList.add(vcrClusterMapPort);
+    vcrPortList.add(vcrSslPort);
+
+    MockDataNodeId vcrNode =
+        new MockDataNodeId("localhost", vcrPortList, Collections.singletonList(vcrMountPath), dcName);
+
+    // create recovery node
+    recoveryNodePort = new Port(12311, PortType.PLAINTEXT);
+    ArrayList<Port> recoveryPortList = new ArrayList<>(2);
+    recoveryPortList.add(recoveryNodePort);
+    recoveryNode = MockClusterMap.createDataNode(recoveryPortList, dcName, 1);
+
+    // create cluster for recovery
+    recoveryCluster = MockCluster.createOneNodeRecoveryCluster(vcrNode, recoveryNode, dcName);
+    partitionId = recoveryCluster.getClusterMap().getWritablePartitionIds(null).get(0);
+
+    // Start Helix Controller and ZK Server.
+    int zkPort = 31999;
+    String zkConnectString = "localhost:" + zkPort;
+    String vcrClusterName = "vcrTestCluster";
+    zkInfo = new TestUtils.ZkInfo(TestUtils.getTempDir("helixVcr"), dcName, (byte) 1, zkPort, true);
+    helixControllerManager =
+        VcrTestUtil.populateZkInfoAndStartController(zkConnectString, vcrClusterName, recoveryCluster.getClusterMap());
+
+    Properties vcrProperties =
+        VcrTestUtil.createVcrProperties(vcrNode.getDatacenterName(), "vcrTestCluster", zkConnectString, 12310, 12410,
+            null);
+    vcrProperties.putAll(recoveryProperties);
+    NotificationSystem notificationSystem = new MockNotificationSystem(recoveryCluster.getClusterMap());
+
+    // Create blobs and data for upload to vcr.
+    int blobCount = 10;
+    blobIds = createBlobIds(blobCount);
+
+    // Create cloud destination and start vcr server.
+    latchBasedInMemoryCloudDestination = new LatchBasedInMemoryCloudDestination(blobIds);
+    CloudDestinationFactory cloudDestinationFactory =
+        new LatchBasedInMemoryCloudDestinationFactory(latchBasedInMemoryCloudDestination);
+    vcrServer =
+        VcrTestUtil.createVcrServer(new VerifiableProperties(vcrProperties), recoveryCluster.getClusterAgentsFactory(),
+            notificationSystem, cloudDestinationFactory);
+    vcrServer.startup();
+
+    // start ambry server with data node
+    recoveryCluster.initializeServers(notificationSystem, vcrNode, recoveryProperties);
+    recoveryCluster.startServers();
+  }
+
+  /**
+   * Shutdown the cluster.
+   * @throws IOException on {@link IOException}
+   */
+  @After
+  public void cleanUp() throws IOException {
+    recoveryCluster.stopServers();
+    vcrServer.shutdown();
+    helixControllerManager.syncStop();
+    zkInfo.shutdown();
+  }
+
+  /**
+   * Create {@code blobCount} number of {@link BlobId}s.
+   * @param blobCount number of {@link BlobId}s to create.
+   * @return list of {@link BlobId}s
+   */
+  private List<BlobId> createBlobIds(int blobCount) {
+    List<BlobId> blobIds = new ArrayList<>(blobCount);
+    for (int i = 0; i < blobCount; i++) {
+      BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
+          recoveryCluster.getClusterMap().getLocalDatacenterId(), accountId, containerId, partitionId, false,
+          BlobId.BlobDataType.DATACHUNK);
+      blobIds.add(blobId);
+    }
+    return blobIds;
+  }
+
+  /**
+   * Do a get on recovery node to test that all the blobids that were uploaded to vcr node have been recovered on recovery node.
+   * @param blobIdToSizeMap {@link Map} of blobid to size uploaded to vcr node.
+   * @throws IOException on {@link IOException}
+   */
+  private void testGetOnRecoveryNode(Map<BlobId, Integer> blobIdToSizeMap) throws IOException {
+    BlockingChannel channel =
+        ServerTestUtil.getBlockingChannelBasedOnPortType(recoveryNodePort, "localhost", null, null);
+    channel.connect();
+
+    AtomicInteger correlationIdGenerator = new AtomicInteger(0);
+    List<PartitionRequestInfo> partitionRequestInfoList =
+        Collections.singletonList(new PartitionRequestInfo(partitionId, blobIds));
+    GetRequest getRequest = new GetRequest(correlationIdGenerator.incrementAndGet(),
+        GetRequest.Replication_Client_Id_Prefix + recoveryNode.getHostname(), MessageFormatFlags.All,
+        partitionRequestInfoList,
+        new ReplicationConfig(new VerifiableProperties(recoveryProperties)).replicationIncludeAll
+            ? GetOption.Include_All : GetOption.None);
+
+    channel.send(getRequest);
+    GetResponse getResponse =
+        GetResponse.readFrom(new DataInputStream(channel.receive().getInputStream()), recoveryCluster.getClusterMap());
+
+    for (PartitionResponseInfo partitionResponseInfo : getResponse.getPartitionResponseInfoList()) {
+      assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
+          partitionResponseInfo.getErrorCode());
+      for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
+        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 270, messageInfo.getSize());
+      }
+    }
+  }
 
   /**
    * Test recovery from one vcr node to one disk based data node.
@@ -54,99 +208,81 @@ public class VcrRecoveryTest {
    * @throws Exception If an exception happens.
    */
   @Test
-  public void cloudRecoveryTest() throws Exception {
-    String dcName = "DC1";
-    Properties recoveryProperties = new Properties();
-    recoveryProperties.setProperty("replication.metadata.request.version", "2");
-
-    // create vcr node
-    Port vcrClusterMapPort = new Port(12310, PortType.PLAINTEXT);
-    Port vcrSslPort = new Port(12410, PortType.SSL);
-    List<Port> vcrPortList = new ArrayList<>(2);
-    vcrPortList.add(vcrClusterMapPort);
-    vcrPortList.add(vcrSslPort);
-    String vcrMountPath = "/vcr/1";
-    MockDataNodeId vcrNode =
-        new MockDataNodeId("localhost", vcrPortList, Collections.singletonList(vcrMountPath), dcName);
-
-    // create data node
-    Port recoveryClusterMapPort = new Port(12311, PortType.PLAINTEXT);
-    ArrayList<Port> recoveryPortList = new ArrayList<>(2);
-    recoveryPortList.add(recoveryClusterMapPort);
-    MockDataNodeId recoveryNode = MockClusterMap.createDataNode(recoveryPortList, dcName, 1);
-
-    //create cluster for recovery
-    MockCluster recoveryCluster = MockCluster.createOneNodeRecoveryCluster(vcrNode, recoveryNode, dcName);
-
-    // Start Helix Controller and ZK Server.
-    int zkPort = 31999;
-    String zkConnectString = "localhost:" + zkPort;
-    String vcrClusterName = "vcrTestCluster";
-    TestUtils.ZkInfo zkInfo = new TestUtils.ZkInfo(TestUtils.getTempDir("helixVcr"), dcName, (byte) 1, zkPort, true);
-    HelixControllerManager helixControllerManager =
-        VcrTestUtil.populateZkInfoAndStartController(zkConnectString, vcrClusterName, recoveryCluster.getClusterMap());
-
-    Properties props =
-        VcrTestUtil.createVcrProperties(vcrNode.getDatacenterName(), "vcrTestCluster", zkConnectString, 12310, 12410,
-            null);
-    props.putAll(recoveryProperties);
-
-    // Create blobs and data for upload to vcr.
-    int blobCount = 10;
-    int blobSize = 100;
+  public void basicCloudRecoveryTest() throws Exception {
+    // Create blobs and upload to cloud destination.
     int userMetaDataSize = 100;
     byte[] userMetadata = new byte[userMetaDataSize];
-    byte[] data = new byte[blobSize];
-    short accountId = Utils.getRandomShort(TestUtils.RANDOM);
-    short containerId = Utils.getRandomShort(TestUtils.RANDOM);
-    BlobProperties blobProperties =
-        new BlobProperties(blobSize, "serviceid1", null, null, false, Utils.Infinite_Time, accountId, containerId,
-            false, null);
     TestUtils.RANDOM.nextBytes(userMetadata);
-    TestUtils.RANDOM.nextBytes(data);
-
-    List<BlobId> blobIds = new ArrayList<>(blobCount);
-    PartitionId partitionId = recoveryCluster.getClusterMap().getWritablePartitionIds(null).get(0);
-
-    for (int i = 0; i < blobCount; i++) {
-      BlobId blobId = new BlobId(CommonTestUtils.getCurrentBlobIdVersion(), BlobId.BlobIdType.NATIVE,
-          recoveryCluster.getClusterMap().getLocalDatacenterId(), blobProperties.getAccountId(),
-          blobProperties.getContainerId(), partitionId, false, BlobId.BlobDataType.DATACHUNK);
-      blobIds.add(blobId);
-    }
-
-    // Create cloud destination and start vcr server.
-    LatchBasedInMemoryCloudDestination latchBasedInMemoryCloudDestination =
-        new LatchBasedInMemoryCloudDestination(blobIds);
-    CloudDestinationFactory cloudDestinationFactory =
-        new LatchBasedInMemoryCloudDestinationFactory(latchBasedInMemoryCloudDestination);
-
-    NotificationSystem notificationSystem = new MockNotificationSystem(recoveryCluster.getClusterMap());
-    VcrServer vcrServer =
-        VcrTestUtil.createVcrServer(new VerifiableProperties(props), recoveryCluster.getClusterAgentsFactory(),
-            notificationSystem, cloudDestinationFactory);
-    vcrServer.startup();
-
-    // Upload created blobs to cloud destination.
+    Map<BlobId, Integer> blobIdToSizeMap = new HashMap<>();
     for (BlobId blobId : blobIds) {
+      int blobSize = Utils.getRandomShort(TestUtils.RANDOM);
+      byte[] data = new byte[blobSize];
+      BlobProperties blobProperties =
+          new BlobProperties(blobSize, "serviceid1", null, null, false, Utils.Infinite_Time, accountId, containerId,
+              false, null);
+      TestUtils.RANDOM.nextBytes(data);
+      blobIdToSizeMap.put(blobId, blobSize);
+      PutMessageFormatInputStream putMessageFormatInputStream =
+          new PutMessageFormatInputStream(blobId, null, blobProperties, ByteBuffer.wrap(userMetadata),
+              new ByteBufferInputStream(ByteBuffer.wrap(data)), blobSize);
       long time = System.currentTimeMillis();
       CloudBlobMetadata cloudBlobMetadata =
-          new CloudBlobMetadata(blobId, time, Utils.Infinite_Time, blobSize, CloudBlobMetadata.EncryptionOrigin.NONE);
-      latchBasedInMemoryCloudDestination.uploadBlob(blobId, blobSize, cloudBlobMetadata,
-          new ByteArrayInputStream(data));
+          new CloudBlobMetadata(blobId, time, Utils.Infinite_Time, putMessageFormatInputStream.getSize(),
+              CloudBlobMetadata.EncryptionOrigin.NONE);
+      latchBasedInMemoryCloudDestination.uploadBlob(blobId, putMessageFormatInputStream.getSize(), cloudBlobMetadata,
+          putMessageFormatInputStream);
     }
 
-    // start ambry server with data node
-    recoveryCluster.initializeServers(notificationSystem, vcrNode, recoveryProperties);
-    recoveryCluster.startServers();
-
-    //Waiting for recovery
+    // Waiting for download attempt
     assertTrue("Did not recover all blobs in 2 minutes",
         latchBasedInMemoryCloudDestination.awaitDownload(2, TimeUnit.MINUTES));
 
-    recoveryCluster.stopServers();
-    vcrServer.shutdown();
-    helixControllerManager.syncStop();
-    zkInfo.shutdown();
+    // Waiting for replication to complete
+    Thread.sleep(10000);
+
+    // Test recovery by sending get request to recovery node
+    testGetOnRecoveryNode(blobIdToSizeMap);
+  }
+
+  /**
+   * Test recovery from one vcr node to one disk based data node for large blobs.
+   * Creates a vcr node and a disk based data node. Uploads data to vcr node and verifies that they have been downloaded.
+   * @throws Exception If an exception happens.
+   */
+  @Test
+  public void cloudRecoveryTestForLargeBlob() throws Exception {
+    // Create blobs and upload to cloud destination.
+    int userMetaDataSize = 100;
+    byte[] userMetadata = new byte[userMetaDataSize];
+    TestUtils.RANDOM.nextBytes(userMetadata);
+    Map<BlobId, Integer> blobIdToSizeMap = new HashMap<>();
+    int blobSize = FOUR_MB_SZ;
+    for (BlobId blobId : blobIds) {
+      byte[] data = new byte[blobSize];
+      BlobProperties blobProperties =
+          new BlobProperties(blobSize, "serviceid1", null, null, false, Utils.Infinite_Time, accountId, containerId,
+              false, null);
+      TestUtils.RANDOM.nextBytes(data);
+      blobIdToSizeMap.put(blobId, blobSize);
+      PutMessageFormatInputStream putMessageFormatInputStream =
+          new PutMessageFormatInputStream(blobId, null, blobProperties, ByteBuffer.wrap(userMetadata),
+              new ByteBufferInputStream(ByteBuffer.wrap(data)), blobSize);
+      long time = System.currentTimeMillis();
+      CloudBlobMetadata cloudBlobMetadata =
+          new CloudBlobMetadata(blobId, time, Utils.Infinite_Time, putMessageFormatInputStream.getSize(),
+              CloudBlobMetadata.EncryptionOrigin.NONE);
+      latchBasedInMemoryCloudDestination.uploadBlob(blobId, putMessageFormatInputStream.getSize(), cloudBlobMetadata,
+          putMessageFormatInputStream);
+    }
+
+    // Waiting for download attempt
+    assertTrue("Did not recover all blobs in 2 minutes",
+        latchBasedInMemoryCloudDestination.awaitDownload(2, TimeUnit.MINUTES));
+
+    // Waiting for replication to complete
+    Thread.sleep(10000);
+
+    // Test recovery by sending get request to recovery node
+    testGetOnRecoveryNode(blobIdToSizeMap);
   }
 }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
@@ -234,8 +234,8 @@ public class VcrRecoveryTest {
     }
 
     // Waiting for download attempt
-    assertTrue("Did not recover all blobs in 2 minutes",
-        latchBasedInMemoryCloudDestination.awaitDownload(2, TimeUnit.MINUTES));
+    assertTrue("Did not recover all blobs in 1 minute",
+        latchBasedInMemoryCloudDestination.awaitDownload(1, TimeUnit.MINUTES));
 
     // Waiting for replication to complete
     Thread.sleep(10000);
@@ -276,8 +276,8 @@ public class VcrRecoveryTest {
     }
 
     // Waiting for download attempt
-    assertTrue("Did not recover all blobs in 2 minutes",
-        latchBasedInMemoryCloudDestination.awaitDownload(2, TimeUnit.MINUTES));
+    assertTrue("Did not recover all blobs in 1 minute",
+        latchBasedInMemoryCloudDestination.awaitDownload(1, TimeUnit.MINUTES));
 
     // Waiting for replication to complete
     Thread.sleep(10000);


### PR DESCRIPTION
This fixes two issues with recovery, and adds a more robust recovery test.

ISSUES
- CloudMessageReadSet should keep track of partial sends over network.
- OperationTime should be determined by creation time or delete time, and not ttl update time.

TEST
- Create a separate test for large blobs recovery.