### PR TITLE
Disable FQDN verification in some test cases

### DIFF
--- a/ambry-router/src/test/java/com.github.ambry.router/CloudRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/CloudRouterTest.java
@@ -99,6 +99,7 @@ public class CloudRouterTest extends NonBlockingRouterTest {
     properties.setProperty("router.ttl.update.success.target", Integer.toString(SUCCESS_TARGET));
     properties.setProperty("clustermap.port", "1666");
     properties.setProperty("clustermap.default.partition.class", MockClusterMap.DEFAULT_PARTITION_CLASS);
+    properties.setProperty("clustermap.resolve.hostnames", "false");
     properties.setProperty(CloudConfig.CLOUD_DESTINATION_FACTORY_CLASS,
         LatchBasedInMemoryCloudDestinationFactory.class.getName());
     properties.setProperty(CloudConfig.VCR_MIN_TTL_DAYS, "0");

--- a/ambry-router/src/test/java/com.github.ambry.router/RouterFactoryTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/RouterFactoryTest.java
@@ -56,6 +56,7 @@ public class RouterFactoryTest {
     properties.setProperty("clustermap.datacenter.name", "DC1");
     properties.setProperty("clustermap.host.name", "localhost");
     properties.setProperty("clustermap.port", "1666");
+    properties.setProperty("clustermap.resolve.hostnames", "false");
     properties.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
     properties.setProperty(CloudConfig.CLOUD_DESTINATION_FACTORY_CLASS, LatchBasedInMemoryCloudDestinationFactory.class.getName());
     return new VerifiableProperties(properties);


### PR DESCRIPTION
Many machines don't treat localhost as the canonical hostname so
hostname verification should be disabled in unit tests that set up a
datanode as localhost.