### PR TITLE
Improve Helix bootstrap tool for moving replica

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -62,7 +62,7 @@ import org.slf4j.LoggerFactory;
  *InstanceConfig: {
  *  "id" : "localhost_17088",                              # id is the instanceName [host_port]
  *  "mapFields" : {
- *    "/tmp/c/0" : {                                       # disk is identified by the [mountpath]. DiskInfo conists of:
+ *    "/tmp/c/0" : {                                       # disk is identified by the [mountpath]. DiskInfo consists of:
  *      "capacityInBytes" : "912680550400",                # [capacity]
  *      "diskState" : "AVAILABLE",                         # [state]
  *      "Replicas" : "10:107374182400:default,"            # comma-separated list of partition ids whose replicas are
@@ -98,7 +98,7 @@ class HelixBootstrapUpgradeUtil {
   private final String zkLayoutPath;
   private final String stateModelDef;
   private final Map<String, HelixAdmin> adminForDc = new HashMap<>();
-  // These two maps should be concurrent map because there are accessed in multi-threaded context (see addUpdateInstances
+  // These two maps should be concurrent map because they are accessed in multi-threaded context (see addUpdateInstances
   // method).
   // For now, the inner map doesn't need to be concurrent map because it is within a certain dc which means there should
   // be only one thread that updates it.
@@ -162,7 +162,7 @@ class HelixBootstrapUpgradeUtil {
    * @param zkLayoutPath the path to the zookeeper layout file.
    * @param clusterNamePrefix the prefix that when combined with the cluster name in the static cluster map files
    *                          will give the cluster name in Helix to bootstrap or upgrade.
-   * @param dcs the comma-separated list of datacenters that should be updated in this run.
+   * @param dcs the comma-separated list of data centers that should be updated in this run.
    * @param maxPartitionsInOneResource the maximum number of Ambry partitions to group under a single Helix resource.
    * @param dryRun if true, perform a dry run; do not update anything in Helix.
    * @param forceRemove if true, removes any hosts from Helix not present in the json files.
@@ -244,7 +244,7 @@ class HelixBootstrapUpgradeUtil {
    * @param zkLayoutPath the path to the zookeeper layout file.
    * @param clusterNamePrefix the prefix that when combined with the cluster name in the static cluster map files
    *                          will give the cluster name in Helix to bootstrap or upgrade.
-   * @param dcs the comma-separated list of datacenters that needs to be upgraded/bootstrapped.
+   * @param dcs the comma-separated list of data centers that needs to be upgraded/bootstrapped.
    * @param helixAdminFactory the {@link HelixAdminFactory} to use to instantiate {@link HelixAdmin}
    * @param stateModelDef the state model definition to use in Ambry cluster.
    * @throws IOException if there is an error reading a file.
@@ -264,7 +264,7 @@ class HelixBootstrapUpgradeUtil {
    * Drop a cluster from Helix.
    * @param zkLayoutPath the path to the zookeeper layout file.
    * @param clusterName the name of the cluster in Helix.
-   * @param dcs the comma-separated list of datacenters that needs to be upgraded/bootstrapped.
+   * @param dcs the comma-separated list of data centers that needs to be upgraded/bootstrapped.
    * @param helixAdminFactory the {@link HelixAdminFactory} to use to instantiate {@link HelixAdmin}
    * @throws Exception if there is an error reading a file or in parsing json.
    */
@@ -352,7 +352,7 @@ class HelixBootstrapUpgradeUtil {
     info("Associating static Ambry cluster \"" + clusterNameInStaticClusterMap + "\" with cluster\"" + clusterName
         + "\" in Helix");
     for (Datacenter datacenter : staticClusterMap.hardwareLayout.getDatacenters()) {
-      if (dcs.equalsIgnoreCase(ALL) && !dataCenterToZkAddress.keySet().contains(datacenter.getName())) {
+      if (dcs.equalsIgnoreCase(ALL) && !dataCenterToZkAddress.containsKey(datacenter.getName())) {
         throw new IllegalArgumentException(
             "There is no ZK host for datacenter " + datacenter.getName() + " in the static clustermap");
       }
@@ -683,7 +683,7 @@ class HelixBootstrapUpgradeUtil {
         // cluster map. These will be ignored.
         continue;
       }
-      maxResource = Math.max(maxResource, Integer.valueOf(resourceName));
+      maxResource = Math.max(maxResource, Integer.parseInt(resourceName));
       IdealState resourceIs = dcAdmin.getResourceIdealState(clusterName, resourceName);
       for (String partitionName : new HashSet<>(resourceIs.getPartitionSet())) {
         Set<String> instanceSetInHelix = resourceIs.getInstanceSet(partitionName);
@@ -1039,7 +1039,7 @@ class HelixBootstrapUpgradeUtil {
             "[" + dcName.toUpperCase() + "] Disk not present for instance " + instanceName + " disk "
                 + disk.getMountPath());
         ensureOrThrow(
-            disk.getRawCapacityInBytes() == Long.valueOf(diskInfoInHelix.get(ClusterMapUtils.DISK_CAPACITY_STR)),
+            disk.getRawCapacityInBytes() == Long.parseLong(diskInfoInHelix.get(ClusterMapUtils.DISK_CAPACITY_STR)),
             "[" + dcName.toUpperCase() + "] Capacity mismatch for instance " + instanceName + " disk "
                 + disk.getMountPath());
 
@@ -1080,10 +1080,10 @@ class HelixBootstrapUpgradeUtil {
       ensureOrThrow(diskInfos.isEmpty(),
           "[" + dcName.toUpperCase() + "] Instance " + instanceName + " has extra disks in Helix: " + diskInfos);
 
-      ensureOrThrow(!dataNode.hasSSLPort() || (dataNode.getSSLPort() == Integer.valueOf(
+      ensureOrThrow(!dataNode.hasSSLPort() || (dataNode.getSSLPort() == Integer.parseInt(
           instanceConfig.getRecord().getSimpleField(ClusterMapUtils.SSL_PORT_STR))),
           "[" + dcName.toUpperCase() + "] SSL Port mismatch for instance " + instanceName);
-      ensureOrThrow(!dataNode.hasHttp2Port() || (dataNode.getHttp2Port() == Integer.valueOf(
+      ensureOrThrow(!dataNode.hasHttp2Port() || (dataNode.getHttp2Port() == Integer.parseInt(
           instanceConfig.getRecord().getSimpleField(ClusterMapUtils.HTTP2_PORT_STR))),
           "[" + dcName.toUpperCase() + "] HTTP2 Port mismatch for instance " + instanceName);
       ensureOrThrow(dataNode.getDatacenterName()

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixBootstrapUpgradeUtil.java
@@ -705,10 +705,14 @@ class HelixBootstrapUpgradeUtil {
                 .add(partitionName);
           }
         } else if (!instanceSetInStatic.equals(instanceSetInHelix)) {
+          // @formatter:off
           info(
-              "[{}] Different instance sets for partition {} under resource {}. Updating Helix using static. Previous instance set: [{}], new instance set: [{}]",
-              dcName.toUpperCase(), partitionName, resourceName, String.join(",", instanceSetInHelix),
-              String.join(",", instanceSetInStatic));
+              "[{}] Different instance sets for partition {} under resource {}. "
+                  + "Updating Helix using static. "
+                  + "Previous instance set: [{}], new instance set: [{}]",
+              dcName.toUpperCase(), partitionName, resourceName,
+              String.join(",", instanceSetInHelix), String.join(",", instanceSetInStatic));
+          // @formatter:on
           ArrayList<String> newInstances = new ArrayList<>(instanceSetInStatic);
           Collections.shuffle(newInstances);
           resourceIs.setPreferenceList(partitionName, newInstances);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockHelixCluster.java
@@ -58,7 +58,7 @@ public class MockHelixCluster {
     dataCenterToZkAddress = parseDcJsonAndPopulateDcInfo(jsonString);
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
         "all", MAX_PARTITIONS_IN_ONE_RESOURCE, false, false, helixAdminFactory, false,
-        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
+        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, false);
     this.clusterName = clusterName;
   }
 
@@ -70,7 +70,7 @@ public class MockHelixCluster {
   void upgradeWithNewHardwareLayout(String hardwareLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
         "all", MAX_PARTITIONS_IN_ONE_RESOURCE, false, false, helixAdminFactory, false,
-        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
+        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, false);
     triggerInstanceConfigChangeNotification();
   }
 
@@ -81,7 +81,7 @@ public class MockHelixCluster {
    */
   void upgradeWithNewPartitionLayout(String partitionLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
+        "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, false);
     triggerInstanceConfigChangeNotification();
   }
 

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/ValidatingTransformer.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/ValidatingTransformer.java
@@ -73,9 +73,9 @@ public class ValidatingTransformer implements Transformer {
         throw new IllegalStateException("Message cannot be a deleted record ");
       }
       if (msgInfo.getStoreKey().equals(keyInStream)) {
-        // ValidatingTransformer only exists on ambry-server and we don't enable netty on ambry server yet. So And blobData.getAndRelease
-        // will return an Unpooled ByteBuf, it's not not to release it.
-        // @todo, when enabling netty in ambry-server, release this ByteBuf.
+        // BlobIDTransformer only exists on ambry-server and replication between servers is relying on blocking channel
+        // which is still using java ByteBuffer. So, no need to consider releasing stuff.
+        // @todo, when netty Bytebuf is adopted for blocking channel on ambry-server, remember to release this ByteBuf.
         PutMessageFormatInputStream transformedStream =
             new PutMessageFormatInputStream(keyInStream, encryptionKey, props, metadata,
                 new ByteBufInputStream(blobData.content(), true), blobData.getSize(), blobData.getBlobType());

--- a/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/BlobIdTransformer.java
@@ -234,9 +234,9 @@ public class BlobIdTransformer implements Transformer {
               oldProperties.getCreationTimeInMs(), newBlobId.getAccountId(), newBlobId.getContainerId(),
               oldProperties.isEncrypted(), null);
 
-      // BlobIDTransformer only exists on ambry-server and we don't enable netty on ambry server yet. So And blobData.getAndRelease
-      // will return an Unpooled ByteBuf, it's not required to release it.
-      // @todo, when enabling netty in ambry-server, release this ByteBuf.
+      // BlobIDTransformer only exists on ambry-server and replication between servers is relying on blocking channel
+      // which is still using java ByteBuffer. So, no need to consider releasing stuff.
+      // @todo, when netty Bytebuf is adopted for blocking channel on ambry-server, remember to release this ByteBuf.
       PutMessageFormatInputStream putMessageFormatInputStream =
           new PutMessageFormatInputStream(newKey, blobEncryptionKey, newProperties, userMetaData,
               new ByteBufInputStream(blobDataBytes, true), blobData.getSize(), blobData.getBlobType());

--- a/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com.github.ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ZNRecord;
@@ -184,7 +185,7 @@ public class HelixBootstrapUpgradeToolTest {
     // bootstrap a cluster
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(), false,
-        ClusterMapConfig.OLD_STATE_MODEL_DEF);
+        ClusterMapConfig.OLD_STATE_MODEL_DEF, false);
     // add new state model def
     HelixBootstrapUpgradeUtil.addStateModelDef(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, new HelixAdminFactory(),
@@ -225,7 +226,7 @@ public class HelixBootstrapUpgradeToolTest {
       try {
         HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
             CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(),
-            false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
+            false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, false);
         fail("Should have thrown IllegalArgumentException as a zk host is missing for one of the dcs");
       } catch (IllegalArgumentException e) {
         // OK
@@ -248,7 +249,7 @@ public class HelixBootstrapUpgradeToolTest {
     dataNode = new DataNode(dataNode.getDatacenter(), jsonObject, clusterMapConfig);
     InstanceConfig referenceInstanceConfig =
         HelixBootstrapUpgradeUtil.createInstanceConfigFromStaticInfo(dataNode, partitionToInstances,
-            Collections.emptyMap(), null);
+            new ConcurrentHashMap<>(), null);
     // Assert that xid field does not get set in InstanceConfig when it is the default.
     assertNull(referenceInstanceConfig.getRecord().getSimpleField(ClusterMapUtils.XID_STR));
 
@@ -257,7 +258,7 @@ public class HelixBootstrapUpgradeToolTest {
     dataNode = new DataNode(dataNode.getDatacenter(), jsonObject, clusterMapConfig);
     InstanceConfig instanceConfig =
         HelixBootstrapUpgradeUtil.createInstanceConfigFromStaticInfo(dataNode, partitionToInstances,
-            Collections.emptyMap(), null);
+            new ConcurrentHashMap<>(), null);
     assertEquals("10", instanceConfig.getRecord().getSimpleField(ClusterMapUtils.XID_STR));
     assertThat(referenceInstanceConfig.getRecord(), not(equalTo(instanceConfig.getRecord())));
 
@@ -269,7 +270,7 @@ public class HelixBootstrapUpgradeToolTest {
     // set the field to null. The created InstanceConfig should not have null fields.
     referenceInstanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, null);
     instanceConfig = HelixBootstrapUpgradeUtil.createInstanceConfigFromStaticInfo(dataNode, partitionToInstances,
-        Collections.emptyMap(), referenceInstanceConfig);
+        new ConcurrentHashMap<>(), referenceInstanceConfig);
     // Stopped replicas should be an empty list and not null, so set that in referenceInstanceConfig for comparison.
     referenceInstanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, Collections.emptyList());
     assertEquals(instanceConfig.getRecord(), referenceInstanceConfig.getRecord());
@@ -278,7 +279,7 @@ public class HelixBootstrapUpgradeToolTest {
     List<String> stoppedReplicas = Arrays.asList("11", "15");
     referenceInstanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, stoppedReplicas);
     instanceConfig = HelixBootstrapUpgradeUtil.createInstanceConfigFromStaticInfo(dataNode, partitionToInstances,
-        Collections.emptyMap(), referenceInstanceConfig);
+        new ConcurrentHashMap<>(), referenceInstanceConfig);
     assertEquals(instanceConfig.getRecord(), referenceInstanceConfig.getRecord());
   }
 
@@ -487,7 +488,7 @@ public class HelixBootstrapUpgradeToolTest {
     // This updates and verifies that the information in Helix is consistent with the one in the static cluster map.
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, forceRemove, new HelixAdminFactory(),
-        false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF);
+        false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, false);
     verifyResourceCount(testHardwareLayout.getHardwareLayout(), expectedResourceCount);
   }
 


### PR DESCRIPTION
1. Assigned dedicated thread for each dc to speed up upgrading clustermap in Helix. It allows tool to bootstrap/upgrade multiple dcs concurrently.
2. Introduced an option that only update resource (IdealState) in Helix without changing InstanceConfig. This is used when initiating replica movement (We change IdealState in Helix to trigger moving replica and Helix is responsible for notifying nodes that are involved). The InstanceConfig will be updated eventually by ambry nodes themselves.