### PR TITLE
Return http status conflict when blob is undeleted or not deleted in undelete operation

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/ResponseStatus.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/ResponseStatus.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.rest;
 
+
 /**
  * All the REST response statuses.
  */
@@ -73,6 +74,11 @@ public enum ResponseStatus {
    * 407 - Proxy authentication required
    */
   ProxyAuthenticationRequired(407),
+
+  /**
+   * 409 - Request conflicts with the current state of the server
+   */
+  Conflict(409),
 
   /**
    * 410 Gone - Resource has been deleted or has expired.
@@ -169,6 +175,8 @@ public enum ResponseStatus {
     switch (restServiceErrorCode) {
       case RequestTooLarge:
         return RequestTooLarge;
+      case Conflict:
+        return Conflict;
       case Deleted:
         return Gone;
       case NotFound:

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestServiceErrorCode.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestServiceErrorCode.java
@@ -168,7 +168,12 @@ public enum RestServiceErrorCode {
   /**
    * Action not allowed
    */
-  NotAllowed;
+  NotAllowed,
+
+  /**
+   * Request conflicts with the current state of the server.
+   */
+  Conflict;
 
   /**
    * Gets the RestServiceErrorCode that corresponds to the {@code routerErrorCode}.
@@ -199,8 +204,12 @@ public enum RestServiceErrorCode {
         return ServiceUnavailable;
       case InsufficientCapacity:
         return InsufficientCapacity;
+      case BlobUndeleted:
+      case BlobNotDeleted:
+        return Conflict;
       case UnexpectedInternalError:
       case ChannelClosed:
+      case LifeVersionConflict:
       default:
         return InternalServerError;
     }

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyMetrics.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyMetrics.java
@@ -127,6 +127,7 @@ public class NettyMetrics {
   public final Counter preconditionFailedErrorCount;
   public final Counter methodNotAllowedErrorCount;
   public final Counter notFoundCount;
+  public final Counter conflictCount;
   public final Counter forbiddenCount;
   public final Counter proxyAuthRequiredCount;
   public final Counter rangeNotSatisfiableCount;
@@ -308,6 +309,7 @@ public class NettyMetrics {
     methodNotAllowedErrorCount =
         metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "MethodNotAllowedErrorCount"));
     notFoundCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "NotFoundCount"));
+    conflictCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ConflictCount"));
     forbiddenCount = metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ForbiddenCount"));
     proxyAuthRequiredCount =
         metricRegistry.counter(MetricRegistry.name(NettyResponseChannel.class, "ProxyAuthenticationRequiredCount"));

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
@@ -624,6 +624,10 @@ class NettyResponseChannel implements RestResponseChannel {
         nettyMetrics.notFoundCount.inc();
         status = HttpResponseStatus.NOT_FOUND;
         break;
+      case Conflict:
+        nettyMetrics.conflictCount.inc();
+        status = HttpResponseStatus.CONFLICT;
+        break;
       case Gone:
         nettyMetrics.goneCount.inc();
         status = HttpResponseStatus.GONE;

--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyResponseChannelTest.java
@@ -134,17 +134,17 @@ public class NettyResponseChannelTest {
       channel.writeInbound(createContent(lastContent, true));
       verifyCallbacks(processor);
       // first outbound has to be response.
-      HttpResponse response = (HttpResponse) channel.readOutbound();
+      HttpResponse response = channel.readOutbound();
       assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
       assertTrue("Response must say 'Transfer-Encoding : chunked'", HttpUtil.isTransferEncodingChunked(response));
       // content echoed back.
       for (String srcOfTruth : contents) {
-        HttpContent responseContent = (HttpContent) channel.readOutbound();
+        HttpContent responseContent = channel.readOutbound();
         String returnedContent = RestTestUtils.getContentString(responseContent);
         responseContent.release();
         assertEquals("Content does not match with expected content", srcOfTruth, returnedContent);
       }
-      HttpContent responseContent = (HttpContent) channel.readOutbound();
+      HttpContent responseContent = channel.readOutbound();
       // last content echoed back.
       String returnedContent = RestTestUtils.getContentString(responseContent);
       responseContent.release();
@@ -216,7 +216,7 @@ public class NettyResponseChannelTest {
       verifyCallbacks(processor);
 
       // first outbound has to be response.
-      HttpResponse response = (HttpResponse) channel.readOutbound();
+      HttpResponse response = channel.readOutbound();
       assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
       long contentLength = HttpUtil.getContentLength(response, -1);
       assertEquals("Unexpected Content-Length", MockNettyMessageProcessor.CHUNK.length * i, contentLength);
@@ -226,7 +226,7 @@ public class NettyResponseChannelTest {
       } else {
         HttpContent httpContent = null;
         for (int j = 0; j < i; j++) {
-          httpContent = (HttpContent) channel.readOutbound();
+          httpContent = channel.readOutbound();
           byte[] returnedContent = new byte[httpContent.content().readableBytes()];
           httpContent.content().readBytes(returnedContent);
           httpContent.release();
@@ -254,7 +254,7 @@ public class NettyResponseChannelTest {
         RestTestUtils.createRequest(HttpMethod.GET, TestingUri.ImmediateResponseComplete.toString(), null);
     channel.writeInbound(httpRequest);
     // There should be a response.
-    HttpResponse response = (HttpResponse) channel.readOutbound();
+    HttpResponse response = channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
     assertTrue("Response must say 'Transfer-Encoding : chunked'", HttpUtil.isTransferEncodingChunked(response));
     // since this is Transfer-Encoding:chunked, there should be a LastHttpContent
@@ -268,7 +268,7 @@ public class NettyResponseChannelTest {
     HttpUtil.setKeepAlive(httpRequest, false);
     channel.writeInbound(httpRequest);
     // There should be a response.
-    response = (HttpResponse) channel.readOutbound();
+    response = channel.readOutbound();
     assertEquals("Response must have Content-Length set to 0", 0, HttpUtil.getContentLength(response, -1));
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
     // since Content-Length is set, the response should be an instance of FullHttpResponse.
@@ -387,12 +387,12 @@ public class NettyResponseChannelTest {
     channel.writeInbound(createContent(lastContent, true));
 
     // first outbound has to be response.
-    HttpResponse response = (HttpResponse) channel.readOutbound();
+    HttpResponse response = channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.OK, response.status());
     // content echoed back.
     StringBuilder returnedContent = new StringBuilder();
     while (returnedContent.length() < content.length()) {
-      HttpContent responseContent = (HttpContent) channel.readOutbound();
+      HttpContent responseContent = channel.readOutbound();
       returnedContent.append(RestTestUtils.getContentString(responseContent));
       responseContent.release();
     }
@@ -400,7 +400,7 @@ public class NettyResponseChannelTest {
     // last content echoed back.
     StringBuilder returnedLastContent = new StringBuilder();
     while (returnedLastContent.length() < lastContent.length()) {
-      HttpContent responseContent = (HttpContent) channel.readOutbound();
+      HttpContent responseContent = channel.readOutbound();
       returnedLastContent.append(RestTestUtils.getContentString(responseContent));
       responseContent.release();
     }
@@ -420,7 +420,7 @@ public class NettyResponseChannelTest {
     EmbeddedChannel channel = createEmbeddedChannel();
     channel.writeInbound(request);
 
-    HttpResponse response = (HttpResponse) channel.readOutbound();
+    HttpResponse response = channel.readOutbound();
     assertFalse("Channel not closed on the server", channel.isActive());
 
     checkHeaders(request, response);
@@ -437,7 +437,7 @@ public class NettyResponseChannelTest {
     EmbeddedChannel channel = createEmbeddedChannel();
     channel.writeInbound(request);
 
-    HttpResponse response = (HttpResponse) channel.readOutbound();
+    HttpResponse response = channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.ACCEPTED, response.status());
     assertFalse("Channel not closed on the server", channel.isActive());
   }
@@ -452,7 +452,7 @@ public class NettyResponseChannelTest {
     EmbeddedChannel channel = createEmbeddedChannel();
     channel.writeInbound(request);
 
-    HttpResponse response = (HttpResponse) channel.readOutbound();
+    HttpResponse response = channel.readOutbound();
     assertEquals("Unexpected response status", HttpResponseStatus.ACCEPTED, response.status());
     assertFalse("Channel not closed on the server", channel.isActive());
   }
@@ -723,6 +723,8 @@ public class NettyResponseChannelTest {
     switch (code) {
       case RequestTooLarge:
         return HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
+      case Conflict:
+        return HttpResponseStatus.CONFLICT;
       case Deleted:
         return HttpResponseStatus.GONE;
       case NotFound:


### PR DESCRIPTION
When the blob is already undeleted or not yet deleted, ambry frontend would return CONFLICT as http status.