### PR TITLE
Implement replica Inactive-To-Offline transition on server side

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
@@ -47,4 +47,10 @@ public interface PartitionStateChangeListener {
    * @param partitionName of the partition
    */
   void onPartitionBecomeInactiveFromStandby(String partitionName);
+
+  /**
+   * Action to take when partition becomes offline from inactive.
+   * @param partitionName of the partition
+   */
+  void onPartitionBecomeOfflineFromInactive(String partitionName);
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaSyncUpManager.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ReplicaSyncUpManager.java
@@ -41,7 +41,7 @@ public interface ReplicaSyncUpManager {
    * @param localReplica the replica that resides on current node
    * @param peerReplica the peer replica of local one.
    * @param lagInBytes replica lag bytes
-   * @return whether the lag is updated or not. If {@code false}, it means the source replica is not tracked in this service.
+   * @return whether the lag is updated or not. If {@code false}, it means the local replica is not tracked in this service.
    *         Either the replica has caught up and removed from service or it is an existing replica that doesn't need catchup.
    */
   boolean updateLagBetweenReplicas(ReplicaId localReplica, ReplicaId peerReplica, long lagInBytes);
@@ -90,4 +90,29 @@ public interface ReplicaSyncUpManager {
    * @throws InterruptedException
    */
   void waitDeactivationCompleted(String partitionName) throws InterruptedException;
+
+  /**
+   * Initiate disconnection process to stop replica and make it offline. This happens when replica is going to be
+   * removed from current node. For Ambry, it disconnection occurs in Inactive-To-Offline transition.
+   * @param replicaId the {@link ReplicaId} to be disconnected.
+   */
+  void initiateDisconnection(ReplicaId replicaId);
+
+  /**
+   * Wait until disconnection on given partition is complete.
+   * @param partitionName partition name of replica that in disconnection process
+   */
+  void waitDisconnectionCompleted(String partitionName) throws InterruptedException;
+
+  /**
+   * When disconnection completes on given replica and then it becomes offline.
+   * @param replicaId the {@link ReplicaId} on which disconnection completes
+   */
+  void onDisconnectionComplete(ReplicaId replicaId);
+
+  /**
+   * When exception/error occurs during disconnection.
+   * @param replicaId the {@link ReplicaId} which encounters error.
+   */
+  void onDisconnectionError(ReplicaId replicaId);
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/StateTransitionException.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/StateTransitionException.java
@@ -54,6 +54,10 @@ public class StateTransitionException extends RuntimeException {
     /**
      * If failure occurs during Standby-To-Inactive transition.
      */
-    DeactivationFailure
+    DeactivationFailure,
+    /**
+     * If disconnection process fails on specific replica.
+     */
+    DisconnectionFailure
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/store/Store.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/Store.java
@@ -122,6 +122,12 @@ public interface Store {
   boolean isBootstrapInProgress();
 
   /**
+   * @return {@code true} if store has initiated decommission process (STANDBY -> INACTIVE -> OFFLINE) and decommission
+   * is still in progress.
+   */
+  boolean isDecommissionInProgress();
+
+  /**
    * Take actions (if any) to complete the bootstrap (i.e, delete bootstrap file in store directory)
    */
   void completeBootstrap();

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
@@ -472,6 +472,11 @@ class CloudBlobStore implements Store {
   }
 
   @Override
+  public boolean isDecommissionInProgress() {
+    return false;
+  }
+
+  @Override
   public void completeBootstrap() {
     // no op
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
@@ -88,8 +88,12 @@ public class AmbryPartitionStateModel extends StateModel {
 
   @Transition(to = "OFFLINE", from = "INACTIVE")
   public void onBecomeOfflineFromInactive(Message message, NotificationContext context) {
-    logger.info("Partition {} in resource {} is becoming OFFLINE from INACTIVE", message.getPartitionName(),
+    String partitionName = message.getPartitionName();
+    logger.info("Partition {} in resource {} is becoming OFFLINE from INACTIVE", partitionName,
         message.getResourceName());
+    if (clusterMapConfig.clustermapEnableStateModelListener) {
+      partitionStateChangeListener.onPartitionBecomeOfflineFromInactive(partitionName);
+    }
   }
 
   @Transition(to = "DROPPED", from = "OFFLINE")

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
@@ -40,9 +40,9 @@ import static com.github.ambry.clustermap.StateTransitionException.TransitionErr
 public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
   private final ConcurrentHashMap<String, CountDownLatch> partitionToBootstrapLatch = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, CountDownLatch> partitionToDeactivationLatch = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, CountDownLatch> partitionToDisconnectionLatch = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Boolean> partitionToBootstrapSuccess = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Boolean> partitionToDeactivationSuccess = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<String, CountDownLatch> partitionToDisconnectionLatch = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Boolean> partitionToDisconnectionSuccess = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<ReplicaId, LocalReplicaLagInfos> replicaToLagInfos = new ConcurrentHashMap<>();
   private final ClusterMapConfig clusterMapConfig;
@@ -183,15 +183,14 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
     if (latch == null) {
       logger.error("Partition {} is not found for disconnection", partitionName);
       throw new StateTransitionException("No disconnection latch is found for partition " + partitionName,
-          StateTransitionException.TransitionErrorCode.ReplicaNotFound);
+          ReplicaNotFound);
     } else {
       logger.info("Waiting for partition {} to be disconnected", partitionName);
       latch.await();
       partitionToDisconnectionLatch.remove(partitionName);
       // throw exception to put replica into ERROR state， this happens when disk crashes during disconnection
       if (!partitionToDisconnectionSuccess.remove(partitionName)) {
-        throw new StateTransitionException("Disconnection failed on partition " + partitionName,
-            StateTransitionException.TransitionErrorCode.DisconnectionFailure);
+        throw new StateTransitionException("Disconnection failed on partition " + partitionName, DisconnectionFailure);
       }
       logger.info("Disconnection is complete on partition {}", partitionName);
     }
@@ -218,9 +217,9 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
     partitionToBootstrapSuccess.clear();
     partitionToDeactivationLatch.clear();
     partitionToDeactivationSuccess.clear();
-    replicaToLagInfos.clear();
     partitionToDisconnectionLatch.clear();
     partitionToDisconnectionSuccess.clear();
+    replicaToLagInfos.clear();
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManager.java
@@ -42,6 +42,8 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
   private final ConcurrentHashMap<String, CountDownLatch> partitionToDeactivationLatch = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Boolean> partitionToBootstrapSuccess = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Boolean> partitionToDeactivationSuccess = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, CountDownLatch> partitionToDisconnectionLatch = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Boolean> partitionToDisconnectionSuccess = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<ReplicaId, LocalReplicaLagInfos> replicaToLagInfos = new ConcurrentHashMap<>();
   private final ClusterMapConfig clusterMapConfig;
 
@@ -166,6 +168,48 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
     countDownLatch(partitionToDeactivationLatch, replicaId.getPartitionId().toPathString());
   }
 
+  @Override
+  public void initiateDisconnection(ReplicaId replicaId) {
+    partitionToDisconnectionLatch.put(replicaId.getPartitionId().toPathString(), new CountDownLatch(1));
+    partitionToDisconnectionSuccess.put(replicaId.getPartitionId().toPathString(), false);
+    // once disconnection is initiated, local replica won't receive any PUT/DELETE/TTLUpdate. All remote replicas should
+    // be able to eventually catch with local replica. Hence, we set acceptable lag threshold to 0.
+    replicaToLagInfos.put(replicaId, new LocalReplicaLagInfos(replicaId, 0, ReplicaState.OFFLINE));
+  }
+
+  @Override
+  public void waitDisconnectionCompleted(String partitionName) throws InterruptedException {
+    CountDownLatch latch = partitionToDisconnectionLatch.get(partitionName);
+    if (latch == null) {
+      logger.error("Partition {} is not found for disconnection", partitionName);
+      throw new StateTransitionException("No disconnection latch is found for partition " + partitionName,
+          StateTransitionException.TransitionErrorCode.ReplicaNotFound);
+    } else {
+      logger.info("Waiting for partition {} to be disconnected", partitionName);
+      latch.await();
+      partitionToDisconnectionLatch.remove(partitionName);
+      // throw exception to put replica into ERROR state， this happens when disk crashes during disconnection
+      if (!partitionToDisconnectionSuccess.remove(partitionName)) {
+        throw new StateTransitionException("Disconnection failed on partition " + partitionName,
+            StateTransitionException.TransitionErrorCode.DisconnectionFailure);
+      }
+      logger.info("Disconnection is complete on partition {}", partitionName);
+    }
+  }
+
+  @Override
+  public void onDisconnectionComplete(ReplicaId replicaId) {
+    partitionToDisconnectionSuccess.put(replicaId.getPartitionId().toPathString(), true);
+    replicaToLagInfos.remove(replicaId);
+    countDownLatch(partitionToDisconnectionLatch, replicaId.getPartitionId().toPathString());
+  }
+
+  @Override
+  public void onDisconnectionError(ReplicaId replicaId) {
+    replicaToLagInfos.remove(replicaId);
+    countDownLatch(partitionToDisconnectionLatch, replicaId.getPartitionId().toPathString());
+  }
+
   /**
    * clean up in-mem maps
    */
@@ -175,6 +219,8 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
     partitionToDeactivationLatch.clear();
     partitionToDeactivationSuccess.clear();
     replicaToLagInfos.clear();
+    partitionToDisconnectionLatch.clear();
+    partitionToDisconnectionSuccess.clear();
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -376,4 +376,34 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       }
     }
   }
+
+  @Override
+  public void onPartitionBecomeOfflineFromInactive(String partitionName) {
+    // 1. take actions in replication manager
+    //    (1) set local store state to OFFLINE
+    //    (2) initiate decommission in ReplicaSyncUpManager
+    PartitionStateChangeListener replicationManagerListener =
+        partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
+    if (replicationManagerListener != null) {
+      replicationManagerListener.onPartitionBecomeOfflineFromInactive(partitionName);
+    }
+    // 2. wait until peer replicas have caught up with local replica
+    try {
+      replicaSyncUpManager.waitDisconnectionCompleted(partitionName);
+    } catch (InterruptedException e) {
+      logger.error("Disconnection was interrupted on partition {}", partitionName);
+      throw new StateTransitionException("Disconnection failed or was interrupted",
+          StateTransitionException.TransitionErrorCode.DisconnectionFailure);
+    } catch (StateTransitionException e) {
+      logger.error("Disconnection didn't complete ", e);
+      throw e;
+    }
+    // 3. take actions in storage manager (stop the store)
+    PartitionStateChangeListener storageManagerListener =
+        partitionStateChangeListeners.get(StateModelListenerType.StorageManagerListener);
+    if (storageManagerListener != null) {
+      storageManagerListener.onPartitionBecomeOfflineFromInactive(partitionName);
+    }
+    // 4. todo update instanceConfig in helix
+  }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -384,7 +384,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     if (replicationManagerListener != null) {
       // 1. take actions in replication manager
       //    (1) set local store state to OFFLINE
-      //    (2) initiate decommission in ReplicaSyncUpManager
+      //    (2) initiate disconnection in ReplicaSyncUpManager
       replicationManagerListener.onPartitionBecomeOfflineFromInactive(partitionName);
       // 2. wait until peer replicas have caught up with local replica
       try {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -379,24 +379,24 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
 
   @Override
   public void onPartitionBecomeOfflineFromInactive(String partitionName) {
-    // 1. take actions in replication manager
-    //    (1) set local store state to OFFLINE
-    //    (2) initiate decommission in ReplicaSyncUpManager
     PartitionStateChangeListener replicationManagerListener =
         partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
     if (replicationManagerListener != null) {
+      // 1. take actions in replication manager
+      //    (1) set local store state to OFFLINE
+      //    (2) initiate decommission in ReplicaSyncUpManager
       replicationManagerListener.onPartitionBecomeOfflineFromInactive(partitionName);
-    }
-    // 2. wait until peer replicas have caught up with local replica
-    try {
-      replicaSyncUpManager.waitDisconnectionCompleted(partitionName);
-    } catch (InterruptedException e) {
-      logger.error("Disconnection was interrupted on partition {}", partitionName);
-      throw new StateTransitionException("Disconnection failed or was interrupted",
-          StateTransitionException.TransitionErrorCode.DisconnectionFailure);
-    } catch (StateTransitionException e) {
-      logger.error("Disconnection didn't complete ", e);
-      throw e;
+      // 2. wait until peer replicas have caught up with local replica
+      try {
+        replicaSyncUpManager.waitDisconnectionCompleted(partitionName);
+      } catch (InterruptedException e) {
+        logger.error("Disconnection was interrupted on partition {}", partitionName);
+        throw new StateTransitionException("Disconnection failed or was interrupted",
+            StateTransitionException.TransitionErrorCode.DisconnectionFailure);
+      } catch (StateTransitionException e) {
+        logger.error("Disconnection didn't complete ", e);
+        throw e;
+      }
     }
     // 3. take actions in storage manager (stop the store)
     PartitionStateChangeListener storageManagerListener =

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -391,8 +391,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         replicaSyncUpManager.waitDisconnectionCompleted(partitionName);
       } catch (InterruptedException e) {
         logger.error("Disconnection was interrupted on partition {}", partitionName);
-        throw new StateTransitionException("Disconnection failed or was interrupted",
-            StateTransitionException.TransitionErrorCode.DisconnectionFailure);
+        throw new StateTransitionException("Disconnection failed or was interrupted", DisconnectionFailure);
       } catch (StateTransitionException e) {
         logger.error("Disconnection didn't complete ", e);
         throw e;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -31,6 +31,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
 import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -217,8 +218,7 @@ public class AmbryReplicaSyncUpManagerTest {
       replicaSyncUpService.waitDeactivationCompleted(partition.toPathString());
       fail("should fail because replica is not found");
     } catch (StateTransitionException e) {
-      assertEquals("Error code is not expected", StateTransitionException.TransitionErrorCode.ReplicaNotFound,
-          e.getErrorCode());
+      assertEquals("Error code is not expected", ReplicaNotFound, e.getErrorCode());
     }
     // test deactivation failure for some reason (triggered by calling onDeactivationError)
     CountDownLatch stateModelLatch = new CountDownLatch(1);
@@ -229,8 +229,7 @@ public class AmbryReplicaSyncUpManagerTest {
       try {
         stateModel.onBecomeInactiveFromStandby(mockMessage, null);
       } catch (StateTransitionException e) {
-        assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.DeactivationFailure,
-            e.getErrorCode());
+        assertEquals("Error code doesn't match", DeactivationFailure, e.getErrorCode());
         stateModelLatch.countDown();
       }
     }, false).start();
@@ -255,8 +254,7 @@ public class AmbryReplicaSyncUpManagerTest {
       try {
         stateModel.onBecomeStandbyFromBootstrap(mockMessage, null);
       } catch (StateTransitionException e) {
-        assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.BootstrapFailure,
-            e.getErrorCode());
+        assertEquals("Error code doesn't match", BootstrapFailure, e.getErrorCode());
         stateModelLatch.countDown();
       }
     }, false).start();
@@ -280,8 +278,7 @@ public class AmbryReplicaSyncUpManagerTest {
       replicaSyncUpService.waitDisconnectionCompleted(secondPartition.toPathString());
       fail("should fail because replica is not tracked by ReplicaSyncUpManager");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaNotFound,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", ReplicaNotFound, e.getErrorCode());
     }
     // test disconnection failure (this is induced by call onDisconnectionError)
     CountDownLatch stateModelLatch = new CountDownLatch(1);
@@ -292,8 +289,7 @@ public class AmbryReplicaSyncUpManagerTest {
       try {
         stateModel.onBecomeOfflineFromInactive(mockMessage, null);
       } catch (StateTransitionException e) {
-        assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.DisconnectionFailure,
-            e.getErrorCode());
+        assertEquals("Error code doesn't match", DisconnectionFailure, e.getErrorCode());
         stateModelLatch.countDown();
       }
     }, false).start();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
