### PR TITLE
Integrate CompositeNetworkClient with CloudRouterFactory

### DIFF
--- a/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com.github.ambry.clustermap/HelixClusterManager.java
@@ -316,10 +316,14 @@ public class HelixClusterManager implements ClusterMap {
         replica.getDataNodeId().onNodeTimeout();
         break;
       case Disk_Error:
-        replica.getDiskId().onDiskError();
+        if (replica.getReplicaType() == ReplicaType.DISK_BACKED) {
+          replica.getDiskId().onDiskError();
+        }
         break;
       case Disk_Ok:
-        replica.getDiskId().onDiskOk();
+        if (replica.getReplicaType() == ReplicaType.DISK_BACKED) {
+          replica.getDiskId().onDiskOk();
+        }
         break;
       case Partition_ReadOnly:
         replica.getPartitionId().onPartitionReadOnly();

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/HelixParticipantTest.java
@@ -332,7 +332,7 @@ public class HelixParticipantTest {
   @Test
   public void testUpdateNodeInfoInCluster() throws Exception {
     // test setup: 3 disks on local node, each disk has 3 replicas
-    MockClusterMap clusterMap = new MockClusterMap(false, 1, 3, 3, false);
+    MockClusterMap clusterMap = new MockClusterMap(false, 1, 3, 3, false, false);
     MockDataNodeId localNode = clusterMap.getDataNodes().get(0);
     List<ReplicaId> localReplicas = clusterMap.getReplicaIds(localNode);
     ReplicaId existingReplica = localReplicas.get(0);

--- a/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
+++ b/ambry-clustermap/src/test/java/com.github.ambry.clustermap/MockClusterAgentsFactory.java
@@ -63,7 +63,7 @@ public class MockClusterAgentsFactory implements ClusterAgentsFactory {
   public MockClusterMap getClusterMap() throws IOException {
     if (mockClusterMap == null) {
       mockClusterMap =
-          new MockClusterMap(enableSslPorts, numNodes, numMountPointsPerNode, numStoresPerMountPoint, false);
+          new MockClusterMap(enableSslPorts, numNodes, numMountPointsPerNode, numStoresPerMountPoint, false, false);
     }
     return mockClusterMap;
   }

--- a/ambry-network/src/main/java/com.github.ambry.network/LocalNetworkClient.java
+++ b/ambry-network/src/main/java/com.github.ambry.network/LocalNetworkClient.java
@@ -15,11 +15,9 @@ package com.github.ambry.network;
 
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.network.LocalRequestResponseChannel.LocalChannelRequest;
-import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.Time;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -112,6 +110,6 @@ public class LocalNetworkClient implements NetworkClient {
 
   @Override
   public void wakeup() {
-    // TODO: need to do anything here?
+    channel.wakeup(processorId);
   }
 }

--- a/ambry-network/src/test/java/com.github.ambry.network/SocketNetworkClientTest.java
+++ b/ambry-network/src/test/java/com.github.ambry.network/SocketNetworkClientTest.java
@@ -107,7 +107,7 @@ public class SocketNetworkClientTest {
     networkClient =
         new SocketNetworkClient(selector, networkConfig, networkMetrics, MAX_PORTS_PLAIN_TEXT, MAX_PORTS_SSL,
             CHECKOUT_TIMEOUT_MS, time);
-    sslEnabledClusterMap = new MockClusterMap(true, 9, 3, 3, false);
+    sslEnabledClusterMap = new MockClusterMap(true, 9, 3, 3, false, false);
     localSslDataNodes = sslEnabledClusterMap.getDataNodeIds()
         .stream()
         .filter(dataNodeId -> sslEnabledClusterMap.getDatacenterName(sslEnabledClusterMap.getLocalDatacenterId())

--- a/ambry-replication/src/test/java/com.github.ambry.replication/CloudToStoreReplicationManagerTest.java
+++ b/ambry-replication/src/test/java/com.github.ambry.replication/CloudToStoreReplicationManagerTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.replication;
 
+import com.github.ambry.clustermap.ClusterMapSnapshotConstants;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockClusterSpectator;
@@ -62,7 +63,7 @@ import static org.junit.Assert.*;
 public class CloudToStoreReplicationManagerTest {
   private static final String NEW_PARTITION_NAME = "12";
   private static final String CLOUD_DC_NAME = "CloudDc";
-  private static final String VCR_MOUNT_PATH = "/vcr/1";
+  private static final String VCR_MOUNT_PATH = ClusterMapSnapshotConstants.CLOUD_REPLICA_MOUNT + "/1";
   private static final String VCR_REPLICA_THREAD_PREFIX = "VcrReplicaThread-";
   private final VerifiableProperties verifiableProperties;
   private final ScheduledExecutorService mockScheduler;

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/CloudAndStoreReplicationTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/CloudAndStoreReplicationTest.java
@@ -130,7 +130,7 @@ public class CloudAndStoreReplicationTest {
         new MockDataNodeId("localhost", vcrPortList, Collections.singletonList(vcrMountPath), cloudDc);
 
     // create ambry server recovery cluster
-    MockClusterMap serverClusterMap = new MockClusterMap(false, 2, 1, 1, true);
+    MockClusterMap serverClusterMap = new MockClusterMap(false, 2, 1, 1, true, false);
     recoveryCluster = new MockCluster(serverClusterMap, Collections.singletonList(vcrNode), recoveryProperties);
     partitionId = recoveryCluster.getClusterMap().getWritablePartitionIds(null).get(0);
     allRecoveryNodes = serverClusterMap.getDataNodes();

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/CloudAndStoreReplicationTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/CloudAndStoreReplicationTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.cloud.LatchBasedInMemoryCloudDestination;
 import com.github.ambry.cloud.LatchBasedInMemoryCloudDestinationFactory;
 import com.github.ambry.cloud.VcrServer;
 import com.github.ambry.cloud.VcrTestUtil;
+import com.github.ambry.clustermap.ClusterMapSnapshotConstants;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterAgentsFactory;
 import com.github.ambry.clustermap.MockClusterMap;
@@ -113,7 +114,7 @@ public class CloudAndStoreReplicationTest {
   @Before
   public void setup() throws Exception {
     String cloudDc = "CloudDc";
-    String vcrMountPath = "/vcr/1";
+    String vcrMountPath = ClusterMapSnapshotConstants.CLOUD_REPLICA_MOUNT + "/1";
     recoveryProperties = new Properties();
     recoveryProperties.setProperty("replication.metadata.request.version", "2");
     recoveryProperties.setProperty("replication.enabled.with.vcr.cluster", "true");

--- a/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
+++ b/ambry-server/src/integration-test/java/com.github.ambry.server/VcrRecoveryTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.cloud.LatchBasedInMemoryCloudDestination;
 import com.github.ambry.cloud.LatchBasedInMemoryCloudDestinationFactory;
 import com.github.ambry.cloud.VcrServer;
 import com.github.ambry.cloud.VcrTestUtil;
+import com.github.ambry.clustermap.ClusterMapSnapshotConstants;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.PartitionId;
@@ -82,7 +83,7 @@ public class VcrRecoveryTest {
   @Before
   public void setup() throws Exception {
     String dcName = "DC1";
-    String vcrMountPath = "/vcr/1";
+    String vcrMountPath = ClusterMapSnapshotConstants.CLOUD_REPLICA_MOUNT + "/1";
     recoveryProperties = new Properties();
     recoveryProperties.setProperty("replication.metadata.request.version", "2");
 

--- a/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com.github.ambry.store/StorageManagerTest.java
@@ -89,7 +89,7 @@ public class StorageManagerTest {
    */
   @Before
   public void initializeCluster() throws IOException {
-    clusterMap = new MockClusterMap(false, 1, 3, 3, false);
+    clusterMap = new MockClusterMap(false, 1, 3, 3, false, false);
     metricRegistry = clusterMap.getMetricRegistry();
     generateConfigs(false, false);
   }

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockReplicaId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockReplicaId.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.json.JSONObject;
 
 import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
@@ -40,18 +41,23 @@ public class MockReplicaId implements ReplicaId {
   public MockReplicaId(int port, MockPartitionId partitionId, MockDataNodeId dataNodeId, int indexOfMountPathToUse) {
     this.partitionId = partitionId;
     this.dataNodeId = dataNodeId;
-    mountPath = dataNodeId.getMountPaths().get(indexOfMountPathToUse);
-    File mountFile = new File(mountPath);
-    File replicaFile = new File(mountFile, "replica" + port + partitionId.partition);
-    replicaFile.mkdir();
-    replicaFile.deleteOnExit();
-    if (mountPath.startsWith("/vcr")) {
+    if (dataNodeId.getMountPaths().isEmpty()) {
+      // a data node with no mount paths is a virtual data node which holds cloud service replicas.
       replicaType = ReplicaType.CLOUD_BACKED;
     } else {
-      replicaType = ReplicaType.DISK_BACKED;
+      mountPath = dataNodeId.getMountPaths().get(indexOfMountPathToUse);
+      File mountFile = new File(mountPath);
+      File replicaFile = new File(mountFile, "replica" + port + partitionId.partition);
+      replicaFile.mkdir();
+      replicaFile.deleteOnExit();
+      if (mountPath.startsWith("/vcr")) {
+        replicaType = ReplicaType.CLOUD_BACKED;
+      } else {
+        replicaType = ReplicaType.DISK_BACKED;
+      }
+      replicaPath = replicaFile.getAbsolutePath();
+      diskId = new MockDiskId(dataNodeId, mountPath);
     }
-    replicaPath = replicaFile.getAbsolutePath();
-    diskId = new MockDiskId(dataNodeId, mountPath);
     isSealed = partitionId.getPartitionState().equals(PartitionState.READ_ONLY);
   }
 
@@ -83,7 +89,7 @@ public class MockReplicaId implements ReplicaId {
   public void setPeerReplicas(List<ReplicaId> peerReplicas) {
     this.peerReplicas = new ArrayList<>();
     for (ReplicaId replicaId : peerReplicas) {
-      if (!(replicaId.getMountPath().compareTo(mountPath) == 0)) {
+      if (!Objects.equals(mountPath, replicaId.getMountPath())) {
         this.peerReplicas.add(replicaId);
       }
     }
@@ -104,8 +110,8 @@ public class MockReplicaId implements ReplicaId {
    */
   @Override
   public boolean isDown() {
-    return isMarkedDown || getDataNodeId().getState() == HardwareState.UNAVAILABLE
-        || getDiskId().getState() == HardwareState.UNAVAILABLE;
+    return isMarkedDown || getDataNodeId().getState() == HardwareState.UNAVAILABLE || (getDiskId() != null
+        && getDiskId().getState() == HardwareState.UNAVAILABLE);
   }
 
   @Override
@@ -118,7 +124,9 @@ public class MockReplicaId implements ReplicaId {
     JSONObject snapshot = new JSONObject();
     snapshot.put(REPLICA_NODE, dataNodeId.getHostname() + ":" + dataNodeId.getPort());
     snapshot.put(REPLICA_PARTITION, partitionId.toPathString());
-    snapshot.put(REPLICA_DISK, diskId.getMountPath());
+    if (diskId != null) {
+      snapshot.put(REPLICA_DISK, diskId.getMountPath());
+    }
     snapshot.put(REPLICA_PATH, replicaPath);
     snapshot.put(REPLICA_WRITE_STATE, isSealed() ? PartitionState.READ_ONLY.name() : PartitionState.READ_WRITE.name());
     String liveness = UP;
@@ -126,7 +134,7 @@ public class MockReplicaId implements ReplicaId {
       liveness = DOWN;
     } else if (getDataNodeId().getState() == HardwareState.UNAVAILABLE) {
       liveness = NODE_DOWN;
-    } else if (getDiskId().getState() == HardwareState.UNAVAILABLE) {
+    } else if (getDiskId() != null && getDiskId().getState() == HardwareState.UNAVAILABLE) {
       liveness = DISK_DOWN;
     }
     snapshot.put(LIVENESS, liveness);

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockReplicaId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockReplicaId.java
@@ -24,6 +24,7 @@ import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 
 public class MockReplicaId implements ReplicaId {
   public static final long MOCK_REPLICA_CAPACITY = 100000000;
+  private static final String REPLICA_FILE_PREFIX = "replica";
   private String mountPath;
   private String replicaPath;
   private List<ReplicaId> peerReplicas;
@@ -47,10 +48,10 @@ public class MockReplicaId implements ReplicaId {
     } else {
       mountPath = dataNodeId.getMountPaths().get(indexOfMountPathToUse);
       File mountFile = new File(mountPath);
-      File replicaFile = new File(mountFile, "replica" + port + partitionId.partition);
+      File replicaFile = new File(mountFile, REPLICA_FILE_PREFIX + port + partitionId.partition);
       replicaFile.mkdir();
       replicaFile.deleteOnExit();
-      if (mountPath.startsWith("/vcr")) {
+      if (mountPath.startsWith(CLOUD_REPLICA_MOUNT)) {
         replicaType = ReplicaType.CLOUD_BACKED;
       } else {
         replicaType = ReplicaType.DISK_BACKED;


### PR DESCRIPTION
Prior to this change, CloudRouterFactory could only communicate with
cloud services. This integrates CompositeNetworkClient which lets it
address both cloud service replicas and ambry-server replicas.

- Fix a bug in CompositeNetworkClient. sendAndPoll on the child clients
  needs to be called regardless of if there are new requests to send so
  that any responses that come back are received in a timely manner.
- Add support for the wakeup call to
  LocalNetworkClient/LocalRequestResponseChannel. This allows a
  sendAndPoll call to end before the timeout if the router indicates
  that there is extra work to do (e.g. processing decrypted blobs)
- Some MockClusterMap changes to support adding a datacenter with
  CLOUD_BACKED replicas to the cluster. This will help test retry
  policies with heterogenous clusters down the line and makes the
  existing tests work with CompositeNetworkClient for now.