### PR TITLE
Make writable partition selection account for partitions with more than 3 replicas

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -216,6 +216,14 @@ public class ClusterMapConfig {
   @Config("clustermap.replica.catchup.target")
   public final int clustermapReplicaCatchupTarget;
 
+  /**
+   * The minimum number of replicas in local datacenter required for a partition to serve PUT request. This is used to
+   * get writable partitions for PUT operation. Any partition with replica count larger than or equal to this number is
+   * acceptable to be considered as a candidate.
+   */
+  @Config("clustermap.writable.partition.min.replica.count")
+  public final int clustermapWritablePartitionMinReplicaCount;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -261,5 +269,6 @@ public class ClusterMapConfig {
         verifiableProperties.getLongInRange("clustermap.replica.catchup.acceptable.lag.bytes", 0L, 0L, Long.MAX_VALUE);
     clustermapReplicaCatchupTarget =
         verifiableProperties.getIntInRange("clustermap.replica.catchup.target", 0, 0, Integer.MAX_VALUE);
+    clustermapWritablePartitionMinReplicaCount = verifiableProperties.getIntInRange("clustermap.writable.partition.min.replica.count", 3, 0, Integer.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -269,6 +269,7 @@ public class ClusterMapConfig {
         verifiableProperties.getLongInRange("clustermap.replica.catchup.acceptable.lag.bytes", 0L, 0L, Long.MAX_VALUE);
     clustermapReplicaCatchupTarget =
         verifiableProperties.getIntInRange("clustermap.replica.catchup.target", 0, 0, Integer.MAX_VALUE);
-    clustermapWritablePartitionMinReplicaCount = verifiableProperties.getIntInRange("clustermap.writable.partition.min.replica.count", 3, 0, Integer.MAX_VALUE);
+    clustermapWritablePartitionMinReplicaCount =
+        verifiableProperties.getIntInRange("clustermap.writable.partition.min.replica.count", 3, 0, Integer.MAX_VALUE);
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -368,6 +368,7 @@ public class ClusterMapUtils {
      */
     void updatePartitions(Collection<? extends PartitionId> allPartitions, String localDatacenterName) {
       this.allPartitions = allPartitions;
+      // todo when new partitions added into clustermap, dynamically update these two maps.
       partitionIdsByClassAndLocalReplicaCount = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
       partitionIdToLocalReplicas = new HashMap<>();
       for (PartitionId partition : allPartitions) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -436,7 +436,6 @@ public class ClusterMapUtils {
     PartitionId getRandomWritablePartition(String partitionClass, List<PartitionId> partitionsToExclude) {
       PartitionId anyWritablePartition = null;
       List<PartitionId> partitionsInClass = getPartitionsInClass(partitionClass, true);
-
       int workingSize = partitionsInClass.size();
       while (workingSize > 0) {
         int randomIndex = ThreadLocalRandom.current().nextInt(workingSize);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -329,7 +329,7 @@ class HelixBootstrapUpgradeUtil {
     } else {
       staticClusterMap = (new StaticClusterAgentsFactory(clusterMapConfig, new PartitionLayout(
           new HardwareLayout(new JSONObject(Utils.readStringFromFile(hardwareLayoutPath)), clusterMapConfig),
-          null))).getClusterMap();
+          clusterMapConfig))).getClusterMap();
     }
     String clusterNameInStaticClusterMap = staticClusterMap.partitionLayout.getClusterName();
     clusterName = clusterNamePrefix + clusterNameInStaticClusterMap;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -232,7 +232,8 @@ public class HelixClusterManager implements ClusterMap {
     }
     localDatacenterId = dcToDcZkInfo.get(clusterMapConfig.clusterMapDatacenterName).dcZkInfo.getDcId();
     partitionSelectionHelper =
-        new PartitionSelectionHelper(partitionMap.values(), clusterMapConfig.clusterMapDatacenterName);
+        new PartitionSelectionHelper(partitionMap.values(), clusterMapConfig.clusterMapDatacenterName,
+            clusterMapConfig.clustermapWritablePartitionMinReplicaCount);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.clustermap;
 
+import com.github.ambry.config.ClusterMapConfig;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -52,16 +53,16 @@ class PartitionLayout {
    * Create a PartitionLayout
    * @param hardwareLayout the {@link HardwareLayout} to use.
    * @param jsonObject the {@link JSONObject} that represents the partition layout
-   * @param localDatacenterName the name of the local datacenter. Can be {@code null}.
+   * @param clusterMapConfig the {@link ClusterMapConfig} to use.
    * @throws JSONException
    */
-  public PartitionLayout(HardwareLayout hardwareLayout, JSONObject jsonObject, String localDatacenterName)
+  public PartitionLayout(HardwareLayout hardwareLayout, JSONObject jsonObject, ClusterMapConfig clusterMapConfig)
       throws JSONException {
     if (logger.isTraceEnabled()) {
       logger.trace("PartitionLayout " + hardwareLayout + ", " + jsonObject.toString());
     }
     this.hardwareLayout = hardwareLayout;
-    this.localDatacenterName = localDatacenterName;
+    this.localDatacenterName = clusterMapConfig.clusterMapDatacenterName;
     this.clusterName = jsonObject.getString("clusterName");
     this.version = jsonObject.getLong("version");
     this.partitionMap = new HashMap<>();
@@ -70,26 +71,28 @@ class PartitionLayout {
     }
 
     validate();
-    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitionMap.values(), localDatacenterName);
+    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitionMap.values(), localDatacenterName,
+        clusterMapConfig.clustermapWritablePartitionMinReplicaCount);
   }
 
   /**
    * Constructor for initial PartitionLayout
    * @param hardwareLayout the {@link JSONObject} that represents the partition layout
-   * @param localDatacenterName the name of the local datacenter. Can be {@code null}.
+   * @param clusterMapConfig the {@link ClusterMapConfig} to use.
    */
-  public PartitionLayout(HardwareLayout hardwareLayout, String localDatacenterName) {
+  public PartitionLayout(HardwareLayout hardwareLayout, ClusterMapConfig clusterMapConfig) {
     if (logger.isTraceEnabled()) {
       logger.trace("PartitionLayout " + hardwareLayout);
     }
     this.hardwareLayout = hardwareLayout;
-    this.localDatacenterName = localDatacenterName;
+    this.localDatacenterName = clusterMapConfig.clusterMapDatacenterName;
     this.clusterName = hardwareLayout.getClusterName();
     this.version = 1;
     this.maxPartitionId = MinPartitionId;
     this.partitionMap = new HashMap<>();
     validate();
-    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitionMap.values(), localDatacenterName);
+    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitionMap.values(), localDatacenterName,
+        clusterMapConfig.clustermapWritablePartitionMinReplicaCount);
   }
 
   public HardwareLayout getHardwareLayout() {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterAgentsFactory.java
@@ -52,7 +52,7 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
       String partitionLayoutFilePath) throws JSONException, IOException {
     this(clusterMapConfig, new PartitionLayout(
         new HardwareLayout(new JSONObject(readStringFromFile(hardwareLayoutFilePath)), clusterMapConfig),
-        new JSONObject(readStringFromFile(partitionLayoutFilePath)), clusterMapConfig.clusterMapDatacenterName));
+        new JSONObject(readStringFromFile(partitionLayoutFilePath)), clusterMapConfig));
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -49,7 +49,6 @@ public class MockClusterMap implements ClusterMap {
   protected final Map<Long, PartitionId> partitions;
   protected final List<MockDataNodeId> dataNodes;
   protected final int numMountPointsPerNode;
-  private static final int MIN_LOCAL_REPLICA_COUNT_FOR_WRITE = 3;
   private final List<String> dataCentersInClusterMap = new ArrayList<>();
   private final Map<String, List<MockDataNodeId>> dcToDataNodes = new HashMap<>();
   private final ClusterMapUtils.PartitionSelectionHelper partitionSelectionHelper;
@@ -157,8 +156,14 @@ public class MockClusterMap implements ClusterMap {
     } else {
       specialPartition = null;
     }
+    // find a partition belong to DEFAULT_PARTITION_CLASS
+    PartitionId defaultPartition = partitions.values()
+        .stream()
+        .filter(p -> p.getPartitionClass().equals(DEFAULT_PARTITION_CLASS))
+        .findFirst()
+        .get();
     partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName,
-        MIN_LOCAL_REPLICA_COUNT_FOR_WRITE);
+        Math.min(defaultPartition.getReplicaIds().size(), 3));
   }
 
   /**
@@ -178,7 +183,7 @@ public class MockClusterMap implements ClusterMap {
     partitionIdList.forEach(p -> partitions.put(Long.valueOf(p.toPathString()), p));
     this.localDatacenterName = localDatacenterName;
     partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName,
-        MIN_LOCAL_REPLICA_COUNT_FOR_WRITE);
+        Math.min(partitionIdList.get(0).getReplicaIds().size(), 3));
     Set<String> dcNames = new HashSet<>();
     datanodes.forEach(node -> dcNames.add(node.getDatacenterName()));
     dataCentersInClusterMap.addAll(dcNames);
@@ -221,7 +226,7 @@ public class MockClusterMap implements ClusterMap {
     partitions.put(mockPartitionId.partition, mockPartitionId);
 
     partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName,
-        MIN_LOCAL_REPLICA_COUNT_FOR_WRITE);
+        Math.min(mockPartitionId.getReplicaIds().size(), 3));
     specialPartition = null;
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -49,6 +49,7 @@ public class MockClusterMap implements ClusterMap {
   protected final Map<Long, PartitionId> partitions;
   protected final List<MockDataNodeId> dataNodes;
   protected final int numMountPointsPerNode;
+  private static final int MIN_LOCAL_REPLICA_COUNT_FOR_WRITE = 3;
   private final List<String> dataCentersInClusterMap = new ArrayList<>();
   private final Map<String, List<MockDataNodeId>> dcToDataNodes = new HashMap<>();
   private final ClusterMapUtils.PartitionSelectionHelper partitionSelectionHelper;
@@ -156,7 +157,8 @@ public class MockClusterMap implements ClusterMap {
     } else {
       specialPartition = null;
     }
-    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName);
+    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName,
+        MIN_LOCAL_REPLICA_COUNT_FOR_WRITE);
   }
 
   /**
@@ -175,7 +177,8 @@ public class MockClusterMap implements ClusterMap {
     partitions = new HashMap<>();
     partitionIdList.forEach(p -> partitions.put(Long.valueOf(p.toPathString()), p));
     this.localDatacenterName = localDatacenterName;
-    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName);
+    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName,
+        MIN_LOCAL_REPLICA_COUNT_FOR_WRITE);
     Set<String> dcNames = new HashSet<>();
     datanodes.forEach(node -> dcNames.add(node.getDatacenterName()));
     dataCentersInClusterMap.addAll(dcNames);
@@ -217,7 +220,8 @@ public class MockClusterMap implements ClusterMap {
     recoveryReplica.setPeerReplicas(Collections.singletonList(vcrReplica));
     partitions.put(mockPartitionId.partition, mockPartitionId);
 
-    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName);
+    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitions.values(), localDatacenterName,
+        MIN_LOCAL_REPLICA_COUNT_FOR_WRITE);
     specialPartition = null;
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/StaticClusterManagerTest.java
@@ -13,9 +13,9 @@
  */
 package com.github.ambry.clustermap;
 
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
@@ -46,8 +46,17 @@ import static org.junit.Assert.*;
  * Tests {@link StaticClusterManager} class.
  */
 public class StaticClusterManagerTest {
+  private final ClusterMapConfig clusterMapConfig;
   @Rule
   public org.junit.rules.TemporaryFolder folder = new TemporaryFolder();
+
+  public StaticClusterManagerTest() {
+    Properties props = new Properties();
+    props.setProperty("clustermap.host.name", "localhost");
+    props.setProperty("clustermap.cluster.name", "cluster");
+    props.setProperty("clustermap.datacenter.name", "dc1");
+    clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+  }
 
   // Useful for understanding partition layout affect on free capacity across all hardware.
   public String freeCapacityDump(StaticClusterManager clusterMapManager, HardwareLayout hardwareLayout) {
@@ -159,7 +168,7 @@ public class StaticClusterManagerTest {
   @Test
   public void addNewPartition() {
     TestHardwareLayout testHardwareLayout = new TestHardwareLayout("Alpha");
-    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), null);
+    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), clusterMapConfig);
 
     StaticClusterManager clusterMapManager =
         (new StaticClusterAgentsFactory(getDummyConfig(), partitionLayout)).getClusterMap();
@@ -181,7 +190,7 @@ public class StaticClusterManagerTest {
     long replicaCapacityInBytes = 100 * 1024 * 1024 * 1024L;
 
     TestHardwareLayout testHardwareLayout = new TestHardwareLayout("Alpha");
-    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), null);
+    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), clusterMapConfig);
 
     StaticClusterManager clusterMapManager =
         (new StaticClusterAgentsFactory(getDummyConfig(), partitionLayout)).getClusterMap();
