### PR TITLE
Allow PutOperation to use dynamic success target

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -455,6 +455,9 @@ public class RouterConfig {
   @Default("false")
   public final boolean routerGetEligibleReplicasByStateEnabled;
 
+  /**
+   * Whether to use dynamic success target for put operation in router.
+   */
   @Config(ROUTER_PUT_USE_DYNAMIC_SUCCESS_TARGET)
   @Default("false")
   public final boolean routerPutUseDynamicSuccessTarget;

--- a/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/RouterConfig.java
@@ -97,6 +97,8 @@ public class RouterConfig {
   public static final String ROUTER_GET_BLOB_OPERATION_SHARE_MEMORY = "router.get.blob.operation.share.memory";
   public static final String ROUTER_GET_ELIGIBLE_REPLICAS_BY_STATE_ENABLED =
       "router.get.eligible.replicas.by.state.enabled";
+  public static final String ROUTER_PUT_USE_DYNAMIC_SUCCESS_TARGET = "router.put.use.dynamic.success.target";
+
   /**
    * Number of independent scaling units for the router.
    */
@@ -453,6 +455,10 @@ public class RouterConfig {
   @Default("false")
   public final boolean routerGetEligibleReplicasByStateEnabled;
 
+  @Config(ROUTER_PUT_USE_DYNAMIC_SUCCESS_TARGET)
+  @Default("false")
+  public final boolean routerPutUseDynamicSuccessTarget;
+
   /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
@@ -552,5 +558,6 @@ public class RouterConfig {
     routerGetBlobOperationShareMemory = verifiableProperties.getBoolean(ROUTER_GET_BLOB_OPERATION_SHARE_MEMORY, false);
     routerGetEligibleReplicasByStateEnabled =
         verifiableProperties.getBoolean(ROUTER_GET_ELIGIBLE_REPLICAS_BY_STATE_ENABLED, false);
+    routerPutUseDynamicSuccessTarget = verifiableProperties.getBoolean(ROUTER_PUT_USE_DYNAMIC_SUCCESS_TARGET, false);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/router/RouterErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/RouterErrorCode.java
@@ -108,10 +108,5 @@ public enum RouterErrorCode {
   /**
    * ContainerId or AccountId from blobId doesn't match these in store server.
    */
-  BlobAuthorizationFailure,
-
-  /**
-   * Operation is disabled on specific replica that is either being decommissioned or under admin control.
-   */
-  OperationDisabled
+  BlobAuthorizationFailure
 }

--- a/ambry-api/src/main/java/com.github.ambry/router/RouterErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/RouterErrorCode.java
@@ -108,5 +108,10 @@ public enum RouterErrorCode {
   /**
    * ContainerId or AccountId from blobId doesn't match these in store server.
    */
-  BlobAuthorizationFailure
+  BlobAuthorizationFailure,
+
+  /**
+   * Operation is disabled on specific replica that is either being decommissioned or under admin control.
+   */
+  OperationDisabled
 }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockPartitionId.java
@@ -171,6 +171,8 @@ public class MockPartitionId implements PartitionId {
     for (ReplicaId replicaId : replicaIds) {
       ((MockReplicaId) replicaId).cleanup();
     }
+    replicaIds.clear();
+    replicaAndState.clear();
   }
 
   public void onPartitionReadOnly() {

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -1446,7 +1446,7 @@ class PutOperation {
     /**
      * Perform the necessary actions when a request to a replica fails.
      * @param replicaId the {@link ReplicaId} associated with the failed response.
-     * @param routerErrorCode
+     * @param routerErrorCode the {@link RouterErrorCode} associated with failed response.
      */
     private void onErrorResponse(ReplicaId replicaId, RouterErrorCode routerErrorCode) {
       // For Put, final state could be TIMED_OUT, REQUEST_DISABLED and FAILURE

--- a/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/PutOperation.java
@@ -585,6 +585,13 @@ class PutOperation {
   }
 
   /**
+   * @return a snapshot of current put chunks
+   */
+  List<PutChunk> getPutChunks() {
+    return new ArrayList<>(putChunks);
+  }
+
+  /**
    * Called whenever the channel has data but no free or building chunk is available to be filled.
    */
   private void maybeStartTrackingWaitForChunkTime() {
@@ -1062,6 +1069,13 @@ class PutOperation {
      */
     boolean isComplete() {
       return state == ChunkState.Complete;
+    }
+
+    /**
+     * @return operation tracker used by current put chunk
+     */
+    OperationTracker getOperationTrackerInUse() {
+      return operationTracker;
     }
 
     /**

--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -361,6 +361,20 @@ class SimpleOperationTracker implements OperationTracker {
   }
 
   /**
+   * @return the number of requests that are temporarily disabled on certain replicas.
+   */
+  int getDisabledCount() {
+    return disabledCount;
+  }
+
+  /**
+   * @return current failed count in this tracker
+   */
+  int getFailedCount() {
+    return failedCount;
+  }
+
+  /**
    * Helper function to catch a potential race condition in {@link SimpleOperationTracker#SimpleOperationTracker(RouterConfig, RouterOperation, PartitionId, String, boolean)}.
    *
    * @param partitionId The partition on which the operation is performed.

--- a/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/SimpleOperationTracker.java
@@ -286,6 +286,12 @@ class SimpleOperationTracker implements OperationTracker {
       case SUCCESS:
         succeededCount++;
         break;
+      // Request disabled may happen when PUT/DELETE/TTLUpdate requests attempt to perform on replicas that are being
+      // decommissioned (i.e STANDBY -> INACTIVE). This is because decommission may take some time and frontends still
+      // hold old view. Aforementioned requests are rejected by server with Temporarily_Disabled error. For DELETE/TTLUpdate,
+      // even though we may receive such errors, the success target is still same(=2). For PUT, we have to adjust the
+      // success target (quorum) to let some PUT operations (with at least 2 requests succeeded on new replicas) succeed.
+      // Currently, disabledCount only applies to PUT operation.
       case REQUEST_DISABLED:
         disabledCount++;
         break;

--- a/ambry-router/src/main/java/com.github.ambry.router/TrackedRequestFinalState.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TrackedRequestFinalState.java
@@ -32,8 +32,6 @@ public enum TrackedRequestFinalState {
         return TIMED_OUT;
       case BlobDoesNotExist:
         return NOT_FOUND;
-      case OperationDisabled:
-        return REQUEST_DISABLED;
       default:
         return FAILURE;
     }

--- a/ambry-router/src/main/java/com.github.ambry.router/TrackedRequestFinalState.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TrackedRequestFinalState.java
@@ -19,7 +19,7 @@ package com.github.ambry.router;
  * consumed by operation tracker to change success/failure counter and determine whether to update Histograms.
  */
 public enum TrackedRequestFinalState {
-  SUCCESS, FAILURE, TIMED_OUT, NOT_FOUND;
+  SUCCESS, FAILURE, TIMED_OUT, NOT_FOUND, REQUEST_DISABLED;
 
   /**
    *  Return the corresponding {@link TrackedRequestFinalState}  for the given {@link RouterErrorCode}.
@@ -32,6 +32,8 @@ public enum TrackedRequestFinalState {
         return TIMED_OUT;
       case BlobDoesNotExist:
         return NOT_FOUND;
+      case OperationDisabled:
+        return REQUEST_DISABLED;
       default:
         return FAILURE;
     }

--- a/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/OperationTrackerTest.java
@@ -112,7 +112,8 @@ public class OperationTrackerTest {
   @Test
   public void localSucceedTest() {
     initialize();
-    OperationTracker ot = getOperationTracker(false, 2, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+    OperationTracker ot =
+        getOperationTracker(false, 2, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
     // 3-0-0-0; 9-0-0-0
     assertFalse("Operation should not have been done.", ot.isDone());
     sendRequests(ot, 3, false);
@@ -142,7 +143,8 @@ public class OperationTrackerTest {
   @Test
   public void localFailTest() {
     initialize();
-    OperationTracker ot = getOperationTracker(false, 2, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+    OperationTracker ot =
+        getOperationTracker(false, 2, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
     // 3-0-0-0; 9-0-0-0
     assertFalse("Operation should not have been done.", ot.isDone());
     sendRequests(ot, 3, false);
@@ -157,6 +159,127 @@ public class OperationTrackerTest {
     // 0-0-1-2; 9-0-0-0
     assertFalse("Operation should not have succeeded", ot.hasSucceeded());
     assertTrue("Operation should be done", ot.isDone());
+  }
+
+  /**
+   * Test put operation with both dynamic success target and get replica by state enabled.
+   * Test cases:
+   * Case 1: 1 LEADER and 2 STANDBY replicas (regular case)
+   * Case 2: 1 LEADER and 3 STANDBY replicas. One of them returns REQUEST_DISABLED error code. There are two combinations
+   *         for remaining 3 replicas:
+   *         (1) two success and one failure (whole operation should succeed)
+   *         (2) one success and two failure (whole operation should fail)
+   * Case 3: 1 LEADER and 5 STANDBY replicas. Several combinations to discuss:
+   *         (1) 3 REQUEST_DISABLED, 2 success and 1 failure (operation should succeed)
+   *         (2) 2 REQUEST_DISABLED, 2 failure (operation should fail no matter what results are from remaining replicas)
+   *         (3) 1 REQUEST_DISABLED, 1 failure, 4 success (operation should succeed)
+   * Case 4: 1 LEADER, 4 STANDBY, 1 INACTIVE  (this is to mock one replica has completed STANDBY -> INACTIVE)
+   *         (1) 2 REQUEST_DISABLED, 1 failure and 2 success (operation should succeed)
+   *         (2) 3 REQUEST_DISABLED, 1 failure (operation should fail no matter what result is from remaining replica)
+   */
+  @Test
+  public void putOperationWithDynamicTargetTest() {
+    assumeTrue(operationTrackerType.equals(SIMPLE_OP_TRACKER) && replicasStateEnabled);
+    List<Port> portList = Collections.singletonList(new Port(PORT, PortType.PLAINTEXT));
+    List<String> mountPaths = Collections.singletonList("mockMountPath");
+    datanodes = Collections.singletonList(new MockDataNodeId(portList, mountPaths, "dc-0"));
+    mockPartition = new MockPartitionId();
+    // Case 1
+    populateReplicaList(1, ReplicaState.LEADER);
+    populateReplicaList(2, ReplicaState.STANDBY);
+    localDcName = datanodes.get(0).getDatacenterName();
+    mockClusterMap = new MockClusterMap(false, datanodes, 1, Collections.singletonList(mockPartition), localDcName);
+    OperationTracker ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation, true);
+    sendRequests(ot, 3, false);
+    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
+    for (int i = 0; i < 2; ++i) {
+      ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.SUCCESS);
+    }
+    assertTrue("Operation should succeed", ot.hasSucceeded());
+    // Case 2.1
+    populateReplicaList(1, ReplicaState.STANDBY);
+    repetitionTracker.clear();
+    ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation, true);
+    sendRequests(ot, 4, false);
+    // make 1 replica return REQUEST_DISABLED, then 1 failure and 2 success
+    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.REQUEST_DISABLED);
+    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
+    for (int i = 0; i < 2; ++i) {
+      ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.SUCCESS);
+    }
+    assertTrue("Operation should succeed", ot.hasSucceeded());
+    // Case 2.2
+    repetitionTracker.clear();
+    ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation, true);
+    sendRequests(ot, 4, false);
+    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.REQUEST_DISABLED);
+    for (int i = 0; i < 2; ++i) {
+      ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
+    }
+    assertFalse("Operation should fail", ot.hasSucceeded());
+    // Case 3.1
+    populateReplicaList(2, ReplicaState.STANDBY);
+    repetitionTracker.clear();
+    ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation, true);
+    sendRequests(ot, 6, false);
+    for (int i = 0; i < 3; ++i) {
+      ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.REQUEST_DISABLED);
+    }
+    assertFalse("Operation should not be done yet", ot.isDone());
+    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
+    assertFalse("Operation should not be done yet", ot.isDone());
+    for (int i = 0; i < 2; ++i) {
+      ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.SUCCESS);
+    }
+    assertTrue("Operation should succeed", ot.hasSucceeded());
+    // Case 3.2
+    repetitionTracker.clear();
+    ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation, true);
+    sendRequests(ot, 6, false);
+    for (int i = 0; i < 2; ++i) {
+      ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.REQUEST_DISABLED);
+      ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
+    }
+    assertFalse("Operation should fail", ot.hasSucceeded());
+    // Case 3.3
+    repetitionTracker.clear();
+    ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation, true);
+    sendRequests(ot, 6, false);
+    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.REQUEST_DISABLED);
+    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
+    for (int i = 0; i < 4; ++i) {
+      ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.SUCCESS);
+    }
+    assertTrue("Operation should succeed", ot.hasSucceeded());
+    // Case 4
+    // re-populate replica list
+    mockPartition.cleanUp();
+    repetitionTracker.clear();
+    populateReplicaList(1, ReplicaState.LEADER);
+    populateReplicaList(4, ReplicaState.STANDBY);
+    populateReplicaList(1, ReplicaState.INACTIVE);
+    ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation, true);
+    sendRequests(ot, 5, false);
+    // Case 4.1
+    for (int i = 0; i < 2; ++i) {
+      ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.REQUEST_DISABLED);
+    }
+    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
+    assertFalse("Operation should not be done yet", ot.isDone());
+    for (int i = 0; i < 2; ++i) {
+      ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.SUCCESS);
+    }
+    assertTrue("Operation should succeed", ot.hasSucceeded());
+    // Case 4.2
+    repetitionTracker.clear();
+    ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation, true);
+    sendRequests(ot, 5, false);
+    for (int i = 0; i < 3; ++i) {
+      ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.REQUEST_DISABLED);
+    }
+    ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
+    assertTrue("Operation should not be done", ot.isDone());
+    assertFalse("Operation should fail", ot.hasSucceeded());
   }
 
   /**
@@ -180,7 +303,7 @@ public class OperationTrackerTest {
     populateReplicaList(2, ReplicaState.STANDBY);
     localDcName = datanodes.get(0).getDatacenterName();
     mockClusterMap = new MockClusterMap(false, datanodes, 1, Collections.singletonList(mockPartition), localDcName);
-    OperationTracker ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation);
+    OperationTracker ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation, false);
     assertFalse("Operation should not have been done.", ot.isDone());
     sendRequests(ot, 2, false);
     // make one requests succeed, the other fail
@@ -192,7 +315,7 @@ public class OperationTrackerTest {
     // add one more replica in INACTIVE state, now we have 2 STANDBY and 1 INACTIVE replicas
     populateReplicaList(1, ReplicaState.INACTIVE);
     repetitionTracker.clear();
-    ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation);
+    ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation, false);
     // issue PUT request
     sendRequests(ot, replicasStateEnabled ? 2 : 3, false);
     // make first request fail and rest requests succeed
@@ -211,7 +334,7 @@ public class OperationTrackerTest {
     populateReplicaList(2, ReplicaState.STANDBY);
     // now we have 6 replicas: 1 LEADER, 4 STANDBY and 1 INACTIVE. Number of eligible replicas = 1 + 4 = 5
     repetitionTracker.clear();
-    ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation);
+    ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.PutOperation, false);
     // issue PUT request, parallelism should be 5 when replicaState is enabled.
     sendRequests(ot, replicasStateEnabled ? 5 : 3, false);
     // remaining test is for replicaState enabled operation tracker
@@ -242,7 +365,7 @@ public class OperationTrackerTest {
    * 5. Make remaining requests succeed, this only applies for tracker with replicaState disabled and operation should succeed.
    */
   @Test
