### PR TITLE
Filter out INACTIVE/DELETE_IN_PROGRESS containers during compaction

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -313,6 +313,13 @@ public class StoreConfig {
   @Default("false")
   public final boolean storeIndexRebuildBloomFilterEnabled;
 
+  /**
+   * True to enable container deletion in store.
+   */
+  @Config("store.container.deletion.enabled")
+  @Default("false")
+  public final boolean storeContainerDeletionEnabled;
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -381,6 +388,8 @@ public class StoreConfig {
     storeUuidBasedBloomFilterEnabled = verifiableProperties.getBoolean("store.uuid.based.bloom.filter.enabled", false);
     storeIndexRebuildBloomFilterEnabled =
         verifiableProperties.getBoolean("store.index.rebuild.bloom.filter.enabled", false);
+    storeContainerDeletionEnabled =
+        verifiableProperties.getBoolean("store.container.deletion.enabled", false);
   }
 }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/CloudToStoreReplicationManagerTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.replication;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockClusterSpectator;
@@ -132,7 +133,8 @@ public class CloudToStoreReplicationManagerTest {
     StorageManager storageManager =
         new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
             clusterMap.getMetricRegistry(), null, clusterMap, currentNode, null,
-            Collections.singletonList(mockHelixParticipant), new MockTime(), null, null);
+            Collections.singletonList(mockHelixParticipant), new MockTime(), null,
+            new InMemAccountService(false, false));
     CloudToStoreReplicationManager cloudToStoreReplicationManager =
         new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
             storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,
@@ -172,7 +174,8 @@ public class CloudToStoreReplicationManagerTest {
     StorageManager storageManager =
         new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
             clusterMap.getMetricRegistry(), null, clusterMap, currentNode, null,
-            Collections.singletonList(mockHelixParticipant), new MockTime(), null, null);
+            Collections.singletonList(mockHelixParticipant), new MockTime(), null,
+            new InMemAccountService(false, false));
     CloudToStoreReplicationManager cloudToStoreReplicationManager =
         new CloudToStoreReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager,
             storeKeyFactory, clusterMap, mockScheduler, currentNode, null, clusterMap.getMetricRegistry(), null,

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.replication;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.AmbryReplicaSyncUpManager;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.ClusterMapChangeListener;
@@ -260,7 +261,8 @@ public class ReplicationTest {
     storeKeyConverterFactory.setConversionMap(new HashMap<>());
     StorageManager storageManager =
         new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
-            new MetricRegistry(), null, clusterMap, dataNodeId, null, null, new MockTime(), null, null);
+            new MetricRegistry(), null, clusterMap, dataNodeId, null, null, new MockTime(), null,
+            new InMemAccountService(false, false));
     storageManager.start();
     MockReplicationManager replicationManager =
         new MockReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap,
@@ -349,7 +351,8 @@ public class ReplicationTest {
     storeKeyConverterFactory.setConversionMap(new HashMap<>());
     StorageManager storageManager =
         new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
-            new MetricRegistry(), null, clusterMap, currentNode, null, null, new MockTime(), null, null);
+            new MetricRegistry(), null, clusterMap, currentNode, null, null, new MockTime(), null,
+            new InMemAccountService(false, false));
     storageManager.start();
     MockReplicationManager replicationManager =
         new MockReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap,
@@ -2840,7 +2843,7 @@ public class ReplicationTest {
         new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
             new MetricRegistry(), null, clusterMap, dataNodeId, null,
             clusterParticipant == null ? null : Collections.singletonList(clusterParticipant), new MockTime(), null,
-            null);
+            new InMemAccountService(false, false));
     storageManager.start();
     MockReplicationManager replicationManager =
         new MockReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, clusterMap,

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -14,6 +14,7 @@
 package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
