### PR TITLE
Passing netty ByteBuf from NettyRequest to ByteBufferAsyncWritableChannel

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/router/AsyncWritableChannel.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/AsyncWritableChannel.java
@@ -70,7 +70,7 @@ public interface AsyncWritableChannel extends Channel {
       if (result != 0) {
         src.readerIndex(src.readerIndex() + (int) result.longValue());
       }
-      futureResult.done(result.longValue(), exception);
+      futureResult.done(result, exception);
       if (callback != null) {
         callback.onCompletion(result, exception);
       }

--- a/ambry-commons/src/main/java/com.github.ambry.commons/ByteBufferAsyncWritableChannel.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/ByteBufferAsyncWritableChannel.java
@@ -187,8 +187,9 @@ public class ByteBufferAsyncWritableChannel implements AsyncWritableChannel {
         return buffer;
       default:
         ByteBuffer byteBuffer = ByteBuffer.allocate(buf.readableBytes());
+        // This would also update the readerIndex for buf.
         buf.readBytes(byteBuffer);
-        byteBuffer.rewind();
+        byteBuffer.flip();
         return byteBuffer;
     }
   }

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -466,7 +466,7 @@ class NettyRequest implements RestRequest {
       // this will not happen (looking at current implementations of ByteBuf in Netty), but if it does, we cannot avoid
       // a copy (or we can introduce a read(GatheringByteChannel) method in ReadableStreamChannel if required).
       nettyMetrics.contentCopyCount.inc();
-      ByteBuf  content = httpContent.content();
+      ByteBuf content = httpContent.content();
       logger.warn("HttpContent had to be copied because ByteBuf did not have a backing ByteBuffer");
       ByteBuffer contentBuffer = ByteBuffer.allocate(content.readableBytes());
       // don't change the readerIndex

--- a/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/NettyRequest.java
@@ -420,7 +420,7 @@ class NettyRequest implements RestRequest {
           writeContent(writeChannel, callbackWrapper, httpContent);
           continueReadIfPossible(size);
         } else {
-          requestContents.add(ReferenceCountUtil.retain(httpContent));
+          requestContents.add(httpContent.retain());
           continueReadIfPossible(size);
         }
       } finally {
@@ -453,25 +453,14 @@ class NettyRequest implements RestRequest {
    */
   protected void writeContent(AsyncWritableChannel writeChannel, ReadIntoCallbackWrapper callbackWrapper,
       HttpContent httpContent) {
-    boolean retained = false;
     ByteBuffer[] contentBuffers;
-    Callback<Long>[] writeCallbacks;
     // LastHttpContent in the end marker in netty http world.
     boolean isLast = httpContent instanceof LastHttpContent;
     if (isLast) {
       setAutoRead(true);
     }
     if (httpContent.content().nioBufferCount() > 0) {
-      // not a copy.
-      httpContent = ReferenceCountUtil.retain(httpContent);
-      retained = true;
       contentBuffers = httpContent.content().nioBuffers();
-      writeCallbacks = new ContentWriteCallback[contentBuffers.length];
-      int i = 0;
-      for (; i < contentBuffers.length - 1; i++) {
-        writeCallbacks[i] = new ContentWriteCallback(null, false, callbackWrapper);
-      }
-      writeCallbacks[i] = new ContentWriteCallback(httpContent, isLast, callbackWrapper);
     } else {
       // this will not happen (looking at current implementations of ByteBuf in Netty), but if it does, we cannot avoid
       // a copy (or we can introduce a read(GatheringByteChannel) method in ReadableStreamChannel if required).
@@ -480,29 +469,18 @@ class NettyRequest implements RestRequest {
       ByteBuffer contentBuffer = ByteBuffer.allocate(httpContent.content().readableBytes());
       httpContent.content().readBytes(contentBuffer);
       contentBuffer.rewind();
-      // no need to retain httpContent since we have a copy.
-      ContentWriteCallback writeCallback = new ContentWriteCallback(null, isLast, callbackWrapper);
       contentBuffers = new ByteBuffer[]{contentBuffer};
-      writeCallbacks = new ContentWriteCallback[]{writeCallback};
     }
-    boolean asyncWritesCalled = false;
-    try {
+    if (digest != null) {
       for (int i = 0; i < contentBuffers.length; i++) {
-        if (digest != null) {
-          long startTime = System.currentTimeMillis();
-          int savedPosition = contentBuffers[i].position();
-          digest.update(contentBuffers[i]);
-          contentBuffers[i].position(savedPosition);
-          digestCalculationTimeInMs += (System.currentTimeMillis() - startTime);
-        }
-        writeChannel.write(contentBuffers[i], writeCallbacks[i]);
-      }
-      asyncWritesCalled = true;
-    } finally {
-      if (retained && !asyncWritesCalled) {
-        ReferenceCountUtil.release(httpContent);
+        long startTime = System.currentTimeMillis();
+        digest.update(contentBuffers[i]);
+        digestCalculationTimeInMs += (System.currentTimeMillis() - startTime);
       }
     }
+    // Retain this httpContent so it won't be garbage collected right away. Release it in the callback.
+    httpContent.retain();
+    writeChannel.write(httpContent.content(), new ContentWriteCallback(httpContent, isLast, callbackWrapper));
     allContentReceived = isLast;
   }
 
@@ -622,7 +600,7 @@ class NettyRequest implements RestRequest {
     @Override
     public void onCompletion(Long result, Exception exception) {
       if (httpContent != null) {
-        ReferenceCountUtil.release(httpContent);
+        httpContent.release();
       }
       callbackWrapper.updateBytesRead(result);
       continueReadIfPossible(-result);

--- a/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com.github.ambry.rest/NettyRequestTest.java
@@ -293,7 +293,6 @@ public class NettyRequestTest {
   }
 
   /**
-   * sed(line('.')) < 0) ? 'zc' : 'zo')<CR></CR>
    * Tests {@link NettyRequest#addContent(HttpContent)} and
    * {@link NettyRequest#readInto(AsyncWritableChannel, Callback)} with different digest algorithms (including a test
    * with no digest algorithm).


### PR DESCRIPTION
Passing netty ByteBuf in NettyRequest to ByteBufferAsyncWritableChannel.
By doing this, we can avoid creating a java ByteBuffer ( one less memory allocation) and copying data from httpContent.content() to newly created java ByteBuffer (one less memory copy).