### PR TITLE
Epoll patch and HTTP2 frame size tune.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
@@ -24,6 +24,8 @@ public class Http2ClientConfig {
   public static final String HTTP2_NETTY_EVENT_LOOP_GROUP_THREADS = "http2.netty.event.loop.group.threads";
   public static final String HTTP2_IDLE_CONNECTION_TIMEOUT_MS = "http2.idle.connection.timeout.ms";
   public static final String HTTP2_MAX_CONTENT_LENGTH = "http2.max.content.length";
+  public static final String HTTP2_FRAME_MAX_SIZE = "http2.frame.max.size";
+  public static final String HTTP2_INITIAL_WINDOW_SIZE = "http2.initial.window.size";
   public static final String NETTY_RECEIVE_BUFFER_SIZE = "netty.receive.buffer.size";
   public static final String NETTY_SEND_BUFFER_SIZE = "netty.send.buffer.size";
 
@@ -68,6 +70,23 @@ public class Http2ClientConfig {
   public final int http2MaxContentLength;
 
   /**
+   * The maximum allowed http2 frame size.This value is used to represent
+   * <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>.
+   */
+  @Config(HTTP2_FRAME_MAX_SIZE)
+  @Default("5 * 1024 * 1024")
+  public final int http2FrameMaxSize;
+
+
+  /**
+   * The initial window size used in http streams. This allows sender send big frame.
+   */
+  @Config(HTTP2_INITIAL_WINDOW_SIZE)
+  @Default("5 * 1024 * 1024")
+  public final int http2initialWindowSize;
+
+
+  /**
    * The socket receive buffer size for netty http2 channel.
    */
   @Config(NETTY_RECEIVE_BUFFER_SIZE)
@@ -89,6 +108,8 @@ public class Http2ClientConfig {
             Integer.MAX_VALUE);
     http2NettyEventLoopGroupThreads = verifiableProperties.getInt(HTTP2_NETTY_EVENT_LOOP_GROUP_THREADS, 0);
     http2MaxContentLength = verifiableProperties.getInt(HTTP2_MAX_CONTENT_LENGTH, 25 * 1024 * 1024);
+    http2FrameMaxSize = verifiableProperties.getInt(HTTP2_FRAME_MAX_SIZE, 5 * 1024 * 1024);
+    http2initialWindowSize = verifiableProperties.getInt(HTTP2_INITIAL_WINDOW_SIZE, 5 * 1024 * 1024);
 
     nettyReceiveBufferSize = verifiableProperties.getInt(NETTY_RECEIVE_BUFFER_SIZE, 1024 * 1024);
     nettySendBufferSize = verifiableProperties.getInt(NETTY_SEND_BUFFER_SIZE, 1024 * 1024);

--- a/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/Http2ClientConfig.java
@@ -70,7 +70,7 @@ public class Http2ClientConfig {
   public final int http2MaxContentLength;
 
   /**
-   * The maximum allowed http2 frame size.This value is used to represent
+   * The maximum allowed http2 frame size. This value is used to represent
    * <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>.
    */
   @Config(HTTP2_FRAME_MAX_SIZE)
@@ -83,7 +83,7 @@ public class Http2ClientConfig {
    */
   @Config(HTTP2_INITIAL_WINDOW_SIZE)
   @Default("5 * 1024 * 1024")
-  public final int http2initialWindowSize;
+  public final int http2InitialWindowSize;
 
 
   /**
@@ -109,7 +109,7 @@ public class Http2ClientConfig {
     http2NettyEventLoopGroupThreads = verifiableProperties.getInt(HTTP2_NETTY_EVENT_LOOP_GROUP_THREADS, 0);
     http2MaxContentLength = verifiableProperties.getInt(HTTP2_MAX_CONTENT_LENGTH, 25 * 1024 * 1024);
     http2FrameMaxSize = verifiableProperties.getInt(HTTP2_FRAME_MAX_SIZE, 5 * 1024 * 1024);
-    http2initialWindowSize = verifiableProperties.getInt(HTTP2_INITIAL_WINDOW_SIZE, 5 * 1024 * 1024);
+    http2InitialWindowSize = verifiableProperties.getInt(HTTP2_INITIAL_WINDOW_SIZE, 5 * 1024 * 1024);
 
     nettyReceiveBufferSize = verifiableProperties.getInt(NETTY_RECEIVE_BUFFER_SIZE, 1024 * 1024);
     nettySendBufferSize = verifiableProperties.getInt(NETTY_SEND_BUFFER_SIZE, 1024 * 1024);

--- a/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/RequestInfo.java
@@ -26,7 +26,8 @@ public class RequestInfo {
   private final SendWithCorrelationId request;
   private final ReplicaId replicaId;
   private long streamSendTime = -1;
-  private long streamReceiveTime = -1;
+  private long streamHeaderFrameReceiveTime = -1;
+  public int responseFramesCount = 0;
 
   /**
    * Construct a RequestInfo with the given parameters
@@ -70,16 +71,16 @@ public class RequestInfo {
     return replicaId;
   }
 
-  public long getStreamReceiveTime() {
-    return streamReceiveTime;
+  public long getStreamHeaderFrameReceiveTime() {
+    return streamHeaderFrameReceiveTime;
+  }
+
+  public void setStreamHeaderFrameReceiveTime(long streamHeaderFrameReceiveTime) {
+    this.streamHeaderFrameReceiveTime = streamHeaderFrameReceiveTime;
   }
 
   public long getStreamSendTime() {
     return streamSendTime;
-  }
-
-  public void setStreamReceiveTime(long streamReceiveTime) {
-    this.streamReceiveTime = streamReceiveTime;
   }
 
   public void setStreamSendTime(long streamSendTime) {

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolHandler.java
@@ -59,7 +59,7 @@ public class Http2ChannelPoolHandler extends AbstractChannelPoolHandler {
     pipeline.addLast(Http2FrameCodecBuilder.forClient()
         .initialSettings(Http2Settings.defaultSettings()
             .maxFrameSize(http2ClientConfig.http2FrameMaxSize)
-            .initialWindowSize(http2ClientConfig.http2initialWindowSize))
+            .initialWindowSize(http2ClientConfig.http2InitialWindowSize))
         .frameLogger(new Http2FrameLogger(LogLevel.DEBUG, "client"))
         .build());
     pipeline.addLast(new Http2MultiplexHandler(new ChannelInboundHandlerAdapter()));

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
@@ -31,8 +31,11 @@ public class Http2ClientMetrics {
   public final Histogram http2RegularStreamAcquireTime;
   public final Histogram http2StreamWriteAndFlushTime;
   public final Histogram http2StreamRoundTripTime;
+  public final Histogram http2StreamFirstToLastFrameTime;
+  public final Histogram http2StreamFirstToAllFrameReadyTime;
   public final Histogram http2ClientSendTime;
   public final Histogram http2ClientSendAndPollTime;
+  public final Histogram http2ResponseFrameCount;
 
   public final Counter http2NewPoolCount;
   public final Counter http2NewConnectionCount;
@@ -59,9 +62,15 @@ public class Http2ClientMetrics {
         registry.histogram(MetricRegistry.name(Http2NetworkClient.class, "Http2StreamWriteAndFlushTime"));
     http2StreamRoundTripTime =
         registry.histogram(MetricRegistry.name(Http2NetworkClient.class, "Http2StreamRoundTripTime"));
+    http2StreamFirstToLastFrameTime =
+        registry.histogram(MetricRegistry.name(Http2NetworkClient.class, "Http2StreamFirstToLastFrameTime"));
+    http2StreamFirstToAllFrameReadyTime =
+        registry.histogram(MetricRegistry.name(Http2NetworkClient.class, "Http2StreamFirstToAllFrameReadyTime"));
     http2ClientSendTime = registry.histogram(MetricRegistry.name(Http2NetworkClient.class, "Http2ClientSendTime"));
     http2ClientSendAndPollTime =
         registry.histogram(MetricRegistry.name(Http2NetworkClient.class, "Http2ClientSendAndPollTime"));
+    http2ResponseFrameCount =
+        registry.histogram(MetricRegistry.name(Http2NetworkClient.class, "Http2ResponseFrameCount"));
 
     http2NewPoolCount = registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2NewPoolCount"));
     http2NewConnectionCount =

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientResponseHandler.java
@@ -21,8 +21,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
 import java.util.concurrent.LinkedBlockingQueue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -44,9 +42,8 @@ class Http2ClientResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
     // Consume length
     dup.readLong();
     RequestInfo requestInfo = ctx.channel().attr(Http2NetworkClient.REQUEST_INFO).get();
-    http2NetworkClient.getHttp2ClientMetrics().http2StreamRoundTripTime.update(
-        System.currentTimeMillis() - requestInfo.getStreamSendTime());
-    requestInfo.setStreamReceiveTime(System.currentTimeMillis());
+    http2NetworkClient.getHttp2ClientMetrics().http2StreamFirstToAllFrameReadyTime.update(
+        System.currentTimeMillis() - requestInfo.getStreamHeaderFrameReceiveTime());
     ResponseInfo responseInfo = new ResponseInfo(requestInfo, null, dup);
     responseInfoQueue.offer(responseInfo);
     // TODO: is this a good place to release stream channel?

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientStreamStatsHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientStreamStatsHandler.java
@@ -47,17 +47,16 @@ class Http2ClientStreamStatsHandler extends SimpleChannelInboundHandler<Http2Fra
       requestInfo.setStreamHeaderFrameReceiveTime(System.currentTimeMillis());
       http2NetworkClient.getHttp2ClientMetrics().http2StreamRoundTripTime.update(
           System.currentTimeMillis() - requestInfo.getStreamSendTime());
-      logger.debug("Header Frame received. Request: {}", requestInfo.toString());
+      logger.debug("Header Frame received. Request: {}", requestInfo);
     } else if (frame instanceof Http2DataFrame) {
-      logger.debug("Data Frame size: {}. Request: {}", ((Http2DataFrame) frame).content().readableBytes(),
-          requestInfo.toString());
+      logger.debug("Data Frame size: {}. Request: {}", ((Http2DataFrame) frame).content().readableBytes(), requestInfo);
     }
 
     if (frame instanceof Http2DataFrame && ((Http2DataFrame) frame).isEndStream()) {
       long time = System.currentTimeMillis() - requestInfo.getStreamHeaderFrameReceiveTime();
       http2NetworkClient.getHttp2ClientMetrics().http2StreamFirstToLastFrameTime.update(time);
       http2NetworkClient.getHttp2ClientMetrics().http2ResponseFrameCount.update(requestInfo.responseFramesCount);
-      logger.debug("All Frame received. Time: {}ms. Request: {}", time, requestInfo.toString());
+      logger.debug("All Frame received. Time: {}ms. Request: {}", time, requestInfo);
     }
     ctx.fireChannelRead(frame);
   }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientStreamStatsHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientStreamStatsHandler.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.network.http2;
+
+import com.github.ambry.network.RequestInfo;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http2.Http2DataFrame;
+import io.netty.handler.codec.http2.Http2Frame;
+import io.netty.handler.codec.http2.Http2HeadersFrame;
+import io.netty.util.ReferenceCountUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A handler to stats response streams.
+ */
+
+@ChannelHandler.Sharable
+class Http2ClientStreamStatsHandler extends SimpleChannelInboundHandler<Http2Frame> {
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private Http2NetworkClient http2NetworkClient;
+
+  public Http2ClientStreamStatsHandler(Http2NetworkClient http2NetworkClient) {
+    this.http2NetworkClient = http2NetworkClient;
+  }
+
+  @Override
+  protected void channelRead0(ChannelHandlerContext ctx, Http2Frame frame) throws Exception {
+    ReferenceCountUtil.retain(frame);
+    RequestInfo requestInfo = ctx.channel().attr(Http2NetworkClient.REQUEST_INFO).get();
+    requestInfo.responseFramesCount++;
+    if (frame instanceof Http2HeadersFrame) {
+      requestInfo.setStreamHeaderFrameReceiveTime(System.currentTimeMillis());
+      http2NetworkClient.getHttp2ClientMetrics().http2StreamRoundTripTime.update(
+          System.currentTimeMillis() - requestInfo.getStreamSendTime());
+      logger.debug("Header Frame received. Request: {}", requestInfo.toString());
+    } else if (frame instanceof Http2DataFrame) {
+      logger.debug("Data Frame size: {}. Request: {}", ((Http2DataFrame) frame).content().readableBytes(),
+          requestInfo.toString());
+    }
+
+    if (frame instanceof Http2DataFrame && ((Http2DataFrame) frame).isEndStream()) {
+      long time = System.currentTimeMillis() - requestInfo.getStreamHeaderFrameReceiveTime();
+      http2NetworkClient.getHttp2ClientMetrics().http2StreamFirstToLastFrameTime.update(time);
+      http2NetworkClient.getHttp2ClientMetrics().http2ResponseFrameCount.update(requestInfo.responseFramesCount);
+      logger.debug("All Frame received. Time: {}ms. Request: {}", time, requestInfo.toString());
+    }
+    ctx.fireChannelRead(frame);
+  }
+}
+

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
@@ -103,8 +103,8 @@ public class Http2MultiplexedChannelPool implements ChannelPool {
             // To honor http2 window size, WriteBufferWaterMark.high() should be greater or equal to http2 window size.
             // Also see: https://github.com/netty/netty/issues/10193
             .option(ChannelOption.WRITE_BUFFER_WATER_MARK,
-                new WriteBufferWaterMark(http2ClientConfig.http2initialWindowSize,
-                    2 * http2ClientConfig.http2initialWindowSize))
+                new WriteBufferWaterMark(http2ClientConfig.http2InitialWindowSize,
+                    2 * http2ClientConfig.http2InitialWindowSize))
             .remoteAddress(inetSocketAddress),
             new Http2ChannelPoolHandler(sslFactory, inetSocketAddress.getHostName(), inetSocketAddress.getPort(),
                 http2ClientConfig)), eventLoopGroup, ConcurrentHashMap.newKeySet(),

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
@@ -103,7 +103,8 @@ public class Http2MultiplexedChannelPool implements ChannelPool {
             // To honor http2 window size, WriteBufferWaterMark.high() should be greater or equal to http2 window size.
             // Also see: https://github.com/netty/netty/issues/10193
             .option(ChannelOption.WRITE_BUFFER_WATER_MARK,
-                new WriteBufferWaterMark(WriteBufferWaterMark.DEFAULT.low(), http2ClientConfig.http2initialWindowSize))
+                new WriteBufferWaterMark(http2ClientConfig.http2initialWindowSize,
+                    2 * http2ClientConfig.http2initialWindowSize))
             .remoteAddress(inetSocketAddress),
             new Http2ChannelPoolHandler(sslFactory, inetSocketAddress.getHostName(), inetSocketAddress.getPort(),
                 http2ClientConfig)), eventLoopGroup, ConcurrentHashMap.newKeySet(),

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/MultiplexedChannelRecord.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/MultiplexedChannelRecord.java
@@ -107,14 +107,8 @@ public class MultiplexedChannelRecord {
       }
 
       Future<Http2StreamChannel> streamFuture =
-          new Http2StreamChannelBootstrap(parentChannel).handler(new ChannelInitializer<Channel>() {
-            @Override
-            protected void initChannel(Channel ch) throws Exception {
-              ChannelPipeline p = ch.pipeline();
-              p.addLast(new Http2StreamFrameToHttpObjectCodec(false));
-              p.addLast(new HttpObjectAggregator(maxContentLength));
-            }
-          }).open();
+          new Http2StreamChannelBootstrap(parentChannel).open();
+      // handler are added when stream is returned to claimer.
       streamFuture.addListener((GenericFutureListener<Future<Http2StreamChannel>>) future -> {
         NettyUtils.warnIfNotInEventLoop(parentChannel.eventLoop());
 

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
@@ -165,6 +165,7 @@ class NettyResponseChannel implements RestResponseChannel {
       return future;
     }
     Chunk chunk = new Chunk(src, callback);
+    logger.debug("Netty Response Chunk size: " + src.readableBytes());
     chunksToWrite.add(chunk);
     if (HttpUtil.isContentLengthSet(finalResponseMetadata) && totalBytesReceived.get() > HttpUtil.getContentLength(
         finalResponseMetadata)) {

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyServer.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyServer.java
@@ -135,6 +135,7 @@ public class NettyServer implements NioServer {
     ServerBootstrap b = new ServerBootstrap();
     Class<? extends ServerSocketChannel> channelClass =
         Epoll.isAvailable() ? EpollServerSocketChannel.class : NioServerSocketChannel.class;
+    // Note: ServerSocketChannel option doesn't apply to SocketChannel
     b.group(bossGroup, workerGroup)
         .channel(channelClass)
         .option(ChannelOption.SO_BACKLOG, nettyConfig.nettyServerSoBacklog)

--- a/ambry-rest/src/main/java/com/github/ambry/rest/StorageServerNettyChannelInitializer.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/StorageServerNettyChannelInitializer.java
@@ -76,11 +76,12 @@ public class StorageServerNettyChannelInitializer extends ChannelInitializer<Soc
   protected void initChannel(SocketChannel ch) throws Exception {
     // To honor http2 window size, WriteBufferWaterMark.high() should be greater or equal to http2 window size.
     // Also see: https://github.com/netty/netty/issues/10193
+    // https://stackoverflow.com/questions/25281124/netty-4-high-and-low-write-watermarks
     ch.config()
         .setSendBufferSize(http2ClientConfig.nettySendBufferSize)
         .setReceiveBufferSize(http2ClientConfig.nettyReceiveBufferSize)
-        .setWriteBufferWaterMark(
-            new WriteBufferWaterMark(WriteBufferWaterMark.DEFAULT.low(), http2ClientConfig.http2initialWindowSize));
+        .setWriteBufferWaterMark(new WriteBufferWaterMark(http2ClientConfig.http2initialWindowSize,
+            2 * http2ClientConfig.http2initialWindowSize));
     // If channel handler implementations are not annotated with @Sharable, Netty creates a new instance of every class
     // in the pipeline for every connection.
     // i.e. if there are a 1000 active connections there will be a 1000 NettyMessageProcessor instances.

--- a/ambry-rest/src/main/java/com/github/ambry/rest/StorageServerNettyChannelInitializer.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/StorageServerNettyChannelInitializer.java
@@ -80,8 +80,8 @@ public class StorageServerNettyChannelInitializer extends ChannelInitializer<Soc
     ch.config()
         .setSendBufferSize(http2ClientConfig.nettySendBufferSize)
         .setReceiveBufferSize(http2ClientConfig.nettyReceiveBufferSize)
-        .setWriteBufferWaterMark(new WriteBufferWaterMark(http2ClientConfig.http2initialWindowSize,
-            2 * http2ClientConfig.http2initialWindowSize));
+        .setWriteBufferWaterMark(new WriteBufferWaterMark(http2ClientConfig.http2InitialWindowSize,
+            2 * http2ClientConfig.http2InitialWindowSize));
     // If channel handler implementations are not annotated with @Sharable, Netty creates a new instance of every class
     // in the pipeline for every connection.
     // i.e. if there are a 1000 active connections there will be a 1000 NettyMessageProcessor instances.
@@ -96,7 +96,7 @@ public class StorageServerNettyChannelInitializer extends ChannelInitializer<Soc
     pipeline.addLast(Http2FrameCodecBuilder.forServer()
         .initialSettings(Http2Settings.defaultSettings()
             .maxFrameSize(http2ClientConfig.http2FrameMaxSize)
-            .initialWindowSize(http2ClientConfig.http2initialWindowSize))
+            .initialWindowSize(http2ClientConfig.http2InitialWindowSize))
         .frameLogger(new Http2FrameLogger(LogLevel.DEBUG, "server"))
         .build())
         .addLast("Http2MultiplexHandler", new Http2MultiplexHandler(

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -25,7 +25,6 @@ import com.github.ambry.network.NetworkClient;
 import com.github.ambry.network.NetworkClientFactory;
 import com.github.ambry.network.RequestInfo;
 import com.github.ambry.network.ResponseInfo;
-import com.github.ambry.network.http2.Http2NetworkClient;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.protocol.GetOption;
 import com.github.ambry.protocol.RequestOrResponse;
@@ -851,7 +850,7 @@ class NonBlockingRouter implements Router {
             DataNodeId dataNodeId = responseInfo.getDataNode();
             responseHandler.onConnectionTimeout(dataNodeId);
           } else {
-            long responseReceiveTime = requestInfo.getStreamReceiveTime();
+            long responseReceiveTime = requestInfo.getStreamHeaderFrameReceiveTime();
             if (responseReceiveTime != -1) {
               routerMetrics.responseReceiveToHandleLatencyMs.update(System.currentTimeMillis() - responseReceiveTime);
             }

--- a/build.gradle
+++ b/build.gradle
@@ -232,6 +232,7 @@ project(':ambry-network') {
                 project(':ambry-clustermap')
         compile "io.netty:netty-all:$nettyVersion"
         compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
+        compile "io.netty:netty-transport-native-epoll:$nettyVersion"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         testCompile project(':ambry-test-utils')
     }
@@ -344,6 +345,7 @@ project(':ambry-rest') {
         compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
         compile "io.netty:netty-all:$nettyVersion"
         compile "io.netty:netty-tcnative-boringssl-static:$nettyTcnativeVersion"
+        compile "io.netty:netty-transport-native-epoll:$nettyVersion"
         compile "javax.servlet:javax.servlet-api:$javaxVersion"
         runtimeOnly "log4j:log4j:$log4jVersion"
         runtimeOnly "org.slf4j:slf4j-log4j12:$slf4jVersion"


### PR DESCRIPTION
Include epoll in gradle build.
Add config for http2FrameMaxSize, http2initialWindowSize and WriteBufferWaterMark to support larger frame size.
Background:
In a recent performance test, we noticed 1MB http2 response time is high: round trip time is good but time from first frame to last frame is terrible. The reason is Netty chunks 1MB data to multiple 64KB frames and this caused multiple round trips and delayed Netty processing. The change is to support large frame size by configuring http2FrameMaxSize, http2initialWindowSize and WriteBufferWaterMark.