@@ -75,6 +75,10 @@ public class AmbryStateModelFactoryTest {
       public void onPartitionBecomeInactiveFromStandby(String partitionName) {
         // no op
       }
+
+      public void onPartitionBecomeOfflineFromInactive(String partitionName) {
+        // no op
+      }
     });
     StateModel stateModel;
     switch (config.clustermapStateModelDefinition) {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixParticipant.java
@@ -64,6 +64,17 @@ public class MockHelixParticipant extends HelixParticipant {
       }
       return null;
     }).when(mockReplicationManagerListener).onPartitionBecomeInactiveFromStandby(any(String.class));
+    // mock Inactive-To-Offline change
+    doAnswer((Answer) invocation -> {
+      replicaState = ReplicaState.OFFLINE;
+      if (replicaSyncUpService != null && currentReplica != null) {
+        replicaSyncUpService.initiateDisconnection(currentReplica);
+      }
+      if (listenerLatch != null) {
+        listenerLatch.countDown();
+      }
+      return null;
+    }).when(mockReplicationManagerListener).onPartitionBecomeOfflineFromInactive(any(String.class));
   }
 
   @Override

--- a/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
@@ -379,6 +379,12 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
           partitionName);
     }
 
+    @Override
+    public void onPartitionBecomeOfflineFromInactive(String partitionName) {
+      logger.info("Partition state change notification from Inactive to Offline received for partition {}",
+          partitionName);
+    }
+
     /**
      * If only config specified list of partitions are being replicated from cloud, then check that the partition
      * belongs to the specified list.

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -285,5 +285,25 @@ public class ReplicationManager extends ReplicationEngine {
       }
       replicaSyncUpManager.initiateDeactivation(localReplica);
     }
+
+    @Override
+    public void onPartitionBecomeOfflineFromInactive(String partitionName) {
+      ReplicaId localReplica = storeManager.getReplica(partitionName);
+      // check if local replica exists
+      if (localReplica == null) {
+        throw new StateTransitionException("Replica " + partitionName + " is not found on current node",
+            StateTransitionException.TransitionErrorCode.ReplicaNotFound);
+      }
+      // check if store is started
+      Store store = storeManager.getStore(localReplica.getPartitionId());
+      if (store == null) {
+        throw new StateTransitionException(
+            "Store " + partitionName + " is not started during Inactive-To-Offline transition",
+            StateTransitionException.TransitionErrorCode.StoreNotStarted);
+      }
+      // set local store state to OFFLINE and initiate disconnection
+      store.setCurrentState(ReplicaState.OFFLINE);
+      replicaSyncUpManager.initiateDisconnection(localReplica);
+    }
   }
 }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -292,14 +292,13 @@ public class ReplicationManager extends ReplicationEngine {
       // check if local replica exists
       if (localReplica == null) {
         throw new StateTransitionException("Replica " + partitionName + " is not found on current node",
-            StateTransitionException.TransitionErrorCode.ReplicaNotFound);
+            ReplicaNotFound);
       }
       // check if store is started
       Store store = storeManager.getStore(localReplica.getPartitionId());
       if (store == null) {
         throw new StateTransitionException(
-            "Store " + partitionName + " is not started during Inactive-To-Offline transition",
-            StateTransitionException.TransitionErrorCode.StoreNotStarted);
+            "Store " + partitionName + " is not started during Inactive-To-Offline transition", StoreNotStarted);
       }
       // set local store state to OFFLINE and initiate disconnection
       store.setCurrentState(ReplicaState.OFFLINE);

--- a/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
@@ -317,6 +317,11 @@ class InMemoryStore implements Store {
   }
 
   @Override
+  public boolean isDecommissionInProgress() {
+    throw new UnsupportedOperationException("Method not supported");
+  }
+
+  @Override
   public void completeBootstrap() {
     // no-op
   }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
@@ -187,5 +187,13 @@ public class MockReplicationManager extends ReplicationManager {
         listenerExecutionLatch.countDown();
       }
     }
+
+    @Override
+    public void onPartitionBecomeOfflineFromInactive(String partitionName) {
+      super.onPartitionBecomeOfflineFromInactive(partitionName);
+      if (listenerExecutionLatch != null) {
+        listenerExecutionLatch.countDown();
+      }
+    }
   }
 }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -68,6 +68,7 @@ import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -507,6 +508,102 @@ public class ReplicationTest {
     MockReplicationManager replicationManager = (MockReplicationManager) managers.getSecond();
     PartitionId existingPartition = replicationManager.partitionToPartitionInfo.keySet().iterator().next();
     mockHelixParticipant.onPartitionBecomeStandbyFromLeader(existingPartition.toPathString());
+    storageManager.shutdown();
+  }
+
+  /**
+   * Test INACTIVE -> OFFLINE transition on existing replica (both success and failure cases)
+   */
+  @Test
+  public void replicaFromInactiveToOfflineTest() throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
+    Pair<StorageManager, ReplicationManager> managers =
+        createStorageManagerAndReplicationManager(clusterMap, clusterMapConfig, mockHelixParticipant);
+    StorageManager storageManager = managers.getFirst();
+    MockReplicationManager replicationManager = (MockReplicationManager) managers.getSecond();
+    // 1. test replica not found case
+    try {
+      mockHelixParticipant.onPartitionBecomeOfflineFromInactive("-1");
+      fail("should fail because of invalid partition");
+    } catch (StateTransitionException e) {
+      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaNotFound,
+          e.getErrorCode());
+    }
+    // 2. test store not started case
+    PartitionId existingPartition = replicationManager.partitionToPartitionInfo.keySet().iterator().next();
+    storageManager.shutdownBlobStore(existingPartition);
+    try {
+      mockHelixParticipant.onPartitionBecomeOfflineFromInactive(existingPartition.toPathString());
+      fail("should fail because store is not started");
+    } catch (StateTransitionException e) {
+      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.StoreNotStarted,
+          e.getErrorCode());
+    }
+    storageManager.startBlobStore(existingPartition);
+    // before testing success case, let's write a blob (size = 100) into local store and add a delete record for new blob
+    Store localStore = storageManager.getStore(existingPartition);
+    MockId id = new MockId(UtilsTest.getRandomString(10), Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM));
+    long crc = (new Random()).nextLong();
+    long blobSize = 100;
+    MessageInfo info =
+        new MessageInfo(id, blobSize, false, false, Utils.Infinite_Time, crc, id.getAccountId(), id.getContainerId(),
+            Utils.Infinite_Time);
+    List<MessageInfo> infos = new ArrayList<>();
+    List<ByteBuffer> buffers = new ArrayList<>();
+    ByteBuffer buffer = ByteBuffer.wrap(TestUtils.getRandomBytes((int) blobSize));
+    infos.add(info);
+    buffers.add(buffer);
+    localStore.put(new MockMessageWriteSet(infos, buffers));
+    // delete the blob
+    int deleteRecordSize = 29;
+    MessageInfo deleteInfo =
+        new MessageInfo(id, deleteRecordSize, id.getAccountId(), id.getContainerId(), time.milliseconds());
+    ByteBuffer deleteBuffer = ByteBuffer.wrap(TestUtils.getRandomBytes(deleteRecordSize));
+    localStore.delete(
+        new MockMessageWriteSet(Collections.singletonList(deleteInfo), Collections.singletonList(deleteBuffer)));
+    // note that end offset of last PUT = 100 + 18 = 118, end offset of the store is 147 (118 + 29)
+    // 3. test success case (create a new thread and trigger INACTIVE -> OFFLINE transition)
+    ReplicaId localReplica = storageManager.getReplica(existingPartition.toPathString());
+    // put a decommission-in-progress file into local store dir
+    File decommissionFile = new File(localReplica.getReplicaPath(), "decommission_in_progress");
+    assertTrue("Couldn't create decommission file in local store", decommissionFile.createNewFile());
+    decommissionFile.deleteOnExit();
+    assertNotSame("Before disconnection, the local store state shouldn't be OFFLINE", ReplicaState.OFFLINE,
+        localStore.getCurrentState());
+    mockHelixParticipant.registerPartitionStateChangeListener(StateModelListenerType.ReplicationManagerListener,
+        replicationManager.replicationListener);
+    CountDownLatch participantLatch = new CountDownLatch(1);
+    replicationManager.listenerExcuctionLatch = new CountDownLatch(1);
+    Utils.newThread(() -> {
+      mockHelixParticipant.onPartitionBecomeOfflineFromInactive(existingPartition.toPathString());
+      participantLatch.countDown();
+    }, false).start();
+    assertTrue("Partition state change listener in ReplicationManager didn't get called within 1 sec",
+        replicationManager.listenerExcuctionLatch.await(1, TimeUnit.SECONDS));
+    // the state of local store should be updated to OFFLINE
+    assertEquals("Local store state is not expected", ReplicaState.OFFLINE, localStore.getCurrentState());
+    // update replication lag between local and peer replicas
+    List<RemoteReplicaInfo> remoteReplicaInfos =
+        replicationManager.partitionToPartitionInfo.get(existingPartition).getRemoteReplicaInfos();
+    ReplicaId peerReplica1 = remoteReplicaInfos.get(0).getReplicaId();
+    ReplicaId peerReplica2 = remoteReplicaInfos.get(1).getReplicaId();
+    // peer1 catches up with last PUT, peer2 catches up with end offset of local store. In this case, SyncUp is not complete
+    replicationManager.updateTotalBytesReadByRemoteReplica(existingPartition,
+        peerReplica1.getDataNodeId().getHostname(), peerReplica1.getReplicaPath(), 118);
+    replicationManager.updateTotalBytesReadByRemoteReplica(existingPartition,
+        peerReplica2.getDataNodeId().getHostname(), peerReplica2.getReplicaPath(), 147);
+    assertFalse("Only one peer replica has fully caught up with end offset so sync-up should not complete",
+        mockHelixParticipant.getReplicaSyncUpManager().isSyncUpComplete(localReplica));
+    // make peer1 catch up with end offset
+    replicationManager.updateTotalBytesReadByRemoteReplica(existingPartition,
+        peerReplica1.getDataNodeId().getHostname(), peerReplica1.getReplicaPath(), 147);
+    // Now, sync-up should complete and transition should be able to proceed.
+    assertTrue("Inactive-To-Offline transition didn't complete within 1 sec",
+        participantLatch.await(1, TimeUnit.SECONDS));
+    assertFalse("Local store should be stopped after transition", localStore.isStarted());
     storageManager.shutdown();
   }
 

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -576,13 +576,13 @@ public class ReplicationTest {
     mockHelixParticipant.registerPartitionStateChangeListener(StateModelListenerType.ReplicationManagerListener,
         replicationManager.replicationListener);
     CountDownLatch participantLatch = new CountDownLatch(1);
-    replicationManager.listenerExcuctionLatch = new CountDownLatch(1);
+    replicationManager.listenerExecutionLatch = new CountDownLatch(1);
     Utils.newThread(() -> {
       mockHelixParticipant.onPartitionBecomeOfflineFromInactive(existingPartition.toPathString());
       participantLatch.countDown();
     }, false).start();
     assertTrue("Partition state change listener in ReplicationManager didn't get called within 1 sec",
-        replicationManager.listenerExcuctionLatch.await(1, TimeUnit.SECONDS));
+        replicationManager.listenerExecutionLatch.await(1, TimeUnit.SECONDS));
     // the state of local store should be updated to OFFLINE
     assertEquals("Local store state is not expected", ReplicaState.OFFLINE, localStore.getCurrentState());
     // update replication lag between local and peer replicas

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -97,6 +97,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
+import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
 import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -306,8 +307,7 @@ public class ReplicationTest {
       mockHelixParticipant.onPartitionBecomeBootstrapFromOffline("-1");
       fail("should fail because replica is not found");
     } catch (StateTransitionException e) {
-      assertEquals("Transition error doesn't match", StateTransitionException.TransitionErrorCode.ReplicaNotFound,
-          e.getErrorCode());
+      assertEquals("Transition error doesn't match", ReplicaNotFound, e.getErrorCode());
     }
     // 2. create a new partition and test replica addition success case
     ReplicaId newReplicaToAdd = getNewReplicaToAdd(clusterMap);
