### PR TITLE
Revert the message header version back to 2 and fix a hard deleter race condition

### DIFF
--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -59,7 +59,7 @@ public class MessageFormatRecord {
   public static final short Metadata_Content_Version_V3 = 3;
   public static final int Message_Header_Invalid_Relative_Offset = -1;
 
-  static short headerVersionToUse = Message_Header_Version_V3;
+  static short headerVersionToUse = Message_Header_Version_V2;
 
   private static final short Delete_Subrecord_Version_V1 = 1;
   private static final short Undelete_Subrecord_Version_V1 = 1;

--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -59,6 +59,13 @@ public class MessageFormatRecord {
   public static final short Metadata_Content_Version_V3 = 3;
   public static final int Message_Header_Invalid_Relative_Offset = -1;
 
+  // Bumping version to a high number requires several things
+  // 1. Change transformers to support newer version, in open source and closed source
+  // 2. Release a newer version to all ambry-frontend and ambry-server
+  // 3. Change the version to a high value.
+  //
+  // We have to do first two steps, then can we bump the version, otherwise, other ambry-server would
+  // fail to replicate blobs through GetRequest/GetResponse, they don't know how to decode the bytes.
   static short headerVersionToUse = Message_Header_Version_V2;
 
   private static final short Delete_Subrecord_Version_V1 = 1;

--- a/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com.github.ambry.messageformat/MessageFormatInputStreamTest.java
@@ -500,6 +500,7 @@ public class MessageFormatInputStreamTest {
    */
   @Test
   public void messageFormatUndeleteUpdateRecordTest() throws Exception {
+    MessageFormatRecord.headerVersionToUse = MessageFormatRecord.Message_Header_Version_V3;
     StoreKey key = new MockId("id1");
     short accountId = Utils.getRandomShort(TestUtils.RANDOM);
     short containerId = Utils.getRandomShort(TestUtils.RANDOM);

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/CloudAndStoreReplicationTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/CloudAndStoreReplicationTest.java
@@ -294,7 +294,7 @@ public class CloudAndStoreReplicationTest {
       assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
           partitionResponseInfo.getErrorCode());
       for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
-        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 272, messageInfo.getSize());
+        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 270, messageInfo.getSize());
       }
     }
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -311,9 +311,9 @@ public class ServerHardDeleteTest {
     // For each future change to this offset, add to this variable and write an explanation of why the number changed.
     // old value: 198728. Increased by 4 to 198732 because the format for delete record went from 2 to 3 which adds
     // 4 bytes (two shorts) extra. The last record is a delete record so its extra 4 bytes are not (yet) added
-    // Add 14 here, since the message header version went from 2 to 3 and adds a short to every record, which include 6
+    // Add 14 here for version 3, since the message header version went from 2 to 3 and adds a short to every record, which include 6
     // puts and 1 delete. (last delete is not included).
-    int expectedTokenValueT1 = 198732 + 14;
+    int expectedTokenValueT1 = 198732;// + 14
     ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap,
         expectedTokenValueT1);
 
@@ -350,7 +350,7 @@ public class ServerHardDeleteTest {
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
     // For each future change to this offset, add to this variable and write an explanation of why the number changed.
-    int expectedTokenValueT2 = 298416 + 98 + 14 * 2;
+    int expectedTokenValueT2 = 298416 + 98;// + 14 * 2
     // old value: 298400. Increased by 16 (4 * 4) to 298416 because the format for delete record went from 2 to 3 which
     // adds 4 bytes (two shorts) extra. The last record is a delete record so its extra 4 bytes are not added
     // old value 298416. Increased by 98. The end offset is now a journal-based offset, so the offset is not inclusive.

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -311,9 +311,10 @@ public class ServerHardDeleteTest {
     // For each future change to this offset, add to this variable and write an explanation of why the number changed.
     // old value: 198728. Increased by 4 to 198732 because the format for delete record went from 2 to 3 which adds
     // 4 bytes (two shorts) extra. The last record is a delete record so its extra 4 bytes are not (yet) added
-    // Add 14 here for version 3, since the message header version went from 2 to 3 and adds a short to every record, which include 6
-    // puts and 1 delete. (last delete is not included).
-    int expectedTokenValueT1 = 198732;// + 14
+    //
+    // Add 14 here when changing message header version to 3, since the message header version went from 2 to 3 and adds
+    // a short to every record, which include 6 puts and 1 delete. (last delete is not included).
+    int expectedTokenValueT1 = 198732;
     ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap,
         expectedTokenValueT1);
 
@@ -350,13 +351,15 @@ public class ServerHardDeleteTest {
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
     // For each future change to this offset, add to this variable and write an explanation of why the number changed.
-    int expectedTokenValueT2 = 298416 + 98;// + 14 * 2
+    int expectedTokenValueT2 = 298416 + 98;
     // old value: 298400. Increased by 16 (4 * 4) to 298416 because the format for delete record went from 2 to 3 which
     // adds 4 bytes (two shorts) extra. The last record is a delete record so its extra 4 bytes are not added
+    //
     // old value 298416. Increased by 98. The end offset is now a journal-based offset, so the offset is not inclusive.
     // It points to the last record in the journal. Before adding an undelete record, the last record in journal is the
     // delete record for blob 6, now it's undelete for blob 0. Since a delete record is 98 bytes, so increase 98 bytes.
-    // old value is 298416 + 98. Increased by 28 since the message header version went from 2 to 3, which adds a short
+    //
+    // old value is 298416 + 98. Increased by 28 when changing the message header version from 2 to 3, which adds a short
     // to all the records, which includes 9 puts and 5 deletes and 1 undelete. Undelete is not include since it's the last
     // record.
     ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap,

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
@@ -178,7 +178,7 @@ public class VcrRecoveryTest {
       assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
           partitionResponseInfo.getErrorCode());
       for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
-        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 272, messageInfo.getSize());
+        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 270, messageInfo.getSize());
       }
     }
   }

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryServerRequestsTest.java
@@ -38,6 +38,7 @@ import com.github.ambry.messageformat.BlobType;
 import com.github.ambry.messageformat.MessageFormatException;
 import com.github.ambry.messageformat.MessageFormatFlags;
 import com.github.ambry.messageformat.MessageFormatInputStreamTest;
