### PR TITLE
Fix a MessageSievingInputStream test failure

### DIFF
--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
@@ -97,10 +97,8 @@ public class MessageSievingInputStream extends InputStream {
     List<InputStream> msgStreamList = new ArrayList<>();
     long batchStartTime = SystemTime.getInstance().milliseconds();
     logger.trace("Starting to validate message stream ");
-    int i = 0;
     for (MessageInfo msgInfo : messageInfoList) {
       int msgSize = (int) msgInfo.getSize();
-      System.out.println("Dealing with " + i + "th message " + msgInfo);
       // @todo: We can use a BoundedInputStream for each message and then empty it out in case all of it was not read
       // @todo: (say, due to corruption). This can help avoid a copy.
       if (msgInfo.isDeleted()) {
@@ -120,7 +118,6 @@ public class MessageSievingInputStream extends InputStream {
         validateAndTransform(msg, msgStreamList, bytesRead);
       }
       bytesRead += msgSize;
-      i++;
     }
     if (bytesRead != totalMessageListSize) {
       logger.error(

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
@@ -97,8 +97,10 @@ public class MessageSievingInputStream extends InputStream {
     List<InputStream> msgStreamList = new ArrayList<>();
     long batchStartTime = SystemTime.getInstance().milliseconds();
     logger.trace("Starting to validate message stream ");
+    int i = 0;
     for (MessageInfo msgInfo : messageInfoList) {
       int msgSize = (int) msgInfo.getSize();
+      System.out.println("Dealing with " + i + "th message " + msgInfo);
       // @todo: We can use a BoundedInputStream for each message and then empty it out in case all of it was not read
       // @todo: (say, due to corruption). This can help avoid a copy.
       if (msgInfo.isDeleted()) {
@@ -118,6 +120,7 @@ public class MessageSievingInputStream extends InputStream {
         validateAndTransform(msg, msgStreamList, bytesRead);
       }
       bytesRead += msgSize;
+      i++;
     }
     if (bytesRead != totalMessageListSize) {
       logger.error(

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
@@ -66,6 +66,7 @@ public class ValidatingTransformer implements Transformer {
       msgStream.read(headerBuffer.array(), Version_Field_Size_In_Bytes, headerSize - Version_Field_Size_In_Bytes);
       headerBuffer.rewind();
       MessageHeader_Format header = getMessageHeader(version, headerBuffer);
+      header.verifyHeader();
       StoreKey keyInStream = storeKeyFactory.getStoreKey(new DataInputStream(msgStream));
       if (header.isPutRecord()) {
         if (header.hasLifeVersion() && header.getLifeVersion() != msgInfo.getLifeVersion()) {

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -107,7 +107,7 @@ public class Utils {
   public static String readShortString(DataInputStream input) throws IOException {
     Short size = input.readShort();
     if (size < 0) {
-      throw new IllegalArgumentException("readShortString : the size cannot be negative");
+      throw new IllegalArgumentException("readShortString : the size " + size + " cannot be negative");
     }
     byte[] bytes = new byte[size];
     int read = 0;
@@ -119,7 +119,7 @@ public class Utils {
       read += readBytes;
     }
     if (read != size) {
-      throw new IllegalArgumentException("readShortString : the size of the input does not match the actual data size");
+      throw new IllegalArgumentException("readShortString : the size of the input does not match the actual data size: " + read + " != " + size);
     }
     return new String(bytes, StandardCharsets.UTF_8);
   }


### PR DESCRIPTION
This PR is to fix this issue https://github.com/linkedin/ambry/issues/1489.

The root cause for this failure is we create a corrupted data stream for message info 2, and sometimes the header version is valid since it's all a random number. When the header version is valid, it will might fail because of StoreKey is not valid. Since when the header version is valid, the entire header bytes are valid, and store key is the item following the header, and it will fail.

In this PR, we start verifying the header's sanity after reading the header out. This will make header invalid even if the header version is valid.