### PR TITLE
Adding extra ChannelHandlers to RestServer and RestRequestContext

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestRequest.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestRequest.java
@@ -157,4 +157,15 @@ public interface RestRequest extends ReadableStreamChannel {
   default boolean isSslUsed() {
     return getSSLSession() != null;
   }
+
+  /**
+   * @return The {@link RestRequestContext}.
+   */
+  RestRequestContext getRestRequestContext();
+
+  /**
+   * The RestRequestContext that carries some of the internal states of different implementation.
+   */
+  interface RestRequestContext {
+  }
 }

--- a/ambry-api/src/test/java/com/github/ambry/rest/MockNioServerFactory.java
+++ b/ambry-api/src/test/java/com/github/ambry/rest/MockNioServerFactory.java
@@ -15,6 +15,8 @@ package com.github.ambry.rest;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.config.VerifiableProperties;
+import io.netty.channel.ChannelHandler;
+import java.util.List;
 
 
 /**
@@ -29,7 +31,8 @@ public class MockNioServerFactory implements NioServerFactory {
   private final boolean isFaulty;
 
   public MockNioServerFactory(VerifiableProperties verifiableProperties, MetricRegistry metricRegistry,
-      Object restRequestHandler, Object publicAccessLogger, Object restServerState, Object sslFactory) {
+      Object restRequestHandler, Object publicAccessLogger, Object restServerState, Object sslFactory,
+      List<ChannelHandler> addedChannelHandlers) {
     isFaulty = verifiableProperties.getBoolean(IS_FAULTY_KEY, false);
   }
 

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -2800,6 +2800,11 @@ class BadRestRequest extends BadRSC implements RestRequest {
   public long getBytesReceived() {
     return 0;
   }
+
+  @Override
+  public RestRequestContext getRestRequestContext() {
+    return null;
+  }
 }
 
 /**

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
@@ -661,4 +661,42 @@ class NettyRequest implements RestRequest {
       }
     }
   }
+
+  /**
+   * The {@link NettyRequest}'s implementation of {@link com.github.ambry.rest.RestRequest.RestRequestContext}. It carries
+   * {@link Channel} and {@link HttpRequest}.
+   */
+  public class NettyRequestContext implements RestRequestContext {
+    private final Channel channel;
+    private final HttpRequest httpRequest;
+
+    /**
+     * Constructor to create a {@link NettyRequestContext}.
+     * @param channel The netty {@link Channel}
+     * @param httpRequest The netty {@link HttpRequest}.
+     */
+    NettyRequestContext(final Channel channel, final HttpRequest httpRequest) {
+      this.channel = channel;
+      this.httpRequest = httpRequest;
+    }
+
+    /**
+     * @return the netty {@link Channel}.
+     */
+    public Channel getChannel() {
+      return channel;
+    }
+
+    /**
+     * @return the netty {@link HttpRequest}.
+     */
+    public HttpRequest getHttpRequest() {
+      return httpRequest;
+    }
+  }
+
+  @Override
+  public NettyRequestContext getRestRequestContext() {
+    return new NettyRequestContext(channel, request);
+  }
 }

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
  * <p/>
  * A wrapper over {@link HttpRequest} and all the {@link HttpContent} associated with the request.
  */
