### PR TITLE
Fix http2 port not initialzed issue in DynamicClusterHandler

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
@@ -429,8 +429,8 @@ public class DynamicClusterChangeHandler implements ClusterChangeHandler {
     logger.info("Adding node {} and its disks and replicas in {}", instanceName, dcName);
     AmbryDataNode datanode =
         new AmbryDataNode(getDcName(instanceConfig), clusterMapConfig, instanceConfig.getHostName(),
-            Integer.parseInt(instanceConfig.getPort()), getRackId(instanceConfig), getSslPortStr(instanceConfig), null,
-            getXid(instanceConfig), helixClusterManagerCallback);
+            Integer.parseInt(instanceConfig.getPort()), getRackId(instanceConfig), getSslPortStr(instanceConfig),
+            getHttp2PortStr(instanceConfig), getXid(instanceConfig), helixClusterManagerCallback);
     // for new instance, we first set it to unavailable and rely on its participation to update its liveness
     if (!instanceName.equals(selfInstanceName)) {
       datanode.setState(HardwareState.UNAVAILABLE);

--- a/ambry-rest/src/main/java/com.github.ambry.rest/Http2StreamHandler.java
+++ b/ambry-rest/src/main/java/com.github.ambry.rest/Http2StreamHandler.java
@@ -18,6 +18,7 @@ import com.github.ambry.config.PerformanceConfig;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec;
 import io.netty.handler.stream.ChunkedWriteHandler;
 
@@ -44,6 +45,8 @@ public class Http2StreamHandler extends ChannelInboundHandlerAdapter {
   @Override
   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
     ctx.pipeline().addLast(new Http2StreamFrameToHttpObjectCodec(true));
+    // TODO: this is known issue in PR 1421. Since it may take time to merge 1421, just add it to be a quick fix.
+    ctx.pipeline().addLast(new HttpObjectAggregator(10 * 1024 * 1024));
     // NettyMessageProcessor depends on ChunkedWriteHandler.
     // TODO: add deployment health check handler.
     ctx.pipeline().addLast(new ChunkedWriteHandler());

--- a/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
+++ b/ambry-server/src/main/java/com.github.ambry.server/AmbryServer.java
@@ -217,6 +217,7 @@ public class AmbryServer {
 
       // Start netty http2 server
       if (nodeId.hasHttp2Port()) {
+        logger.info("Http2 port is enabled: " + nodeId.getHttp2Port());
         RestServerConfig restServerConfig = new RestServerConfig(properties);
         SSLFactory sslFactory = new NettySslHttp2Factory(sslConfig);
         NettyServerRequestResponseChannel requestResponseChannel = new NettyServerRequestResponseChannel(1);


### PR DESCRIPTION
This is a quick fix for http2 and DynamicClusterHandler.
A temporary change is made to make http2 workable in next release.