### PR TITLE
Implement Offline-To-Bootstrap transition in Replication/Stats Managers

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
@@ -25,7 +25,7 @@ public interface PartitionStateChangeListener {
   void onPartitionBecomeBootstrapFromOffline(String partitionName);
 
   /**
-   * Action to take when partition becomes bootstrap from offline.
+   * Action to take when partition becomes standby from bootstrap.
    * @param partitionName of the partition.
    */
   void onPartitionBecomeStandbyFromBootstrap(String partitionName);

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/StateTransitionException.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/StateTransitionException.java
@@ -32,9 +32,9 @@ public class StateTransitionException extends RuntimeException {
      */
     ReplicaNotFound,
     /**
-     * If failure occurs during store operation (i.e. store addition/removal in StoreManager).
+     * If failure occurs during replica operation (i.e. replica addition/removal in StoreManager, ReplicationManager).
      */
-    StoreOperationFailure,
+    ReplicaOperationFailure,
     /**
      * If store is not started and unavailable for specific operations.
      */

--- a/ambry-api/src/main/java/com.github.ambry/server/StoreManager.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/StoreManager.java
@@ -60,7 +60,8 @@ public interface StoreManager {
   Store getStore(PartitionId id);
 
   /**
-   * Get replicaId by partition name.
+   * Get replicaId on current node by partition name. (There should be at most one replica belonging to specific
+   * partition on single node)
    * @param partitionName name of {@link PartitionId}
    * @return {@link ReplicaId} associated with given partition name. {@code null} if replica is not found in storage manager.
    */

--- a/ambry-api/src/main/java/com.github.ambry/server/StoreManager.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/StoreManager.java
@@ -60,6 +60,13 @@ public interface StoreManager {
   Store getStore(PartitionId id);
 
   /**
+   * Get replicaId by partition name.
+   * @param partitionName name of {@link PartitionId}
+   * @return {@link ReplicaId} associated with given partition name. {@code null} if replica is not found in storage manager.
+   */
+  ReplicaId getReplica(String partitionName);
+
+  /**
    * Set BlobStore Stopped state with given {@link PartitionId} {@code id}.
    * @param partitionIds a list {@link PartitionId} of the {@link Store} whose stopped state should be set.
    * @param markStop whether to mark BlobStore as stopped ({@code true}) or started.

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudStorageManager.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudStorageManager.java
@@ -113,6 +113,11 @@ public class CloudStorageManager implements StoreManager {
   }
 
   @Override
+  public ReplicaId getReplica(String partitionName) {
+    throw new UnsupportedOperationException("Method not supported");
+  }
+
+  @Override
   public boolean removeBlobStore(PartitionId id) {
     try {
       lock.writeLock().lock();

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -48,10 +48,10 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   private final String zkConnectStr;
   private final Object helixAdministrationLock = new Object();
   private final ClusterMapConfig clusterMapConfig;
-  private final Map<StateModelListenerType, PartitionStateChangeListener> partitionStateChangeListeners;
   private HelixManager manager;
   private String instanceName;
   private HelixAdmin helixAdmin;
+  final Map<StateModelListenerType, PartitionStateChangeListener> partitionStateChangeListeners;
 
   private static final Logger logger = LoggerFactory.getLogger(HelixParticipant.class);
 
@@ -283,10 +283,23 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
 
   @Override
   public void onPartitionBecomeBootstrapFromOffline(String partitionName) {
+    // 1. take actions in storage manager (add new replica if necessary)
     PartitionStateChangeListener storageManagerListener =
         partitionStateChangeListeners.get(StateModelListenerType.StorageManagerListener);
     if (storageManagerListener != null) {
       storageManagerListener.onPartitionBecomeBootstrapFromOffline(partitionName);
+    }
+    // 2. take actions in replication manager (add new replica if necessary)
+    PartitionStateChangeListener replicationManagerListener =
+        partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
+    if (replicationManagerListener != null) {
+      replicationManagerListener.onPartitionBecomeBootstrapFromOffline(partitionName);
+    }
+    // 3. take actions in stats manager (add new replica if necessary)
+    PartitionStateChangeListener statsManagerListener =
+        partitionStateChangeListeners.get(StateModelListenerType.StatsManagerListener);
+    if (statsManagerListener != null) {
+      statsManagerListener.onPartitionBecomeBootstrapFromOffline(partitionName);
     }
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixParticipant.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.server.AmbryHealthReport;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+public class MockHelixParticipant extends HelixParticipant {
+  Set<ReplicaId> sealedReplicas = new HashSet<>();
+  Set<ReplicaId> stoppedReplicas = new HashSet<>();
+
+  public MockHelixParticipant(ClusterMapConfig clusterMapConfig) throws IOException {
+    super(clusterMapConfig, new MockHelixManagerFactory());
+  }
+
+  @Override
+  public void participate(List<AmbryHealthReport> ambryHealthReports) throws IOException {
+    // no op
+  }
+
+  @Override
+  public boolean setReplicaSealedState(ReplicaId replicaId, boolean isSealed) {
+    if (isSealed) {
+      sealedReplicas.add(replicaId);
+    } else {
+      sealedReplicas.remove(replicaId);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean markStop) {
+    if (markStop) {
+      stoppedReplicas.addAll(replicaIds);
+    } else {
+      stoppedReplicas.removeAll(replicaIds);
+    }
+    return true;
+  }
+
+  @Override
+  public List<String> getSealedReplicas() {
+    return sealedReplicas.stream().map(r -> r.getPartitionId().toPathString()).collect(Collectors.toList());
+  }
+
+  @Override
+  public List<String> getStoppedReplicas() {
+    return stoppedReplicas.stream().map(r -> r.getPartitionId().toPathString()).collect(Collectors.toList());
+  }
+
+  @Override
+  public void close() {
+    // no op
+  }
+
+  public List<PartitionStateChangeListener> getPartitionStateChangeListeners() {
+    return Collections.unmodifiableList(partitionStateChangeListeners);
+  }
+}

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixParticipant.java
@@ -71,6 +71,9 @@ public class MockHelixParticipant extends HelixParticipant {
     // no op
   }
 
+  /**
+   * @return a snapshot of current state change listeners.
+   */
   public List<PartitionStateChangeListener> getPartitionStateChangeListeners() {
     return Collections.unmodifiableList(partitionStateChangeListeners);
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixParticipant.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -74,7 +75,7 @@ public class MockHelixParticipant extends HelixParticipant {
   /**
    * @return a snapshot of current state change listeners.
    */
-  public List<PartitionStateChangeListener> getPartitionStateChangeListeners() {
-    return Collections.unmodifiableList(partitionStateChangeListeners);
+  public Map<StateModelListenerType, PartitionStateChangeListener> getPartitionStateChangeListeners() {
+    return Collections.unmodifiableMap(partitionStateChangeListeners);
   }
 }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockReplicaId.java
@@ -22,7 +22,7 @@ import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 
 
 public class MockReplicaId implements ReplicaId {
-
+  public static final long MOCK_REPLICA_CAPACITY = 100000000;
   private String mountPath;
   private String replicaPath;
   private List<ReplicaId> peerReplicas;
@@ -91,7 +91,7 @@ public class MockReplicaId implements ReplicaId {
 
   @Override
   public long getCapacityInBytes() {
-    return 100000000;
+    return MOCK_REPLICA_CAPACITY;
   }
 
   @Override

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -15,8 +15,10 @@ package com.github.ambry.replication;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.PartitionStateChangeListener;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
@@ -48,7 +50,8 @@ public class ReplicationManager extends ReplicationEngine {
       StoreConfig storeConfig, StoreManager storeManager, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap,
       ScheduledExecutorService scheduler, DataNodeId dataNode, ConnectionPool connectionPool,
       MetricRegistry metricRegistry, NotificationSystem requestNotification,
-      StoreKeyConverterFactory storeKeyConverterFactory, String transformerClassName) throws ReplicationException {
+      StoreKeyConverterFactory storeKeyConverterFactory, String transformerClassName,
+      ClusterParticipant clusterParticipant) throws ReplicationException {
     super(replicationConfig, clusterMapConfig, storeKeyFactory, clusterMap, scheduler, dataNode,
         clusterMap.getReplicaIds(dataNode), connectionPool, metricRegistry, requestNotification,
         storeKeyConverterFactory, transformerClassName);
@@ -69,6 +72,11 @@ public class ReplicationManager extends ReplicationEngine {
       } else {
         logger.error("Not replicating to partition " + partition + " because an initialized store could not be found");
       }
+    }
+    // register replication manager's state change listener if clusterParticipant is not null
+    if (clusterParticipant != null) {
+      clusterParticipant.registerPartitionStateChangeListener(new PartitionStateChangeListenerImpl());
+      logger.info("Replication manager's state change listener registered!");
     }
     persistor = new DiskTokenPersistor(replicaTokenFileName, mountPathToPartitionInfos, replicationMetrics, clusterMap,
         tokenHelper, storeManager);
@@ -98,7 +106,6 @@ public class ReplicationManager extends ReplicationEngine {
         }
       }
 
-      // start background persistent thread
       // start scheduler thread to persist replica token in the background
       if (persistor != null) {
         this.scheduler.scheduleAtFixedRate(persistor, replicationConfig.replicationTokenFlushDelaySeconds,
@@ -200,5 +207,43 @@ public class ReplicationManager extends ReplicationEngine {
     partitionToPartitionInfo.put(partition, partitionInfo);
     mountPathToPartitionInfos.computeIfAbsent(replicaId.getMountPath(), key -> ConcurrentHashMap.newKeySet())
         .add(partitionInfo);
+  }
+
+  /**
+   * {@link PartitionStateChangeListener} to capture changes in partition state.
+   */
+  private class PartitionStateChangeListenerImpl implements PartitionStateChangeListener {
+
+    @Override
+    public void onPartitionBecomeBootstrapFromOffline(String partitionName) {
+      // check if partition exists
+      ReplicaId replica = storeManager.getReplica(partitionName);
+      if (replica == null) {
+        // no matter this is an existing replica or new added one, it should be present in storage manager because new
+        // replica is added into storage manager first.
+        throw new IllegalStateException("Partition " + partitionName + " is not found on current node");
+      }
+
+      if (!partitionToPartitionInfo.containsKey(replica.getPartitionId())) {
+        // if partition is not present in partitionToPartitionInfo map, it means this partition was just added in storage
+        // manager and next step is to add it into replication manager
+        logger.info("Didn't find replica {} in replication manager, starting to add it.", partitionName);
+        if (!addReplica(replica)) {
+          throw new IllegalStateException("Failed to add new replica into replication manager");
+        }
+      }
+    }
+
+    @Override
+    public void onPartitionBecomeLeaderFromStandby(String partitionName) {
+      logger.info("Partition state change notification from Standby to Leader received for partition {}",
+          partitionName);
+    }
+
+    @Override
+    public void onPartitionBecomeStandbyFromLeader(String partitionName) {
+      logger.info("Partition state change notification from Leader to Standby received for partition {}",
+          partitionName);
+    }
   }
 }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
@@ -14,8 +14,10 @@
 package com.github.ambry.replication;
 
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.config.StoreConfig;
@@ -39,6 +41,7 @@ public class MockReplicationManager extends ReplicationManager {
   public RuntimeException exceptionToThrow = null;
   // Variables for controlling and examining the values provided to controlReplicationForPartitions()
   public Boolean controlReplicationReturnVal;
+  public Boolean addReplicaReturnVal = null;
   public Collection<PartitionId> idsVal;
   public List<String> originsVal;
   public Boolean enableVal;
@@ -63,12 +66,13 @@ public class MockReplicationManager extends ReplicationManager {
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
     StoreConfig storeConfig = new StoreConfig(verifiableProperties);
     return new MockReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap,
-        dataNodeId, storeKeyConverterFactory);
+        dataNodeId, storeKeyConverterFactory, null);
   }
 
   MockReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
       StoreConfig storeConfig, StorageManager storageManager, ClusterMap clusterMap, DataNodeId dataNodeId,
-      StoreKeyConverterFactory storeKeyConverterFactory) throws ReplicationException {
+      StoreKeyConverterFactory storeKeyConverterFactory, ClusterParticipant clusterParticipant)
+      throws ReplicationException {
     super(replicationConfig, clusterMapConfig, storeConfig, storageManager, new StoreKeyFactory() {
           @Override
           public StoreKey getStoreKey(DataInputStream stream) {
@@ -80,7 +84,7 @@ public class MockReplicationManager extends ReplicationManager {
             return null;
           }
         }, clusterMap, null, dataNodeId, null, clusterMap.getMetricRegistry(), null, storeKeyConverterFactory,
-        BlobIdTransformer.class.getName());
+        BlobIdTransformer.class.getName(), clusterParticipant);
     reset();
   }
 
@@ -107,6 +111,11 @@ public class MockReplicationManager extends ReplicationManager {
       lag = lagOverrides.get(key);
     }
     return lag;
+  }
+
+  @Override
+  public boolean addReplica(ReplicaId replicaId) {
+    return addReplicaReturnVal == null ? super.addReplica(replicaId) : addReplicaReturnVal;
   }
 
   /**

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
@@ -165,7 +165,7 @@ public class AmbryServer {
       replicationManager =
           new ReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, storeKeyFactory,
               clusterMap, scheduler, nodeId, connectionPool, registry, notificationSystem, storeKeyConverterFactory,
-              serverConfig.serverMessageTransformer);
+              serverConfig.serverMessageTransformer, clusterParticipant);
       replicationManager.start();
 
       if (replicationConfig.replicationEnabledWithVcrCluster) {
@@ -180,7 +180,8 @@ public class AmbryServer {
       }
 
       logger.info("Creating StatsManager to publish stats");
-      statsManager = new StatsManager(storageManager, clusterMap.getReplicaIds(nodeId), registry, statsConfig, time);
+      statsManager = new StatsManager(storageManager, clusterMap.getReplicaIds(nodeId), registry, statsConfig, time,
+          clusterParticipant);
       if (serverConfig.serverStatsPublishLocalEnabled) {
         statsManager.start();
       }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryServerRequestsTest.java
@@ -172,7 +172,7 @@ public class AmbryServerRequestsTest {
             storeKeyConverterFactory);
     statsManager =
         new MockStatsManager(storageManager, clusterMap.getReplicaIds(dataNodeId), clusterMap.getMetricRegistry(),
-            statsManagerConfig);
+            statsManagerConfig, null);
     ServerMetrics serverMetrics =
         new ServerMetrics(clusterMap.getMetricRegistry(), AmbryRequests.class, AmbryServer.class);
     ambryRequests = new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, dataNodeId,

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryStatsReportTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryStatsReportTest.java
@@ -42,7 +42,7 @@ public class AmbryStatsReportTest {
     StatsManager testStatsManager = new StatsManager(new MockStorageManager(Collections.emptyMap(),
         new MockDataNodeId(Collections.singletonList(new Port(6667, PortType.PLAINTEXT)),
             Collections.singletonList("/tmp"), "DC1")), Collections.emptyList(), new MetricRegistry(), config,
-        new MockTime());
+        new MockTime(), null);
     // test account stats report
     AmbryStatsReport ambryStatsReport =
         new AmbryStatsReport(testStatsManager, AGGREGATE_INTERVAL_MINS, StatsReportType.ACCOUNT_REPORT);

--- a/ambry-server/src/test/java/com.github.ambry.server/MockStatsManager.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/MockStatsManager.java
@@ -14,6 +14,7 @@
 package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.StatsManagerConfig;
 import com.github.ambry.store.StorageManager;
@@ -25,15 +26,15 @@ import java.util.List;
  * An extension of {@link StatsManager} to help with tests.
  */
 class MockStatsManager extends StatsManager {
-  boolean returnValOfAddReplica = true;
+  Boolean returnValOfAddReplica = null;
 
   MockStatsManager(StorageManager storageManager, List<? extends ReplicaId> replicaIds, MetricRegistry metricRegistry,
-      StatsManagerConfig statsManagerConfig) {
-    super(storageManager, replicaIds, metricRegistry, statsManagerConfig, new MockTime());
+      StatsManagerConfig statsManagerConfig, ClusterParticipant clusterParticipant) {
+    super(storageManager, replicaIds, metricRegistry, statsManagerConfig, new MockTime(), clusterParticipant);
   }
 
   @Override
   boolean addReplica(ReplicaId id) {
-    return returnValOfAddReplica;
+    return returnValOfAddReplica == null ? super.addReplica(id) : returnValOfAddReplica;
   }
 }

--- a/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
@@ -325,6 +325,7 @@ class MockStorageManager extends StorageManager {
    */
   PartitionId startedPartitionId = null;
   PartitionId addedPartitionId = null;
+  ReplicaId getReplicaReturnVal = null;
   CountDownLatch waitOperationCountdown = new CountDownLatch(0);
   boolean firstCall = true;
   List<PartitionId> unreachablePartitions = new ArrayList<>();
@@ -374,6 +375,11 @@ class MockStorageManager extends StorageManager {
       storeToReturn = store;
     }
     return storeToReturn;
+  }
+
+  @Override
+  public ReplicaId getReplica(String partitionName) {
+    return getReplicaReturnVal;
   }
 
   @Override

--- a/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
@@ -18,10 +18,12 @@ import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
+import com.github.ambry.clustermap.MockHelixParticipant;
 import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.ReplicaState;
+import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.StatsManagerConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.Port;
@@ -58,9 +60,11 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Test;
 
+import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
 
 
@@ -73,6 +77,8 @@ public class StatsManagerTest {
   private static final int MAX_CONTAINER_COUNT = 6;
   private static final int MIN_CONTAINER_COUNT = 3;
   private final StatsManager statsManager;
+  private final StorageManager storageManager;
+  private final MockHelixParticipant clusterParticipant;
   private final String outputFileString;
   private final File tempDir;
   private final StatsSnapshot preAggregatedSnapshot;
@@ -81,7 +87,8 @@ public class StatsManagerTest {
   private final List<ReplicaId> replicas;
   private final Random random = new Random();
   private final ObjectMapper mapper = new ObjectMapper();
-  private final StatsManagerConfig config;
+  private final StatsManagerConfig statsManagerConfig;
+  private DataNodeId dataNodeId;
 
   /**
    * Deletes the temporary directory.
@@ -102,13 +109,24 @@ public class StatsManagerTest {
     tempDir = Files.createTempDirectory("nodeStatsDir-" + UtilsTest.getRandomString(10)).toFile();
     tempDir.deleteOnExit();
     outputFileString = (new File(tempDir.getAbsolutePath(), "stats_output.json")).getAbsolutePath();
+    List<com.github.ambry.utils.TestUtils.ZkInfo> zkInfoList = new ArrayList<>();
+    zkInfoList.add(new com.github.ambry.utils.TestUtils.ZkInfo(null, "DC1", (byte) 0, 2199, false));
+    JSONObject zkJson = constructZkLayoutJSON(zkInfoList);
+    Properties properties = new Properties();
+    properties.put("stats.output.file.path", outputFileString);
+    properties.setProperty("clustermap.cluster.name", "test");
+    properties.setProperty("clustermap.datacenter.name", "DC1");
+    properties.setProperty("clustermap.host.name", "localhost");
+    properties.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
+    statsManagerConfig = new StatsManagerConfig(new VerifiableProperties(properties));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(properties));
     storeMap = new HashMap<>();
     partitionToSnapshot = new HashMap<>();
     preAggregatedSnapshot = generateRandomSnapshot().get(StatsReportType.ACCOUNT_REPORT);
     Pair<StatsSnapshot, StatsSnapshot> baseSliceAndNewSlice = new Pair<>(preAggregatedSnapshot, null);
     replicas = new ArrayList<>();
     PartitionId partitionId;
-    DataNodeId dataNodeId = new MockDataNodeId(Collections.singletonList(new Port(6667, PortType.PLAINTEXT)),
+    dataNodeId = new MockDataNodeId(Collections.singletonList(new Port(6667, PortType.PLAINTEXT)),
         Collections.singletonList("/tmp"), "DC1");
     for (int i = 0; i < 2; i++) {
       partitionId = new MockPartitionId(i, MockClusterMap.DEFAULT_PARTITION_CLASS,
@@ -126,11 +144,10 @@ public class StatsManagerTest {
     partitionId = new MockPartitionId(2, MockClusterMap.DEFAULT_PARTITION_CLASS);
     storeMap.put(partitionId, new MockStore(new MockStoreStats(snapshotsByType, false)));
     partitionToSnapshot.put(partitionId, snapshotsByType.get(StatsReportType.ACCOUNT_REPORT));
-    StorageManager storageManager = new MockStorageManager(storeMap, dataNodeId);
-    Properties properties = new Properties();
-    properties.put("stats.output.file.path", outputFileString);
-    config = new StatsManagerConfig(new VerifiableProperties(properties));
-    statsManager = new StatsManager(storageManager, replicas, new MetricRegistry(), config, new MockTime());
+    storageManager = new MockStorageManager(storeMap, dataNodeId);
+    clusterParticipant = new MockHelixParticipant(clusterMapConfig);
+    statsManager =
+        new StatsManager(storageManager, replicas, new MetricRegistry(), statsManagerConfig, new MockTime(), null);
   }
 
   /**
@@ -180,7 +197,7 @@ public class StatsManagerTest {
     problematicStoreMap.put(partitionId2, exceptionStore);
     StatsManager testStatsManager = new StatsManager(new MockStorageManager(problematicStoreMap, dataNodeId),
         Arrays.asList(partitionId1.getReplicaIds().get(0), partitionId2.getReplicaIds().get(0)), new MetricRegistry(),
-        config, new MockTime());
+        statsManagerConfig, new MockTime(), null);
     List<PartitionId> unreachablePartitions = new ArrayList<>();
     StatsSnapshot actualSnapshot = new StatsSnapshot(0L, null);
     for (PartitionId partitionId : problematicStoreMap.keySet()) {
@@ -204,7 +221,7 @@ public class StatsManagerTest {
     mixedStoreMap.put(partitionId4, exceptionStore);
     testStatsManager = new StatsManager(new MockStorageManager(mixedStoreMap, dataNodeId),
         Arrays.asList(partitionId3.getReplicaIds().get(0), partitionId4.getReplicaIds().get(0)), new MetricRegistry(),
-        config, new MockTime());
+        statsManagerConfig, new MockTime(), null);
     actualSnapshot = new StatsSnapshot(0L, null);
     for (PartitionId partitionId : mixedStoreMap.keySet()) {
       testStatsManager.collectAndAggregate(actualSnapshot, partitionId, unreachablePartitions);
@@ -247,7 +264,8 @@ public class StatsManagerTest {
     }
     StorageManager mockStorageManager = new MockStorageManager(testStoreMap, dataNodeId);
     StatsManager testStatsManager =
-        new StatsManager(mockStorageManager, testReplicas, new MetricRegistry(), config, new MockTime());
+        new StatsManager(mockStorageManager, testReplicas, new MetricRegistry(), statsManagerConfig, new MockTime(),
+            null);
 
     // verify that adding an existing store to StatsManager should fail
     assertFalse("Adding a store which already exists should fail", testStatsManager.addReplica(testReplicas.get(0)));
@@ -359,6 +377,42 @@ public class StatsManagerTest {
         statsWrapper.getSnapshot().getSubMap().containsKey(partitionId4.toPathString()));
   }
 
+  @Test
+  public void testReplicaFromOfflineToBootstrap() {
+    MockStatsManager mockStatsManager =
+        new MockStatsManager(storageManager, replicas, new MetricRegistry(), statsManagerConfig, clusterParticipant);
+    // 1. verify stats manager's listener is registered
+    assertFalse("No listener is found in cluster participant",
+        clusterParticipant.getPartitionStateChangeListeners().isEmpty());
+    // 2. test partition not found
+    try {
+      clusterParticipant.onPartitionBecomeBootstrapFromOffline("InvalidPartition");
+      fail("should fail because partition is not found");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    // 3. create a new partition and test replica addition failure
+    PartitionId newPartition = new MockPartitionId(3, MockClusterMap.DEFAULT_PARTITION_CLASS,
+        Collections.singletonList((MockDataNodeId) dataNodeId), 0);
+    ((MockStorageManager) storageManager).getReplicaReturnVal = newPartition.getReplicaIds().get(0);
+    mockStatsManager.returnValOfAddReplica = false;
+    try {
+      clusterParticipant.onPartitionBecomeBootstrapFromOffline(newPartition.toPathString());
+      fail();
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    // 4. test replica addition success during Offline-To-Bootstrap transition
+    assertFalse("Before adding new replica, in-mem data structure should not contain new partition",
+        mockStatsManager.partitionToReplicaMap.containsKey(newPartition));
+    mockStatsManager.returnValOfAddReplica = null;
+    clusterParticipant.onPartitionBecomeBootstrapFromOffline(newPartition.toPathString());
+    assertTrue("After adding new replica, in-mem data structure should contain new partition",
+        mockStatsManager.partitionToReplicaMap.containsKey(newPartition));
+    // 5. state transition on existing replica should be no-op
+    clusterParticipant.onPartitionBecomeBootstrapFromOffline(replicas.get(0).getPartitionId().toPathString());
+  }
+
   /**
    * Test that the {@link StatsManager} can correctly collect and aggregate all type of stats on the node. This
    * test is using randomly generated account snapshot and partitionClass snapshot in mock {@link StoreStats}.
@@ -386,7 +440,7 @@ public class StatsManagerTest {
     }
     StorageManager storageManager = new MockStorageManager(storeMap, dataNodeId);
     StatsManager statsManager =
-        new StatsManager(storageManager, replicaIds, new MetricRegistry(), config, new MockTime());
+        new StatsManager(storageManager, replicaIds, new MetricRegistry(), statsManagerConfig, new MockTime(), null);
 
     StatsSnapshot expectAccountSnapshot = new StatsSnapshot(0L, new HashMap<>());
     StatsSnapshot expectPartitionClassSnapshot = new StatsSnapshot(0L, new HashMap<>());

--- a/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
@@ -377,6 +377,9 @@ public class StatsManagerTest {
         statsWrapper.getSnapshot().getSubMap().containsKey(partitionId4.toPathString()));
   }
 
+  /**
+   * Test state transition in stats manager from OFFLINE to BOOTSTRAP
+   */
   @Test
   public void testReplicaFromOfflineToBootstrap() {
     MockStatsManager mockStatsManager =
@@ -411,6 +414,28 @@ public class StatsManagerTest {
         mockStatsManager.partitionToReplicaMap.containsKey(newPartition));
     // 5. state transition on existing replica should be no-op
     clusterParticipant.onPartitionBecomeBootstrapFromOffline(replicas.get(0).getPartitionId().toPathString());
+  }
+
+  /**
+   * Test state transition in stats manager from STANDBY to LEADER
+   */
+  @Test
+  public void testReplicaFromStandbyToLeader() {
+    MockStatsManager mockStatsManager =
+        new MockStatsManager(storageManager, replicas, new MetricRegistry(), statsManagerConfig, clusterParticipant);
+    // state transition on existing replica should be no-op
+    clusterParticipant.onPartitionBecomeLeaderFromStandby(replicas.get(0).getPartitionId().toPathString());
+  }
+
+  /**
+   * Test state transition in stats manager from LEADER to STANDBY
+   */
+  @Test
+  public void testReplicaFromLeaderToStandby() {
+    MockStatsManager mockStatsManager =
+        new MockStatsManager(storageManager, replicas, new MetricRegistry(), statsManagerConfig, clusterParticipant);
+    // state transition on existing replica should be no-op
+    clusterParticipant.onPartitionBecomeStandbyFromLeader(replicas.get(0).getPartitionId().toPathString());
   }
 
   /**

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -196,6 +196,11 @@ public class StorageManager implements StoreManager {
   }
 
   @Override
+  public ReplicaId getReplica(String partitionName) {
+    return partitionNameToReplicaId.get(partitionName);
+  }
+
+  @Override
   public ServerErrorCode checkLocalPartitionStatus(PartitionId partition, ReplicaId localReplica) {
     if (getStore(partition) == null) {
       if (localReplica != null) {

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -394,7 +394,7 @@ public class StorageManager implements StoreManager {
         if (!addBlobStore(replicaToAdd)) {
           logger.error("Failed to add store {} into storage manager", partitionName);
           throw new StateTransitionException("Failed to add store " + partitionName + " into storage manager",
-              StateTransitionException.TransitionErrorCode.StoreOperationFailure);
+              StateTransitionException.TransitionErrorCode.ReplicaOperationFailure);
         }
         // TODO, update InstanceConfig in Helix
         // note that partitionNameToReplicaId should be updated if addBlobStore succeeds, so replicationManager should be

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -282,7 +282,7 @@ public class StorageManagerTest {
     try {
       mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(newPartition.toPathString());
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.StoreOperationFailure,
+      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaOperationFailure,
           e.getErrorCode());
     }
     // restart disk manager to test case where new replica(store) is successfully added into StorageManager


### PR DESCRIPTION
1. introduced ClusterParticipant into ReplicationManager and StatsManager to register state change listeners
2. implemented Offline-To-Bootstrap logic in Replication/Stats Manager.
(Note: this change is remaining part of PR #1326)