### PR TITLE
Fix NPE in router due to handling response with empty request

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -843,10 +843,6 @@ class NonBlockingRouter implements Router {
       for (ResponseInfo responseInfo : responseInfoList) {
         try {
           RequestInfo requestInfo = responseInfo.getRequestInfo();
-          long responseReceiveTime = requestInfo.getStreamReceiveTime();
-          if (responseReceiveTime != -1) {
-            routerMetrics.responseReceiveToHandleLatencyMs.update(System.currentTimeMillis() - responseReceiveTime);
-          }
           if (requestInfo == null) {
             // If requestInfo is null, it means request has been failed previously due to long wait in pending requests
             // queue. The failed request was already handled by one of the managers(PutManager, GetManager, etc). Current
@@ -855,6 +851,10 @@ class NonBlockingRouter implements Router {
             DataNodeId dataNodeId = responseInfo.getDataNode();
             responseHandler.onConnectionTimeout(dataNodeId);
           } else {
+            long responseReceiveTime = requestInfo.getStreamReceiveTime();
+            if (responseReceiveTime != -1) {
+              routerMetrics.responseReceiveToHandleLatencyMs.update(System.currentTimeMillis() - responseReceiveTime);
+            }
             RequestOrResponseType type = ((RequestOrResponse) requestInfo.getRequest()).getRequestType();
             logger.debug("Handling response of type {} for {}", type, requestInfo.getRequest().getCorrelationId());
             switch (type) {

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -20,6 +20,7 @@ import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.ReplicaId;
+import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.commons.ByteBufferReadableStreamChannel;
 import com.github.ambry.commons.LoggingNotificationSystem;
@@ -911,15 +912,20 @@ public class NonBlockingRouterTest {
     List<ResponseInfo> responseInfoList = new ArrayList<>();
     MockDataNodeId testDataNode = (MockDataNodeId) mockClusterMap.getDataNodeIds().get(0);
     responseInfoList.add(new ResponseInfo(null, NetworkClientErrorCode.NetworkError, null, testDataNode));
-    Mockito.when(mockNetworkClient.sendAndPoll(anyList(), anySet(), anyInt())).thenReturn(responseInfoList);
+    // By default, there are 1 operation controller and 1 background deleter thread. We set CountDownLatch to 3 so that
+    // at least one thread has completed calling onResponse() and test node's state has been updated in ResponseHandler
+    CountDownLatch invocationLatch = new CountDownLatch(3);
+    doAnswer(invocation -> {
+      invocationLatch.countDown();
+      return responseInfoList;
+    }).when(mockNetworkClient).sendAndPoll(anyList(), anySet(), anyInt());
     NetworkClientFactory networkClientFactory = Mockito.mock(NetworkClientFactory.class);
     Mockito.when(networkClientFactory.getNetworkClient()).thenReturn(mockNetworkClient);
-    Router testRouter =
+    NonBlockingRouter testRouter =
         new NonBlockingRouter(routerConfig, routerMetrics, networkClientFactory, new LoggingNotificationSystem(),
             mockClusterMap, kms, cryptoService, cryptoJobHandler, accountService, mockTime,
             MockClusterMap.DEFAULT_PARTITION_CLASS);
-    setOperationParams();
-    testRouter.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build());
+    assertTrue("Invocation latch didn't count to 0 within 10 seconds", invocationLatch.await(10, TimeUnit.SECONDS));
     // verify the test node is considered timeout
     assertTrue("The node should be considered timeout", testDataNode.isTimedOut());
     testRouter.close();

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -30,7 +30,9 @@ import com.github.ambry.config.RouterConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.messageformat.BlobProperties;
 import com.github.ambry.messageformat.MessageFormatRecord;
+import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientErrorCode;
+import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
 import com.github.ambry.network.SocketNetworkClient;
@@ -73,12 +75,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.router.RouterTestHelpers.*;
 import static com.github.ambry.utils.TestUtils.*;
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -130,8 +135,7 @@ public class NonBlockingRouterTest {
    */
   @Parameterized.Parameters
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][]{
-        {false, MessageFormatRecord.Metadata_Content_Version_V2},
+    return Arrays.asList(new Object[][]{{false, MessageFormatRecord.Metadata_Content_Version_V2},
         {false, MessageFormatRecord.Metadata_Content_Version_V3},
         {true, MessageFormatRecord.Metadata_Content_Version_V2},
         {true, MessageFormatRecord.Metadata_Content_Version_V3}});
@@ -891,6 +895,37 @@ public class NonBlockingRouterTest {
   }
 
   /**
+   * Test the case where request is timed out in the pending queue and network client returns response with null requestInfo
+   * to mark node down via response handler.
+   * @throws Exception
+   */
+  @Test
+  public void testResponseWithNullRequestInfo() throws Exception {
+    Properties props = getNonBlockingRouterProperties("DC1");
+    VerifiableProperties verifiableProperties = new VerifiableProperties((props));
+    RouterConfig routerConfig = new RouterConfig(verifiableProperties);
+    routerMetrics = new NonBlockingRouterMetrics(mockClusterMap, routerConfig);
+    NetworkClient mockNetworkClient = Mockito.mock(NetworkClient.class);
+    Mockito.when(mockNetworkClient.warmUpConnections(anyList(), anyInt(), anyLong(), anyList())).thenReturn(1);
+    doNothing().when(mockNetworkClient).close();
+    List<ResponseInfo> responseInfoList = new ArrayList<>();
+    MockDataNodeId testDataNode = (MockDataNodeId) mockClusterMap.getDataNodeIds().get(0);
+    responseInfoList.add(new ResponseInfo(null, NetworkClientErrorCode.NetworkError, null, testDataNode));
+    Mockito.when(mockNetworkClient.sendAndPoll(anyList(), anySet(), anyInt())).thenReturn(responseInfoList);
+    NetworkClientFactory networkClientFactory = Mockito.mock(NetworkClientFactory.class);
+    Mockito.when(networkClientFactory.getNetworkClient()).thenReturn(mockNetworkClient);
+    Router testRouter =
+        new NonBlockingRouter(routerConfig, routerMetrics, networkClientFactory, new LoggingNotificationSystem(),
+            mockClusterMap, kms, cryptoService, cryptoJobHandler, accountService, mockTime,
+            MockClusterMap.DEFAULT_PARTITION_CLASS);
+    setOperationParams();
+    testRouter.putBlob(putBlobProperties, putUserMetadata, putChannel, new PutBlobOptionsBuilder().build());
+    // verify the test node is considered timeout
+    assertTrue("The node should be considered timeout", testDataNode.isTimedOut());
+    testRouter.close();
+  }
+
+  /**
    * Response handling related tests for all operation managers.
    */
   @Test
@@ -1226,9 +1261,7 @@ public class NonBlockingRouterTest {
    * Enum for the three operation types.
    */
   private enum OperationType {
-    PUT,
-    GET,
-    DELETE,
+    PUT, GET, DELETE,
   }
 
   /**


### PR DESCRIPTION
To account for timeout requests in network client, we create response with
empty requestInfo (set it to null) to make ResponseHandler mark timeout node
down. In recent PR, we added a router metric to record response-receive-to-handle
latency which didn't account for requestInfo == null case. This PR fixes such issue.