### PR TITLE
Account for replica state when randomly selecting writable partition

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -20,6 +20,7 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -487,7 +488,7 @@ public class ClusterMapUtils {
               selected)) {
             if (selected.getPartitionState() == PartitionState.READ_WRITE) {
               anyWritablePartition = selected;
-              if (areEnoughReplicasForPartitionUp(selected)) {
+              if (hasEnoughEligibleReplicasForPut(selected)) {
                 return selected;
               }
             }
@@ -505,17 +506,19 @@ public class ClusterMapUtils {
     }
 
     /**
-     * Check whether the parition has has enough replicas up for write operations to try. Enough replicas is considered
-     * to be all local replicas if such information is available. In case localDatacenterName is not available, all of
-     * the partition's replicas should be up.
+     * Check whether the partition has enough eligible replicas for write operations to try. Here, "eligible" means
+     * replica is up and in required states for PUT request. Enough replicas is considered to be all local replicas if
+     * such information is available. In case localDatacenterName is not available, all of the partition's replicas
+     * should be up.
      * @param partitionId the {@link PartitionId} to check.
-     * @return true if enough replicas are up; false otherwise.
+     * @return true if enough replicas are eligible; false otherwise.
      */
-    private boolean areEnoughReplicasForPartitionUp(PartitionId partitionId) {
+    private boolean hasEnoughEligibleReplicasForPut(PartitionId partitionId) {
       if (localDatacenterName != null && !localDatacenterName.isEmpty()) {
-        return areAllLocalReplicasForPartitionUp(partitionId);
+        return areAllLocalReplicasForPartitionUp(partitionId) && areAllReplicaStatesEligibleForPut(partitionId,
+            localDatacenterName);
       } else {
-        return areAllReplicasForPartitionUp(partitionId);
+        return areAllReplicasForPartitionUp(partitionId) && areAllReplicaStatesEligibleForPut(partitionId, null);
       }
     }
 
@@ -531,6 +534,23 @@ public class ClusterMapUtils {
         }
       }
       return true;
+    }
+
+    /**
+     * Check if all replicas from given partition are in eligible states for PUT request. (That is, replica state should
+     * be either LEADER or STANDBY.)
+     * @param partitionId the {@link PartitionId} to check.
+     * @param dcName the datacenter which replicas come from. If null, replicas from all datacenters should be checked.
+     * @return true if all replicas are eligible for put.
+     */
+    private boolean areAllReplicaStatesEligibleForPut(PartitionId partitionId, String dcName) {
+      Set<ReplicaId> eligibleReplicas = new HashSet<>();
+      EnumSet.of(ReplicaState.STANDBY, ReplicaState.LEADER)
+          .forEach(state -> eligibleReplicas.addAll(partitionId.getReplicaIdsByState(state, dcName)));
+      if (dcName != null) {
+        return partitionIdToLocalReplicas.get(partitionId).size() == eligibleReplicas.size();
+      }
+      return partitionId.getReplicaIds().size() == eligibleReplicas.size();
     }
 
     /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -488,7 +488,7 @@ public class ClusterMapUtils {
               selected)) {
             if (selected.getPartitionState() == PartitionState.READ_WRITE) {
               anyWritablePartition = selected;
-              if (hasEnoughEligibleReplicasForPut(selected)) {
+              if (hasEnoughEligibleWritableReplicas(selected)) {
                 return selected;
               }
             }
@@ -507,13 +507,13 @@ public class ClusterMapUtils {
 
     /**
      * Check whether the partition has enough eligible replicas for write operations to try. Here, "eligible" means
-     * replica is up and in required states for PUT request. Enough replicas is considered to be all local replicas if
-     * such information is available. In case localDatacenterName is not available, all of the partition's replicas
-     * should be up.
+     * replica is up and in required states for PUT request (i.e LEADER or STANDBY). Enough replicas is considered to be
+     * all local replicas if such information is available. In case localDatacenterName is not available, all of the
+     * partition's replicas should be up.
      * @param partitionId the {@link PartitionId} to check.
      * @return true if enough replicas are eligible; false otherwise.
      */
-    private boolean hasEnoughEligibleReplicasForPut(PartitionId partitionId) {
+    private boolean hasEnoughEligibleWritableReplicas(PartitionId partitionId) {
       if (localDatacenterName != null && !localDatacenterName.isEmpty()) {
         return areAllLocalReplicasForPartitionUp(partitionId) && areAllReplicaStatesEligibleForPut(partitionId,
             localDatacenterName);

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
@@ -136,6 +136,15 @@ public class MockPartitionId implements PartitionId {
   }
 
   /**
+   * Set state of certain replica for this partition.
+   * @param replicaId the {@link ReplicaId} to use.
+   * @param state the {@link ReplicaState} to set.
+   */
+  public void setReplicaState(ReplicaId replicaId, ReplicaState state){
+    replicaAndState.computeIfPresent(replicaId, (k, v) -> state);
+  }
+
+  /**
    * If all replicaIds == !isSealed, then partition status = Read-Write, else Read-Only
    */
   public void resolvePartitionStatus() {


### PR DESCRIPTION
Previously writable partition is selected based on 1. partition state(read-write)
2.replicas of partition are up. This logic is correct in most cases but may have
two minor issues: (1) replicas are up but not in a required state for PUT. (2)
replica is actually down but failure detector temporarily marks it up after backoff.
This PR introduces 3rd criterion that ensures alive replicas are in eligible states
for PUT operation. Together with previous two criteria, the partition selection logic
is able to preclude some unsatisfied partitions.