### PR TITLE
Support netty bytebuf in PutOperation

### DIFF
--- a/ambry-api/src/main/java/com.github.ambry/network/Send.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/Send.java
@@ -52,7 +52,7 @@ public interface Send {
   long sizeInBytes();
 
   /**
-   * Release all the resource this object holds.
+   * Release all the resource this object holds. Make this a default method so subclasses don't have to override it.
    */
   default void release() {}
 }

--- a/ambry-api/src/main/java/com.github.ambry/network/Send.java
+++ b/ambry-api/src/main/java/com.github.ambry/network/Send.java
@@ -50,4 +50,9 @@ public interface Send {
    * @return The size of the data in bytes to be written
    */
   long sizeInBytes();
+
+  /**
+   * Release all the resource this object holds.
+   */
+  default void release() {}
 }

--- a/ambry-api/src/main/java/com.github.ambry/router/AsyncWritableChannel.java
+++ b/ambry-api/src/main/java/com.github.ambry/router/AsyncWritableChannel.java
@@ -54,7 +54,7 @@ public interface AsyncWritableChannel extends Channel {
    * Write data in {@code src} to the channel and the {@code callback} will be invoked once the write succeeds or fails.
    * This method is the counterpart for {@link ByteBuf}. It shares the same guarantee as the {@link #write(ByteBuffer, Callback)}.
    * Whoever implements this interface, shouldn't release the {@code src}. If releasing is expected after finishing writing
-   * to channel, please releas this {@link ByteBuf} in the callback method.
+   * to channel, please release this {@link ByteBuf} in the callback method.
    * @param src The data taht needs to be written to the channel.
    * @param callback The {@link Callback} that will be invoked once the write succeeds/fails. This can be null.
    * @return a {@link Future} that will eventually contain the result of the write operation (the number of bytes

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ByteBufferAsyncWritableChannelTest.java
@@ -167,7 +167,7 @@ public class ByteBufferAsyncWritableChannelTest {
     // null input.
     ByteBufferAsyncWritableChannel channel = new ByteBufferAsyncWritableChannel();
     try {
-      channel.write((ByteBuffer) null, null);
+      channel.write((ByteBuf) null, null);
       fail("Write should have failed");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -788,6 +788,7 @@ public class Selector implements Selectable {
     } catch (IOException e) {
       // We have key information if we log IOException here.
       handleReadWriteIOException(e, key);
+      transmission.networkSend.getPayload().release();
       return null;
     } finally {
       long writeTime = time.milliseconds() - startTimeToWriteInMs;

--- a/ambry-network/src/main/java/com.github.ambry.network/Selector.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Selector.java
@@ -788,7 +788,7 @@ public class Selector implements Selectable {
     } catch (IOException e) {
       // We have key information if we log IOException here.
       handleReadWriteIOException(e, key);
-      transmission.networkSend.getPayload().release();
+      //transmission.networkSend.getPayload().release();
       return null;
     } finally {
       long writeTime = time.milliseconds() - startTimeToWriteInMs;

--- a/ambry-network/src/main/java/com.github.ambry.network/SocketNetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/SocketNetworkClient.java
@@ -108,11 +108,12 @@ public class SocketNetworkClient implements NetworkClient {
     }
     long startTime = time.milliseconds();
     List<ResponseInfo> responseInfoList = new ArrayList<>();
+    List<NetworkSend> sends = null;
     try {
       for (RequestInfo requestInfo : requestsToSend) {
         pendingRequests.add(new RequestMetadata(requestInfo));
       }
-      List<NetworkSend> sends = prepareSends(requestsToDrop, responseInfoList);
+      sends = prepareSends(requestsToDrop, responseInfoList);
       replenishConnections();
       for (Integer correlationId : requestsToDrop) {
         String connectionId = correlationIdInFlightToConnectionId.get(correlationId);
@@ -127,6 +128,9 @@ public class SocketNetworkClient implements NetworkClient {
     } catch (Exception e) {
       logger.error("Received an unexpected error during sendAndPoll(): ", e);
       networkMetrics.networkClientException.inc();
+      if (sends != null) {
+        sends.forEach(send -> send.getPayload().release());
+      }
     } finally {
       numPendingRequests.set(pendingRequests.size());
       networkMetrics.networkClientSendAndPollTime.update(time.milliseconds() - startTime, TimeUnit.MILLISECONDS);
@@ -157,6 +161,7 @@ public class SocketNetworkClient implements NetworkClient {
         logger.trace("Failing request to host {} port {} due to connection unavailability",
             requestMetadata.requestInfo.getHost(), requestMetadata.requestInfo.getPort());
         iter.remove();
+        requestMetadata.requestInfo.getRequest().release();
         if (requestMetadata.pendingConnectionId != null) {
           pendingConnectionsToAssociatedRequests.remove(requestMetadata.pendingConnectionId);
           requestMetadata.pendingConnectionId = null;
@@ -217,6 +222,7 @@ public class SocketNetworkClient implements NetworkClient {
           }
         }
       } catch (IOException e) {
+        requestMetadata.requestInfo.getRequest().release();
         networkMetrics.networkClientIOError.inc();
         logger.error("Received exception while checking out a connection", e);
       }
@@ -344,6 +350,9 @@ public class SocketNetworkClient implements NetworkClient {
           responseInfoList.add(new ResponseInfo(null, NetworkClientErrorCode.NetworkError, null, dataNodeId));
           // No need to call pendingRequests.remove() because it has been removed due to connection unavailability in prepareSends()
         }
+      }
+      if (requestMetadata != null) {
+        requestMetadata.requestInfo.getRequest().release();
       }
       networkMetrics.connectionDisconnected.inc();
     }

--- a/ambry-network/src/main/java/com.github.ambry.network/Transmission.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/Transmission.java
@@ -119,7 +119,7 @@ public abstract class Transmission {
   }
 
   /**
-   * Actions to be taken on completion of {@link BoundedReceive} in {@link NetworkReceive}
+   * Actions to be taken on completion of {@link BoundedNettyByteBufReceive} in {@link NetworkReceive}
    */
   public void onReceiveComplete() {
     long receiveTimeMs = time.milliseconds() - networkReceive.getReceiveStartTimeInMs();
@@ -177,6 +177,9 @@ public abstract class Transmission {
   }
 
   protected void release() {
+    if (networkSend != null) {
+      networkSend.getPayload().release();
+    }
     if (networkReceive != null) {
       networkReceive.getReceivedBytes().release();
     }

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
@@ -222,17 +222,14 @@ public class PutRequest extends RequestOrResponse {
         if (!bufferToSend.hasRemaining() && blob != null) {
           int totalWrittenBytesForBlob = 0, currentWritten = -1;
           while (bufferIndex < nioBuffersFromBlob.length && currentWritten != 0) {
+            currentWritten = -1;
             ByteBuffer byteBuffer = nioBuffersFromBlob[bufferIndex];
-            currentWritten = channel.write(byteBuffer);
-            totalWrittenBytesForBlob += currentWritten;
-            while (!byteBuffer.hasRemaining()) {
+            if (!byteBuffer.hasRemaining()) {
               // some bytebuffers are zero length, ignore those bytebuffers.
-              bufferIndex++;
-              if (bufferIndex < nioBuffersFromBlob.length) {
-                byteBuffer = nioBuffersFromBlob[bufferIndex];
-              } else {
-                break;
-              }
+              bufferIndex ++;
+            } else {
+              currentWritten = channel.write(byteBuffer);
+              totalWrittenBytesForBlob += currentWritten;
             }
           }
           blob.skipBytes(totalWrittenBytesForBlob);

--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/PutRequest.java
@@ -225,8 +225,14 @@ public class PutRequest extends RequestOrResponse {
             ByteBuffer byteBuffer = nioBuffersFromBlob[bufferIndex];
             currentWritten = channel.write(byteBuffer);
             totalWrittenBytesForBlob += currentWritten;
-            if (!byteBuffer.hasRemaining()) {
+            while (!byteBuffer.hasRemaining()) {
+              // some bytebuffers are zero length, ignore those bytebuffers.
               bufferIndex++;
+              if (bufferIndex < nioBuffersFromBlob.length) {
+                byteBuffer = nioBuffersFromBlob[bufferIndex];
+              } else {
+                break;
+              }
             }
           }
           blob.skipBytes(totalWrittenBytesForBlob);
@@ -251,6 +257,14 @@ public class PutRequest extends RequestOrResponse {
       }
     }
     return written;
+  }
+
+  @Override
+  public void release() {
+    if (blob != null) {
+      blob.release();
+      blob = null;
+    }
   }
 
   @Override

--- a/ambry-router/src/main/java/com.github.ambry.router/CryptoJobHandler.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/CryptoJobHandler.java
@@ -71,7 +71,7 @@ class CryptoJobHandler implements Closeable {
         }
       }
       try {
-        scheduler.awaitTermination(1000, TimeUnit.MILLISECONDS);
+        scheduler.awaitTermination(10000, TimeUnit.MILLISECONDS);
       } catch (Exception e) {
         logger.error("Unexpected exception while waiting for crypto jobs to terminate", e);
       }

--- a/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com.github.ambry.router/NonBlockingRouter.java
@@ -889,8 +889,6 @@ class NonBlockingRouter implements Router {
           Set<Integer> requestsToDrop = new HashSet<>();
           pollForRequests(requestsToSend, requestsToDrop);
 
-
-
           List<ResponseInfo> responseInfoList = networkClient.sendAndPoll(requestsToSend,
               routerConfig.routerDropRequestOnTimeout ? requestsToDrop : Collections.emptySet(),
               NETWORK_CLIENT_POLL_TIMEOUT);

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -57,7 +57,7 @@ import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.PooledByteBufAllocator;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -251,7 +251,7 @@ public class GetBlobOperationTest {
    * @param blobContent the raw content for the blob to upload (i.e. this can be serialized composite blob metadata or
    *                    an encrypted blob).
    */
-  private void doDirectPut(BlobType blobType, ByteBuffer blobContent) throws Exception {
+  private void doDirectPut(BlobType blobType, ByteBuf blobContent) throws Exception {
     List<PartitionId> writablePartitionIds = mockClusterMap.getWritablePartitionIds(null);
     PartitionId partitionId = writablePartitionIds.get(random.nextInt(writablePartitionIds.size()));
     blobId = new BlobId(routerConfig.routerBlobidCurrentVersion, BlobId.BlobIdType.NATIVE,
@@ -270,23 +270,27 @@ public class GetBlobOperationTest {
     if (blobProperties.isEncrypted()) {
       FutureResult<EncryptJob.EncryptJobResult> futureResult = new FutureResult<>();
       cryptoJobHandler.submitJob(new EncryptJob(blobProperties.getAccountId(), blobProperties.getContainerId(),
-          blobType == BlobType.MetadataBlob ? null : blobContent.duplicate(), userMetadataBuf.duplicate(),
+          blobType == BlobType.MetadataBlob ? null : blobContent.retainedDuplicate(), userMetadataBuf.duplicate(),
           kms.getRandomKey(), cryptoService, kms, new CryptoJobMetricsTracker(routerMetrics.encryptJobMetrics),
           futureResult::done));
       EncryptJob.EncryptJobResult result = futureResult.get(5, TimeUnit.SECONDS);
       blobEncryptionKey = result.getEncryptedKey();
-      blobContent = blobType == BlobType.MetadataBlob ? blobContent : result.getEncryptedBlobContent();
+      if (blobType != BlobType.MetadataBlob) {
+        blobContent.release();
+        blobContent = result.getEncryptedBlobContent();
+      }
       userMetadataBuf = result.getEncryptedUserMetadata();
     }
     while (servers.hasNext()) {
       MockServer server = servers.next();
       PutRequest request =
           new PutRequest(random.nextInt(), "clientId", blobId, blobProperties, userMetadataBuf.duplicate(),
-              Unpooled.wrappedBuffer(blobContent.duplicate()), blobContent.remaining(), blobType,
+              blobContent.retainedDuplicate(), blobContent.readableBytes(), blobType,
               blobEncryptionKey == null ? null : blobEncryptionKey.duplicate());
       // Make sure we release the BoundedNettyByteBufReceive.
       server.send(request).release();
     }
+    blobContent.release();
   }
 
   /**
@@ -976,7 +980,10 @@ public class GetBlobOperationTest {
     blobProperties =
         new BlobProperties(blobSize + 20, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(random), Utils.getRandomShort(random), testEncryption, null);
-    doDirectPut(BlobType.DataBlob, ByteBuffer.wrap(putContent));
+    ByteBuf putContentBuf = PooledByteBufAllocator.DEFAULT.heapBuffer(blobSize);
+    putContentBuf.writeBytes(putContent);
+    doDirectPut(BlobType.DataBlob, putContentBuf.retainedDuplicate());
+    putContentBuf.release();
     Counter sizeMismatchCounter = (testEncryption ? routerMetrics.simpleEncryptedBlobSizeMismatchCount
         : routerMetrics.simpleUnencryptedBlobSizeMismatchCount);
     long startCount = sizeMismatchCounter.getCount();
@@ -998,7 +1005,10 @@ public class GetBlobOperationTest {
     blobProperties =
         new BlobProperties(blobSize - 20, "serviceId", "memberId", "contentType", false, Utils.Infinite_Time,
             Utils.getRandomShort(random), Utils.getRandomShort(random), testEncryption, null);
-    doDirectPut(BlobType.MetadataBlob, metadataContent);
+    ByteBuf metadataContentBuf = PooledByteBufAllocator.DEFAULT.heapBuffer(metadataContent.remaining());
+    metadataContentBuf.writeBytes(metadataContent.duplicate());
+    doDirectPut(BlobType.MetadataBlob, metadataContentBuf.retainedDuplicate());
+    metadataContentBuf.release();
     startCount = routerMetrics.compositeBlobSizeMismatchCount.getCount();
     getAndAssertSuccess();
     endCount = routerMetrics.compositeBlobSizeMismatchCount.getCount();

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServer.java
@@ -132,6 +132,9 @@ class MockServer {
   PutResponse makePutResponse(PutRequest putRequest, ServerErrorCode putError) throws IOException {
     if (putError == ServerErrorCode.No_Error) {
       updateBlobMap(putRequest);
+    } else {
+      // we have to read the put request out so that the blob in put request can be released.
+      new StoredBlob(putRequest, clusterMap);
     }
     return new PutResponse(putRequest.getCorrelationId(), putRequest.getClientId(), putError);
   }

--- a/ambry-test-utils/src/main/java/com/github/ambry/utils/NettyByteBufLeakHelper.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/utils/NettyByteBufLeakHelper.java
@@ -39,6 +39,8 @@ public class NettyByteBufLeakHelper {
   // when the cache is enable, just don't check the allocation and deallocation.
   private boolean cachedEnabled;
 
+  private boolean disabled;
+
   /**
    * Constructor to create a {@link NettyByteBufLeakHelper}.
    */
@@ -71,7 +73,7 @@ public class NettyByteBufLeakHelper {
    * Method to call at any method that is tagged {@link org.junit.After} to verify there is no leak within this test case.
    */
   public void afterTest() {
-    if (cachedEnabled) {
+    if (cachedEnabled || disabled) {
       return;
     }
 
@@ -92,5 +94,14 @@ public class NettyByteBufLeakHelper {
     message = String.format("HeapMemoryLeak: [allocation|deallocation] before test[%d|%d], after test[%d|%d]",
         heapAllocations, heapDeallocations, currentHeapAllocations, currentHeapDeallocations);
     Assert.assertEquals(message, activeHeapAllocations, currentActiveHeapAllocations);
+  }
+
+  /**
+   * Disable this leak detector by passing true to this function. Some test cases would perform some usual behaviors, like
+   * kill thread, forcefully close some service. In those cases, there might be some leaks that can't be fixed.
+   * @param disabled true to disable the leak detector.
+   */
+  public void setDisabled(boolean disabled) {
+    this.disabled = disabled;
   }
 }


### PR DESCRIPTION
This PR starts to support netty bytebuf in the PutOperation. There are some benefits out of it.
1. We don't have to copy the content from http channel to a java bytebuffer 
2. We can avoid a memory allocation for java bytebuffer.