-  public void deleteTtlUpdateWithReplica() {
+  public void deleteTtlUpdateWithReplicaStateTest() {
     assumeTrue(operationTrackerType.equals(SIMPLE_OP_TRACKER));
     List<Port> portList = Collections.singletonList(new Port(PORT, PortType.PLAINTEXT));
     List<String> mountPaths = Collections.singletonList("mockMountPath");
@@ -261,7 +384,7 @@ public class OperationTrackerTest {
     // test both delete and Ttl Update cases
     for (RouterOperation operation : EnumSet.of(RouterOperation.DeleteOperation, RouterOperation.TtlUpdateOperation)) {
       repetitionTracker.clear();
-      OperationTracker ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, operation);
+      OperationTracker ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, operation, false);
       // issue delete/ttlUpdate requests to 2 local replica and 1 remote replica
       sendRequests(ot, 3, false);
 
@@ -298,7 +421,8 @@ public class OperationTrackerTest {
   @Test
   public void localSucceedWithDifferentParameterTest() {
     initialize();
-    OperationTracker ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+    OperationTracker ot =
+        getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
     // 3-0-0-0; 9-0-0-0
     sendRequests(ot, 2, false);
     // 1-2-0-0; 9-0-0-0
@@ -335,7 +459,8 @@ public class OperationTrackerTest {
   @Test
   public void remoteReplicaTest() {
     initialize();
-    OperationTracker ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+    OperationTracker ot =
+        getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
     // 3-0-0-0; 9-0-0-0
     sendRequests(ot, 2, false);
     // 1-2-0-0; 9-0-0-0
@@ -387,7 +512,8 @@ public class OperationTrackerTest {
   @Test
   public void fullSuccessTargetTest() {
     initialize();
-    OperationTracker ot = getOperationTracker(true, 12, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+    OperationTracker ot =
+        getOperationTracker(true, 12, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
     while (!ot.hasSucceeded()) {
       sendRequests(ot, 3, false);
       for (int i = 0; i < 3; i++) {
@@ -423,7 +549,8 @@ public class OperationTrackerTest {
     populateReplicaList(replicaCount, ReplicaState.STANDBY);
     localDcName = datanodes.get(0).getDatacenterName();
     mockClusterMap = new MockClusterMap(false, datanodes, 1, Collections.singletonList(mockPartition), localDcName);
-    OperationTracker ot = getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+    OperationTracker ot =
+        getOperationTracker(true, 1, 2, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
     sendRequests(ot, 2, true);
     ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
     ot.onResponse(inflightReplicas.poll(), TrackedRequestFinalState.FAILURE);
@@ -466,7 +593,7 @@ public class OperationTrackerTest {
   public void replicasOrderingTestOriginatingUnknown() {
     initialize();
     originatingDcName = null;
-    OperationTracker ot = getOperationTracker(true, 3, 3, false, 6, RouterOperation.GetBlobOperation);
+    OperationTracker ot = getOperationTracker(true, 3, 3, false, 6, RouterOperation.GetBlobOperation, false);
     sendRequests(ot, 3, false);
     for (int i = 0; i < 3; i++) {
       ReplicaId replica = inflightReplicas.poll();
@@ -497,7 +624,7 @@ public class OperationTrackerTest {
   public void replicasOrderingTestOriginatingIsLocal() {
     initialize();
     originatingDcName = localDcName;
-    OperationTracker ot = getOperationTracker(true, 3, 3, false, 6, RouterOperation.GetBlobOperation);
+    OperationTracker ot = getOperationTracker(true, 3, 3, false, 6, RouterOperation.GetBlobOperation, false);
     sendRequests(ot, 3, false);
     for (int i = 0; i < 3; i++) {
       ReplicaId replica = inflightReplicas.poll();
@@ -516,7 +643,7 @@ public class OperationTrackerTest {
   public void replicasOrderingTestOriginatingNotLocal() {
     initialize();
     originatingDcName = datanodes.get(datanodes.size() - 1).getDatacenterName();
-    OperationTracker ot = getOperationTracker(true, 3, 6, false, 6, RouterOperation.GetBlobOperation);
+    OperationTracker ot = getOperationTracker(true, 3, 6, false, 6, RouterOperation.GetBlobOperation, false);
     sendRequests(ot, 6, false);
     for (int i = 0; i < 3; i++) {
       ReplicaId replica = inflightReplicas.poll();
@@ -544,7 +671,7 @@ public class OperationTrackerTest {
   public void replicasOrderTestOriginatingDcOnly() {
     initialize();
     originatingDcName = datanodes.get(datanodes.size() - 1).getDatacenterName();
-    OperationTracker ot = getOperationTracker(true, 3, 9, false, 6, RouterOperation.GetBlobOperation);
+    OperationTracker ot = getOperationTracker(true, 3, 9, false, 6, RouterOperation.GetBlobOperation, false);
     sendRequests(ot, 6, false);
     assertEquals("Should have 6 replicas", 6, inflightReplicas.size());
     for (int i = 0; i < 3; i++) {
@@ -572,7 +699,8 @@ public class OperationTrackerTest {
   public void blobNotFoundInOriginDcAndCrossColoDisabledTest() {
     initialize();
     originatingDcName = datanodes.get(datanodes.size() - 1).getDatacenterName();
-    OperationTracker ot = getOperationTracker(false, 1, 3, false, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+    OperationTracker ot =
+        getOperationTracker(false, 1, 3, false, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
     sendRequests(ot, 3, false);
     assertEquals("Should have 3 replicas", 3, inflightReplicas.size());
     for (int i = 0; i < 3; i++) {
@@ -593,7 +721,8 @@ public class OperationTrackerTest {
   public void originDcNotFoundUnknownOriginDcTest() {
     initialize();
     originatingDcName = null;
-    OperationTracker ot = getOperationTracker(true, 1, 12, false, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+    OperationTracker ot =
+        getOperationTracker(true, 1, 12, false, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
     sendRequests(ot, 12, false);
     assertEquals("Should have 12 replicas", 12, inflightReplicas.size());
     for (int i = 0; i < 12; i++) {
@@ -613,7 +742,8 @@ public class OperationTrackerTest {
   public void originDcNotFoundTriggeredTest() {
     initialize();
     originatingDcName = datanodes.get(datanodes.size() - 1).getDatacenterName();
-    OperationTracker ot = getOperationTracker(true, 2, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+    OperationTracker ot =
+        getOperationTracker(true, 2, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
     sendRequests(ot, 3, false);
     assertEquals("Should have 3 replicas", 3, inflightReplicas.size());
     for (int i = 0; i < 3; i++) {
@@ -645,7 +775,7 @@ public class OperationTrackerTest {
   public void notEnoughReplicasToMeetTargetTest() {
     initialize();
     try {
-      getOperationTracker(true, 13, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+      getOperationTracker(true, 13, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
       fail("Should have failed to construct tracker because success target > replica count");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
@@ -660,7 +790,7 @@ public class OperationTrackerTest {
     initialize();
     for (int parallelism : Arrays.asList(0, -1)) {
       try {
-        getOperationTracker(true, 13, 0, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+        getOperationTracker(true, 13, 0, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
         fail("Should have failed to construct tracker because parallelism is " + parallelism);
       } catch (IllegalArgumentException e) {
         // expected. Nothing to do.
@@ -747,20 +877,22 @@ public class OperationTrackerTest {
   /**
    * Returns the right {@link OperationTracker} based on {@link #operationTrackerType}.
    * @param crossColoEnabled {@code true} if cross colo needs to be enabled. {@code false} otherwise.
-   * @param successTarget the number of successful responses required for the operation to succeed.
+   * @param successTargetForGet the number of successful responses required for GET operation to succeed.
    * @param parallelism the number of parallel requests that can be in flight.
    * @param includeNonOriginatingDcReplicas if take the option to include remote non originating DC replicas.
    * @param replicasRequired The number of replicas required for the operation.
    * @param routerOperation the {@link RouterOperation} associate with this request.
+   * @param useDynamicTargetForPut whether to enable dynamic success target for PUT operation.
    * @return the right {@link OperationTracker} based on {@link #operationTrackerType}.
    */
-  private OperationTracker getOperationTracker(boolean crossColoEnabled, int successTarget, int parallelism,
-      boolean includeNonOriginatingDcReplicas, int replicasRequired, RouterOperation routerOperation) {
+  private OperationTracker getOperationTracker(boolean crossColoEnabled, int successTargetForGet, int parallelism,
+      boolean includeNonOriginatingDcReplicas, int replicasRequired, RouterOperation routerOperation,
+      boolean useDynamicTargetForPut) {
     Properties props = new Properties();
     props.setProperty("router.hostname", "localhost");
     props.setProperty("router.datacenter.name", localDcName);
     props.setProperty("router.get.cross.dc.enabled", Boolean.toString(crossColoEnabled));
-    props.setProperty("router.get.success.target", Integer.toString(successTarget));
+    props.setProperty("router.get.success.target", Integer.toString(successTargetForGet));
     props.setProperty("router.get.request.parallelism", Integer.toString(parallelism));
     props.setProperty("router.get.include.non.originating.dc.replicas",
         Boolean.toString(includeNonOriginatingDcReplicas));
@@ -769,6 +901,7 @@ public class OperationTrackerTest {
     props.setProperty("router.operation.tracker.max.inflight.requests", Integer.toString(parallelism));
     props.setProperty("router.operation.tracker.terminate.on.not.found.enabled", "true");
     props.setProperty("router.get.eligible.replicas.by.state.enabled", Boolean.toString(replicasStateEnabled));
+    props.setProperty(RouterConfig.ROUTER_PUT_USE_DYNAMIC_SUCCESS_TARGET, Boolean.toString(useDynamicTargetForPut));
     RouterConfig routerConfig = new RouterConfig(new VerifiableProperties(props));
     NonBlockingRouterMetrics routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
     OperationTracker tracker;
@@ -838,7 +971,8 @@ public class OperationTrackerTest {
       ((MockReplicaId) mockReplicaIds.get(i)).markReplicaDownStatus(downStatus.get(i));
     }
     localDcName = datanodes.get(0).getDatacenterName();
-    OperationTracker ot = getOperationTracker(true, 2, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation);
+    OperationTracker ot =
+        getOperationTracker(true, 2, 3, true, Integer.MAX_VALUE, RouterOperation.GetBlobOperation, false);
     // The iterator should return all replicas, with the first half being the up replicas
     // and the last half being the down replicas.
     Iterator<ReplicaId> itr = ot.getReplicaIterator();


### PR DESCRIPTION
In the intermediate state of "move replica", when decommission of old replicas is initiated(but hasn't transited to INACTIVE yet), the PUT requests should be rejected on old replicas. For frontends, they are seeing both old and new replicas(lets say 3 old and 3 new) and the success target should be 6 - 1 = 5. In the aforementioned scenario, PUT request failed on 3 old replicas and we are supposed to fail whole PUT operation because number of remaining requests is already less than success target. From another point of view, however, PUT request is highly likely to succeed on 3 new replicas and we actually could consider it success without generating "slip put" (which makes PUT latency worse)
In this PR, we propose a new success criterion:
             success count > Math.max(parallelism - disabled count - 1, 2)
The 2 here is original PUT success target from config, which is the lower bound of PUT operation target.