### PR TITLE
Adding operationCount metric in preparation to replace operationRate

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetrics.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetrics.java
@@ -39,6 +39,7 @@ public class RestRequestMetrics {
 
   static final String OPERATION_RATE_SUFFIX = "Rate";
   static final String OPERATION_ERROR_SUFFIX = "Error";
+  static final String OPERATION_COUNT_SUFFIX = "Count";
 
   static final String UNSATISFIED_REQUEST_COUNT_SUFFIX = "UnsatisfiedRequestCount";
   static final String SATISFIED_REQUEST_COUNT_SUFFIX = "SatisfiedRequestCount";
@@ -56,6 +57,7 @@ public class RestRequestMetrics {
 
   final Meter operationRate;
   final Counter operationError;
+  final Counter operationCount;
   final Counter unsatisfiedRequestCount;
   final Counter satisfiedRequestCount;
 
@@ -95,6 +97,7 @@ public class RestRequestMetrics {
 
     operationRate = metricRegistry.meter(MetricRegistry.name(ownerClass, requestType + OPERATION_RATE_SUFFIX));
     operationError = metricRegistry.counter(MetricRegistry.name(ownerClass, requestType + OPERATION_ERROR_SUFFIX));
+    operationCount = metricRegistry.counter(MetricRegistry.name(ownerClass, requestType + OPERATION_COUNT_SUFFIX));
 
     unsatisfiedRequestCount =
         metricRegistry.counter(MetricRegistry.name(ownerClass, requestType + UNSATISFIED_REQUEST_COUNT_SUFFIX));

--- a/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
+++ b/ambry-api/src/main/java/com.github.ambry/rest/RestRequestMetricsTracker.java
@@ -248,6 +248,7 @@ public class RestRequestMetricsTracker {
     if (metrics != null) {
       if (metricsRecorded.compareAndSet(false, true)) {
         metrics.operationRate.mark();
+        metrics.operationCount.inc();
         metrics.nioRequestProcessingTimeInMs.update(nioMetricsTracker.requestProcessingTimeInMs.get());
         metrics.nioResponseProcessingTimeInMs.update(nioMetricsTracker.responseProcessingTimeInMs.get());
         metrics.nioRoundTripTimeInMs.update(nioMetricsTracker.roundTripTimeInMs);


### PR DESCRIPTION
In order to record more accurate and time-wise precise request rates we're going to test using Count metric as opposed to Meter (which is an average of 1, 5 and 15 minute periods)