### PR TITLE
Fix two instances of same replica during replica addition

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DatacenterInitializer.java
@@ -54,8 +54,6 @@ class DatacenterInitializer {
   private final HelixClusterManager.HelixClusterManagerCallback helixClusterManagerCallback;
   private final HelixClusterManagerMetrics helixClusterManagerMetrics;
   private final AtomicLong sealedStateChangeCounter;
-  // Fields to pass into only DynamicClusterChangeHandler
-  private final ConcurrentHashMap<String, ReplicaId> bootstrapReplicas;
   // Fields to pass into only SimpleClusterChangeHandler (These can be removed if SimpleClusterChangeHandler is removed)
   private final ConcurrentHashMap<ByteBuffer, AmbryPartition> partitionMap;
   private final ConcurrentHashMap<String, AmbryPartition> partitionNameToAmbryPartition;
@@ -75,7 +73,6 @@ class DatacenterInitializer {
    * @param partitionMap a map from serialized bytes to corresponding partition.
    * @param partitionNameToAmbryPartition a map from partition name to {@link AmbryPartition} object.
    * @param ambryPartitionToAmbryReplicas a map from {@link AmbryPartition} to its replicas.
-   * @param bootstrapReplicas a map recording bootstrap replicas created on current node (only applicable to server)
    */
   DatacenterInitializer(ClusterMapConfig clusterMapConfig, HelixManager localManager, HelixFactory helixFactory,
       ClusterMapUtils.DcZkInfo dcZkInfo, String selfInstanceName,
@@ -85,8 +82,7 @@ class DatacenterInitializer {
       HelixClusterManagerMetrics helixClusterManagerMetrics, AtomicLong sealedStateChangeCounter,
       ConcurrentHashMap<ByteBuffer, AmbryPartition> partitionMap,
       ConcurrentHashMap<String, AmbryPartition> partitionNameToAmbryPartition,
-      ConcurrentHashMap<AmbryPartition, Set<AmbryReplica>> ambryPartitionToAmbryReplicas,
-      ConcurrentHashMap<String, ReplicaId> bootstrapReplicas) {
+      ConcurrentHashMap<AmbryPartition, Set<AmbryReplica>> ambryPartitionToAmbryReplicas) {
     this.clusterMapConfig = clusterMapConfig;
     this.localManager = localManager;
     this.helixFactory = helixFactory;
@@ -100,7 +96,6 @@ class DatacenterInitializer {
     this.partitionMap = partitionMap;
     this.partitionNameToAmbryPartition = partitionNameToAmbryPartition;
     this.ambryPartitionToAmbryReplicas = ambryPartitionToAmbryReplicas;
-    this.bootstrapReplicas = bootstrapReplicas;
     dcName = dcZkInfo.getDcName();
   }
 
@@ -185,7 +180,7 @@ class DatacenterInitializer {
       clusterChangeHandler =
           new DynamicClusterChangeHandler(clusterMapConfig, dcName, selfInstanceName, partitionOverrideInfoMap,
               helixClusterManagerCallback, clusterChangeHandlerCallback, helixClusterManagerMetrics,
-              this::onInitializationFailure, sealedStateChangeCounter, bootstrapReplicas);
+              this::onInitializationFailure, sealedStateChangeCounter);
     } else {
       throw new IllegalArgumentException("Unsupported cluster change handler type: " + clusterChangeHandlerType);
     }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DatacenterInitializer.java
@@ -54,6 +54,8 @@ class DatacenterInitializer {
   private final HelixClusterManager.HelixClusterManagerCallback helixClusterManagerCallback;
   private final HelixClusterManagerMetrics helixClusterManagerMetrics;
   private final AtomicLong sealedStateChangeCounter;
+  // Fields to pass into only DynamicClusterChangeHandler
+  private final ConcurrentHashMap<String, ReplicaId> bootstrapReplicas;
   // Fields to pass into only SimpleClusterChangeHandler (These can be removed if SimpleClusterChangeHandler is removed)
   private final ConcurrentHashMap<ByteBuffer, AmbryPartition> partitionMap;
   private final ConcurrentHashMap<String, AmbryPartition> partitionNameToAmbryPartition;
@@ -73,6 +75,7 @@ class DatacenterInitializer {
    * @param partitionMap a map from serialized bytes to corresponding partition.
    * @param partitionNameToAmbryPartition a map from partition name to {@link AmbryPartition} object.
    * @param ambryPartitionToAmbryReplicas a map from {@link AmbryPartition} to its replicas.
+   * @param bootstrapReplicas a map recording bootstrap replicas created on current node (only applicable to server)
    */
   DatacenterInitializer(ClusterMapConfig clusterMapConfig, HelixManager localManager, HelixFactory helixFactory,
       ClusterMapUtils.DcZkInfo dcZkInfo, String selfInstanceName,
@@ -82,7 +85,8 @@ class DatacenterInitializer {
       HelixClusterManagerMetrics helixClusterManagerMetrics, AtomicLong sealedStateChangeCounter,
       ConcurrentHashMap<ByteBuffer, AmbryPartition> partitionMap,
       ConcurrentHashMap<String, AmbryPartition> partitionNameToAmbryPartition,
-      ConcurrentHashMap<AmbryPartition, Set<AmbryReplica>> ambryPartitionToAmbryReplicas) {
+      ConcurrentHashMap<AmbryPartition, Set<AmbryReplica>> ambryPartitionToAmbryReplicas,
+      ConcurrentHashMap<String, ReplicaId> bootstrapReplicas) {
     this.clusterMapConfig = clusterMapConfig;
     this.localManager = localManager;
     this.helixFactory = helixFactory;
@@ -96,6 +100,7 @@ class DatacenterInitializer {
     this.partitionMap = partitionMap;
     this.partitionNameToAmbryPartition = partitionNameToAmbryPartition;
     this.ambryPartitionToAmbryReplicas = ambryPartitionToAmbryReplicas;
+    this.bootstrapReplicas = bootstrapReplicas;
     dcName = dcZkInfo.getDcName();
   }
 
@@ -180,7 +185,7 @@ class DatacenterInitializer {
       clusterChangeHandler =
           new DynamicClusterChangeHandler(clusterMapConfig, dcName, selfInstanceName, partitionOverrideInfoMap,
               helixClusterManagerCallback, clusterChangeHandlerCallback, helixClusterManagerMetrics,
-              this::onInitializationFailure, sealedStateChangeCounter);
+              this::onInitializationFailure, sealedStateChangeCounter, bootstrapReplicas);
     } else {
       throw new IllegalArgumentException("Unsupported cluster change handler type: " + clusterChangeHandlerType);
     }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/DynamicClusterChangeHandler.java
@@ -365,7 +365,7 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
             AmbryReplica replica;
             if (selfInstanceName.equals(instanceName)) {
               // if this is a newly added replica on current instance, it should be present in bootstrapReplicas map.
-              replica = clusterChangeHandlerCallback.popBootstrapReplica(mappedPartition.toPathString());
+              replica = clusterChangeHandlerCallback.fetchBootstrapReplica(mappedPartition.toPathString());
               if (replica == null) {
                 logger.error("Replica {} is not present in bootstrap replica set, abort instance info update",
                     mappedPartition.toPathString());

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -119,7 +119,7 @@ public class HelixClusterManager implements ClusterMap {
             new DatacenterInitializer(clusterMapConfig, localManager, helixFactory, dcZkInfo, selfInstanceName,
                 partitionOverrideInfoMap, clusterChangeHandlerCallback, helixClusterManagerCallback,
                 helixClusterManagerMetrics, sealedStateChangeCounter, partitionMap, partitionNameToAmbryPartition,
-                ambryPartitionToAmbryReplicas, bootstrapReplicas);
+                ambryPartitionToAmbryReplicas);
         initializer.start();
         initializers.add(initializer);
       }
@@ -636,6 +636,16 @@ public class HelixClusterManager implements ClusterMap {
      */
     void addClusterWideRawCapacity(long diskRawCapacityBytes) {
       clusterWideRawCapacityBytes.getAndAdd(diskRawCapacityBytes);
+    }
+
+    /**
+     * Pop out bootstrap replica (if any) on current instance. A bootstrap replica is a replica dynamically added to
+     * current node at runtime.
+     * @param partitionName the partition name of bootstrap replica.
+     * @return bootstrap replica or {@code null} if not found.
+     */
+    AmbryReplica popBootstrapReplica(String partitionName) {
+      return (AmbryReplica) bootstrapReplicas.remove(partitionName);
     }
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -425,8 +425,8 @@ public class HelixClusterManager implements ClusterMap {
     }
     long replicaCapacity = Long.parseLong(replicaInfos.get(REPLICAS_CAPACITY_STR));
     String partitionClass = replicaInfos.get(PARTITION_CLASS_STR);
-    AmbryPartition mappedPartition = new AmbryPartition(Long.parseLong(partitionIdStr), partitionClass,
-        helixClusterManagerCallback);
+    AmbryPartition mappedPartition =
+        new AmbryPartition(Long.parseLong(partitionIdStr), partitionClass, helixClusterManagerCallback);
     AmbryPartition currentPartition =
         partitionNameToAmbryPartition.putIfAbsent(mappedPartition.toPathString(), mappedPartition);
     if (currentPartition == null) {
@@ -554,6 +554,14 @@ public class HelixClusterManager implements ClusterMap {
       }
     }
     return Collections.unmodifiableMap(dcToRoutingTableSnapshot);
+  }
+
+  /**
+   * Exposed for testing
+   * @return a snapshot of current bootstrap replicas
+   */
+  Map<String, ReplicaId> getBootstrapReplicas() {
+    return Collections.unmodifiableMap(bootstrapReplicas);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -456,11 +456,11 @@ public class HelixClusterManager implements ClusterMap {
       logger.error(
           "Either datanode or disk that associated with bootstrap replica is not found in cluster map. Cannot create the replica.");
     }
-    // For now this method is only called by server to which new replica will be added. So if datanode equals to current
-    // node, we temporarily add this into a map (because we don't know if the new replica can be added into storage
-    // manager successfully). After replica addition succeeds, current node will update InstanceConfig and will receive
-    // notification from Helix. At that time, we move replica from this map to clustermap related data structures that
-    // can be queried by other components.
+    // For now this method is only called by server which new replica will be added to. So if datanode equals to current
+    // node, we temporarily add this into a map (because we don't know whether store addition in storage manager
+    // succeeds or not). After store addition succeeds, current node is supposed to update InstanceConfig and will
+    // receive notification from Helix afterwards. At that time, dynamic cluster change handler will move replica from
+    // this map to clustermap related data structures that can be queried by other components.
     if (bootstrapReplica != null && instanceName.equals(selfInstanceName)) {
       // Note that this method might be called by several state transition threads concurrently.
       bootstrapReplicas.put(currentPartition.toPathString(), bootstrapReplica);
@@ -558,9 +558,9 @@ public class HelixClusterManager implements ClusterMap {
 
   /**
    * Exposed for testing
-   * @return a snapshot of current bootstrap replicas
+   * @return a snapshot of current bootstrap replica map
    */
-  Map<String, ReplicaId> getBootstrapReplicas() {
+  Map<String, ReplicaId> getBootstrapReplicaMap() {
     return Collections.unmodifiableMap(bootstrapReplicas);
   }
 

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -73,7 +73,7 @@ public class HelixClusterManager implements ClusterMap {
   private final AtomicLong sealedStateChangeCounter = new AtomicLong(0);
   private final PartitionSelectionHelper partitionSelectionHelper;
   private final Map<String, Map<String, String>> partitionOverrideInfoMap = new HashMap<>();
-  private final ConcurrentHashMap<String, ReplicaId> bootstrapReplicas = new ConcurrentHashMap<>();
+  private final Map<String, ReplicaId> bootstrapReplicas = new ConcurrentHashMap<>();
   private ZkHelixPropertyStore<ZNRecord> helixPropertyStoreInLocalDc = null;
   // The current xid currently does not change after instantiation. This can change in the future, allowing the cluster
   // manager to dynamically incorporate newer changes in the cluster. This variable is atomic so that the gauge metric
@@ -644,7 +644,7 @@ public class HelixClusterManager implements ClusterMap {
      * @param partitionName the partition name of bootstrap replica.
      * @return bootstrap replica or {@code null} if not found.
      */
-    AmbryReplica popBootstrapReplica(String partitionName) {
+    AmbryReplica fetchBootstrapReplica(String partitionName) {
       return (AmbryReplica) bootstrapReplicas.remove(partitionName);
     }
   }

--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManagerMetrics.java
@@ -40,6 +40,7 @@ class HelixClusterManagerMetrics {
   public final Counter getReplicaIdsMismatchCount;
   public final Counter getDataNodeIdsMismatchCount;
   public final Counter ignoredUpdatesCount;
+  public final Counter instanceConfigChangeErrorCount;
 
   public Gauge<Long> helixClusterManagerInstantiationFailed;
   public Gauge<Long> helixClusterManagerRemoteInstantiationFailed;
@@ -80,6 +81,8 @@ class HelixClusterManagerMetrics {
     getDataNodeIdsMismatchCount =
         registry.counter(MetricRegistry.name(HelixClusterManager.class, "getDataNodeIdsMismatchCount"));
     ignoredUpdatesCount = registry.counter(MetricRegistry.name(HelixClusterManager.class, "ignoredUpdatesCount"));
+    instanceConfigChangeErrorCount =
+        registry.counter(MetricRegistry.name(HelixClusterManager.class, "instanceConfigChangeErrorCount"));
   }
 
   void initializeInstantiationMetric(final boolean instantiated, final long instantiationExceptionCount) {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/ClusterChangeHandlerTest.java
@@ -278,7 +278,7 @@ public class ClusterChangeHandlerTest {
     assertEquals("Number of data nodes is not expected", dataNodesInLayout.size(),
         helixClusterManager.getDataNodeIds().size());
 
-    // pick up 2 existing nodes from each dc (also the nodes from local dc should be different from currentNode)
+    // pick 2 existing nodes from each dc (also the nodes from local dc should be different from currentNode)
     List<DataNode> nodesToHostNewPartition = new ArrayList<>();
     List<DataNode> localDcNodes = testHardwareLayout.getAllDataNodesFromDc(localDc);
     localDcNodes.remove(currentNode);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixClusterManagerTest.java
@@ -554,12 +554,12 @@ public class HelixClusterManagerTest {
     assertNotNull("New replica should be created successfully",
         helixClusterManager.getBootstrapReplica(NEW_PARTITION_ID_STR, dataNodeOfNewPartition));
     // verify that boostrap replica map is empty because recently added replica is not on current node
-    assertTrue("Bootstrap replica map should be empty", helixClusterManager.getBootstrapReplicas().isEmpty());
+    assertTrue("Bootstrap replica map should be empty", helixClusterManager.getBootstrapReplicaMap().isEmpty());
     // 4. test that new replica of existing partition is successfully created based on infos from Helix property store.
     assertNotNull("New replica should be created successfully",
         helixClusterManager.getBootstrapReplica(partitionOfNewReplica.toPathString(), dataNodeOfNewReplica));
     assertEquals("There should be exactly one entry in bootstrap replica map", 1,
-        helixClusterManager.getBootstrapReplicas().size());
+        helixClusterManager.getBootstrapReplicaMap().size());
     helixClusterManager.close();
   }
 

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -39,20 +39,14 @@ public class TestUtils {
   static final int DEFAULT_XID = 64;
 
   enum ReplicaStateType {
-    SealedState,
-    StoppedState
+    SealedState, StoppedState
   }
 
   /**
    * Resource state associated with datanode, disk and replica.
    */
   enum ResourceState {
-    Node_Up,
-    Node_Down,
-    Disk_Up,
-    Disk_Down,
-    Replica_Up,
-    Replica_Down
+    Node_Up, Node_Down, Disk_Up, Disk_Down, Replica_Up, Replica_Down
   }
 
   public static String getLocalHost() {
@@ -726,6 +720,22 @@ public class TestUtils {
         return null;
       }
       return datacenter.getDataNodes().get(new Random().nextInt(datacenter.getDataNodes().size()));
+    }
+
+    /**
+     * Get all data nodes that are from given data center.
+     * @param dc the data center to get nodes from.
+     * @return a list of nodes from given data center.
+     */
+    public List<DataNode> getAllDataNodesFromDc(String dc) {
+      List<DataNode> dataNodes = new ArrayList<>();
+      for (Datacenter dcObj : hardwareLayout.getDatacenters()) {
+        if (dcObj.getName().equals(dc)) {
+          dataNodes.addAll(dcObj.getDataNodes());
+          break;
+        }
+      }
+      return dataNodes;
     }
 
     public DataNode getRandomDataNode() {

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/TestUtils.java
@@ -39,14 +39,24 @@ public class TestUtils {
   static final int DEFAULT_XID = 64;
 
   enum ReplicaStateType {
-    SealedState, StoppedState
+    // @formatter:off
+    SealedState,
+    StoppedState
+    // @formatter:om
   }
 
   /**
    * Resource state associated with datanode, disk and replica.
    */
   enum ResourceState {
-    Node_Up, Node_Down, Disk_Up, Disk_Down, Replica_Up, Replica_Down
+    // @formatter:off
+    Node_Up,
+    Node_Down,
+    Disk_Up,
+    Disk_Down,
+    Replica_Up,
+    Replica_Down
+    // @formatter:on
   }
 
   public static String getLocalHost() {


### PR DESCRIPTION
When adding a new replica to certain node, the node first creates a bootstrap replica and uses it to perform bootstrap work(i.e. allocate files and create new store). Afterwards, the node updates Helix
InstanceConfig which notifies all listeners in cluster (including itself). When dealing with InstanceConfig change, this node creates a second instance of same replica and adds it into in-mem clustermap.

The consequence is storage manager holds a different instance from Helix Cluster Manager, which mistakenly adds self replica into peer replicas when performing replication catchup. It blocks decommission process because there is always a self replica that will never catch up.

This PR fixes this problem by maintaining bootstrap replica set in cluster manager and it checks if there are existing replica instances when handling InstanceConfig change.