### PR TITLE
Introduce dynamic cluster change handler in HelixClusterManager

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -89,6 +89,13 @@ public class ClusterMapConfig {
   public final String clusterMapClusterAgentsFactory;
 
   /**
+   * The cluster change handler to use for Cluster Map.
+   */
+  @Config("clustermap.cluster.change.handler.type")
+  @Default("SimpleClusterChangeHandler")
+  public final String clusterMapClusterChangeHandlerType;
+
+  /**
    * Serialized json containing the information about all the zk hosts that the Helix based cluster manager should
    * be aware of. This information should be of the following form:
    *
@@ -252,6 +259,8 @@ public class ClusterMapConfig {
     clusterMapSslEnabledDatacenters = verifiableProperties.getString("clustermap.ssl.enabled.datacenters", "");
     clusterMapClusterAgentsFactory = verifiableProperties.getString("clustermap.clusteragents.factory",
         "com.github.ambry.clustermap.StaticClusterAgentsFactory");
+    clusterMapClusterChangeHandlerType =
+        verifiableProperties.getString("clustermap.cluster.change.handler.type", "SimpleClusterChangeHandler");
     clusterMapDcsZkConnectStrings = verifiableProperties.getString("clustermap.dcs.zk.connect.strings", "");
     clusterMapClusterName = verifiableProperties.getString("clustermap.cluster.name");
     clusterMapDatacenterName = verifiableProperties.getString("clustermap.datacenter.name");

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -274,7 +274,7 @@ class CompositeClusterManager implements ClusterMap {
     staticClusterManager.onReplicaEvent(replicaId, event);
     if (helixClusterManager != null) {
       AmbryReplica ambryReplica = helixClusterManager.getReplicaForPartitionOnNode(replicaId.getDataNodeId(),
-          replicaId.getPartitionId().toString());
+          replicaId.getPartitionId().toPathString());
       helixClusterManager.onReplicaEvent(ambryReplica, event);
     }
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
@@ -357,14 +357,6 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
     // update ambryDataNodeToAmbryReplicas map by adding "replicasFromConfig"
     ambryDataNodeToAmbryReplicas.put(instanceNameToAmbryDataNode.get(instanceName), replicasFromConfig);
     // Derive old replicas that are removed and delete them from partition
-/*    Set<AmbryReplica> previousReplicas = new HashSet<>(currentReplicasOnNode.values());
-    previousReplicas.removeAll(replicasFromConfig.values());
-    for (AmbryReplica ambryReplica : previousReplicas) {
-      logger.info("Removing replica {} from existing node {}", ambryReplica.getPartitionId().toPathString(),
-          instanceName);
-      clusterChangeHandlerCallback.removeReplicasFromPartition(ambryReplica.getPartitionId(),
-          Collections.singletonList(ambryReplica));
-    }*/
     currentReplicasOnNode.keySet()
         .stream()
         .filter(partitionName -> !replicasFromConfig.containsKey(partitionName))

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.spectator.RoutingTableSnapshot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+
+
+public class DynamicClusterChangeHandler implements ClusterChangeHandler {
+  private final String dcName;
+  private final Object notificationLock = new Object();
+  private final AtomicBoolean instanceConfigInitialized = new AtomicBoolean(false);
+  private final AtomicBoolean liveStateInitialized = new AtomicBoolean(false);
+  private final AtomicBoolean idealStateInitialized = new AtomicBoolean(false);
+  private final HelixClusterManagerMetrics helixClusterManagerMetrics;
+  private final AtomicLong sealedStateChangeCounter;
+  private final ConcurrentHashMap<String, Exception> initializationFailureMap;
+  private final ClusterMapConfig clusterMapConfig;
+  private final String selfInstanceName;
+  private final Map<String, Map<String, String>> partitionOverrideInfoMap;
+  private final HelixClusterManager.HelixClusterManagerCallback helixClusterManagerCallback;
+  private final HelixClusterManager.ClusterChangeHandlerCallback clusterChangeHandlerCallback;
+  private final CountDownLatch routingTableInitLatch = new CountDownLatch(1);
+  // A map whose key is ambry datanode and value is a map of partitionName to corresponding replica on this datanode
+  // Note: the partitionName (inner map key) comes from partitionId.toString() not partitionId.toPathString()
+  private final ConcurrentHashMap<AmbryDataNode, ConcurrentHashMap<String, AmbryReplica>> ambryDataNodeToAmbryReplicas =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<AmbryDataNode, Set<AmbryDisk>> ambryDataNodeToAmbryDisks = new ConcurrentHashMap<>();
+  private final AtomicLong errorCount = new AtomicLong(0);
+
+  private volatile ConcurrentHashMap<String, String> partitionNameToResource = new ConcurrentHashMap<>();
+  private AtomicReference<RoutingTableSnapshot> routingTableSnapshotRef = new AtomicReference<>();
+  private ConcurrentHashMap<String, AmbryDataNode> instanceNameToAmbryDataNode = new ConcurrentHashMap<>();
+  private static final Logger logger = LoggerFactory.getLogger(DynamicClusterChangeHandler.class);
+
+  DynamicClusterChangeHandler(ClusterMapConfig clusterMapConfig, String dcName, String selfInstanceName,
+      Map<String, Map<String, String>> partitionOverrideInfoMap,
+      HelixClusterManager.HelixClusterManagerCallback helixClusterManagerCallback,
+      HelixClusterManager.ClusterChangeHandlerCallback clusterChangeHandlerCallback,
+      HelixClusterManagerMetrics helixClusterManagerMetrics,
+      ConcurrentHashMap<String, Exception> initializationFailureMap, AtomicLong sealedStateChangeCounter) {
+    this.clusterMapConfig = clusterMapConfig;
+    this.dcName = dcName;
+    this.selfInstanceName = selfInstanceName;
+    this.partitionOverrideInfoMap = partitionOverrideInfoMap;
+    this.helixClusterManagerCallback = helixClusterManagerCallback;
+    this.clusterChangeHandlerCallback = clusterChangeHandlerCallback;
+    this.helixClusterManagerMetrics = helixClusterManagerMetrics;
+    this.initializationFailureMap = initializationFailureMap;
+    this.sealedStateChangeCounter = sealedStateChangeCounter;
+  }
+
+  /**
+   * Handle any {@link InstanceConfig} related change in current datacenter. Several events will trigger instance config
+   * change: (1) replica's seal or stop state has changed; (2) new node or new partition is added; (3) new replica is
+   * added to existing node; (4) old replica is removed from existing node; (5) data node is deleted from cluster.
+   * For now, {@link DynamicClusterChangeHandler} supports (1)~(4). We may consider supporting (5) in the future.
+   * @param configs all the {@link InstanceConfig}(s) in current data center. (Note that PreFetch is enabled by default
+   *                in Helix, which means all instance configs under "participants" ZNode will be sent to this method)
+   * @param changeContext the {@link NotificationContext} associated.
+   */
+  @Override
+  public void onInstanceConfigChange(List<InstanceConfig> configs, NotificationContext changeContext) {
+    try {
+      synchronized (notificationLock) {
+        if (!instanceConfigInitialized.get()) {
+          logger.info("Received initial notification for instance config change from {}", dcName);
+        } else {
+          logger.info("Instance config change triggered from {}", dcName);
+          logger.info("Detailed instance configs in {} are: {}", dcName, configs);
+        }
+//        logger.debug("Detailed instance configs in {} are: {}", dcName, configs);
+        try {
+          addOrUpdateInstanceInfos(configs);
+          instanceConfigInitialized.set(true);
+        } catch (Exception e) {
+          if (!instanceConfigInitialized.get()) {
+            logger.error("Exception occurred when initializing instances in {}: ", dcName, e);
+            initializationFailureMap.putIfAbsent(dcName, e);
+            instanceConfigInitialized.set(true);
+          } else {
+            logger.error("Exception occurred at runtime when handling instance config changes in {}: ", dcName, e);
+          }
+        }
+        sealedStateChangeCounter.incrementAndGet();
+        helixClusterManagerMetrics.instanceConfigChangeTriggerCount.inc();
+      }
+    } catch (Throwable t) {
+      errorCount.incrementAndGet();
+      throw t;
+    }
+  }
+
+  /**
+   * Triggered whenever the IdealState in current data center has changed (for now, it is usually updated by Helix
+   * Bootstrap tool).
+   * @param idealState a list of {@link IdealState} that specifies ideal location of replicas.
+   * @param changeContext the {@link NotificationContext} associated.
+   * @throws InterruptedException
+   */
+  @Override
+  public void onIdealStateChange(List<IdealState> idealState, NotificationContext changeContext)
+      throws InterruptedException {
+    if (!idealStateInitialized.get()) {
+      logger.info("Received initial notification for IdealState change from {}", dcName);
+      idealStateInitialized.set(true);
+    } else {
+      logger.info("IdealState change triggered from {}", dcName);
+    }
+    logger.debug("Detailed ideal states in {} are: {}", dcName, idealState);
+    // rebuild the entire partition-to-resource map in current dc
+    ConcurrentHashMap<String, String> partitionToResourceMap = new ConcurrentHashMap<>();
+    for (IdealState state : idealState) {
+      String resourceName = state.getResourceName();
+      state.getPartitionSet().forEach(partitionName -> partitionToResourceMap.put(partitionName, resourceName));
+    }
+    partitionNameToResource = partitionToResourceMap;
+    helixClusterManagerMetrics.idealStateChangeTriggerCount.inc();
+  }
+
+  /**
+   * Triggered whenever there is a change in the list of live instances.
+   * @param liveInstances the list of all live instances (not a change set) at the time of this call.
+   * @param changeContext the {@link NotificationContext} associated.
+   */
+  @Override
+  public void onLiveInstanceChange(List<LiveInstance> liveInstances, NotificationContext changeContext) {
+    try {
+      if (!liveStateInitialized.get()) {
+        logger.info("Received initial notification for live instance change from {}", dcName);
+        liveStateInitialized.set(true);
+      } else {
+        logger.info("Live instance change triggered from {}", dcName);
+      }
+      logger.debug("Detailed live instances in {} are: {}", dcName, liveInstances);
+      synchronized (notificationLock) {
+        updateInstanceLiveness(liveInstances);
+        helixClusterManagerMetrics.liveInstanceChangeTriggerCount.inc();
+      }
+    } catch (Throwable t) {
+      errorCount.incrementAndGet();
+      throw t;
+    }
+  }
+
+  /**
+   * Triggered whenever the state of replica in cluster has changed. The snapshot contains up-to-date state of all
+   * resources(replicas) in this data center.
+   * @param routingTableSnapshot a snapshot of routing table for this data center.
+   * @param context additional context associated with this change.
+   */
+  @Override
+  public void onRoutingTableChange(RoutingTableSnapshot routingTableSnapshot, Object context) {
+    routingTableSnapshotRef.getAndSet(routingTableSnapshot);
+    if (routingTableInitLatch.getCount() == 1) {
+      logger.info("Received initial notification for routing table change from {}", dcName);
+      routingTableInitLatch.countDown();
+    } else {
+      logger.info("Routing table change triggered from {}", dcName);
+    }
+    helixClusterManagerMetrics.routingTableChangeTriggerCount.inc();
+  }
+
+  @Override
+  public void setRoutingTableSnapshot(RoutingTableSnapshot routingTableSnapshot) {
+    routingTableSnapshotRef.getAndSet(routingTableSnapshot);
+  }
+
+  @Override
+  public RoutingTableSnapshot getRoutingTableSnapshot() {
+    return routingTableSnapshotRef.get();
+  }
+
+  @Override
+  public Map<AmbryDataNode, Set<AmbryDisk>> getDataNodeToDisksMap() {
+    return Collections.unmodifiableMap(ambryDataNodeToAmbryDisks);
+  }
+
+  @Override
+  public AmbryDataNode getDataNode(String instanceName) {
+    return instanceNameToAmbryDataNode.get(instanceName);
+  }
+
+  @Override
+  public AmbryReplica getReplicaId(AmbryDataNode ambryDataNode, String partitionName) {
+    return ambryDataNodeToAmbryReplicas.getOrDefault(ambryDataNode, new ConcurrentHashMap<>()).get(partitionName);
+  }
+
+  @Override
+  public List<AmbryReplica> getReplicaIds(AmbryDataNode ambryDataNode) {
+    return new ArrayList<>(ambryDataNodeToAmbryReplicas.get(ambryDataNode).values());
+  }
+
+  @Override
+  public List<AmbryDataNode> getAllDataNodes() {
+    return new ArrayList<>(instanceNameToAmbryDataNode.values());
+  }
+
+  @Override
+  public Set<AmbryDisk> getDisks(AmbryDataNode ambryDataNode) {
+    return ambryDataNodeToAmbryDisks.get(ambryDataNode);
+  }
+
+  @Override
+  public Map<String, String> getPartitionToResourceMap() {
+    return Collections.unmodifiableMap(partitionNameToResource);
+  }
+
+  @Override
+  public long getErrorCount() {
+    return errorCount.get();
+  }
+
+  @Override
+  public void waitForInitNotification() throws InterruptedException {
+    // wait slightly more than 5 mins to ensure routerUpdater refreshes the snapshot.
+    if (!routingTableInitLatch.await(320, TimeUnit.SECONDS)) {
+      throw new IllegalStateException("Initial routing table change from " + dcName + " didn't come within 5 mins");
+    }
+  }
+
+  /**
+   *
+   * @param instanceConfigs
+   * @throws Exception
+   */
+  private void addOrUpdateInstanceInfos(List<InstanceConfig> instanceConfigs) throws Exception {
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      int schemaVersion = getSchemaVersion(instanceConfig);
+      if (schemaVersion != 0) {
+        logger.error("Unknown InstanceConfig schema version: {}, ignoring.", schemaVersion);
+        continue;
+      }
+      if (instanceNameToAmbryDataNode.containsKey(instanceConfig.getInstanceName())) {
+        updateInstanceInfo(instanceConfig);
+      } else {
+        createNewInstance(instanceConfig);
+      }
+    }
+  }
+
+  /**
+   * Update info of an existing instance. This may happen in following cases: (1) new replica is added; (2) old replica
+   * is removed; (3) replica's state has changed (i.e. becomes seal/unseal).
+   * @param instanceConfig the {@link InstanceConfig} used to update info of instance.
+   */
+  private void updateInstanceInfo(InstanceConfig instanceConfig) throws Exception {
+    String instanceName = instanceConfig.getInstanceName();
+    logger.info("Updating replicas info for existing node {}", instanceName);
+    List<String> sealedReplicas = getSealedReplicas(instanceConfig);
+    List<String> stoppedReplicas = getStoppedReplicas(instanceConfig);
+    ConcurrentHashMap<String, AmbryReplica> currentReplicasOnNode =
+        ambryDataNodeToAmbryReplicas.get(instanceNameToAmbryDataNode.get(instanceName));
+    ConcurrentHashMap<String, AmbryReplica> replicasFromConfig = new ConcurrentHashMap<>();
+    Map<String, Map<String, String>> diskInfos = instanceConfig.getRecord().getMapFields();
+    for (Map.Entry<String, Map<String, String>> entry : diskInfos.entrySet()) {
+      String mountPath = entry.getKey();
+      Map<String, String> diskInfo = entry.getValue();
+      String replicasStr = diskInfo.get(ClusterMapUtils.REPLICAS_STR);
+      if (!replicasStr.isEmpty()) {
+        for (String replicaInfo : replicasStr.split(ClusterMapUtils.REPLICAS_DELIM_STR)) {
+          String[] info = replicaInfo.split(ClusterMapUtils.REPLICAS_STR_SEPARATOR);
+          // partition name and replica name are the same.
+          String partitionName = info[0];
+          if (currentReplicasOnNode.containsKey(partitionName)) {
+            // if replica is already present
+            AmbryReplica existingReplica = currentReplicasOnNode.get(partitionName);
+            // 1. directly add it into "replicasFromConfig" map
+            replicasFromConfig.put(partitionName, existingReplica);
+            // 2. update replica seal/stop state
+            updateReplicaStateAndOverrideIfNeeded(existingReplica, sealedReplicas, stoppedReplicas);
+          } else {
+            // if this is a new replica and doesn't exist on node
+            logger.info("Adding new replica {} to existing node {}", partitionName, instanceName);
+            long replicaCapacity = Long.valueOf(info[1]);
+            String partitionClass = info.length > 2 ? info[2] : clusterMapConfig.clusterMapDefaultPartitionClass;
+            AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instanceName);
+            AmbryDisk disk = ambryDataNodeToAmbryDisks.get(dataNode)
+                .stream()
+                .filter(d -> d.getMountPath().equals(mountPath))
+                .findFirst()
+                .get();
+            // this can be a brand new partition that is added to an existing node
+            AmbryPartition mappedPartition =
+                new AmbryPartition(Long.valueOf(partitionName), partitionClass, helixClusterManagerCallback);
+            // Ensure only one AmbryPartition instance exists for specific partition.
+            mappedPartition = clusterChangeHandlerCallback.addPartitionIfAbsent(mappedPartition, replicaCapacity);
+            ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, dataNode, replicaCapacity);
+            // create new replica belonging to this partition
+            AmbryReplica replica =
+                new AmbryReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
+                    replicaCapacity, sealedReplicas.contains(partitionName));
+            updateReplicaStateAndOverrideIfNeeded(replica, sealedReplicas, stoppedReplicas);
+            // add new created replica to "replicasFromConfig" map
+            replicasFromConfig.put(partitionName, replica);
+            // add new replica to specific partition
+            clusterChangeHandlerCallback.addReplicasToPartition(mappedPartition, Collections.singletonList(replica));
+          }
+        }
+      }
+    }
+    // update ambryDataNodeToAmbryReplicas map by adding "replicasFromConfig"
+    ambryDataNodeToAmbryReplicas.put(instanceNameToAmbryDataNode.get(instanceName), replicasFromConfig);
+    // compare replicasFromConfig with current replica set to derive old replicas that are removed
+    Set<AmbryReplica> previousReplicas = new HashSet<>(currentReplicasOnNode.values());
+    previousReplicas.removeAll(replicasFromConfig.values());
+    for (AmbryReplica ambryReplica : previousReplicas) {
+      logger.info("Removing replica {} from existing node {}", ambryReplica.getPartitionId().toPathString(),
+          instanceName);
+      clusterChangeHandlerCallback.removeReplicasFromPartition(ambryReplica.getPartitionId(),
+          Collections.singletonList(ambryReplica));
+    }
+  }
+
+  /**
+   *
+   * @param replica
+   * @param sealedReplicas
+   * @param stoppedReplicas
+   */
+  private void updateReplicaStateAndOverrideIfNeeded(AmbryReplica replica, List<String> sealedReplicas,
+      List<String> stoppedReplicas) {
+    String partitionName = replica.getPartitionId().toPathString();
+    boolean isSealed;
+    if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(partitionName)) {
+      isSealed = partitionOverrideInfoMap.get(partitionName)
+          .get(ClusterMapUtils.PARTITION_STATE)
+          .equals(ClusterMapUtils.READ_ONLY_STR);
+    } else {
+      isSealed = sealedReplicas.contains(partitionName);
+    }
+    replica.setSealedState(isSealed);
+    replica.setStoppedState(stoppedReplicas.contains(partitionName));
+  }
+
+  /**
+   *
+   * @param instanceConfig
+   * @throws Exception
+   */
+  private void createNewInstance(InstanceConfig instanceConfig) throws Exception {
+    String instanceName = instanceConfig.getInstanceName();
+    logger.info("Adding node {} and its disks and replicas", instanceName);
+    AmbryDataNode datanode =
+        new AmbryDataNode(getDcName(instanceConfig), clusterMapConfig, instanceConfig.getHostName(),
+            Integer.valueOf(instanceConfig.getPort()), getRackId(instanceConfig), getSslPortStr(instanceConfig),
+            getXid(instanceConfig), helixClusterManagerCallback);
+    // for new instance, we first set it to unavailable and rely on its participation to update its liveness
+    if (!instanceName.equals(selfInstanceName)) {
+      datanode.setState(HardwareState.UNAVAILABLE);
+    }
+    initializeDisksAndReplicasOnNode(datanode, instanceConfig);
+    instanceNameToAmbryDataNode.put(instanceName, datanode);
+  }
+
+  /**
+   *
+   * @param datanode
+   * @param instanceConfig
+   * @throws Exception
+   */
+  private void initializeDisksAndReplicasOnNode(AmbryDataNode datanode, InstanceConfig instanceConfig)
+      throws Exception {
+    List<String> sealedReplicas = getSealedReplicas(instanceConfig);
+    List<String> stoppedReplicas = getStoppedReplicas(instanceConfig);
+    ambryDataNodeToAmbryReplicas.put(datanode, new ConcurrentHashMap<>());
+    ambryDataNodeToAmbryDisks.put(datanode, new HashSet<>());
+    Map<String, Map<String, String>> diskInfos = instanceConfig.getRecord().getMapFields();
+    for (Map.Entry<String, Map<String, String>> entry : diskInfos.entrySet()) {
+      String mountPath = entry.getKey();
+      Map<String, String> diskInfo = entry.getValue();
+      HardwareState diskState =
+          diskInfo.get(DISK_STATE).equals(AVAILABLE_STR) ? HardwareState.AVAILABLE : HardwareState.UNAVAILABLE;
+      long capacityBytes = Long.valueOf(diskInfo.get(DISK_CAPACITY_STR));
+
+      // Create disk
+      AmbryDisk disk = new AmbryDisk(clusterMapConfig, datanode, mountPath, diskState, capacityBytes);
+      ambryDataNodeToAmbryDisks.get(datanode).add(disk);
+      clusterChangeHandlerCallback.addClusterWideRawCapacity(capacityBytes);
+
+      String replicasStr = diskInfo.get(ClusterMapUtils.REPLICAS_STR);
+      if (!replicasStr.isEmpty()) {
+        for (String replicaInfo : replicasStr.split(ClusterMapUtils.REPLICAS_DELIM_STR)) {
+          String[] info = replicaInfo.split(ClusterMapUtils.REPLICAS_STR_SEPARATOR);
+          // partition name and replica name are the same.
+          String partitionName = info[0];
+          long replicaCapacity = Long.valueOf(info[1]);
+          String partitionClass = info.length > 2 ? info[2] : clusterMapConfig.clusterMapDefaultPartitionClass;
+
+          AmbryPartition mappedPartition =
+              new AmbryPartition(Long.valueOf(partitionName), partitionClass, helixClusterManagerCallback);
+          // Ensure only one AmbryPartition instance exists for specific partition.
+          mappedPartition = clusterChangeHandlerCallback.addPartitionIfAbsent(mappedPartition, replicaCapacity);
+          ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, datanode, replicaCapacity);
+          // Create replica associated with this node and this partition
+          boolean isSealed = sealedReplicas.contains(partitionName);
+          if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(
+              partitionName)) {
+            // override sealed state if PartitionOverride is enabled.
+            isSealed = partitionOverrideInfoMap.get(partitionName)
+                .get(ClusterMapUtils.PARTITION_STATE)
+                .equals(ClusterMapUtils.READ_ONLY_STR);
+          }
+          AmbryReplica replica =
+              new AmbryReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
+                  replicaCapacity, isSealed);
+          ambryDataNodeToAmbryReplicas.get(datanode).put(mappedPartition.toPathString(), replica);
+          clusterChangeHandlerCallback.addReplicasToPartition(mappedPartition, Collections.singletonList(replica));
+        }
+      }
+    }
+  }
+
+  /**
+   * Update the liveness states of existing instances based on the input.
+   * @param liveInstances the list of instances that are up.
+   */
+  private void updateInstanceLiveness(List<LiveInstance> liveInstances) {
+    Set<String> liveInstancesSet = new HashSet<>();
+    liveInstances.forEach(e -> liveInstancesSet.add(e.getInstanceName()));
+    for (String instanceName : instanceNameToAmbryDataNode.keySet()) {
+      // Here we ignore live instance change it's about self instance. The reason is, during server's startup, current
+      // node should be AVAILABLE but the list of live instances doesn't include current node since it hasn't joined yet.
+      if (liveInstancesSet.contains(instanceName) || instanceName.equals(selfInstanceName)) {
+        instanceNameToAmbryDataNode.get(instanceName).setState(HardwareState.AVAILABLE);
+      } else {
+        instanceNameToAmbryDataNode.get(instanceName).setState(HardwareState.UNAVAILABLE);
+      }
+    }
+  }
+
+  /**
+   * Ensure that the given partition is absent on the given datanode. This is called as part of an inline validation
+   * done to ensure that two replicas of the same partition do not exist on the same datanode.
+   * @param partition the {@link AmbryPartition} to check.
+   * @param datanode the {@link AmbryDataNode} on which to check.
+   * @param expectedReplicaCapacity the capacity expected for the replicas of the partition.
+   */
+  private void ensurePartitionAbsenceOnNodeAndValidateCapacity(AmbryPartition partition, AmbryDataNode datanode,
+      long expectedReplicaCapacity) {
+    for (AmbryReplica replica : helixClusterManagerCallback.getReplicaIdsForPartition(partition)) {
+      if (replica.getDataNodeId().equals(datanode)) {
+        throw new IllegalStateException("Replica already exists on " + datanode + " for " + partition);
+      } else if (replica.getCapacityInBytes() != expectedReplicaCapacity) {
+        throw new IllegalStateException("Expected replica capacity " + expectedReplicaCapacity + " is different from "
+            + "the capacity of an existing replica " + replica.getCapacityInBytes());
+      }
+    }
+  }
+}

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
@@ -395,7 +395,7 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
     logger.info("Adding node {} and its disks and replicas", instanceName);
     AmbryDataNode datanode =
         new AmbryDataNode(getDcName(instanceConfig), clusterMapConfig, instanceConfig.getHostName(),
-            Integer.valueOf(instanceConfig.getPort()), getRackId(instanceConfig), getSslPortStr(instanceConfig),
+            Integer.valueOf(instanceConfig.getPort()), getRackId(instanceConfig), getSslPortStr(instanceConfig), null,
             getXid(instanceConfig), helixClusterManagerCallback);
     // for new instance, we first set it to unavailable and rely on its participation to update its liveness
     if (!instanceName.equals(selfInstanceName)) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
