### PR TITLE
Clean up publishing set up and add ambry-all

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,18 +43,9 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    if (project.hasProperty('disableShipkit')) {
-        // internal builds still want the test jar, but not sources/javadoc targets
-        task testJar(type: Jar, dependsOn: testClasses) {
-            from sourceSets.test.output
-            classifier = 'test'
-        }
 
-        artifacts {
-            archives testJar
-        }
-    } else {
-        apply from: "$rootDir/gradle/java-publishing.gradle"
+    if (!project.hasProperty('disableShipkit')) {
+      apply from: "$rootDir/gradle/java-publishing.gradle"
     }
 
     sourceCompatibility = 1.8
@@ -79,6 +70,13 @@ subprojects {
         // Integration tests should be able to get the same dependencies as the corresponding unit tests.
         intTestCompile.extendsFrom testCompile
         intTestRuntime.extendsFrom testRuntime
+    }
+
+    // this test jar is used to represent a test dependency for a subproject, since depending directly on a source set
+    // does not guarantee that the source set was actually built.
+    task testJar(type: Jar, dependsOn: testClasses) {
+        classifier = 'test'
+        from sourceSets.test.output
     }
 
     artifacts {
@@ -408,6 +406,18 @@ project(':ambry-cloud') {
         testCompile project(path: ':ambry-clustermap', configuration: 'testArchives')
         testCompile project(path: ':ambry-store', configuration: 'testArchives')
         testCompile project(path: ':ambry-replication', configuration: 'testArchives')
+    }
+}
+
+project(':ambry-all') {
+    dependencies {
+        // this is a meta project that depends on all of the "entry-point" subprojects to make it easier to pull in the
+        // entire dependency tree.
+        compile project(':ambry-frontend')
+        compile project(':ambry-server')
+        compile project(':ambry-tools')
+        compile project(':ambry-cloud')
+        compile project(':ambry-test-utils')
     }
 }
 

--- a/gradle/java-publishing.gradle
+++ b/gradle/java-publishing.gradle
@@ -18,15 +18,9 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
-task testJar(type: Jar, dependsOn: testClasses) {
-    classifier = 'test'
-    from sourceSets.test.output
-}
-
 artifacts {
     archives sourcesJar
     archives javadocJar
-    archives testJar
 }
 
 publishing {
@@ -36,7 +30,6 @@ publishing {
 
             artifact javadocJar
             artifact sourcesJar
-            artifact testJar
 
             pom {
                 licenses {

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,4 +24,5 @@ include 'ambry-api',
         'ambry-router',
         'ambry-frontend',
         'ambry-cloud',
-        'log4j-test-config'
+        'log4j-test-config',
+        'ambry-all'


### PR DESCRIPTION
- Remove publishing of test jars. This is no longer needed after setting
  up the ambry-test-utils subproject. Move the testJar task into
  build.gradle since that is the only place its needed now.
- Add an "ambry-all" subproject that makes it easier to depend on the
  entirety of ambry.

Testing:
publish locally:
```
./gradlew -Dmaven.repo.local=$HOME/local-repo assemble publishToMavenLocal
```
checked pom:
```
❯ cat ~/local-repo/com/github/ambry/ambry-all/0.3.146/ambry-all-0.3.146.pom
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.github.ambry</groupId>
  <artifactId>ambry-all</artifactId>
  <version>0.3.146</version>
  <licenses>
    <license>
      <name>The Apache License, Version 2.0</name>
      <url>https://github.com/linkedin/ambry/blob/master/LICENSE</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <scm>
    <url>https://github.com/linkedin/ambry.git</url>
  </scm>
  <issueManagement>
    <system>GitHub issues</system>
    <url>https://github.com/linkedin/ambry/issues</url>
  </issueManagement>
  <ciManagement>
    <system>TravisCI</system>
    <url>https://travis-ci.org/linkedin/ambry</url>
  </ciManagement>
  <dependencies>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>1.7.5</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.github.ambry</groupId>
      <artifactId>ambry-frontend</artifactId>
      <version>0.3.146</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.github.ambry</groupId>
      <artifactId>ambry-server</artifactId>
      <version>0.3.146</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.github.ambry</groupId>
      <artifactId>ambry-tools</artifactId>
      <version>0.3.146</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.github.ambry</groupId>
      <artifactId>ambry-cloud</artifactId>
      <version>0.3.146</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.github.ambry</groupId>
      <artifactId>ambry-test-utils</artifactId>
      <version>0.3.146</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
</project>
```