### PR TITLE
Add skeleton for router to support undelete

### DIFF
--- a/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/MockRouter.java
@@ -164,6 +164,11 @@ public class MockRouter implements Router {
     throw new UnsupportedOperationException("updateBlobTtl is not supported by this mock");
   }
 
+  @Override
+  public Future<Void> undeleteBlob(String blobId, String serviceId, Callback<Void> callback) {
+    throw new UnsupportedOperationException("Undelete is currently unsupported");
+  }
+
   /**
    * clear would remove all the blob in the map.
    */

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -100,6 +100,7 @@ public class RouterConfig {
   public static final String ROUTER_CLOUD_SUCCESS_TARGET = "router.cloud.success.target";
   public static final String ROUTER_CLOUD_REQUEST_PARALLELISM = "router.cloud.request.parallelism";
   public static final String ROUTER_ENABLE_HTTP2_NETWORK_CLIENT = "router.enable.http2.network.client";
+  public static final String ROUTER_ENABLE_UNDELETE = "router.enable.undelete";
 
   /**
    * Number of independent scaling units for the router.
@@ -481,6 +482,13 @@ public class RouterConfig {
   public final boolean routerEnableHttp2NetworkClient;
 
   /**
+   * Whether or not to enable undelete operation
+   */
+  @Config(ROUTER_ENABLE_UNDELETE)
+  @Default("false")
+  public final boolean routerEnableUndelete;
+
+  /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
    */
@@ -583,5 +591,6 @@ public class RouterConfig {
     routerCloudRequestParallelism =
         verifiableProperties.getIntInRange(ROUTER_CLOUD_REQUEST_PARALLELISM, 1, 1, Integer.MAX_VALUE);
     routerEnableHttp2NetworkClient = verifiableProperties.getBoolean(ROUTER_ENABLE_HTTP2_NETWORK_CLIENT, false);
+    routerEnableUndelete = verifiableProperties.getBoolean(ROUTER_ENABLE_UNDELETE, false);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/RouterConfig.java
@@ -100,7 +100,6 @@ public class RouterConfig {
   public static final String ROUTER_CLOUD_SUCCESS_TARGET = "router.cloud.success.target";
   public static final String ROUTER_CLOUD_REQUEST_PARALLELISM = "router.cloud.request.parallelism";
   public static final String ROUTER_ENABLE_HTTP2_NETWORK_CLIENT = "router.enable.http2.network.client";
-  public static final String ROUTER_ENABLE_UNDELETE = "router.enable.undelete";
 
   /**
    * Number of independent scaling units for the router.
@@ -482,13 +481,6 @@ public class RouterConfig {
   public final boolean routerEnableHttp2NetworkClient;
 
   /**
-   * Whether or not to enable undelete operation
-   */
-  @Config(ROUTER_ENABLE_UNDELETE)
-  @Default("false")
-  public final boolean routerEnableUndelete;
-
-  /**
    * Create a RouterConfig instance.
    * @param verifiableProperties the properties map to refer to.
    */
@@ -591,6 +583,5 @@ public class RouterConfig {
     routerCloudRequestParallelism =
         verifiableProperties.getIntInRange(ROUTER_CLOUD_REQUEST_PARALLELISM, 1, 1, Integer.MAX_VALUE);
     routerEnableHttp2NetworkClient = verifiableProperties.getBoolean(ROUTER_ENABLE_HTTP2_NETWORK_CLIENT, false);
-    routerEnableUndelete = verifiableProperties.getBoolean(ROUTER_ENABLE_UNDELETE, false);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/router/Router.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/Router.java
@@ -95,14 +95,7 @@ public interface Router extends Closeable {
    * @param callback The {@link Callback} which will be invoked on the completion of a request.
    * @return A future that would contain information about whether the undelete succeeded or not, eventually.
    */
-  default Future<Void> undeleteBlob(String blobId, String serviceId, Callback<Void> callback) {
-    FutureResult<Void> result = new FutureResult<>();
-    result.done(null, null);
-    if (callback != null) {
-      callback.onCompletion(null, null);
-    }
-    return result;
-  }
+  Future<Void> undeleteBlob(String blobId, String serviceId, Callback<Void> callback);
 
   /**
    * Closes the router and releases any resources held by the router. If the router is already closed, then this

--- a/ambry-api/src/main/java/com/github/ambry/router/Router.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/Router.java
@@ -89,6 +89,22 @@ public interface Router extends Closeable {
   Future<Void> updateBlobTtl(String blobId, String serviceId, long expiresAtMs, Callback<Void> callback);
 
   /**
+   * Requests for a blob to be undeleted asynchronously and invokes the {@link Callback} when the request completes.
+   * @param blobId The ID of the blob that needs to be undeleted.
+   * @param serviceId The service ID of the service undeleting the blob. This can be null if unknown.
+   * @param callback The {@link Callback} which will be invoked on the completion of a request.
+   * @return A future that would contain information about whether the undelete succeeded or not, eventually.
+   */
+  default Future<Void> undeleteBlob(String blobId, String serviceId, Callback<Void> callback) {
+    FutureResult<Void> result = new FutureResult<>();
+    result.done(null, null);
+    if (callback != null) {
+      callback.onCompletion(null, null);
+    }
+    return result;
+  }
+
+  /**
    * Closes the router and releases any resources held by the router. If the router is already closed, then this
    * method has no effect.
    * <p/>
@@ -166,5 +182,15 @@ public interface Router extends Closeable {
    */
   default Future<Void> updateBlobTtl(String blobId, String serviceId, long expiresAtMs) {
     return updateBlobTtl(blobId, serviceId, expiresAtMs, null);
+  }
+
+  /**
+   * Requests for a blob to be undeleted asynchronously and invokes the {@link Callback} when the request completes.
+   * @param blobId The ID of the blob that needs to be undeleted.
+   * @param serviceId The service ID of the service undeleting the blob. This can be null if unknown.
+   * @return A future that would contain information about whether the undelete succeeded or not, eventually.
+   */
+  default Future<Void> undeleteBlob(String blobId, String serviceId) {
+    return undeleteBlob(blobId, serviceId, null);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/router/Router.java
+++ b/ambry-api/src/main/java/com/github/ambry/router/Router.java
@@ -178,7 +178,8 @@ public interface Router extends Closeable {
   }
 
   /**
-   * Requests for a blob to be undeleted asynchronously and invokes the {@link Callback} when the request completes.
+   * Requests for a blob to be undeleted asynchronously and returns a future that will eventually contain information
+   * about whether the request succeeded or not.
    * @param blobId The ID of the blob that needs to be undeleted.
    * @param serviceId The service ID of the service undeleting the blob. This can be null if unknown.
    * @return A future that would contain information about whether the undelete succeeded or not, eventually.

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -2838,11 +2838,7 @@ class FrontendTestRouter implements Router {
    * Enumerates the different operation types in the router.
    */
   enum OpType {
-    DeleteBlob,
-    GetBlob,
-    PutBlob,
-    StitchBlob,
-    UpdateBlobTtl
+    DeleteBlob, GetBlob, PutBlob, StitchBlob, UpdateBlobTtl, UndeleteBlob,
   }
 
   OpType exceptionOpType = null;
@@ -2850,6 +2846,7 @@ class FrontendTestRouter implements Router {
   RuntimeException exceptionToThrow = null;
   String deleteServiceId = null;
   String ttlUpdateServiceId = null;
+  String undeleteServiceId = null;
 
   @Override
   public Future<GetBlobResult> getBlob(String blobId, GetBlobOptions options, Callback<GetBlobResult> callback) {
@@ -2894,6 +2891,12 @@ class FrontendTestRouter implements Router {
   public Future<Void> updateBlobTtl(String blobId, String serviceId, long expiresAtMs, Callback<Void> callback) {
     ttlUpdateServiceId = serviceId;
     return completeOperation(null, callback, OpType.UpdateBlobTtl);
+  }
+
+  @Override
+  public Future<Void> undeleteBlob(String blobId, String serviceId, Callback<Void> callback) {
+    undeleteServiceId = serviceId;
+    return completeOperation(null, callback, OpType.UndeleteBlob);
   }
 
   @Override

--- a/ambry-router/src/main/java/com/github/ambry/router/BatchOperationCallbackTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/BatchOperationCallbackTracker.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import com.github.ambry.commons.BlobId;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+/**
+ * Tracks callbacks for TtlUpdate operations over multiple chunks of a single blob
+ */
+class BatchOperationCallbackTracker {
+  static final FutureResult<Void> DUMMY_FUTURE = new FutureResult<>();
+
+  private final FutureResult<Void> futureResult;
+  private final Callback<Void> callback;
+  private final long numBlobIds;
+  private final ConcurrentMap<BlobId, Boolean> blobIdToAck = new ConcurrentHashMap<>();
+  private final AtomicLong ackedCount = new AtomicLong(0);
+  private final AtomicBoolean completed = new AtomicBoolean(false);
+
+  /**
+   * Constructor
+   * @param blobIds the {@link BlobId}s being tracked
+   * @param futureResult the {@link FutureResult} to be triggered once acks are received for all blobs
+   * @param callback the {@link Callback} to be triggered once acks are received for all blobs
+   */
+  BatchOperationCallbackTracker(List<BlobId> blobIds, FutureResult<Void> futureResult,
+      Callback<Void> callback) {
+    numBlobIds = blobIds.size();
+    blobIds.forEach(blobId -> blobIdToAck.put(blobId, false));
+    if (blobIdToAck.size() != numBlobIds) {
+      throw new IllegalArgumentException("The list of BlobIds provided has duplicates: " + blobIds);
+    }
+    this.futureResult = futureResult;
+    this.callback = callback;
+  }
+
+  /**
+   * Gets a {@link Callback} personalized for {@code blobId}.
+   * @param blobId the {@link BlobId} for which the
+   * @return the {@link Callback} to be used with the {@link TtlUpdateOperation} for {@code blobId}.
+   */
+  Callback<Void> getCallback(final BlobId blobId) {
+    return (result, exception) -> {
+      if (exception == null) {
+        if (blobIdToAck.put(blobId, true)) {
+          // already acked once
+          complete(new RouterException("Ack for " + blobId + " arrived more than once",
+              RouterErrorCode.UnexpectedInternalError));
+        } else if (ackedCount.incrementAndGet() >= numBlobIds) {
+          // acked for the first time for this blob id and all the blob ids have been acked
+          complete(null);
+        }
+      } else {
+        complete(exception);
+      }
+    };
+  }
+
+  /**
+   * Completes the batch operation
+   * @param e the {@link Exception} that occurred (if any).
+   */
+  private void complete(Exception e) {
+    if (completed.compareAndSet(false, true)) {
+      NonBlockingRouter.completeOperation(futureResult, callback, null, e, false);
+    }
+  }
+}

--- a/ambry-router/src/main/java/com/github/ambry/router/BatchOperationCallbackTracker.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/BatchOperationCallbackTracker.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 
 /**
- * Tracks callbacks for TtlUpdate operations over multiple chunks of a single blob
+ * Tracks callbacks for {@link TtlUpdateOperation} and {@link UndeleteOperation} over multiple chunks of a single blob
  */
 class BatchOperationCallbackTracker {
   static final FutureResult<Void> DUMMY_FUTURE = new FutureResult<>();
@@ -40,8 +40,7 @@ class BatchOperationCallbackTracker {
    * @param futureResult the {@link FutureResult} to be triggered once acks are received for all blobs
    * @param callback the {@link Callback} to be triggered once acks are received for all blobs
    */
-  BatchOperationCallbackTracker(List<BlobId> blobIds, FutureResult<Void> futureResult,
-      Callback<Void> callback) {
+  BatchOperationCallbackTracker(List<BlobId> blobIds, FutureResult<Void> futureResult, Callback<Void> callback) {
     numBlobIds = blobIds.size();
     blobIds.forEach(blobId -> blobIdToAck.put(blobId, false));
     if (blobIdToAck.size() != numBlobIds) {
@@ -54,7 +53,7 @@ class BatchOperationCallbackTracker {
   /**
    * Gets a {@link Callback} personalized for {@code blobId}.
    * @param blobId the {@link BlobId} for which the
-   * @return the {@link Callback} to be used with the {@link TtlUpdateOperation} for {@code blobId}.
+   * @return the {@link Callback} to be used with the {@link TtlUpdateOperation} and {@link UndeleteOperation} for {@code blobId}.
    */
   Callback<Void> getCallback(final BlobId blobId) {
     return (result, exception) -> {

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -287,11 +287,15 @@ class NonBlockingRouter implements Router {
     return futureResult;
   }
 
+  /**
+   * Requests for a blob to be undeleted asynchronously and invokes the {@link Callback} when the request completes.
+   * @param blobId The ID of the blob that needs to be undeleted.
+   * @param serviceId The service ID of the service undeleting the blob. This can be null if unknown.
+   * @param callback The {@link Callback} which will be invoked on the completion of a request.
+   * @return A future that would contain information about whether the undelete succeeded or not, eventually.
+   */
   @Override
   public Future<Void> undeleteBlob(String blobId, String serviceId, Callback<Void> callback) {
-    if (!routerConfig.routerEnableUndelete) {
-      throw new IllegalStateException("Undelete not supported");
-    }
     if (blobId == null) {
       throw new IllegalArgumentException("blobId must not be null");
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -769,7 +769,7 @@ class NonBlockingRouter implements Router {
             completeOperation(futureResult, callback, null, exception, false);
           } else if (result.getBlobResult != null) {
             exception = new RouterException(
-                "GET blob call returned the blob instead of just the store keys (before TTL update)",
+                "GET blob call returned the blob instead of just the store keys (before undelete)",
                 RouterErrorCode.UnexpectedInternalError);
             completeOperation(futureResult, callback, null, exception, false);
           } else {
@@ -788,11 +788,11 @@ class NonBlockingRouter implements Router {
             .getOption(GetOption.None)
             .build();
         GetBlobOptionsInternal optionsInternal =
-            new GetBlobOptionsInternal(options, true, routerMetrics.ageAtTtlUpdate);
+            new GetBlobOptionsInternal(options, true, routerMetrics.ageAtUndelete);
         try {
           getBlob(blobIdStr, optionsInternal, internalCallback);
         } catch (RouterException e) {
-          completeUpdateBlobTtlOperation(e, futureResult, callback);
+          completeUndeleteBlobOperation(e, futureResult, callback);
         }
       } else {
         // do undelete directly on single blobId

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -61,6 +61,7 @@ public class NonBlockingRouterMetrics {
   public final Meter getBlobWithRangeOperationRate;
   public final Meter getBlobWithSegmentOperationRate;
   public final Meter deleteBlobOperationRate;
+  public final Meter undeleteBlobOperationRate;
   public final Meter updateBlobTtlOperationRate;
   public final Meter putEncryptedBlobOperationRate;
   public final Meter stitchEncryptedBlobOperationRate;
@@ -72,6 +73,7 @@ public class NonBlockingRouterMetrics {
   public final Meter operationDequeuingRate;
   public final Meter getBlobNotOriginateLocalOperationRate;
   public final Meter deleteBlobNotOriginateLocalOperationRate;
+  public final Meter undeleteBlobNotOriginateLocalOperationRate;
   public final Meter ttlUpdateBlobNotOriginateLocalOperationRate;
 
   // Latency.
@@ -88,6 +90,7 @@ public class NonBlockingRouterMetrics {
   public final Histogram getEncryptedBlobOperationLatencyMs;
   public final Histogram getEncryptedBlobOperationTotalTimeMs;
   public final Histogram deleteBlobOperationLatencyMs;
+  public final Histogram undeleteBlobOperationLatencyMs;
   public final Histogram updateBlobTtlOperationLatencyMs;
   public final Histogram routerRequestLatencyMs;
   public final Histogram responseReceiveToHandleLatencyMs;
@@ -106,6 +109,7 @@ public class NonBlockingRouterMetrics {
   public final Counter getEncryptedBlobWithRangeErrorCount;
   public final Counter getEncryptedBlobWithSegmentErrorCount;
   public final Counter deleteBlobErrorCount;
+  public final Counter undeleteBlobErrorCount;
   public final Counter updateBlobTtlErrorCount;
   public final Counter operationAbortCount;
   public final Counter routerRequestErrorCount;
@@ -138,10 +142,12 @@ public class NonBlockingRouterMetrics {
   public final Histogram putManagerPollTimeMs;
   public final Histogram getManagerPollTimeMs;
   public final Histogram deleteManagerPollTimeMs;
+  public final Histogram undeleteManagerPollTimeMs;
   public final Histogram ttlUpdateManagerPollTimeMs;
   public final Histogram putManagerHandleResponseTimeMs;
   public final Histogram getManagerHandleResponseTimeMs;
   public final Histogram deleteManagerHandleResponseTimeMs;
+  public final Histogram undeleteManagerHandleResponseTimeMs;
   public final Histogram ttlUpdateManagerHandleResponseTimeMs;
   // time spent in getting a chunk filled once it is available.
   public final Histogram chunkFillTimeMs;
@@ -243,6 +249,8 @@ public class NonBlockingRouterMetrics {
         metricRegistry.meter(MetricRegistry.name(GetBlobOperation.class, "GetEncryptedBlobWithSegmentOperationRate"));
     deleteBlobOperationRate =
         metricRegistry.meter(MetricRegistry.name(DeleteOperation.class, "DeleteBlobOperationRate"));
+    undeleteBlobOperationRate =
+        metricRegistry.meter(MetricRegistry.name(DeleteOperation.class, "UndeleteBlobOperationRate"));
     updateBlobTtlOperationRate =
         metricRegistry.meter(MetricRegistry.name(TtlUpdateOperation.class, "UpdateBlobTtlOperationRate"));
     operationQueuingRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "OperationQueuingRate"));
@@ -252,6 +260,8 @@ public class NonBlockingRouterMetrics {
         metricRegistry.meter(MetricRegistry.name(GetBlobOperation.class, "GetBlobNotOriginateLocalOperationRate"));
     deleteBlobNotOriginateLocalOperationRate =
         metricRegistry.meter(MetricRegistry.name(DeleteOperation.class, "DeleteBlobNotOriginateLocalOperationRate"));
+    undeleteBlobNotOriginateLocalOperationRate =
+        metricRegistry.meter(MetricRegistry.name(DeleteOperation.class, "UndeleteBlobNotOriginateLocalOperationRate"));
     ttlUpdateBlobNotOriginateLocalOperationRate = metricRegistry.meter(
         MetricRegistry.name(TtlUpdateOperation.class, "TtlUpdateBlobNotOriginateLocalOperationRate"));
 
@@ -282,6 +292,8 @@ public class NonBlockingRouterMetrics {
         metricRegistry.histogram(MetricRegistry.name(GetBlobOperation.class, "GetEncryptedBlobOperationTotalTimeMs"));
     deleteBlobOperationLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(DeleteOperation.class, "DeleteBlobOperationLatencyMs"));
+    undeleteBlobOperationLatencyMs =
+        metricRegistry.histogram(MetricRegistry.name(DeleteOperation.class, "UndeleteBlobOperationLatencyMs"));
     updateBlobTtlOperationLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(TtlUpdateOperation.class, "UpdateBlobTtlOperationLatencyMs"));
     routerRequestLatencyMs =
@@ -312,6 +324,7 @@ public class NonBlockingRouterMetrics {
     getEncryptedBlobWithSegmentErrorCount =
         metricRegistry.counter(MetricRegistry.name(GetBlobOperation.class, "GetEncryptedBlobWithSegmentErrorCount"));
     deleteBlobErrorCount = metricRegistry.counter(MetricRegistry.name(DeleteOperation.class, "DeleteBlobErrorCount"));
+    undeleteBlobErrorCount = metricRegistry.counter(MetricRegistry.name(DeleteOperation.class, "UndeleteBlobErrorCount"));
     updateBlobTtlErrorCount =
         metricRegistry.counter(MetricRegistry.name(TtlUpdateOperation.class, "UpdateBlobTtlErrorCount"));
     operationAbortCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OperationAbortCount"));
@@ -369,6 +382,8 @@ public class NonBlockingRouterMetrics {
     getManagerPollTimeMs = metricRegistry.histogram(MetricRegistry.name(GetManager.class, "GetManagerPollTimeMs"));
     deleteManagerPollTimeMs =
         metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "DeleteManagerPollTimeMs"));
+    undeleteManagerPollTimeMs =
+        metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "UndeleteManagerPollTimeMs"));
     ttlUpdateManagerPollTimeMs =
         metricRegistry.histogram(MetricRegistry.name(TtlUpdateManager.class, "TtlUpdateManagerPollTimeMs"));
     putManagerHandleResponseTimeMs =
@@ -377,6 +392,8 @@ public class NonBlockingRouterMetrics {
         metricRegistry.histogram(MetricRegistry.name(GetManager.class, "GetManagerHandleResponseTimeMs"));
     deleteManagerHandleResponseTimeMs =
         metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "DeleteManagerHandleResponseTimeMs"));
+    undeleteManagerHandleResponseTimeMs =
+        metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "UndeleteManagerHandleResponseTimeMs"));
     ttlUpdateManagerHandleResponseTimeMs =
         metricRegistry.histogram(MetricRegistry.name(TtlUpdateManager.class, "TtlUpdateManagerHandleResponseTimeMs"));
     chunkFillTimeMs = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "ChunkFillTimeMs"));
@@ -786,6 +803,18 @@ public class NonBlockingRouterMetrics {
     onError(e);
     if (RouterUtils.isSystemHealthError(e)) {
       updateBlobTtlErrorCount.inc();
+      operationErrorRate.mark();
+    }
+  }
+
+  /**
+   * Update appropriate metrics on a undeleteBlob operation related error.
+   * @param e the {@link Exception} associated with the error.
+   */
+  void onUndeleteBlobError(Exception e) {
+    onError(e);
+    if (RouterUtils.isSystemHealthError(e)) {
+      undeleteBlobErrorCount.inc();
       operationErrorRate.mark();
     }
   }

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -203,6 +203,7 @@ public class NonBlockingRouterMetrics {
   // Workload characteristics
   public final AgeAtAccessMetrics ageAtGet;
   public final AgeAtAccessMetrics ageAtDelete;
+  public final AgeAtAccessMetrics ageAtUndelete;
   public final AgeAtAccessMetrics ageAtTtlUpdate;
 
   // Crypto job metrics
@@ -470,6 +471,7 @@ public class NonBlockingRouterMetrics {
     // Workload
     ageAtGet = new AgeAtAccessMetrics(metricRegistry, "OnGet");
     ageAtDelete = new AgeAtAccessMetrics(metricRegistry, "OnDelete");
+    ageAtUndelete = new AgeAtAccessMetrics(metricRegistry, "OnUndelete");
     ageAtTtlUpdate = new AgeAtAccessMetrics(metricRegistry, "OnTtlUpdate");
 
     // Encrypt/Decrypt job metrics

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -251,7 +251,7 @@ public class NonBlockingRouterMetrics {
     deleteBlobOperationRate =
         metricRegistry.meter(MetricRegistry.name(DeleteOperation.class, "DeleteBlobOperationRate"));
     undeleteBlobOperationRate =
-        metricRegistry.meter(MetricRegistry.name(DeleteOperation.class, "UndeleteBlobOperationRate"));
+        metricRegistry.meter(MetricRegistry.name(UndeleteOperation.class, "UndeleteBlobOperationRate"));
     updateBlobTtlOperationRate =
         metricRegistry.meter(MetricRegistry.name(TtlUpdateOperation.class, "UpdateBlobTtlOperationRate"));
     operationQueuingRate = metricRegistry.meter(MetricRegistry.name(NonBlockingRouter.class, "OperationQueuingRate"));
@@ -261,8 +261,8 @@ public class NonBlockingRouterMetrics {
         metricRegistry.meter(MetricRegistry.name(GetBlobOperation.class, "GetBlobNotOriginateLocalOperationRate"));
     deleteBlobNotOriginateLocalOperationRate =
         metricRegistry.meter(MetricRegistry.name(DeleteOperation.class, "DeleteBlobNotOriginateLocalOperationRate"));
-    undeleteBlobNotOriginateLocalOperationRate =
-        metricRegistry.meter(MetricRegistry.name(DeleteOperation.class, "UndeleteBlobNotOriginateLocalOperationRate"));
+    undeleteBlobNotOriginateLocalOperationRate = metricRegistry.meter(
+        MetricRegistry.name(UndeleteOperation.class, "UndeleteBlobNotOriginateLocalOperationRate"));
     ttlUpdateBlobNotOriginateLocalOperationRate = metricRegistry.meter(
         MetricRegistry.name(TtlUpdateOperation.class, "TtlUpdateBlobNotOriginateLocalOperationRate"));
 
@@ -294,7 +294,7 @@ public class NonBlockingRouterMetrics {
     deleteBlobOperationLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(DeleteOperation.class, "DeleteBlobOperationLatencyMs"));
     undeleteBlobOperationLatencyMs =
-        metricRegistry.histogram(MetricRegistry.name(DeleteOperation.class, "UndeleteBlobOperationLatencyMs"));
+        metricRegistry.histogram(MetricRegistry.name(UndeleteOperation.class, "UndeleteBlobOperationLatencyMs"));
     updateBlobTtlOperationLatencyMs =
         metricRegistry.histogram(MetricRegistry.name(TtlUpdateOperation.class, "UpdateBlobTtlOperationLatencyMs"));
     routerRequestLatencyMs =
@@ -325,7 +325,8 @@ public class NonBlockingRouterMetrics {
     getEncryptedBlobWithSegmentErrorCount =
         metricRegistry.counter(MetricRegistry.name(GetBlobOperation.class, "GetEncryptedBlobWithSegmentErrorCount"));
     deleteBlobErrorCount = metricRegistry.counter(MetricRegistry.name(DeleteOperation.class, "DeleteBlobErrorCount"));
-    undeleteBlobErrorCount = metricRegistry.counter(MetricRegistry.name(DeleteOperation.class, "UndeleteBlobErrorCount"));
+    undeleteBlobErrorCount =
+        metricRegistry.counter(MetricRegistry.name(UndeleteOperation.class, "UndeleteBlobErrorCount"));
     updateBlobTtlErrorCount =
         metricRegistry.counter(MetricRegistry.name(TtlUpdateOperation.class, "UpdateBlobTtlErrorCount"));
     operationAbortCount = metricRegistry.counter(MetricRegistry.name(NonBlockingRouter.class, "OperationAbortCount"));
@@ -384,7 +385,7 @@ public class NonBlockingRouterMetrics {
     deleteManagerPollTimeMs =
         metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "DeleteManagerPollTimeMs"));
     undeleteManagerPollTimeMs =
-        metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "UndeleteManagerPollTimeMs"));
+        metricRegistry.histogram(MetricRegistry.name(UndeleteManager.class, "UndeleteManagerPollTimeMs"));
     ttlUpdateManagerPollTimeMs =
         metricRegistry.histogram(MetricRegistry.name(TtlUpdateManager.class, "TtlUpdateManagerPollTimeMs"));
     putManagerHandleResponseTimeMs =
@@ -394,7 +395,7 @@ public class NonBlockingRouterMetrics {
     deleteManagerHandleResponseTimeMs =
         metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "DeleteManagerHandleResponseTimeMs"));
     undeleteManagerHandleResponseTimeMs =
-        metricRegistry.histogram(MetricRegistry.name(DeleteManager.class, "UndeleteManagerHandleResponseTimeMs"));
+        metricRegistry.histogram(MetricRegistry.name(UndeleteManager.class, "UndeleteManagerHandleResponseTimeMs"));
     ttlUpdateManagerHandleResponseTimeMs =
         metricRegistry.histogram(MetricRegistry.name(TtlUpdateManager.class, "TtlUpdateManagerHandleResponseTimeMs"));
     chunkFillTimeMs = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "ChunkFillTimeMs"));

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterOperation.java
@@ -14,5 +14,5 @@
 package com.github.ambry.router;
 
 public enum RouterOperation {
-  GetBlobOperation, GetBlobInfoOperation, PutOperation, DeleteOperation, TtlUpdateOperation
+  GetBlobOperation, GetBlobInfoOperation, PutOperation, DeleteOperation, TtlUpdateOperation, UndeleteOperation
 }

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteManager.java
@@ -151,7 +151,7 @@ public class UndeleteManager {
         RouterUtils.extractResponseAndNotifyResponseHandler(responseHandler, routerMetrics, responseInfo,
             UndeleteResponse::readFrom, UndeleteResponse::getError);
     RequestInfo routerRequestInfo = responseInfo.getRequestInfo();
-    int correlationId = ((UndeleteRequest) routerRequestInfo.getRequest()).getCorrelationId();
+    int correlationId = routerRequestInfo.getRequest().getCorrelationId();
     UndeleteOperation undeleteOperation = correlationIdToUndeleteOperation.remove(correlationId);
     // If it is still an active operation, hand over the response. Otherwise, ignore.
     if (undeleteOperations.contains(undeleteOperation)) {

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteManager.java
@@ -35,9 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 
 /**
@@ -103,13 +100,12 @@ public class UndeleteManager {
               callback, time, futureResult);
       undeleteOperations.add(undeleteOperation);
     } else {
-      BatchUndeleteOperationCallbackTracker tracker =
-          new BatchUndeleteOperationCallbackTracker(blobIds, futureResult, callback);
+      BatchOperationCallbackTracker tracker = new BatchOperationCallbackTracker(blobIds, futureResult, callback);
       long operationTimeMs = time.milliseconds();
       for (BlobId blobId : blobIds) {
         UndeleteOperation undeleteOperation =
             new UndeleteOperation(clusterMap, routerConfig, routerMetrics, blobId, serviceId, operationTimeMs,
-                tracker.getCallback(blobId), time, BatchUndeleteOperationCallbackTracker.DUMMY_FUTURE);
+                tracker.getCallback(blobId), time, BatchOperationCallbackTracker.DUMMY_FUTURE);
         undeleteOperations.add(undeleteOperation);
       }
     }
@@ -131,8 +127,8 @@ public class UndeleteManager {
         op.poll(requestRegistrationCallback);
       } catch (Exception e) {
         exceptionEncountered = true;
-        op.setOperationException(
-            new RouterException("Undelete poll encountered unexpected error", e, RouterErrorCode.UnexpectedInternalError));
+        op.setOperationException(new RouterException("Undelete poll encountered unexpected error", e,
+            RouterErrorCode.UnexpectedInternalError));
       }
       if (exceptionEncountered || op.isOperationComplete()) {
         if (undeleteOperations.remove(op)) {
@@ -216,69 +212,6 @@ public class UndeleteManager {
         routerMetrics.operationAbortCount.inc();
         routerMetrics.onUndeleteBlobError(e);
         NonBlockingRouter.completeOperation(op.getFutureResult(), op.getCallback(), null, e);
-      }
-    }
-  }
-
-  /**
-   * Tracks callbacks for Undelete operations over multiple chunks of a single blob
-   */
-  private static class BatchUndeleteOperationCallbackTracker {
-    static final FutureResult<Void> DUMMY_FUTURE = new FutureResult<>();
-
-    private final FutureResult<Void> futureResult;
-    private final Callback<Void> callback;
-    private final long numBlobIds;
-    private final ConcurrentMap<BlobId, Boolean> blobIdToAck = new ConcurrentHashMap<>();
-    private final AtomicLong ackedCount = new AtomicLong(0);
-    private final AtomicBoolean completed = new AtomicBoolean(false);
-
-    /**
-     * Constructor
-     * @param blobIds the {@link BlobId}s being tracked
-     * @param futureResult the {@link FutureResult} to be triggered once acks are received for all blobs
-     * @param callback the {@link Callback} to be triggered once acks are received for all blobs
-     */
-    BatchUndeleteOperationCallbackTracker(List<BlobId> blobIds, FutureResult<Void> futureResult,
-        Callback<Void> callback) {
-      numBlobIds = blobIds.size();
-      blobIds.forEach(blobId -> blobIdToAck.put(blobId, false));
-      if (blobIdToAck.size() != numBlobIds) {
-        throw new IllegalArgumentException("The list of BlobIds provided has duplicates: " + blobIds);
-      }
-      this.futureResult = futureResult;
-      this.callback = callback;
-    }
-
-    /**
-     * Gets a {@link Callback} personalized for {@code blobId}.
-     * @param blobId the {@link BlobId} for which the
-     * @return the {@link Callback} to be used with the {@link UndeleteOperation} for {@code blobId}.
-     */
-    Callback<Void> getCallback(final BlobId blobId) {
-      return (result, exception) -> {
-        if (exception == null) {
-          if (blobIdToAck.put(blobId, true)) {
-            // already acked once
-            complete(new RouterException("Ack for " + blobId + " arrived more than once",
-                RouterErrorCode.UnexpectedInternalError));
-          } else if (ackedCount.incrementAndGet() >= numBlobIds) {
-            // acked for the first time for this blob id and all the blob ids have been acked
-            complete(null);
-          }
-        } else {
-          complete(exception);
-        }
-      };
-    }
-
-    /**
-     * Completes the batch operation
-     * @param e the {@link Exception} that occurred (if any).
-     */
-    private void complete(Exception e) {
-      if (completed.compareAndSet(false, true)) {
-        NonBlockingRouter.completeOperation(futureResult, callback, null, e, false);
       }
     }
   }

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.router;
+
+import com.github.ambry.clustermap.ClusterMap;
+import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.config.RouterConfig;
+import com.github.ambry.network.ResponseInfo;
+import com.github.ambry.protocol.UndeleteRequest;
+import com.github.ambry.protocol.UndeleteResponse;
+import com.github.ambry.server.ServerErrorCode;
+import com.github.ambry.utils.Time;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This class manages the internal state of a {@link UndeleteOperation} during its life cycle.
+ */
+public class UndeleteOperation {
+  //Operation arguments
+  private final RouterConfig routerConfig;
+  private final BlobId blobId;
+  private final String serviceId;
+  private final FutureResult<Void> futureResult;
+  private final Callback<Void> callback;
+  private final Time time;
+  private final NonBlockingRouterMetrics routerMetrics;
+  private final long operationTimeMs;
+  // Parameters associated with the state.
+  // The operation tracker that tracks the state of this operation.
+  private final OperationTracker operationTracker;
+  // A map used to find inflight requests using a correlation id.
+  private final Map<Integer, UndeleteRequestInfo> undeleteRequestInfos = new TreeMap<>();
+  // The result of this operation to be set into FutureResult.
+  private final Void operationResult = null;
+  // the cause for failure of this operation. This will be set if and when the operation encounters an irrecoverable
+  // failure.
+  private final AtomicReference<Exception> operationException = new AtomicReference<Exception>();
+  // RouterErrorCode that is resolved from all the received ServerErrorCode for this operation.
+  private RouterErrorCode resolvedRouterErrorCode;
+  // Denotes whether the operation is complete.
+  private boolean operationCompleted = false;
+  private static final Logger LOGGER = LoggerFactory.getLogger(UndeleteOperation.class);
+
+  /**
+   * Instantiates a {@link UndeleteOperation}.
+   * @param clusterMap the {@link ClusterMap} to use.
+   * @param routerConfig The {@link RouterConfig} that contains router-level configurations.
+   * @param routerMetrics The {@link NonBlockingRouterMetrics} to record all router-related metrics.
+   * @param blobId The {@link BlobId} needs to be undeleted by this {@link UndeleteOperation}.
+   * @param serviceId The service ID of the service deleting the blob. This can be null if unknown.
+   * @param operationTimeMs the time at which the operation occurred.
+   * @param callback The {@link Callback} that is supplied by the caller.
+   * @param time A {@link Time} reference.
+   * @param futureResult The {@link FutureResult} that is returned to the caller.
+   */
+  UndeleteOperation(ClusterMap clusterMap, RouterConfig routerConfig, NonBlockingRouterMetrics routerMetrics,
+      BlobId blobId, String serviceId, long operationTimeMs, Callback<Void> callback, Time time,
+      FutureResult<Void> futureResult) {
+    this.routerConfig = routerConfig;
+    this.routerMetrics = routerMetrics;
+    this.blobId = blobId;
+    this.serviceId = serviceId;
+    this.futureResult = futureResult;
+    this.callback = callback;
+    this.time = time;
+    this.operationTimeMs = operationTimeMs;
+    byte blobDcId = blobId.getDatacenterId();
+    String originatingDcName = clusterMap.getDatacenterName(blobDcId);
+    this.operationTracker =
+        new SimpleOperationTracker(routerConfig, RouterOperation.UndeleteOperation, blobId.getPartition(),
+            originatingDcName, false);
+  }
+
+  /**
+   * Gets a list of {@link UndeleteRequest} for sending to replicas.
+   * @param requestRegistrationCallback the {@link RequestRegistrationCallback} to call for every request
+   *                            that gets created as part of this poll operation.
+   */
+  void poll(RequestRegistrationCallback<UndeleteOperation> requestRegistrationCallback) {
+  }
+
+  /**
+   * Handles a response for a Undelete operation. It determines whether the request was successful and updates
+   * operation tracker. For the same operation, it is possible that different {@link ServerErrorCode} are received from
+   * different replicas. These error codes are eventually resolved to a single {@link RouterErrorCode}.
+   * @param responseInfo The {@link ResponseInfo} to be handled.
+   * @param undeleteResponse The {@link UndeleteResponse} associated with this response.
+   */
+  void handleResponse(ResponseInfo responseInfo, UndeleteResponse undeleteResponse) {
+  }
+
+  /**
+   * A wrapper class that is used to check if a request has been expired.
+   */
+  private class UndeleteRequestInfo {
+    final long startTimeMs;
+    final ReplicaId replica;
+
+    UndeleteRequestInfo(long submissionTime, ReplicaId replica) {
+      this.startTimeMs = submissionTime;
+      this.replica = replica;
+    }
+  }
+
+  /**
+   * Set the exception associated with this operation.
+   * If operationException exists, compare ErrorCodes of exception and existing operation Exception depending
+   * on precedence level. An ErrorCode with a smaller precedence level overrides an ErrorCode with a larger precedence
+   * level. Update the operationException if necessary.
+   * @param exception the {@link RouterException} to possibly set.
+   */
+  void setOperationException(RouterException exception) {
+    RouterUtils.replaceOperationException(operationException, exception, this::getPrecedenceLevel);
+  }
+
+  /**
+   * Gets the precedence level for a {@link RouterErrorCode}. A precedence level is a relative priority assigned
+   * to a {@link RouterErrorCode}. If a {@link RouterErrorCode} has not been assigned a precedence level, a
+   * {@code Integer.MIN_VALUE} will be returned.
+   * @param routerErrorCode The {@link RouterErrorCode} for which to get its precedence level.
+   * @return The precedence level of the {@link RouterErrorCode}.
+   */
+  private int getPrecedenceLevel(RouterErrorCode routerErrorCode) {
+    switch (routerErrorCode) {
+      case BlobAuthorizationFailure:
+        return 0;
+      case BlobDeleted:
+        return 1;
+      case BlobExpired:
+        return 2;
+      case BlobUpdateNotAllowed:
+        return 3;
+      case AmbryUnavailable:
+        return 4;
+      case UnexpectedInternalError:
+        return 5;
+      case OperationTimedOut:
+        return 6;
+      case BlobDoesNotExist:
+        return 7;
+      default:
+        return Integer.MIN_VALUE;
+    }
+  }
+
+  /**
+   * Returns whether the operation has completed.
+   * @return whether the operation has completed.
+   */
+  boolean isOperationComplete() {
+    return operationCompleted;
+  }
+
+  /**
+   * Gets {@link BlobId} of this {@link UndeleteOperation}.
+   * @return The {@link BlobId}.
+   */
+  BlobId getBlobId() {
+    return blobId;
+  }
+
+  /**
+   * @return the service ID for the service requesting this undelete operation.
+   */
+  String getServiceId() {
+    return serviceId;
+  }
+
+  /**
+   * Get the {@link FutureResult} for this {@link UndeleteOperation}.
+   * @return The {@link FutureResult}.
+   */
+  FutureResult<Void> getFutureResult() {
+    return futureResult;
+  }
+
+  /**
+   * Gets the {@link Callback} for this {@link UndeleteOperation}.
+   * @return The {@link Callback}.
+   */
+  Callback<Void> getCallback() {
+    return callback;
+  }
+
+  /**
+   * Gets the exception associated with this operation if it failed; null otherwise.
+   * @return exception associated with this operation if it failed; null otherwise.
+   */
+  Exception getOperationException() {
+    return operationException.get();
+  }
+
+  /**
+   * Gets the result for this {@link UndeleteOperation}. In a {@link UndeleteOperation}, nothing is returned
+   * to the caller as a result of this operation. Including this {@link Void} result is for consistency
+   * with other operations.
+   * @return Void.
+   */
+  Void getOperationResult() {
+    return operationResult;
+  }
+
+  /**
+   * @return the time (in ms) at which the operation was submitted
+   */
+  long getOperationTimeMs() {
+    return operationTimeMs;
+  }
+}

--- a/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
@@ -303,6 +303,11 @@ public class InMemoryRouter implements Router {
   }
 
   @Override
+  public Future<Void> undeleteBlob(String blobId, String serviceId, Callback<Void> callback) {
+    throw new UnsupportedOperationException("Undelete is currently unsupported");
+  }
+
+  @Override
   public void close() {
     if (routerOpen.compareAndSet(true, false)) {
       shutDownExecutorService(operationPool, 1, TimeUnit.MINUTES);
@@ -447,9 +452,8 @@ public class InMemoryRouter implements Router {
         } else {
           blobData = readBlob(postData.getReadableStreamChannel(), postData.getOptions().getMaxUploadSize());
         }
-        InMemoryBlob blob =
-            new InMemoryBlob(postData.getBlobProperties(), postData.getUsermetadata(), blobData,
-                postData.getChunksToStitch());
+        InMemoryBlob blob = new InMemoryBlob(postData.getBlobProperties(), postData.getUsermetadata(), blobData,
+            postData.getChunksToStitch());
         blobs.put(blobId, blob);
         if (notificationSystem != null) {
           notificationSystem.onBlobCreated(blobId, postData.getBlobProperties(), null, null,
@@ -558,7 +562,8 @@ public class InMemoryRouter implements Router {
     }
 
     PostData(BlobProperties blobProperties, byte[] usermetadata, ReadableStreamChannel readableStreamChannel,
-        List<ChunkInfo> chunksToStitch, PutBlobOptions options, Callback<String> callback, FutureResult<String> future) {
+        List<ChunkInfo> chunksToStitch, PutBlobOptions options, Callback<String> callback,
+        FutureResult<String> future) {
       this.blobProperties = blobProperties;
       this.usermetadata = usermetadata;
       this.readableStreamChannel = readableStreamChannel;

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouter.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouter.java
@@ -188,6 +188,25 @@ class PerfRouter implements Router {
     return futureResult;
   }
 
+  /**
+   * Does nothing. Simply indicates success immediately.
+   * @param blobId (ignored).
+   * @param serviceId (ignored).
+   * @param callback the {@link Callback} to invoke on operation completion.
+   * @return a {@link FutureResult} that will eventually contain the result of the operation.
+   */
+  @Override
+  public Future<Void> undeleteBlob(String blobId, String serviceId, Callback<Void> callback) {
+    logger.trace("Received undeleteBlob call");
+    FutureResult<Void> futureResult = new FutureResult<Void>();
+    if (!routerOpen) {
+      completeOperation(futureResult, callback, null, ROUTER_CLOSED_EXCEPTION);
+    } else {
+      completeOperation(futureResult, callback, null, null);
+    }
+    return futureResult;
+  }
+
   @Override
   public void close() {
     routerOpen = false;


### PR DESCRIPTION
First step to support undelete in the frontend. This PR adds skeleton code in the router for undelete manager and undelete operation.