### PR TITLE
Fix a bytebuf leak in transmission

### DIFF
--- a/ambry-network/src/main/java/com.github.ambry.network/Transmission.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Transmission.java
@@ -16,6 +16,7 @@ package com.github.ambry.network;
 import com.github.ambry.config.NetworkConfig;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Time;
+import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.channels.SelectionKey;
@@ -180,7 +181,7 @@ public abstract class Transmission {
 
   protected void release() {
     if (networkReceive != null) {
-      networkReceive.getReceivedBytes().getAndRelease();
+      ReferenceCountUtil.release(networkReceive.getReceivedBytes().getAndRelease());
     }
   }
 


### PR DESCRIPTION
Transmission's close method forgets to release the bytebuf.