### PR TITLE
Make partition class more permissive for migrations

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -559,7 +559,8 @@ public class ClusterMapUtils {
           }
           if (partitionsByReplicaCount == null) {
             throw new IllegalArgumentException(
-                "No partitions for default partition class " + partitionClass + " found");
+                "No partitions for partition class = '" + partitionClass + "' or default partition class = '"
+                    + defaultPartitionClass + "' found");
           }
           if (minimumReplicaCountRequired) {
             // get partitions with replica count >= min replica count specified in ClusterMapConfig

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -395,21 +395,24 @@ public class ClusterMapUtils {
     private final int minimumLocalReplicaCount;
     private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
     private final ClusterManagerCallback<?, ?, ?, ?> clusterManagerCallback;
+    private final String localDatacenterName;
+    private final String defaultPartitionClass;
     private Collection<? extends PartitionId> allPartitions;
     private Map<String, SortedMap<Integer, List<PartitionId>>> partitionIdsByClassAndLocalReplicaCount;
     private Map<PartitionId, List<ReplicaId>> partitionIdToLocalReplicas;
-    private String localDatacenterName;
 
     /**
      * @param clusterManagerCallback the {@link ClusterManagerCallback} to query current cluster info
      * @param localDatacenterName the name of the local datacenter. Can be null if datacenter specific replica counts
      * @param minimumLocalReplicaCount the minimum number of replicas in local datacenter. This is used when selecting
+     * @param defaultPartitionClass the default partition class to use if a partition class is not found
      */
     PartitionSelectionHelper(ClusterManagerCallback<?, ?, ?, ?> clusterManagerCallback, String localDatacenterName,
-        int minimumLocalReplicaCount) {
+        int minimumLocalReplicaCount, String defaultPartitionClass) {
       this.localDatacenterName = localDatacenterName;
       this.minimumLocalReplicaCount = minimumLocalReplicaCount;
       this.clusterManagerCallback = clusterManagerCallback;
+      this.defaultPartitionClass = defaultPartitionClass;
       updatePartitions(clusterManagerCallback.getPartitions(), localDatacenterName);
     }
 
@@ -548,22 +551,26 @@ public class ClusterMapUtils {
       try {
         if (partitionClass == null) {
           toReturn.addAll(allPartitions);
-        } else if (partitionIdsByClassAndLocalReplicaCount.containsKey(partitionClass)) {
+        } else {
           SortedMap<Integer, List<PartitionId>> partitionsByReplicaCount =
               partitionIdsByClassAndLocalReplicaCount.get(partitionClass);
+          if (partitionsByReplicaCount == null) {
+            partitionsByReplicaCount = partitionIdsByClassAndLocalReplicaCount.get(defaultPartitionClass);
+          }
+          if (partitionsByReplicaCount == null) {
+            throw new IllegalArgumentException(
+                "No partitions for default partition class " + partitionClass + " found");
+          }
           if (minimumReplicaCountRequired) {
             // get partitions with replica count >= min replica count specified in ClusterMapConfig
             for (List<PartitionId> partitionIds : partitionsByReplicaCount.tailMap(minimumLocalReplicaCount).values()) {
               toReturn.addAll(partitionIds);
             }
           } else {
-            for (List<PartitionId> partitionIds : partitionIdsByClassAndLocalReplicaCount.get(partitionClass)
-                .values()) {
+            for (List<PartitionId> partitionIds : partitionsByReplicaCount.values()) {
               toReturn.addAll(partitionIds);
             }
           }
-        } else {
-          throw new IllegalArgumentException("Unrecognized partition class " + partitionClass);
         }
       } finally {
         rwLock.readLock().unlock();

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -177,7 +177,8 @@ public class HelixClusterManager implements ClusterMap {
     localDatacenterId = dcToDcInfo.get(clusterMapConfig.clusterMapDatacenterName).dcZkInfo.getDcId();
     partitionSelectionHelper =
         new PartitionSelectionHelper(helixClusterManagerCallback, clusterMapConfig.clusterMapDatacenterName,
-            clusterMapConfig.clustermapWritablePartitionMinReplicaCount);
+            clusterMapConfig.clustermapWritablePartitionMinReplicaCount,
+            clusterMapConfig.clusterMapDefaultPartitionClass);
     // register partition selection helper as a listener of cluster map changes.
     registerClusterMapListener(partitionSelectionHelper);
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -74,7 +74,8 @@ class PartitionLayout {
     validate();
     partitionSelectionHelper =
         new ClusterMapUtils.PartitionSelectionHelper(new StaticClusterManagerCallback(), localDatacenterName,
-            clusterMapConfig.clustermapWritablePartitionMinReplicaCount);
+            clusterMapConfig.clustermapWritablePartitionMinReplicaCount,
+            clusterMapConfig.clusterMapDefaultPartitionClass);
   }
 
   /**
@@ -95,7 +96,8 @@ class PartitionLayout {
     validate();
     partitionSelectionHelper =
         new ClusterMapUtils.PartitionSelectionHelper(new StaticClusterManagerCallback(), localDatacenterName,
-            clusterMapConfig.clustermapWritablePartitionMinReplicaCount);
+            clusterMapConfig.clustermapWritablePartitionMinReplicaCount,
+            clusterMapConfig.clusterMapDefaultPartitionClass);
   }
 
   public HardwareLayout getHardwareLayout() {

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouterMetrics.java
@@ -171,6 +171,7 @@ public class NonBlockingRouterMetrics {
   public final Counter simpleEncryptedBlobSizeMismatchCount;
   public final Counter simpleUnencryptedBlobSizeMismatchCount;
   public final Counter compositeBlobSizeMismatchCount;
+  public final Counter unknownPartitionClassCount;
   // Number of unnecessary blob gets avoided via use of BlobDataType
   public final Counter skippedGetBlobCount;
   public Gauge<Long> chunkFillerThreadRunning;
@@ -423,6 +424,8 @@ public class NonBlockingRouterMetrics {
         metricRegistry.counter(MetricRegistry.name(GetBlobOperation.class, "SimpleUnencryptedBlobSizeMismatchCount"));
     compositeBlobSizeMismatchCount =
         metricRegistry.counter(MetricRegistry.name(GetBlobOperation.class, "CompositeBlobSizeMismatchCount"));
+    unknownPartitionClassCount =
+        metricRegistry.counter(MetricRegistry.name(PutOperation.class, "UnknownPartitionClassCount"));
 
     // metrics to track blob sizes and chunking.
     putBlobSizeBytes = metricRegistry.histogram(MetricRegistry.name(PutManager.class, "PutBlobSizeBytes"));

--- a/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutManager.java
@@ -176,7 +176,7 @@ class PutManager {
     Account account = accountService.getAccountById(blobProperties.getAccountId());
     if (account != null) {
       Container container = account.getContainerById(blobProperties.getContainerId());
-      if (container != null && container.getReplicationPolicy() != null) {
+      if (container != null && !Utils.isNullOrEmpty(container.getReplicationPolicy())) {
         partitionClass = container.getReplicationPolicy();
       }
     }

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -1390,12 +1390,13 @@ class PutOperation {
         throws RouterException {
       PartitionId selected = clusterMap.getRandomWritablePartition(partitionClass, partitionIdsToExclude);
       if (selected == null) {
-        throw new RouterException("No writable partitions of class " + partitionClass + " available.",
+        throw new RouterException("No writable partitions of class '" + partitionClass + "' or default available.",
             RouterErrorCode.AmbryUnavailable);
       }
       if (!partitionClass.equals(selected.getPartitionClass())) {
-        throw new IllegalStateException(
-            "Selected partition's class [" + selected.getPartitionClass() + "] is not as required: " + partitionClass);
+        logger.warn("No partitions for partitionClass='{}' found, partitionClass='{}' used instead. blobProperties={}",
+            partitionClass, selected.getPartitionClass(), passedInBlobProperties);
+        routerMetrics.unknownPartitionClassCount.inc();
       }
       return selected;
     }

--- a/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/PutManagerTest.java
@@ -846,13 +846,13 @@ public class PutManagerTest {
       }
     }
 
-    // exception if there is no partition class that conforms to the replication policy
+    // if there is no partition class that conforms to the replication policy, the default should be used.
     String nonExistentClass = TestUtils.getRandomString(3);
     accountService.addReplicationPolicyToContainer(container, nonExistentClass);
     requestAndResultsList.clear();
     requestAndResultsList.add(new RequestAndResult(chunkSize, container, PutBlobOptions.DEFAULT, null));
     mockClusterMap.clearLastNRequestedPartitionClasses();
-    submitPutsAndAssertFailure(new RouterException("", RouterErrorCode.UnexpectedInternalError), true, false, false);
+    submitPutsAndAssertSuccess(true);
     // because of how the non-encrypted flow is, prepareForSending() may be called twice. So not checking for count
     checkLastRequestPartitionClasses(-1, nonExistentClass);
   }

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockClusterMap.java
@@ -193,7 +193,7 @@ public class MockClusterMap implements ClusterMap {
     doReturn(partitions.values()).when(mockClusterManagerCallback).getPartitions();
     partitionSelectionHelper =
         new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerCallback, localDatacenterName,
-            Math.min(defaultPartition.getReplicaIds().size(), 3));
+            Math.min(defaultPartition.getReplicaIds().size(), 3), DEFAULT_PARTITION_CLASS);
   }
 
   /**
@@ -215,7 +215,7 @@ public class MockClusterMap implements ClusterMap {
     doReturn(partitions.values()).when(mockClusterManagerCallback).getPartitions();
     partitionSelectionHelper =
         new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerCallback, localDatacenterName,
-            Math.min(partitionIdList.get(0).getReplicaIds().size(), 3));
+            Math.min(partitionIdList.get(0).getReplicaIds().size(), 3), DEFAULT_PARTITION_CLASS);
     Set<String> dcNames = new HashSet<>();
     datanodes.forEach(node -> dcNames.add(node.getDatacenterName()));
     dataCentersInClusterMap.addAll(dcNames);
@@ -257,7 +257,7 @@ public class MockClusterMap implements ClusterMap {
     doReturn(partitions.values()).when(mockClusterManagerCallback).getPartitions();
     partitionSelectionHelper =
         new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerCallback, localDatacenterName,
-            Math.min(mockPartitionId.getReplicaIds().size(), 3));
+            Math.min(mockPartitionId.getReplicaIds().size(), 3), DEFAULT_PARTITION_CLASS);
     specialPartition = null;
   }
 


### PR DESCRIPTION
If a user is migrating between ambry clusters where the partition classes
are different, they may run into a situation where they either change
replicationPolicy on their container first, leading to puts in the
original cluster fail, or change the cluster used first, which leads to
puts in the new cluster failing. To aid in migration, this PR changes
the partition class selection behavior to fall back to the default
partition class. In this case, a metric will be emitted and a warn log
message will be written.

Additionally, this PR treats an empty string in replicationPolicy the
same as a null string, as this case was ambiguous before.