### PR TITLE
Fix early close refcnt error

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/CryptoJobHandler.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/CryptoJobHandler.java
@@ -18,6 +18,7 @@ import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +69,11 @@ class CryptoJobHandler implements Closeable {
         } else {
           logger.error("Unknown type of job seen : " + task.getClass());
         }
+      }
+      try {
+        scheduler.awaitTermination(1000, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        logger.error("Unexpected exception while waiting for crypto jobs to terminate", e);
       }
     }
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/DecryptJob.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/DecryptJob.java
@@ -97,6 +97,7 @@ class DecryptJob implements CryptoJob {
    * Close the job with the given {@code gse}
    * @param gse the {@link GeneralSecurityException} that needs to be set while invoking callback for the job
    */
+  @Override
   public void closeJob(GeneralSecurityException gse) {
     callback.onCompletion(null, gse);
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/EncryptJob.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/EncryptJob.java
@@ -93,6 +93,7 @@ public class EncryptJob implements CryptoJob {
    * Close the job with the given {@code gse}
    * @param gse the {@link GeneralSecurityException} that needs to be set while invoking callback for the job
    */
+  @Override
   public void closeJob(GeneralSecurityException gse) {
     callback.onCompletion(null, gse);
   }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -153,6 +153,12 @@ class GetBlobOperation extends GetOperation {
     if (chunkIndexToBuf == null) {
       return;
     }
+    for (Integer key : chunkIndexToBufWaitingForRelease.keySet()) {
+      ByteBuf byteBuf = chunkIndexToBufWaitingForRelease.remove(key);
+      if (byteBuf != null) {
+        byteBuf.release();
+      }
+    }
     for (Integer key : chunkIndexToBuf.keySet()) {
       ByteBuf byteBuf = chunkIndexToBuf.remove(key);
       if (byteBuf != null) {
@@ -384,6 +390,8 @@ class GetBlobOperation extends GetOperation {
         routerCallback.onPollReady();
       }
     };
+
+    private Object closeLock = new Object();
 
     /**
      * The bytes that will be read from this channel is not known until the read is complete.

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -152,12 +152,6 @@ class GetBlobOperation extends GetOperation {
     if (chunkIndexToBuf == null) {
       return;
     }
-    for (Integer key : chunkIndexToBufWaitingForRelease.keySet()) {
-      ByteBuf byteBuf = chunkIndexToBufWaitingForRelease.remove(key);
-      if (byteBuf != null) {
-        byteBuf.release();
-      }
-    }
     for (Integer key : chunkIndexToBuf.keySet()) {
       ByteBuf byteBuf = chunkIndexToBuf.remove(key);
       if (byteBuf != null) {
@@ -451,8 +445,8 @@ class GetBlobOperation extends GetOperation {
         while (operationException.get() == null && chunkIndexToBuf.containsKey(indexOfNextChunkToWriteOut)) {
           ByteBuf byteBuf = chunkIndexToBuf.remove(indexOfNextChunkToWriteOut);
           if (byteBuf != null) {
-            asyncWritableChannel.write(byteBuf.nioBuffer(), chunkAsyncWriteCallback);
             chunkIndexToBufWaitingForRelease.put(indexOfNextChunkToWriteOut, byteBuf);
+            asyncWritableChannel.write(byteBuf.nioBuffer(), chunkAsyncWriteCallback);
             indexOfNextChunkToWriteOut++;
           }
         }

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -391,8 +391,6 @@ class GetBlobOperation extends GetOperation {
       }
     };
 
-    private Object closeLock = new Object();
-
     /**
      * The bytes that will be read from this channel is not known until the read is complete.
      * @return -1

--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -48,7 +48,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -371,15 +370,7 @@ class GetBlobOperation extends GetOperation {
       public void onCompletion(Long result, Exception exception) {
         bytesWritten.addAndGet(result);
         if (exception != null) {
-          if (exception instanceof RouterException) {
-            setOperationException(exception);
-          } else if (exception instanceof ClosedChannelException) {
-            setOperationException(new RouterException(
-                "The ReadableStreamChannel for blob data has been closed by the user before all chunks were written out.",
-                RouterErrorCode.ChannelClosed));
-          } else {
-            setOperationException(exception);
-          }
+          setOperationException(exception);
         }
         int currentNumChunk = numChunksWrittenOut.get();
         ByteBuf byteBuf = chunkIndexToBufWaitingForRelease.remove(currentNumChunk);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -61,7 +61,6 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -171,9 +171,6 @@ public class GetBlobOperationTest {
   public void after() {
     router.close();
     Assert.assertEquals("All operations should have completed", 0, router.getOperationsCount());
-    if (cryptoJobHandler != null) {
-      cryptoJobHandler.close();
-    }
     nettyByteBufLeakHelper.afterTest();
   }
 
@@ -1214,14 +1211,6 @@ public class GetBlobOperationTest {
                   writableChannel.getNextChunk();
                   writableChannel.resolveOldestChunk(null);
                   chunksLeftToRead--;
-                }
-                ByteBuf buffer = null;
-                while(true){
-                  buffer = writableChannel.getNextByteBuf(0);
-                  if (buffer == null) {
-                    break;
-                  }
-                  writableChannel.resolveOldestChunk(new ClosedChannelException());
                 }
                 result.getBlobResult.getBlobDataChannel().close();
               } catch (Exception e) {

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -1212,6 +1212,9 @@ public class GetBlobOperationTest {
                   chunksLeftToRead--;
                 }
                 result.getBlobResult.getBlobDataChannel().close();
+                while (writableChannel.getNextChunk(100) != null) {
+                  writableChannel.resolveOldestChunk(null);
+                }
               } catch (Exception e) {
                 callbackException.set(e);
               } finally {

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -61,6 +61,7 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1213,6 +1214,14 @@ public class GetBlobOperationTest {
                   writableChannel.getNextChunk();
                   writableChannel.resolveOldestChunk(null);
                   chunksLeftToRead--;
+                }
+                ByteBuf buffer = null;
+                while(true){
+                  buffer = writableChannel.getNextByteBuf(0);
+                  if (buffer == null) {
+                    break;
+                  }
+                  writableChannel.resolveOldestChunk(new ClosedChannelException());
                 }
                 result.getBlobResult.getBlobDataChannel().close();
               } catch (Exception e) {


### PR DESCRIPTION
This pr should fix this test error:
![image](https://user-images.githubusercontent.com/51347395/74777316-131fcf80-524e-11ea-8c01-0ebdf036a44e.png)

In order to prevent concurrent access of chunkIndexToBuf, this pr separates ByteBufs waiting to be written and the ByteBuf that already written but waiting for callback to comeback.