### PR TITLE
Support getting end position of last PUT in BlobStore

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -719,6 +719,14 @@ public class BlobStore implements Store {
   }
 
   /**
+   * @return return absolute end position of last PUT in current store when this method is invoked.
+   * @throws StoreException
+   */
+  public long getEndPositionOfLastPut() throws StoreException {
+    return index.getAbsoluteEndPositionOfLastPut();
+  }
+
+  /**
    * @return {@link ReplicaStatusDelegate} associated with this store
    */
   public ReplicaStatusDelegate getReplicaStatusDelegate() {

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -778,6 +778,10 @@ class IndexSegment {
           if (indexValue.getFlags() == IndexValue.FLAGS_DEFAULT_VALUE && (indexValueOfLastPut == null
               || indexValue.compareTo(indexValueOfLastPut) > 0)) {
             indexValueOfLastPut = indexValue;
+            // note that values set contains all entries associated with specific key, so there are at most 3 entries in
+            // this set (one PUT, one TTL Update and one DELETE). Due to nature of log, PUT always comes first. And if we
+            // already find PUT, we can jump out of the inner loop.
+            break;
           }
         }
       }
@@ -788,6 +792,7 @@ class IndexSegment {
           if (indexValue.getFlags() == IndexValue.FLAGS_DEFAULT_VALUE && (indexValueOfLastPut == null
               || indexValue.compareTo(indexValueOfLastPut) > 0)) {
             indexValueOfLastPut = indexValue;
+            break;
           }
         }
       }

--- a/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/IndexSegment.java
@@ -761,6 +761,41 @@ class IndexSegment {
   }
 
   /**
+   * @return index value of last PUT record in this index segment. Return {@code null} if no PUT is found
+   */
+  IndexValue getIndexValueOfLastPut() throws StoreException {
+    IndexValue indexValueOfLastPut = null;
+    if (sealed.get()) {
+      ByteBuffer readBuf = serEntries.duplicate();
+      int numOfIndexEntries = numberOfEntries(readBuf);
+      NavigableSet<IndexValue> values = new TreeSet<>();
+      for (int i = 0; i < numOfIndexEntries; i++) {
+        StoreKey key = getKeyAt(readBuf, i);
+        values.clear();
+        getAllValuesFromMmap(readBuf, key, i, numOfIndexEntries, values);
+        for (IndexValue indexValue : values) {
+          // FLAGS_DEFAULT_VALUE means PUT record
+          if (indexValue.getFlags() == IndexValue.FLAGS_DEFAULT_VALUE && (indexValueOfLastPut == null
+              || indexValue.compareTo(indexValueOfLastPut) > 0)) {
+            indexValueOfLastPut = indexValue;
+          }
+        }
+      }
+    } else {
+      for (Map.Entry<StoreKey, ConcurrentSkipListSet<IndexValue>> entry : index.entrySet()) {
+        for (IndexValue indexValue : entry.getValue()) {
+          // FLAGS_DEFAULT_VALUE means PUT record
+          if (indexValue.getFlags() == IndexValue.FLAGS_DEFAULT_VALUE && (indexValueOfLastPut == null
+              || indexValue.compareTo(indexValueOfLastPut) > 0)) {
+            indexValueOfLastPut = indexValue;
+          }
+        }
+      }
+    }
+    return indexValueOfLastPut;
+  }
+
+  /**
    * Maps the segment of index either as a memory map or a in memory buffer depending on config.
    * @throws StoreException if there are problems with the index
    */

--- a/ambry-store/src/main/java/com.github.ambry.store/Journal.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/Journal.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -52,6 +53,11 @@ class JournalEntry {
     }
     JournalEntry entry = (JournalEntry) o;
     return this.offset == entry.offset && this.key == entry.key;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(offset, key);
   }
 }
 
