### PR TITLE
Support generating partition override map from config file in bootstrap tool

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -502,7 +502,7 @@ public class HelixBootstrapUpgradeUtil {
 
   /**
    * Generate partition override map a static config file. It requires file to be a list of partition ids (separated by
-   * comma). These partitions will overridden to READ_ONLY state.
+   * comma). These partitions will be overridden to READ_ONLY state.
    * @param adminConfigFilePath the path to config file
    * @return the constructed partitionOverrideInfos by dc. The format is as follows.
    * "mapFields": {

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -13,7 +13,7 @@
  */
 package com.github.ambry.clustermap;
 
-import com.github.ambry.clustermap.HelixBootstrapUpgradeUtil.HelixAdminOperation;
+import com.github.ambry.clustermap.HelixBootstrapUpgradeUtil.*;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.tools.util.ToolUtils;
 import java.util.ArrayList;
@@ -212,9 +212,17 @@ public class HelixBootstrapUpgradeTool {
     OptionSpecBuilder disableValidatingClusterManager = parser.accepts("disableVCM",
         "(Optional argument) whether to disable validating cluster manager(VCM) in Helix bootstrap tool.");
 
+    ArgumentAcceptingOptionSpec<String> adminConfigFilePathOpt = parser.accepts("adminConfigFilePath",
+        "The path to a static admin config file. For example, it can be a file that holds a list of partitions"
+            + "(comma separated) that should be overridden to ReadOnly")
+        .withRequiredArg()
+        .describedAs("admin_config_file_path")
+        .ofType(String.class);
+
     OptionSet options = parser.parse(args);
     String hardwareLayoutPath = options.valueOf(hardwareLayoutPathOpt);
     String partitionLayoutPath = options.valueOf(partitionLayoutPathOpt);
+    String adminConfigFilePath = options.valueOf(adminConfigFilePathOpt);
     String zkLayoutPath = options.valueOf(zkLayoutPathOpt);
     String clusterNamePrefix = options.valueOf(clusterNamePrefixOpt);
     String clusterName = options.valueOf(clusterNameOpt);
@@ -244,7 +252,7 @@ public class HelixBootstrapUpgradeTool {
       ToolUtils.ensureOrExit(listOpt, options, parser);
       String[] adminTypes = adminConfigStr.replaceAll("\\p{Space}", "").split(",");
       HelixBootstrapUpgradeUtil.uploadOrDeleteAdminConfigs(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
-          clusterNamePrefix, dcs, options.has(forceRemove), new HelixAdminFactory(), adminTypes);
+          clusterNamePrefix, dcs, options.has(forceRemove), new HelixAdminFactory(), adminTypes, adminConfigFilePath);
     } else if (options.has(addStateModel)) {
       listOpt.add(stateModelDefinitionOpt);
       ToolUtils.ensureOrExit(listOpt, options, parser);


### PR DESCRIPTION
Previously, we have to manually edit the state of partition in static clustermap. If there are thousands of partitions to be marked as ReadOnly, it will take a lot of effort to change clustermap(either by script or manually). This PR allows user to feed tool with a static config file that contains a list of partition ids to override. These partitions are separated by comma and bootstrap tool will check if id is valid (i.e. numeric, within valid range).