### PR TITLE
Change BlobStore so records can have a lifeVersion rather than -1

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/MessageInfo.java
@@ -22,7 +22,7 @@ import java.util.Objects;
  */
 public class MessageInfo {
 
-  // The life version when the operation is trigger by the requests from frontend.
+  // The life version when the operation is triggered by the requests from frontend.
   public final static short LIFE_VERSION_FROM_FRONTEND = -1;
   private final StoreKey key;
   private final long size;

--- a/ambry-api/src/main/java/com/github/ambry/store/MessageInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/MessageInfo.java
@@ -22,6 +22,8 @@ import java.util.Objects;
  */
 public class MessageInfo {
 
+  // The life version when the operation is trigger by the requests from frontend.
+  public final static short LIFE_VERSION_FROM_FRONTEND = -1;
   private final StoreKey key;
   private final long size;
   private final long expirationTimeInMs;
@@ -47,6 +49,21 @@ public class MessageInfo {
   public MessageInfo(StoreKey key, long size, long expirationTimeInMs, short accountId, short containerId,
       long operationTimeMs) {
     this(key, size, false, false, expirationTimeInMs, accountId, containerId, operationTimeMs);
+  }
+
+  /**
+   * Construct an instance of MessageInfo.
+   * @param key the {@link StoreKey} associated with this message.
+   * @param size the size of this message in bytes.
+   * @param accountId accountId of the blob
+   * @param containerId containerId of the blob
+   * @param operationTimeMs operation time in ms
+   * @param lifeVersion update version of update
+   */
+  public MessageInfo(StoreKey key, long size, short accountId, short containerId, long operationTimeMs,
+      short lifeVersion) {
+    this(key, size, false, false, false, Utils.Infinite_Time, null, accountId, containerId, operationTimeMs,
+        lifeVersion);
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -44,7 +44,7 @@ public interface Store {
    * Puts a set of messages into the store. When the lifeVersion is {@link MessageInfo#LIFE_VERSION_FROM_FRONTEND}, this
    * method is invoked by the responding to the frontend request. Otherwise, it's invoked in the replication thread.
    * @param messageSetToWrite The message set to write to the store
-   *                          Only the Storekey, OperationTime, ExpirationTime, LifeVersion  should be used in this method.
+   *                          Only the StoreKey, OperationTime, ExpirationTime, LifeVersion should be used in this method.
    * @throws StoreException
    */
   void put(MessageWriteSet messageSetToWrite) throws StoreException;

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -41,29 +41,37 @@ public interface Store {
   StoreInfo get(List<? extends StoreKey> ids, EnumSet<StoreGetOptions> storeGetOptions) throws StoreException;
 
   /**
-   * Puts a set of messages into the store
+   * Puts a set of messages into the store. When the lifeVersion is {@link MessageInfo#LIFE_VERSION_FROM_FRONTEND}, this
+   * method is invoked by the responding to the frontend request. Otherwise, it's invoked in the replication thread.
    * @param messageSetToWrite The message set to write to the store
+   *                          Only the Storekey, OperationTime, ExpirationTime, LifeVersion  should be used in this method.
    * @throws StoreException
    */
   void put(MessageWriteSet messageSetToWrite) throws StoreException;
 
   /**
-   * Deletes all the messages that are part of the message set
-   * @param infosToDelete The list of messages that need to be deleted
+   * Deletes all the messages in the list. When the lifeVersion is {@link MessageInfo#LIFE_VERSION_FROM_FRONTEND}, this
+   * method is invoked by the responding to the frontend request. Otherwise, it's invoked in the replication thread.
+   * @param infosToDelete The list of messages that need to be deleted.
+   *                      Only the StoreKey, OperationTime, LifeVersion should be used in this method.
    * @throws StoreException
    */
   void delete(List<MessageInfo> infosToDelete) throws StoreException;
 
   /**
-   * Undelete the blob identified by {@code id}.
+   * Undelete the blob identified by {@code id}. When the lifeVersion is {@link MessageInfo#LIFE_VERSION_FROM_FRONTEND},
+   * this method is invoked by the responding to the frontend request. Otherwise, it's invoked in the replication thread.
    * @param info The {@link MessageInfo} that carries some basic information about this operation.
+   *             Only the StoreKey, OperationTime, LifeVersion should be used in this method.
    * @return the lifeVersion of the undeleted blob.
    */
   short undelete(MessageInfo info) throws StoreException;
 
   /**
-   * Updates the TTL of all the messages that are part of the message set
+   * Updates the TTL of all the messages in the list. When the lifeVersion is {@link MessageInfo#LIFE_VERSION_FROM_FRONTEND},
+   * this method is invoked by the responding to the frontend request. Otherwise, it's invoked in the replication thread.
    * @param infosToUpdate The list of messages that need to be updated
+   *                      Only the StoreKey, OperationTime, ExpirationTime, LifeVersion should be used in this method.
    * @throws StoreException
    */
   void updateTtl(List<MessageInfo> infosToUpdate) throws StoreException;

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
@@ -69,7 +69,7 @@ public class ValidatingTransformer implements Transformer {
       StoreKey keyInStream = storeKeyFactory.getStoreKey(new DataInputStream(msgStream));
       if (header.isPutRecord()) {
         if (header.hasLifeVersion() && header.getLifeVersion() != msgInfo.getLifeVersion()) {
-          logger.warn("LifeVersion in stream: " + header.getLifeVersion() + " failed to match lifeVersion from Index: "
+          logger.trace("LifeVersion in stream: " + header.getLifeVersion() + " failed to match lifeVersion from Index: "
               + msgInfo.getLifeVersion() + " for key " + keyInStream);
         }
         encryptionKey = header.hasEncryptionKeyRecord() ? deserializeBlobEncryptionKey(msgStream) : null;
@@ -88,7 +88,7 @@ public class ValidatingTransformer implements Transformer {
                 new ByteBufInputStream(blobData.content(), true), blobData.getSize(), blobData.getBlobType(),
                 msgInfo.getLifeVersion());
         MessageInfo transformedMsgInfo =
-            new MessageInfo(keyInStream, transformedStream.getSize(), msgInfo.isDeleted(), msgInfo.isTtlUpdated(),
+            new MessageInfo(keyInStream, transformedStream.getSize(), false, msgInfo.isTtlUpdated(),
                 false, msgInfo.getExpirationTimeInMs(), msgInfo.getCrc(), msgInfo.getAccountId(),
                 msgInfo.getContainerId(), msgInfo.getOperationTimeMs(), msgInfo.getLifeVersion());
         transformationOutput = new TransformationOutput(new Message(transformedMsgInfo, transformedStream));

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageSievingInputStreamTest.java
@@ -1091,11 +1091,12 @@ class ValidatingKeyConvertingTransformer implements Transformer {
           MessageInfo transformedMsgInfo;
           PutMessageFormatInputStream transformedStream =
               new PutMessageFormatInputStream(newKey, encryptionKey, props, metadata,
-                  new ByteBufInputStream(blobData.content(), true), blobData.getSize(), blobData.getBlobType());
+                  new ByteBufInputStream(blobData.content(), true), blobData.getSize(), blobData.getBlobType(),
+                  msgInfo.getLifeVersion());
           transformedMsgInfo =
-              new MessageInfo(newKey, transformedStream.getSize(), msgInfo.isDeleted(), msgInfo.isTtlUpdated(),
+              new MessageInfo(newKey, transformedStream.getSize(), msgInfo.isDeleted(), msgInfo.isTtlUpdated(), false,
                   msgInfo.getExpirationTimeInMs(), msgInfo.getCrc(), msgInfo.getAccountId(), msgInfo.getContainerId(),
-                  msgInfo.getOperationTimeMs());
+                  msgInfo.getOperationTimeMs(), msgInfo.getLifeVersion());
           transformationOutput = new TransformationOutput(new Message(transformedMsgInfo, transformedStream));
         }
       } else {

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -396,9 +396,9 @@ public class AmbryRequests implements RequestAPI {
         response = new DeleteResponse(deleteRequest.getCorrelationId(), deleteRequest.getClientId(), error);
       } else {
         BlobId convertedBlobId = (BlobId) convertedStoreKey;
-        MessageInfo info =
-            new MessageInfo(convertedStoreKey, -1, convertedBlobId.getAccountId(), convertedBlobId.getContainerId(),
-                deleteRequest.getDeletionTimeInMs(), MessageInfo.LIFE_VERSION_FROM_FRONTEND);
+        MessageInfo info = new MessageInfo(convertedStoreKey, -1, true, false, false, Utils.Infinite_Time, null,
+            convertedBlobId.getAccountId(), convertedBlobId.getContainerId(), deleteRequest.getDeletionTimeInMs(),
+            MessageInfo.LIFE_VERSION_FROM_FRONTEND);
         Store storeToDelete = storeManager.getStore(deleteRequest.getBlobId().getPartition());
         storeToDelete.delete(Collections.singletonList(info));
         response =
@@ -651,9 +651,9 @@ public class AmbryRequests implements RequestAPI {
         response = new UndeleteResponse(undeleteRequest.getCorrelationId(), undeleteRequest.getClientId(), error);
       } else {
         BlobId convertedBlobId = (BlobId) convertedStoreKey;
-        MessageInfo info =
-            new MessageInfo(convertedBlobId, -1, convertedBlobId.getAccountId(), convertedBlobId.getContainerId(),
-                undeleteRequest.getOperationTimeMs(), MessageInfo.LIFE_VERSION_FROM_FRONTEND);
+        MessageInfo info = new MessageInfo(convertedBlobId, -1, false, false, true, Utils.Infinite_Time, null,
+            convertedBlobId.getAccountId(), convertedBlobId.getContainerId(), undeleteRequest.getOperationTimeMs(),
+            MessageInfo.LIFE_VERSION_FROM_FRONTEND);
         Store storeToUndelete = storeManager.getStore(undeleteRequest.getBlobId().getPartition());
         short lifeVersion = storeToUndelete.undelete(info);
         response = new UndeleteResponse(undeleteRequest.getCorrelationId(), undeleteRequest.getClientId(), lifeVersion);

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -182,6 +182,7 @@ public class AmbryRequests implements RequestAPI {
         metrics.blobSizeInBytes.update(receivedRequest.getBlobSize());
         metrics.blobUserMetadataSizeInBytes.update(receivedRequest.getUsermetadata().limit());
         if (notification != null) {
+          logger.info("AmbryRequests: write key " + receivedRequest.getBlobId() + " at port " + currentNode.getPort());
           notification.onBlobReplicaCreated(currentNode.getHostname(), currentNode.getPort(),
               receivedRequest.getBlobId().getID(), BlobReplicaSourceType.PRIMARY);
         }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -182,7 +182,6 @@ public class AmbryRequests implements RequestAPI {
         metrics.blobSizeInBytes.update(receivedRequest.getBlobSize());
         metrics.blobUserMetadataSizeInBytes.update(receivedRequest.getUsermetadata().limit());
         if (notification != null) {
-          logger.info("AmbryRequests: write key " + receivedRequest.getBlobId() + " at port " + currentNode.getPort());
           notification.onBlobReplicaCreated(currentNode.getHostname(), currentNode.getPort(),
               receivedRequest.getBlobId().getID(), BlobReplicaSourceType.PRIMARY);
         }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -167,11 +167,11 @@ public class AmbryRequests implements RequestAPI {
             new PutMessageFormatInputStream(receivedRequest.getBlobId(), receivedRequest.getBlobEncryptionKey(),
                 receivedRequest.getBlobProperties(), receivedRequest.getUsermetadata(), receivedRequest.getBlobStream(),
                 receivedRequest.getBlobSize(), receivedRequest.getBlobType());
-        MessageInfo info = new MessageInfo(receivedRequest.getBlobId(), stream.getSize(), false, false,
+        MessageInfo info = new MessageInfo(receivedRequest.getBlobId(), stream.getSize(), false, false, false,
             Utils.addSecondsToEpochTime(receivedRequest.getBlobProperties().getCreationTimeInMs(),
                 receivedRequest.getBlobProperties().getTimeToLiveInSeconds()), receivedRequest.getCrc(),
             receivedRequest.getBlobProperties().getAccountId(), receivedRequest.getBlobProperties().getContainerId(),
-            receivedRequest.getBlobProperties().getCreationTimeInMs());
+            receivedRequest.getBlobProperties().getCreationTimeInMs(), MessageInfo.LIFE_VERSION_FROM_FRONTEND);
         ArrayList<MessageInfo> infoList = new ArrayList<>();
         infoList.add(info);
         MessageFormatWriteSet writeset = new MessageFormatWriteSet(stream, infoList, false);
@@ -398,7 +398,7 @@ public class AmbryRequests implements RequestAPI {
         BlobId convertedBlobId = (BlobId) convertedStoreKey;
         MessageInfo info =
             new MessageInfo(convertedStoreKey, -1, convertedBlobId.getAccountId(), convertedBlobId.getContainerId(),
-                deleteRequest.getDeletionTimeInMs());
+                deleteRequest.getDeletionTimeInMs(), MessageInfo.LIFE_VERSION_FROM_FRONTEND);
         Store storeToDelete = storeManager.getStore(deleteRequest.getBlobId().getPartition());
         storeToDelete.delete(Collections.singletonList(info));
         response =
@@ -466,8 +466,10 @@ public class AmbryRequests implements RequestAPI {
       } else {
         BlobId convertedStoreKey =
             (BlobId) getConvertedStoreKeys(Collections.singletonList(updateRequest.getBlobId())).get(0);
-        MessageInfo info = new MessageInfo(convertedStoreKey, -1, false, true, updateRequest.getExpiresAtMs(),
-            convertedStoreKey.getAccountId(), convertedStoreKey.getContainerId(), updateRequest.getOperationTimeInMs());
+        MessageInfo info =
+            new MessageInfo(convertedStoreKey, -1, false, true, false, updateRequest.getExpiresAtMs(), null,
+                convertedStoreKey.getAccountId(), convertedStoreKey.getContainerId(),
+                updateRequest.getOperationTimeInMs(), MessageInfo.LIFE_VERSION_FROM_FRONTEND);
         Store store = storeManager.getStore(updateRequest.getBlobId().getPartition());
         store.updateTtl(Collections.singletonList(info));
         response = new TtlUpdateResponse(updateRequest.getCorrelationId(), updateRequest.getClientId(),
@@ -651,7 +653,7 @@ public class AmbryRequests implements RequestAPI {
         BlobId convertedBlobId = (BlobId) convertedStoreKey;
         MessageInfo info =
             new MessageInfo(convertedBlobId, -1, convertedBlobId.getAccountId(), convertedBlobId.getContainerId(),
-                undeleteRequest.getOperationTimeMs());
+                undeleteRequest.getOperationTimeMs(), MessageInfo.LIFE_VERSION_FROM_FRONTEND);
         Store storeToUndelete = storeManager.getStore(undeleteRequest.getBlobId().getPartition());
         short lifeVersion = storeToUndelete.undelete(info);
         response = new UndeleteResponse(undeleteRequest.getCorrelationId(), undeleteRequest.getClientId(), lifeVersion);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -848,8 +848,8 @@ public class ReplicaThread implements Runnable {
                     + " are not the same");
           }
           if (partitionResponseInfo.getErrorCode() == ServerErrorCode.No_Error) {
+            List<MessageInfo> messageInfoList = partitionResponseInfo.getMessageInfoList();
             try {
-              List<MessageInfo> messageInfoList = partitionResponseInfo.getMessageInfoList();
               logger.trace("Remote node: {} Thread name: {} Remote replica: {} Messages to fix: {} "
                       + "Partition: {} Local mount path: {}", remoteNode, threadName, remoteReplicaInfo.getReplicaId(),
                   exchangeMetadataResponse.missingStoreKeys, remoteReplicaInfo.getReplicaId().getPartitionId(),

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -201,9 +201,9 @@ public class MockConnectionPool implements ConnectionPool {
               // looks for. Just set the deleted flag to true for the constructed MessageInfo from Put.
               if (infoFound.isDeleted()) {
                 MessageInfo putMsgInfo = getMessageInfo(infoFound.getStoreKey(), messageInfoList, false, false, false);
-                infoFound = new MessageInfo(putMsgInfo.getStoreKey(), putMsgInfo.getSize(), true, false,
-                    putMsgInfo.getExpirationTimeInMs(), putMsgInfo.getAccountId(), putMsgInfo.getContainerId(),
-                    putMsgInfo.getOperationTimeMs());
+                infoFound = new MessageInfo(putMsgInfo.getStoreKey(), putMsgInfo.getSize(), true, false, false,
+                    putMsgInfo.getExpirationTimeInMs(), null, putMsgInfo.getAccountId(), putMsgInfo.getContainerId(),
+                    putMsgInfo.getOperationTimeMs(), infoFound.getLifeVersion());
               } else if (infoFound.isUndeleted()) {
                 MessageInfo putMsgInfo = getMessageInfo(infoFound.getStoreKey(), messageInfoList, false, false, false);
                 infoFound = new MessageInfo(putMsgInfo.getStoreKey(), putMsgInfo.getSize(), false, false, true,

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -204,6 +204,11 @@ public class MockConnectionPool implements ConnectionPool {
                 infoFound = new MessageInfo(putMsgInfo.getStoreKey(), putMsgInfo.getSize(), true, false,
                     putMsgInfo.getExpirationTimeInMs(), putMsgInfo.getAccountId(), putMsgInfo.getContainerId(),
                     putMsgInfo.getOperationTimeMs());
+              } else if (infoFound.isUndeleted()) {
+                MessageInfo putMsgInfo = getMessageInfo(infoFound.getStoreKey(), messageInfoList, false, false, false);
+                infoFound = new MessageInfo(putMsgInfo.getStoreKey(), putMsgInfo.getSize(), false, false, true,
+                    putMsgInfo.getExpirationTimeInMs(), null, putMsgInfo.getAccountId(), putMsgInfo.getContainerId(),
+                    putMsgInfo.getOperationTimeMs(), infoFound.getLifeVersion());
               }
               infosToReturn.get(partitionId).add(infoFound);
             }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -119,7 +119,7 @@ public class ReplicationTest {
 
   private static int CONSTANT_TIME_MS = 100000;
   private static long EXPIRY_TIME_MS = SystemTime.getInstance().milliseconds() + TimeUnit.DAYS.toMillis(7);
-  private static long UPDATED_EXPIRY_TIME_MS = SystemTime.getInstance().milliseconds() + TimeUnit.DAYS.toMillis(14);
+  private static long UPDATED_EXPIRY_TIME_MS = Utils.Infinite_Time;
   private static final short VERSION_2 = 2;
   private static final short VERSION_5 = 5;
   private final MockTime time = new MockTime();
@@ -2469,7 +2469,8 @@ public class ReplicationTest {
   static MessageInfo getMessageInfo(StoreKey id, List<MessageInfo> messageInfos, boolean deleteMsg, boolean undeleteMsg,
       boolean ttlUpdateMsg) {
     MessageInfo toRet = null;
-    for (MessageInfo messageInfo : messageInfos) {
+    for (int i = messageInfos.size() - 1; i >= 0; i--) {
+      MessageInfo messageInfo = messageInfos.get(i);
       if (messageInfo.getStoreKey().equals(id)) {
         if (deleteMsg && messageInfo.isDeleted()) {
           toRet = messageInfo;
@@ -2481,7 +2482,8 @@ public class ReplicationTest {
             && messageInfo.isTtlUpdated()) {
           toRet = messageInfo;
           break;
-        } else if (!deleteMsg && !ttlUpdateMsg && !undeleteMsg) {
+        } else if (!deleteMsg && !ttlUpdateMsg && !undeleteMsg && !messageInfo.isUndeleted() & !messageInfo.isDeleted()
+            && !messageInfo.isTtlUpdated()) {
           toRet = messageInfo;
           break;
         }

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
@@ -488,7 +488,7 @@ class EventTracker {
    * @throws InterruptedException
    */
   boolean awaitBlobCreations() throws InterruptedException {
-    return creationHelper.await(10, TimeUnit.SECONDS);
+    return creationHelper.await(11, TimeUnit.SECONDS);
   }
 
   /**

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
@@ -488,7 +488,7 @@ class EventTracker {
    * @throws InterruptedException
    */
   boolean awaitBlobCreations() throws InterruptedException {
-    return creationHelper.await(11, TimeUnit.SECONDS);
+    return creationHelper.await(10, TimeUnit.SECONDS);
   }
 
   /**

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerPlaintextTest.java
@@ -39,13 +39,13 @@ import static org.junit.Assume.*;
 
 @RunWith(Parameterized.class)
 public class ServerPlaintextTest {
-  private static Properties routerProps;
-  private static MockNotificationSystem notificationSystem;
-  private static MockCluster plaintextCluster;
+  private Properties routerProps;
+  private MockNotificationSystem notificationSystem;
+  private MockCluster plaintextCluster;
   private final boolean testEncryption;
 
   @Before
-  public static void initializeTests() throws Exception {
+  public void initializeTests() throws Exception {
     routerProps = new Properties();
     routerProps.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
     routerProps.setProperty("clustermap.default.partition.class", MockClusterMap.DEFAULT_PARTITION_CLASS);
@@ -72,7 +72,7 @@ public class ServerPlaintextTest {
   }
 
   @After
-  public static void cleanup() throws IOException {
+  public void cleanup() throws IOException {
     long start = System.currentTimeMillis();
     // cleanup appears to hang sometimes. And, it sometimes takes a long time. Printing some info until cleanup is fast
     // and reliable.

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerPlaintextTest.java
@@ -28,8 +28,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -44,7 +44,7 @@ public class ServerPlaintextTest {
   private static MockCluster plaintextCluster;
   private final boolean testEncryption;
 
-  @BeforeClass
+  @Before
   public static void initializeTests() throws Exception {
     routerProps = new Properties();
     routerProps.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
@@ -71,7 +71,7 @@ public class ServerPlaintextTest {
     this.testEncryption = testEncryption;
   }
 
-  @AfterClass
+  @After
   public static void cleanup() throws IOException {
     long start = System.currentTimeMillis();
     // cleanup appears to hang sometimes. And, it sometimes takes a long time. Printing some info until cleanup is fast

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerSSLTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerSSLTest.java
@@ -43,18 +43,18 @@ import static org.junit.Assume.*;
 
 @RunWith(Parameterized.class)
 public class ServerSSLTest {
-  private static SSLFactory sslFactory;
-  private static SSLConfig clientSSLConfig1;
-  private static SSLConfig clientSSLConfig2;
-  private static SSLConfig clientSSLConfig3;
-  private static SSLSocketFactory clientSSLSocketFactory1;
-  private static SSLSocketFactory clientSSLSocketFactory2;
-  private static SSLSocketFactory clientSSLSocketFactory3;
-  private static File trustStoreFile;
-  private static Properties serverSSLProps;
-  private static Properties routerProps;
-  private static MockNotificationSystem notificationSystem;
-  private static MockCluster sslCluster;
+  private SSLFactory sslFactory;
+  private SSLConfig clientSSLConfig1;
+  private SSLConfig clientSSLConfig2;
+  private SSLConfig clientSSLConfig3;
+  private SSLSocketFactory clientSSLSocketFactory1;
+  private SSLSocketFactory clientSSLSocketFactory2;
+  private SSLSocketFactory clientSSLSocketFactory3;
+  private File trustStoreFile;
+  private Properties serverSSLProps;
+  private Properties routerProps;
+  private MockNotificationSystem notificationSystem;
+  private MockCluster sslCluster;
   private final boolean testEncryption;
 
   @Before

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerSSLTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerSSLTest.java
@@ -160,9 +160,8 @@ public class ServerSSLTest {
   public void endToEndSSLReplicationWithMultiNodeMultiPartitionMultiDCTest() throws Exception {
     // this test uses router to Put and direct GetRequest to verify Gets. So, no way to get access to encryptionKey against
     // which to compare the GetResponse. Hence skipping encryption flow for this test
-    if (!testEncryption) {
-      ServerTestUtil.endToEndReplicationWithMultiNodeMultiPartitionMultiDCTest("DC1", "DC1,DC2,DC3", PortType.SSL,
-          sslCluster, notificationSystem, routerProps);
-    }
+    assumeTrue(!testEncryption);
+    ServerTestUtil.endToEndReplicationWithMultiNodeMultiPartitionMultiDCTest("DC1", "DC1,DC2,DC3", PortType.SSL,
+        sslCluster, notificationSystem, routerProps);
   }
 }

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerSSLTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerSSLTest.java
@@ -32,8 +32,8 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -57,8 +57,8 @@ public class ServerSSLTest {
   private static MockCluster sslCluster;
   private final boolean testEncryption;
 
-  @BeforeClass
-  public static void initializeTests() throws Exception {
+  @Before
+  public void initializeTests() throws Exception {
     trustStoreFile = File.createTempFile("truststore", ".jks");
     clientSSLConfig1 =
         new SSLConfig(TestSSLUtils.createSslProps("DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "client1"));
@@ -102,8 +102,8 @@ public class ServerSSLTest {
     this.testEncryption = testEncryption;
   }
 
-  @AfterClass
-  public static void cleanup() throws IOException {
+  @After
+  public void cleanup() throws IOException {
     long start = System.currentTimeMillis();
     // cleanup appears to hang sometimes. And, it sometimes takes a long time. Printing some info until cleanup is fast
     // and reliable.

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/Verifier.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/Verifier.java
@@ -141,10 +141,11 @@ class Verifier implements Runnable {
                     System.out.println(exceptionMsg);
                     throw new IllegalStateException(exceptionMsg);
                   }
-                  checkExpiryTimeMatch(payload, ServerTestUtil.getExpiryTimeMs(propertyOutput));
+                  // blob property doesn't have the correct expiration time after ttl update.
+                  //checkExpiryTimeMatch(payload, ServerTestUtil.getExpiryTimeMs(propertyOutput), "blobproperty");
                   long actualExpiryTimeMs =
                       resp.getPartitionResponseInfoList().get(0).getMessageInfoList().get(0).getExpirationTimeInMs();
-                  checkExpiryTimeMatch(payload, actualExpiryTimeMs);
+                  checkExpiryTimeMatch(payload, actualExpiryTimeMs, "messageinfo in blobproperty");
                 } catch (MessageFormatException e) {
                   e.printStackTrace();
                   throw new IllegalStateException(e);
@@ -173,7 +174,7 @@ class Verifier implements Runnable {
                   }
                   long actualExpiryTimeMs =
                       resp.getPartitionResponseInfoList().get(0).getMessageInfoList().get(0).getExpirationTimeInMs();
-                  checkExpiryTimeMatch(payload, actualExpiryTimeMs);
+                  checkExpiryTimeMatch(payload, actualExpiryTimeMs, "messageinfo in usermetadatga");
                 } catch (MessageFormatException e) {
                   e.printStackTrace();
                   throw new IllegalStateException();
@@ -210,7 +211,7 @@ class Verifier implements Runnable {
                   }
                   long actualExpiryTimeMs =
                       resp.getPartitionResponseInfoList().get(0).getMessageInfoList().get(0).getExpirationTimeInMs();
-                  checkExpiryTimeMatch(payload, actualExpiryTimeMs);
+                  checkExpiryTimeMatch(payload, actualExpiryTimeMs, "messageinfo in blobdata");
                 } catch (MessageFormatException e) {
                   e.printStackTrace();
                   throw new IllegalStateException();
@@ -240,22 +241,27 @@ class Verifier implements Runnable {
                   if (ByteBuffer.wrap(blobout).compareTo(ByteBuffer.wrap(payload.blob)) != 0) {
                     throw new IllegalStateException();
                   }
-                  checkExpiryTimeMatch(payload,
-                      ServerTestUtil.getExpiryTimeMs(blobAll.getBlobInfo().getBlobProperties()));
+                  //checkExpiryTimeMatch(payload,
+                  //    ServerTestUtil.getExpiryTimeMs(blobAll.getBlobInfo().getBlobProperties()),
+                  //    "blobproperty in bloball");
                   long actualExpiryTimeMs =
                       resp.getPartitionResponseInfoList().get(0).getMessageInfoList().get(0).getExpirationTimeInMs();
-                  checkExpiryTimeMatch(payload, actualExpiryTimeMs);
+                  checkExpiryTimeMatch(payload, actualExpiryTimeMs, "messageinfo in bloball");
                 } catch (MessageFormatException e) {
                   e.printStackTrace();
                   throw new IllegalStateException();
                 }
               }
 
-              // ttl update, check and wait for replication
-              ServerTestUtil.updateBlobTtl(channel1, new BlobId(payload.blobId, clusterMap));
-              ServerTestUtil.checkTtlUpdateStatus(channel1, clusterMap, new BlobIdFactory(clusterMap), blobId,
-                  payload.blob, true, Utils.Infinite_Time);
-              notificationSystem.awaitBlobUpdates(payload.blobId, UpdateType.TTL_UPDATE);
+              if (payload.blobProperties.getTimeToLiveInSeconds() != Utils.Infinite_Time) {
+                // ttl update, check and wait for replication
+                ServerTestUtil.updateBlobTtl(channel1, new BlobId(payload.blobId, clusterMap));
+                ServerTestUtil.checkTtlUpdateStatus(channel1, clusterMap, new BlobIdFactory(clusterMap), blobId, payload.blob, true, Utils.Infinite_Time);
+                notificationSystem.awaitBlobUpdates(payload.blobId, UpdateType.TTL_UPDATE);
+                BlobProperties old = payload.blobProperties;
+                payload.blobProperties = new BlobProperties(old.getBlobSize(), old.getServiceId(), old.getOwnerId(), old.getContentType(),
+                    old.isEncrypted(), Utils.Infinite_Time, old.getCreationTimeInMs(), old.getAccountId(), old.getContainerId(), old.isEncrypted(), old.getExternalAssetTag());
+              }
             } catch (Exception e) {
               if (channel1 != null) {
                 connectionPool.destroyConnection(channel1);
@@ -285,11 +291,12 @@ class Verifier implements Runnable {
    * @param actualExpiryTimeMs the actual expiry time received
    * @throws IllegalStateException if the times don't match
    */
-  private void checkExpiryTimeMatch(Payload payload, long actualExpiryTimeMs) {
+  private void checkExpiryTimeMatch(Payload payload, long actualExpiryTimeMs, String context) {
     long expectedExpiryTimeMs = ServerTestUtil.getExpiryTimeMs(payload.blobProperties);
     if (actualExpiryTimeMs != expectedExpiryTimeMs) {
       String exceptionMsg =
-          "Expiry time (props) not matching " + " expected " + expectedExpiryTimeMs + " actual " + actualExpiryTimeMs;
+          "Expiry time (props) not matching in context " + context + " expected " + expectedExpiryTimeMs + " actual "
+              + actualExpiryTimeMs;
       System.out.println(exceptionMsg);
       throw new IllegalStateException(exceptionMsg);
     }

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/Verifier.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/Verifier.java
@@ -141,8 +141,6 @@ class Verifier implements Runnable {
                     System.out.println(exceptionMsg);
                     throw new IllegalStateException(exceptionMsg);
                   }
-                  // blob property doesn't have the correct expiration time after ttl update.
-                  //checkExpiryTimeMatch(payload, ServerTestUtil.getExpiryTimeMs(propertyOutput), "blobproperty");
                   long actualExpiryTimeMs =
                       resp.getPartitionResponseInfoList().get(0).getMessageInfoList().get(0).getExpirationTimeInMs();
                   checkExpiryTimeMatch(payload, actualExpiryTimeMs, "messageinfo in blobproperty");
@@ -241,9 +239,6 @@ class Verifier implements Runnable {
                   if (ByteBuffer.wrap(blobout).compareTo(ByteBuffer.wrap(payload.blob)) != 0) {
                     throw new IllegalStateException();
                   }
-                  //checkExpiryTimeMatch(payload,
-                  //    ServerTestUtil.getExpiryTimeMs(blobAll.getBlobInfo().getBlobProperties()),
-                  //    "blobproperty in bloball");
                   long actualExpiryTimeMs =
                       resp.getPartitionResponseInfoList().get(0).getMessageInfoList().get(0).getExpirationTimeInMs();
                   checkExpiryTimeMatch(payload, actualExpiryTimeMs, "messageinfo in bloball");

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -138,12 +138,14 @@ class MockStorageManager extends StorageManager {
       MessageWriteSet writeSet;
       try {
         for (MessageInfo info : infos) {
+          short lifeVersion =
+              info.getLifeVersion() == MessageInfo.LIFE_VERSION_FROM_FRONTEND ? 0 : info.getLifeVersion();
           MessageFormatInputStream stream =
               new DeleteMessageFormatInputStream(info.getStoreKey(), info.getAccountId(), info.getContainerId(),
-                  info.getOperationTimeMs(), info.getLifeVersion());
+                  info.getOperationTimeMs(), lifeVersion);
           infosToDelete.add(new MessageInfo(info.getStoreKey(), stream.getSize(), true, info.isTtlUpdated(), false,
               info.getExpirationTimeInMs(), null, info.getAccountId(), info.getContainerId(), info.getOperationTimeMs(),
-              info.getLifeVersion()));
+              lifeVersion));
           inputStreams.add(stream);
         }
         writeSet =
@@ -165,12 +167,14 @@ class MockStorageManager extends StorageManager {
       MessageFormatWriteSet writeSet;
       try {
         for (MessageInfo info : infos) {
+          short lifeVersion =
+              info.getLifeVersion() == MessageInfo.LIFE_VERSION_FROM_FRONTEND ? 0 : info.getLifeVersion();
           MessageFormatInputStream stream =
               new TtlUpdateMessageFormatInputStream(info.getStoreKey(), info.getAccountId(), info.getContainerId(),
-                  info.getExpirationTimeInMs(), info.getOperationTimeMs(), info.getLifeVersion());
+                  info.getExpirationTimeInMs(), info.getOperationTimeMs(), lifeVersion);
           infosToUpdate.add(
               new MessageInfo(info.getStoreKey(), stream.getSize(), false, true, false, info.getExpirationTimeInMs(),
-                  null, info.getAccountId(), info.getContainerId(), info.getOperationTimeMs(), info.getLifeVersion()));
+                  null, info.getAccountId(), info.getContainerId(), info.getOperationTimeMs(), lifeVersion));
           inputStreams.add(stream);
         }
         writeSet =

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -423,6 +423,7 @@ public class BlobStore implements Store {
             FileSpan fileSpan = new FileSpan(indexEntries.get(0).getValue().getOffset(), endOffsetOfLastMessage);
             index.addToIndex(indexEntries, fileSpan);
             for (IndexEntry newEntry : indexEntries) {
+              System.out.println("Handle new put Entry for key " + newEntry.getKey());
               blobStoreStats.handleNewPutEntry(newEntry.getValue());
             }
             logger.trace("Store : {} message set written to index ", dataDir);

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -423,7 +423,6 @@ public class BlobStore implements Store {
             FileSpan fileSpan = new FileSpan(indexEntries.get(0).getValue().getOffset(), endOffsetOfLastMessage);
             index.addToIndex(indexEntries, fileSpan);
             for (IndexEntry newEntry : indexEntries) {
-              System.out.println("Handle new put Entry for key " + newEntry.getKey());
               blobStoreStats.handleNewPutEntry(newEntry.getValue());
             }
             logger.trace("Store : {} message set written to index ", dataDir);

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -542,9 +542,11 @@ class IndexSegment {
       }
       if (resetKey == null) {
         PersistentIndex.IndexEntryType type = PersistentIndex.IndexEntryType.PUT;
-        if (entry.getValue().isFlagSet(IndexValue.Flags.Delete_Index)) {
+        if (entry.getValue().isDelete()) {
           type = PersistentIndex.IndexEntryType.DELETE;
-        } else if (entry.getValue().isFlagSet(IndexValue.Flags.Ttl_Update_Index)) {
+        } else if (entry.getValue().isUndelete()) {
+          type = PersistentIndex.IndexEntryType.UNDELETE;
+        } else if (entry.getValue().isTTLUpdate()) {
           type = PersistentIndex.IndexEntryType.TTL_UPDATE;
         }
         resetKey = new Pair<>(entry.getKey(), type);
@@ -969,7 +971,7 @@ class IndexSegment {
               "IndexSegment : {} ignoring index entry outside the log end offset that was not synced logEndOffset "
                   + "{} key {} entryOffset {} entrySize {} entryDeleteState {}", indexFile.getAbsolutePath(),
               logEndOffset, key, blobValue.getOffset(), blobValue.getSize(),
-              blobValue.isFlagSet(IndexValue.Flags.Delete_Index));
+              blobValue.isDelete());
         }
       }
       endOffset.set(new Offset(startOffset.getName(), maxEndOffset));

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -546,7 +546,7 @@ class IndexSegment {
           type = PersistentIndex.IndexEntryType.DELETE;
         } else if (entry.getValue().isUndelete()) {
           type = PersistentIndex.IndexEntryType.UNDELETE;
-        } else if (entry.getValue().isTTLUpdate()) {
+        } else if (entry.getValue().isTtlUpdate()) {
           type = PersistentIndex.IndexEntryType.TTL_UPDATE;
         }
         resetKey = new Pair<>(entry.getKey(), type);
@@ -1012,7 +1012,7 @@ class IndexSegment {
         getIndexEntriesSince(key, findEntriesCondition, indexEntries, currentTotalSizeOfEntriesInBytes, true);
     for (IndexEntry indexEntry : indexEntries) {
       IndexValue value = indexEntry.getValue();
-      MessageInfo info = new MessageInfo(indexEntry.getKey(), value.getSize(), value.isDelete(), value.isTTLUpdate(),
+      MessageInfo info = new MessageInfo(indexEntry.getKey(), value.getSize(), value.isDelete(), value.isTtlUpdate(),
           value.isUndelete(), value.getExpiresAtMs(), null, value.getAccountId(), value.getContainerId(),
           value.getOperationTimeInMs(), value.getLifeVersion());
       entries.add(info);

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexValue.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexValue.java
@@ -256,7 +256,7 @@ class IndexValue implements Comparable<IndexValue> {
    * Helper function for isFlagSet(Flags.Ttl_Update_Index).
    * @return true when the Ttl_Update_Index is set.
    */
-  boolean isTTLUpdate() {
+  boolean isTtlUpdate() {
     return isFlagSet(Flags.Ttl_Update_Index);
   }
 
@@ -435,7 +435,7 @@ class IndexValue implements Comparable<IndexValue> {
 
   @Override
   public String toString() {
-    return "Offset: " + offset + ", Size: " + getSize() + ", Deleted: " + isDelete() + ", TTL Updated: " + isTTLUpdate()
+    return "Offset: " + offset + ", Size: " + getSize() + ", Deleted: " + isDelete() + ", TTL Updated: " + isTtlUpdate()
         + ", Undelete: " + isUndelete() + ", ExpiresAtMs: " + getExpiresAtMs() + ", Original Message Offset: "
         + getOriginalMessageOffset() + (formatVersion != PersistentIndex.VERSION_0 ? (", OperationTimeAtSecs "
         + getOperationTimeInMs() + ", AccountId " + getAccountId() + ", ContainerId " + getContainerId()) : "") + (

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexValue.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexValue.java
@@ -55,8 +55,6 @@ class IndexValue implements Comparable<IndexValue> {
 
   final static byte FLAGS_DEFAULT_VALUE = (byte) 0;
   final static long UNKNOWN_ORIGINAL_MESSAGE_OFFSET = -1;
-  // The life version when the operation is trigger by the requests from frontend.
-  final static short LIFE_VERSION_FROM_FRONTEND = -1;
 
   private final static int BLOB_SIZE_IN_BYTES = 8;
   private final static int OFFSET_SIZE_IN_BYTES = 8;
@@ -328,7 +326,7 @@ class IndexValue implements Comparable<IndexValue> {
    * @return true when it's not from frontend requests.
    */
   static boolean hasLifeVersion(short lifeVersion) {
-    return lifeVersion > LIFE_VERSION_FROM_FRONTEND;
+    return lifeVersion > MessageInfo.LIFE_VERSION_FROM_FRONTEND;
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -608,7 +608,7 @@ class CuratedLogIndexState {
         retCandidate = value;
         break;
       } else if (types.contains(PersistentIndex.IndexEntryType.TTL_UPDATE) && !value.isDelete() && !value.isUndelete()
-          && value.isTTLUpdate()) {
+          && value.isTtlUpdate()) {
         retCandidate = value;
         break;
       } else if (types.contains(PersistentIndex.IndexEntryType.PUT) && value.isPut()) {
@@ -619,8 +619,8 @@ class CuratedLogIndexState {
 
     if (retCandidate != null) {
       IndexValue latest = toConsider.get(toConsider.size() - 1);
-      if (latest.getExpiresAtMs() != retCandidate.getExpiresAtMs() || (!retCandidate.isTTLUpdate()
-          && latest.isTTLUpdate())) {
+      if (latest.getExpiresAtMs() != retCandidate.getExpiresAtMs() || (!retCandidate.isTtlUpdate()
+          && latest.isTtlUpdate())) {
         retCandidate = new IndexValue(retCandidate.getOffset().getName(), retCandidate.getBytes(),
             retCandidate.getFormatVersion());
         retCandidate.setFlag(IndexValue.Flags.Ttl_Update_Index);

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -275,7 +275,7 @@ class CuratedLogIndexState {
    * @throws StoreException
    */
   FileSpan makePermanent(MockId id, boolean forcePut) throws StoreException {
-    return makePermanent(id, forcePut, IndexValue.LIFE_VERSION_FROM_FRONTEND);
+    return makePermanent(id, forcePut, MessageInfo.LIFE_VERSION_FROM_FRONTEND);
   }
 
   /**
@@ -353,7 +353,7 @@ class CuratedLogIndexState {
   }
 
   FileSpan addDeleteEntry(MockId idToDelete, MessageInfo info) throws StoreException {
-    return addDeleteEntry(idToDelete, info, IndexValue.LIFE_VERSION_FROM_FRONTEND);
+    return addDeleteEntry(idToDelete, info, MessageInfo.LIFE_VERSION_FROM_FRONTEND);
   }
 
   /**
@@ -444,7 +444,7 @@ class CuratedLogIndexState {
    * @throws StoreException
    */
   FileSpan addUndeleteEntry(MockId idToDelete) throws StoreException {
-    return addUndeleteEntry(idToDelete, IndexValue.LIFE_VERSION_FROM_FRONTEND);
+    return addUndeleteEntry(idToDelete, MessageInfo.LIFE_VERSION_FROM_FRONTEND);
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/IndexTest.java
@@ -135,7 +135,7 @@ public class IndexTest {
     assertNotNull("Version 3 should be able to read version 2 expired key", value);
     assertEquals("Version doesn't match", PersistentIndex.VERSION_2, value.getFormatVersion());
     assertFalse("Not deleted", value.isDelete());
-    assertFalse("Not ttlupdated", value.isTTLUpdate());
+    assertFalse("Not ttlupdated", value.isTtlUpdate());
 
     value = state.index.findKey(state.deletedKeys.iterator().next());
     assertNotNull("Version 3 should be able to read version 2 deleted key", value);
@@ -374,7 +374,7 @@ public class IndexTest {
     assertNotNull(value);
     assertTrue("targetKey is not undeleted", value.isUndelete());
     assertTrue("targetKey has delete flag", !value.isDelete());
-    assertEquals("Ttl update flag mismatch", expectTtlUpdateSet, value.isTTLUpdate());
+    assertEquals("Ttl update flag mismatch", expectTtlUpdateSet, value.isTtlUpdate());
     actualLifeVersion = value.getLifeVersion();
     assertEquals("Life version isn't " + expectedLifeVersion + " but " + actualLifeVersion, expectedLifeVersion,
         actualLifeVersion);
@@ -2482,7 +2482,7 @@ public class IndexTest {
       long operationTimeMs = undeleteValue != null ? undeleteValue.getOperationTimeInMs()
           : deleteValue != null ? deleteValue.getOperationTimeInMs()
               : ttlUpdateValue != null ? ttlUpdateValue.getOperationTimeInMs() : putValue.getOperationTimeInMs();
-      boolean isTtlUpdated = undeleteValue != null ? undeleteValue.isTTLUpdate()
+      boolean isTtlUpdated = undeleteValue != null ? undeleteValue.isTtlUpdate()
           : deleteValue != null ? deleteValue.isFlagSet(IndexValue.Flags.Ttl_Update_Index) : ttlUpdateValue != null;
       // if a key is updated, it doesn't matter if we reached the update record or not, the updated state will be
       // the one that is returned.


### PR DESCRIPTION
BlobStore doesn't support operations where the lifeVersion is not -1. It always assume those operations are from frontend. This PR extends support to replication.

After this PR, BlobStore will be able to put, ttl update, delete and undelete a blob that should have a higher lifeVersion.