### PR TITLE
Fix the null pointer exception in hard deleter

### DIFF
--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -217,6 +217,7 @@ public class HardDeleter implements Runnable {
         readOptionsList.add(item.blobReadOptions);
         messageStoreRecoveryInfoList.add(item.messagesStoreRecoveryInfo);
       }
+      //hardDeleteRecoveryRange.clear();
 
         /* Next, perform the log write. The token file does not have to be persisted again as only entries that are
            currently in it are being hard deleted as part of recovery. */

--- a/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
@@ -612,11 +612,7 @@ public class HardDeleterTest {
     }
 
     public void setException(Exception e) {
-      if (e == null) {
-        this.e = null;
-      } else {
-        this.e = new RuntimeException(e);
-      }
+      this.e = e == null ? null : new RuntimeException(e);
     }
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
@@ -22,7 +22,6 @@ import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
-import com.github.ambry.utils.Throttler;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
 import java.io.File;
@@ -37,7 +36,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Set;
@@ -482,19 +480,35 @@ public class HardDeleterTest {
     index.performHardDeleteRecovery();
     checkRecordHardDeleted(keys, hardDeletedKeys);
 
+    StoreFindToken startToken = (StoreFindToken) index.hardDeleter.getStartToken();
+    StoreFindToken endToken = (StoreFindToken) index.hardDeleter.getEndToken();
+    Assert.assertEquals("StartToken should match EndToken", startToken, endToken);
+    assertEquals("Token type mismatch", startToken.getType(), FindTokenType.IndexBased);
+    assertEquals("Token key mismatch", startToken.getStoreKey(), keys.get(5)); // blobId06
+    assertEquals("Token offset mismatch", startToken.getOffset().getOffset(), 4 * 2 * helper.sizeOfEntry);
+
     // Now make sure we can move on with hard deleter.
-    // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d*] [8 9] [1d 10] [8d 10d] [1u 3u]
+    // After perform recovery, the start token is now equal to end token.
+    // indexes: [1 2] [3 4] [3d 5] [6 7] [2d 6d**] [8 9] [1d 10] [8d 10d] [1u 3u]
     // journal:                                                     [10d 8d 3u 1u]
     index.hardDelete();
 
-    // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d] [8 9*] [1d 10] [8d 10d] [1u 3u]
+    // indexes: [1 2] [3 4] [3d 5] [6 7] [2d 6d*] [8 9*] [1d 10] [8d 10d] [1u 3u]
     // journal:                                                     [10d 8d 3u 1u]
-    index.persistAndAdvanceStartTokenSafeToPersist();
     index.hardDelete();
 
-    // indexes: [1 2] [3 4] [3d 5] [6 7] [2d 6d] [8 9*] [1d 10*] [8d 10d] [1u 3u]
+    // inject this supplier to mimic the persistor thread to persist recovery range.
+    // The reason to set it here and not above is the hardDelete method below would actually trigger a
+    // change of recovery range.
+    index.hardDeleter.setInjectedBeforeHardDeleteSupplier(() -> {
+      index.persistAndAdvanceStartTokenSafeToPersist();
+      return null;
+    });
+    // indexes: [1 2] [3 4] [3d 5] [6 7] [2d 6d*] [8 9] [1d 10*] [8d 10d] [1u 3u]
     // journal:                                                     [10d 8d 3u 1u]
     index.hardDelete();
+    index.hardDeleter.setInjectedBeforeHardDeleteSupplier(null);
+
     hardDeletedKeys.add(keys.get(9)); // blobId10
     hardDeletedKeys.add(keys.get(7)); // blobId08
     checkRecordHardDeleted(keys, hardDeletedKeys);
@@ -598,7 +612,11 @@ public class HardDeleterTest {
     }
 
     public void setException(Exception e) {
-      this.e = new RuntimeException(e);
+      if (e == null) {
+        this.e = null;
+      } else {
+        this.e = new RuntimeException(e);
+      }
     }
   }
 

--- a/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/HardDeleterTest.java
@@ -481,6 +481,23 @@ public class HardDeleterTest {
     hardDeletedKeys.add(keys.get(5)); // blobId06
     index.performHardDeleteRecovery();
     checkRecordHardDeleted(keys, hardDeletedKeys);
+
+    // Now make sure we can move on with hard deleter.
+    // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d*] [8 9] [1d 10] [8d 10d] [1u 3u]
+    // journal:                                                     [10d 8d 3u 1u]
+    index.hardDelete();
+
+    // indexes: [1 2] [3 4] [3d 5*] [6 7] [2d 6d] [8 9*] [1d 10] [8d 10d] [1u 3u]
+    // journal:                                                     [10d 8d 3u 1u]
+    index.persistAndAdvanceStartTokenSafeToPersist();
+    index.hardDelete();
+
+    // indexes: [1 2] [3 4] [3d 5] [6 7] [2d 6d] [8 9*] [1d 10*] [8d 10d] [1u 3u]
+    // journal:                                                     [10d 8d 3u 1u]
+    index.hardDelete();
+    hardDeletedKeys.add(keys.get(9)); // blobId10
+    hardDeletedKeys.add(keys.get(7)); // blobId08
+    checkRecordHardDeleted(keys, hardDeletedKeys);
   }
 
   /**


### PR DESCRIPTION
This should fix the null pointer exception in hard deleter that recorded in this issue https://github.com/linkedin/ambry/issues/1425

The NPE is caused by performing recovery. When we persist HardDeletePersistItem to the disk, we only write the BlobReadOptions and the recoveryInfo bytes, without the start token. So when we perform the recovery, we read the BlobReadOptions and the recovery info bytes out, but now the HardDeletePersistItem doesn't have a start token. Luckily, we don't need start token for recovery, we only have to use the BlobReadOption and recovery info bytes. After performing the recovery, we have to clear the hardDeleteRecoveryRange, so later all the items added to the list would have all three fields.

Before the PR, the hardDeleteRecoveryRange is not cleared after performing the recovery, so next time when calling pruneTill method, some of the item doesn't have a startToken. Clearing it would fix this issue.