### PR TITLE
Adding an option to enable/disable TCP_NODELAY socket option

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ConnectionPoolConfig.java
@@ -67,6 +67,13 @@ public class ConnectionPoolConfig {
   @Default("true")
   public final boolean connectionPoolSocketResetOnError;
 
+  /**
+   * Enable TCP_NODELAY socket option
+   */
+  @Config("connectionpool.socket.enable.tcp.no.delay")
+  @Default("true")
+  public final boolean connectionPoolSocketEnableTcpNoDelay;
+
   public ConnectionPoolConfig(VerifiableProperties verifiableProperties) {
     connectionPoolReadBufferSizeBytes =
         verifiableProperties.getIntInRange("connectionpool.read.buffer.size.bytes", 1048576, 1, 1024 * 1024 * 1024);
@@ -80,5 +87,6 @@ public class ConnectionPoolConfig {
     connectionPoolMaxConnectionsPerPortSSL =
         verifiableProperties.getIntInRange("connectionpool.max.connections.per.port.ssl", 2, 1, 20);
     connectionPoolSocketResetOnError = verifiableProperties.getBoolean("connectionpool.socket.reset.on.error", true);
+    connectionPoolSocketEnableTcpNoDelay = verifiableProperties.getBoolean("connectionpool.socket.enable.tcp.no.delay", true);
   }
 }

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannel.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannel.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.network;
 
+import com.github.ambry.config.ConnectionPoolConfig;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -39,16 +40,29 @@ public class BlockingChannel implements ConnectedChannel {
   protected boolean connected = false;
   protected InputStream readChannel = null;
   protected WritableByteChannel writeChannel = null;
+  protected boolean enableTcpNoDelay;
   private Socket socket = null;
 
   public BlockingChannel(String host, int port, int readBufferSize, int writeBufferSize, int readTimeoutMs,
-      int connectTimeoutMs) {
+      int connectTimeoutMs, boolean enableTcpNoDelay) {
     this.host = host;
     this.port = port;
     this.readBufferSize = readBufferSize;
     this.writeBufferSize = writeBufferSize;
     this.readTimeoutMs = readTimeoutMs;
     this.connectTimeoutMs = connectTimeoutMs;
+    this.enableTcpNoDelay = enableTcpNoDelay;
+  }
+
+  public BlockingChannel(String host, int port, int readBufferSize, int writeBufferSize, int readTimeoutMs,
+      int connectTimeoutMs) {
+    this(host, port, readBufferSize, writeBufferSize, readTimeoutMs, connectTimeoutMs, true);
+  }
+
+  public BlockingChannel(String host, int port, ConnectionPoolConfig config) {
+    this(host, port, config.connectionPoolReadBufferSizeBytes, config.connectionPoolWriteBufferSizeBytes,
+        config.connectionPoolReadTimeoutMs, config.connectionPoolConnectTimeoutMs,
+        config.connectionPoolSocketEnableTcpNoDelay);
   }
 
   /**
@@ -89,7 +103,7 @@ public class BlockingChannel implements ConnectedChannel {
     }
     tcpSocket.setSoTimeout(readTimeoutMs);
     tcpSocket.setKeepAlive(true);
-    tcpSocket.setTcpNoDelay(true);
+    tcpSocket.setTcpNoDelay(enableTcpNoDelay);
     tcpSocket.connect(new InetSocketAddress(host, port), connectTimeoutMs);
 
     logger.debug("Created socket with SO_TIMEOUT = {} (requested {}), "

--- a/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelInfo.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/BlockingChannelInfo.java
@@ -166,13 +166,9 @@ class BlockingChannelInfo {
   private BlockingChannel getBlockingChannelBasedOnPortType(String host, int port) {
     BlockingChannel channel = null;
     if (this.port.getPortType() == PortType.PLAINTEXT) {
-      channel = new BlockingChannel(host, port, config.connectionPoolReadBufferSizeBytes,
-          config.connectionPoolWriteBufferSizeBytes, config.connectionPoolReadTimeoutMs,
-          config.connectionPoolConnectTimeoutMs);
+      channel = new BlockingChannel(host, port, config);
     } else if (this.port.getPortType() == PortType.SSL) {
-      channel = new SSLBlockingChannel(host, port, registry, config.connectionPoolReadBufferSizeBytes,
-          config.connectionPoolWriteBufferSizeBytes, config.connectionPoolReadTimeoutMs,
-          config.connectionPoolConnectTimeoutMs, sslSocketFactory, sslConfig);
+      channel = new SSLBlockingChannel(host, port, registry, config, sslSocketFactory, sslConfig);
     }
     return channel;
   }

--- a/ambry-network/src/main/java/com.github.ambry.network/SSLBlockingChannel.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/SSLBlockingChannel.java
@@ -15,6 +15,7 @@ package com.github.ambry.network;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.ConnectionPoolConfig;
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
@@ -34,8 +35,9 @@ public class SSLBlockingChannel extends BlockingChannel {
   public final Counter sslClientHandshakeCount;
 
   public SSLBlockingChannel(String host, int port, MetricRegistry registry, int readBufferSize, int writeBufferSize,
-      int readTimeoutMs, int connectTimeoutMs, SSLSocketFactory sslSocketFactory, SSLConfig sslConfig) {
-    super(host, port, readBufferSize, writeBufferSize, readTimeoutMs, connectTimeoutMs);
+      int readTimeoutMs, int connectTimeoutMs, boolean enableTcpNoDelay, SSLSocketFactory sslSocketFactory,
+      SSLConfig sslConfig) {
+    super(host, port, readBufferSize, writeBufferSize, readTimeoutMs, connectTimeoutMs, enableTcpNoDelay);
     if (sslSocketFactory == null) {
       throw new IllegalArgumentException("sslSocketFactory is null when creating SSLBlockingChannel");
     }
@@ -45,6 +47,19 @@ public class SSLBlockingChannel extends BlockingChannel {
         registry.counter(MetricRegistry.name(SSLBlockingChannel.class, "SslClientHandshakeErrorCount"));
     sslClientHandshakeCount =
         registry.counter(MetricRegistry.name(SSLBlockingChannel.class, "SslClientHandshakeCount"));
+  }
+
+  public SSLBlockingChannel(String host, int port, MetricRegistry registry, int readBufferSize, int writeBufferSize,
+      int readTimeoutMs, int connectTimeoutMs, SSLSocketFactory sslSocketFactory, SSLConfig sslConfig) {
+    this(host, port, registry, readBufferSize, writeBufferSize, readTimeoutMs, connectTimeoutMs, true, sslSocketFactory,
+        sslConfig);
+  }
+
+  public SSLBlockingChannel(String host, int port, MetricRegistry registry, ConnectionPoolConfig config,
+      SSLSocketFactory sslSocketFactory, SSLConfig sslConfig) {
+    this(host, port, registry, config.connectionPoolReadBufferSizeBytes, config.connectionPoolWriteBufferSizeBytes,
+        config.connectionPoolReadTimeoutMs, config.connectionPoolConnectTimeoutMs,
+        config.connectionPoolSocketEnableTcpNoDelay, sslSocketFactory, sslConfig);
   }
 
   /**


### PR DESCRIPTION
This change adds a configuration property to enable or disable TCP_NODELAY socket option in BlockingChannel (used for replication only ATM) and adds an additional (optional) parameter for the same. If the parameter is not provided - a default 'true' (enabled) is assumed. This means that the tests (which have not been updated) will have TCP_NODELAY socket option set to 'true'.