@@ -223,7 +232,7 @@ public class StaticClusterManagerTest {
     long replicaCapacityInBytes = 100 * 1024 * 1024 * 1024L;
 
     TestHardwareLayout testHardwareLayout = new TestHardwareLayout("Alpha", true);
-    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), null);
+    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), clusterMapConfig);
 
     StaticClusterManager clusterMapManager =
         (new StaticClusterAgentsFactory(getDummyConfig(), partitionLayout)).getClusterMap();
@@ -259,7 +268,7 @@ public class StaticClusterManagerTest {
     long replicaCapacityInBytes = 100 * 1024 * 1024 * 1024L;
 
     TestHardwareLayout testHardwareLayout = new TestHardwareLayout("Alpha", true);
-    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), null);
+    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), clusterMapConfig);
 
     StaticClusterManager clusterMapManager =
         (new StaticClusterAgentsFactory(getDummyConfig(), partitionLayout)).getClusterMap();
@@ -284,7 +293,7 @@ public class StaticClusterManagerTest {
   @Test
   public void capacities() {
     TestHardwareLayout testHardwareLayout = new TestHardwareLayout("Alpha");
-    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), null);
+    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), clusterMapConfig);
 
     StaticClusterManager clusterMapManager =
         (new StaticClusterAgentsFactory(getDummyConfig(), partitionLayout)).getClusterMap();
