### PR TITLE
Add metrics to track progress of replication from cloud.

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/CloudToStoreReplicationManager.java
@@ -196,6 +196,7 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
     if (replicationConfig.replicationTrackPerPartitionLagFromRemote) {
       replicationMetrics.addLagMetricForPartition(partitionId);
     }
+    replicationMetrics.addCatchUpPointMetricForPartition(partitionId);
   }
 
   /**
@@ -231,6 +232,8 @@ public class CloudToStoreReplicationManager extends ReplicationEngine {
     }
     PartitionId partitionId = localReplica.getPartitionId();
     stopPartitionReplication(partitionId);
+    replicationMetrics.removeLagMetricForPartition(partitionId);
+    replicationMetrics.removeCatchupPointMetricForPartition(partitionId);
     logger.info("Cloud Partition {} removed from {}", partitionId, dataNodeId);
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -482,6 +482,10 @@ public class ReplicaThread implements Runnable {
               exchangeMetadataResponseList.add(exchangeMetadataResponse);
               replicationMetrics.updateLagMetricForRemoteReplica(remoteReplicaInfo,
                   exchangeMetadataResponse.localLagFromRemoteInBytes);
+              replicationMetrics.updateCatchupPointMetricForRemoteReplica(
+                  remoteReplicaInfo, replicaMetadataResponseInfo.getMessageInfoList()
+                      .get(replicaMetadataResponseInfo.getMessageInfoList().size() - 1)
+                      .getOperationTimeMs());
             } catch (Exception e) {
               if (e instanceof StoreException
                   && ((StoreException) e).getErrorCode() == StoreErrorCodes.Store_Not_Started) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -482,8 +482,8 @@ public class ReplicaThread implements Runnable {
               exchangeMetadataResponseList.add(exchangeMetadataResponse);
               replicationMetrics.updateLagMetricForRemoteReplica(remoteReplicaInfo,
                   exchangeMetadataResponse.localLagFromRemoteInBytes);
-              replicationMetrics.updateCatchupPointMetricForRemoteReplica(
-                  remoteReplicaInfo, replicaMetadataResponseInfo.getMessageInfoList()
+              replicationMetrics.updateCatchupPointMetricForCloudReplica(remoteReplicaInfo,
+                  replicaMetadataResponseInfo.getMessageInfoList()
                       .get(replicaMetadataResponseInfo.getMessageInfoList().size() - 1)
                       .getOperationTimeMs());
             } catch (Exception e) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -482,10 +482,12 @@ public class ReplicaThread implements Runnable {
               exchangeMetadataResponseList.add(exchangeMetadataResponse);
               replicationMetrics.updateLagMetricForRemoteReplica(remoteReplicaInfo,
                   exchangeMetadataResponse.localLagFromRemoteInBytes);
-              replicationMetrics.updateCatchupPointMetricForCloudReplica(remoteReplicaInfo,
-                  replicaMetadataResponseInfo.getMessageInfoList()
-                      .get(replicaMetadataResponseInfo.getMessageInfoList().size() - 1)
-                      .getOperationTimeMs());
+              if (replicaMetadataResponseInfo.getMessageInfoList().size() > 0) {
+                replicationMetrics.updateCatchupPointMetricForCloudReplica(remoteReplicaInfo,
+                    replicaMetadataResponseInfo.getMessageInfoList()
+                        .get(replicaMetadataResponseInfo.getMessageInfoList().size() - 1)
+                        .getOperationTimeMs());
+              }
             } catch (Exception e) {
               if (e instanceof StoreException
                   && ((StoreException) e).getErrorCode() == StoreErrorCodes.Store_Not_Started) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -40,7 +40,7 @@ public class ReplicationMetrics {
 
   private final static String MAX_LAG_FROM_PEERS_IN_BYTE_METRIC_NAME_TEMPLATE = "Partition-%s-maxLagFromPeersInBytes";
   private final static String CATCH_POINT_FROM_CLOUD_METRIC_NAME_TEMPLATE = "Partition-%s-catchupPointFromCloud";
-  
+
   public final Map<String, Meter> interColoReplicationBytesRate = new HashMap<String, Meter>();
   public final Meter intraColoReplicationBytesRate;
   public final Map<String, Meter> plainTextInterColoReplicationBytesRate = new HashMap<String, Meter>();
@@ -736,7 +736,7 @@ public class ReplicationMetrics {
     // update this metric only for cloud peer replica. There will only be one cloud replica peer per partition.
     if (remoteReplicaInfo.getReplicaId().getReplicaType() == ReplicaType.CLOUD_BACKED
         && cloudReplicaCatchUpPoint.containsKey(remoteReplicaInfo.getLocalReplicaId().getPartitionId())) {
-      // update the partition's lag if and only if it was tracked.
+      // update the partition's catch up point if and only if it was tracked.
       cloudReplicaCatchUpPoint.put(remoteReplicaInfo.getLocalReplicaId().getPartitionId(), catchUpPoint);
     }
   }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -137,7 +137,7 @@ public class ReplicationMetrics {
   private final Map<PartitionId, Counter> partitionIdToInvalidMessageStreamErrorCounter = new HashMap<>();
   // ConcurrentHashMap is used to avoid cache incoherence.
   private final Map<PartitionId, Map<DataNodeId, Long>> partitionLags = new ConcurrentHashMap<>();
-  private Map<PartitionId, Long> partitionCatchUpPoint = new ConcurrentHashMap<>();
+  private Map<PartitionId, Long> cloudReplicaCatchUpPoint = new ConcurrentHashMap<>();
   private final Map<String, Set<RemoteReplicaInfo>> remoteReplicaInfosByDc = new ConcurrentHashMap<>();
   private final Map<String, LongSummaryStatistics> dcToReplicaLagStats = new ConcurrentHashMap<>();
 
@@ -438,10 +438,10 @@ public class ReplicationMetrics {
    * @param partitionId partition to add metric for.
    */
   public void addCatchUpPointMetricForPartition(PartitionId partitionId) {
-    if (!partitionCatchUpPoint.containsKey(partitionId)) {
-      partitionCatchUpPoint.put(partitionId, 0L);
+    if (!cloudReplicaCatchUpPoint.containsKey(partitionId)) {
+      cloudReplicaCatchUpPoint.put(partitionId, 0L);
       // Set up metrics if and only if no mapping for this partition before.
-      Gauge<Long> catchUpPoint = () -> partitionCatchUpPoint.get(partitionId);
+      Gauge<Long> catchUpPoint = () -> cloudReplicaCatchUpPoint.get(partitionId);
       registry.register(MetricRegistry.name(ReplicaThread.class,
           "Partition-" + partitionId.toPathString() + "-catchupPointFromCloud"), catchUpPoint);
     }
@@ -463,7 +463,7 @@ public class ReplicationMetrics {
    * @param partitionId the given partition whose catch up point metric should be removed.
    */
   public void removeCatchupPointMetricForPartition(PartitionId partitionId) {
-    if (partitionCatchUpPoint.containsKey(partitionId)) {
+    if (cloudReplicaCatchUpPoint.containsKey(partitionId)) {
       registry.remove(MetricRegistry.name(ReplicaThread.class,
           "Partition-" + partitionId.toPathString() + "-catchupPointFromCloud"));
     }
@@ -729,12 +729,12 @@ public class ReplicationMetrics {
    * @param remoteReplicaInfo {@link RemoteReplicaInfo} of the cloud replica.
    * @param catchUpPoint timestamp upto which local replica has caught with the cloud replica.
    */
-  public void updateCatchupPointMetricForRemoteReplica(RemoteReplicaInfo remoteReplicaInfo, long catchUpPoint) {
+  public void updateCatchupPointMetricForCloudReplica(RemoteReplicaInfo remoteReplicaInfo, long catchUpPoint) {
     // update this metric only for cloud peer replica. There will only be one cloud replica peer per partition.
     if (remoteReplicaInfo.getReplicaId().getReplicaType() == ReplicaType.CLOUD_BACKED
-        && partitionCatchUpPoint.containsKey(remoteReplicaInfo.getLocalReplicaId().getPartitionId())) {
+        && cloudReplicaCatchUpPoint.containsKey(remoteReplicaInfo.getLocalReplicaId().getPartitionId())) {
       // update the partition's lag if and only if it was tracked.
-      partitionCatchUpPoint.put(remoteReplicaInfo.getLocalReplicaId().getPartitionId(), catchUpPoint);
+      cloudReplicaCatchUpPoint.put(remoteReplicaInfo.getLocalReplicaId().getPartitionId(), catchUpPoint);
     }
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -38,6 +38,9 @@ import java.util.stream.Collectors;
  */
 public class ReplicationMetrics {
 
+  private final static String MAX_LAG_FROM_PEERS_IN_BYTE_METRIC_NAME_TEMPLATE = "Partition-%s-maxLagFromPeersInBytes";
+  private final static String CATCH_POINT_FROM_CLOUD_METRIC_NAME_TEMPLATE = "Partition-%s-catchupPointFromCloud";
+  
   public final Map<String, Meter> interColoReplicationBytesRate = new HashMap<String, Meter>();
   public final Meter intraColoReplicationBytesRate;
   public final Map<String, Meter> plainTextInterColoReplicationBytesRate = new HashMap<String, Meter>();
@@ -429,7 +432,7 @@ public class ReplicationMetrics {
       // Set up metrics if and only if no mapping for this partition before.
       Gauge<Long> replicaLag = () -> getMaxLagForPartition(partitionId);
       registry.register(MetricRegistry.name(ReplicaThread.class,
-          "Partition-" + partitionId.toPathString() + "-maxLagFromPeersInBytes"), replicaLag);
+          String.format(MAX_LAG_FROM_PEERS_IN_BYTE_METRIC_NAME_TEMPLATE, partitionId.toPathString())), replicaLag);
     }
   }
 
@@ -443,7 +446,7 @@ public class ReplicationMetrics {
       // Set up metrics if and only if no mapping for this partition before.
       Gauge<Long> catchUpPoint = () -> cloudReplicaCatchUpPoint.get(partitionId);
       registry.register(MetricRegistry.name(ReplicaThread.class,
-          "Partition-" + partitionId.toPathString() + "-catchupPointFromCloud"), catchUpPoint);
+          String.format(CATCH_POINT_FROM_CLOUD_METRIC_NAME_TEMPLATE, partitionId.toPathString())), catchUpPoint);
     }
   }
 
@@ -454,7 +457,7 @@ public class ReplicationMetrics {
   public void removeLagMetricForPartition(PartitionId partitionId) {
     if (partitionLags.containsKey(partitionId)) {
       registry.remove(MetricRegistry.name(ReplicaThread.class,
-          "Partition-" + partitionId.toPathString() + "-maxLagFromPeersInBytes"));
+          String.format(MAX_LAG_FROM_PEERS_IN_BYTE_METRIC_NAME_TEMPLATE, partitionId.toPathString())));
     }
   }
 
@@ -465,7 +468,7 @@ public class ReplicationMetrics {
   public void removeCatchupPointMetricForPartition(PartitionId partitionId) {
     if (cloudReplicaCatchUpPoint.containsKey(partitionId)) {
       registry.remove(MetricRegistry.name(ReplicaThread.class,
-          "Partition-" + partitionId.toPathString() + "-catchupPointFromCloud"));
+          String.format(CATCH_POINT_FROM_CLOUD_METRIC_NAME_TEMPLATE, partitionId.toPathString())));
     }
   }
 


### PR DESCRIPTION
Since a metric like replication lag in bytes is not possible from cloud, a metric that can be used to track replication progress from cloud can be the point of time up to which the local replica has caught up from the cloud replica. Below are considerations for implementing such a metric. 

There are two options to emit metrics for recovery/vcr-replication progress

1. Progress is reported by the VCR that is the recovery source.
2. Progress is reported by the storage node itself that is recovering.

## Progress Reported By Vcr

When a VCR gets a replica metadata request, then it can look at the token to see the lastUpdateTime (which needs to be added to the CloudFindToken) in the incoming token, and can add it to a metric called *partition_<partitionid_datanodeid>_catchup_point*. This metric is the time up to which the remote is caught up from the VCR.

A major assumption here is that one storage node recovers/replicates from only one VCR node. If there is a possibility of one storage node replicating from multiple VCR nodes (which basically doesn't make sense, since the source of data is same for all VCRs), then it will not be possible to determine which VCR node has most up to date progress. Since such a possibility is not expected, this assumption is expected to hold true.

A major issue with approach is that there will be no way to know when to drop the metrics from a VCR node. Since this happens in the request path, a VCR node will never be able to drop the metrics. Due to this issue, the next approach is a better approach to report progress.

## Progress Reported by the Storage Node

Just like a storage node emits metrics for *replicationLagInBytes*, it can also emit metrics for *replicationCatchupTime* (time up to which a replica has caught up). The response of replica metadata exchange consists of an ordered list of *MessageInfo*, representing the metadata of a blob. The operation time of the last MessageInfo, can be used as the point in time up to which the local replica has caught up from cloud replica. While this information can be obtained for both replication from cloud as well as from store, it makes more sense to track this only for replication from cloud, because there will be three peer store replicas for a local replica, and it is difficult to determine how to merge the three catch up timestamps to get accurate information about catch up point (there can be a remote store peer replica, which is new, and is still catching up with the existing replicas. It will be far behind the other replicas). With the assumption that there will be only one cloud replica per local replica in a store, this approach can be used to track progress of replication from cloud, and hence progress of disaster recovery.

Due to the reasons above, approach 2 (progress reported by the storage node), is used to get the recovery progress metric.