### PR TITLE
Fix netty ByteBuf release bug in the ambry-frontend

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
@@ -68,7 +68,7 @@ public class ResponseInfo {
   }
 
   /**
-   *  Increase the reference count of underlying response.
+   * Increase the reference count of underlying response.
    */
   public void retain() {
     if (response != null) {

--- a/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
@@ -15,7 +15,6 @@ package com.github.ambry.network;
 
 import com.github.ambry.clustermap.DataNodeId;
 import io.netty.util.ReferenceCountUtil;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 
 /**

--- a/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
@@ -29,7 +29,6 @@ public class ResponseInfo {
   private final NetworkClientErrorCode error;
   private final Object response;
   private final DataNodeId dataNode;
-  private AtomicBoolean delayRelease = new AtomicBoolean();
 
   /**
    * Constructs a ResponseInfo with the given parameters.
@@ -69,16 +68,19 @@ public class ResponseInfo {
     return response;
   }
 
-  public void setDelayRelease() {
-    delayRelease.getAndSet(true);
+  /**
+   *  Increase the reference count of underlying response.
+   */
+  public void retain() {
+    if (response != null) {
+      ReferenceCountUtil.retain(response);
+    }
   }
 
+  /**
+   * Decrease the reference count of undelying response.
+   */
   public void release() {
-    // if set delay release, then when this method is invoked for the first time, don't do anything.
-    // when it's called second time, release it.
-    if (delayRelease.compareAndSet(true, false)) {
-      return;
-    }
     if (response != null) {
       ReferenceCountUtil.release(response);
     }

--- a/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
@@ -77,7 +77,7 @@ public class ResponseInfo {
   }
 
   /**
-   * Decrease the reference count of undelying response.
+   * Decrease the reference count of underlying response.
    */
   public void release() {
     if (response != null) {

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -1214,7 +1214,7 @@ class GetBlobOperation extends GetOperation {
           }
         } else {
           if (blobType == BlobType.MetadataBlob) {
-            handleMetadataBlob(responseInfo, blobData, userMetadata, encryptionKey);
+            handleMetadataBlob(blobData, userMetadata, encryptionKey);
           } else {
             handleSimpleBlob(responseInfo, blobData, userMetadata, encryptionKey);
           }
@@ -1262,15 +1262,14 @@ class GetBlobOperation extends GetOperation {
 
     /**
      * Process a metadata blob to find the data chunks that need to be fetched.
-     * @param responseInfo the response received for a request sent out on behalf of this chunk.
      * @param blobData the metadata blob's data.
      * @param userMetadata userMetadata of the blob
      * @param encryptionKey blob encryption key. Could be null for un-encrypted blobs
      * @throws IOException
      * @throws MessageFormatException
      */
-    private void handleMetadataBlob(ResponseInfo responseInfo, BlobData blobData, byte[] userMetadata,
-        ByteBuffer encryptionKey) throws IOException, MessageFormatException {
+    private void handleMetadataBlob(BlobData blobData, byte[] userMetadata, ByteBuffer encryptionKey)
+        throws IOException, MessageFormatException {
       ByteBuffer serializedMetadataContent = blobData.getStream().getByteBuffer();
       compositeBlobInfo =
           MetadataContentSerDe.deserializeMetadataContentRecord(serializedMetadataContent, blobIdFactory);


### PR DESCRIPTION
ResponseInfo release the ByteBuf when GetOperation finishes handleResponse, and it would effectively put ByteBuf back to the pool. But GetOperation might buffer those bytes in a BlobDataReadableStreamChannel so releasing the ByteBuf would eventually corrupt the response if the same ByteBuf is checked out to hold different bytes.

This PR fixes this bug, but retaining ResponseInfo and put it in a map and later release it. The reason to add retain method is to make logic easier to understand. After this PR, ResponseInfo would be released after GetOperation finishes handleResponse, but if it's retained, it will then again get released after BlobDataReadableStreamChannel finishes writing to HttpResponse. 