### PR TITLE
Vcr node fix to be able to handle replica metadata request for any partition

### DIFF
--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
@@ -253,4 +253,18 @@ public class VcrReplicationManager extends ReplicationEngine {
   public VcrMetrics getVcrMetrics() {
     return vcrMetrics;
   }
+
+  @Override
+  public void updateTotalBytesReadByRemoteReplica(PartitionId partitionId, String hostName, String replicaPath,
+      long totalBytesRead) {
+    // Since replica metadata request for a single partition can goto multiple vcr nodes, totalBytesReadByRemoteReplica
+    // cannot be  populated locally on any vcr node.
+    return;
+  }
+
+  @Override
+  public long getRemoteReplicaLagFromLocalInBytes(PartitionId partitionId, String hostName, String replicaPath) {
+    // TODO get replica lag from cosmos?
+    return -1;
+  }
 }


### PR DESCRIPTION
This change fixes an issue due to which vcr node cannot handle replica metadata request for partition which it is not a leader of. This is part of cloudreplicationengine PR, but I am separating it out so that I can test the helix related cloudreplicationengine code changes in ambry server against vcr nodes in EI.