@@ -174,6 +180,7 @@ class Journal {
     List<JournalEntry> result = new ArrayList<>();
     // get current last Offset
     Offset lastOffset = getLastOffset();
+    journal.entrySet();
     if (lastOffset != null) {
       // get portion view of journal whose key is less than or equal to lastOffset
       NavigableMap<Offset, StoreKey> journalView = journal.headMap(lastOffset, true);
@@ -232,11 +239,11 @@ class Journal {
     inBootstrapMode = false;
   }
 
-  boolean isInBootstrapMode(){
+  boolean isInBootstrapMode() {
     return inBootstrapMode;
   }
 
-  int getMaxEntriesToJournal(){
+  int getMaxEntriesToJournal() {
     return maxEntriesToJournal;
   }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -1064,6 +1064,47 @@ class PersistentIndex {
   }
 
   /**
+   * @return absolute end position (in bytes) of latest PUT record when this method is invoked.
+   * @throws StoreException
+   */
+  long getAbsoluteEndPositionOfLastPut() throws StoreException {
+    IndexValue indexValueOfLastPut = null;
+    // 1. go through keys in journal in reverse order to see if there is a PUT index entry associated with the key
+    List<JournalEntry> journalEntries = journal.getAllEntries();
+    ConcurrentSkipListMap<Offset, IndexSegment> indexSegments = validIndexSegments;
+    // check entry in reverse order (from the most recent one) to find first PUT record in index
+    for (int i = journalEntries.size() - 1; i >= 0; --i) {
+      JournalEntry entry = journalEntries.get(i);
+      indexValueOfLastPut = findKey(entry.getKey(), new FileSpan(entry.getOffset(), getCurrentEndOffset(indexSegments)),
+          EnumSet.of(IndexEntryType.PUT), indexSegments);
+      if (indexValueOfLastPut != null) {
+        break;
+      }
+    }
+    if (!journalEntries.isEmpty() && indexValueOfLastPut == null) {
+      // 2. if not find in the journal, check index segments starting from most recent one (until latest PUT is found)
+      JournalEntry firstJournalEntry = journalEntries.get(0);
+      // generate a segment map in reverse order
+      ConcurrentNavigableMap<Offset, IndexSegment> segmentsMapToSearch =
+          indexSegments.subMap(indexSegments.firstKey(), true, indexSegments.lowerKey(firstJournalEntry.getOffset()),
+              true).descendingMap();
+      for (Map.Entry<Offset, IndexSegment> entry : segmentsMapToSearch.entrySet()) {
+        indexValueOfLastPut = entry.getValue().getIndexValueOfLastPut();
+        if (indexValueOfLastPut != null) {
+          break;
+        }
+      }
+    }
+    if (indexValueOfLastPut == null) {
+      // if no PUT record is found in this store, return -1. This is possible when current store is a brand new store.
+      logger.info("No PUT record is found for store {}", dataDir);
+      return -1;
+    }
+    return getAbsolutePositionInLogForOffset(indexValueOfLastPut.getOffset(), indexSegments)
+        + indexValueOfLastPut.getSize();
+  }
+
+  /**
    * @return the number of valid log segments starting from the first segment.
    */
   long getLogSegmentCount() {

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -1064,7 +1064,8 @@ class PersistentIndex {
   }
 
   /**
-   * @return absolute end position (in bytes) of latest PUT record when this method is invoked.
+   * @return absolute end position (in bytes) of latest PUT record when this method is invoked. If no PUT is found in
+   *         current store, -1 will be returned.
    * @throws StoreException
    */
   long getAbsoluteEndPositionOfLastPut() throws StoreException {
@@ -1072,7 +1073,7 @@ class PersistentIndex {
     // 1. go through keys in journal in reverse order to see if there is a PUT index entry associated with the key
     List<JournalEntry> journalEntries = journal.getAllEntries();
     ConcurrentSkipListMap<Offset, IndexSegment> indexSegments = validIndexSegments;
-    // check entry in reverse order (from the most recent one) to find first PUT record in index
+    // check entry in reverse order (from the most recent one) to find last PUT record in index
     for (int i = journalEntries.size() - 1; i >= 0; --i) {
       JournalEntry entry = journalEntries.get(i);
       indexValueOfLastPut = findKey(entry.getKey(), new FileSpan(entry.getOffset(), getCurrentEndOffset(indexSegments)),

--- a/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
@@ -69,8 +69,8 @@ class CuratedLogIndexState {
   private static final long SEGMENT_CAPACITY = 3000;
   private static final long HARD_DELETE_START_OFFSET = 11;
   private static final long HARD_DELETE_LAST_PART_SIZE = 13;
-  private static final int DEFAULT_MAX_IN_MEM_ELEMENTS = 5;
 
+  static final int DEFAULT_MAX_IN_MEM_ELEMENTS = 5;
   static final DiskIOScheduler DISK_IO_SCHEDULER = new DiskIOScheduler(null);
   static final long DELAY_BETWEEN_LAST_MODIFIED_TIMES_MS = 10 * Time.MsPerSec;
   static final StoreKeyFactory STORE_KEY_FACTORY;
@@ -312,10 +312,9 @@ class CuratedLogIndexState {
    * Adds a delete entry in the index (real and reference) for {@code idToDelete}.
    * @param idToDelete the id to be deleted.
    * @return the {@link FileSpan} of the added entries.
-   * @throws IOException
    * @throws StoreException
    */
-  FileSpan addDeleteEntry(MockId idToDelete) throws IOException, StoreException {
+  FileSpan addDeleteEntry(MockId idToDelete) throws StoreException {
     return addDeleteEntry(idToDelete, null);
   }
 
@@ -1004,11 +1003,10 @@ class CuratedLogIndexState {
    * @param expectedLogSegmentCount the number of log segments that are expected to assist after the addition of the
    *                                first entry and at the end of the addition of all entries.
    * @param addTtlUpdates if {@code true}, adds entries that update TTL.
-   * @throws IOException
    * @throws StoreException
    */
   private void addCuratedIndexEntriesToLogSegment(long sizeToMakeIndexEntriesFor, int expectedLogSegmentCount,
-      boolean addTtlUpdates) throws IOException, StoreException {
+      boolean addTtlUpdates) throws StoreException {
     // First Index Segment
     // 1 PUT
     Offset firstJournalEntryAddedNow =

--- a/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/IndexTest.java
@@ -566,6 +566,11 @@ public class IndexTest {
     // for segmented log, there is a header size = 18
     assertEquals("Absolute end position of last PUT record not expected",
         5 * PUT_RECORD_SIZE + (isLogSegmented ? 18 : 0), indexState.index.getAbsoluteEndPositionOfLastPut());
+    // close the index to seal all index segments
+    indexState.index.close(false);
+    // get end position of last PUT again, it should return same result (this is to test getting last PUT in sealed index segment)
+    assertEquals("Absolute end position of last PUT record not expected",
+        5 * PUT_RECORD_SIZE + (isLogSegmented ? 18 : 0), indexState.index.getAbsoluteEndPositionOfLastPut());
 
     // calculate current end position in log segment (note that there are 5 PUT, 5 TTL update and 5 DELETE entries)
     long currentEndPosition =

--- a/ambry-store/src/test/java/com.github.ambry.store/JournalTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/JournalTest.java
@@ -15,6 +15,8 @@ package com.github.ambry.store;
 
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
+import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,24 +31,28 @@ public class JournalTest {
     String firstLogSegmentName = LogSegmentNameHelper.getName(pos, gen);
     String secondLogSegmentName = LogSegmentNameHelper.getNextPositionName(firstLogSegmentName);
     Journal journal = new Journal("test", 10, 5);
+    // maintain a queue to keep track of entries in journal for verification purpose
+    List<JournalEntry> journalEntries = new LinkedList<>();
     Assert.assertNull("First offset should be null", journal.getFirstOffset());
     Assert.assertNull("Last offset should be null", journal.getLastOffset());
     Assert.assertNull("Should not be able to get entries because there are none",
         journal.getEntriesSince(new Offset(firstLogSegmentName, 0), true));
-    addEntryAndVerify(journal, new Offset(firstLogSegmentName, 0), new MockId("id1"));
+    Assert.assertTrue("Get all entries should return empty list", journal.getAllEntries().isEmpty());
+    addEntryAndVerify(journal, new Offset(firstLogSegmentName, 0), new MockId("id1"), journalEntries);
     Assert.assertEquals("Did not get expected key at offset", new MockId("id1"),
         journal.getKeyAtOffset(new Offset(firstLogSegmentName, 0)));
-    addEntryAndVerify(journal, new Offset(firstLogSegmentName, 1000), new MockId("id2"));
-    addEntryAndVerify(journal, new Offset(firstLogSegmentName, 2000), new MockId("id3"));
-    addEntryAndVerify(journal, new Offset(firstLogSegmentName, 3000), new MockId("id4"));
-    addEntryAndVerify(journal, new Offset(firstLogSegmentName, 4000), new MockId("id5"));
-    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 0), new MockId("id6"));
-    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 1000), new MockId("id7"));
-    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 2000), new MockId("id8"));
-    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 3000), new MockId("id9"));
-    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 4000), new MockId("id10"));
+    addEntryAndVerify(journal, new Offset(firstLogSegmentName, 1000), new MockId("id2"), journalEntries);
+    addEntryAndVerify(journal, new Offset(firstLogSegmentName, 2000), new MockId("id3"), journalEntries);
+    addEntryAndVerify(journal, new Offset(firstLogSegmentName, 3000), new MockId("id4"), journalEntries);
+    addEntryAndVerify(journal, new Offset(firstLogSegmentName, 4000), new MockId("id5"), journalEntries);
+    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 0), new MockId("id6"), journalEntries);
+    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 1000), new MockId("id7"), journalEntries);
+    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 2000), new MockId("id8"), journalEntries);
+    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 3000), new MockId("id9"), journalEntries);
+    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 4000), new MockId("id10"), journalEntries);
     Assert.assertEquals("First offset not as expected", new Offset(firstLogSegmentName, 0), journal.getFirstOffset());
     Assert.assertEquals("Last offset not as expected", new Offset(secondLogSegmentName, 4000), journal.getLastOffset());
