### PR TITLE
Allow HelixClusterManager to adopt different implementations of ClusterChangeHandler

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterChangeHandler.java
@@ -90,4 +90,10 @@ interface ClusterChangeHandler
    * @return number of errors occurred during handling cluster changes.
    */
   long getErrorCount();
+
+  /**
+   * Wait for initial notification during startup.
+   * @throws InterruptedException
+   */
+  void waitForInitNotification() throws InterruptedException;
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterChangeHandler.java
@@ -16,7 +16,6 @@ package com.github.ambry.clustermap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.api.listeners.IdealStateChangeListener;
 import org.apache.helix.api.listeners.InstanceConfigChangeListener;
 import org.apache.helix.api.listeners.LiveInstanceChangeListener;
@@ -24,27 +23,71 @@ import org.apache.helix.api.listeners.RoutingTableChangeListener;
 import org.apache.helix.spectator.RoutingTableSnapshot;
 
 
+/**
+ * General handler that handles any resource or state changes in cluster. It exposes API(s) for cluster manager to
+ * access up-to-date cluster infos. Each data center has its own {@link ClusterChangeHandler}.
+ */
 interface ClusterChangeHandler
     extends InstanceConfigChangeListener, LiveInstanceChangeListener, IdealStateChangeListener,
             RoutingTableChangeListener {
 
+  /**
+   * Set the initial snapshot in this {@link ClusterChangeHandler}.
+   * @param routingTableSnapshot the snapshot to set
+   */
   void setRoutingTableSnapshot(RoutingTableSnapshot routingTableSnapshot);
 
+  /**
+   * @return current snapshot held by this {@link ClusterChangeHandler}.
+   */
   RoutingTableSnapshot getRoutingTableSnapshot();
 
+  /**
+   * @return a map from ambry data node to its disks.
+   */
   Map<AmbryDataNode, Set<AmbryDisk>> getDataNodeToDisksMap();
 
+  /**
+   * Get ambry data node associated with given instance name.
+   * @param instanceName associated with ambry node.
+   * @return requested {@link AmbryDataNode}
+   */
   AmbryDataNode getDataNode(String instanceName);
 
+  /**
+   * Get {@link AmbryReplica} on given node that belongs to specified partition.
+   * @param ambryDataNode the node on which the replica resides.
+   * @param partitionName name of partition which the replica belongs to.
+   * @return requested {@link AmbryReplica}
+   */
   AmbryReplica getReplicaId(AmbryDataNode ambryDataNode, String partitionName);
 
+  /**
+   * Get all replicas on given node.
+   * @param ambryDataNode the node on which replicas reside
+   * @return a list of {@link AmbryReplica} on given node.
+   */
   List<AmbryReplica> getReplicaIds(AmbryDataNode ambryDataNode);
 
+  /**
+   * @return all {@link AmbryDataNode} tracked by this {@link ClusterChangeHandler}
+   */
   List<AmbryDataNode> getAllDataNodes();
 
+  /**
+   * Get all disks belong to given data node.
+   * @param ambryDataNode the node which the disks belong to.
+   * @return a set of {@link AmbryDisk} that belongs to given node.
+   */
   Set<AmbryDisk> getDisks(AmbryDataNode ambryDataNode);
 
+  /**
+   * @return a map from partition name to its corresponding resource name in this {@link ClusterChangeHandler}.
+   */
   Map<String, String> getPartitionToResourceMap();
 
+  /**
+   * @return number of errors occurred during handling cluster changes.
+   */
   long getErrorCount();
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterChangeHandler.java
@@ -25,7 +25,7 @@ import org.apache.helix.spectator.RoutingTableSnapshot;
 
 /**
  * General handler that handles any resource or state changes in cluster. It exposes API(s) for cluster manager to
- * access up-to-date cluster infos. Each data center has its own {@link ClusterChangeHandler}.
+ * access up-to-date cluster info. Each data center has its own {@link ClusterChangeHandler}.
  */
 interface ClusterChangeHandler
     extends InstanceConfigChangeListener, LiveInstanceChangeListener, IdealStateChangeListener,

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterChangeHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.helix.api.listeners.IdealStateChangeListener;
+import org.apache.helix.api.listeners.InstanceConfigChangeListener;
+import org.apache.helix.api.listeners.LiveInstanceChangeListener;
+import org.apache.helix.api.listeners.RoutingTableChangeListener;
+import org.apache.helix.spectator.RoutingTableSnapshot;
+
+
+interface ClusterChangeHandler
+    extends InstanceConfigChangeListener, LiveInstanceChangeListener, IdealStateChangeListener,
+            RoutingTableChangeListener {
+
+  void setRoutingTableSnapshot(RoutingTableSnapshot routingTableSnapshot);
+
+  RoutingTableSnapshot getRoutingTableSnapshot();
+
+  Map<AmbryDataNode, Set<AmbryDisk>> getDataNodeToDisksMap();
+
+  AmbryDataNode getDataNode(String instanceName);
+
+  AmbryReplica getReplicaId(AmbryDataNode ambryDataNode, String partitionName);
+
+  List<AmbryReplica> getReplicaIds(AmbryDataNode ambryDataNode);
+
+  List<AmbryDataNode> getAllDataNodes();
+
+  Set<AmbryDisk> getDisks(AmbryDataNode ambryDataNode);
+
+  Map<String, String> getPartitionToResourceMap();
+
+  long getErrorCount();
+}

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -273,9 +273,8 @@ class CompositeClusterManager implements ClusterMap {
   public void onReplicaEvent(ReplicaId replicaId, ReplicaEventType event) {
     staticClusterManager.onReplicaEvent(replicaId, event);
     if (helixClusterManager != null) {
-      AmbryReplica ambryReplica =
-          helixClusterManager.getReplicaForPartitionOnNode(replicaId.getDataNodeId().getHostname(),
-              replicaId.getDataNodeId().getPort(), replicaId.getPartitionId().toString());
+      AmbryReplica ambryReplica = helixClusterManager.getReplicaForPartitionOnNode(replicaId.getDataNodeId(),
+          replicaId.getPartitionId().toString());
       helixClusterManager.onReplicaEvent(ambryReplica, event);
     }
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -163,7 +163,6 @@ public class HelixClusterManager implements ClusterMap {
             manager.addLiveInstanceChangeListener(clusterChangeHandler);
             logger.info("Registered live instance change listeners for Helix manager at {}", zkConnectStr);
 
-
             // in case initial event occurs before adding routing table listener, here we explicitly set snapshot in
             // ClusterChangeHandler. The reason is, if listener missed initial event, snapshot inside routing table
             // provider should be already populated.

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -169,11 +169,11 @@ public class HelixClusterManager implements ClusterMap {
             clusterChangeHandler.setRoutingTableSnapshot(routingTableProvider.getRoutingTableSnapshot());
             // the initial routing table change should populate the instanceConfigs. If it's empty that means initial
             // change didn't come and thread should wait on the init latch to ensure routing table snapshot is non-empty
-            if (dcToDcZkInfo.get(dcName).clusterChangeHandler.getRoutingTableSnapshot().getInstanceConfigs().size()
-                == 0) {
+            if (clusterChangeHandler.getRoutingTableSnapshot().getInstanceConfigs().isEmpty()) {
               // Periodic refresh in routing table provider is enabled by default. In worst case, routerUpdater should
               // trigger routing table change within 5 minutes
-              dcToDcZkInfo.get(dcName).clusterChangeHandler.waitForInitNotification();
+              logger.info("Routing table snapshot in {} is currently empty. Waiting for initial notification.", dcName);
+              clusterChangeHandler.waitForInitNotification();
             }
 
             if (!clusterMapConfig.clustermapListenCrossColo && manager != localManager) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.spectator.RoutingTableSnapshot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+
+
+/**
+ * An instance of this object is used to register as listener for Helix related changes in each datacenter. This
+ * class is also responsible for handling events received.
+ */
+public class SimpleClusterChangeHandler implements ClusterChangeHandler {
+  final Set<String> allInstances = new HashSet<>();
+  private final String dcName;
+  private final Object notificationLock = new Object();
+  private final AtomicBoolean instanceConfigInitialized = new AtomicBoolean(false);
+  private final AtomicBoolean liveStateInitialized = new AtomicBoolean(false);
+  private final AtomicBoolean idealStateInitialized = new AtomicBoolean(false);
+  private final AtomicBoolean routingTableInitialized = new AtomicBoolean(false);
+  private final HelixClusterManagerMetrics helixClusterManagerMetrics;
+  private final AtomicLong sealedStateChangeCounter;
+  private final ConcurrentHashMap<String, Exception> initializationFailureMap;
+  private final ClusterMapConfig clusterMapConfig;
+  private final String selfInstanceName;
+  private final AtomicLong currentXid;
+  private final Map<String, Map<String, String>> partitionOverrideInfoMap;
+  private final ConcurrentHashMap<ByteBuffer, AmbryPartition> partitionMap;
+  private final ConcurrentHashMap<String, AmbryPartition> partitionNameToAmbryPartition;
+  private final ConcurrentHashMap<AmbryPartition, Set<AmbryReplica>> ambryPartitionToAmbryReplicas;
+  private final HelixClusterManager.HelixClusterManagerCallback helixClusterManagerCallback;
+  private final CountDownLatch routingTableInitLatch;
+
+  private ConcurrentHashMap<String, String> partitionNameToResource = new ConcurrentHashMap<>();
+  private AtomicReference<RoutingTableSnapshot> routingTableSnapshotRef = new AtomicReference<>();
+  private ConcurrentHashMap<String, AmbryDataNode> instanceNameToAmbryDataNode = new ConcurrentHashMap<>();
+  // A map whose key is ambry datanode and value is a map of partitionId to corresponding replica associated with this datanode
+  // Note: the partitionName (inner map key) comes from partitionId.toString() not partitionId.toPathString()
+  private final ConcurrentHashMap<AmbryDataNode, ConcurrentHashMap<String, AmbryReplica>> ambryDataNodeToAmbryReplicas =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<AmbryDataNode, Set<AmbryDisk>> ambryDataNodeToAmbryDisks = new ConcurrentHashMap<>();
+  private final AtomicLong errorCount = new AtomicLong(0);
+
+  private static final Logger logger = LoggerFactory.getLogger(SimpleClusterChangeHandler.class);
+
+  /**
+   * Initialize a ClusterChangeHandler in the given datacenter.
+   * @param dcName the datacenter associated with this ClusterChangeHandler.
+   * @param selfInstanceName
+   * @param routingTableInitLatch
+   * @param sealedStateChangeCounter
+   */
+  SimpleClusterChangeHandler(ClusterMapConfig clusterMapConfig, String dcName, String selfInstanceName,
+      Map<String, Map<String, String>> partitionOverrideInfoMap,
+      ConcurrentHashMap<ByteBuffer, AmbryPartition> partitionMap,
+      ConcurrentHashMap<String, AmbryPartition> partitionNameToAmbryPartition,
+      ConcurrentHashMap<AmbryPartition, Set<AmbryReplica>> ambryPartitionToAmbryReplicas,
+      HelixClusterManager.HelixClusterManagerCallback helixClusterManagerCallback,
+      HelixClusterManagerMetrics helixClusterManagerMetrics,
+      ConcurrentHashMap<String, Exception> initializationFailureMap, CountDownLatch routingTableInitLatch,
+      AtomicLong sealedStateChangeCounter) {
+    this.clusterMapConfig = clusterMapConfig;
+    this.dcName = dcName;
+    this.selfInstanceName = selfInstanceName;
+    this.partitionOverrideInfoMap = partitionOverrideInfoMap;
+    this.partitionMap = partitionMap;
+    this.partitionNameToAmbryPartition = partitionNameToAmbryPartition;
+    this.ambryPartitionToAmbryReplicas = ambryPartitionToAmbryReplicas;
+    this.helixClusterManagerCallback = helixClusterManagerCallback;
+    this.helixClusterManagerMetrics = helixClusterManagerMetrics;
+    this.initializationFailureMap = initializationFailureMap;
+    this.routingTableInitLatch = routingTableInitLatch;
+    this.sealedStateChangeCounter = sealedStateChangeCounter;
+    currentXid = new AtomicLong(clusterMapConfig.clustermapCurrentXid);
+  }
+
+  @Override
+  public void onInstanceConfigChange(List<InstanceConfig> configs, NotificationContext changeContext) {
+    try {
+      logger.debug("InstanceConfig change triggered in {} with: {}", dcName, configs);
+      synchronized (notificationLock) {
+        if (!instanceConfigInitialized.get()) {
+          logger.info("Received initial notification for instance config change from {}", dcName);
+          try {
+            initializeInstances(configs);
+          } catch (Exception e) {
+            logger.error("Exception occurred when initializing instances in {}: ", dcName, e);
+            initializationFailureMap.putIfAbsent(dcName, e);
+          }
+          instanceConfigInitialized.set(true);
+        } else {
+          updateStateOfReplicas(configs);
+        }
+        sealedStateChangeCounter.incrementAndGet();
+        helixClusterManagerMetrics.instanceConfigChangeTriggerCount.inc();
+      }
+    } catch (Throwable t) {
+      errorCount.incrementAndGet();
+      throw t;
+    }
+  }
+
+  /**
+   * Triggered whenever the IdealState in current data center has changed (for now, it is usually updated by Helix
+   * Bootstrap tool).
+   * @param idealState a list of {@link IdealState} that specifies ideal location of replicas.
+   * @param changeContext the {@link NotificationContext} associated.
+   * @throws InterruptedException
+   */
+  @Override
+  public void onIdealStateChange(List<IdealState> idealState, NotificationContext changeContext)
+      throws InterruptedException {
+    if (!idealStateInitialized.get()) {
+      logger.info("Received initial notification for IdealState change from {}", dcName);
+      idealStateInitialized.set(true);
+    } else {
+      logger.info("IdealState change triggered from {}", dcName);
+    }
+    // rebuild the entire partition-to-resource map in current dc
+    ConcurrentHashMap<String, String> newPartitionToResourceMap = new ConcurrentHashMap<>();
+    for (IdealState state : idealState) {
+      String resourceName = state.getResourceName();
+      for (String partitionStr : state.getPartitionSet()) {
+        newPartitionToResourceMap.put(partitionStr, resourceName);
+      }
+    }
+    partitionNameToResource = newPartitionToResourceMap;
+    helixClusterManagerMetrics.idealStateChangeTriggerCount.inc();
+  }
+
+  /**
+   * Triggered whenever there is a change in the list of live instances.
+   * @param liveInstances the list of all live instances (not a change set) at the time of this call.
+   * @param changeContext the {@link NotificationContext} associated.
+   */
+  @Override
+  public void onLiveInstanceChange(List<LiveInstance> liveInstances, NotificationContext changeContext) {
+    try {
+      logger.debug("Live instance change triggered from {} with: {}", dcName, liveInstances);
+      updateInstanceLiveness(liveInstances);
+      if (!liveStateInitialized.get()) {
+        logger.info("Received initial notification for live instance change from {}", dcName);
+        liveStateInitialized.set(true);
+      }
+      helixClusterManagerMetrics.liveInstanceChangeTriggerCount.inc();
+    } catch (Throwable t) {
+      errorCount.incrementAndGet();
+      throw t;
+    }
+  }
+
+  /**
+   * Triggered whenever the state of replica in cluster has changed. The snapshot contains up-to-date state of all
+   * resources(replicas) in this data center.
+   * @param routingTableSnapshot a snapshot of routing table for this data center.
+   * @param context additional context associated with this change.
+   */
+  @Override
+  public void onRoutingTableChange(RoutingTableSnapshot routingTableSnapshot, Object context) {
+    if (!routingTableInitialized.get()) {
+      logger.info("Received initial notification for routing table change from {}", dcName);
+      routingTableSnapshotRef.getAndSet(routingTableSnapshot);
+      routingTableInitLatch.countDown();
+      routingTableInitialized.set(true);
+    } else {
+      logger.info("Routing table change triggered from {}", dcName);
+      routingTableSnapshotRef.getAndSet(routingTableSnapshot);
+    }
+    helixClusterManagerMetrics.routingTableChangeTriggerCount.inc();
+  }
+
+  @Override
+  public void setRoutingTableSnapshot(RoutingTableSnapshot routingTableSnapshot) {
+    routingTableSnapshotRef.getAndSet(routingTableSnapshot);
+  }
+
+  @Override
+  public RoutingTableSnapshot getRoutingTableSnapshot() {
+    return routingTableSnapshotRef.get();
+  }
+
+  @Override
+  public Map<AmbryDataNode, Set<AmbryDisk>> getDataNodeToDisksMap() {
+    return Collections.unmodifiableMap(ambryDataNodeToAmbryDisks);
+  }
+
+  @Override
+  public AmbryDataNode getDataNode(String instanceName) {
+    return instanceNameToAmbryDataNode.get(instanceName);
+  }
+
+  @Override
+  public AmbryReplica getReplicaId(AmbryDataNode ambryDataNode, String partitionName) {
+    return ambryDataNodeToAmbryReplicas.getOrDefault(ambryDataNode, new ConcurrentHashMap<>()).get(partitionName);
+  }
+
+  @Override
+  public List<AmbryReplica> getReplicaIds(AmbryDataNode ambryDataNode) {
+    return new ArrayList<>(ambryDataNodeToAmbryReplicas.get(ambryDataNode).values());
+  }
+
+  @Override
+  public List<AmbryDataNode> getAllDataNodes() {
+    return new ArrayList<>(instanceNameToAmbryDataNode.values());
+  }
+
+  @Override
+  public Set<AmbryDisk> getDisks(AmbryDataNode ambryDataNode) {
+    return ambryDataNodeToAmbryDisks.get(ambryDataNode);
+  }
+
+  @Override
+  public Map<String, String> getPartitionToResourceMap() {
+    return Collections.unmodifiableMap(partitionNameToResource);
+  }
+
+  @Override
+  public long getErrorCount() {
+    return errorCount.get();
+  }
+
+  /**
+   * Populate the initial data from the admin connection. Create nodes, disks, partitions and replicas for the entire
+   * cluster. An {@link InstanceConfig} will only be looked at if the xid in it is <= currentXid.
+   * @param instanceConfigs the list of {@link InstanceConfig}s containing the information about the sealed states of replicas.
+   * @throws Exception if creation of {@link AmbryDataNode}s or {@link AmbryDisk}s throw an Exception.
+   */
+  private void initializeInstances(List<InstanceConfig> instanceConfigs) throws Exception {
+    logger.info("Initializing cluster information from {}", dcName);
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      int schemaVersion = getSchemaVersion(instanceConfig);
+      switch (schemaVersion) {
+        case 0:
+          String instanceName = instanceConfig.getInstanceName();
+          long instanceXid = getXid(instanceConfig);
+          if (instanceName.equals(selfInstanceName) || instanceXid <= currentXid.get()) {
+            logger.info("Adding node {} and its disks and replicas", instanceName);
+            AmbryDataNode datanode =
+                new AmbryDataNode(getDcName(instanceConfig), clusterMapConfig, instanceConfig.getHostName(),
+                    Integer.valueOf(instanceConfig.getPort()), getRackId(instanceConfig), getSslPortStr(instanceConfig),
+                    instanceXid, helixClusterManagerCallback);
+            initializeDisksAndReplicasOnNode(datanode, instanceConfig);
+            instanceNameToAmbryDataNode.put(instanceName, datanode);
+            allInstances.add(instanceName);
+          } else {
+            logger.info(
+                "Ignoring instanceConfig for {} because the xid associated with it ({}) is later than current xid ({})",
+                instanceName, instanceXid, currentXid.get());
+            helixClusterManagerMetrics.ignoredUpdatesCount.inc();
+          }
+          break;
+        default:
+          logger.error("Unknown InstanceConfig schema version: {}, ignoring.", schemaVersion);
+          break;
+      }
+    }
+    logger.info("Initialized cluster information from {}", dcName);
+  }
+
+  /**
+   * Go over the given list of {@link InstanceConfig}s and update the both sealed and stopped states of replicas.
+   * An {@link InstanceConfig} will only be looked at if the xid in it is <= currentXid.
+   * @param instanceConfigs the list of {@link InstanceConfig}s containing the up-to-date information about the
+   *                        sealed states of replicas.
+   */
+  private void updateStateOfReplicas(List<InstanceConfig> instanceConfigs) {
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      int schemaVersion = getSchemaVersion(instanceConfig);
+      switch (schemaVersion) {
+        case 0:
+          String instanceName = instanceConfig.getInstanceName();
+          long instanceXid = getXid(instanceConfig);
+          AmbryDataNode node = instanceNameToAmbryDataNode.get(instanceName);
+          if (instanceName.equals(selfInstanceName) || instanceXid <= currentXid.get()) {
+            if (node == null) {
+              logger.trace("Dynamic addition of new nodes is not yet supported, ignoring InstanceConfig {}",
+                  instanceConfig);
+            } else {
+              Set<String> sealedReplicas = new HashSet<>(getSealedReplicas(instanceConfig));
+              Set<String> stoppedReplicas = new HashSet<>(getStoppedReplicas(instanceConfig));
+              for (AmbryReplica replica : ambryDataNodeToAmbryReplicas.get(node).values()) {
+                String partitionId = replica.getPartitionId().toPathString();
+                if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(
+                    partitionId)) {
+                  logger.trace(
+                      "Ignoring instanceConfig change for partition {} on instance {} because partition override is enabled",
+                      partitionId, instanceName);
+                  helixClusterManagerMetrics.ignoredUpdatesCount.inc();
+                } else {
+                  replica.setSealedState(sealedReplicas.contains(partitionId));
+                  replica.setStoppedState(stoppedReplicas.contains(partitionId));
+                }
+              }
+            }
+          } else {
+            logger.trace(
+                "Ignoring instanceConfig change for {} because the xid associated with it ({}) is later than current xid ({})",
+                instanceName, instanceXid, currentXid.get());
+            helixClusterManagerMetrics.ignoredUpdatesCount.inc();
+          }
+          break;
+        default:
+          logger.error("Unknown InstanceConfig schema version: {}, ignoring.", schemaVersion);
+      }
+    }
+  }
+
+  /**
+   * Update the liveness states of existing instances based on the input.
+   * @param liveInstances the list of instances that are up.
+   */
+  private void updateInstanceLiveness(List<LiveInstance> liveInstances) {
+    synchronized (notificationLock) {
+      Set<String> liveInstancesSet = new HashSet<>();
+      for (LiveInstance liveInstance : liveInstances) {
+        liveInstancesSet.add(liveInstance.getInstanceName());
+      }
+      for (String instanceName : allInstances) {
+        // Here we ignore live instance change it's about self instance. The reason is, during server's startup, current
+        // node should be AVAILABLE but the list of live instances doesn't include current node since it hasn't joined yet.
+        if (liveInstancesSet.contains(instanceName) || instanceName.equals(selfInstanceName)) {
+          instanceNameToAmbryDataNode.get(instanceName).setState(HardwareState.AVAILABLE);
+        } else {
+          instanceNameToAmbryDataNode.get(instanceName).setState(HardwareState.UNAVAILABLE);
+        }
+      }
+    }
+  }
+
+  /**
+   * Initialize the disks and replicas on the given node. Create partitions if this is the first time a replica of
+   * that partition is being constructed. If partition override is enabled, the seal state of replica is determined by
+   * partition info in HelixPropertyStore, if disabled, the seal state is determined by instanceConfig.
+   * @param datanode the {@link AmbryDataNode} that is being initialized.
+   * @param instanceConfig the {@link InstanceConfig} associated with this datanode.
+   * @throws Exception if creation of {@link AmbryDisk} throws an Exception.
+   */
+  private void initializeDisksAndReplicasOnNode(AmbryDataNode datanode, InstanceConfig instanceConfig)
+      throws Exception {
+    ambryDataNodeToAmbryReplicas.put(datanode, new ConcurrentHashMap<>());
+    ambryDataNodeToAmbryDisks.put(datanode, new HashSet<AmbryDisk>());
+    List<String> sealedReplicas = getSealedReplicas(instanceConfig);
+    List<String> stoppedReplicas = getStoppedReplicas(instanceConfig);
+    Map<String, Map<String, String>> diskInfos = instanceConfig.getRecord().getMapFields();
+    for (Map.Entry<String, Map<String, String>> entry : diskInfos.entrySet()) {
+      String mountPath = entry.getKey();
+      Map<String, String> diskInfo = entry.getValue();
+      long capacityBytes = Long.valueOf(diskInfo.get(DISK_CAPACITY_STR));
+      HardwareState diskState =
+          diskInfo.get(DISK_STATE).equals(AVAILABLE_STR) ? HardwareState.AVAILABLE : HardwareState.UNAVAILABLE;
+      String replicasStr = diskInfo.get(ClusterMapUtils.REPLICAS_STR);
+
+      // Create disk
+      AmbryDisk disk = new AmbryDisk(clusterMapConfig, datanode, mountPath, diskState, capacityBytes);
+      ambryDataNodeToAmbryDisks.get(datanode).add(disk);
+
+      if (!replicasStr.isEmpty()) {
+        String[] replicaInfoList = replicasStr.split(ClusterMapUtils.REPLICAS_DELIM_STR);
+        for (String replicaInfo : replicaInfoList) {
+          String[] info = replicaInfo.split(ClusterMapUtils.REPLICAS_STR_SEPARATOR);
+          // partition name and replica name are the same.
+          String partitionName = info[0];
+          long replicaCapacity = Long.valueOf(info[1]);
+          String partitionClass = clusterMapConfig.clusterMapDefaultPartitionClass;
+          if (info.length > 2) {
+            partitionClass = info[2];
+          }
+          AmbryPartition mappedPartition =
+              new AmbryPartition(Long.valueOf(partitionName), partitionClass, helixClusterManagerCallback);
+          // Ensure only one AmbryPartition entry goes in to the mapping based on the name.
+          AmbryPartition existing = partitionNameToAmbryPartition.putIfAbsent(partitionName, mappedPartition);
+          if (existing != null) {
+            mappedPartition = existing;
+          }
+          // mappedPartition is now the final mapped AmbryPartition object for this partition.
+          synchronized (mappedPartition) {
+            if (!ambryPartitionToAmbryReplicas.containsKey(mappedPartition)) {
+              ambryPartitionToAmbryReplicas.put(mappedPartition, Collections.newSetFromMap(new ConcurrentHashMap<>()));
+              partitionMap.put(ByteBuffer.wrap(mappedPartition.getBytes()), mappedPartition);
+            }
+          }
+          ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, datanode, replicaCapacity);
+          // Create replica associated with this node.
+          boolean isSealed;
+          if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(
+              partitionName)) {
+            isSealed = partitionOverrideInfoMap.get(partitionName)
+                .get(ClusterMapUtils.PARTITION_STATE)
+                .equals(ClusterMapUtils.READ_ONLY_STR);
+          } else {
+            isSealed = sealedReplicas.contains(partitionName);
+          }
+          AmbryReplica replica =
+              new AmbryReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
+                  replicaCapacity, isSealed);
+          ambryPartitionToAmbryReplicas.get(mappedPartition).add(replica);
+          ambryDataNodeToAmbryReplicas.get(datanode).put(mappedPartition.toString(), replica);
+        }
+      }
+    }
+  }
+
+  /**
+   * Ensure that the given partition is absent on the given datanode. This is called as part of an inline validation
+   * done to ensure that two replicas of the same partition do not exist on the same datanode.
+   * @param partition the {@link AmbryPartition} to check.
+   * @param datanode the {@link AmbryDataNode} on which to check.
+   * @param expectedReplicaCapacity the capacity expected for the replicas of the partition.
+   */
+  private void ensurePartitionAbsenceOnNodeAndValidateCapacity(AmbryPartition partition, AmbryDataNode datanode,
+      long expectedReplicaCapacity) {
+    for (AmbryReplica replica : ambryPartitionToAmbryReplicas.get(partition)) {
+      if (replica.getDataNodeId().equals(datanode)) {
+        throw new IllegalStateException("Replica already exists on " + datanode + " for " + partition);
+      } else if (replica.getCapacityInBytes() != expectedReplicaCapacity) {
+        throw new IllegalStateException("Expected replica capacity " + expectedReplicaCapacity + " is different from "
+            + "the capacity of an existing replica " + replica.getCapacityInBytes());
+      }
+    }
+  }
+}

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
@@ -38,11 +38,11 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
 
 
 /**
- * An instance of this object is used to register as listener for Helix related changes in each datacenter. This
- * class is also responsible for handling events received.
+ * An implementation of {@link ClusterChangeHandler} to register as listener for Helix related changes in each datacenter.
+ * This class is also responsible for handling events received.
  */
 public class SimpleClusterChangeHandler implements ClusterChangeHandler {
-  final Set<String> allInstances = new HashSet<>();
+  private final Set<String> allInstances = new HashSet<>();
   private final String dcName;
   private final Object notificationLock = new Object();
   private final AtomicBoolean instanceConfigInitialized = new AtomicBoolean(false);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
@@ -61,7 +61,7 @@ public class SimpleClusterChangeHandler implements ClusterChangeHandler {
   private final HelixClusterManager.HelixClusterManagerCallback helixClusterManagerCallback;
   private final CountDownLatch routingTableInitLatch = new CountDownLatch(1);
 
-  private ConcurrentHashMap<String, String> partitionNameToResource = new ConcurrentHashMap<>();
+  private volatile ConcurrentHashMap<String, String> partitionNameToResource = new ConcurrentHashMap<>();
   private AtomicReference<RoutingTableSnapshot> routingTableSnapshotRef = new AtomicReference<>();
   private ConcurrentHashMap<String, AmbryDataNode> instanceNameToAmbryDataNode = new ConcurrentHashMap<>();
   // A map whose key is ambry datanode and value is a map of partitionId to corresponding replica associated with this datanode

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -267,7 +267,6 @@ public class HelixClusterManagerTest {
     Utils.writeJsonObjectToFile(testHardwareLayout1.getHardwareLayout().toJSONObject(), testHardwareLayoutPath);
     DataNode newAddedNode =
         testHardwareLayout1.getAllExistingDataNodes().stream().filter(n -> !initialNodes.contains(n)).findAny().get();
-    System.out.println("new Added Node instance :" + newAddedNode.getHostname() + "_" + newAddedNode.getPort());
     // add a new replica on new node for partitionToTest
     Disk diskOnNewNode = newAddedNode.getDisks().get(0);
     // deliberately change capacity of partition to ensure new replica picks new capacity


### PR DESCRIPTION
1. Introduced ClusterChangeHandler interface which allows different implementations.
2. Moved current ClusterChangeHandler to a separate class (SimpleClusterChangeHandler).
3. Rewrote some APIs in HelixClusterManager to aggregate cluster-wide infos from all ClusterChangeHandlers.