### PR TITLE
Remove getMessageInfo from MessageStoreHardDelete interface

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/store/MessageStoreHardDelete.java
+++ b/ambry-api/src/main/java/com.github.ambry/store/MessageStoreHardDelete.java
@@ -29,15 +29,6 @@ public interface MessageStoreHardDelete {
    * @param recoveryInfoList An optional list of recoveryInfo messages.
    * @return iterator over the HardDeleteInfo for the messages in the readSet.
    */
-  public Iterator<HardDeleteInfo> getHardDeleteMessages(MessageReadSet readSet, StoreKeyFactory factory,
+  Iterator<HardDeleteInfo> getHardDeleteMessages(MessageReadSet readSet, StoreKeyFactory factory,
       List<byte[]> recoveryInfoList) throws IOException;
-
-  /**
-   * Returns the message info of message at the given offset from the given Read interface.
-   * @param read The read interface from which the message info is to be read.
-   * @param offset The start offset of the message.
-   * @param factory the store key factory.
-   * @return a MessageInfo object for the message at the offset.
-   */
-  public MessageInfo getMessageInfo(Read read, long offset, StoreKeyFactory factory) throws IOException;
 }

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/BlobStoreHardDeleteTest.java
@@ -16,7 +16,6 @@ package com.github.ambry.messageformat;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
 import com.github.ambry.store.HardDeleteInfo;
-import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.MessageReadSet;
 import com.github.ambry.store.MessageStoreHardDelete;
 import com.github.ambry.store.MockId;
@@ -397,29 +396,6 @@ public class BlobStoreHardDeleteTest {
     // create log and write to it
     ReadImp readImp = new ReadImp();
     ArrayList<Long> msgOffsets = readImp.initialize(blobVersions, blobTypes);
-
-    // read a put record.
-    MessageInfo info = hardDelete.getMessageInfo(readImp, msgOffsets.get(0), keyFactory);
-
-    // read a ttl update record
-    hardDelete.getMessageInfo(readImp, msgOffsets.get(3), keyFactory);
-
-    // read a delete record.
-    hardDelete.getMessageInfo(readImp, msgOffsets.get(4), keyFactory);
-
-    // read from a random location.
-    try {
-      hardDelete.getMessageInfo(readImp, (msgOffsets.get(0) + msgOffsets.get(1)) / 2, keyFactory);
-      Assert.fail("Should have failed to read data from a random location");
-    } catch (IOException e) {
-    }
-
-    // offset outside of valid range.
-    try {
-      hardDelete.getMessageInfo(readImp, (msgOffsets.get(msgOffsets.size() - 1) + 1), keyFactory);
-      Assert.fail("Should have failed to read data from an offset out of valid range");
-    } catch (IOException e) {
-    }
 
     Iterator<HardDeleteInfo> iter =
         hardDelete.getHardDeleteMessages(readImp.getMessageReadSet(), keyFactory, readImp.getRecoveryInfoList());

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -1055,57 +1055,20 @@ class PersistentIndex {
   private BlobReadOptions getDeletedBlobReadOptions(IndexValue value, StoreKey key,
       ConcurrentSkipListMap<Offset, IndexSegment> indexSegments) throws StoreException {
     BlobReadOptions readOptions;
-    try {
-      IndexValue putValue =
-          findKey(key, new FileSpan(getStartOffset(indexSegments), value.getOffset()), EnumSet.of(IndexEntryType.PUT),
-              indexSegments);
-      if (value.getOriginalMessageOffset() != IndexValue.UNKNOWN_ORIGINAL_MESSAGE_OFFSET
-          && value.getOriginalMessageOffset() != value.getOffset().getOffset()) {
-        // PUT record in the same log segment.
-        String logSegmentName = value.getOffset().getName();
-        // The delete entry in the index might not contain the information about the size of the original blob. So we
-        // use the Message format to read and provide the information. The range in log that we provide starts at the
-        // original message offset and ends at the delete message's start offset (the original message surely cannot go
-        // beyond the start offset of the delete message).
-        MessageInfo deletedBlobInfo =
-            hardDelete.getMessageInfo(log.getSegment(logSegmentName), value.getOriginalMessageOffset(), factory);
-        if (putValue != null && putValue.getOffset().getName().equals(value.getOffset().getName())) {
-          if (putValue.getOffset().getOffset() != value.getOriginalMessageOffset()) {
-            logger.error(
-                "Offset in PUT index entry {} is different from original message offset in delete entry {} for key {}",
-                putValue.getOffset().getOffset(), value.getOriginalMessageOffset(), key);
-            metrics.putEntryDeletedInfoMismatchCount.inc();
-          }
-          if (putValue.getSize() != deletedBlobInfo.getSize()) {
-            logger.error("Size in PUT index entry {} is different from that in the PUT record {} for ID {}",
-                putValue.getSize(), deletedBlobInfo.getSize(), key);
-            metrics.putEntryDeletedInfoMismatchCount.inc();
-          }
-        }
-        Offset offset = new Offset(logSegmentName, value.getOriginalMessageOffset());
-        // use the expiration time from the original value because it may have been updated
-        readOptions = new BlobReadOptions(log, offset,
-            new MessageInfo(deletedBlobInfo.getStoreKey(), deletedBlobInfo.getSize(), true,
-                value.isFlagSet(IndexValue.Flags.Ttl_Update_Index), value.getExpiresAtMs(),
-                deletedBlobInfo.getAccountId(), deletedBlobInfo.getContainerId(),
-                deletedBlobInfo.getOperationTimeMs()));
-      } else if (putValue != null) {
-        // PUT record in a different log segment.
-        // use the expiration time from the original value because it may have been updated
-        readOptions = new BlobReadOptions(log, putValue.getOffset(),
-            new MessageInfo(key, putValue.getSize(), true, value.isFlagSet(IndexValue.Flags.Ttl_Update_Index),
-                value.getExpiresAtMs(), putValue.getAccountId(), putValue.getContainerId(),
-                putValue.getOperationTimeInMs()));
-      } else {
-        // PUT record no longer available.
-        throw new StoreException("Did not find PUT index entry for key [" + key
-            + "] and the the original offset in value of the DELETE entry was [" + value.getOriginalMessageOffset()
-            + "]", StoreErrorCodes.ID_Deleted);
-      }
-    } catch (IOException e) {
-      StoreErrorCodes errorCode = StoreException.resolveErrorCode(e);
-      throw new StoreException(errorCode.toString() + " when reading delete blob info from the log " + dataDir, e,
-          errorCode);
+    IndexValue putValue =
+        findKey(key, new FileSpan(getStartOffset(indexSegments), value.getOffset()), EnumSet.of(IndexEntryType.PUT),
+            indexSegments);
+    if (putValue != null) {
+      // use the expiration time from the original value because it may have been updated
+      readOptions = new BlobReadOptions(log, putValue.getOffset(),
+          new MessageInfo(key, putValue.getSize(), true, value.isFlagSet(IndexValue.Flags.Ttl_Update_Index),
+              value.getExpiresAtMs(), putValue.getAccountId(), putValue.getContainerId(),
+              putValue.getOperationTimeInMs()));
+    } else {
+      // PUT record no longer available.
+      throw new StoreException("Did not find PUT index entry for key [" + key
+          + "] and the the original offset in value of the DELETE entry was [" + value.getOriginalMessageOffset() + "]",
+          StoreErrorCodes.ID_Deleted);
     }
     return readOptions;
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -1061,9 +1061,8 @@ class PersistentIndex {
     if (putValue != null) {
       // use the expiration time from the original value because it may have been updated
       readOptions = new BlobReadOptions(log, putValue.getOffset(),
-          new MessageInfo(key, putValue.getSize(), true, value.isFlagSet(IndexValue.Flags.Ttl_Update_Index),
-              value.getExpiresAtMs(), putValue.getAccountId(), putValue.getContainerId(),
-              putValue.getOperationTimeInMs()));
+          new MessageInfo(key, putValue.getSize(), true, value.isTTLUpdate(), value.getExpiresAtMs(),
+              putValue.getAccountId(), putValue.getContainerId(), putValue.getOperationTimeInMs()));
     } else {
       // PUT record no longer available.
       throw new StoreException("Did not find PUT index entry for key [" + key

--- a/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/StoreMetrics.java
@@ -53,7 +53,6 @@ public class StoreMetrics {
   public final Timer indexFlushTime;
   public final Timer cleanupTokenFlushTime;
   public final Timer hardDeleteTime;
-  public final Counter putEntryDeletedInfoMismatchCount;
   public final Counter nonzeroMessageRecovery;
   public final Counter blobFoundInMemSegmentCount;
   public final Counter bloomAccessedCount;
@@ -133,8 +132,6 @@ public class StoreMetrics {
     indexFlushTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "IndexFlushTime"));
     cleanupTokenFlushTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "CleanupTokenFlushTime"));
     hardDeleteTime = registry.timer(MetricRegistry.name(PersistentIndex.class, name + "HardDeleteTime"));
-    putEntryDeletedInfoMismatchCount =
-        registry.counter(MetricRegistry.name(PersistentIndex.class, name + "PutEntryDeletedInfoMismatchCount"));
     nonzeroMessageRecovery =
         registry.counter(MetricRegistry.name(PersistentIndex.class, name + "NonZeroMessageRecovery"));
     blobFoundInMemSegmentCount =

--- a/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/BlobStoreTest.java
@@ -115,21 +115,10 @@ public class BlobStoreTest {
    * particular {@link MockId}.
    */
   private static class MockMessageStoreHardDelete implements MessageStoreHardDelete {
-    private MessageInfo messageInfo = null;
-
     @Override
     public Iterator<HardDeleteInfo> getHardDeleteMessages(MessageReadSet readSet, StoreKeyFactory factory,
         List<byte[]> recoveryInfoList) {
       throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public MessageInfo getMessageInfo(Read read, long offset, StoreKeyFactory factory) {
-      return messageInfo;
-    }
-
-    void setMessageInfo(MessageInfo messageInfo) {
-      this.messageInfo = messageInfo;
     }
   }
 
@@ -508,8 +497,6 @@ public class BlobStoreTest {
 
     MockMessageStoreHardDelete hd = (MockMessageStoreHardDelete) hardDelete;
     for (MockId id : deletedKeys) {
-      hd.setMessageInfo(allKeys.get(id).getFirst());
-
       // cannot get without StoreGetOptions
       verifyGetFailure(id, StoreErrorCodes.ID_Deleted);
 

--- a/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/CuratedLogIndexState.java
@@ -1635,15 +1635,6 @@ class CuratedLogIndexState {
 
       return new MockMessageStoreHardDeleteIterator(readSet);
     }
-
-    @Override
-    public MessageInfo getMessageInfo(Read read, long offset, StoreKeyFactory factory) {
-      String segmentName = ((LogSegment) read).getName();
-      Pair<MockId, LogEntry> idAndValue = logOrder.get(new Offset(segmentName, offset));
-      IndexValue value = idAndValue.getSecond().indexValue;
-      return new MessageInfo(idAndValue.getFirst(), value.getSize(), value.getExpiresAtMs(), value.getAccountId(),
-          value.getContainerId(), value.getOperationTimeInMs());
-    }
   }
 
   /**

--- a/ambry-store/src/test/java/com.github.ambry.store/DummyMessageStoreHardDelete.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/DummyMessageStoreHardDelete.java
@@ -13,18 +13,11 @@
  */
 package com.github.ambry.store;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
 
 public class DummyMessageStoreHardDelete implements MessageStoreHardDelete {
-  HashMap<Long, MessageInfo> dummyMap;
-
-  public DummyMessageStoreHardDelete(HashMap<Long, MessageInfo> dummyMap) {
-    this.dummyMap = dummyMap;
-  }
-
   public DummyMessageStoreHardDelete() {
   }
 
@@ -47,11 +40,6 @@ public class DummyMessageStoreHardDelete implements MessageStoreHardDelete {
         throw new UnsupportedOperationException();
       }
     };
-  }
-
-  @Override
-  public MessageInfo getMessageInfo(Read read, long offset, StoreKeyFactory factory) {
-    return dummyMap.get(offset);
   }
 }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
@@ -139,11 +139,6 @@ public class HardDeleterTest {
 
       return new MockMessageStoreHardDeleteIterator(readSet);
     }
-
-    @Override
-    public MessageInfo getMessageInfo(Read read, long offset, StoreKeyFactory factory) {
-      return offsetMap.get(offset);
-    }
   }
 
   private MockIndex index = null;


### PR DESCRIPTION
Remove unnecessary method getMessageInfo from MessageStoreHardDelete interface.

When the log files are not segmented, each delete index entry has a field "originalMessageOffset" pointing to the original Put record, so that when fetching content for a deleted blob, we don't have to search the Put record from the index again, we simple read the content from the Put record located by the "originalMessageOffset".

This is not true after we segmented log files and start compaction. Now a Delete index entry might not have a "originalMessageOffset" when the Put entry is not located in the same segment as the delete entry, so we have to search the Put entry from the index again not matter what. This totally obsolete the "originalMessageOffset" and thus the logic to read the content from the "origianlMessageOffset".