-class NettyRequest implements RestRequest {
+public class NettyRequest implements RestRequest {
   // If the write of at least {@code bufferWatermark} amount of data is unacknowledged, reading from the channel will be
   // temporarily suspended. It will be resumed when the amount of data unacknowledged drops below this number. If this
   // is <=0, it is assumed that there is no limit on the size of unacknowledged data.

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
@@ -666,18 +666,15 @@ public class NettyRequest implements RestRequest {
    * The {@link NettyRequest}'s implementation of {@link com.github.ambry.rest.RestRequest.RestRequestContext}. It carries
    * {@link Channel} and {@link HttpRequest}.
    */
-  public class NettyRequestContext implements RestRequestContext {
+  public static class NettyRequestContext implements RestRequestContext {
     private final Channel channel;
-    private final HttpRequest httpRequest;
 
     /**
      * Constructor to create a {@link NettyRequestContext}.
      * @param channel The netty {@link Channel}
-     * @param httpRequest The netty {@link HttpRequest}.
      */
-    NettyRequestContext(final Channel channel, final HttpRequest httpRequest) {
+    NettyRequestContext(final Channel channel) {
       this.channel = channel;
-      this.httpRequest = httpRequest;
     }
 
     /**
@@ -686,17 +683,10 @@ public class NettyRequest implements RestRequest {
     public Channel getChannel() {
       return channel;
     }
-
-    /**
-     * @return the netty {@link HttpRequest}.
-     */
-    public HttpRequest getHttpRequest() {
-      return httpRequest;
-    }
   }
 
   @Override
   public NettyRequestContext getRestRequestContext() {
-    return new NettyRequestContext(channel, request);
+    return new NettyRequestContext(channel);
   }
 }

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
@@ -663,8 +663,8 @@ public class NettyRequest implements RestRequest {
   }
 
   /**
-   * The {@link NettyRequest}'s implementation of {@link com.github.ambry.rest.RestRequest.RestRequestContext}. It carries
-   * {@link Channel} and {@link HttpRequest}.
+   * The {@link NettyRequest}'s implementation of {@link com.github.ambry.rest.RestRequest.RestRequestContext}.
+   * It carries the netty {@link Channel} instance.
    */
   public static class NettyRequestContext implements RestRequestContext {
     private final Channel channel;

--- a/ambry-rest/src/main/java/com/github/ambry/rest/RestServer.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/RestServer.java
@@ -34,7 +34,9 @@ import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.router.Router;
 import com.github.ambry.router.RouterFactory;
 import com.github.ambry.utils.Utils;
+import io.netty.channel.ChannelHandler;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,6 +160,21 @@ public class RestServer {
    */
   public RestServer(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
       NotificationSystem notificationSystem, SSLFactory sslFactory) throws Exception {
+    this(verifiableProperties, clusterMap, notificationSystem, sslFactory, null);
+  }
+
+  /**
+   * Creates an instance of RestServer.
+   * @param verifiableProperties the properties that define the behavior of the RestServer and its components.
+   * @param clusterMap the {@link ClusterMap} instance that needs to be used.
+   * @param notificationSystem the {@link NotificationSystem} instance that needs to be used.
+   * @param sslFactory the {@link SSLFactory} to be used. This can be {@code null} if no components require SSL support.
+   * @param addedChannelHandlers a list of {@link ChannelHandler} to add to the {@link io.netty.channel.ChannelInitializer} before
+   *                             the final handler.
+   * @throws InstantiationException if there is any error instantiating an instance of RestServer.
+   */
+  public RestServer(VerifiableProperties verifiableProperties, ClusterMap clusterMap,
+      NotificationSystem notificationSystem, SSLFactory sslFactory, List<ChannelHandler> addedChannelHandlers) throws Exception {
     if (verifiableProperties == null || clusterMap == null || notificationSystem == null) {
       throw new IllegalArgumentException("Null arg(s) received during instantiation of RestServer");
     }
@@ -210,7 +227,7 @@ public class RestServer {
 
     NioServerFactory nioServerFactory =
         Utils.getObj(restServerConfig.restServerNioServerFactory, verifiableProperties, metricRegistry,
-            restRequestHandler, publicAccessLogger, restServerState, sslFactory);
+            restRequestHandler, publicAccessLogger, restServerState, sslFactory, addedChannelHandlers);
     nioServer = nioServerFactory.getNioServer();
 
     if (accountService == null || router == null || restResponseHandler == null || restRequestHandler == null

--- a/ambry-rest/src/test/java/com/github/ambry/rest/AsyncRequestResponseHandlerTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/AsyncRequestResponseHandlerTest.java
@@ -936,4 +936,9 @@ class BadRestRequest implements RestRequest {
   public long getBytesReceived() {
     return 0;
   }
+
+  @Override
+  public RestRequestContext getRestRequestContext() {
+    return null;
+  }
 }

--- a/ambry-rest/src/test/java/com/github/ambry/rest/FaultyFactory.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/FaultyFactory.java
@@ -53,6 +53,11 @@ public class FaultyFactory
     // don't care.
   }
 
+  // for NioServerFactory
+  public FaultyFactory(Object obj1, Object obj2, Object obj3, Object obj4, Object obj5, Object obj6, Object obj7) {
+    // don't care.
+  }
+
   @Override
   public RestRequestService getRestRequestService() throws InstantiationException {
     return null;

--- a/ambry-rest/src/test/java/com/github/ambry/rest/FrontendNettyFactoryTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/FrontendNettyFactoryTest.java
@@ -71,7 +71,7 @@ public class FrontendNettyFactoryTest {
     NettyConfig nettyConfig = new NettyConfig(verifiableProperties);
     FrontendNettyFactory nettyServerFactory =
         new FrontendNettyFactory(verifiableProperties, new MetricRegistry(), REST_REQUEST_HANDLER, PUBLIC_ACCESS_LOGGER,
-            REST_SERVER_STATE, defaultSslFactory);
+            REST_SERVER_STATE, defaultSslFactory, null);
     NioServer nioServer = nettyServerFactory.getNioServer();
     assertNotNull("No NioServer returned", nioServer);
     assertEquals("Did not receive a NettyServer instance", NettyServer.class.getCanonicalName(),
@@ -123,7 +123,7 @@ public class FrontendNettyFactoryTest {
       SSLFactory sslFactory) throws Exception {
     try {
       new FrontendNettyFactory(verifiableProperties, metricRegistry, restRequestHandler, publicAccessLogger,
-          restServerState, sslFactory);
+          restServerState, sslFactory, null);
       fail("Instantiation should have failed");
     } catch (IllegalArgumentException e) {
       // expected. Nothing to do.

--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyRequestTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyRequestTest.java
@@ -695,6 +695,10 @@ public class NettyRequestTest {
     assertEquals("Mismatch in uri", uri, nettyRequest.getUri());
     assertNotNull("There should have been a RestRequestMetricsTracker", nettyRequest.getMetricsTracker());
     assertFalse("Should not have been a multipart request", nettyRequest.isMultipart());
+    RestRequest.RestRequestContext context = nettyRequest.getRestRequestContext();
+    assertNotNull("Should have RestRequestContext", context);
+    assertTrue(context instanceof NettyRequest.NettyRequestContext);
+    assertSame(((NettyRequest.NettyRequestContext) context).getChannel(), channel);
     SSLSession sslSession = nettyRequest.getSSLSession();
     if (channel.pipeline().get(SslHandler.class) == null) {
       assertNull("Non-null SSLSession when pipeline does not contain an SslHandler", sslSession);

--- a/ambry-rest/src/test/java/com/github/ambry/rest/NettyServerTest.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/NettyServerTest.java
@@ -109,10 +109,10 @@ public class NettyServerTest {
     Map<Integer, ChannelInitializer<SocketChannel>> channelInitializers = new HashMap<>();
     channelInitializers.put(nettyConfig.nettyServerPort,
         new FrontendNettyChannelInitializer(nettyConfig, performanceConfig, NETTY_METRICS, CONNECTION_STATS_HANDLER,
-            REQUEST_HANDLER, PUBLIC_ACCESS_LOGGER, REST_SERVER_STATE, null));
+            REQUEST_HANDLER, PUBLIC_ACCESS_LOGGER, REST_SERVER_STATE, null, null));
     channelInitializers.put(nettyConfig.nettyServerSSLPort,
         new FrontendNettyChannelInitializer(nettyConfig, performanceConfig, NETTY_METRICS, CONNECTION_STATS_HANDLER,
-            REQUEST_HANDLER, PUBLIC_ACCESS_LOGGER, REST_SERVER_STATE, SSL_FACTORY));
+            REQUEST_HANDLER, PUBLIC_ACCESS_LOGGER, REST_SERVER_STATE, SSL_FACTORY, null));
     return new NettyServer(nettyConfig, NETTY_METRICS, channelInitializers);
   }
 

--- a/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestRequest.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/rest/MockRestRequest.java
@@ -261,6 +261,11 @@ public class MockRestRequest implements RestRequest {
   }
 
   @Override
+  public RestRequestContext getRestRequestContext() {
+    return null;
+  }
+
+  @Override
   public boolean isOpen() {
     onEventComplete(Event.IsOpen);
     return channelOpen.get();

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServer.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServer.java
@@ -312,6 +312,11 @@ class PerfNioServer implements NioServer {
       return 0;
     }
 
+    @Override
+    public RestRequestContext getRestRequestContext() {
+      return null;
+    }
+
     /**
      * Adds a value for a header.
      * @param toAddTo the map to add the {@code key} with value {@code value} to.


### PR DESCRIPTION
Adding some extra ChannelHandlers to the ChannelHandlerInitializer, so the closed source extension can add closed source ChannelHandler to the pipeline.
Adding RestRequestContext so the SecurityService in closed source extension can get the channel.