### PR TITLE
Treat 'SSLEngine closed already' as a client termination exception.

### DIFF
--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -58,7 +58,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.net.ssl.SSLException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -1030,14 +1029,9 @@ public class Utils {
    * @return {@code true} this cause indicates a possible early termination from the client. {@code false} otherwise.
    */
   public static boolean isPossibleClientTermination(Throwable cause) {
-    if (cause instanceof SSLException) {
-      return SSL_ENGINE_CLOSED_EXCEPTION_MSG.equals(cause.getMessage());
-    } else if (cause instanceof IOException) {
-      return CLIENT_RESET_EXCEPTION_MSG.equals(cause.getMessage()) || CLIENT_BROKEN_PIPE_EXCEPTION_MSG.equals(
-          cause.getMessage());
-    } else {
-      return false;
-    }
+    return cause instanceof IOException && (CLIENT_RESET_EXCEPTION_MSG.equals(cause.getMessage())
+        || CLIENT_BROKEN_PIPE_EXCEPTION_MSG.equals(cause.getMessage()) || SSL_ENGINE_CLOSED_EXCEPTION_MSG.equals(
+        cause.getMessage()));
   }
 
   /**

--- a/ambry-utils/src/test/java/com/github/ambry/utils/UtilsTest.java
+++ b/ambry-utils/src/test/java/com/github/ambry/utils/UtilsTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.net.ssl.SSLException;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -576,6 +577,11 @@ public class UtilsTest {
     // debatable but this is the current implementation.
     assertFalse("Should not be declared as a client termination", Utils.isPossibleClientTermination(exception));
     exception = Utils.convertToClientTerminationException(exception);
+    assertTrue("Should be declared as a client termination", Utils.isPossibleClientTermination(exception));
+
+    exception = new SSLException("Handshake failure");
+    assertFalse("Should not be declared as a client termination", Utils.isPossibleClientTermination(exception));
+    exception = new SSLException("SSLEngine closed already");
     assertTrue("Should be declared as a client termination", Utils.isPossibleClientTermination(exception));
   }
 


### PR DESCRIPTION
When clients close the connection from their side, the router may
still be delivering data. When using SSL, the write call in
NettyResponseChannel may encounter an exception indicating the SSLEngine
has already been closed, which can happen when the connection is in the
process of being closed.

This change treats such exceptions as client-side connection
terminations so they will not be logged so verbosely. See
NettyResponseChannel::log for how Utils::isPossibleClientTermination
is used.