### PR TITLE
Implement replica Standby-To-Inactive transition on server side

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
@@ -41,4 +41,10 @@ public interface PartitionStateChangeListener {
    * @param partitionName of the partition.
    */
   void onPartitionBecomeStandbyFromLeader(String partitionName);
+
+  /**
+   * Action to take when partition becomes inactive from standby.
+   * @param partitionName of the partition
+   */
+  void onPartitionBecomeInactiveFromStandby(String partitionName);
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaSyncUpManager.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaSyncUpManager.java
@@ -29,7 +29,7 @@ public interface ReplicaSyncUpManager {
   void initiateBootstrap(ReplicaId replicaId);
 
   /**
-   * Wait until bootstrap for given replica is complete.
+   * Wait until bootstrap on given replica is complete.
    * until given replica has caught up with enough peer replicas either in local DC or remote DCs
    * @param partitionName partition name of replica that in bootstrap state
    * @throws InterruptedException
@@ -56,15 +56,30 @@ public interface ReplicaSyncUpManager {
 
   /**
    * Bootstrap on given replica is complete.
-   * @param partitionName partition name of replica on which bootstrap completes.
+   * @param replicaId the replica which completes bootstrap.
    */
-  void onBootstrapComplete(String partitionName);
+  void onBootstrapComplete(ReplicaId replicaId);
+
+  void onDeactivationComplete(ReplicaId replicaId);
 
   /**
    * When exception/error occurs during bootstrap.
-   * @param partitionName partition name of replica which encounters error.
+   * @param replicaId the replica which encounters error.
    */
-  void onBootstrapError(String partitionName);
+  void onBootstrapError(ReplicaId replicaId);
 
-  // TODO introduce decommission logic in sync-up service. For example, initiateDecommission(String partitionName)
+  void onDeactivationError(ReplicaId replicaId);
+
+  /**
+   * Initiate deactivation process if the replica should become INACTIVE from STANDBY on current node.
+   * @param replicaId the replica to deactivate
+   */
+  void initiateDeactivation(ReplicaId replicaId);
+
+  /**
+   * Wait until deactivation on given replica is complete.
+   * @param partitionName the name of replica that is within Standby-To-Inactive transition.
+   * @throws InterruptedException
+   */
+  void waitDeactivationCompleted(String partitionName) throws InterruptedException;
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaSyncUpManager.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaSyncUpManager.java
@@ -60,6 +60,10 @@ public interface ReplicaSyncUpManager {
    */
   void onBootstrapComplete(ReplicaId replicaId);
 
+  /**
+   * Deactivation on given replica is complete.
+   * @param replicaId the replica which completes deactivation.
+   */
   void onDeactivationComplete(ReplicaId replicaId);
 
   /**
@@ -68,6 +72,10 @@ public interface ReplicaSyncUpManager {
    */
   void onBootstrapError(ReplicaId replicaId);
 
+  /**
+   * When exception/error occurs during deactivation.
+   * @param replicaId the replica which encounters error.
+   */
   void onDeactivationError(ReplicaId replicaId);
 
   /**

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaSyncUpManager.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaSyncUpManager.java
@@ -37,14 +37,14 @@ public interface ReplicaSyncUpManager {
   void waitBootstrapCompleted(String partitionName) throws InterruptedException;
 
   /**
-   * Update replica lag (in byte) between two replicas (source and target)
-   * @param source the replica which is catching up with target replica
-   * @param target the replica which is in leading position
+   * Update replica lag (in byte) between two replicas (local and peer replica)
+   * @param localReplica the replica that resides on current node
+   * @param peerReplica the peer replica of local one.
    * @param lagInBytes replica lag bytes
    * @return whether the lag is updated or not. If {@code false}, it means the source replica is not tracked in this service.
    *         Either the replica has caught up and removed from service or it is an existing replica that doesn't need catchup.
    */
-  boolean updateLagBetweenReplicas(ReplicaId source, ReplicaId target, long lagInBytes);
+  boolean updateLagBetweenReplicas(ReplicaId localReplica, ReplicaId peerReplica, long lagInBytes);
 
   /**
    * Whether given replica has synced up with its peers.

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/StateTransitionException.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/StateTransitionException.java
@@ -13,6 +13,9 @@
  */
 package com.github.ambry.clustermap;
 
+/**
+ * An extension of {@link RuntimeException} used to record exceptions occurred during state transition.
+ */
 public class StateTransitionException extends RuntimeException {
   private static final long serialVersionUID = 1L;
   private final TransitionErrorCode error;
@@ -26,6 +29,11 @@ public class StateTransitionException extends RuntimeException {
     return error;
   }
 
+  /**
+   * All types of error code that associate with {@link StateTransitionException}. The error code is currently used by
+   * tests to determine location of exception. In production environment, if transition exception occurs, the message
+   * together with error code should be recorded in Helix log which helps us investigate failure cause.
+   */
   public enum TransitionErrorCode {
     /**
      * If replica is not present in Helix and not found on current node.

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/StateTransitionException.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/StateTransitionException.java
@@ -42,6 +42,10 @@ public class StateTransitionException extends RuntimeException {
     /**
      * If bootstrap process fails at some point for specific replica.
      */
-    BootstrapFailure
+    BootstrapFailure,
+    /**
+     * If failure occurs during Standby-To-Inactive transition.
+     */
+    DeactivationFailure
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/replication/ReplicationAPI.java
+++ b/ambry-api/src/main/java/com.github.ambry/replication/ReplicationAPI.java
@@ -14,6 +14,7 @@
 package com.github.ambry.replication;
 
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.store.StoreException;
 import java.util.Collection;
 import java.util.List;
 
@@ -41,9 +42,10 @@ public interface ReplicationAPI {
    * @param hostName HostName of the datanode where the replica belongs to
    * @param replicaPath Replica Path of the replica interested in
    * @param totalBytesRead Total bytes read by the replica
+   * @throws StoreException
    */
   void updateTotalBytesReadByRemoteReplica(PartitionId partitionId, String hostName, String replicaPath,
-      long totalBytesRead);
+      long totalBytesRead) throws StoreException;
 
   /**
    * Gets the replica lag of the remote replica with the local store

--- a/ambry-api/src/main/java/com.github.ambry/store/Store.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/Store.java
@@ -101,6 +101,12 @@ public interface Store {
   long getSizeInBytes();
 
   /**
+   * @return absolute end position of last PUT in bytes.
+   * @throws StoreException
+   */
+  long getEndPositionOfLastPut() throws StoreException;
+
+  /**
    * @return true if the store contains no data
    */
   boolean isEmpty();

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
@@ -487,6 +487,11 @@ class CloudBlobStore implements Store {
   }
 
   @Override
+  public long getEndPositionOfLastPut() throws StoreException {
+    throw new UnsupportedOperationException("Method not supported");
+  }
+
+  @Override
   public void shutdown() {
     recentBlobCache.clear();
     started = false;

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
@@ -60,7 +60,6 @@ public class VcrReplicationManager extends ReplicationEngine {
   private final VirtualReplicatorCluster virtualReplicatorCluster;
   private final CloudStorageCompactor cloudStorageCompactor;
   private final Map<String, Store> partitionStoreMap = new HashMap<>();
-  private final StoreManager storeManager;
 
   public VcrReplicationManager(VerifiableProperties properties, CloudConfig cloudConfig,
       ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig, StoreConfig storeConfig,
@@ -71,11 +70,11 @@ public class VcrReplicationManager extends ReplicationEngine {
       String transformerClassName) throws ReplicationException {
     super(replicationConfig, clusterMapConfig, storeKeyFactory, clusterMap, scheduler,
         virtualReplicatorCluster.getCurrentDataNodeId(), Collections.emptyList(), connectionPool,
-        vcrMetrics.getMetricRegistry(), requestNotification, storeKeyConverterFactory, transformerClassName, null);
+        vcrMetrics.getMetricRegistry(), requestNotification, storeKeyConverterFactory, transformerClassName, null,
+        storeManager);
     this.properties = properties;
     this.cloudConfig = cloudConfig;
     this.storeConfig = storeConfig;
-    this.storeManager = storeManager;
     this.virtualReplicatorCluster = virtualReplicatorCluster;
     this.vcrMetrics = vcrMetrics;
     this.cloudDestination = cloudDestination;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
@@ -79,8 +79,8 @@ public class AmbryPartitionStateModel extends StateModel {
   @Transition(to = "INACTIVE", from = "STANDBY")
   public void onBecomeInactiveFromStandby(Message message, NotificationContext context) {
     String partitionName = message.getPartitionName();
-    logger.info("Partition {} in resource {} is becoming INACTIVE from STANDBY", message.getPartitionName(),
-        partitionName);
+    logger.info("Partition {} in resource {} is becoming INACTIVE from STANDBY", partitionName,
+        message.getResourceName());
     if (clusterMapConfig.clustermapEnableStateModelListener) {
       partitionStateChangeListener.onPartitionBecomeInactiveFromStandby(partitionName);
     }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
@@ -32,16 +32,13 @@ public class AmbryPartitionStateModel extends StateModel {
   private final String partitionName;
   private final PartitionStateChangeListener partitionStateChangeListener;
   private final ClusterMapConfig clusterMapConfig;
-  private final ReplicaSyncUpManager replicaSyncUpManager;
 
   AmbryPartitionStateModel(String resourceName, String partitionName,
-      PartitionStateChangeListener partitionStateChangeListener, ClusterMapConfig clusterMapConfig,
-      ReplicaSyncUpManager replicaSyncUpManager) {
+      PartitionStateChangeListener partitionStateChangeListener, ClusterMapConfig clusterMapConfig) {
     this.resourceName = resourceName;
     this.partitionName = partitionName;
     this.partitionStateChangeListener = Objects.requireNonNull(partitionStateChangeListener);
     this.clusterMapConfig = Objects.requireNonNull(clusterMapConfig);
-    this.replicaSyncUpManager = Objects.requireNonNull(replicaSyncUpManager);
     StateModelParser parser = new StateModelParser();
     _currentState = parser.getInitialState(AmbryPartitionStateModel.class);
   }
@@ -62,16 +59,6 @@ public class AmbryPartitionStateModel extends StateModel {
         message.getResourceName());
     if (clusterMapConfig.clustermapEnableStateModelListener) {
       partitionStateChangeListener.onPartitionBecomeStandbyFromBootstrap(partitionName);
-      try {
-        replicaSyncUpManager.waitBootstrapCompleted(partitionName);
-      } catch (InterruptedException e) {
-        logger.error("Bootstrap was interrupted on partition {}", partitionName);
-        throw new StateTransitionException("Bootstrap failed or was interrupted",
-            StateTransitionException.TransitionErrorCode.BootstrapFailure);
-      } catch (StateTransitionException e) {
-        logger.error("Bootstrap didn't complete on partition {}", partitionName, e);
-        throw e;
-      }
     }
   }
 
@@ -96,16 +83,6 @@ public class AmbryPartitionStateModel extends StateModel {
         partitionName);
     if (clusterMapConfig.clustermapEnableStateModelListener) {
       partitionStateChangeListener.onPartitionBecomeInactiveFromStandby(partitionName);
-      try {
-        replicaSyncUpManager.waitDeactivationCompleted(partitionName);
-      } catch (InterruptedException e) {
-        logger.error("Deactivation was interrupted on partition {}", partitionName);
-        throw new StateTransitionException("Deactivation failed or was interrupted",
-            StateTransitionException.TransitionErrorCode.DeactivationFailure);
-      } catch (StateTransitionException e) {
-        logger.error("Deactivation didn't complete on partition {}", partitionName, e);
-        throw e;
-      }
     }
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
@@ -23,6 +23,8 @@ import java.util.concurrent.CountDownLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
+
 
 /**
  * An implementation of {@link ReplicaSyncUpManager} that helps track replica catchup state.
@@ -81,8 +83,7 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
       latch.await();
       partitionToBootstrapLatch.remove(partitionName);
       if (!partitionToBootstrapSuccess.remove(partitionName)) {
-        throw new StateTransitionException("Partition " + partitionName + " failed to bootstrap.",
-            StateTransitionException.TransitionErrorCode.BootstrapFailure);
+        throw new StateTransitionException("Partition " + partitionName + " failed to bootstrap.", BootstrapFailure);
       }
       logger.info("Bootstrap is complete on partition {}", partitionName);
     }
@@ -94,15 +95,14 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
     if (latch == null) {
       logger.error("Partition {} is not found for deactivation", partitionName);
       throw new StateTransitionException("No deactivation latch is found for partition " + partitionName,
-          StateTransitionException.TransitionErrorCode.ReplicaNotFound);
+          ReplicaNotFound);
     } else {
       logger.info("Waiting for partition {} to be deactivated", partitionName);
       latch.await();
       partitionToDeactivationLatch.remove(partitionName);
       // throw exception to put replica into ERROR state， this happens when disk crashes during deactivation
       if (!partitionToDeactivationSuccess.remove(partitionName)) {
-        throw new StateTransitionException("Deactivation failed on partition " + partitionName,
-            StateTransitionException.TransitionErrorCode.DeactivationFailure);
+        throw new StateTransitionException("Deactivation failed on partition " + partitionName, DeactivationFailure);
       }
       logger.info("Deactivation is complete on partition {}", partitionName);
     }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
@@ -109,12 +109,12 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
   }
 
   @Override
-  public boolean updateLagBetweenReplicas(ReplicaId source, ReplicaId target, long lagInBytes) {
+  public boolean updateLagBetweenReplicas(ReplicaId localReplica, ReplicaId peerReplica, long lagInBytes) {
     boolean updated = false;
-    if (replicaToLagInfos.containsKey(source)) {
-      replicaToLagInfos.get(source).updateLagInfo(target, lagInBytes);
+    if (replicaToLagInfos.containsKey(localReplica)) {
+      replicaToLagInfos.get(localReplica).updateLagInfo(peerReplica, lagInBytes);
       if (logger.isDebugEnabled()) {
-        logger.debug(replicaToLagInfos.get(source).toString());
+        logger.debug(replicaToLagInfos.get(localReplica).toString());
       }
       updated = true;
     }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
@@ -31,13 +31,15 @@ import org.slf4j.LoggerFactory;
  * Every time {@link ReplicaSyncUpManager#initiateBootstrap(ReplicaId)} is called, a new latch (with initial value = 1)
  * is created associated with given replica. Any caller that invokes {@link ReplicaSyncUpManager#waitBootstrapCompleted(String)}
  * is blocked and wait until corresponding latch counts to zero. External component (i.e. replication manager) is able to
- * call {@link ReplicaSyncUpManager#onBootstrapComplete(String)} or {@link ReplicaSyncUpManager#onBootstrapError(String)}
+ * call {@link ReplicaSyncUpManager#onBootstrapComplete(ReplicaId)} or {@link ReplicaSyncUpManager#onBootstrapError(ReplicaId)}
  * to mark sync-up success or failure by counting down the latch. This will unblock caller waiting fot this latch and
  * proceed with subsequent actions.
  */
 public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
   private final ConcurrentHashMap<String, CountDownLatch> partitionToBootstrapLatch = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, CountDownLatch> partitionToDeactivationLatch = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Boolean> partitionToBootstrapSuccess = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Boolean> partitionToDeactivationSuccess = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<ReplicaId, LocalReplicaLagInfos> replicaToLagInfos = new ConcurrentHashMap<>();
   private final ClusterMapConfig clusterMapConfig;
 
@@ -52,7 +54,17 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
     partitionToBootstrapLatch.put(replicaId.getPartitionId().toPathString(), new CountDownLatch(1));
     partitionToBootstrapSuccess.put(replicaId.getPartitionId().toPathString(), false);
     replicaToLagInfos.put(replicaId,
-        new LocalReplicaLagInfos(replicaId, clusterMapConfig.clustermapReplicaCatchupAcceptableLagBytes));
+        new LocalReplicaLagInfos(replicaId, clusterMapConfig.clustermapReplicaCatchupAcceptableLagBytes,
+            ReplicaState.BOOTSTRAP));
+  }
+
+  @Override
+  public void initiateDeactivation(ReplicaId replicaId) {
+    partitionToDeactivationLatch.put(replicaId.getPartitionId().toPathString(), new CountDownLatch(1));
+    partitionToDeactivationSuccess.put(replicaId.getPartitionId().toPathString(), false);
+    // once deactivation is initiated, local replica won't receive new PUTs. All remote replicas should be able to
+    // catch with last PUT in local store. Hence, we set acceptable lag threshold to 0.
+    replicaToLagInfos.put(replicaId, new LocalReplicaLagInfos(replicaId, 0, ReplicaState.INACTIVE));
   }
 
   /**
@@ -69,10 +81,30 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
       latch.await();
       partitionToBootstrapLatch.remove(partitionName);
       if (!partitionToBootstrapSuccess.remove(partitionName)) {
-        throw new StateTransitionException("Partition " + partitionName + " failed on bootstrap.",
+        throw new StateTransitionException("Partition " + partitionName + " failed to bootstrap.",
             StateTransitionException.TransitionErrorCode.BootstrapFailure);
       }
       logger.info("Bootstrap is complete on partition {}", partitionName);
+    }
+  }
+
+  @Override
+  public void waitDeactivationCompleted(String partitionName) throws InterruptedException {
+    CountDownLatch latch = partitionToDeactivationLatch.get(partitionName);
+    if (latch == null) {
+      logger.error("Partition {} is not found for deactivation", partitionName);
+      throw new StateTransitionException("No deactivation latch is found for partition " + partitionName,
+          StateTransitionException.TransitionErrorCode.ReplicaNotFound);
+    } else {
+      logger.info("Waiting for partition {} to be deactivated", partitionName);
+      latch.await();
+      partitionToDeactivationLatch.remove(partitionName);
+      // throw exception to put replica into ERROR state， this happens when disk crashes during deactivation
+      if (!partitionToDeactivationSuccess.remove(partitionName)) {
+        throw new StateTransitionException("Deactivation failed on partition " + partitionName,
+            StateTransitionException.TransitionErrorCode.DeactivationFailure);
+      }
+      logger.info("Deactivation is complete on partition {}", partitionName);
     }
   }
 
@@ -105,9 +137,17 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
    * unblock external service waiting on this latch.
    */
   @Override
-  public void onBootstrapComplete(String partitionName) {
-    partitionToBootstrapSuccess.put(partitionName, true);
-    countDownLatch(partitionName);
+  public void onBootstrapComplete(ReplicaId replicaId) {
+    partitionToBootstrapSuccess.put(replicaId.getPartitionId().toPathString(), true);
+    replicaToLagInfos.remove(replicaId);
+    countDownLatch(partitionToBootstrapLatch, replicaId.getPartitionId().toPathString());
+  }
+
+  @Override
+  public void onDeactivationComplete(ReplicaId replicaId) {
+    partitionToDeactivationSuccess.put(replicaId.getPartitionId().toPathString(), true);
+    replicaToLagInfos.remove(replicaId);
+    countDownLatch(partitionToDeactivationLatch, replicaId.getPartitionId().toPathString());
   }
 
   /**
@@ -115,8 +155,15 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
    * This method will count down latch and terminates bootstrap.
    */
   @Override
-  public void onBootstrapError(String partitionName) {
-    countDownLatch(partitionName);
+  public void onBootstrapError(ReplicaId replicaId) {
+    replicaToLagInfos.remove(replicaId);
+    countDownLatch(partitionToBootstrapLatch, replicaId.getPartitionId().toPathString());
+  }
+
+  @Override
+  public void onDeactivationError(ReplicaId replicaId) {
+    replicaToLagInfos.remove(replicaId);
+    countDownLatch(partitionToDeactivationLatch, replicaId.getPartitionId().toPathString());
   }
 
   /**
@@ -125,17 +172,20 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
   void reset() {
     partitionToBootstrapLatch.clear();
     partitionToBootstrapSuccess.clear();
+    partitionToDeactivationLatch.clear();
+    partitionToDeactivationSuccess.clear();
     replicaToLagInfos.clear();
   }
 
   /**
    * Count down the latch associated with given partition
+   * @param countDownLatchMap the map in which the latch is specified for given partition.
    * @param partitionName the partition whose corresponding latch needs to count down.
    */
-  private void countDownLatch(String partitionName) {
-    CountDownLatch latch = partitionToBootstrapLatch.get(partitionName);
+  private void countDownLatch(Map<String, CountDownLatch> countDownLatchMap, String partitionName) {
+    CountDownLatch latch = countDownLatchMap.get(partitionName);
     if (latch == null) {
-      throw new IllegalStateException("No bootstrap latch is found for partition " + partitionName);
+      throw new IllegalStateException("No countdown latch is found for partition " + partitionName);
     } else {
       latch.countDown();
     }
@@ -156,9 +206,18 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
     private final long acceptableThreshold;
     private final int catchupTarget;
     private final ReplicaId replicaOnCurrentNode;
+    private final ReplicaState currentState;
 
-    LocalReplicaLagInfos(ReplicaId localReplica, long acceptableThreshold) {
+    /**
+     * Constructor for {@link LocalReplicaLagInfos}.
+     * @param localReplica {@link ReplicaId} on current node.
+     * @param acceptableThreshold acceptable threshold in byte to determine if replica has caught up (or has been caught
+     *                            up with by peer replicas)
+     * @param currentState the current {@link ReplicaState} of local replica.
+     */
+    LocalReplicaLagInfos(ReplicaId localReplica, long acceptableThreshold, ReplicaState currentState) {
       this.acceptableThreshold = acceptableThreshold;
+      this.currentState = currentState;
       Set<ReplicaId> peerReplicas = new HashSet<>();
       // new replica only needs to catch up with STANDBY or LEADER replicas
       for (ReplicaState state : EnumSet.of(ReplicaState.STANDBY, ReplicaState.LEADER)) {
@@ -167,6 +226,11 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
       replicaOnCurrentNode = localReplica;
       localDcName = localReplica.getDataNodeId().getDatacenterName();
       for (ReplicaId peerReplica : peerReplicas) {
+        if (peerReplica == replicaOnCurrentNode) {
+          // This may happen when local replica transits from STANDBY to INACTIVE because Helix still shows local replica
+          // is in STANDBY. We skip here if peer replica == replica on current node.
+          continue;
+        }
         // put peer replicas into local/remote DC maps (initial value is Long.MAX_VALUE)
         if (peerReplica.getDataNodeId().getDatacenterName().equals(localDcName)) {
           localDcPeerReplicaAndLag.put(peerReplica, Long.MAX_VALUE);
@@ -213,7 +277,11 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
     @Override
     public String toString() {
       StringBuilder sb = new StringBuilder();
-      sb.append("Replica(").append(replicaOnCurrentNode.getReplicaPath()).append(") lag infos: ");
+      sb.append("Replica(")
+          .append(replicaOnCurrentNode.getReplicaPath())
+          .append("), current state: ")
+          .append(currentState)
+          .append(", lag infos: ");
       sb.append("Local DC peer replicas lag: {");
       for (Map.Entry<ReplicaId, Long> replicaAndLag : localDcPeerReplicaAndLag.entrySet()) {
         sb.append(" [")

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
@@ -63,7 +63,7 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
     partitionToDeactivationLatch.put(replicaId.getPartitionId().toPathString(), new CountDownLatch(1));
     partitionToDeactivationSuccess.put(replicaId.getPartitionId().toPathString(), false);
     // once deactivation is initiated, local replica won't receive new PUTs. All remote replicas should be able to
-    // catch with last PUT in local store. Hence, we set acceptable lag threshold to 0.
+    // eventually catch with last PUT in local store. Hence, we set acceptable lag threshold to 0.
     replicaToLagInfos.put(replicaId, new LocalReplicaLagInfos(replicaId, 0, ReplicaState.INACTIVE));
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryStateModelFactory.java
@@ -25,13 +25,10 @@ import org.apache.helix.participant.statemachine.StateModelFactory;
 class AmbryStateModelFactory extends StateModelFactory<StateModel> {
   private final ClusterMapConfig clustermapConfig;
   private final PartitionStateChangeListener partitionStateChangeListener;
-  private final ReplicaSyncUpManager replicaSyncUpManager;
 
-  AmbryStateModelFactory(ClusterMapConfig clusterMapConfig, PartitionStateChangeListener partitionStateChangeListener,
-      ReplicaSyncUpManager replicaSyncUpManager) {
+  AmbryStateModelFactory(ClusterMapConfig clusterMapConfig, PartitionStateChangeListener partitionStateChangeListener) {
     this.clustermapConfig = clusterMapConfig;
     this.partitionStateChangeListener = partitionStateChangeListener;
-    this.replicaSyncUpManager = replicaSyncUpManager;
   }
 
   /**
@@ -46,8 +43,7 @@ class AmbryStateModelFactory extends StateModelFactory<StateModel> {
     switch (clustermapConfig.clustermapStateModelDefinition) {
       case AmbryStateModelDefinition.AMBRY_LEADER_STANDBY_MODEL:
         stateModelToReturn =
-            new AmbryPartitionStateModel(resourceName, partitionName, partitionStateChangeListener, clustermapConfig,
-                replicaSyncUpManager);
+            new AmbryPartitionStateModel(resourceName, partitionName, partitionStateChangeListener, clustermapConfig);
         break;
       case LeaderStandbySMD.name:
         stateModelToReturn = new DefaultLeaderStandbyStateModel();

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -39,6 +39,8 @@ import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
+
 
 /**
  * An implementation of {@link ClusterParticipant} that registers as a participant to a Helix cluster.
@@ -322,8 +324,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         replicaSyncUpManager.waitBootstrapCompleted(partitionName);
       } catch (InterruptedException e) {
         logger.error("Bootstrap was interrupted on partition {}", partitionName);
-        throw new StateTransitionException("Bootstrap failed or was interrupted",
-            StateTransitionException.TransitionErrorCode.BootstrapFailure);
+        throw new StateTransitionException("Bootstrap failed or was interrupted", BootstrapFailure);
       } catch (StateTransitionException e) {
         logger.error("Bootstrap didn't complete on partition {}", partitionName, e);
         throw e;
@@ -368,8 +369,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         replicaSyncUpManager.waitDeactivationCompleted(partitionName);
       } catch (InterruptedException e) {
         logger.error("Deactivation was interrupted on partition {}", partitionName);
-        throw new StateTransitionException("Deactivation failed or was interrupted",
-            StateTransitionException.TransitionErrorCode.DeactivationFailure);
+        throw new StateTransitionException("Deactivation failed or was interrupted", DeactivationFailure);
       } catch (StateTransitionException e) {
         logger.error("Deactivation didn't complete on partition {}", partitionName, e);
         throw e;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -336,4 +336,20 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       cloudToStoreReplicationListener.onPartitionBecomeStandbyFromLeader(partitionName);
     }
   }
+
+  @Override
+  public void onPartitionBecomeInactiveFromStandby(String partitionName) {
+    // 1. storage manager marks store local state as INACTIVE and disables compaction on this partition
+    PartitionStateChangeListener storageManagerListener =
+        partitionStateChangeListeners.get(StateModelListenerType.StorageManagerListener);
+    if (storageManagerListener != null) {
+      storageManagerListener.onPartitionBecomeInactiveFromStandby(partitionName);
+    }
+    // 2. replication manager initiates deactivation
+    PartitionStateChangeListener replicationManagerListener =
+        partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
+    if (replicationManagerListener != null) {
+      replicationManagerListener.onPartitionBecomeInactiveFromStandby(partitionName);
+    }
+  }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -316,6 +316,8 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
     if (replicationManagerListener != null) {
       replicationManagerListener.onPartitionBecomeStandbyFromBootstrap(partitionName);
+      // after bootstrap is initiated in ReplicationManager, transition is blocked here and wait until local replica has
+      // caught up with enough peer replicas.
       try {
         replicaSyncUpManager.waitBootstrapCompleted(partitionName);
       } catch (InterruptedException e) {
@@ -360,6 +362,8 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
     if (replicationManagerListener != null) {
       replicationManagerListener.onPartitionBecomeInactiveFromStandby(partitionName);
+      // after deactivation is initiated in ReplicationManager, transition is blocked here and wait until enough peer
+      // replicas have caught up with last PUT in local store.
       try {
         replicaSyncUpManager.waitDeactivationCompleted(partitionName);
       } catch (InterruptedException e) {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -89,7 +89,7 @@ public class AmbryReplicaSyncUpManagerTest {
    * @throws Exception
    */
   @Test
-  public void basicTest() throws Exception {
+  public void bootstrapBasicTest() throws Exception {
     CountDownLatch stateModelLatch = new CountDownLatch(1);
     listenerLatch = new CountDownLatch(1);
     // create a new thread and trigger BOOTSTRAP -> STANDBY transition
@@ -117,12 +117,8 @@ public class AmbryReplicaSyncUpManagerTest {
     replicaSyncUpService.updateLagBetweenReplicas(currentReplica, remotePeer2, 10L);
     // make current replica fall behind first peer replica in local DC again (update lag to 150 > 100)
     replicaSyncUpService.updateLagBetweenReplicas(currentReplica, localPeer1, 150L);
-    // at this time, current replica has caught up with two replicas only, so SyncUp is not complete
-    assertFalse("Catchup shouldn't complete on current replica because only one peer replica is caught up",
-        replicaSyncUpService.isSyncUpComplete(currentReplica));
-    // make current replica catch up with first peer remote dc replica
-    replicaSyncUpService.updateLagBetweenReplicas(currentReplica, remotePeer1, 10L);
-    assertTrue("Catch up should be complete on current replica because it has caught up at least 3 peer replicas",
+    // at this time, current replica has caught up with two replicas in local DC, so SyncUp is complete
+    assertTrue("Catch up should be complete on current replica because it has caught up at least 2 peer replicas",
         replicaSyncUpService.isSyncUpComplete(currentReplica));
     replicaSyncUpService.onBootstrapComplete(currentReplica);
     assertTrue("Bootstrap-To-Standby transition didn't complete within 1 sec.",

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -124,7 +124,7 @@ public class AmbryReplicaSyncUpManagerTest {
     replicaSyncUpService.updateLagBetweenReplicas(currentReplica, remotePeer1, 10L);
     assertTrue("Catch up should be complete on current replica because it has caught up at least 3 peer replicas",
         replicaSyncUpService.isSyncUpComplete(currentReplica));
-    replicaSyncUpService.onBootstrapComplete(currentReplica.getPartitionId().toPathString());
+    replicaSyncUpService.onBootstrapComplete(currentReplica);
     assertTrue("Bootstrap-To-Standby transition didn't complete within 1 sec.",
         stateModelLatch.await(1, TimeUnit.SECONDS));
     // reset ReplicaSyncUpManager
@@ -150,7 +150,7 @@ public class AmbryReplicaSyncUpManagerTest {
     assertFalse("Updating lag should return false because replica is not present",
         replicaSyncUpService.updateLagBetweenReplicas(replicaToTest, peerReplica, 100L));
     try {
-      replicaSyncUpService.onBootstrapError(partition.toPathString());
+      replicaSyncUpService.onBootstrapError(replicaToTest);
       fail("should fail because replica is not present");
     } catch (IllegalStateException e) {
       // expected
@@ -178,7 +178,7 @@ public class AmbryReplicaSyncUpManagerTest {
       }
     }, false).start();
     assertTrue("State change listener didn't get invoked within 1 sec.", listenerLatch.await(1, TimeUnit.SECONDS));
-    replicaSyncUpService.onBootstrapError(currentReplica.getPartitionId().toPathString());
+    replicaSyncUpService.onBootstrapError(currentReplica);
     assertTrue("Bootstrap-To-Standby transition didn't complete within 1 sec.",
         stateModelLatch.await(1, TimeUnit.SECONDS));
   }
@@ -204,6 +204,10 @@ public class AmbryReplicaSyncUpManagerTest {
 
     @Override
     public void onPartitionBecomeStandbyFromLeader(String partitionName) {
+    }
+
+    @Override
+    public void onPartitionBecomeInactiveFromStandby(String partitionName) {
     }
   }
 }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -63,8 +64,8 @@ public class AmbryReplicaSyncUpManagerTest {
     replicas.removeAll(localDcPeers);
     localDcPeerReplicas = new ArrayList<>(localDcPeers);
     remoteDcPeerReplicas = new ArrayList<>(replicas);
-    List<com.github.ambry.utils.TestUtils.ZkInfo> zkInfoList = new ArrayList<>();
-    zkInfoList.add(new com.github.ambry.utils.TestUtils.ZkInfo(null, "DC1", (byte) 0, 2199, false));
+    List<TestUtils.ZkInfo> zkInfoList = new ArrayList<>();
+    zkInfoList.add(new TestUtils.ZkInfo(null, "DC1", (byte) 0, 2199, false));
     JSONObject zkJson = constructZkLayoutJSON(zkInfoList);
     Properties properties = new Properties();
     properties.setProperty("clustermap.cluster.name", "test");

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
@@ -75,7 +75,7 @@ public class AmbryStateModelFactoryTest {
       public void onPartitionBecomeInactiveFromStandby(String partitionName) {
         // no op
       }
-    }, new AmbryReplicaSyncUpManager(config));
+    });
     StateModel stateModel;
     switch (config.clustermapStateModelDefinition) {
       case ClusterMapConfig.OLD_STATE_MODEL_DEF:

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
@@ -70,6 +70,11 @@ public class AmbryStateModelFactoryTest {
       public void onPartitionBecomeStandbyFromLeader(String partitionName) {
         //no op
       }
+
+      @Override
+      public void onPartitionBecomeInactiveFromStandby(String partitionName) {
+        // no op
+      }
     }, new AmbryReplicaSyncUpManager(config));
     StateModel stateModel;
     switch (config.clustermapStateModelDefinition) {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
@@ -65,7 +65,6 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
 public class CloudToStoreReplicationManager extends ReplicationEngine {
   private final ClusterMapConfig clusterMapConfig;
   private final StoreConfig storeConfig;
-  private final StoreManager storeManager;
   private final ClusterSpectator vcrClusterSpectator;
   private final ClusterParticipant clusterParticipant;
   private static final String cloudReplicaTokenFileName = "cloudReplicaTokens";
@@ -101,10 +100,9 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
       ClusterSpectator vcrClusterSpectator, ClusterParticipant clusterParticipant) throws ReplicationException {
     super(replicationConfig, clusterMapConfig, storeKeyFactory, clusterMap, scheduler, currentNode,
         Collections.emptyList(), connectionPool, metricRegistry, requestNotification, storeKeyConverterFactory,
-        transformerClassName, clusterParticipant);
+        transformerClassName, clusterParticipant, storeManager);
     this.clusterMapConfig = clusterMapConfig;
     this.storeConfig = storeConfig;
-    this.storeManager = storeManager;
     this.vcrClusterSpectator = vcrClusterSpectator;
     this.clusterParticipant = clusterParticipant;
     this.instanceNameToCloudDataNode = new AtomicReference<>(new ConcurrentHashMap<>());
@@ -373,6 +371,12 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
           removeCloudReplica(partitionName);
         }
       }
+    }
+
+    @Override
+    public void onPartitionBecomeInactiveFromStandby(String partitionName) {
+      logger.info("Partition state change notification from Standby to Inactive received for partition {}",
+          partitionName);
     }
 
     /**

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -448,12 +448,12 @@ public class ReplicaThread implements Runnable {
                 ReplicaId remoteReplica = remoteReplicaInfo.getReplicaId();
                 boolean updated = replicaSyncUpManager.updateLagBetweenReplicas(localReplica, remoteReplica,
                     exchangeMetadataResponse.localLagFromRemoteInBytes);
-                // if updated is false, it means local replica is not found in replicaSyncUpManager and is therefore in
-                // bootstrap state
+                // if updated is false, it means local replica is not found in replicaSyncUpManager and is therefore not
+                // in bootstrap state.
                 if (updated && replicaSyncUpManager.isSyncUpComplete(localReplica)) {
                   // complete BOOTSTRAP -> STANDBY transition
                   remoteReplicaInfo.getLocalStore().setCurrentState(ReplicaState.STANDBY);
-                  replicaSyncUpManager.onBootstrapComplete(localReplica.getPartitionId().toPathString());
+                  replicaSyncUpManager.onBootstrapComplete(localReplica);
                   remoteReplicaInfo.getLocalStore().completeBootstrap();
                 }
               }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -156,6 +156,10 @@ public abstract class ReplicationEngine implements ReplicationAPI {
         if (localStore.getCurrentState() == ReplicaState.INACTIVE) {
           // if local store is in INACTIVE state, that means deactivation process is initiated and in progress on this
           // replica. We update SyncUpManager by peer's lag from last PUT offset in local store.
+          // it's ok if deactivation has completed and subsequent metadata request attempts to update lag of same replica
+          // again. The reason is, in previous request, onDeactivationComplete method should have removed local replica
+          // from SyncUpManager and it should be no-op and "updated" should be false when calling updateLagBetweenReplicas()
+          // for subsequent request. Hence, it won't call onDeactivationComplete() twice.
           boolean updated =
               replicaSyncUpManager.updateLagBetweenReplicas(localReplica, remoteReplicaInfo.getReplicaId(),
                   localStore.getEndPositionOfLastPut() - totalBytesRead);

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -167,7 +167,8 @@ public abstract class ReplicationEngine implements ReplicationAPI {
             replicaSyncUpManager.onDeactivationComplete(localReplica);
           }
         }
-        // todo local state = OFFLINE, update lag in replicaSyncUpManager
+        // TODO, if local state == OFFLINE, it means replica might be in Inactive-To-Offline transition.
+        //  We need to update lag in replicaSyncUpManager accordingly as well.
       }
     }
   }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -41,6 +41,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
+
 
 /**
  * Set up replicas based on {@link ReplicationEngine} and do replication across all data centers.
@@ -224,7 +226,7 @@ public class ReplicationManager extends ReplicationEngine {
         // no matter this is an existing replica or new added one, it should be present in storage manager because new
         // replica is added into storage manager first.
         throw new StateTransitionException("Replica " + partitionName + " is not found on current node",
-            StateTransitionException.TransitionErrorCode.ReplicaNotFound);
+            ReplicaNotFound);
       }
 
       if (!partitionToPartitionInfo.containsKey(replica.getPartitionId())) {
@@ -233,7 +235,7 @@ public class ReplicationManager extends ReplicationEngine {
         logger.info("Didn't find replica {} in replication manager, starting to add it.", partitionName);
         if (!addReplica(replica)) {
           throw new StateTransitionException("Failed to add new replica " + partitionName + " into replication manager",
-              StateTransitionException.TransitionErrorCode.ReplicaOperationFailure);
+              ReplicaOperationFailure);
         }
       }
     }
@@ -247,8 +249,7 @@ public class ReplicationManager extends ReplicationEngine {
       // 1. check if store is started
       if (store == null) {
         throw new StateTransitionException(
-            "Store " + partitionName + " is not started during Bootstrap-To-Standby transition",
-            StateTransitionException.TransitionErrorCode.StoreNotStarted);
+            "Store " + partitionName + " is not started during Bootstrap-To-Standby transition", StoreNotStarted);
       }
       // 2. check if store is new added and needs to catch up with peer replicas.
       if (store.isBootstrapInProgress()) {
@@ -280,8 +281,7 @@ public class ReplicationManager extends ReplicationEngine {
       // 1. check if store is started
       if (store == null) {
         throw new StateTransitionException(
-            "Store " + partitionName + " is not started during Standby-To-Inactive transition",
-            StateTransitionException.TransitionErrorCode.StoreNotStarted);
+            "Store " + partitionName + " is not started during Standby-To-Inactive transition", StoreNotStarted);
       }
       replicaSyncUpManager.initiateDeactivation(localReplica);
     }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -214,7 +214,7 @@ public class ReplicationManager extends ReplicationEngine {
   /**
    * {@link PartitionStateChangeListener} to capture changes in partition state.
    */
-  private class PartitionStateChangeListenerImpl implements PartitionStateChangeListener {
+  class PartitionStateChangeListenerImpl implements PartitionStateChangeListener {
 
     @Override
     public void onPartitionBecomeBootstrapFromOffline(String partitionName) {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
@@ -332,6 +332,11 @@ class InMemoryStore implements Store {
   }
 
   @Override
+  public long getEndPositionOfLastPut() throws StoreException {
+    throw new UnsupportedOperationException("Method not supported");
+  }
+
+  @Override
   public void shutdown() throws StoreException {
     started = false;
   }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
@@ -49,7 +49,7 @@ public class MockReplicationManager extends ReplicationManager {
   // Variables for controlling getRemoteReplicaLagFromLocalInBytes()
   // the key is partitionId:hostname:replicaPath
   public Map<String, Long> lagOverrides = null;
-  CountDownLatch listenerExcuctionLatch = null;
+  CountDownLatch listenerExecutionLatch = null;
   MockReplicationListener replicationListener = new MockReplicationListener();
 
   /**
@@ -175,16 +175,16 @@ public class MockReplicationManager extends ReplicationManager {
     @Override
     public void onPartitionBecomeStandbyFromBootstrap(String partitionName) {
       super.onPartitionBecomeStandbyFromBootstrap(partitionName);
-      if (listenerExcuctionLatch != null) {
-        listenerExcuctionLatch.countDown();
+      if (listenerExecutionLatch != null) {
+        listenerExecutionLatch.countDown();
       }
     }
 
     @Override
     public void onPartitionBecomeInactiveFromStandby(String partitionName) {
       super.onPartitionBecomeInactiveFromStandby(partitionName);
-      if (listenerExcuctionLatch != null) {
-        listenerExcuctionLatch.countDown();
+      if (listenerExecutionLatch != null) {
+        listenerExecutionLatch.countDown();
       }
     }
   }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -372,14 +372,14 @@ public class ReplicationTest {
     mockHelixParticipant.registerPartitionStateChangeListener(StateModelListenerType.ReplicationManagerListener,
         replicationManager.replicationListener);
     CountDownLatch participantLatch = new CountDownLatch(1);
-    replicationManager.listenerExcuctionLatch = new CountDownLatch(1);
+    replicationManager.listenerExecutionLatch = new CountDownLatch(1);
     // create a new thread and trigger BOOTSTRAP -> STANDBY transition
     Utils.newThread(() -> {
       mockHelixParticipant.onPartitionBecomeStandbyFromBootstrap(newReplicaToAdd.getPartitionId().toPathString());
       participantLatch.countDown();
     }, false).start();
     assertTrue("Partition state change listener in ReplicationManager didn't get called within 1 sec",
-        replicationManager.listenerExcuctionLatch.await(1, TimeUnit.SECONDS));
+        replicationManager.listenerExecutionLatch.await(1, TimeUnit.SECONDS));
     assertEquals("Replica should be in BOOTSTRAP state before bootstrap is complete", ReplicaState.BOOTSTRAP,
         storageManager.getStore(newReplicaToAdd.getPartitionId()).getCurrentState());
     // make bootstrap succeed
@@ -435,14 +435,14 @@ public class ReplicationTest {
     mockHelixParticipant.registerPartitionStateChangeListener(StateModelListenerType.ReplicationManagerListener,
         replicationManager.replicationListener);
     CountDownLatch participantLatch = new CountDownLatch(1);
-    replicationManager.listenerExcuctionLatch = new CountDownLatch(1);
+    replicationManager.listenerExecutionLatch = new CountDownLatch(1);
     // create a new thread and trigger STANDBY -> INACTIVE transition
     Utils.newThread(() -> {
       mockHelixParticipant.onPartitionBecomeInactiveFromStandby(existingPartition.toPathString());
       participantLatch.countDown();
     }, false).start();
     assertTrue("Partition state change listener didn't get called within 1 sec",
-        replicationManager.listenerExcuctionLatch.await(1, TimeUnit.SECONDS));
+        replicationManager.listenerExecutionLatch.await(1, TimeUnit.SECONDS));
     assertEquals("Local store state should be INACTIVE", ReplicaState.INACTIVE,
         storageManager.getStore(existingPartition).getCurrentState());
 

--- a/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
@@ -410,5 +410,11 @@ class StatsManager {
       logger.info("Partition state change notification from Leader to Standby received for partition {}",
           partitionName);
     }
+
+    @Override
+    public void onPartitionBecomeInactiveFromStandby(String partitionName) {
+      logger.info("Partition state change notification from Standby to Inactive received for partition {}",
+          partitionName);
+    }
   }
 }

--- a/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
@@ -47,6 +47,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
 import static com.github.ambry.utils.Utils.*;
 
 
@@ -380,15 +381,14 @@ class StatsManager {
         // no matter this is an existing replica or new added one, it should be present in storage manager because new
         // replica is added into storage manager first.
         throw new StateTransitionException("Replica " + partitionName + " is not found on current node",
-            StateTransitionException.TransitionErrorCode.ReplicaNotFound);
+            ReplicaNotFound);
       }
       if (!partitionToReplicaMap.containsKey(replica.getPartitionId())) {
         // if replica is not present in partitionToReplicaMap, it means this new replica was just added into storage
         // manager. Here we add it into stats manager accordingly.
         logger.info("Didn't find replica {} in stats manager, starting to add it.", partitionName);
         if (!addReplica(replica)) {
-          throw new StateTransitionException("Failed to add new replica into stats manager",
-              StateTransitionException.TransitionErrorCode.ReplicaOperationFailure);
+          throw new StateTransitionException("Failed to add new replica into stats manager", ReplicaOperationFailure);
         }
       }
     }

--- a/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
@@ -194,6 +194,11 @@ class MockStorageManager extends StorageManager {
       return started;
     }
 
+    @Override
+    public long getEndPositionOfLastPut() throws StoreException {
+      throw new UnsupportedOperationException("Method not supported");
+    }
+
     public void shutdown() throws StoreException {
       throwExceptionIfRequired();
       started = false;

--- a/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
@@ -691,6 +691,11 @@ public class StatsManagerTest {
     }
 
     @Override
+    public long getEndPositionOfLastPut() throws StoreException {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
     public void shutdown() throws StoreException {
       throw new IllegalStateException("Not implemented");
     }

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -757,6 +757,7 @@ public class BlobStore implements Store {
    * @return return absolute end position of last PUT in current store when this method is invoked.
    * @throws StoreException
    */
+  @Override
   public long getEndPositionOfLastPut() throws StoreException {
     return index.getAbsoluteEndPositionOfLastPut();
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -435,7 +435,7 @@ public class StorageManager implements StoreManager {
       // check if partition exists on current node
       ReplicaId replica = partitionNameToReplicaId.get(partitionName);
       // if replica is null that means partition is not on current node (this shouldn't happen unless we use server admin
-      // tool to remove the store before initiating decommission on this partition). We don't throw exception in this case.
+      // tool to remove the store before initiating decommission on this partition). We throw exception in this case.
       if (replica != null) {
         Store localStore = getStore(replica.getPartitionId());
         if (localStore != null) {
@@ -454,6 +454,9 @@ public class StorageManager implements StoreManager {
           throw new StateTransitionException("Store " + partitionName + " is not started",
               StateTransitionException.TransitionErrorCode.StoreNotStarted);
         }
+      } else {
+        throw new StateTransitionException("Replica " + partitionName + " is not found on current node",
+            StateTransitionException.TransitionErrorCode.ReplicaNotFound);
       }
     }
   }

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -348,7 +348,7 @@ public class StorageManagerTest {
     try {
       mockHelixParticipant.onPartitionBecomeInactiveFromStandby(localReplica.getPartitionId().toPathString());
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaOperationFailure,
+      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaNotFound,
           e.getErrorCode());
     } finally {
       shutdownAndAssertStoresInaccessible(mockStorageManager, localReplicas);

--- a/build.gradle
+++ b/build.gradle
@@ -274,6 +274,7 @@ project(':ambry-replication') {
         testCompile project(':ambry-commons').sourceSets.test.output
         testCompile project(':ambry-messageformat').sourceSets.test.output
         testCompile project(':ambry-store').sourceSets.main.output
+        testCompile project(':ambry-store').sourceSets.test.output
     }
 }
 


### PR DESCRIPTION
Standby-To-Inactive transition is triggered when replica is being
decommissioned. To avoid race condition due to inconsisten view and to
ensure other peer replicas have caught up with last PUT in local store,
we take following actions in order during the transition:
1. server sets local replica to INACTIVE state
2. disable compaction on local store
3. reject new PUTs but accept DELETE/TTLUpdates on this replica
4. check remote replica lag to ensure they catch up with last PUT
5. complete the transition