### PR TITLE
Refactoring BlockingChannel and SSLBlockingChannel for better code reuse

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/SSLBlockingChannel.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/SSLBlockingChannel.java
@@ -18,9 +18,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.nio.channels.Channels;
 import java.util.ArrayList;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -30,7 +28,6 @@ import javax.net.ssl.SSLSocketFactory;
  * A blocking channel that is used to communicate with a server using SSL
  */
 public class SSLBlockingChannel extends BlockingChannel {
-  private SSLSocket sslSocket = null;
   private final SSLSocketFactory sslSocketFactory;
   private final SSLConfig sslConfig;
   public final Counter sslClientHandshakeErrorCount;
@@ -50,76 +47,49 @@ public class SSLBlockingChannel extends BlockingChannel {
         registry.counter(MetricRegistry.name(SSLBlockingChannel.class, "SslClientHandshakeCount"));
   }
 
+  /**
+   * Calls BlockingChannel's createSocket() to create and connect a new TCP socket,
+   * then wraps it inside an SSLSocket
+   * @return Socket
+   * @throws IOException
+   */
   @Override
-  public void connect() throws IOException {
-    synchronized (lock) {
-      if (!connected) {
-        Socket socket = new Socket();
-        socket.setSoTimeout(readTimeoutMs);
-        socket.setKeepAlive(true);
-        socket.setTcpNoDelay(true);
-        if (readBufferSize > 0) {
-          socket.setReceiveBufferSize(readBufferSize);
-        }
-        if (writeBufferSize > 0) {
-          socket.setSendBufferSize(writeBufferSize);
-        }
-        socket.connect(new InetSocketAddress(host, port), connectTimeoutMs);
-        sslSocket = (SSLSocket) sslSocketFactory.createSocket(socket, host, port, true);
+  public Socket createSocket() throws IOException {
+    Socket tcpSocket = super.createSocket();
 
-        ArrayList<String> protocolsList = Utils.splitString(sslConfig.sslEnabledProtocols, ",");
-        if (!protocolsList.isEmpty()) {
-          String[] enabledProtocols = protocolsList.toArray(new String[protocolsList.size()]);
-          sslSocket.setEnabledProtocols(enabledProtocols);
-        }
+    SSLSocket sslSocket = null;
 
-        ArrayList<String> cipherSuitesList = Utils.splitString(sslConfig.sslCipherSuites, ",");
-        if (!cipherSuitesList.isEmpty()) {
-          String[] cipherSuites = cipherSuitesList.toArray(new String[cipherSuitesList.size()]);
-          sslSocket.setEnabledCipherSuites(cipherSuites);
-        }
+    try {
+      sslSocket = (SSLSocket) sslSocketFactory.createSocket(tcpSocket, host, port, true);
 
-        // handshake in a blocking way
-        try {
-          sslSocket.startHandshake();
-          sslClientHandshakeCount.inc();
-        } catch (IOException e) {
-          sslClientHandshakeErrorCount.inc();
-          throw e;
-        }
-        writeChannel = Channels.newChannel(sslSocket.getOutputStream());
-        readChannel = sslSocket.getInputStream();
-        connected = true;
-        logger.debug(
-            "Created socket with SO_TIMEOUT = {} (requested {}), SO_RCVBUF = {} (requested {}), SO_SNDBUF = {} (requested {})",
-            sslSocket.getSoTimeout(), readTimeoutMs, sslSocket.getReceiveBufferSize(), readBufferSize,
-            sslSocket.getSendBufferSize(), writeBufferSize);
+      ArrayList<String> protocolsList = Utils.splitString(sslConfig.sslEnabledProtocols, ",");
+      if (!protocolsList.isEmpty()) {
+        String[] enabledProtocols = protocolsList.toArray(new String[protocolsList.size()]);
+        sslSocket.setEnabledProtocols(enabledProtocols);
       }
-    }
-  }
 
-  @Override
-  public void disconnect() {
-    synchronized (lock) {
-      try {
-        if (connected || sslSocket != null) {
-          // closing the main socket channel *should* close the read channel
-          // but let's do it to be sure.
-          sslSocket.close();
-          if (readChannel != null) {
-            readChannel.close();
-            readChannel = null;
-          }
-          if (writeChannel != null) {
-            writeChannel.close();
-            writeChannel = null;
-          }
-          sslSocket = null;
-          connected = false;
-        }
-      } catch (Exception e) {
-        logger.error("error while disconnecting {}", e);
+      ArrayList<String> cipherSuitesList = Utils.splitString(sslConfig.sslCipherSuites, ",");
+      if (!cipherSuitesList.isEmpty()) {
+        String[] cipherSuites = cipherSuitesList.toArray(new String[cipherSuitesList.size()]);
+        sslSocket.setEnabledCipherSuites(cipherSuites);
       }
+
+      // handshake in a blocking way
+      sslSocket.startHandshake();
+      sslClientHandshakeCount.inc();
+    } catch (IOException e) {
+      sslClientHandshakeErrorCount.inc();
+      tcpSocket.setSoLinger(true, 0);
+      tcpSocket.close();
+      throw e;
     }
+
+    logger.debug(
+        "Converted socket to SSL with enabled protocols {} and ciphers {}",
+        sslSocket.getEnabledProtocols(),
+        sslSocket.getEnabledCipherSuites()
+    );
+
+    return sslSocket;
   }
 }


### PR DESCRIPTION
This change optimizes the code and allows for a better code reuse:

1. Removing SocketChannel from BlockingChannel class
2. Adding a private "socket" field to BlockingChannel
3. Adding "createSocket()" method, which returns a connected socket
4. Removing all overrides from SSLBlockingChannel and instead adding one override for "createSocket()" method, which calls super.createSocket() and "wraps" SSL around it.
5. Replacing "writeChannel" value in BlockingChannel from SocketChannel to socket.getOutputChannel() wrapped in a WriteByteChannel (same as used to be in SSLBlockingChannel)
6. Ditching a separate lock object in favor of locking on 'this'.