### PR TITLE
Fix for ResponseMetadata race condition.

### DIFF
--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -37,7 +37,6 @@ public class NettyMetrics {
   public final Meter channelDestructionRate;
   public final Meter requestArrivalRate;
   public final Meter multipartPostRequestRate;
-  public final Meter channelStatusInconsistent;
   // NettyResponseChannel
   public final Meter bytesWriteRate;
   public final Meter requestCompletionRate;
@@ -135,6 +134,7 @@ public class NettyMetrics {
   public final Counter requestTooLargeCount;
   public final Counter throwableCount;
   public final Counter unknownResponseStatusCount;
+  public final Counter channelStatusInconsistentCount;
   // NettyServer
   public final Histogram nettyServerShutdownTimeInMs;
   public final Histogram nettyServerStartTimeInMs;
@@ -171,8 +171,6 @@ public class NettyMetrics {
     publicAccessLogRequestRate =
         metricRegistry.meter(MetricRegistry.name(PublicAccessLogHandler.class, "RequestArrivalRate"));
     healthCheckRequestRate = metricRegistry.meter(MetricRegistry.name(HealthCheckHandler.class, "RequestArrivalRate"));
-    channelStatusInconsistent =
-        metricRegistry.meter(MetricRegistry.name(NettyMessageProcessor.class, "ChannelStatusInconsistent"));
 
     // Latencies
     // NettyMessageProcessor
@@ -321,6 +319,8 @@ public class NettyMetrics {
     throwableCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ThrowableCount"));
     unknownResponseStatusCount =
         metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "UnknownResponseStatusCount"));
+    channelStatusInconsistentCount =
+        metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ChannelStatusInconsistentCount"));
     // NettyServer
     nettyServerShutdownTimeInMs = metricRegistry.histogram(MetricRegistry.name(NettyServer.class, "ShutdownTimeInMs"));
     nettyServerStartTimeInMs = metricRegistry.histogram(MetricRegistry.name(NettyServer.class, "StartTimeInMs"));

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyMetrics.java
@@ -37,6 +37,7 @@ public class NettyMetrics {
   public final Meter channelDestructionRate;
   public final Meter requestArrivalRate;
   public final Meter multipartPostRequestRate;
+  public final Meter channelStatusInconsistent;
   // NettyResponseChannel
   public final Meter bytesWriteRate;
   public final Meter requestCompletionRate;
@@ -170,6 +171,8 @@ public class NettyMetrics {
     publicAccessLogRequestRate =
         metricRegistry.meter(MetricRegistry.name(PublicAccessLogHandler.class, "RequestArrivalRate"));
     healthCheckRequestRate = metricRegistry.meter(MetricRegistry.name(HealthCheckHandler.class, "RequestArrivalRate"));
+    channelStatusInconsistent =
+        metricRegistry.meter(MetricRegistry.name(NettyMessageProcessor.class, "ChannelStatusInconsistent"));
 
     // Latencies
     // NettyMessageProcessor

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -289,7 +289,9 @@ class NettyResponseChannel implements RestResponseChannel {
       responseMetadata.headers().set(headerName, headerValue);
       if (responseMetadataWriteInitiated.get()) {
         nettyMetrics.deadResponseAccessError.inc();
-        throw new IllegalStateException("Response metadata changed after it has already been written to the channel");
+        throw new IllegalStateException(
+            "Response metadata changed after it has already been written to the channel. Channel Active: "
+                + ctx.channel().isActive());
       } else {
         logger.trace("Header {} set to {} for channel {}", headerName, responseMetadata.headers().get(headerName),
             ctx.channel());

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -56,9 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
@@ -108,8 +106,6 @@ class NettyResponseChannel implements RestResponseChannel {
   private volatile ResponseStatus responseStatus = ResponseStatus.Ok;
   // the response metadata that was actually sent.
   private volatile HttpResponse finalResponseMetadata = null;
-  // A CountDownLatch to make sure finalResponseMetadata is ready when access.
-  private final CountDownLatch finalResponseMetadataReadyLatch = new CountDownLatch(1);
   // temp variable to hold the error response status which will be overwritten on responseStatus if the error response
   // was successfully sent
   private ResponseStatus errorResponseStatus = null;
@@ -152,10 +148,17 @@ class NettyResponseChannel implements RestResponseChannel {
     if (!responseMetadataWriteInitiated.get()) {
       maybeWriteResponseMetadata(responseMetadata, new ResponseMetadataWriteListener());
     }
-    try {
-      finalResponseMetadataReadyLatch.await(5, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      logger.error("finalResponseMetadataReadyLatch is interrupted.");
+    if (finalResponseMetadata == null) {
+      // If finalResponseMetadata is still null, it indicates channel becomes inactive.
+      if (ctx.channel().isActive()) {
+        logger.warn("Channel should be inactive status. {}", ctx.channel());
+      } else {
+        logger.debug("Scheduling a chunk cleanup on channel {} because response channel is closed.", ctx.channel());
+        writeFuture.addListener(new CleanupCallback(new ClosedChannelException()));
+      }
+      FutureResult<Long> future = new FutureResult<Long>();
+      future.done(-1L, null);
+      return future;
     }
     Chunk chunk = new Chunk(src, callback);
     chunksToWrite.add(chunk);
@@ -455,7 +458,6 @@ class NettyResponseChannel implements RestResponseChannel {
       }
       logger.trace("Sending response with status {} on channel {}", responseMetadata.status(), ctx.channel());
       finalResponseMetadata = responseMetadata;
-      finalResponseMetadataReadyLatch.countDown();
       ChannelPromise writePromise = ctx.newPromise().addListener(listener);
       ctx.writeAndFlush(responseMetadata, writePromise);
       writtenThisTime = true;
@@ -810,8 +812,8 @@ class NettyResponseChannel implements RestResponseChannel {
       writeCompleteThreshold = totalBytesReceived.addAndGet(bytesToBeWritten);
       chunksToWriteCount.incrementAndGet();
 
-      // if we are here, it means that finalResponseMetadata has been set and there is no danger of it being null
-      long contentLength = HttpUtil.getContentLength(finalResponseMetadata, -1);
+      // if channel becomes inactive, no one set finalResponseMetadata. It's possible finalResponseMetadata is null.
+      long contentLength = finalResponseMetadata == null ? -1 : HttpUtil.getContentLength(finalResponseMetadata, -1);
       isLast = contentLength != -1 && writeCompleteThreshold >= contentLength;
     }
 

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -152,7 +152,7 @@ class NettyResponseChannel implements RestResponseChannel {
       // If finalResponseMetadata is still null, it indicates channel becomes inactive.
       if (ctx.channel().isActive()) {
         logger.warn("Channel should be inactive status. {}", ctx.channel());
-        nettyMetrics.channelStatusInconsistent.mark();
+        nettyMetrics.channelStatusInconsistentCount.inc();
       } else {
         logger.debug("Scheduling a chunk cleanup on channel {} because response channel is closed.", ctx.channel());
         writeFuture.addListener(new CleanupCallback(new ClosedChannelException()));

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -159,7 +159,9 @@ class NettyResponseChannel implements RestResponseChannel {
       }
       FutureResult<Long> future = new FutureResult<Long>();
       future.done(0L, new ClosedChannelException());
-      callback.onCompletion(0L, new ClosedChannelException());
+      if (callback != null) {
+        callback.onCompletion(0L, new ClosedChannelException());
+      }
       return future;
     }
     Chunk chunk = new Chunk(src, callback);

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -152,12 +152,14 @@ class NettyResponseChannel implements RestResponseChannel {
       // If finalResponseMetadata is still null, it indicates channel becomes inactive.
       if (ctx.channel().isActive()) {
         logger.warn("Channel should be inactive status. {}", ctx.channel());
+        nettyMetrics.channelStatusInconsistent.mark();
       } else {
         logger.debug("Scheduling a chunk cleanup on channel {} because response channel is closed.", ctx.channel());
         writeFuture.addListener(new CleanupCallback(new ClosedChannelException()));
       }
       FutureResult<Long> future = new FutureResult<Long>();
-      future.done(-1L, null);
+      future.done(0L, new ClosedChannelException());
+      callback.onCompletion(0L, new ClosedChannelException());
       return future;
     }
     Chunk chunk = new Chunk(src, callback);

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyResponseChannel.java
@@ -443,7 +443,7 @@ class NettyResponseChannel implements RestResponseChannel {
       GenericFutureListener<ChannelFuture> listener) {
     long writeProcessingStartTime = System.currentTimeMillis();
     boolean writtenThisTime = false;
-    if (responseMetadataWriteInitiated.compareAndSet(false, true) && ctx.channel().isActive()) {
+    if (ctx.channel().isActive() && responseMetadataWriteInitiated.compareAndSet(false, true)) {
       // we do some manipulation here for chunking. According to the HTTP spec, we can have either a Content-Length
       // or Transfer-Encoding:chunked, never both. So we check for Content-Length - if it is not there, we add
       // Transfer-Encoding:chunked on 200 response. Note that sending HttpContent chunks data anyway - we are just

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -664,6 +664,7 @@ public class NettyResponseChannelTest {
     Future<Long> future = nettyResponseChannel.write(Unpooled.buffer(1), null);
     try {
       future.get();
+      fail("Future.get() should throw exception.");
     } catch (InterruptedException | ExecutionException e) {
       assertTrue("Should be ClosedChannelException", e.getCause() instanceof ClosedChannelException);
     }
@@ -1748,7 +1749,7 @@ class ChannelWriteCallback implements Callback<Long> {
 }
 
 /**
- * Mock class for ChannelHandlerContext used in .
+ * Mock class for ChannelHandlerContext used in channelInactiveTest.
  */
 class MockChannelHandlerContext implements ChannelHandlerContext {
   private final EmbeddedChannel embeddedChannel;

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyResponseChannelTest.java
@@ -21,12 +21,19 @@ import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelProgressivePromise;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelProgressivePromise;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -47,7 +54,11 @@ import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.stream.ChunkedWriteHandler;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.EventExecutor;
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.text.ParseException;
@@ -634,6 +645,28 @@ public class NettyResponseChannelTest {
     while (channel.readOutbound() != null) {
     }
     assertFalse("Channel should be closed", channel.isOpen());
+  }
+
+  /**
+   * ClosedChannelException is expected when write to a NettyResponseChannel and channel is inactive.
+   */
+  @Test
+  public void channelInactiveTest() {
+    // request is keep-alive by default.
+    HttpRequest request = createRequestWithHeaders(HttpMethod.GET, TestingUri.Close.toString());
+    ChunkedWriteHandler chunkedWriteHandler = new ChunkedWriteHandler();
+    EmbeddedChannel channel = new EmbeddedChannel(chunkedWriteHandler);
+    NettyResponseChannel nettyResponseChannel =
+        new NettyResponseChannel(new MockChannelHandlerContext(channel), new NettyMetrics(new MetricRegistry()),
+            new PerformanceConfig(new VerifiableProperties(new Properties())));
+    channel.disconnect().awaitUninterruptibly();
+    assertFalse("Channel should be closed", channel.isOpen());
+    Future<Long> future = nettyResponseChannel.write(Unpooled.buffer(1), null);
+    try {
+      future.get();
+    } catch (InterruptedException | ExecutionException e) {
+      assertTrue("Should be ClosedChannelException", e.getCause() instanceof ClosedChannelException);
+    }
   }
 
   // helpers
@@ -1713,3 +1746,221 @@ class ChannelWriteCallback implements Callback<Long> {
     }
   }
 }
+
+/**
+ * Mock class for ChannelHandlerContext used in .
+ */
+class MockChannelHandlerContext implements ChannelHandlerContext {
+  private final EmbeddedChannel embeddedChannel;
+
+  MockChannelHandlerContext(EmbeddedChannel embeddedChannel) {
+    this.embeddedChannel = embeddedChannel;
+  }
+
+  @Override
+  public Channel channel() {
+    return embeddedChannel;
+  }
+
+  @Override
+  public EventExecutor executor() {
+    return null;
+  }
+
+  @Override
+  public String name() {
+    return null;
+  }
+
+  @Override
+  public ChannelHandler handler() {
+    return null;
+  }
+
+  @Override
+  public boolean isRemoved() {
+    return false;
+  }
+
+  @Override
+  public ChannelHandlerContext fireChannelRegistered() {
+    return null;
+  }
+
+  @Override
+  public ChannelHandlerContext fireChannelUnregistered() {
+    return null;
+  }
+
+  @Override
+  public ChannelHandlerContext fireChannelActive() {
+    return null;
+  }
+
+  @Override
+  public ChannelHandlerContext fireChannelInactive() {
+    return null;
+  }
+
+  @Override
+  public ChannelHandlerContext fireExceptionCaught(Throwable cause) {
+    return null;
+  }
+
+  @Override
+  public ChannelHandlerContext fireUserEventTriggered(Object evt) {
+    return null;
+  }
+
+  @Override
+  public ChannelHandlerContext fireChannelRead(Object msg) {
+    return null;
+  }
+
+  @Override
+  public ChannelHandlerContext fireChannelReadComplete() {
+    return null;
+  }
+
+  @Override
+  public ChannelHandlerContext fireChannelWritabilityChanged() {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture bind(SocketAddress localAddress) {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture connect(SocketAddress remoteAddress) {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture disconnect() {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture close() {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture deregister() {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture disconnect(ChannelPromise promise) {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture close(ChannelPromise promise) {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture deregister(ChannelPromise promise) {
+    return null;
+  }
+
+  @Override
+  public ChannelHandlerContext read() {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture write(Object msg) {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture write(Object msg, ChannelPromise promise) {
+    return null;
+  }
+
+  @Override
+  public ChannelHandlerContext flush() {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture writeAndFlush(Object msg) {
+    return null;
+  }
+
+  @Override
+  public ChannelPromise newPromise() {
+    return null;
+  }
+
+  @Override
+  public ChannelProgressivePromise newProgressivePromise() {
+    return new DefaultChannelProgressivePromise(embeddedChannel);
+  }
+
+  @Override
+  public ChannelFuture newSucceededFuture() {
+    return null;
+  }
+
+  @Override
+  public ChannelFuture newFailedFuture(Throwable cause) {
+    return null;
+  }
+
+  @Override
+  public ChannelPromise voidPromise() {
+    return null;
+  }
+
+  @Override
+  public ChannelPipeline pipeline() {
+    return embeddedChannel.pipeline();
+  }
+
+  @Override
+  public ByteBufAllocator alloc() {
+    return null;
+  }
+
+  @Override
+  public <T> Attribute<T> attr(AttributeKey<T> key) {
+    return null;
+  }
+
+  @Override
+  public <T> boolean hasAttr(AttributeKey<T> key) {
+    return false;
+  }
+}
+
+


### PR DESCRIPTION
Before this change, responseMetadata is accessed without confirming if it is ready or not.
This fix introduces a latch to avoid such race condition.