### PR TITLE
Getting single blob should avoid Cosmos

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobMetadata.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobMetadata.java
@@ -434,6 +434,14 @@ public class CloudBlobMetadata {
     });
   }
 
+  /**
+   * @return a {@link CloudBlobMetadata} from a property map.
+   * @param properties the key-value property map.
+   */
+  public static CloudBlobMetadata fromMap(Map<String, String> properties) {
+    return objectMapper.convertValue(properties, CloudBlobMetadata.class);
+  }
+
   /** Custom serializer for CloudBlobMetadata class that omits fields with default values. */
   static class MetadataSerializer extends StdSerializer<CloudBlobMetadata> {
 
@@ -469,7 +477,7 @@ public class CloudBlobMetadata {
         gen.writeNumberField(FIELD_NAME_SCHEME_VERSION, value.nameSchemeVersion);
       }
       // Encryption fields that may or may not apply
-      if (value.encryptionOrigin != EncryptionOrigin.NONE) {
+      if (value.encryptionOrigin != null && value.encryptionOrigin != EncryptionOrigin.NONE) {
         gen.writeStringField(FIELD_ENCRYPTION_ORIGIN, value.encryptionOrigin.toString());
         if (value.encryptionOrigin == EncryptionOrigin.VCR) {
           gen.writeStringField(FIELD_VCR_KMS_CONTEXT, value.vcrKmsContext);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -525,7 +525,7 @@ class CloudBlobStore implements Store {
   public boolean isKeyDeleted(StoreKey key) throws StoreException {
     checkStarted();
     // Not definitive, but okay for some deletes to be replayed.
-    return (checkCacheState(key.getID(),BlobState.DELETED));
+    return checkCacheState(key.getID(),BlobState.DELETED);
   }
 
   @Override

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMetrics.java
@@ -31,6 +31,8 @@ public class VcrMetrics {
   public final Timer blobDecryptionTime;
   // Time to run compaction task
   public final Timer blobCompactionTime;
+  // Cache counters
+  public final Counter blobCacheLookupCount;
   public final Counter blobCacheHitCount;
   // Error counters
   public final Counter blobUploadSkippedCount;
@@ -56,6 +58,7 @@ public class VcrMetrics {
     blobUploadSkippedCount = registry.counter(MetricRegistry.name(CloudBlobStore.class, "BlobUploadSkippedCount"));
     updateTtlNotSetError = registry.counter(MetricRegistry.name(CloudBlobStore.class, "UpdateTtlNotSetError"));
     blobCompactionTime = registry.timer(MetricRegistry.name(CloudBlobStore.class, "BlobCompactionTime"));
+    blobCacheLookupCount = registry.counter(MetricRegistry.name(CloudBlobStore.class, "BlobCacheLookupCount"));
     blobCacheHitCount = registry.counter(MetricRegistry.name(CloudBlobStore.class, "BlobCacheHitCount"));
     addPartitionErrorCount =
         registry.counter(MetricRegistry.name(VcrReplicationManager.class, "AddPartitionErrorCount"));

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMetrics.java
@@ -31,12 +31,14 @@ public class VcrMetrics {
   public final Timer blobDecryptionTime;
   // Time to run compaction task
   public final Timer blobCompactionTime;
+  public final Counter blobCacheHitCount;
   // Error counters
   public final Counter blobUploadSkippedCount;
   public final Counter updateTtlNotSetError;
   public final Counter addPartitionErrorCount;
   public final Counter removePartitionErrorCount;
   public final Counter tokenReloadWarnCount;
+
   // Retry metrics
   /** Number of times operation was retried */
   public final Counter retryCount;
@@ -54,6 +56,7 @@ public class VcrMetrics {
     blobUploadSkippedCount = registry.counter(MetricRegistry.name(CloudBlobStore.class, "BlobUploadSkippedCount"));
     updateTtlNotSetError = registry.counter(MetricRegistry.name(CloudBlobStore.class, "UpdateTtlNotSetError"));
     blobCompactionTime = registry.timer(MetricRegistry.name(CloudBlobStore.class, "BlobCompactionTime"));
+    blobCacheHitCount = registry.counter(MetricRegistry.name(CloudBlobStore.class, "BlobCacheHitCount"));
     addPartitionErrorCount =
         registry.counter(MetricRegistry.name(VcrReplicationManager.class, "AddPartitionErrorCount"));
     removePartitionErrorCount =

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
@@ -263,12 +263,40 @@ public class AzureBlobDataAccessor {
   }
 
   /**
+   * Retrieve the metadata for the specified blob.
+   * @param blobId The {@link BlobId} to retrieve.
+   * @return The {@link CloudBlobMetadata} if the blob was found, or null otherwise.
+   * @throws BlobStorageException
+   */
+  public CloudBlobMetadata getBlobMetadata(BlobId blobId) throws BlobStorageException {
+    BlockBlobClient blobClient = getBlockBlobClient(blobId, false);
+    BlobProperties blobProperties = null;
+    try {
+      blobProperties =
+          blobClient.getPropertiesWithResponse(defaultRequestConditions, requestTimeout, Context.NONE).getValue();
+      if (blobProperties == null) {
+        logger.debug("Blob {} not found.", blobId);
+        return null;
+      }
+    } catch (BlobStorageException e) {
+      if (e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND) {
+        logger.debug("Blob {} not found.", blobId);
+        return null;
+      }
+      throw e;
+    }
+    Map<String, String> metadata = blobProperties.getMetadata();
+    return CloudBlobMetadata.fromMap(metadata);
+  }
+
+  /**
    * Update the metadata for the specified blob.
    * @param blobId The {@link BlobId} to update.
    * @param fieldName The metadata field to modify.
    * @param value The new value.
    * @return {@code true} if the udpate succeeded, {@code false} if the blob was not found.
    * @throws BlobStorageException
+   * @throws IllegalStateException on request timeout.
    */
   public boolean updateBlobMetadata(BlobId blobId, String fieldName, Object value) throws BlobStorageException {
     Objects.requireNonNull(blobId, "BlobId cannot be null");

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureBlobDataAccessor.java
@@ -279,7 +279,7 @@ public class AzureBlobDataAccessor {
         return null;
       }
     } catch (BlobStorageException e) {
-      if (e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND) {
+      if (isNotFoundError(e.getErrorCode())) {
         logger.debug("Blob {} not found.", blobId);
         return null;
       }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
@@ -384,8 +384,8 @@ class AzureCloudDestination implements CloudDestination {
     } else if (e instanceof DocumentClientException) {
       statusCode = ((DocumentClientException) e).getStatusCode();
       retryDelayMs = ((DocumentClientException) e).getRetryAfterInMilliseconds();
-    } else if (e instanceof RuntimeException) {
-      // Note: handling this separately since ABS timeouts are thrown as IllegalStateException
+    } else {
+      // Note: catch-all since ABS can throw things like IOException, IllegalStateException
       statusCode = StatusCodes.INTERNAL_SERVER_ERROR;
     }
     logger.info("{} status {}, {}", message, statusCode, e.toString());

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
@@ -55,8 +55,6 @@ public class AzureMetrics {
   public static final String BACKUP_SUCCESS_LATENCY = "BackupSuccessLatency";
   public static final String BACKUP_SUCCESS_BYTE_RATE = "BackupSuccessByteRate";
   public static final String BACKUP_ERROR_COUNT = "BackupErrorCount";
-  public static final String RETRY_COUNT = "RetryCount";
-  public static final String RETRY_WAIT_TIME = "RetryWaitTime";
 
   // Metrics
   public final Counter blobUploadRequestCount;
@@ -93,8 +91,6 @@ public class AzureMetrics {
   public final Timer backupSuccessLatency;
   public final Meter backupSuccessByteRate;
   public final Counter backupErrorCount;
-  public final Counter retryCount;
-  public final Timer retryWaitTime;
 
   public AzureMetrics(MetricRegistry registry) {
     blobUploadRequestCount =
@@ -139,7 +135,5 @@ public class AzureMetrics {
     backupSuccessByteRate = registry.meter(MetricRegistry.name(AzureCloudDestination.class, BACKUP_SUCCESS_BYTE_RATE));
     backupSuccessLatency = registry.timer(MetricRegistry.name(AzureCloudDestination.class, BACKUP_SUCCESS_LATENCY));
     backupErrorCount = registry.counter(MetricRegistry.name(AzureCloudDestination.class, BACKUP_ERROR_COUNT));
-    retryCount = registry.counter(MetricRegistry.name(AzureCloudDestination.class, RETRY_COUNT));
-    retryWaitTime = registry.timer(MetricRegistry.name(AzureCloudDestination.class, RETRY_WAIT_TIME));
   }
 }

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/LatchBasedInMemoryCloudDestination.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/LatchBasedInMemoryCloudDestination.java
@@ -147,7 +147,9 @@ public class LatchBasedInMemoryCloudDestination implements CloudDestination {
   @Override
   synchronized public boolean uploadBlob(BlobId blobId, long blobSize, CloudBlobMetadata cloudBlobMetadata,
       InputStream blobInputStream) {
-
+    if (map.containsKey(blobId)) {
+      return false;
+    }
     // Note: blobSize can be -1 when we dont know the actual blob size being uploaded.
     // So we have to do buffered reads to handle that case.
     int bufferSz = (blobSize == -1) ? 1024 : (int) blobSize;

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/CosmosDataAccessorTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/CosmosDataAccessorTest.java
@@ -88,8 +88,6 @@ public class CosmosDataAccessorTest {
         mockResponse);
     cosmosAccessor.upsertMetadata(blobMetadata);
     assertEquals(1, azureMetrics.documentCreateTime.getCount());
-    assertEquals(0, azureMetrics.retryCount.getCount());
-    assertEquals(0, azureMetrics.retryWaitTime.getCount());
   }
 
   /** Test read. */
@@ -103,8 +101,6 @@ public class CosmosDataAccessorTest {
     when(mockumentClient.readDocument(anyString(), any(RequestOptions.class))).thenReturn(mockResponse);
     cosmosAccessor.readMetadata(blobId);
     assertEquals(1, azureMetrics.documentReadTime.getCount());
-    assertEquals(0, azureMetrics.retryCount.getCount());
-    assertEquals(0, azureMetrics.retryWaitTime.getCount());
   }
 
   /** Test query metadata. */
@@ -122,8 +118,6 @@ public class CosmosDataAccessorTest {
     assertEquals("Returned metadata does not match original", blobMetadata, outputMetadata);
     assertEquals(1, azureMetrics.documentQueryCount.getCount());
     assertEquals(1, azureMetrics.missingKeysQueryTime.getCount());
-    assertEquals(0, azureMetrics.retryCount.getCount());
-    assertEquals(0, azureMetrics.retryWaitTime.getCount());
   }
 
   /** Test change feed query. */

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
@@ -30,7 +30,7 @@ import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
  * {@link PartitionId} implementation to use within dynamic cluster managers.
  */
 public class AmbryPartition implements PartitionId {
-  private final Long id;
+  private final long id;
   private final String partitionClass;
   private final ClusterManagerCallback<AmbryReplica, AmbryDisk, AmbryPartition, AmbryDataNode> clusterManagerCallback;
   private final Lock stateChangeLock = new ReentrantLock();
@@ -81,7 +81,7 @@ public class AmbryPartition implements PartitionId {
 
   @Override
   public boolean isEqual(String other) {
-    return id.toString().equals(other);
+    return Long.toString(id).equals(other);
   }
 
   @Override
@@ -94,12 +94,12 @@ public class AmbryPartition implements PartitionId {
     }
 
     AmbryPartition partition = (AmbryPartition) o;
-    return id.equals(partition.id);
+    return id == partition.id;
   }
 
   @Override
   public int hashCode() {
-    return id.hashCode();
+    return Long.hashCode(id);
   }
 
   @Override
@@ -110,7 +110,7 @@ public class AmbryPartition implements PartitionId {
   @Override
   public int compareTo(PartitionId o) {
     AmbryPartition other = (AmbryPartition) o;
-    return id.compareTo(other.id);
+    return Long.compare(id, other.id);
   }
 
   /**
@@ -129,7 +129,7 @@ public class AmbryPartition implements PartitionId {
    */
   @Override
   public String toPathString() {
-    return id.toString();
+    return Long.toString(id);
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartition.java
@@ -85,6 +85,24 @@ public class AmbryPartition implements PartitionId {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AmbryPartition partition = (AmbryPartition) o;
+    return id.equals(partition.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return id.hashCode();
+  }
+
+  @Override
   public String toString() {
     return "Partition[" + id + "]";
   }


### PR DESCRIPTION
Add cache hit counter for CloudBlobStore
Frontend uploads blob regardless of TTL
Handle IllegalStateException on ABS timeouts
AmbryPartition overrides equals and hashcode