### PR TITLE
Adding reset() method to BlockingChannel

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
@@ -64,7 +64,7 @@ public class ConnectionPoolConfig {
    * Use TCP RST instead of FIN on replication socket error
    */
   @Config("connectionpool.socket.reset.on.error")
-  @Default(true)
+  @Default("true")
   public final boolean connectionPoolSocketResetOnError;
 
   public ConnectionPoolConfig(VerifiableProperties verifiableProperties) {
@@ -79,5 +79,6 @@ public class ConnectionPoolConfig {
         verifiableProperties.getIntInRange("connectionpool.max.connections.per.port.plain.text", 5, 1, 20);
     connectionPoolMaxConnectionsPerPortSSL =
         verifiableProperties.getIntInRange("connectionpool.max.connections.per.port.ssl", 2, 1, 20);
+    connectionPoolSocketResetOnError = verifiableProperties.getBoolean("connectionpool.socket.reset.on.error", true);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
@@ -60,6 +60,13 @@ public class ConnectionPoolConfig {
   @Default("2")
   public final int connectionPoolMaxConnectionsPerPortSSL;
 
+  /**
+   * Use TCP RST instead of FIN on replication socket error
+   */
+  @Config("connectionpool.socket.reset.on.error")
+  @Default(true)
+  public final boolean connectionPoolSocketResetOnError;
+
   public ConnectionPoolConfig(VerifiableProperties verifiableProperties) {
     connectionPoolReadBufferSizeBytes =
         verifiableProperties.getIntInRange("connectionpool.read.buffer.size.bytes", 1048576, 1, 1024 * 1024 * 1024);

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannel.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannel.java
@@ -102,6 +102,20 @@ public class BlockingChannel implements ConnectedChannel {
     }
   }
 
+  public void reset() {
+    synchronized (lock) {
+      try {
+        if (connected || channel != null) {
+          // Setting SO_LINGER to true and time to 0 to send TCP RST instead of TCP FIN
+          channel.socket().setSoLinger(true, 0);
+        }
+      } catch (Exception e) {
+        logger.error("Error while setting socket linger option {}", e);
+      }
+    }
+    this.disconnect();
+  }
+
   public boolean isConnected() {
     return connected;
   }

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelInfo.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelInfo.java
@@ -208,7 +208,11 @@ class BlockingChannelInfo {
           if (channel == null) {
             break;
           }
-          channel.reset();
+          if (config.connectionPoolSocketResetOnError) {
+            channel.reset();
+          } else {
+            channel.disconnect()
+          }
           numberOfConnections.decrementAndGet();
         } while (true);
       }

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelInfo.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelInfo.java
@@ -208,7 +208,7 @@ class BlockingChannelInfo {
           if (channel == null) {
             break;
           }
-          channel.disconnect();
+          channel.reset();
           numberOfConnections.decrementAndGet();
         } while (true);
       }

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelInfo.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelInfo.java
@@ -211,7 +211,7 @@ class BlockingChannelInfo {
           if (config.connectionPoolSocketResetOnError) {
             channel.reset();
           } else {
-            channel.disconnect()
+            channel.disconnect();
           }
           numberOfConnections.decrementAndGet();
         } while (true);


### PR DESCRIPTION
The reset() method is forcing the socket to be closed by sending TCP RST instead of TCP FIN and is used in cases when we close the socket due to an error, for example - this prevents the socket from becoming an 'orphan'