### PR TITLE
Changing the MessageInfoAndMetadataListSerde version to 6

### DIFF
--- a/ambry-protocol/src/main/java/com.github.ambry.protocol/MessageInfoAndMetadataListSerde.java
+++ b/ambry-protocol/src/main/java/com.github.ambry.protocol/MessageInfoAndMetadataListSerde.java
@@ -44,7 +44,7 @@ class MessageInfoAndMetadataListSerde {
   static final short VERSION_6 = 6;
   static final short VERSION_MAX = VERSION_6;
 
-  static short AUTO_VERSION = VERSION_5;
+  static short AUTO_VERSION = VERSION_6;
 
   private final short version;
 


### PR DESCRIPTION
Changing the MessageInfoAndMetadataListSerde's AutoVersion to version 6. In the new version, we can send out the lifeVersion in the message info so the other server can replicate based on the lifeVersion.

This has to be merged after the deployment of server 16.1.399 on both frontend and server.