### PR TITLE
Add some metrics for cloud replication feed

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureMetrics.java
@@ -42,6 +42,10 @@ public class AzureMetrics {
   public static final String CHANGEFEED_QUERY_FAILURE_COUNT = "ChangeFeedFailureQueryCount";
   public static final String MISSING_KEYS_QUERY_TIME = "MissingKeysQueryTime";
   public static final String CHANGE_FEED_QUERY_TIME = "ChangeFeedQueryTime";
+  public static final String REPLICATION_FEED_QUERY_TIME = "ReplicationFeedQueryTime";
+  public static final String CHANGE_FEED_CACHE_HIT_RATE = "ChangeFeedCacheHitRate";
+  public static final String CHANGE_FEED_CACHE_MISS_RATE = "ChangeFeedCacheMissRate";
+  public static final String CHANGE_FEED_CACHE_REFRESH_RATE = "ChangeFeedCacheRefreshRate";
   public static final String DEAD_BLOBS_QUERY_TIME = "DeadBlobsQueryTime";
   public static final String FIND_SINCE_QUERY_TIME = "FindSinceQueryTime";
   public static final String BLOB_UPDATE_ERROR_COUNT = "BlobUpdateErrorCount";
@@ -75,6 +79,10 @@ public class AzureMetrics {
   public final Timer documentDeleteTime;
   public final Timer missingKeysQueryTime;
   public final Timer changeFeedQueryTime;
+  public final Timer replicationFeedQueryTime;
+  public final Meter changeFeedCacheHitRate;
+  public final Meter changeFeedCacheMissRate;
+  public final Meter changeFeedCacheRefreshRate;
   public final Counter documentQueryCount;
   public final Counter changeFeedQueryCount;
   public final Counter changeFeedQueryFailureCount;
@@ -121,6 +129,14 @@ public class AzureMetrics {
         registry.counter(MetricRegistry.name(AzureCloudDestination.class, CHANGEFEED_QUERY_FAILURE_COUNT));
     missingKeysQueryTime = registry.timer(MetricRegistry.name(AzureCloudDestination.class, MISSING_KEYS_QUERY_TIME));
     changeFeedQueryTime = registry.timer(MetricRegistry.name(AzureCloudDestination.class, CHANGE_FEED_QUERY_TIME));
+    replicationFeedQueryTime =
+        registry.timer(MetricRegistry.name(AzureCloudDestination.class, REPLICATION_FEED_QUERY_TIME));
+    changeFeedCacheHitRate =
+        registry.meter(MetricRegistry.name(AzureCloudDestination.class, CHANGE_FEED_CACHE_HIT_RATE));
+    changeFeedCacheMissRate =
+        registry.meter(MetricRegistry.name(AzureCloudDestination.class, CHANGE_FEED_CACHE_MISS_RATE));
+    changeFeedCacheRefreshRate =
+        registry.meter(MetricRegistry.name(AzureCloudDestination.class, CHANGE_FEED_CACHE_REFRESH_RATE));
     deadBlobsQueryTime = registry.timer(MetricRegistry.name(AzureCloudDestination.class, DEAD_BLOBS_QUERY_TIME));
     findSinceQueryTime = registry.timer(MetricRegistry.name(AzureCloudDestination.class, FIND_SINCE_QUERY_TIME));
     blobUpdateErrorCount = registry.counter(MetricRegistry.name(AzureCloudDestination.class, BLOB_UPDATE_ERROR_COUNT));

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosChangeFeedBasedReplicationFeed.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosChangeFeedBasedReplicationFeed.java
@@ -172,11 +172,11 @@ public final class CosmosChangeFeedBasedReplicationFeed implements AzureReplicat
       if (changeFeedCacheEntry == null || !isCacheValid(partitionPath, cosmosChangeFeedFindToken,
           changeFeedCacheEntry)) {
         // the cache may not be valid. So we cannot use session id
+        azureMetrics.changeFeedCacheMissRate.mark();
+        cacheHit = false;
         changeFeedCacheEntry = getNextChangeFeed(partitionPath, cosmosChangeFeedFindToken.getStartContinuationToken());
         // invalidate the previous token's cache
         changeFeedCache.remove(cosmosChangeFeedFindToken.getCacheSessionId());
-        azureMetrics.changeFeedCacheMissRate.mark();
-        cacheHit = false;
         index = 0;
       }
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosChangeFeedBasedReplicationFeed.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosChangeFeedBasedReplicationFeed.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.cloud.azure;
 
+import com.codahale.metrics.Timer;
 import com.github.ambry.cloud.CloudBlobMetadata;
 import com.github.ambry.cloud.FindResult;
 import com.github.ambry.replication.FindToken;
@@ -161,52 +162,67 @@ public final class CosmosChangeFeedBasedReplicationFeed implements AzureReplicat
   @Override
   public FindResult getNextEntriesAndUpdatedToken(FindToken curFindToken, long maxTotalSizeOfEntries,
       String partitionPath) throws DocumentClientException {
-    List<CloudBlobMetadata> nextEntries = new ArrayList<>();
-    CosmosChangeFeedFindToken cosmosChangeFeedFindToken = (CosmosChangeFeedFindToken) curFindToken;
-    int index = cosmosChangeFeedFindToken.getIndex();
-    ChangeFeedCacheEntry changeFeedCacheEntry = changeFeedCache.get(cosmosChangeFeedFindToken.getCacheSessionId());
-    if (changeFeedCacheEntry == null || !isCacheValid(partitionPath, cosmosChangeFeedFindToken, changeFeedCacheEntry)) {
-      // the cache may not be valid. So we cannot use session id
-      changeFeedCacheEntry = getNextChangeFeed(partitionPath, cosmosChangeFeedFindToken.getStartContinuationToken());
-      // invalidate the previous token's cache
-      changeFeedCache.remove(cosmosChangeFeedFindToken.getCacheSessionId());
-      index = 0;
-    }
-
-    long resultSize = 0;
-
-    List<CloudBlobMetadata> fetchedEntries = changeFeedCacheEntry.getFetchedEntries();
-    while (true) {
-      if (index < fetchedEntries.size()) {
-        if (resultSize + fetchedEntries.get(index).getSize() < maxTotalSizeOfEntries || resultSize == 0) {
-          nextEntries.add(fetchedEntries.get(index));
-          resultSize = resultSize + fetchedEntries.get(index).getSize();
-          index++;
-        } else {
-          break;
-        }
-      } else {
-        // we can reuse the session id in this case, because we know that the cache ran out of new items.
-        changeFeedCacheEntry = getNextChangeFeed(partitionPath, changeFeedCacheEntry.getEndContinuationToken(),
-            changeFeedCacheEntry.getCacheSessionId());
-        fetchedEntries = changeFeedCacheEntry.getFetchedEntries();
-        if (fetchedEntries.isEmpty()) {
-          // This means that either there are no new changes, or change feed made progress in continuation token
-          // but no change feed results were returned (probably because this cosmos shard's change feed has other
-          // other partition feed too, and they were filtered out). In either case its appropriate to break here and
-          // return updated token. The source replication logic will retry replication with updated token.
-          break;
-        }
+    Timer.Context operationTimer = azureMetrics.replicationFeedQueryTime.time();
+    try {
+      List<CloudBlobMetadata> nextEntries = new ArrayList<>();
+      CosmosChangeFeedFindToken cosmosChangeFeedFindToken = (CosmosChangeFeedFindToken) curFindToken;
+      int index = cosmosChangeFeedFindToken.getIndex();
+      ChangeFeedCacheEntry changeFeedCacheEntry = changeFeedCache.get(cosmosChangeFeedFindToken.getCacheSessionId());
+      boolean cacheHit = true;
+      if (changeFeedCacheEntry == null || !isCacheValid(partitionPath, cosmosChangeFeedFindToken,
+          changeFeedCacheEntry)) {
+        // the cache may not be valid. So we cannot use session id
+        changeFeedCacheEntry = getNextChangeFeed(partitionPath, cosmosChangeFeedFindToken.getStartContinuationToken());
+        // invalidate the previous token's cache
+        changeFeedCache.remove(cosmosChangeFeedFindToken.getCacheSessionId());
+        azureMetrics.changeFeedCacheMissRate.mark();
+        cacheHit = false;
         index = 0;
       }
-    }
 
-    FindToken updatedToken = new CosmosChangeFeedFindToken(cosmosChangeFeedFindToken.getBytesRead() + resultSize,
-        changeFeedCacheEntry.getStartContinuationToken(), changeFeedCacheEntry.getEndContinuationToken(), index,
-        changeFeedCacheEntry.getFetchedEntries().size(), changeFeedCacheEntry.getCacheSessionId(),
-        cosmosChangeFeedFindToken.getVersion());
-    changeFeedCache.put(changeFeedCacheEntry.getCacheSessionId(), new ChangeFeedCacheEntry(changeFeedCacheEntry));
-    return new FindResult(nextEntries, updatedToken);
+      long resultSize = 0;
+
+      List<CloudBlobMetadata> fetchedEntries = changeFeedCacheEntry.getFetchedEntries();
+      while (true) {
+        if (index < fetchedEntries.size()) {
+          if (cacheHit) {
+            azureMetrics.changeFeedCacheHitRate.mark();
+            cacheHit = false;
+          }
+          if (resultSize + fetchedEntries.get(index).getSize() < maxTotalSizeOfEntries || resultSize == 0) {
+            nextEntries.add(fetchedEntries.get(index));
+            resultSize = resultSize + fetchedEntries.get(index).getSize();
+            index++;
+          } else {
+            break;
+          }
+        } else {
+          // we can reuse the session id in this case, because we know that the cache ran out of new items.
+          changeFeedCacheEntry = getNextChangeFeed(partitionPath, changeFeedCacheEntry.getEndContinuationToken(),
+              changeFeedCacheEntry.getCacheSessionId());
+          fetchedEntries = changeFeedCacheEntry.getFetchedEntries();
+          if (fetchedEntries.isEmpty()) {
+            // This means that either there are no new changes, or change feed made progress in continuation token
+            // but no change feed results were returned (probably because this cosmos shard's change feed has other
+            // other partition feed too, and they were filtered out). In either case its appropriate to break here and
+            // return updated token. The source replication logic will retry replication with updated token.
+            break;
+          } else {
+            azureMetrics.changeFeedCacheRefreshRate.mark();
+          }
+          index = 0;
+        }
+      }
+
+      FindToken updatedToken = new CosmosChangeFeedFindToken(cosmosChangeFeedFindToken.getBytesRead() + resultSize,
+          changeFeedCacheEntry.getStartContinuationToken(), changeFeedCacheEntry.getEndContinuationToken(), index,
+          changeFeedCacheEntry.getFetchedEntries().size(), changeFeedCacheEntry.getCacheSessionId(),
+          cosmosChangeFeedFindToken.getVersion());
+      changeFeedCache.put(changeFeedCacheEntry.getCacheSessionId(), new ChangeFeedCacheEntry(changeFeedCacheEntry));
+      return new FindResult(nextEntries, updatedToken);
+    } finally {
+      operationTimer.stop();
+    }
   }
 
   @Override


### PR DESCRIPTION
Add metrics to check cosmos change feed cache hit, miss and refresh rate.
Add metrics to check time taken for cloud replication feed query.