### PR TITLE
Implement replica Offline-To-Dropped transition on server side

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/PartitionStateChangeListener.java
@@ -53,4 +53,10 @@ public interface PartitionStateChangeListener {
    * @param partitionName of the partition
    */
   void onPartitionBecomeOfflineFromInactive(String partitionName);
+
+  /**
+   * Action to take when partition becomes dropped from offline.
+   * @param partitionName of the partition.
+   */
+  void onPartitionBecomeDroppedFromOffline(String partitionName);
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartitionStateModel.java
@@ -98,8 +98,12 @@ public class AmbryPartitionStateModel extends StateModel {
 
   @Transition(to = "DROPPED", from = "OFFLINE")
   public void onBecomeDroppedFromOffline(Message message, NotificationContext context) {
-    logger.info("Partition {} in resource {} is becoming DROPPED from OFFLINE", message.getPartitionName(),
+    String partitionName = message.getPartitionName();
+    logger.info("Partition {} in resource {} is becoming DROPPED from OFFLINE", partitionName,
         message.getResourceName());
+    if (clusterMapConfig.clustermapEnableStateModelListener) {
+      partitionStateChangeListener.onPartitionBecomeDroppedFromOffline(partitionName);
+    }
   }
 
   @Transition(to = "DROPPED", from = "ERROR")

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -19,7 +19,6 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -166,7 +165,7 @@ public class ClusterMapUtils {
    */
   static List<String> getSealedReplicas(InstanceConfig instanceConfig) {
     List<String> sealedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
-    return sealedReplicas == null ? Collections.emptyList() : sealedReplicas;
+    return sealedReplicas == null ? new ArrayList<>() : sealedReplicas;
   }
 
   /**
@@ -177,7 +176,7 @@ public class ClusterMapUtils {
    */
   static List<String> getStoppedReplicas(InstanceConfig instanceConfig) {
     List<String> stoppedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.STOPPED_REPLICAS_STR);
-    return stoppedReplicas == null ? Collections.emptyList() : stoppedReplicas;
+    return stoppedReplicas == null ? new ArrayList<>() : stoppedReplicas;
   }
 
   /**
@@ -217,7 +216,6 @@ public class ClusterMapUtils {
     String http2PortStr = instanceConfig.getRecord().getSimpleField(HTTP2_PORT_STR);
     return http2PortStr == null ? null : Integer.valueOf(http2PortStr);
   }
-
 
   /**
    * Get the xid associated with this instance. The xid is like a timestamp or a change number, so if it is absent,

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -489,7 +489,6 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   }
 
   @Override
-<<<<<<< HEAD
   public void onPartitionBecomeInactiveFromStandby(String partitionName) {
     // 1. storage manager marks store local state as INACTIVE and disables compaction on this partition
     PartitionStateChangeListener storageManagerListener =
@@ -543,7 +542,9 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       storageManagerListener.onPartitionBecomeOfflineFromInactive(partitionName);
     }
     // 4. todo update instanceConfig in helix
-=======
+  }
+
+  @Override
   public void onPartitionBecomeDroppedFromOffline(String partitionName) {
     // 1. remove old replica from StatsManager
     PartitionStateChangeListener statsManagerListener =
@@ -563,6 +564,5 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     if (storageManagerListener != null) {
       storageManagerListener.onPartitionBecomeDroppedFromOffline(partitionName);
     }
->>>>>>> WIP: Implement replica Offline-To-Dropped transition on server side
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -489,6 +489,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   }
 
   @Override
+<<<<<<< HEAD
   public void onPartitionBecomeInactiveFromStandby(String partitionName) {
     // 1. storage manager marks store local state as INACTIVE and disables compaction on this partition
     PartitionStateChangeListener storageManagerListener =
@@ -542,5 +543,26 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       storageManagerListener.onPartitionBecomeOfflineFromInactive(partitionName);
     }
     // 4. todo update instanceConfig in helix
+=======
+  public void onPartitionBecomeDroppedFromOffline(String partitionName) {
+    // 1. remove old replica from StatsManager
+    PartitionStateChangeListener statsManagerListener =
+        partitionStateChangeListeners.get(StateModelListenerType.StatsManagerListener);
+    if (statsManagerListener != null) {
+      statsManagerListener.onPartitionBecomeDroppedFromOffline(partitionName);
+    }
+    // 2. remove old replica from ReplicationManager
+    PartitionStateChangeListener replicationManagerListener =
+        partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
+    if (replicationManagerListener != null) {
+      replicationManagerListener.onPartitionBecomeDroppedFromOffline(partitionName);
+    }
+    // 3. remove old replica from StorageManager and delete store directory
+    PartitionStateChangeListener storageManagerListener =
+        partitionStateChangeListeners.get(StateModelListenerType.StorageManagerListener);
+    if (storageManagerListener != null) {
+      storageManagerListener.onPartitionBecomeDroppedFromOffline(partitionName);
+    }
+>>>>>>> WIP: Implement replica Offline-To-Dropped transition on server side
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -333,8 +333,8 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     String partitionName = replicaId.getPartitionId().toPathString();
     List<String> stoppedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.STOPPED_REPLICAS_STR);
     List<String> sealedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
-    stoppedReplicas = stoppedReplicas == null ? Collections.emptyList() : stoppedReplicas;
-    sealedReplicas = sealedReplicas == null ? Collections.emptyList() : sealedReplicas;
+    stoppedReplicas = stoppedReplicas == null ? new ArrayList<>() : stoppedReplicas;
+    sealedReplicas = sealedReplicas == null ? new ArrayList<>() : sealedReplicas;
     if (stoppedReplicas.remove(partitionName) || sealedReplicas.remove(partitionName)) {
       logger.info("Removing partition {} from stopped and sealed list", partitionName);
       instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, stoppedReplicas);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixParticipant.java
@@ -328,8 +328,19 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
    */
   private boolean removeOldReplicaInfo(ReplicaId replicaId, InstanceConfig instanceConfig) {
     boolean removalResult = true;
-    boolean replicaFound = false;
+    boolean instanceConfigUpdated = false;
+    boolean replicaFound;
     String partitionName = replicaId.getPartitionId().toPathString();
+    List<String> stoppedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.STOPPED_REPLICAS_STR);
+    List<String> sealedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
+    stoppedReplicas = stoppedReplicas == null ? Collections.emptyList() : stoppedReplicas;
+    sealedReplicas = sealedReplicas == null ? Collections.emptyList() : sealedReplicas;
+    if (stoppedReplicas.remove(partitionName) || sealedReplicas.remove(partitionName)) {
+      logger.info("Removing partition {} from stopped and sealed list", partitionName);
+      instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, stoppedReplicas);
+      instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, sealedReplicas);
+      instanceConfigUpdated = true;
+    }
     Map<String, Map<String, String>> mountPathToDiskInfos = instanceConfig.getRecord().getMapFields();
     Map<String, String> diskInfo = mountPathToDiskInfos.get(replicaId.getMountPath());
     if (diskInfo != null) {
@@ -354,12 +365,14 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
           mountPathToDiskInfos.put(replicaId.getMountPath(), diskInfo);
           // update InstanceConfig
           instanceConfig.getRecord().setMapFields(mountPathToDiskInfos);
-          logger.info("Updating config: {} in Helix by removing partition {}", instanceConfig, partitionName);
-          removalResult = helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
+          instanceConfigUpdated = true;
         }
       }
     }
