### PR TITLE
Add basic support for cloud replicas in clustermap

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMapChangeListener.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMapChangeListener.java
@@ -13,7 +13,7 @@
  */
 package com.github.ambry.clustermap;
 
-import java.util.List;
+import java.util.Collection;
 
 
 /**
@@ -22,8 +22,9 @@ import java.util.List;
 public interface ClusterMapChangeListener {
   /**
    * Take actions when replicas are added or removed on local node.
-   * @param addedReplicas a list of {@link ReplicaId}(s) that have been added.
-   * @param removedReplicas a list of {@link ReplicaId}(s) that have been removed.
+   * @param addedReplicas {@link ReplicaId}(s) that have been added.
+   * @param removedReplicas {@link ReplicaId}(s) that have been removed.
    */
-  void onReplicaAddedOrRemoved(List<ReplicaId> addedReplicas, List<ReplicaId> removedReplicas);
+  void onReplicaAddedOrRemoved(Collection<? extends ReplicaId> addedReplicas,
+      Collection<? extends ReplicaId> removedReplicas);
 }

--- a/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMapSnapshotConstants.java
+++ b/ambry-api/src/main/java/com.github.ambry/clustermap/ClusterMapSnapshotConstants.java
@@ -66,6 +66,7 @@ public class ClusterMapSnapshotConstants {
   public static final String REPLICA_NODE = "node";
   public static final String REPLICA_PARTITION = "partition";
   public static final String REPLICA_DISK = "disk";
+  public static final String REPLICA_TYPE = "type";
   // values
   public static final String REPLICA_STOPPED = "stopped";
 

--- a/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/ClusterMapConfig.java
@@ -99,7 +99,7 @@ public class ClusterMapConfig {
   /**
    * Serialized json containing the information about all the zk hosts that the Helix based cluster manager should
    * be aware of. This information should be of the following form:
-   *
+   * <pre>
    * {
    *   "zkInfo" : [
    *     {
@@ -111,10 +111,15 @@ public class ClusterMapConfig {
    *       "datacenter":"dc2",
    *       "id" : "2",
    *       "zkConnectStr":"def.example.com:2300",
+   *     },
+   *     {
+   *       "datacenter":"cloud-dc",
+   *       "id" : "3",
+   *       "replicaType": "CLOUD_BACKED"
    *     }
    *   ]
    * }
-   *
+   * </pre>
    */
   @Config("clustermap.dcs.zk.connect.strings")
   @Default("")

--- a/ambry-api/src/main/java/com.github.ambry/router/CryptoService.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/CryptoService.java
@@ -49,9 +49,7 @@ public interface CryptoService<T> {
    * @throws {@link GeneralSecurityException} on any exception with encryption
    */
   default ByteBuf encrypt(ByteBuf toEncrypt, T key) throws GeneralSecurityException {
-    return Utils.applyByteBufferFunctionToByteBuf(toEncrypt, (buffer) -> {
-      return encrypt(buffer, key);
-    });
+    return Utils.applyByteBufferFunctionToByteBuf(toEncrypt, buffer -> encrypt(buffer, key));
   }
 
   /**
@@ -72,9 +70,7 @@ public interface CryptoService<T> {
    * @throws {@link GeneralSecurityException} on any exception with decryption
    */
   default ByteBuf decrypt(ByteBuf toDecrypt, T key) throws GeneralSecurityException {
-    return Utils.applyByteBufferFunctionToByteBuf(toDecrypt, (buffer) -> {
-      return decrypt(buffer, key);
-    });
+    return Utils.applyByteBufferFunctionToByteBuf(toDecrypt, buffer -> decrypt(buffer, key));
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudAmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudAmbryReplica.java
@@ -1,0 +1,78 @@
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import org.json.JSONObject;
+
+import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+
+
+class CloudAmbryReplica extends AmbryReplica {
+  /**
+   * Instantiate an AmbryReplica instance for a virtual cloud replica. This does no
+   * @param clusterMapConfig the {@link ClusterMapConfig} to use.
+   * @param partition the {@link AmbryPartition} of which this is a replica.
+   * @param capacityBytes the capacity in bytes for this replica.
+   */
+  CloudAmbryReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, long capacityBytes) throws Exception {
+    super(clusterMapConfig, partition, false, capacityBytes, false);
+  }
+
+  @Override
+  public AmbryDisk getDiskId() {
+    throw new UnsupportedOperationException("No disk for cloud replica");
+  }
+
+  @Override
+  public AmbryDataNode getDataNodeId() {
+    // TODO figure out callers, if too many change this behavior
+    throw new UnsupportedOperationException("No datanode for cloud replica");
+  }
+
+  @Override
+  public String getMountPath() {
+    throw new UnsupportedOperationException("No mount path for cloud replica");
+  }
+
+  @Override
+  public String getReplicaPath() {
+    throw new UnsupportedOperationException("No replica path for cloud replica");
+  }
+
+  @Override
+  public ReplicaType getReplicaType() {
+    return ReplicaType.DISK_BACKED;
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    JSONObject snapshot = new JSONObject();
+    snapshot.put(REPLICA_PARTITION, getPartitionId().toPathString());
+    snapshot.put(REPLICA_TYPE, getReplicaType());
+    snapshot.put(CAPACITY_BYTES, getCapacityInBytes());
+    snapshot.put(REPLICA_WRITE_STATE, isSealed() ? PartitionState.READ_ONLY.name() : PartitionState.READ_WRITE.name());
+    String replicaLiveness = UP;
+    if (isStopped) {
+      replicaLiveness = REPLICA_STOPPED;
+    } else if (resourceStatePolicy.isHardDown()) {
+      replicaLiveness = DOWN;
+    } else if (resourceStatePolicy.isDown()) {
+      replicaLiveness = SOFT_DOWN;
+    }
+    snapshot.put(LIVENESS, replicaLiveness);
+    return snapshot;
+  }
+
+  @Override
+  public String toString() {
+    return "Replica[cloud:" + getPartitionId().toPathString() + "]";
+  }
+
+  @Override
+  public void markDiskDown() {
+  }
+
+  @Override
+  public void markDiskUp() {
+  }
+}

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudChangeListener.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudChangeListener.java
@@ -1,0 +1,54 @@
+package com.github.ambry.clustermap;
+
+import com.github.ambry.clustermap.HelixClusterManager.ClusterChangeHandlerCallback;
+import com.github.ambry.config.ClusterMapConfig;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Currently, this just adds a single {@link ReplicaType#CLOUD_BACKED} replica every time a partition is added to allow
+ * for requests to be routed to cloud services. Currently it is only registered as a {@link ClusterMapChangeListener},
+ * but once the clustermap natively supports VCR clusters, this class can implement {@link ClusterChangeHandler} and
+ * listen for changes in the VCR cluster.
+ */
+class CloudChangeListener implements ClusterMapChangeListener {
+  private static final Logger logger = LoggerFactory.getLogger(CloudChangeListener.class);
+  private final Set<String> knownPartitions = ConcurrentHashMap.newKeySet();
+  private final String dcName;
+  private final ClusterMapConfig clusterMapConfig;
+  private final ClusterChangeHandlerCallback changeHandlerCallback;
+
+  public CloudChangeListener(String dcName, ClusterMapConfig clusterMapConfig,
+      ClusterChangeHandlerCallback changeHandlerCallback) {
+    this.dcName = dcName;
+    this.clusterMapConfig = clusterMapConfig;
+    this.changeHandlerCallback = changeHandlerCallback;
+  }
+
+  @Override
+  public void onReplicaAddedOrRemoved(Collection<? extends ReplicaId> addedReplicas,
+      Collection<? extends ReplicaId> removedReplicas) {
+    // This impl assumes that no partition will ever be completely removed.
+    for (ReplicaId replica : addedReplicas) {
+      AmbryPartition partition = (AmbryPartition) replica.getPartitionId();
+      String partitionName = replica.getPartitionId().toPathString();
+      if (knownPartitions.add(partitionName)) {
+        try {
+          logger.debug("Adding cloud replica: dc={}, partition={}", dcName, partitionName);
+          // Copy the capacity from an existing replica
+          AmbryReplica cloudAmbryReplica =
+              new CloudAmbryReplica(clusterMapConfig, partition, replica.getCapacityInBytes());
+          changeHandlerCallback.addReplicasToPartition(partition, Collections.singletonList(cloudAmbryReplica));
+        } catch (Exception e) {
+          logger.error("Exception while adding cloud replica: dc={}, partition={}", dcName, partitionName, e);
+        }
+      }
+    }
+  }
+}

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/ClusterMapUtils.java
@@ -60,6 +60,7 @@ public class ClusterMapUtils {
   static final String REPLICAS_DELIM_STR = ",";
   static final String REPLICAS_STR_SEPARATOR = ":";
   static final String REPLICAS_CAPACITY_STR = "replicaCapacityInBytes";
+  static final String REPLICA_TYPE_STR = "replicaType";
   static final String SSL_PORT_STR = "sslPort";
   static final String HTTP2_PORT_STR = "http2Port";
   static final String RACKID_STR = "rackId";
@@ -91,17 +92,20 @@ public class ClusterMapUtils {
     private final String dcName;
     private final byte dcId;
     private final String zkConnectStr;
+    private final ReplicaType replicaType;
 
     /**
      * Construct a DcInfo object with the given parameters.
      * @param dcName the associated datacenter name.
      * @param dcId the associated datacenter ID.
      * @param zkConnectStr the associated ZK connect string for this datacenter.
+     * @param replicaType the type of replicas (cloud or disk backed) present in this datacenter.
      */
-    DcZkInfo(String dcName, byte dcId, String zkConnectStr) {
+    DcZkInfo(String dcName, byte dcId, String zkConnectStr, ReplicaType replicaType) {
       this.dcName = dcName;
       this.dcId = dcId;
       this.zkConnectStr = zkConnectStr;
+      this.replicaType = replicaType;
     }
 
     public String getDcName() {
@@ -114,6 +118,10 @@ public class ClusterMapUtils {
 
     public String getZkConnectStr() {
       return zkConnectStr;
+    }
+
+    public ReplicaType getReplicaType() {
+      return replicaType;
     }
   }
 
@@ -139,8 +147,12 @@ public class ClusterMapUtils {
     JSONArray all = root.getJSONArray(ZKINFO_STR);
     for (int i = 0; i < all.length(); i++) {
       JSONObject entry = all.getJSONObject(i);
+      String name = entry.getString(DATACENTER_STR);
       byte id = (byte) entry.getInt(DATACENTER_ID_STR);
-      DcZkInfo dcZkInfo = new DcZkInfo(entry.getString(DATACENTER_STR), id, entry.getString(ZKCONNECTSTR_STR));
+      ReplicaType replicaType = entry.optEnum(ReplicaType.class, REPLICA_TYPE_STR, ReplicaType.DISK_BACKED);
+      String zkConnectStr = (replicaType == ReplicaType.DISK_BACKED) ? entry.getString(ZKCONNECTSTR_STR)
+          : entry.optString(ZKCONNECTSTR_STR);
+      DcZkInfo dcZkInfo = new DcZkInfo(name, id, zkConnectStr, replicaType);
       dataCenterToZkAddress.put(dcZkInfo.dcName, dcZkInfo);
     }
     return dataCenterToZkAddress;

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DiskAmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DiskAmbryReplica.java
@@ -1,0 +1,100 @@
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import java.io.File;
+import java.util.Objects;
+import org.json.JSONObject;
+
+import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
+
+
+class DiskAmbryReplica extends AmbryReplica {
+  private final AmbryDisk disk;
+
+  /**
+   * Instantiate a disk backed AmbryReplica instance.
+   * @param clusterMapConfig the {@link ClusterMapConfig} to use.
+   * @param partition the {@link AmbryPartition} of which this is a replica.
+   * @param disk the {@link AmbryDisk} on which this replica resides.
+   * @param isReplicaStopped whether this replica is stopped or not.
+   * @param capacityBytes the capacity in bytes for this replica.
+   * @param isSealed whether this replica is in sealed state.
+   */
+  DiskAmbryReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, AmbryDisk disk,
+      boolean isReplicaStopped, long capacityBytes, boolean isSealed) throws Exception {
+    super(clusterMapConfig, partition, isReplicaStopped, capacityBytes, isSealed);
+    this.disk = Objects.requireNonNull(disk, "null disk");
+  }
+
+  @Override
+  public AmbryDisk getDiskId() {
+    return disk;
+  }
+
+  @Override
+  public AmbryDataNode getDataNodeId() {
+    return disk != null ? disk.getDataNode() : null;
+  }
+
+  @Override
+  public String getMountPath() {
+    return disk.getMountPath();
+  }
+
+  @Override
+  public String getReplicaPath() {
+    return disk.getMountPath() + File.separator + getPartitionId().toPathString();
+  }
+
+  @Override
+  public ReplicaType getReplicaType() {
+    return ReplicaType.DISK_BACKED;
+  }
+
+  @Override
+  public JSONObject getSnapshot() {
+    JSONObject snapshot = new JSONObject();
+    DataNodeId dataNodeId = getDataNodeId();
+    snapshot.put(REPLICA_NODE, dataNodeId.getHostname() + ":" + dataNodeId.getPort());
+    snapshot.put(REPLICA_PARTITION, getPartitionId().toPathString());
+    snapshot.put(REPLICA_TYPE, getReplicaType());
+    snapshot.put(REPLICA_DISK, getDiskId().getMountPath());
+    snapshot.put(REPLICA_PATH, getReplicaPath());
+    snapshot.put(CAPACITY_BYTES, getCapacityInBytes());
+    snapshot.put(REPLICA_WRITE_STATE, isSealed() ? PartitionState.READ_ONLY.name() : PartitionState.READ_WRITE.name());
+    String replicaLiveness = UP;
+    if (dataNodeId.getState() == HardwareState.UNAVAILABLE) {
+      replicaLiveness = NODE_DOWN;
+    } else if (disk.getState() == HardwareState.UNAVAILABLE) {
+      replicaLiveness = DISK_DOWN;
+    } else if (isStopped) {
+      replicaLiveness = REPLICA_STOPPED;
+    } else if (resourceStatePolicy.isHardDown()) {
+      replicaLiveness = DOWN;
+    } else if (resourceStatePolicy.isDown()) {
+      replicaLiveness = SOFT_DOWN;
+    }
+    snapshot.put(LIVENESS, replicaLiveness);
+    return snapshot;
+  }
+
+  @Override
+  public String toString() {
+    return "Replica[" + getDataNodeId().getHostname() + ":" + getDataNodeId().getPort() + ":" + getReplicaPath() + "]";
+  }
+
+  @Override
+  public boolean isDown() {
+    return disk.getState() == HardwareState.UNAVAILABLE || super.isDown();
+  }
+
+  @Override
+  public void markDiskDown() {
+    disk.onDiskError();
+  }
+
+  @Override
+  public void markDiskUp() {
+    disk.onDiskOk();
+  }
+}

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
@@ -338,7 +338,7 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
             ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, dataNode, replicaCapacity);
             // create new replica belonging to this partition
             AmbryReplica replica =
-                new AmbryReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
+                new DiskAmbryReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
                     replicaCapacity, sealedReplicas.contains(partitionName));
             updateReplicaStateAndOverrideIfNeeded(replica, sealedReplicas, stoppedReplicas);
             // add new created replica to "replicasFromConfig" map
@@ -461,7 +461,7 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
                 .equals(ClusterMapUtils.READ_ONLY_STR);
           }
           AmbryReplica replica =
-              new AmbryReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
+              new DiskAmbryReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
                   replicaCapacity, isSealed);
           ambryDataNodeToAmbryReplicas.get(datanode).put(mappedPartition.toPathString(), replica);
           clusterChangeHandlerCallback.addReplicasToPartition(mappedPartition, Collections.singletonList(replica));

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterSpectator.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterSpectator.java
@@ -63,15 +63,17 @@ public class HelixClusterSpectator implements ClusterSpectator {
     // zk connection fails on both data centers, then things like replication between data centers might just stop.
     // For now, since we have only one fabric in cloud, and the spectator is being used for only cloud to store replication, this will work.
     // Once we add more fabrics, we should revisit this.
-    for (Map.Entry<String, DcZkInfo> entry : dataCenterToZkAddress.entrySet()) {
-      String zkConnectStr = entry.getValue().getZkConnectStr();
-      HelixManager helixManager =
-          helixFactory.getZKHelixManager(cloudConfig.vcrClusterName, selfInstanceName, InstanceType.SPECTATOR,
-              zkConnectStr);
-      helixManager.connect();
+    for (DcZkInfo dcZkInfo: dataCenterToZkAddress.values()) {
+      // only handle vcr clusters for now
+      if (dcZkInfo.getReplicaType() == ReplicaType.CLOUD_BACKED) {
+        HelixManager helixManager =
+            helixFactory.getZKHelixManager(cloudConfig.vcrClusterName, selfInstanceName, InstanceType.SPECTATOR,
+                dcZkInfo.getZkConnectStr());
+        helixManager.connect();
 
-      helixManager.addInstanceConfigChangeListener(this);
-      helixManager.addLiveInstanceChangeListener(this);
+        helixManager.addInstanceConfigChangeListener(this);
+        helixManager.addLiveInstanceChangeListener(this);
+      }
     }
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/SimpleClusterChangeHandler.java
@@ -417,7 +417,7 @@ public class SimpleClusterChangeHandler implements ClusterChangeHandler {
           // mappedPartition is now the final mapped AmbryPartition object for this partition.
           synchronized (mappedPartition) {
             if (!ambryPartitionToAmbryReplicas.containsKey(mappedPartition)) {
-              ambryPartitionToAmbryReplicas.put(mappedPartition, Collections.newSetFromMap(new ConcurrentHashMap<>()));
+              ambryPartitionToAmbryReplicas.put(mappedPartition, ConcurrentHashMap.newKeySet());
               partitionMap.put(ByteBuffer.wrap(mappedPartition.getBytes()), mappedPartition);
             }
           }
@@ -433,7 +433,7 @@ public class SimpleClusterChangeHandler implements ClusterChangeHandler {
             isSealed = sealedReplicas.contains(partitionName);
           }
           AmbryReplica replica =
-              new AmbryReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
+              new DiskAmbryReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
                   replicaCapacity, isSealed);
           ambryPartitionToAmbryReplicas.get(mappedPartition).add(replica);
           ambryDataNodeToAmbryReplicas.get(datanode).put(mappedPartition.toPathString(), replica);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/DynamicClusterManagerComponentsTest.java
@@ -171,21 +171,21 @@ public class DynamicClusterManagerComponentsTest {
 
     // AmbryReplica tests
     try {
-      new AmbryReplica(clusterMapConfig1, null, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
+      new DiskAmbryReplica(clusterMapConfig1, null, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
       fail("Replica initialization should fail with invalid arguments");
-    } catch (IllegalStateException e) {
+    } catch (NullPointerException e) {
       // OK
     }
 
     try {
-      new AmbryReplica(clusterMapConfig1, partition1, null, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
+      new DiskAmbryReplica(clusterMapConfig1, partition1, null, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
       fail("Replica initialization should fail with invalid arguments");
-    } catch (IllegalStateException e) {
+    } catch (NullPointerException e) {
       // OK
     }
 
     try {
-      new AmbryReplica(clusterMapConfig1, partition1, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES + 1, false);
+      new DiskAmbryReplica(clusterMapConfig1, partition1, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES + 1, false);
       fail("Replica initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
@@ -193,19 +193,19 @@ public class DynamicClusterManagerComponentsTest {
 
     // Create a few replicas and make the mockClusterManagerCallback aware of the association.
     AmbryReplica replica1 =
-        new AmbryReplica(clusterMapConfig1, partition1, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
+        new DiskAmbryReplica(clusterMapConfig1, partition1, disk1, false, MAX_REPLICA_CAPACITY_IN_BYTES, false);
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica1);
     AmbryReplica replica2 =
-        new AmbryReplica(clusterMapConfig1, partition2, disk1, false, MIN_REPLICA_CAPACITY_IN_BYTES, false);
+        new DiskAmbryReplica(clusterMapConfig1, partition2, disk1, false, MIN_REPLICA_CAPACITY_IN_BYTES, false);
     mockClusterManagerCallback.addReplicaToPartition(partition2, replica2);
     AmbryReplica replica3 =
-        new AmbryReplica(clusterMapConfig2, partition1, disk2, false, MIN_REPLICA_CAPACITY_IN_BYTES, false);
+        new DiskAmbryReplica(clusterMapConfig2, partition1, disk2, false, MIN_REPLICA_CAPACITY_IN_BYTES, false);
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica3);
     AmbryReplica replica4 =
-        new AmbryReplica(clusterMapConfig2, partition2, disk2, false, MIN_REPLICA_CAPACITY_IN_BYTES, true);
+        new DiskAmbryReplica(clusterMapConfig2, partition2, disk2, false, MIN_REPLICA_CAPACITY_IN_BYTES, true);
     mockClusterManagerCallback.addReplicaToPartition(partition2, replica4);
     AmbryReplica replica5 =
-        new AmbryReplica(clusterMapConfig1, partition1, disk1, true, MIN_REPLICA_CAPACITY_IN_BYTES, false);
+        new DiskAmbryReplica(clusterMapConfig1, partition1, disk1, true, MIN_REPLICA_CAPACITY_IN_BYTES, false);
     mockClusterManagerCallback.addReplicaToPartition(partition1, replica5);
 
     sealedStateChangeCounter.incrementAndGet();

--- a/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
+++ b/ambry-commons/src/main/java/com.github.ambry.commons/BlobId.java
@@ -88,7 +88,7 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
  * </pre>
  *
  * <br>
- * Version 4, which is the same as Version 3 now.
+ * Version 4, which is the same as Version 3 now but indicates that .
  * <br>
  * <pre>
  * +---------+-------+--------------+-----------+-------------+-------------+----------+----------+
@@ -120,6 +120,23 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
  * |  un-assigned | BlobDataType  | IsEncrypted |  BlobIdType   |
  * +--------------+---------------+-------------+---------------|
  * </pre>
+ *
+ * <br>
+ * Version 6, which has a more compact encoding for the UUID where it is encoded as a 16 byte value instead of a
+ * size-prefixed hexadecimal string.
+ * <br>
+ * <pre>
+ * +---------+--------+--------------+-----------+-------------+-------------+------------+
+ * | version | flag   | datacenterId | accountId | containerId | partitionId | uuid       |
+ * | (short) | (byte) | (byte)       | (short)   | (short)     | (n bytes)   | (16 bytes) |
+ * +---------+--------+--------------+-----------+-------------+-------------+------------+
+ *
+ * Flag format: 1 Byte
+ * +--------------+---------------+-------------+---------------+
+ * |  1 to 3 bits | 4 and 5th bit |    6th bit  | 7 and 8th bit |
+ * |  un-assigned | BlobDataType  | IsEncrypted |  BlobIdType   |
+ * +--------------+---------------+-------------+---------------|
+ * </pre>
  */
 
 public class BlobId extends StoreKey {
@@ -139,7 +156,6 @@ public class BlobId extends StoreKey {
   private static final int IS_ENCRYPTED_MASK = 0x4;
   private static final int BLOB_DATA_TYPE_MASK = 0x18;
   private static final int BLOB_DATA_TYPE_SHIFT = 3;
-  private static final Logger LOGGER = LoggerFactory.getLogger(BlobId.class);
 
   private final short version;
   private final BlobIdType type;

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationManager.java
@@ -37,6 +37,7 @@ import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -251,7 +252,8 @@ public class ReplicationManager extends ReplicationEngine {
      * concurrently update remote replica infos.
      */
     @Override
-    public void onReplicaAddedOrRemoved(List<ReplicaId> addedReplicas, List<ReplicaId> removedReplicas) {
+    public void onReplicaAddedOrRemoved(Collection<? extends ReplicaId> addedReplicas,
+        Collection<? extends ReplicaId> removedReplicas) {
       // 1. wait for start() to complete
       try {
         startupLatch.await();

--- a/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
+++ b/ambry-utils/src/main/java/com.github.ambry.utils/Utils.java
@@ -310,7 +310,7 @@ public class Utils {
    * @param <T> The exception to throw in this operation.
    */
   @FunctionalInterface
-  public static interface ByteBufferFunction<T extends Throwable> {
+  public interface ByteBufferFunction<T extends Throwable> {
     ByteBuffer apply(ByteBuffer buffer) throws T;
   }
 


### PR DESCRIPTION
- Add a representation of a cloud datacenter to configs
- Refactor AmbryReplica into abstract class to allow for cloud and disk
  backed replicas in HelixClusterManager.
- Implement listener logic to create a CloudAmbryReplica whenever a new
  partition is registered in the clustermap. This makes the assumption
  that any partition that exists in Ambry will be accessible via a cloud
  store if a cloud datacenter is present.

Note that this PR does not add first-class support for VCR clusters in
HelixClusterManager. That will come later.