### PR TITLE
Simplify PutRequest by removing ReceivedPutRequest

### DIFF
--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AmbryRequests.java
@@ -148,7 +148,7 @@ public class AmbryRequests implements RequestAPI {
   public void handlePutRequest(Request request) throws IOException, InterruptedException {
     InputStream is = request.getInputStream();
     DataInputStream dis = is instanceof DataInputStream ? (DataInputStream) is : new DataInputStream(is);
-    PutRequest.ReceivedPutRequest receivedRequest = PutRequest.readFrom(dis, clusterMap);
+    PutRequest receivedRequest = PutRequest.readFrom(dis, clusterMap);
     long requestQueueTime = SystemTime.getInstance().milliseconds() - request.getStartTimeInMs();
     long totalTimeSpent = requestQueueTime;
     metrics.putBlobRequestQueueTimeInMs.update(requestQueueTime);

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
@@ -40,19 +40,26 @@ public class PutRequest extends RequestOrResponse {
   protected final BlobProperties properties;
   protected final BlobType blobType;
   protected final ByteBuffer blobEncryptionKey;
+
+  // Used to carry blob content in ambry-frontend when creating this PutRequest.
   protected final ByteBuffer blob;
-  protected final InputStream blobStream;
-  protected final Long crcValue;
   // crc will cover all the fields associated with the blob, namely:
   // blob type
   // BlobId
   // BlobProperties
   // UserMetadata
   // BlobData
+
+  // Used to calculate crc value in ambry-frontend.
   private final Crc32 crc;
   private final ByteBuffer crcBuf;
   private boolean okayToWriteCrc = false;
   private int sizeExcludingBlobAndCrc = -1;
+
+  // Used to carry blob content in ambry-server when receiving this PutRequest.
+  protected final InputStream blobStream;
+  // Crc value received from network.
+  protected final Long crcValue;
 
   private static final int USERMETADATA_SIZE_IN_BYTES = Integer.BYTES;
   private static final int BLOB_SIZE_IN_BYTES = Long.BYTES;
@@ -281,6 +288,7 @@ public class PutRequest extends RequestOrResponse {
   }
 
   /**
+   * This method should only be used in the ambry-server after receiving a PutRequest.
    * @return the {@link InputStream} from which to stream in the data associated with the blob.
    */
   public InputStream getBlobStream() {
@@ -288,6 +296,7 @@ public class PutRequest extends RequestOrResponse {
   }
 
   /**
+   * This method should only be used in the ambry-server after receiving a PutRequest.
    * @return the crc associated with the request.
    */
   public Long getCrc() {

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
@@ -123,6 +123,13 @@ public class PutRequest extends RequestOrResponse {
     this.crcValue = crc;
   }
 
+  /**
+   * Deserialize {@link PutRequest} from a given {@link DataInputStream}.
+   * @param stream The stream that contains the serialized bytes.
+   * @param map The {@link ClusterMap} to help build {@link BlobId}.
+   * @return A deserialized {@link PutRequest}.
+   * @throws IOException Any I/O Errors.
+   */
   public static PutRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
     short versionId = stream.readShort();
     switch (versionId) {

--- a/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
+++ b/ambry-protocol/src/test/java/com.github.ambry.protocol/RequestResponseTest.java
@@ -212,7 +212,7 @@ public class RequestResponseTest {
             ByteBuffer.wrap(blob), blobSize, blobType, blobKey == null ? null : ByteBuffer.wrap(blobKey)).sizeInBytes();
     // Initialize channel write limits in such a way that writeTo() may or may not be able to write out all the
     // data at once.
-   int channelWriteLimits[] =
+    int channelWriteLimits[] =
         {sizeInBytes, 2 * sizeInBytes, sizeInBytes / 2, sizeInBytes / (TestUtils.RANDOM.nextInt(sizeInBytes - 1) + 1)};
     int sizeInBlobProperties = (int) blobProperties.getBlobSize();
     DataInputStream requestStream;
@@ -235,7 +235,7 @@ public class RequestResponseTest {
                 ByteBuffer.wrap(blob), blobSize, blobType, blobKey == null ? null : ByteBuffer.wrap(blobKey));
           }
           requestStream = serAndPrepForRead(request, allocationSize, true);
-          PutRequest.ReceivedPutRequest deserializedPutRequest = PutRequest.readFrom(requestStream, clusterMap);
+          PutRequest deserializedPutRequest = PutRequest.readFrom(requestStream, clusterMap);
           Assert.assertEquals(blobId, deserializedPutRequest.getBlobId());
           Assert.assertEquals(sizeInBlobProperties, deserializedPutRequest.getBlobProperties().getBlobSize());
           Assert.assertArrayEquals(userMetadata, deserializedPutRequest.getUsermetadata().array());

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
@@ -197,7 +197,7 @@ class MockServer {
         buf.getLong();
         // read off the type.
         buf.getShort();
-        PutRequest.ReceivedPutRequest originalBlobPutReq =
+        PutRequest originalBlobPutReq =
             PutRequest.readFrom(new DataInputStream(new ByteBufferInputStream(buf)), clusterMap);
         switch (getRequest.getMessageFormatFlag()) {
           case BlobInfo:
@@ -575,7 +575,7 @@ class StoredBlob {
     receivedStream.readLong();
     // read of the RequestResponse type.
     receivedStream.readShort();
-    PutRequest.ReceivedPutRequest receivedPutRequest = PutRequest.readFrom(receivedStream, clusterMap);
+    PutRequest receivedPutRequest = PutRequest.readFrom(receivedStream, clusterMap);
     id = receivedPutRequest.getBlobId().getID();
     type = receivedPutRequest.getBlobType();
     properties = receivedPutRequest.getBlobProperties();

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -1041,7 +1041,7 @@ public class PutManagerTest {
       throws Exception {
     String blobId = requestAndResult.result.result();
     ByteBuffer serializedRequest = serializedRequests.get(blobId);
-    PutRequest.ReceivedPutRequest request = deserializePutRequest(serializedRequest);
+    PutRequest request = deserializePutRequest(serializedRequest);
     NotificationBlobType notificationBlobType;
     BlobId origBlobId = new BlobId(blobId, mockClusterMap);
     boolean stitchOperation = requestAndResult.chunksToStitch != null;
@@ -1134,18 +1134,17 @@ public class PutManagerTest {
    * @param originalPutContent original out content
    * @param originalUserMetadata original user-metadata
    * @param dataBlobIds {@link List} of {@link StoreKey}s of the composite blob in context
-   * @param request {@link com.github.ambry.protocol.PutRequest.ReceivedPutRequest} to fetch info from
+   * @param request {@link com.github.ambry.protocol.PutRequest} to fetch info from
    * @param serializedRequests the mapping from blob ids to their corresponding serialized {@link PutRequest}.
    * @throws Exception
    */
   private void verifyCompositeBlob(BlobProperties properties, byte[] originalPutContent, byte[] originalUserMetadata,
-      List<StoreKey> dataBlobIds, PutRequest.ReceivedPutRequest request, HashMap<String, ByteBuffer> serializedRequests)
-      throws Exception {
+      List<StoreKey> dataBlobIds, PutRequest request, HashMap<String, ByteBuffer> serializedRequests) throws Exception {
     StoreKey lastKey = dataBlobIds.get(dataBlobIds.size() - 1);
     byte[] content = new byte[(int) request.getBlobProperties().getBlobSize()];
     AtomicInteger offset = new AtomicInteger(0);
     for (StoreKey key : dataBlobIds) {
-      PutRequest.ReceivedPutRequest dataBlobPutRequest = deserializePutRequest(serializedRequests.get(key.getID()));
+      PutRequest dataBlobPutRequest = deserializePutRequest(serializedRequests.get(key.getID()));
       AtomicInteger dataBlobLength = new AtomicInteger((int) dataBlobPutRequest.getBlobSize());
       InputStream dataBlobStream = dataBlobPutRequest.getBlobStream();
       if (!properties.isEncrypted()) {
@@ -1186,7 +1185,7 @@ public class PutManagerTest {
    * @param serialized the serialized ByteBuffer.
    * @return returns the deserialized output.
    */
-  private PutRequest.ReceivedPutRequest deserializePutRequest(ByteBuffer serialized) throws IOException {
+  private PutRequest deserializePutRequest(ByteBuffer serialized) throws IOException {
     serialized.getLong();
     serialized.getShort();
     return PutRequest.readFrom(new DataInputStream(new ByteBufferInputStream(serialized)), mockClusterMap);


### PR DESCRIPTION
We don't really need it ReceivedPutRequest, just like we don't have ReceivedGetResponse.