### PR TITLE
Bump the message header version from 2 to 3

### DIFF
--- a/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com.github.ambry.messageformat/MessageFormatRecord.java
@@ -66,7 +66,7 @@ public class MessageFormatRecord {
   //
   // We have to do first two steps, then can we bump the version, otherwise, other ambry-server would
   // fail to replicate blobs through GetRequest/GetResponse, they don't know how to decode the bytes.
-  static short headerVersionToUse = Message_Header_Version_V2;
+  static short headerVersionToUse = Message_Header_Version_V3;
 
   private static final short Delete_Subrecord_Version_V1 = 1;
   private static final short Undelete_Subrecord_Version_V1 = 1;

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/CloudAndStoreReplicationTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/CloudAndStoreReplicationTest.java
@@ -294,7 +294,7 @@ public class CloudAndStoreReplicationTest {
       assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
           partitionResponseInfo.getErrorCode());
       for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
-        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 270, messageInfo.getSize());
+        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 272, messageInfo.getSize());
       }
     }
   }

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/ServerHardDeleteTest.java
@@ -314,7 +314,7 @@ public class ServerHardDeleteTest {
     //
     // Add 14 here when changing message header version to 3, since the message header version went from 2 to 3 and adds
     // a short to every record, which include 6 puts and 1 delete. (last delete is not included).
-    int expectedTokenValueT1 = 198732;
+    int expectedTokenValueT1 = 198732 + 14;
     ensureCleanupTokenCatchesUp(chosenPartition.getReplicaIds().get(0).getReplicaPath(), mockClusterMap,
         expectedTokenValueT1);
 
@@ -351,7 +351,7 @@ public class ServerHardDeleteTest {
 
     time.sleep(TimeUnit.DAYS.toMillis(1));
     // For each future change to this offset, add to this variable and write an explanation of why the number changed.
-    int expectedTokenValueT2 = 298416 + 98;
+    int expectedTokenValueT2 = 298416 + 98 + 28;
     // old value: 298400. Increased by 16 (4 * 4) to 298416 because the format for delete record went from 2 to 3 which
     // adds 4 bytes (two shorts) extra. The last record is a delete record so its extra 4 bytes are not added
     //

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
@@ -178,7 +178,7 @@ public class VcrRecoveryTest {
       assertEquals("Error in getting the recovered blobs", ServerErrorCode.No_Error,
           partitionResponseInfo.getErrorCode());
       for (MessageInfo messageInfo : partitionResponseInfo.getMessageInfoList()) {
-        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 270, messageInfo.getSize());
+        assertEquals(blobIdToSizeMap.get(messageInfo.getStoreKey()) + 272, messageInfo.getSize());
       }
     }
   }

--- a/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com.github.ambry.store/PersistentIndex.java
@@ -66,7 +66,7 @@ class PersistentIndex {
   static final short VERSION_1 = 1;
   static final short VERSION_2 = 2;
   static final short VERSION_3 = 3;
-  static short CURRENT_VERSION = VERSION_2;
+  static short CURRENT_VERSION = VERSION_3;
   static final String CLEAN_SHUTDOWN_FILENAME = "cleanshutdown";
 
   static final FilenameFilter INDEX_SEGMENT_FILE_FILTER = new FilenameFilter() {


### PR DESCRIPTION
Bump the message header version to 3.

This has to be done after all the current version is deployed to all fabrics, so that all ambry-servers understand version 3 and know how to deal with version 3.