@@ -450,7 +451,7 @@ class MockStorageManager extends StorageManager {
   MockStorageManager(Set<StoreKey> validKeysInStore, ClusterMap clusterMap, DataNodeId dataNodeId,
       FindTokenHelper findTokenHelper) throws StoreException {
     super(new StoreConfig(VPROPS), new DiskManagerConfig(VPROPS), Utils.newScheduler(1, true), new MetricRegistry(),
-        null, clusterMap, dataNodeId, null, null, new MockTime(), null, null);
+        null, clusterMap, dataNodeId, null, null, new MockTime(), null, new InMemAccountService(false, false));
     this.validKeysInStore = validKeysInStore;
     this.findTokenHelper = findTokenHelper;
     for (ReplicaId replica : clusterMap.getReplicaIds(dataNodeId)) {
@@ -460,7 +461,8 @@ class MockStorageManager extends StorageManager {
 
   MockStorageManager(Map<PartitionId, Store> map, DataNodeId dataNodeId) throws Exception {
     super(new StoreConfig(VPROPS), new DiskManagerConfig(VPROPS), null, new MetricRegistry(), null,
-        new MockClusterMap(), dataNodeId, null, null, SystemTime.getInstance(), null, null);
+        new MockClusterMap(), dataNodeId, null, null, SystemTime.getInstance(), null,
+        new InMemAccountService(false, false));
     storeMap = map;
   }
 

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -15,6 +15,7 @@
 package com.github.ambry.server;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockDataNodeId;
@@ -550,7 +551,7 @@ public class StatsManagerTest {
     StorageManager storageManager =
         new StorageManager(storeConfig, new DiskManagerConfig(verifiableProperties), Utils.newScheduler(1, true),
             new MetricRegistry(), null, clusterMap, currentNode, null, Collections.singletonList(clusterParticipant),
-            new MockTime(), null, null);
+            new MockTime(), null, new InMemAccountService(false, false));
     storageManager.start();
     MockStoreKeyConverterFactory storeKeyConverterFactory = new MockStoreKeyConverterFactory(null, null);
     storeKeyConverterFactory.setConversionMap(new HashMap<>());

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -248,7 +248,9 @@ class BlobStoreCompactor {
     runningLatch = new CountDownLatch(1);
     compactionInProgress.set(true);
     selectedContainers.clear();
-    getAllContainersByStatus(EnumSet.of(Container.ContainerStatus.INACTIVE, Container.ContainerStatus.DELETE_IN_PROGRESS));
+    getAllContainersByStatus(
+        EnumSet.of(Container.ContainerStatus.INACTIVE, Container.ContainerStatus.DELETE_IN_PROGRESS));
+    logger.trace("Selected containers are {} for {}", selectedContainers, storeId);
     try {
       while (isActive && !compactionLog.getCompactionPhase().equals(CompactionLog.Phase.DONE)) {
         CompactionLog.Phase phase = compactionLog.getCompactionPhase();

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -19,7 +19,6 @@ import com.github.ambry.config.StoreConfig;
 import com.github.ambry.utils.Pair;
 import com.github.ambry.utils.Time;
 import com.github.ambry.utils.Utils;
-import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -129,7 +128,6 @@ class BlobStoreCompactor {
     this.srcLog = srcLog;
     this.diskIOScheduler = diskIOScheduler;
     this.diskSpaceAllocator = diskSpaceAllocator;
-    Preconditions.checkNotNull(accountService, "Account Service should not be null");
     this.accountService = accountService;
     this.time = time;
     this.sessionId = sessionId;
@@ -204,8 +202,10 @@ class BlobStoreCompactor {
    */
   private void getAllContainersByStatus(Container.ContainerStatus containerStatus) {
     Set<Pair<Short, Short>> selectedContainerPairSet = new HashSet<>();
-    for (Container container : accountService.getContainersByStatus(containerStatus)) {
-      selectedContainerPairSet.add(new Pair<>(container.getParentAccountId(), container.getId()));
+    if (accountService != null) {
+      for (Container container : accountService.getContainersByStatus(containerStatus)) {
+        selectedContainerPairSet.add(new Pair<>(container.getParentAccountId(), container.getId()));
+      }
     }
     selectedContainers.addAll(selectedContainerPairSet);
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -947,7 +947,6 @@ public class BlobStoreCompactorTest {
     state.properties.setProperty("store.index.max.number.of.inmem.elements", "5");
     state.initIndex(null);
     long notExpiredMs = state.time.milliseconds() + TimeUnit.SECONDS.toMillis(Short.MAX_VALUE);
-
     // LS (Log Segment) 0
     // IS (Index Segment) 0.1
     // p1 DeleteInProgress
@@ -957,6 +956,7 @@ public class BlobStoreCompactorTest {
     state.addPutEntries(1, CuratedLogIndexState.PUT_RECORD_SIZE, notExpiredMs).get(0);
     state.addPutEntries(1, CuratedLogIndexState.PUT_RECORD_SIZE, notExpiredMs).get(0);
     state.addPutEntries(1, CuratedLogIndexState.PUT_RECORD_SIZE, notExpiredMs).get(0);
+    
     // IS (Index Segment) 0.2
     // p3 DeleteInProgress
     // p4 Inactive

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreCompactorTest.java
@@ -944,6 +944,8 @@ public class BlobStoreCompactorTest {
   @Test
   public void containerDeletionTest() throws Exception {
     refreshState(false, false);
+
+    state.properties.setProperty("store.container.deletion.enabled", "true");
     state.properties.setProperty("store.index.max.number.of.inmem.elements", "5");
     state.initIndex(null);
     long notExpiredMs = state.time.milliseconds() + TimeUnit.SECONDS.toMillis(Short.MAX_VALUE);
@@ -956,7 +958,7 @@ public class BlobStoreCompactorTest {
     state.addPutEntries(1, CuratedLogIndexState.PUT_RECORD_SIZE, notExpiredMs).get(0);
     state.addPutEntries(1, CuratedLogIndexState.PUT_RECORD_SIZE, notExpiredMs).get(0);
     state.addPutEntries(1, CuratedLogIndexState.PUT_RECORD_SIZE, notExpiredMs).get(0);
-    
+
     // IS (Index Segment) 0.2
     // p3 DeleteInProgress
     // p4 Inactive

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.ReplicaState;
 import com.github.ambry.clustermap.ReplicaStatusDelegate;
@@ -1456,7 +1457,7 @@ public class BlobStoreTest {
     BlobStore testStore2 =
         new BlobStore(getMockReplicaId(tempDirStr), new StoreConfig(new VerifiableProperties(properties)), scheduler,
             storeStatsScheduler, diskIOScheduler, diskSpaceAllocator, metrics, metrics, mockStoreKeyFactory, recovery,
-            hardDelete, Collections.singletonList(mockDelegate), time, null);
+            hardDelete, Collections.singletonList(mockDelegate), time, new InMemAccountService(false, false));
 
     testStore2.start();
     assertTrue("Store should start up", testStore2.isStarted());
@@ -1572,7 +1573,7 @@ public class BlobStoreTest {
     BlobStore testStore =
         new BlobStore(getMockReplicaId(storeDir.getAbsolutePath()), config, scheduler, storeStatsScheduler,
             diskIOScheduler, diskAllocator, metrics, metrics, STORE_KEY_FACTORY, recovery, hardDelete, null, time,
-            null);
+            new InMemAccountService(false, false));
     testStore.start();
     DiskSpaceRequirements diskSpaceRequirements = testStore.getDiskSpaceRequirements();
     diskAllocator.initializePool(diskSpaceRequirements == null ? Collections.emptyList()
@@ -2729,7 +2730,8 @@ public class BlobStoreTest {
     MetricRegistry registry = new MetricRegistry();
     StoreMetrics metrics = new StoreMetrics(registry);
     return new BlobStore(replicaId, config, scheduler, storeStatsScheduler, diskIOScheduler, diskSpaceAllocator,
-        metrics, metrics, STORE_KEY_FACTORY, recovery, hardDelete, replicaStatusDelegates, time, null);
+        metrics, metrics, STORE_KEY_FACTORY, recovery, hardDelete, replicaStatusDelegates, time,
+        new InMemAccountService(false, false));
   }
 
   private StoreTestUtils.MockReplicaId getMockReplicaId(String filePath) {
@@ -2789,7 +2791,7 @@ public class BlobStoreTest {
     MockBlobStore(ReplicaId replicaId, StoreConfig config, List<ReplicaStatusDelegate> replicaStatusDelegates,
         StoreMetrics metrics) {
       super(replicaId, config, scheduler, storeStatsScheduler, diskIOScheduler, diskSpaceAllocator, metrics, metrics,
-          STORE_KEY_FACTORY, recovery, hardDelete, replicaStatusDelegates, time, null);
+          STORE_KEY_FACTORY, recovery, hardDelete, replicaStatusDelegates, time, new InMemAccountService(false, false));
     }
 
     /**

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionManagerTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.MockTime;
@@ -520,7 +521,7 @@ public class CompactionManagerTest {
     MockBlobStore(StoreConfig config, StoreMetrics metrics, Time time, CountDownLatch compactCallsCountdown,
         CompactionDetails details) {
       super(StoreTestUtils.createMockReplicaId("", 0, null), config, null, null, null, null, metrics, metrics, null,
-          null, null, null, time, null);
+          null, null, null, time, new InMemAccountService(false, false));
       this.compactCallsCountdown = compactCallsCountdown;
       this.details = details;
     }

--- a/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CompactionPolicyTest.java
@@ -14,6 +14,7 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.MockTime;
@@ -312,7 +313,7 @@ class MockBlobStore extends BlobStore {
   MockBlobStore(StoreConfig config, StoreMetrics metrics, Time time, long capacityInBytes, long segmentCapacity,
       long segmentHeaderSize, long usedCapacity, MockBlobStoreStats mockBlobStoreStats) {
     super(StoreTestUtils.createMockReplicaId("", 0, null), config, null, null, null, null, metrics, metrics, null, null,
-        null, null, time, null);
+        null, null, time, new InMemAccountService(false, false));
     this.capacityInBytes = capacityInBytes;
     this.segmentCapacity = segmentCapacity;
     this.segmentHeaderSize = segmentHeaderSize;

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -16,6 +16,7 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.account.InMemAccountService;
 import com.github.ambry.clustermap.ClusterMapUtils;
 import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.DataNodeId;
@@ -684,7 +685,7 @@ public class StorageManagerTest {
     storageManager =
         new StorageManager(new StoreConfig(vProps), diskManagerConfig, Utils.newScheduler(1, false), metricRegistry,
             new MockIdFactory(), clusterMap, dataNode, new DummyMessageStoreHardDelete(), null,
-            SystemTime.getInstance(), new DummyMessageStoreRecovery(), null);
+            SystemTime.getInstance(), new DummyMessageStoreRecovery(), new InMemAccountService(false, false));
     storageManager.start();
     for (ReplicaId replica : replicas) {
       id = replica.getPartitionId();
@@ -1133,7 +1134,7 @@ public class StorageManagerTest {
       List<ClusterParticipant> clusterParticipants) throws StoreException {
     return new StorageManager(storeConfig, diskManagerConfig, Utils.newScheduler(1, false), metricRegistry,
         new MockIdFactory(), clusterMap, currentNode, new DummyMessageStoreHardDelete(), clusterParticipants,
-        SystemTime.getInstance(), new DummyMessageStoreRecovery(), null);
+        SystemTime.getInstance(), new DummyMessageStoreRecovery(), new InMemAccountService(false, false));
   }
 
   /**
@@ -1362,7 +1363,7 @@ public class StorageManagerTest {
     MockStorageManager(DataNodeId currentNode, List<ClusterParticipant> clusterParticipants) throws Exception {
       super(storeConfig, diskManagerConfig, Utils.newScheduler(1, false), metricRegistry, new MockIdFactory(),
           clusterMap, currentNode, new DummyMessageStoreHardDelete(), clusterParticipants, SystemTime.getInstance(),
-          new DummyMessageStoreRecovery(), null);
+          new DummyMessageStoreRecovery(), new InMemAccountService(false, false));
     }
 
     @Override


### PR DESCRIPTION
This PR supports below part of stages for container deletion compaction phase:
1. Filter out index entries that corresponding to INACTIVE/DELETE_IN_PROGRESS containers inside each compaction copy phase.
2. Implement unit test to check if selected indexEntries can be removed successfully.