### PR TITLE
Log the peer leader replica info in onPartitionBecomeLeaderFromStandBy

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -536,7 +536,6 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     } finally {
       participantMetrics.standbyCount.addAndGet(-1);
     }
-
     participantMetrics.leaderCount.addAndGet(1);
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -525,12 +525,18 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       if (cloudToStoreReplicationListener != null) {
         cloudToStoreReplicationListener.onPartitionBecomeLeaderFromStandby(partitionName);
       }
+      PartitionStateChangeListener replicationManagerListener =
+          partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
+      if (replicationManagerListener != null) {
+        replicationManagerListener.onPartitionBecomeLeaderFromStandby(partitionName);
+      }
     } catch (Exception e) {
       participantMetrics.errorStateCount.addAndGet(1);
       throw e;
     } finally {
       participantMetrics.standbyCount.addAndGet(-1);
     }
+
     participantMetrics.leaderCount.addAndGet(1);
   }
 
@@ -541,6 +547,11 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
           partitionStateChangeListeners.get(StateModelListenerType.CloudToStoreReplicationManagerListener);
       if (cloudToStoreReplicationListener != null) {
         cloudToStoreReplicationListener.onPartitionBecomeStandbyFromLeader(partitionName);
+      }
+      PartitionStateChangeListener replicationManagerListener =
+          partitionStateChangeListeners.get(StateModelListenerType.ReplicationManagerListener);
+      if (replicationManagerListener != null) {
+        replicationManagerListener.onPartitionBecomeStandbyFromLeader(partitionName);
       }
     } catch (Exception e) {
       participantMetrics.errorStateCount.addAndGet(1);

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -80,6 +80,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
   protected final Logger logger = LoggerFactory.getLogger(getClass());
   protected final Map<PartitionId, PartitionInfo> partitionToPartitionInfo;
   protected final Map<String, Set<PartitionInfo>> mountPathToPartitionInfos;
+  protected final Map<String, List<ReplicaId>> peerLeaderReplicasByPartition;
   protected final ReplicaSyncUpManager replicaSyncUpManager;
   protected final StoreManager storeManager;
   protected ReplicaTokenPersistor persistor = null;
@@ -119,6 +120,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
     this.transformerClassName = transformerClassName;
     this.storeManager = storeManager;
     replicaSyncUpManager = clusterParticipant == null ? null : clusterParticipant.getReplicaSyncUpManager();
+    peerLeaderReplicasByPartition = new ConcurrentHashMap<>();
   }
 
   /**

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -402,7 +402,6 @@ public class ReplicationManager extends ReplicationEngine {
               leaderReplica.getDataNodeId().getDatacenterName());
         }
       }
-
       peerLeaderReplicasByPartition.put(partitionName, peerLeaderReplicas);
     }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -37,7 +37,9 @@ import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -47,6 +49,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
 
 
@@ -242,6 +245,14 @@ public class ReplicationManager extends ReplicationEngine {
   }
 
   /**
+   * Get a map of partition to list of peer leader replicas
+   * @return an unmodifiable map of peer leader replicas stored by partition {@link ReplicationEngine#peerLeaderReplicasByPartition}
+   */
+  Map<String, List<ReplicaId>> getPeerLeaderReplicasByPartition() {
+    return Collections.unmodifiableMap(peerLeaderReplicasByPartition);
+  }
+
+  /**
    * Implementation of {@link ClusterMapChangeListener} that helps replication manager react to cluster map changes.
    */
   class ClusterMapChangeListenerImpl implements ClusterMapChangeListener {
@@ -373,12 +384,35 @@ public class ReplicationManager extends ReplicationEngine {
     public void onPartitionBecomeLeaderFromStandby(String partitionName) {
       logger.info("Partition state change notification from Standby to Leader received for partition {}",
           partitionName);
+      //Changes for leader based replication - for now, we just log the list of peer leader replicas
+      // 1. get replica ID of current node from store manager
+      ReplicaId localReplica = storeManager.getReplica(partitionName);
+
+      // 2. Get the peer leader replicas from all data centers for this partition
+      List<? extends ReplicaId> leaderReplicas =
+          localReplica.getPartitionId().getReplicaIdsByState(ReplicaState.LEADER, null);
+
+      // 3. Log the list of leader replicas associated with this partition (will be used later for leadership based replication)
+      List<ReplicaId> peerLeaderReplicas = new ArrayList<>();
+      for (ReplicaId leaderReplica : leaderReplicas) {
+        if (leaderReplica.getDataNodeId() != localReplica.getDataNodeId()) {
+          peerLeaderReplicas.add(leaderReplica);
+          logger.info("Partition {} on node instance {} is leader in remote dc {}", partitionName,
+              getInstanceName(leaderReplica.getDataNodeId().getHostname(), leaderReplica.getDataNodeId().getPort()),
+              leaderReplica.getDataNodeId().getDatacenterName());
+        }
+      }
+
+      peerLeaderReplicasByPartition.put(partitionName, peerLeaderReplicas);
     }
 
     @Override
     public void onPartitionBecomeStandbyFromLeader(String partitionName) {
       logger.info("Partition state change notification from Leader to Standby received for partition {}",
           partitionName);
+      if (peerLeaderReplicasByPartition.containsKey(partitionName)) {
+        peerLeaderReplicasByPartition.remove((partitionName));
+      }
     }
 
     @Override

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
@@ -16,8 +16,10 @@ package com.github.ambry.clustermap;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -53,10 +55,16 @@ public class MockPartitionId implements PartitionId {
     this.partitionClass = partitionClass;
     this.replicaIds = new ArrayList<>(dataNodes.size());
     replicaAndState = new HashMap<>();
+    Set<String> dataCenters = new HashSet<>();
     for (MockDataNodeId dataNode : dataNodes) {
       MockReplicaId replicaId = new MockReplicaId(dataNode.getPort(), this, dataNode, mountPathIndexToUse);
       replicaIds.add(replicaId);
-      replicaAndState.put(replicaId, ReplicaState.STANDBY);
+      if (dataCenters.contains(dataNode.getDatacenterName())) {
+        replicaAndState.put(replicaId, ReplicaState.STANDBY);
+      } else {
+        dataCenters.add(dataNode.getDatacenterName());
+        replicaAndState.put(replicaId, ReplicaState.LEADER);
+      }
     }
     for (ReplicaId replicaId : replicaIds) {
       ((MockReplicaId) replicaId).setPeerReplicas(replicaIds);


### PR DESCRIPTION
Warmup changes for the leader based replication project.  This change logs and prints all peer leader replica information (including the current node) when a node transitions from standby to leader.