### PR TITLE
Fix some quickstart issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The log will be available at `logs/frontend.log`. Alternately, you can change th
 ##### Step 4: Interact with Ambry !
 We are now ready to store and retrieve data from Ambry. Let us start by storing a simple image. For demonstration purposes, we will use an image `demo.gif` that has been copied into the `target` folder.
 ###### POST
-    $ curl -i -H "x-ambry-blob-size : `wc -c demo.gif | xargs | cut -d" " -f1`" -H "x-ambry-service-id : CUrlUpload"  -H "x-ambry-owner-id : `whoami`" -H "x-ambry-content-type : image/gif" -H "x-ambry-um-description : Demonstration Image" http://localhost:1174/ --data-binary @demo.gif
+    $ curl -i -H "x-ambry-service-id:CUrlUpload"  -H "x-ambry-owner-id:`whoami`" -H "x-ambry-content-type:image/gif" -H "x-ambry-um-description:Demonstration Image" http://localhost:1174/ --data-binary @demo.gif
     HTTP/1.1 201 Created
     Location: AmbryID
     Content-Length: 0

--- a/config/frontend.properties
+++ b/config/frontend.properties
@@ -25,6 +25,7 @@ router.delete.success.target=1
 clustermap.cluster.name=Ambry_Dev
 clustermap.datacenter.name=Datacenter
 clustermap.host.name=localhost
+clustermap.writable.partition.min.replica.count=1
 
 # helix property store
 # helix.property.store.zk.client.connect.string=localhost:2182


### PR DESCRIPTION
- New config is needed for partitions that have fewer than 3 local
  replicas
- Newer netty versions no longer accept spaces before the colon in
  headers
- `x-ambry-blob-size` no longer required on uploads