### PR TITLE
Add basic support for multiple participants on server side

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterAgentsFactory.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterAgentsFactory.java
@@ -32,8 +32,8 @@ public interface ClusterAgentsFactory {
   /**
    * Construct and return the references or return the references to the previously constructed
    * {@link ClusterParticipant}(s). We extend this method to support multiple participants on same node. In some special
-   * cases we require a data node to participate into multiple clusters and each participant interacts with corresponding
-   * cluster independently.
+   * cases (i.e. migrating cluster to another Zookeeper), we require a data node to participate into multiple ZK clusters
+   * and each participant interacts with corresponding ZK independently.
    * @return a list of {@link ClusterParticipant}(s) on current node.
    */
   List<ClusterParticipant> getClusterParticipants() throws IOException;

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterAgentsFactory.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterAgentsFactory.java
@@ -15,6 +15,7 @@
 package com.github.ambry.clustermap;
 
 import java.io.IOException;
+import java.util.List;
 
 
 /**
@@ -29,9 +30,12 @@ public interface ClusterAgentsFactory {
   ClusterMap getClusterMap() throws IOException;
 
   /**
-   * Construct and return the reference or return the reference to the previously constructed
-   * {@link ClusterParticipant}
+   * Construct and return the references or return the references to the previously constructed
+   * {@link ClusterParticipant}(s). We extend this method to support multiple participants on same node. In some special
+   * cases we require a data node to participate into multiple clusters and each participant interacts with corresponding
+   * cluster independently.
+   * @return a list of {@link ClusterParticipant}(s) on current node.
    */
-  ClusterParticipant getClusterParticipant() throws IOException;
+  List<ClusterParticipant> getClusterParticipants() throws IOException;
 }
 

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -120,6 +120,9 @@ public class ClusterMapConfig {
    *   ]
    * }
    * </pre>
