### PR TITLE
Add NettyByteBuf to GetBlobOperation

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
@@ -27,8 +27,8 @@ import io.netty.util.ReferenceCountUtil;
 public class ResponseInfo {
   private final RequestInfo requestInfo;
   private final NetworkClientErrorCode error;
-  private final Object response;
   private final DataNodeId dataNode;
+  private Object response;
 
   /**
    * Constructs a ResponseInfo with the given parameters.
@@ -69,20 +69,12 @@ public class ResponseInfo {
   }
 
   /**
-   * Increase the reference count of underlying response.
-   */
-  public void retain() {
-    if (response != null) {
-      ReferenceCountUtil.retain(response);
-    }
-  }
-
-  /**
    * Decrease the reference count of underlying response.
    */
   public void release() {
     if (response != null) {
       ReferenceCountUtil.release(response);
+      response = null;
     }
   }
 

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.commons;
 
 import com.github.ambry.router.Callback;
+import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;

--- a/ambry-commons/src/test/java/com.github.ambry.commons/CopyingAsyncWritableChannelTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/CopyingAsyncWritableChannelTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.rest.RestServiceErrorCode;
 import com.github.ambry.rest.RestServiceException;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.FutureResult;
+import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.utils.TestUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobData.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobData.java
@@ -90,7 +90,7 @@ public class BlobData {
   }
 
   /**
-   * Return the netty {@link ByteBuf} and then transfer the ownship to the caller. It's not safe
+   * Return the netty {@link ByteBuf} and then transfer the ownership to the caller. It's not safe
    * to call this method more than once.
    */
   public ByteBuf getAndRelease() {

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobData.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobData.java
@@ -14,6 +14,9 @@
 package com.github.ambry.messageformat;
 
 import com.github.ambry.utils.ByteBufferInputStream;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.nio.ByteBuffer;
 
 
 /**
@@ -22,7 +25,20 @@ import com.github.ambry.utils.ByteBufferInputStream;
 public class BlobData {
   private final BlobType blobType;
   private final long size;
-  private final ByteBufferInputStream stream;
+  private ByteBuf byteBuf;
+  private ByteBufferInputStream stream = null;
+
+  /**
+   * The blob data contains the stream and other required info
+   * @param blobType {@link BlobType} of the blob
+   * @param size The size of the blob content.
+   * @param byteBuf The content of this blob in a {@link ByteBuf}.
+   */
+  public BlobData(BlobType blobType, long size, ByteBuf byteBuf) {
+    this.blobType = blobType;
+    this.size = size;
+    this.byteBuf = byteBuf;
+  }
 
   /**
    * The blob data contains the stream and other required info
@@ -30,9 +46,11 @@ public class BlobData {
    * @param size The size of the blob content.
    * @param stream The {@link ByteBufferInputStream} containing the blob content.
    */
+  @Deprecated
   public BlobData(BlobType blobType, long size, ByteBufferInputStream stream) {
     this.blobType = blobType;
     this.size = size;
+    this.byteBuf = Unpooled.wrappedBuffer(stream.getByteBuffer());
     this.stream = stream;
   }
 
@@ -53,7 +71,36 @@ public class BlobData {
   /**
    * @return the {@link ByteBufferInputStream} containing the blob content.
    */
+  @Deprecated
   public ByteBufferInputStream getStream() {
+    if (stream != null) {
+      return stream;
+    }
+    // The blob content is passed as a ByteBuf
+    if (byteBuf == null) {
+      return null;
+    }
+    ByteBuffer temp = ByteBuffer.allocate(byteBuf.readableBytes());
+    byteBuf.writeBytes(temp);
+    byteBuf.release();
+    byteBuf = null;
+    stream = new ByteBufferInputStream(temp);
     return stream;
+  }
+
+  /**
+   * Return the netty {@link ByteBuf} and then transfer the ownship to the caller. It's not safe
+   * to call this method more than once.
+   */
+  public ByteBuf getAndRelease() {
+    if (byteBuf == null) {
+      return null;
+    }
+    try {
+      return byteBuf.retainedDuplicate();
+    } finally {
+      byteBuf.release();
+      byteBuf = null;
+    }
   }
 }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobData.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/BlobData.java
@@ -76,14 +76,15 @@ public class BlobData {
     if (stream != null) {
       return stream;
     }
-    // The blob content is passed as a ByteBuf
+    // The blob content is passed as a ByteBuf since the stream is nulle
     if (byteBuf == null) {
       return null;
     }
     ByteBuffer temp = ByteBuffer.allocate(byteBuf.readableBytes());
-    byteBuf.writeBytes(temp);
+    byteBuf.readBytes(temp);
     byteBuf.release();
     byteBuf = null;
+    temp.flip();
     stream = new ByteBufferInputStream(temp);
     return stream;
   }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatRecordTest.java
@@ -173,7 +173,7 @@ public class MessageFormatRecordTest {
     BlobData blobData = MessageFormatRecord.deserializeBlob(new ByteBufferInputStream(sData));
     Assert.assertEquals(blobData.getSize(), 2000);
     byte[] verify = new byte[2000];
-    blobData.getStream().read(verify);
+    blobData.getAndRelease().readBytes(verify);
     Assert.assertArrayEquals(verify, data.array());
 
     // corrupt blob record V1
@@ -640,7 +640,7 @@ public class MessageFormatRecordTest {
     BlobData blobData = getBlobRecordV2(blobSize, blobType, blobContent, entireBlob);
     Assert.assertEquals("Blob size mismatch", blobSize, blobData.getSize());
     byte[] verify = new byte[blobSize];
-    blobData.getStream().read(verify);
+    blobData.getAndRelease().readBytes(verify);
     Assert.assertArrayEquals("BlobContent mismatch", blobContent.array(), verify);
 
     // corrupt blob record V2
@@ -694,7 +694,7 @@ public class MessageFormatRecordTest {
 
       Assert.assertEquals(metadataContentSize, blobData.getSize());
       byte[] verify = new byte[metadataContentSize];
-      blobData.getStream().read(verify);
+      blobData.getAndRelease().readBytes(verify);
       Assert.assertArrayEquals("Metadata content mismatch", metadataContent.array(), verify);
 
       // deserialize and check for metadata contents
@@ -728,7 +728,7 @@ public class MessageFormatRecordTest {
     BlobData blobData = getBlobRecordV2(metadataContentSize, BlobType.MetadataBlob, metadataContent, blob);
     Assert.assertEquals(metadataContentSize, blobData.getSize());
     byte[] verify = new byte[metadataContentSize];
-    blobData.getStream().read(verify);
+    blobData.getAndRelease().readBytes(verify);
     Assert.assertArrayEquals("Metadata content mismatch", metadataContent.array(), verify);
 
     metadataContent.rewind();

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatSendTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatSendTest.java
@@ -468,7 +468,7 @@ public class MessageFormatSendTest {
       Assert.assertEquals(BlobType.DataBlob, deserializedBlob.getBlobData().getBlobType());
       Assert.assertEquals(blob[i].length, deserializedBlob.getBlobData().getSize());
       byte[] readBlob = new byte[blob[i].length];
-      deserializedBlob.getBlobData().getStream().read(readBlob);
+      deserializedBlob.getBlobData().getAndRelease().readBytes(readBlob);
       Assert.assertArrayEquals(blob[i], readBlob);
 
       if (headerVersions[i] == MessageFormatRecord.Message_Header_Version_V1) {

--- a/ambry-network/src/test/java/com.github.ambry.network/SocketNetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SocketNetworkClientTest.java
@@ -18,7 +18,7 @@ import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.ReplicaId;
-import com.github.ambry.commons.NettyByteBufLeakHelper;
+import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.config.NetworkConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.MockTime;

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -150,6 +150,9 @@ class GetBlobOperation extends GetOperation {
    * conflict with the release call in the chunk async callback.
    */
   private void releaseResource() {
+    if (chunkIndexToBuf == null) {
+      return;
+    }
     for (Integer key : chunkIndexToBuf.keySet()) {
       ByteBuf byteBuf = chunkIndexToBuf.remove(key);
       if (byteBuf != null) {

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -44,7 +44,6 @@ import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.Time;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.ReferenceCountUtil;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/ChunkFillTest.java
@@ -28,6 +28,7 @@ import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
+import io.netty.buffer.Unpooled;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -331,7 +332,7 @@ public class ChunkFillTest {
       for (int i = 0; i < numChunks; i++) {
         compositeBuffers[i].flip();
         DecryptJob decryptJob =
-            new DecryptJob(compositeBlobIds[i], compositeEncryptionKeys[i], compositeBuffers[i], null, cryptoService,
+            new DecryptJob(compositeBlobIds[i], compositeEncryptionKeys[i], Unpooled.wrappedBuffer(compositeBuffers[i]), null, cryptoService,
                 kms, new CryptoJobMetricsTracker(routerMetrics.decryptJobMetrics), (result, exception) -> {
               Assert.assertNull("Exception shouldn't have been thrown", exception);
               int chunkSize = result.getDecryptedBlobContent().remaining();

--- a/ambry-router/src/test/java/com.github.ambry.router/CryptoServiceTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CryptoServiceTest.java
@@ -14,8 +14,8 @@
 package com.github.ambry.router;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.commons.NettyByteBufLeakHelper;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.utils.TestUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;

--- a/ambry-router/src/test/java/com.github.ambry.router/GCMCryptoServiceTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GCMCryptoServiceTest.java
@@ -14,8 +14,8 @@
 package com.github.ambry.router;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.commons.NettyByteBufLeakHelper;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.utils.TestUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -1064,7 +1064,6 @@ public class GetBlobOperationTest {
   public void testEarlyReadableStreamChannelClose() throws Exception {
     for (int numChunksInBlob = 0; numChunksInBlob <= 4; numChunksInBlob++) {
       for (int numChunksToRead = 0; numChunksToRead < numChunksInBlob; numChunksToRead++) {
-        System.out.println("" + numChunksInBlob + " chunks but only read " + numChunksToRead);
         testEarlyReadableStreamChannelClose(numChunksInBlob, numChunksToRead);
       }
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClient.java
@@ -16,6 +16,7 @@ package com.github.ambry.router;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.config.NetworkConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.SocketNetworkClient;
 import com.github.ambry.network.NetworkMetrics;
 import com.github.ambry.network.RequestInfo;
@@ -25,6 +26,7 @@ import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.Time;
 import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
 
@@ -41,8 +43,9 @@ class MockNetworkClient extends SocketNetworkClient {
    * Construct a MockNetworkClient with mock components.
    */
   MockNetworkClient() throws IOException {
-    super(new MockSelector(new MockServerLayout(new MockClusterMap()), null, new MockTime()), null,
-        new NetworkMetrics(new MetricRegistry()), 0, 0, 0, new MockTime());
+    super(new MockSelector(new MockServerLayout(new MockClusterMap()), null, new MockTime(),
+            new NetworkConfig(new VerifiableProperties(new Properties()))), null, new NetworkMetrics(new MetricRegistry()),
+        0, 0, 0, new MockTime());
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClientFactory.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockNetworkClientFactory.java
@@ -66,7 +66,7 @@ class MockNetworkClientFactory extends SocketNetworkClientFactory {
    */
   @Override
   public SocketNetworkClient getNetworkClient() throws IOException {
-    MockSelector selector = new MockSelector(serverLayout, state, time);
+    MockSelector selector = new MockSelector(serverLayout, state, time, networkConfig);
     return new SocketNetworkClient(selector, networkConfig, new NetworkMetrics(new MetricRegistry()), maxPortsPlainText,
         maxPortsSsl, checkoutTimeoutMs, time);
   }
@@ -77,7 +77,7 @@ class MockNetworkClientFactory extends SocketNetworkClientFactory {
    * @throws IOException if the selector could not be constructed.
    */
   public MockNetworkClient getMockNetworkClient() throws IOException {
-    MockSelector selector = new MockSelector(serverLayout, state, time);
+    MockSelector selector = new MockSelector(serverLayout, state, time, networkConfig);
     return new MockNetworkClient(selector, networkConfig, new NetworkMetrics(new MetricRegistry()), maxPortsPlainText,
         maxPortsSsl, checkoutTimeoutMs, time);
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -44,6 +44,7 @@ import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.ThrowingConsumer;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
+import io.netty.buffer.Unpooled;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1117,7 +1118,7 @@ public class PutManagerTest {
         ByteBuffer userMetadata = request.getUsermetadata();
         // reason to directly call run() instead of spinning up a thread instead of calling start() is that, any exceptions or
         // assertion failures in non main thread will not fail the test.
-        new DecryptJob(origBlobId, request.getBlobEncryptionKey().duplicate(), ByteBuffer.wrap(content), userMetadata,
+        new DecryptJob(origBlobId, request.getBlobEncryptionKey().duplicate(), Unpooled.wrappedBuffer(content), userMetadata,
             cryptoService, kms, new CryptoJobMetricsTracker(metrics.decryptJobMetrics), (result, exception) -> {
           assertNull("Exception should not be thrown", exception);
           assertEquals("BlobId mismatch", origBlobId, result.getBlobId());
@@ -1158,7 +1159,7 @@ public class PutManagerTest {
         // reason to directly call run() instead of spinning up a thread instead of calling start() is that, any exceptions or
         // assertion failures in non main thread will not fail the test.
         new DecryptJob(dataBlobPutRequest.getBlobId(), dataBlobPutRequest.getBlobEncryptionKey().duplicate(),
-            ByteBuffer.wrap(dataBlobContent), dataBlobPutRequest.getUsermetadata().duplicate(), cryptoService, kms,
+            Unpooled.wrappedBuffer(dataBlobContent), dataBlobPutRequest.getUsermetadata().duplicate(), cryptoService, kms,
             new CryptoJobMetricsTracker(metrics.decryptJobMetrics), (result, exception) -> {
           Assert.assertNull("Exception should not be thrown", exception);
           assertEquals("BlobId mismatch", dataBlobPutRequest.getBlobId(), result.getBlobId());

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -48,6 +48,7 @@ import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
+import io.netty.buffer.ByteBuf;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -436,7 +437,12 @@ public class ServerHardDeleteTest {
           BlobData blobData = MessageFormatRecord.deserializeBlob(resp.getInputStream());
           Assert.assertEquals(properties.get(i).getBlobSize(), blobData.getSize());
           byte[] dataOutput = new byte[(int) blobData.getSize()];
-          blobData.getStream().read(dataOutput);
+          ByteBuf buffer = blobData.getAndRelease();
+          try {
+            buffer.readBytes(dataOutput);
+          } finally {
+            buffer.release();
+          }
           Assert.assertArrayEquals(dataOutput, data.get(i));
         }
       } else {

--- a/ambry-utils/src/main/java/com.github.ambry.utils/ByteBufferInputStream.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/ByteBufferInputStream.java
@@ -42,17 +42,7 @@ public class ByteBufferInputStream extends InputStream {
    * @throws IOException
    */
   public ByteBufferInputStream(InputStream stream, int size) throws IOException {
-    this.byteBuffer = ByteBuffer.allocate(size);
-    int read = 0;
-    ReadableByteChannel readableByteChannel = Channels.newChannel(stream);
-    while (read < size) {
-      int sizeRead = readableByteChannel.read(byteBuffer);
-      if (sizeRead == 0 || sizeRead == -1) {
-        throw new IOException("Total size read " + read + " is less than the size to be read " + size);
-      }
-      read += sizeRead;
-    }
-    byteBuffer.flip();
+    this.byteBuffer = Utils.getByteBufferFromInputStream(stream, size);
     this.mark = -1;
     this.readLimit = -1;
   }

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -261,7 +261,7 @@ public class Utils {
    * @return The {@link ByteBuffer}
    * @throws IOException Unexpected IO errors.
    */
-   public static ByteBuffer getByteBufferFromInputStream(InputStream stream, int dataSize) throws IOException {
+  public static ByteBuffer getByteBufferFromInputStream(InputStream stream, int dataSize) throws IOException {
     ByteBuffer output = ByteBuffer.allocate(dataSize);
     int read = 0;
     ReadableByteChannel readableByteChannel = Channels.newChannel(stream);
@@ -907,7 +907,8 @@ public class Utils {
    * @throws IOException
    */
   public static byte[] readBytesFromByteBuf(ByteBuf buffer, byte[] data, int offset, int size) throws IOException {
-    return readBytesFromStream(new ByteBufInputStream(buffer), data, offset, size);
+    buffer.readBytes(data, offset, size);
+    return data;
   }
 
   /**

--- a/ambry-utils/src/test/java/com.github.ambry.utils/NettyByteBufLeakHelper.java
+++ b/ambry-utils/src/test/java/com.github.ambry.utils/NettyByteBufLeakHelper.java
@@ -11,7 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package com.github.ambry.commons;
+package com.github.ambry.utils;
 
 import io.netty.buffer.PoolArenaMetric;
 import io.netty.buffer.PooledByteBufAllocator;

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ subprojects {
         systemProperty 'io.netty.allocator.smallCacheSize', '0'
         systemProperty 'io.netty.allocator.normalCacheSize', '0'
         systemProperty 'io.netty.allocator.maxCachedBufferCapacity', '0'
+        systemProperty 'io.netty.leakDetection.acquireAndReleaseOnly', 'true'
     }
 
     task intTest(type: Test) {


### PR DESCRIPTION
This starts to use Netty ByteBuf in GetBlobOperation.

This PR seeks the least intrusive way to introduce Netty ByteBuf to GetBlobOperation, so it ignores a lot of places where the ByteBuffer can be replaced by Netty ByteBuf.

The major change is to change the buffer/inputstream in BlobData to use Netty ByteBuf.