### PR TITLE
Improve FailOnNotFound by accounting for disk down and cross-colo NotFound

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/TrackedRequestFinalState.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/TrackedRequestFinalState.java
@@ -19,7 +19,7 @@ package com.github.ambry.router;
  * consumed by operation tracker to change success/failure counter and determine whether to update Histograms.
  */
 public enum TrackedRequestFinalState {
-  SUCCESS, FAILURE, TIMED_OUT, NOT_FOUND, REQUEST_DISABLED;
+  SUCCESS, FAILURE, TIMED_OUT, NOT_FOUND, REQUEST_DISABLED, DISK_DOWN;
 
   /**
    *  Return the corresponding {@link TrackedRequestFinalState}  for the given {@link RouterErrorCode}.

--- a/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/DeleteManagerTest.java
@@ -19,11 +19,11 @@ import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.LoggingNotificationSystem;
-import com.github.ambry.network.SocketNetworkClient;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.network.SocketNetworkClient;
 import com.github.ambry.router.RouterTestHelpers.*;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
@@ -266,7 +266,7 @@ public class DeleteManagerTest {
     HashMap<ServerErrorCode, RouterErrorCode> map = new HashMap<>();
     map.put(ServerErrorCode.Blob_Expired, RouterErrorCode.BlobExpired);
     map.put(ServerErrorCode.Blob_Not_Found, RouterErrorCode.BlobDoesNotExist);
-    map.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
+    map.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.BlobDoesNotExist);
     map.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
     map.put(ServerErrorCode.Blob_Authorization_Failure, RouterErrorCode.BlobAuthorizationFailure);
     for (ServerErrorCode serverErrorCode : ServerErrorCode.values()) {

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -24,8 +24,6 @@ import com.github.ambry.commons.BlobIdFactory;
 import com.github.ambry.commons.ByteBufferAsyncWritableChannel;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
-import com.github.ambry.utils.NettyByteBufDataInputStream;
-import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.commons.ResponseHandler;
 import com.github.ambry.config.CryptoServiceConfig;
 import com.github.ambry.config.KMSConfig;
@@ -39,10 +37,10 @@ import com.github.ambry.messageformat.CompositeBlobInfo;
 import com.github.ambry.messageformat.MessageFormatFlags;
 import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.messageformat.MetadataContentSerDe;
-import com.github.ambry.network.SocketNetworkClient;
 import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.network.SocketNetworkClient;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.protocol.GetRequest;
 import com.github.ambry.protocol.GetResponse;
@@ -54,6 +52,8 @@ import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferChannel;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.NettyByteBufDataInputStream;
+import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
@@ -77,6 +77,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -105,6 +106,7 @@ public class GetBlobOperationTest {
   private static final int MAX_PORTS_PLAIN_TEXT = 3;
   private static final int MAX_PORTS_SSL = 3;
   private static final int CHECKOUT_TIMEOUT_MS = 1000;
+  private static final String LOCAL_DC = "DC3";
   private final int replicasCount;
   private final int maxChunkSize;
   private final MockTime time = new MockTime();
@@ -612,7 +614,6 @@ public class GetBlobOperationTest {
     routerConfig = new RouterConfig(new VerifiableProperties(props));
 
     GetBlobOperation op = createOperation(routerConfig, null);
-    AdaptiveOperationTracker tracker = (AdaptiveOperationTracker) op.getFirstChunkOperationTrackerInUse();
     correlationIdToGetOperation.clear();
     for (MockServer server : mockServerLayout.getMockServers()) {
       server.setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
@@ -714,6 +715,34 @@ public class GetBlobOperationTest {
   }
 
   /**
+   * Test the case where originating dc returns 2 Disk_Unavailable and 1 Not_Found and rest replicas return Not_Found.
+   * In this case, result of GET operation will be Not_Found.
+   * @throws Exception
+   */
+  @Test
+  public void testCombinedDiskDownAndNotFoundCase() throws Exception {
+    doPut();
+    List<MockServer> localDcServers = mockServerLayout.getMockServers()
+        .stream()
+        .filter(s -> s.getDataCenter().equals(LOCAL_DC))
+        .collect(Collectors.toList());
+    mockServerLayout.getMockServers().forEach(s -> {
+      if (!localDcServers.contains(s)) {
+        s.setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+      }
+    });
+    for (int i = 0; i < 3; ++i) {
+      if (i < 2) {
+        localDcServers.get(i).setServerErrorForAllRequests(ServerErrorCode.Disk_Unavailable);
+      } else {
+        localDcServers.get(i).setServerErrorForAllRequests(ServerErrorCode.Blob_Not_Found);
+      }
+    }
+    getErrorCodeChecker.testAndAssert(RouterErrorCode.BlobDoesNotExist);
+    mockServerLayout.getMockServers().forEach(MockServer::resetServerErrors);
+  }
+
+  /**
    * Test the case where servers return different {@link ServerErrorCode} or success, and the {@link GetBlobOperation}
    * is able to resolve and conclude the correct {@link RouterErrorCode}. The get operation should be able
    * to resolve the router error code as {@code Blob_Authorization_Failure}.
@@ -784,9 +813,20 @@ public class GetBlobOperationTest {
     for (ServerErrorCode serverErrorCode : serverErrors) {
       mockServerLayout.getMockServers().forEach(server -> server.setServerErrorForAllRequests(serverErrorCode));
       GetBlobOperation op = createOperationAndComplete(null);
-      assertFailureAndCheckErrorCode(op,
-          EnumSet.of(ServerErrorCode.Disk_Unavailable, ServerErrorCode.Replica_Unavailable).contains(serverErrorCode)
-              ? RouterErrorCode.AmbryUnavailable : RouterErrorCode.UnexpectedInternalError);
+      RouterErrorCode expectedRouterError;
+      switch (serverErrorCode) {
+        case Replica_Unavailable:
+          expectedRouterError = RouterErrorCode.AmbryUnavailable;
+          break;
+        case Disk_Unavailable:
+          // if all the disks are unavailable (which should be extremely rare), after replacing these disks, the blob is
+          // definitely not present.
+          expectedRouterError = RouterErrorCode.BlobDoesNotExist;
+          break;
+        default:
+          expectedRouterError = RouterErrorCode.UnexpectedInternalError;
+      }
+      assertFailureAndCheckErrorCode(op, expectedRouterError);
     }
   }
 
@@ -1609,7 +1649,7 @@ public class GetBlobOperationTest {
   private Properties getDefaultNonBlockingRouterProperties(boolean excludeTimeout) {
     Properties properties = new Properties();
     properties.setProperty("router.hostname", "localhost");
-    properties.setProperty("router.datacenter.name", "DC3");
+    properties.setProperty("router.datacenter.name", LOCAL_DC);
     properties.setProperty("router.put.request.parallelism", Integer.toString(3));
     properties.setProperty("router.put.success.target", Integer.toString(2));
     properties.setProperty("router.max.put.chunk.size.bytes", Integer.toString(maxChunkSize));

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
@@ -16,13 +16,12 @@ package com.github.ambry.router;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
 import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.network.BoundedNettyByteBufReceive;
-import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.BlobType;
 import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.messageformat.MessageMetadata;
+import com.github.ambry.network.BoundedNettyByteBufReceive;
 import com.github.ambry.network.ByteBufferSend;
 import com.github.ambry.network.Send;
 import com.github.ambry.protocol.DeleteRequest;
@@ -38,6 +37,7 @@ import com.github.ambry.protocol.RequestOrResponse;
 import com.github.ambry.protocol.RequestOrResponseType;
 import com.github.ambry.protocol.TtlUpdateRequest;
 import com.github.ambry.protocol.TtlUpdateResponse;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.ByteBufferChannel;
@@ -168,7 +168,7 @@ class MockServer {
       // set it in the partitionResponseInfo
       if (getError == ServerErrorCode.No_Error || getError == ServerErrorCode.Blob_Expired
           || getError == ServerErrorCode.Blob_Deleted || getError == ServerErrorCode.Blob_Not_Found
-          || getError == ServerErrorCode.Blob_Authorization_Failure) {
+          || getError == ServerErrorCode.Blob_Authorization_Failure || getError == ServerErrorCode.Disk_Unavailable) {
         partitionError = getError;
         serverError = ServerErrorCode.No_Error;
       } else {

--- a/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/NonBlockingRouterTest.java
@@ -30,10 +30,10 @@ import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.MessageFormatRecord;
-import com.github.ambry.network.SocketNetworkClient;
 import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.network.SocketNetworkClient;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.protocol.RequestOrResponseType;
@@ -782,9 +782,11 @@ public class NonBlockingRouterTest {
     testsAndExpected.put(ServerErrorCode.Blob_Not_Found, RouterErrorCode.BlobDoesNotExist);
     testsAndExpected.put(ServerErrorCode.Blob_Deleted, RouterErrorCode.BlobDeleted);
     testsAndExpected.put(ServerErrorCode.Blob_Expired, RouterErrorCode.BlobExpired);
-    testsAndExpected.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.AmbryUnavailable);
+    testsAndExpected.put(ServerErrorCode.Disk_Unavailable, RouterErrorCode.BlobDoesNotExist);
     testsAndExpected.put(ServerErrorCode.Replica_Unavailable, RouterErrorCode.AmbryUnavailable);
     testsAndExpected.put(ServerErrorCode.Unknown_Error, RouterErrorCode.UnexpectedInternalError);
+    // note that this test makes all nodes return same server error code. For Disk_Unavailable error, the router will
+    // return BlobDoesNotExist because all disks are down (which should be extremely rare) and blob is gone.
     for (Map.Entry<ServerErrorCode, RouterErrorCode> testAndExpected : testsAndExpected.entrySet()) {
       layout.getMockServers().forEach(mockServer -> mockServer.setServerErrorForAllRequests(testAndExpected.getKey()));
       TestCallback<Void> testCallback = new TestCallback<>();


### PR DESCRIPTION
Current operation tracker supports terminating when at least two
NotFound occur in originating DC. Such strategy is not able to
handle edge case where originating DC replicas return Disk_Unavailable,
Deleted and NotFound separately. Even though rest remote replicas
all return NotFound, the operation still returns AmbryUnavailable
which makes client keep retrying. This PR improve FailOnNotFound logic
by accounting for number of Disk_Unavailable and NotFound across all
dcs. It adds additional check in hasFailedOnNotFound to correctly return
404 reminding client the blob is no longer present. This is helpful when
client attempts to delete some blobs which have expired and been compacted
but encounters Disk_Unavailable during delete operation.