### PR TITLE
Introducing Helix Routing Table Provider to track state of replicas

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionId.java
@@ -35,6 +35,14 @@ public interface PartitionId extends Resource, Comparable<PartitionId> {
   List<? extends ReplicaId> getReplicaIds();
 
   /**
+   * Gets Replicas from specified datacenter that are in required state.
+   * @param state the {@link ReplicaState}
+   * @param dcName the name of datacenter from which the replica should come. If null, choose replicas from all datacenters.
+   * @return list of Replicas that satisfy requirement.
+   */
+  List<? extends ReplicaId> getReplicaIdsInRequiredState(String state, String dcName);
+
+  /**
    * Gets the state of this PartitionId.
    *
    * @return state of this PartitionId.

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionId.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionId.java
@@ -40,7 +40,7 @@ public interface PartitionId extends Resource, Comparable<PartitionId> {
    * @param dcName the name of datacenter from which the replica should come. If null, choose replicas from all datacenters.
    * @return list of Replicas that satisfy requirement.
    */
-  List<? extends ReplicaId> getReplicaIdsInRequiredState(String state, String dcName);
+  List<? extends ReplicaId> getReplicaIdsByState(ReplicaState state, String dcName);
 
   /**
    * Gets the state of this PartitionId.

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaState.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaState.java
@@ -17,7 +17,7 @@ package com.github.ambry.clustermap;
  * The states of ambry replica that are managed by Helix controller.
  * Ambry router makes decision based on these states when routing requests.
  */
-public enum AmbryHelixState {
+public enum ReplicaState {
   /**
    * Initial state of replica when starting up.
    * Router should not send any request to replica in this state.

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
@@ -68,8 +68,8 @@ class AmbryPartition implements PartitionId {
   }
 
   @Override
-  public List<AmbryReplica> getReplicaIdsInRequiredState(String state, String dcName) {
-    return clusterManagerCallback.getReplicaIdsInRequiredState(this, state, dcName);
+  public List<AmbryReplica> getReplicaIdsByState(ReplicaState state, String dcName) {
+    return clusterManagerCallback.getReplicaIdsByState(this, state, dcName);
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
@@ -17,7 +17,6 @@ import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -65,7 +64,12 @@ class AmbryPartition implements PartitionId {
 
   @Override
   public List<AmbryReplica> getReplicaIds() {
-    return new ArrayList<>(clusterManagerCallback.getReplicaIdsForPartition(this));
+    return clusterManagerCallback.getReplicaIdsForPartition(this);
+  }
+
+  @Override
+  public List<AmbryReplica> getReplicaIdsInRequiredState(String state, String dcName) {
+    return clusterManagerCallback.getReplicaIdsInRequiredState(this, state, dcName);
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 @StateModelInfo(initialState = "OFFLINE", states = {"BOOTSTRAP", "LEADER", "STANDBY", "INACTIVE"})
 public class AmbryPartitionStateModel extends StateModel {
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(AmbryPartitionStateModel.class);
   private final String resourceName;
   private final String partitionName;
 
@@ -33,7 +33,7 @@ public class AmbryPartitionStateModel extends StateModel {
     this.resourceName = resourceName;
     this.partitionName = partitionName;
     StateModelParser parser = new StateModelParser();
-    _currentState = parser.getInitialState(DefaultLeaderStandbyStateModel.class);
+    _currentState = parser.getInitialState(AmbryPartitionStateModel.class);
   }
 
   @Transition(to = "BOOTSTRAP", from = "OFFLINE")

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelDefinition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelDefinition.java
@@ -40,7 +40,7 @@ class AmbryStateModelDefinition {
 
     StateModelDefinition.Builder builder = new StateModelDefinition.Builder(AMBRY_LEADER_STANDBY_MODEL);
     // Init state
-    builder.initialState(AmbryHelixState.OFFLINE.name());
+    builder.initialState(ReplicaState.OFFLINE.name());
 
     /*
      * States and their priority which are managed by Helix controller.
@@ -49,35 +49,35 @@ class AmbryStateModelDefinition {
      * considered a "downward" transition by Helix. Downward transitions are not
      * throttled.
      */
-    builder.addState(AmbryHelixState.LEADER.name(), 0);
-    builder.addState(AmbryHelixState.STANDBY.name(), 1);
-    builder.addState(AmbryHelixState.BOOTSTRAP.name(), 2);
-    builder.addState(AmbryHelixState.INACTIVE.name(), 2);
-    builder.addState(AmbryHelixState.OFFLINE.name(), 3);
+    builder.addState(ReplicaState.LEADER.name(), 0);
+    builder.addState(ReplicaState.STANDBY.name(), 1);
+    builder.addState(ReplicaState.BOOTSTRAP.name(), 2);
+    builder.addState(ReplicaState.INACTIVE.name(), 2);
+    builder.addState(ReplicaState.OFFLINE.name(), 3);
     // HelixDefinedState adds two additional states: ERROR and DROPPED. The priority is Integer.MAX_VALUE
     for (HelixDefinedState state : HelixDefinedState.values()) {
       builder.addState(state.name());
     }
 
     // Add valid transitions between the states.
-    builder.addTransition(AmbryHelixState.OFFLINE.name(), AmbryHelixState.BOOTSTRAP.name(), 3);
-    builder.addTransition(AmbryHelixState.BOOTSTRAP.name(), AmbryHelixState.STANDBY.name(), 2);
-    builder.addTransition(AmbryHelixState.STANDBY.name(), AmbryHelixState.LEADER.name(), 1);
-    builder.addTransition(AmbryHelixState.LEADER.name(), AmbryHelixState.STANDBY.name(), 0);
-    builder.addTransition(AmbryHelixState.STANDBY.name(), AmbryHelixState.INACTIVE.name(), 2);
-    builder.addTransition(AmbryHelixState.INACTIVE.name(), AmbryHelixState.OFFLINE.name(), 3);
-    builder.addTransition(AmbryHelixState.OFFLINE.name(), HelixDefinedState.DROPPED.name());
+    builder.addTransition(ReplicaState.OFFLINE.name(), ReplicaState.BOOTSTRAP.name(), 3);
+    builder.addTransition(ReplicaState.BOOTSTRAP.name(), ReplicaState.STANDBY.name(), 2);
+    builder.addTransition(ReplicaState.STANDBY.name(), ReplicaState.LEADER.name(), 1);
+    builder.addTransition(ReplicaState.LEADER.name(), ReplicaState.STANDBY.name(), 0);
+    builder.addTransition(ReplicaState.STANDBY.name(), ReplicaState.INACTIVE.name(), 2);
+    builder.addTransition(ReplicaState.INACTIVE.name(), ReplicaState.OFFLINE.name(), 3);
+    builder.addTransition(ReplicaState.OFFLINE.name(), HelixDefinedState.DROPPED.name());
 
     // States constraints
     /*
      * Static constraint: number of leader replica for certain partition shouldn't exceed 1 at any time.
      */
-    builder.upperBound(AmbryHelixState.LEADER.name(), 1);
+    builder.upperBound(ReplicaState.LEADER.name(), 1);
     /*
      * Dynamic constraint: R means it should be derived based on the replication factor for the cluster
      * this allows a different replication factor for each resource without having to define a new state model.
      */
-    builder.dynamicUpperBound(AmbryHelixState.STANDBY.name(), UPPER_BOUND_REPLICATION_FACTOR);
+    builder.dynamicUpperBound(ReplicaState.STANDBY.name(), UPPER_BOUND_REPLICATION_FACTOR);
 
     return builder.build();
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
@@ -31,6 +31,15 @@ interface ClusterManagerCallback {
   List<AmbryReplica> getReplicaIdsForPartition(AmbryPartition partition);
 
   /**
+   * Get replicas of given partition from specified datacenter that are in required state
+   * @param partition the {@link AmbryPartition} for which to get the list of replicas.
+   * @param state {@link ReplicaState} associated with replica
+   * @param dcName name of datacenter from which the replicas should come
+   * @return the list of {@link AmbryReplica}s satisfying requirements.
+   */
+  List<AmbryReplica> getReplicaIdsInRequiredState(AmbryPartition partition, String state, String dcName);
+
+  /**
    * Get the counter for the sealed state change for partitions.
    * @return the counter for the sealed state change for partitions.
    */

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
@@ -37,7 +37,7 @@ interface ClusterManagerCallback {
    * @param dcName name of datacenter from which the replicas should come
    * @return the list of {@link AmbryReplica}s satisfying requirements.
    */
-  List<AmbryReplica> getReplicaIdsInRequiredState(AmbryPartition partition, String state, String dcName);
+  List<AmbryReplica> getReplicaIdsByState(AmbryPartition partition, ReplicaState state, String dcName);
 
   /**
    * Get the counter for the sealed state change for partitions.

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -539,7 +539,6 @@ class HelixBootstrapUpgradeUtil {
    *
    * @param startValidatingClusterManager whether validation should include staring up a {@link HelixClusterManager}
    */
-
   private void updateClusterMapInHelix(boolean startValidatingClusterManager) throws IOException {
     info("Initializing admins and possibly adding cluster in Helix (if non-existent)");
     maybeAddCluster();

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -1101,7 +1101,8 @@ class HelixBootstrapUpgradeUtil {
       }
     }
     if (expectMoreInHelixDuringValidate) {
-      ensureOrThrow(allPartitionsToInstancesInHelix.keySet().equals(partitionsNotForceRemovedByDc.get(dcName)),
+      ensureOrThrow(allPartitionsToInstancesInHelix.keySet()
+              .equals(partitionsNotForceRemovedByDc.getOrDefault(dcName, new HashSet<>())),
           "Additional partitions in Helix: " + allPartitionsToInstancesInHelix.keySet() + " not what is expected "
               + partitionsNotForceRemovedByDc.get(dcName));
       info("*** Helix may have more partitions or replicas than in the given clustermap as removals were not forced.");

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -87,8 +87,7 @@ class HelixClusterManager implements ClusterMap {
   private final ConcurrentHashMap<ByteBuffer, AmbryPartition> partitionMap = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, ConcurrentHashMap<String, String>> partitionToResourceNameByDc =
       new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<String, AtomicReference<RoutingTableSnapshot>> dcToRoutingTableSnapshotRef =
-      new ConcurrentHashMap<>();
+  private final Map<String, AtomicReference<RoutingTableSnapshot>> dcToRoutingTableSnapshotRef = new HashMap<>();
   private long clusterWideRawCapacityBytes;
   private long clusterWideAllocatedRawCapacityBytes;
   private long clusterWideAllocatedUsableCapacityBytes;
@@ -892,6 +891,7 @@ class HelixClusterManager implements ClusterMap {
 
     /**
      * {@inheritDoc}
+     * If dcName is null, then get replicas by given state from all datacenters.
      * If no routing table snapshot is found for dc name, or no resource name found for given partition, return empty list.
      */
     @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -159,7 +159,7 @@ class HelixClusterManager implements ClusterMap {
             logger.info("Creating routing table provider associated with Helix manager at {}", zkConnectStr);
             RoutingTableProvider routingTableProvider = new RoutingTableProvider(manager, PropertyType.CURRENTSTATES);
             logger.info("Routing table provider is created in {}", dcName);
-            DcInfo dcInfo = new DcInfo(dcName, entry.getValue(), manager, clusterChangeHandler, routingTableProvider);
+            DcInfo dcInfo = new DcInfo(dcName, entry.getValue(), manager, clusterChangeHandler);
             dcToDcZkInfo.put(dcName, dcInfo);
             dcIdToDcName.put(dcInfo.dcZkInfo.getDcId(), dcName);
             dcToRoutingTableSnapshotRef.put(dcName,
@@ -855,7 +855,6 @@ class HelixClusterManager implements ClusterMap {
     final DcZkInfo dcZkInfo;
     final HelixManager helixManager;
     final ClusterChangeHandler clusterChangeHandler;
-    final RoutingTableProvider routingTableProvider;
 
     /**
      * Construct a DcInfo object with the given parameters.
@@ -863,15 +862,12 @@ class HelixClusterManager implements ClusterMap {
      * @param dcZkInfo the {@link DcZkInfo} associated with the DC.
      * @param helixManager the associated {@link HelixManager} for this datacenter.
      * @param clusterChangeHandler the associated {@link ClusterChangeHandler} for this datacenter.
-     * @param routingTableProvider the associated {@link RoutingTableProvider} for this datacenter.
      */
-    DcInfo(String dcName, DcZkInfo dcZkInfo, HelixManager helixManager, ClusterChangeHandler clusterChangeHandler,
-        RoutingTableProvider routingTableProvider) {
+    DcInfo(String dcName, DcZkInfo dcZkInfo, HelixManager helixManager, ClusterChangeHandler clusterChangeHandler) {
       this.dcName = dcName;
       this.dcZkInfo = dcZkInfo;
       this.helixManager = helixManager;
       this.clusterChangeHandler = clusterChangeHandler;
-      this.routingTableProvider = routingTableProvider;
     }
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
@@ -28,8 +28,9 @@ class HelixClusterManagerMetrics {
   private final MetricRegistry registry;
 
   public final Counter liveInstanceChangeTriggerCount;
-  public final Counter externalViewChangeTriggerCount;
   public final Counter instanceConfigChangeTriggerCount;
+  public final Counter idealStateChangeTriggerCount;
+  public final Counter routingTableChangeTriggerCount;
   public final Counter getPartitionIdFromStreamMismatchCount;
   public final Counter getWritablePartitionIdsMismatchCount;
   public final Counter getAllPartitionIdsMismatchCount;
@@ -56,10 +57,12 @@ class HelixClusterManagerMetrics {
     this.registry = registry;
     liveInstanceChangeTriggerCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "liveInstanceChangeTriggerCount"));
-    externalViewChangeTriggerCount =
-        registry.counter(MetricRegistry.name(HelixClusterManager.class, "externalViewChangeTriggerCount"));
     instanceConfigChangeTriggerCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "instanceConfigChangeTriggerCount"));
+    idealStateChangeTriggerCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "idealStateChangeTriggerCount"));
+    routingTableChangeTriggerCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "routingTableChangeTriggerCount"));
     getPartitionIdFromStreamMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getPartitionIdFromStreamMismatchCount"));
     getWritablePartitionIdsMismatchCount =

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
@@ -98,7 +98,7 @@ class Partition implements PartitionId {
   }
 
   @Override
-  public List<ReplicaId> getReplicaIdsInRequiredState(String state, String dcName) {
+  public List<ReplicaId> getReplicaIdsByState(ReplicaState state, String dcName) {
     // for static clustermap we assume all replicas are in StandBy state.
     List<ReplicaId> result = new ArrayList<>();
     if (state.equals(ReplicaState.STANDBY.name())) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
@@ -83,8 +83,7 @@ class Partition implements PartitionId {
   }
 
   static byte[] readPartitionBytesFromStream(InputStream stream) throws IOException {
-    byte[] partitionBytes = Utils.readBytesFromStream(stream, Partition_Size_In_Bytes);
-    return partitionBytes;
+    return Utils.readBytesFromStream(stream, Partition_Size_In_Bytes);
   }
 
   @Override
@@ -95,7 +94,21 @@ class Partition implements PartitionId {
   @Override
   public List<ReplicaId> getReplicaIds() {
     List<Replica> replicas = getReplicas();
-    return new ArrayList<ReplicaId>(replicas);
+    return new ArrayList<>(replicas);
+  }
+
+  @Override
+  public List<ReplicaId> getReplicaIdsInRequiredState(String state, String dcName) {
+    // for static clustermap we assume all replicas are in StandBy state.
+    List<ReplicaId> result = new ArrayList<>();
+    if (state.equals(ReplicaState.STANDBY.name())) {
+      for (ReplicaId replicaId : replicas) {
+        if (dcName == null || replicaId.getDataNodeId().getDatacenterName().equals(dcName)) {
+          result.add(replicaId);
+        }
+      }
+    }
+    return result;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/Partition.java
@@ -17,9 +17,11 @@ import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -93,22 +95,19 @@ class Partition implements PartitionId {
 
   @Override
   public List<ReplicaId> getReplicaIds() {
-    List<Replica> replicas = getReplicas();
-    return new ArrayList<>(replicas);
+    return getReplicaIdsByState(ReplicaState.STANDBY, null);
   }
 
   @Override
   public List<ReplicaId> getReplicaIdsByState(ReplicaState state, String dcName) {
     // for static clustermap we assume all replicas are in StandBy state.
     List<ReplicaId> result = new ArrayList<>();
-    if (state.equals(ReplicaState.STANDBY.name())) {
-      for (ReplicaId replicaId : replicas) {
-        if (dcName == null || replicaId.getDataNodeId().getDatacenterName().equals(dcName)) {
-          result.add(replicaId);
-        }
-      }
+    if (state == ReplicaState.STANDBY) {
+      result = replicas.stream()
+          .filter(k -> dcName == null || k.getDataNodeId().getDatacenterName().equals(dcName))
+          .collect(Collectors.toList());
     }
-    return result;
+    return Collections.unmodifiableList(result);
   }
 
   @Override

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
@@ -261,7 +261,7 @@ public class DynamicClusterManagerComponentsTest {
     }
 
     @Override
-    public List<AmbryReplica> getReplicaIdsInRequiredState(AmbryPartition partition, String state, String dcName) {
+    public List<AmbryReplica> getReplicaIdsByState(AmbryPartition partition, ReplicaState state, String dcName) {
       throw new UnsupportedOperationException("Temporarily unsupported");
     }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
@@ -261,6 +261,11 @@ public class DynamicClusterManagerComponentsTest {
     }
 
     @Override
+    public List<AmbryReplica> getReplicaIdsInRequiredState(AmbryPartition partition, String state, String dcName) {
+      throw new UnsupportedOperationException("Temporarily unsupported");
+    }
+
+    @Override
     public Collection<AmbryDisk> getDisks(AmbryDataNode dataNode) {
       if (dataNode != null) {
         return dataNodeToDisks.get(dataNode);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -500,6 +500,10 @@ public class HelixClusterManagerTest {
     assertStateEquivalency(expectedDownInstances, expectedUpInstances);
   }
 
+  /**
+   * Test helix initiated ideal state change can be correctly handled by {@link HelixClusterManager}.
+   * @throws Exception
+   */
   @Test
   public void helixInitiatedIdealStateChangeTest() throws Exception {
     assumeTrue(!useComposite && !overrideEnabled);
@@ -519,6 +523,10 @@ public class HelixClusterManagerTest {
         .containsKey(partitionName));
   }
 
+  /**
+   * Test that routing table change reflects correct state of each replica and {@link HelixClusterManager} is able to get
+   * replica in required state.
+   */
   @Test
   public void routingTableProviderChangeTest() {
     assumeTrue(!useComposite && !overrideEnabled);
@@ -1078,8 +1086,8 @@ public class HelixClusterManagerTest {
   // Helpers
 
   /**
-   * Verify that {@link HelixClusterManager} received and handled initial cluster changes (i.e InstanceConfig, IdealState
-   * change), and populated the in-mem clustermap is correctly
+   * Verify that {@link HelixClusterManager} receives and handles initial cluster changes (i.e InstanceConfig, IdealState
+   * change), and populates the in-mem clustermap correctly.
    * @param clusterManager the {@link HelixClusterManager} to use for verification.
    * @param helixCluster the {@link MockHelixCluster} to provide cluster infos
    */

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
@@ -185,6 +185,14 @@ public class MockHelixAdmin implements HelixAdmin {
     triggerInstanceConfigChangeNotification(tagAsInit);
   }
 
+  /**
+   * Add new resource and its associated ideal state into cluster (Note that, each dc has its own HelixAdmin so resource
+   * is actually added into dc where current HelixAdmin sits). This would trigger ideal state change which should be captured
+   * by Helix Cluster Manager on each node.
+   * @param resourceName name of resource. (The resource may contain one or more partitions)
+   * @param idealstate ideal state associated with the resource. (it defines location of each replica from each partition)
+   * @throws Exception
+   */
   void addNewResource(String resourceName, IdealState idealstate) throws Exception {
     resourcesToIdealStates.put(resourceName, idealstate);
     triggerIdealStateChangeNotification();
@@ -326,12 +334,20 @@ public class MockHelixAdmin implements HelixAdmin {
     return writablePartitions;
   }
 
+  /**
+   * Get states of all partitions that reside on given instance.
+   * @param instanceName the name of instance where partitions reside
+   * @return a map representing states of partitions from given instance.
+   */
   Map<String, Map<String, String>> getPartitionStateMapForInstance(String instanceName) {
     ReplicaStateInfos replicaStateInfos = instanceToReplicaStateInfos.get(instanceName);
     return replicaStateInfos != null ? replicaStateInfos.getReplicaStateMap() : new HashMap<>();
   }
 
-  Map<String, String> getPartitionToLeaderReplica(){
+  /**
+   * @return a map of partition to its leader replica in current dc.
+   */
+  Map<String, String> getPartitionToLeaderReplica() {
     return Collections.unmodifiableMap(partitionToLeaderReplica);
   }
 
@@ -358,6 +374,9 @@ public class MockHelixAdmin implements HelixAdmin {
     return totalDiskCapacity;
   }
 
+  /**
+   * Private class that holds partition state infos from one data node.
+   */
   class ReplicaStateInfos {
     Map<String, Map<String, String>> replicaStateMap;
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixAdmin.java
@@ -182,6 +182,13 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   /**
+   * @return a list of {@link IdealState} via Helix admin.
+   */
+  List<IdealState> getIdealStates() {
+    return new ArrayList<>(new HashSet<>(resourcesToIdealStates.values()));
+  }
+
+  /**
    * @return all instances registered via this Helix admin that are up.
    */
   List<String> getUpInstances() {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixDataAccessor.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixDataAccessor.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.I0Itec.zkclient.DataUpdater;
+import org.apache.helix.BaseDataAccessor;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixProperty;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.MaintenanceSignal;
+import org.apache.helix.model.Message;
+import org.apache.helix.model.PauseSignal;
+import org.apache.helix.model.StateModelDefinition;
+
+
+public class MockHelixDataAccessor implements HelixDataAccessor {
+  private final String clusterName;
+  private final PropertyKey.Builder propertyKeyBuilder;
+
+  MockHelixDataAccessor(String clusterName) {
+    this.clusterName = clusterName;
+    propertyKeyBuilder = new PropertyKey.Builder(clusterName);
+  }
+
+  @Override
+  public boolean createStateModelDef(StateModelDefinition stateModelDef) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public boolean createControllerMessage(Message message) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public boolean createControllerLeader(LiveInstance leader) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public boolean createPause(PauseSignal pauseSignal) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public boolean createMaintenance(MaintenanceSignal maintenanceSignal) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public <T extends HelixProperty> boolean setProperty(PropertyKey key, T value) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public <T extends HelixProperty> boolean updateProperty(PropertyKey key, T value) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public <T extends HelixProperty> boolean updateProperty(PropertyKey key, DataUpdater<ZNRecord> updater, T value) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public <T extends HelixProperty> T getProperty(PropertyKey key) {
+    //return (T) (new HelixProperty("id"));
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public <T extends HelixProperty> List<T> getProperty(List<PropertyKey> keys) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public <T extends HelixProperty> List<T> getProperty(List<PropertyKey> keys, boolean throwException) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean removeProperty(PropertyKey key) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public HelixProperty.Stat getPropertyStat(PropertyKey key) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public List<HelixProperty.Stat> getPropertyStats(List<PropertyKey> keys) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<String> getChildNames(PropertyKey key) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public <T extends HelixProperty> List<T> getChildValues(PropertyKey key) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public <T extends HelixProperty> List<T> getChildValues(PropertyKey key, boolean throwException) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public <T extends HelixProperty> Map<String, T> getChildValuesMap(PropertyKey key) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public <T extends HelixProperty> Map<String, T> getChildValuesMap(PropertyKey key, boolean throwException) {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public <T extends HelixProperty> boolean[] createChildren(List<PropertyKey> keys, List<T> children) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public <T extends HelixProperty> boolean[] setChildren(List<PropertyKey> keys, List<T> children) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public <T extends HelixProperty> boolean[] updateChildren(List<String> paths, List<DataUpdater<ZNRecord>> updaters,
+      int options) {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+
+  @Override
+  public PropertyKey.Builder keyBuilder() {
+    return propertyKeyBuilder;
+  }
+
+  @Override
+  public BaseDataAccessor<ZNRecord> getBaseDataAccessor() {
+    throw new UnsupportedOperationException("Unsupported in MockHelixDataAccessor");
+  }
+}

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixDataAccessor.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixDataAccessor.java
@@ -32,6 +32,10 @@ import org.apache.helix.model.PauseSignal;
 import org.apache.helix.model.StateModelDefinition;
 
 
+/**
+ * A class that mocks {@link HelixDataAccessor} to help with {@link org.apache.helix.spectator.RoutingTableProvider}
+ * creation and any state changes within cluster. Some methods are hard coded to directly return result we need.
+ */
 public class MockHelixDataAccessor implements HelixDataAccessor {
   private static final String SESSION_ID = "sessionId";
   private final String LIVEINSTANCE_PATH;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
@@ -203,10 +203,6 @@ class MockHelixManager implements HelixManager {
     idealStateChangeListener.onIdealStateChange(mockAdmin.getIdealStates(), notificationContext);
   }
 
-  void triggerRoutingTableProviderNotification() {
-    //routingTableProvider.onR();
-  }
-
   //****************************
   // Not implemented.
   //****************************

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
@@ -50,6 +50,7 @@ import org.apache.helix.healthcheck.ParticipantHealthReportCollector;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.spectator.RoutingTableProvider;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 
 
@@ -65,6 +66,7 @@ class MockHelixManager implements HelixManager {
   private ExternalViewChangeListener externalViewChangeListener;
   private InstanceConfigChangeListener instanceConfigChangeListener;
   private IdealStateChangeListener idealStateChangeListener;
+  private RoutingTableProvider routingTableProvider;
   private final MockHelixAdmin mockAdmin;
   private final MockHelixDataAccessor dataAccessor;
   private final Exception beBadException;
@@ -87,7 +89,7 @@ class MockHelixManager implements HelixManager {
     mockAdmin = helixCluster.getHelixAdminFactory().getHelixAdmin(zkAddr);
     mockAdmin.addHelixManager(this);
     clusterName = helixCluster.getClusterName();
-    dataAccessor = new MockHelixDataAccessor(clusterName);
+    dataAccessor = new MockHelixDataAccessor(clusterName, mockAdmin);
     this.beBadException = beBadException;
     this.znRecordMap = znRecordMap;
     Properties storeProps = new Properties();
@@ -201,6 +203,10 @@ class MockHelixManager implements HelixManager {
     idealStateChangeListener.onIdealStateChange(mockAdmin.getIdealStates(), notificationContext);
   }
 
+  void triggerRoutingTableProviderNotification() {
+    //routingTableProvider.onR();
+  }
+
   //****************************
   // Not implemented.
   //****************************
@@ -221,7 +227,7 @@ class MockHelixManager implements HelixManager {
   @Override
   public void addLiveInstanceChangeListener(LiveInstanceChangeListener liveInstanceChangeListener) throws Exception {
     this.liveInstanceChangeListener = liveInstanceChangeListener;
-    triggerLiveInstanceNotification(true);
+    triggerLiveInstanceNotification(false);
   }
 
   @Override
@@ -273,7 +279,8 @@ class MockHelixManager implements HelixManager {
   @Override
   public void addCurrentStateChangeListener(CurrentStateChangeListener currentStateChangeListener, String s, String s1)
       throws Exception {
-    // do nothing
+    // Note: routingTableProvider implements current state change listener
+    this.routingTableProvider = (RoutingTableProvider) currentStateChangeListener;
   }
 
   @Override

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixManager.java
@@ -203,6 +203,11 @@ class MockHelixManager implements HelixManager {
     idealStateChangeListener.onIdealStateChange(mockAdmin.getIdealStates(), notificationContext);
   }
 
+  void triggerRoutingTableNotification() {
+    NotificationContext notificationContext = new NotificationContext(this);
+    routingTableProvider.onStateChange(instanceName, Collections.emptyList(), notificationContext);
+  }
+
   //****************************
   // Not implemented.
   //****************************

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
@@ -70,6 +70,11 @@ public class MockPartitionId implements PartitionId {
   }
 
   @Override
+  public List<ReplicaId> getReplicaIdsInRequiredState(String state, String dcName) {
+    throw new UnsupportedOperationException("Temporarily Unsupported");
+  }
+
+  @Override
   public PartitionState getPartitionState() {
     return partitionState;
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
@@ -70,7 +70,7 @@ public class MockPartitionId implements PartitionId {
   }
 
   @Override
-  public List<ReplicaId> getReplicaIdsInRequiredState(String state, String dcName) {
+  public List<ReplicaId> getReplicaIdsByState(ReplicaState state, String dcName) {
     throw new UnsupportedOperationException("Temporarily Unsupported");
   }
 

--- a/log4j-test-config/src/main/resources/log4j.properties
+++ b/log4j-test-config/src/main/resources/log4j.properties
@@ -30,7 +30,7 @@ log4j.logger.PublicAccessLogger = WARN, PublicAccessLog
 log4j.additivity.PublicAccessLogger = false
 
 # Package specific levels:
-log4j.logger.org.apache.helix=INFO
+log4j.logger.org.apache.helix=WARN
 log4j.logger.org.apache.zookeeper=WARN
 log4j.logger.org.I0Itec.zkclient=WARN
 # these three are disabled because MockClusterMap does not currently mark nodes offline when requests fail, which

--- a/log4j-test-config/src/main/resources/log4j.properties
+++ b/log4j-test-config/src/main/resources/log4j.properties
@@ -30,7 +30,7 @@ log4j.logger.PublicAccessLogger = WARN, PublicAccessLog
 log4j.additivity.PublicAccessLogger = false
 
 # Package specific levels:
-log4j.logger.org.apache.helix=WARN
+log4j.logger.org.apache.helix=INFO
 log4j.logger.org.apache.zookeeper=WARN
 log4j.logger.org.I0Itec.zkclient=WARN
 # these three are disabled because MockClusterMap does not currently mark nodes offline when requests fail, which


### PR DESCRIPTION
1. Current state based RoutingTableProvider is introduced to track state of replicas in cluster. When any replica changes state or datanode joins cluster, a new RoutingTableSnapshot (from certain DC) will be generated within onRoutingTableChange() method. The snapshot contains all instances/replicas information in certain DC. (Note: each DC has its own RoutingTableProvider)
2. Add IdealState listener to build partition to resource map during initialization. This map helps getting replicas in required state because the exposed API from Helix requires to pass in both resource name and partition id. 
3. Support getting replicas in required state from specified datacenter. This can be leveraged by router when choosing eligible replica to send PUT/GET/DELETE request.