### PR TITLE
Make registerClusterMapListener no-op in static cluster manager

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/StaticClusterManager.java
@@ -155,7 +155,7 @@ class StaticClusterManager implements ClusterMap {
 
   @Override
   public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
-    throw new UnsupportedOperationException("Registering clustermap listener is not supported in static clustermap");
+    // no op for static cluster manager
   }
 
   // Administrative API


### PR DESCRIPTION
Change exception to no-op behavior for static clustermap. The method is
going to be invoked by ReplicationManager during startup if we use
static clustermap.