@@ -347,10 +356,9 @@ public class StaticClusterManagerTest {
     String hardwareLayoutDe = tmpDir + "/hardwareLayoutDe.json";
     String partitionLayoutDe = tmpDir + "/partitionLayoutDe.json";
 
-    StaticClusterManager clusterMapManagerSer = getTestClusterMap();
-    clusterMapManagerSer.persist(hardwareLayoutSer, partitionLayoutSer);
-
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+    StaticClusterManager clusterMapManagerSer = getTestClusterMap(clusterMapConfig);
+    clusterMapManagerSer.persist(hardwareLayoutSer, partitionLayoutSer);
 
     StaticClusterManager clusterMapManagerDe =
         (new StaticClusterAgentsFactory(clusterMapConfig, hardwareLayoutSer, partitionLayoutSer)).getClusterMap();
@@ -481,11 +489,6 @@ public class StaticClusterManagerTest {
    */
   @Test
   public void onReplicaEventTest() {
-    Properties props = new Properties();
-    props.setProperty("clustermap.host.name", "localhost");
-    props.setProperty("clustermap.cluster.name", "cluster");
-    props.setProperty("clustermap.datacenter.name", "dc1");
-    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
     TestHardwareLayout testHardwareLayout = new TestHardwareLayout("Alpha");
     TestPartitionLayout testPartitionLayout = new TestPartitionLayout(testHardwareLayout, null);
     ClusterMap clusterMapManager =

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -15,9 +15,9 @@ package com.github.ambry.clustermap;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.commons.ResponseHandler;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.server.ServerErrorCode;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -792,6 +792,7 @@ public class TestUtils {
     protected PartitionLayout partitionLayout;
     private JSONArray jsonPartitions;
     private long version;
+    private ClusterMapConfig clusterMapConfig;
 
     protected JSONObject makeJsonPartitionLayout() throws JSONException {
       return makeJsonPartitionLayout(DEFAULT_PARTITION_CLASS);
@@ -830,9 +831,14 @@ public class TestUtils {
       this.replicaCountPerDc = replicaCountPerDc;
 
       this.testHardwareLayout = testHardwareLayout;
-      this.partitionLayout =
-          new PartitionLayout(testHardwareLayout.getHardwareLayout(), makeJsonPartitionLayout(), localDc);
       this.dcCount = testHardwareLayout.getHardwareLayout().getDatacenterCount();
+      Properties props = new Properties();
+      props.setProperty("clustermap.host.name", "localhost");
+      props.setProperty("clustermap.cluster.name", "cluster");
+      props.setProperty("clustermap.datacenter.name", localDc == null ? "" : localDc);
+      clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+      this.partitionLayout =
+          new PartitionLayout(testHardwareLayout.getHardwareLayout(), makeJsonPartitionLayout(), clusterMapConfig);
     }
 
     public TestPartitionLayout(TestHardwareLayout testHardwareLayout, String localDc) throws JSONException {
@@ -844,7 +850,7 @@ public class TestUtils {
         throws JSONException {
       this.partitionCount += i;
       this.partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(),
-          updateJsonPartitionLayout(partitionClass, partitionState), localDc);
+          updateJsonPartitionLayout(partitionClass, partitionState), clusterMapConfig);
     }
 
     public PartitionLayout getPartitionLayout() {
@@ -910,10 +916,10 @@ public class TestUtils {
   }
 
   public static StaticClusterManager getTestClusterMap(int partitionCount, int replicaCountPerDatacenter,
-      long replicaCapacityInBytes) throws JSONException {
+      long replicaCapacityInBytes, ClusterMapConfig clusterMapConfig) throws JSONException {
 
     TestUtils.TestHardwareLayout testHardwareLayout = new TestHardwareLayout("Alpha");
-    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), null);
+    PartitionLayout partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), clusterMapConfig);
 
     StaticClusterManager clusterMapManager = new StaticClusterManager(partitionLayout, null, new MetricRegistry());
     List<PartitionId> allocatedPartitions;
@@ -925,12 +931,12 @@ public class TestUtils {
     return clusterMapManager;
   }
 
-  public static StaticClusterManager getTestClusterMap() throws JSONException {
+  public static StaticClusterManager getTestClusterMap(ClusterMapConfig clusterMapConfig) throws JSONException {
     int numPartitions = 5;
     int replicaCountPerDatacenter = 2;
     long replicaCapacityInBytes = 100 * 1024 * 1024 * 1024L;
 
-    return getTestClusterMap(numPartitions, replicaCountPerDatacenter, replicaCapacityInBytes);
+    return getTestClusterMap(numPartitions, replicaCountPerDatacenter, replicaCapacityInBytes, clusterMapConfig);
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/PutManagerTest.java
@@ -23,7 +23,6 @@ import com.github.ambry.commons.BlobId.BlobDataType;
 import com.github.ambry.commons.BlobIdFactory;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.CryptoServiceConfig;
 import com.github.ambry.config.KMSConfig;
 import com.github.ambry.config.RouterConfig;
@@ -35,6 +34,7 @@ import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.messageformat.MetadataContentSerDe;
 import com.github.ambry.notification.NotificationBlobType;
 import com.github.ambry.protocol.PutRequest;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
@@ -108,7 +108,9 @@ public class PutManagerTest {
   private static final int MAX_PORTS_PLAIN_TEXT = 3;
   private static final int MAX_PORTS_SSL = 3;
   private static final int CHECKOUT_TIMEOUT_MS = 1000;
-  private static final String LOCAL_DC = "DC1";
+  // here we set local dc to "DC3" because MockClusterMap uses DC3 as default local dc (where special class partition
+  // has 3 replicas)
+  private static final String LOCAL_DC = "DC3";
   private static final String EXTERNAL_ASSET_TAG = "ExternalAssetTag";
 
   /**

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -144,7 +144,6 @@ public class MockCluster {
    * @param recoveryNode The data node.
    * @param dcName Name of the datacenter.
    * @return {@link MockCluster} object.
-   * @throws IOException if an exception happens during cluster creation.
    */
   public static MockCluster createOneNodeRecoveryCluster(MockDataNodeId vcrNode, MockDataNodeId recoveryNode,
       String dcName) {

--- a/ambry-tools/src/main/java/com.github.ambry/clustermap/PartitionManager.java
+++ b/ambry-tools/src/main/java/com.github.ambry/clustermap/PartitionManager.java
@@ -127,7 +127,7 @@ public class PartitionManager {
       if (fileString == null) {
         manager = (new StaticClusterAgentsFactory(clusterMapConfig, new PartitionLayout(
             new HardwareLayout(new JSONObject(Utils.readStringFromFile(hardwareLayoutPath)), clusterMapConfig),
-            null))).getClusterMap();
+            clusterMapConfig))).getClusterMap();
       } else {
         manager =
             (new StaticClusterAgentsFactory(clusterMapConfig, hardwareLayoutPath, partitionLayoutPath)).getClusterMap();


### PR DESCRIPTION
Currently, selecting writable partition for PUT operation only picks partitions with highest local replica count. This will become a problem when "move replica" is rolled out. In the intermediate state of "move replica", particular partition may have 6 replicas and if we stick with current logic. All the write traffic will be routed to this particular partition. Hence, this PR we make changes to allow partition selection to pick partitions with replicas count >= min replica count(specified in
ClusterMapConfig). In most cases, min replica count = 3.