### PR TITLE
Make PartitionSelectionHelper incorporate clustermap changes

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
@@ -39,10 +39,10 @@ class AmbryDataNode implements DataNodeId {
   private final String rackId;
   private final long xid;
   private final List<String> sslEnabledDataCenters;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
   private final ResourceStatePolicy resourceStatePolicy;
   private final boolean http2ClientEnabled;
   private final ClusterManagerCallback<AmbryReplica, AmbryDisk, AmbryPartition, AmbryDataNode> clusterManagerCallback;
+  private static final Logger logger = LoggerFactory.getLogger(AmbryDataNode.class);
 
   /**
    * Instantiate an AmbryDataNode object.

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryDatanode.java
@@ -41,8 +41,8 @@ class AmbryDataNode implements DataNodeId {
   private final List<String> sslEnabledDataCenters;
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final ResourceStatePolicy resourceStatePolicy;
-  private final ClusterManagerCallback clusterManagerCallback;
   private final boolean http2ClientEnabled;
+  private final ClusterManagerCallback<AmbryReplica, AmbryDisk, AmbryPartition, AmbryDataNode> clusterManagerCallback;
 
   /**
    * Instantiate an AmbryDataNode object.
@@ -58,7 +58,8 @@ class AmbryDataNode implements DataNodeId {
    * @throws Exception if there is an exception in instantiating the {@link ResourceStatePolicy}
    */
   AmbryDataNode(String dataCenterName, ClusterMapConfig clusterMapConfig, String hostName, int portNum, String rackId,
-      Integer sslPortNum, Integer http2PortNumber, long xid, ClusterManagerCallback clusterManagerCallback)
+      Integer sslPortNum, Integer http2PortNumber, long xid,
+      ClusterManagerCallback<AmbryReplica, AmbryDisk, AmbryPartition, AmbryDataNode> clusterManagerCallback)
       throws Exception {
     this.hostName = hostName;
     this.plainTextPort = new Port(portNum, PortType.PLAINTEXT);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/AmbryPartition.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -46,7 +47,7 @@ public class AmbryPartition implements PartitionId {
    * Instantiate an AmbryPartition instance.
    * @param id the id associated with this partition.
    * @param partitionClass the partition class that this partition belongs to
-   * @param clusterManagerCallback the {@link ClusterManagerCallback} to use to make callbacks
+   * @param clusterManagerCallback the {@link HelixClusterManager.HelixClusterManagerCallback} to use to make callbacks
    *                               to the {@link HelixClusterManager}
    * The initial state defaults to {@link PartitionState#READ_WRITE}.
    */
@@ -64,12 +65,18 @@ public class AmbryPartition implements PartitionId {
 
   @Override
   public List<AmbryReplica> getReplicaIds() {
-    return clusterManagerCallback.getReplicaIdsForPartition(this);
+    return clusterManagerCallback.getReplicaIdsForPartition(this)
+        .stream()
+        .map(r -> (AmbryReplica) r)
+        .collect(Collectors.toList());
   }
 
   @Override
   public List<AmbryReplica> getReplicaIdsByState(ReplicaState state, String dcName) {
-    return clusterManagerCallback.getReplicaIdsByState(this, state, dcName);
+    return clusterManagerCallback.getReplicaIdsByState(this, state, dcName)
+        .stream()
+        .map(r -> (AmbryReplica) r)
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -152,7 +159,7 @@ public class AmbryPartition implements PartitionId {
       try {
         lastUpdatedSealedStateChangeCounter = currentCounterValue;
         boolean isSealed = false;
-        for (AmbryReplica replica : clusterManagerCallback.getReplicaIdsForPartition(this)) {
+        for (ReplicaId replica : clusterManagerCallback.getReplicaIdsForPartition(this)) {
           if (replica.isSealed()) {
             isSealed = true;
             break;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterChangeHandler.java
@@ -30,6 +30,11 @@ import org.apache.helix.spectator.RoutingTableSnapshot;
 interface ClusterChangeHandler
     extends InstanceConfigChangeListener, LiveInstanceChangeListener, IdealStateChangeListener,
             RoutingTableChangeListener {
+  /**
+   * Register a listener of cluster map for any changes.
+   * @param clusterMapChangeListener the {@link ClusterMapChangeListener} to add.
+   */
+  void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener);
 
   /**
    * Set the initial snapshot in this {@link ClusterChangeHandler}.

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
@@ -19,15 +19,15 @@ import java.util.List;
 
 /**
  * A callback that needs to be implemented by different implementations of the cluster manager. External components may
- * get resources (i.e. {@link ReplicaId}, {@link PartitionId}, {@link DiskId}) via this callback.
+ * get resources (i.e. {@link ReplicaId}, {@link PartitionId}, {@link DiskId}, {@link DataNodeId}) via this callback.
  */
-interface ClusterManagerCallback {
+interface ClusterManagerCallback<R extends ReplicaId, D extends DiskId, P extends PartitionId, N extends DataNodeId> {
   /**
    * Get all replica ids associated with the given {@link AmbryPartition}
    * @param partition the {@link PartitionId} for which to get the list of replicas.
    * @return the list of {@link ReplicaId}s associated with the given partition.
    */
-  List<? extends ReplicaId> getReplicaIdsForPartition(PartitionId partition);
+  List<R> getReplicaIdsForPartition(P partition);
 
   /**
    * Get replicas of given partition from specified datacenter that are in required state
@@ -36,7 +36,7 @@ interface ClusterManagerCallback {
    * @param dcName name of datacenter from which the replicas should come
    * @return the list of {@link ReplicaId}s satisfying requirements.
    */
-  List<? extends ReplicaId> getReplicaIdsByState(PartitionId partition, ReplicaState state, String dcName);
+  List<R> getReplicaIdsByState(P partition, ReplicaState state, String dcName);
 
   /**
    * Get the counter for the sealed state change for partitions.
@@ -45,14 +45,14 @@ interface ClusterManagerCallback {
   long getSealedStateChangeCounter();
 
   /**
-   * Get the list of {@link DiskId}s (all or assoicated with a particular {@link DataNodeId}.
+   * Get the list of {@link DiskId}s (all or associated with a particular {@link DataNodeId}.
    * @param dataNode if disks of a particular data node is required, {@code null} for all disks.
    * @return a collection of all the disks in this datacenter.
    */
-  Collection<? extends DiskId> getDisks(DataNodeId dataNode);
+  Collection<D> getDisks(N dataNode);
 
   /**
    * @return a collection of partitions in this cluster.
    */
-  Collection<? extends PartitionId> getPartitions();
+  Collection<P> getPartitions();
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterManagerCallback.java
@@ -18,26 +18,25 @@ import java.util.List;
 
 
 /**
- * A callback that needs to be implemented by dynamic implementations of the cluster manager which can be
- * used by dynamic cluster manager components such as {@link AmbryDataNode}, {@link AmbryDisk},
- * {@link AmbryPartition}, and {@link AmbryReplica}
+ * A callback that needs to be implemented by different implementations of the cluster manager. External components may
+ * get resources (i.e. {@link ReplicaId}, {@link PartitionId}, {@link DiskId}) via this callback.
  */
 interface ClusterManagerCallback {
   /**
    * Get all replica ids associated with the given {@link AmbryPartition}
-   * @param partition the {@link AmbryPartition} for which to get the list of replicas.
-   * @return the list of {@link AmbryReplica}s associated with the given partition.
+   * @param partition the {@link PartitionId} for which to get the list of replicas.
+   * @return the list of {@link ReplicaId}s associated with the given partition.
    */
-  List<AmbryReplica> getReplicaIdsForPartition(AmbryPartition partition);
+  List<? extends ReplicaId> getReplicaIdsForPartition(PartitionId partition);
 
   /**
    * Get replicas of given partition from specified datacenter that are in required state
-   * @param partition the {@link AmbryPartition} for which to get the list of replicas.
+   * @param partition the {@link PartitionId} for which to get the list of replicas.
    * @param state {@link ReplicaState} associated with replica
    * @param dcName name of datacenter from which the replicas should come
-   * @return the list of {@link AmbryReplica}s satisfying requirements.
+   * @return the list of {@link ReplicaId}s satisfying requirements.
    */
-  List<AmbryReplica> getReplicaIdsByState(AmbryPartition partition, ReplicaState state, String dcName);
+  List<? extends ReplicaId> getReplicaIdsByState(PartitionId partition, ReplicaState state, String dcName);
 
   /**
    * Get the counter for the sealed state change for partitions.
@@ -46,9 +45,14 @@ interface ClusterManagerCallback {
   long getSealedStateChangeCounter();
 
   /**
-   * Get the list of {@link AmbryDisk}s (all or assoicated with a particular {@link AmbryDataNode}.
+   * Get the list of {@link DiskId}s (all or assoicated with a particular {@link DataNodeId}.
    * @param dataNode if disks of a particular data node is required, {@code null} for all disks.
    * @return a collection of all the disks in this datacenter.
    */
-  Collection<AmbryDisk> getDisks(AmbryDataNode dataNode);
+  Collection<? extends DiskId> getDisks(DataNodeId dataNode);
+
+  /**
+   * @return a collection of partitions in this cluster.
+   */
+  Collection<? extends PartitionId> getPartitions();
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -409,7 +409,7 @@ public class ClusterMapUtils {
       partitionIdsByClassAndLocalReplicaCount = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
       partitionIdToLocalReplicas = new HashMap<>();
       populatePartitionAndLocalReplicaMaps(allPartitions, partitionIdsByClassAndLocalReplicaCount,
-          partitionIdToLocalReplicas);
+          partitionIdToLocalReplicas, localDatacenterName);
     }
 
     /**
@@ -583,7 +583,7 @@ public class ClusterMapUtils {
           new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
       Map<PartitionId, List<ReplicaId>> partitionAndLocalReplicas = new HashMap<>();
       populatePartitionAndLocalReplicaMaps(partitionsInCluster, partitionSortedByReplicaCount,
-          partitionAndLocalReplicas);
+          partitionAndLocalReplicas, localDatacenterName);
       rwLock.writeLock().lock();
       // switch references to newly generated maps
       try {
@@ -601,10 +601,11 @@ public class ClusterMapUtils {
      * @param allPartitions all the partitions in cluster.
      * @param partitionIdsByClassAndLocalReplicaCount a map that tracks partitions sorted by local replica count.
      * @param partitionIdToLocalReplicas a map that tracks partition to its local replicas.
+     * @param localDatacenterName the name of local dc. Can be null if dc specific replica counts are not required.
      */
     private void populatePartitionAndLocalReplicaMaps(Collection<? extends PartitionId> allPartitions,
         Map<String, SortedMap<Integer, List<PartitionId>>> partitionIdsByClassAndLocalReplicaCount,
-        Map<PartitionId, List<ReplicaId>> partitionIdToLocalReplicas) {
+        Map<PartitionId, List<ReplicaId>> partitionIdToLocalReplicas, String localDatacenterName) {
       for (PartitionId partition : allPartitions) {
         String partitionClass = partition.getPartitionClass();
         int localReplicaCount = 0;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -578,6 +578,7 @@ public class ClusterMapUtils {
       // be fine with the overhead of re-populating these two maps.
       // No matter whether this method is called by local dc's or remote dcs' cluster change handler, we need to populate
       // "allPartitions" again because there may be some new partitions with special class added to remote dc only.
+      logger.info("Re-populating partition-selection related maps because replicas are added or removed");
       updatePartitions(clusterManagerCallback.getPartitions(), localDatacenterName);
     }
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
@@ -351,11 +351,11 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
           } else {
             // if this is a new replica and doesn't exist on node
             logger.info("Adding new replica {} to existing node {} in {}", partitionName, instanceName, dcName);
-            long replicaCapacity = Long.valueOf(info[1]);
+            long replicaCapacity = Long.parseLong(info[1]);
             String partitionClass = info.length > 2 ? info[2] : clusterMapConfig.clusterMapDefaultPartitionClass;
             // this can be a brand new partition that is added to an existing node
             AmbryPartition mappedPartition =
-                new AmbryPartition(Long.valueOf(partitionName), partitionClass, helixClusterManagerCallback);
+                new AmbryPartition(Long.parseLong(partitionName), partitionClass, helixClusterManagerCallback);
             // Ensure only one AmbryPartition instance exists for specific partition.
             mappedPartition = clusterChangeHandlerCallback.addPartitionIfAbsent(mappedPartition, replicaCapacity);
             ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, dataNode, replicaCapacity);
@@ -462,7 +462,7 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
       Map<String, String> diskInfo = entry.getValue();
       HardwareState diskState =
           diskInfo.get(DISK_STATE).equals(AVAILABLE_STR) ? HardwareState.AVAILABLE : HardwareState.UNAVAILABLE;
-      long capacityBytes = Long.valueOf(diskInfo.get(DISK_CAPACITY_STR));
+      long capacityBytes = Long.parseLong(diskInfo.get(DISK_CAPACITY_STR));
 
       // Create disk
       AmbryDisk disk = new AmbryDisk(clusterMapConfig, datanode, mountPath, diskState, capacityBytes);
@@ -475,11 +475,11 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
           String[] info = replicaInfo.split(ClusterMapUtils.REPLICAS_STR_SEPARATOR);
           // partition name and replica name are the same.
           String partitionName = info[0];
-          long replicaCapacity = Long.valueOf(info[1]);
+          long replicaCapacity = Long.parseLong(info[1]);
           String partitionClass = info.length > 2 ? info[2] : clusterMapConfig.clusterMapDefaultPartitionClass;
 
           AmbryPartition mappedPartition =
-              new AmbryPartition(Long.valueOf(partitionName), partitionClass, helixClusterManagerCallback);
+              new AmbryPartition(Long.parseLong(partitionName), partitionClass, helixClusterManagerCallback);
           // Ensure only one AmbryPartition instance exists for specific partition.
           mappedPartition = clusterChangeHandlerCallback.addPartitionIfAbsent(mappedPartition, replicaCapacity);
           ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, datanode, replicaCapacity);

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
@@ -298,7 +298,7 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
     }
     // if this is not initial InstanceConfig change and any replicas are added or removed, we should invoke callbacks
     // for different clustermap change listeners (i.e replication manager, partition selection helper)
-    if (!instanceConfigInitialized && (!totalAddedReplicas.isEmpty() || !totalRemovedReplicas.isEmpty())) {
+    if (instanceConfigInitialized && (!totalAddedReplicas.isEmpty() || !totalRemovedReplicas.isEmpty())) {
       for (ClusterMapChangeListener listener : clusterMapChangeListeners) {
         listener.onReplicaAddedOrRemoved(totalAddedReplicas, totalRemovedReplicas);
       }
@@ -350,7 +350,7 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
             updateReplicaStateAndOverrideIfNeeded(existingReplica, sealedReplicas, stoppedReplicas);
           } else {
             // if this is a new replica and doesn't exist on node
-            logger.info("Adding new replica {} to existing node {}", partitionName, instanceName);
+            logger.info("Adding new replica {} to existing node {} in {}", partitionName, instanceName, dcName);
             long replicaCapacity = Long.valueOf(info[1]);
             String partitionClass = info.length > 2 ? info[2] : clusterMapConfig.clusterMapDefaultPartitionClass;
             // this can be a brand new partition that is added to an existing node
@@ -426,7 +426,7 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
    */
   private Pair<List<ReplicaId>, List<ReplicaId>> createNewInstance(InstanceConfig instanceConfig) throws Exception {
     String instanceName = instanceConfig.getInstanceName();
-    logger.info("Adding node {} and its disks and replicas", instanceName);
+    logger.info("Adding node {} and its disks and replicas in {}", instanceName, dcName);
     AmbryDataNode datanode =
         new AmbryDataNode(getDcName(instanceConfig), clusterMapConfig, instanceConfig.getHostName(),
             Integer.valueOf(instanceConfig.getPort()), getRackId(instanceConfig), getSslPortStr(instanceConfig), null,

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -695,16 +695,16 @@ public class HelixClusterManager implements ClusterMap {
   /**
    * A callback class used to query information from the {@link HelixClusterManager}
    */
-  class HelixClusterManagerCallback implements ClusterManagerCallback {
+  class HelixClusterManagerCallback
+      implements ClusterManagerCallback<AmbryReplica, AmbryDisk, AmbryPartition, AmbryDataNode> {
     /**
      * Get all replica ids associated with the given {@link AmbryPartition}
      * @param partition the {@link AmbryPartition} for which to get the list of replicas.
      * @return the list of {@link AmbryReplica}s associated with the given partition.
      */
     @Override
-    public List<AmbryReplica> getReplicaIdsForPartition(PartitionId partition) {
-      AmbryPartition ambryPartition = (AmbryPartition) partition;
-      return new ArrayList<>(ambryPartitionToAmbryReplicas.get(ambryPartition));
+    public List<AmbryReplica> getReplicaIdsForPartition(AmbryPartition partition) {
+      return new ArrayList<>(ambryPartitionToAmbryReplicas.get(partition));
     }
 
     /**
@@ -713,7 +713,7 @@ public class HelixClusterManager implements ClusterMap {
      * If no routing table snapshot is found for dc name, or no resource name found for given partition, return empty list.
      */
     @Override
-    public List<AmbryReplica> getReplicaIdsByState(PartitionId partition, ReplicaState state, String dcName) {
+    public List<AmbryReplica> getReplicaIdsByState(AmbryPartition partition, ReplicaState state, String dcName) {
       List<AmbryReplica> replicas = new ArrayList<>();
       for (DcInfo dcInfo : dcToDcZkInfo.values()) {
         String dc = dcInfo.dcName;
@@ -775,9 +775,9 @@ public class HelixClusterManager implements ClusterMap {
     }
 
     @Override
-    public Collection<AmbryDisk> getDisks(DataNodeId dataNode) {
+    public Collection<AmbryDisk> getDisks(AmbryDataNode dataNode) {
       if (dataNode != null) {
-        return dcToDcZkInfo.get(dataNode.getDatacenterName()).clusterChangeHandler.getDisks((AmbryDataNode) dataNode);
+        return dcToDcZkInfo.get(dataNode.getDatacenterName()).clusterChangeHandler.getDisks(dataNode);
       }
       List<AmbryDisk> disksToReturn = new ArrayList<>();
       for (DcInfo dcInfo : dcToDcZkInfo.values()) {

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
@@ -313,15 +313,15 @@ class PartitionLayout {
   /**
    * An implementation of {@link ClusterManagerCallback} that supports getting resource from static clustermap.
    */
-  class StaticClusterManagerCallback implements ClusterManagerCallback {
+  class StaticClusterManagerCallback implements ClusterManagerCallback<Replica, Disk, Partition, DataNode> {
 
     @Override
-    public List<Replica> getReplicaIdsForPartition(PartitionId partition) {
+    public List<Replica> getReplicaIdsForPartition(Partition partition) {
       throw new UnsupportedOperationException("Not supported in static cluster map");
     }
 
     @Override
-    public List<Replica> getReplicaIdsByState(PartitionId partition, ReplicaState state, String dcName) {
+    public List<Replica> getReplicaIdsByState(Partition partition, ReplicaState state, String dcName) {
       throw new UnsupportedOperationException("Not supported in static cluster map");
     }
 
@@ -331,7 +331,7 @@ class PartitionLayout {
     }
 
     @Override
-    public Collection<Disk> getDisks(DataNodeId dataNode) {
+    public Collection<Disk> getDisks(DataNode dataNode) {
       throw new UnsupportedOperationException("Not supported in static cluster map");
     }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/PartitionLayout.java
@@ -17,6 +17,7 @@ import com.github.ambry.config.ClusterMapConfig;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -71,8 +72,9 @@ class PartitionLayout {
     }
 
     validate();
-    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitionMap.values(), localDatacenterName,
-        clusterMapConfig.clustermapWritablePartitionMinReplicaCount);
+    partitionSelectionHelper =
+        new ClusterMapUtils.PartitionSelectionHelper(new StaticClusterManagerCallback(), localDatacenterName,
+            clusterMapConfig.clustermapWritablePartitionMinReplicaCount);
   }
 
   /**
@@ -91,8 +93,9 @@ class PartitionLayout {
     this.maxPartitionId = MinPartitionId;
     this.partitionMap = new HashMap<>();
     validate();
-    partitionSelectionHelper = new ClusterMapUtils.PartitionSelectionHelper(partitionMap.values(), localDatacenterName,
-        clusterMapConfig.clustermapWritablePartitionMinReplicaCount);
+    partitionSelectionHelper =
+        new ClusterMapUtils.PartitionSelectionHelper(new StaticClusterManagerCallback(), localDatacenterName,
+            clusterMapConfig.clustermapWritablePartitionMinReplicaCount);
   }
 
   public HardwareLayout getHardwareLayout() {
@@ -305,5 +308,39 @@ class PartitionLayout {
       return false;
     }
     return hardwareLayout.equals(that.hardwareLayout);
+  }
+
+  /**
+   * An implementation of {@link ClusterManagerCallback} that supports getting resource from static clustermap.
+   */
+  class StaticClusterManagerCallback implements ClusterManagerCallback {
+
+    @Override
+    public List<Replica> getReplicaIdsForPartition(PartitionId partition) {
+      throw new UnsupportedOperationException("Not supported in static cluster map");
+    }
+
+    @Override
+    public List<Replica> getReplicaIdsByState(PartitionId partition, ReplicaState state, String dcName) {
+      throw new UnsupportedOperationException("Not supported in static cluster map");
+    }
+
+    @Override
+    public long getSealedStateChangeCounter() {
+      throw new UnsupportedOperationException("Not supported in static cluster map");
+    }
+
+    @Override
+    public Collection<Disk> getDisks(DataNodeId dataNode) {
+      throw new UnsupportedOperationException("Not supported in static cluster map");
+    }
+
+    /**
+     * @return a collection of partitions in this cluster.
+     */
+    @Override
+    public Collection<Partition> getPartitions() {
+      return partitionMap.values();
+    }
   }
 }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
@@ -261,6 +261,11 @@ public class SimpleClusterChangeHandler implements ClusterChangeHandler {
     }
   }
 
+  @Override
+  public void registerClusterMapListener(ClusterMapChangeListener clusterMapChangeListener) {
+    // no-op for SimpleClusterChangeHandler because it doesn't supporting adding/removing replicas dynamically
+  }
+
   /**
    * Populate the initial data from the admin connection. Create nodes, disks, partitions and replicas for the entire
    * cluster. An {@link InstanceConfig} will only be looked at if the xid in it is <= currentXid.

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterChangeHandlerTest.java
@@ -299,13 +299,14 @@ public class ClusterChangeHandlerTest {
     nodesToHostNewPartition.addAll(Arrays.asList(remoteDcNode1, remoteDcNode2));
     nodesToHostNewPartition.addAll(newAddedNodes);
     testPartitionLayout.addNewPartition(testHardwareLayout, nodesToHostNewPartition, DEFAULT_PARTITION_CLASS);
-
+    System.out.println("======================= cut line 111 =============================");
     // write new HardwareLayout and PartitionLayout into files
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
     // this triggers a InstanceConfig change notification.
     // In each dc, 2 existing instance configs are updated and 1 new instance is added as well as 1 new partition
     helixCluster.upgradeWithNewHardwareLayout(hardwareLayoutPath);
+    System.out.println("======================= cut line 222 =============================");
 
     // verify after InstanceConfig change, HelixClusterManager contains the one more node per dc.
     assertEquals("Number of data nodes after instance addition is not correct",

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterMapUtilsTest.java
@@ -24,8 +24,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 
 public class ClusterMapUtilsTest {
@@ -87,8 +89,10 @@ public class ClusterMapUtilsTest {
 
     Collection<MockPartitionId> allPartitionIdsMain = Collections.unmodifiableSet(
         new HashSet<>(Arrays.asList(everywhere1, everywhere2, majorDc11, majorDc12, majorDc21, majorDc22)));
+    ClusterManagerCallback mockClusterManagerCallback = Mockito.mock(ClusterManagerCallback.class);
+    doReturn(allPartitionIdsMain).when(mockClusterManagerCallback).getPartitions();
     ClusterMapUtils.PartitionSelectionHelper psh =
-        new ClusterMapUtils.PartitionSelectionHelper(allPartitionIdsMain, null, minimumLocalReplicaCount);
+        new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerCallback, null, minimumLocalReplicaCount);
 
     String[] dcsToTry = {null, "", dc1, dc2};
     for (String dc : dcsToTry) {
@@ -170,9 +174,11 @@ public class ClusterMapUtilsTest {
     MockPartitionId partition2 = new MockPartitionId(2, partitionClass, dataNodeIdList.subList(0, 3), 0);
     MockPartitionId partition3 = new MockPartitionId(3, partitionClass, dataNodeIdList.subList(0, 4), 0);
     List<MockPartitionId> allPartitions = Arrays.asList(partition1, partition2, partition3);
+    ClusterManagerCallback mockClusterManagerCallback = Mockito.mock(ClusterManagerCallback.class);
+    doReturn(allPartitions).when(mockClusterManagerCallback).getPartitions();
     int minimumLocalReplicaCount = 3;
     ClusterMapUtils.PartitionSelectionHelper psh =
-        new ClusterMapUtils.PartitionSelectionHelper(allPartitions, dc1, minimumLocalReplicaCount);
+        new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerCallback, dc1, minimumLocalReplicaCount);
     // verify get all partitions return correct result
     assertEquals("Returned partitions are not expected", allPartitions, psh.getPartitions(null));
     // verify get writable partitions return partition2 and partition3 only
@@ -183,7 +189,7 @@ public class ClusterMapUtilsTest {
 
     // create another partition selection helper with minimumLocalReplicaCount = 4
     minimumLocalReplicaCount = 4;
-    psh = new ClusterMapUtils.PartitionSelectionHelper(allPartitions, dc1, minimumLocalReplicaCount);
+    psh = new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerCallback, dc1, minimumLocalReplicaCount);
     assertEquals("Returned writable partitions are not expected", Arrays.asList(partition3),
         psh.getWritablePartitions(partitionClass));
     assertEquals("Get random writable partition should return partition3 only", partition3,

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
@@ -252,26 +252,25 @@ public class DynamicClusterManagerComponentsTest {
    * A helper class that mocks the {@link ClusterManagerCallback} and stores partition to replicas mapping internally
    * as told.
    */
-  private class MockClusterManagerCallback implements ClusterManagerCallback {
+  private class MockClusterManagerCallback
+      implements ClusterManagerCallback<AmbryReplica, AmbryDisk, AmbryPartition, AmbryDataNode> {
     Map<AmbryPartition, List<AmbryReplica>> partitionToReplicas = new HashMap<>();
     Map<AmbryDataNode, Set<AmbryDisk>> dataNodeToDisks = new HashMap<>();
 
     @Override
-    public List<AmbryReplica> getReplicaIdsForPartition(PartitionId partition) {
-      AmbryPartition ambryPartition = (AmbryPartition) partition;
-      return new ArrayList<>(partitionToReplicas.get(ambryPartition));
+    public List<AmbryReplica> getReplicaIdsForPartition(AmbryPartition partition) {
+      return new ArrayList<>(partitionToReplicas.get(partition));
     }
 
     @Override
-    public List<AmbryReplica> getReplicaIdsByState(PartitionId partition, ReplicaState state, String dcName) {
+    public List<AmbryReplica> getReplicaIdsByState(AmbryPartition partition, ReplicaState state, String dcName) {
       throw new UnsupportedOperationException("Temporarily unsupported");
     }
 
     @Override
-    public Collection<AmbryDisk> getDisks(DataNodeId dataNode) {
-      AmbryDataNode ambryDataNode = (AmbryDataNode) dataNode;
-      if (ambryDataNode != null) {
-        return dataNodeToDisks.get(ambryDataNode);
+    public Collection<AmbryDisk> getDisks(AmbryDataNode dataNode) {
+      if (dataNode != null) {
+        return dataNodeToDisks.get(dataNode);
       }
       List<AmbryDisk> disksToReturn = new ArrayList<>();
       for (Set<AmbryDisk> disks : dataNodeToDisks.values()) {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
@@ -69,7 +69,8 @@ public class DynamicClusterManagerComponentsTest {
     MockClusterManagerCallback mockClusterManagerCallback = new MockClusterManagerCallback();
     // AmbryDataNode test
     try {
-      new AmbryDataNode("DC1", clusterMapConfig2, HOST_NAME, PORT_NUM1, RACK_ID, null, null, XID, mockClusterManagerCallback);
+      new AmbryDataNode("DC1", clusterMapConfig2, HOST_NAME, PORT_NUM1, RACK_ID, null, null, XID,
+          mockClusterManagerCallback);
       fail("Datanode construction should have failed when SSL is enabled and SSL port is null");
     } catch (IllegalArgumentException e) {
       // OK
@@ -256,19 +257,21 @@ public class DynamicClusterManagerComponentsTest {
     Map<AmbryDataNode, Set<AmbryDisk>> dataNodeToDisks = new HashMap<>();
 
     @Override
-    public List<AmbryReplica> getReplicaIdsForPartition(AmbryPartition partition) {
-      return new ArrayList<AmbryReplica>(partitionToReplicas.get(partition));
+    public List<AmbryReplica> getReplicaIdsForPartition(PartitionId partition) {
+      AmbryPartition ambryPartition = (AmbryPartition) partition;
+      return new ArrayList<>(partitionToReplicas.get(ambryPartition));
     }
 
     @Override
-    public List<AmbryReplica> getReplicaIdsByState(AmbryPartition partition, ReplicaState state, String dcName) {
+    public List<AmbryReplica> getReplicaIdsByState(PartitionId partition, ReplicaState state, String dcName) {
       throw new UnsupportedOperationException("Temporarily unsupported");
     }
 
     @Override
-    public Collection<AmbryDisk> getDisks(AmbryDataNode dataNode) {
-      if (dataNode != null) {
-        return dataNodeToDisks.get(dataNode);
+    public Collection<AmbryDisk> getDisks(DataNodeId dataNode) {
+      AmbryDataNode ambryDataNode = (AmbryDataNode) dataNode;
+      if (ambryDataNode != null) {
+        return dataNodeToDisks.get(ambryDataNode);
       }
       List<AmbryDisk> disksToReturn = new ArrayList<>();
       for (Set<AmbryDisk> disks : dataNodeToDisks.values()) {
@@ -282,6 +285,11 @@ public class DynamicClusterManagerComponentsTest {
       return sealedStateChangeCounter.get();
     }
 
+    @Override
+    public Collection<AmbryPartition> getPartitions() {
+      return partitionToReplicas.keySet();
+    }
+
     /**
      * Associate the replica with the given partition.
      * @param partition the {@link AmbryPartition}.
@@ -289,7 +297,7 @@ public class DynamicClusterManagerComponentsTest {
      */
     void addReplicaToPartition(AmbryPartition partition, AmbryReplica replica) {
       if (!partitionToReplicas.containsKey(partition)) {
-        partitionToReplicas.put(partition, new ArrayList<AmbryReplica>());
+        partitionToReplicas.put(partition, new ArrayList<>());
       }
       partitionToReplicas.get(partition).add(replica);
     }

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
@@ -152,7 +152,7 @@ public class DynamicClusterManagerComponentsTest {
     assertEquals(HardwareState.UNAVAILABLE, disk1.getState());
     disk1.setState(HardwareState.AVAILABLE);
     assertEquals(HardwareState.AVAILABLE, disk1.getState());
-    assertTrue(disk1.getDataNode().equals(datanode1));
+    assertEquals(disk1.getDataNode(), datanode1);
     datanode1.setState(HardwareState.UNAVAILABLE);
     assertEquals(HardwareState.UNAVAILABLE, disk1.getState());
 


### PR DESCRIPTION
Previously, data structures in PartitionSelectionHelper are constant after initialization. With "Move Replica" feature on, this should dynamically incorporate any changes in clustermap (i.e. new replica / partition added or old replica removed). In this PR, we make PartitionSelectionHelper as a listener of clustermap and re-populate all in-mem data structures if number of replicas / partitions has changed.