@@ -325,8 +325,7 @@ public class ReplicationTest {
       mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(newPartition.toPathString());
       fail("should fail due to replica addition failure");
     } catch (StateTransitionException e) {
-      assertEquals("Transition error doesn't match",
-          StateTransitionException.TransitionErrorCode.ReplicaOperationFailure, e.getErrorCode());
+      assertEquals("Transition error doesn't match", ReplicaOperationFailure, e.getErrorCode());
     }
     replicationManager.addReplicaReturnVal = null;
     // 4. test OFFLINE -> BOOTSTRAP on existing replica (should be no-op)
@@ -362,8 +361,7 @@ public class ReplicationTest {
       mockHelixParticipant.onPartitionBecomeStandbyFromBootstrap(existingPartition.toPathString());
       fail("should fail because store is not started");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.StoreNotStarted,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", StoreNotStarted, e.getErrorCode());
     }
 
     // 3. create new replica and add it into storage manager, test replica that needs to initiate bootstrap
@@ -409,8 +407,7 @@ public class ReplicationTest {
       mockHelixParticipant.onPartitionBecomeInactiveFromStandby(existingPartition.toPathString());
       fail("should fail because store is not started");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.StoreNotStarted,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", StoreNotStarted, e.getErrorCode());
     }
     // restart the store and trigger Standby-To-Inactive transition again
     storageManager.startBlobStore(existingPartition);
