### PR TITLE
Optional account/container in NettyPerfClient

### DIFF
--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/NettyPerfClient.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/NettyPerfClient.java
@@ -267,10 +267,7 @@ public class NettyPerfClient {
             || postBlobChunkSize <= 0) {
           throw new IllegalArgumentException(
               "Total size to be posted and size of each chunk need to be specified with POST and have to be > 0");
-        } else if (targetAccountName == null || targetAccountName.isEmpty() || targetContainerName == null
-            || targetContainerName.isEmpty()) {
-          throw new IllegalArgumentException("TargetAccountName and TargetContainerName cannot be empty with POST");
-        }
+        } 
       }
       if (serviceId == null || serviceId.isEmpty()) {
         throw new IllegalArgumentException("serviceId cannot be empty");

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/NettyPerfClient.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/NettyPerfClient.java
@@ -267,7 +267,7 @@ public class NettyPerfClient {
             || postBlobChunkSize <= 0) {
           throw new IllegalArgumentException(
               "Total size to be posted and size of each chunk need to be specified with POST and have to be > 0");
-        } 
+        }
       }
       if (serviceId == null || serviceId.isEmpty()) {
         throw new IllegalArgumentException("serviceId cannot be empty");
@@ -621,8 +621,12 @@ public class NettyPerfClient {
         request.headers().add(RestUtils.Headers.BLOB_SIZE, totalSize);
         request.headers().add(RestUtils.Headers.SERVICE_ID, serviceId);
         request.headers().add(RestUtils.Headers.AMBRY_CONTENT_TYPE, "application/octet-stream");
-        request.headers().add(RestUtils.Headers.TARGET_ACCOUNT_NAME, targetAccountName);
-        request.headers().add(RestUtils.Headers.TARGET_CONTAINER_NAME, targetContainerName);
+        if (targetAccountName != null) {
+          request.headers().add(RestUtils.Headers.TARGET_ACCOUNT_NAME, targetAccountName);
+        }
+        if (targetContainerName != null) {
+          request.headers().add(RestUtils.Headers.TARGET_CONTAINER_NAME, targetContainerName);
+        }
       } else {
         if (pathList == null) {
           request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, path);

--- a/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/NettyPerfClient.java
+++ b/ambry-tools/src/main/java/com.github.ambry/tools/perf/rest/NettyPerfClient.java
@@ -621,10 +621,10 @@ public class NettyPerfClient {
         request.headers().add(RestUtils.Headers.BLOB_SIZE, totalSize);
         request.headers().add(RestUtils.Headers.SERVICE_ID, serviceId);
         request.headers().add(RestUtils.Headers.AMBRY_CONTENT_TYPE, "application/octet-stream");
-        if (targetAccountName != null) {
+        if (targetAccountName != null && !targetAccountName.isEmpty()) {
           request.headers().add(RestUtils.Headers.TARGET_ACCOUNT_NAME, targetAccountName);
         }
-        if (targetContainerName != null) {
+        if (targetContainerName != null && !targetContainerName.isEmpty() ) {
           request.headers().add(RestUtils.Headers.TARGET_CONTAINER_NAME, targetContainerName);
         }
       } else {


### PR DESCRIPTION
This PR supports optional targetAccountName/targetContainerName in NettyPerfClient. 
1. Remove account/container check in validateArgs so it won't throw exception.
2. Make sure reset won't throw exception when account/container is null.

