### PR TITLE
Updating replica status(sealed/stopped) in multiple clusters

### DIFF
--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -211,7 +211,7 @@ public class HelixParticipantTest {
     //Check that invoking setReplicaStoppedState with a non-AmbryReplica ReplicaId throws an IllegalArgumentException
     ReplicaId nonAmbryReplica = createMockNotAmbryReplica(partitionId1);
     try {
-      helixParticipant.setReplicaStoppedState(Arrays.asList(nonAmbryReplica), true);
+      helixParticipant.setReplicaStoppedState(Collections.singletonList(nonAmbryReplica), true);
       fail("Expected an IllegalArgumentException here");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.
@@ -219,7 +219,7 @@ public class HelixParticipantTest {
 
     //Check that invoking setReplicaStoppedState with null instanceConfig
     try {
-      helixParticipantDummy.setReplicaStoppedState(Arrays.asList(replicaId1), true);
+      helixParticipantDummy.setReplicaStoppedState(Collections.singletonList(replicaId1), true);
       fail("Expected an IllegalStateException here");
     } catch (IllegalStateException e) {
       // expected. Nothing to do.
@@ -534,7 +534,7 @@ public class HelixParticipantTest {
     return replicaId;
   }
 
-  private void listIsExpectedSize(List list, int expectedSize, String listName) {
+  private void listIsExpectedSize(List<String> list, int expectedSize, String listName) {
     assertNotNull(listName + " is null", list);
     assertEquals(listName + " doesn't have the expected size " + expectedSize, expectedSize, list.size());
   }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
@@ -131,8 +131,8 @@ public class CloudToStoreReplicationManagerTest {
   public void cloudReplicaAdditionTest() throws Exception {
     StorageManager storageManager =
         new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
-            clusterMap.getMetricRegistry(), null, clusterMap, currentNode, null, mockHelixParticipant, new MockTime(),
-            null, null);
+            clusterMap.getMetricRegistry(), null, clusterMap, currentNode, null,
+            Collections.singletonList(mockHelixParticipant), new MockTime(), null, null);
     CloudToStoreReplicationManager cloudToStoreReplicationManager =
         new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
             storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,
@@ -171,8 +171,8 @@ public class CloudToStoreReplicationManagerTest {
   public void cloudReplicaRemovalTest() throws Exception {
     StorageManager storageManager =
         new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
-            clusterMap.getMetricRegistry(), null, clusterMap, currentNode, null, mockHelixParticipant, new MockTime(),
-            null, null);
+            clusterMap.getMetricRegistry(), null, clusterMap, currentNode, null,
+            Collections.singletonList(mockHelixParticipant), new MockTime(), null, null);
     CloudToStoreReplicationManager cloudToStoreReplicationManager =
         new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
             storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -2811,8 +2811,9 @@ public class ReplicationTest {
     storeKeyConverterFactory.setConversionMap(new HashMap<>());
     StorageManager storageManager =
         new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
-            new MetricRegistry(), null, clusterMap, dataNodeId, null, Collections.singletonList(clusterParticipant),
-            new MockTime(), null, null);
+            new MetricRegistry(), null, clusterMap, dataNodeId, null,
+            clusterParticipant == null ? null : Collections.singletonList(clusterParticipant), new MockTime(), null,
+            null);
     storageManager.start();
     MockReplicationManager replicationManager =
         new MockReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap,

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -2811,7 +2811,8 @@ public class ReplicationTest {
     storeKeyConverterFactory.setConversionMap(new HashMap<>());
     StorageManager storageManager =
         new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
-            new MetricRegistry(), null, clusterMap, dataNodeId, null, clusterParticipant, new MockTime(), null, null);
+            new MetricRegistry(), null, clusterMap, dataNodeId, null, Collections.singletonList(clusterParticipant),
+            new MockTime(), null, null);
     storageManager.start();
     MockReplicationManager replicationManager =
         new MockReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap,

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -166,16 +166,15 @@ public class AmbryServer {
       }
 
       AccountServiceFactory accountServiceFactory =
-          Utils.getObj(serverConfig.serverAccountServiceFactory, properties,
-              registry);
+          Utils.getObj(serverConfig.serverAccountServiceFactory, properties, registry);
       AccountService accountService = accountServiceFactory.getAccountService();
 
       StoreKeyFactory storeKeyFactory = Utils.getObj(storeConfig.storeKeyFactory, clusterMap);
-      // TODO make StorageManager, ReplicationManager, CloudToStoreReplicationManager and StatsManager support multiple participants
-      // For now, we assume there is only one element in clusterParticipants list.
+      // In most cases, there should be only on participant in the clusterParticipants list. If there are more than one
+      // participants and some components require sole participant, the first one in the list will be primary participant.
       storageManager =
           new StorageManager(storeConfig, diskManagerConfig, scheduler, registry, storeKeyFactory, clusterMap, nodeId,
-              new BlobStoreHardDelete(), clusterParticipants.get(0), time, new BlobStoreRecovery(), accountService);
+              new BlobStoreHardDelete(), clusterParticipants, time, new BlobStoreRecovery(), accountService);
       storageManager.start();
 
       connectionPool = new BlockingChannelConnectionPool(connectionPoolConfig, sslConfig, clusterMapConfig, registry);

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -542,11 +542,12 @@ public class AmbryServerRequests extends AmbryRequests {
     // Attempt to remove store from storage manager.
     if (storeManager.removeBlobStore(partitionId) && store != null) {
       ((BlobStore) store).deleteStoreFiles();
-      ReplicaStatusDelegate replicaStatusDelegate = ((BlobStore) store).getReplicaStatusDelegate();
-      // Remove store from sealed and stopped list (if present)
-      logger.info("Removing store from sealed and stopped list(if present)");
-      replicaStatusDelegate.unseal(replicaId);
-      replicaStatusDelegate.unmarkStopped(Collections.singletonList(replicaId));
+      for (ReplicaStatusDelegate replicaStatusDelegate : ((BlobStore) store).getReplicaStatusDelegates()) {
+        // Remove store from sealed and stopped list (if present)
+        logger.info("Removing store from sealed and stopped list(if present)");
+        replicaStatusDelegate.unseal(replicaId);
+        replicaStatusDelegate.unmarkStopped(Collections.singletonList(replicaId));
+      }
     } else {
       errorCode = ServerErrorCode.Unknown_Error;
     }

--- a/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/AmbryServerRequestsTest.java
@@ -509,7 +509,7 @@ public class AmbryServerRequestsTest {
     BlobStore mockStore = Mockito.mock(BlobStore.class);
     storageManager.overrideStoreToReturn = mockStore;
     doNothing().when(mockStore).deleteStoreFiles();
-    Mockito.when(mockStore.getReplicaStatusDelegate()).thenReturn(mockDelegate);
+    Mockito.when(mockStore.getReplicaStatusDelegates()).thenReturn(Collections.singletonList(mockDelegate));
     sendAndVerifyStoreControlRequest(newPartition, BlobStoreControlAction.RemoveStore, numReplicasCaughtUpPerPartition,
         ServerErrorCode.No_Error);
     storageManager.overrideStoreToReturn = null;
@@ -573,7 +573,7 @@ public class AmbryServerRequestsTest {
         ServerErrorCode.Unknown_Error);
     // test store removal success case
     doNothing().when(mockStore).deleteStoreFiles();
-    Mockito.when(mockStore.getReplicaStatusDelegate()).thenReturn(mockDelegate);
+    Mockito.when(mockStore.getReplicaStatusDelegates()).thenReturn(Collections.singletonList(mockDelegate));
     sendAndVerifyStoreControlRequest(newPartition, BlobStoreControlAction.RemoveStore, (short) 0,
         ServerErrorCode.No_Error);
     storageManager.overrideStoreToReturn = null;

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -134,7 +134,7 @@ class MockStorageManager extends StorageManager {
     public void delete(List<MessageInfo> infos) throws StoreException {
       operationReceived = RequestOrResponseType.DeleteRequest;
       List<MessageInfo> infosToDelete = new ArrayList<>(infos.size());
-      List<InputStream> inputStreams = new ArrayList();
+      List<InputStream> inputStreams = new ArrayList<>();
       MessageWriteSet writeSet;
       try {
         for (MessageInfo info : infos) {
@@ -163,7 +163,7 @@ class MockStorageManager extends StorageManager {
     public void updateTtl(List<MessageInfo> infos) throws StoreException {
       operationReceived = RequestOrResponseType.TtlUpdateRequest;
       List<MessageInfo> infosToUpdate = new ArrayList<>(infos.size());
-      List<InputStream> inputStreams = new ArrayList();
+      List<InputStream> inputStreams = new ArrayList<>();
       MessageFormatWriteSet writeSet;
       try {
         for (MessageInfo info : infos) {

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -174,8 +174,8 @@ public class StatsManagerTest {
     for (PartitionId partitionId : storeMap.keySet()) {
       statsManager.collectAndAggregate(actualSnapshot, partitionId, unreachablePartitions);
     }
-    assertTrue("Actual aggregated StatsSnapshot does not match with expected snapshot",
-        preAggregatedSnapshot.equals(actualSnapshot));
+    assertEquals("Actual aggregated StatsSnapshot does not match with expected snapshot", preAggregatedSnapshot,
+        actualSnapshot);
     List<String> unreachableStores = statsManager.examineUnreachablePartitions(unreachablePartitions);
     StatsHeader statsHeader =
         new StatsHeader(StatsHeader.StatsDescription.STORED_DATA_SIZE, SystemTime.getInstance().milliseconds(),
@@ -238,8 +238,8 @@ public class StatsManagerTest {
     for (PartitionId partitionId : mixedStoreMap.keySet()) {
       testStatsManager.collectAndAggregate(actualSnapshot, partitionId, unreachablePartitions);
     }
-    assertTrue("Actual aggregated StatsSnapshot does not match with expected snapshot",
-        preAggregatedSnapshot.equals(actualSnapshot));
+    assertEquals("Actual aggregated StatsSnapshot does not match with expected snapshot", preAggregatedSnapshot,
+        actualSnapshot);
     assertEquals("Unreachable store count mismatch with expected value", 2, unreachablePartitions.size());
     // test fetchSnapshot method in StatsManager
     unreachablePartitions.clear();
@@ -247,9 +247,9 @@ public class StatsManagerTest {
     for (PartitionId partitionId : mixedStoreMap.keySet()) {
       StatsSnapshot snapshot =
           testStatsManager.fetchSnapshot(partitionId, unreachablePartitions, StatsReportType.ACCOUNT_REPORT);
-      if (Integer.valueOf(partitionId.toPathString()) < 3) {
-        assertTrue("Actual StatsSnapshot does not match with expected snapshot",
-            snapshot.equals(partitionToSnapshot.get(partitionId)));
+      if (Integer.parseInt(partitionId.toPathString()) < 3) {
+        assertEquals("Actual StatsSnapshot does not match with expected snapshot", snapshot,
+            partitionToSnapshot.get(partitionId));
       }
     }
     assertEquals("Unreachable store count mismatch with expected value", 2, unreachablePartitions.size());
@@ -549,7 +549,8 @@ public class StatsManagerTest {
     List<ReplicaId> localReplicas = clusterMap.getReplicaIds(currentNode);
     StorageManager storageManager =
         new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
-            new MetricRegistry(), null, clusterMap, currentNode, null, clusterParticipant, new MockTime(), null, null);
+            new MetricRegistry(), null, clusterMap, currentNode, null, Collections.singletonList(clusterParticipant),
+            new MockTime(), null, null);
     storageManager.start();
     MockStoreKeyConverterFactory storeKeyConverterFactory = new MockStoreKeyConverterFactory(null, null);
     storeKeyConverterFactory.setConversionMap(new HashMap<>());

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -943,7 +943,7 @@ public class BlobStore implements Store {
   }
 
   /**
-   * @return {@link ReplicaStatusDelegate} associated with this store
+   * @return a {@link ReplicaStatusDelegate}(s) associated with this store
    */
   public List<ReplicaStatusDelegate> getReplicaStatusDelegates() {
     return replicaStatusDelegates;


### PR DESCRIPTION
As an effort for migrating Ambry from one ZK cluster to another, storage manager
should update replica status in both clusters to make sure they are consistent.
This PR allows storage manager to take in a list of participants and generate
corresponding replica status delegates. BlobStore will update sealing/unsealing
state via these delegates.