+import com.github.ambry.messageformat.MessageFormatRecord;
 import com.github.ambry.network.NetworkRequest;
 import com.github.ambry.network.Send;
 import com.github.ambry.network.ServerNetworkResponseMetrics;
@@ -106,6 +107,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -789,6 +791,7 @@ public class AmbryServerRequestsTest {
    */
   @Test
   public void undeleteEnableDisableTest() throws Exception {
+    Assume.assumeTrue(MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
     Properties properties = createProperties(validateRequestOnStoreState, false);
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     ServerConfig serverConfig = new ServerConfig(verifiableProperties);
@@ -819,6 +822,7 @@ public class AmbryServerRequestsTest {
    */
   @Test
   public void undeleteTest() throws Exception {
+    Assume.assumeTrue(MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
     MockPartitionId id = (MockPartitionId) clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
     int correlationId = TestUtils.RANDOM.nextInt();
     String clientId = TestUtils.getRandomString(10);

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryServerRequestsTest.java
@@ -791,7 +791,8 @@ public class AmbryServerRequestsTest {
    */
   @Test
   public void undeleteEnableDisableTest() throws Exception {
-    Assume.assumeTrue(MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
     Properties properties = createProperties(validateRequestOnStoreState, false);
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
     ServerConfig serverConfig = new ServerConfig(verifiableProperties);
@@ -822,7 +823,8 @@ public class AmbryServerRequestsTest {
    */
   @Test
   public void undeleteTest() throws Exception {
-    Assume.assumeTrue(MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
+    Assume.assumeTrue(
+        MessageFormatRecord.getCurrentMessageHeaderVersion() >= MessageFormatRecord.Message_Header_Version_V3);
     MockPartitionId id = (MockPartitionId) clusterMap.getWritablePartitionIds(DEFAULT_PARTITION_CLASS).get(0);
     int correlationId = TestUtils.RANDOM.nextInt();
     String clientId = TestUtils.getRandomString(10);

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -371,9 +371,11 @@ public class HardDeleter implements Runnable {
     persistFileLock.lock();
     startTokenSafeToPersist = startTokenBeforeLogFlush;
     try {
-      // PersistCleanupToken because startTokenSafeToPersist changed.
-      pruneHardDeleteRecoveryRange();
-      persistCleanupToken();
+      if (!isPaused()) {
+        // PersistCleanupToken because startTokenSafeToPersist changed.
+        pruneHardDeleteRecoveryRange();
+        persistCleanupToken();
+      }
     } catch (Exception e) {
       logger.error("Failed to persist cleanup token", e);
     } finally {

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -653,6 +653,10 @@ public class HardDeleter implements Runnable {
         /* Next, get the information to persist hard delete recovery info. Get all the information and save it, as only
          * after the whole range is persisted can we start with the actual log write */
         while (hardDeleteIterator.hasNext()) {
+          if (!enabled.get()) {
+            throw new StoreException("Aborting hard deletes as store is shutting down",
+                StoreErrorCodes.Store_Shutting_Down);
+          }
           HardDeleteInfo hardDeleteInfo = hardDeleteIterator.next();
           BlobReadOptions readOptions = readOptionsIterator.next();
           if (hardDeleteInfo == null) {

--- a/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/HardDeleter.java
@@ -168,7 +168,7 @@ public class HardDeleter implements Runnable {
    * the hard delete tokens are persisted before returning from pause. Hard delete will be in a paused state until
    * {@link #resume()} is called.
    */
-  void pause() throws StoreException, IOException {
+  void pause() throws StoreException {
     hardDeleteLock.lock();
     try {
       if (paused.compareAndSet(false, true)) {
@@ -445,7 +445,7 @@ public class HardDeleter implements Runnable {
     return isCaughtUp;
   }
 
-  void shutdown() throws InterruptedException, StoreException, IOException {
+  void shutdown() throws InterruptedException {
     long startTimeInMs = time.milliseconds();
     try {
       if (enabled.get()) {

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -66,7 +66,7 @@ class PersistentIndex {
   static final short VERSION_1 = 1;
   static final short VERSION_2 = 2;
   static final short VERSION_3 = 3;
-  static short CURRENT_VERSION = VERSION_3;
+  static short CURRENT_VERSION = VERSION_2;
   static final String CLEAN_SHUTDOWN_FILENAME = "cleanshutdown";
 
   static final FilenameFilter INDEX_SEGMENT_FILE_FILTER = new FilenameFilter() {


### PR DESCRIPTION
Bump the version from 2 to 3 without deploying a version of ambry server that knows how to transform version 3 message is a mistake. And it causes replication to fail. 

When we deploy a new version of ambry server that has version 3 to one machine, the other machines doesn't know how to transform the message in version 3. So in replication, they all fail. The right way of changing version should be
1. Add version 3 to all transformers, open source and close source.
2. Deploy this version to all ambry servers
3. Change the version to 3
4. Deploy the new version to all ambry servers.