### PR TITLE
Return UNKNOWN_PORT on CloudServiceDataNode.getPortToConnectTo()

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/DataNodeId.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/DataNodeId.java
@@ -20,6 +20,10 @@ import com.github.ambry.network.Port;
  * A DataNodeId has many devices. A DataNodeId stores one or more {@link ReplicaId}s upon each device.
  */
 public interface DataNodeId extends Resource, Comparable<DataNodeId> {
+  /**
+   * Can be used for {@link DataNodeId} objects that represent in-process entities without a real port.
+   */
+  static final int UNKNOWN_PORT = -1;
 
   /**
    * Gets the hostname of this DataNodeId.
@@ -31,7 +35,9 @@ public interface DataNodeId extends Resource, Comparable<DataNodeId> {
   /**
    * Gets the DataNodeId's connection port number.
    *
-   * @return Port number upon which to establish a connection with the DataNodeId.
+   * @return Port number upon which to establish a connection with the DataNodeId, or {@link #UNKNOWN_PORT} if this
+   *         data node cannot be connected to via a socket. This behavior differs from other "optional" ports since many
+   *         callers currently require this method to return without throwing exceptions for logging purposes.
    */
   int getPort();
 
@@ -66,7 +72,8 @@ public interface DataNodeId extends Resource, Comparable<DataNodeId> {
   /**
    * Returns the {@link Port} of this node to connect to.
    *
-   * @return {@link Port} to which the caller can connect to.
+   * @return {@link Port} to which the caller can connect to, or a {@link Port} with number {@link #UNKNOWN_PORT} if
+   *         this data node cannot be connected to via a socket.
    */
   Port getPortToConnectTo();
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDatanode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDatanode.java
@@ -43,7 +43,7 @@ abstract class AmbryDataNode implements DataNodeId {
    * @param clusterMapConfig the {@link ClusterMapConfig} to use.
    * @param hostName the hostName identifying this data node.
    * @param plaintextPortNum the plaintext port identifying this data node. This can be
-   *        {@link ClusterMapUtils#UNKNOWN_PORT} if this object represents an in-process entity without a real TCP
+   *        {@link DataNodeId#UNKNOWN_PORT} if this object represents an in-process entity without a real TCP
    *        port.
    * @param sslPortNum the ssl port associated with this data node (may be null).
    * @param http2PortNum the http2 ssl port associated with this data node (may be null).

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudServiceDataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudServiceDataNode.java
@@ -41,9 +41,13 @@ class CloudServiceDataNode extends AmbryDataNode {
     super(dataCenterName, clusterMapConfig, dataCenterName, UNKNOWN_PORT, null, null);
   }
 
+  /**
+   * @return a port with number {@link #UNKNOWN_PORT}, since CloudServiceDataNode cannot be connected to via a socket.
+   */
   @Override
   public Port getPortToConnectTo() {
-    throw new UnsupportedOperationException("No port to connect to CloudServiceDataNode");
+    // plaintextPort is constructed using UNKNOWN_PORT
+    return plainTextPort;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -44,10 +44,6 @@ import org.slf4j.LoggerFactory;
 public class ClusterMapUtils {
   // datacenterId == UNKNOWN_DATACENTER_ID indicate datacenterId is not available at the time when this blobId is formed.
   public static final byte UNKNOWN_DATACENTER_ID = -1;
-  /**
-   * Can be used for {@link DataNodeId} objects that represent in-process entities without a real port.
-   */
-  public static final int UNKNOWN_PORT = -1;
   public static final String PARTITION_OVERRIDE_STR = "PartitionOverride";
   public static final String REPLICA_ADDITION_STR = "ReplicaAddition";
   public static final String PROPERTYSTORE_STR = "PROPERTYSTORE";

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DynamicClusterManagerComponentsTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -264,8 +265,8 @@ public class DynamicClusterManagerComponentsTest {
     CloudServiceDataNode node = new CloudServiceDataNode(dcName, clusterMapConfig1);
     assertEquals(dcName, node.getHostname());
     assertEquals(dcName, node.getDatacenterName());
-    assertEquals(UNKNOWN_PORT, node.getPort());
-    assertException(UnsupportedOperationException.class, node::getPortToConnectTo, null);
+    assertEquals(DataNodeId.UNKNOWN_PORT, node.getPort());
+    assertEquals(new Port(DataNodeId.UNKNOWN_PORT, PortType.PLAINTEXT), node.getPortToConnectTo());
     assertNull(node.getRackId());
     assertEquals(DEFAULT_XID, node.getXid());
     // the snapshot is for debug info, but just check that it works without throwing exceptions.

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
@@ -162,7 +162,7 @@ public class MockHelixCluster {
     dataCenterToZkAddress.values()
         .stream()
         .filter(info -> info.getReplicaType() == ReplicaType.CLOUD_BACKED)
-        .forEach(info -> upInstances.add(ClusterMapUtils.getInstanceName(info.getDcName(), UNKNOWN_PORT)));
+        .forEach(info -> upInstances.add(ClusterMapUtils.getInstanceName(info.getDcName(), DataNodeId.UNKNOWN_PORT)));
     return upInstances;
   }
 

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -15,7 +15,6 @@ package com.github.ambry.router;
 
 import com.github.ambry.account.AccountService;
 import com.github.ambry.clustermap.ClusterMap;
-import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ResponseHandler;
@@ -581,7 +580,7 @@ class NonBlockingRouter implements Router {
       Map<Boolean, List<DataNodeId>> localAndRemoteNodes = clusterMap.getDataNodeIds()
           .stream()
           // ignore any in-process "data nodes" without TCP ports
-          .filter(dataNodeId -> dataNodeId.getPort() != ClusterMapUtils.UNKNOWN_PORT)
+          .filter(dataNodeId -> dataNodeId.getPort() != DataNodeId.UNKNOWN_PORT)
           .collect(Collectors.partitioningBy(dataNodeId -> localDatacenter.equals(dataNodeId.getDatacenterName())));
       logger.info("Warming up local datacenter connections to {} nodes", localAndRemoteNodes.get(true).size());
       networkClient.warmUpConnections(localAndRemoteNodes.get(true),

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
@@ -132,7 +132,7 @@ public class MockClusterMap implements ClusterMap {
       dcIndex++;
       dcName = "DC" + dcIndex;
       dataCentersInClusterMap.add(dcName);
-      MockDataNodeId virtualNode = createDataNode(getListOfPorts(ClusterMapUtils.UNKNOWN_PORT, null, null), dcName, 0);
+      MockDataNodeId virtualNode = createDataNode(getListOfPorts(DataNodeId.UNKNOWN_PORT, null, null), dcName, 0);
       dataNodes.add(virtualNode);
       dcToDataNodes.computeIfAbsent(dcName, name -> new ArrayList<>()).add(virtualNode);
       cloudDc = dcName;


### PR DESCRIPTION
Previously, this method would throw an exception, which is not
acceptable by the router. Instead of adding branches for this
condition to the router codebase, this method can return UNKNOWN_PORT.

This matches the behavior of MockClusterMap in this situation.