### PR TITLE
Azure blob layout strategy

### DIFF
--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureBlobDataAccessor.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureBlobDataAccessor.java
@@ -114,7 +114,7 @@ public class AzureBlobDataAccessor {
       AzureMetrics azureMetrics) {
     this.storageClient = storageClient;
     this.storageConfiguration = new Configuration();
-    this.blobLayoutStrategy = new AzureBlobLayoutStrategy(clusterName, null);
+    this.blobLayoutStrategy = new AzureBlobLayoutStrategy(clusterName);
     this.azureMetrics = azureMetrics;
     this.blobBatchClient = blobBatchClient;
     this.purgeBatchSize = AzureCloudConfig.DEFAULT_PURGE_BATCH_SIZE;

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureBlobDataAccessor.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureBlobDataAccessor.java
@@ -330,10 +330,7 @@ public class AzureBlobDataAccessor {
       List<Response<Void>> responseList = new ArrayList<>();
       for (CloudBlobMetadata blobMetadata : batchOfBlobs) {
         BlobLayout blobLayout = blobLayoutStrategy.getDataBlobLayout(blobMetadata);
-        String containerName = blobLayout.containerName;
-        String blobFileName = blobLayout.blobFilePath;
-        String partitionPath = blobMetadata.getPartitionId();
-        responseList.add(blobBatch.deleteBlob(containerName, blobFileName));
+        responseList.add(blobBatch.deleteBlob(blobLayout.containerName, blobLayout.blobFilePath));
       }
       blobBatchClient.submitBatchWithResponse(blobBatch, false, Duration.ofSeconds(batchPurgeTimeoutSec), Context.NONE);
       for (int j = 0; j < responseList.size(); j++) {

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureBlobLayoutStrategy.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureBlobLayoutStrategy.java
@@ -17,67 +17,128 @@ import com.github.ambry.cloud.CloudBlobMetadata;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.utils.Utils;
 
-// TODO: if blobs are organized by container, then need a different container for tokens
-// Use separate dedicated token container, using replicaTokens//partitionPath/replicaTokens
 
+/**
+ * Strategy class that decides where Ambry blobs and tokens are stored in the Azure storage.
+ * The decision is governed by two {@link AzureCloudConfig} properties:
+ * <ol>
+ * <li>nameSchemeVersion: version of the translation scheme for blob names.</li>
+ * <li>blobContainerStrategy: strategy for organizing Azure containers.</li>
+ * </ol>
+ */
 public class AzureBlobLayoutStrategy {
 
   private static final String SEPARATOR = "-";
+  // Note: Azure container name needs to be lower case
   private static final String TOKEN_CONTAINER_NAME = "replicatokens";
   private final String clusterName;
   private int currentVersion;
   private BlobContainerStrategy blobContainerStrategy;
 
+  /**
+   * Enum for deciding how Azure storage containers are organized.
+   */
   enum BlobContainerStrategy {
-    PARTITION, CONTAINER
+
+    /** Each Azure container corresponds to an Ambry partitionId. */
+    PARTITION,
+
+    /** Each Azure container corresponds to an Ambry accountId-containerId combination. */
+    CONTAINER;
+
+    /**
+     * @return {@link BlobContainerStrategy} using case-insensitive string match.
+     * @param enumVal the enum string value.
+     * @throws IllegalArgumentException for invalid enumVal.
+     */
+    static BlobContainerStrategy get(String enumVal) {
+      return BlobContainerStrategy.valueOf(enumVal.toUpperCase());
+    }
   }
 
+  /** A struct holding Azure container name and file path within the container. */
   static class BlobLayout {
-    public String containerName;
-    public String blobFilePath;
+    final String containerName;
+    final String blobFilePath;
 
-    public BlobLayout(String containerName, String blobFilePath) {
+    /**
+     * @param containerName Name of the Azure storage container.
+     * @param blobFilePath Name of the file path for the blob within the container.
+     */
+    BlobLayout(String containerName, String blobFilePath) {
       this.containerName = containerName;
       this.blobFilePath = blobFilePath;
     }
   }
 
+  /**
+   * Constuctor for {@link AzureBlobLayoutStrategy}.
+   * @param clusterName Name of the Ambry cluster.
+   * @param azureCloudConfig The {@link AzureCloudConfig} to use.
+   * @throws IllegalArgumentException if invalid config properties are present.
+   */
   public AzureBlobLayoutStrategy(String clusterName, AzureCloudConfig azureCloudConfig) {
     this.clusterName = clusterName;
-    currentVersion = 0;  // azureCloudConfig.nameSchemeVersion;
-    blobContainerStrategy = BlobContainerStrategy.PARTITION; // azureCloudConfig.blobContainerStrategy
+    currentVersion = azureCloudConfig.azureNameSchemeVersion;
+    blobContainerStrategy = BlobContainerStrategy.get(azureCloudConfig.azureBlobContainerStrategy);
   }
 
+  /** Test constructor */
+  public AzureBlobLayoutStrategy(String clusterName) {
+    this.clusterName = clusterName;
+    currentVersion = 0;
+    blobContainerStrategy = BlobContainerStrategy.PARTITION;
+  }
   /**
-   * @return the name of the Azure storage container to store the specified blob.
-   * @param blobMetadata the blob metadata.
+   * @return the {@link BlobLayout} for the specified blob.
+   * @param blobMetadata the {@link CloudBlobMetadata for the data blob.
    */
   public BlobLayout getDataBlobLayout(CloudBlobMetadata blobMetadata) {
-    String baseContainerName =
-        (blobContainerStrategy == BlobContainerStrategy.PARTITION) ? blobMetadata.getPartitionId()
-            : blobMetadata.getAccountId() + SEPARATOR + blobMetadata.getContainerId();
-    String blobName = getAzureBlobName(blobMetadata.getId(), blobMetadata.getNameSchemeVersion());
-    return new BlobLayout(baseContainerName, blobName);
+    return new BlobLayout(getAzureContainerName(blobMetadata), getAzureBlobName(blobMetadata));
   }
 
   /**
-   * @return the name of the Azure storage container to store the specified blob.
+   * @return the {@link BlobLayout} for the specified blob.
    * @param blobId the id of the blob.
    */
   public BlobLayout getDataBlobLayout(BlobId blobId) {
     return getDataBlobLayout(toMetadata(blobId));
   }
 
+  /**
+   * @return the {@link BlobLayout} for token files in the specified partition.
+   * @param partitionPath the lexical partitionId name.
+   * @param tokenFileName the name of the token file to store.
+   */
   public BlobLayout getTokenBlobLayout(String partitionPath, String tokenFileName) {
     if (blobContainerStrategy == BlobContainerStrategy.PARTITION) {
       return new BlobLayout(getClusterAwareAzureContainerName(partitionPath), tokenFileName);
     } else {
+      // Use separate dedicated token container, using replicaTokens//partitionPath/replicaTokens
       return new BlobLayout(getClusterAwareAzureContainerName(TOKEN_CONTAINER_NAME),
           partitionPath + "/" + tokenFileName);
     }
   }
 
-  private String getAzureBlobName(String blobIdStr, int nameVersion) {
+  /**
+   * Gets the Azure container name for the blob, depending on the configured strategy.
+   * @param blobMetadata the {@link CloudBlobMetadata} to store.
+   * @return the container name to use.
+   */
+  private String getAzureContainerName(CloudBlobMetadata blobMetadata) {
+    String baseContainerName =
+        (blobContainerStrategy == BlobContainerStrategy.PARTITION) ? blobMetadata.getPartitionId()
+            : blobMetadata.getAccountId() + SEPARATOR + blobMetadata.getContainerId();
+    return getClusterAwareAzureContainerName(baseContainerName);
+  }
+
+  /**
+   * @return the blob name to use in Azure storage.
+   * @param blobMetadata the {@link CloudBlobMetadata} to store.
+   */
+  private String getAzureBlobName(CloudBlobMetadata blobMetadata) {
+    String blobIdStr = blobMetadata.getId();
+    int nameVersion = blobMetadata.getNameSchemeVersion();
     switch (nameVersion) {
       default:
         // Use the last four chars as prefix to assist in Azure sharding, since beginning of blobId has little variation.
@@ -85,11 +146,21 @@ public class AzureBlobLayoutStrategy {
     }
   }
 
+  /**
+   * Converts an input container name to one that is multi-cluster friendly.
+   * @param inputName the input container name.
+   * @return a container name scoped to the cluster.
+   */
   private String getClusterAwareAzureContainerName(String inputName) {
     String containerName = clusterName + SEPARATOR + inputName;
     return containerName.toLowerCase();
   }
 
+  /**
+   * Convert a {@link BlobId} to a {@link CloudBlobMetadata}.
+   * @param blobId the input {@link BlobId}.
+   * @return the output {@link CloudBlobMetadata}.
+   */
   private CloudBlobMetadata toMetadata(BlobId blobId) {
     return new CloudBlobMetadata(blobId, 0, Utils.Infinite_Time, 0,
         CloudBlobMetadata.EncryptionOrigin.NONE).setNameSchemeVersion(currentVersion);

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureBlobLayoutStrategy.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureBlobLayoutStrategy.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud.azure;
+
+import com.github.ambry.cloud.CloudBlobMetadata;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.utils.Utils;
+
+// TODO: if blobs are organized by container, then need a different container for tokens
+// Use separate dedicated token container, using replicaTokens//partitionPath/replicaTokens
+
+public class AzureBlobLayoutStrategy {
+
+  private static final String SEPARATOR = "-";
+  private static final String TOKEN_CONTAINER_NAME = "replicatokens";
+  private final String clusterName;
+  private int currentVersion;
+  private BlobContainerStrategy blobContainerStrategy;
+
+  enum BlobContainerStrategy {
+    PARTITION, CONTAINER
+  }
+
+  static class BlobLayout {
+    public String containerName;
+    public String blobFilePath;
+
+    public BlobLayout(String containerName, String blobFilePath) {
+      this.containerName = containerName;
+      this.blobFilePath = blobFilePath;
+    }
+  }
+
+  public AzureBlobLayoutStrategy(String clusterName, AzureCloudConfig azureCloudConfig) {
+    this.clusterName = clusterName;
+    currentVersion = 0;  // azureCloudConfig.nameSchemeVersion;
+    blobContainerStrategy = BlobContainerStrategy.PARTITION; // azureCloudConfig.blobContainerStrategy
+  }
+
+  /**
+   * @return the name of the Azure storage container to store the specified blob.
+   * @param blobMetadata the blob metadata.
+   */
+  public BlobLayout getDataBlobLayout(CloudBlobMetadata blobMetadata) {
+    String baseContainerName =
+        (blobContainerStrategy == BlobContainerStrategy.PARTITION) ? blobMetadata.getPartitionId()
+            : blobMetadata.getAccountId() + SEPARATOR + blobMetadata.getContainerId();
+    String blobName = getAzureBlobName(blobMetadata.getId(), blobMetadata.getNameSchemeVersion());
+    return new BlobLayout(baseContainerName, blobName);
+  }
+
+  /**
+   * @return the name of the Azure storage container to store the specified blob.
+   * @param blobId the id of the blob.
+   */
+  public BlobLayout getDataBlobLayout(BlobId blobId) {
+    return getDataBlobLayout(toMetadata(blobId));
+  }
+
+  public BlobLayout getTokenBlobLayout(String partitionPath, String tokenFileName) {
+    if (blobContainerStrategy == BlobContainerStrategy.PARTITION) {
+      return new BlobLayout(getClusterAwareAzureContainerName(partitionPath), tokenFileName);
+    } else {
+      return new BlobLayout(getClusterAwareAzureContainerName(TOKEN_CONTAINER_NAME),
+          partitionPath + "/" + tokenFileName);
+    }
+  }
+
+  private String getAzureBlobName(String blobIdStr, int nameVersion) {
+    switch (nameVersion) {
+      default:
+        // Use the last four chars as prefix to assist in Azure sharding, since beginning of blobId has little variation.
+        return blobIdStr.substring(blobIdStr.length() - 4) + SEPARATOR + blobIdStr;
+    }
+  }
+
+  private String getClusterAwareAzureContainerName(String inputName) {
+    String containerName = clusterName + SEPARATOR + inputName;
+    return containerName.toLowerCase();
+  }
+
+  private CloudBlobMetadata toMetadata(BlobId blobId) {
+    return new CloudBlobMetadata(blobId, 0, Utils.Infinite_Time, 0,
+        CloudBlobMetadata.EncryptionOrigin.NONE).setNameSchemeVersion(currentVersion);
+  }
+}

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudConfig.java
@@ -16,6 +16,7 @@ package com.github.ambry.cloud.azure;
 import com.github.ambry.config.Config;
 import com.github.ambry.config.Default;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.cloud.azure.AzureBlobLayoutStrategy.BlobContainerStrategy;
 
 
 /**
@@ -30,10 +31,14 @@ public class AzureCloudConfig {
   public static final String COSMOS_MAX_RETRIES = "cosmos.max.retries";
   public static final String COSMOS_DIRECT_HTTPS = "cosmos.direct.https";
   public static final String AZURE_PURGE_BATCH_SIZE = "azure.purge.batch.size";
-  public static final int DEFAULT_COSMOS_MAX_RETRIES = 5;
+  public static final String AZURE_NAME_SCHEME_VERSION = "azure.name.scheme.version";
+  public static final String AZURE_BLOB_CONTAINER_STRATEGY = "azure.blob.container.strategy";
   // Per docs.microsoft.com/en-us/rest/api/storageservices/blob-batch
   public static final int MAX_PURGE_BATCH_SIZE = 256;
   public static final int DEFAULT_PURGE_BATCH_SIZE = 100;
+  public static final int DEFAULT_COSMOS_MAX_RETRIES = 5;
+  public static final int DEFAULT_NAME_SCHEME_VERSION = 0;
+  public static final String DEFAULT_CONTAINER_STRATEGY = "Partition";
 
   /**
    * The Azure Blob Storage connection string.
@@ -69,7 +74,14 @@ public class AzureCloudConfig {
   @Config(AZURE_PURGE_BATCH_SIZE)
   @Default("100")
   public final int azurePurgeBatchSize;
-  // TODO: Add blobNamingSchemeVersion, containerNamingScheme
+
+  @Config(AZURE_NAME_SCHEME_VERSION)
+  @Default("0")
+  public final int azureNameSchemeVersion;
+
+  @Config(AZURE_BLOB_CONTAINER_STRATEGY)
+  @Default("partition")
+  public final String azureBlobContainerStrategy;
 
   /**
    * Flag indicating whether to use DirectHttps CosmosDB connection mode.
@@ -88,5 +100,7 @@ public class AzureCloudConfig {
     azurePurgeBatchSize =
         verifiableProperties.getIntInRange(AZURE_PURGE_BATCH_SIZE, DEFAULT_PURGE_BATCH_SIZE, 1, MAX_PURGE_BATCH_SIZE);
     cosmosDirectHttps = verifiableProperties.getBoolean(COSMOS_DIRECT_HTTPS, false);
+    azureBlobContainerStrategy = verifiableProperties.getString(AZURE_BLOB_CONTAINER_STRATEGY, DEFAULT_CONTAINER_STRATEGY);
+    azureNameSchemeVersion = verifiableProperties.getInt(AZURE_NAME_SCHEME_VERSION, DEFAULT_NAME_SCHEME_VERSION);
   }
 }

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudConfig.java
@@ -80,7 +80,7 @@ public class AzureCloudConfig {
   public final int azureNameSchemeVersion;
 
   @Config(AZURE_BLOB_CONTAINER_STRATEGY)
-  @Default("partition")
+  @Default("Partition")
   public final String azureBlobContainerStrategy;
 
   /**

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudDestination.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudDestination.java
@@ -145,7 +145,7 @@ class AzureCloudDestination implements CloudDestination {
     this.asyncDocumentClient = asyncDocumentClient;
     this.azureMetrics = azureMetrics;
     this.clusterName = clusterName;
-    this.blobLayoutStrategy = new AzureBlobLayoutStrategy(clusterName, null);
+    this.blobLayoutStrategy = new AzureBlobLayoutStrategy(clusterName);
     this.retentionPeriodMs = TimeUnit.DAYS.toMillis(CloudConfig.DEFAULT_RETENTION_DAYS);
     this.deadBlobsQueryLimit = CloudConfig.DEFAULT_COMPACTION_QUERY_LIMIT;
     cosmosDataAccessor = new CosmosDataAccessor(asyncDocumentClient, cosmosCollectionLink, azureMetrics);

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureBlobDataAccessorTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureBlobDataAccessorTest.java
@@ -25,15 +25,11 @@ import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.specialized.BlockBlobClient;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.cloud.CloudBlobMetadata;
-import com.github.ambry.clustermap.MockClusterMap;
-import com.github.ambry.clustermap.MockPartitionId;
-import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,7 +43,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static com.github.ambry.commons.BlobId.*;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -151,19 +146,17 @@ public class AzureBlobDataAccessorTest {
     when(mockBatchClient.getBlobBatch()).thenReturn(mockBatch);
     Response<Void> okResponse = mock(Response.class);
     when(okResponse.getStatusCode()).thenReturn(202);
-    when(mockBatch.deleteBlob(anyString(), eq(dataAccessor.getAzureBlobName(blobNameOkStatus)))).thenReturn(okResponse);
+    when(mockBatch.deleteBlob(anyString(), endsWith(blobNameOkStatus))).thenReturn(okResponse);
     BlobStorageException notFoundException = mock(BlobStorageException.class);
     when(notFoundException.getStatusCode()).thenReturn(404);
     Response<Void> notFoundResponse = mock(Response.class);
     when(notFoundResponse.getStatusCode()).thenThrow(notFoundException);
-    when(mockBatch.deleteBlob(anyString(), eq(dataAccessor.getAzureBlobName(blobNameNotFoundStatus)))).thenReturn(
-        notFoundResponse);
+    when(mockBatch.deleteBlob(anyString(), endsWith(blobNameNotFoundStatus))).thenReturn(notFoundResponse);
     BlobStorageException badException = mock(BlobStorageException.class);
     when(badException.getStatusCode()).thenReturn(503);
     Response<Void> badResponse = mock(Response.class);
     when(badResponse.getStatusCode()).thenThrow(badException);
-    when(mockBatch.deleteBlob(anyString(), eq(dataAccessor.getAzureBlobName(blobNameErrorStatus)))).thenReturn(
-        badResponse);
+    when(mockBatch.deleteBlob(anyString(), endsWith(blobNameErrorStatus))).thenReturn(badResponse);
     List<CloudBlobMetadata> purgeList = new ArrayList<>();
     purgeList.add(new CloudBlobMetadata().setId(blobNameOkStatus));
     purgeList.add(new CloudBlobMetadata().setId(blobNameNotFoundStatus));
@@ -265,6 +258,4 @@ public class AzureBlobDataAccessorTest {
     } catch (BlobStorageException csex) {
     }
   }
-
-
 }

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureBlobDataAccessorTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureBlobDataAccessorTest.java
@@ -199,7 +199,8 @@ public class AzureBlobDataAccessorTest {
     // Test without proxy
     CloudConfig cloudConfig = new CloudConfig(new VerifiableProperties(configProps));
     AzureCloudConfig azureConfig = new AzureCloudConfig(new VerifiableProperties(configProps));
-    AzureBlobDataAccessor dataAccessor = new AzureBlobDataAccessor(cloudConfig, azureConfig, clusterName, azureMetrics);
+    AzureBlobLayoutStrategy blobLayoutStrategy = new AzureBlobLayoutStrategy(clusterName, azureConfig);
+    AzureBlobDataAccessor dataAccessor = new AzureBlobDataAccessor(cloudConfig, azureConfig, blobLayoutStrategy, azureMetrics);
 
     // Test with proxy
     String proxyHost = "azure-proxy.randomcompany.com";
@@ -207,7 +208,7 @@ public class AzureBlobDataAccessorTest {
     configProps.setProperty(CloudConfig.VCR_PROXY_HOST, proxyHost);
     configProps.setProperty(CloudConfig.VCR_PROXY_PORT, String.valueOf(proxyPort));
     cloudConfig = new CloudConfig(new VerifiableProperties(configProps));
-    dataAccessor = new AzureBlobDataAccessor(cloudConfig, azureConfig, clusterName, azureMetrics);
+    dataAccessor = new AzureBlobDataAccessor(cloudConfig, azureConfig, blobLayoutStrategy, azureMetrics);
   }
 
   /** Test upload of existing blob. */

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureBlobLayoutStrategyTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureBlobLayoutStrategyTest.java
@@ -71,7 +71,7 @@ public class AzureBlobLayoutStrategyTest {
     BlobLayout layout = strategy.getDataBlobLayout(blobId);
     // Container name should be main-101-5
     String expectedContainerName =
-        String.format("%s-%d-%d", clusterName, AzureTestUtils.accountId, AzureTestUtils.containerId);
+        String.format("%s_%d_%d", clusterName, AzureTestUtils.accountId, AzureTestUtils.containerId);
     String blobIdStr = blobId.getID();
     String expectedBlobName = blobIdStr.substring(blobIdStr.length() - 4) + "-" + blobIdStr;
     checkLayout(layout, expectedContainerName, expectedBlobName);
@@ -79,9 +79,9 @@ public class AzureBlobLayoutStrategyTest {
     layout = strategy.getDataBlobLayout(blobMetadata);
     checkLayout(layout, expectedContainerName, expectedBlobName);
 
-    // Tokens should go in their own container: main-replicaTokens
+    // Tokens should go in their own container: main_replicaTokens
     layout = strategy.getTokenBlobLayout(partitionPath, tokenFileName);
-    expectedContainerName = clusterName + "-" + tokenFileName.toLowerCase();
+    expectedContainerName = clusterName + "_" + tokenFileName.toLowerCase();
     expectedBlobName = partitionPath + "/" + tokenFileName;
     checkLayout(layout, expectedContainerName, expectedBlobName);
   }

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureBlobLayoutStrategyTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureBlobLayoutStrategyTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud.azure;
+
+import com.github.ambry.cloud.CloudBlobMetadata;
+import com.github.ambry.cloud.azure.AzureBlobLayoutStrategy.BlobLayout;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.config.VerifiableProperties;
+import java.util.Properties;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+
+
+/** Test cases for {@link AzureBlobLayoutStrategy} */
+@RunWith(MockitoJUnitRunner.class)
+public class AzureBlobLayoutStrategyTest {
+
+  private Properties configProps = new Properties();
+  private BlobId blobId;
+  private final String clusterName = "main";
+  private final String tokenFileName = "replicaTokens";
+  private final String partitionPath = String.valueOf(AzureTestUtils.partition);
+
+  @Before
+  public void setup() {
+    blobId = AzureTestUtils.generateBlobId();
+    AzureTestUtils.setConfigProperties(configProps);
+  }
+
+  /** Test default strategy and make sure it is partition-based */
+  @Test
+  public void testDefaultStrategy() {
+    AzureCloudConfig azureCloudConfig = new AzureCloudConfig(new VerifiableProperties(configProps));
+    AzureBlobLayoutStrategy strategy = new AzureBlobLayoutStrategy(clusterName, azureCloudConfig);
+    BlobLayout layout = strategy.getDataBlobLayout(blobId);
+    // Container name should be main-666
+    String expectedContainerName = clusterName + "-" + partitionPath;
+    String blobIdStr = blobId.getID();
+    String expectedBlobName = blobIdStr.substring(blobIdStr.length() - 4) + "-" + blobIdStr;
+    checkLayout(layout, expectedContainerName, expectedBlobName);
+    CloudBlobMetadata blobMetadata = new CloudBlobMetadata(blobId, 0, 0, 0, null);
+    layout = strategy.getDataBlobLayout(blobMetadata);
+    checkLayout(layout, expectedContainerName, expectedBlobName);
+
+    // Tokens should go in same container
+    layout = strategy.getTokenBlobLayout(partitionPath, tokenFileName);
+    checkLayout(layout, expectedContainerName, tokenFileName);
+  }
+
+  /** Test container layout strategy */
+  @Test
+  public void testContainerStrategy() {
+    configProps.setProperty(AzureCloudConfig.AZURE_BLOB_CONTAINER_STRATEGY, "container");
+    AzureCloudConfig azureCloudConfig = new AzureCloudConfig(new VerifiableProperties(configProps));
+    AzureBlobLayoutStrategy strategy = new AzureBlobLayoutStrategy(clusterName, azureCloudConfig);
+    BlobLayout layout = strategy.getDataBlobLayout(blobId);
+    // Container name should be main-101-5
+    String expectedContainerName =
+        String.format("%s-%d-%d", clusterName, AzureTestUtils.accountId, AzureTestUtils.containerId);
+    String blobIdStr = blobId.getID();
+    String expectedBlobName = blobIdStr.substring(blobIdStr.length() - 4) + "-" + blobIdStr;
+    checkLayout(layout, expectedContainerName, expectedBlobName);
+    CloudBlobMetadata blobMetadata = new CloudBlobMetadata(blobId, 0, 0, 0, null);
+    layout = strategy.getDataBlobLayout(blobMetadata);
+    checkLayout(layout, expectedContainerName, expectedBlobName);
+
+    // Tokens should go in their own container: main-replicaTokens
+    layout = strategy.getTokenBlobLayout(partitionPath, tokenFileName);
+    expectedContainerName = clusterName + "-" + tokenFileName.toLowerCase();
+    expectedBlobName = partitionPath + "/" + tokenFileName;
+    checkLayout(layout, expectedContainerName, expectedBlobName);
+  }
+
+  /** Test that only valid strategy properties are accepted. */
+  @Test
+  public void testValidStrategies() {
+    // Valid ones
+    configProps.setProperty(AzureCloudConfig.AZURE_BLOB_CONTAINER_STRATEGY, "CONTAINER");
+    AzureCloudConfig azureCloudConfig = new AzureCloudConfig(new VerifiableProperties(configProps));
+    AzureBlobLayoutStrategy strategy = new AzureBlobLayoutStrategy(clusterName, azureCloudConfig);
+    configProps.setProperty(AzureCloudConfig.AZURE_BLOB_CONTAINER_STRATEGY, "Partition");
+    azureCloudConfig = new AzureCloudConfig(new VerifiableProperties(configProps));
+    strategy = new AzureBlobLayoutStrategy(clusterName, azureCloudConfig);
+
+    // Invalid ones
+    configProps.setProperty(AzureCloudConfig.AZURE_BLOB_CONTAINER_STRATEGY, "SomethingElse");
+    azureCloudConfig = new AzureCloudConfig(new VerifiableProperties(configProps));
+    try {
+      strategy = new AzureBlobLayoutStrategy(clusterName, azureCloudConfig);
+      fail("Expected failure");
+    } catch (IllegalArgumentException ex) {
+    }
+  }
+
+  /**
+   * Verify the layout is as expected.
+   * @param layout the {@link BlobLayout} to check.
+   * @param expectedContainerName the expected container name.
+   * @param expectedBlobPath the expected blob path.
+   */
+  private static void checkLayout(BlobLayout layout, String expectedContainerName, String expectedBlobPath) {
+    assertEquals("Unexpected container name", expectedContainerName, layout.containerName);
+    assertEquals("Unexpected blob path", expectedBlobPath, layout.blobFilePath);
+  }
+}

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzurePerformanceTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzurePerformanceTest.java
@@ -66,8 +66,9 @@ public class AzurePerformanceTest {
       CloudConfig cloudConfig = new CloudConfig(verifiableProperties);
       AzureCloudConfig azureCloudConfig = new AzureCloudConfig(verifiableProperties);
       String clusterName = "perftest";
-      blobDataAccessor =
-          new AzureBlobDataAccessor(cloudConfig, azureCloudConfig, clusterName, new AzureMetrics(new MetricRegistry()));
+      AzureBlobLayoutStrategy blobLayoutStrategy = new AzureBlobLayoutStrategy(clusterName, azureCloudConfig);
+      blobDataAccessor = new AzureBlobDataAccessor(cloudConfig, azureCloudConfig, blobLayoutStrategy,
+          new AzureMetrics(new MetricRegistry()));
 
       testPerformance();
     } catch (Exception ex) {


### PR DESCRIPTION
Allow configuration of how blobs (and tokens) are laid out in ABS.
By default, uses BlobContainerStrategy.PARTITION, which is compatible with existing backup impl.
If  BlobContainerStrategy.CONTAINER is specified, Azure container maps to accountId_containerId (underscore used as separator to avoid confusion with negative numbers), and replica tokens are all stored in their own dedicated container.