### PR TITLE
Add handleUndeleteRequest method to AmbryRequests

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/ServerConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ServerConfig.java
@@ -93,6 +93,13 @@ public class ServerConfig {
   @Default("false")
   public final boolean serverValidateRequestBasedOnStoreState;
 
+  /**
+   * True to enable ambry server handling undelete requests.
+   */
+  @Config("server.handle.undelete.request.enabled")
+  @Default("false")
+  public final boolean serverHandleUndeleteRequestEnabled;
+
   public ServerConfig(VerifiableProperties verifiableProperties) {
     serverRequestHandlerNumOfThreads = verifiableProperties.getInt("server.request.handler.num.of.threads", 7);
     serverSchedulerNumOfthreads = verifiableProperties.getInt("server.scheduler.num.of.threads", 10);
@@ -110,5 +117,7 @@ public class ServerConfig {
         Utils.splitString(verifiableProperties.getString("server.stats.reports.to.publish", ""), ",");
     serverValidateRequestBasedOnStoreState =
         verifiableProperties.getBoolean("server.validate.request.based.on.store.state", false);
+    serverHandleUndeleteRequestEnabled =
+        verifiableProperties.getBoolean("server.handle.undelete.request.enabled", false);
   }
 }

--- a/ambry-api/src/main/java/com.github.ambry/server/ServerErrorCode.java
+++ b/ambry-api/src/main/java/com.github.ambry/server/ServerErrorCode.java
@@ -37,5 +37,9 @@ public enum ServerErrorCode {
   Blob_Already_Updated,
   Blob_Update_Not_Allowed,
   Replica_Unavailable,
-  Blob_Authorization_Failure
+  Blob_Authorization_Failure,
+  Blob_Life_Version_Conflict,
+  Blob_Not_Deleted,
+  Blob_Already_Undeleted,
+  Blob_Deleted_Permanently
 }

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ErrorMapping.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ErrorMapping.java
@@ -38,6 +38,10 @@ public class ErrorMapping {
     tempMap.put(StoreErrorCodes.Authorization_Failure, ServerErrorCode.Blob_Authorization_Failure);
     tempMap.put(StoreErrorCodes.Already_Updated, ServerErrorCode.Blob_Already_Updated);
     tempMap.put(StoreErrorCodes.Update_Not_Allowed, ServerErrorCode.Blob_Update_Not_Allowed);
+    tempMap.put(StoreErrorCodes.Life_Version_Conflict, ServerErrorCode.Blob_Life_Version_Conflict);
+    tempMap.put(StoreErrorCodes.ID_Not_Deleted, ServerErrorCode.Blob_Not_Deleted);
+    tempMap.put(StoreErrorCodes.ID_Undeleted, ServerErrorCode.Blob_Already_Undeleted);
+    tempMap.put(StoreErrorCodes.ID_Deleted_Permanently, ServerErrorCode.Blob_Deleted_Permanently);
     storeErrorMapping = Collections.unmodifiableMap(tempMap);
   }
 

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ServerMetrics.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ServerMetrics.java
@@ -190,6 +190,7 @@ public class ServerMetrics {
   public final Counter unExpectedStoreGetError;
   public final Counter unExpectedStoreTtlUpdateError;
   public final Counter unExpectedStoreDeleteError;
+  public final Counter unExpectedStoreUndeleteError;
   public final Counter unExpectedAdminOperationError;
   public final Counter unExpectedStoreFindEntriesError;
   public final Counter idAlreadyExistError;
@@ -197,11 +198,15 @@ public class ServerMetrics {
   public final Counter unknownFormatError;
   public final Counter idNotFoundError;
   public final Counter idDeletedError;
+  public final Counter idUndeletedError;
+  public final Counter idNotDeletedError;
+  public final Counter lifeVersionConflictError;
   public final Counter ttlExpiredError;
   public final Counter badRequestError;
   public final Counter temporarilyDisabledError;
   public final Counter getAuthorizationFailure;
   public final Counter deleteAuthorizationFailure;
+  public final Counter undeleteAuthorizationFailure;
   public final Counter ttlUpdateAuthorizationFailure;
   public final Counter ttlAlreadyUpdatedError;
   public final Counter ttlUpdateRejectedError;
@@ -312,7 +317,8 @@ public class ServerMetrics {
 
     undeleteBlobRequestQueueTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "UndeleteBlobRequestQueueTime"));
-    undeleteBlobProcessingTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "UndeleteBlobProcessingTime"));
+    undeleteBlobProcessingTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "UndeleteBlobProcessingTime"));
     undeleteBlobResponseQueueTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "UndeleteBlobResponseQueueTime"));
     undeleteBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "UndeleteBlobSendTime"));
