### PR TITLE
Change query size to AzureCloudConfig.cosmosQueryBatchSize

### DIFF
--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/CosmosChangeFeedBasedReplicationFeed.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/CosmosChangeFeedBasedReplicationFeed.java
@@ -140,9 +140,11 @@ public final class CosmosChangeFeedBasedReplicationFeed implements AzureReplicat
    * Constructor to create a {@link CosmosChangeFeedBasedReplicationFeed} object.
    * @param cosmosDataAccessor {@link CosmosDataAccessor} object.
    * @param azureMetrics{@link {@link AzureMetrics} object.
+   * @param changeFeedBatchSize batch size for each change feed request.
    */
-  public CosmosChangeFeedBasedReplicationFeed(CosmosDataAccessor cosmosDataAccessor, AzureMetrics azureMetrics) {
-    this.defaultCacheSize = AzureCloudDestination.getFindSinceQueryLimit();
+  public CosmosChangeFeedBasedReplicationFeed(CosmosDataAccessor cosmosDataAccessor, AzureMetrics azureMetrics,
+      int changeFeedBatchSize) {
+    this.defaultCacheSize = changeFeedBatchSize;
     changeFeedCache = new ConcurrentHashMap<>();
     this.cosmosDataAccessor = cosmosDataAccessor;
     this.azureMetrics = azureMetrics;

--- a/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/CosmosUpdateTimeBasedReplicationFeed.java
+++ b/ambry-cloud/src/main/java/com.github.ambry.cloud/azure/CosmosUpdateTimeBasedReplicationFeed.java
@@ -43,15 +43,19 @@ public class CosmosUpdateTimeBasedReplicationFeed implements AzureReplicationFee
           + TIME_SINCE_PARAM + " ORDER BY c." + CosmosDataAccessor.COSMOS_LAST_UPDATED_COLUMN + " ASC";
   private final CosmosDataAccessor cosmosDataAccessor;
   private final AzureMetrics azureMetrics;
+  private final int queryBatchSize;
 
   /**
    * Constructor for {@link CosmosUpdateTimeBasedReplicationFeed} object.
    * @param cosmosDataAccessor {@link CosmosDataAccessor} object to run Cosmos change feed queries.
    * @param azureMetrics {@link AzureMetrics} object.
+   * @param queryBatchSize batch size for each find since query.
    */
-  public CosmosUpdateTimeBasedReplicationFeed(CosmosDataAccessor cosmosDataAccessor, AzureMetrics azureMetrics) {
+  public CosmosUpdateTimeBasedReplicationFeed(CosmosDataAccessor cosmosDataAccessor, AzureMetrics azureMetrics,
+      int queryBatchSize) {
     this.cosmosDataAccessor = cosmosDataAccessor;
     this.azureMetrics = azureMetrics;
+    this.queryBatchSize = queryBatchSize;
   }
 
   @Override
@@ -59,7 +63,7 @@ public class CosmosUpdateTimeBasedReplicationFeed implements AzureReplicationFee
       String partitionPath) throws DocumentClientException {
     CosmosUpdateTimeFindToken findToken = (CosmosUpdateTimeFindToken) curfindToken;
     SqlQuerySpec entriesSinceQuery = new SqlQuerySpec(ENTRIES_SINCE_QUERY_TEMPLATE,
-        new SqlParameterCollection(new SqlParameter(LIMIT_PARAM, AzureCloudDestination.getFindSinceQueryLimit()),
+        new SqlParameterCollection(new SqlParameter(LIMIT_PARAM, queryBatchSize),
             new SqlParameter(TIME_SINCE_PARAM, findToken.getLastUpdateTime())));
     List<CloudBlobMetadata> queryResults =
         cosmosDataAccessor.queryMetadata(partitionPath, entriesSinceQuery, azureMetrics.findSinceQueryTime);

--- a/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureCloudDestinationTest.java
+++ b/ambry-cloud/src/test/java/com.github.ambry.cloud/azure/AzureCloudDestinationTest.java
@@ -435,7 +435,8 @@ public class AzureCloudDestinationTest {
     MockChangeFeedQuery mockChangeFeedQuery = new MockChangeFeedQuery();
     AzureReplicationFeed azureReplicationFeed = null;
     try {
-      azureReplicationFeed = new CosmosChangeFeedBasedReplicationFeed(mockChangeFeedQuery, azureMetrics);
+      azureReplicationFeed =
+          new CosmosChangeFeedBasedReplicationFeed(mockChangeFeedQuery, azureMetrics, azureDest.getQueryBatchSize());
       FieldSetter.setField(azureDest, azureDest.getClass().getDeclaredField("azureReplicationFeed"),
           azureReplicationFeed);
       cloudBlobMetadataList.stream().forEach(doc -> mockChangeFeedQuery.add(doc));
@@ -448,7 +449,7 @@ public class AzureCloudDestinationTest {
 
       assertEquals("Find token has wrong end continuation token", (findToken).getIndex(), firstResult.size());
       assertEquals("Find token has wrong totalItems count", (findToken).getTotalItems(),
-          Math.min(blobIdList.size(), AzureCloudDestination.getFindSinceQueryLimit()));
+          Math.min(blobIdList.size(), azureDest.getQueryBatchSize()));
       cloudBlobMetadataList = cloudBlobMetadataList.subList(firstResult.size(), cloudBlobMetadataList.size());
 
       findResult = azureDest.findEntriesSince(blobId.getPartition().toPathString(), findToken, maxTotalSize);
@@ -459,7 +460,7 @@ public class AzureCloudDestinationTest {
       assertEquals("Unexpected first blobId", blobIdList.get(firstResult.size()), secondResult.get(0).getId());
 
       assertEquals("Find token has wrong totalItems count", (findToken).getTotalItems(),
-          Math.min(blobIdList.size(), AzureCloudDestination.getFindSinceQueryLimit()));
+          Math.min(blobIdList.size(), azureDest.getQueryBatchSize()));
 
       // Rerun with max size below blob size, and make sure it returns one result
       findResult = azureDest.findEntriesSince(blobId.getPartition().toPathString(), findToken, chunkSize - 1);


### PR DESCRIPTION
Change replication feed query size to AzureCloudConfig.cosmosQueryBatchSize from the hardcoded value.