### PR TITLE
Split compaction query into deletion/expiration

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/CloudConfig.java
@@ -59,7 +59,7 @@ public class CloudConfig {
   public static final String DEFAULT_VCR_CLUSTER_NAME = "VCRCluster";
   public static final int DEFAULT_MIN_TTL_DAYS = 14;
   public static final int DEFAULT_RETENTION_DAYS = 7;
-  public static final int DEFAULT_COMPACTION_QUERY_LIMIT = 1000;
+  public static final int DEFAULT_COMPACTION_QUERY_LIMIT = 500;
   public static final int DEFAULT_RECENT_BLOB_CACHE_LIMIT = 10000;
   public static final int DEFAULT_MAX_ATTEMPTS = 3;
   public static final int DEFAULT_RETRY_DELAY_VALUE = 50;

--- a/ambry-api/src/main/java/com.github.ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com.github.ambry/config/CloudConfig.java
@@ -59,7 +59,7 @@ public class CloudConfig {
   public static final String DEFAULT_VCR_CLUSTER_NAME = "VCRCluster";
   public static final int DEFAULT_MIN_TTL_DAYS = 14;
   public static final int DEFAULT_RETENTION_DAYS = 7;
-  public static final int DEFAULT_COMPACTION_QUERY_LIMIT = 500;
+  public static final int DEFAULT_COMPACTION_QUERY_LIMIT = 100;
   public static final int DEFAULT_RECENT_BLOB_CACHE_LIMIT = 10000;
   public static final int DEFAULT_MAX_ATTEMPTS = 3;
   public static final int DEFAULT_RETRY_DELAY_VALUE = 50;
@@ -180,7 +180,7 @@ public class CloudConfig {
    * The result set limit to set on the dead blobs query used in compaction.
    */
   @Config(CLOUD_BLOB_COMPACTION_QUERY_LIMIT)
-  @Default("1000")
+  @Default("100")
   public final int cloudBlobCompactionQueryLimit;
 
   /**

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudDestination.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudDestination.java
@@ -74,7 +74,7 @@ public interface CloudDestination extends Closeable {
   Map<String, CloudBlobMetadata> getBlobMetadata(List<BlobId> blobIds) throws CloudStorageException;
 
   /**
-   * Get the list of blobs in the specified partition that have been deleted or expired for at least the
+   * Get the list of blobs in the specified partition that have been deleted for at least the
    * configured retention period.
    * @param partitionPath the partition to query.
    * @param cutoffTime the cutoff time for the query time range.
@@ -82,18 +82,20 @@ public interface CloudDestination extends Closeable {
    * @return a List of {@link CloudBlobMetadata} referencing the dead blobs found.
    * @throws CloudStorageException
    */
-  List<CloudBlobMetadata> getDeadBlobs(String partitionPath, long cutoffTime, int maxEntries)
+  List<CloudBlobMetadata> getDeletedBlobs(String partitionPath, long cutoffTime, int maxEntries)
       throws CloudStorageException;
 
   /**
-   * Get the number of blobs in the specified partition that have been deleted or expired for at least the
+   * Get the list of blobs in the specified partition that have been expired for at least the
    * configured retention period.
    * @param partitionPath the partition to query.
    * @param cutoffTime the cutoff time for the query time range.
-   * @return the number of dead blobs found.
+   * @param maxEntries the max number of metadata records to return.
+   * @return a List of {@link CloudBlobMetadata} referencing the dead blobs found.
    * @throws CloudStorageException
    */
-  int getDeadBlobCount(String partitionPath, long cutoffTime) throws CloudStorageException;
+  List<CloudBlobMetadata> getExpiredBlobs(String partitionPath, long cutoffTime, int maxEntries)
+      throws CloudStorageException;
 
   /**
    * Returns an ordered sequenced list of blobs within the specified partition and updated

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudDestination.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudDestination.java
@@ -77,24 +77,26 @@ public interface CloudDestination extends Closeable {
    * Get the list of blobs in the specified partition that have been deleted for at least the
    * configured retention period.
    * @param partitionPath the partition to query.
-   * @param cutoffTime the cutoff time for the query time range.
+   * @param startTime the start of the query time range.
+   * @param endTime the end of the query time range.
    * @param maxEntries the max number of metadata records to return.
    * @return a List of {@link CloudBlobMetadata} referencing the deleted blobs found.
    * @throws CloudStorageException
    */
-  List<CloudBlobMetadata> getDeletedBlobs(String partitionPath, long cutoffTime, int maxEntries)
+  List<CloudBlobMetadata> getDeletedBlobs(String partitionPath, long startTime, long endTime, int maxEntries)
       throws CloudStorageException;
 
   /**
    * Get the list of blobs in the specified partition that have been expired for at least the
    * configured retention period.
    * @param partitionPath the partition to query.
-   * @param cutoffTime the cutoff time for the query time range.
+   * @param startTime the start of the query time range.
+   * @param endTime the end of the query time range.
    * @param maxEntries the max number of metadata records to return.
    * @return a List of {@link CloudBlobMetadata} referencing the expired blobs found.
    * @throws CloudStorageException
    */
-  List<CloudBlobMetadata> getExpiredBlobs(String partitionPath, long cutoffTime, int maxEntries)
+  List<CloudBlobMetadata> getExpiredBlobs(String partitionPath, long startTime, long endTime, int maxEntries)
       throws CloudStorageException;
 
   /**

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudDestination.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudDestination.java
@@ -79,7 +79,7 @@ public interface CloudDestination extends Closeable {
    * @param partitionPath the partition to query.
    * @param cutoffTime the cutoff time for the query time range.
    * @param maxEntries the max number of metadata records to return.
-   * @return a List of {@link CloudBlobMetadata} referencing the dead blobs found.
+   * @return a List of {@link CloudBlobMetadata} referencing the deleted blobs found.
    * @throws CloudStorageException
    */
   List<CloudBlobMetadata> getDeletedBlobs(String partitionPath, long cutoffTime, int maxEntries)
@@ -91,7 +91,7 @@ public interface CloudDestination extends Closeable {
    * @param partitionPath the partition to query.
    * @param cutoffTime the cutoff time for the query time range.
    * @param maxEntries the max number of metadata records to return.
-   * @return a List of {@link CloudBlobMetadata} referencing the dead blobs found.
+   * @return a List of {@link CloudBlobMetadata} referencing the expired blobs found.
    * @throws CloudStorageException
    */
   List<CloudBlobMetadata> getExpiredBlobs(String partitionPath, long cutoffTime, int maxEntries)

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudStorageCompactor.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudStorageCompactor.java
@@ -99,6 +99,12 @@ public class CloudStorageCompactor implements Runnable {
     return totalBlobsPurged;
   }
 
+  /**
+   * Returns the expired blob in the specified partition with the earliest expiration time.
+   * @param partitionPath the partition to check.
+   * @return the {@link CloudBlobMetadata} for the expired blob, or NULL if none was found.
+   * @throws CloudStorageException
+   */
   public CloudBlobMetadata getOldestExpiredBlob(String partitionPath) throws CloudStorageException {
     List<CloudBlobMetadata> deadBlobs = requestAgent.doWithRetries(
         () -> cloudDestination.getExpiredBlobs(partitionPath, System.currentTimeMillis(), queryLimit), "GetDeadBlobs",
@@ -106,6 +112,12 @@ public class CloudStorageCompactor implements Runnable {
     return deadBlobs.isEmpty() ? null : deadBlobs.get(0);
   }
 
+  /**
+   * Returns the deleted blob in the specified partition with the earliest deletion time.
+   * @param partitionPath the partition to check.
+   * @return the {@link CloudBlobMetadata} for the deleted blob, or NULL if none was found.
+   * @throws CloudStorageException
+   */
   public CloudBlobMetadata getOldestDeletedBlob(String partitionPath) throws CloudStorageException {
     List<CloudBlobMetadata> deadBlobs = requestAgent.doWithRetries(
         () -> cloudDestination.getDeletedBlobs(partitionPath, System.currentTimeMillis(), queryLimit), "GetDeadBlobs",

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudStorageManager.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/CloudStorageManager.java
@@ -157,7 +157,6 @@ public class CloudStorageManager implements StoreManager {
       CloudBlobStore store = new CloudBlobStore(properties, partitionId, cloudDestination, clusterMap, vcrMetrics);
       partitionToStore.put(partitionId, store);
       store.start();
-      logger.info("Cloudblobstore started for partition {}", partitionId);
       return store;
     } finally {
       lock.writeLock().unlock();

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/VcrReplicationManager.java
@@ -78,7 +78,7 @@ public class VcrReplicationManager extends ReplicationEngine {
             tokenHelper, cloudDestination);
     this.cloudStorageCompactor =
         cloudConfig.cloudBlobCompactionEnabled ? new CloudStorageCompactor(cloudDestination, cloudConfig,
-            partitionToPartitionInfo.keySet(), vcrMetrics, false) : null;
+            partitionToPartitionInfo.keySet(), vcrMetrics) : null;
   }
 
   @Override

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudConfig.java
@@ -16,7 +16,6 @@ package com.github.ambry.cloud.azure;
 import com.github.ambry.config.Config;
 import com.github.ambry.config.Default;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.cloud.azure.AzureBlobLayoutStrategy.BlobContainerStrategy;
 
 
 /**
@@ -29,12 +28,20 @@ public class AzureCloudConfig {
   public static final String COSMOS_COLLECTION_LINK = "cosmos.collection.link";
   public static final String COSMOS_KEY = "cosmos.key";
   public static final String COSMOS_DIRECT_HTTPS = "cosmos.direct.https";
+  public static final String COSMOS_QUERY_BATCH_SIZE = "cosmos.query.batch.size";
+  public static final String COSMOS_REQUEST_CHARGE_THRESHOLD = "cosmos.request.charge.threshold";
+  public static final String COSMOS_CONTINUATION_TOKEN_LIMIT = "cosmos.continuation.token.limit";
   public static final String AZURE_PURGE_BATCH_SIZE = "azure.purge.batch.size";
   public static final String AZURE_NAME_SCHEME_VERSION = "azure.name.scheme.version";
   public static final String AZURE_BLOB_CONTAINER_STRATEGY = "azure.blob.container.strategy";
   // Per docs.microsoft.com/en-us/rest/api/storageservices/blob-batch
   public static final int MAX_PURGE_BATCH_SIZE = 256;
   public static final int DEFAULT_PURGE_BATCH_SIZE = 100;
+  public static final int DEFAULT_QUERY_BATCH_SIZE = 100;
+  public static final int DEFAULT_COSMOS_MAX_RETRIES = 5;
+  public static final int DEFAULT_COSMOS_CONTINUATION_TOKEN_LIMIT = 4;
+  public static final int DEFAULT_COSMOS_REQUEST_CHARGE_THRESHOLD = 100;
+
   public static final int DEFAULT_NAME_SCHEME_VERSION = 0;
   public static final String DEFAULT_CONTAINER_STRATEGY = "Partition";
 
@@ -75,6 +82,24 @@ public class AzureCloudConfig {
   public final String azureBlobContainerStrategy;
 
   /**
+   * Max number of metadata records to fetch in a single Cosmos query.
+   */
+  @Config(COSMOS_QUERY_BATCH_SIZE)
+  public final int cosmosQueryBatchSize;
+
+  /**
+   * The size limit in KB on Cosmos continuation token.
+   */
+  @Config(COSMOS_CONTINUATION_TOKEN_LIMIT)
+  public final int cosmosContinuationTokenLimit;
+
+  /**
+   * The Cosmos request charge threshold to log.
+   */
+  @Config(COSMOS_REQUEST_CHARGE_THRESHOLD)
+  public final int cosmosRequestChargeThreshold;
+
+  /**
    * Flag indicating whether to use DirectHttps CosmosDB connection mode.
    * Provides better performance but may not work with all firewall settings.
    */
@@ -87,10 +112,16 @@ public class AzureCloudConfig {
     cosmosEndpoint = verifiableProperties.getString(COSMOS_ENDPOINT);
     cosmosCollectionLink = verifiableProperties.getString(COSMOS_COLLECTION_LINK);
     cosmosKey = verifiableProperties.getString(COSMOS_KEY);
+    cosmosQueryBatchSize = verifiableProperties.getInt(COSMOS_QUERY_BATCH_SIZE, DEFAULT_QUERY_BATCH_SIZE);
+    cosmosContinuationTokenLimit =
+        verifiableProperties.getInt(COSMOS_CONTINUATION_TOKEN_LIMIT, DEFAULT_COSMOS_CONTINUATION_TOKEN_LIMIT);
+    cosmosRequestChargeThreshold =
+        verifiableProperties.getInt(COSMOS_REQUEST_CHARGE_THRESHOLD, DEFAULT_COSMOS_REQUEST_CHARGE_THRESHOLD);
     azurePurgeBatchSize =
         verifiableProperties.getIntInRange(AZURE_PURGE_BATCH_SIZE, DEFAULT_PURGE_BATCH_SIZE, 1, MAX_PURGE_BATCH_SIZE);
     cosmosDirectHttps = verifiableProperties.getBoolean(COSMOS_DIRECT_HTTPS, false);
-    azureBlobContainerStrategy = verifiableProperties.getString(AZURE_BLOB_CONTAINER_STRATEGY, DEFAULT_CONTAINER_STRATEGY);
+    azureBlobContainerStrategy =
+        verifiableProperties.getString(AZURE_BLOB_CONTAINER_STRATEGY, DEFAULT_CONTAINER_STRATEGY);
     azureNameSchemeVersion = verifiableProperties.getInt(AZURE_NAME_SCHEME_VERSION, DEFAULT_NAME_SCHEME_VERSION);
   }
 }

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudConfig.java
@@ -38,7 +38,6 @@ public class AzureCloudConfig {
   public static final int MAX_PURGE_BATCH_SIZE = 256;
   public static final int DEFAULT_PURGE_BATCH_SIZE = 100;
   public static final int DEFAULT_QUERY_BATCH_SIZE = 100;
-  public static final int DEFAULT_COSMOS_MAX_RETRIES = 5;
   public static final int DEFAULT_COSMOS_CONTINUATION_TOKEN_LIMIT = 4;
   public static final int DEFAULT_COSMOS_REQUEST_CHARGE_THRESHOLD = 100;
 

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudConfig.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudConfig.java
@@ -30,7 +30,7 @@ public class AzureCloudConfig {
   public static final String COSMOS_DIRECT_HTTPS = "cosmos.direct.https";
   public static final String COSMOS_QUERY_BATCH_SIZE = "cosmos.query.batch.size";
   public static final String COSMOS_REQUEST_CHARGE_THRESHOLD = "cosmos.request.charge.threshold";
-  public static final String COSMOS_CONTINUATION_TOKEN_LIMIT = "cosmos.continuation.token.limit";
+  public static final String COSMOS_CONTINUATION_TOKEN_LIMIT_KB = "cosmos.continuation.token.limit.kb";
   public static final String AZURE_PURGE_BATCH_SIZE = "azure.purge.batch.size";
   public static final String AZURE_NAME_SCHEME_VERSION = "azure.name.scheme.version";
   public static final String AZURE_BLOB_CONTAINER_STRATEGY = "azure.blob.container.strategy";
@@ -89,8 +89,8 @@ public class AzureCloudConfig {
   /**
    * The size limit in KB on Cosmos continuation token.
    */
-  @Config(COSMOS_CONTINUATION_TOKEN_LIMIT)
-  public final int cosmosContinuationTokenLimit;
+  @Config(COSMOS_CONTINUATION_TOKEN_LIMIT_KB)
+  public final int cosmosContinuationTokenLimitKb;
 
   /**
    * The Cosmos request charge threshold to log.
@@ -112,8 +112,8 @@ public class AzureCloudConfig {
     cosmosCollectionLink = verifiableProperties.getString(COSMOS_COLLECTION_LINK);
     cosmosKey = verifiableProperties.getString(COSMOS_KEY);
     cosmosQueryBatchSize = verifiableProperties.getInt(COSMOS_QUERY_BATCH_SIZE, DEFAULT_QUERY_BATCH_SIZE);
-    cosmosContinuationTokenLimit =
-        verifiableProperties.getInt(COSMOS_CONTINUATION_TOKEN_LIMIT, DEFAULT_COSMOS_CONTINUATION_TOKEN_LIMIT);
+    cosmosContinuationTokenLimitKb =
+        verifiableProperties.getInt(COSMOS_CONTINUATION_TOKEN_LIMIT_KB, DEFAULT_COSMOS_CONTINUATION_TOKEN_LIMIT);
     cosmosRequestChargeThreshold =
         verifiableProperties.getInt(COSMOS_REQUEST_CHARGE_THRESHOLD, DEFAULT_COSMOS_REQUEST_CHARGE_THRESHOLD);
     azurePurgeBatchSize =

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudDestination.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/AzureCloudDestination.java
@@ -201,21 +201,20 @@ class AzureCloudDestination implements CloudDestination {
   @Override
   public List<CloudBlobMetadata> getDeletedBlobs(String partitionPath, long startTime, long endTime, int maxEntries)
       throws CloudStorageException {
-    return getDeadBlobs(partitionPath, CloudBlobMetadata.FIELD_DELETION_TIME, startTime, endTime, maxEntries);
+    try {
+      return cosmosDataAccessor.getDeadBlobs(partitionPath, CloudBlobMetadata.FIELD_DELETION_TIME, startTime, endTime, maxEntries);
+    } catch (DocumentClientException dex) {
+      throw toCloudStorageException("Failed to query deleted blobs for partition " + partitionPath, dex);
+    }
   }
 
   @Override
   public List<CloudBlobMetadata> getExpiredBlobs(String partitionPath, long startTime, long endTime, int maxEntries)
       throws CloudStorageException {
-    return getDeadBlobs(partitionPath, CloudBlobMetadata.FIELD_EXPIRATION_TIME, startTime, endTime, maxEntries);
-  }
-
-  private List<CloudBlobMetadata> getDeadBlobs(String partitionPath, String fieldName, long startTime, long endTime,
-      int maxEntries) throws CloudStorageException {
     try {
-      return cosmosDataAccessor.getDeadBlobs(partitionPath, fieldName, startTime, endTime, maxEntries);
+      return cosmosDataAccessor.getDeadBlobs(partitionPath, CloudBlobMetadata.FIELD_EXPIRATION_TIME, startTime, endTime, maxEntries);
     } catch (DocumentClientException dex) {
-      throw toCloudStorageException("Failed to query dead blobs for partition " + partitionPath, dex);
+      throw toCloudStorageException("Failed to query expired blobs for partition " + partitionPath, dex);
     }
   }
 

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/CosmosDataAccessor.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/CosmosDataAccessor.java
@@ -15,10 +15,15 @@ package com.github.ambry.cloud.azure;
 
 import com.codahale.metrics.Timer;
 import com.github.ambry.cloud.CloudBlobMetadata;
+import com.github.ambry.cloud.CloudStorageException;
 import com.github.ambry.commons.BlobId;
+import com.github.ambry.config.CloudConfig;
 import com.github.ambry.utils.Utils;
 import com.microsoft.azure.cosmosdb.AccessCondition;
 import com.microsoft.azure.cosmosdb.ChangeFeedOptions;
+import com.microsoft.azure.cosmosdb.ConnectionMode;
+import com.microsoft.azure.cosmosdb.ConnectionPolicy;
+import com.microsoft.azure.cosmosdb.ConsistencyLevel;
 import com.microsoft.azure.cosmosdb.Document;
 import com.microsoft.azure.cosmosdb.DocumentClientException;
 import com.microsoft.azure.cosmosdb.DocumentCollection;
@@ -27,9 +32,11 @@ import com.microsoft.azure.cosmosdb.FeedResponse;
 import com.microsoft.azure.cosmosdb.PartitionKey;
 import com.microsoft.azure.cosmosdb.RequestOptions;
 import com.microsoft.azure.cosmosdb.ResourceResponse;
+import com.microsoft.azure.cosmosdb.RetryOptions;
+import com.microsoft.azure.cosmosdb.SqlParameter;
+import com.microsoft.azure.cosmosdb.SqlParameterCollection;
 import com.microsoft.azure.cosmosdb.SqlQuerySpec;
 import com.microsoft.azure.cosmosdb.internal.HttpConstants;
-import com.microsoft.azure.cosmosdb.internal.Constants;
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -44,21 +51,53 @@ public class CosmosDataAccessor {
   private static final Logger logger = LoggerFactory.getLogger(CosmosDataAccessor.class);
   private static final String DOCS = "/docs/";
   public static final String COSMOS_LAST_UPDATED_COLUMN = "_ts";
+  private static final String THRESHOLD_PARAM = "@threshold";
+  private static final String LIMIT_PARAM = "@limit";
+  private static final String EXPIRED_BLOBS_QUERY = constructDeadBlobsQuery(CloudBlobMetadata.FIELD_EXPIRATION_TIME);
+  private static final String DELETED_BLOBS_QUERY = constructDeadBlobsQuery(CloudBlobMetadata.FIELD_DELETION_TIME);
   private final AsyncDocumentClient asyncDocumentClient;
   private final String cosmosCollectionLink;
   private final AzureMetrics azureMetrics;
   private Callable<?> updateCallback = null;
+  private final int continuationTokenLimit;
+  private final int requestChargeThreshold;
 
   /** Production constructor */
-  CosmosDataAccessor(AsyncDocumentClient asyncDocumentClient, AzureCloudConfig azureCloudConfig,
-      AzureMetrics azureMetrics) {
-    this(asyncDocumentClient, azureCloudConfig.cosmosCollectionLink, azureMetrics);
+  CosmosDataAccessor(CloudConfig cloudConfig, AzureCloudConfig azureCloudConfig, AzureMetrics azureMetrics) {
+    // Set up CosmosDB connection, including retry options and any proxy setting
+    ConnectionPolicy connectionPolicy = new ConnectionPolicy();
+    // TODO: would like to use different timeouts for queries and single-doc reads/writes
+    connectionPolicy.setRequestTimeoutInMillis(cloudConfig.cloudQueryRequestTimeout);
+    // Note: retry decisions are made at CloudBlobStore level.  Configure Cosmos with no retries.
+    RetryOptions noRetries = new RetryOptions();
+    noRetries.setMaxRetryAttemptsOnThrottledRequests(0);
+    connectionPolicy.setRetryOptions(noRetries);
+    if (azureCloudConfig.cosmosDirectHttps) {
+      logger.info("Using CosmosDB DirectHttps connection mode");
+      connectionPolicy.setConnectionMode(ConnectionMode.Direct);
+    }
+    if (cloudConfig.vcrProxyHost != null) {
+      connectionPolicy.setProxy(cloudConfig.vcrProxyHost, cloudConfig.vcrProxyPort);
+    }
+    // TODO: test option to set connectionPolicy.setEnableEndpointDiscovery(false);
+    asyncDocumentClient = new AsyncDocumentClient.Builder().withServiceEndpoint(azureCloudConfig.cosmosEndpoint)
+        .withMasterKeyOrResourceToken(azureCloudConfig.cosmosKey)
+        .withConnectionPolicy(connectionPolicy)
+        .withConsistencyLevel(ConsistencyLevel.Session)
+        .build();
+
+    this.cosmosCollectionLink = azureCloudConfig.cosmosCollectionLink;
+    this.continuationTokenLimit = azureCloudConfig.cosmosContinuationTokenLimit;
+    this.requestChargeThreshold = azureCloudConfig.cosmosRequestChargeThreshold;
+    this.azureMetrics = azureMetrics;
   }
 
   /** Test constructor */
   CosmosDataAccessor(AsyncDocumentClient asyncDocumentClient, String cosmosCollectionLink, AzureMetrics azureMetrics) {
     this.asyncDocumentClient = asyncDocumentClient;
     this.cosmosCollectionLink = cosmosCollectionLink;
+    this.continuationTokenLimit = AzureCloudConfig.DEFAULT_COSMOS_CONTINUATION_TOKEN_LIMIT;
+    this.requestChargeThreshold = AzureCloudConfig.DEFAULT_COSMOS_REQUEST_CHARGE_THRESHOLD;
     this.azureMetrics = azureMetrics;
   }
 
@@ -169,32 +208,53 @@ public class CosmosDataAccessor {
   }
 
   /**
-   * Get the list of blobs in the specified partition matching the specified DocumentDB query.
+   * Get the list of blobs in the specified partition that have been deleted or expired for at least the
+   * configured retention period.
    * @param partitionPath the partition to query.
-   * @param querySpec the DocumentDB query to execute.
-   * @param timer the {@link Timer} to use to record query time (excluding waiting).
-   * @return a List of {@link CloudBlobMetadata} referencing the matching blobs.
+   * @param fieldName the field name to query on. Allowed values are {@link CloudBlobMetadata#FIELD_DELETION_TIME} and
+   *                  {@link CloudBlobMetadata#FIELD_EXPIRATION_TIME}.
+   * @param retentionThreshold the latest time where blobs are considered dead if they were expired
+   *                           or deleted before that point.
+   * @param maxEntries the max number of metadata records to return.
+   * @return a List of {@link CloudBlobMetadata} referencing the dead blobs found.
+   * @throws CloudStorageException
    */
-  List<CloudBlobMetadata> queryMetadata(String partitionPath, SqlQuerySpec querySpec, Timer timer)
+  List<CloudBlobMetadata> getDeadBlobs(String partitionPath, String fieldName, long retentionThreshold, int maxEntries)
       throws DocumentClientException {
-    azureMetrics.documentQueryCount.inc();
+
+    String deadBlobsQuery;
+    if (fieldName.equals(CloudBlobMetadata.FIELD_DELETION_TIME)) {
+      deadBlobsQuery = DELETED_BLOBS_QUERY;
+    } else if (fieldName.equals(CloudBlobMetadata.FIELD_EXPIRATION_TIME)) {
+      deadBlobsQuery = EXPIRED_BLOBS_QUERY;
+    } else {
+      throw new IllegalArgumentException("Invalid field: " + fieldName);
+    }
+    SqlQuerySpec querySpec = new SqlQuerySpec(deadBlobsQuery,
+        new SqlParameterCollection(new SqlParameter(LIMIT_PARAM, maxEntries),
+            new SqlParameter(THRESHOLD_PARAM, retentionThreshold)));
+
     FeedOptions feedOptions = new FeedOptions();
+    feedOptions.setMaxItemCount(maxEntries);
+    feedOptions.setResponseContinuationTokenLimitInKb(continuationTokenLimit);
     feedOptions.setPartitionKey(new PartitionKey(partitionPath));
-    // TODO: consolidate error count here
     try {
-      Iterator<FeedResponse<Document>> iterator = executeCosmosQuery(querySpec, feedOptions, timer).getIterator();
-      List<CloudBlobMetadata> metadataList = new ArrayList<>();
-      // TODO: Track request charge per record (requestCharge / metadataList.size())
+      Iterator<FeedResponse<Document>> iterator =
+          executeCosmosQuery(partitionPath, querySpec, feedOptions, azureMetrics.deadBlobsQueryTime).getIterator();
+      List<CloudBlobMetadata> deadBlobsList = new ArrayList<>();
+      // TODO: Tally request charge per partition and log on 429
       double requestCharge = 0.0;
       while (iterator.hasNext()) {
         FeedResponse<Document> response = iterator.next();
         requestCharge += response.getRequestCharge();
-        response.getResults().iterator().forEachRemaining(doc -> metadataList.add(createMetadataFromDocument(doc)));
+        response.getResults().iterator().forEachRemaining(doc -> deadBlobsList.add(createMetadataFromDocument(doc)));
       }
-      logger.debug("Request charge {} for {} records returned", requestCharge, metadataList.size());
-      return metadataList;
+      logger.info("Dead blobs query on partition {} got request charge {} for {} records", partitionPath, requestCharge,
+          deadBlobsList.size());
+      return deadBlobsList;
     } catch (RuntimeException rex) {
       if (rex.getCause() instanceof DocumentClientException) {
+        logger.warn("Dead blobs query {} on partition {} got {}", deadBlobsQuery, partitionPath, rex);
         throw (DocumentClientException) rex.getCause();
       }
       throw rex;
@@ -202,21 +262,64 @@ public class CosmosDataAccessor {
   }
 
   /**
-   * Get the number of blobs in the specified partition matching the specified DocumentDB query.
-   * @param partitionPath the partition to query.
-   * @param querySpec the DocumentDB query to execute.
-   * @param timer the {@link Timer} to use to record query time (excluding waiting).
-   * @return the number of matching blobs.
+   * Returns a query like:
+   * SELECT TOP 500 * FROM c WHERE c.deletionTime BETWEEN 1 AND <7 days ago> ORDER BY c.deletionTime ASC
+   * @param fieldName the field to use in the filter condition.  Must be deletionTime or expirationTime.
+   * @return the query text.
    */
-  int countMetadata(String partitionPath, SqlQuerySpec querySpec, Timer timer)
+  private static String constructDeadBlobsQuery(String fieldName) {
+    StringBuilder builder = new StringBuilder("SELECT TOP " + LIMIT_PARAM + " * FROM c WHERE c.").append(fieldName)
+        .append(" BETWEEN 1 AND " + THRESHOLD_PARAM)
+        .append(" ORDER BY c.")
+        .append(fieldName)
+        .append(" ASC");
+    return builder.toString();
+  }
+
+  /**
+   * Get the list of blobs in the specified partition matching the specified DocumentDB query.
+   * @param partitionPath the partition to query.
+   * @param queryText the DocumentDB query to execute.
+   * @param timer the {@link Timer} to use to record query time (excluding waiting).
+   * @return a List of {@link CloudBlobMetadata} referencing the matching blobs.
+   */
+  List<CloudBlobMetadata> queryMetadata(String partitionPath, String queryText, Timer timer)
+      throws DocumentClientException {
+    return queryMetadata(partitionPath, new SqlQuerySpec(queryText), timer);
+  }
+
+  /**
+   * Get the list of blobs in the specified partition matching the specified DocumentDB query spec.
+   * @param partitionPath the partition to query.
+   * @param querySpec the DocumentDB {@link SqlQuerySpec} to execute.
+   * @param timer the {@link Timer} to use to record query time (excluding waiting).
+   * @return a List of {@link CloudBlobMetadata} referencing the matching blobs.
+   */
+  List<CloudBlobMetadata> queryMetadata(String partitionPath, SqlQuerySpec querySpec, Timer timer)
       throws DocumentClientException {
     FeedOptions feedOptions = new FeedOptions();
+    // TODO: set maxItemCount
+    feedOptions.setResponseContinuationTokenLimitInKb(continuationTokenLimit);
     feedOptions.setPartitionKey(new PartitionKey(partitionPath));
+    // TODO: consolidate error count here
     try {
-      FeedResponse<Document> response = executeCosmosQuery(querySpec, feedOptions, timer).single();
-      return response.getResults().get(0).getLong(Constants.Properties.AGGREGATE).intValue();
+      Iterator<FeedResponse<Document>> iterator = executeCosmosQuery(partitionPath, querySpec, feedOptions, timer).getIterator();
+      List<CloudBlobMetadata> metadataList = new ArrayList<>();
+      // TODO: Tally request charge per partition and log on 429
+      double requestCharge = 0.0;
+      while (iterator.hasNext()) {
+        FeedResponse<Document> response = iterator.next();
+        requestCharge += response.getRequestCharge();
+        response.getResults().iterator().forEachRemaining(doc -> metadataList.add(createMetadataFromDocument(doc)));
+      }
+      if (requestCharge >= requestChargeThreshold) {
+        logger.info("Query partition {} request charge {} for {} records", partitionPath, requestCharge,
+            metadataList.size());
+      }
+      return metadataList;
     } catch (RuntimeException rex) {
       if (rex.getCause() instanceof DocumentClientException) {
+        logger.warn("Query {} on partition {} got {}", querySpec.getQueryText(), partitionPath, rex);
         throw (DocumentClientException) rex.getCause();
       }
       throw rex;
@@ -286,6 +389,7 @@ public class CosmosDataAccessor {
     try {
       operationTimer = timer.time();
       resourceResponse = action.call();
+      // TODO: add partition, tally request charge per partition and log on 429
     } catch (RuntimeException rex) {
       if (rex.getCause() instanceof DocumentClientException) {
         throw (DocumentClientException) rex.getCause();
@@ -303,13 +407,16 @@ public class CosmosDataAccessor {
 
   /**
    * Utility method to call Cosmos document query method and record the query time.
+   * @param partitionPath the partition to query.
    * @param sqlQuerySpec the DocumentDB query to execute.
    * @param feedOptions {@link FeedOptions} object specifying the options associated with the method.
    * @param timer the {@link Timer} to use to record query time (excluding waiting).
    * @return {@link BlockingObservable} object containing the query response.
    */
-  private BlockingObservable<FeedResponse<Document>> executeCosmosQuery(SqlQuerySpec sqlQuerySpec,
+  private BlockingObservable<FeedResponse<Document>> executeCosmosQuery(String partitionPath, SqlQuerySpec sqlQuerySpec,
       FeedOptions feedOptions, Timer timer) {
+    azureMetrics.documentQueryCount.inc();
+    logger.debug("Running query on partition {}: {}", partitionPath, sqlQuerySpec.getQueryText());
     Timer.Context operationTimer = timer.time();
     try {
       return asyncDocumentClient.queryDocuments(cosmosCollectionLink, sqlQuerySpec, feedOptions).toBlocking();
@@ -336,6 +443,14 @@ public class CosmosDataAccessor {
     } finally {
       operationTimer.stop();
     }
+  }
+
+  /**
+   * Getter for {@link AsyncDocumentClient} object.
+   * @return {@link AsyncDocumentClient} object.
+   */
+  AsyncDocumentClient getAsyncDocumentClient() {
+    return asyncDocumentClient;
   }
 
   private String getDocumentLink(String documentId) {

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/LatchBasedInMemoryCloudDestination.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/LatchBasedInMemoryCloudDestination.java
@@ -224,13 +224,13 @@ public class LatchBasedInMemoryCloudDestination implements CloudDestination {
   }
 
   @Override
-  public List<CloudBlobMetadata> getDeadBlobs(String partitionPath, long cutoffTime, int maxEntries) {
+  public List<CloudBlobMetadata> getExpiredBlobs(String partitionPath, long cutoffTime, int maxEntries) {
     return Collections.emptyList();
   }
 
   @Override
-  public int getDeadBlobCount(String partitionPath, long cutoffTime) {
-    return 0;
+  public List<CloudBlobMetadata> getDeletedBlobs(String partitionPath, long cutoffTime, int maxEntries) {
+    return Collections.emptyList();
   }
 
   @Override

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/LatchBasedInMemoryCloudDestination.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/LatchBasedInMemoryCloudDestination.java
@@ -224,12 +224,12 @@ public class LatchBasedInMemoryCloudDestination implements CloudDestination {
   }
 
   @Override
-  public List<CloudBlobMetadata> getExpiredBlobs(String partitionPath, long cutoffTime, int maxEntries) {
+  public List<CloudBlobMetadata> getExpiredBlobs(String partitionPath, long startTime, long endTime, int maxEntries) {
     return Collections.emptyList();
   }
 
   @Override
-  public List<CloudBlobMetadata> getDeletedBlobs(String partitionPath, long cutoffTime, int maxEntries) {
+  public List<CloudBlobMetadata> getDeletedBlobs(String partitionPath, long startTime, long endTime, int maxEntries) {
     return Collections.emptyList();
   }
 

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureCloudDestinationTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureCloudDestinationTest.java
@@ -401,12 +401,12 @@ public class AzureCloudDestinationTest {
     when(mockumentClient.queryDocuments(anyString(), any(SqlQuerySpec.class), any(FeedOptions.class))).thenReturn(
         mockResponse);
     long now = System.currentTimeMillis();
-    List<CloudBlobMetadata> metadataList = azureDest.getDeletedBlobs(blobId.getPartition().toPathString(), now, 10);
+    List<CloudBlobMetadata> metadataList = azureDest.getDeletedBlobs(blobId.getPartition().toPathString(), 1, now, 10);
     assertEquals("Expected no deleted blobs", 0, metadataList.size());
     assertEquals(1, azureMetrics.documentQueryCount.getCount());
     assertEquals(1, azureMetrics.deadBlobsQueryTime.getCount());
 
-    metadataList = azureDest.getExpiredBlobs(blobId.getPartition().toPathString(), now, 10);
+    metadataList = azureDest.getExpiredBlobs(blobId.getPartition().toPathString(), 1, now, 10);
     assertEquals("Expected no expired blobs", 0, metadataList.size());
     assertEquals(2, azureMetrics.documentQueryCount.getCount());
     assertEquals(2, azureMetrics.deadBlobsQueryTime.getCount());

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureIntegrationTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureIntegrationTest.java
@@ -280,19 +280,21 @@ public class AzureIntegrationTest {
 
     // run getDeadBlobs query, should return 2 * bucketCount
     String partitionPath = String.valueOf(testPartition);
-    assertEquals("Unexpected number of dead blobs", expectedDeadBlobs, azureDest.getDeadBlobCount(partitionPath, now));
-    logger.info("First call to getDeadBlobs");
-    List<CloudBlobMetadata> deadBlobs = azureDest.getDeadBlobs(partitionPath, now, bucketCount);
+    logger.info("First call to getDeletedBlobs");
+    List<CloudBlobMetadata> deadBlobs = azureDest.getDeletedBlobs(partitionPath, now, bucketCount);
     assertEquals("Unexpected number returned", bucketCount, deadBlobs.size());
     logger.info("First call to purge");
     assertEquals("Not all blobs were purged", bucketCount, azureDest.purgeBlobs(deadBlobs));
-    logger.info("Second call to getDeadBlobs");
-    deadBlobs = azureDest.getDeadBlobs(partitionPath, now, bucketCount);
+    logger.info("Second call to getDeletedBlobs");
+    deadBlobs = azureDest.getDeletedBlobs(partitionPath, now, bucketCount);
+    assertEquals("Expected zero", 0, deadBlobs.size());
+    logger.info("First call to getExpiredBlobs");
+    deadBlobs = azureDest.getExpiredBlobs(partitionPath, now, bucketCount);
     assertEquals("Unexpected number returned", bucketCount, deadBlobs.size());
-    logger.info("Second call to purge");
+    logger.info("First call to purge");
     assertEquals("Not all blobs were purged", bucketCount, azureDest.purgeBlobs(deadBlobs));
-    logger.info("Final call to getDeadBlobs");
-    deadBlobs = azureDest.getDeadBlobs(partitionPath, now, bucketCount);
+    logger.info("Second call to getExpiredBlobs");
+    deadBlobs = azureDest.getExpiredBlobs(partitionPath, now, bucketCount);
     assertEquals("Expected zero", 0, deadBlobs.size());
     cleanup();
   }
@@ -421,7 +423,7 @@ public class AzureIntegrationTest {
     String partitionPath = String.valueOf(testPartition);
     Timer dummyTimer = new Timer();
     List<CloudBlobMetadata> allBlobsInPartition =
-        azureDest.getCosmosDataAccessor().queryMetadata(partitionPath, new SqlQuerySpec("SELECT * FROM c"), dummyTimer);
+        azureDest.getCosmosDataAccessor().queryMetadata(partitionPath, "SELECT * FROM c", dummyTimer);
     int numPurged = azureDest.purgeBlobs(allBlobsInPartition);
     logger.info("Cleaned up {} blobs", numPurged);
   }

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureIntegrationTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureIntegrationTest.java
@@ -280,21 +280,23 @@ public class AzureIntegrationTest {
 
     // run getDeadBlobs query, should return 2 * bucketCount
     String partitionPath = String.valueOf(testPartition);
+    long queryStartTime = 1;
+    long queryEndTime = now - TimeUnit.DAYS.toMillis(retentionPeriodDays);
     logger.info("First call to getDeletedBlobs");
-    List<CloudBlobMetadata> deadBlobs = azureDest.getDeletedBlobs(partitionPath, now, bucketCount);
+    List<CloudBlobMetadata> deadBlobs = azureDest.getDeletedBlobs(partitionPath, queryStartTime, queryEndTime, bucketCount);
     assertEquals("Unexpected number returned", bucketCount, deadBlobs.size());
     logger.info("First call to purge");
     assertEquals("Not all blobs were purged", bucketCount, azureDest.purgeBlobs(deadBlobs));
     logger.info("Second call to getDeletedBlobs");
-    deadBlobs = azureDest.getDeletedBlobs(partitionPath, now, bucketCount);
+    deadBlobs = azureDest.getDeletedBlobs(partitionPath, queryStartTime, queryEndTime, bucketCount);
     assertEquals("Expected zero", 0, deadBlobs.size());
     logger.info("First call to getExpiredBlobs");
-    deadBlobs = azureDest.getExpiredBlobs(partitionPath, now, bucketCount);
+    deadBlobs = azureDest.getExpiredBlobs(partitionPath, queryStartTime, queryEndTime, bucketCount);
     assertEquals("Unexpected number returned", bucketCount, deadBlobs.size());
     logger.info("First call to purge");
     assertEquals("Not all blobs were purged", bucketCount, azureDest.purgeBlobs(deadBlobs));
     logger.info("Second call to getExpiredBlobs");
-    deadBlobs = azureDest.getExpiredBlobs(partitionPath, now, bucketCount);
+    deadBlobs = azureDest.getExpiredBlobs(partitionPath, queryStartTime, queryEndTime, bucketCount);
     assertEquals("Expected zero", 0, deadBlobs.size());
     cleanup();
   }
@@ -310,7 +312,7 @@ public class AzureIntegrationTest {
   /**
    * Test findEntriesSince with CosmosChangeFeedFindTokenFactory.
    */
-  @Ignore // Fails with wrong number of queries.
+  //@Ignore // Fails with wrong number of queries.
   @Test
   public void testFindEntriesSinceByChangeFeed() throws Exception {
     testFindEntriesSince("com.github.ambry.cloud.azure.CosmosChangeFeedFindTokenFactory");

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureIntegrationTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureIntegrationTest.java
@@ -312,7 +312,7 @@ public class AzureIntegrationTest {
   /**
    * Test findEntriesSince with CosmosChangeFeedFindTokenFactory.
    */
-  //@Ignore // Fails with wrong number of queries.
+  @Ignore // Fails with wrong number of queries.
   @Test
   public void testFindEntriesSinceByChangeFeed() throws Exception {
     testFindEntriesSince("com.github.ambry.cloud.azure.CosmosChangeFeedFindTokenFactory");

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/CosmosDataAccessorTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/CosmosDataAccessorTest.java
@@ -163,7 +163,7 @@ public class CosmosDataAccessorTest {
 
   /** Utility method to run metadata query with default parameters. */
   private List<CloudBlobMetadata> doQueryMetadata() throws Exception {
-    return cosmosAccessor.queryMetadata(blobId.getPartition().toPathString(), new SqlQuerySpec("select * from c"),
+    return cosmosAccessor.queryMetadata(blobId.getPartition().toPathString(), "select * from c",
         azureMetrics.missingKeysQueryTime);
   }
 

--- a/ambry-tools/src/main/java/com.github.ambry/tools/admin/AzureCompactionTool.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/admin/AzureCompactionTool.java
@@ -96,9 +96,16 @@ public class AzureCompactionTool {
         }
         System.exit(0);
       }
-      int result = compactor.compactPartition(partitionPath, CloudBlobMetadata.FIELD_DELETION_TIME, now);
+
+      long queryStartTime = 1;
+      long queryEndTime = now - TimeUnit.DAYS.toMillis(cloudConfig.cloudDeletedBlobRetentionDays);
+      long timeToQuit = now + TimeUnit.HOURS.toMillis(cloudConfig.cloudBlobCompactionIntervalHours);
+      int result =
+          compactor.compactPartition(partitionPath, CloudBlobMetadata.FIELD_DELETION_TIME, queryStartTime, queryEndTime,
+              timeToQuit);
       logger.info("In partition {}: {} deleted blobs purged", partitionPath, result);
-      result = compactor.compactPartition(partitionPath, CloudBlobMetadata.FIELD_EXPIRATION_TIME, now);
+      result = compactor.compactPartition(partitionPath, CloudBlobMetadata.FIELD_EXPIRATION_TIME, queryStartTime,
+          queryEndTime, timeToQuit);
       logger.info("In partition {}: {} expired blobs purged", partitionPath, result);
       System.exit(0);
     } catch (Exception ex) {


### PR DESCRIPTION
Previous combined query was found to be too expensive on Cosmos.
In CloudDestination, split getDeadBlob() method along same lines.
Added config properties for query batch size and other Cosmos things.
Moved Cosmos setup into CosmosDataAccessor class.
Added logging around queries and request charges.