### PR TITLE
Fix CryptoService to work with CompositeByteBuf

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/router/CryptoService.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/CryptoService.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.router;
 
+import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
@@ -48,17 +49,9 @@ public interface CryptoService<T> {
    * @throws {@link GeneralSecurityException} on any exception with encryption
    */
   default ByteBuf encrypt(ByteBuf toEncrypt, T key) throws GeneralSecurityException {
-    if (toEncrypt.nioBufferCount() == 1) {
-      return Unpooled.wrappedBuffer(encrypt(toEncrypt.nioBuffer(), key));
-    } else {
-      ByteBuf temp = ByteBufAllocator.DEFAULT.heapBuffer(toEncrypt.readableBytes());
-      try {
-        temp.writeBytes(toEncrypt);
-        return Unpooled.wrappedBuffer(encrypt(temp.nioBuffer(), key));
-      } finally {
-        temp.release();
-      }
-    }
+    return Utils.applyByteBufferFunctionToByteBuf(toEncrypt, (buffer) -> {
+      return encrypt(buffer, key);
+    });
   }
 
   /**
@@ -79,17 +72,9 @@ public interface CryptoService<T> {
    * @throws {@link GeneralSecurityException} on any exception with decryption
    */
   default ByteBuf decrypt(ByteBuf toDecrypt, T key) throws GeneralSecurityException {
-    if (toDecrypt.nioBufferCount() == 1) {
-      return Unpooled.wrappedBuffer(decrypt(toDecrypt.nioBuffer(), key));
-    } else {
-      ByteBuf temp = ByteBufAllocator.DEFAULT.heapBuffer(toDecrypt.readableBytes());
-      try {
-        temp.writeBytes(toDecrypt);
-        return Unpooled.wrappedBuffer(decrypt(temp.nioBuffer(), key));
-      } finally {
-        temp.release();
-      }
-    }
+    return Utils.applyByteBufferFunctionToByteBuf(toDecrypt, (buffer) -> {
+      return decrypt(buffer, key);
+    });
   }
 
   /**

--- a/ambry-router/src/main/java/com.github.ambry.router/GCMCryptoService.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GCMCryptoService.java
@@ -145,7 +145,7 @@ public class GCMCryptoService implements CryptoService<SecretKeySpec> {
         if (toRelease) {
           toEncrypt.release();
         } else {
-          toEncrypt.readerIndex(toEncrypt.readerIndex() + toEncrypt.readableBytes());
+          toEncrypt.skipBytes(toEncrypt.readableBytes());
         }
       }
     } catch (Exception e) {
@@ -195,7 +195,7 @@ public class GCMCryptoService implements CryptoService<SecretKeySpec> {
         if (toRelease) {
           toDecrypt.release();
         } else {
-          toDecrypt.readerIndex(toDecrypt.readerIndex() + toDecrypt.readableBytes());
+          toDecrypt.skipBytes(toDecrypt.readableBytes());
         }
       }
     } catch (Exception e) {

--- a/ambry-router/src/test/java/com.github.ambry.router/CryptoServiceTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CryptoServiceTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.commons.NettyByteBufLeakHelper;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.TestUtils;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import javax.crypto.spec.SecretKeySpec;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.github.ambry.router.CryptoTestUtils.*;
+
+
+/**
+ * Tests for default method in interface {@link CryptoService}.
+ */
+@RunWith(Parameterized.class)
+public class CryptoServiceTest {
+  private final NettyByteBufLeakHelper nettyByteBufLeakHelper = new NettyByteBufLeakHelper();
+  private static final MetricRegistry REGISTRY = new MetricRegistry();
+  private static final int DEFAULT_KEY_SIZE_IN_CHARS = 64;
+  private static final int MAX_DATA_SIZE = 10000;
+  private static final int MIN_DATA_SIZE = 100;
+  private final boolean isCompositeByteBuf;
+
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][]{{false}, {true}});
+  }
+
+  /**
+   * Constructor to create a CryptoServiceTest.
+   * @param isCompositeByteBuf
+   */
+  public CryptoServiceTest(boolean isCompositeByteBuf) {
+    this.isCompositeByteBuf = isCompositeByteBuf;
+  }
+
+  @Before
+  public void before() {
+    nettyByteBufLeakHelper.beforeTest();
+  }
+
+  @After
+  public void after() {
+    nettyByteBufLeakHelper.afterTest();
+  }
+
+  /**
+   * Create a {@link ByteBuf} based on whether it should be a composite ByteBuf or not. If it should, then
+   * create a {@link CompositeByteBuf} with three components.
+   * @return A {@link ByteBuf}.
+   */
+  private ByteBuf createByteBuf() {
+    int size = TestUtils.RANDOM.nextInt(MAX_DATA_SIZE - MIN_DATA_SIZE) + MIN_DATA_SIZE;
+    byte[] randomData = new byte[size];
+    TestUtils.RANDOM.nextBytes(randomData);
+    if (isCompositeByteBuf) {
+      ByteBuf toEncrypt = Unpooled.wrappedBuffer(randomData);
+      CompositeByteBuf composite = new CompositeByteBuf(toEncrypt.alloc(), toEncrypt.isDirect(), size);
+      int start = 0;
+      int end = 0;
+      for (int j = 0; j < 3; j++) {
+        start = end;
+        end = TestUtils.RANDOM.nextInt(size / 2 - 1) + end;
+        if (j == 2) {
+          end = size;
+        }
+        ByteBuf c = Unpooled.buffer(end - start);
+        c.writeBytes(randomData, start, end - start);
+        composite.addComponent(true, c);
+      }
+      return composite;
+    } else {
+      return ByteBufAllocator.DEFAULT.heapBuffer(size);
+    }
+  }
+
+  /**
+   * Create a {@link ByteBuffer} from given {@link ByteBuf} so that they have the same content.
+   * @param byteBuf The given {@link ByteBuf}....
+   * @return The {@link ByteBuffer}.
+   */
+  private ByteBuffer fromByteBufToByteBuffer(ByteBuf byteBuf) {
+    int size = byteBuf.readableBytes();
+    ByteBuffer buffer = ByteBuffer.allocate(size);
+    byteBuf.getBytes(0, buffer);
+    buffer.flip();
+    return buffer;
+  }
+
+  /**
+   * Test the default methods for those implementations that don't implement the default methods.
+   * @throws Exception
+   */
+  @Test
+  public void testDefaultMethodForEncryptDecrypt() throws Exception {
+    CryptoService<SecretKeySpec> cryptoService = new MockCryptoService();
+    String key = ((MockCryptoService) cryptoService).getKey();
+    SecretKeySpec secretKeySpec = new SecretKeySpec(Hex.decode(key), "AES");
+    for (int i = 0; i < 5; i++) {
+      ByteBuf toEncryptByteBuf = createByteBuf();
+      ByteBuffer toEncrypt = fromByteBufToByteBuffer(toEncryptByteBuf);
+      ByteBuffer encryptedBytes = cryptoService.encrypt(toEncrypt, secretKeySpec);
+      ByteBuf encryptedBytesByteBuf = cryptoService.encrypt(toEncryptByteBuf, secretKeySpec);
+
+      Assert.assertTrue(encryptedBytesByteBuf.hasArray());
+      Assert.assertEquals(encryptedBytes.remaining(), encryptedBytesByteBuf.readableBytes());
+      byte[] arrayFromByteBuf = new byte[encryptedBytesByteBuf.readableBytes()];
+      encryptedBytesByteBuf.getBytes(encryptedBytesByteBuf.readerIndex(), arrayFromByteBuf);
+      Assert.assertArrayEquals(encryptedBytes.array(), arrayFromByteBuf);
+
+      ByteBuf toDecryptByteBuf = encryptedBytesByteBuf;
+      ByteBuffer toDecrypt = encryptedBytes;
+      ByteBuffer decryptedBytes = cryptoService.decrypt(encryptedBytes, secretKeySpec);
+      ByteBuf decryptedBytesByteBuf = cryptoService.decrypt(toDecryptByteBuf, secretKeySpec);
+
+      Assert.assertTrue(decryptedBytesByteBuf.hasArray());
+      Assert.assertEquals(decryptedBytes.remaining(), decryptedBytesByteBuf.readableBytes());
+      arrayFromByteBuf = new byte[decryptedBytesByteBuf.readableBytes()];
+      decryptedBytesByteBuf.getBytes(decryptedBytesByteBuf.readerIndex(), arrayFromByteBuf);
+      Assert.assertArrayEquals(decryptedBytes.array(), arrayFromByteBuf);
+
+      toEncryptByteBuf.release();
+      encryptedBytesByteBuf.release();
+      decryptedBytesByteBuf.release();
+    }
+  }
+
+  /**
+   * A mock {@link CryptoService} that doesn't implements default methods.
+   */
+  static class MockCryptoService implements CryptoService<SecretKeySpec> {
+    private GCMCryptoService cryptoService;
+    private final String key;
+    private final byte[] fixedIv;
+
+    public MockCryptoService() {
+      key = TestUtils.getRandomKey(DEFAULT_KEY_SIZE_IN_CHARS);
+      Properties props = getKMSProperties(key, DEFAULT_KEY_SIZE_IN_CHARS);
+      VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+      cryptoService = (GCMCryptoService) new GCMCryptoServiceFactory(verifiableProperties, REGISTRY).getCryptoService();
+      fixedIv = new byte[12];
+    }
+
+    @Override
+    public ByteBuffer encrypt(ByteBuffer toEncrypt, SecretKeySpec key) throws GeneralSecurityException {
+      return cryptoService.encrypt(toEncrypt, key, fixedIv);
+    }
+
+    @Override
+    public ByteBuffer decrypt(ByteBuffer toDecrypt, SecretKeySpec key) throws GeneralSecurityException {
+      return cryptoService.decrypt(toDecrypt, key);
+    }
+
+    @Override
+    public ByteBuffer encryptKey(SecretKeySpec toEncrypt, SecretKeySpec key) throws GeneralSecurityException {
+      return cryptoService.encryptKey(toEncrypt, key);
+    }
+
+    @Override
+    public SecretKeySpec decryptKey(ByteBuffer toDecrypt, SecretKeySpec key) throws GeneralSecurityException {
+      return cryptoService.decryptKey(toDecrypt, key);
+    }
+
+    public String getKey() {
+      return key;
+    }
+  }
+}

