### PR TITLE
Fix http2 bytebuf leak issue

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -99,12 +99,16 @@ public class Http2NetworkClient implements NetworkClient {
                     http2ClientMetrics.http2StreamWriteAndFlushErrorCount.inc();
                     logger.warn("Stream writeAndFlush fail: {}", future.cause());
                   }
+                  // release related bytebuf
+                  requestInfo.getRequest().release();
                 }
               });
               requestInfo.setStreamSendTime(System.currentTimeMillis());
             } else {
               logger.error("Couldn't acquire stream channel to {}:{} . Cause: {}.", requestInfo.getHost(),
                   requestInfo.getPort().getPort(), future.cause());
+              // release related bytebuf
+              requestInfo.getRequest().release();
               readyResponseInfos.add(new ResponseInfo(requestInfo, NetworkClientErrorCode.NetworkError, null));
             }
           });

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -583,11 +583,13 @@ class NonBlockingRouter implements Router {
           // ignore any in-process "data nodes" without TCP ports
           .filter(dataNodeId -> dataNodeId.getPort() != DataNodeId.UNKNOWN_PORT)
           .collect(Collectors.partitioningBy(dataNodeId -> localDatacenter.equals(dataNodeId.getDatacenterName())));
-      logger.info("Warming up local datacenter connections to {} nodes", localAndRemoteNodes.get(true).size());
+      logger.info("Warming up local datacenter connections to {} nodes. Connections warmup percentage: {}%.",
+          localAndRemoteNodes.get(true).size(), routerConfig.routerConnectionsLocalDcWarmUpPercentage);
       networkClient.warmUpConnections(localAndRemoteNodes.get(true),
           routerConfig.routerConnectionsLocalDcWarmUpPercentage, routerConfig.routerConnectionsWarmUpTimeoutMs,
           responseInfos);
-      logger.info("Warming up remote datacenter connections to {} nodes", localAndRemoteNodes.get(false).size());
+      logger.info("Warming up remote datacenter connections to {} nodes. Connections warmup percentage: {}%.",
+          localAndRemoteNodes.get(false).size(), routerConfig.routerConnectionsRemoteDcWarmUpPercentage);
       networkClient.warmUpConnections(localAndRemoteNodes.get(false),
           routerConfig.routerConnectionsRemoteDcWarmUpPercentage, routerConfig.routerConnectionsWarmUpTimeoutMs,
           responseInfos);


### PR DESCRIPTION
ByteBuf from PutRequest(or other requests) should be released by networkClient if exception happens in networkClient. 