### PR TITLE
Change Store interface to not use MessageWriteSet

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/store/Store.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/Store.java
@@ -49,10 +49,10 @@ public interface Store {
 
   /**
    * Deletes all the messages that are part of the message set
-   * @param messageSetToDelete The list of messages that need to be deleted
+   * @param infosToDelete The list of messages that need to be deleted
    * @throws StoreException
    */
-  void delete(MessageWriteSet messageSetToDelete) throws StoreException;
+  void delete(List<MessageInfo> infosToDelete) throws StoreException;
 
   /**
    * Undelete the blob identified by {@code id}.
@@ -63,10 +63,10 @@ public interface Store {
 
   /**
    * Updates the TTL of all the messages that are part of the message set
-   * @param messageSetToUpdate The list of messages that need to be updated
+   * @param infosToUpdate The list of messages that need to be updated
    * @throws StoreException
    */
-  void updateTtl(MessageWriteSet messageSetToUpdate) throws StoreException;
+  void updateTtl(List<MessageInfo> infosToUpdate) throws StoreException;
 
   /**
    * Finds all the entries from the store given a find token

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
@@ -129,7 +129,7 @@ class CloudBlobStore implements Store {
   @Override
   public StoreInfo get(List<? extends StoreKey> ids, EnumSet<StoreGetOptions> storeGetOptions) throws StoreException {
     checkStarted();
-    checkDuplicates(ids);
+    checkStoreKeyDuplicates(ids);
     List<CloudMessageReadSet.BlobReadInfo> blobReadInfos = new ArrayList<>(ids.size());
     List<MessageInfo> messageInfos = new ArrayList<>(ids.size());
     try {
@@ -253,7 +253,7 @@ class CloudBlobStore implements Store {
     if (messageSetToWrite.getMessageSetInfo().isEmpty()) {
       throw new IllegalArgumentException("Message write set cannot be empty");
     }
-    checkDuplicates(messageSetToWrite);
+    checkDuplicates(messageSetToWrite.getMessageSetInfo());
 
     // Write the blobs in the message set
     CloudWriteChannel cloudWriter = new CloudWriteChannel(this, messageSetToWrite.getMessageSetInfo());
@@ -343,12 +343,12 @@ class CloudBlobStore implements Store {
   }
 
   @Override
-  public void delete(MessageWriteSet messageSetToDelete) throws StoreException {
+  public void delete(List<MessageInfo> infos) throws StoreException {
     checkStarted();
-    checkDuplicates(messageSetToDelete);
+    checkDuplicates(infos);
 
     try {
-      for (MessageInfo msgInfo : messageSetToDelete.getMessageSetInfo()) {
+      for (MessageInfo msgInfo : infos) {
         BlobId blobId = (BlobId) msgInfo.getStoreKey();
         String blobKey = msgInfo.getStoreKey().getID();
         BlobState blobState = recentBlobCache.get(blobKey);
@@ -367,18 +367,12 @@ class CloudBlobStore implements Store {
     throw new UnsupportedOperationException("Undelete not supported in cloud store");
   }
 
-  /**
-   * {@inheritDoc}
-   * Currently, the only supported operation is to set the TTL to infinite (i.e. no arbitrary increase or decrease)
-   * @param messageSetToUpdate The list of messages that need to be updated
-   * @throws StoreException if there is a problem persisting the operation in the store.
-   */
   @Override
-  public void updateTtl(MessageWriteSet messageSetToUpdate) throws StoreException {
+  public void updateTtl(List<MessageInfo> infos) throws StoreException {
     checkStarted();
     // Note: we skipped uploading the blob on PUT record if the TTL was below threshold.
     try {
-      for (MessageInfo msgInfo : messageSetToUpdate.getMessageSetInfo()) {
+      for (MessageInfo msgInfo : infos) {
         // MessageInfo.expirationTimeInMs is not reliable if ttlUpdate is set. See {@code PersistentIndex#findKey()}
         // and {@code PersistentIndex#markAsPermanent()}. If we change updateTtl to be more flexible, code here will
         // need to be modified.
@@ -543,13 +537,12 @@ class CloudBlobStore implements Store {
 
   /**
    * Detects duplicates in {@code writeSet}
-   * @param writeSet the {@link MessageWriteSet} to detect duplicates in
+   * @param infos the list of {@link MessageInfo} to detect duplicates in
    * @throws IllegalArgumentException if a duplicate is detected
    */
-  private void checkDuplicates(MessageWriteSet writeSet) throws IllegalArgumentException {
-    List<MessageInfo> infos = writeSet.getMessageSetInfo();
+  private void checkDuplicates(List<MessageInfo> infos) throws IllegalArgumentException{
     List<StoreKey> keys = infos.stream().map(info -> info.getStoreKey()).collect(Collectors.toList());
-    checkDuplicates(keys);
+    checkStoreKeyDuplicates(keys);
   }
 
   /**
@@ -557,7 +550,7 @@ class CloudBlobStore implements Store {
    * @param keys list of {@link StoreKey} to detect duplicates in
    * @throws IllegalArgumentException if a duplicate is detected
    */
-  private void checkDuplicates(List<? extends StoreKey> keys) throws IllegalArgumentException {
+  private void checkStoreKeyDuplicates(List<? extends StoreKey> keys) throws IllegalArgumentException {
     if (keys.size() > 1) {
       new HashSet<>();
       Set<StoreKey> seenKeys = new HashSet<>();

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudBlobStore.java
@@ -247,6 +247,11 @@ class CloudBlobStore implements Store {
     return metadata.getExpirationTime() != Utils.Infinite_Time && metadata.getExpirationTime() < currentTimeStamp;
   }
 
+  /**
+   * Puts a set of messages into the store
+   * @param messageSetToWrite The message set to write to the store
+   * @throws StoreException
+   */
   @Override
   public void put(MessageWriteSet messageSetToWrite) throws StoreException {
     checkStarted();
@@ -367,6 +372,12 @@ class CloudBlobStore implements Store {
     throw new UnsupportedOperationException("Undelete not supported in cloud store");
   }
 
+  /**
+   * {@inheritDoc}
+   * Currently, the only supported operation is to set the TTL to infinite (i.e. no arbitrary increase or decrease)
+   * @param infos The list of messages that need to be updated
+   * @throws StoreException
+   */
   @Override
   public void updateTtl(List<MessageInfo> infos) throws StoreException {
     checkStarted();
@@ -540,7 +551,7 @@ class CloudBlobStore implements Store {
    * @param infos the list of {@link MessageInfo} to detect duplicates in
    * @throws IllegalArgumentException if a duplicate is detected
    */
-  private void checkDuplicates(List<MessageInfo> infos) throws IllegalArgumentException{
+  private void checkDuplicates(List<MessageInfo> infos) throws IllegalArgumentException {
     List<StoreKey> keys = infos.stream().map(info -> info.getStoreKey()).collect(Collectors.toList());
     checkStoreKeyDuplicates(keys);
   }

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudBlobStoreTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudBlobStoreTest.java
@@ -228,11 +228,11 @@ public class CloudBlobStoreTest {
       long size = 10;
       addBlobToSet(messageWriteSet, size, Utils.Infinite_Time, refAccountId, refContainerId, true);
     }
-    store.delete(messageWriteSet);
+    store.delete(messageWriteSet.getMessageSetInfo());
     verify(dest, times(count)).deleteBlob(any(BlobId.class), eq(operationTime));
 
     // Call second time.  If isVcr, should be cached causing deletions to be skipped.
-    store.delete(messageWriteSet);
+    store.delete(messageWriteSet.getMessageSetInfo());
     int expectedCount = isVcr ? count : count * 2;
     verify(dest, times(expectedCount)).deleteBlob(any(BlobId.class), eq(operationTime));
   }
@@ -248,11 +248,11 @@ public class CloudBlobStoreTest {
       long expirationTime = Math.abs(random.nextLong());
       addBlobToSet(messageWriteSet, size, expirationTime, refAccountId, refContainerId, true);
     }
-    store.updateTtl(messageWriteSet);
+    store.updateTtl(messageWriteSet.getMessageSetInfo());
     verify(dest, times(count)).updateBlobExpiration(any(BlobId.class), anyLong());
 
     // Call second time, If isVcr, should be cached causing updates to be skipped.
-    store.updateTtl(messageWriteSet);
+    store.updateTtl(messageWriteSet.getMessageSetInfo());
     int expectedCount = isVcr ? count : count * 2;
     verify(dest, times(expectedCount)).updateBlobExpiration(any(BlobId.class), anyLong());
   }
@@ -363,7 +363,7 @@ public class CloudBlobStoreTest {
     for (int j = 0; j < 5; j++) {
       addBlobToSet(messageWriteSet, (BlobId) blobIdList.get(j), blobSize, Utils.Infinite_Time);
     }
-    store.updateTtl(messageWriteSet);
+    store.updateTtl(messageWriteSet.getMessageSetInfo());
 
     // put 5 more blobs
     for (int j = 10; j < 15; j++) {
@@ -393,7 +393,7 @@ public class CloudBlobStoreTest {
       assertEquals(StoreErrorCodes.Store_Not_Started, e.getErrorCode());
     }
     try {
-      store.delete(messageWriteSet);
+      store.delete(messageWriteSet.getMessageSetInfo());
       fail("Store delete should have failed.");
     } catch (StoreException e) {
       assertEquals(StoreErrorCodes.Store_Not_Started, e.getErrorCode());
@@ -433,7 +433,7 @@ public class CloudBlobStoreTest {
       assertEquals(StoreErrorCodes.IOError, e.getErrorCode());
     }
     try {
-      exStore.delete(messageWriteSet);
+      exStore.delete(messageWriteSet.getMessageSetInfo());
       fail("Store delete should have failed.");
     } catch (StoreException e) {
       assertEquals(StoreErrorCodes.IOError, e.getErrorCode());
@@ -475,7 +475,7 @@ public class CloudBlobStoreTest {
 
     // Run all three operations, they should be retried and succeed second time.
     exStore.put(messageWriteSet);
-    exStore.delete(messageWriteSet);
+    exStore.delete(messageWriteSet.getMessageSetInfo());
     exStore.get(keys, EnumSet.noneOf(StoreGetOptions.class));
     exStore.downloadBlob(metadata, blobId, new ByteArrayOutputStream());
     assertEquals("Unexpected retry count", 4, vcrMetrics.retryCount.getCount());
@@ -762,7 +762,7 @@ public class CloudBlobStoreTest {
     MessageInfo deletedMessageInfo = messageWriteSet.getMessageSetInfo().get(0);
     MockMessageWriteSet deleteMockMessageWriteSet = new MockMessageWriteSet();
     deleteMockMessageWriteSet.add(deletedMessageInfo, null);
-    store.delete(deleteMockMessageWriteSet);
+    store.delete(deleteMockMessageWriteSet.getMessageSetInfo());
 
     //test get with a deleted blob in blob list to get, but {@code StoreGetOptions.Store_Include_Deleted} not set in get options
     testGetForDeletedBlobWithoutIncludeDeleteOption(blobIds);

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/DeleteMessageFormatInputStream.java
@@ -55,4 +55,22 @@ public class DeleteMessageFormatInputStream extends MessageFormatInputStream {
     messageLength = buffer.capacity();
     buffer.flip();
   }
+
+  public DeleteMessageFormatInputStream(StoreKey key, short accountId, short containerId, long deletionTimeMs,
+      short lifeVersion) throws MessageFormatException {
+    int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.Message_Header_Version_V3);
+    int deleteRecordSize = MessageFormatRecord.Update_Format_V3.getRecordSize(SubRecord.Type.DELETE);
+    buffer = ByteBuffer.allocate(headerSize + key.sizeInBytes() + deleteRecordSize);
+    MessageFormatRecord.MessageHeader_Format_V3.serializeHeader(buffer, lifeVersion, deleteRecordSize,
+        MessageFormatRecord.Message_Header_Invalid_Relative_Offset,
+        MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerSize + key.sizeInBytes(),
+        MessageFormatRecord.Message_Header_Invalid_Relative_Offset,
+        MessageFormatRecord.Message_Header_Invalid_Relative_Offset);
+    buffer.put(key.toBytes());
+    // set the message as deleted
+    MessageFormatRecord.Update_Format_V3.serialize(buffer,
+        new UpdateRecord(accountId, containerId, deletionTimeMs, new DeleteSubRecord()));
+    messageLength = buffer.capacity();
+    buffer.flip();
+  }
 }

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -15,10 +15,8 @@ package com.github.ambry.messageformat;
 
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
-import com.github.ambry.utils.ByteBufferDataInputStream;
 import com.github.ambry.utils.Crc32;
 import com.github.ambry.utils.CrcInputStream;
-import com.github.ambry.utils.NettyByteBufDataInputStream;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
@@ -76,6 +74,14 @@ public class MessageFormatRecord {
       default:
         return false;
     }
+  }
+
+  /**
+   * Return the currently used message header version.
+   * @return currently used message header version
+   */
+  public static short getCurrentMessageHeaderVersion() {
+    return headerVersionToUse;
   }
 
   /**

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/TtlUpdateMessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/TtlUpdateMessageFormatInputStream.java
@@ -46,4 +46,21 @@ public class TtlUpdateMessageFormatInputStream extends MessageFormatInputStream 
     messageLength = buffer.capacity();
     buffer.flip();
   }
+
+  public TtlUpdateMessageFormatInputStream(StoreKey key, short accountId, short containerId, long expiresAtMs,
+      long updateTimeInMs, short lifeVersion) throws MessageFormatException {
+    int headerSize = MessageFormatRecord.getHeaderSizeForVersion(MessageFormatRecord.Message_Header_Version_V3);
+    int recordSize = MessageFormatRecord.Update_Format_V3.getRecordSize(SubRecord.Type.TTL_UPDATE);
+    buffer = ByteBuffer.allocate(headerSize + key.sizeInBytes() + recordSize);
+    MessageFormatRecord.MessageHeader_Format_V3.serializeHeader(buffer, lifeVersion, recordSize,
+        MessageFormatRecord.Message_Header_Invalid_Relative_Offset,
+        MessageFormatRecord.Message_Header_Invalid_Relative_Offset, headerSize + key.sizeInBytes(),
+        MessageFormatRecord.Message_Header_Invalid_Relative_Offset,
+        MessageFormatRecord.Message_Header_Invalid_Relative_Offset);
+    buffer.put(key.toBytes());
+    MessageFormatRecord.Update_Format_V3.serialize(buffer,
+        new UpdateRecord(accountId, containerId, updateTimeInMs, new TtlUpdateSubRecord(expiresAtMs)));
+    messageLength = buffer.capacity();
+    buffer.flip();
+  }
 }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AmbryRequests.java
@@ -397,7 +397,7 @@ public class AmbryRequests implements RequestAPI {
       } else {
         BlobId convertedBlobId = (BlobId) convertedStoreKey;
         MessageInfo info =
-            new MessageInfo(convertedStoreKey, 0, convertedBlobId.getAccountId(), convertedBlobId.getContainerId(),
+            new MessageInfo(convertedStoreKey, -1, convertedBlobId.getAccountId(), convertedBlobId.getContainerId(),
                 deleteRequest.getDeletionTimeInMs());
         Store storeToDelete = storeManager.getStore(deleteRequest.getBlobId().getPartition());
         storeToDelete.delete(Collections.singletonList(info));
@@ -466,7 +466,7 @@ public class AmbryRequests implements RequestAPI {
       } else {
         BlobId convertedStoreKey =
             (BlobId) getConvertedStoreKeys(Collections.singletonList(updateRequest.getBlobId())).get(0);
-        MessageInfo info = new MessageInfo(convertedStoreKey, 0, false, true, updateRequest.getExpiresAtMs(),
+        MessageInfo info = new MessageInfo(convertedStoreKey, -1, false, true, updateRequest.getExpiresAtMs(),
             convertedStoreKey.getAccountId(), convertedStoreKey.getContainerId(), updateRequest.getOperationTimeInMs());
         Store store = storeManager.getStore(updateRequest.getBlobId().getPartition());
         store.updateTtl(Collections.singletonList(info));
@@ -650,7 +650,7 @@ public class AmbryRequests implements RequestAPI {
       } else {
         BlobId convertedBlobId = (BlobId) convertedStoreKey;
         MessageInfo info =
-            new MessageInfo(convertedBlobId, 0, convertedBlobId.getAccountId(), convertedBlobId.getContainerId(),
+            new MessageInfo(convertedBlobId, -1, convertedBlobId.getAccountId(), convertedBlobId.getContainerId(),
                 undeleteRequest.getOperationTimeMs());
         Store storeToUndelete = storeManager.getStore(undeleteRequest.getBlobId().getPartition());
         short lifeVersion = storeToUndelete.undelete(info);

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/AmbryRequests.java
@@ -23,7 +23,6 @@ import com.github.ambry.clustermap.ReplicaType;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ErrorMapping;
 import com.github.ambry.commons.ServerMetrics;
-import com.github.ambry.messageformat.DeleteMessageFormatInputStream;
 import com.github.ambry.messageformat.MessageFormatErrorCodes;
 import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatFlags;
@@ -32,7 +31,6 @@ import com.github.ambry.messageformat.MessageFormatMetrics;
 import com.github.ambry.messageformat.MessageFormatSend;
 import com.github.ambry.messageformat.MessageFormatWriteSet;
 import com.github.ambry.messageformat.PutMessageFormatInputStream;
-import com.github.ambry.messageformat.TtlUpdateMessageFormatInputStream;
 import com.github.ambry.network.NetworkRequest;
 import com.github.ambry.network.RequestResponseChannel;
 import com.github.ambry.network.Send;
@@ -398,16 +396,11 @@ public class AmbryRequests implements RequestAPI {
         response = new DeleteResponse(deleteRequest.getCorrelationId(), deleteRequest.getClientId(), error);
       } else {
         BlobId convertedBlobId = (BlobId) convertedStoreKey;
-        MessageFormatInputStream stream =
-            new DeleteMessageFormatInputStream(convertedStoreKey, convertedBlobId.getAccountId(),
-                convertedBlobId.getContainerId(), deleteRequest.getDeletionTimeInMs());
-        MessageInfo info = new MessageInfo(convertedStoreKey, stream.getSize(), convertedBlobId.getAccountId(),
-            convertedBlobId.getContainerId(), deleteRequest.getDeletionTimeInMs());
-        ArrayList<MessageInfo> infoList = new ArrayList<MessageInfo>();
-        infoList.add(info);
-        MessageFormatWriteSet writeSet = new MessageFormatWriteSet(stream, infoList, false);
+        MessageInfo info =
+            new MessageInfo(convertedStoreKey, 0, convertedBlobId.getAccountId(), convertedBlobId.getContainerId(),
+                deleteRequest.getDeletionTimeInMs());
         Store storeToDelete = storeManager.getStore(deleteRequest.getBlobId().getPartition());
-        storeToDelete.delete(writeSet);
+        storeToDelete.delete(Collections.singletonList(info));
         response =
             new DeleteResponse(deleteRequest.getCorrelationId(), deleteRequest.getClientId(), ServerErrorCode.No_Error);
         if (notification != null) {
@@ -473,17 +466,10 @@ public class AmbryRequests implements RequestAPI {
       } else {
         BlobId convertedStoreKey =
             (BlobId) getConvertedStoreKeys(Collections.singletonList(updateRequest.getBlobId())).get(0);
-        MessageFormatInputStream stream =
-            new TtlUpdateMessageFormatInputStream(convertedStoreKey, convertedStoreKey.getAccountId(),
-                convertedStoreKey.getContainerId(), updateRequest.getExpiresAtMs(),
-                updateRequest.getOperationTimeInMs());
-        MessageInfo info =
-            new MessageInfo(convertedStoreKey, stream.getSize(), false, true, updateRequest.getExpiresAtMs(),
-                convertedStoreKey.getAccountId(), convertedStoreKey.getContainerId(),
-                updateRequest.getOperationTimeInMs());
-        MessageFormatWriteSet writeset = new MessageFormatWriteSet(stream, Collections.singletonList(info), false);
+        MessageInfo info = new MessageInfo(convertedStoreKey, 0, false, true, updateRequest.getExpiresAtMs(),
+            convertedStoreKey.getAccountId(), convertedStoreKey.getContainerId(), updateRequest.getOperationTimeInMs());
         Store store = storeManager.getStore(updateRequest.getBlobId().getPartition());
-        store.updateTtl(writeset);
+        store.updateTtl(Collections.singletonList(info));
         response = new TtlUpdateResponse(updateRequest.getCorrelationId(), updateRequest.getClientId(),
             ServerErrorCode.No_Error);
         if (notification != null) {

--- a/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/StatsManagerTest.java
@@ -704,7 +704,7 @@ public class StatsManagerTest {
     }
 
     @Override
-    public void delete(MessageWriteSet messageSetToDelete) throws StoreException {
+    public void delete(List<MessageInfo> infos) throws StoreException {
       throw new IllegalStateException("Not implemented");
     }
 
@@ -714,7 +714,7 @@ public class StatsManagerTest {
     }
 
     @Override
-    public void updateTtl(MessageWriteSet messageSetToUpdate) throws StoreException {
+    public void updateTtl(List<MessageInfo> infos) throws StoreException {
       throw new IllegalStateException("Not implemented");
     }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CompactionPolicyTest.java
@@ -99,11 +99,10 @@ public class CompactionPolicyTest {
     }
 
     // if used capacity is <= 60%, compaction details will be null. If not, logSegmentsNotInJournal needs to be returned.
-    Long[] usedCapacities = new Long[]{
-        CAPACITY_IN_BYTES * 2 / 10, (CAPACITY_IN_BYTES * 4 / 10),
-        CAPACITY_IN_BYTES * 5 / 10,
-        CAPACITY_IN_BYTES * 51 / 100, (CAPACITY_IN_BYTES * 6 / 10),
-        CAPACITY_IN_BYTES * 7 / 10, CAPACITY_IN_BYTES * 9 / 10};
+    Long[] usedCapacities =
+        new Long[]{CAPACITY_IN_BYTES * 2 / 10, (CAPACITY_IN_BYTES * 4 / 10), CAPACITY_IN_BYTES * 5 / 10,
+            CAPACITY_IN_BYTES * 51 / 100, (CAPACITY_IN_BYTES * 6 / 10), CAPACITY_IN_BYTES * 7 / 10,
+            CAPACITY_IN_BYTES * 9 / 10};
     for (Long usedCapacity : usedCapacities) {
       blobStore.usedCapacity = usedCapacity;
       if (blobStore.usedCapacity < (config.storeMinUsedCapacityToTriggerCompactionInPercentage / 100.0

--- a/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
+++ b/ambry-tools/src/main/java/com.github.ambry/store/StoreCopier.java
@@ -22,7 +22,6 @@ import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobStoreRecovery;
 import com.github.ambry.messageformat.MessageFormatWriteSet;
-import com.github.ambry.messageformat.TtlUpdateMessageFormatInputStream;
 import com.github.ambry.replication.FindToken;
 import com.github.ambry.tools.util.ToolUtils;
 import com.github.ambry.utils.ByteBufferChannel;
@@ -246,14 +245,10 @@ public class StoreCopier implements Closeable {
             tgt.put(writeSet);
             MessageInfo tgtMsgInfo = message.getMessageInfo();
             if (tgtMsgInfo.isTtlUpdated()) {
-              TtlUpdateMessageFormatInputStream stream =
-                  new TtlUpdateMessageFormatInputStream(tgtMsgInfo.getStoreKey(), tgtMsgInfo.getAccountId(),
-                      tgtMsgInfo.getContainerId(), tgtMsgInfo.getExpirationTimeInMs(), tgtMsgInfo.getOperationTimeMs());
-              MessageInfo updateMsgInfo = new MessageInfo(tgtMsgInfo.getStoreKey(), stream.getSize(), false, true,
-                  tgtMsgInfo.getExpirationTimeInMs(), tgtMsgInfo.getAccountId(), tgtMsgInfo.getContainerId(),
-                  tgtMsgInfo.getOperationTimeMs());
-              writeSet = new MessageFormatWriteSet(stream, Collections.singletonList(updateMsgInfo), false);
-              tgt.updateTtl(writeSet);
+              MessageInfo updateMsgInfo =
+                  new MessageInfo(tgtMsgInfo.getStoreKey(), 0, false, true, tgtMsgInfo.getExpirationTimeInMs(),
+                      tgtMsgInfo.getAccountId(), tgtMsgInfo.getContainerId(), tgtMsgInfo.getOperationTimeMs());
+              tgt.updateTtl(Collections.singletonList(updateMsgInfo));
             }
             logger.trace("Copied {} as {}", messageInfo.getStoreKey(), tgtMsgInfo.getStoreKey());
           } else if (!messageInfo.isTtlUpdated()) {

--- a/ambry-tools/src/test/java/com.github.ambry/store/StoreCopierTest.java
+++ b/ambry-tools/src/test/java/com.github.ambry/store/StoreCopierTest.java
@@ -65,8 +65,6 @@ public class StoreCopierTest {
 
   private static final long STORE_CAPACITY = 1000;
   private static final int PUT_RECORD_SIZE = 53;
-  private static final int DELETE_RECORD_SIZE = 29;
-  private static final int TTL_UPDATE_RECORD_SIZE = 37;
 
   private final File srcDir;
   private final File tgtDir;
@@ -233,16 +231,16 @@ public class StoreCopierTest {
    */
   private byte[] addMessage(Store store, StoreKey key, long expiryTimeMs, boolean isDelete, boolean isTtlUpdate,
       short accountId, short containerId, long operationTimeMs) throws IOException, StoreException {
-    int size = isDelete ? DELETE_RECORD_SIZE : isTtlUpdate ? TTL_UPDATE_RECORD_SIZE : PUT_RECORD_SIZE;
+    int size = PUT_RECORD_SIZE;
     MessageInfo messageInfo =
         new MessageInfo(key, size, isDelete, isTtlUpdate, expiryTimeMs, accountId, containerId, operationTimeMs);
     byte[] data = TestUtils.getRandomBytes(size);
     MessageFormatWriteSet writeSet =
         new MessageFormatWriteSet(new ByteArrayInputStream(data), Collections.singletonList(messageInfo), false);
     if (isDelete) {
-      store.delete(writeSet);
+      store.delete(writeSet.getMessageSetInfo());
     } else if (isTtlUpdate) {
-      store.updateTtl(writeSet);
+      store.updateTtl(writeSet.getMessageSetInfo());
     } else {
       store.put(writeSet);
     }


### PR DESCRIPTION
delete and updateTtl method in interface Store take MessageWriteSet as its only parameter. This is not ideal since the data from MessageWriteSet would be persisted in the LogSegment files on disk, which means there is a chance that outside of the BlobStore implementation, we can construct any arbitrary bytes and persist them in the log files. This is not very bad, for we control how to construct those bytes, but from interface's perspective, it's not a good one.

And in order to support persisting undelete record, we need to get the lifeVersion from the PersistentIndex before we can construct a UndeleteFormatInputStream. The same goes to delete and ttlUpdate record. But in AmbryRequests, we don't yet know the lifeVersion before creating FormatInputStream for those record because of Store interface requires MessageWriteSet as the parameter. Changing the interface to take MessageInfo not MessageWriteSet solves this problem.

This PR changes that to make sure BlobStore would construct all the delete and updateTtl records by itself. We should change put method as well, but later.