### PR TITLE
Fix a bug in the segment range request

### DIFF
--- a/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/GetBlobOperation.java
@@ -1311,6 +1311,7 @@ class GetBlobOperation extends GetOperation {
         chunkMetadataList = compositeBlobInfo.getChunkMetadataList();
         boolean rangeResolutionFailure = false;
         try {
+          long rangeTotalSize = totalSize;
           if (options.getBlobOptions.hasBlobSegmentIdx()) {
             int requestedSegment = options.getBlobOptions.getBlobSegmentIdx();
             if (requestedSegment < 0 || requestedSegment >= chunkMetadataList.size()) {
@@ -1318,9 +1319,10 @@ class GetBlobOperation extends GetOperation {
                   "Bad segment number: " + requestedSegment + ", num of keys: " + chunkMetadataList.size());
             }
             chunkMetadataList = chunkMetadataList.subList(requestedSegment, requestedSegment + 1);
+            rangeTotalSize = chunkMetadataList.get(0).getSize();
           }
           if (options.getBlobOptions.getRange() != null) {
-            resolvedByteRange = options.getBlobOptions.getRange().toResolvedByteRange(totalSize);
+            resolvedByteRange = options.getBlobOptions.getRange().toResolvedByteRange(rangeTotalSize);
             // Get only the chunks within the range.
             if (!options.getBlobOptions.hasBlobSegmentIdx()) {
               chunkMetadataList = compositeBlobInfo.getStoreKeysInByteRange(resolvedByteRange.getStartOffset(),

--- a/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetManagerTest.java
@@ -227,7 +227,7 @@ public class GetManagerTest {
         this.options = new GetBlobOptionsBuilder().blobSegment(i).range(ByteRanges.fromLastNBytes(100)).build();
         getBlobAndCompareContent(blobId);
 
-        // range: [chunkSize/2, chunkSize-100]
+        // range: [chunkSize/2, chunkSize/2 + Random number]
         int end = new Random().nextInt(chunkSize / 2) + chunkSize / 2;
         this.options =
             new GetBlobOptionsBuilder().blobSegment(i).range(ByteRanges.fromOffsetRange(chunkSize / 2, end)).build();


### PR DESCRIPTION
When we resolve the range request, we should pass the chunk size instead of total blob size to the method.