@@ -98,9 +98,8 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
           logger.info("Received initial notification for instance config change from {}", dcName);
         } else {
           logger.info("Instance config change triggered from {}", dcName);
-          logger.info("Detailed instance configs in {} are: {}", dcName, configs);
         }
-//        logger.debug("Detailed instance configs in {} are: {}", dcName, configs);
+        logger.debug("Detailed instance configs in {} are: {}", dcName, configs);
         try {
           addOrUpdateInstanceInfos(configs);
           instanceConfigInitialized.set(true);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -656,7 +656,12 @@ public class HelixClusterManager implements ClusterMap {
      * @param replicas list of {@link AmbryReplica} to be added.
      */
     void addReplicasToPartition(AmbryPartition partition, List<AmbryReplica> replicas) {
-      ambryPartitionToAmbryReplicas.computeIfAbsent(partition, k -> ConcurrentHashMap.newKeySet()).addAll(replicas);
+      AmbryPartition currentPartition = addPartitionIfAbsent(partition, replicas.get(0).getCapacityInBytes());
+      ambryPartitionToAmbryReplicas.compute(currentPartition, (k, v) -> {
+        // calling addPartitionIfAbsent guarantees that v is not null
+        v.addAll(replicas);
+        return v;
+      });
       clusterWideAllocatedRawCapacityBytes.getAndAdd(replicas.get(0).getCapacityInBytes() * replicas.size());
     }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
@@ -277,7 +277,7 @@ class PartitionLayout {
   }
 
   public List<String> getAllPartitionNames() {
-    return partitionMap.values().stream().map(partition -> partition.toPathString()).collect(Collectors.toList());
+    return partitionMap.values().stream().map(Partition::toPathString).collect(Collectors.toList());
   }
 
   @Override
@@ -285,7 +285,7 @@ class PartitionLayout {
     try {
       return toJSONObject().toString(2);
     } catch (JSONException e) {
-      logger.error("JSONException caught in toString: {}", e.getCause());
+      logger.error("JSONException caught in toString: ", e.getCause());
     }
     return null;
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
@@ -436,7 +436,7 @@ public class SimpleClusterChangeHandler implements ClusterChangeHandler {
               new AmbryReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
                   replicaCapacity, isSealed);
           ambryPartitionToAmbryReplicas.get(mappedPartition).add(replica);
-          ambryDataNodeToAmbryReplicas.get(datanode).put(mappedPartition.toString(), replica);
+          ambryDataNodeToAmbryReplicas.get(datanode).put(mappedPartition.toPathString(), replica);
         }
       }
     }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterChangeHandlerTest.java