@@ -528,8 +525,7 @@ public class ReplicationTest {
       mockHelixParticipant.onPartitionBecomeOfflineFromInactive("-1");
       fail("should fail because of invalid partition");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaNotFound,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", ReplicaNotFound, e.getErrorCode());
     }
     // 2. test store not started case
     PartitionId existingPartition = replicationManager.partitionToPartitionInfo.keySet().iterator().next();
@@ -538,8 +534,7 @@ public class ReplicationTest {
       mockHelixParticipant.onPartitionBecomeOfflineFromInactive(existingPartition.toPathString());
       fail("should fail because store is not started");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.StoreNotStarted,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", StoreNotStarted, e.getErrorCode());
     }
     storageManager.startBlobStore(existingPartition);
     // before testing success case, let's write a blob (size = 100) into local store and add a delete record for new blob

--- a/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
@@ -416,5 +416,11 @@ class StatsManager {
       logger.info("Partition state change notification from Standby to Inactive received for partition {}",
           partitionName);
     }
+
+    @Override
+    public void onPartitionBecomeOfflineFromInactive(String partitionName) {
+      logger.info("Partition state change notification from Inactive to Offline received for partition {}",
+          partitionName);
+    }
   }
 }

--- a/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
@@ -175,6 +175,11 @@ class MockStorageManager extends StorageManager {
     }
 
     @Override
