### PR TITLE
Misc fixes in adaptive tracker, cluster manager and partition state model

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.server.AmbryHealthReport;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -86,10 +87,10 @@ public interface ClusterParticipant extends AutoCloseable {
   boolean updateDataNodeInfoInCluster(ReplicaId replicaId, boolean shouldExist);
 
   /**
-   * Initialize participant related metrics if needed.
-   * @param localPartitionCount total number of partitions on local node.
+   * Set initial local partitions that the cluster participant hosts.
+   * @param localPartitions a collection of initial local partitions.
    */
-  default void initializeParticipantMetrics(int localPartitionCount) {
+  default void setInitialLocalPartitions(Collection<String> localPartitions) {
   }
 
   /**

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/PartitionStateChangeListener.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/PartitionStateChangeListener.java
@@ -59,4 +59,25 @@ public interface PartitionStateChangeListener {
    * @param partitionName of the partition.
    */
   void onPartitionBecomeDroppedFromOffline(String partitionName);
+
+  /**
+   * Action to take when partition becomes dropped from error.
+   * @param partitionName of the partition.
+   */
+  default void onPartitionBecomeDroppedFromError(String partitionName) {
+  }
+
+  /**
+   * Action to take when partition becomes offline from error.
+   * @param partitionName of the partition.
+   */
+  default void onPartitionBecomeOfflineFromError(String partitionName) {
+  }
+
+  /**
+   * Action to take when reset method is called on certain partition.
+   * @param partitionName of the partition.
+   */
+  default void onReset(String partitionName) {
+  }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryPartitionStateModel.java
@@ -130,6 +130,13 @@ public class AmbryPartitionStateModel extends StateModel {
     helixParticipantMetrics.partitionDroppedCount.inc();
   }
 
+  @Transition(to = "OFFLINE", from = "ERROR")
+  public void onBecomeOfflineFromError(Message message, NotificationContext context){
+    logger.info("Partition {} in resource {} is becoming OFFLINE from ERROR", message.getPartitionName(),
+        message.getResourceName());
+    helixParticipantMetrics.offlineCount.addAndGet(1);
+  }
+
   @Override
   public void reset() {
     logger.info("Reset method invoked. Partition {} in resource {} is reset to OFFLINE", partitionName, resourceName);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryStateModelFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryStateModelFactory.java
@@ -25,13 +25,10 @@ import org.apache.helix.participant.statemachine.StateModelFactory;
 class AmbryStateModelFactory extends StateModelFactory<StateModel> {
   private final ClusterMapConfig clustermapConfig;
   private final PartitionStateChangeListener partitionStateChangeListener;
-  private final HelixParticipantMetrics helixParticipantMetrics;
 
-  AmbryStateModelFactory(ClusterMapConfig clusterMapConfig, PartitionStateChangeListener partitionStateChangeListener,
-      HelixParticipantMetrics helixParticipantMetrics) {
+  AmbryStateModelFactory(ClusterMapConfig clusterMapConfig, PartitionStateChangeListener partitionStateChangeListener) {
     this.clustermapConfig = clusterMapConfig;
     this.partitionStateChangeListener = partitionStateChangeListener;
-    this.helixParticipantMetrics = helixParticipantMetrics;
   }
 
   /**
@@ -46,8 +43,7 @@ class AmbryStateModelFactory extends StateModelFactory<StateModel> {
     switch (clustermapConfig.clustermapStateModelDefinition) {
       case AmbryStateModelDefinition.AMBRY_LEADER_STANDBY_MODEL:
         stateModelToReturn =
-            new AmbryPartitionStateModel(resourceName, partitionName, partitionStateChangeListener, clustermapConfig,
-                helixParticipantMetrics);
+            new AmbryPartitionStateModel(resourceName, partitionName, partitionStateChangeListener, clustermapConfig);
         break;
       case LeaderStandbySMD.name:
         stateModelToReturn = new DefaultLeaderStandbyStateModel();

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DynamicClusterChangeHandler.java
@@ -333,7 +333,8 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
       Map<String, String> diskInfo = entry.getValue();
       AmbryDisk disk = mountPathToDisk.getOrDefault(mountPath, null);
       if (disk == null) {
-        logger.info("Temporarily don't support adding new disk to existing node.");
+        logger.info("{} is a new disk or unrecognizable disk which is not supported on existing node {}.", mountPath,
+            instanceName);
         // TODO support dynamically adding disk in the future
         continue;
       }
@@ -472,6 +473,13 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
     for (Map.Entry<String, Map<String, String>> entry : diskInfos.entrySet()) {
       String mountPath = entry.getKey();
       Map<String, String> diskInfo = entry.getValue();
+      if (diskInfo.get(DISK_STATE) == null) {
+        // This may happen when Helix controller adds partitions in ERROR state to InstanceConfig. (The additional string
+        // is not recognizable for current HelixClusterManager)
+        logger.warn("{} is invalid disk info on {}. Skip it and continue on next one.", mountPath,
+            instanceConfig.getInstanceName());
+        continue;
+      }
       HardwareState diskState =
           diskInfo.get(DISK_STATE).equals(AVAILABLE_STR) ? HardwareState.AVAILABLE : HardwareState.UNAVAILABLE;
       long capacityBytes = Long.parseLong(diskInfo.get(DISK_CAPACITY_STR));

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DynamicClusterChangeHandler.java
@@ -333,7 +333,7 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
       Map<String, String> diskInfo = entry.getValue();
       AmbryDisk disk = mountPathToDisk.getOrDefault(mountPath, null);
       if (disk == null) {
-        logger.info("{} is a new disk or unrecognizable disk which is not supported on existing node {}.", mountPath,
+        logger.warn("{} is a new disk or unrecognizable disk which is not supported on existing node {}.", mountPath,
             instanceName);
         // TODO support dynamically adding disk in the future
         continue;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -20,12 +20,14 @@ import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
@@ -48,11 +50,12 @@ import static com.github.ambry.clustermap.StateTransitionException.TransitionErr
  * An implementation of {@link ClusterParticipant} that registers as a participant to a Helix cluster.
  */
 public class HelixParticipant implements ClusterParticipant, PartitionStateChangeListener {
+  protected final HelixParticipantMetrics participantMetrics;
   private final String clusterName;
   private final String zkConnectStr;
   private final Object helixAdministrationLock = new Object();
   private final ClusterMapConfig clusterMapConfig;
-  private final HelixParticipantMetrics participantMetrics;
+  private final Set<String> localPartitions = ConcurrentHashMap.newKeySet();
   private HelixManager manager;
   private String instanceName;
   private HelixAdmin helixAdmin;
@@ -76,7 +79,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     instanceName =
         ClusterMapUtils.getInstanceName(clusterMapConfig.clusterMapHostName, clusterMapConfig.clusterMapPort);
     if (clusterName.isEmpty()) {
-      throw new IllegalStateException("Clustername is empty in clusterMapConfig");
+      throw new IllegalStateException("Cluster name is empty in clusterMapConfig");
     }
     try {
       zkConnectStr = ClusterMapUtils.parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings)
@@ -94,8 +97,9 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   }
 
   @Override
-  public void initializeParticipantMetrics(int localPartitionCount) {
-    participantMetrics.setLocalPartitionCount(localPartitionCount);
+  public void setInitialLocalPartitions(Collection<String> localPartitions) {
+    this.localPartitions.addAll(localPartitions);
+    participantMetrics.setLocalPartitionCount(localPartitions.size());
   }
 
   /**
@@ -110,7 +114,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         clusterMapConfig.clustermapStateModelDefinition);
     StateMachineEngine stateMachineEngine = manager.getStateMachineEngine();
     stateMachineEngine.registerStateModelFactory(clusterMapConfig.clustermapStateModelDefinition,
-        new AmbryStateModelFactory(clusterMapConfig, this, participantMetrics));
+        new AmbryStateModelFactory(clusterMapConfig, this));
     registerHealthReportTasks(stateMachineEngine, ambryHealthReports);
     try {
       synchronized (helixAdministrationLock) {
@@ -454,24 +458,37 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
 
   @Override
   public void onPartitionBecomeBootstrapFromOffline(String partitionName) {
-    // 1. take actions in storage manager (add new replica if necessary)
-    PartitionStateChangeListener storageManagerListener =
-        partitionStateChangeListeners.get(StateModelListenerType.StorageManagerListener);
-    if (storageManagerListener != null) {
-      storageManagerListener.onPartitionBecomeBootstrapFromOffline(partitionName);
+    // this method may be called when dynamically adding a new replica that is not present on local node previously. In
+    // this case we don't change offline count as the metric was set to initial number of local partitions during startup.
+    int offlineCountChange = localPartitions.contains(partitionName) ? -1 : 0;
+    try {
+      // 1. take actions in storage manager (add new replica if necessary)
+      PartitionStateChangeListener storageManagerListener =
+          partitionStateChangeListeners.get(StateModelListenerType.StorageManagerListener);
+      if (storageManagerListener != null) {
+        storageManagerListener.onPartitionBecomeBootstrapFromOffline(partitionName);
+      }
+      // 2. take actions in replication manager (add new replica if necessary)
+      PartitionStateChangeListener replicationManagerListener =
+          partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
+      if (replicationManagerListener != null) {
+        replicationManagerListener.onPartitionBecomeBootstrapFromOffline(partitionName);
+      }
+      // 3. take actions in stats manager (add new replica if necessary)
+      PartitionStateChangeListener statsManagerListener =
+          partitionStateChangeListeners.get(StateModelListenerType.StatsManagerListener);
+      if (statsManagerListener != null) {
+        statsManagerListener.onPartitionBecomeBootstrapFromOffline(partitionName);
+      }
+    } catch (Exception e) {
+      participantMetrics.offlineCount.addAndGet(offlineCountChange);
+      participantMetrics.errorStateCount.addAndGet(1);
+      throw e;
     }
-    // 2. take actions in replication manager (add new replica if necessary)
-    PartitionStateChangeListener replicationManagerListener =
-        partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
-    if (replicationManagerListener != null) {
-      replicationManagerListener.onPartitionBecomeBootstrapFromOffline(partitionName);
-    }
-    // 3. take actions in stats manager (add new replica if necessary)
-    PartitionStateChangeListener statsManagerListener =
-        partitionStateChangeListeners.get(StateModelListenerType.StatsManagerListener);
-    if (statsManagerListener != null) {
-      statsManagerListener.onPartitionBecomeBootstrapFromOffline(partitionName);
-    }
+    participantMetrics.offlineCount.addAndGet(offlineCountChange);
+    participantMetrics.bootstrapCount.addAndGet(1);
+    // Here we directly add the partition into set even though it may already exit because the op should be idempotent)
+    localPartitions.add(partitionName);
   }
 
   @Override
@@ -479,37 +496,59 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     PartitionStateChangeListener replicationManagerListener =
         partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
     if (replicationManagerListener != null) {
-      replicationManagerListener.onPartitionBecomeStandbyFromBootstrap(partitionName);
-      // after bootstrap is initiated in ReplicationManager, transition is blocked here and wait until local replica has
-      // caught up with enough peer replicas.
       try {
+        replicationManagerListener.onPartitionBecomeStandbyFromBootstrap(partitionName);
+        // after bootstrap is initiated in ReplicationManager, transition is blocked here and wait until local replica has
+        // caught up with enough peer replicas.
         replicaSyncUpManager.waitBootstrapCompleted(partitionName);
       } catch (InterruptedException e) {
         logger.error("Bootstrap was interrupted on partition {}", partitionName);
+        participantMetrics.bootstrapCount.addAndGet(-1);
+        participantMetrics.errorStateCount.addAndGet(1);
         throw new StateTransitionException("Bootstrap failed or was interrupted", BootstrapFailure);
       } catch (StateTransitionException e) {
         logger.error("Bootstrap didn't complete on partition {}", partitionName, e);
+        participantMetrics.bootstrapCount.addAndGet(-1);
+        participantMetrics.errorStateCount.addAndGet(1);
         throw e;
       }
     }
+    participantMetrics.bootstrapCount.addAndGet(-1);
+    participantMetrics.standbyCount.addAndGet(1);
   }
 
   @Override
   public void onPartitionBecomeLeaderFromStandby(String partitionName) {
-    PartitionStateChangeListener cloudToStoreReplicationListener =
-        partitionStateChangeListeners.get(StateModelListenerType.CloudToStoreReplicationManagerListener);
-    if (cloudToStoreReplicationListener != null) {
-      cloudToStoreReplicationListener.onPartitionBecomeLeaderFromStandby(partitionName);
+    try {
+      PartitionStateChangeListener cloudToStoreReplicationListener =
+          partitionStateChangeListeners.get(StateModelListenerType.CloudToStoreReplicationManagerListener);
+      if (cloudToStoreReplicationListener != null) {
+        cloudToStoreReplicationListener.onPartitionBecomeLeaderFromStandby(partitionName);
+      }
+    } catch (Exception e) {
+      participantMetrics.standbyCount.addAndGet(-1);
+      participantMetrics.errorStateCount.addAndGet(1);
+      throw e;
     }
+    participantMetrics.standbyCount.addAndGet(-1);
+    participantMetrics.leaderCount.addAndGet(1);
   }
 
   @Override
   public void onPartitionBecomeStandbyFromLeader(String partitionName) {
-    PartitionStateChangeListener cloudToStoreReplicationListener =
-        partitionStateChangeListeners.get(StateModelListenerType.CloudToStoreReplicationManagerListener);
-    if (cloudToStoreReplicationListener != null) {
-      cloudToStoreReplicationListener.onPartitionBecomeStandbyFromLeader(partitionName);
+    try {
+      PartitionStateChangeListener cloudToStoreReplicationListener =
+          partitionStateChangeListeners.get(StateModelListenerType.CloudToStoreReplicationManagerListener);
+      if (cloudToStoreReplicationListener != null) {
+        cloudToStoreReplicationListener.onPartitionBecomeStandbyFromLeader(partitionName);
+      }
+    } catch (Exception e) {
+      participantMetrics.leaderCount.addAndGet(-1);
+      participantMetrics.errorStateCount.addAndGet(1);
+      throw e;
     }
+    participantMetrics.leaderCount.addAndGet(-1);
+    participantMetrics.standbyCount.addAndGet(1);
   }
 
   @Override
@@ -518,26 +557,38 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     PartitionStateChangeListener storageManagerListener =
         partitionStateChangeListeners.get(StateModelListenerType.StorageManagerListener);
     if (storageManagerListener != null) {
-      storageManagerListener.onPartitionBecomeInactiveFromStandby(partitionName);
+      try {
+        storageManagerListener.onPartitionBecomeInactiveFromStandby(partitionName);
+      } catch (Exception e) {
+        participantMetrics.standbyCount.addAndGet(-1);
+        participantMetrics.errorStateCount.addAndGet(1);
+        throw e;
+      }
     }
     // 2. replication manager initiates deactivation
     PartitionStateChangeListener replicationManagerListener =
         partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
     if (replicationManagerListener != null) {
-      replicationManagerListener.onPartitionBecomeInactiveFromStandby(partitionName);
-      // after deactivation is initiated in ReplicationManager, transition is blocked here and wait until enough peer
-      // replicas have caught up with last PUT in local store.
       try {
+        replicationManagerListener.onPartitionBecomeInactiveFromStandby(partitionName);
+        // after deactivation is initiated in ReplicationManager, transition is blocked here and wait until enough peer
+        // replicas have caught up with last PUT in local store.
         // TODO considering moving wait deactivation logic into replication manager listener
         replicaSyncUpManager.waitDeactivationCompleted(partitionName);
       } catch (InterruptedException e) {
         logger.error("Deactivation was interrupted on partition {}", partitionName);
+        participantMetrics.standbyCount.addAndGet(-1);
+        participantMetrics.errorStateCount.addAndGet(1);
         throw new StateTransitionException("Deactivation failed or was interrupted", DeactivationFailure);
       } catch (StateTransitionException e) {
         logger.error("Deactivation didn't complete on partition {}", partitionName, e);
+        participantMetrics.standbyCount.addAndGet(-1);
+        participantMetrics.errorStateCount.addAndGet(1);
         throw e;
       }
     }
+    participantMetrics.standbyCount.addAndGet(-1);
+    participantMetrics.inactiveCount.addAndGet(1);
   }
 
   @Override
@@ -545,19 +596,23 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     PartitionStateChangeListener replicationManagerListener =
         partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
     if (replicationManagerListener != null) {
-      // 1. take actions in replication manager
-      //    (1) set local store state to OFFLINE
-      //    (2) initiate disconnection in ReplicaSyncUpManager
-      replicationManagerListener.onPartitionBecomeOfflineFromInactive(partitionName);
-      // 2. wait until peer replicas have caught up with local replica
       try {
+        // 1. take actions in replication manager
+        //    (1) set local store state to OFFLINE
+        //    (2) initiate disconnection in ReplicaSyncUpManager
+        replicationManagerListener.onPartitionBecomeOfflineFromInactive(partitionName);
+        // 2. wait until peer replicas have caught up with local replica
         // TODO considering moving wait disconnection logic into replication manager listener
         replicaSyncUpManager.waitDisconnectionCompleted(partitionName);
       } catch (InterruptedException e) {
         logger.error("Disconnection was interrupted on partition {}", partitionName);
+        participantMetrics.inactiveCount.addAndGet(-1);
+        participantMetrics.errorStateCount.addAndGet(1);
         throw new StateTransitionException("Disconnection failed or was interrupted", DisconnectionFailure);
       } catch (StateTransitionException e) {
         logger.error("Disconnection didn't complete ", e);
+        participantMetrics.inactiveCount.addAndGet(-1);
+        participantMetrics.errorStateCount.addAndGet(1);
         throw e;
       }
     }
@@ -565,8 +620,16 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     PartitionStateChangeListener storageManagerListener =
         partitionStateChangeListeners.get(StateModelListenerType.StorageManagerListener);
     if (storageManagerListener != null) {
-      storageManagerListener.onPartitionBecomeOfflineFromInactive(partitionName);
+      try {
+        storageManagerListener.onPartitionBecomeOfflineFromInactive(partitionName);
+      } catch (Exception e) {
+        participantMetrics.inactiveCount.addAndGet(-1);
+        participantMetrics.errorStateCount.addAndGet(1);
+        throw e;
+      }
     }
+    participantMetrics.inactiveCount.addAndGet(-1);
+    participantMetrics.offlineCount.addAndGet(1);
   }
 
   @Override
@@ -576,7 +639,32 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     PartitionStateChangeListener storageManagerListener =
         partitionStateChangeListeners.get(StateModelListenerType.StorageManagerListener);
     if (storageManagerListener != null) {
-      storageManagerListener.onPartitionBecomeDroppedFromOffline(partitionName);
+      try {
+        storageManagerListener.onPartitionBecomeDroppedFromOffline(partitionName);
+      } catch (Exception e) {
+        participantMetrics.offlineCount.addAndGet(-1);
+        participantMetrics.errorStateCount.addAndGet(1);
+        throw e;
+      }
     }
+    participantMetrics.offlineCount.addAndGet(-1);
+    participantMetrics.partitionDroppedCount.inc();
+  }
+
+  @Override
+  public void onPartitionBecomeDroppedFromError(String partitionName) {
+    participantMetrics.errorStateCount.addAndGet(-1);
+    participantMetrics.partitionDroppedCount.inc();
+  }
+
+  @Override
+  public void onPartitionBecomeOfflineFromError(String partitionName) {
+    participantMetrics.errorStateCount.addAndGet(-1);
+    participantMetrics.offlineCount.addAndGet(1);
+  }
+
+  @Override
+  public void onReset(String partitionName) {
+    participantMetrics.offlineCount.addAndGet(1);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
@@ -47,6 +47,9 @@ class HelixParticipantMetrics {
     Gauge<Integer> offlinePartitionCount = offlineCount::get;
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "offlinePartitionCount"),
         offlinePartitionCount);
+    Gauge<Integer> errorStatePartitionCount = errorStateCount::get;
+    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "errorStatePartitionCount"),
+        errorStatePartitionCount);
     partitionDroppedCount =
         metricRegistry.counter(MetricRegistry.name(HelixParticipant.class, "partitionDroppedCount"));
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
@@ -28,6 +28,7 @@ class HelixParticipantMetrics {
   final AtomicInteger leaderCount = new AtomicInteger();
   final AtomicInteger inactiveCount = new AtomicInteger();
   final AtomicInteger offlineCount = new AtomicInteger();
+  final AtomicInteger errorStateCount = new AtomicInteger();
   // no need to record exact number of "dropped" partition, a counter to track partition-dropped events would suffice
   final Counter partitionDroppedCount;
 
@@ -57,8 +58,8 @@ class HelixParticipantMetrics {
   void setLocalPartitionCount(int partitionCount) {
     // this method should be invoked before participation, so the initial value is expected to be 0.
     if (!offlineCount.compareAndSet(0, partitionCount)) {
-      throw new IllegalStateException(
-          "Number of OFFLINE partitions has changed before initializing participant metrics");
+      throw new IllegalStateException("Number of OFFLINE partitions has changed to " + offlineCount.get()
+          + " before initializing participant metrics ");
     }
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManagerTest.java
@@ -77,13 +77,13 @@ public class AmbryReplicaSyncUpManagerTest {
     properties.setProperty("clustermap.enable.state.model.listener", Boolean.toString(true));
     properties.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(properties));
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
     mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
     replicaSyncUpService = (AmbryReplicaSyncUpManager) mockHelixParticipant.getReplicaSyncUpManager();
     mockHelixParticipant.currentReplica = currentReplica;
     mockHelixParticipant.replicaSyncUpService = replicaSyncUpService;
     stateModel =
-        new AmbryPartitionStateModel(RESOURCE_NAME, partition.toPathString(), mockHelixParticipant, clusterMapConfig,
-            new HelixParticipantMetrics(new MetricRegistry()));
+        new AmbryPartitionStateModel(RESOURCE_NAME, partition.toPathString(), mockHelixParticipant, clusterMapConfig);
     mockMessage = Mockito.mock(Message.class);
     when(mockMessage.getPartitionName()).thenReturn(partition.toPathString());
     when(mockMessage.getResourceName()).thenReturn(RESOURCE_NAME);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
@@ -177,10 +177,14 @@ public class AmbryStateModelFactoryTest {
     assertEquals("Offline count should be 0", 0,
         metricRegistry.getGauges().get(HelixParticipant.class.getName() + ".offlinePartitionCount").getValue());
     assertEquals("Dropped count should be updated", 1, participantMetrics.partitionDroppedCount.getCount());
+    // ERROR -> OFFLINE (this occurs when we use Helix API to reset certain partition in ERROR state)
+    stateModel.onBecomeOfflineFromError(mockMessage, null);
+    assertEquals("Offline count should be 1", 1,
+        metricRegistry.getGauges().get(HelixParticipant.class.getName() + ".offlinePartitionCount").getValue());
 
     // reset method
     stateModel.reset();
-    assertEquals("Offline count should be 1 after reset", 1,
+    assertEquals("Offline count should be 1 after reset", 2,
         metricRegistry.getGauges().get(HelixParticipant.class.getName() + ".offlinePartitionCount").getValue());
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
@@ -19,6 +19,8 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.TestUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import org.apache.helix.model.Message;
@@ -59,6 +61,7 @@ public class AmbryStateModelFactoryTest {
     props.setProperty("clustermap.datacenter.name", "DC0");
     props.setProperty("clustermap.state.model.definition", stateModelDef);
     props.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
+    props.setProperty("clustermap.enable.state.model.listener", Boolean.toString(true));
     config = new ClusterMapConfig(new VerifiableProperties(props));
     this.stateModelDef = stateModelDef;
   }
@@ -100,7 +103,7 @@ public class AmbryStateModelFactoryTest {
       public void onPartitionBecomeDroppedFromOffline(String partitionName) {
         // no op
       }
-    }, new HelixParticipantMetrics(new MetricRegistry()));
+    });
     StateModel stateModel;
     switch (config.clustermapStateModelDefinition) {
       case ClusterMapConfig.OLD_STATE_MODEL_DEF:
@@ -123,17 +126,18 @@ public class AmbryStateModelFactoryTest {
   @Test
   public void testAmbryPartitionStateModel() throws Exception {
     assumeTrue(stateModelDef.equals(ClusterMapConfig.AMBRY_STATE_MODEL_DEF));
-    MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(config);
     MetricRegistry metricRegistry = new MetricRegistry();
-    HelixParticipantMetrics participantMetrics = new HelixParticipantMetrics(metricRegistry);
+    MockHelixParticipant.metricRegistry = metricRegistry;
+    MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(config);
+    HelixParticipantMetrics participantMetrics = mockHelixParticipant.getHelixParticipantMetrics();
     String resourceName = "0";
     String partitionName = "1";
     Message mockMessage = Mockito.mock(Message.class);
     when(mockMessage.getPartitionName()).thenReturn(partitionName);
     when(mockMessage.getResourceName()).thenReturn(resourceName);
     AmbryPartitionStateModel stateModel =
-        new AmbryPartitionStateModel(resourceName, partitionName, mockHelixParticipant, config, participantMetrics);
-    participantMetrics.setLocalPartitionCount(1);
+        new AmbryPartitionStateModel(resourceName, partitionName, mockHelixParticipant, config);
+    mockHelixParticipant.setInitialLocalPartitions(new HashSet<>(Collections.singletonList(partitionName)));
     assertEquals("Offline count is not expected", 1,
         metricRegistry.getGauges().get(HelixParticipant.class.getName() + ".offlinePartitionCount").getValue());
     // OFFLINE -> BOOTSTRAP

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
@@ -181,11 +181,13 @@ public class AmbryStateModelFactoryTest {
     assertEquals("Offline count should be 0", 0,
         metricRegistry.getGauges().get(HelixParticipant.class.getName() + ".offlinePartitionCount").getValue());
     assertEquals("Dropped count should be updated", 1, participantMetrics.partitionDroppedCount.getCount());
+    // ERROR -> DROPPED
+    stateModel.onBecomeDroppedFromError(mockMessage, null);
+    assertEquals("Dropped count should be updated", 2, participantMetrics.partitionDroppedCount.getCount());
     // ERROR -> OFFLINE (this occurs when we use Helix API to reset certain partition in ERROR state)
     stateModel.onBecomeOfflineFromError(mockMessage, null);
     assertEquals("Offline count should be 1", 1,
         metricRegistry.getGauges().get(HelixParticipant.class.getName() + ".offlinePartitionCount").getValue());
-
     // reset method
     stateModel.reset();
     assertEquals("Offline count should be 1 after reset", 2,

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
@@ -244,6 +244,10 @@ public class ClusterChangeHandlerTest {
     dcsToZkInfo.get(localDc).setPort(savedport);
   }
 
+  /**
+   * Test that {@link DynamicClusterChangeHandler} is able to handle invalid info entry in the InstanceConfig at runtime
+   * or during initialization.
+   */
   @Test
   public void instanceConfigInvalidInfoEntryTest() {
     Properties properties = new Properties();

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -124,6 +124,9 @@ public class MockHelixParticipant extends HelixParticipant {
     // no op
   }
 
+  /**
+   * @return the {@link HelixParticipantMetrics} associated with this participant.
+   */
   HelixParticipantMetrics getHelixParticipantMetrics() {
     return participantMetrics;
   }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -23,12 +23,12 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 
 import static org.mockito.Mockito.*;
 
 
 public class MockHelixParticipant extends HelixParticipant {
+  public static MetricRegistry metricRegistry = new MetricRegistry();
   public Boolean updateNodeInfoReturnVal = null;
   public PartitionStateChangeListener mockStatsManagerListener = null;
   CountDownLatch listenerLatch = null;
@@ -40,11 +40,11 @@ public class MockHelixParticipant extends HelixParticipant {
   private PartitionStateChangeListener mockReplicationManagerListener;
 
   public MockHelixParticipant(ClusterMapConfig clusterMapConfig) throws IOException {
-    super(clusterMapConfig, new MockHelixManagerFactory(), new MetricRegistry());
+    super(clusterMapConfig, new MockHelixManagerFactory(), metricRegistry);
     // create mock state change listener for ReplicationManager
     mockReplicationManagerListener = Mockito.mock(PartitionStateChangeListener.class);
     // mock Bootstrap-To-Standby change
-    doAnswer((Answer) invocation -> {
+    doAnswer(invocation -> {
       replicaState = ReplicaState.BOOTSTRAP;
       if (replicaSyncUpService != null && currentReplica != null) {
         replicaSyncUpService.initiateBootstrap(currentReplica);
@@ -55,7 +55,7 @@ public class MockHelixParticipant extends HelixParticipant {
       return null;
     }).when(mockReplicationManagerListener).onPartitionBecomeStandbyFromBootstrap(any(String.class));
     // mock Standby-To-Inactive change
-    doAnswer((Answer) invocation -> {
+    doAnswer(invocation -> {
       replicaState = ReplicaState.INACTIVE;
       if (replicaSyncUpService != null && currentReplica != null) {
         replicaSyncUpService.initiateDeactivation(currentReplica);
@@ -66,7 +66,7 @@ public class MockHelixParticipant extends HelixParticipant {
       return null;
     }).when(mockReplicationManagerListener).onPartitionBecomeInactiveFromStandby(any(String.class));
     // mock Inactive-To-Offline change
-    doAnswer((Answer) invocation -> {
+    doAnswer(invocation -> {
       replicaState = ReplicaState.OFFLINE;
       if (replicaSyncUpService != null && currentReplica != null) {
         replicaSyncUpService.initiateDisconnection(currentReplica);
@@ -122,6 +122,10 @@ public class MockHelixParticipant extends HelixParticipant {
   @Override
   public void close() {
     // no op
+  }
+
+  HelixParticipantMetrics getHelixParticipantMetrics() {
+    return participantMetrics;
   }
 
   /**

--- a/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.replication;
 
+import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockClusterSpectator;
@@ -118,6 +119,7 @@ public class CloudToStoreReplicationManagerTest {
     clusterMapConfig = new ClusterMapConfig(verifiableProperties);
     replicationConfig = new ReplicationConfig(verifiableProperties);
     serverConfig = new ServerConfig(verifiableProperties);
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
     mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
   }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -409,6 +409,7 @@ public class ReplicationTest {
   public void replicaFromOfflineToBootstrapTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
     MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
     DataNodeId currentNode = clusterMap.getDataNodeIds().get(0);
     Pair<StorageManager, ReplicationManager> managers =
@@ -461,6 +462,7 @@ public class ReplicationTest {
   public void replicaFromBootstrapToStandbyTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
     MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
     Pair<StorageManager, ReplicationManager> managers =
         createStorageManagerAndReplicationManager(clusterMap, clusterMapConfig, mockHelixParticipant);
@@ -511,6 +513,7 @@ public class ReplicationTest {
   public void replicaFromStandbyToInactiveTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
     MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
     Pair<StorageManager, ReplicationManager> managers =
         createStorageManagerAndReplicationManager(clusterMap, clusterMapConfig, mockHelixParticipant);
@@ -595,6 +598,7 @@ public class ReplicationTest {
   public void replicaFromStandbyToLeaderTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
     MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
     Pair<StorageManager, ReplicationManager> managers =
         createStorageManagerAndReplicationManager(clusterMap, clusterMapConfig, mockHelixParticipant);
@@ -614,6 +618,7 @@ public class ReplicationTest {
   public void replicaFromLeaderToStandbyTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
     MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
     Pair<StorageManager, ReplicationManager> managers =
         createStorageManagerAndReplicationManager(clusterMap, clusterMapConfig, mockHelixParticipant);
@@ -631,6 +636,7 @@ public class ReplicationTest {
   public void replicaFromInactiveToOfflineTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
     MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
     Pair<StorageManager, ReplicationManager> managers =
         createStorageManagerAndReplicationManager(clusterMap, clusterMapConfig, mockHelixParticipant);
@@ -726,6 +732,7 @@ public class ReplicationTest {
   public void replicaResumeDecommissionTest() throws Exception {
     MockClusterMap clusterMap = new MockClusterMap();
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(verifiableProperties);
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
     MockHelixParticipant mockHelixParticipant = new MockHelixParticipant(clusterMapConfig);
     // choose a replica on local node and put decommission file into its dir
     ReplicaId localReplica = clusterMap.getReplicaIds(clusterMap.getDataNodeIds().get(0)).get(0);

--- a/ambry-router/src/main/java/com/github/ambry/router/AdaptiveOperationTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/AdaptiveOperationTracker.java
@@ -30,6 +30,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import static com.github.ambry.router.NonBlockingRouterMetrics.*;
+
 
 /**
  * An implementation of {@link OperationTracker}. It internally maintains the status of a corresponding operation, and
@@ -135,18 +137,21 @@ class AdaptiveOperationTracker extends SimpleOperationTracker {
         break;
       case Partition:
         PartitionId partitionId = replicaId.getPartitionId();
-        histogramToReturn =
-            isLocalReplica ? localDcResourceToHistogram.get(partitionId) : crossDcResourceToHistogram.get(partitionId);
+        histogramToReturn = isLocalReplica ? localDcResourceToHistogram.computeIfAbsent(partitionId,
+            k -> createHistogram(routerConfig, false))
+            : crossDcResourceToHistogram.computeIfAbsent(partitionId, k -> createHistogram(routerConfig, false));
         break;
       case DataNode:
         DataNodeId dataNodeId = replicaId.getDataNodeId();
-        histogramToReturn =
-            isLocalReplica ? localDcResourceToHistogram.get(dataNodeId) : crossDcResourceToHistogram.get(dataNodeId);
+        histogramToReturn = isLocalReplica ? localDcResourceToHistogram.computeIfAbsent(dataNodeId,
+            k -> createHistogram(routerConfig, false))
+            : crossDcResourceToHistogram.computeIfAbsent(dataNodeId, k -> createHistogram(routerConfig, false));
         break;
       case Disk:
         DiskId diskId = replicaId.getDiskId();
-        histogramToReturn =
-            isLocalReplica ? localDcResourceToHistogram.get(diskId) : crossDcResourceToHistogram.get(diskId);
+        histogramToReturn = isLocalReplica ? localDcResourceToHistogram.computeIfAbsent(diskId,
+            k -> createHistogram(routerConfig, false))
+            : crossDcResourceToHistogram.computeIfAbsent(diskId, k -> createHistogram(routerConfig, false));
         break;
       default:
         throw new IllegalArgumentException("Unsupported operation tracker metric scope.");

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -547,7 +547,7 @@ public class NonBlockingRouterMetrics {
    *                                  instead of the parameters from the config.
    * @return a configured {@link CachedHistogram}.
    */
-  private static CachedHistogram createHistogram(RouterConfig routerConfig, boolean useDefaultReservoirParams) {
+  static CachedHistogram createHistogram(RouterConfig routerConfig, boolean useDefaultReservoirParams) {
     Reservoir reservoir;
     long cacheTimeoutMs;
     double quantile;

--- a/ambry-router/src/test/java/com/github/ambry/router/AdaptiveOperationTrackerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/AdaptiveOperationTrackerTest.java
@@ -352,7 +352,6 @@ public class AdaptiveOperationTrackerTest {
     // mock different latency distribution of local hosts and remote host
     Histogram localHistogram1 = localColoMap.get(localHost1);
     Histogram localHistogram2 = localColoMap.get(localHost2);
-    //Histogram remoteHistogram1 = crossColoMap.get(remoteHost1);
     primeTracker(localHistogram1, routerConfig.routerOperationTrackerMinDataPointsRequired, new Pair<>(0L, 50L));
     primeTracker(localHistogram2, routerConfig.routerOperationTrackerMinDataPointsRequired, new Pair<>(100L, 120L));
     double localHostCutoff1 = localHistogram1.getSnapshot().getValue(QUANTILE);

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -156,6 +156,7 @@ public class StatsManagerTest {
     storeMap.put(partitionId, new MockStore(new MockStoreStats(snapshotsByType, false)));
     partitionToSnapshot.put(partitionId, snapshotsByType.get(StatsReportType.ACCOUNT_REPORT));
     storageManager = new MockStorageManager(storeMap, dataNodeId);
+    MockHelixParticipant.metricRegistry = new MetricRegistry();
     clusterParticipant = new MockHelixParticipant(clusterMapConfig);
     statsManager =
         new StatsManager(storageManager, replicas, new MetricRegistry(), statsManagerConfig, new MockTime(), null);

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -184,7 +184,7 @@ public class StorageManager implements StoreManager {
       if (clusterParticipant != null) {
         clusterParticipant.registerPartitionStateChangeListener(StateModelListenerType.StorageManagerListener,
             new PartitionStateChangeListenerImpl());
-        clusterParticipant.initializeParticipantMetrics(partitionNameToReplicaId.size());
+        clusterParticipant.setInitialLocalPartitions(partitionNameToReplicaId.keySet());
       }
       diskToDiskManager.values().forEach(diskManager -> unexpectedDirs.addAll(diskManager.getUnexpectedDirs()));
       logger.info("Starting storage manager complete");


### PR DESCRIPTION
1. Make adaptive tracker to support newly added partition/disk/node; Otherwise, it will throw NPE when handling new resource.
2. Make DynamicClusterChangeHandler gracefully handle invalid string in InstanceConfig. More context: Helix sometimes inserts additional info into InstanceConfig that is not recognizable. The cluster manager is supposed to skip these invalid strings at runtime or during startup.
3. Add ERROR -> OFFLINE state transition for resetting partition. When resetting a partition in ERROR state, Helix controller requires a state transition method to perform logic from ERROR to OFFLINE (can be no-op but method is required to be existent)
4. Move HelixParticipantMetrics out of AmbryPartitionStateModel. This will simply state model logic and allow us to maintain more accurate metrics by accounting for replica movement. 