### PR TITLE
Support ByteBuf writing in NettyResponseChannel

### DIFF
--- a/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com.github.ambry.frontend/FrontendIntegrationTest.java
@@ -267,14 +267,13 @@ public class FrontendIntegrationTest {
     assertFalse("Channel should not be active", HttpUtil.isKeepAlive(response));
   }
 
-  /*
+  /**
    * Tests health check request
    * @throws ExecutionException
    * @throws InterruptedException
-   * @throws IOException
    */
   @Test
-  public void healthCheckRequestTest() throws ExecutionException, InterruptedException, IOException {
+  public void healthCheckRequestTest() throws ExecutionException, InterruptedException {
     FullHttpRequest httpRequest =
         new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/healthCheck", Unpooled.buffer(0));
     ResponseParts responseParts = nettyClient.sendRequest(httpRequest, null, null).get();
@@ -513,7 +512,7 @@ public class FrontendIntegrationTest {
       HttpContent content = (HttpContent) object;
       buffer.put(content.content().nioBuffer());
       endMarkerFound = object instanceof LastHttpContent;
-      ReferenceCountUtil.release(content);
+      content.release();
     }
     assertEquals("Content length did not match expected", expectedContentLength, buffer.position());
     assertTrue("End marker was not found", endMarkerFound);

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -86,7 +86,7 @@ class NettyResponseChannel implements RestResponseChannel {
   private final ChunkedWriteHandler chunkedWriteHandler;
   private final PerformanceConfig perfConfig;
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final static Logger logger = LoggerFactory.getLogger(NettyResponseChannel.class);
   private final HttpResponse responseMetadata = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
   // tracks whether onResponseComplete() has been called. Helps make it idempotent and also treats response channel as
   // closed if this is true.
@@ -443,7 +443,7 @@ class NettyResponseChannel implements RestResponseChannel {
 
   /**
    * Builds and sends an error response to the client based on {@code cause}.
-   * @param exception the cause of the request handling failure.
+   *j@param exception the cause of the request handling failure.
    * @return {@code true} if error response was scheduled to be sent. {@code false} otherwise.
    */
   private boolean maybeSendErrorResponse(Exception exception) {

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -828,7 +828,7 @@ class NettyResponseChannel implements RestResponseChannel {
       long bytesWritten = 0;
       if (exception == null) {
         bytesWritten = bytesToBeWritten;
-        buffer.skipBytes((int)bytesWritten);
+        buffer.skipBytes((int) bytesWritten);
       }
       nettyMetrics.bytesWriteRate.mark(bytesWritten);
       future.done(bytesWritten, exception);

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -23,7 +23,6 @@ import com.github.ambry.utils.Utils;
 import com.github.ambry.utils.UtilsTest;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -446,7 +446,7 @@ class GetBlobOperation extends GetOperation {
           ByteBuf byteBuf = chunkIndexToBuf.remove(indexOfNextChunkToWriteOut);
           if (byteBuf != null) {
             chunkIndexToBufWaitingForRelease.put(indexOfNextChunkToWriteOut, byteBuf);
-            asyncWritableChannel.write(byteBuf.nioBuffer(), chunkAsyncWriteCallback);
+            asyncWritableChannel.write(byteBuf, chunkAsyncWriteCallback);
             indexOfNextChunkToWriteOut++;
           }
         }

--- a/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/InMemoryRouter.java
@@ -157,7 +157,11 @@ public class InMemoryRouter implements Router {
         } catch (IllegalArgumentException e) {
           throw new RouterException("Invalid range for blob", e, RouterErrorCode.RangeNotSatisfiable);
         }
-        buf = ByteBuffer.wrap(blob.array(), (int) resolvedRange.getStartOffset(), (int) resolvedRange.getRangeSize());
+        byte[] bytes = new byte[(int) resolvedRange.getRangeSize()];
+        ByteBuffer duplicate = blob.duplicate();
+        duplicate.position((int) resolvedRange.getStartOffset());
+        duplicate.get(bytes);
+        buf = ByteBuffer.wrap(bytes);
       }
       return buf;
     }


### PR DESCRIPTION
Start to support writing ByteBuf in the NettyResponseChannel.

This is another step to stop supporting writing java ByteBuffer in the AsyncWritableChannel.