+    public boolean isDecommissionInProgress() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void completeBootstrap() {
       throw new UnsupportedOperationException();
     }

--- a/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
@@ -676,6 +676,11 @@ public class StatsManagerTest {
     }
 
     @Override
+    public boolean isDecommissionInProgress() {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
     public void completeBootstrap() {
       throw new IllegalStateException("Not implemented");
     }

--- a/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/BlobStore.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 public class BlobStore implements Store {
   static final String SEPARATOR = "_";
   static final String BOOTSTRAP_FILE_NAME = "bootstrap_in_progress";
+  static final String DECOMMISSION_FILE_NAME = "decommission_in_progress";
   private final static String LockFile = ".lock";
 
   private final String storeId;
@@ -681,6 +682,13 @@ public class BlobStore implements Store {
   @Override
   public boolean isBootstrapInProgress() {
     return (new File(dataDir, BOOTSTRAP_FILE_NAME)).exists();
+  }
+
+  @Override
+  public boolean isDecommissionInProgress() {
+    // note that, the decommission file will be removed by calling deleteStoreFiles() when replica is being dropped. We
+    // don't need to explicitly delete it. The file is also used for failure recovery to resume decommission process.
+    return (new File(dataDir, DECOMMISSION_FILE_NAME)).exists();
   }
 
   @Override

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -460,5 +460,17 @@ public class StorageManager implements StoreManager {
             ReplicaNotFound);
       }
     }
+
+    @Override
+    public void onPartitionBecomeOfflineFromInactive(String partitionName) {
+      // if code arrives here, which means replica exists on current node. This is guaranteed by replication manager,
+      // which checks existence of local replica (see onPartitionBecomeOfflineFromInactive method in ReplicationManager)
+      ReplicaId replica = partitionNameToReplicaId.get(partitionName);
+      if (!shutdownBlobStore(replica.getPartitionId())) {
+        throw new StateTransitionException("Failed to shutdown store " + partitionName,
+            StateTransitionException.TransitionErrorCode.ReplicaOperationFailure);
+      }
+      logger.info("Store {} is successfully shut down during Inactive-To-Offline transition", partitionName);
+    }
   }
 }

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -1192,6 +1192,7 @@ public class BlobStoreTest {
     // create test store directory
     File storeDir = StoreTestUtils.createTempDirectory("store-" + storeId);
     File reserveDir = StoreTestUtils.createTempDirectory("reserve-pool");
+    reserveDir.deleteOnExit();
     DiskSpaceAllocator diskAllocator =
         new DiskSpaceAllocator(true, reserveDir, 0, new StorageManagerMetrics(new MetricRegistry()));
     StoreConfig config = new StoreConfig(new VerifiableProperties(properties));
@@ -1258,6 +1259,7 @@ public class BlobStoreTest {
   public void inBootstrapAndCompleteBootstrapTest() throws Exception {
     store.shutdown();
     File testDir = StoreTestUtils.createTempDirectory("testStoreDir-" + storeId);
+    testDir.deleteOnExit();
     StoreTestUtils.MockReplicaId testReplica = getMockReplicaId(testDir.getAbsolutePath());
     BlobStore blobStore = createBlobStore(testReplica);
     blobStore.start();
@@ -1267,6 +1269,29 @@ public class BlobStoreTest {
     assertTrue("Store should be in bootstrap state", blobStore.isBootstrapInProgress());
     blobStore.completeBootstrap();
     assertFalse("Bootstrap file should be deleted", bootstrapFile.exists());
+  }
+
+  /**
+   * Test store in decommission process.
+   */
+  @Test
+  public void inDecommissionTest() throws Exception {
+    store.shutdown();
+    File testDir = StoreTestUtils.createTempDirectory("testStoreDir-" + storeId);
+    testDir.deleteOnExit();
+    StoreTestUtils.MockReplicaId testReplica = getMockReplicaId(testDir.getAbsolutePath());
+    BlobStore blobStore = createBlobStore(testReplica);
+    blobStore.start();
+    assertFalse("Store should not be in decommission state because there is no decommission file",
+        blobStore.isDecommissionInProgress());
+    // create a decommission file
+    File decommissionFile = new File(testReplica.getReplicaPath(), BlobStore.DECOMMISSION_FILE_NAME);
+    assertTrue("Couldn't create a decommission file", decommissionFile.createNewFile());
+    assertTrue("Store should be in decommission state", blobStore.isDecommissionInProgress());
+    // delete store files
+    blobStore.shutdown();
+    blobStore.deleteStoreFiles();
+    assertFalse("Decommission file should be deleted", decommissionFile.exists());
   }
 
   // helpers

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -61,6 +61,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
 import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -255,8 +256,7 @@ public class StorageManagerTest {
       mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(String.valueOf(partitionIds.size() + 1));
       fail("should fail due to bootstrap replica not found");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaNotFound,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", ReplicaNotFound, e.getErrorCode());
     }
 
     // 3. test regular store didn't start up (which triggers StoreNotStarted exception)
@@ -267,8 +267,7 @@ public class StorageManagerTest {
       mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(replicaId.getPartitionId().toPathString());
       fail("should fail due to store not started");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.StoreNotStarted,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", StoreNotStarted, e.getErrorCode());
     }
     localStore.start();
 
@@ -285,8 +284,7 @@ public class StorageManagerTest {
     try {
       mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(newPartition.toPathString());
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaOperationFailure,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", ReplicaOperationFailure, e.getErrorCode());
     }
     // restart disk manager to test case where new replica(store) is successfully added into StorageManager
     storageManager.getDiskManager(replicaOnSameDisk.getPartitionId()).start();
@@ -324,8 +322,7 @@ public class StorageManagerTest {
       mockHelixParticipant.onPartitionBecomeInactiveFromStandby("-1");
       fail("should fail because replica is not found");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaNotFound,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", ReplicaNotFound, e.getErrorCode());
     }
     // 3. store not started exception
     ReplicaId localReplica = localReplicas.get(0);
@@ -334,14 +331,15 @@ public class StorageManagerTest {
       mockHelixParticipant.onPartitionBecomeInactiveFromStandby(localReplica.getPartitionId().toPathString());
       fail("should fail because store is not started");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.StoreNotStarted,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", StoreNotStarted, e.getErrorCode());
     }
     storageManager.startBlobStore(localReplica.getPartitionId());
-    // 4. success case
+    // 4. success case (verify both replica's state and decommission file)
     mockHelixParticipant.onPartitionBecomeInactiveFromStandby(localReplica.getPartitionId().toPathString());
     assertEquals("local store state should be set to INACTIVE", ReplicaState.INACTIVE,
         storageManager.getStore(localReplica.getPartitionId()).getCurrentState());
+    File decommissionFile = new File(localReplica.getReplicaPath(), BlobStore.DECOMMISSION_FILE_NAME);
+    assertTrue("Decommission file is not found in local replica's dir", decommissionFile.exists());
     shutdownAndAssertStoresInaccessible(storageManager, localReplicas);
 
     // 5. mock disable compaction failure
@@ -350,8 +348,7 @@ public class StorageManagerTest {
     try {
       mockHelixParticipant.onPartitionBecomeInactiveFromStandby(localReplica.getPartitionId().toPathString());
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaNotFound,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", ReplicaNotFound, e.getErrorCode());
     } finally {
       shutdownAndAssertStoresInaccessible(mockStorageManager, localReplicas);
     }
@@ -379,8 +376,7 @@ public class StorageManagerTest {
         mockHelixParticipant.onPartitionBecomeOfflineFromInactive(testReplica.getPartitionId().toPathString());
         fail("should fail because of shutting down store failure");
       } catch (StateTransitionException e) {
-        assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaOperationFailure,
-            e.getErrorCode());
+        assertEquals("Error code doesn't match", ReplicaOperationFailure, e.getErrorCode());
         participantLatch.countDown();
       }
     }, false).start();


### PR DESCRIPTION
The major change in this PR is to implement Inactive-To-Offline logic
during the transition. Specfically, there are 3 steps to go:
1. set local store state to OFFLINE and initiate disconnection
2. wait until enough peer replicas have fully caught up with local
store (include DELETE/TTLUpdate records)
3. storage manager stop the store
4. (TODO) update instanceConfig in Helix (will be in a separate PR)
In addition, this PR also allows store to create a decommission file to
indicate if local store is in decommission process. This is to
distinguish such store from regular stores and it also helps failure
recovery.