### PR TITLE
Patch blobID to ByteBuf for resource leaking purpose

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/ResponseInfo.java
@@ -14,6 +14,7 @@
 package com.github.ambry.network;
 
 import com.github.ambry.clustermap.DataNodeId;
+import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCountUtil;
 
 
@@ -82,6 +83,18 @@ public class ResponseInfo {
   public void release() {
     if (response != null) {
       ReferenceCountUtil.release(response);
+    }
+  }
+
+  /**
+   * Tries to call {@link ByteBuf#touch(Object)} if the specified message implements
+   * {@link ByteBuf}.  If the specified message doesn't implement {@link ByteBuf},
+   * this method does nothing.
+   * @param hint hint object.
+   */
+  public void touch(Object hint) {
+    if (response != null) {
+      ReferenceCountUtil.touch(response, hint);
     }
   }
 

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -241,6 +241,7 @@ class GetBlobOperation extends GetOperation {
    */
   @Override
   void handleResponse(ResponseInfo responseInfo, GetResponse getResponse) {
+    responseInfo.touch(blobId);
     GetChunk getChunk = correlationIdToGetChunk.remove(
         ((RequestOrResponse) responseInfo.getRequestInfo().getRequest()).getCorrelationId());
     getChunk.handleResponse(responseInfo, getResponse);


### PR DESCRIPTION
Use touch method to patch blob id to a bytebuf, so when printing out stack trace in resource leak detector, we can see which blob id causes this problem.