### PR TITLE
Support Disable/Enable/Reset partition in Helix bootstrap tool

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -726,13 +726,13 @@ public class HelixBootstrapUpgradeUtil {
           if (EnumSet.of(HelixAdminOperation.UpdateIdealState, HelixAdminOperation.BootstrapCluster)
               .contains(helixAdminOperation)) {
             // @formatter:off
-          info(
-              "[{}] Different instance sets for partition {} under resource {}. "
-                  + "Updating Helix using static. "
-                  + "Previous instance set: [{}], new instance set: [{}]",
-              dcName.toUpperCase(), partitionName, resourceName,
-              String.join(",", instanceSetInHelix), String.join(",", instanceSetInStatic));
-          // @formatter:on
+            info(
+                "[{}] Different instance sets for partition {} under resource {}. "
+                    + "Updating Helix using static. "
+                    + "Previous instance set: [{}], new instance set: [{}]",
+                dcName.toUpperCase(), partitionName, resourceName,
+                String.join(",", instanceSetInHelix), String.join(",", instanceSetInStatic));
+            // @formatter:on
             ArrayList<String> newInstances = new ArrayList<>(instanceSetInStatic);
             Collections.shuffle(newInstances);
             resourceIs.setPreferenceList(partitionName, newInstances);

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
@@ -24,6 +24,7 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
+import static com.github.ambry.clustermap.HelixBootstrapUpgradeUtil.HelixAdminOperation.*;
 
 
 /**
@@ -58,7 +59,7 @@ public class MockHelixCluster {
     dataCenterToZkAddress = parseDcJsonAndPopulateDcInfo(jsonString);
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
         "all", MAX_PARTITIONS_IN_ONE_RESOURCE, false, false, helixAdminFactory, false,
-        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, false);
+        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster);
     this.clusterName = clusterName;
   }
 
@@ -70,7 +71,7 @@ public class MockHelixCluster {
   void upgradeWithNewHardwareLayout(String hardwareLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
         "all", MAX_PARTITIONS_IN_ONE_RESOURCE, false, false, helixAdminFactory, false,
-        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, false);
+        ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster);
     triggerInstanceConfigChangeNotification();
   }
 
@@ -81,7 +82,7 @@ public class MockHelixCluster {
    */
   void upgradeWithNewPartitionLayout(String partitionLayoutPath) throws Exception {
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterName,
-        "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, false);
+        "all", 3, false, false, helixAdminFactory, false, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, BootstrapCluster);
     triggerInstanceConfigChangeNotification();
   }
 

--- a/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
@@ -332,9 +332,8 @@ public class TestUtils {
      * @param dcName the name of the datacenter.
      * @param id the id of the datacenter.
      * @param port the port at which this Zk server should run on localhost.
-     * @throws IOException
      */
-    public ZkInfo(String tempDirPath, String dcName, byte id, int port, boolean start) throws IOException {
+    public ZkInfo(String tempDirPath, String dcName, byte id, int port, boolean start) {
       this.dcName = dcName;
       this.id = id;
       this.port = port;

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -179,8 +179,7 @@ public class HelixBootstrapUpgradeToolTest {
     // test add state model to non-exist cluster, which should fail
     try {
       HelixBootstrapUpgradeUtil.addStateModelDef(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-          CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(),
-          ClusterMapConfig.AMBRY_STATE_MODEL_DEF);
+          CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(), ClusterMapConfig.AMBRY_STATE_MODEL_DEF);
       fail("should fail due to non-exist cluster");
     } catch (IllegalStateException e) {
       // expected
@@ -191,12 +190,10 @@ public class HelixBootstrapUpgradeToolTest {
         ClusterMapConfig.OLD_STATE_MODEL_DEF, BootstrapCluster);
     // add new state model def
     HelixBootstrapUpgradeUtil.addStateModelDef(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-        CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(),
-        ClusterMapConfig.AMBRY_STATE_MODEL_DEF);
+        CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(), ClusterMapConfig.AMBRY_STATE_MODEL_DEF);
     // add existing state model def should be no-op
     HelixBootstrapUpgradeUtil.addStateModelDef(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-        CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(),
-        ClusterMapConfig.OLD_STATE_MODEL_DEF);
+        CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(), ClusterMapConfig.OLD_STATE_MODEL_DEF);
     // ensure that active dcs have new state model def
     String clusterName = CLUSTER_NAME_PREFIX + CLUSTER_NAME_IN_STATIC_CLUSTER_MAP;
     for (Datacenter dc : testHardwareLayout.getHardwareLayout().getDatacenters()) {
@@ -433,16 +430,14 @@ public class HelixBootstrapUpgradeToolTest {
     // test invalid admin type
     try {
       HelixBootstrapUpgradeUtil.uploadClusterAdminConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-          CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(),
-          new String[]{"invalid_admin_type"});
+          CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(), new String[]{"invalid_admin_type"});
       fail("should fail because of invalid admin type");
     } catch (IllegalArgumentException e) {
       // expected
     }
     // upload replica addition admin config
     HelixBootstrapUpgradeUtil.uploadClusterAdminConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-        CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(),
-        new String[]{ClusterMapUtils.REPLICA_ADDITION_STR});
+        CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(), new String[]{ClusterMapUtils.REPLICA_ADDITION_STR});
     // verify replica addition znode in Helix PropertyStore
     for (ZkInfo zkInfo : dcsToZkInfo.values()) {
       HelixPropertyStore<ZNRecord> propertyStore =
@@ -769,8 +764,7 @@ public class HelixBootstrapUpgradeToolTest {
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
     HelixBootstrapUpgradeUtil.uploadClusterAdminConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-        CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(),
-        new String[]{ClusterMapUtils.PARTITION_OVERRIDE_STR});
+        CLUSTER_NAME_PREFIX, dcStr, new HelixAdminFactory(), new String[]{ClusterMapUtils.PARTITION_OVERRIDE_STR});
     // Check writable partitions in each datacenter
     for (ZkInfo zkInfo : dcsToZkInfo.values()) {
       HelixPropertyStore<ZNRecord> propertyStore =

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -176,7 +176,8 @@ public class HelixBootstrapUpgradeTool {
     ArgumentAcceptingOptionSpec<String> adminOperationOpt = parser.accepts("adminOperation",
         "(Optional argument) Perform admin operations to manage resources in cluster. For example: "
             + " '--adminOperation UpdateIdealState'  # Update IdealState based on static clustermap. This won't change InstanceConfig"
-            + " '--adminOperation DisablePartition'  # Disable partitions that are not present in static clustermap."
+            + " '--adminOperation DisablePartition'  # Disable partition on certain node. Usually used as first step to decommission certain replica"
+            + " '--adminOperation EnablePartition'   # Enable partitions on certain node (if partition is previously disabled)"
             + " '--adminOperation ValidateCluster'   # Validates the information in static clustermap is consistent with the information in Helix"
             + " '--adminOperation BootstrapCluster'  # (Default operation if not specified) Bootstrap cluster based on static clustermap")
         .withRequiredArg()

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -240,10 +240,8 @@ public class HelixBootstrapUpgradeTool {
       ToolUtils.ensureExactOrExit(expectedOpts, options.specs(), parser);
       HelixBootstrapUpgradeUtil.dropCluster(zkLayoutPath, clusterName, dcs, new HelixAdminFactory());
     } else if (adminConfigStr != null) {
-      List<OptionSpec<?>> expectedOpts =
-          Arrays.asList(adminConfigsOpt, zkLayoutPathOpt, hardwareLayoutPathOpt, partitionLayoutPathOpt,
-              clusterNamePrefixOpt, dcsNameOpt);
-      ToolUtils.ensureExactOrExit(expectedOpts, options.specs(), parser);
+      listOpt.add(adminConfigsOpt);
+      ToolUtils.ensureOrExit(listOpt, options, parser);
       String[] adminTypes = adminConfigStr.replaceAll("\\p{Space}", "").split(",");
       HelixBootstrapUpgradeUtil.uploadOrDeleteAdminConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
           clusterNamePrefix, dcs, options.has(forceRemove), new HelixAdminFactory(), adminTypes);

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -245,8 +245,8 @@ public class HelixBootstrapUpgradeTool {
               clusterNamePrefixOpt, dcsNameOpt);
       ToolUtils.ensureExactOrExit(expectedOpts, options.specs(), parser);
       String[] adminTypes = adminConfigStr.replaceAll("\\p{Space}", "").split(",");
-      HelixBootstrapUpgradeUtil.uploadClusterAdminConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-          clusterNamePrefix, dcs, new HelixAdminFactory(), adminTypes);
+      HelixBootstrapUpgradeUtil.uploadOrDeleteAdminConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
+          clusterNamePrefix, dcs, options.has(forceRemove), new HelixAdminFactory(), adminTypes);
     } else if (options.has(addStateModel)) {
       listOpt.add(stateModelDefinitionOpt);
       ToolUtils.ensureOrExit(listOpt, options, parser);


### PR DESCRIPTION
1. support disabling partition when decommissioning a replica. (This is supposed to be done before removing it from IdealState)
2. support enabling partition if it is previously disabled
3. support resetting partition if it is previously in ERROR state
4. introduced HelixAdminOperation in bootstrap tool to simplify some code logic
5. added option to remove admin configs (i.e. PartitionOverride map)