### PR TITLE
Support getting eligible replicas by state in OperationTracker

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -368,6 +368,10 @@ public class RouterConfig {
   @Default("false")
   public final boolean routerGetBlobOperationShareMemory;
 
+  @Config("router.get.eligible.replicas.by.state.enabled")
+  @Default("false")
+  public final boolean routerGetEligibleReplicasByStateEnabled;
+
   /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
@@ -462,5 +466,7 @@ public class RouterConfig {
         Integer.MAX_VALUE / routerMaxPutChunkSizeBytes);
     routerGetBlobOperationShareMemory =
         verifiableProperties.getBoolean("router.get.blob.operation.share.memory", false);
+    routerGetEligibleReplicasByStateEnabled =
+        verifiableProperties.getBoolean("router.get.eligible.replicas.by.state.enabled", false);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -364,10 +364,16 @@ public class RouterConfig {
   @Default("4")
   public final int routerMaxInMemGetChunks;
 
+  /**
+   * If {@code true}, the blob data shares memory with networking buffer in GetBlobOperation
+   */
   @Config("router.get.blob.operation.share.memory")
   @Default("false")
   public final boolean routerGetBlobOperationShareMemory;
 
+  /**
+   * if {@code true}, operation tracker will get replicas in required states based on the type of operation.
+   */
   @Config("router.get.eligible.replicas.by.state.enabled")
   @Default("false")
   public final boolean routerGetEligibleReplicasByStateEnabled;

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -372,7 +372,8 @@ public class RouterConfig {
   public final boolean routerGetBlobOperationShareMemory;
 
   /**
-   * if {@code true}, operation tracker will get replicas in required states based on the type of operation.
+   * if {@code true}, operation tracker will get replicas in required states based on the type of operation. This helps
+   * dynamically manage replicas in cluster (i.e. add/remove/move replicas) without restarting frontends.
    */
   @Config("router.get.eligible.replicas.by.state.enabled")
   @Default("false")

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -77,13 +78,11 @@ public class MockPartitionId implements PartitionId {
 
   @Override
   public List<ReplicaId> getReplicaIdsByState(ReplicaState state, String dcName) {
-    List<ReplicaId> replicas = new ArrayList<>();
-    replicaIds.forEach(r -> {
-      if (replicaAndState.get(r) == state && (dcName == null || r.getDataNodeId().getDatacenterName().equals(dcName))) {
-        replicas.add(r);
-      }
-    });
-    return replicas;
+    return replicaIds.stream()
+        .filter(r -> replicaAndState.get(r) == state && (dcName == null || r.getDataNodeId()
+            .getDatacenterName()
+            .equals(dcName)))
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
@@ -51,6 +51,7 @@ public class MockPartitionId implements PartitionId {
     this.partition = partition;
     this.partitionClass = partitionClass;
     this.replicaIds = new ArrayList<>(dataNodes.size());
+    replicaAndState = new HashMap<>();
     for (MockDataNodeId dataNode : dataNodes) {
       MockReplicaId replicaId = new MockReplicaId(dataNode.getPort(), this, dataNode, mountPathIndexToUse);
       replicaIds.add(replicaId);

--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -83,12 +83,9 @@ class SimpleOperationTracker implements OperationTracker {
   private static final Logger logger = LoggerFactory.getLogger(SimpleOperationTracker.class);
 
   /**
-   * Constructor for an {@code SimpleOperationTracker}.
-   * @param routerConfig The {@link RouterConfig} containing the configs for operation tracker.
-   * @param routerOperation The {@link RouterOperation} which {@link SimpleOperationTracker} is associated with.
-   * @param partitionId The partition on which the operation is performed.
-   * @param originatingDcName The original DC where blob was put.
-   * @param shuffleReplicas Indicates if the replicas need to be shuffled.
+   * Constructor for an {@code SimpleOperationTracker}. In constructor, there is a config allowing operation tracker to
+   * use eligible replicas to populate replica pool. ("eligible" replicas are those in required states for specific
+   * operation)
    * Following are different types of operation and their eligible replica states:
    *  ---------------------------------------------------------
    * |  Operation Type  |        Eligible Replica State        |
@@ -102,13 +99,18 @@ class SimpleOperationTracker implements OperationTracker {
    *  -----------------------------------------------------------------------
    * |  Operation Type  |        Parallelism              |  Success Target  |
    *  -----------------------------------------------------------------------
-   * |     POST         | 1~2 decided by adaptive tracker |         1        |
-   * |     GET          |           N                     |       N - 1      |
+   * |     GET          | 1~2 decided by adaptive tracker |         1        |
+   * |     PUT          |           N                     |       N - 1      |
    * |    DELETE        |          3~N                    |         2        |
    * |   TTLUpdate      |          3~N                    |         2        |
    *  -----------------------------------------------------------------------
    *  Note: for now, we still use 3 as parallelism for DELETE/TTLUpdate even though there are N eligible replicas, this
    *        can be adjusted to any number between 3 and N (inclusive)
+   * @param routerConfig The {@link RouterConfig} containing the configs for operation tracker.
+   * @param routerOperation The {@link RouterOperation} which {@link SimpleOperationTracker} is associated with.
+   * @param partitionId The partition on which the operation is performed.
+   * @param originatingDcName The original DC where blob was put.
+   * @param shuffleReplicas Indicates if the replicas need to be shuffled.
    */
   SimpleOperationTracker(RouterConfig routerConfig, RouterOperation routerOperation, PartitionId partitionId,
       String originatingDcName, boolean shuffleReplicas) {

--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -90,8 +90,8 @@ class SimpleOperationTracker implements OperationTracker {
    *  ---------------------------------------------------------
    * |  Operation Type  |        Eligible Replica State        |
    *  ---------------------------------------------------------
-   * |     POST         | STANDBY, LEADER                      |
-   * |     GET          | STANDBY, LEADER, BOOTSTRAP, INACTIVE |
+   * |      PUT         | STANDBY, LEADER                      |
+   * |      GET         | STANDBY, LEADER, BOOTSTRAP, INACTIVE |
    * |    DELETE        | STANDBY, LEADER, BOOTSTRAP           |
    * |   TTLUpdate      | STANDBY, LEADER, BOOTSTRAP           |
    *  ---------------------------------------------------------

--- a/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
@@ -159,6 +159,16 @@ public class OperationTrackerTest {
     assertTrue("Operation should be done", ot.isDone());
   }
 
+  /**
+   * Test put operation in local dc when replicasStateEnabled is enabled/disabled.
+   * Test steps:
+   * Case1: Only 2 STANDBY replicas in local dc;
+   *        Make 1 succeed and the other fail (both current and replicaState enabled tracker should fail)
+   * Case2: 2 STANDBY, 1 INACTIVE replicas in local dc
+   *        Make 1 fail and 2 succeed (replicaState enabled operation tracker should fail)
+   * Case3: 1 LEADER, 4 STANDBY and 1 INACTIVE in local dc
+   *        Make 3 succeed and 2 fail (replicaState enabled operation tracker should fail)
+   */
   @Test
   public void localPutWithReplicaStateTest() {
     assumeTrue(operationTrackerType.equals(SIMPLE_OP_TRACKER));
@@ -222,6 +232,15 @@ public class OperationTrackerTest {
     }
   }
 
+  /**
+   * Test delete/ttlUpdate operation when replicasStateEnabled is enabled/disabled.
+   * local dc: 2 STANDBY and 1 INACTIVE; remote dc: 2 STANDBY and 1 INACTIVE
+   * 1. Issue 3 requests in parallel
+   * 2. Make 2 requests fail
+   * 3. Issue 1 requests (replicaState enabled tracker only has 4 eligible replicas)
+   * 4. Make 1 succeed and 1 fail (replicaState enabled tracker should fail)
+   * 5. Make remaining requests succeed, this only applies for tracker with replicaState disabled and operation should succeed.
+   */
   @Test
   public void deleteTtlUpdateWithReplica() {
     assumeTrue(operationTrackerType.equals(SIMPLE_OP_TRACKER));


### PR DESCRIPTION
Previously, OperationTracker directly calls partition.getReplicaIds() to
populate replicaPool before sending out requests. With this change
OperationTracker is able to get eligible replicas by state (i.e. STANDBY,
LEADER) and then populate replicaPool with eligible replicas only.
Introducing eligible replicas will help router avoid sending requests to
some replicas in BOOTSTRAP or INACTIVE state due to ongoing replica movement.