### PR TITLE
Update snapshotVersion of Account in AccountUpdateTool

### DIFF
--- a/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/account/AccountUpdateToolTest.java
@@ -189,9 +189,9 @@ public class AccountUpdateToolTest {
     createOrUpdateAccountsAndWait(idToRefAccountMap.values());
     assertAccountsInAccountService(idToRefAccountMap.values(), NUM_REF_ACCOUNT, accountService);
 
+    // then, update the name of all the accounts but make the snapshot version smaller than current number.
     String accountNameAppendix = "-accountNameAppendix";
     Collection<Account> updatedAccounts = new ArrayList<>();
-    // Create a different set of accounts to update, but this time, make snapshot version smaller than the existing one.
     updatedAccounts = new ArrayList<>();
     for (Account account : accountService.getAllAccounts()) {
       AccountBuilder accountBuilder = new AccountBuilder(account).snapshotVersion(account.getSnapshotVersion() - 1)

--- a/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/account/AccountUpdateTool.java
@@ -186,8 +186,8 @@ public class AccountUpdateTool {
             .ofType(String.class)
             .defaultsTo(DEFAULT_LOCAL_BACKUP_DIR);
 
+    parser.accepts("ignoreSnapshotVersion", "Ignore the snapshot version conflict. Defaults to false");
     parser.accepts("help", "print this help message.");
-
     parser.accepts("h", "print this help message.");
 
     OptionSet options = parser.parse(args);
@@ -204,6 +204,7 @@ public class AccountUpdateTool {
     Short containerJsonVersion = options.valueOf(containerJsonVersionOpt);
     String accountJsonPath = options.valueOf(accountJsonPathOpt);
     List<String> accountsToEdit = options.valuesOf(accountsToEditOpt);
+    boolean ignoreSnapshotVersion = options.has("ignoreSnapshotVersion");
     if (!((accountJsonPath == null) ^ (accountsToEdit.isEmpty()))) {
       System.err.println("Must provide exactly one of --accountJsonPath or --accountsToEdit");
       parser.printHelpOn(System.err);
@@ -213,9 +214,9 @@ public class AccountUpdateTool {
         zkSessionTimeoutMs)) {
       AccountUpdateTool accountUpdateTool = new AccountUpdateTool(accountService, containerJsonVersion);
       if (accountJsonPath != null) {
-        accountUpdateTool.updateAccountsFromFile(accountJsonPath);
+        accountUpdateTool.updateAccountsFromFile(accountJsonPath, ignoreSnapshotVersion);
       } else {
-        accountUpdateTool.editAccounts(accountsToEdit);
+        accountUpdateTool.editAccounts(accountsToEdit, ignoreSnapshotVersion);
       }
     } catch (Exception e) {
       System.err.println("Updating accounts failed with exception: " + e);
@@ -237,10 +238,12 @@ public class AccountUpdateTool {
   /**
    * Edit accounts in a text editor and upload them to zookeeper.
    * @param accountNames the name of the accounts to edit.
+   * @param ignoreSnapshotVersion if {@code true}, don't verify the snapshot version.
    * @throws IOException
    * @throws InterruptedException
    */
-  void editAccounts(Collection<String> accountNames) throws IOException, InterruptedException {
+  void editAccounts(Collection<String> accountNames, boolean ignoreSnapshotVersion)
+      throws IOException, InterruptedException {
     Path accountJsonPath = Files.createTempFile("account-update-", ".json");
     JSONArray accountsToEdit = new JSONArray();
     accountNames.stream()
@@ -257,7 +260,7 @@ public class AccountUpdateTool {
       lines.forEach(System.out::println);
     }
     if (ToolUtils.yesNoPrompt("Do you want to update these accounts?")) {
-      updateAccountsFromFile(accountJsonPath.toAbsolutePath().toString());
+      updateAccountsFromFile(accountJsonPath.toAbsolutePath().toString(), ignoreSnapshotVersion);
     } else {
       System.out.println("Not updating any accounts");
     }
@@ -267,29 +270,33 @@ public class AccountUpdateTool {
   /**
    * Update accounts from a file containing a json array of account metadata.
    * @param accountJsonPath the path to the file containing the account metadata to upload.
+   * @param ignoreSnapshotVersion if {@code true}, don't verify the snapshot version.
    * @throws IOException
    */
-  void updateAccountsFromFile(String accountJsonPath) throws IOException {
+  void updateAccountsFromFile(String accountJsonPath, boolean ignoreSnapshotVersion) throws IOException {
     long startTime = System.currentTimeMillis();
     Collection<Account> accountsToUpdate = getAccountsFromJson(accountJsonPath);
     if (!hasDuplicateAccountIdOrName(accountsToUpdate)) {
-      Collection<Account> allAccounts = accountService.getAllAccounts();
-      // Update the snapshot version to resolve conflict
-      Map<Short, Account> existingAccountsMap = new HashMap<>();
-      for (Account account : allAccounts) {
-        existingAccountsMap.put(account.getId(), account);
-      }
-      Collection<Account> newAccounts = new ArrayList<>(accountsToUpdate.size());
-      // resolve the snapshot conflict.
-      for (Account account : accountsToUpdate) {
-        Account accountInMap = existingAccountsMap.get(account.getId());
-        if (accountInMap != null && accountInMap.getSnapshotVersion() != account.getSnapshotVersion()) {
-          newAccounts.add(new AccountBuilder(account).snapshotVersion(accountInMap.getSnapshotVersion()).build());
-        } else {
-          newAccounts.add(account);
+      if (ignoreSnapshotVersion) {
+        Collection<Account> allAccounts = accountService.getAllAccounts();
+        // Update the snapshot version to resolve conflict
+        Map<Short, Account> existingAccountsMap = new HashMap<>();
+        for (Account account : allAccounts) {
+          existingAccountsMap.put(account.getId(), account);
         }
+        Collection<Account> newAccounts = new ArrayList<>(accountsToUpdate.size());
+        // resolve the snapshot conflict.
+        for (Account account : accountsToUpdate) {
+          Account accountInMap = existingAccountsMap.get(account.getId());
+          if (accountInMap != null && accountInMap.getSnapshotVersion() != account.getSnapshotVersion()) {
+            newAccounts.add(new AccountBuilder(account).snapshotVersion(accountInMap.getSnapshotVersion()).build());
+          } else {
+            newAccounts.add(account);
+          }
+        }
+        accountsToUpdate = newAccounts;
       }
-      if (accountService.updateAccounts(newAccounts)) {
+      if (accountService.updateAccounts(accountsToUpdate)) {
         System.out.println(
             accountsToUpdate.size() + " account(s) successfully created or updated, took " + (System.currentTimeMillis()
                 - startTime) + " ms");


### PR DESCRIPTION
Update snapshotVersion of Accounts in AccountUpdateTool before passing the Accounts to account service. This way, we don't have to change snapshot versions for every account to update.