### PR TITLE
Limit the number of partitions per ReplicaMetadataRequest

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -114,6 +114,15 @@ public class ReplicationConfig {
   public final long replicationFetchSizeInBytes;
 
   /**
+   * The maximum number of partitions on remote node can be replicated with in a single replication request. If local
+   * node shares more partitions than this number with peer node, the partitions will be split into several lists (with
+   * size <= max partition count) and will be replicated sequentially in separate replication cycles.
+   */
+  @Config("replication.max.partition.count.per.request")
+  @Default("20")
+  public final int replicationMaxPartitionCountPerRequest;
+
+  /**
    * If true, replication Get requests asks for deleted and expired blobs as well to succeed in scenarios where blobs
    * get deleted or expired after replication metadata exchange.
    */
@@ -189,6 +198,8 @@ public class ReplicationConfig {
         verifiableProperties.getLongInRange("replication.synced.replica.backoff.duration.ms", 0, 0, Long.MAX_VALUE);
     replicationFetchSizeInBytes =
         verifiableProperties.getLongInRange("replication.fetch.size.in.bytes", 1048576, 1, Long.MAX_VALUE);
+    replicationMaxPartitionCountPerRequest =
+        verifiableProperties.getIntInRange("replication.max.partition.count.per.request", 20, 1, Integer.MAX_VALUE);
     replicationIncludeAll = verifiableProperties.getBoolean("replication.include.all", true);
     replicationPersistTokenOnShutdownOrReplicaRemove =
         verifiableProperties.getBoolean("replication.persist.token.on.shutdown.or.replica.remove", true);

--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -116,7 +116,8 @@ public class ReplicationConfig {
   /**
    * The maximum number of partitions on remote node can be replicated within a single replication request. If local
    * node shares more partitions than this number with peer node, the partitions will be split into several lists (with
-   * size <= max partition count) and will be replicated sequentially in separate replication cycles.
+   * size <= max partition count) and will be replicated sequentially in separate replication cycles. If set to 0, it
+   * means there is no limit.
    */
   @Config("replication.max.partition.count.per.request")
   @Default("20")
@@ -199,7 +200,7 @@ public class ReplicationConfig {
     replicationFetchSizeInBytes =
         verifiableProperties.getLongInRange("replication.fetch.size.in.bytes", 1048576, 1, Long.MAX_VALUE);
     replicationMaxPartitionCountPerRequest =
-        verifiableProperties.getIntInRange("replication.max.partition.count.per.request", 20, 1, Integer.MAX_VALUE);
+        verifiableProperties.getIntInRange("replication.max.partition.count.per.request", 20, 0, Integer.MAX_VALUE);
     replicationIncludeAll = verifiableProperties.getBoolean("replication.include.all", true);
     replicationPersistTokenOnShutdownOrReplicaRemove =
         verifiableProperties.getBoolean("replication.persist.token.on.shutdown.or.replica.remove", true);

--- a/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ReplicationConfig.java
@@ -114,7 +114,7 @@ public class ReplicationConfig {
   public final long replicationFetchSizeInBytes;
 
   /**
-   * The maximum number of partitions on remote node can be replicated with in a single replication request. If local
+   * The maximum number of partitions on remote node can be replicated within a single replication request. If local
    * node shares more partitions than this number with peer node, the partitions will be split into several lists (with
    * size <= max partition count) and will be replicated sequentially in separate replication cycles.
    */

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -58,6 +58,7 @@ import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -334,9 +335,12 @@ public class ReplicaThread implements Runnable {
       logger.trace("Replicating from {} RemoteReplicaInfos.", activeReplicasPerNode.size());
       if (activeReplicasPerNode.size() > 0) {
         allCaughtUp = false;
-        // split remote replicas on same node into multiple lists
+        // if maxReplicaCountPerRequest > 0, split remote replicas on same node into multiple lists; otherwise there is
+        // no limit.
         List<List<RemoteReplicaInfo>> activeReplicaSubLists =
-            Utils.partitionList(activeReplicasPerNode, maxReplicaCountPerRequest);
+            maxReplicaCountPerRequest > 0 ? Utils.partitionList(activeReplicasPerNode, maxReplicaCountPerRequest)
+                : Collections.singletonList(activeReplicasPerNode);
+
         // use a variable to track current replica list to replicate (for logging purpose)
         List<RemoteReplicaInfo> currentReplicaList = activeReplicasPerNode;
         try {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -54,6 +54,7 @@ import com.github.ambry.store.Transformer;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.Time;
+import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -334,13 +335,8 @@ public class ReplicaThread implements Runnable {
       if (activeReplicasPerNode.size() > 0) {
         allCaughtUp = false;
         // split remote replicas on same node into multiple lists
-        List<List<RemoteReplicaInfo>> activeReplicaSubLists = new ArrayList<>();
-        int fromIndex = 0;
-        while (fromIndex + maxReplicaCountPerRequest < activeReplicasPerNode.size()) {
-          activeReplicaSubLists.add(activeReplicasPerNode.subList(fromIndex, fromIndex + maxReplicaCountPerRequest));
-          fromIndex += maxReplicaCountPerRequest;
-        }
-        activeReplicaSubLists.add(activeReplicasPerNode.subList(fromIndex, activeReplicasPerNode.size()));
+        List<List<RemoteReplicaInfo>> activeReplicaSubLists =
+            Utils.partitionList(activeReplicasPerNode, maxReplicaCountPerRequest);
         // use a variable to track current replica list to replicate (for logging purpose)
         List<RemoteReplicaInfo> currentReplicaList = activeReplicasPerNode;
         try {

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -166,6 +166,7 @@ public class MockConnectionPool implements ConnectionPool {
     public void send(Send request) {
       if (request instanceof ReplicaMetadataRequest) {
         metadataRequest = (ReplicaMetadataRequest) request;
+        host.replicaCountPerRequestTracker.add(metadataRequest.getReplicaMetadataRequestInfoList().size());
       } else if (request instanceof GetRequest) {
         getRequest = (GetRequest) request;
         buffersToReturn = new ArrayList<>();
@@ -237,8 +238,9 @@ public class MockConnectionPool implements ConnectionPool {
             }
             indexRequested = i;
           }
-          long bytesRead = allMessageInfos.subList(0, indexRequested + 1).stream().mapToLong(i -> i.getSize()).sum();
-          long total = allMessageInfos.stream().mapToLong(i -> i.getSize()).sum();
+          long bytesRead =
+              allMessageInfos.subList(0, indexRequested + 1).stream().mapToLong(MessageInfo::getSize).sum();
+          long total = allMessageInfos.stream().mapToLong(MessageInfo::getSize).sum();
           ReplicaMetadataResponseInfo replicaMetadataResponseInfo =
               new ReplicaMetadataResponseInfo(requestInfo.getPartitionId(), requestInfo.getReplicaType(),
                   new MockFindToken(indexRequested, bytesRead), messageInfosToReturn, total - bytesRead,

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockHost.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockHost.java
@@ -41,6 +41,8 @@ public class MockHost {
   private final ClusterMap clusterMap;
 
   public final DataNodeId dataNodeId;
+  // creat a list to track number of replicas in each metadata request
+  final List<Integer> replicaCountPerRequestTracker = new ArrayList<>();
   final Map<PartitionId, List<MessageInfo>> infosByPartition = new HashMap<>();
   final Map<PartitionId, List<ByteBuffer>> buffersByPartition = new HashMap<>();
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -165,6 +165,7 @@ public class ReplicationTest {
     properties.setProperty("replication.inter.replica.thread.throttle.sleep.duration.ms", "200");
     properties.setProperty("replication.replica.thread.idle.sleep.duration.ms", "1000");
     properties.setProperty("replication.track.per.partition.lag.from.remote", "true");
+    properties.setProperty("replication.max.partition.count.per.request", Integer.toString(0));
     properties.put("store.segment.size.in.bytes", Long.toString(MockReplicaId.MOCK_REPLICA_CAPACITY / 2L));
     verifiableProperties = new VerifiableProperties(properties);
     replicationConfig = new ReplicationConfig(verifiableProperties);

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -126,6 +126,7 @@ public class ReplicationTest {
   private static final short VERSION_2 = 2;
   private static final short VERSION_5 = 5;
   private final MockTime time = new MockTime();
+  private Properties properties;
   private VerifiableProperties verifiableProperties;
   private ReplicationConfig replicationConfig;
 
@@ -150,7 +151,7 @@ public class ReplicationTest {
     List<com.github.ambry.utils.TestUtils.ZkInfo> zkInfoList = new ArrayList<>();
     zkInfoList.add(new com.github.ambry.utils.TestUtils.ZkInfo(null, "DC1", (byte) 0, 2199, false));
     JSONObject zkJson = constructZkLayoutJSON(zkInfoList);
-    Properties properties = new Properties();
+    properties = new Properties();
     properties.setProperty("replication.metadata.request.version", Short.toString(requestVersion));
     properties.setProperty("replication.metadataresponse.version", Short.toString(responseVersion));
     properties.setProperty("replication.cloud.token.factory", "com.github.ambry.replication.MockFindTokenFactory");
@@ -648,9 +649,9 @@ public class ReplicationTest {
         "Partition is not present in the map of partition to peer leader replicas after it moved from standby to leader",
         peerLeaderReplicasByPartition.containsKey(existingPartition.toPathString()));
     mockHelixParticipant.onPartitionBecomeStandbyFromLeader(existingPartition.toPathString());
-    assertTrue(
+    assertFalse(
         "Partition is still present in the map of partition to peer leader replicas after it moved from leader to standby",
-        !peerLeaderReplicasByPartition.containsKey(existingPartition.toPathString()));
+        peerLeaderReplicasByPartition.containsKey(existingPartition.toPathString()));
     storageManager.shutdown();
   }
 
@@ -848,7 +849,7 @@ public class ReplicationTest {
 
     List<PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
     for (PartitionId partitionId : partitionIds) {
-      // add  10 messages to the remote host only
+      // add 10 messages into each partition and place it on remote host only
       addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 10);
     }
 
@@ -920,6 +921,67 @@ public class ReplicationTest {
     for (Map.Entry<PartitionId, List<ByteBuffer>> entry : missingBuffers.entrySet()) {
       assertEquals("No buffers should be missing", 0, entry.getValue().size());
     }
+  }
+
+  /**
+   * Test that max partition count per request is honored in {@link ReplicaThread} if there are too many partitions to
+   * replicate from the remote node.
+   * @throws Exception
+   */
+  @Test
+  public void limitMaxPartitionCountPerRequestTest() throws Exception {
+    MockClusterMap clusterMap = new MockClusterMap();
+    Pair<MockHost, MockHost> localAndRemoteHosts = getLocalAndRemoteHosts(clusterMap);
+    MockHost localHost = localAndRemoteHosts.getFirst();
+    MockHost remoteHost = localAndRemoteHosts.getSecond();
+
+    List<PartitionId> partitionIds = clusterMap.getAllPartitionIds(null);
+    for (PartitionId partitionId : partitionIds) {
+      // add 5 messages into each partition and place it on remote host only
+      addPutMessagesToReplicasOfPartition(partitionId, Collections.singletonList(remoteHost), 5);
+    }
+    StoreKeyFactory storeKeyFactory = Utils.getObj("com.github.ambry.commons.BlobIdFactory", clusterMap);
+    MockStoreKeyConverterFactory mockStoreKeyConverterFactory = new MockStoreKeyConverterFactory(null, null);
+    mockStoreKeyConverterFactory.setReturnInputIfAbsent(true);
+    mockStoreKeyConverterFactory.setConversionMap(new HashMap<>());
+    // we set batchSize to 10 in order to get all messages from one partition within single replication cycle
+    int batchSize = 10;
+    StoreKeyConverter storeKeyConverter = mockStoreKeyConverterFactory.getStoreKeyConverter();
+    Transformer transformer = new ValidatingTransformer(storeKeyFactory, storeKeyConverter);
+    // we set max partition count per request to 5, which forces thread to replicate replicas in two cycles. (Note that
+    // number of partition to replicate is 10, they will be replicated in two batches)
+    ReplicationConfig initialReplicationConfig = replicationConfig;
+    properties.setProperty("replication.max.partition.count.per.request", String.valueOf(5));
+    replicationConfig = new ReplicationConfig(new VerifiableProperties(properties));
+    CountDownLatch replicationCompleted = new CountDownLatch(partitionIds.size());
+    AtomicReference<Exception> exception = new AtomicReference<>();
+    Pair<Map<DataNodeId, List<RemoteReplicaInfo>>, ReplicaThread> replicasAndThread =
+        getRemoteReplicasAndReplicaThread(batchSize, clusterMap, localHost, remoteHost, storeKeyConverter, transformer,
+            (store, messageInfos) -> {
+              try {
+                replicationCompleted.countDown();
+                // for each partition, replication should complete within single cycle (fetch once should suffice), so
+                // we shut down local store once blobs are written. This can avoid unnecessary metadata requests sent to
+                // remote host.
+                store.shutdown();
+              } catch (Exception e) {
+                exception.set(e);
+              }
+            }, null);
+    ReplicaThread replicaThread = replicasAndThread.getSecond();
+    Thread thread = Utils.newThread(replicaThread, false);
+    thread.start();
+    assertTrue("Replication didn't complete within 10 secs", replicationCompleted.await(10, TimeUnit.SECONDS));
+    // verify the # of replicas per metadata request is limited to 5 (note that there are 10 replicas to replicate, they
+    // are split into to 2 small batches and get replicated in separate requests)
+    assertEquals("There should be 2 metadata requests and each has 5 replicas to replicate", Arrays.asList(5, 5),
+        remoteHost.replicaCountPerRequestTracker);
+    // shutdown
+    replicaThread.shutdown();
+    if (exception.get() != null) {
+      throw exception.get();
+    }
+    replicationConfig = initialReplicationConfig;
   }
 
   /**
@@ -1127,7 +1189,6 @@ public class ReplicationTest {
     assertTrue(missingBuffers.isEmpty());
     missingBuffers = localHost.getMissingBuffers(expectedLocalHost.buffersByPartition);
     assertTrue(missingBuffers.isEmpty());
-
     /*
         BEFORE
         Local   Remote
@@ -1147,7 +1208,6 @@ public class ReplicationTest {
         delete B0 gets converted
         to delete B0' in Local
         Missing Keys: 0
-
      */
     //delete blob
     for (int i = 0; i < partitionIds.size(); i++) {


### PR DESCRIPTION
Two peer nodes may share many partitions. Imagine an edge case where
one node has been down for several weeks and is being brought up. If
the two nodes share 250 partitions and each partition has one 4 MB new
blob, in worst case, the previously down node will attempt to fetch 250
blobs which is roughly 1 GB in single get request. This causes memory
pressure on source node and may induce Out-of-Memory issue. This pr
introduces a config to limit number of partitions per replication request
with aim to split partitions into small batches and replicate in sequential
order.