### PR TITLE
Introduce CompositeNetworkClient and factory

### DIFF
--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudStorageManagerTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/CloudStorageManagerTest.java
@@ -20,6 +20,7 @@ import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaType;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.Store;
@@ -154,14 +155,16 @@ public class CloudStorageManagerTest {
     PartitionId partitionId = mockReplicaId.getPartitionId();
 
     //try checkLocalPartitionStatus for a partition that doesn't exist
-    Assert.assertEquals(cloudStorageManager.checkLocalPartitionStatus(partitionId, new MockReplicaId()),
+    Assert.assertEquals(
+        cloudStorageManager.checkLocalPartitionStatus(partitionId, new MockReplicaId(ReplicaType.DISK_BACKED)),
         ServerErrorCode.No_Error);
 
     //add and start a replica to the store
     Assert.assertTrue(cloudStorageManager.addBlobStore(mockReplicaId));
 
     //try checkLocalPartitionStatus for an added replica
-    Assert.assertEquals(cloudStorageManager.checkLocalPartitionStatus(partitionId, new MockReplicaId()),
+    Assert.assertEquals(
+        cloudStorageManager.checkLocalPartitionStatus(partitionId, new MockReplicaId(ReplicaType.DISK_BACKED)),
         ServerErrorCode.No_Error);
 
     //stop a replica on the store
@@ -173,7 +176,8 @@ public class CloudStorageManagerTest {
 
     //try checkLocalPartitionStatus for a removed replica
     Assert.assertTrue(cloudStorageManager.removeBlobStore(partitionId));
-    Assert.assertEquals(cloudStorageManager.checkLocalPartitionStatus(partitionId, new MockReplicaId()),
+    Assert.assertEquals(
+        cloudStorageManager.checkLocalPartitionStatus(partitionId, new MockReplicaId(ReplicaType.DISK_BACKED)),
         ServerErrorCode.No_Error);
   }
 

--- a/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
+++ b/ambry-commons/src/test/java/com.github.ambry.commons/ResponseHandlerTest.java
@@ -21,6 +21,7 @@ import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaEventType;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaType;
 import com.github.ambry.network.ConnectionPoolTimeoutException;
 import com.github.ambry.network.NetworkClientErrorCode;
 import com.github.ambry.router.RouterErrorCode;
@@ -186,7 +187,7 @@ public class ResponseHandlerTest {
 
     for (Map.Entry<Object, ReplicaEventType[]> entry : expectedEventTypes.entrySet()) {
       mockClusterMap.reset();
-      handler.onEvent(new MockReplicaId(), entry.getKey());
+      handler.onEvent(new MockReplicaId(ReplicaType.DISK_BACKED), entry.getKey());
       Set<ReplicaEventType> expectedEvents = new HashSet<>(Arrays.asList(entry.getValue()));
       Set<ReplicaEventType> generatedEvents = mockClusterMap.getLastReplicaEvents();
       Assert.assertEquals(

--- a/ambry-network/src/main/java/com.github.ambry.network/CompositeNetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/CompositeNetworkClient.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.network;
+
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.ReplicaType;
+import com.github.ambry.utils.Pair;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+
+public class CompositeNetworkClient implements NetworkClient {
+  /**
+   * Used to properly route requests to drop.
+   */
+  private final Map<Integer, ReplicaType> correlationIdToReplicaType = new HashMap<>();
+  private final EnumMap<ReplicaType, NetworkClient> childNetworkClients;
+
+  CompositeNetworkClient(EnumMap<ReplicaType, NetworkClient> childNetworkClients) {
+    this.childNetworkClients = childNetworkClients;
+  }
+
+  @Override
+  public List<ResponseInfo> sendAndPoll(List<RequestInfo> allRequestsToSend, Set<Integer> allRequestsToDrop,
+      int pollTimeoutMs) {
+    // the first item of the pair is requests to send, the second is correlation IDs to drop
+    Function<ReplicaType, Pair<List<RequestInfo>, Set<Integer>>> pairBuilder =
+        replicaType -> new Pair<>(new ArrayList<>(), new HashSet<>());
+    EnumMap<ReplicaType, Pair<List<RequestInfo>, Set<Integer>>> requestsToSendAndDropByType =
+        new EnumMap<>(ReplicaType.class);
+    for (RequestInfo requestInfo : allRequestsToSend) {
+      ReplicaType replicaType = requestInfo.getReplicaId().getReplicaType();
+      requestsToSendAndDropByType.computeIfAbsent(replicaType, pairBuilder).getFirst().add(requestInfo);
+      correlationIdToReplicaType.put(requestInfo.getRequest().getCorrelationId(), replicaType);
+    }
+    for (Integer correlationId : allRequestsToDrop) {
+      ReplicaType replicaType = correlationIdToReplicaType.get(correlationId);
+      if (replicaType != null) {
+        requestsToSendAndDropByType.computeIfAbsent(replicaType, pairBuilder).getSecond().add(correlationId);
+      }
+    }
+    List<ResponseInfo> responses = new ArrayList<>();
+    requestsToSendAndDropByType.forEach((replicaType, requestsToSendAndDrop) -> {
+      NetworkClient client = childNetworkClients.get(replicaType);
+      if (client == null) {
+        throw new IllegalStateException("No NetworkClient configured for replica type: " + replicaType);
+      }
+      responses.addAll(
+          client.sendAndPoll(requestsToSendAndDrop.getFirst(), requestsToSendAndDrop.getSecond(), pollTimeoutMs));
+    });
+    // clean up correlation ids for completed requests
+    responses.forEach(
+        response -> correlationIdToReplicaType.remove(response.getRequestInfo().getRequest().getCorrelationId()));
+    return responses;
+  }
+
+  @Override
+  public int warmUpConnections(List<DataNodeId> dataNodeIds, int connectionWarmUpPercentagePerDataNode,
+      long timeForWarmUp, List<ResponseInfo> responseInfoList) {
+    // currently warm-up is only supported for connections to ambry-server.
+    NetworkClient client = childNetworkClients.get(ReplicaType.DISK_BACKED);
+    if (client != null) {
+      return client.warmUpConnections(dataNodeIds, connectionWarmUpPercentagePerDataNode, timeForWarmUp,
+          responseInfoList);
+    } else {
+      return 0;
+    }
+  }
+
+  @Override
+  public void wakeup() {
+    childNetworkClients.values().forEach(NetworkClient::wakeup);
+  }
+
+  @Override
+  public void close() {
+    childNetworkClients.values().forEach(NetworkClient::close);
+  }
+}

--- a/ambry-network/src/main/java/com.github.ambry.network/CompositeNetworkClientFactory.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/CompositeNetworkClientFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.network;
+
+import com.github.ambry.clustermap.ReplicaType;
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.Map;
+
+
+public class CompositeNetworkClientFactory implements NetworkClientFactory {
+  EnumMap<ReplicaType, NetworkClientFactory> childNetworkClientFactories;
+
+  public CompositeNetworkClientFactory(Map<ReplicaType, NetworkClientFactory> childNetworkClientFactories) {
+    this.childNetworkClientFactories = new EnumMap<>(childNetworkClientFactories);
+  }
+
+  @Override
+  public NetworkClient getNetworkClient() throws IOException {
+    EnumMap<ReplicaType, NetworkClient> childNetworkClients = new EnumMap<>(ReplicaType.class);
+    for (Map.Entry<ReplicaType, NetworkClientFactory> entry : childNetworkClientFactories.entrySet()) {
+      childNetworkClients.put(entry.getKey(), entry.getValue().getNetworkClient());
+    }
+    return new CompositeNetworkClient(childNetworkClients);
+  }
+}

--- a/ambry-network/src/main/java/com.github.ambry.network/CompositeNetworkClientFactory.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/CompositeNetworkClientFactory.java
@@ -21,9 +21,17 @@ import java.util.EnumMap;
 import java.util.Map;
 
 
+/**
+ * An implementation of {@link NetworkClient} that returns a {@link CompositeNetworkClient}, which routes requests to
+ * child clients based on the {@link ReplicaType} in the provided requests.
+ */
 public class CompositeNetworkClientFactory implements NetworkClientFactory {
   EnumMap<ReplicaType, NetworkClientFactory> childNetworkClientFactories;
 
+  /**
+   * @param childNetworkClientFactories a map from {@link ReplicaType} to the {@link NetworkClientFactory} to use for
+   *                                    that type.
+   */
   public CompositeNetworkClientFactory(Map<ReplicaType, NetworkClientFactory> childNetworkClientFactories) {
     this.childNetworkClientFactories = new EnumMap<>(childNetworkClientFactories);
   }

--- a/ambry-network/src/test/java/com/github/ambry/network/CompositeNetworkClientTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/CompositeNetworkClientTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.network;
+
+import com.github.ambry.clustermap.DataNodeId;
+import com.github.ambry.clustermap.MockReplicaId;
+import com.github.ambry.clustermap.ReplicaType;
+import com.github.ambry.utils.Pair;
+import io.netty.buffer.Unpooled;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Test {@link CompositeNetworkClient} and {@link CompositeNetworkClientFactory}.
+ */
+public class CompositeNetworkClientTest {
+  int nextCorrelationId = 0;
+
+  @Test
+  public void testDelegation() throws IOException {
+    Map<ReplicaType, NetworkClientFactory> childFactories = new HashMap<>();
+    Pair<NetworkClientFactory, NetworkClient> mockOne = getMocks();
+    childFactories.put(ReplicaType.DISK_BACKED, mockOne.getFirst());
+    Pair<NetworkClientFactory, NetworkClient> mockTwo = getMocks();
+    childFactories.put(ReplicaType.CLOUD_BACKED, mockTwo.getFirst());
+
+    CompositeNetworkClientFactory factory = new CompositeNetworkClientFactory(childFactories);
+    factory.getNetworkClient();
+    // the second call should call the underlying factories again
+    NetworkClient compositeClient = factory.getNetworkClient();
+    verify(mockOne.getFirst(), times(2)).getNetworkClient();
+    verify(mockTwo.getFirst(), times(2)).getNetworkClient();
+
+    // warmUpConnections
+//    reset(mockOne.getSecond());
+//    when(mockOne.getSecond().warmUpConnections(any(), any(), any(), any())).thenReturn(25);
+//    List<DataNodeId> nodesToWarmUp = Collections.nCopies(3, mock(DataNodeId.class));
+//    assertEquals(0, compositeClient.warmUpConnections(nodesToWarmUp, 100, 1000, Collections.emptyList()));
+//    verify(mockOne.getSecond()).warmUpConnections(nodesToWarmUp, 100, 1000, Collections.emptyList());
+
+    // sendAndPoll
+//    List<RequestInfo> requestsToSend =
+//        Arrays.asList(getRequestInfo(ReplicaType.DISK_BACKED), getRequestInfo(ReplicaType.CLOUD_BACKED),
+//            getRequestInfo(ReplicaType.DISK_BACKED));
+//    // unknown correlation ID
+//    Set<Integer> requestsToDrop = Collections.singleton(77);
+//    int pollTimeoutMs = 1000;
+//    List<ResponseInfo> responsesOne =
+//        Collections.singletonList(new ResponseInfo(requestsToSend.get(0), null, Unpooled.EMPTY_BUFFER));
+//    when(mockOne.getSecond().sendAndPoll(any(), any(), any())).thenReturn(responsesOne);
+//    when(mockTwo.getSecond().sendAndPoll(any(), any(), any())).thenReturn(Collections.emptyList());
+//    List<ResponseInfo> responses = compositeClient.sendAndPoll(requestsToSend, requestsToDrop, pollTimeoutMs);
+//    verify(mockOne.getSecond()).sendAndPoll(Arrays.asList(requestsToSend.get(0), requestsToSend.get(2)),
+//        Collections.emptySet(), pollTimeoutMs);
+  }
+
+  private Pair<NetworkClientFactory, NetworkClient> getMocks() throws IOException {
+    NetworkClientFactory factory = mock(NetworkClientFactory.class);
+    NetworkClient client = mock(NetworkClient.class);
+    Pair<NetworkClientFactory, NetworkClient> mocks = new Pair<>(factory, client);
+    when(factory.getNetworkClient()).thenReturn(client);
+    return mocks;
+  }
+
+  private void resetMocks(Pair<NetworkClientFactory, NetworkClient> mocks) throws IOException {
+    NetworkClientFactory factory = mocks.getFirst();
+    NetworkClient client = mocks.getSecond();
+    reset(factory, client);
+  }
+
+  private RequestInfo getRequestInfo(ReplicaType replicaType) {
+    return new RequestInfo("a", new Port(1, PortType.SSL), new MockSend(nextCorrelationId++),
+        new MockReplicaId(replicaType));
+  }
+}

--- a/ambry-network/src/test/java/com/github/ambry/network/CompositeNetworkClientTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/CompositeNetworkClientTest.java
@@ -18,10 +18,12 @@ package com.github.ambry.network;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.ReplicaType;
+import com.github.ambry.utils.TestUtils;
 import io.netty.buffer.Unpooled;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -152,6 +154,17 @@ public class CompositeNetworkClientTest {
     compositeClient.close();
     verify(diskMocks.client).close();
     verify(cloudMocks.client).close();
+  }
+
+  /**
+   * Test when a child client is not configured for a type of replica
+   */
+  @Test
+  public void testReplicaTypeNotFound() throws Exception {
+    NetworkClient compositeClient = new CompositeNetworkClient(new EnumMap<>(ReplicaType.class));
+    TestUtils.assertException(IllegalStateException.class,
+        () -> compositeClient.sendAndPoll(Collections.singletonList(getRequestInfo(ReplicaType.CLOUD_BACKED)),
+            Collections.emptySet(), 1000), null);
   }
 
   /**

--- a/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/ReplicationTest.java
@@ -29,6 +29,7 @@ import com.github.ambry.clustermap.PartitionStateChangeListener;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.ReplicaSyncUpManager;
+import com.github.ambry.clustermap.ReplicaType;
 import com.github.ambry.clustermap.StateModelListenerType;
 import com.github.ambry.clustermap.StateTransitionException;
 import com.github.ambry.commons.BlobId;
@@ -1944,9 +1945,10 @@ public class ReplicationTest {
     final long tokenPersistInterval = 100;
     Time time = new MockTime();
     MockFindToken token1 = new MockFindToken(0, 0);
-    RemoteReplicaInfo remoteReplicaInfo = new RemoteReplicaInfo(new MockReplicaId(), new MockReplicaId(),
-        new InMemoryStore(null, Collections.emptyList(), Collections.emptyList(), null), token1, tokenPersistInterval,
-        time, new Port(5000, PortType.PLAINTEXT));
+    RemoteReplicaInfo remoteReplicaInfo =
+        new RemoteReplicaInfo(new MockReplicaId(ReplicaType.DISK_BACKED), new MockReplicaId(ReplicaType.DISK_BACKED),
+            new InMemoryStore(null, Collections.emptyList(), Collections.emptyList(), null), token1,
+            tokenPersistInterval, time, new Port(5000, PortType.PLAINTEXT));
 
     // The equality check is for the reference, which is fine.
     // Initially, the current token and the token to persist are the same.

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockReplicaId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockReplicaId.java
@@ -33,8 +33,8 @@ public class MockReplicaId implements ReplicaId {
   private ReplicaType replicaType;
   private volatile boolean isSealed;
 
-  public MockReplicaId() {
-    replicaType = ReplicaType.DISK_BACKED;
+  public MockReplicaId(ReplicaType replicaType) {
+    this.replicaType = replicaType;
   }
 
   public MockReplicaId(int port, MockPartitionId partitionId, MockDataNodeId dataNodeId, int indexOfMountPathToUse) {


### PR DESCRIPTION
This will allow requests to be routed to either an ambry-server or cloud
destination based on replica type for hybrid deployments of Ambry. It
takes in a map from replica type to client factory and chooses which
requests to send to which client.