### PR TITLE
Refactor the replication engine to create a separate replication mananger from cloud to store and a separate cloud replica token file

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterParticipant.java
@@ -60,6 +60,12 @@ public interface ClusterParticipant extends AutoCloseable {
   List<String> getStoppedReplicas();
 
   /**
+   * Register a listener for leadership changes in partitions of this node.
+   * @param partitionStateChangeListener listener to register.
+   */
+  void registerPartitionStateChangeListener(PartitionStateChangeListener partitionStateChangeListener);
+
+  /**
    * Terminate the participant.
    */
   @Override

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterSpectator.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterSpectator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import org.apache.helix.api.listeners.InstanceConfigChangeListener;
+import org.apache.helix.api.listeners.LiveInstanceChangeListener;
+
+
+/**
+ * {@link ClusterSpectator} adds itself as a spectator of a cluster and registers some cluster change listeners.
+ */
+public interface ClusterSpectator extends InstanceConfigChangeListener, LiveInstanceChangeListener {
+
+  /**
+   * Register with helix cluster as a spectator.
+   */
+  void spectate() throws Exception;
+
+  /**
+   * Register a listener for changes to instance config in cluster.
+   * @param instanceConfigChangeListener listener to add.
+   */
+  void registerInstanceConfigChangeListener(InstanceConfigChangeListener instanceConfigChangeListener);
+
+  /**
+   * Register a listener for changes to instance liveness information in cluster.
+   * @param liveInstanceChangeListener listener to add.
+   */
+  void registerLiveInstanceChangeListener(LiveInstanceChangeListener liveInstanceChangeListener);
+}

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterSpectatorFactory.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterSpectatorFactory.java
@@ -24,6 +24,8 @@ public interface ClusterSpectatorFactory {
 
   /**
    * Create and return a {@link ClusterSpectator} object.
+   * @param cloudConfig {@link CloudConfig} object.
+   * @param clusterMapConfig {@link ClusterMapConfig} object.
    * @return {@link ClusterSpectator} object.
    */
   ClusterSpectator getClusterSpectator(CloudConfig cloudConfig, ClusterMapConfig clusterMapConfig);

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterSpectatorFactory.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterSpectatorFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.CloudConfig;
+import com.github.ambry.config.ClusterMapConfig;
+
+
+/**
+ * A factory interface to get an instance of {@link ClusterSpectator}.
+ */
+public interface ClusterSpectatorFactory {
+
+  /**
+   * Create and return a {@link ClusterSpectator} object.
+   * @return {@link ClusterSpectator} object.
+   */
+  ClusterSpectator getClusterSpectator(CloudConfig cloudConfig, ClusterMapConfig clusterMapConfig);
+}

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+/**
+ * {@link PartitionStateChangeListener} takes action when partition state changes.
+ */
+public interface PartitionStateChangeListener {
+
+  /**
+   * Action to take on becoming leader of a partition.
+   * @param partitionName of the partition.
+   */
+  void onPartitionLeadFromStandby(String partitionName);
+
+  /**
+   * Action to take on being removed as leader of a partition.
+   * @param partitionName of the partition.
+   */
+  void onPartitionStandbyFromLead(String partitionName);
+}

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
@@ -22,11 +22,11 @@ public interface PartitionStateChangeListener {
    * Action to take on becoming leader of a partition.
    * @param partitionName of the partition.
    */
-  void onPartitionLeadFromStandby(String partitionName);
+  void onPartitionStateChangeToLeaderFromStandby(String partitionName);
 
   /**
    * Action to take on being removed as leader of a partition.
    * @param partitionName of the partition.
    */
-  void onPartitionStandbyFromLead(String partitionName);
+  void onPartitionStateChangeToStandbyFromLeader(String partitionName);
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/CloudConfig.java
@@ -35,6 +35,7 @@ public class CloudConfig {
   public static final String VCR_ASSIGNED_PARTITIONS = "vcr.assigned.partitions";
   public static final String VCR_PROXY_HOST = "vcr.proxy.host";
   public static final String VCR_PROXY_PORT = "vcr.proxy.port";
+  public static final String VCR_CLUSTER_SPECTATOR_FACTORY_CLASS = "vcr.cluster.spectator.factory.class";
 
   public static final String DEFAULT_VIRTUAL_REPLICATOR_CLUSTER_FACTORY_CLASS =
       "com.github.ambry.cloud.StaticVcrClusterFactory";
@@ -52,6 +53,8 @@ public class CloudConfig {
   public static final int DEFAULT_COMPACTION_QUERY_LIMIT = 100000;
   public static final int DEFAULT_RECENT_BLOB_CACHE_LIMIT = 10000;
   public static final int DEFAULT_VCR_PROXY_PORT = 3128;
+  public static final String DEFAULT_VCR_CLUSTER_SPECTATOR_FACTORY_CLASS =
+      "com.github.ambry.clustermap.HelixClusterSpectatorFactory";
 
   /**
    * The virtual replicator cluster factory class name.
@@ -180,6 +183,14 @@ public class CloudConfig {
   @Default("3128")
   public final int vcrProxyPort;
 
+  /**
+   *
+   * @param verifiableProperties
+   */
+  @Config(VCR_CLUSTER_SPECTATOR_FACTORY_CLASS)
+  @Default(DEFAULT_VCR_CLUSTER_SPECTATOR_FACTORY_CLASS)
+  public final String vcrClusterSpectatorFactoryClass;
+
   public CloudConfig(VerifiableProperties verifiableProperties) {
 
     virtualReplicatorClusterFactoryClass = verifiableProperties.getString(VIRTUAL_REPLICATOR_CLUSTER_FACTORY_CLASS,
@@ -209,5 +220,8 @@ public class CloudConfig {
     // Proxy settings
     vcrProxyHost = verifiableProperties.getString(VCR_PROXY_HOST, null);
     vcrProxyPort = verifiableProperties.getInt(VCR_PROXY_PORT, DEFAULT_VCR_PROXY_PORT);
+
+    vcrClusterSpectatorFactoryClass = verifiableProperties.getString(VCR_CLUSTER_SPECTATOR_FACTORY_CLASS,
+        DEFAULT_VCR_CLUSTER_SPECTATOR_FACTORY_CLASS);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -23,7 +23,6 @@ public class ClusterMapConfig {
   public static final String DEFAULT_STATE_MODEL_DEF = LeaderStandbySMD.name;
   public static final String AMBRY_STATE_MODEL_DEF = "AmbryLeaderStandby";
   private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
-  private static final String DEFAULT_VCR_DATACENTER_NAME = "ei4";
 
   /**
    * The factory class used to get the resource state policies.
@@ -184,10 +183,9 @@ public class ClusterMapConfig {
   public final boolean clustermapListenCrossColo;
 
   /**
-   * Name of the datacenter of vcrnodes. It is expected that all the vcr nodes will reside in the same datacenter.
+   * Name of the datacenter of vcr nodes. It is expected that all the vcr nodes will reside in the same datacenter.
    */
   @Config("clustermap.vcr.datacenter.name")
-  @Default(DEFAULT_VCR_DATACENTER_NAME)
   public final String clustermapVcrDatacenterName;
 
   /**
@@ -232,7 +230,7 @@ public class ClusterMapConfig {
     clustermapStateModelDefinition =
         verifiableProperties.getString("clustermap.state.model.definition", DEFAULT_STATE_MODEL_DEF);
     clustermapVcrDatacenterName =
-        verifiableProperties.getString("clustermap.vcr.datacenter.name", DEFAULT_VCR_DATACENTER_NAME);
+        verifiableProperties.getString("clustermap.vcr.datacenter.name", null);
     if (!clustermapStateModelDefinition.equals(DEFAULT_STATE_MODEL_DEF) && !clustermapStateModelDefinition.equals(
         AMBRY_STATE_MODEL_DEF)) {
       throw new IllegalArgumentException("Unsupported state model definition: " + clustermapStateModelDefinition);

--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -23,6 +23,7 @@ public class ClusterMapConfig {
   public static final String DEFAULT_STATE_MODEL_DEF = LeaderStandbySMD.name;
   public static final String AMBRY_STATE_MODEL_DEF = "AmbryLeaderStandby";
   private static final String MAX_REPLICAS_ALL_DATACENTERS = "max-replicas-all-datacenters";
+  private static final String DEFAULT_VCR_DATACENTER_NAME = "ei4";
 
   /**
    * The factory class used to get the resource state policies.
@@ -182,6 +183,16 @@ public class ClusterMapConfig {
   @Default("true")
   public final boolean clustermapListenCrossColo;
 
+  /**
+   * Name of the datacenter of vcrnodes. It is expected that all the vcr nodes will reside in the same datacenter.
+   */
+  @Config("clustermap.vcr.datacenter.name")
+  @Default(DEFAULT_VCR_DATACENTER_NAME)
+  public final String clustermapVcrDatacenterName;
+
+  /**
+   * State model definition to register with helix cluster.
+   */
   @Config("clustermap.state.model.definition")
   @Default(DEFAULT_STATE_MODEL_DEF)
   public final String clustermapStateModelDefinition;
@@ -220,6 +231,8 @@ public class ClusterMapConfig {
     clustermapListenCrossColo = verifiableProperties.getBoolean("clustermap.listen.cross.colo", true);
     clustermapStateModelDefinition =
         verifiableProperties.getString("clustermap.state.model.definition", DEFAULT_STATE_MODEL_DEF);
+    clustermapVcrDatacenterName =
+        verifiableProperties.getString("clustermap.vcr.datacenter.name", DEFAULT_VCR_DATACENTER_NAME);
     if (!clustermapStateModelDefinition.equals(DEFAULT_STATE_MODEL_DEF) && !clustermapStateModelDefinition.equals(
         AMBRY_STATE_MODEL_DEF)) {
       throw new IllegalArgumentException("Unsupported state model definition: " + clustermapStateModelDefinition);

--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -138,6 +138,13 @@ public class ReplicationConfig {
   @Default("1")
   public final short replicaMetadataRequestVersion;
 
+  /**
+   * If set to true, the Ambry data nodes will also replicate from vcr nodes based on vcr helix cluster map.
+   */
+  @Config("vcr.cluster.replication.enabled")
+  @Default("false")
+  public final boolean isVcrClusterReplicationEnabled;
+
   public ReplicationConfig(VerifiableProperties verifiableProperties) {
 
     replicationStoreTokenFactory =
@@ -173,5 +180,6 @@ public class ReplicationConfig {
         verifiableProperties.getBoolean("replication.track.per.partition.lag.from.remote", false);
     replicaMetadataRequestVersion =
         verifiableProperties.getShortInRange("replication.metadata.request.version", (short) 1, (short) 1, (short) 2);
+    isVcrClusterReplicationEnabled = verifiableProperties.getBoolean("vcr.cluster.replication.enabled", false);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -180,6 +180,6 @@ public class ReplicationConfig {
         verifiableProperties.getBoolean("replication.track.per.partition.lag.from.remote", false);
     replicaMetadataRequestVersion =
         verifiableProperties.getShortInRange("replication.metadata.request.version", (short) 1, (short) 1, (short) 2);
-    replicationEnabledWithVcrCluster = verifiableProperties.getBoolean("vcr.cluster.replication.enabled", false);
+    replicationEnabledWithVcrCluster = verifiableProperties.getBoolean("replication.enabled.with.vcr.cluster", false);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ReplicationConfig.java
@@ -141,9 +141,9 @@ public class ReplicationConfig {
   /**
    * If set to true, the Ambry data nodes will also replicate from vcr nodes based on vcr helix cluster map.
    */
-  @Config("vcr.cluster.replication.enabled")
+  @Config("replication.enabled.with.vcr.cluster")
   @Default("false")
-  public final boolean isVcrClusterReplicationEnabled;
+  public final boolean replicationEnabledWithVcrCluster;
 
   public ReplicationConfig(VerifiableProperties verifiableProperties) {
 
@@ -180,6 +180,6 @@ public class ReplicationConfig {
         verifiableProperties.getBoolean("replication.track.per.partition.lag.from.remote", false);
     replicaMetadataRequestVersion =
         verifiableProperties.getShortInRange("replication.metadata.request.version", (short) 1, (short) 1, (short) 2);
-    isVcrClusterReplicationEnabled = verifiableProperties.getBoolean("vcr.cluster.replication.enabled", false);
+    replicationEnabledWithVcrCluster = verifiableProperties.getBoolean("vcr.cluster.replication.enabled", false);
   }
 }

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
@@ -129,7 +129,9 @@ class CloudMessageReadSet implements MessageReadSet {
       // However, if in future, if very large size of blobs are allowed, then prefetching logic should be changed.
       prefetchedBuffer = ByteBuffer.allocate((int) blobMetadata.getSize());
       ByteBufferOutputStream outputStream = new ByteBufferOutputStream(prefetchedBuffer);
+
       blobStore.downloadBlob(blobMetadata, blobId, outputStream);
+
       isPrefetched = true;
     }
 

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudMessageReadSet.java
@@ -129,9 +129,7 @@ class CloudMessageReadSet implements MessageReadSet {
       // However, if in future, if very large size of blobs are allowed, then prefetching logic should be changed.
       prefetchedBuffer = ByteBuffer.allocate((int) blobMetadata.getSize());
       ByteBufferOutputStream outputStream = new ByteBufferOutputStream(prefetchedBuffer);
-
       blobStore.downloadBlob(blobMetadata, blobId, outputStream);
-
       isPrefetched = true;
     }
 

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudTokenPersistor.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudTokenPersistor.java
@@ -59,7 +59,6 @@ public class CloudTokenPersistor extends ReplicaTokenPersistor {
   }
 
   // Note: assuming that passed mountPath is the partitionId path
-
   @Override
   protected void persist(String mountPath, List<ReplicaTokenInfo> tokenInfoList)
       throws IOException, ReplicationException {

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/HelixVcrCluster.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/HelixVcrCluster.java
@@ -64,9 +64,9 @@ public class HelixVcrCluster implements VirtualReplicatorCluster {
    * @param clusterMap The clusterMap to use.
    */
   public HelixVcrCluster(CloudConfig cloudConfig, ClusterMapConfig clusterMapConfig, ClusterMap clusterMap) {
-    if (Utils.isNullOrEmpty(CloudConfig.VCR_CLUSTER_ZK_CONNECT_STRING)) {
+    if (Utils.isNullOrEmpty(cloudConfig.vcrClusterZkConnectString)) {
       throw new IllegalArgumentException("Missing value for " + CloudConfig.VCR_CLUSTER_ZK_CONNECT_STRING);
-    } else if (Utils.isNullOrEmpty(CloudConfig.VCR_CLUSTER_NAME)) {
+    } else if (Utils.isNullOrEmpty(cloudConfig.vcrClusterName)) {
       throw new IllegalArgumentException("Missing value for " + CloudConfig.VCR_CLUSTER_NAME);
     }
     this.cloudConfig = cloudConfig;

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/HelixVcrCluster.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/HelixVcrCluster.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.cloud;
 
+import com.github.ambry.clustermap.CloudDataNode;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.DataNodeId;
@@ -63,9 +64,9 @@ public class HelixVcrCluster implements VirtualReplicatorCluster {
    * @param clusterMap The clusterMap to use.
    */
   public HelixVcrCluster(CloudConfig cloudConfig, ClusterMapConfig clusterMapConfig, ClusterMap clusterMap) {
-    if (Utils.isNullOrEmpty(cloudConfig.VCR_CLUSTER_ZK_CONNECT_STRING)) {
+    if (Utils.isNullOrEmpty(CloudConfig.VCR_CLUSTER_ZK_CONNECT_STRING)) {
       throw new IllegalArgumentException("Missing value for " + CloudConfig.VCR_CLUSTER_ZK_CONNECT_STRING);
-    } else if (Utils.isNullOrEmpty(cloudConfig.VCR_CLUSTER_NAME)) {
+    } else if (Utils.isNullOrEmpty(CloudConfig.VCR_CLUSTER_NAME)) {
       throw new IllegalArgumentException("Missing value for " + CloudConfig.VCR_CLUSTER_NAME);
     }
     this.cloudConfig = cloudConfig;
@@ -167,4 +168,3 @@ public class HelixVcrCluster implements VirtualReplicatorCluster {
     helixAdmin.close();
   }
 }
-

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/StaticVcrCluster.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/StaticVcrCluster.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.cloud;
 
+import com.github.ambry.clustermap.CloudDataNode;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
@@ -201,9 +201,8 @@ public class VcrReplicationManager extends ReplicationEngine {
   /**
    * Remove a replica of given {@link PartitionId} and its {@link RemoteReplicaInfo}s from the backup list.
    * @param partitionId the {@link PartitionId} of the replica to removed.
-   * @throws ReplicationException if replicas initialization failed.
    */
-  void removeReplica(PartitionId partitionId) throws ReplicationException {
+  void removeReplica(PartitionId partitionId) {
     stopPartitionReplication(partitionId);
     Store cloudStore = partitionStoreMap.get(partitionId.toPathString());
     if (cloudStore != null) {

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.cloud;
 
+import com.github.ambry.clustermap.CloudReplica;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudBlobStoreTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudBlobStoreTest.java
@@ -14,6 +14,8 @@
 package com.github.ambry.cloud;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.CloudDataNode;
+import com.github.ambry.clustermap.CloudReplica;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.DataNodeId;

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudDataNodeTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudDataNodeTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.cloud;
 
+import com.github.ambry.clustermap.CloudDataNode;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudTokenPersistorTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudTokenPersistorTest.java
@@ -14,6 +14,8 @@
 package com.github.ambry.cloud;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.CloudDataNode;
+import com.github.ambry.clustermap.CloudReplica;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
@@ -30,7 +30,7 @@ import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 /**
  * {@link PartitionId} implementation to use within dynamic cluster managers.
  */
-class AmbryPartition implements PartitionId {
+public class AmbryPartition implements PartitionId {
   private final Long id;
   private final String partitionClass;
   private final ClusterManagerCallback clusterManagerCallback;
@@ -161,4 +161,3 @@ class AmbryPartition implements PartitionId {
     }
   }
 }
-

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
@@ -28,10 +28,13 @@ public class AmbryPartitionStateModel extends StateModel {
   private Logger logger = LoggerFactory.getLogger(getClass());
   private final String resourceName;
   private final String partitionName;
+  private final PartitionStateChangeListener partitionStateChangeListener;
 
-  AmbryPartitionStateModel(String resourceName, String partitionName) {
+  AmbryPartitionStateModel(String resourceName, String partitionName,
+      PartitionStateChangeListener partitionStateChangeListener) {
     this.resourceName = resourceName;
     this.partitionName = partitionName;
+    this.partitionStateChangeListener = partitionStateChangeListener;
     StateModelParser parser = new StateModelParser();
     _currentState = parser.getInitialState(DefaultLeaderStandbyStateModel.class);
   }
@@ -52,12 +55,14 @@ public class AmbryPartitionStateModel extends StateModel {
   public void onBecomeLeaderFromStandby(Message message, NotificationContext context) {
     logger.info("Partition {} in resource {} is becoming LEADER from STANDBY", message.getPartitionName(),
         message.getResourceName());
+    partitionStateChangeListener.onPartitionLeadFromStandby(message.getPartitionName());
   }
 
   @Transition(to = "STANDBY", from = "LEADER")
   public void onBecomeStandbyFromLeader(Message message, NotificationContext context) {
     logger.info("Partition {} in resource {} is becoming STANDBY from LEADER", message.getPartitionName(),
         message.getResourceName());
+    partitionStateChangeListener.onPartitionStandbyFromLead(message.getPartitionName());
   }
 
   @Transition(to = "INACTIVE", from = "STANDBY")

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.clustermap;
 
+import java.util.Objects;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.Message;
 import org.apache.helix.participant.statemachine.StateModel;
@@ -34,10 +35,7 @@ public class AmbryPartitionStateModel extends StateModel {
       PartitionStateChangeListener partitionStateChangeListener) {
     this.resourceName = resourceName;
     this.partitionName = partitionName;
-    if(partitionStateChangeListener == null) {
-      throw new IllegalArgumentException("partition state change listener cannot be null");
-    }
-    this.partitionStateChangeListener = partitionStateChangeListener;
+    this.partitionStateChangeListener = Objects.requireNonNull(partitionStateChangeListener);
     StateModelParser parser = new StateModelParser();
     _currentState = parser.getInitialState(DefaultLeaderStandbyStateModel.class);
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
@@ -34,6 +34,9 @@ public class AmbryPartitionStateModel extends StateModel {
       PartitionStateChangeListener partitionStateChangeListener) {
     this.resourceName = resourceName;
     this.partitionName = partitionName;
+    if(partitionStateChangeListener == null) {
+      throw new IllegalArgumentException("partition state change listener cannot be null");
+    }
     this.partitionStateChangeListener = partitionStateChangeListener;
     StateModelParser parser = new StateModelParser();
     _currentState = parser.getInitialState(DefaultLeaderStandbyStateModel.class);
@@ -55,14 +58,14 @@ public class AmbryPartitionStateModel extends StateModel {
   public void onBecomeLeaderFromStandby(Message message, NotificationContext context) {
     logger.info("Partition {} in resource {} is becoming LEADER from STANDBY", message.getPartitionName(),
         message.getResourceName());
-    partitionStateChangeListener.onPartitionLeadFromStandby(message.getPartitionName());
+    partitionStateChangeListener.onPartitionStateChangeToLeaderFromStandby(message.getPartitionName());
   }
 
   @Transition(to = "STANDBY", from = "LEADER")
   public void onBecomeStandbyFromLeader(Message message, NotificationContext context) {
     logger.info("Partition {} in resource {} is becoming STANDBY from LEADER", message.getPartitionName(),
         message.getResourceName());
-    partitionStateChangeListener.onPartitionStandbyFromLead(message.getPartitionName());
+    partitionStateChangeListener.onPartitionStateChangeToStandbyFromLeader(message.getPartitionName());
   }
 
   @Transition(to = "INACTIVE", from = "STANDBY")

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
@@ -23,9 +23,11 @@ import org.apache.helix.participant.statemachine.StateModelFactory;
  */
 class AmbryStateModelFactory extends StateModelFactory<StateModel> {
   private final String ambryStateModelDef;
+  private final PartitionStateChangeListener partitionStateChangeListener;
 
-  AmbryStateModelFactory(String stateModelDef) {
+  AmbryStateModelFactory(String stateModelDef, PartitionStateChangeListener partitionStateChangeListener) {
     ambryStateModelDef = stateModelDef;
+    this.partitionStateChangeListener = partitionStateChangeListener;
   }
 
   /**
@@ -39,7 +41,7 @@ class AmbryStateModelFactory extends StateModelFactory<StateModel> {
     StateModel stateModelToReturn;
     switch (ambryStateModelDef) {
       case AmbryStateModelDefinition.AMBRY_LEADER_STANDBY_MODEL:
-        stateModelToReturn = new AmbryPartitionStateModel(resourceName, partitionName);
+        stateModelToReturn = new AmbryPartitionStateModel(resourceName, partitionName, partitionStateChangeListener);
         break;
       case LeaderStandbySMD.name:
         stateModelToReturn = new DefaultLeaderStandbyStateModel();
@@ -50,4 +52,3 @@ class AmbryStateModelFactory extends StateModelFactory<StateModel> {
     return stateModelToReturn;
   }
 }
-

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudDataNode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudDataNode.java
@@ -61,7 +61,6 @@ public class CloudDataNode implements DataNodeId {
 
   /**
    * Instantiate a CloudDataNode object from hostname, port and datacentername.
-   * @return
    */
   public CloudDataNode(String hostName, Port plainTextPort, Port sslPort, String dataCenterName,
       ClusterMapConfig clusterMapConfig) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudReplica.java
@@ -11,15 +11,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package com.github.ambry.cloud;
+package com.github.ambry.clustermap;
 
-import com.github.ambry.clustermap.DataNodeId;
-import com.github.ambry.clustermap.DiskId;
-import com.github.ambry.clustermap.PartitionId;
-import com.github.ambry.clustermap.PartitionState;
-import com.github.ambry.clustermap.ReplicaId;
-import com.github.ambry.clustermap.ReplicaType;
-import com.github.ambry.protocol.GetRequest;
 import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,9 +24,10 @@ import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 /**
  * {@link ReplicaId} implementation to use within virtual cloud replicator.
  */
-class CloudReplica implements ReplicaId {
+public class CloudReplica implements ReplicaId {
   private final PartitionId partitionId;
   private final DataNodeId dataNodeId;
+  public static final String Cloud_Replica_Keyword = "vcr";
 
   /**
    * Instantiate an CloudReplica instance.
@@ -41,7 +35,7 @@ class CloudReplica implements ReplicaId {
    * @param dataNodeId which hosts this replica.
    *
    */
-  CloudReplica(PartitionId partitionId, DataNodeId dataNodeId) {
+  public CloudReplica(PartitionId partitionId, DataNodeId dataNodeId) {
     this.partitionId = partitionId;
     this.dataNodeId = dataNodeId;
   }
@@ -64,8 +58,7 @@ class CloudReplica implements ReplicaId {
   @Override
   public String getReplicaPath() {
     // GetRequest.Cloud_Replica_Keyword is added to avoid error on its peers.
-    return GetRequest.Cloud_Replica_Keyword + File.separator + getMountPath() + File.separator
-        + partitionId.toPathString();
+    return Cloud_Replica_Keyword + File.separator + getMountPath() + File.separator + partitionId.toPathString();
   }
 
   @Override
@@ -104,7 +97,8 @@ class CloudReplica implements ReplicaId {
 
   @Override
   public boolean isDown() {
-    throw new UnsupportedOperationException("isDown() is not supported.");
+    // Cloud replica is the vcr replica that stays on public cloud, so we dont expect it to go down.
+    return false;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudReplica.java
@@ -33,7 +33,6 @@ public class CloudReplica implements ReplicaId {
    * Instantiate an CloudReplica instance.
    * @param partitionId the {@link PartitionId} of which this is a replica.
    * @param dataNodeId which hosts this replica.
-   *
    */
   public CloudReplica(PartitionId partitionId, DataNodeId dataNodeId) {
     this.partitionId = partitionId;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -66,7 +66,6 @@ public class ClusterMapUtils {
   static final String AVAILABLE_STR = "AVAILABLE";
   static final String READ_ONLY_STR = "RO";
   static final String READ_WRITE_STR = "RW";
-  static final String UNAVAILABLE_STR = "UNAVAILABLE";
   static final String ZKCONNECTSTR_STR = "zkConnectStr";
   static final String ZKINFO_STR = "zkInfo";
   static final String DATACENTER_STR = "datacenter";
@@ -132,7 +131,7 @@ public class ClusterMapUtils {
    * @return a map of dcName -> DcInfo.
    * @throws JSONException if there is an error parsing the JSON.
    */
-  static Map<String, DcZkInfo> parseDcJsonAndPopulateDcInfo(String dcInfoJsonString) throws JSONException {
+  public static Map<String, DcZkInfo> parseDcJsonAndPopulateDcInfo(String dcInfoJsonString) throws JSONException {
     Map<String, DcZkInfo> dataCenterToZkAddress = new HashMap<>();
     JSONObject root = new JSONObject(dcInfoJsonString);
     JSONArray all = root.getJSONArray(ZKINFO_STR);
@@ -192,7 +191,7 @@ public class ClusterMapUtils {
    * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
    * @return the datacenter name associated with the given instance.
    */
-  static String getDcName(InstanceConfig instanceConfig) {
+  public static String getDcName(InstanceConfig instanceConfig) {
     return instanceConfig.getRecord().getSimpleField(DATACENTER_STR);
   }
 
@@ -201,7 +200,7 @@ public class ClusterMapUtils {
    * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
    * @return the ssl port associated with the given instance.
    */
-  static Integer getSslPortStr(InstanceConfig instanceConfig) {
+  public static Integer getSslPortStr(InstanceConfig instanceConfig) {
     String sslPortStr = instanceConfig.getRecord().getSimpleField(SSLPORT_STR);
     return sslPortStr == null ? null : Integer.valueOf(sslPortStr);
   }
@@ -514,4 +513,3 @@ public class ClusterMapUtils {
     }
   }
 }
-

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,7 +60,7 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
  *
  * @see <a href="http://helix.apache.org">http://helix.apache.org</a>
  */
-class HelixClusterManager implements ClusterMap {
+public class HelixClusterManager implements ClusterMap {
   private static final Logger logger = LoggerFactory.getLogger(HelixClusterManager.class);
   private final String clusterName;
   private final String selfInstanceName;
@@ -104,7 +103,7 @@ class HelixClusterManager implements ClusterMap {
    * @throws IOException if there is an error in parsing the clusterMapConfig or in connecting with the associated
    *                     remote Zookeeper services.
    */
-  HelixClusterManager(ClusterMapConfig clusterMapConfig, String instanceName, HelixFactory helixFactory,
+  public HelixClusterManager(ClusterMapConfig clusterMapConfig, String instanceName, HelixFactory helixFactory,
       MetricRegistry metricRegistry) throws IOException {
     this.clusterMapConfig = clusterMapConfig;
     currentXid = new AtomicLong(clusterMapConfig.clustermapCurrentXid);
@@ -701,7 +700,7 @@ class HelixClusterManager implements ClusterMap {
         ambryDataNodeToAmbryDisks.get(datanode).add(disk);
 
         if (!replicasStr.isEmpty()) {
-          List<String> replicaInfoList = Arrays.asList(replicasStr.split(ClusterMapUtils.REPLICAS_DELIM_STR));
+          String[] replicaInfoList = replicasStr.split(ClusterMapUtils.REPLICAS_DELIM_STR);
           for (String replicaInfo : replicaInfoList) {
             String[] info = replicaInfo.split(ClusterMapUtils.REPLICAS_STR_SEPARATOR);
             // partition name and replica name are the same.
@@ -948,4 +947,3 @@ class HelixClusterManager implements ClusterMap {
     }
   }
 }
-

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterSpectatorFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterSpectatorFactory.java
@@ -21,9 +21,9 @@ import com.github.ambry.config.ClusterMapConfig;
  * A factory to create {@link ClusterSpectator} object.
  */
 public class HelixClusterSpectatorFactory implements ClusterSpectatorFactory {
-  
+
   @Override
   public ClusterSpectator getClusterSpectator(CloudConfig cloudConfig, ClusterMapConfig clusterMapConfig) {
-    return new VcrHelixClusterSpectator(cloudConfig, clusterMapConfig);
+    return new HelixClusterSpectator(cloudConfig, clusterMapConfig);
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterSpectatorFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterSpectatorFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.CloudConfig;
+import com.github.ambry.config.ClusterMapConfig;
+
+
+/**
+ * A factory to create {@link ClusterSpectator} object.
+ */
+public class HelixClusterSpectatorFactory implements ClusterSpectatorFactory {
+  
+  @Override
+  public ClusterSpectator getClusterSpectator(CloudConfig cloudConfig, ClusterMapConfig clusterMapConfig) {
+    return new VcrHelixClusterSpectator(cloudConfig, clusterMapConfig);
+  }
+}

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixFactory.java
@@ -31,7 +31,8 @@ public class HelixFactory {
    * @param zkAddr the address identifying the zk service to which this request is to be made.
    * @return the constructed {@link HelixManager}.
    */
-  HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddr) {
+  public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
+      String zkAddr) {
     return HelixManagerFactory.getZKHelixManager(clusterName, instanceName, instanceType, zkAddr);
   }
 
@@ -40,8 +41,7 @@ public class HelixFactory {
    * @param zkAddr the address identifying the zk service to which this request is to be made.
    * @return the constructed {@link HelixAdmin}.
    */
-  HelixAdmin getHelixAdmin(String zkAddr) {
+  public HelixAdmin getHelixAdmin(String zkAddr) {
     return new HelixAdminFactory().getHelixAdmin(zkAddr);
   }
 }
-

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -275,16 +275,16 @@ class HelixParticipant implements ClusterParticipant, PartitionStateChangeListen
   }
 
   @Override
-  public void onPartitionLeadFromStandby(String partitionName) {
+  public void onPartitionStateChangeToLeaderFromStandby(String partitionName) {
     for (PartitionStateChangeListener partitionStateChangeListener : partitionStateChangeListeners) {
-      partitionStateChangeListener.onPartitionLeadFromStandby(partitionName);
+      partitionStateChangeListener.onPartitionStateChangeToLeaderFromStandby(partitionName);
     }
   }
 
   @Override
-  public void onPartitionStandbyFromLead(String partitionName) {
+  public void onPartitionStateChangeToStandbyFromLeader(String partitionName) {
     for (PartitionStateChangeListener partitionStateChangeListener : partitionStateChangeListeners) {
-      partitionStateChangeListener.onPartitionLeadFromStandby(partitionName);
+      partitionStateChangeListener.onPartitionStateChangeToStandbyFromLeader(partitionName);
     }
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +43,7 @@ import org.slf4j.LoggerFactory;
 /**
  * An implementation of {@link ClusterParticipant} that registers as a participant to a Helix cluster.
  */
-class HelixParticipant implements ClusterParticipant {
+class HelixParticipant implements ClusterParticipant, PartitionStateChangeListener {
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final String clusterName;
   private final String zkConnectStr;
@@ -52,6 +53,7 @@ class HelixParticipant implements ClusterParticipant {
   private HelixManager manager;
   private String instanceName;
   private HelixAdmin helixAdmin;
+  private List<PartitionStateChangeListener> partitionStateChangeListeners;
 
   /**
    * Instantiate a HelixParticipant.
@@ -79,6 +81,7 @@ class HelixParticipant implements ClusterParticipant {
       throw new IOException("Received JSON exception while parsing ZKInfo json string", e);
     }
     manager = helixFactory.getZKHelixManager(clusterName, instanceName, InstanceType.PARTICIPANT, zkConnectStr);
+    partitionStateChangeListeners = new LinkedList<>();
   }
 
   /**
@@ -93,7 +96,7 @@ class HelixParticipant implements ClusterParticipant {
         clusterMapConfig.clustermapStateModelDefinition);
     StateMachineEngine stateMachineEngine = manager.getStateMachineEngine();
     stateMachineEngine.registerStateModelFactory(clusterMapConfig.clustermapStateModelDefinition,
-        new AmbryStateModelFactory(clusterMapConfig.clustermapStateModelDefinition));
+        new AmbryStateModelFactory(clusterMapConfig.clustermapStateModelDefinition, this));
     registerHealthReportTasks(stateMachineEngine, ambryHealthReports);
     try {
       synchronized (helixAdministrationLock) {
@@ -111,6 +114,11 @@ class HelixParticipant implements ClusterParticipant {
     for (AmbryHealthReport ambryHealthReport : ambryHealthReports) {
       manager.getHealthReportCollector().addHealthReportProvider((HealthReportProvider) ambryHealthReport);
     }
+  }
+
+  @Override
+  public void registerPartitionStateChangeListener(PartitionStateChangeListener partitionStateChangeListener) {
+    partitionStateChangeListeners.add(partitionStateChangeListener);
   }
 
   @Override
@@ -264,5 +272,19 @@ class HelixParticipant implements ClusterParticipant {
     logger.trace("Setting InstanceConfig with list of stopped replicas: {}", stoppedReplicas.toArray());
     instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, stoppedReplicas);
     return helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
+  }
+
+  @Override
+  public void onPartitionLeadFromStandby(String partitionName) {
+    for (PartitionStateChangeListener partitionStateChangeListener : partitionStateChangeListeners) {
+      partitionStateChangeListener.onPartitionLeadFromStandby(partitionName);
+    }
+  }
+
+  @Override
+  public void onPartitionStandbyFromLead(String partitionName) {
+    for (PartitionStateChangeListener partitionStateChangeListener : partitionStateChangeListeners) {
+      partitionStateChangeListener.onPartitionLeadFromStandby(partitionName);
+    }
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -270,6 +271,10 @@ class PartitionLayout {
       jsonObject.accumulate("partitions", partition.toJSONObject());
     }
     return jsonObject;
+  }
+
+  public List<String> getAllPartitionNames() {
+    return partitionMap.values().stream().map(partition -> partition.toPathString()).collect(Collectors.toList());
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
@@ -18,6 +18,7 @@ import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.server.AmbryHealthReport;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import org.json.JSONException;
@@ -75,9 +76,15 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
   public ClusterParticipant getClusterParticipant() throws IOException {
     if (clusterParticipant == null) {
       clusterParticipant = new ClusterParticipant() {
+        private final List<PartitionStateChangeListener> listeners = new LinkedList<>();
+
         @Override
         public void participate(List<AmbryHealthReport> ambryHealthReports) {
-
+          for (PartitionStateChangeListener listener : listeners) {
+            for (String partitionName : partitionLayout.getAllPartitionNames()) {
+              listener.onPartitionLeadFromStandby(partitionName);
+            }
+          }
         }
 
         @Override
@@ -104,6 +111,11 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
         public List<String> getStoppedReplicas() {
           return Collections.emptyList();
         }
+
+        @Override
+        public void registerPartitionStateChangeListener(PartitionStateChangeListener partitionStateChangeListener) {
+          listeners.add(partitionStateChangeListener);
+        }
       };
     }
     return clusterParticipant;
@@ -116,4 +128,3 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
     return metricRegistry;
   }
 }
-

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
@@ -82,7 +82,7 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
         public void participate(List<AmbryHealthReport> ambryHealthReports) {
           for (PartitionStateChangeListener listener : listeners) {
             for (String partitionName : partitionLayout.getAllPartitionNames()) {
-              listener.onPartitionLeadFromStandby(partitionName);
+              listener.onPartitionStateChangeToLeaderFromStandby(partitionName);
             }
           }
         }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/VcrHelixClusterSpectator.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/VcrHelixClusterSpectator.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.CloudConfig;
+import com.github.ambry.config.ClusterMapConfig;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.HelixManager;
+import org.apache.helix.InstanceType;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.api.listeners.InstanceConfigChangeListener;
+import org.apache.helix.api.listeners.LiveInstanceChangeListener;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+
+
+/**
+ * Spectator for vcr helix cluster.
+ */
+public class VcrHelixClusterSpectator implements ClusterSpectator {
+
+  private final ClusterMapConfig clusterMapConfig;
+  private final CloudConfig cloudConfig;
+  private List<InstanceConfigChangeListener> registeredInstanceConfigChangeListeners;
+  private List<LiveInstanceChangeListener> registeredLiveInstanceChangeListeners;
+
+  /**
+   * Constructor for {@link VcrHelixClusterSpectator}.
+   * @param cloudConfig Cluster config of vcr.
+   * @param clusterMapConfig Cluster Map config.
+   */
+  public VcrHelixClusterSpectator(CloudConfig cloudConfig, ClusterMapConfig clusterMapConfig) {
+    this.cloudConfig = cloudConfig;
+    this.clusterMapConfig = clusterMapConfig;
+    registeredInstanceConfigChangeListeners = new LinkedList<>();
+    registeredLiveInstanceChangeListeners = new LinkedList<>();
+  }
+
+  @Override
+  public void spectate() throws Exception {
+    Map<String, DcZkInfo> dataCenterToZkAddress =
+        parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings);
+    HelixFactory helixFactory = new HelixFactory();
+    String selfInstanceName = ClusterMapUtils.getInstanceName(clusterMapConfig.clusterMapHostName, 12111);
+
+    for (Map.Entry<String, DcZkInfo> entry : dataCenterToZkAddress.entrySet()) {
+      String zkConnectStr = entry.getValue().getZkConnectStr();
+      HelixManager helixManager =
+          helixFactory.getZKHelixManager(cloudConfig.vcrClusterName, selfInstanceName, InstanceType.SPECTATOR,
+              zkConnectStr);
+      helixManager.connect();
+
+      helixManager.addInstanceConfigChangeListener(this);
+      helixManager.addLiveInstanceChangeListener(this);
+    }
+  }
+
+  @Override
+  public void onInstanceConfigChange(List<InstanceConfig> instanceConfigs, NotificationContext context) {
+    for (InstanceConfigChangeListener registeredInstanceConfigChangeListener : registeredInstanceConfigChangeListeners) {
+      registeredInstanceConfigChangeListener.onInstanceConfigChange(instanceConfigs, context);
+    }
+  }
+
+  @Override
+  public void onLiveInstanceChange(List<LiveInstance> liveInstances, NotificationContext changeContext) {
+    for (LiveInstanceChangeListener registeredLiveInstanceChangeListener : registeredLiveInstanceChangeListeners) {
+      registeredLiveInstanceChangeListener.onLiveInstanceChange(liveInstances, changeContext);
+    }
+  }
+
+  @Override
+  public void registerInstanceConfigChangeListener(InstanceConfigChangeListener instanceConfigChangeListener) {
+    registeredInstanceConfigChangeListeners.add(instanceConfigChangeListener);
+  }
+
+  @Override
+  public void registerLiveInstanceChangeListener(LiveInstanceChangeListener liveInstanceChangeListener) {
+    registeredLiveInstanceChangeListeners.add(liveInstanceChangeListener);
+  }
+}

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
@@ -44,7 +44,7 @@ public class AmbryStateModelFactoryTest {
 
   @Test
   public void testDifferentStateModelDefs() {
-    AmbryStateModelFactory factory = new AmbryStateModelFactory(stateModelDef);
+    AmbryStateModelFactory factory = new AmbryStateModelFactory(stateModelDef, null);
     StateModel stateModel;
     switch (stateModelDef) {
       case ClusterMapConfig.DEFAULT_STATE_MODEL_DEF:

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
@@ -44,7 +44,17 @@ public class AmbryStateModelFactoryTest {
 
   @Test
   public void testDifferentStateModelDefs() {
-    AmbryStateModelFactory factory = new AmbryStateModelFactory(stateModelDef, null);
+    AmbryStateModelFactory factory = new AmbryStateModelFactory(stateModelDef, new PartitionStateChangeListener() {
+      @Override
+      public void onPartitionStateChangeToLeaderFromStandby(String partitionName) {
+        // no op
+      }
+
+      @Override
+      public void onPartitionStateChangeToStandbyFromLeader(String partitionName) {
+        //no op
+      }
+    });
     StateModel stateModel;
     switch (stateModelDef) {
       case ClusterMapConfig.DEFAULT_STATE_MODEL_DEF:

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/CloudReplicaTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/CloudReplicaTest.java
@@ -11,13 +11,11 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package com.github.ambry.cloud;
+package com.github.ambry.clustermap;
 
-import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.protocol.GetRequest;
 import java.io.File;
 import java.util.Properties;
 import org.junit.Test;
@@ -57,7 +55,7 @@ public class CloudReplicaTest {
     CloudReplica cloudReplica = new CloudReplica(new MockPartitionId(), cloudDataNode);
     assertEquals("Wrong mount path", mockPartitionId.toPathString(), cloudReplica.getMountPath());
     assertEquals("Wrong replica path",
-        GetRequest.Cloud_Replica_Keyword + File.separator + mockPartitionId.toPathString() + File.separator
+        CloudReplica.Cloud_Replica_Keyword + File.separator + mockPartitionId.toPathString() + File.separator
             + mockPartitionId.toPathString(), cloudReplica.getReplicaPath());
     assertEquals("Wrong dataNodeId", cloudDataNode, cloudReplica.getDataNodeId());
     assertEquals("Wrong partitionId", mockPartitionId, cloudReplica.getPartitionId());

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -310,8 +310,7 @@ public class HelixClusterManagerTest {
 
     Set<String> writableInClusterManager = new HashSet<>();
     for (PartitionId partition : clusterManagerWithEmptyRecord.getWritablePartitionIds(null)) {
-      String partitionStr =
-          useComposite ? ((Partition) partition).toPathString() : ((AmbryPartition) partition).toPathString();
+      String partitionStr = useComposite ? partition.toPathString() : partition.toPathString();
       writableInClusterManager.add(partitionStr);
     }
     Set<String> writableInCluster = helixCluster.getWritablePartitions();
@@ -1043,8 +1042,7 @@ public class HelixClusterManagerTest {
   private Pair<Set<String>, Set<String>> getWritablePartitions() {
     Set<String> writableInClusterManager = new HashSet<>();
     for (PartitionId partition : clusterManager.getWritablePartitionIds(null)) {
-      String partitionStr =
-          useComposite ? ((Partition) partition).toPathString() : ((AmbryPartition) partition).toPathString();
+      String partitionStr = useComposite ? partition.toPathString() : partition.toPathString();
       writableInClusterManager.add(partitionStr);
     }
     Set<String> writableInCluster = helixCluster.getWritablePartitions();
@@ -1061,8 +1059,7 @@ public class HelixClusterManagerTest {
   private void testAllPartitions() {
     Set<String> partitionsInClusterManager = new HashSet<>();
     for (PartitionId partition : clusterManager.getAllPartitionIds(null)) {
-      String partitionStr =
-          useComposite ? ((Partition) partition).toPathString() : ((AmbryPartition) partition).toPathString();
+      String partitionStr = useComposite ? partition.toPathString() : partition.toPathString();
       partitionsInClusterManager.add(partitionStr);
     }
     Set<String> allPartitions = helixCluster.getAllPartitions();
@@ -1180,7 +1177,8 @@ public class HelixClusterManagerTest {
      * @param zkAddr the address identifying the zk service to which this request is to be made.
      * @return the {@link MockHelixManager}
      */
-    HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddr) {
+    public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
+        String zkAddr) {
       if (helixCluster.getZkAddrs().contains(zkAddr)) {
         return new MockHelixManager(instanceName, instanceType, zkAddr, helixCluster, znRecordMap, beBadException);
       } else {
@@ -1189,4 +1187,3 @@ public class HelixClusterManagerTest {
     }
   }
 }
-

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -310,7 +310,7 @@ public class HelixClusterManagerTest {
 
     Set<String> writableInClusterManager = new HashSet<>();
     for (PartitionId partition : clusterManagerWithEmptyRecord.getWritablePartitionIds(null)) {
-      String partitionStr = useComposite ? partition.toPathString() : partition.toPathString();
+      String partitionStr = partition.toPathString();
       writableInClusterManager.add(partitionStr);
     }
     Set<String> writableInCluster = helixCluster.getWritablePartitions();
@@ -1042,7 +1042,7 @@ public class HelixClusterManagerTest {
   private Pair<Set<String>, Set<String>> getWritablePartitions() {
     Set<String> writableInClusterManager = new HashSet<>();
     for (PartitionId partition : clusterManager.getWritablePartitionIds(null)) {
-      String partitionStr = useComposite ? partition.toPathString() : partition.toPathString();
+      String partitionStr = partition.toPathString();
       writableInClusterManager.add(partitionStr);
     }
     Set<String> writableInCluster = helixCluster.getWritablePartitions();
@@ -1059,7 +1059,7 @@ public class HelixClusterManagerTest {
   private void testAllPartitions() {
     Set<String> partitionsInClusterManager = new HashSet<>();
     for (PartitionId partition : clusterManager.getAllPartitionIds(null)) {
-      String partitionStr = useComposite ? partition.toPathString() : partition.toPathString();
+      String partitionStr = partition.toPathString();
       partitionsInClusterManager.add(partitionStr);
     }
     Set<String> allPartitions = helixCluster.getAllPartitions();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
@@ -365,7 +365,8 @@ public class HelixParticipantTest {
      * @return the {@link MockHelixManager}
      */
     @Override
-    HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddr) {
+    public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
+        String zkAddr) {
       return helixManager;
     }
 
@@ -375,7 +376,7 @@ public class HelixParticipantTest {
      * @return the {@link MockHelixAdmin}
      */
     @Override
-    HelixAdmin getHelixAdmin(String zkAddr) {
+    public HelixAdmin getHelixAdmin(String zkAddr) {
       return new MockHelixAdmin();
     }
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
@@ -108,6 +108,11 @@ public class MockClusterAgentsFactory implements ClusterAgentsFactory {
         public List<String> getStoppedReplicas() {
           return new ArrayList<>();
         }
+
+        @Override
+        public void registerPartitionStateChangeListener(PartitionStateChangeListener partitionStateChangeListener) {
+
+        }
       };
     }
     return clusterParticipant;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterSpectator.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterSpectator.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.api.listeners.InstanceConfigChangeListener;
+import org.apache.helix.api.listeners.LiveInstanceChangeListener;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+
+
+/**
+ * Mock implementation of {@link ClusterSpectator} that can give callback for instance configs.
+ */
+public class MockClusterSpectator implements ClusterSpectator {
+  private final List<InstanceConfig> instanceConfigList;
+  private final List<InstanceConfigChangeListener> registeredInstanceConfigChangeListeners;
+
+  /**
+   * Constructor for {@link MockClusterSpectator} object.
+   * @param cloudDataNodeList list of cloud {@link MockDataNodeId}s in instance config of {@link MockClusterSpectator}.
+   */
+  public MockClusterSpectator(List<MockDataNodeId> cloudDataNodeList) {
+    registeredInstanceConfigChangeListeners = new ArrayList<>();
+    this.instanceConfigList = new ArrayList<>();
+    for (MockDataNodeId cloudDataNode : cloudDataNodeList) {
+      ZNRecord znRecord = new ZNRecord(cloudDataNode.getHostname() + "_" + cloudDataNode.getPort());
+      Map<String, String> simpleFields = new HashMap<>();
+      simpleFields.put("HELIX_ENABLED", "true");
+      simpleFields.put("HELIX_ENABLED_TIMESTAMP", Long.toString(System.currentTimeMillis()));
+      simpleFields.put("HELIX_HOST", cloudDataNode.getHostname());
+      simpleFields.put("HELIX_PORT", Integer.toString(cloudDataNode.getPort()));
+      znRecord.setSimpleFields(simpleFields);
+      instanceConfigList.add(new InstanceConfig(znRecord));
+    }
+  }
+
+  @Override
+  public void spectate() {
+    onInstanceConfigChange(instanceConfigList, null);
+  }
+
+  @Override
+  public void registerInstanceConfigChangeListener(InstanceConfigChangeListener instanceConfigChangeListener) {
+    registeredInstanceConfigChangeListeners.add(instanceConfigChangeListener);
+  }
+
+  @Override
+  public void registerLiveInstanceChangeListener(LiveInstanceChangeListener liveInstanceChangeListener) {
+    // no op
+  }
+
+  @Override
+  public void onInstanceConfigChange(List<InstanceConfig> instanceConfigs, NotificationContext context) {
+    for (InstanceConfigChangeListener registeredInstanceConfigChangeListener : registeredInstanceConfigChangeListeners) {
+      registeredInstanceConfigChangeListener.onInstanceConfigChange(instanceConfigs, context);
+    }
+  }
+
+  @Override
+  public void onLiveInstanceChange(List<LiveInstance> liveInstances, NotificationContext changeContext) {
+
+  }
+}

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterSpectatorFactory.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterSpectatorFactory.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.CloudConfig;
+import com.github.ambry.config.ClusterMapConfig;
+import java.util.List;
+
+
+/**
+ * Mock {@link ClusterSpectatorFactory} to instantiate {@link MockClusterSpectator}.
+ */
+public class MockClusterSpectatorFactory implements ClusterSpectatorFactory {
+  private final List<MockDataNodeId> cloudDataNodes;
+
+  /**
+   * Constructor for {@link MockClusterSpectatorFactory} object.
+   * @param cloudDataNodes list of cloud {@link MockDataNodeId}s in instance config of {@link MockClusterSpectator}.
+   */
+  public MockClusterSpectatorFactory(List<MockDataNodeId> cloudDataNodes) {
+    this.cloudDataNodes = cloudDataNodes;
+  }
+
+  @Override
+  public ClusterSpectator getClusterSpectator(CloudConfig cloudConfig, ClusterMapConfig clusterMapConfig) {
+    return new MockClusterSpectator(cloudDataNodes);
+  }
+}

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ResponseHandler.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ResponseHandler.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.commons;
 
+import com.github.ambry.clustermap.CloudReplica;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.ReplicaEventType;
@@ -109,6 +110,8 @@ public class ResponseHandler {
    * {@link ServerErrorCode}.
    */
   public void onEvent(ReplicaId replicaId, Object event) {
+    if(replicaId instanceof CloudReplica)
+      return;
     if (event instanceof ServerErrorCode) {
       onServerEvent(replicaId, (ServerErrorCode) event);
     } else if (event instanceof Exception) {

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/GetRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/GetRequest.java
@@ -40,7 +40,6 @@ public class GetRequest extends RequestOrResponse {
   private static final int Partition_Request_Info_List_Size = 4;
   private static final short Get_Request_Version_V2 = 2;
   public static final String Replication_Client_Id_Prefix = "replication-fetch-";
-  public static final String Cloud_Replica_Keyword = "vcr";
 
   public GetRequest(int correlationId, String clientId, MessageFormatFlags flags,
       List<PartitionRequestInfo> partitionRequestInfoList, GetOption getOption) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
@@ -298,9 +298,6 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
     }
   }
 
-  Add CloudToStoreReplicationManager to separate out replication from cloud replicas to data nodes.
-  Add Code to enable spectator on helix vcr cluster and to react to changes on helix.
-
   /**
    * Remove a replica of given partition and its {@link RemoteReplicaInfo}s from the backup list.
    * @param partitionName the partition of the replica to removed.

--- a/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
@@ -255,7 +255,7 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
         removeCloudReplica(partitionId.toPathString());
         addCloudReplica(partitionId.toPathString());
       } catch (ReplicationException rex) {
-        logger.error("Could not remove/add replica for partitionId {}", partitionId);
+        logger.error("Exception {} during remove/add replica for partitionId {}", rex, partitionId);
       }
     }
   }
@@ -266,7 +266,7 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
   private class InstanceConfigChangeListenerImpl implements InstanceConfigChangeListener {
     @Override
     public void onInstanceConfigChange(List<InstanceConfig> instanceConfigs, NotificationContext context) {
-      logger.debug("Instance config change notification received with instanceConfigs: {}", instanceConfigs);
+      logger.info("Instance config change notification received with instanceConfigs: {}", instanceConfigs);
       ConcurrentSkipListSet<CloudDataNode> newVcrNodes = new ConcurrentSkipListSet<>();
       ConcurrentHashMap<String, CloudDataNode> newInstanceNameToCloudDataNode = new ConcurrentHashMap<>();
 
@@ -295,7 +295,7 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
   private class LiveInstanceChangeListenerImpl implements LiveInstanceChangeListener {
     @Override
     public void onLiveInstanceChange(List<LiveInstance> liveInstances, NotificationContext changeContext) {
-      logger.debug("Live instance change notification received. liveInstances: {}", liveInstances);
+      logger.info("Live instance change notification received. liveInstances: {}", liveInstances);
       ConcurrentSkipListSet<CloudDataNode> newVcrNodes = new ConcurrentSkipListSet<>();
       // react to change in liveness of vcr nodes if the instance was earlier reported by helix as part of
       // {@code onInstanceConfigChange} notification.
@@ -316,27 +316,27 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
   private class PartitionStateChangeListenerImpl implements PartitionStateChangeListener {
     @Override
     public void onPartitionStateChangeToLeaderFromStandby(String partitionName) {
-      logger.debug("Partition state change notification from Standby to Leader received for partition {}",
+      logger.info("Partition state change notification from Standby to Leader received for partition {}",
           partitionName);
       synchronized (notificationLock) {
         try {
           addCloudReplica(partitionName);
         } catch (ReplicationException rex) {
-          logger.error("Could not add replication for paritition {}", partitionName);
+          logger.error("Exception {} while adding replication for partition {}", rex, partitionName);
         }
       }
     }
 
     @Override
     public void onPartitionStateChangeToStandbyFromLeader(String partitionName) {
-      logger.debug("Partition state change notification from Leader to Standby received for partition {}",
+      logger.info("Partition state change notification from Leader to Standby received for partition {}",
           partitionName);
       synchronized (notificationLock) {
         try {
           removeCloudReplica(partitionName);
         } catch (ReplicationException rex) {
           // Helix will run into error state if exception throws in Helix context.
-          logger.error("Exception on removing Partition {} from {}: ", partitionName, dataNodeId, rex);
+          logger.error("Exception {} on removing Partition {} from {}: ", rex, partitionName, dataNodeId);
         }
       }
     }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
@@ -1,0 +1,336 @@
+/**
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.replication;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.CloudDataNode;
+import com.github.ambry.clustermap.CloudReplica;
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ClusterParticipant;
+import com.github.ambry.clustermap.ClusterSpectator;
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.PartitionStateChangeListener;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.ReplicationConfig;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.network.ConnectionPool;
+import com.github.ambry.network.Port;
+import com.github.ambry.network.PortType;
+import com.github.ambry.notification.NotificationSystem;
+import com.github.ambry.server.StoreManager;
+import com.github.ambry.store.Store;
+import com.github.ambry.store.StoreKeyConverterFactory;
+import com.github.ambry.store.StoreKeyFactory;
+import com.github.ambry.utils.SystemTime;
+import com.github.ambry.utils.Utils;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.api.listeners.InstanceConfigChangeListener;
+import org.apache.helix.api.listeners.LiveInstanceChangeListener;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+
+
+/**
+ * {@link CloudToStoreReplicationManager} replicates data from Vcr nodes to ambry data nodes.
+ */
+public class CloudToStoreReplicationManager extends ReplicationEngine {
+  private final ClusterMapConfig clusterMapConfig;
+  private final StoreConfig storeConfig;
+  private final StoreManager storeManager;
+  private final ClusterSpectator vcrClusterSpectator;
+  private final ClusterParticipant clusterParticipant;
+  private static final String cloudReplicaTokenFileName = "cloudReplicaTokens";
+  private ConcurrentHashMap<String, CloudDataNode> instanceNameToCloudDataNode;
+  private ConcurrentSkipListSet<CloudDataNode> vcrNodes;
+  private final ConcurrentHashMap<String, PartitionId> localPartitionNameToPartition;
+  private final Object notificationLock = new Object();
+
+  /**
+   * Constructor for {@link CloudToStoreReplicationManager}
+   * @param replicationConfig {@link ReplicationConfig} object.
+   * @param clusterMapConfig {@link ClusterMapConfig} objeect.
+   * @param storeConfig {@link StoreConfig} object.
+   * @param storeManager {@link StoreManager} object to get stores for replicas.
+   * @param storeKeyFactory {@link StoreKeyFactory} object.
+   * @param clusterMap {@link ClusterMap} object to get the ambry datanode cluster map.
+   * @param scheduler {@link ScheduledExecutorService} object for scheduling token persistence.
+   * @param currentNode {@link DataNodeId} representing the current node.
+   * @param connectionPool {@link ConnectionPool} object representing the connection pool to talk to replicas.
+   * @param metricRegistry {@link MetricRegistry} object.
+   * @param requestNotification {@link NotificationSystem} object to notify on events.
+   * @param storeKeyConverterFactory {@link StoreKeyConverterFactory} object.
+   * @param transformerClassName name of the class to transform and validate replication messages.
+   * @param vcrClusterSpectator {@link ClusterSpectator} object to get changes in vcr cluster map.
+   * @param clusterParticipant {@link ClusterParticipant} object to get changes in partition state of partitions on datanodes.
+   * @throws ReplicationException
+   */
+  public CloudToStoreReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
+      StoreConfig storeConfig, StoreManager storeManager, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap,
+      ScheduledExecutorService scheduler, DataNodeId currentNode, ConnectionPool connectionPool,
+      MetricRegistry metricRegistry, NotificationSystem requestNotification,
+      StoreKeyConverterFactory storeKeyConverterFactory, String transformerClassName,
+      ClusterSpectator vcrClusterSpectator, ClusterParticipant clusterParticipant) throws ReplicationException {
+    super(replicationConfig, clusterMapConfig, storeKeyFactory, clusterMap, scheduler, currentNode,
+        Collections.emptyList(), connectionPool, metricRegistry, requestNotification, storeKeyConverterFactory,
+        transformerClassName);
+    this.clusterMapConfig = clusterMapConfig;
+    this.storeConfig = storeConfig;
+    this.storeManager = storeManager;
+    this.vcrClusterSpectator = vcrClusterSpectator;
+    this.clusterParticipant = clusterParticipant;
+    this.instanceNameToCloudDataNode = new ConcurrentHashMap<>();
+    this.vcrNodes = new ConcurrentSkipListSet<>();
+    this.persistor =
+        new DiskTokenPersistor(cloudReplicaTokenFileName, mountPathToPartitionInfos, replicationMetrics, clusterMap,
+            tokenHelper);
+    this.localPartitionNameToPartition = mapPartitionNameToPartition(clusterMap, currentNode);
+  }
+
+  private ConcurrentHashMap<String, PartitionId> mapPartitionNameToPartition(ClusterMap clusterMap,
+      DataNodeId localNode) {
+    List<? extends ReplicaId> localReplicas = clusterMap.getReplicaIds(localNode);
+    return localReplicas.stream()
+        .collect(Collectors.toMap(replicaId -> replicaId.getPartitionId().toPathString(), ReplicaId::getPartitionId,
+            (e1, e2) -> e2, ConcurrentHashMap::new));
+  }
+
+  @Override
+  public void start() throws ReplicationException {
+    // Add listener for vcr instance config changes
+    vcrClusterSpectator.registerInstanceConfigChangeListener(new InstanceConfigChangeListener() {
+      @Override
+      public void onInstanceConfigChange(List<InstanceConfig> instanceConfigs, NotificationContext context) {
+        ConcurrentSkipListSet<CloudDataNode> newVcrNodes = new ConcurrentSkipListSet<>();
+        ConcurrentHashMap<String, CloudDataNode> newInstanceNameToCloudDataNode = new ConcurrentHashMap<>();
+        Set<CloudDataNode> removedNodes = new HashSet<>(vcrNodes);
+        synchronized (notificationLock) {
+          for (InstanceConfig instanceConfig : instanceConfigs) {
+            String instanceName = instanceConfig.getInstanceName();
+            Port sslPort =
+                getSslPortStr(instanceConfig) == null ? null : new Port(getSslPortStr(instanceConfig), PortType.SSL);
+            CloudDataNode cloudDataNode = new CloudDataNode(instanceConfig.getHostName(),
+                new Port(Integer.valueOf(instanceConfig.getPort()), PortType.PLAINTEXT), sslPort,
+                clusterMapConfig.clustermapVcrDatacenterName, clusterMapConfig);
+            newInstanceNameToCloudDataNode.put(instanceName, cloudDataNode);
+            newVcrNodes.add(cloudDataNode);
+          }
+          removedNodes.removeAll(newVcrNodes);
+          vcrNodes = newVcrNodes;
+          instanceNameToCloudDataNode = newInstanceNameToCloudDataNode;
+          List<PartitionId> partitionsOnRemovedNodes = getPartitionsOnRemovedNodes(removedNodes);
+          for (PartitionId partitionId : partitionsOnRemovedNodes) {
+            try {
+              removeCloudReplica(partitionId.toPathString());
+              addCloudReplica(partitionId.toPathString());
+            } catch (ReplicationException rex) {
+              logger.error("Could not remove/add replica for partitionId {}", partitionId);
+            }
+          }
+        }
+      }
+    });
+
+    // Add listener for vcr instance liveness changes
+    vcrClusterSpectator.registerLiveInstanceChangeListener(new LiveInstanceChangeListener() {
+      @Override
+      public void onLiveInstanceChange(List<LiveInstance> liveInstances, NotificationContext changeContext) {
+        ConcurrentSkipListSet<CloudDataNode> newVcrNodes = new ConcurrentSkipListSet<>();
+        synchronized (notificationLock) {
+          for (LiveInstance liveInstance : liveInstances) {
+            if (instanceNameToCloudDataNode.containsKey(liveInstance.getInstanceName())) {
+              newVcrNodes.add(instanceNameToCloudDataNode.get(liveInstance.getInstanceName()));
+            }
+          }
+          Set<CloudDataNode> removedNodes = new HashSet<>(vcrNodes);
+          removedNodes.removeAll(newVcrNodes);
+          vcrNodes = newVcrNodes;
+          List<PartitionId> partitionsOnRemovedNodes = getPartitionsOnRemovedNodes(removedNodes);
+          for (PartitionId partitionId : partitionsOnRemovedNodes) {
+            try {
+              removeCloudReplica(partitionId.toPathString());
+              addCloudReplica(partitionId.toPathString());
+            } catch (ReplicationException rex) {
+              logger.error("Could not remove/add replica for partitionId {}", partitionId);
+            }
+          }
+        }
+      }
+    });
+
+    // Add listener for new coming assigned partition
+    clusterParticipant.registerPartitionStateChangeListener(new PartitionStateChangeListener() {
+      @Override
+      public void onPartitionLeadFromStandby(String partitionName) {
+        synchronized (notificationLock) {
+          try {
+            addCloudReplica(partitionName);
+          } catch (ReplicationException rex) {
+            logger.error("Could not add replication for paritition {}", partitionName);
+          }
+        }
+      }
+
+      @Override
+      public void onPartitionStandbyFromLead(String partitionName) {
+        synchronized (notificationLock) {
+          try {
+            removeCloudReplica(partitionName);
+          } catch (Exception e) {
+            // Helix will run into error state if exception throws in Helix context.
+            logger.error("Exception on removing Partition {} from {}: ", partitionName, dataNodeId, e);
+          }
+        }
+      }
+    });
+
+    // start background persistent thread
+    // start scheduler thread to persist index in the background
+    scheduler.scheduleAtFixedRate(persistor, replicationConfig.replicationTokenFlushDelaySeconds,
+        replicationConfig.replicationTokenFlushIntervalSeconds, TimeUnit.SECONDS);
+  }
+
+  private List<PartitionId> getPartitionsOnRemovedNodes(Set<CloudDataNode> removedNodes) {
+    List<PartitionId> partitionsOnRemovedNodes = new LinkedList<>();
+    Set<String> removedHostNames = removedNodes.stream().map(DataNodeId::getHostname).collect(Collectors.toSet());
+    for (Map.Entry<PartitionId, PartitionInfo> entry : partitionToPartitionInfo.entrySet()) {
+      List<RemoteReplicaInfo> remotes = entry.getValue()
+          .getRemoteReplicaInfos()
+          .stream()
+          .filter(remoteReplicaInfo -> removedHostNames.contains(
+              remoteReplicaInfo.getReplicaId().getDataNodeId().getHostname()))
+          .collect(Collectors.toList());
+      if (!remotes.isEmpty()) {
+        partitionsOnRemovedNodes.add(entry.getKey());
+      }
+    }
+    return partitionsOnRemovedNodes;
+  }
+
+  /**
+   * Add a replica of given partition and its {@link RemoteReplicaInfo}s to backup list.
+   * @param partitionName name of the partition of the replica to add.
+   * @throws ReplicationException if replicas initialization failed.
+   */
+  private void addCloudReplica(String partitionName) throws ReplicationException {
+    if (!localPartitionNameToPartition.containsKey(partitionName)) {
+      logger.error("Got partition leader notification for partition {} that is not present on the node", partitionName);
+      return;
+    }
+    PartitionId partitionId = localPartitionNameToPartition.get(partitionName);
+    Store store = storeManager.getStore(partitionId);
+    if (store == null) {
+      logger.error("Unable to add cloud replica for partition {} as store for the partition doesn't exist.",
+          partitionName);
+      return;
+    }
+    ReplicaId localReplicaId = (ReplicaId) partitionId.getReplicaIds()
+        .stream()
+        .filter(r -> (r.getDataNodeId().getHostname().equals(dataNodeId.getHostname())))
+        .toArray()[0];
+    CloudReplica peerReplica = new CloudReplica(partitionId, getCloudDataNode());
+    FindTokenFactory findTokenFactory = tokenHelper.getFindTokenFactoryFromReplicaType(peerReplica.getReplicaType());
+    RemoteReplicaInfo remoteReplicaInfo =
+        new RemoteReplicaInfo(peerReplica, localReplicaId, store, findTokenFactory.getNewFindToken(),
+            storeConfig.storeDataFlushIntervalSeconds * SystemTime.MsPerSec * Replication_Delay_Multiplier,
+            SystemTime.getInstance(), peerReplica.getDataNodeId().getPortToConnectTo());
+    replicationMetrics.addMetricsForRemoteReplicaInfo(remoteReplicaInfo);
+    List<RemoteReplicaInfo> remoteReplicaInfos = Collections.singletonList(remoteReplicaInfo);
+    PartitionInfo partitionInfo = new PartitionInfo(remoteReplicaInfos, partitionId, store, localReplicaId);
+    partitionToPartitionInfo.put(partitionId, partitionInfo);
+    mountPathToPartitionInfos.computeIfAbsent(localReplicaId.getMountPath(), key -> ConcurrentHashMap.newKeySet())
+        .add(partitionInfo);
+    logger.info("Cloud Partition {} added to {}", partitionName, dataNodeId);
+
+    // Reload replication token if exist.
+    List<RemoteReplicaInfo.ReplicaTokenInfo> tokenInfos = persistor.retrieve(localReplicaId.getMountPath());
+    if (tokenInfos.size() != 0) {
+      for (RemoteReplicaInfo remoteInfo : remoteReplicaInfos) {
+        boolean tokenReloaded = false;
+        for (RemoteReplicaInfo.ReplicaTokenInfo tokenInfo : tokenInfos) {
+          if (isTokenForRemoteReplicaInfo(remoteInfo, tokenInfo)) {
+            logger.info("Read token for partition {} remote host {} port {} token {}", partitionId,
+                tokenInfo.getHostname(), tokenInfo.getPort(), tokenInfo.getReplicaToken());
+            tokenReloaded = true;
+            remoteInfo.initializeTokens(tokenInfo.getReplicaToken());
+            remoteInfo.setTotalBytesReadFromLocalStore(tokenInfo.getTotalBytesReadFromLocalStore());
+            break;
+          }
+        }
+        if (!tokenReloaded) {
+          // This may happen on clusterMap update: replica removed or added.
+          // Or error on token persist/retrieve.
+          logger.warn("Token not found or reload failed. remoteReplicaInfo: {} tokenInfos: {}", remoteInfo, tokenInfos);
+        }
+      }
+    }
+    // Add remoteReplicaInfos to {@link ReplicaThread}.
+    addRemoteReplicaInfoToReplicaThread(remoteReplicaInfos, true);
+    if (replicationConfig.replicationTrackPerPartitionLagFromRemote) {
+      replicationMetrics.addLagMetricForPartition(partitionId);
+    }
+  }
+
+  Add CloudToStoreReplicationManager to separate out replication from cloud replicas to data nodes.
+  Add Code to enable spectator on helix vcr cluster and to react to changes on helix.
+
+  /**
+   * Remove a replica of given partition and its {@link RemoteReplicaInfo}s from the backup list.
+   * @param partitionName the partition of the replica to removed.
+   * @throws ReplicationException if replicas initialization failed.
+   */
+  private void removeCloudReplica(String partitionName) throws ReplicationException {
+    if (!localPartitionNameToPartition.containsKey(partitionName)) {
+      logger.error("Got partition standby notification for partition {} that is not present on the node",
+          partitionName);
+      return;
+    }
+    PartitionId partitionId = localPartitionNameToPartition.get(partitionName);
+    PartitionInfo partitionInfo = partitionToPartitionInfo.remove(partitionId);
+    if (partitionInfo == null) {
+      logger.error("Partition {} not exist when remove from {}. ", partitionId, dataNodeId);
+      throw new ReplicationException("Partition not found");
+    }
+    removeRemoteReplicaInfoFromReplicaThread(partitionInfo.getRemoteReplicaInfos());
+    if (replicationConfig.replicationPersistTokenOnShutdownOrReplicaRemove) {
+      try {
+        persistor.write(partitionInfo.getLocalReplicaId().getMountPath(), false);
+      } catch (IOException | ReplicationException e) {
+        logger.error("Exception on token write when remove Partition {} from {}: ", partitionId, dataNodeId, e);
+        throw new ReplicationException("Exception on token write.");
+      }
+    }
+    logger.info("Cloud Partition {} removed from {}", partitionId, dataNodeId);
+  }
+
+  private DataNodeId getCloudDataNode() {
+    return vcrNodes.toArray(new CloudDataNode[0])[Utils.getRandomShort(new Random()) % vcrNodes.size()];
+  }
+}

--- a/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
@@ -114,6 +114,13 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
     this.localPartitionNameToPartition = mapPartitionNameToPartition(clusterMap, currentNode);
   }
 
+  /**
+   * Create a {@link Map} of partition name to {@link PartitionId} for local replicas on specified node from
+   * specified cluster map.
+   * @param clusterMap specified {@link ClusterMap} object.
+   * @param localNode specified {@link DataNodeId} object.
+   * @return
+   */
   private ConcurrentHashMap<String, PartitionId> mapPartitionNameToPartition(ClusterMap clusterMap,
       DataNodeId localNode) {
     return clusterMap.getReplicaIds(localNode)

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -24,7 +24,6 @@ import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.network.ConnectionPool;
 import com.github.ambry.notification.NotificationSystem;
-import com.github.ambry.protocol.GetRequest;
 import com.github.ambry.store.StoreKeyConverter;
 import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
@@ -400,5 +399,62 @@ public abstract class ReplicationEngine implements ReplicationAPI {
         && dataNodeId.getPort() == tokenInfo.getPort() && remoteReplicaInfo.getReplicaId()
         .getReplicaPath()
         .equals(tokenInfo.getReplicaPath());
+  }
+
+  /**
+   * Reload replication token if exist for all remote replicas of {@code localReplicaId}.
+   * @param localReplicaId local {@link ReplicaId} for which to reload tokens.
+   * @param remoteReplicaInfos {@link List} of {@link RemoteReplicaInfo} of the {@code localReplicaId}.
+   * @return Number of remote replicas for which reload failed.
+   */
+  protected int reloadReplicationTokenIfExists(ReplicaId localReplicaId, List<RemoteReplicaInfo> remoteReplicaInfos)
+      throws ReplicationException {
+    int tokenReloadFailureCount = 0;
+    List<RemoteReplicaInfo.ReplicaTokenInfo> tokenInfos = persistor.retrieve(localReplicaId.getMountPath());
+    if (tokenInfos.size() != 0) {
+      for (RemoteReplicaInfo remoteReplicaInfo : remoteReplicaInfos) {
+        boolean tokenReloaded = false;
+        for (RemoteReplicaInfo.ReplicaTokenInfo tokenInfo : tokenInfos) {
+          if (isTokenForRemoteReplicaInfo(remoteReplicaInfo, tokenInfo)) {
+            logger.info("Read token for partition {} remote host {} port {} token {}", localReplicaId.getPartitionId(),
+                tokenInfo.getHostname(), tokenInfo.getPort(), tokenInfo.getReplicaToken());
+            tokenReloaded = true;
+            remoteReplicaInfo.initializeTokens(tokenInfo.getReplicaToken());
+            remoteReplicaInfo.setTotalBytesReadFromLocalStore(tokenInfo.getTotalBytesReadFromLocalStore());
+            break;
+          }
+        }
+        if (!tokenReloaded) {
+          // This may happen on clusterMap update: replica removed or added.
+          // Or error on token persist/retrieve.
+          logger.warn("Token not found or reload failed. remoteReplicaInfo: {} tokenInfos: {}", remoteReplicaInfo,
+              tokenInfos);
+          tokenReloadFailureCount++;
+        }
+      }
+    }
+    return tokenReloadFailureCount;
+  }
+
+  /**
+   * Stop replication for the specified {@link PartitionId}.
+   * @param partitionId {@link PartitionId} for which replication should be removed.
+   * @throws ReplicationException
+   */
+  protected void stopPartitionReplication(PartitionId partitionId) throws ReplicationException {
+    PartitionInfo partitionInfo = partitionToPartitionInfo.remove(partitionId);
+    if (partitionInfo == null) {
+      logger.warn("Partition {} not exist when remove from {}. ", partitionId, dataNodeId);
+      return;
+    }
+    removeRemoteReplicaInfoFromReplicaThread(partitionInfo.getRemoteReplicaInfos());
+    if (replicationConfig.replicationPersistTokenOnShutdownOrReplicaRemove) {
+      try {
+        persistor.write(partitionInfo.getLocalReplicaId().getMountPath(), false);
+      } catch (IOException | ReplicationException e) {
+        throw new ReplicationException(
+            "Exception on token write when removing Partition " + partitionId + " from: " + dataNodeId);
+      }
+    }
   }
 }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -14,6 +14,7 @@
 package com.github.ambry.replication;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.CloudReplica;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
@@ -170,7 +171,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
         break;
       }
     }
-    if (foundRemoteReplicaInfo == null && !replicaPath.startsWith(GetRequest.Cloud_Replica_Keyword)) {
+    if (foundRemoteReplicaInfo == null && !replicaPath.startsWith(CloudReplica.Cloud_Replica_Keyword)) {
       replicationMetrics.unknownRemoteReplicaRequestCount.inc();
       logger.error("ReplicaMetaDataRequest from unknown Replica {}, with path {}", hostName, replicaPath);
     }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -439,9 +439,8 @@ public abstract class ReplicationEngine implements ReplicationAPI {
   /**
    * Stop replication for the specified {@link PartitionId}.
    * @param partitionId {@link PartitionId} for which replication should be removed.
-   * @throws ReplicationException
    */
-  protected void stopPartitionReplication(PartitionId partitionId) throws ReplicationException {
+  protected void stopPartitionReplication(PartitionId partitionId) {
     PartitionInfo partitionInfo = partitionToPartitionInfo.remove(partitionId);
     if (partitionInfo == null) {
       logger.warn("Partition {} not exist when remove from {}. ", partitionId, dataNodeId);
@@ -452,8 +451,8 @@ public abstract class ReplicationEngine implements ReplicationAPI {
       try {
         persistor.write(partitionInfo.getLocalReplicaId().getMountPath(), false);
       } catch (IOException | ReplicationException e) {
-        throw new ReplicationException(
-            "Exception on token write when removing Partition " + partitionId + " from: " + dataNodeId);
+        logger.warn(
+            "Exception " + e + " on token write when removing Partition " + partitionId + " from: " + dataNodeId);
       }
     }
   }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -451,7 +451,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
       try {
         persistor.write(partitionInfo.getLocalReplicaId().getMountPath(), false);
       } catch (IOException | ReplicationException e) {
-        logger.warn(
+        logger.error(
             "Exception " + e + " on token write when removing Partition " + partitionId + " from: " + dataNodeId);
       }
     }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationMetrics.java
@@ -125,6 +125,10 @@ public class ReplicationMetrics {
   public final Counter remoteReplicaInfoAddError;
   public final Counter allResponsedKeysExist;
 
+  // Metrics for replication from cloud
+  public final Counter addCloudPartitionErrorCount;
+  public final Counter cloudTokenReloadWarnCount;
+
   private MetricRegistry registry;
   private Map<String, Counter> metadataRequestErrorMap;
   private Map<String, Counter> getRequestErrorMap;
@@ -239,6 +243,10 @@ public class ReplicationMetrics {
         registry.counter(MetricRegistry.name(ReplicaThread.class, "RemoteReplicaInfoRemoveError"));
     remoteReplicaInfoAddError = registry.counter(MetricRegistry.name(ReplicaThread.class, "RemoteReplicaInfoAddError"));
     allResponsedKeysExist = registry.counter(MetricRegistry.name(ReplicaThread.class, "AllResponsedKeysExist"));
+    addCloudPartitionErrorCount =
+        registry.counter(MetricRegistry.name(CloudToStoreReplicationManager.class, "AddCloudPartitionErrorCount"));
+    cloudTokenReloadWarnCount =
+        registry.counter(MetricRegistry.name(CloudToStoreReplicationManager.class, "CloudTokenReloadWarnCount"));
     this.registry = registry;
     populateInvalidMessageMetricForReplicas(replicaIds);
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/CloudRouterFactory.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/CloudRouterFactory.java
@@ -15,11 +15,11 @@ package com.github.ambry.router;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.AccountService;
-import com.github.ambry.cloud.CloudDataNode;
 import com.github.ambry.cloud.CloudDestination;
 import com.github.ambry.cloud.CloudDestinationFactory;
 import com.github.ambry.cloud.CloudStorageManager;
 import com.github.ambry.cloud.VcrMetrics;
+import com.github.ambry.clustermap.CloudDataNode;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.commons.BlobIdFactory;

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/DirectSender.java
@@ -33,7 +33,7 @@ import org.junit.Assert;
 
 
 /**
- *
+ * Sender for put messages directly to server nodes.
  */
 class DirectSender implements Runnable {
 
@@ -45,6 +45,17 @@ class DirectSender implements Runnable {
   BlobProperties blobProperties;
   CountDownLatch endLatch;
 
+  /**
+   * Constructor for {@link DirectSender} object.
+   * @param cluster {@link MockCluster} object to obtain {@link MockClusterMap} from.
+   * @param channel {@link BlockingChannel} object to connect to destination.
+   * @param totalBlobsToPut number of blobs to put.
+   * @param data data to put in each blob.
+   * @param usermetadata user metadata to put in each blob.
+   * @param blobProperties {@link BlobProperties} object to add to each blob.
+   * @param encryptionKey encryption key to encrypt blobs.
+   * @param endLatch {@link CountDownLatch} object to signal all blobs have been uploaded.
+   */
   public DirectSender(MockCluster cluster, BlockingChannel channel, int totalBlobsToPut, byte[] data,
       byte[] usermetadata, BlobProperties blobProperties, byte[] encryptionKey, CountDownLatch endLatch) {
     MockClusterMap clusterMap = cluster.getClusterMap();
@@ -63,6 +74,27 @@ class DirectSender implements Runnable {
     this.blobProperties = blobProperties;
     this.encryptionKey = encryptionKey;
     this.endLatch = endLatch;
+  }
+
+  /**
+   * Constructor for {@link DirectSender} object.
+   * @param channel {@link BlockingChannel} object to connect to destination.
+   * @param blobIds {@link List} of {@link BlobId}s to send.
+   * @param data data data to put in each blob.
+   * @param usermetadata usermetadata user metadata to put in each blob.
+   * @param blobProperties {@link BlobProperties} object to add to each blob.
+   * @param encryptionKey encryption key to encrypt blobs.
+   * @param endLatch {@link CountDownLatch} object to signal all blobs have been uploaded.
+   */
+  public DirectSender(BlockingChannel channel, List<BlobId> blobIds, byte[] data, byte[] usermetadata,
+      BlobProperties blobProperties, byte[] encryptionKey, CountDownLatch endLatch) {
+    this.channel = channel;
+    this.data = data;
+    this.usermetadata = usermetadata;
+    this.blobProperties = blobProperties;
+    this.encryptionKey = encryptionKey;
+    this.endLatch = endLatch;
+    this.blobIds = blobIds;
   }
 
   @Override
@@ -86,8 +118,11 @@ class DirectSender implements Runnable {
     }
   }
 
+  /**
+   * Get {@link List} of {@link BlobId}s.
+   * @return {@link List} of {@link BlobId}s.
+   */
   List<BlobId> getBlobIds() {
     return blobIds;
   }
 }
-

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -163,7 +163,7 @@ public class MockCluster {
         dataNodes.get(i).setSslEnabledDataCenters(sslEnabledDataCenterList);
       }
       initializeServer(dataNodes.get(i), sslProps, enableHardDeletes, prefetchDataNodeIndex == i, notificationSystem,
-          time);
+          time, null);
     }
   }
 
@@ -184,7 +184,7 @@ public class MockCluster {
       }
       sslProps.putAll(props);
       initializeServer(dataNodes.get(i), sslProps, enableHardDeletes, prefetchDataNodeIndex == i, notificationSystem,
-          time);
+          time, null);
     }
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -262,33 +262,20 @@ public class MockCluster {
    * @param enableDataPrefetch {@code enableDataPrefetch} flag.
    * @param notificationSystem {@link NotificationSystem} object.
    * @param time {@link Time} object.
-   * @return {@link VerifiableProperties} object.
-   */
-  public void initializeServer(DataNodeId dataNodeId, Properties sslProperties, boolean enableHardDeletes,
-      boolean enableDataPrefetch, NotificationSystem notificationSystem, Time time) {
-    AmbryServer server =
-        new AmbryServer(createInitProperties(dataNodeId, enableDataPrefetch, enableHardDeletes, sslProperties),
-            mockClusterAgentsFactory, mockClusterSpectatorFactory, notificationSystem, time);
-    serverList.add(server);
-  }
-
-  /**
-   * Initialize {@link AmbryServer} node.
-   * @param dataNodeId {@link DataNodeId} object of the server initialized.
-   * @param sslProperties {@link Properties} object.
-   * @param enableHardDeletes {@code enableHardDeletes} flag.
-   * @param enableDataPrefetch {@code enableDataPrefetch} flag.
-   * @param notificationSystem {@link NotificationSystem} object.
-   * @param time {@link Time} object.
-   * @param mockClusterAgentsFactory {@link MockClusterAgentsFactory} object.
+   * @param mockClusterAgentsFactory {@link MockClusterAgentsFactory} object. If null, use the member {@code mockClusterAgentsFactory}.
    * @return {@link VerifiableProperties} object.
    */
   public void initializeServer(DataNodeId dataNodeId, Properties sslProperties, boolean enableHardDeletes,
       boolean enableDataPrefetch, NotificationSystem notificationSystem, Time time,
       MockClusterAgentsFactory mockClusterAgentsFactory) {
-    AmbryServer server =
-        new AmbryServer(createInitProperties(dataNodeId, enableDataPrefetch, enableHardDeletes, sslProperties),
-            mockClusterAgentsFactory, mockClusterSpectatorFactory, notificationSystem, time);
+    AmbryServer server;
+    if (mockClusterAgentsFactory != null) {
+      server = new AmbryServer(createInitProperties(dataNodeId, enableDataPrefetch, enableHardDeletes, sslProperties),
+          mockClusterAgentsFactory, mockClusterSpectatorFactory, notificationSystem, time);
+    } else {
+      server = new AmbryServer(createInitProperties(dataNodeId, enableDataPrefetch, enableHardDeletes, sslProperties),
+          this.mockClusterAgentsFactory, mockClusterSpectatorFactory, notificationSystem, time);
+    }
     serverList.add(server);
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -17,9 +17,11 @@ import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterAgentsFactory;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ClusterSpectatorFactory;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterAgentsFactory;
 import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockClusterSpectatorFactory;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
@@ -60,6 +62,7 @@ import static org.junit.Assert.*;
 public class MockCluster {
   private static final Logger logger = LoggerFactory.getLogger(MockCluster.class);
   private final MockClusterAgentsFactory mockClusterAgentsFactory;
+  private MockClusterSpectatorFactory mockClusterSpectatorFactory;
   private final MockClusterMap clusterMap;
   private final List<AmbryServer> serverList;
   private boolean serverInitialized = false;
@@ -94,6 +97,21 @@ public class MockCluster {
     prefetchDataNodeIndex = clusterMap.getDataNodes().size() - 1;
   }
 
+  public MockCluster(MockClusterMap mockClusterMap, List<MockDataNodeId> cloudDataNodes, Properties sslProps) {
+    this.sslProps = sslProps;
+    this.enableHardDeletes = false;
+    this.time = SystemTime.getInstance();
+
+    sslEnabledDataCenterList = new ArrayList<>();
+    mockClusterAgentsFactory = new MockClusterAgentsFactory(mockClusterMap, null);
+    clusterMap = mockClusterMap;
+    serverList = new ArrayList<>();
+    generalDataNodeIndex = 0;
+    prefetchDataNodeIndex = clusterMap.getDataNodes().size() - 1;
+
+    mockClusterSpectatorFactory = new MockClusterSpectatorFactory(cloudDataNodes);
+  }
+
   /**
    * Creates {@link MockCluster} object based on the {@code mockClusterMap} passed.
    * @param mockClusterMap {@link MockClusterMap} from which to create the cluster.
@@ -111,7 +129,7 @@ public class MockCluster {
     sslEnabledDataCenterList =
         sslEnabledDataCentersStr != null ? Utils.splitString(sslEnabledDataCentersStr, ",") : new ArrayList<>();
 
-    mockClusterAgentsFactory = new MockClusterAgentsFactory(mockClusterMap);
+    mockClusterAgentsFactory = new MockClusterAgentsFactory(mockClusterMap, null);
     clusterMap = mockClusterMap;
 
     serverList = new ArrayList<>();
@@ -202,8 +220,20 @@ public class MockCluster {
     return mockClusterAgentsFactory;
   }
 
-  private void initializeServer(DataNodeId dataNodeId, Properties sslProperties, boolean enableHardDeletes,
-      boolean enableDataPrefetch, NotificationSystem notificationSystem, Time time) {
+  public ClusterSpectatorFactory getClusterSpectatorFactory() {
+    return mockClusterSpectatorFactory;
+  }
+
+  /**
+   * Create initialization {@link VerifiableProperties} for server.
+   * @param dataNodeId {@link DataNodeId} object of the server initialized.
+   * @param enableDataPrefetch {@code enableDataPrefetch} flag.
+   * @param enableHardDeletes {@code enableHardDeletes} flag.
+   * @param sslProperties {@link Properties} object.
+   * @return {@link VerifiableProperties} object.
+   */
+  private VerifiableProperties createInitProperties(DataNodeId dataNodeId, boolean enableDataPrefetch,
+      boolean enableHardDeletes, Properties sslProperties) {
     Properties props = new Properties();
     props.setProperty("host.name", dataNodeId.getHostname());
     props.setProperty("port", Integer.toString(dataNodeId.getPort()));
@@ -221,8 +251,44 @@ public class MockCluster {
     props.setProperty("replication.intra.replica.thread.throttle.sleep.duration.ms", "100");
     props.setProperty("replication.inter.replica.thread.throttle.sleep.duration.ms", "100");
     props.putAll(sslProperties);
-    VerifiableProperties propverify = new VerifiableProperties(props);
-    AmbryServer server = new AmbryServer(propverify, mockClusterAgentsFactory, notificationSystem, time);
+    return new VerifiableProperties(props);
+  }
+
+  /**
+   * Initialize {@link AmbryServer} node.
+   * @param dataNodeId {@link DataNodeId} object of the server initialized.
+   * @param sslProperties {@link Properties} object.
+   * @param enableHardDeletes {@code enableHardDeletes} flag.
+   * @param enableDataPrefetch {@code enableDataPrefetch} flag.
+   * @param notificationSystem {@link NotificationSystem} object.
+   * @param time {@link Time} object.
+   * @return {@link VerifiableProperties} object.
+   */
+  public void initializeServer(DataNodeId dataNodeId, Properties sslProperties, boolean enableHardDeletes,
+      boolean enableDataPrefetch, NotificationSystem notificationSystem, Time time) {
+    AmbryServer server =
+        new AmbryServer(createInitProperties(dataNodeId, enableDataPrefetch, enableHardDeletes, sslProperties),
+            mockClusterAgentsFactory, mockClusterSpectatorFactory, notificationSystem, time);
+    serverList.add(server);
+  }
+
+  /**
+   * Initialize {@link AmbryServer} node.
+   * @param dataNodeId {@link DataNodeId} object of the server initialized.
+   * @param sslProperties {@link Properties} object.
+   * @param enableHardDeletes {@code enableHardDeletes} flag.
+   * @param enableDataPrefetch {@code enableDataPrefetch} flag.
+   * @param notificationSystem {@link NotificationSystem} object.
+   * @param time {@link Time} object.
+   * @param mockClusterAgentsFactory {@link MockClusterAgentsFactory} object.
+   * @return {@link VerifiableProperties} object.
+   */
+  public void initializeServer(DataNodeId dataNodeId, Properties sslProperties, boolean enableHardDeletes,
+      boolean enableDataPrefetch, NotificationSystem notificationSystem, Time time,
+      MockClusterAgentsFactory mockClusterAgentsFactory) {
+    AmbryServer server =
+        new AmbryServer(createInitProperties(dataNodeId, enableDataPrefetch, enableHardDeletes, sslProperties),
+            mockClusterAgentsFactory, mockClusterSpectatorFactory, notificationSystem, time);
     serverList.add(server);
   }
 

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
@@ -197,7 +197,7 @@ public class VcrRecoveryTest {
       assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
           partitionResponseInfo.getErrorCode());
       for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
-        assertEquals(blobIdToSizeMap.get((BlobId) messageInfo.getStoreKey()) + 270, messageInfo.getSize());
+        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 270, messageInfo.getSize());
       }
     }
   }

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryMain.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryMain.java
@@ -14,6 +14,8 @@
 package com.github.ambry.server;
 
 import com.github.ambry.clustermap.ClusterAgentsFactory;
+import com.github.ambry.clustermap.ClusterSpectatorFactory;
+import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.InvocationOptions;
@@ -38,11 +40,14 @@ public class AmbryMain {
       Properties properties = Utils.loadProps(options.serverPropsFilePath);
       VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
       ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+      CloudConfig cloudConfig = new CloudConfig(verifiableProperties);
       ClusterAgentsFactory clusterAgentsFactory =
           Utils.getObj(clusterMapConfig.clusterMapClusterAgentsFactory, clusterMapConfig,
               options.hardwareLayoutFilePath, options.partitionLayoutFilePath);
       logger.info("Bootstrapping AmbryServer");
-      ambryServer = new AmbryServer(verifiableProperties, clusterAgentsFactory, SystemTime.getInstance());
+      ClusterSpectatorFactory clusterSpectatorFactory = Utils.getObj(cloudConfig.vcrClusterSpectatorFactoryClass);
+      ambryServer = new AmbryServer(verifiableProperties, clusterAgentsFactory, clusterSpectatorFactory,
+          SystemTime.getInstance());
       // attach shutdown handler to catch control-c
       Runtime.getRuntime().addShutdownHook(new Thread() {
         public void run() {

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
@@ -164,6 +164,7 @@ public class AmbryServer {
       replicationManager.start();
 
       if (replicationConfig.replicationEnabledWithVcrCluster) {
+        logger.info("Creating Helix cluster spectator for cloud to store replication.");
         vcrClusterSpectator = new HelixClusterSpectatorFactory().getClusterSpectator(cloudConfig, clusterMapConfig);
         cloudToStoreReplicationManager =
             new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
@@ -163,7 +163,7 @@ public class AmbryServer {
               serverConfig.serverMessageTransformer);
       replicationManager.start();
 
-      if (replicationConfig.isVcrClusterReplicationEnabled) {
+      if (replicationConfig.replicationEnabledWithVcrCluster) {
         vcrClusterSpectator = new HelixClusterSpectatorFactory().getClusterSpectator(cloudConfig, clusterMapConfig);
         cloudToStoreReplicationManager =
             new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
@@ -246,6 +246,9 @@ public class AmbryServer {
       }
       if (requestHandlerPool != null) {
         requestHandlerPool.shutdown();
+      }
+      if (cloudToStoreReplicationManager != null) {
+        cloudToStoreReplicationManager.shutdown();
       }
       if (replicationManager != null) {
         replicationManager.shutdown();

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
@@ -19,8 +19,8 @@ import com.github.ambry.clustermap.ClusterAgentsFactory;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.ClusterSpectator;
+import com.github.ambry.clustermap.ClusterSpectatorFactory;
 import com.github.ambry.clustermap.DataNodeId;
-import com.github.ambry.clustermap.HelixClusterSpectatorFactory;
 import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.commons.LoggingNotificationSystem;
 import com.github.ambry.commons.ServerMetrics;
@@ -86,6 +86,7 @@ public class AmbryServer {
   private Logger logger = LoggerFactory.getLogger(getClass());
   private final VerifiableProperties properties;
   private final ClusterAgentsFactory clusterAgentsFactory;
+  private final ClusterSpectatorFactory clusterSpectatorFactory;
   private ClusterMap clusterMap;
   private ClusterParticipant clusterParticipant;
   private ClusterSpectator vcrClusterSpectator;
@@ -96,15 +97,21 @@ public class AmbryServer {
   private ServerMetrics metrics = null;
   private Time time;
 
-  public AmbryServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory, Time time)
-      throws IOException {
-    this(properties, clusterAgentsFactory, new LoggingNotificationSystem(), time);
+  public AmbryServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory,
+      ClusterSpectatorFactory clusterSpectatorFactory, Time time) {
+    this(properties, clusterAgentsFactory, clusterSpectatorFactory, new LoggingNotificationSystem(), time);
   }
 
   public AmbryServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory,
       NotificationSystem notificationSystem, Time time) {
+    this(properties, clusterAgentsFactory, null, notificationSystem, time);
+  }
+
+  public AmbryServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory,
+      ClusterSpectatorFactory clusterSpectatorFactory, NotificationSystem notificationSystem, Time time) {
     this.properties = properties;
     this.clusterAgentsFactory = clusterAgentsFactory;
+    this.clusterSpectatorFactory = clusterSpectatorFactory;
     this.notificationSystem = notificationSystem;
     this.time = time;
   }
@@ -165,7 +172,7 @@ public class AmbryServer {
 
       if (replicationConfig.replicationEnabledWithVcrCluster) {
         logger.info("Creating Helix cluster spectator for cloud to store replication.");
-        vcrClusterSpectator = new HelixClusterSpectatorFactory().getClusterSpectator(cloudConfig, clusterMapConfig);
+        vcrClusterSpectator = clusterSpectatorFactory.getClusterSpectator(cloudConfig, clusterMapConfig);
         cloudToStoreReplicationManager =
             new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
                 storeKeyFactory, clusterMap, scheduler, nodeId, connectionPool, registry, notificationSystem,


### PR DESCRIPTION
Add CloudToStoreReplicationManager to separate out replication from cloud replicas to data nodes.
Add Code to enable spectator on helix vcr cluster and to react to changes on helix.
Add listener for partition leadership changes.