### PR TITLE
Fix hard deleter bug when the startToken is journal-based token

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/HardDeleter.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/HardDeleter.java
@@ -863,7 +863,8 @@ public class HardDeleter implements Runnable {
      */
     int compareTwoTokens(StoreFindToken token1, StoreFindToken token2) {
       if (token1.getType() != FindTokenType.IndexBased || token2.getType() != FindTokenType.IndexBased) {
-        throw new IllegalStateException("Tokens need to be index based. First: " + token1 + " Second: " + token2);
+        throw new IllegalStateException(
+            "At store " + dataDir + " Tokens need to be index based. First: " + token1 + " Second: " + token2);
       }
       if (token1.equals(token2)) {
         return 0;


### PR DESCRIPTION
We are seeing lots of hard deleter failure from EI. 
```java.lang.IllegalStateException: Tokens need to be index based. First: version: 2 type: JournalBased incarnationId fdfd41b1-3e2b-4608-bffd-8778bba28b3f inclusiveness false sessionId 9246ffbe-b7b5-4b0f-a26a-ca9330260b31 offset Name = [58_0] Offset = [2147389511] bytesRead -1 Second: version: 2 type: IndexBased incarnationId fdfd41b1-3e2b-4608-bffd-8778bba28b3f inclusiveness false sessionId 75037dd0-9ac3-4983-a8fa-b1e423cba745 storeKey AAYQAgQrAAgAAQAAAAAAAACThd34PDz9Qgy0m8c6AcMhng offset Name = [58_0] Offset = [18] bytesRead -1
at com.github.ambry.store.HardDeleter$HardDeletePersistInfo.compareTwoTokens(HardDeleter.java:853)
at com.github.ambry.store.HardDeleter$HardDeletePersistInfo.pruneTill(HardDeleter.java:835)
at com.github.ambry.store.HardDeleter.pruneHardDeleteRecoveryRange(HardDeleter.java:290)
at com.github.ambry.store.HardDeleter.postLogFlush(HardDeleter.java:384)
at com.github.ambry.store.PersistentIndex$IndexPersistor.write(PersistentIndex.java:1949)
at com.github.ambry.store.PersistentIndex$IndexPersistor.run(PersistentIndex.java:1989)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)```
This also cause compaction to fail. 

The root cause of this exception is that startToken for some blobReadOption is journalBased, but we didn't include the logic to deal with it, instead we just throw an exception.