### PR TITLE
Add back property to disable publishing/releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,9 @@ println "Building version $version"
 apply from: file('gradle/license.gradle')
 apply from: file('gradle/environment.gradle')
 apply from: file("gradle/dependency-versions.gradle")
-apply from: file("gradle/ci-release.gradle")
+if (!project.hasProperty('disableShipkit')) {
+    apply from: file("gradle/ci-release.gradle")
+}
 
 allprojects {
     group = "com.github.ambry"
@@ -41,7 +43,9 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    apply from: "$rootDir/gradle/java-publishing.gradle"    
+    if (!project.hasProperty('disableShipkit')) {
+        apply from: "$rootDir/gradle/java-publishing.gradle"
+    }
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -110,7 +114,7 @@ subprojects {
         group = 'verification'
     }
     allTest.dependsOn test
-    allTest.dependsOn intTest    
+    allTest.dependsOn intTest
     javadoc {
         // TODO audit and fix our javadocs so that we don't need this setting
         // This is mainly for cases where param/throws tags don't have descriptions

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,17 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    if (!project.hasProperty('disableShipkit')) {
+    if (project.hasProperty('disableShipkit')) {
+        // internal builds still want the test jar, but not sources/javadoc targets
+        task testJar(type: Jar, dependsOn: testClasses) {
+            from sourceSets.test.output
+            classifier = 'test'
+        }
+
+        artifacts {
+            archives testJar
+        }
+    } else {
         apply from: "$rootDir/gradle/java-publishing.gradle"
     }
 


### PR DESCRIPTION
To support internal adapted gradle builds, we used to have a flag that
disables the release/publishing related gradle plugins,
"disableShipkit". This commit adds it back, as it got removed in
PR #1387.