+   * Also, there could be multiple zk connection strings within same datacenter(except for cloud-dc). The intention is to
+   * allow ambry server to participate into multiple clusters for special case like migrating ambry to another ZK. For
+   * ambry frontend, if there are multiple zk connection strings, only the first one will be adopted.
    */
   @Config("clustermap.dcs.zk.connect.strings")
   @Default("")

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -14,11 +14,11 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.network.Port;
+import com.github.ambry.utils.Utils;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -72,8 +72,8 @@ public class ClusterMapUtils {
   static final String AVAILABLE_STR = "AVAILABLE";
   static final String READ_ONLY_STR = "RO";
   static final String READ_WRITE_STR = "RW";
-  static final String ZKCONNECTSTR_STR = "zkConnectStr";
-  static final String ZKCONNECTSTR_DELIMITER = ",";
+  static final String ZKCONNECT_STR = "zkConnectStr";
+  static final String ZKCONNECT_STR_DELIMITER = ",";
   static final String ZKINFO_STR = "zkInfo";
   static final String DATACENTER_STR = "datacenter";
   static final String DATACENTER_ID_STR = "id";
@@ -155,10 +155,10 @@ public class ClusterMapUtils {
       String name = entry.getString(DATACENTER_STR);
       byte id = (byte) entry.getInt(DATACENTER_ID_STR);
       ReplicaType replicaType = entry.optEnum(ReplicaType.class, REPLICA_TYPE_STR, ReplicaType.DISK_BACKED);
-      String[] zkConnectStrs =
-          (replicaType == ReplicaType.DISK_BACKED) ? entry.getString(ZKCONNECTSTR_STR).split(ZKCONNECTSTR_DELIMITER)
-              : entry.optString(ZKCONNECTSTR_STR).split(ZKCONNECTSTR_DELIMITER);
-      DcZkInfo dcZkInfo = new DcZkInfo(name, id, Arrays.asList(zkConnectStrs), replicaType);
+      ArrayList<String> zkConnectStrs =
+          (replicaType == ReplicaType.DISK_BACKED) ? Utils.splitString(entry.getString(ZKCONNECT_STR),
+              ZKCONNECT_STR_DELIMITER) : Utils.splitString(entry.optString(ZKCONNECT_STR), ZKCONNECT_STR_DELIMITER);
+      DcZkInfo dcZkInfo = new DcZkInfo(name, id, zkConnectStrs, replicaType);
       dataCenterToZkAddress.put(dcZkInfo.dcName, dcZkInfo);
     }
     return dataCenterToZkAddress;
@@ -243,7 +243,7 @@ public class ClusterMapUtils {
    */
   static long getXid(InstanceConfig instanceConfig) {
     String xid = instanceConfig.getRecord().getSimpleField(XID_STR);
-    return xid == null ? DEFAULT_XID : Long.valueOf(xid);
+    return xid == null ? DEFAULT_XID : Long.parseLong(xid);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -18,6 +18,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -72,6 +73,7 @@ public class ClusterMapUtils {
   static final String READ_ONLY_STR = "RO";
   static final String READ_WRITE_STR = "RW";
   static final String ZKCONNECTSTR_STR = "zkConnectStr";
+  static final String ZKCONNECTSTR_DELIMITER = ",";
   static final String ZKINFO_STR = "zkInfo";
   static final String DATACENTER_STR = "datacenter";
   static final String DATACENTER_ID_STR = "id";
@@ -93,20 +95,21 @@ public class ClusterMapUtils {
   public static class DcZkInfo {
     private final String dcName;
     private final byte dcId;
-    private final String zkConnectStr;
+    private final List<String> zkConnectStrs;
     private final ReplicaType replicaType;
 
     /**
      * Construct a DcInfo object with the given parameters.
      * @param dcName the associated datacenter name.
      * @param dcId the associated datacenter ID.
-     * @param zkConnectStr the associated ZK connect string for this datacenter.
+     * @param zkConnectStrs the associated ZK connect strings for this datacenter. (Usually there should be only one ZK
+     *                      endpoint but in special case we allow multiple ZK endpoints in same dc)
      * @param replicaType the type of replicas (cloud or disk backed) present in this datacenter.
      */
-    DcZkInfo(String dcName, byte dcId, String zkConnectStr, ReplicaType replicaType) {
+    DcZkInfo(String dcName, byte dcId, List<String> zkConnectStrs, ReplicaType replicaType) {
       this.dcName = dcName;
       this.dcId = dcId;
-      this.zkConnectStr = zkConnectStr;
+      this.zkConnectStrs = zkConnectStrs;
       this.replicaType = replicaType;
     }
 
@@ -118,8 +121,8 @@ public class ClusterMapUtils {
       return dcId;
     }
 
-    public String getZkConnectStr() {
-      return zkConnectStr;
+    public List<String> getZkConnectStrs() {
+      return zkConnectStrs;
     }
 
     public ReplicaType getReplicaType() {
@@ -152,9 +155,10 @@ public class ClusterMapUtils {
       String name = entry.getString(DATACENTER_STR);
       byte id = (byte) entry.getInt(DATACENTER_ID_STR);
       ReplicaType replicaType = entry.optEnum(ReplicaType.class, REPLICA_TYPE_STR, ReplicaType.DISK_BACKED);
-      String zkConnectStr = (replicaType == ReplicaType.DISK_BACKED) ? entry.getString(ZKCONNECTSTR_STR)
-          : entry.optString(ZKCONNECTSTR_STR);
-      DcZkInfo dcZkInfo = new DcZkInfo(name, id, zkConnectStr, replicaType);
+      String[] zkConnectStrs =
+          (replicaType == ReplicaType.DISK_BACKED) ? entry.getString(ZKCONNECTSTR_STR).split(ZKCONNECTSTR_DELIMITER)
+              : entry.optString(ZKCONNECTSTR_STR).split(ZKCONNECTSTR_DELIMITER);
+      DcZkInfo dcZkInfo = new DcZkInfo(name, id, Arrays.asList(zkConnectStrs), replicaType);
       dataCenterToZkAddress.put(dcZkInfo.dcName, dcZkInfo);
     }
     return dataCenterToZkAddress;
@@ -168,7 +172,7 @@ public class ClusterMapUtils {
    */
   static int getSchemaVersion(InstanceConfig instanceConfig) {
     String schemaVersionStr = instanceConfig.getRecord().getSimpleField(SCHEMA_VERSION_STR);
-    return schemaVersionStr == null ? 0 : Integer.valueOf(schemaVersionStr);
+    return schemaVersionStr == null ? 0 : Integer.parseInt(schemaVersionStr);
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeClusterAgentsFactory.java
@@ -15,6 +15,7 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
 import java.io.IOException;
+import java.util.List;
 import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +30,7 @@ public class CompositeClusterAgentsFactory implements ClusterAgentsFactory {
   private final StaticClusterAgentsFactory staticClusterAgentsFactory;
   private final HelixClusterAgentsFactory helixClusterAgentsFactory;
   private CompositeClusterManager compositeClusterManager;
-  private ClusterParticipant clusterParticipant;
+  private List<ClusterParticipant> clusterParticipants;
 
   /**
    * Create an instance of this class.
@@ -83,11 +84,11 @@ public class CompositeClusterAgentsFactory implements ClusterAgentsFactory {
   }
 
   @Override
-  public ClusterParticipant getClusterParticipant() throws IOException {
-    if (clusterParticipant == null) {
-      clusterParticipant = helixClusterAgentsFactory.getClusterParticipant();
+  public List<ClusterParticipant> getClusterParticipants() throws IOException {
+    if (clusterParticipants == null) {
+      clusterParticipants = helixClusterAgentsFactory.getClusterParticipants();
     }
-    return clusterParticipant;
+    return clusterParticipants;
   }
 }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
@@ -158,7 +158,10 @@ class DatacenterInitializer {
    * @throws Exception if something went wrong during startup
    */
   private DcInfo initializeHelixDatacenter() throws Exception {
-    String zkConnectStr = dcZkInfo.getZkConnectStr();
+    // For now, the first ZK endpoint (if there are more than one endpoints) will be adopted by default for initialization.
+    // If we really need multiple HelixClusterManagers on same node in the future, we can use separate zk connect str configs
+    // for HelixClusterManager and HelixParticipant.
+    String zkConnectStr = dcZkInfo.getZkConnectStrs().get(0);
     HelixManager manager;
     if (dcZkInfo.getDcName().equals(clusterMapConfig.clusterMapDatacenterName)) {
       manager = Objects.requireNonNull(localManager, "localManager should have been set");

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
@@ -159,8 +159,7 @@ class DatacenterInitializer {
    */
   private DcInfo initializeHelixDatacenter() throws Exception {
     // For now, the first ZK endpoint (if there are more than one endpoints) will be adopted by default for initialization.
-    // If we really need multiple HelixClusterManagers on same node in the future, we can use separate zk connect str configs
-    // for HelixClusterManager and HelixParticipant.
+    // Note that, Ambry currently doesn't support multiple spectators, because there should be only one source of truth.
     String zkConnectStr = dcZkInfo.getZkConnectStrs().get(0);
     HelixManager manager;
     if (dcZkInfo.getDcName().equals(clusterMapConfig.clusterMapDatacenterName)) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -277,7 +277,8 @@ class HelixBootstrapUpgradeUtil {
     for (Map.Entry<String, ClusterMapUtils.DcZkInfo> entry : dataCenterToZkAddress.entrySet()) {
       List<String> zkConnectStrs = entry.getValue().getZkConnectStrs();
       if (zkConnectStrs.size() != 1) {
-        throw new AssertionError(entry.getKey() + " has invalid number of ZK endpoints: " + zkConnectStrs.size());
+        throw new IllegalArgumentException(
+            entry.getKey() + " has invalid number of ZK endpoints: " + zkConnectStrs.size());
       }
       HelixAdmin admin = helixAdminFactory.getHelixAdmin(zkConnectStrs.get(0));
       admin.dropCluster(clusterName);
@@ -365,8 +366,10 @@ class HelixBootstrapUpgradeUtil {
     }
     for (Map.Entry<String, ClusterMapUtils.DcZkInfo> entry : dataCenterToZkAddress.entrySet()) {
       List<String> zkConnectStrs = entry.getValue().getZkConnectStrs();
-      ensureOrThrow(zkConnectStrs.size() == 1,
-          entry.getKey() + "has invalid number of ZK endpoints: " + zkConnectStrs.size());
+      if (zkConnectStrs.size() != 1) {
+        throw new IllegalArgumentException(
+            entry.getKey() + " has invalid number of ZK endpoints: " + zkConnectStrs.size());
+      }
       HelixAdmin admin = helixAdminFactory.getHelixAdmin(zkConnectStrs.get(0));
       adminForDc.put(entry.getKey(), admin);
     }
@@ -498,8 +501,7 @@ class HelixBootstrapUpgradeUtil {
     for (Map.Entry<String, ClusterMapUtils.DcZkInfo> entry : dataCenterToZkAddress.entrySet()) {
       info("Uploading {} infos for datacenter {}.", clusterAdminType, entry.getKey());
       List<String> zkConnectStrs = entry.getValue().getZkConnectStrs();
-      ensureOrThrow(zkConnectStrs.size() == 1,
-          entry.getKey() + "has invalid number of ZK endpoints: " + zkConnectStrs.size());
+      // The number of zk endpoints has been validated in the ctor of HelixBootstrapUpgradeUtil, no need to check it again
       HelixPropertyStore<ZNRecord> helixPropertyStore =
           CommonUtils.createHelixPropertyStore(zkConnectStrs.get(0), propertyStoreConfig, null);
       ZNRecord znRecord = new ZNRecord(clusterAdminType);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterAgentsFactory.java
@@ -52,6 +52,19 @@ public class HelixClusterAgentsFactory implements ClusterAgentsFactory {
     this.metricRegistry = metricRegistry;
   }
 
+  /**
+   * Ctor exposed for testing purpose
+   * @param clusterMapConfig the {@link ClusterMapConfig} to specify cluster configuration parameters.
+   * @param helixFactory the {@link HelixFactory} that helps get reference of HelixManager and HelixAdmin.
+   */
+  HelixClusterAgentsFactory(ClusterMapConfig clusterMapConfig, HelixFactory helixFactory) {
+    this.clusterMapConfig = clusterMapConfig;
+    this.instanceName =
+        ClusterMapUtils.getInstanceName(clusterMapConfig.clusterMapHostName, clusterMapConfig.clusterMapPort);
+    this.helixFactory = helixFactory;
+    this.metricRegistry = new MetricRegistry();
+  }
+
   @Override
   public HelixClusterManager getClusterMap() throws IOException {
     if (helixClusterManager == null) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -200,8 +200,8 @@ public class HelixClusterManager implements ClusterMap {
     if (dcZkInfo.getReplicaType() == ReplicaType.CLOUD_BACKED) {
       return null;
     }
-    // For now, the first ZK endpoint (if there are more than one endpoints) will be adopted by default. We can update
-    // this if we really need to initialize multiple HelixManagers in local dc.
+    // For now, the first ZK endpoint (if there are more than one endpoints) will be adopted by default. Note that, Ambry
+    // doesn't support multiple HelixClusterManagers(spectators) on same node.
     String zkConnectStr = dcZkInfo.getZkConnectStrs().get(0);
     HelixManager manager =
         helixFactory.getZKHelixManager(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectStr);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -197,12 +197,12 @@ public class HelixClusterManager implements ClusterMap {
   private HelixManager initializeHelixManagerAndPropertyStoreInLocalDC(Map<String, DcZkInfo> dataCenterToZkAddress,
       String instanceName, HelixFactory helixFactory) throws Exception {
     DcZkInfo dcZkInfo = dataCenterToZkAddress.get(clusterMapConfig.clusterMapDatacenterName);
-    // For now, the first ZK endpoint (if there are more than one endpoints) will be adopted by default. We can update
-    // this if we really need to initialize mulitiple HelixManager in local dc.
-    String zkConnectStr = dcZkInfo.getZkConnectStrs().get(0);
     if (dcZkInfo.getReplicaType() == ReplicaType.CLOUD_BACKED) {
       return null;
     }
+    // For now, the first ZK endpoint (if there are more than one endpoints) will be adopted by default. We can update
+    // this if we really need to initialize multiple HelixManagers in local dc.
+    String zkConnectStr = dcZkInfo.getZkConnectStrs().get(0);
     HelixManager manager =
         helixFactory.getZKHelixManager(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectStr);
     logger.info("Connecting to Helix manager in local zookeeper at {}", zkConnectStr);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -197,7 +197,9 @@ public class HelixClusterManager implements ClusterMap {
   private HelixManager initializeHelixManagerAndPropertyStoreInLocalDC(Map<String, DcZkInfo> dataCenterToZkAddress,
       String instanceName, HelixFactory helixFactory) throws Exception {
     DcZkInfo dcZkInfo = dataCenterToZkAddress.get(clusterMapConfig.clusterMapDatacenterName);
-    String zkConnectStr = dcZkInfo.getZkConnectStr();
+    // For now, the first ZK endpoint (if there are more than one endpoints) will be adopted by default. We can update
+    // this if we really need to initialize mulitiple HelixManager in local dc.
+    String zkConnectStr = dcZkInfo.getZkConnectStrs().get(0);
     if (dcZkInfo.getReplicaType() == ReplicaType.CLOUD_BACKED) {
       return null;
     }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterSpectator.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterSpectator.java
@@ -56,19 +56,20 @@ public class HelixClusterSpectator implements ClusterSpectator {
     Map<String, DcZkInfo> dataCenterToZkAddress =
         parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings);
     HelixFactory helixFactory = new HelixFactory();
-    String selfInstanceName = ClusterMapUtils.getInstanceName(clusterMapConfig.clusterMapHostName, clusterMapConfig.clusterMapPort);
+    String selfInstanceName =
+        ClusterMapUtils.getInstanceName(clusterMapConfig.clusterMapHostName, clusterMapConfig.clusterMapPort);
 
     // Should we fail here if even one of the remote zk connection fails? If we have just one datacenter, then this will not be a problem.
     // If we have two data centers, then its not clear if we should pass the startup with one remote zk connection failure. Because if remote
     // zk connection fails on both data centers, then things like replication between data centers might just stop.
     // For now, since we have only one fabric in cloud, and the spectator is being used for only cloud to store replication, this will work.
     // Once we add more fabrics, we should revisit this.
-    for (DcZkInfo dcZkInfo: dataCenterToZkAddress.values()) {
+    for (DcZkInfo dcZkInfo : dataCenterToZkAddress.values()) {
       // only handle vcr clusters for now
       if (dcZkInfo.getReplicaType() == ReplicaType.CLOUD_BACKED) {
         HelixManager helixManager =
             helixFactory.getZKHelixManager(cloudConfig.vcrClusterName, selfInstanceName, InstanceType.SPECTATOR,
-                dcZkInfo.getZkConnectStr());
+                dcZkInfo.getZkConnectStrs().get(0));
         helixManager.connect();
 
         helixManager.addInstanceConfigChangeListener(this);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -39,7 +39,6 @@ import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskConstants;
 import org.apache.helix.task.TaskFactory;
 import org.apache.helix.task.TaskStateModelFactory;
-import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +74,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       String zkConnectStr) {
     this.clusterMapConfig = clusterMapConfig;
     this.zkConnectStr = zkConnectStr;
-    participantMetrics = new HelixParticipantMetrics(metricRegistry);
+    participantMetrics = new HelixParticipantMetrics(metricRegistry, zkConnectStr);
     clusterName = clusterMapConfig.clusterMapClusterName;
     instanceName =
         ClusterMapUtils.getInstanceName(clusterMapConfig.clusterMapHostName, clusterMapConfig.clusterMapPort);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
@@ -32,26 +32,27 @@ class HelixParticipantMetrics {
   // no need to record exact number of "dropped" partition, a counter to track partition-dropped events would suffice
   final Counter partitionDroppedCount;
 
-  HelixParticipantMetrics(MetricRegistry metricRegistry) {
+  HelixParticipantMetrics(MetricRegistry metricRegistry, String zkConnectStr) {
     Gauge<Integer> bootstrapPartitionCount = bootstrapCount::get;
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "bootstrapPartitionCount"),
+    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "bootstrapPartitionCount-" + zkConnectStr),
         bootstrapPartitionCount);
     Gauge<Integer> standbyPartitionCount = standbyCount::get;
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "standbyPartitionCount"),
+    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "standbyPartitionCount-" + zkConnectStr),
         standbyPartitionCount);
     Gauge<Integer> leaderPartitionCount = leaderCount::get;
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "leaderPartitionCount"), leaderPartitionCount);
+    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "leaderPartitionCount-" + zkConnectStr),
+        leaderPartitionCount);
     Gauge<Integer> inactivePartitionCount = inactiveCount::get;
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "inactivePartitionCount"),
+    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "inactivePartitionCount-" + zkConnectStr),
         inactivePartitionCount);
     Gauge<Integer> offlinePartitionCount = offlineCount::get;
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "offlinePartitionCount"),
+    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "offlinePartitionCount-" + zkConnectStr),
         offlinePartitionCount);
     Gauge<Integer> errorStatePartitionCount = errorStateCount::get;
-    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "errorStatePartitionCount"),
+    metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "errorStatePartitionCount-" + zkConnectStr),
         errorStatePartitionCount);
     partitionDroppedCount =
-        metricRegistry.counter(MetricRegistry.name(HelixParticipant.class, "partitionDroppedCount"));
+        metricRegistry.counter(MetricRegistry.name(HelixParticipant.class, "partitionDroppedCount-" + zkConnectStr));
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterAgentsFactory.java
@@ -78,7 +78,7 @@ public class RecoveryTestClusterAgentsFactory implements ClusterAgentsFactory {
   }
 
   @Override
-  public ClusterParticipant getClusterParticipant() throws IOException {
+  public List<ClusterParticipant> getClusterParticipants() throws IOException {
     if (clusterParticipantRef.get() == null) {
       // create a no op cluster participant that does nothing. Just sits idly by!!! ¯\_(ツ)_/¯
       ClusterParticipant clusterParticipant = new ClusterParticipant() {
@@ -132,6 +132,6 @@ public class RecoveryTestClusterAgentsFactory implements ClusterAgentsFactory {
       };
       clusterParticipantRef.compareAndSet(null, clusterParticipant);
     }
-    return clusterParticipantRef.get();
+    return Collections.singletonList(clusterParticipantRef.get());
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterAgentsFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterAgentsFactory.java
@@ -76,7 +76,7 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
   }
 
   @Override
-  public ClusterParticipant getClusterParticipant() throws IOException {
+  public List<ClusterParticipant> getClusterParticipants() throws IOException {
     if (clusterParticipant == null) {
       clusterParticipant = new ClusterParticipant() {
         private final Map<StateModelListenerType, PartitionStateChangeListener> listeners = new HashMap<>();
@@ -144,7 +144,7 @@ public class StaticClusterAgentsFactory implements ClusterAgentsFactory {
         }
       };
     }
-    return clusterParticipant;
+    return Collections.singletonList(clusterParticipant);
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -325,7 +325,7 @@ public class HelixParticipantTest {
     JSONObject zkInfoJson = new JSONObject();
     zkInfoJson.put(ClusterMapUtils.DATACENTER_STR, "DC0");
     zkInfoJson.put(ClusterMapUtils.DATACENTER_ID_STR, (byte) 0);
-    zkInfoJson.put(ClusterMapUtils.ZKCONNECTSTR_STR, "localhost:2199" + ZKCONNECTSTR_DELIMITER + "localhost:2299");
+    zkInfoJson.put(ClusterMapUtils.ZKCONNECT_STR, "localhost:2199" + ZKCONNECT_STR_DELIMITER + "localhost:2299");
     zkInfosJson.put(zkInfoJson);
     JSONObject jsonObject = new JSONObject().put(ClusterMapUtils.ZKINFO_STR, zkInfosJson);
     props.setProperty("clustermap.dcs.zk.connect.strings", jsonObject.toString(2));

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockClusterAgentsFactory.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockClusterAgentsFactory.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 import com.github.ambry.server.AmbryHealthReport;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +70,7 @@ public class MockClusterAgentsFactory implements ClusterAgentsFactory {
   }
 
   @Override
-  public ClusterParticipant getClusterParticipant() {
+  public List<ClusterParticipant> getClusterParticipants() {
     if (clusterParticipant == null) {
       clusterParticipant = new ClusterParticipant() {
         private final Map<StateModelListenerType, PartitionStateChangeListener>
@@ -143,6 +144,6 @@ public class MockClusterAgentsFactory implements ClusterAgentsFactory {
         }
       };
     }
-    return clusterParticipant;
+    return Collections.singletonList(clusterParticipant);
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixCluster.java
@@ -241,12 +241,12 @@ public class MockHelixCluster {
   }
 
   void addNewResource(String resourceName, IdealState idealState, String dcName) throws Exception {
-    MockHelixAdmin helixAdmin = helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStr());
+    MockHelixAdmin helixAdmin = helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0));
     helixAdmin.addNewResource(resourceName, idealState);
   }
 
   Map<String, String> getPartitionToLeaderReplica(String dcName) {
-    MockHelixAdmin helixAdmin = helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStr());
+    MockHelixAdmin helixAdmin = helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0));
     return helixAdmin.getPartitionToLeaderReplica();
   }
 
@@ -254,7 +254,7 @@ public class MockHelixCluster {
    * @return {@link MockHelixAdmin} from specified dc
    */
   MockHelixAdmin getHelixAdminFromDc(String dcName) {
-    return helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStr());
+    return helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0));
   }
 
   InstanceConfig getInstanceConfig(String instanceName) {
@@ -276,7 +276,7 @@ public class MockHelixCluster {
   List<InstanceConfig> getInstanceConfigsFromDcs(String[] dcNames) {
     List<InstanceConfig> configs = new ArrayList<>();
     for (String dcName : dcNames) {
-      MockHelixAdmin helixAdmin = helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStr());
+      MockHelixAdmin helixAdmin = helixAdmins.get(dataCenterToZkAddress.get(dcName).getZkConnectStrs().get(0));
       configs.addAll(helixAdmin.getInstanceConfigs(clusterName));
     }
     return configs;

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import org.mockito.Mockito;
 
 import static org.mockito.Mockito.*;
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
 
 
 public class MockHelixParticipant extends HelixParticipant {
@@ -39,8 +40,10 @@ public class MockHelixParticipant extends HelixParticipant {
   private Set<ReplicaId> stoppedReplicas = new HashSet<>();
   private PartitionStateChangeListener mockReplicationManagerListener;
 
-  public MockHelixParticipant(ClusterMapConfig clusterMapConfig) throws IOException {
-    super(clusterMapConfig, new MockHelixManagerFactory(), metricRegistry);
+  public MockHelixParticipant(ClusterMapConfig clusterMapConfig) {
+    super(clusterMapConfig, new MockHelixManagerFactory(), metricRegistry,
+        parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings).get(
+            clusterMapConfig.clusterMapDatacenterName).getZkConnectStrs().get(0));
     // create mock state change listener for ReplicationManager
     mockReplicationManagerListener = Mockito.mock(PartitionStateChangeListener.class);
     // mock Bootstrap-To-Standby change

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/TestUtils.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/TestUtils.java
@@ -1071,7 +1071,7 @@ public class TestUtils {
       JSONObject zkInfoJson = new JSONObject();
       zkInfoJson.put(ClusterMapUtils.DATACENTER_STR, zkInfo.getDcName());
       zkInfoJson.put(ClusterMapUtils.DATACENTER_ID_STR, zkInfo.getId());
-      zkInfoJson.put(ClusterMapUtils.ZKCONNECTSTR_STR, "localhost:" + zkInfo.getPort());
+      zkInfoJson.put(ClusterMapUtils.ZKCONNECT_STR, "localhost:" + zkInfo.getPort());
       zkInfosJson.put(zkInfoJson);
     }
     return new JSONObject().put(ClusterMapUtils.ZKINFO_STR, zkInfosJson);

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -64,6 +64,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
 import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
@@ -1241,7 +1242,9 @@ public class StorageManagerTest {
     Set<ReplicaId> stoppedReplicas = new HashSet<>();
 
     MockClusterParticipant() throws IOException {
-      super(clusterMapConfig, new MockHelixManagerFactory(), new MetricRegistry());
+      super(clusterMapConfig, new MockHelixManagerFactory(), new MetricRegistry(),
+          parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings).get(
+              clusterMapConfig.clusterMapDatacenterName).getZkConnectStrs().get(0));
     }
 
     @Override

--- a/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/utils/TestUtils.java
@@ -332,9 +332,8 @@ public class TestUtils {
      * @param dcName the name of the datacenter.
      * @param id the id of the datacenter.
      * @param port the port at which this Zk server should run on localhost.
-     * @throws IOException
      */
-    public ZkInfo(String tempDirPath, String dcName, byte id, int port, boolean start) throws IOException {
+    public ZkInfo(String tempDirPath, String dcName, byte id, int port, boolean start) {
       this.dcName = dcName;
       this.id = id;
       this.port = port;

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -37,6 +37,7 @@ import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.store.HelixPropertyStore;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
@@ -232,6 +233,33 @@ public class HelixBootstrapUpgradeToolTest {
       } catch (IllegalArgumentException e) {
         // OK
       }
+    }
+  }
+
+  /**
+   * Test that dropping cluster fails because of invalid zk endpoints count. (HelixBootstrapTool should perform operation
+   * against one ZK endpoint in certain dc at a time. Bootstrapping multiple clusters concurrently is not allowed)
+   * @throws Exception
+   */
+  @Test
+  public void testInvalidZKEndpointCount() throws Exception {
+    JSONArray zkInfosJson = new JSONArray();
+    for (ZkInfo zkInfo : dcsToZkInfo.values()) {
+      JSONObject zkInfoJson = new JSONObject();
+      zkInfoJson.put(ClusterMapUtils.DATACENTER_STR, zkInfo.getDcName());
+      zkInfoJson.put(ClusterMapUtils.DATACENTER_ID_STR, zkInfo.getId());
+      zkInfoJson.put(ClusterMapUtils.ZKCONNECTSTR_STR,
+          "localhost1:" + zkInfo.getPort() + ClusterMapUtils.ZKCONNECTSTR_DELIMITER + "localhost2:" + zkInfo.getPort());
+      zkInfosJson.put(zkInfoJson);
+    }
+    JSONObject jsonObject = new JSONObject().put(ClusterMapUtils.ZKINFO_STR, zkInfosJson);
+    Utils.writeJsonObjectToFile(jsonObject, zkLayoutPath);
+    try {
+      HelixBootstrapUpgradeUtil.dropCluster(zkLayoutPath, CLUSTER_NAME_PREFIX + CLUSTER_NAME_IN_STATIC_CLUSTER_MAP,
+          dcStr, new HelixAdminFactory());
+      fail("should fail because of invalid zk endpoint count");
+    } catch (AssertionError error) {
+      // expected
     }
   }
 

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -248,8 +248,9 @@ public class HelixBootstrapUpgradeToolTest {
       JSONObject zkInfoJson = new JSONObject();
       zkInfoJson.put(ClusterMapUtils.DATACENTER_STR, zkInfo.getDcName());
       zkInfoJson.put(ClusterMapUtils.DATACENTER_ID_STR, zkInfo.getId());
-      zkInfoJson.put(ClusterMapUtils.ZKCONNECTSTR_STR,
-          "localhost1:" + zkInfo.getPort() + ClusterMapUtils.ZKCONNECTSTR_DELIMITER + "localhost2:" + zkInfo.getPort());
+      zkInfoJson.put(ClusterMapUtils.ZKCONNECT_STR,
+          "localhost1:" + zkInfo.getPort() + ClusterMapUtils.ZKCONNECT_STR_DELIMITER + "localhost2:"
+              + zkInfo.getPort());
       zkInfosJson.put(zkInfoJson);
     }
     JSONObject jsonObject = new JSONObject().put(ClusterMapUtils.ZKINFO_STR, zkInfosJson);
@@ -258,7 +259,7 @@ public class HelixBootstrapUpgradeToolTest {
       HelixBootstrapUpgradeUtil.dropCluster(zkLayoutPath, CLUSTER_NAME_PREFIX + CLUSTER_NAME_IN_STATIC_CLUSTER_MAP,
           dcStr, new HelixAdminFactory());
       fail("should fail because of invalid zk endpoint count");
-    } catch (AssertionError error) {
+    } catch (IllegalArgumentException e) {
       // expected
     }
   }

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixClusterWideAggregationTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixClusterWideAggregationTool.java
@@ -129,67 +129,69 @@ public class HelixClusterWideAggregationTool {
    * @param args arguments specifying config file. For example: --propsFile /path/AggregationToolConfig
    * @throws Exception
    */
-  public static void main(String args[]) throws Exception {
+  public static void main(String[] args) throws Exception {
     VerifiableProperties verifiableProperties = ToolUtils.getVerifiableProperties(args);
     AggregationToolConfig config = new AggregationToolConfig(verifiableProperties);
     Map<String, ClusterMapUtils.DcZkInfo> dataCenterToZKAddress =
         ClusterMapUtils.parseDcJsonAndPopulateDcInfo(Utils.readStringFromFile(config.zkLayoutFilePath));
     String clusterName = config.clusterName;
     String workflowName = config.workflowName;
-    Long recurrentIntervalInMinutes = config.recurrentIntervalInMinutes;
+    long recurrentIntervalInMinutes = config.recurrentIntervalInMinutes;
     boolean isDelete = config.deleteSpecifiedWorkflow;
     boolean isRecurrentWorkflow = recurrentIntervalInMinutes != Utils.Infinite_Time;
     for (ClusterMapUtils.DcZkInfo zkInfo : dataCenterToZKAddress.values()) {
-      String zkAddress = zkInfo.getZkConnectStr();
-      ZkClient zkClient = new ZkClient(zkAddress, SESSION_TIMEOUT, CONNECTION_TIMEOUT, new ZNRecordSerializer());
-      TaskDriver taskDriver = new TaskDriver(zkClient, clusterName);
-      if (isDelete) {
-        try {
-          taskDriver.waitToStop(workflowName, TIME_OUT_MILLI_SEC);
-          taskDriver.delete(workflowName);
-          System.out.println(
-              String.format("Successfully deleted the workflow: %s in cluster %s at %s", workflowName, clusterName,
-                  zkAddress));
-        } catch (Exception | Error e) {
-          System.out.println(
-              String.format("Failed to delete %s. Workflow not found in cluster %s at %s", workflowName, clusterName,
-                  zkAddress));
-        }
-      } else {
-        Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
-        try {
-          // create separate job for each type of stats report
-          for (String report : config.statsReportsToAggregate) {
-            StatsReportType statsType = StatsReportType.valueOf(report);
-            String reportName =
-                AmbryStatsReport.convertStatsReportTypeToProperString(statsType) + AmbryStatsReport.REPORT_NAME_SUFFIX;
-            String jobId =
-                statsType.toString().toLowerCase() + (isRecurrentWorkflow ? RECURRENT_JOB_SUFFIX : ONE_TIME_JOB_SUFFIX);
-            String taskId = statsType.toString().toLowerCase() + TASK_SUFFIX;
-            String aggregationCommand =
-                String.format("%s_%s", HelixHealthReportAggregatorTask.TASK_COMMAND_PREFIX, reportName);
-            // build task
-            List<TaskConfig> taskConfigs = new ArrayList<>();
-            taskConfigs.add(new TaskConfig.Builder().setTaskId(taskId).setCommand(aggregationCommand).build());
-            // build job
-            JobConfig.Builder jobConfigBuilder = new JobConfig.Builder();
-            jobConfigBuilder.addTaskConfigs(taskConfigs);
-            jobConfigBuilder.setCommand(aggregationCommand);
-            // add job into workflow
-            workflowBuilder.addJob(jobId, jobConfigBuilder);
+      // If there are multiple ZK endpoints in same dc, we trigger stats aggregation for each of them.
+      for (String zkAddress : zkInfo.getZkConnectStrs()) {
+        ZkClient zkClient = new ZkClient(zkAddress, SESSION_TIMEOUT, CONNECTION_TIMEOUT, new ZNRecordSerializer());
+        TaskDriver taskDriver = new TaskDriver(zkClient, clusterName);
+        if (isDelete) {
+          try {
+            taskDriver.waitToStop(workflowName, TIME_OUT_MILLI_SEC);
+            taskDriver.delete(workflowName);
+            System.out.println(
+                String.format("Successfully deleted the workflow: %s in cluster %s at %s", workflowName, clusterName,
+                    zkAddress));
+          } catch (Exception | Error e) {
+            System.out.println(
+                String.format("Failed to delete %s. Workflow not found in cluster %s at %s", workflowName, clusterName,
+                    zkAddress));
           }
-          if (isRecurrentWorkflow) {
-            workflowBuilder.setScheduleConfig(
-                ScheduleConfig.recurringFromNow(TimeUnit.MINUTES, recurrentIntervalInMinutes));
-            workflowBuilder.setExpiry(TimeUnit.MINUTES.toMillis(recurrentIntervalInMinutes));
+        } else {
+          Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+          try {
+            // create separate job for each type of stats report
+            for (String report : config.statsReportsToAggregate) {
+              StatsReportType statsType = StatsReportType.valueOf(report);
+              String reportName = AmbryStatsReport.convertStatsReportTypeToProperString(statsType)
+                  + AmbryStatsReport.REPORT_NAME_SUFFIX;
+              String jobId = statsType.toString().toLowerCase() + (isRecurrentWorkflow ? RECURRENT_JOB_SUFFIX
+                  : ONE_TIME_JOB_SUFFIX);
+              String taskId = statsType.toString().toLowerCase() + TASK_SUFFIX;
+              String aggregationCommand =
+                  String.format("%s_%s", HelixHealthReportAggregatorTask.TASK_COMMAND_PREFIX, reportName);
+              // build task
+              List<TaskConfig> taskConfigs = new ArrayList<>();
+              taskConfigs.add(new TaskConfig.Builder().setTaskId(taskId).setCommand(aggregationCommand).build());
+              // build job
+              JobConfig.Builder jobConfigBuilder = new JobConfig.Builder();
+              jobConfigBuilder.addTaskConfigs(taskConfigs);
+              jobConfigBuilder.setCommand(aggregationCommand);
+              // add job into workflow
+              workflowBuilder.addJob(jobId, jobConfigBuilder);
+            }
+            if (isRecurrentWorkflow) {
+              workflowBuilder.setScheduleConfig(
+                  ScheduleConfig.recurringFromNow(TimeUnit.MINUTES, recurrentIntervalInMinutes));
+              workflowBuilder.setExpiry(TimeUnit.MINUTES.toMillis(recurrentIntervalInMinutes));
+            }
+            Workflow workflow = workflowBuilder.build();
+            taskDriver.start(workflow);
+            System.out.println(
+                String.format("%s started successfully in cluster %s at %s", workflowName, clusterName, zkAddress));
+          } catch (Exception | Error e) {
+            System.out.println(
+                String.format("Failed to start %s in cluster %s at %s", workflowName, clusterName, zkAddress));
           }
-          Workflow workflow = workflowBuilder.build();
-          taskDriver.start(workflow);
-          System.out.println(
-              String.format("%s started successfully in cluster %s at %s", workflowName, clusterName, zkAddress));
-        } catch (Exception | Error e) {
-          System.out.println(
-              String.format("Failed to start %s in cluster %s at %s", workflowName, clusterName, zkAddress));
         }
       }
     }


### PR DESCRIPTION
In some cases where single datanode has to parcipate into mulitiple clusters
and it needs to update node info in these clusters separately. This requires
muptiple participants on same node and each of them is responsible for interacting
with corresponding cluster. With this feature, we are able to build a mirror cluster
that helps us perform some monitoring and adminstration operations (i.e. ZK migration).