-    if (!replicaFound) {
+    if (instanceConfigUpdated) {
+      logger.info("Updating config: {} in Helix by removing partition {}", instanceConfig, partitionName);
+      removalResult = helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
+    } else {
       logger.warn("Partition {} is not found on instance {}, skipping removing it from InstanceConfig in Helix.",
           partitionName, instanceName);
     }
@@ -535,13 +548,12 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         throw e;
       }
     }
-    // 3. take actions in storage manager (stop the store)
+    // 3. take actions in storage manager (stop the store and update instanceConfig)
     PartitionStateChangeListener storageManagerListener =
         partitionStateChangeListeners.get(StateModelListenerType.StorageManagerListener);
     if (storageManagerListener != null) {
       storageManagerListener.onPartitionBecomeOfflineFromInactive(partitionName);
     }
-    // 4. todo update instanceConfig in helix
   }
 
   @Override

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/AmbryStateModelFactoryTest.java
@@ -76,7 +76,13 @@ public class AmbryStateModelFactoryTest {
         // no op
       }
 
+      @Override
       public void onPartitionBecomeOfflineFromInactive(String partitionName) {
+        // no op
+      }
+
+      @Override
+      public void onPartitionBecomeDroppedFromOffline(String partitionName) {
         // no op
       }
     });

--- a/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
@@ -387,6 +387,12 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
           partitionName);
     }
 
