### PR TITLE
Minor changes to support recovering from replica addition failure

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StorageManager.java
@@ -394,7 +394,9 @@ public class StorageManager implements StoreManager {
           throw new StateTransitionException(
               "New replica " + partitionName + " is not found in clustermap for " + currentNode, ReplicaNotFound);
         }
-        // Attempt to add store into storage manager. If store already exists, fail adding store request.
+        // Attempt to add store into storage manager. If store already exists on disk (but not in clustermap), make
+        // sure old store of this replica is deleted (this store may be created in previous replica addition but failed
+        // at some point). Then a brand new store associated with this replica should be created and started.
         if (!addBlobStore(replicaToAdd)) {
           logger.error("Failed to add store {} into storage manager", partitionName);
           throw new StateTransitionException("Failed to add store " + partitionName + " into storage manager",


### PR DESCRIPTION
This PR adds minor changes to resume dynamic replica addition if it failed last time before updating InstanceConfig(clustermap update in Helix). The logic is simple: if diskManager finds there is a existing
directory associated with replica to add, it first deletes it and recreates a new one. (The files in previous directory may not be reliable)