@@ -442,12 +448,16 @@ public class ServerMetrics {
     unknownFormatError = registry.counter(MetricRegistry.name(requestClass, "UnknownFormatError"));
     idNotFoundError = registry.counter(MetricRegistry.name(requestClass, "IDNotFoundError"));
     idDeletedError = registry.counter(MetricRegistry.name(requestClass, "IDDeletedError"));
+    idUndeletedError = registry.counter(MetricRegistry.name(requestClass, "IDUndeletedError"));
+    idNotDeletedError = registry.counter(MetricRegistry.name(requestClass, "IDNotDeletedError"));
+    lifeVersionConflictError = registry.counter(MetricRegistry.name(requestClass, "lifeVersionConflictError"));
     ttlExpiredError = registry.counter(MetricRegistry.name(requestClass, "TTLExpiredError"));
     temporarilyDisabledError = registry.counter(MetricRegistry.name(requestClass, "TemporarilyDisabledError"));
     badRequestError = registry.counter(MetricRegistry.name(requestClass, "BadRequestError"));
     unExpectedStorePutError = registry.counter(MetricRegistry.name(requestClass, "UnexpectedStorePutError"));
     unExpectedStoreGetError = registry.counter(MetricRegistry.name(requestClass, "UnexpectedStoreGetError"));
     unExpectedStoreDeleteError = registry.counter(MetricRegistry.name(requestClass, "UnexpectedStoreDeleteError"));
+    unExpectedStoreUndeleteError = registry.counter(MetricRegistry.name(requestClass, "UnexpectedStoreUndeleteError"));
     unExpectedAdminOperationError =
         registry.counter(MetricRegistry.name(requestClass, "UnexpectedAdminOperationError"));
     unExpectedStoreTtlUpdateError =
@@ -456,6 +466,7 @@ public class ServerMetrics {
         registry.counter(MetricRegistry.name(requestClass, "UnexpectedStoreFindEntriesError"));
     getAuthorizationFailure = registry.counter(MetricRegistry.name(requestClass, "GetAuthorizationFailure"));
     deleteAuthorizationFailure = registry.counter(MetricRegistry.name(requestClass, "DeleteAuthorizationFailure"));
+    undeleteAuthorizationFailure = registry.counter(MetricRegistry.name(requestClass, "UndeleteAuthorizationFailure"));
     ttlUpdateAuthorizationFailure =
         registry.counter(MetricRegistry.name(requestClass, "TtlUpdateAuthorizationFailure"));
     ttlAlreadyUpdatedError = registry.counter(MetricRegistry.name(requestClass, "TtlAlreadyUpdatedError"));

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ServerMetrics.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ServerMetrics.java
@@ -100,6 +100,12 @@ public class ServerMetrics {
   public final Histogram deleteBlobSendTimeInMs;
   public final Histogram deleteBlobTotalTimeInMs;
 
+  public final Histogram undeleteBlobRequestQueueTimeInMs;
+  public final Histogram undeleteBlobProcessingTimeInMs;
+  public final Histogram undeleteBlobResponseQueueTimeInMs;
+  public final Histogram undeleteBlobSendTimeInMs;
+  public final Histogram undeleteBlobTotalTimeInMs;
+
   public final Histogram updateBlobTtlRequestQueueTimeInMs;
   public final Histogram updateBlobTtlProcessingTimeInMs;
   public final Histogram updateBlobTtlResponseQueueTimeInMs;
@@ -157,6 +163,7 @@ public class ServerMetrics {
   public final Meter getBlobAllByReplicaRequestRate;
   public final Meter getBlobInfoRequestRate;
   public final Meter deleteBlobRequestRate;
+  public final Meter undeleteBlobRequestRate;
   public final Meter updateBlobTtlRequestRate;
   public final Meter replicaMetadataRequestRate;
   public final Meter triggerCompactionRequestRate;
@@ -303,6 +310,14 @@ public class ServerMetrics {
     deleteBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "DeleteBlobSendTime"));
     deleteBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "DeleteBlobTotalTime"));
 
+    undeleteBlobRequestQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "UndeleteBlobRequestQueueTime"));
+    undeleteBlobProcessingTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "UndeleteBlobProcessingTime"));
+    undeleteBlobResponseQueueTimeInMs =
+        registry.histogram(MetricRegistry.name(requestClass, "UndeleteBlobResponseQueueTime"));
+    undeleteBlobSendTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "UndeleteBlobSendTime"));
+    undeleteBlobTotalTimeInMs = registry.histogram(MetricRegistry.name(requestClass, "UndeleteBlobTotalTime"));
+
     updateBlobTtlRequestQueueTimeInMs =
         registry.histogram(MetricRegistry.name(requestClass, "UpdateBlobTtlRequestQueueTime"));
     updateBlobTtlProcessingTimeInMs =