+    Assert.assertEquals("Current entries in journal not expected", journalEntries, journal.getAllEntries());
     List<JournalEntry> entries = journal.getEntriesSince(new Offset(firstLogSegmentName, 0), true);
     Assert.assertEquals(entries.get(0).getOffset(), new Offset(firstLogSegmentName, 0));
     Assert.assertEquals(entries.get(0).getKey(), new MockId("id1"));
@@ -73,7 +79,10 @@ public class JournalTest {
     Assert.assertEquals(entries.size(), 5);
     Assert.assertNull("Should not be able to get entries because offset does not exist",
         journal.getEntriesSince(new Offset(firstLogSegmentName, 1), true));
-    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 5000), new MockId("id11"));
+    addEntryAndVerify(journal, new Offset(secondLogSegmentName, 5000), new MockId("id11"), journalEntries);
+    Assert.assertEquals("Current entries in journal not expected", journalEntries, journal.getAllEntries());
+    Assert.assertEquals("Number of entries in journal not expected", journal.getMaxEntriesToJournal(),
+        journal.getAllEntries().size());
     Assert.assertEquals("First offset not as expected", new Offset(firstLogSegmentName, 1000),
         journal.getFirstOffset());
     Assert.assertEquals("Last offset not as expected", new Offset(secondLogSegmentName, 5000), journal.getLastOffset());
