### PR TITLE
Introduce clustermap change listener to propagate remote replica addition/removal events

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMap.java
@@ -133,6 +133,12 @@ public interface ClusterMap extends AutoCloseable {
   ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId);
 
   /**
+   * Register a listener of cluster map for any changes.
+   * @param clusterMapChangeListener the {@link ClusterMapChangeListener} to add.
+   */
+  void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener);
+
+  /**
    * Close the cluster map. Any cleanups should be done in this call.
    */
   @Override

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMapChangeListener.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMapChangeListener.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.clustermap;
+
+import java.util.List;
+
+
+/**
+ * A {@link ClusterMap} listener that takes actions on local node when cluster map is changed.
+ */
+public interface ClusterMapChangeListener {
+  /**
+   * Take actions when replicas are added or removed on local node.
+   * @param addedReplicas a list of {@link ReplicaId}(s) that have been added.
+   * @param removedReplicas a list of {@link ReplicaId}(s) that have been removed.
+   */
+  void onReplicaAddedOrRemoved(List<ReplicaId> addedReplicas, List<ReplicaId> removedReplicas);
+}

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CompositeClusterManager.java
@@ -292,6 +292,14 @@ class CompositeClusterManager implements ClusterMap {
   }
 
   @Override
+  public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
+    staticClusterManager.registerClusterMapListener(clusterMapChangeListener);
+    if (helixClusterManager != null) {
+      helixClusterManager.registerClusterMapListener(clusterMapChangeListener);
+    }
+  }
+
+  @Override
   public void close() {
     staticClusterManager.close();
     if (helixClusterManager != null) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -83,6 +83,7 @@ public class HelixClusterManager implements ClusterMap {
   // manager to dynamically incorporate newer changes in the cluster. This variable is atomic so that the gauge metric
   // reflects the current value.
   private final AtomicLong currentXid;
+  private final List<ClusterMapChangeListener> clusterMapChangeListeners = new ArrayList<>();
   final HelixClusterManagerMetrics helixClusterManagerMetrics;
 
   /**
@@ -487,6 +488,11 @@ public class HelixClusterManager implements ClusterMap {
           "Either datanode or disk that associated with bootstrap replica is not found in cluster map. Cannot create the replica.");
     }
     return bootstrapReplica;
+  }
+
+  @Override
+  public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
+    clusterMapChangeListeners.add(clusterMapChangeListener);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -153,6 +153,11 @@ class StaticClusterManager implements ClusterMap {
     return metricRegistry;
   }
 
+  @Override
+  public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
+    // no op for static cluster map.
+  }
+
   // Administrative API
   // -----------------------
 
@@ -535,8 +540,7 @@ class StaticClusterManager implements ClusterMap {
 
   @Override
   public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
-    throw new UnsupportedOperationException(
-        "Adding new replica is currently not supported in static cluster manager.");
+    throw new UnsupportedOperationException("Adding new replica is currently not supported in static cluster manager.");
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -155,7 +155,7 @@ class StaticClusterManager implements ClusterMap {
 
   @Override
   public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
-    // no op for static cluster map.
+    throw new UnsupportedOperationException("Registering clustermap listener is not supported in static clustermap");
   }
 
   // Administrative API

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -538,6 +538,11 @@ public class MockClusterMap implements ClusterMap {
   }
 
   @Override
+  public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
+    // No-op.
+  }
+
+  @Override
   public void close() {
     // No-op.
   }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -62,6 +62,7 @@ public class MockClusterMap implements ClusterMap {
   private String localDatacenterName;
 
   private final MockPartitionId specialPartition;
+  private ClusterMapChangeListener clusterMapChangeListener = null;
 
   private RuntimeException exceptionOnSnapshot = null;
 
@@ -539,12 +540,19 @@ public class MockClusterMap implements ClusterMap {
 
   @Override
   public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
-    // No-op.
+    this.clusterMapChangeListener = clusterMapChangeListener;
   }
 
   @Override
   public void close() {
     // No-op.
+  }
+
+  /**
+   * @return {@link ClusterMapChangeListener} registered to this cluster map.
+   */
+  public ClusterMapChangeListener getClusterMapChangeListener() {
+    return clusterMapChangeListener;
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterMap.java
@@ -249,7 +249,7 @@ public class MockClusterMap implements ClusterMap {
     return ports;
   }
 
-  protected ArrayList<Port> getListOfPorts(int port, int sslPort) {
+  public static ArrayList<Port> getListOfPorts(int port, int sslPort) {
     ArrayList<Port> ports = new ArrayList<Port>();
     ports.add(new Port(port, PortType.PLAINTEXT));
     ports.add(new Port(sslPort, PortType.SSL));

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.commons;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ClusterMapChangeListener;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.PartitionId;
@@ -124,6 +125,10 @@ public class ResponseHandlerTest {
     @Override
     public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
       return null;
+    }
+
+    @Override
+    public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
     }
 
     @Override

--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/GetPeersHandlerTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.frontend;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ClusterMapChangeListener;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
@@ -384,8 +385,11 @@ class TailoredPeersClusterMap implements ClusterMap {
   }
 
   @Override
-  public void close() {
+  public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
+  }
 
+  @Override
+  public void close() {
   }
 
   @Override

--- a/ambry-replication/src/main/java/com.github.ambry.replication/PartitionInfo.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/PartitionInfo.java
@@ -82,9 +82,9 @@ public class PartitionInfo {
   }
 
   /**
-   * Remove {@link RemoteReplicaInfo} from this {@link PartitionInfo} if it is present.
-   * @param remoteReplica the {@link RemoteReplicaInfo} to remove.
-   * @return {@code true} if given remote replica info previously existed and is successfully removed. {@code false}, otherwise.
+   * Remove {@link RemoteReplicaInfo} of given replica from this {@link PartitionInfo} if it is present.
+   * @param remoteReplica the {@link ReplicaId} whose info should be removed.
+   * @return {@link RemoteReplicaInfo} that is removed, can be null if it is not present.
    */
   RemoteReplicaInfo removeReplicaInfoIfPresent(ReplicaId remoteReplica) {
     rwLock.writeLock().lock();

--- a/ambry-replication/src/main/java/com.github.ambry.replication/PartitionInfo.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/PartitionInfo.java
@@ -53,6 +53,11 @@ public class PartitionInfo {
     return this.localReplicaId;
   }
 
+  /**
+   * Add {@link RemoteReplicaInfo} to this {@link PartitionInfo} if it is previously absent.
+   * @param remoteReplicaInfo the {@link RemoteReplicaInfo} to add.
+   * @return {@code true} if remote replica info is added. {@code false} if it is already present
+   */
   boolean addReplicaInfoIfAbsent(RemoteReplicaInfo remoteReplicaInfo) {
     lock.lock();
     boolean isAdded = false;
@@ -70,6 +75,11 @@ public class PartitionInfo {
     return isAdded;
   }
 
+  /**
+   * Remove {@link RemoteReplicaInfo} from this {@link PartitionInfo} if it is present.
+   * @param remoteReplicaInfo the {@link RemoteReplicaInfo} to remove.
+   * @return {@code true} if given remote replica info previously existed and is successfully removed. {@code false}, otherwise.
+   */
   boolean removeRelicaInfoIfPresent(RemoteReplicaInfo remoteReplicaInfo) {
     lock.lock();
     boolean isRemoved;

--- a/ambry-replication/src/main/java/com.github.ambry.replication/PartitionInfo.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/PartitionInfo.java
@@ -17,6 +17,8 @@ import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.store.Store;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 
 public class PartitionInfo {
@@ -25,6 +27,7 @@ public class PartitionInfo {
   private final PartitionId partitionId;
   private final Store store;
   private final ReplicaId localReplicaId;
+  private final ReentrantLock lock = new ReentrantLock();
 
   public PartitionInfo(List<RemoteReplicaInfo> remoteReplicas, PartitionId partitionId, Store store,
       ReplicaId localReplicaId) {
@@ -48,6 +51,34 @@ public class PartitionInfo {
 
   public ReplicaId getLocalReplicaId() {
     return this.localReplicaId;
+  }
+
+  boolean addReplicaInfoIfAbsent(RemoteReplicaInfo remoteReplicaInfo) {
+    lock.lock();
+    boolean isAdded = false;
+    try {
+      List<RemoteReplicaInfo> foundSameReplica = remoteReplicas.stream()
+          .filter(info -> info.getReplicaId() == remoteReplicaInfo.getReplicaId())
+          .collect(Collectors.toList());
+      if (foundSameReplica.isEmpty()) {
+        remoteReplicas.add(remoteReplicaInfo);
+        isAdded = true;
+      }
+    } finally {
+      lock.unlock();
+    }
+    return isAdded;
+  }
+
+  boolean removeRelicaInfoIfPresent(RemoteReplicaInfo remoteReplicaInfo) {
+    lock.lock();
+    boolean isRemoved;
+    try {
+      isRemoved = remoteReplicas.remove(remoteReplicaInfo);
+    } finally {
+      lock.unlock();
+    }
+    return isRemoved;
   }
 
   @Override

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -252,7 +252,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
   protected void removeRemoteReplicaInfoFromReplicaThread(List<RemoteReplicaInfo> remoteReplicaInfos) {
     for (RemoteReplicaInfo remoteReplicaInfo : remoteReplicaInfos) {
       // Thread safe with addRemoteReplicaInfoToReplicaThread.
-      // For ReplicationManger, for same thread, removeRemoteReplicaInfo() ensures lock is held by only one thread at any time.
+      // For ReplicationManger, removeRemoteReplicaInfo() ensures lock is held by only one thread at any time.
       // For CloudBackUpManager with HelixVcrCluster, Helix requires acknowledgement before next message for the same
       // resource, which means methods in HelixVcrStateModel will be executed sequentially for same partition.
       // So do listener actions in addPartition() and removePartition().

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -241,6 +241,9 @@ public class ReplicationManager extends ReplicationEngine {
         .add(partitionInfo);
   }
 
+  /**
+   * Implementation of {@link ClusterMapChangeListener} that helps replication manager react to cluster map changes.
+   */
   class ClusterMapChangeListenerImpl implements ClusterMapChangeListener {
     /**
      * {@inheritDoc}

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -54,7 +54,7 @@ import static com.github.ambry.clustermap.StateTransitionException.TransitionErr
  * Set up replicas based on {@link ReplicationEngine} and do replication across all data centers.
  */
 public class ReplicationManager extends ReplicationEngine {
-  protected final CountDownLatch startupLatch = new CountDownLatch(1);
+  protected CountDownLatch startupLatch = new CountDownLatch(1);
   protected boolean started = false;
   private final StoreConfig storeConfig;
   private final DataNodeId currentNode;

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -15,6 +15,7 @@ package com.github.ambry.replication;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ClusterMapChangeListener;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.PartitionId;
@@ -37,9 +38,14 @@ import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
 
@@ -47,8 +53,12 @@ import static com.github.ambry.clustermap.StateTransitionException.TransitionErr
 /**
  * Set up replicas based on {@link ReplicationEngine} and do replication across all data centers.
  */
-public class ReplicationManager extends ReplicationEngine {
+public class ReplicationManager extends ReplicationEngine implements ClusterMapChangeListener {
   private final StoreConfig storeConfig;
+  private final CountDownLatch startupLatch = new CountDownLatch(1);
+  private final DataNodeId currentNode;
+  private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+  private boolean started = false;
 
   public ReplicationManager(ReplicationConfig replicationConfig, ClusterMapConfig clusterMapConfig,
       StoreConfig storeConfig, StoreManager storeManager, StoreKeyFactory storeKeyFactory, ClusterMap clusterMap,
@@ -60,6 +70,8 @@ public class ReplicationManager extends ReplicationEngine {
         clusterMap.getReplicaIds(dataNode), connectionPool, metricRegistry, requestNotification,
         storeKeyConverterFactory, transformerClassName, clusterParticipant, storeManager);
     this.storeConfig = storeConfig;
+    this.currentNode = dataNode;
+    clusterMap.registerClusterMapListener(this);
     List<? extends ReplicaId> replicaIds = clusterMap.getReplicaIds(dataNode);
     // initialize all partitions
     for (ReplicaId replicaId : replicaIds) {
@@ -115,8 +127,86 @@ public class ReplicationManager extends ReplicationEngine {
         this.scheduler.scheduleAtFixedRate(persistor, replicationConfig.replicationTokenFlushDelaySeconds,
             replicationConfig.replicationTokenFlushIntervalSeconds, TimeUnit.SECONDS);
       }
+      started = true;
     } catch (IOException e) {
       logger.error("IO error while starting replication", e);
+    } finally {
+      startupLatch.countDown();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   * Note that, this method should be thread-safe because multiple threads (from different cluster change handlers) may
+   * concurrently update remote replica infos.
+   */
+  @Override
+  public void onReplicaAddedOrRemoved(List<ReplicaId> addedReplicas, List<ReplicaId> removedReplicas) {
+    // 1. wait for start() to complete
+    try {
+      startupLatch.await();
+    } catch (InterruptedException e) {
+      logger.warn("Waiting for startup is interrupted.");
+    }
+    if (started) {
+      // Read-write lock avoids contention between addReplica()/removeReplica() and onReplicaAddedOrRemoved() methods.
+      // Read lock for current method should suffice because multiple threads from cluster change handlers should be able
+      // to access partitionToPartitionInfo map. Each thead only updates PartitionInfo of certain partition and synchronization
+      // is only required within PartitionInfo. Also, addRemoteReplicaInfoToReplicaThread() is thread-safe which allows
+      // several threads from cluster change handlers to add remoteReplicaInfo
+      rwLock.readLock().lock();
+      try {
+        // 2. determine if added/removed replicas have peer replica on local node.
+        //    We skip the replica on current node because it should already be added/removed by state transition thread.
+        Set<ReplicaId> addedPeerReplicas = addedReplicas.stream()
+            .filter(r -> partitionToPartitionInfo.containsKey(r.getPartitionId()) && r.getDataNodeId() != currentNode)
+            .collect(Collectors.toSet());
+        Set<ReplicaId> removedPeerReplicas = removedReplicas.stream()
+            .filter(r -> partitionToPartitionInfo.containsKey(r.getPartitionId()) && r.getDataNodeId() != currentNode)
+            .collect(Collectors.toSet());
+
+        // No additional synchronization is required because cluster change handler of each dc only updates replica-threads
+        // belonging to certain dc. Hence, there is only one thread adding/removing remote replicas within a certain dc.
+
+        // 3. create replicaInfo for new remote replicas and assign them to replica-threads.
+        List<RemoteReplicaInfo> replicaInfosToAdd = new ArrayList<>();
+        for (ReplicaId remoteReplica : addedPeerReplicas) {
+          PartitionInfo partitionInfo = partitionToPartitionInfo.get(remoteReplica.getPartitionId());
+          // create findToken, remoteReplicaInfo
+          FindToken findToken =
+              this.tokenHelper.getFindTokenFactoryFromReplicaType(remoteReplica.getReplicaType()).getNewFindToken();
+          RemoteReplicaInfo remoteReplicaInfo =
+              new RemoteReplicaInfo(remoteReplica, partitionInfo.getLocalReplicaId(), partitionInfo.getStore(),
+                  findToken,
+                  TimeUnit.SECONDS.toMillis(storeConfig.storeDataFlushIntervalSeconds) * Replication_Delay_Multiplier,
+                  SystemTime.getInstance(), remoteReplica.getDataNodeId().getPortToConnectTo());
+          logger.info("Adding info of remote replica {} on {} to partition info.", remoteReplica.getReplicaPath(),
+              remoteReplica.getDataNodeId());
+          if (partitionInfo.addReplicaInfoIfAbsent(remoteReplicaInfo)) {
+            replicationMetrics.addMetricsForRemoteReplicaInfo(remoteReplicaInfo);
+          }
+          replicaInfosToAdd.add(remoteReplicaInfo);
+        }
+        addRemoteReplicaInfoToReplicaThread(replicaInfosToAdd, true);
+
+        // 4. remove replicaInfo from existing partitionInfo and replica-threads
+        List<RemoteReplicaInfo> replicaInfosToRemove = new ArrayList<>();
+        for (ReplicaId remoteReplica : removedPeerReplicas) {
+          PartitionInfo partitionInfo = partitionToPartitionInfo.get(remoteReplica.getPartitionId());
+          for (RemoteReplicaInfo remoteReplicaInfo : partitionInfo.getRemoteReplicaInfos()) {
+            if (remoteReplicaInfo.getReplicaId() == remoteReplica) {
+              logger.info("Removing info of remote replica {} on {} from replica threads.",
+                  remoteReplica.getReplicaPath(), remoteReplica.getDataNodeId());
+              replicaInfosToRemove.add(remoteReplicaInfo);
+              partitionInfo.removeRelicaInfoIfPresent(remoteReplicaInfo);
+              break;
+            }
+          }
+        }
+        removeRemoteReplicaInfoFromReplicaThread(replicaInfosToRemove);
+      } finally {
+        rwLock.readLock().unlock();
+      }
     }
   }
 
@@ -131,17 +221,22 @@ public class ReplicationManager extends ReplicationEngine {
           replicaId.getPartitionId());
       return false;
     }
-    List<? extends ReplicaId> peerReplicas = replicaId.getPeerReplicaIds();
-    List<RemoteReplicaInfo> remoteReplicaInfos = new ArrayList<>();
-    if (!peerReplicas.isEmpty()) {
-      remoteReplicaInfos = createRemoteReplicaInfos(peerReplicas, replicaId);
-      updatePartitionInfoMaps(remoteReplicaInfos, replicaId);
+    rwLock.writeLock().lock();
+    try {
+      List<? extends ReplicaId> peerReplicas = replicaId.getPeerReplicaIds();
+      List<RemoteReplicaInfo> remoteReplicaInfos = new ArrayList<>();
+      if (!peerReplicas.isEmpty()) {
+        remoteReplicaInfos = createRemoteReplicaInfos(peerReplicas, replicaId);
+        updatePartitionInfoMaps(remoteReplicaInfos, replicaId);
+      }
+      logger.info("Assigning thread for {}", replicaId.getPartitionId());
+      addRemoteReplicaInfoToReplicaThread(remoteReplicaInfos, true);
+      // No need to update persistor to explicitly persist tokens for new replica because background persistor will
+      // periodically persist all tokens including new added replica's
+      logger.info("{} is successfully added into replication manager", replicaId.getPartitionId());
+    } finally {
+      rwLock.writeLock().unlock();
     }
-    logger.info("Assigning thread for partition {}", replicaId.getPartitionId());
-    addRemoteReplicaInfoToReplicaThread(remoteReplicaInfos, true);
-    // No need to update persistor to explicitly persist tokens for new replica because background persistor will
-    // periodically persist all tokens including new added replica's
-    logger.info("Partition {} is successfully added into replication manager", replicaId.getPartitionId());
     return true;
   }
 
@@ -156,16 +251,21 @@ public class ReplicationManager extends ReplicationEngine {
           replicaId.getPartitionId());
       return false;
     }
-    PartitionInfo partitionInfo = partitionToPartitionInfo.get(replicaId.getPartitionId());
-    List<RemoteReplicaInfo> remoteReplicaInfos = partitionInfo.getRemoteReplicaInfos();
-    logger.info("Removing remote replicas of {} from replica threads", replicaId.getPartitionId());
-    removeRemoteReplicaInfoFromReplicaThread(remoteReplicaInfos);
-    mountPathToPartitionInfos.computeIfPresent(replicaId.getMountPath(), (k, v) -> {
-      v.remove(partitionInfo);
-      return v;
-    });
-    partitionToPartitionInfo.remove(replicaId.getPartitionId());
-    logger.info("Partition {} is successfully removed from replication manager", replicaId.getPartitionId());
+    rwLock.writeLock().lock();
+    try {
+      PartitionInfo partitionInfo = partitionToPartitionInfo.get(replicaId.getPartitionId());
+      List<RemoteReplicaInfo> remoteReplicaInfos = partitionInfo.getRemoteReplicaInfos();
+      logger.info("Removing remote replicas of {} from replica threads", replicaId.getPartitionId());
+      removeRemoteReplicaInfoFromReplicaThread(remoteReplicaInfos);
+      mountPathToPartitionInfos.computeIfPresent(replicaId.getMountPath(), (k, v) -> {
+        v.remove(partitionInfo);
+        return v;
+      });
+      partitionToPartitionInfo.remove(replicaId.getPartitionId());
+      logger.info("{} is successfully removed from replication manager", replicaId.getPartitionId());
+    } finally {
+      rwLock.writeLock().unlock();
+    }
     return true;
   }
 

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -193,8 +193,9 @@ public class ReplicationManager extends ReplicationEngine implements ClusterMapC
         List<RemoteReplicaInfo> replicaInfosToRemove = new ArrayList<>();
         for (ReplicaId remoteReplica : removedPeerReplicas) {
           PartitionInfo partitionInfo = partitionToPartitionInfo.get(remoteReplica.getPartitionId());
-          for (RemoteReplicaInfo remoteReplicaInfo : partitionInfo.getRemoteReplicaInfos()) {
-            if (remoteReplicaInfo.getReplicaId() == remoteReplica) {
+          List<RemoteReplicaInfo> remoteReplicaInfos = new ArrayList<>(partitionInfo.getRemoteReplicaInfos());
+          for (RemoteReplicaInfo remoteReplicaInfo : remoteReplicaInfos) {
+            if (remoteReplicaInfo.getReplicaId().getDataNodeId() == remoteReplica.getDataNodeId()) {
               logger.info("Removing remote replica {} on {} from replica threads.", remoteReplica.getReplicaPath(),
                   remoteReplica.getDataNodeId());
               replicaInfosToRemove.add(remoteReplicaInfo);

--- a/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/BlobIdTransformerTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.replication;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ClusterMapChangeListener;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
@@ -684,6 +685,10 @@ public class BlobIdTransformerTest {
     @Override
     public ReplicaId getBootstrapReplica(String partitionIdStr, DataNodeId dataNodeId) {
       return null;
+    }
+
+    @Override
+    public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
     }
 
     public void close() {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
@@ -92,6 +92,12 @@ public class MockReplicationManager extends ReplicationManager {
   }
 
   @Override
+  public void start() {
+    startupLatch.countDown();
+    started = true;
+  }
+
+  @Override
   public boolean controlReplicationForPartitions(Collection<PartitionId> ids, List<String> origins, boolean enable) {
     failIfRequired();
     if (controlReplicationReturnVal == null) {
@@ -156,6 +162,13 @@ public class MockReplicationManager extends ReplicationManager {
    */
   Map<String, Set<PartitionInfo>> getMountPathToPartitionInfosMap() {
     return mountPathToPartitionInfos;
+  }
+
+  /**
+   * Mock that replication manager starts with an exception and boolean variable started is not updated to true.
+   */
+  void startWithException() {
+    startupLatch.countDown();
   }
 
   /**

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockReplicationManager.java
@@ -151,6 +151,13 @@ public class MockReplicationManager extends ReplicationManager {
   }
 
   /**
+   * @return dataNodeIdToReplicaThread map
+   */
+  Map<DataNodeId, ReplicaThread> getDataNodeIdToReplicaThreadMap() {
+    return dataNodeIdToReplicaThread;
+  }
+
+  /**
    * @return partitionToPartitionInfo map
    */
   Map<PartitionId, PartitionInfo> getPartitionToPartitionInfoMap() {

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -157,6 +157,7 @@ public class ReplicationTest {
     properties.setProperty("replication.intra.replica.thread.throttle.sleep.duration.ms", "100");
     properties.setProperty("replication.inter.replica.thread.throttle.sleep.duration.ms", "200");
     properties.setProperty("replication.replica.thread.idle.sleep.duration.ms", "1000");
+    properties.setProperty("replication.track.per.partition.lag.from.remote", "true");
     properties.put("store.segment.size.in.bytes", Long.toString(MockReplicaId.MOCK_REPLICA_CAPACITY / 2L));
     verifiableProperties = new VerifiableProperties(properties);
     replicationConfig = new ReplicationConfig(verifiableProperties);
@@ -297,7 +298,7 @@ public class ReplicationTest {
    * @throws Exception
    */
   @Test
-  public void onRemoteReplicaAddedOrRemovedTest() throws Exception {
+  public void onReplicaAddedOrRemovedCallbackTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
     StoreConfig storeConfig = new StoreConfig(verifiableProperties);

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.replication;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.AmbryReplicaSyncUpManager;
 import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ClusterMapChangeListener;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
@@ -319,6 +320,7 @@ public class ReplicationTest {
     MockReplicationManager replicationManager =
         new MockReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap,
             currentNode, storeKeyConverterFactory, null);
+    ClusterMapChangeListener clusterMapChangeListener = clusterMap.getClusterMapChangeListener();
     // find the special partition (not on current node) and get an irrelevant replica from it
     PartitionId absentPartition = clusterMap.getSpecialPartition();
     ReplicaId irrelevantReplica = absentPartition.getReplicaIds().get(0);
@@ -349,14 +351,14 @@ public class ReplicationTest {
 
     // Test Case 1: replication manager encountered exception during startup (remote replica addition/removal will be skipped)
     replicationManager.startWithException();
-    replicationManager.onReplicaAddedOrRemoved(replicasToAdd, replicasToRemove);
+    clusterMapChangeListener.onReplicaAddedOrRemoved(replicasToAdd, replicasToRemove);
     // verify that PartitionInfo stays unchanged
     verifyRemoteReplicaInfo(partitionInfo, addedReplica, false);
     verifyRemoteReplicaInfo(partitionInfo, peerReplicaToRemove, true);
 
     // Test Case 2: replication manager is successfully started
     replicationManager.start();
-    replicationManager.onReplicaAddedOrRemoved(replicasToAdd, replicasToRemove);
+    clusterMapChangeListener.onReplicaAddedOrRemoved(replicasToAdd, replicasToRemove);
     // verify that PartitionInfo has latest remote replica infos
     verifyRemoteReplicaInfo(partitionInfo, addedReplica, true);
     verifyRemoteReplicaInfo(partitionInfo, peerReplicaToRemove, false);


### PR DESCRIPTION
With "move replica", Helix cluster manager should be able to dynamically add/remove remote replica infos and therefore clustermap will be dynamically changed. External components like ReplicationManager needs to update thread assignment and some in-mem data structures in repsonse to such changes. This PR introduces clustermap change listener which allows ReplicationManager to listen to any change in 
clustermap and take actions accordingly. For now, there is only one method in clustermap
change listener: onReplicaAddedOrRemoved(), we could add more methods like onReplicaLeadershipChange etc if needed.

---
Remote replica addition/removal in clustermap is currently supported by dynamic cluster change handler only.( #1355 ) 