### PR TITLE
Rebuild bloom filter with appropriate size

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -411,10 +411,9 @@ class IndexSegment {
    */
   private void generateBloomFilterAndPersist() throws StoreException {
     int numOfIndexEntries = numberOfEntries(serEntries);
-    // The number of elements that used to create bloom filter should be no less than "storeIndexMaxNumberOfInmemElements"
-    // specified in current config. The number of entries in each index segment varies (from hundreds to thousands), we
-    // have to ensure bloom filter of each index segment uses at least storeIndexMaxNumberOfInmemElements as parameter
-    // for creation.
+    // This is a workaround since we found higher than intended false positive rates with small bloom filter sizes. Note
+    // that the number of entries in each index segment varies (from hundreds to thousands), the workaround ensures bloom
+    // filter uses at least storeIndexMaxNumberOfInmemElements for creation to achieve decent performance.
     bloomFilter = FilterFactory.getFilter(Math.max(numOfIndexEntries, config.storeIndexMaxNumberOfInmemElements),
         config.storeIndexBloomMaxFalsePositiveProbability);
     for (int i = 0; i < numOfIndexEntries; i++) {

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -411,7 +411,12 @@ class IndexSegment {
    */
   private void generateBloomFilterAndPersist() throws StoreException {
     int numOfIndexEntries = numberOfEntries(serEntries);
-    bloomFilter = FilterFactory.getFilter(numOfIndexEntries, config.storeIndexBloomMaxFalsePositiveProbability);
+    // The number of elements that used to create bloom filter should be no less than "storeIndexMaxNumberOfInmemElements"
+    // specified in current config. The number of entries in each index segment varies (from hundreds to thousands), we
+    // have to ensure bloom filter of each index segment uses at least storeIndexMaxNumberOfInmemElements as parameter
+    // for creation.
+    bloomFilter = FilterFactory.getFilter(Math.max(numOfIndexEntries, config.storeIndexMaxNumberOfInmemElements),
+        config.storeIndexBloomMaxFalsePositiveProbability);
     for (int i = 0; i < numOfIndexEntries; i++) {
       StoreKey key = getKeyAt(serEntries, i);
       bloomFilter.add(getStoreKeyBytes(key));


### PR DESCRIPTION
Previously, size of rebuilt bloom filter is based on the actual number of
entries in index segment. That number varies in different index segments
and could be very small. This PR ensures size of rebuilt bloom filter is
no less than "storeIndexMaxNumberOfInmemElements" in config and thus the
rebuilt bloom filters should have same performance (compared with previous
bloom filters) on false positive rate.