@@ -110,22 +119,26 @@ public class JournalTest {
       offsets[i] = new Offset(logSegmentName, i * 1000);
       keys[i] = new MockId("id" + i);
     }
+    List<JournalEntry> journalEntries = new ArrayList<>();
     // Bootstrap mode is off by default and journal entries should respect the max constraint
     Journal journal = new Journal("test", 1, 1);
-    addEntryAndVerify(journal, offsets[0], keys[0]);
-    addEntryAndVerify(journal, offsets[1], keys[1]);
+    addEntryAndVerify(journal, offsets[0], keys[0], journalEntries);
+    addEntryAndVerify(journal, offsets[1], keys[1], journalEntries);
     Assert.assertEquals("Unexpected journal size", 1, journal.getCurrentNumberOfEntries());
     Assert.assertEquals("Oldest entry is not being replaced", offsets[1], journal.getFirstOffset());
+    Assert.assertEquals("Entries in journal not expected", journalEntries, journal.getAllEntries());
     // Bootstrap mode is turned on and journal entries should be able to exceed the max constraint
     journal.startBootstrap();
-    addEntryAndVerify(journal, offsets[2], keys[2]);
+    addEntryAndVerify(journal, offsets[2], keys[2], journalEntries);
     Assert.assertEquals("Unexpected journal size", 2, journal.getCurrentNumberOfEntries());
     Assert.assertEquals("Oldest entry should not be replaced", offsets[1], journal.getFirstOffset());
+    Assert.assertEquals("Entries in journal not expected", journalEntries, journal.getAllEntries());
     // Bootstrap mode is off and journal entries should respect the max constraint again
     journal.finishBootstrap();
-    addEntryAndVerify(journal, offsets[3], keys[3]);
+    addEntryAndVerify(journal, offsets[3], keys[3], journalEntries);
     Assert.assertEquals("Unexpected journal size", 2, journal.getCurrentNumberOfEntries());
     Assert.assertEquals("Oldest entry is not being replaced", offsets[2], journal.getFirstOffset());
+    Assert.assertEquals("Entries in journal not expected", journalEntries, journal.getAllEntries());
   }
 
   /**
@@ -133,10 +146,18 @@ public class JournalTest {
    * @param journal the {@link Journal} to add to
    * @param offset the {@link Offset} to add an entry for
    * @param id the {@link StoreKey}  at {@code offset}
+   * @param journalEntries a list of {@link JournalEntry} to track entries in current journal. This is for verification
+   *                       purpose.
    */
-  private void addEntryAndVerify(Journal journal, Offset offset, MockId id) {
+  private void addEntryAndVerify(Journal journal, Offset offset, MockId id, List<JournalEntry> journalEntries) {
     long crc = Utils.getRandomLong(TestUtils.RANDOM, Long.MAX_VALUE);
     journal.addEntry(offset, id, crc);
+    if (journalEntries != null) {
+      if (!journal.isInBootstrapMode() && journalEntries.size() >= journal.getMaxEntriesToJournal()) {
+        journalEntries.remove(0);
+      }
+      journalEntries.add(new JournalEntry(offset, id));
+    }
     Assert.assertEquals("Unexpected key at offset", id, journal.getKeyAtOffset(offset));
     Assert.assertEquals("Unexpected crc for key", crc, journal.getCrcOfKey(id).longValue());
   }


### PR DESCRIPTION
The PR introduces a new method in PersistentIndex to get end position of
last PUT record in BlobStore. Note that, the "last" PUT record is valid
only when the method is invoked. That is, there could be new PUTs
afterwards. The intention here is to help replica to check if its peer
replicas have caught up with latest PUT record when PUT is disabled on
this replica (this happens when current replica is being decommissioned)