### PR TITLE
Fix potential empty routing table snapshot during HelixClusterManager initialization

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -173,7 +173,8 @@ public class HelixClusterManager implements ClusterMap {
               // Periodic refresh in routing table provider is enabled by default. In worst case, routerUpdater should
               // trigger routing table change within 5 minutes
               if (!routingTableInitLatch.await(5, TimeUnit.MINUTES)) {
-                throw new IllegalStateException("Initial routing table change didn't come within 5 mins");
+                throw new IllegalStateException(
+                    "Initial routing table change from " + dcName + " didn't come within 5 mins");
               }
             }
             logger.info("Registered routing table change listeners in {}", dcName);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -568,9 +568,9 @@ public class HelixClusterManagerTest {
     int sleepCnt = 0;
     while (helixClusterManager.getRoutingTableSnapshots().get(localDc).get().getLiveInstances().size()
         != initialLiveCnt - 1) {
+      assertTrue("Routing table change (triggered by bringing down node) didn't come within 1 sec", sleepCnt < 5);
       Thread.sleep(200);
       sleepCnt++;
-      assertTrue("Routing table change (triggered by bringing down node) didn't come within 1 sec", sleepCnt < 5);
     }
     // then bring up the same instance, the number of live instances should equal to initial count
     mockHelixAdmin.bringInstanceUp(instance);
@@ -578,9 +578,9 @@ public class HelixClusterManagerTest {
     sleepCnt = 0;
     while (helixClusterManager.getRoutingTableSnapshots().get(localDc).get().getLiveInstances().size()
         != initialLiveCnt) {
+      assertTrue("Routing table change (triggered by bringing up node) didn't come within 1 sec", sleepCnt < 5);
       Thread.sleep(200);
       sleepCnt++;
-      assertTrue("Routing table change (triggered by bringing up node) didn't come within 1 sec", sleepCnt < 5);
     }
 
     // randomly choose a partition and change the leader replica of it in cluster
@@ -598,9 +598,9 @@ public class HelixClusterManagerTest {
     sleepCnt = 0;
     while (partitionToChange.getReplicaIdsByState(ReplicaState.LEADER, localDc).get(0).getDataNodeId().getPort()
         == currentLeaderPort) {
+      assertTrue("Routing table change (triggered by leadership change) didn't come within 1 sec", sleepCnt < 5);
       Thread.sleep(200);
       sleepCnt++;
-      assertTrue("Routing table change (triggered by leadership change) didn't come within 1 sec", sleepCnt < 5);
     }
     verifyLeaderReplicasInDc(helixClusterManager, localDc);
 

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -183,7 +183,7 @@ public class HelixBootstrapUpgradeToolTest {
     }
     // bootstrap a cluster
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-        CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(), true,
+        CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(), false,
         ClusterMapConfig.OLD_STATE_MODEL_DEF);
     // add new state model def
     HelixBootstrapUpgradeUtil.addStateModelDef(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
@@ -225,7 +225,7 @@ public class HelixBootstrapUpgradeToolTest {
       try {
         HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
             CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(),
-            true, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
+            false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
         fail("Should have thrown IllegalArgumentException as a zk host is missing for one of the dcs");
       } catch (IllegalArgumentException e) {
         // OK
@@ -487,7 +487,7 @@ public class HelixBootstrapUpgradeToolTest {
     // This updates and verifies that the information in Helix is consistent with the one in the static cluster map.
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, forceRemove, new HelixAdminFactory(),
-        true, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
+        false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
     verifyResourceCount(testHardwareLayout.getHardwareLayout(), expectedResourceCount);
   }
 


### PR DESCRIPTION
After routing table provider is created, initial instance config change event is added into the queue. However, when the event will be dequeued is not able to be determined (dequeue is called by background thread). There could be an edge case where even after clustermap is initialized, the initial event is still in the queue which causes routing table snapshot to be empty. This PR explicitly
checks the snapshot and waits until it gets populated. Otherwise, there may be no available replicas for router to send requests.