### PR TITLE
Introduce current state in BlobStore to help validate requests

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ServerConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ServerConfig.java
@@ -86,6 +86,9 @@ public class ServerConfig {
   @Default("")
   public final List<String> serverStatsReportsToPublish;
 
+  /**
+   * The option to enable or disable validating request based on store state.
+   */
   @Config("server.validate.request.based.on.store.state")
   @Default("false")
   public final boolean serverValidateRequestBasedOnStoreState;

--- a/ambry-api/src/main/java/com.github.ambry/config/ServerConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ServerConfig.java
@@ -86,6 +86,10 @@ public class ServerConfig {
   @Default("")
   public final List<String> serverStatsReportsToPublish;
 
+  @Config("server.validate.request.based.on.store.state")
+  @Default("false")
+  public final boolean serverValidateRequestBasedOnStoreState;
+
   public ServerConfig(VerifiableProperties verifiableProperties) {
     serverRequestHandlerNumOfThreads = verifiableProperties.getInt("server.request.handler.num.of.threads", 7);
     serverSchedulerNumOfthreads = verifiableProperties.getInt("server.scheduler.num.of.threads", 10);
@@ -101,5 +105,7 @@ public class ServerConfig {
         "com.github.ambry.messageformat.ValidatingTransformer");
     serverStatsReportsToPublish =
         Utils.splitString(verifiableProperties.getString("server.stats.reports.to.publish", ""), ",");
+    serverValidateRequestBasedOnStoreState =
+        verifiableProperties.getBoolean("server.validate.request.based.on.store.state", false);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/server/StoreManager.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/StoreManager.java
@@ -70,7 +70,7 @@ public interface StoreManager {
   /**
    * Check if a certain partition is available locally.
    * @param partition the {@link PartitionId} to check.
-   * @param localReplica {@link ReplicaId} of localreplica of the partition {@code PartitionId}.
+   * @param localReplica {@link ReplicaId} of local replica of the partition {@code PartitionId}.
    * @return {@code true} if the partition is available. {@code false} if not.
    */
   ServerErrorCode checkLocalPartitionStatus(PartitionId partition, ReplicaId localReplica);

--- a/ambry-api/src/main/java/com.github.ambry/store/Store.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/Store.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.store;
 
+import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.replication.FindToken;
 import java.util.EnumSet;
 import java.util.List;
@@ -108,6 +109,17 @@ public interface Store {
    * @return true if the store is started
    */
   boolean isStarted();
+
+  /**
+   * Set current state of the store.
+   * @param state {@link ReplicaState} associated with local store
+   */
+  void setCurrentState(ReplicaState state);
+
+  /**
+   * @return current {@link ReplicaState} of the store
+   */
+  ReplicaState getCurrentState();
 
   /**
    * Shuts down the store

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
@@ -16,6 +16,7 @@ package com.github.ambry.cloud;
 import com.codahale.metrics.Timer;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.ClusterMapConfig;
@@ -463,6 +464,16 @@ class CloudBlobStore implements Store {
   public boolean isEmpty() {
     // TODO: query destination stats in start method
     return false;
+  }
+
+  @Override
+  public void setCurrentState(ReplicaState state) {
+    throw new UnsupportedOperationException("Method not supported");
+  }
+
+  @Override
+  public ReplicaState getCurrentState() {
+    throw new UnsupportedOperationException("Method not supported");
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
@@ -42,6 +42,7 @@ public class AmbryPartitionStateModel extends StateModel {
 
   @Transition(to = "BOOTSTRAP", from = "OFFLINE")
   public void onBecomeBootstrapFromOffline(Message message, NotificationContext context) {
+    // TODO to distinguish between regular start and dynamic replica addition, check 1. store dir, 2. if there is bootstrap log
     logger.info("Partition {} in resource {} is becoming BOOTSTRAP from OFFLINE", message.getPartitionName(),
         message.getResourceName());
   }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
@@ -14,6 +14,7 @@
 package com.github.ambry.replication;
 
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.store.FindInfo;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MessageReadSet;
@@ -307,6 +308,16 @@ class InMemoryStore implements Store {
   @Override
   public boolean isEmpty() {
     return log.blobs.isEmpty();
+  }
+
+  @Override
+  public void setCurrentState(ReplicaState state) {
+    throw new UnsupportedOperationException("Method not supported");
+  }
+
+  @Override
+  public ReplicaState getCurrentState() {
+    throw new UnsupportedOperationException("Method not supported");
   }
 
   @Override

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
@@ -197,7 +197,7 @@ public class AmbryServer {
       ServerMetrics serverMetrics = new ServerMetrics(registry, AmbryRequests.class, AmbryServer.class);
       requests = new AmbryServerRequests(storageManager, networkServer.getRequestResponseChannel(), clusterMap, nodeId,
           registry, serverMetrics, findTokenHelper, notificationSystem, replicationManager, storeKeyFactory,
-          serverConfig.serverEnableStoreDataPrefetch, storeKeyConverterFactory, statsManager);
+          serverConfig, storeKeyConverterFactory, statsManager);
       requestHandlerPool = new RequestHandlerPool(serverConfig.serverRequestHandlerNumOfThreads,
           networkServer.getRequestResponseChannel(), requests);
       networkServer.start();

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
@@ -72,10 +72,9 @@ public class AmbryServerRequests extends AmbryRequests {
   private final ConcurrentHashMap<RequestOrResponseType, Set<PartitionId>> requestsDisableInfo =
       new ConcurrentHashMap<>();
   private final ConcurrentHashMap<PartitionId, ReplicaId> localPartitionToReplicaMap;
-  // POST requests are allowed on stores which are in LEADER or STANDBY state
-  static final Set<ReplicaState> POST_ALLOWED_STORE_STATES =
-      EnumSet.of(ReplicaState.LEADER, ReplicaState.STANDBY);
-  // UPDATE requests (including DELETE, TTLUpdate) are allowed on stores that are LEADER/STANDBY/INACTIVE/BOOTSTRAP
+  // POST requests are allowed on stores states: { LEADER, STANDBY }
+  static final Set<ReplicaState> POST_ALLOWED_STORE_STATES = EnumSet.of(ReplicaState.LEADER, ReplicaState.STANDBY);
+  // UPDATE requests (including DELETE, TTLUpdate) are allowed on stores states: { LEADER, STANDBY, INACTIVE, BOOTSTRAP }
   static final Set<ReplicaState> UPDATE_ALLOWED_STORE_STATES =
       EnumSet.of(ReplicaState.LEADER, ReplicaState.STANDBY, ReplicaState.INACTIVE, ReplicaState.BOOTSTRAP);
   static final Set<RequestOrResponseType> UPDATE_REQUEST_TYPES =

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
@@ -73,7 +73,7 @@ public class AmbryServerRequests extends AmbryRequests {
       new ConcurrentHashMap<>();
   private final ConcurrentHashMap<PartitionId, ReplicaId> localPartitionToReplicaMap;
   // POST requests are allowed on stores states: { LEADER, STANDBY }
-  static final Set<ReplicaState> POST_ALLOWED_STORE_STATES = EnumSet.of(ReplicaState.LEADER, ReplicaState.STANDBY);
+  static final Set<ReplicaState> PUT_ALLOWED_STORE_STATES = EnumSet.of(ReplicaState.LEADER, ReplicaState.STANDBY);
   // UPDATE requests (including DELETE, TTLUpdate) are allowed on stores states: { LEADER, STANDBY, INACTIVE, BOOTSTRAP }
   static final Set<ReplicaState> UPDATE_ALLOWED_STORE_STATES =
       EnumSet.of(ReplicaState.LEADER, ReplicaState.STANDBY, ReplicaState.INACTIVE, ReplicaState.BOOTSTRAP);
@@ -162,15 +162,15 @@ public class AmbryServerRequests extends AmbryRequests {
     if (serverConfig.serverValidateRequestBasedOnStoreState) {
       // 2. check if request is disabled due to current state of store
       Store store = storeManager.getStore(id);
-      if (requestType == RequestOrResponseType.PutRequest && !POST_ALLOWED_STORE_STATES.contains(
+      if (requestType == RequestOrResponseType.PutRequest && !PUT_ALLOWED_STORE_STATES.contains(
           store.getCurrentState())) {
-        logger.error("{} is not allowed because current state of store {} is {}", requestType, id,
+        logger.warn("{} is not allowed because current state of store {} is {}", requestType, id,
             store.getCurrentState());
         return false;
       }
       if (UPDATE_REQUEST_TYPES.contains(requestType) && !UPDATE_ALLOWED_STORE_STATES.contains(
           store.getCurrentState())) {
-        logger.error("{} is not allowed because current state of store {} is {}", requestType, id,
+        logger.warn("{} is not allowed because current state of store {} is {}", requestType, id,
             store.getCurrentState());
         return false;
       }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryServerRequestsTest.java
@@ -201,7 +201,8 @@ public class AmbryServerRequestsTest {
     Map<ReplicaState, ReplicaId> stateToReplica = new HashMap<>();
     int cnt = 0;
     for (ReplicaState state : EnumSet.complementOf(EnumSet.of(ReplicaState.ERROR))) {
-      stateToReplica.put(state, localReplicas.get(cnt++));
+      stateToReplica.put(state, localReplicas.get(cnt));
+      cnt++;
     }
     // set store state
     for (Map.Entry<ReplicaState, ReplicaId> entry : stateToReplica.entrySet()) {
@@ -212,10 +213,8 @@ public class AmbryServerRequestsTest {
         RequestOrResponseType.DeleteRequest, RequestOrResponseType.TtlUpdateRequest)) {
       for (Map.Entry<ReplicaState, ReplicaId> entry : stateToReplica.entrySet()) {
         if (request == RequestOrResponseType.PutRequest) {
-          System.out.println("replica state = " + entry.getKey() + ", store state = " + storageManager.getStore(
-              entry.getValue().getPartitionId()).getCurrentState());
           // for PUT request, it is not allowed on OFFLINE,BOOTSTRAP and INACTIVE when validateRequestOnStoreState = true
-          if (AmbryServerRequests.POST_ALLOWED_STORE_STATES.contains(entry.getKey())) {
+          if (AmbryServerRequests.PUT_ALLOWED_STORE_STATES.contains(entry.getKey())) {
             assertEquals("Error code is not expected for PUT request", ServerErrorCode.No_Error,
                 ambryRequests.validateRequest(entry.getValue().getPartitionId(), request, false));
           } else {

--- a/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
@@ -59,6 +59,9 @@ import java.util.stream.Collectors;
  */
 class MockStorageManager extends StorageManager {
 
+  /**
+   * Mocked {@link Store} that is intended to perform predefined behavior.
+   */
   private class TestStore implements Store {
     boolean started;
     ReplicaState currentState = ReplicaState.STANDBY;

--- a/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
@@ -21,6 +21,7 @@ import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.config.StatsManagerConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.Port;
@@ -587,6 +588,16 @@ public class StatsManagerTest {
 
     @Override
     public boolean isEmpty() {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public void setCurrentState(ReplicaState state) {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public ReplicaState getCurrentState() {
       throw new IllegalStateException("Not implemented");
     }
 

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -15,6 +15,7 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.Timer;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.replication.FindToken;
@@ -76,6 +77,7 @@ public class BlobStore implements Store {
   private BlobStoreStats blobStoreStats;
   private boolean started;
   private FileLock fileLock;
+  private ReplicaState currentState;
   protected PersistentIndex index;
 
   /**
@@ -171,6 +173,7 @@ public class BlobStore implements Store {
     this.thresholdBytesLow = (long) (capacityInBytes * ((threshold - delta) / 100.0));
     ttlUpdateBufferTimeMs = TimeUnit.SECONDS.toMillis(config.storeTtlUpdateBufferTimeSeconds);
     errorCount = new AtomicInteger(0);
+    currentState = ReplicaState.OFFLINE;
     logger.debug(
         "The enable state of replicaStatusDelegate is {} on store {}. The high threshold is {} bytes and the low threshold is {} bytes",
         config.storeReplicaStatusDelegateEnable, storeId, this.thresholdBytesHigh, this.thresholdBytesLow);
@@ -669,6 +672,16 @@ public class BlobStore implements Store {
   @Override
   public boolean isEmpty() {
     return index.isEmpty();
+  }
+
+  @Override
+  public void setCurrentState(ReplicaState state) {
+    currentState = state;
+  }
+
+  @Override
+  public ReplicaState getCurrentState() {
+    return currentState;
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -230,6 +230,9 @@ public class BlobStore implements Store {
         logger.trace("The store {} is successfully started", storeId);
         onSuccess();
         started = true;
+        // This is to be compatible with static clustermap. If static cluster manager is adopted, all replicas are supposed to be STANDBY
+        // and router relies on failure detector to track liveness of replicas(stores).
+        currentState = ReplicaState.STANDBY;
         if (replicaId != null) {
           replicaId.markDiskUp();
         }

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -77,7 +77,7 @@ public class BlobStore implements Store {
   private BlobStoreStats blobStoreStats;
   private boolean started;
   private FileLock fileLock;
-  private ReplicaState currentState;
+  private volatile ReplicaState currentState;
   protected PersistentIndex index;
 
   /**

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.ReplicaStatusDelegate;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
@@ -1816,6 +1817,7 @@ public class BlobStoreTest {
     }
     assertFalse("Store should be shutdown", store.isStarted());
     store = createBlobStore(replicaId, config, delegate);
+    assertEquals("Store should be in OFFLINE state after creation", ReplicaState.OFFLINE, store.getCurrentState());
     assertFalse("Store should not be started", store.isStarted());
     store.start();
     assertTrue("Store should be started", store.isStarted());
@@ -1831,6 +1833,8 @@ public class BlobStoreTest {
   private void verifyStartupSuccess(BlobStore blobStore) throws StoreException {
     blobStore.start();
     assertTrue("Store has not been started", blobStore.isStarted());
+    assertEquals("Store current state should be STANDBY after it is successfully started", ReplicaState.STANDBY,
+        blobStore.getCurrentState());
     blobStore.shutdown();
   }
 


### PR DESCRIPTION
This PR introduces current state in BlobStore that is updated by state
transition (Helix controller initiates the transition). Store's current
state is used to validate requests and reject some of them if frontends
have old view of the store. For example, store has transitted to
INACTIVE state but due to Helix notification delay, some frontends may
still believe store is in STANDBY. To avoid such inconsistent view, we
use current state (which is always up-to-date) to validate coming
requests.