+    @Override
+    public void onPartitionBecomeDroppedFromOffline(String partitionName) {
+      logger.info("Partition state change notification from Offline to Dropped received for partition {}",
+          partitionName);
+    }
+
     /**
      * If only config specified list of partitions are being replicated from cloud, then check that the partition
      * belongs to the specified list.

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -304,5 +304,14 @@ public class ReplicationManager extends ReplicationEngine {
       store.setCurrentState(ReplicaState.OFFLINE);
       replicaSyncUpManager.initiateDisconnection(localReplica);
     }
+
+    @Override
+    public void onPartitionBecomeDroppedFromOffline(String partitionName) {
+      ReplicaId replica = storeManager.getReplica(partitionName);
+      // if code arrives here, we don't need to check if replica exists, it has been checked in StatsManager
+      // here we attempt to remove replica from replication manager. If replica doesn't exist, log info but don't fail
+      // the transition
+      removeReplica(replica);
+    }
   }
 }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -127,7 +127,7 @@ public class ReplicationManager extends ReplicationEngine {
    */
   public boolean addReplica(ReplicaId replicaId) {
     if (partitionToPartitionInfo.containsKey(replicaId.getPartitionId())) {
-      logger.error("{} already exists in replication manager, rejecting adding replica request.",
+      logger.error("Partition {} already exists in replication manager, rejecting adding replica request.",
           replicaId.getPartitionId());
       return false;
     }
@@ -137,11 +137,11 @@ public class ReplicationManager extends ReplicationEngine {
       remoteReplicaInfos = createRemoteReplicaInfos(peerReplicas, replicaId);
       updatePartitionInfoMaps(remoteReplicaInfos, replicaId);
     }
-    logger.info("Assigning thread for {}", replicaId.getPartitionId());
+    logger.info("Assigning thread for partition {}", replicaId.getPartitionId());
     addRemoteReplicaInfoToReplicaThread(remoteReplicaInfos, true);
     // No need to update persistor to explicitly persist tokens for new replica because background persistor will
     // periodically persist all tokens including new added replica's
-    logger.info("{} is successfully added into replication manager", replicaId.getPartitionId());
+    logger.info("Partition {} is successfully added into replication manager", replicaId.getPartitionId());
     return true;
   }
 
@@ -152,7 +152,7 @@ public class ReplicationManager extends ReplicationEngine {
    */
   public boolean removeReplica(ReplicaId replicaId) {
     if (!partitionToPartitionInfo.containsKey(replicaId.getPartitionId())) {
-      logger.error("{} doesn't exist in replication manager, skipping removing replica request.",
+      logger.error("Partition {} doesn't exist in replication manager, skipping removing replica request.",
           replicaId.getPartitionId());
       return false;
     }
@@ -165,7 +165,7 @@ public class ReplicationManager extends ReplicationEngine {
       return v;
     });
     partitionToPartitionInfo.remove(replicaId.getPartitionId());
-    logger.info("{} is successfully removed from replication manager", replicaId.getPartitionId());
+    logger.info("Partition {} is successfully removed from replication manager", replicaId.getPartitionId());
     return true;
   }
 

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
@@ -72,7 +72,7 @@ public class MockReplicationManager extends ReplicationManager {
         dataNodeId, storeKeyConverterFactory, null);
   }
 
-  MockReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
+  public MockReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
       StoreConfig storeConfig, StorageManager storageManager, ClusterMap clusterMap, DataNodeId dataNodeId,
       StoreKeyConverterFactory storeKeyConverterFactory, ClusterParticipant clusterParticipant)
       throws ReplicationException {

--- a/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
@@ -429,7 +429,7 @@ class StatsManager {
       ReplicaId replica = storageManager.getReplica(partitionName);
       if (replica == null) {
         throw new StateTransitionException("Replica " + partitionName + " is not found on current node",
-            StateTransitionException.TransitionErrorCode.ReplicaNotFound);
+            ReplicaNotFound);
       }
       // remove replica from in-mem data structure. If replica doesn't exist, log info but don't fail the transition
       removeReplica(replica);

--- a/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
@@ -422,5 +422,17 @@ class StatsManager {
       logger.info("Partition state change notification from Inactive to Offline received for partition {}",
           partitionName);
     }
+
+    @Override
+    public void onPartitionBecomeDroppedFromOffline(String partitionName) {
+      // check if partition exists
+      ReplicaId replica = storageManager.getReplica(partitionName);
+      if (replica == null) {
+        throw new StateTransitionException("Replica " + partitionName + " is not found on current node",
+            StateTransitionException.TransitionErrorCode.ReplicaNotFound);
+      }
+      // remove replica from in-mem data structure. If replica doesn't exist, log info but don't fail the transition
+      removeReplica(replica);
+    }
   }
 }

