### PR TITLE
Fix intermittent routing table test failure

### DIFF
--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -580,14 +580,14 @@ public class HelixClusterManagerTest {
         .get();
     // ensure previous latch has counted down to zero, otherwise the delayed routing table change may falsely count down
     // new latch and verification is performed based on old view. (if condition is not met, skip rest test)
-    if (routingTableChangeLatch.get().await(1, TimeUnit.SECONDS)) {
-      routingTableChangeLatch.set(new CountDownLatch(1));
-      mockHelixAdmin.changeLeaderReplicaForPartition(partitionToChange.toPathString(), newLeaderInstance);
-      mockHelixAdmin.triggerRoutingTableNotification();
-      assertTrue("Routing table change didn't come within 1 second",
-          routingTableChangeLatch.get().await(1, TimeUnit.SECONDS));
-      verifyLeaderReplicasInDc(helixClusterManager, localDc);
-    }
+    assertTrue("Routing table change didn't come within 10 seconds",
+        routingTableChangeLatch.get().await(10, TimeUnit.SECONDS));
+    routingTableChangeLatch.set(new CountDownLatch(1));
+    mockHelixAdmin.changeLeaderReplicaForPartition(partitionToChange.toPathString(), newLeaderInstance);
+    mockHelixAdmin.triggerRoutingTableNotification();
+    assertTrue("Routing table change didn't come within 1 second",
+        routingTableChangeLatch.get().await(1, TimeUnit.SECONDS));
+    verifyLeaderReplicasInDc(helixClusterManager, localDc);
 
     helixClusterManager.close();
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -580,8 +580,11 @@ public class HelixClusterManagerTest {
         .get();
     // ensure previous latch has counted down to zero, otherwise the delayed routing table change may falsely count down
     // new latch and verification is performed based on old view. (if condition is not met, skip rest test)
+    long startTimeMs = System.currentTimeMillis();
     assertTrue("Routing table change didn't come within 10 seconds",
-        routingTableChangeLatch.get().await(10, TimeUnit.SECONDS));
+        routingTableChangeLatch.get().await(1, TimeUnit.MINUTES));
+    long elapsedTimeSec = (System.currentTimeMillis() - startTimeMs) / 1000;
+    System.out.println("Elapsed time for counting down latch: " + elapsedTimeSec);
     routingTableChangeLatch.set(new CountDownLatch(1));
     mockHelixAdmin.changeLeaderReplicaForPartition(partitionToChange.toPathString(), newLeaderInstance);
     mockHelixAdmin.triggerRoutingTableNotification();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -579,8 +579,8 @@ public class HelixClusterManagerTest {
         .findFirst()
         .get();
     // ensure previous latch has counted down to zero, otherwise the delayed routing table change may falsely count down
-    // new latch and verification is performed based on old view.
-    if (routingTableChangeLatch.get().await(5, TimeUnit.SECONDS)) {
+    // new latch and verification is performed based on old view. (if condition is not met, skip rest test)
+    if (routingTableChangeLatch.get().await(1, TimeUnit.SECONDS)) {
       routingTableChangeLatch.set(new CountDownLatch(1));
       mockHelixAdmin.changeLeaderReplicaForPartition(partitionToChange.toPathString(), newLeaderInstance);
       mockHelixAdmin.triggerRoutingTableNotification();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -165,10 +165,6 @@ public class HelixClusterManagerTest {
         new PartitionRangeCheckParams(defaultRo.rangeEnd + 1, 5, SPECIAL_PARTITION_CLASS, PartitionState.READ_ONLY);
     testPartitionLayout.addNewPartitions(specialRo.count, SPECIAL_PARTITION_CLASS, PartitionState.READ_ONLY, localDc);
 
-//    List<PartitionId> specialPartitions = testPartitionLayout.getPartitionLayout().getPartitions(SPECIAL_PARTITION_CLASS);
-//    for(PartitionId specialPartition : specialPartitions){
-//      System.out.println("Partition " + specialPartition.toPathString() + ", replica size = " + specialPartition.getReplicaIds().size());
-//    }
     Utils.writeJsonObjectToFile(zkJson, zkLayoutPath);
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -579,8 +579,8 @@ public class HelixClusterManagerTest {
         .findFirst()
         .get();
     // ensure previous latch has counted down to zero
-    assertTrue("Not all of routing table changes (during initialization) came within 1 second",
-        routingTableChangeLatch.get().await(1, TimeUnit.SECONDS));
+    assertTrue("Not all of routing table changes (during initialization) came within 5 second",
+        routingTableChangeLatch.get().await(5, TimeUnit.SECONDS));
     routingTableChangeLatch.set(new CountDownLatch(1));
     mockHelixAdmin.changeLeaderReplicaForPartition(partitionToChange.toPathString(), newLeaderInstance);
     mockHelixAdmin.triggerRoutingTableNotification();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -578,15 +578,16 @@ public class HelixClusterManagerTest {
         .filter(k -> !k.equals(currentLeaderInstance))
         .findFirst()
         .get();
-    // ensure previous latch has counted down to zero
-    assertTrue("Not all of routing table changes (during initialization) came within 5 second",
-        routingTableChangeLatch.get().await(5, TimeUnit.SECONDS));
-    routingTableChangeLatch.set(new CountDownLatch(1));
-    mockHelixAdmin.changeLeaderReplicaForPartition(partitionToChange.toPathString(), newLeaderInstance);
-    mockHelixAdmin.triggerRoutingTableNotification();
-    assertTrue("Routing table change didn't come within 1 second",
-        routingTableChangeLatch.get().await(1, TimeUnit.SECONDS));
-    verifyLeaderReplicasInDc(helixClusterManager, localDc);
+    // ensure previous latch has counted down to zero, otherwise the delayed routing table change may falsely count down
+    // new latch and verification is performed based on old view.
+    if (routingTableChangeLatch.get().await(5, TimeUnit.SECONDS)) {
+      routingTableChangeLatch.set(new CountDownLatch(1));
+      mockHelixAdmin.changeLeaderReplicaForPartition(partitionToChange.toPathString(), newLeaderInstance);
+      mockHelixAdmin.triggerRoutingTableNotification();
+      assertTrue("Routing table change didn't come within 1 second",
+          routingTableChangeLatch.get().await(1, TimeUnit.SECONDS));
+      verifyLeaderReplicasInDc(helixClusterManager, localDc);
+    }
 
     helixClusterManager.close();
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -580,11 +580,8 @@ public class HelixClusterManagerTest {
         .get();
     // ensure previous latch has counted down to zero, otherwise the delayed routing table change may falsely count down
     // new latch and verification is performed based on old view. (if condition is not met, skip rest test)
-    long startTimeMs = System.currentTimeMillis();
-    assertTrue("Routing table change didn't come within 10 seconds",
-        routingTableChangeLatch.get().await(1, TimeUnit.MINUTES));
-    long elapsedTimeSec = (System.currentTimeMillis() - startTimeMs) / 1000;
-    System.out.println("Elapsed time for counting down latch: " + elapsedTimeSec);
+    assertTrue("Routing table change didn't come within 30 seconds",
+        routingTableChangeLatch.get().await(30, TimeUnit.SECONDS));
     routingTableChangeLatch.set(new CountDownLatch(1));
     mockHelixAdmin.changeLeaderReplicaForPartition(partitionToChange.toPathString(), newLeaderInstance);
     mockHelixAdmin.triggerRoutingTableNotification();


### PR DESCRIPTION
There is a very rare race condition induced by delayed routing table changes. Basically, initializing HelixClusterManager and connecting to two DCs should trigger routing table change 4 times.
However these routing table changes may not come in time. After initialization, we  manually triggered routing table change and used latch to ensure the change occurs. Unfortunately, the aforementioned delayed routing table change could falsely count down the latch and subsequent verification was performed based on old view of routing table change, which would definitely fail. 
This PR makes routing table provider listen to local DC only, wait until all initialization changes have occurred and then change leadership of one partition to perform subsequent verification. (For some reason, the countdown latch always times out. Hence, this PR conditionally disables manual-triggered routing table change after initialization if previous countdown latch timed out)