### PR TITLE
Refactoring connect() in SSLBlockingChannel

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/SSLBlockingChannel.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/SSLBlockingChannel.java
@@ -53,18 +53,8 @@ public class SSLBlockingChannel extends BlockingChannel {
   @Override
   public void connect() throws IOException {
     synchronized (lock) {
-      if (!connected) {
-        Socket socket = new Socket();
-        socket.setSoTimeout(readTimeoutMs);
-        socket.setKeepAlive(true);
-        socket.setTcpNoDelay(true);
-        if (readBufferSize > 0) {
-          socket.setReceiveBufferSize(readBufferSize);
-        }
-        if (writeBufferSize > 0) {
-          socket.setSendBufferSize(writeBufferSize);
-        }
-        socket.connect(new InetSocketAddress(host, port), connectTimeoutMs);
+      super.connect();
+      if (connected) {
         sslSocket = (SSLSocket) sslSocketFactory.createSocket(socket, host, port, true);
 
         ArrayList<String> protocolsList = Utils.splitString(sslConfig.sslEnabledProtocols, ",");


### PR DESCRIPTION
This change removes duplicate code from SSLBlockingChannel.connect() and instead calls its parent's (BlockingChannel) method first, and only add SSL portion afterwards