--- a/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/StatsManager.java
@@ -195,9 +195,9 @@ class StatsManager {
   boolean addReplica(ReplicaId id) {
     boolean success = partitionToReplicaMap.putIfAbsent(id.getPartitionId(), id) == null;
     if (success) {
-      logger.info(id.getPartitionId() + " is added into StatsManager");
+      logger.info("Partition " + id.getPartitionId() + " is added into StatsManager");
     } else {
-      logger.error("Failed to add " + id.getPartitionId() + " because it is already in StatsManager");
+      logger.error("Failed to add partition " + id.getPartitionId() + " because it is already in StatsManager");
     }
     return success;
   }
@@ -210,9 +210,9 @@ class StatsManager {
   boolean removeReplica(ReplicaId id) {
     boolean success = partitionToReplicaMap.remove(id.getPartitionId()) != null;
     if (success) {
-      logger.info(id.getPartitionId() + " is removed from StatsManager");
+      logger.info("Partition " + id.getPartitionId() + " is removed from StatsManager");
     } else {
-      logger.error("Failed to remove " + id.getPartitionId() + " because it doesn't exist in StatsManager");
+      logger.error("Failed to remove partition " + id.getPartitionId() + " because it doesn't exist in StatsManager");
     }
     return success;
   }

--- a/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
@@ -595,6 +595,12 @@ public class StatsManagerTest {
     ReplicaId replica = localReplicas.get(1);
     storageManager.shutdownBlobStore(replica.getPartitionId());
     clusterParticipant.onPartitionBecomeDroppedFromOffline(replica.getPartitionId().toPathString());
+    // verify that the replica is no longer present in StorageManager
+    assertNull("Store of removed replica should not exist", storageManager.getStore(replica.getPartitionId(), true));
+    // purposely remove the same replica in ReplicationManager again to verify it no longer exists
+    assertFalse("Should return false because replica no longer exists", mockReplicationManager.removeReplica(replica));
+    // purposely remove the same replica in StatsManager again to verify it no longer exists
+    assertFalse("Should return false because replica no longer exists", mockStatsManager.removeReplica(replica));
     storageManager.shutdown();
     mockStatsManager.shutdown();
   }

--- a/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
@@ -71,6 +71,7 @@ import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Test;
 
+import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
 import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
 
@@ -401,8 +402,7 @@ public class StatsManagerTest {
       clusterParticipant.onPartitionBecomeBootstrapFromOffline("InvalidPartition");
       fail("should fail because partition is not found");
     } catch (StateTransitionException e) {
-      assertEquals("Transition error doesn't match", StateTransitionException.TransitionErrorCode.ReplicaNotFound,
-          e.getErrorCode());
+      assertEquals("Transition error doesn't match", ReplicaNotFound, e.getErrorCode());
     }
     // 3. create a new partition and test replica addition failure
     PartitionId newPartition = new MockPartitionId(3, MockClusterMap.DEFAULT_PARTITION_CLASS,
@@ -413,8 +413,7 @@ public class StatsManagerTest {
       clusterParticipant.onPartitionBecomeBootstrapFromOffline(newPartition.toPathString());
       fail("should fail because adding replica to stats manager failed");
     } catch (StateTransitionException e) {
-      assertEquals("Transition error code doesn't match",
-          StateTransitionException.TransitionErrorCode.ReplicaOperationFailure, e.getErrorCode());
+      assertEquals("Transition error code doesn't match", ReplicaOperationFailure, e.getErrorCode());
     }
     // 4. test replica addition success during Offline-To-Bootstrap transition
     assertFalse("Before adding new replica, in-mem data structure should not contain new partition",
@@ -563,8 +562,7 @@ public class StatsManagerTest {
       clusterParticipant.onPartitionBecomeDroppedFromOffline("-1");
       fail("should fail because replica is not found");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaNotFound,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", ReplicaNotFound, e.getErrorCode());
     }
     // 2. attempt to remove replica while store is still running (remove store failure case)
     ReplicaId replicaToDrop = localReplicas.get(0);
@@ -572,8 +570,7 @@ public class StatsManagerTest {
       clusterParticipant.onPartitionBecomeDroppedFromOffline(replicaToDrop.getPartitionId().toPathString());
       fail("should fail because store is still running");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaOperationFailure,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", ReplicaOperationFailure, e.getErrorCode());
     }
     // 4. shutdown the store but introduce file deletion failure (put a invalid dir in store dir)
     storageManager.shutdownBlobStore(replicaToDrop.getPartitionId());
@@ -585,8 +582,7 @@ public class StatsManagerTest {
       clusterParticipant.onPartitionBecomeDroppedFromOffline(replicaToDrop.getPartitionId().toPathString());
       fail("should fail because store deletion fails");
     } catch (StateTransitionException e) {
-      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.ReplicaOperationFailure,
-          e.getErrorCode());
+      assertEquals("Error code doesn't match", ReplicaOperationFailure, e.getErrorCode());
     }
     // reset permission to allow deletion to succeed.
     assertTrue("Could not make readable", invalidDir.setReadable(true));

--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -510,7 +510,7 @@ public class StorageManager implements StoreManager {
           store.deleteStoreFiles();
         } catch (Exception e) {
           throw new StateTransitionException("Failed to delete directory for store " + partitionName,
-              StateTransitionException.TransitionErrorCode.ReplicaOperationFailure);
+              ReplicaOperationFailure);
         }
         // Remove store from sealed and stopped list (if present)
         logger.info("Removing store from sealed and stopped list(if present)");
@@ -518,7 +518,7 @@ public class StorageManager implements StoreManager {
         replicaStatusDelegate.unmarkStopped(Collections.singletonList(replica));
       } else {
         throw new StateTransitionException("Failed to remove store " + partitionName + " from storage manager",
-            StateTransitionException.TransitionErrorCode.ReplicaOperationFailure);
+            ReplicaOperationFailure);
       }
       partitionNameToReplicaId.remove(partitionName);
       logger.info("Partition {} is successfully dropped on current node", partitionName);

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -393,7 +393,7 @@ public class StorageManagerTest {
   }
 
   /**
-   * Test failure case when updating InstanceConfig in Helix after new replica is added in storage manager.
+   * Test failure cases when updating InstanceConfig in Helix for both Offline-To-Bootstrap and Inactive-To-Offline.
    */
   @Test
   public void updateInstanceConfigFailureTest() throws Exception {
@@ -409,7 +409,14 @@ public class StorageManagerTest {
     mockHelixParticipant.updateNodeInfoReturnVal = false;
     try {
       mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(newPartition.toPathString());
-      fail("should fail because updating InstanceConfig didn't succeed");
+      fail("should fail because updating InstanceConfig didn't succeed during Offline-To-Bootstrap");
+    } catch (StateTransitionException e) {
+      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.HelixUpdateFailure,
+          e.getErrorCode());
+    }
+    try {
+      mockHelixParticipant.onPartitionBecomeOfflineFromInactive(localReplicas.get(0).getPartitionId().toPathString());
+      fail("should fail because updating InstanceConfig didn't succeed during Inactive-To-Offline");
     } catch (StateTransitionException e) {
       assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.HelixUpdateFailure,
           e.getErrorCode());
@@ -419,7 +426,14 @@ public class StorageManagerTest {
     newPartition = clusterMap.createNewPartition(Collections.singletonList(localNode));
     try {
       mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(newPartition.toPathString());
-      fail("should fail because InstanceConfig is not found");
+      fail("should fail because InstanceConfig is not found during Offline-To-Bootstrap");
+    } catch (StateTransitionException e) {
+      assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.HelixUpdateFailure,
+          e.getErrorCode());
+    }
+    try {
+      mockHelixParticipant.onPartitionBecomeOfflineFromInactive(localReplicas.get(1).getPartitionId().toPathString());
+      fail("should fail because InstanceConfig is not found during Inactive-To-Offline");
     } catch (StateTransitionException e) {
       assertEquals("Error code doesn't match", StateTransitionException.TransitionErrorCode.HelixUpdateFailure,
           e.getErrorCode());


### PR DESCRIPTION
This PR implements the last step to remove old replica. Specifically, it
removes old replica from in-mem data structures (in StatsManager,
ReplicationManager and StorageManager). Also, during the transition, all
store files would be deleted in the end and seal/stop list in Helix
would be updated as well.