### PR TITLE
Add max replenishment per host per second config

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/NetworkConfig.java
@@ -18,24 +18,39 @@ package com.github.ambry.config;
  */
 public class NetworkConfig {
 
+  public static final String NUM_IO_THREADS = "num.io.threads";
+  public static final String QUEUED_MAX_REQUESTS = "queued.max.requests";
+  public static final String PORT = "port";
+  public static final String HOST_NAME = "host.name";
+  public static final String SOCKET_SEND_BUFFER_BYTES = "socket.send.buffer.bytes";
+  public static final String SOCKET_RECEIVE_BUFFER_BYTES = "socket.receive.buffer.bytes";
+  public static final String SOCKET_REQUEST_MAX_BYTES = "socket.request.max.bytes";
+  public static final String NETWORK_CLIENT_ENABLE_CONNECTION_REPLENISHMENT =
+      "network.client.enable.connection.replenishment";
+  public static final String NETWORK_CLIENT_MAX_REPLENISHMENT_PER_HOST_PER_SECOND =
+      "network.client.max.replenishment.per.host.per.second";
+  public static final String SELECTOR_EXECUTOR_POOL_SIZE = "selector.executor.pool.size";
+  public static final String SELECTOR_MAX_KEY_TO_PROCESS = "selector.max.key.to.process";
+  public static final String SELECTOR_USE_DIRECT_BUFFERS = "selector.use.direct.buffers";
+
   /**
    * The number of io threads that the server uses for carrying out network requests
    */
-  @Config("num.io.threads")
+  @Config(NUM_IO_THREADS)
   @Default("8")
   public final int numIoThreads;
 
   /**
    * The number of queued requests allowed before blocking the network threads
    */
-  @Config("queued.max.requests")
+  @Config(QUEUED_MAX_REQUESTS)
   @Default("500")
   public final int queuedMaxRequests;
 
   /**
    * The port to listen and accept connections on
    */
-  @Config("port")
+  @Config(PORT)
   @Default("6667")
   public final int port;
 
@@ -43,28 +58,28 @@ public class NetworkConfig {
    * Hostname of server. If this is set, it will only bind to this address. If this is not set,
    * it will bind to all interfaces, and publish one to ZK
    */
-  @Config("host.name")
+  @Config(HOST_NAME)
   @Default("localhost")
   public final String hostName;
 
   /**
    * The SO_SNDBUFF buffer of the socket sever sockets
    */
-  @Config("socket.send.buffer.bytes")
+  @Config(SOCKET_SEND_BUFFER_BYTES)
   @Default("1048576")
   public final int socketSendBufferBytes;
 
   /**
    * The SO_RCVBUFF buffer of the socket sever sockets
    */
-  @Config("socket.receive.buffer.bytes")
+  @Config(SOCKET_RECEIVE_BUFFER_BYTES)
   @Default("1048576")
   public final int socketReceiveBufferBytes;
 
   /**
    * The maximum number of bytes in a socket request
    */
-  @Config("socket.request.max.bytes")
+  @Config(SOCKET_REQUEST_MAX_BYTES)
   @Default("104857600")
   public final int socketRequestMaxBytes;
 
@@ -72,47 +87,56 @@ public class NetworkConfig {
    * Whether the client should attempt to replenish connections when the number of connections to a host drops below
    * a minimum number of active connections.
    */
-  @Config("network.client.enable.connection.replenishment")
+  @Config(NETWORK_CLIENT_ENABLE_CONNECTION_REPLENISHMENT)
   @Default("false")
   public final boolean networkClientEnableConnectionReplenishment;
 
   /**
+   * The max number of new connections to a remote host that should be created per second when replenishing connections.
+   */
+  @Config(NETWORK_CLIENT_MAX_REPLENISHMENT_PER_HOST_PER_SECOND)
+  @Default("1")
+  public final int networkClientMaxReplenishmentPerHostPerSecond;
+
+  /**
    * The size of the pool if selector executor pool is employed. When size is 0, executor pool won't be used.
    */
-  @Config("selector.executor.pool.size")
+  @Config(SELECTOR_EXECUTOR_POOL_SIZE)
   @Default("4")
   public final int selectorExecutorPoolSize;
 
   /**
    * The max number of ready keys can be processed in a selector.poll() call. No limitation if -1 is used.
    */
-  @Config("selector.max.key.to.process")
+  @Config(SELECTOR_MAX_KEY_TO_PROCESS)
   @Default("-1")
   public final int selectorMaxKeyToProcess;
 
   /**
    * True to allocate direct buffers within the selector (for things like SSL work).
    */
-  @Config("selector.use.direct.buffers")
+  @Config(SELECTOR_USE_DIRECT_BUFFERS)
   @Default("false")
   public final boolean selectorUseDirectBuffers;
 
   public NetworkConfig(VerifiableProperties verifiableProperties) {
 
-    numIoThreads = verifiableProperties.getIntInRange("num.io.threads", 8, 1, Integer.MAX_VALUE);
-    port = verifiableProperties.getInt("port", 6667);
-    hostName = verifiableProperties.getString("host.name", "localhost");
-    socketSendBufferBytes = verifiableProperties.getInt("socket.send.buffer.bytes", 1 * 1024 * 1024);
-    socketReceiveBufferBytes = verifiableProperties.getInt("socket.receive.buffer.bytes", 1 * 1024 * 1024);
+    numIoThreads = verifiableProperties.getIntInRange(NUM_IO_THREADS, 8, 1, Integer.MAX_VALUE);
+    port = verifiableProperties.getInt(PORT, 6667);
+    hostName = verifiableProperties.getString(HOST_NAME, "localhost");
+    socketSendBufferBytes = verifiableProperties.getInt(SOCKET_SEND_BUFFER_BYTES, 1 * 1024 * 1024);
+    socketReceiveBufferBytes = verifiableProperties.getInt(SOCKET_RECEIVE_BUFFER_BYTES, 1 * 1024 * 1024);
     socketRequestMaxBytes =
-        verifiableProperties.getIntInRange("socket.request.max.bytes", 100 * 1024 * 1024, 1, Integer.MAX_VALUE);
-    queuedMaxRequests = verifiableProperties.getIntInRange("queued.max.requests", 500, 1, Integer.MAX_VALUE);
+        verifiableProperties.getIntInRange(SOCKET_REQUEST_MAX_BYTES, 100 * 1024 * 1024, 1, Integer.MAX_VALUE);
+    queuedMaxRequests = verifiableProperties.getIntInRange(QUEUED_MAX_REQUESTS, 500, 1, Integer.MAX_VALUE);
     networkClientEnableConnectionReplenishment =
-        verifiableProperties.getBoolean("network.client.enable.connection.replenishment", false);
-    selectorExecutorPoolSize =
-        verifiableProperties.getIntInRange("selector.executor.pool.size", 4, 0, Integer.MAX_VALUE);
+        verifiableProperties.getBoolean(NETWORK_CLIENT_ENABLE_CONNECTION_REPLENISHMENT, false);
+    networkClientMaxReplenishmentPerHostPerSecond =
+        verifiableProperties.getIntInRange(NETWORK_CLIENT_MAX_REPLENISHMENT_PER_HOST_PER_SECOND, 1, 1,
+            Integer.MAX_VALUE);
+    selectorExecutorPoolSize = verifiableProperties.getIntInRange(SELECTOR_EXECUTOR_POOL_SIZE, 4, 0, Integer.MAX_VALUE);
     selectorMaxKeyToProcess =
-        verifiableProperties.getIntInRange("selector.max.key.to.process", -1, -1, Integer.MAX_VALUE);
-    selectorUseDirectBuffers = verifiableProperties.getBoolean("selector.use.direct.buffers", false);
+        verifiableProperties.getIntInRange(SELECTOR_MAX_KEY_TO_PROCESS, -1, -1, Integer.MAX_VALUE);
+    selectorUseDirectBuffers = verifiableProperties.getBoolean(SELECTOR_USE_DIRECT_BUFFERS, false);
   }
 }

--- a/ambry-network/src/test/java/com.github.ambry.network/ConnectionTrackerTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/ConnectionTrackerTest.java
@@ -230,7 +230,7 @@ public class ConnectionTrackerTest {
 
     // call replenishConnections to warm up connections
     assertCounts(totalConnectionsCount, availableCount);
-    connectionTracker.replenishConnections(this::mockNewConnection);
+    connectionTracker.replenishConnections(this::mockNewConnection, Integer.MAX_VALUE);
     totalConnectionsCount += minActiveConnectionsCount;
     assertCounts(totalConnectionsCount, availableCount);
     List<String> newConnections = getNewlyEstablishedConnections();
@@ -247,7 +247,7 @@ public class ConnectionTrackerTest {
     assertCounts(totalConnectionsCount, availableCount);
 
     // replenish connections again
-    connectionTracker.replenishConnections(this::mockNewConnection);
+    connectionTracker.replenishConnections(this::mockNewConnection, Integer.MAX_VALUE);
     totalConnectionsCount += 2;
     assertCounts(totalConnectionsCount, availableCount);
     newConnections = getNewlyEstablishedConnections();
@@ -269,7 +269,24 @@ public class ConnectionTrackerTest {
     totalConnectionsCount -= 1;
     availableCount += 1;
     assertCounts(totalConnectionsCount, availableCount);
-    connectionTracker.replenishConnections(this::mockNewConnection);
+    connectionTracker.replenishConnections(this::mockNewConnection, Integer.MAX_VALUE);
+    totalConnectionsCount += 1;
+    assertCounts(totalConnectionsCount, availableCount);
+
+    // check out and destroy all host2 connections
+    String connId;
+    while ((connId = connectionTracker.checkOutConnection("host2", sslPort, dataNodeId2)) != null) {
+      connectionTracker.removeConnection(connId);
+    }
+    totalConnectionsCount -= 2;
+    availableCount -= 2;
+    assertCounts(totalConnectionsCount, availableCount);
+
+    // Replenish connection with rate limit of 1 connection per host per call.
+    connectionTracker.replenishConnections(this::mockNewConnection, 1);
+    totalConnectionsCount += 1;
+    assertCounts(totalConnectionsCount, availableCount);
+    connectionTracker.replenishConnections(this::mockNewConnection, 1);
     totalConnectionsCount += 1;
     assertCounts(totalConnectionsCount, availableCount);
   }

--- a/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/NetworkClientTest.java
@@ -51,7 +51,7 @@ public class NetworkClientTest {
   public static final int POLL_TIMEOUT_MS = 100;
   public static final int TIME_FOR_WARM_UP_MS = 2000;
 
-  private final Time time;
+  private final MockTime time;
 
   private MockSelector selector;
   private NetworkClient networkClient;
@@ -342,26 +342,49 @@ public class NetworkClientTest {
     checkConnectCalls.run();
 
     selector.setState(MockSelectorState.Good);
-    // this sendAndPoll() should use one of the pre-warmed connections
+    // 1. this sendAndPoll() should use one of the pre-warmed connections
     List<ResponseInfo> responseInfoList =
         networkClient.sendAndPoll(requestGen.apply(3), Collections.emptySet(), POLL_TIMEOUT_MS);
     checkConnectCalls.run();
     Assert.assertEquals(3, responseInfoList.size());
 
-    // this sendAndPoll() should disconnect two of the pre-warmed connections
+    // 2. this sendAndPoll() should disconnect two of the pre-warmed connections
     selector.setState(MockSelectorState.DisconnectOnSend);
     responseInfoList = networkClient.sendAndPoll(requestGen.apply(2), Collections.emptySet(), POLL_TIMEOUT_MS);
     checkConnectCalls.run();
     Assert.assertEquals(2, responseInfoList.size());
 
-    // the two connections lost in the previous sendAndPoll should be replenished
+    // 3. the two connections lost in the previous sendAndPoll should not be replenished yet since a second has not yet
+    // passed since startup
     selector.setState(MockSelectorState.Good);
     responseInfoList = networkClient.sendAndPoll(requestGen.apply(1), Collections.emptySet(), POLL_TIMEOUT_MS);
-    expectedConnectCalls.addAndGet(2);
     checkConnectCalls.run();
     Assert.assertEquals(1, responseInfoList.size());
 
-    // this call should use the existing connections in the pool
+    // 4. one of the connection lost in sendAndPoll 3 should be replenished
+    time.setCurrentMilliseconds(time.milliseconds() + Time.MsPerSec);
+    selector.setState(MockSelectorState.Good);
+    responseInfoList = networkClient.sendAndPoll(requestGen.apply(0), Collections.emptySet(), POLL_TIMEOUT_MS);
+    expectedConnectCalls.addAndGet(1);
+    checkConnectCalls.run();
+    Assert.assertEquals(0, responseInfoList.size());
+
+    // 5. no connections replenished this time since only half a second passed.
+    time.setCurrentMilliseconds(time.milliseconds() + 500);
+    selector.setState(MockSelectorState.Good);
+    responseInfoList = networkClient.sendAndPoll(requestGen.apply(0), Collections.emptySet(), POLL_TIMEOUT_MS);
+    checkConnectCalls.run();
+    Assert.assertEquals(0, responseInfoList.size());
+
+    // 6. the second connection lost in sendAndPoll 3 should be replenished
+    time.setCurrentMilliseconds(time.milliseconds() + 500);
+    selector.setState(MockSelectorState.Good);
+    responseInfoList = networkClient.sendAndPoll(requestGen.apply(0), Collections.emptySet(), POLL_TIMEOUT_MS);
+    expectedConnectCalls.addAndGet(1);
+    checkConnectCalls.run();
+    Assert.assertEquals(0, responseInfoList.size());
+
+    // 7. this call should use the existing connections in the pool
     selector.setState(MockSelectorState.Good);
     responseInfoList = networkClient.sendAndPoll(requestGen.apply(3), Collections.emptySet(), POLL_TIMEOUT_MS);
     checkConnectCalls.run();


### PR DESCRIPTION
This config will provide a way to limit the number of connections
created per second by connection replenishment to each host. With this
change, replenishConnections will only be called once per second (in
this case, a good enough approximation that avoids the need for a
per-host token bucket).

This is meant to prevent connect/handshake floods when servers are
restarted in clusters with many frontends.