### PR TITLE
Fix a bug in ResponseInfo.release

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -339,11 +339,12 @@ class GetBlobOperation extends GetOperation {
         if (exception != null) {
           setOperationException(exception);
         }
-        int currentNumChunk = numChunksWrittenOut.getAndIncrement();
+        int currentNumChunk = numChunksWrittenOut.get();
         ResponseInfo responseInfo = chunkIndexToResponseInfo.remove(currentNumChunk);
         if (responseInfo != null) {
           responseInfo.release();
         }
+        numChunksWrittenOut.incrementAndGet();
         routerCallback.onPollReady();
       }
     };


### PR DESCRIPTION
Increment numChunksWrittenOut before releasing the responseInfo might end up another thread calling completeRead at the same time. We might see the same ResponseInfo being released twice.