### PR TITLE
Fix NPE in router metrics when handling newly added nodes

### DIFF
--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -762,6 +762,7 @@ public class GetBlobOperationTest {
     mockServerLayout.addMockServers(newNodes, mockClusterMap);
     // put a composite blob which should go to new partitions on new nodes only
     doPut();
+    // make sure get blob from new partitions on new nodes succeeds
     getAndAssertSuccess();
   }
 

--- a/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/GetBlobOperationTest.java
@@ -17,7 +17,10 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockDataNodeId;
+import com.github.ambry.clustermap.MockPartitionId;
 import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.clustermap.PartitionState;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.BlobIdFactory;
@@ -738,6 +741,28 @@ public class GetBlobOperationTest {
     }
     getErrorCodeChecker.testAndAssert(RouterErrorCode.BlobDoesNotExist);
     mockServerLayout.getMockServers().forEach(MockServer::resetServerErrors);
+  }
+
+  /**
+   * Test the case new nodes/partitions are dynamically added and router should be able to route quests to new replicas
+   * and add new nodes into router metrics (if they are not present previously)
+   */
+  @Test
+  public void testGetBlobFromNewAddedNode() throws Exception {
+    // create 3 new nodes in mock clustermap and place new partitions on these nodes.
+    List<MockDataNodeId> newNodes = mockClusterMap.createNewDataNodes(3, LOCAL_DC);
+    // make all existing partitions READ_ONLY to force router to route PUT against new partitions
+    mockClusterMap.getAllPartitionIds(null)
+        .forEach(p -> ((MockPartitionId) p).setPartitionState(PartitionState.READ_ONLY));
+    // create 3 new partitions on new nodes
+    for (int i = 0; i < 3; ++i) {
+      mockClusterMap.createNewPartition(newNodes);
+    }
+    // add new nodes to mock server layout
+    mockServerLayout.addMockServers(newNodes, mockClusterMap);
+    // put a composite blob which should go to new partitions on new nodes only
+    doPut();
+    getAndAssertSuccess();
   }
 
   /**

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServerLayout.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServerLayout.java
@@ -42,6 +42,11 @@ class MockServerLayout {
     }
   }
 
+  /**
+   * Dynamically add new mock servers into layout.
+   * @param newNodes a list of new nodes to add.
+   * @param clusterMap the {@link ClusterMap} used to associate a host and port with a MockServer.
+   */
   public void addMockServers(List<? extends DataNodeId> newNodes, ClusterMap clusterMap) {
     newNodes.forEach(node -> mockServers.putIfAbsent(node, new MockServer(clusterMap, node.getDatacenterName())));
   }

--- a/ambry-router/src/test/java/com.github.ambry.router/MockServerLayout.java
+++ b/ambry-router/src/test/java/com.github.ambry.router/MockServerLayout.java
@@ -18,6 +18,7 @@ import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.protocol.RequestOrResponseType;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -39,6 +40,10 @@ class MockServerLayout {
     for (DataNodeId dataNodeId : clusterMap.getDataNodeIds()) {
       mockServers.put(dataNodeId, new MockServer(clusterMap, dataNodeId.getDatacenterName()));
     }
+  }
+
+  public void addMockServers(List<? extends DataNodeId> newNodes, ClusterMap clusterMap) {
+    newNodes.forEach(node -> mockServers.putIfAbsent(node, new MockServer(clusterMap, node.getDatacenterName())));
   }
 
   /**

--- a/ambry-server/src/test/java/com.github.ambry.server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com.github.ambry.server/AmbryServerRequestsTest.java
@@ -516,7 +516,7 @@ public class AmbryServerRequestsTest {
     // create newPartition1 that no replica sits on current node.
     List<MockDataNodeId> dataNodes = clusterMap.getDataNodes()
         .stream()
-        .filter(node -> !node.getHostname().equals(dataNodeId.getHostname()) && node.getPort() != dataNodeId.getPort())
+        .filter(node -> !node.getHostname().equals(dataNodeId.getHostname()) || node.getPort() != dataNodeId.getPort())
         .collect(Collectors.toList());
     PartitionId newPartition1 = clusterMap.createNewPartition(dataNodes);
     // test that getting new replica from cluster map fails

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
@@ -119,6 +119,10 @@ public class MockPartitionId implements PartitionId {
     return true;
   }
 
+  /**
+   * Set state of this partition.
+   * @param state the {@link PartitionState} associated with this partition.
+   */
   public void setPartitionState(PartitionState state) {
     partitionState = state;
   }

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
@@ -119,6 +119,10 @@ public class MockPartitionId implements PartitionId {
     return true;
   }
 
+  public void setPartitionState(PartitionState state) {
+    partitionState = state;
+  }
+
   /**
    * If all replicaIds == !isSealed, then partition status = Read-Write, else Read-Only
    */


### PR DESCRIPTION
There is a NPE issue in GetBlobOpertion/DeleteOperation/TtlUpdateOperation due to node level metic not found in router metrics. This happens when we dynamically add new nodes/partitions to cluster. The 
frontend is able to get new replicas but can't find NodeLevelMetric associated with the new nodes that host these new replicas and NullPointerException occurs afterwards. To fix this, we allow router
metrics to dynamically add new node metric if it's not present previously.