### PR TITLE
Fix ReplicaSyncUpManager updates lag of replica in wrong state

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplicaSyncUpManager.java
@@ -113,10 +113,11 @@ public class AmbryReplicaSyncUpManager implements ReplicaSyncUpManager {
   @Override
   public boolean updateLagBetweenReplicas(ReplicaId localReplica, ReplicaId peerReplica, long lagInBytes) {
     boolean updated = false;
-    if (replicaToLagInfos.containsKey(localReplica)) {
-      replicaToLagInfos.get(localReplica).updateLagInfo(peerReplica, lagInBytes);
+    LocalReplicaLagInfos lagInfos = replicaToLagInfos.get(localReplica);
+    if (lagInfos != null) {
+      lagInfos.updateLagInfo(peerReplica, lagInBytes);
       if (logger.isDebugEnabled()) {
-        logger.debug(replicaToLagInfos.get(localReplica).toString());
+        logger.debug(lagInfos.toString());
       }
       updated = true;
     }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -440,7 +440,8 @@ public class ReplicaThread implements Runnable {
                       replicaMetadataResponseInfo.getRemoteReplicaLagInBytes());
               exchangeMetadataResponseList.add(exchangeMetadataResponse);
               // update replication lag in ReplicaSyncUpManager
-              if (replicaSyncUpManager != null) {
+              if (replicaSyncUpManager != null
+                  && remoteReplicaInfo.getLocalStore().getCurrentState() == ReplicaState.BOOTSTRAP) {
                 ReplicaId localReplica = remoteReplicaInfo.getLocalReplicaId();
                 ReplicaId remoteReplica = remoteReplicaInfo.getReplicaId();
                 boolean updated = replicaSyncUpManager.updateLagBetweenReplicas(localReplica, remoteReplica,

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -318,7 +318,7 @@ public class ReplicaThread implements Runnable {
       long replicationStartTimeInMs = SystemTime.getInstance().milliseconds();
       long startTimeInMs = replicationStartTimeInMs;
 
-      List<RemoteReplicaInfo> activeReplicasPerNode = new ArrayList<RemoteReplicaInfo>();
+      List<RemoteReplicaInfo> activeReplicasPerNode = new ArrayList<>();
       for (RemoteReplicaInfo remoteReplicaInfo : replicasToReplicatePerNode) {
         ReplicaId replicaId = remoteReplicaInfo.getReplicaId();
         boolean inBackoff = time.milliseconds() < remoteReplicaInfo.getReEnableReplicationTime();
@@ -438,7 +438,6 @@ public class ReplicaThread implements Runnable {
               ExchangeMetadataResponse exchangeMetadataResponse =
                   new ExchangeMetadataResponse(missingStoreKeys, replicaMetadataResponseInfo.getFindToken(),
                       replicaMetadataResponseInfo.getRemoteReplicaLagInBytes());
-              exchangeMetadataResponseList.add(exchangeMetadataResponse);
               // update replication lag in ReplicaSyncUpManager
               if (replicaSyncUpManager != null
                   && remoteReplicaInfo.getLocalStore().getCurrentState() == ReplicaState.BOOTSTRAP) {
@@ -455,6 +454,10 @@ public class ReplicaThread implements Runnable {
                   remoteReplicaInfo.getLocalStore().completeBootstrap();
                 }
               }
+              // add exchangeMetadataResponse to list after replicaSyncUpManager(if not null) has completed update. The
+              // reason is replicaSyncUpManager may also throw exception and add one more exchangeMetadataResponse
+              // associated with same RemoteReplicaInfo.
+              exchangeMetadataResponseList.add(exchangeMetadataResponse);
               replicationMetrics.updateLagMetricForRemoteReplica(remoteReplicaInfo,
                   exchangeMetadataResponse.localLagFromRemoteInBytes);
             } catch (Exception e) {
@@ -817,11 +820,10 @@ public class ReplicaThread implements Runnable {
    * @param replicasToReplicatePerNode The list of remote replicas for the remote node
    * @param remoteNode The remote node from which replication needs to happen
    * @throws IOException
-   * @throws MessageFormatException
    */
   private void writeMessagesToLocalStoreAndAdvanceTokens(List<ExchangeMetadataResponse> exchangeMetadataResponseList,
       GetResponse getResponse, List<RemoteReplicaInfo> replicasToReplicatePerNode, DataNodeId remoteNode)
-      throws IOException, MessageFormatException {
+      throws IOException {
     int partitionResponseInfoIndex = 0;
     long totalBytesFixed = 0;
     long totalBlobsFixed = 0;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -172,7 +172,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
           if (updated && replicaSyncUpManager.isSyncUpComplete(localReplica)) {
             replicaSyncUpManager.onDeactivationComplete(localReplica);
           }
-        } else if (localStore.isDecommissionInProgress() && localStore.getCurrentState() == ReplicaState.OFFLINE) {
+        } else if (localStore.getCurrentState() == ReplicaState.OFFLINE && localStore.isDecommissionInProgress()) {
           // if local store is in OFFLINE state, we need more info to determine if replica is really in Inactive-To-Offline
           // transition. So we check if decommission file is present. If present, we update SyncUpManager by peer's lag
           // from end offset in local store.

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationMetrics.java
@@ -665,10 +665,11 @@ public class ReplicationMetrics {
    */
   public void updateLagMetricForRemoteReplica(RemoteReplicaInfo remoteReplicaInfo, long lag) {
     ReplicaId replicaId = remoteReplicaInfo.getReplicaId();
-    if (partitionLags.containsKey(replicaId.getPartitionId())) {
-      // update the partition's lag if and only if it was tracked.
-      partitionLags.get(replicaId.getPartitionId()).put(replicaId.getDataNodeId(), lag);
-    }
+    // update the partition's lag if and only if it was tracked.
+    partitionLags.computeIfPresent(replicaId.getPartitionId(), (k, v) -> {
+      v.put(replicaId.getDataNodeId(), lag);
+      return v;
+    });
   }
 
   /**


### PR DESCRIPTION
There is a bug in replica thread where we update replication lag for bootstrap replica in ReplicaSyncUpManager. It relies on whether there is a localReplicaLagInfo present in ReplicaSyncUpManager to update replication lag of certain bootstrap replica. 

However, if a replica is being decommissioned, it also creates a localReplicaLagInfo in ReplicaSyncUpManager. The replica thread may mistakenly updates the replication lag of a decommission replica.

This PR adds additional check to ensure the current state is BOOTSTRAP
before updating replication lag in ReplicaSyncUpManager.