### PR TITLE
Minor changes in CloudToStoreReplicationManager for move replica

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudReplica.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/CloudReplica.java
@@ -62,11 +62,10 @@ public class CloudReplica implements ReplicaId {
 
   @Override
   public List<ReplicaId> getPeerReplicaIds() {
-    List<ReplicaId> replicasOfPartition = partitionId.getReplicaIds()
+    return partitionId.getReplicaIds()
         .stream()
         .filter(replica -> replica.getDataNodeId().compareTo(dataNodeId) != 0)
         .collect(Collectors.toList());
-    return replicasOfPartition;
   }
 
   @Override

--- a/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
@@ -215,12 +215,20 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
   }
 
   /**
+   * @return a map of thread pools grouped by data center.
+   */
+  Map<String, List<ReplicaThread>> getReplicaThreadPoolByDc() {
+    return Collections.unmodifiableMap(replicaThreadPoolByDc);
+  }
+
+  /**
    * Remove a replica of given partition and its {@link RemoteReplicaInfo}s from the backup list.
    * @param partitionName the partition of the replica to be removed.
    */
   private void removeCloudReplica(String partitionName) {
-    // Removing cloud replica occurs when replica from LEADER to STANDBY (this may be triggered by "Move Replica"). No
-    // what triggers such transition, the local replica should be present in storage manager at this point of time.
+    // Removing cloud replica occurs when replica from LEADER to STANDBY (this may be triggered by "Move Replica" or
+    // regular leadership hand-off due to server deployment). No matter what triggers this transition, the local replica
+    // should be present in storage manager at this point of time.
     ReplicaId localReplica = storeManager.getReplica(partitionName);
     if (localReplica == null) {
       logger.warn("Attempting to remove cloud partition {} that is not present on the node", partitionName);

--- a/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
@@ -215,13 +215,6 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
   }
 
   /**
-   * @return a map of thread pools grouped by data center.
-   */
-  Map<String, List<ReplicaThread>> getReplicaThreadPoolByDc() {
-    return Collections.unmodifiableMap(replicaThreadPoolByDc);
-  }
-
-  /**
    * Remove a replica of given partition and its {@link RemoteReplicaInfo}s from the backup list.
    * @param partitionName the partition of the replica to be removed.
    */

--- a/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/CloudToStoreReplicationManager.java
@@ -70,7 +70,6 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
   private static final String cloudReplicaTokenFileName = "cloudReplicaTokens";
   private AtomicReference<ConcurrentHashMap<String, CloudDataNode>> instanceNameToCloudDataNode;
   private AtomicReference<ConcurrentSkipListSet<CloudDataNode>> vcrNodes;
-  private final ConcurrentHashMap<String, PartitionId> localPartitionNameToPartition;
   private final Object notificationLock = new Object();
 
   /**
@@ -110,22 +109,6 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
     this.persistor =
         new DiskTokenPersistor(cloudReplicaTokenFileName, mountPathToPartitionInfos, replicationMetrics, clusterMap,
             tokenHelper, storeManager);
-    this.localPartitionNameToPartition = mapPartitionNameToPartition(clusterMap, currentNode);
-  }
-
-  /**
-   * Create a {@link Map} of partition name to {@link PartitionId} for local replicas on specified node from
-   * specified cluster map.
-   * @param clusterMap specified {@link ClusterMap} object.
-   * @param localNode specified {@link DataNodeId} object.
-   * @return
-   */
-  private ConcurrentHashMap<String, PartitionId> mapPartitionNameToPartition(ClusterMap clusterMap,
-      DataNodeId localNode) {
-    return clusterMap.getReplicaIds(localNode)
-        .stream()
-        .collect(Collectors.toMap(replicaId -> replicaId.getPartitionId().toPathString(), ReplicaId::getPartitionId,
-            (e1, e2) -> e2, ConcurrentHashMap::new));
   }
 
   @Override
@@ -172,39 +155,39 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
    * @throws ReplicationException if replicas initialization failed.
    */
   private void addCloudReplica(String partitionName) throws ReplicationException {
-    if (!localPartitionNameToPartition.containsKey(partitionName)) {
+    // Adding cloud replica occurs when replica becomes leader from standby. Hence, if this a new added replica, it
+    // should be present in storage manager already.
+    ReplicaId localReplica = storeManager.getReplica(partitionName);
+    if (localReplica == null) {
       logger.warn("Got partition leader notification for partition {} that is not present on the node", partitionName);
       return;
     }
-    PartitionId partitionId = localPartitionNameToPartition.get(partitionName);
+    PartitionId partitionId = localReplica.getPartitionId();
     Store store = storeManager.getStore(partitionId);
     if (store == null) {
-      logger.warn("Unable to add cloud replica for partition {} as store for the partition doesn't exist.",
+      logger.warn("Unable to add cloud replica for partition {} as store for the partition is not present or started.",
           partitionName);
       return;
     }
-    ReplicaId localReplicaId = (ReplicaId) partitionId.getReplicaIds()
-        .stream()
-        .filter(r -> (r.getDataNodeId().getHostname().equals(dataNodeId.getHostname())))
-        .toArray()[0];
-    CloudReplica peerReplica = new CloudReplica(partitionId, getCloudDataNode());
-    FindTokenFactory findTokenFactory = tokenHelper.getFindTokenFactoryFromReplicaType(peerReplica.getReplicaType());
+    CloudReplica peerCloudReplica = new CloudReplica(partitionId, getCloudDataNode());
+    FindTokenFactory findTokenFactory =
+        tokenHelper.getFindTokenFactoryFromReplicaType(peerCloudReplica.getReplicaType());
     RemoteReplicaInfo remoteReplicaInfo =
-        new RemoteReplicaInfo(peerReplica, localReplicaId, store, findTokenFactory.getNewFindToken(),
+        new RemoteReplicaInfo(peerCloudReplica, localReplica, store, findTokenFactory.getNewFindToken(),
             storeConfig.storeDataFlushIntervalSeconds * SystemTime.MsPerSec * Replication_Delay_Multiplier,
-            SystemTime.getInstance(), peerReplica.getDataNodeId().getPortToConnectTo());
+            SystemTime.getInstance(), peerCloudReplica.getDataNodeId().getPortToConnectTo());
     replicationMetrics.addMetricsForRemoteReplicaInfo(remoteReplicaInfo);
 
     // Note that for each replica on a Ambry server node, there is only one cloud replica that it will be replicating from.
     List<RemoteReplicaInfo> remoteReplicaInfos = Collections.singletonList(remoteReplicaInfo);
-    PartitionInfo partitionInfo = new PartitionInfo(remoteReplicaInfos, partitionId, store, localReplicaId);
+    PartitionInfo partitionInfo = new PartitionInfo(remoteReplicaInfos, partitionId, store, localReplica);
     partitionToPartitionInfo.put(partitionId, partitionInfo);
-    mountPathToPartitionInfos.computeIfAbsent(localReplicaId.getMountPath(), key -> ConcurrentHashMap.newKeySet())
+    mountPathToPartitionInfos.computeIfAbsent(localReplica.getMountPath(), key -> ConcurrentHashMap.newKeySet())
         .add(partitionInfo);
     logger.info("Cloud Partition {} added to {}", partitionName, dataNodeId);
 
     // Reload replication token if exist.
-    reloadReplicationTokenIfExists(localReplicaId, remoteReplicaInfos);
+    reloadReplicationTokenIfExists(localReplica, remoteReplicaInfos);
 
     // Add remoteReplicaInfos to {@link ReplicaThread}.
     addRemoteReplicaInfoToReplicaThread(remoteReplicaInfos, true);
@@ -233,14 +216,17 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
 
   /**
    * Remove a replica of given partition and its {@link RemoteReplicaInfo}s from the backup list.
-   * @param partitionName the partition of the replica to removed.
+   * @param partitionName the partition of the replica to be removed.
    */
   private void removeCloudReplica(String partitionName) {
-    if (!localPartitionNameToPartition.containsKey(partitionName)) {
-      logger.warn("Got partition standby notification for partition {} that is not present on the node", partitionName);
+    // Removing cloud replica occurs when replica from LEADER to STANDBY (this may be triggered by "Move Replica"). No
+    // what triggers such transition, the local replica should be present in storage manager at this point of time.
+    ReplicaId localReplica = storeManager.getReplica(partitionName);
+    if (localReplica == null) {
+      logger.warn("Attempting to remove cloud partition {} that is not present on the node", partitionName);
       return;
     }
-    PartitionId partitionId = localPartitionNameToPartition.get(partitionName);
+    PartitionId partitionId = localReplica.getPartitionId();
     stopPartitionReplication(partitionId);
     logger.info("Cloud Partition {} removed from {}", partitionId, dataNodeId);
   }
@@ -264,9 +250,9 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
     Set<CloudDataNode> removedNodes = new HashSet<>(vcrNodes.get());
     removedNodes.removeAll(newVcrNodes);
     vcrNodes.set(newVcrNodes);
+    logger.info("Handling VCR nodes change. The removed vcr nodes: {}", removedNodes);
     List<PartitionId> partitionsOnRemovedNodes = getPartitionsOnNodes(removedNodes);
     for (PartitionId partitionId : partitionsOnRemovedNodes) {
-      boolean removed = false;
       try {
         // We first remove replica to stop replication from removed node, and then add replica so that it can pick a
         // new cloud node to start replicating from.
@@ -297,7 +283,7 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
         Port http2Port =
             getHttp2PortStr(instanceConfig) == null ? null : new Port(getHttp2PortStr(instanceConfig), PortType.HTTP2);
         CloudDataNode cloudDataNode = new CloudDataNode(instanceConfig.getHostName(),
-            new Port(Integer.valueOf(instanceConfig.getPort()), PortType.PLAINTEXT), sslPort, http2Port,
+            new Port(Integer.parseInt(instanceConfig.getPort()), PortType.PLAINTEXT), sslPort, http2Port,
             clusterMapConfig.clustermapVcrDatacenterName, clusterMapConfig);
         newInstanceNameToCloudDataNode.put(instanceName, cloudDataNode);
         newVcrNodes.add(cloudDataNode);

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicaThread.java
@@ -272,7 +272,7 @@ public class ReplicaThread implements Runnable {
     try {
       return replicasToReplicateGroupedByNode.entrySet()
           .stream()
-          .collect(Collectors.toMap(e -> e.getKey(), e -> new ArrayList<>(e.getValue())));
+          .collect(Collectors.toMap(Map.Entry::getKey, e -> new ArrayList<>(e.getValue())));
     } finally {
       lock.unlock();
     }

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -201,7 +201,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
    * @param replicaPath replica path on the remote peer replica
    * @return RemoteReplicaInfo
    */
-  private RemoteReplicaInfo getRemoteReplicaInfo(PartitionId partitionId, String hostName, String replicaPath) {
+  protected RemoteReplicaInfo getRemoteReplicaInfo(PartitionId partitionId, String hostName, String replicaPath) {
     RemoteReplicaInfo foundRemoteReplicaInfo = null;
 
     PartitionInfo partitionInfo = partitionToPartitionInfo.get(partitionId);

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -256,8 +256,10 @@ public abstract class ReplicationEngine implements ReplicationAPI {
       // For CloudBackUpManager with HelixVcrCluster, Helix requires acknowledgement before next message for the same
       // resource, which means methods in HelixVcrStateModel will be executed sequentially for same partition.
       // So do listener actions in addPartition() and removePartition().
-      remoteReplicaInfo.getReplicaThread().removeRemoteReplicaInfo(remoteReplicaInfo);
-      remoteReplicaInfo.setReplicaThread(null);
+      if (remoteReplicaInfo.getReplicaThread() != null) {
+        remoteReplicaInfo.getReplicaThread().removeRemoteReplicaInfo(remoteReplicaInfo);
+        remoteReplicaInfo.setReplicaThread(null);
+      }
     }
   }
 

--- a/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com.github.ambry.replication/ReplicationEngine.java
@@ -489,7 +489,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
   protected void stopPartitionReplication(PartitionId partitionId) {
     PartitionInfo partitionInfo = partitionToPartitionInfo.remove(partitionId);
     if (partitionInfo == null) {
-      logger.warn("Partition {} not exist when remove from {}. ", partitionId, dataNodeId);
+      logger.warn("Partition {} doesn't exist when removing it from {}. ", partitionId, dataNodeId);
       return;
     }
     removeRemoteReplicaInfoFromReplicaThread(partitionInfo.getRemoteReplicaInfos());

--- a/ambry-replication/src/test/java/com.github.ambry.replication/CloudToStoreReplicationManagerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/CloudToStoreReplicationManagerTest.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.replication;
+
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockClusterSpectator;
+import com.github.ambry.clustermap.MockDataNodeId;
+import com.github.ambry.clustermap.MockHelixParticipant;
+import com.github.ambry.clustermap.MockPartitionId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.DiskManagerConfig;
+import com.github.ambry.config.ReplicationConfig;
+import com.github.ambry.config.ServerConfig;
+import com.github.ambry.config.StoreConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.network.Port;
+import com.github.ambry.network.PortType;
+import com.github.ambry.store.MockStoreKeyConverterFactory;
+import com.github.ambry.store.StorageManager;
+import com.github.ambry.store.StoreKey;
+import com.github.ambry.store.StoreKeyFactory;
+import com.github.ambry.utils.MockTime;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.Utils;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ScheduledExecutorService;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+import static com.github.ambry.clustermap.TestUtils.*;
+import static org.junit.Assert.*;
+
+
+/**
+ * Tests for {@link CloudToStoreReplicationManager} when adding/removing cloud replica. The tests also cover the case
+ * where new replica is added due to "move replica".
+ */
+public class CloudToStoreReplicationManagerTest {
+  private static final String NEW_PARTITION_NAME = "12";
+  private static final String CLOUD_DC_NAME = "CloudDc";
+  private static final String VCR_MOUNT_PATH = "/vcr/1";
+  private final VerifiableProperties verifiableProperties;
+  private final ScheduledExecutorService mockScheduler;
+  private final StoreKeyFactory storeKeyFactory;
+  private final ClusterMapConfig clusterMapConfig;
+  private final ReplicationConfig replicationConfig;
+  private final ServerConfig serverConfig;
+  private final StoreConfig storeConfig;
+  private final MockStoreKeyConverterFactory storeKeyConverterFactory;
+  private final MockDataNodeId vcrNode;
+  private final DataNodeId currentNode;
+  private final MockHelixParticipant mockHelixParticipant;
+  private final MockClusterSpectator mockClusterSpectator;
+  private final MockClusterMap clusterMap;
+
+  public CloudToStoreReplicationManagerTest() throws Exception {
+    List<TestUtils.ZkInfo> zkInfoList = new ArrayList<>();
+    zkInfoList.add(new TestUtils.ZkInfo(null, "DC1", (byte) 0, 2299, false));
+    JSONObject zkJson = constructZkLayoutJSON(zkInfoList);
+    storeKeyConverterFactory = new MockStoreKeyConverterFactory(null, null);
+    storeKeyConverterFactory.setConversionMap(new HashMap<>());
+    mockScheduler = Mockito.mock(ScheduledExecutorService.class);
+    storeKeyFactory = new StoreKeyFactory() {
+      @Override
+      public StoreKey getStoreKey(DataInputStream stream) throws IOException {
+        return null;
+      }
+
+      @Override
+      public StoreKey getStoreKey(String input) throws IOException {
+        return null;
+      }
+    };
+    // create vcr node
+    List<Port> vcrPortList = Arrays.asList(new Port(12310, PortType.PLAINTEXT), new Port(12410, PortType.SSL));
+    vcrNode = new MockDataNodeId("localhost", vcrPortList, Collections.singletonList(VCR_MOUNT_PATH), CLOUD_DC_NAME);
+    clusterMap = new MockClusterMap();
+    currentNode = clusterMap.getDataNodeIds().get(0);
+    mockClusterSpectator = new MockClusterSpectator(Collections.singletonList(vcrNode));
+    long replicaCapacity = clusterMap.getAllPartitionIds(null).get(0).getReplicaIds().get(0).getCapacityInBytes();
+    Properties properties = new Properties();
+    properties.setProperty("store.segment.size.in.bytes", Long.toString(replicaCapacity / 2L));
+    properties.setProperty("clustermap.cluster.name", "test");
+    properties.setProperty("clustermap.datacenter.name", "DC1");
+    properties.setProperty("clustermap.vcr.datacenter.name", "DC1");
+    properties.setProperty("clustermap.host.name", "localhost");
+    properties.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
+    properties.setProperty("replication.cloud.token.factory", "com.github.ambry.replication.MockFindTokenFactory");
+    properties.setProperty("disk.manager.enable.segment.pooling", "true");
+    verifiableProperties = new VerifiableProperties(properties);
+    storeConfig = new StoreConfig(verifiableProperties);
+    clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    replicationConfig = new ReplicationConfig(verifiableProperties);
+    serverConfig = new ServerConfig(verifiableProperties);
+    mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
+  }
+
+  /**
+   * Test both success and failure cases when adding cloud replica
+   * @throws Exception
+   */
+  @Test
+  public void cloudReplicaAdditionTest() throws Exception {
+    StorageManager storageManager =
+        new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
+            clusterMap.getMetricRegistry(), null, clusterMap, currentNode, null, mockHelixParticipant, new MockTime(),
+            null);
+    CloudToStoreReplicationManager cloudToStoreReplicationManager =
+        new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
+            storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,
+            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator,
+            mockHelixParticipant);
+    storageManager.start();
+    cloudToStoreReplicationManager.start();
+    mockClusterSpectator.spectate();
+    // 1. test adding cloud replica that is not present locally
+    mockHelixParticipant.onPartitionBecomeLeaderFromStandby(NEW_PARTITION_NAME);
+    assertNull("Thread pool for DC1 should be null",
+        cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1"));
+    // create a new partition and add corresponding store in storage manager
+    PartitionId newPartition =
+        new MockPartitionId(Long.parseLong(NEW_PARTITION_NAME), MockClusterMap.DEFAULT_PARTITION_CLASS,
+            clusterMap.getDataNodes(), 0);
+    ReplicaId replicaToAdd = newPartition.getReplicaIds().get(0);
+    assertTrue("Adding new store should succeed", storageManager.addBlobStore(replicaToAdd));
+    // 2. we deliberately shut down the store to induce failure when adding cloud replica
+    storageManager.shutdownBlobStore(newPartition);
+    mockHelixParticipant.onPartitionBecomeLeaderFromStandby(NEW_PARTITION_NAME);
+    assertNull("Thread pool for DC1 should be null",
+        cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1"));
+    storageManager.startBlobStore(newPartition);
+    // 3. mock success case
+    mockHelixParticipant.onPartitionBecomeLeaderFromStandby(NEW_PARTITION_NAME);
+    assertNotNull("There should be a thread for DC1",
+        cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1"));
+    cloudToStoreReplicationManager.shutdown();
+    storageManager.shutdown();
+  }
+
+  /**
+   * Test both success and failure cases when removing cloud replica.
+   * @throws Exception
+   */
+  @Test
+  public void cloudReplicaRemovalTest() throws Exception {
+    StorageManager storageManager =
+        new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
+            clusterMap.getMetricRegistry(), null, clusterMap, currentNode, null, mockHelixParticipant, new MockTime(),
+            null);
+    CloudToStoreReplicationManager cloudToStoreReplicationManager =
+        new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
+            storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,
+            storeKeyConverterFactory, serverConfig.serverMessageTransformer, mockClusterSpectator,
+            mockHelixParticipant);
+    storageManager.start();
+    cloudToStoreReplicationManager.start();
+    mockClusterSpectator.spectate();
+    PartitionId localPartition = storageManager.getLocalPartitions().iterator().next();
+    // 1. add cloud replica first for subsequent removal test
+    mockHelixParticipant.onPartitionBecomeLeaderFromStandby(localPartition.toPathString());
+    assertNotNull("Thread pool should not be null for DC1 ",
+        cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1"));
+    ReplicaThread replicaThread = cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1").get(0);
+    Map<DataNodeId, List<RemoteReplicaInfo>> nodeToRemoteReplicaInfos = replicaThread.getRemoteReplicaInfos();
+    assertEquals("There should be only one remote replica info in replica thread", 1, nodeToRemoteReplicaInfos.size());
+    Map.Entry<DataNodeId, List<RemoteReplicaInfo>> entry = nodeToRemoteReplicaInfos.entrySet().iterator().next();
+    DataNodeId remoteNode = entry.getKey();
+    assertEquals("Mismatch in InstanceName", getInstanceName(vcrNode.getHostname(), vcrNode.getPort()),
+        getInstanceName(remoteNode.getHostname(), remoteNode.getPort()));
+
+    // 2. before removing cloud replica of local partition let's remove a non-existent partition first
+    mockHelixParticipant.onPartitionBecomeStandbyFromLeader(NEW_PARTITION_NAME);
+    // ensure there is no change in replica thread
+    assertEquals("There should be only one thread", 1,
+        cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1").size());
+    assertEquals("Remote replica info should stay unchanged", 1,
+        replicaThread.getRemoteReplicaInfos().entrySet().iterator().next().getValue().size());
+    // 3. remove the cloud replica by calling Leader-To-Standby transition on local partition
+    mockHelixParticipant.onPartitionBecomeStandbyFromLeader(localPartition.toPathString());
+    // ensure that the remote replica info has been successfully removed from replica thread
+    assertEquals("Remote replica info should be removed", 0,
+        replicaThread.getRemoteReplicaInfos().entrySet().iterator().next().getValue().size());
+    cloudToStoreReplicationManager.shutdown();
+    storageManager.shutdown();
+  }
+}

--- a/ambry-replication/src/test/java/com.github.ambry.replication/CloudToStoreReplicationManagerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/CloudToStoreReplicationManagerTest.java
@@ -37,20 +37,20 @@ import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static com.github.ambry.clustermap.ClusterMapUtils.*;
+import static com.github.ambry.clustermap.CloudReplica.*;
 import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
 
@@ -63,6 +63,7 @@ public class CloudToStoreReplicationManagerTest {
   private static final String NEW_PARTITION_NAME = "12";
   private static final String CLOUD_DC_NAME = "CloudDc";
   private static final String VCR_MOUNT_PATH = "/vcr/1";
+  private static final String VCR_REPLICA_THREAD_PREFIX = "VcrReplicaThread-";
   private final VerifiableProperties verifiableProperties;
   private final ScheduledExecutorService mockScheduler;
   private final StoreKeyFactory storeKeyFactory;
@@ -139,8 +140,9 @@ public class CloudToStoreReplicationManagerTest {
     mockClusterSpectator.spectate();
     // 1. test adding cloud replica that is not present locally
     mockHelixParticipant.onPartitionBecomeLeaderFromStandby(NEW_PARTITION_NAME);
-    assertNull("Thread pool for DC1 should be null",
-        cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1"));
+    assertNull("Cloud replica thread should not be created", TestUtils.getThreadByThisName(VCR_REPLICA_THREAD_PREFIX));
+    //assertNull("Thread pool for DC1 should be null",
+    //cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1"));
     // create a new partition and add corresponding store in storage manager
     PartitionId newPartition =
         new MockPartitionId(Long.parseLong(NEW_PARTITION_NAME), MockClusterMap.DEFAULT_PARTITION_CLASS,
@@ -150,13 +152,12 @@ public class CloudToStoreReplicationManagerTest {
     // 2. we deliberately shut down the store to induce failure when adding cloud replica
     storageManager.shutdownBlobStore(newPartition);
     mockHelixParticipant.onPartitionBecomeLeaderFromStandby(NEW_PARTITION_NAME);
-    assertNull("Thread pool for DC1 should be null",
-        cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1"));
+    assertNull("Cloud replica thread should not be created", TestUtils.getThreadByThisName(VCR_REPLICA_THREAD_PREFIX));
     storageManager.startBlobStore(newPartition);
     // 3. mock success case
     mockHelixParticipant.onPartitionBecomeLeaderFromStandby(NEW_PARTITION_NAME);
-    assertNotNull("There should be a thread for DC1",
-        cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1"));
+    assertNotNull("Cloud replica thread should be created for DC1",
+        TestUtils.getThreadByThisName(VCR_REPLICA_THREAD_PREFIX));
     cloudToStoreReplicationManager.shutdown();
     storageManager.shutdown();
   }
@@ -182,28 +183,24 @@ public class CloudToStoreReplicationManagerTest {
     PartitionId localPartition = storageManager.getLocalPartitions().iterator().next();
     // 1. add cloud replica first for subsequent removal test
     mockHelixParticipant.onPartitionBecomeLeaderFromStandby(localPartition.toPathString());
-    assertNotNull("Thread pool should not be null for DC1 ",
-        cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1"));
-    ReplicaThread replicaThread = cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1").get(0);
-    Map<DataNodeId, List<RemoteReplicaInfo>> nodeToRemoteReplicaInfos = replicaThread.getRemoteReplicaInfos();
-    assertEquals("There should be only one remote replica info in replica thread", 1, nodeToRemoteReplicaInfos.size());
-    Map.Entry<DataNodeId, List<RemoteReplicaInfo>> entry = nodeToRemoteReplicaInfos.entrySet().iterator().next();
-    DataNodeId remoteNode = entry.getKey();
-    assertEquals("Mismatch in InstanceName", getInstanceName(vcrNode.getHostname(), vcrNode.getPort()),
-        getInstanceName(remoteNode.getHostname(), remoteNode.getPort()));
+    String replicaPath = Cloud_Replica_Keyword + File.separator + localPartition.toPathString() + File.separator
+        + localPartition.toPathString();
+    RemoteReplicaInfo remoteReplicaInfo =
+        cloudToStoreReplicationManager.getRemoteReplicaInfo(localPartition, vcrNode.getHostname(), replicaPath);
+    assertNotNull("Remote replica info should not be null", remoteReplicaInfo);
+    assertEquals("There should be only one cloud replica thread created", 1,
+        TestUtils.getAllThreadsByThisName(VCR_REPLICA_THREAD_PREFIX).size());
 
     // 2. before removing cloud replica of local partition let's remove a non-existent partition first
     mockHelixParticipant.onPartitionBecomeStandbyFromLeader(NEW_PARTITION_NAME);
     // ensure there is no change in replica thread
-    assertEquals("There should be only one thread", 1,
-        cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1").size());
-    assertEquals("Remote replica info should stay unchanged", 1,
-        replicaThread.getRemoteReplicaInfos().entrySet().iterator().next().getValue().size());
+    assertEquals("There should be only one cloud replica thread created", 1,
+        TestUtils.getAllThreadsByThisName(VCR_REPLICA_THREAD_PREFIX).size());
+
     // 3. remove the cloud replica by calling Leader-To-Standby transition on local partition
     mockHelixParticipant.onPartitionBecomeStandbyFromLeader(localPartition.toPathString());
     // ensure that the remote replica info has been successfully removed from replica thread
-    assertEquals("Remote replica info should be removed", 0,
-        replicaThread.getRemoteReplicaInfos().entrySet().iterator().next().getValue().size());
+    assertNull("Cloud replica should be removed and no thread is assigned to it", remoteReplicaInfo.getReplicaThread());
     cloudToStoreReplicationManager.shutdown();
     storageManager.shutdown();
   }

--- a/ambry-replication/src/test/java/com.github.ambry.replication/CloudToStoreReplicationManagerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/CloudToStoreReplicationManagerTest.java
@@ -141,8 +141,6 @@ public class CloudToStoreReplicationManagerTest {
     // 1. test adding cloud replica that is not present locally
     mockHelixParticipant.onPartitionBecomeLeaderFromStandby(NEW_PARTITION_NAME);
     assertNull("Cloud replica thread should not be created", TestUtils.getThreadByThisName(VCR_REPLICA_THREAD_PREFIX));
-    //assertNull("Thread pool for DC1 should be null",
-    //cloudToStoreReplicationManager.getReplicaThreadPoolByDc().get("DC1"));
     // create a new partition and add corresponding store in storage manager
     PartitionId newPartition =
         new MockPartitionId(Long.parseLong(NEW_PARTITION_NAME), MockClusterMap.DEFAULT_PARTITION_CLASS,

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/CloudAndStoreReplicationTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/CloudAndStoreReplicationTest.java
@@ -94,7 +94,6 @@ public class CloudAndStoreReplicationTest {
    * @param vcrRecoveryPartitionConfig vcrRecoveryPartitionConfig value.
    */
   public CloudAndStoreReplicationTest(String vcrRecoveryPartitionConfig) {
-    super();
     this.vcrRecoveryPartitionConfig = vcrRecoveryPartitionConfig;
   }
 

--- a/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -79,6 +80,21 @@ public class TestUtils {
       }
     }
     return thread;
+  }
+
+  /**
+   * Return all the threads with a name that contains the given name.
+   * @param pattern the pattern to compare
+   * @return all the threads with a name that contains the given pattern.
+   */
+  public static List<Thread> getAllThreadsByThisName(String pattern) {
+    List<Thread> threads = new ArrayList<>();
+    for (Thread t : Thread.getAllStackTraces().keySet()) {
+      if (t.getName().contains(pattern)) {
+        threads.add(t);
+      }
+    }
+    return threads;
   }
 
   /**


### PR DESCRIPTION
CloudToStoreReplicationManager is not really affected by "move replica" except for the local partition map. This PR removes local partition map and makes it fetch the partition from storage manager which maintains an up-to-date list of current local partitions.
Also, this PR fixes NPE issue #1414 .