@@ -298,7 +298,7 @@ public class ClusterChangeHandlerTest {
     nodesToHostNewPartition.addAll(Arrays.asList(localDcNode1, localDcNode2));
     nodesToHostNewPartition.addAll(Arrays.asList(remoteDcNode1, remoteDcNode2));
     nodesToHostNewPartition.addAll(newAddedNodes);
-    testPartitionLayout.addNewPartition(testHardwareLayout, nodesToHostNewPartition, DEFAULT_PARTITION_CLASS, localDc);
+    testPartitionLayout.addNewPartition(testHardwareLayout, nodesToHostNewPartition, DEFAULT_PARTITION_CLASS);
 
     // write new HardwareLayout and PartitionLayout into files
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
@@ -392,7 +392,7 @@ public class ClusterChangeHandlerTest {
         .get();
     DataNode nodeToAddReplica =
         localDatacenter.getDataNodes().stream().filter(node -> !localDcNodes.contains(node)).findFirst().get();
-    testPartitionLayout.addReplicaToPartition(nodeToAddReplica, testPartition, localDc);
+    testPartitionLayout.addReplicaToPartition(nodeToAddReplica, testPartition);
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
     // 3. We upgrade helix by adding new replica to the chosen node in local dc. This is to mock "replica addition" on
     //    chosen node and chosen node updates its instanceConfig in Helix. There should be 7 (= 6+1) replicas in the
@@ -411,7 +411,7 @@ public class ClusterChangeHandlerTest {
         .filter(r -> r.getDataNodeId().getDatacenterName().equals(localDc) && r.getDataNodeId() != nodeToAddReplica)
         .findFirst()
         .get();
-    testPartitionLayout.removeReplicaFromPartition(oldReplica, localDc);
+    testPartitionLayout.removeReplicaFromPartition(oldReplica);
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
     // 5. upgrade Helix again to mock one of the old replicas is removed and the node (where replica previously resides)
     //    updates the InstanceConfig in Helix. The number of replicas should become 6 again.

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterChangeHandlerTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.helix.ZNRecord;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+import static com.github.ambry.clustermap.HelixClusterManagerTest.*;
+import static com.github.ambry.clustermap.TestUtils.*;
+import static org.junit.Assert.*;
+
+
+/**
+ * Test {@link DynamicClusterChangeHandler} to verify its behavior is expected when handling cluster changes.
+ */
+@RunWith(Parameterized.class)
+public class ClusterChangeHandlerTest {
+  private final HashMap<String, com.github.ambry.utils.TestUtils.ZkInfo> dcsToZkInfo = new HashMap<>();
+  private final String[] dcs = new String[]{"DC0", "DC1"};
+  private final String clusterNameStatic = "ClusterChangeHandlerTest";
+  private final MockHelixCluster helixCluster;
+  private final String selfInstanceName;
+  private final String localDc;
+  private final String remoteDc;
+  private final boolean overrideEnabled;
+  private final String hardwareLayoutPath;
+  private final String partitionLayoutPath;
+  private final TestHardwareLayout testHardwareLayout;
+  private final TestPartitionLayout testPartitionLayout;
+  private final Map<String, Map<String, String>> partitionOverrideMap = new HashMap<>();
+  private final ZNRecord znRecord = new ZNRecord(PARTITION_OVERRIDE_STR);
+  private final HelixClusterManagerTest.MockHelixManagerFactory helixManagerFactory;
+  private final Properties props = new Properties();
+
+  @Parameterized.Parameters
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][]{{false}, {true}});
+  }
+
+  // set up a mock helix cluster, create separate HelixClusterManager with both Simple and Dynamic cluster change handler
+  public ClusterChangeHandlerTest(boolean overrideEnabled) throws Exception {
+    this.overrideEnabled = overrideEnabled;
+    File tempDir = Files.createTempDirectory("ClusterChangeHandlerTest-").toFile();
+    String tempDirPath = tempDir.getAbsolutePath();
+    tempDir.deleteOnExit();
+    hardwareLayoutPath = tempDirPath + File.separator + "hardwareLayoutTest.json";
+    partitionLayoutPath = tempDirPath + File.separator + "partitionLayoutTest.json";
+    String zkLayoutPath = tempDirPath + File.separator + "zkLayoutPath.json";
+    localDc = dcs[0];
+    remoteDc = dcs[1];
+    int basePort = 2300;
+    byte dcId = (byte) 0;
+    for (String dc : dcs) {
+      dcsToZkInfo.put(dc, new com.github.ambry.utils.TestUtils.ZkInfo(tempDirPath, dc, dcId++, basePort++, true));
+    }
+    JSONObject zkJson = constructZkLayoutJSON(dcsToZkInfo.values());
+    // initial partition count = 3, all three partitions are Read_Write
+    // cluster default setup:  6 nodes per data center. Each partition has 6 replicas (3 in local dc, 3 in remote dc)
+    testHardwareLayout = constructInitialHardwareLayoutJSON(clusterNameStatic);
+    testPartitionLayout = constructInitialPartitionLayoutJSON(testHardwareLayout, 3, localDc);
+    Utils.writeJsonObjectToFile(zkJson, zkLayoutPath);
+    Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
+    Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
+    // pick one partition to override its SEAL state (mark it Read_Only)
+    Random random = new Random();
+    int partitionIndexToOverride = random.nextInt(testPartitionLayout.getPartitionCount());
+    partitionOverrideMap.computeIfAbsent(String.valueOf(partitionIndexToOverride), k -> new HashMap<>())
+        .put(ClusterMapUtils.PARTITION_STATE, ClusterMapUtils.READ_ONLY_STR);
+    znRecord.setMapFields(partitionOverrideMap);
+    Map<String, ZNRecord> znRecordMap = new HashMap<>();
+    znRecordMap.put(PARTITION_OVERRIDE_ZNODE_PATH, znRecord);
+
+    DataNode currentNode = testHardwareLayout.getRandomDataNodeFromDc(localDc);
+    String hostname = currentNode.getHostname();
+    int portNum = currentNode.getPort();
+    selfInstanceName = getInstanceName(hostname, portNum);
+    props.setProperty("clustermap.host.name", hostname);
+    props.setProperty("clustermap.cluster.name", clusterNamePrefixInHelix + clusterNameStatic);
+    props.setProperty("clustermap.datacenter.name", localDc);
+    props.setProperty("clustermap.port", Integer.toString(portNum));
+    props.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
+    props.setProperty("clustermap.current.xid", Long.toString(CURRENT_XID));
+    props.setProperty("clustermap.enable.partition.override", Boolean.toString(overrideEnabled));
+    props.setProperty("clustermap.listen.cross.colo", Boolean.toString(true));
+    helixCluster =
+        new MockHelixCluster(clusterNamePrefixInHelix, hardwareLayoutPath, partitionLayoutPath, zkLayoutPath);
+    helixManagerFactory = new HelixClusterManagerTest.MockHelixManagerFactory(helixCluster, znRecordMap, null);
+  }
+
+  /**
+   * Close the zk servers.
+   */
+  @After
+  public void after() {
+//    if (clusterManager != null) {
+//      clusterManager.close();
+//    }
+    for (com.github.ambry.utils.TestUtils.ZkInfo zkInfo : dcsToZkInfo.values()) {
+      zkInfo.shutdown();
+    }
+  }
+
+  /**
+   * 1. test static initialization success case
+   * 2. verify live instance change is able to make node HardwareState.AVAILABLE
+   * 3. verify partition override behaves correctly (if enabled)
+   * 4. verify equivalence between {@link SimpleClusterChangeHandler} and {@link DynamicClusterChangeHandler} in terms of
+   *    in-memory cluster info.
+   * @throws Exception
+   */
+  @Test
+  public void initializationSuccessTest() throws Exception {
+    // After Helix bootstrap tool adds instances to cluster, MockHelixAdmin makes them up by default. Let's test a more
+    // realistic case where all instances are added but no node has participated yet. For dynamic cluster change handler,
+    // all instances in this case should be initialized to UNAVAILABLE. Until they have participated into cluster, the
+    // subsequent live instance changes will make them up.
+    helixCluster.bringAllInstancesDown();
+    ClusterMapConfig clusterMapConfig1 = new ClusterMapConfig(new VerifiableProperties(props));
+    HelixClusterManager managerWithSimpleHandler =
+        new HelixClusterManager(clusterMapConfig1, selfInstanceName, helixManagerFactory, new MetricRegistry());
+    Properties properties = new Properties();
+    properties.putAll(props);
+    properties.setProperty("clustermap.cluster.change.handler.type", "DynamicClusterChangeHandler");
+    ClusterMapConfig clusterMapConfig2 = new ClusterMapConfig(new VerifiableProperties(properties));
+    HelixClusterManager managerWithDynamicHandler =
+        new HelixClusterManager(clusterMapConfig2, selfInstanceName, helixManagerFactory, new MetricRegistry());
+    Set<String> partitionsInStaticMap = new HashSet<>(testPartitionLayout.getPartitionLayout().getAllPartitionNames());
+    Set<String> partitionsInSimpleHandler = managerWithSimpleHandler.getAllPartitionIds(null)
+        .stream()
+        .map(PartitionId::toPathString)
+        .collect(Collectors.toSet());
+    Set<String> partitionsInDynamicHandler = managerWithDynamicHandler.getAllPartitionIds(null)
+        .stream()
+        .map(PartitionId::toPathString)
+        .collect(Collectors.toSet());
+    assertEquals("Partitions from dynamic change handler don't match those in static layout", partitionsInStaticMap,
+        partitionsInDynamicHandler);
+    assertEquals("Partitions from two HelixClusterManagers don't match", partitionsInSimpleHandler,
+        partitionsInDynamicHandler);
+    // verify metrics in manager with simple handler and manager with dynamic handler are same
+    HelixClusterManager.HelixClusterManagerCallback dynamicHandlerCallback =
+        managerWithDynamicHandler.getManagerCallback();
+    HelixClusterManager.HelixClusterManagerCallback simpleHandlerCallback =
+        managerWithSimpleHandler.getManagerCallback();
+    assertEquals("Datacenter count doesn't match", simpleHandlerCallback.getDatacenterCount(),
+        dynamicHandlerCallback.getDatacenterCount());
+    assertEquals("Node count doesn't match", simpleHandlerCallback.getDatanodeCount(),
+        dynamicHandlerCallback.getDatanodeCount());
+    assertEquals("Disk count doesn't match", simpleHandlerCallback.getDiskCount(),
+        dynamicHandlerCallback.getDiskCount());
+    assertEquals("Sealed count doesn't match", simpleHandlerCallback.getPartitionSealedCount(),
+        dynamicHandlerCallback.getPartitionSealedCount());
+    assertEquals("Raw capacity doesn't match", simpleHandlerCallback.getRawCapacity(),
+        dynamicHandlerCallback.getRawCapacity());
+    assertEquals("Allocated raw capacity doesn't match", simpleHandlerCallback.getAllocatedRawCapacity(),
+        dynamicHandlerCallback.getAllocatedRawCapacity());
+    assertEquals("Allocated usable capacity doesn't match", simpleHandlerCallback.getAllocatedUsableCapacity(),
+        dynamicHandlerCallback.getAllocatedUsableCapacity());
+
+    // verify that all nodes (except for current node) are down in HelixClusterManager with dynamic cluster change handler
+    assertEquals("All nodes (except for self node) should be down", helixCluster.getDownInstances().size() - 1,
+        dynamicHandlerCallback.getDownDatanodesCount());
+
+    // then we bring all instances up and trigger live instance change again
+    helixCluster.bringAllInstancesUp();
+    // verify all nodes are up now up
+    assertEquals("All nodes should be up now", 0, dynamicHandlerCallback.getDownDatanodesCount());
+    // verify partition override, for now we have 3 partitions and one of them is overridden to Read_Only (if enabled)
+    int partitionCnt = testPartitionLayout.getPartitionCount();
+    assertEquals("Number of writable partitions is not correct", overrideEnabled ? partitionCnt - 1 : partitionCnt,
+        dynamicHandlerCallback.getPartitionReadWriteCount());
+    // close helix cluster managers
+    managerWithDynamicHandler.close();
+    managerWithSimpleHandler.close();
+  }
+
+  /**
+   * Test failure case when initializing {@link HelixClusterManager} with dynamic cluster change handler
+   */
+  @Test
+  public void initializationFailureTest() {
+    // save current local dc for restore purpose
+    int savedport = dcsToZkInfo.get(localDc).getPort();
+    // mock local dc connectivity issue
+    dcsToZkInfo.get(localDc).setPort(0);
+    JSONObject invalidZkJson = constructZkLayoutJSON(dcsToZkInfo.values());
+    Properties properties = new Properties();
+    properties.putAll(props);
+    properties.setProperty("clustermap.dcs.zk.connect.strings", invalidZkJson.toString(2));
+    properties.setProperty("clustermap.cluster.change.handler.type", "DynamicClusterChangeHandler");
+    ClusterMapConfig invalidClusterMapConfig = new ClusterMapConfig(new VerifiableProperties(properties));
+    MetricRegistry metricRegistry = new MetricRegistry();
+    try {
+      new HelixClusterManager(invalidClusterMapConfig, selfInstanceName, helixManagerFactory, metricRegistry);
+      fail("Instantiation with dynamic cluster change handler should fail due to connection issue to zk");
+    } catch (IOException e) {
+      assertEquals(1L,
+          metricRegistry.getGauges().get(HelixClusterManager.class.getName() + ".instantiationFailed").getValue());
+      assertEquals(1L, metricRegistry.getGauges()
+          .get(HelixClusterManager.class.getName() + ".instantiationExceptionCount")
+          .getValue());
+    }
+    // restore original setup
+    dcsToZkInfo.get(localDc).setPort(savedport);
+  }
+
+  /**
+   * Test new instances/partitions are added to cluster dynamically. {@link HelixClusterManager} with
+   * {@link DynamicClusterChangeHandler} should absorb the change and update in-mem cluster map.
+   * 1. add new instances
+   * 2. add new partition onto new instance
+   * 3. add new partition onto existing instance
+   */
+  @Test
+  public void addNewInstancesAndPartitionsTest() throws Exception {
+    // create a HelixClusterManager with DynamicClusterChangeHandler
+    Properties properties = new Properties();
+    properties.putAll(props);
+    properties.setProperty("clustermap.cluster.change.handler.type", "DynamicClusterChangeHandler");
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(properties));
+    HelixClusterManager helixClusterManager =
+        new HelixClusterManager(clusterMapConfig, selfInstanceName, helixManagerFactory, new MetricRegistry());
+    // before adding new instances, let's first ensure current number of nodes is correct.
+    List<DataNode> dataNodesInLayout = new ArrayList<>();
+    testHardwareLayout.getHardwareLayout().getDatacenters().forEach(dc -> dataNodesInLayout.addAll(dc.getDataNodes()));
+    assertEquals("Number of data nodes is not expected", dataNodesInLayout.size(),
+        helixClusterManager.getDataNodeIds().size());
+
+    // pick up 2 existing nodes from each dc
+    List<DataNode> nodesToHostNewPartition = new ArrayList<>();
+    DataNode localDcNode1 = testHardwareLayout.getRandomDataNodeFromDc(localDc);
+    DataNode localDcNode2;
+    do {
+      localDcNode2 = testHardwareLayout.getRandomDataNodeFromDc(localDc);
+    } while (localDcNode1 == localDcNode2);
+    DataNode remoteDcNode1 = testHardwareLayout.getRandomDataNodeFromDc(remoteDc);
+    DataNode remoteDcNode2;
+    do {
+      remoteDcNode2 = testHardwareLayout.getRandomDataNodeFromDc(remoteDc);
+    } while (remoteDcNode1 == remoteDcNode2);
+
+    System.out.println("Initial partition count = " + testPartitionLayout.getPartitionCount());
+
+    // add a new node into static layout
+    testHardwareLayout.addNewDataNodes(1);
+    // add a new partition to static layout and put its replicas to both existing nodes and new node
+    List<DataNode> newAddedNodes = new ArrayList<>();
+    testHardwareLayout.getHardwareLayout().getDatacenters().forEach(dc -> newAddedNodes.addAll(dc.getDataNodes()));
+    newAddedNodes.removeAll(dataNodesInLayout);
+    // pick 2 existing nodes and 1 new node from each dc to place replica of new partition
+    nodesToHostNewPartition.addAll(Arrays.asList(localDcNode1, localDcNode2));
+    nodesToHostNewPartition.addAll(Arrays.asList(remoteDcNode1, remoteDcNode2));
+    nodesToHostNewPartition.addAll(newAddedNodes);
+    testPartitionLayout.addNewPartition(testHardwareLayout, nodesToHostNewPartition, DEFAULT_PARTITION_CLASS, localDc);
+
+    // write new HardwareLayout and PartitionLayout into files
+    Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
+    Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
+    // this triggers a InstanceConfig change notification.
+    // In each dc, 2 existing instance configs are updated and 1 new instance is added as well as 1 new partition
+    helixCluster.upgradeWithNewHardwareLayout(hardwareLayoutPath);
+
+    // verify after InstanceConfig change, HelixClusterManager contains the one more node per dc.
+    assertEquals("Number of data nodes after instance addition is not correct",
+        testHardwareLayout.getAllExistingDataNodes().size(), helixClusterManager.getDataNodeIds().size());
+    System.out.println("Current partition count = " + testPartitionLayout.getPartitionCount());
+    // verify number of partitions in cluster manager has increased by 1
+    assertEquals("Number of partitions after partition addition is not correct",
+        testPartitionLayout.getPartitionCount(), helixClusterManager.getAllPartitionIds(null).size());
+
+    helixClusterManager.close();
+  }
+}

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -66,12 +66,13 @@ import static org.junit.Assume.*;
  */
 @RunWith(Parameterized.class)
 public class HelixClusterManagerTest {
+  static final long CURRENT_XID = 64;
+  static final String clusterNamePrefixInHelix = "Ambry-";
   private final HashMap<String, com.github.ambry.utils.TestUtils.ZkInfo> dcsToZkInfo = new HashMap<>();
   private final String[] dcs = new String[]{"DC0", "DC1"};
-  private final TestUtils.TestHardwareLayout testHardwareLayout;
+  private final TestHardwareLayout testHardwareLayout;
   private final TestPartitionLayout testPartitionLayout;
   private final String clusterNameStatic = "HelixClusterManagerTestCluster";
-  private final String clusterNamePrefixInHelix = "Ambry-";
   private final ClusterMapConfig clusterMapConfig;
   private final MockHelixCluster helixCluster;
   private final String hostname;
@@ -88,7 +89,6 @@ public class HelixClusterManagerTest {
   private final boolean listenCrossColo;
   private final String hardwareLayoutPath;
   private final String partitionLayoutPath;
-  private static final long CURRENT_XID = 64;
 
   // for verifying getPartitions() and getWritablePartitions()
   private static final String SPECIAL_PARTITION_CLASS = "specialPartitionClass";
@@ -1398,7 +1398,7 @@ public class HelixClusterManagerTest {
   /**
    * A Mock implementation of {@link HelixFactory} that returns the {@link MockHelixManager}
    */
-  private static class MockHelixManagerFactory extends HelixFactory {
+  static class MockHelixManagerFactory extends HelixFactory {
     private final MockHelixCluster helixCluster;
     private final Exception beBadException;
     private final Map<String, ZNRecord> znRecordMap;

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -226,6 +226,15 @@ public class MockHelixCluster {
     }
   }
 
+  /**
+   * Trigger ideal state change in each dc to refresh in-mem resource-partition mapping
+   */
+  void refreshIdealState() throws Exception {
+    for (MockHelixAdmin helixAdmin : helixAdmins.values()) {
+      helixAdmin.triggerIdealStateChangeNotification();
+    }
+  }
+
   void addNewResource(String resourceName, IdealState idealState, String dcName) throws Exception {
     MockHelixAdmin helixAdmin = helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStr());
     helixAdmin.addNewResource(resourceName, idealState);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -865,6 +865,27 @@ public class TestUtils {
           updateJsonPartitionLayout(partitionClass, partitionState), clusterMapConfig);
     }
 
+    void addNewPartition(TestHardwareLayout testHardwareLayout, List<DataNode> dataNodes, String partitionClass,
+        String localDc) {
+      this.partitionCount += 1;
+      this.partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(),
+          addPartitionAndUpdateJsonPartitionLayout(partitionClass, dataNodes), localDc);
+    }
+
+    private JSONObject addPartitionAndUpdateJsonPartitionLayout(String partitionClass, List<DataNode> dataNodes) {
+      version += 1;
+      int nextPartitionIndex = jsonPartitions.length();
+      List<Disk> disksToPlaceNewPartition = new ArrayList<>();
+      Random random = new Random();
+      dataNodes.forEach(
+          node -> disksToPlaceNewPartition.add(node.getDisks().get(random.nextInt(node.getDisks().size()))));
+      JSONArray jsonReplicas = TestUtils.getJsonArrayReplicas(disksToPlaceNewPartition);
+      jsonPartitions.put(
+          getJsonPartition(nextPartitionIndex, partitionClass, partitionState, replicaCapacityInBytes, jsonReplicas));
+      return getJsonPartitionLayout(testHardwareLayout.getHardwareLayout().getClusterName(), version, partitionCount,
+          jsonPartitions);
+    }
+
     public PartitionLayout getPartitionLayout() {
       return partitionLayout;
     }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -872,12 +872,66 @@ public class TestUtils {
           addPartitionAndUpdateJsonPartitionLayout(partitionClass, dataNodes), localDc);
     }
 
-    private JSONObject addPartitionAndUpdateJsonPartitionLayout(String partitionClass, List<DataNode> dataNodes) {
+    void removeReplicaFromPartition(Replica replicaToRemove, String localDc) {
+      version += 1;
+      String partitionName = replicaToRemove.getPartitionId().toPathString();
+      int index;
+      for (index = 0; index < jsonPartitions.length(); ++index) {
+        String partitionId = String.valueOf(((JSONObject) jsonPartitions.get(index)).get("id"));
+        if (partitionId.equals(partitionName)) {
+          break;
+        }
+      }
+      JSONObject jsonPartition = (JSONObject) jsonPartitions.get(index);
+      JSONArray jsonReplicas = (JSONArray) jsonPartition.get("replicas");
+      int replicaIdx;
+      DataNode targetNode = (DataNode) replicaToRemove.getDataNodeId();
+      for (replicaIdx = 0; replicaIdx < jsonReplicas.length(); ++replicaIdx) {
+        JSONObject jsonReplica = (JSONObject) jsonReplicas.get(replicaIdx);
+        String hostname = (String) jsonReplica.get("hostname");
+        int port = (int) jsonReplica.get("port");
+        if (hostname.equals(targetNode.getHostname()) && port == targetNode.getPort()) {
+          break;
+        }
+      }
+      // remove given replica from replicas
+      jsonReplicas.remove(replicaIdx);
+      jsonPartition.put("replicas", jsonReplicas);
+      jsonPartitions.put(index, jsonPartition);
+      JSONObject jsonPartitionLayout =
+          getJsonPartitionLayout(testHardwareLayout.getHardwareLayout().getClusterName(), version, partitionCount,
+              jsonPartitions);
+      this.partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), jsonPartitionLayout, localDc);
+    }
+
+    void addReplicaToPartition(DataNode newReplicaNode, Partition partition, String localDc) {
+      version += 1;
+      int index;
+      for (index = 0; index < jsonPartitions.length(); ++index) {
+        String partitionId = String.valueOf(((JSONObject) jsonPartitions.get(index)).get("id"));
+        if (partitionId.equals(partition.toPathString())) {
+          break;
+        }
+      }
+      JSONObject jsonPartition = (JSONObject) jsonPartitions.get(index);
+      JSONArray jsonReplicas = (JSONArray) jsonPartition.get("replicas");
+      List<Disk> disks = newReplicaNode.getDisks();
+      jsonReplicas.put(getJsonReplica(disks.get((new Random()).nextInt(disks.size()))));
+      jsonPartition.put("replicas", jsonReplicas);
+      jsonPartitions.put(index, jsonPartition);
+      JSONObject jsonPartitionLayout =
+          getJsonPartitionLayout(testHardwareLayout.getHardwareLayout().getClusterName(), version, partitionCount,
+              jsonPartitions);
+      this.partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), jsonPartitionLayout, localDc);
+    }
+
+    private JSONObject addPartitionAndUpdateJsonPartitionLayout(String partitionClass,
+        List<DataNode> nodesToHostNewPartition) {
       version += 1;
       int nextPartitionIndex = jsonPartitions.length();
       List<Disk> disksToPlaceNewPartition = new ArrayList<>();
       Random random = new Random();
-      dataNodes.forEach(
+      nodesToHostNewPartition.forEach(
           node -> disksToPlaceNewPartition.add(node.getDisks().get(random.nextInt(node.getDisks().size()))));
       JSONArray jsonReplicas = TestUtils.getJsonArrayReplicas(disksToPlaceNewPartition);
       jsonPartitions.put(

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -865,14 +865,13 @@ public class TestUtils {
           updateJsonPartitionLayout(partitionClass, partitionState), clusterMapConfig);
     }
 
-    void addNewPartition(TestHardwareLayout testHardwareLayout, List<DataNode> dataNodes, String partitionClass,
-        String localDc) {
-      this.partitionCount += 1;
-      this.partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(),
-          addPartitionAndUpdateJsonPartitionLayout(partitionClass, dataNodes), localDc);
+    void addNewPartition(TestHardwareLayout testHardwareLayout, List<DataNode> dataNodes, String partitionClass) {
+      partitionCount += 1;
+      partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(),
+          addPartitionAndUpdateJsonPartitionLayout(partitionClass, dataNodes), clusterMapConfig);
     }
 
-    void removeReplicaFromPartition(Replica replicaToRemove, String localDc) {
+    void removeReplicaFromPartition(Replica replicaToRemove) {
       version += 1;
       String partitionName = replicaToRemove.getPartitionId().toPathString();
       int index;
@@ -901,10 +900,11 @@ public class TestUtils {
       JSONObject jsonPartitionLayout =
           getJsonPartitionLayout(testHardwareLayout.getHardwareLayout().getClusterName(), version, partitionCount,
               jsonPartitions);
-      this.partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), jsonPartitionLayout, localDc);
+      this.partitionLayout =
+          new PartitionLayout(testHardwareLayout.getHardwareLayout(), jsonPartitionLayout, clusterMapConfig);
     }
 
-    void addReplicaToPartition(DataNode newReplicaNode, Partition partition, String localDc) {
+    void addReplicaToPartition(DataNode newReplicaNode, Partition partition) {
       version += 1;
       int index;
       for (index = 0; index < jsonPartitions.length(); ++index) {
@@ -922,7 +922,8 @@ public class TestUtils {
       JSONObject jsonPartitionLayout =
           getJsonPartitionLayout(testHardwareLayout.getHardwareLayout().getClusterName(), version, partitionCount,
               jsonPartitions);
-      this.partitionLayout = new PartitionLayout(testHardwareLayout.getHardwareLayout(), jsonPartitionLayout, localDc);
+      this.partitionLayout =
+          new PartitionLayout(testHardwareLayout.getHardwareLayout(), jsonPartitionLayout, clusterMapConfig);
     }
 
     private JSONObject addPartitionAndUpdateJsonPartitionLayout(String partitionClass,

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
@@ -98,6 +98,7 @@ public class AmbryServerRequests extends AmbryRequests {
       requestsDisableInfo.put(requestType, Collections.newSetFromMap(new ConcurrentHashMap<>()));
     }
     localPartitionToReplicaMap = createLocalPartitionToReplicaMap();
+    // TODO add callback from clustermap in this class once instanceInfo related to current node has changed
   }
 
   /**


### PR DESCRIPTION
Dynamic cluster change handler is another implementation of cluster change handler. Unlike simple cluster change handler which only create instance/partition/replica during initialization, dynamic cluster change handler supports adding new partition/node/replica at runtime. Also it supports removing replica from existing node. With this change, spectators in cluster are able to update membership list of instances/partitions and location of replicas without reboot. Moreover, the cluster metrics are also updated at runtime (i.e. cluster wide capacity, number of partitions etc)