@@ -399,6 +414,7 @@ public class ServerMetrics {
         registry.meter(MetricRegistry.name(requestClass, "GetBlobAllByReplicaRequestRate"));
     getBlobInfoRequestRate = registry.meter(MetricRegistry.name(requestClass, "GetBlobInfoRequestRate"));
     deleteBlobRequestRate = registry.meter(MetricRegistry.name(requestClass, "DeleteBlobRequestRate"));
+    undeleteBlobRequestRate = registry.meter(MetricRegistry.name(requestClass, "UndeleteBlobRequestRate"));
     updateBlobTtlRequestRate = registry.meter(MetricRegistry.name(requestClass, "UpdateBlobTtlRequestRate"));
     replicaMetadataRequestRate = registry.meter(MetricRegistry.name(requestClass, "ReplicaMetadataRequestRate"));
     triggerCompactionRequestRate = registry.meter(MetricRegistry.name(requestClass, "TriggerCompactionRequestRate"));

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
@@ -505,7 +505,7 @@ public class MessageFormatInputStreamTest {
    * @param updateTimeMs the expected time of update
    * @throws Exception any error.
    */
-  private static void checkUndeleteMessage(InputStream stream, Long expectedRecordSize, StoreKey key, short accountId,
+  public static void checkUndeleteMessage(InputStream stream, Long expectedRecordSize, StoreKey key, short accountId,
       short containerId, long updateTimeMs, short lifeVersion) throws Exception {
     checkHeaderAndStoreKeyForUpdate(stream, expectedRecordSize, key, lifeVersion);
     checkUndeleteSubRecord(stream, accountId, containerId, updateTimeMs);

--- a/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
@@ -223,20 +223,14 @@ class InMemoryStore implements Store {
   @Override
   public void delete(MessageWriteSet messageSetToDelete) throws StoreException {
     for (MessageInfo info : messageSetToDelete.getMessageSetInfo()) {
-      MessageInfo prev = getMessageInfo(info.getStoreKey(), messageInfos, true, true, true);
-      if (prev == null) {
-        throw new StoreException("Not Found", StoreErrorCodes.ID_Not_Found);
-      } else if (prev.isDeleted() && prev.getLifeVersion() == info.getLifeVersion()) {
-        throw new StoreException("Deleted", StoreErrorCodes.ID_Deleted);
-      }
       try {
         messageSetToDelete.writeTo(log);
       } catch (StoreException e) {
         throw new IllegalStateException(e);
       }
-      messageInfos.add(new MessageInfo(info.getStoreKey(), info.getSize(), true, prev.isTtlUpdated(), false,
-          prev.getExpirationTimeInMs(), null, info.getAccountId(), info.getContainerId(), info.getOperationTimeMs(),
-          prev.getLifeVersion()));
+      messageInfos.add(new MessageInfo(info.getStoreKey(), info.getSize(), true, info.isTtlUpdated(), false,
+          info.getExpirationTimeInMs(), null, info.getAccountId(), info.getContainerId(), info.getOperationTimeMs(),
+          info.getLifeVersion()));
     }
   }
 

--- a/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/InMemoryStore.java
@@ -17,6 +17,9 @@ import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
+import com.github.ambry.messageformat.MessageFormatInputStream;
+import com.github.ambry.messageformat.MessageFormatWriteSet;
+import com.github.ambry.messageformat.UndeleteMessageFormatInputStream;
 import com.github.ambry.store.FindInfo;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MessageReadSet;
@@ -205,9 +208,9 @@ class InMemoryStore implements Store {
     List<MessageInfo> infos = new ArrayList<>();
     for (MessageInfo info : newInfos) {
       if (info.isTtlUpdated()) {
-        info =
-            new MessageInfo(info.getStoreKey(), info.getSize(), info.isDeleted(), false, info.getExpirationTimeInMs(),
-                info.getCrc(), info.getAccountId(), info.getContainerId(), info.getOperationTimeMs());
+        info = new MessageInfo(info.getStoreKey(), info.getSize(), info.isDeleted(), false, info.isUndeleted(),
+            info.getExpirationTimeInMs(), info.getCrc(), info.getAccountId(), info.getContainerId(),
+            info.getOperationTimeMs(), (short) 0);
       }
       infos.add(info);
     }
@@ -220,41 +223,76 @@ class InMemoryStore implements Store {
   @Override
   public void delete(MessageWriteSet messageSetToDelete) throws StoreException {
     for (MessageInfo info : messageSetToDelete.getMessageSetInfo()) {
+      MessageInfo prev = getMessageInfo(info.getStoreKey(), messageInfos, true, true, true);
+      if (prev == null) {
+        throw new StoreException("Not Found", StoreErrorCodes.ID_Not_Found);
+      } else if (prev.isDeleted() && prev.getLifeVersion() == info.getLifeVersion()) {
+        throw new StoreException("Deleted", StoreErrorCodes.ID_Deleted);
+      }
       try {
         messageSetToDelete.writeTo(log);
       } catch (StoreException e) {
         throw new IllegalStateException(e);
       }
-      MessageInfo ttlUpdateInfo = getMessageInfo(info.getStoreKey(), messageInfos, false, true);
-      messageInfos.add(
-          new MessageInfo(info.getStoreKey(), info.getSize(), true, ttlUpdateInfo != null, info.getExpirationTimeInMs(),
-              info.getAccountId(), info.getContainerId(), info.getOperationTimeMs()));
+      messageInfos.add(new MessageInfo(info.getStoreKey(), info.getSize(), true, prev.isTtlUpdated(), false,
+          prev.getExpirationTimeInMs(), null, info.getAccountId(), info.getContainerId(), info.getOperationTimeMs(),
+          prev.getLifeVersion()));
     }
   }
 
   @Override
   public void updateTtl(MessageWriteSet messageSetToUpdate) throws StoreException {
     for (MessageInfo info : messageSetToUpdate.getMessageSetInfo()) {
-      if (getMessageInfo(info.getStoreKey(), messageInfos, true, false) != null) {
+      if (getMessageInfo(info.getStoreKey(), messageInfos, true, false, false) != null) {
         throw new StoreException("Deleted", StoreErrorCodes.ID_Deleted);
-      } else if (getMessageInfo(info.getStoreKey(), messageInfos, false, true) != null) {
+      } else if (getMessageInfo(info.getStoreKey(), messageInfos, false, false, true) != null) {
         throw new StoreException("Updated already", StoreErrorCodes.Already_Updated);
-      } else if (getMessageInfo(info.getStoreKey(), messageInfos, false, false) == null) {
+      } else if (getMessageInfo(info.getStoreKey(), messageInfos, false, false, false) == null) {
         throw new StoreException("Not Found", StoreErrorCodes.ID_Not_Found);
+      }
+      short lifeVersion = info.getLifeVersion();
+      if (info.getLifeVersion() == 0) {
+        lifeVersion = getMessageInfo(info.getStoreKey(), messageInfos, false, false, false).getLifeVersion();
       }
       try {
         messageSetToUpdate.writeTo(log);
       } catch (StoreException e) {
         throw new IllegalStateException(e);
       }
-      messageInfos.add(new MessageInfo(info.getStoreKey(), info.getSize(), false, true, info.getExpirationTimeInMs(),
-          info.getAccountId(), info.getContainerId(), info.getOperationTimeMs()));
+      messageInfos.add(
+          new MessageInfo(info.getStoreKey(), info.getSize(), false, true, false, info.getExpirationTimeInMs(), null,
+              info.getAccountId(), info.getContainerId(), info.getOperationTimeMs(), lifeVersion));
     }
   }
 
   @Override
   public short undelete(MessageInfo info) throws StoreException {
-    throw new UnsupportedOperationException("Undelete unsupported for now");
+    StoreKey key = info.getStoreKey();
+    MessageInfo deleteInfo = getMessageInfo(key, messageInfos, true, false, false);
+    if (info.getLifeVersion() == -1 && deleteInfo == null) {
+      throw new StoreException("Key " + key + " not delete yet", StoreErrorCodes.ID_Not_Deleted);
+    }
+    short lifeVersion = info.getLifeVersion();
+    if (info.getLifeVersion() == -1) {
+      lifeVersion = (short) (deleteInfo.getLifeVersion() + 1);
+    }
+    try {
+      MessageFormatInputStream stream =
+          new UndeleteMessageFormatInputStream(key, info.getAccountId(), info.getContainerId(),
+              info.getOperationTimeMs(), lifeVersion);
+      // Update info to add stream size;
+      info = new MessageInfo(key, stream.getSize(), false, deleteInfo.isTtlUpdated(), true,
+          deleteInfo.getExpirationTimeInMs(), null, info.getAccountId(), info.getContainerId(),
+          info.getOperationTimeMs(), lifeVersion);
+      ArrayList<MessageInfo> infoList = new ArrayList<>();
+      infoList.add(info);
+      MessageFormatWriteSet writeSet = new MessageFormatWriteSet(stream, infoList, false);
+      writeSet.writeTo(log);
+      return lifeVersion;
+    } catch (Exception e) {
+      throw new StoreException("Unknown error while trying to undelete blobs from store", e,
+          StoreErrorCodes.Unknown_Error);
+    }
   }
 
   @Override
@@ -310,7 +348,7 @@ class InMemoryStore implements Store {
 
   @Override
   public boolean isKeyDeleted(StoreKey key) throws StoreException {
-    return getMessageInfo(key, messageInfos, true, false) != null;
+    return getMessageInfo(key, messageInfos, true, false, false) != null;
   }
 
   @Override

--- a/ambry-replication/src/test/java/com.github.ambry.replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/MockConnectionPool.java
@@ -200,7 +200,7 @@ public class MockConnectionPool implements ConnectionPool {
               // If MsgInfo says it is deleted, get the original Put Message's MessageInfo as that is what Get Request
               // looks for. Just set the deleted flag to true for the constructed MessageInfo from Put.
               if (infoFound.isDeleted()) {
-                MessageInfo putMsgInfo = getMessageInfo(infoFound.getStoreKey(), messageInfoList, false, false);
+                MessageInfo putMsgInfo = getMessageInfo(infoFound.getStoreKey(), messageInfoList, false, false, false);
                 infoFound = new MessageInfo(putMsgInfo.getStoreKey(), putMsgInfo.getSize(), true, false,
                     putMsgInfo.getExpirationTimeInMs(), putMsgInfo.getAccountId(), putMsgInfo.getContainerId(),
                     putMsgInfo.getOperationTimeMs());

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/MockCluster.java
@@ -247,6 +247,7 @@ public class MockCluster {
     props.setProperty("store.validate.authorization", "true");
     props.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
     props.setProperty("server.enable.store.data.prefetch", Boolean.toString(enableDataPrefetch));
+    props.setProperty("server.handle.undelete.request.enabled", "true");
     props.setProperty("replication.intra.replica.thread.throttle.sleep.duration.ms", "100");
     props.setProperty("replication.inter.replica.thread.throttle.sleep.duration.ms", "100");
     props.putAll(sslProperties);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -524,7 +524,7 @@ final class ServerTestUtil {
       channel.send(undeleteRequest);
       stream = channel.receive().getInputStream();
       undeleteResponse = UndeleteResponse.readFrom(new DataInputStream(stream));
-      assertEquals("Undelete blob should succeed", ServerErrorCode.Blob_Already_Undeleted, undeleteResponse.getError());
+      assertEquals("Undelete blob should fail", ServerErrorCode.Blob_Already_Undeleted, undeleteResponse.getError());
 
       // get an undeleted blob, which should succeed
       getRequest1 = new GetRequest(1, "clientid1", MessageFormatFlags.All, partitionRequestInfoList, GetOption.None);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerTestUtil.java
@@ -76,6 +76,8 @@ import com.github.ambry.protocol.PutRequest;
 import com.github.ambry.protocol.PutResponse;
 import com.github.ambry.protocol.TtlUpdateRequest;
 import com.github.ambry.protocol.TtlUpdateResponse;
+import com.github.ambry.protocol.UndeleteRequest;
+import com.github.ambry.protocol.UndeleteResponse;
 import com.github.ambry.replication.FindTokenFactory;
 import com.github.ambry.router.Callback;
 import com.github.ambry.router.GetBlobOptionsBuilder;
@@ -494,6 +496,13 @@ final class ServerTestUtil {
       actualBlobData = getBlobDataAndRelease(blobAll.getBlobData());
       Assert.assertArrayEquals("Content mismatch", data, actualBlobData);
 
+      // undelete a not-deleted blob should return fail
+      UndeleteRequest undeleteRequest = new UndeleteRequest(1, "undeleteClient", blobId1, System.currentTimeMillis());
+      channel.send(undeleteRequest);
+      stream = channel.receive().getInputStream();
+      UndeleteResponse undeleteResponse = UndeleteResponse.readFrom(new DataInputStream(stream));
+      assertEquals("Undelete blob should succeed", ServerErrorCode.Blob_Not_Deleted, undeleteResponse.getError());
+
       // delete a blob on a restarted store , which should succeed
       deleteRequest = new DeleteRequest(1, "deleteClient", blobId1, System.currentTimeMillis());
       channel.send(deleteRequest);
@@ -501,6 +510,31 @@ final class ServerTestUtil {
       deleteResponse = DeleteResponse.readFrom(new DataInputStream(stream));
       assertEquals("Delete blob on restarted store should succeed", ServerErrorCode.No_Error,
           deleteResponse.getError());
+
+      // undelete a deleted blob, which should succeed
+      undeleteRequest = new UndeleteRequest(2, "undeleteClient", blobId1, System.currentTimeMillis());
+      channel.send(undeleteRequest);
+      stream = channel.receive().getInputStream();
+      undeleteResponse = UndeleteResponse.readFrom(new DataInputStream(stream));
+      assertEquals("Undelete blob should succeed", ServerErrorCode.No_Error, undeleteResponse.getError());
+      assertEquals("Undelete life version mismatch", undeleteResponse.getLifeVersion(), (short) 1);
+
+      // undelete an already undeleted blob, which should fail
+      undeleteRequest = new UndeleteRequest(3, "undeleteClient", blobId1, System.currentTimeMillis());
+      channel.send(undeleteRequest);
+      stream = channel.receive().getInputStream();
+      undeleteResponse = UndeleteResponse.readFrom(new DataInputStream(stream));
+      assertEquals("Undelete blob should succeed", ServerErrorCode.Blob_Already_Undeleted, undeleteResponse.getError());
+
+      // get an undeleted blob, which should succeed
+      getRequest1 = new GetRequest(1, "clientid1", MessageFormatFlags.All, partitionRequestInfoList, GetOption.None);
+      channel.send(getRequest1);
+      stream = channel.receive().getInputStream();
+      resp1 = GetResponse.readFrom(new DataInputStream(stream), clusterMap);
+      responseStream = resp1.getInputStream();
+      blobAll = MessageFormatRecord.deserializeBlobAll(responseStream, blobIdFactory);
+      actualBlobData = getBlobDataAndRelease(blobAll.getBlobData());
+      Assert.assertArrayEquals("Content mismatch", data, actualBlobData);
 
       // Bounce servers to make them read the persisted token file.
       cluster.stopServers();

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
@@ -615,6 +615,10 @@ public class AmbryServerRequests extends AmbryRequests {
       metrics.partitionReadOnlyError.inc();
       return ServerErrorCode.Partition_ReadOnly;
     }
+    if (requestType.equals(RequestOrResponseType.UndeleteRequest) && !serverConfig.serverHandleUndeleteRequestEnabled) {
+      metrics.temporarilyDisabledError.inc();
+      return ServerErrorCode.Temporarily_Disabled;
+    }
     // Ensure the request is enabled.
     if (!isRequestEnabled(requestType, partition)) {
       metrics.temporarilyDisabledError.inc();

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
@@ -74,11 +74,12 @@ public class AmbryServerRequests extends AmbryRequests {
   private final ConcurrentHashMap<PartitionId, ReplicaId> localPartitionToReplicaMap;
   // POST requests are allowed on stores states: { LEADER, STANDBY }
   static final Set<ReplicaState> PUT_ALLOWED_STORE_STATES = EnumSet.of(ReplicaState.LEADER, ReplicaState.STANDBY);
-  // UPDATE requests (including DELETE, TTLUpdate) are allowed on stores states: { LEADER, STANDBY, INACTIVE, BOOTSTRAP }
+  // UPDATE requests (including DELETE, TTLUpdate, UNDELETE) are allowed on stores states: { LEADER, STANDBY, INACTIVE, BOOTSTRAP }
   static final Set<ReplicaState> UPDATE_ALLOWED_STORE_STATES =
       EnumSet.of(ReplicaState.LEADER, ReplicaState.STANDBY, ReplicaState.INACTIVE, ReplicaState.BOOTSTRAP);
   static final Set<RequestOrResponseType> UPDATE_REQUEST_TYPES =
-      EnumSet.of(RequestOrResponseType.DeleteRequest, RequestOrResponseType.TtlUpdateRequest);
+      EnumSet.of(RequestOrResponseType.DeleteRequest, RequestOrResponseType.TtlUpdateRequest,
+          RequestOrResponseType.UndeleteResponse);
 
   private static final Logger logger = LoggerFactory.getLogger(AmbryServerRequests.class);
 
@@ -93,7 +94,7 @@ public class AmbryServerRequests extends AmbryRequests {
     this.statsManager = statsManager;
 
     for (RequestOrResponseType requestType : EnumSet.of(RequestOrResponseType.PutRequest,
-        RequestOrResponseType.GetRequest, RequestOrResponseType.DeleteRequest,
+        RequestOrResponseType.GetRequest, RequestOrResponseType.DeleteRequest, RequestOrResponseType.UndeleteRequest,
         RequestOrResponseType.ReplicaMetadataRequest, RequestOrResponseType.TtlUpdateRequest)) {
       requestsDisableInfo.put(requestType, Collections.newSetFromMap(new ConcurrentHashMap<>()));
     }

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServerRequests.java
@@ -122,6 +122,9 @@ public class AmbryServerRequests extends AmbryRequests {
    * @return {@code true} if the request is enabled. {@code false} otherwise.
    */
   private boolean isRequestEnabled(RequestOrResponseType requestType, PartitionId id) {
+    if (requestType.equals(RequestOrResponseType.UndeleteRequest) && !serverConfig.serverHandleUndeleteRequestEnabled) {
+      return false;
+    }
     Set<PartitionId> requestDisableInfo = requestsDisableInfo.get(requestType);
     // 1. check if request is disabled by admin request
     if (requestDisableInfo != null && requestDisableInfo.contains(id)) {
@@ -614,10 +617,6 @@ public class AmbryServerRequests extends AmbryRequests {
         && partition.getPartitionState() == PartitionState.READ_ONLY) {
       metrics.partitionReadOnlyError.inc();
       return ServerErrorCode.Partition_ReadOnly;
-    }
-    if (requestType.equals(RequestOrResponseType.UndeleteRequest) && !serverConfig.serverHandleUndeleteRequestEnabled) {
-      metrics.temporarilyDisabledError.inc();
-      return ServerErrorCode.Temporarily_Disabled;
     }
     // Ensure the request is enabled.
     if (!isRequestEnabled(requestType, partition)) {

--- a/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/MockStorageManager.java
@@ -152,8 +152,8 @@ class MockStorageManager extends StorageManager {
             new UndeleteMessageFormatInputStream(info.getStoreKey(), info.getAccountId(), info.getContainerId(),
                 info.getOperationTimeMs(), (short) returnValueOfUndelete);
         // Update info to add stream size;
-        info = new MessageInfo(info.getStoreKey(), stream.getSize(), info.getAccountId(), info.getContainerId(),
-            info.getOperationTimeMs());
+        info = new MessageInfo(info.getStoreKey(), stream.getSize(), false, false, true, Utils.Infinite_Time, null,
+            info.getAccountId(), info.getContainerId(), info.getOperationTimeMs(), returnValueOfUndelete);
         ArrayList<MessageInfo> infoList = new ArrayList<>();
         infoList.add(info);
         messageWriteSetReceived = new MessageFormatWriteSet(stream, infoList, false);


### PR DESCRIPTION
Adding handleUndeleteRequest method to AmbryRequests class to handle undelete requests from ambry-frontend.
Add unit test and integration test for handleUndeleteRequest
Change some of the Store implementation in replication test, but since we are not change replication logic for undelete now, we don't change those implementation to support undelete for now.