### PR TITLE
Add http2 port support in HelixBootstrapTool

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -61,7 +61,8 @@ public class ClusterMapUtils {
   static final String REPLICAS_DELIM_STR = ",";
   static final String REPLICAS_STR_SEPARATOR = ":";
   static final String REPLICAS_CAPACITY_STR = "replicaCapacityInBytes";
-  static final String SSLPORT_STR = "sslPort";
+  static final String SSL_PORT_STR = "sslPort";
+  static final String HTTP2_PORT_STR = "http2Port";
   static final String RACKID_STR = "rackId";
   static final String SEALED_STR = "SEALED";
   static final String STOPPED_REPLICAS_STR = "STOPPED";
@@ -203,9 +204,20 @@ public class ClusterMapUtils {
    * @return the ssl port associated with the given instance.
    */
   public static Integer getSslPortStr(InstanceConfig instanceConfig) {
-    String sslPortStr = instanceConfig.getRecord().getSimpleField(SSLPORT_STR);
+    String sslPortStr = instanceConfig.getRecord().getSimpleField(SSL_PORT_STR);
     return sslPortStr == null ? null : Integer.valueOf(sslPortStr);
   }
+
+  /**
+   * Get the http2 port associated with the given instance (if any).
+   * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
+   * @return the http2 port associated with the given instance.
+   */
+  public static Integer getHttp2PortStr(InstanceConfig instanceConfig) {
+    String http2PortStr = instanceConfig.getRecord().getSimpleField(HTTP2_PORT_STR);
+    return http2PortStr == null ? null : Integer.valueOf(http2PortStr);
+  }
+
 
   /**
    * Get the xid associated with this instance. The xid is like a timestamp or a change number, so if it is absent,

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -788,7 +788,10 @@ class HelixBootstrapUpgradeUtil {
     instanceConfig.setHostName(node.getHostname());
     instanceConfig.setPort(Integer.toString(node.getPort()));
     if (node.hasSSLPort()) {
-      instanceConfig.getRecord().setSimpleField(ClusterMapUtils.SSLPORT_STR, Integer.toString(node.getSSLPort()));
+      instanceConfig.getRecord().setSimpleField(ClusterMapUtils.SSL_PORT_STR, Integer.toString(node.getSSLPort()));
+    }
+    if (node.hasHttp2Port()) {
+      instanceConfig.getRecord().setSimpleField(ClusterMapUtils.HTTP2_PORT_STR, Integer.toString(node.getHttp2Port()));
     }
     instanceConfig.getRecord().setSimpleField(ClusterMapUtils.DATACENTER_STR, node.getDatacenterName());
     instanceConfig.getRecord().setSimpleField(ClusterMapUtils.RACKID_STR, node.getRackId());
@@ -1024,8 +1027,11 @@ class HelixBootstrapUpgradeUtil {
       ensureOrThrow(diskInfos.isEmpty(), "Instance " + instanceName + " has extra disks in Helix: " + diskInfos);
 
       ensureOrThrow(!dataNode.hasSSLPort() || (dataNode.getSSLPort() == Integer.valueOf(
-          instanceConfig.getRecord().getSimpleField(ClusterMapUtils.SSLPORT_STR))),
+          instanceConfig.getRecord().getSimpleField(ClusterMapUtils.SSL_PORT_STR))),
           "SSL Port mismatch for instance " + instanceName);
+      ensureOrThrow(!dataNode.hasHttp2Port() || (dataNode.getHttp2Port() == Integer.valueOf(
+          instanceConfig.getRecord().getSimpleField(ClusterMapUtils.HTTP2_PORT_STR))),
+          "HTTP2 Port mismatch for instance " + instanceName);
       ensureOrThrow(dataNode.getDatacenterName()
               .equals(instanceConfig.getRecord().getSimpleField(ClusterMapUtils.DATACENTER_STR)),
           "Datacenter mismatch for instance " + instanceName);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
@@ -281,7 +281,7 @@ public class SimpleClusterChangeHandler implements ClusterChangeHandler {
             AmbryDataNode datanode =
                 new AmbryDataNode(getDcName(instanceConfig), clusterMapConfig, instanceConfig.getHostName(),
                     Integer.valueOf(instanceConfig.getPort()), getRackId(instanceConfig), getSslPortStr(instanceConfig),
-                    null, instanceXid, helixClusterManagerCallback);
+                    getHttp2PortStr(instanceConfig), instanceXid, helixClusterManagerCallback);
             initializeDisksAndReplicasOnNode(datanode, instanceConfig);
             instanceNameToAmbryDataNode.put(instanceName, datanode);
           } else {

--- a/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
@@ -294,8 +294,11 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
         String instanceName = instanceConfig.getInstanceName();
         Port sslPort =
             getSslPortStr(instanceConfig) == null ? null : new Port(getSslPortStr(instanceConfig), PortType.SSL);
+        Port http2Port =
+            getHttp2PortStr(instanceConfig) == null ? null : new Port(getHttp2PortStr(instanceConfig), PortType.HTTP2);
         CloudDataNode cloudDataNode = new CloudDataNode(instanceConfig.getHostName(),
-            new Port(Integer.valueOf(instanceConfig.getPort()), PortType.PLAINTEXT), sslPort, null, clusterMapConfig.clustermapVcrDatacenterName, clusterMapConfig);
+            new Port(Integer.valueOf(instanceConfig.getPort()), PortType.PLAINTEXT), sslPort, http2Port,
+            clusterMapConfig.clustermapVcrDatacenterName, clusterMapConfig);
         newInstanceNameToCloudDataNode.put(instanceName, cloudDataNode);
         newVcrNodes.add(cloudDataNode);
       }


### PR DESCRIPTION
Add http2Port in helix instanceConfig when updating helix cluster map.
Rename SSLPORT_STR to SSL_PORT_STR.
Add http2Port to AmbryDataNode and CloudDataNode if not null.