### PR TITLE
Prevent compaction partial failure if possible, recover from it if necessary.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
@@ -39,6 +39,8 @@ public class CloudConfig {
   public static final String CLOUD_BLOB_COMPACTION_ENABLED = "cloud.blob.compaction.enabled";
   public static final String CLOUD_BLOB_COMPACTION_INTERVAL_HOURS = "cloud.blob.compaction.interval.hours";
   public static final String CLOUD_BLOB_COMPACTION_QUERY_LIMIT = "cloud.blob.compaction.query.limit";
+  public static final String CLOUD_BLOB_COMPACTION_SHUTDOWN_TIMEOUT_SECS =
+      "cloud.blob.compaction.shutdown.timeout.secs";
   public static final String CLOUD_RECENT_BLOB_CACHE_LIMIT = "cloud.recent.blob.cache.limit";
   public static final String CLOUD_MAX_ATTEMPTS = "cloud.max.attempts";
   public static final String CLOUD_DEFAULT_RETRY_DELAY = "cloud.default.retry.delay";
@@ -67,6 +69,7 @@ public class CloudConfig {
   public static final int DEFAULT_MIN_TTL_DAYS = 14;
   public static final int DEFAULT_RETENTION_DAYS = 7;
   public static final int DEFAULT_COMPACTION_QUERY_LIMIT = 100;
+  public static final int DEFAULT_COMPACTION_TIMEOUT = 10;
   public static final int DEFAULT_RECENT_BLOB_CACHE_LIMIT = 10000;
   public static final int DEFAULT_MAX_ATTEMPTS = 3;
   public static final int DEFAULT_RETRY_DELAY_VALUE = 50;
@@ -198,6 +201,13 @@ public class CloudConfig {
   public final int cloudBlobCompactionIntervalHours;
 
   /**
+   * Maximum time to wait for in-flight compaction operation to complete on shutdown.
+   */
+  @Config(CLOUD_BLOB_COMPACTION_SHUTDOWN_TIMEOUT_SECS)
+  @Default("10")
+  public final int cloudBlobCompactionShutDownTimeoutSecs;
+
+  /**
    * The max size of recently-accessed blob cache in each cloud blob store.
    */
   @Config(CLOUD_RECENT_BLOB_CACHE_LIMIT)
@@ -303,6 +313,8 @@ public class CloudConfig {
     cloudBlobCompactionIntervalHours = verifiableProperties.getInt(CLOUD_BLOB_COMPACTION_INTERVAL_HOURS, 24);
     cloudBlobCompactionQueryLimit =
         verifiableProperties.getInt(CLOUD_BLOB_COMPACTION_QUERY_LIMIT, DEFAULT_COMPACTION_QUERY_LIMIT);
+    cloudBlobCompactionShutDownTimeoutSecs =
+        verifiableProperties.getInt(CLOUD_BLOB_COMPACTION_SHUTDOWN_TIMEOUT_SECS, DEFAULT_COMPACTION_TIMEOUT);
     recentBlobCacheLimit = verifiableProperties.getInt(CLOUD_RECENT_BLOB_CACHE_LIMIT, DEFAULT_RECENT_BLOB_CACHE_LIMIT);
     cloudMaxAttempts = verifiableProperties.getInt(CLOUD_MAX_ATTEMPTS, DEFAULT_MAX_ATTEMPTS);
     cloudDefaultRetryDelay = verifiableProperties.getInt(CLOUD_DEFAULT_RETRY_DELAY, DEFAULT_RETRY_DELAY_VALUE);

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobMetadata.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobMetadata.java
@@ -412,6 +412,13 @@ public class CloudBlobMetadata {
     return cappedList;
   }
 
+  /**
+   * @return true if this blob is deleted or expired, otherwise false.
+   */
+  public boolean isDeletedOrExpired() {
+    return (expirationTime != Utils.Infinite_Time && expirationTime < System.currentTimeMillis()) || deletionTime != Utils.Infinite_Time;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof CloudBlobMetadata)) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMetrics.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMetrics.java
@@ -29,8 +29,10 @@ public class VcrMetrics {
   public final Counter blobDecryptionErrorCount;
   public final Timer blobEncryptionTime;
   public final Timer blobDecryptionTime;
-  // Time to run compaction task
+  // Compaction metrics
   public final Timer blobCompactionTime;
+  public final Counter compactionFailureCount;
+  public final Counter compactionShutdownTimeoutCount;
   // Cache counters
   public final Counter blobCacheLookupCount;
   public final Counter blobCacheHitCount;
@@ -57,16 +59,19 @@ public class VcrMetrics {
     blobDecryptionTime = registry.timer(MetricRegistry.name(CloudBlobStore.class, "BlobDecryptionTime"));
     blobUploadSkippedCount = registry.counter(MetricRegistry.name(CloudBlobStore.class, "BlobUploadSkippedCount"));
     updateTtlNotSetError = registry.counter(MetricRegistry.name(CloudBlobStore.class, "UpdateTtlNotSetError"));
-    blobCompactionTime = registry.timer(MetricRegistry.name(CloudBlobStore.class, "BlobCompactionTime"));
     blobCacheLookupCount = registry.counter(MetricRegistry.name(CloudBlobStore.class, "BlobCacheLookupCount"));
     blobCacheHitCount = registry.counter(MetricRegistry.name(CloudBlobStore.class, "BlobCacheHitCount"));
+    retryCount = registry.counter(MetricRegistry.name(CloudBlobStore.class, "RetryCount"));
+    retryWaitTimeMsec = registry.counter(MetricRegistry.name(CloudBlobStore.class, "RetryWaitTimeMsec"));
+    blobCompactionTime = registry.timer(MetricRegistry.name(CloudStorageCompactor.class, "BlobCompactionTime"));
+    compactionFailureCount = registry.counter(MetricRegistry.name(CloudStorageCompactor.class, "CompactionFailureCount"));
+    compactionShutdownTimeoutCount =
+        registry.counter(MetricRegistry.name(CloudStorageCompactor.class, "CompactionShutdownTimeoutCount"));
     addPartitionErrorCount =
         registry.counter(MetricRegistry.name(VcrReplicationManager.class, "AddPartitionErrorCount"));
     removePartitionErrorCount =
         registry.counter(MetricRegistry.name(VcrReplicationManager.class, "RemovePartitionErrorCount"));
     tokenReloadWarnCount = registry.counter(MetricRegistry.name(VcrReplicationManager.class, "TokenReloadWarnCount"));
-    retryCount = registry.counter(MetricRegistry.name(CloudBlobStore.class, "RetryCount"));
-    retryWaitTimeMsec = registry.counter(MetricRegistry.name(CloudBlobStore.class, "RetryWaitTimeMsec"));
   }
 
   /**

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -216,6 +216,15 @@ public class VcrReplicationManager extends ReplicationEngine {
     // remoteReplicaInfo which needs CloudBlobStore.
   }
 
+  @Override
+  public void shutdown() throws ReplicationException {
+    // TODO: can do these in parallel
+    if (cloudStorageCompactor != null) {
+      cloudStorageCompactor.shutdown();
+    }
+    super.shutdown();
+  }
+
   public VcrMetrics getVcrMetrics() {
     return vcrMetrics;
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
@@ -249,7 +249,7 @@ class AzureCloudDestination implements CloudDestination {
    * @param blobId The {@link BlobId} to update.
    * @param fieldName The metadata field to modify.
    * @param value The new value.
-   * @return {@code true} if the udpate succeeded, {@code false} if no update was needed.
+   * @return {@code true} if the update succeeded, {@code false} if no update was needed.
    * @throws CloudStorageException if the update fails.
    */
   private boolean updateBlobMetadata(BlobId blobId, String fieldName, Object value) throws CloudStorageException {

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/CloudStorageCompactorTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/CloudStorageCompactorTest.java
@@ -105,6 +105,12 @@ public class CloudStorageCompactorTest {
     verify(mockDest, times(1)).getDeletedBlobs(eq(partitionPath2), anyLong(), anyLong(), anyInt());
     assertNull(compactor.getOldestExpiredBlob(partitionPath1));
     assertNull(compactor.getOldestDeletedBlob(partitionPath2));
+
+    // Test shutdown
+    assertFalse("Should not be shutting down yet", compactor.isShuttingDown());
+    compactor.shutdown();
+    assertTrue("Should be shutting down now", compactor.isShuttingDown());
+    // TODO: test shutting down with compaction still in progress (more involved)
   }
 
   /**

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureTestUtils.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureTestUtils.java
@@ -52,13 +52,14 @@ class AzureTestUtils {
   static final short accountId = 101;
   static final short containerId = 5;
   static final long partition = 666;
+  static final ObjectMapper objectMapper = new ObjectMapper();
 
   /**
    * Create {@link Document} object from {@link CloudBlobMetadata} object.
    * @param cloudBlobMetadata {@link CloudBlobMetadata} object.
    * @return {@link Document} object.
    */
-  static Document createDocumentFromCloudBlobMetadata(CloudBlobMetadata cloudBlobMetadata, ObjectMapper objectMapper)
+  static Document createDocumentFromCloudBlobMetadata(CloudBlobMetadata cloudBlobMetadata)
       throws IOException {
     Document document = new Document(objectMapper.writeValueAsString(cloudBlobMetadata));
     document.set(CosmosDataAccessor.COSMOS_LAST_UPDATED_COLUMN, System.currentTimeMillis());
@@ -71,8 +72,7 @@ class AzureTestUtils {
    * @param uploadTime specified upload time.
    * @return {@link Document} object.
    */
-  static Document createDocumentFromCloudBlobMetadata(CloudBlobMetadata cloudBlobMetadata, long uploadTime,
-      ObjectMapper objectMapper) throws JsonProcessingException {
+  static Document createDocumentFromCloudBlobMetadata(CloudBlobMetadata cloudBlobMetadata, long uploadTime) throws JsonProcessingException {
     Document document = new Document(objectMapper.writeValueAsString(cloudBlobMetadata));
     document.set(CosmosDataAccessor.COSMOS_LAST_UPDATED_COLUMN, uploadTime);
     return document;
@@ -110,15 +110,17 @@ class AzureTestUtils {
 
   /**
    * Utility to mock the call chain to get mocked {@link Observable} for single resource from {@link AsyncDocumentClient}.
+   * @param metadata the {@link CloudBlobMetadata} to return as a document.
    * @return {@link Observable< ResourceResponse <Document>>} object.
    */
-  static Observable<ResourceResponse<Document>> getMockedObservableForSingleResource() {
+  static Observable<ResourceResponse<Document>> getMockedObservableForSingleResource(CloudBlobMetadata metadata)
+      throws IOException {
     Observable<ResourceResponse<Document>> mockResponse = mock(Observable.class);
     BlockingObservable<ResourceResponse<Document>> mockBlockingObservable = mock(BlockingObservable.class);
     when(mockResponse.toBlocking()).thenReturn(mockBlockingObservable);
     ResourceResponse<Document> mockResourceResponse = mock(ResourceResponse.class);
     when(mockBlockingObservable.single()).thenReturn(mockResourceResponse);
-    Document metadataDoc = new Document();
+    Document metadataDoc = createDocumentFromCloudBlobMetadata(metadata);
     when(mockResourceResponse.getResource()).thenReturn(metadataDoc);
     return mockResponse;
   }


### PR DESCRIPTION
Two complementary changes here:

1. Add shutdown hook to let compaction operations to complete.
2. Check for inconsistency in update operation and delete stray Cosmos record.