--- a/ambry-router/src/test/java/com.github.ambry.router/CryptoServiceTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CryptoServiceTest.java
@@ -153,22 +153,26 @@ public class CryptoServiceTest {
     for (int i = 0; i < 5; i++) {
       ByteBuf toEncryptByteBuf = createByteBuf();
       ByteBuffer toEncrypt = fromByteBufToByteBuffer(toEncryptByteBuf);
-      ByteBuffer encryptedBytes = cryptoService.encrypt(toEncrypt, secretKeySpec);
       ByteBuf encryptedBytesByteBuf = cryptoService.encrypt(toEncryptByteBuf, secretKeySpec);
+      ByteBuffer encryptedBytes = cryptoService.encrypt(toEncrypt, secretKeySpec);
 
       Assert.assertTrue(encryptedBytesByteBuf.hasArray());
       Assert.assertEquals(encryptedBytes.remaining(), encryptedBytesByteBuf.readableBytes());
+      Assert.assertEquals(toEncryptByteBuf.readableBytes(), 0);
+      Assert.assertEquals(toEncrypt.remaining(), 0);
       byte[] arrayFromByteBuf = new byte[encryptedBytesByteBuf.readableBytes()];
       encryptedBytesByteBuf.getBytes(encryptedBytesByteBuf.readerIndex(), arrayFromByteBuf);
       Assert.assertArrayEquals(encryptedBytes.array(), arrayFromByteBuf);
 
       ByteBuf toDecryptByteBuf = maybeConvertToComposite(encryptedBytesByteBuf);
       ByteBuffer toDecrypt = encryptedBytes;
-      ByteBuffer decryptedBytes = cryptoService.decrypt(encryptedBytes, secretKeySpec);
       ByteBuf decryptedBytesByteBuf = cryptoService.decrypt(toDecryptByteBuf, secretKeySpec);
+      ByteBuffer decryptedBytes = cryptoService.decrypt(encryptedBytes, secretKeySpec);
 
       Assert.assertTrue(decryptedBytesByteBuf.hasArray());
       Assert.assertEquals(decryptedBytes.remaining(), decryptedBytesByteBuf.readableBytes());
+      Assert.assertEquals(toDecryptByteBuf.readableBytes(), 0);
+      Assert.assertEquals(toDecrypt.remaining(), 0);
       arrayFromByteBuf = new byte[decryptedBytesByteBuf.readableBytes()];
       decryptedBytesByteBuf.getBytes(decryptedBytesByteBuf.readerIndex(), arrayFromByteBuf);
       Assert.assertArrayEquals(decryptedBytes.array(), arrayFromByteBuf);

--- a/ambry-router/src/test/java/com.github.ambry.router/GCMCryptoServiceTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GCMCryptoServiceTest.java
@@ -172,8 +172,6 @@ public class GCMCryptoServiceTest {
 
       ByteBuf toEncrypt = Unpooled.wrappedBuffer(randomData);
       CompositeByteBuf toEncryptComposite = new CompositeByteBuf(toEncrypt.alloc(), toEncrypt.isDirect(), size);
-      // break this array to three parts
-      // First component
       int start = 0;
       int end = 0;
       for (int j = 0; j < 3; j++) {

--- a/ambry-router/src/test/java/com.github.ambry.router/GCMCryptoServiceTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GCMCryptoServiceTest.java
@@ -117,6 +117,9 @@ public class GCMCryptoServiceTest {
       Assert.assertTrue(encryptedBytesByteBufDirect.hasArray());
       Assert.assertEquals(encryptedBytes.remaining(), encryptedBytesByteBufHeap.readableBytes());
       Assert.assertEquals(encryptedBytes.remaining(), encryptedBytesByteBufDirect.readableBytes());
+      Assert.assertEquals(toEncrypt.remaining(), 0);
+      Assert.assertEquals(toEncryptByteBufDirect.readableBytes(), 0);
+      Assert.assertEquals(toEncryptByteBufHeap.readableBytes(), 0);
 
       byte[] arrayFromByteBuf = new byte[encryptedBytesByteBufHeap.readableBytes()];
       encryptedBytesByteBufHeap.getBytes(encryptedBytesByteBufHeap.readerIndex(), arrayFromByteBuf);
@@ -136,6 +139,9 @@ public class GCMCryptoServiceTest {
       Assert.assertTrue(decryptedBytesByteBufDirect.hasArray());
       Assert.assertEquals(decryptedBytes.remaining(), decryptedBytesByteBufHeap.readableBytes());
       Assert.assertEquals(decryptedBytes.remaining(), decryptedBytesByteBufDirect.readableBytes());
+      Assert.assertEquals(encryptedBytes.remaining(), 0);
+      Assert.assertEquals(toDecryptByteBufDirect.readableBytes(), 0);
+      Assert.assertEquals(toDecryptByteBufHeap.readableBytes(), 0);
 
       arrayFromByteBuf = new byte[decryptedBytesByteBufHeap.readableBytes()];
       decryptedBytesByteBufHeap.getBytes(decryptedBytesByteBufHeap.readerIndex(), arrayFromByteBuf);
@@ -188,6 +194,8 @@ public class GCMCryptoServiceTest {
       ByteBuf encryptedBytes = cryptoService.encrypt(toEncrypt, secretKeySpec, fixedIv);
       ByteBuf encryptedBytesComposite = cryptoService.encrypt(toEncryptComposite, secretKeySpec, fixedIv);
       Assert.assertEquals(encryptedBytes.readableBytes(), encryptedBytesComposite.readableBytes());
+      Assert.assertEquals(toEncrypt.readableBytes(), 0);
+      Assert.assertEquals(toEncryptComposite.readableBytes(), 0);
 
       byte[] array = new byte[encryptedBytes.readableBytes()];
       encryptedBytes.getBytes(encryptedBytes.readerIndex(), array);
@@ -215,6 +223,8 @@ public class GCMCryptoServiceTest {
       ByteBuf decryptedBytesComposite = cryptoService.decrypt(toDecryptComposite, secretKeySpec);
 
       Assert.assertEquals(decryptedBytes.readableBytes(), decryptedBytesComposite.readableBytes());
+      Assert.assertEquals(toDecrypt.readableBytes(), 0);
+      Assert.assertEquals(toDecryptComposite.readableBytes(), 0);
 
       array = new byte[decryptedBytes.readableBytes()];
       arrayComposite = new byte[decryptedBytesComposite.readableBytes()];

--- a/ambry-router/src/test/java/com.github.ambry.router/GCMCryptoServiceTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GCMCryptoServiceTest.java
@@ -14,17 +14,22 @@
 package com.github.ambry.router;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.commons.NettyByteBufLeakHelper;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.TestUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.Properties;
 import javax.crypto.spec.SecretKeySpec;
 import org.bouncycastle.util.encoders.Hex;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import static com.github.ambry.router.CryptoTestUtils.*;
@@ -36,8 +41,20 @@ import static com.github.ambry.router.CryptoTestUtils.*;
 public class GCMCryptoServiceTest {
 
   private static final int MAX_DATA_SIZE = 10000;
+  private static final int MIN_DATA_SIZE = 100;
   private static final int DEFAULT_KEY_SIZE_IN_CHARS = 64;
   private static final MetricRegistry REGISTRY = new MetricRegistry();
+  private final NettyByteBufLeakHelper nettyByteBufLeakHelper = new NettyByteBufLeakHelper();
+
+  @Before
+  public void before() {
+    nettyByteBufLeakHelper.beforeTest();
+  }
+
+  @After
+  public void after() {
+    nettyByteBufLeakHelper.afterTest();
+  }
 
   /**
    * Tests basic encryption and decryption for different sizes of keys and random data in bytes
@@ -125,6 +142,95 @@ public class GCMCryptoServiceTest {
       Assert.assertArrayEquals(decryptedBytes.array(), arrayFromByteBuf);
       decryptedBytesByteBufDirect.getBytes(decryptedBytesByteBufDirect.readerIndex(), arrayFromByteBuf);
       Assert.assertArrayEquals(decryptedBytes.array(), arrayFromByteBuf);
+
+      toEncryptByteBufHeap.release();
+      toEncryptByteBufDirect.release();
+      encryptedBytesByteBufHeap.release();
+      encryptedBytesByteBufDirect.release();
+      toDecryptByteBufDirect.release();
+      decryptedBytesByteBufHeap.release();
+      decryptedBytesByteBufDirect.release();
+    }
+  }
+
+  @Test
+  public void testEncryptDecryptNettyCompositeByteBuf() throws Exception {
+    // testEncryptDecryptNettyByte already tests the correctness of the encrypt decrypt methods with non-composite Netty
+    // ByteBuf, in this test case, we can make the assumption that these two functions always provide correct answers.
+
+    String key = TestUtils.getRandomKey(DEFAULT_KEY_SIZE_IN_CHARS);
+    Properties props = getKMSProperties(key, DEFAULT_KEY_SIZE_IN_CHARS);
+    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+    SecretKeySpec secretKeySpec = new SecretKeySpec(Hex.decode(key), "AES");
+    GCMCryptoService cryptoService =
+        (GCMCryptoService) (new GCMCryptoServiceFactory(verifiableProperties, REGISTRY).getCryptoService());
+    byte[] fixedIv = new byte[12];
+    for (int i = 0; i < 5; i++) {
+      int size = TestUtils.RANDOM.nextInt(MAX_DATA_SIZE - MIN_DATA_SIZE) + MIN_DATA_SIZE;
+      byte[] randomData = new byte[size];
+      TestUtils.RANDOM.nextBytes(randomData);
+
+      ByteBuf toEncrypt = Unpooled.wrappedBuffer(randomData);
+      CompositeByteBuf toEncryptComposite = new CompositeByteBuf(toEncrypt.alloc(), toEncrypt.isDirect(), size);
+      // break this array to three parts
+      // First component
+      int start = 0;
+      int end = 0;
+      for (int j = 0; j < 3; j++) {
+        start = end;
+        end = TestUtils.RANDOM.nextInt(size / 2 - 1) + end;
+        if (j == 2) {
+          end = size;
+        }
+        ByteBuf c = Unpooled.buffer(end - start);
+        c.writeBytes(randomData, start, end - start);
+        toEncryptComposite.addComponent(true, c);
+      }
+
+      ByteBuf encryptedBytes = cryptoService.encrypt(toEncrypt, secretKeySpec, fixedIv);
+      ByteBuf encryptedBytesComposite = cryptoService.encrypt(toEncryptComposite, secretKeySpec, fixedIv);
+      Assert.assertEquals(encryptedBytes.readableBytes(), encryptedBytesComposite.readableBytes());
+
+      byte[] array = new byte[encryptedBytes.readableBytes()];
+      encryptedBytes.getBytes(encryptedBytes.readerIndex(), array);
+      byte[] arrayComposite = new byte[encryptedBytesComposite.readableBytes()];
+      encryptedBytesComposite.getBytes(encryptedBytesComposite.readerIndex(), arrayComposite);
+      Assert.assertArrayEquals(array, arrayComposite);
+
+      ByteBuf toDecrypt = encryptedBytes;
+      CompositeByteBuf toDecryptComposite = new CompositeByteBuf(toDecrypt.alloc(), toEncrypt.isDirect(), size);
+      size = encryptedBytes.readableBytes();
+      start = 0;
+      end = 0;
+      for (int j = 0; j < 3; j++) {
+        start = end;
+        end = TestUtils.RANDOM.nextInt(size / 2 - 1) + end;
+        if (j == 2) {
+          end = size;
+        }
+        ByteBuf c = Unpooled.buffer(end - start);
+        c.writeBytes(encryptedBytes, start, end - start);
+        toDecryptComposite.addComponent(true, c);
+      }
+
+      ByteBuf decryptedBytes = cryptoService.decrypt(toDecrypt, secretKeySpec);
+      ByteBuf decryptedBytesComposite = cryptoService.decrypt(toDecryptComposite, secretKeySpec);
+
+      Assert.assertEquals(decryptedBytes.readableBytes(), decryptedBytesComposite.readableBytes());
+
+      array = new byte[decryptedBytes.readableBytes()];
+      arrayComposite = new byte[decryptedBytesComposite.readableBytes()];
+      decryptedBytes.getBytes(decryptedBytes.readerIndex(), array);
+      decryptedBytesComposite.getBytes(decryptedBytesComposite.readerIndex(), arrayComposite);
+      Assert.assertArrayEquals(array, arrayComposite);
+
+      toEncrypt.release();
+      toEncryptComposite.release();
+      encryptedBytes.release();
+      encryptedBytesComposite.release();
+      toDecryptComposite.release();
+      decryptedBytes.release();
+      decryptedBytesComposite.release();
     }
   }
 

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -14,7 +14,9 @@
 package com.github.ambry.utils;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.Unpooled;
 import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.EOFException;
@@ -263,8 +265,7 @@ public class Utils {
     ByteBuffer output;
     InputStream inputStream = crcStream.getUnderlyingInputStream();
     if (inputStream instanceof ByteBufferDataInputStream) {
-      output =
-          getByteBufferFromByteBufferDataInputStream((ByteBufferDataInputStream) inputStream, dataSize);
+      output = getByteBufferFromByteBufferDataInputStream((ByteBufferDataInputStream) inputStream, dataSize);
       crcStream.updateCrc(output.duplicate());
     } else if (inputStream instanceof NettyByteBufDataInputStream) {
       // getBuffer() doesn't increase the reference count on this ByteBuf.
@@ -288,6 +289,43 @@ public class Utils {
       output.flip();
     }
     return output;
+  }
+
+  /**
+   * Represent an operation that accepts a {@link ByteBuffer} and returns another {@link ByteBuffer}. Side effect should
+   * be expected to the input {@link ByteBuffer} and the returned {@link ByteBuffer} should be ready for read.
+   * @param <T> The exception to throw in this operation.
+   */
+  @FunctionalInterface
+  public static interface ByteBufferFunction<T extends Throwable> {
+    ByteBuffer apply(ByteBuffer buffer) throws T;
+  }
+
+  /**
+   * Apply a {@link ByteBufferFunction} to a {@link ByteBuf} and return a {@link ByteBuf}. All the bytes in the input
+   * {@link ByteBuf} will be consumed.
+   * @param buf The input {@link ByteBuf}.
+   * @param fn The {@link ByteBufferFunction}.
+   * @param <T> The exception to throw in the {@code fn}.
+   * @return A {@link ByteBuf}.
+   * @throws T Exception thrown from {@code fn}.
+   */
+  public static <T extends Throwable> ByteBuf applyByteBufferFunctionToByteBuf(ByteBuf buf, ByteBufferFunction<T> fn)
+      throws T {
+    if (buf.nioBufferCount() == 1) {
+      ByteBuffer buffer = buf.nioBuffer();
+      buf.skipBytes(buffer.remaining());
+      return Unpooled.wrappedBuffer(fn.apply(buffer));
+    } else {
+      ByteBuf temp = ByteBufAllocator.DEFAULT.heapBuffer(buf.readableBytes());
+      try {
+        temp.writeBytes(buf);
+        ByteBuffer buffer = temp.nioBuffer();
+        return Unpooled.wrappedBuffer(fn.apply(buffer));
+      } finally {
+        temp.release();
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
PutOperation would read multiple ByteBuf as a Composite from NettyServer layer. If the blob should be encrypted, then the crypto service has to work with CompositeByteBuf. This PR adds such support.