### PR TITLE
Return lifeVersion from get request

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/messageformat/BlobInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/messageformat/BlobInfo.java
@@ -22,7 +22,7 @@ public class BlobInfo {
   private short lifeVersion;
 
   /**
-   * Constructor to creat a {@link BlobInfo}.
+   * Constructor to create a {@link BlobInfo}.
    * @param blobProperties The {@link BlobProperties} of this blob.
    * @param userMetadata The user metadata of this blob.
    */
@@ -31,7 +31,7 @@ public class BlobInfo {
   }
 
   /**
-   * Constructor to creat a {@link BlobInfo}.
+   * Constructor to create a {@link BlobInfo}.
    * @param blobProperties The {@link BlobProperties} of this blob.
    * @param userMetadata The user metadata of this blob.
    * @param lifeVersion The lifeVersion of this blob.

--- a/ambry-api/src/main/java/com/github/ambry/messageformat/BlobInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/messageformat/BlobInfo.java
@@ -22,9 +22,12 @@ public class BlobInfo {
 
   private byte[] userMetadata;
 
+  private short lifeVersion;
+
   public BlobInfo(BlobProperties blobProperties, byte[] userMetadata) {
     this.blobProperties = blobProperties;
     this.userMetadata = userMetadata;
+    this.lifeVersion = 0;
   }
 
   public BlobProperties getBlobProperties() {
@@ -33,5 +36,20 @@ public class BlobInfo {
 
   public byte[] getUserMetadata() {
     return userMetadata;
+  }
+
+  /**
+   * Set the lifeVersion of this blob.
+   * @param lifeVersion The lifeVersion to set.
+   */
+  public void setLifeVersion(short lifeVersion) {
+    this.lifeVersion = lifeVersion;
+  }
+
+  /**
+   * @return The lifeVersion of this blob.
+   */
+  public short getLifeVersion() {
+    return lifeVersion;
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/messageformat/BlobInfo.java
+++ b/ambry-api/src/main/java/com/github/ambry/messageformat/BlobInfo.java
@@ -14,26 +14,44 @@
 package com.github.ambry.messageformat;
 
 /**
- * A BlobInfo class that contains both the blob property and the usermetadata for the blob
+ * A BlobInfo class that contains both the blob property, the usermetadata and the lifeVersion for the blob.
  */
 public class BlobInfo {
-
   private BlobProperties blobProperties;
-
   private byte[] userMetadata;
-
   private short lifeVersion;
 
+  /**
+   * Constructor to creat a {@link BlobInfo}.
+   * @param blobProperties The {@link BlobProperties} of this blob.
+   * @param userMetadata The user metadata of this blob.
+   */
   public BlobInfo(BlobProperties blobProperties, byte[] userMetadata) {
-    this.blobProperties = blobProperties;
-    this.userMetadata = userMetadata;
-    this.lifeVersion = 0;
+    this(blobProperties, userMetadata, (short) 0);
   }
 
+  /**
+   * Constructor to creat a {@link BlobInfo}.
+   * @param blobProperties The {@link BlobProperties} of this blob.
+   * @param userMetadata The user metadata of this blob.
+   * @param lifeVersion The lifeVersion of this blob.
+   */
+  public BlobInfo(BlobProperties blobProperties, byte[] userMetadata, short lifeVersion) {
+    this.blobProperties = blobProperties;
+    this.userMetadata = userMetadata;
+    this.lifeVersion = lifeVersion;
+  }
+
+  /**
+   * @return The {@link BlobProperties} of this blob.
+   */
   public BlobProperties getBlobProperties() {
     return blobProperties;
   }
 
+  /**
+   * @return The user metadata of this blob.
+   */
   public byte[] getUserMetadata() {
     return userMetadata;
   }

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -217,6 +217,11 @@ public class RestUtils {
      */
     public final static String NON_COMPLIANCE_WARNING = "x-ambry-non-compliance-warning";
 
+    /**
+     * The lifeVersion of the blob.
+     */
+    public final static String LIFE_VERSION = "x-ambry-life-version";
+
   }
 
   public static final class TrackingHeaders {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/AmbrySecurityService.java
@@ -195,12 +195,14 @@ class AmbrySecurityService implements SecurityService {
                   setBlobPropertiesHeaders(blobInfo.getBlobProperties(), responseChannel);
                   setAccountAndContainerHeaders(restRequest, responseChannel);
                   setUserMetadataHeaders(blobInfo.getUserMetadata(), responseChannel);
+                  responseChannel.setHeader(RestUtils.Headers.LIFE_VERSION, blobInfo.getLifeVersion());
                 }
                 setCacheHeaders(restRequest, responseChannel);
               } else {
                 if (subResource.equals(RestUtils.SubResource.BlobInfo)) {
                   setBlobPropertiesHeaders(blobInfo.getBlobProperties(), responseChannel);
                   setAccountAndContainerHeaders(restRequest, responseChannel);
+                  responseChannel.setHeader(RestUtils.Headers.LIFE_VERSION, blobInfo.getLifeVersion());
                 }
                 if (!setUserMetadataHeaders(blobInfo.getUserMetadata(), responseChannel)) {
                   restRequest.setArg(InternalKeys.SEND_USER_METADATA_AS_RESPONSE_BODY, true);
@@ -270,6 +272,7 @@ class AmbrySecurityService implements SecurityService {
     restResponseChannel.setHeader(RestUtils.Headers.CONTENT_LENGTH, contentLength);
     setBlobPropertiesHeaders(blobProperties, restResponseChannel);
     setAccountAndContainerHeaders(restRequest, restResponseChannel);
+    restResponseChannel.setHeader(RestUtils.Headers.LIFE_VERSION, blobInfo.getLifeVersion());
   }
 
   /**

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/AmbrySecurityServiceTest.java
@@ -114,8 +114,7 @@ public class AmbrySecurityServiceTest {
       LIFEVERSION_INFO = new BlobInfo(
           new BlobProperties(Utils.getRandomLong(TestUtils.RANDOM, 1000) + 100, SERVICE_ID, OWNER_ID, "image/gif",
               false, Utils.Infinite_Time, REF_ACCOUNT.getId(), REF_CONTAINER.getId(), false, null),
-          RestUtils.buildUserMetadata(USER_METADATA));
-      LIFEVERSION_INFO.setLifeVersion(DEFAULT_LIFEVERSION);
+          RestUtils.buildUserMetadata(USER_METADATA), DEFAULT_LIFEVERSION);
       ACCOUNT_SERVICE.updateAccounts(Collections.singletonList(InMemAccountService.UNKNOWN_ACCOUNT));
     } catch (Exception e) {
       throw new IllegalStateException(e);

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendIntegrationTest.java
@@ -424,6 +424,7 @@ public class FrontendIntegrationTest {
 
     // verify POST
     headers.add(RestUtils.Headers.BLOB_SIZE, content.capacity());
+    headers.add(RestUtils.Headers.LIFE_VERSION, "0");
     getBlobAndVerify(blobId, null, GetOption.None, headers, !container.isCacheable(), content, account.getName(),
         container.getName());
     getBlobInfoAndVerify(blobId, GetOption.None, headers, !container.isCacheable(), account.getName(),
@@ -656,6 +657,7 @@ public class FrontendIntegrationTest {
       blobId = postBlobAndVerify(headers, content, contentSize);
     }
     headers.add(RestUtils.Headers.BLOB_SIZE, content.capacity());
+    headers.add(RestUtils.Headers.LIFE_VERSION, "0");
     getBlobAndVerify(blobId, null, null, headers, isPrivate, content, expectedAccountName, expectedContainerName);
     getHeadAndVerify(blobId, null, null, headers, isPrivate, expectedAccountName, expectedContainerName);
     getBlobAndVerify(blobId, null, GetOption.None, headers, isPrivate, content, expectedAccountName,
@@ -684,6 +686,7 @@ public class FrontendIntegrationTest {
     verifyOperationsAfterDelete(blobId, headers, isPrivate, expectedAccountName, expectedContainerName, content,
         usermetadata);
     // Undelete it
+    headers.add(RestUtils.Headers.LIFE_VERSION, "1");
     undeleteBlobAndVerify(blobId, headers, isPrivate, expectedAccountName, expectedContainerName, usermetadata);
   }
 
@@ -816,6 +819,8 @@ public class FrontendIntegrationTest {
     assertEquals(RestUtils.Headers.BLOB_SIZE + " does not match", expectedHeaders.get(RestUtils.Headers.BLOB_SIZE),
         response.headers().get(RestUtils.Headers.BLOB_SIZE));
     assertEquals("Accept-Ranges not set correctly", "bytes", response.headers().get(RestUtils.Headers.ACCEPT_RANGES));
+    assertEquals(RestUtils.Headers.LIFE_VERSION + " does not match", expectedHeaders.get(RestUtils.Headers.LIFE_VERSION),
+        response.headers().get(RestUtils.Headers.LIFE_VERSION));
     byte[] expectedContentArray = expectedContent.array();
     if (range != null) {
       long blobSize = Long.parseLong(expectedHeaders.get(RestUtils.Headers.BLOB_SIZE));
@@ -863,6 +868,7 @@ public class FrontendIntegrationTest {
     assertNull("Content-Length should not be set", response.headers().get(RestUtils.Headers.CONTENT_LENGTH));
     assertNull("Accept-Ranges should not be set", response.headers().get(RestUtils.Headers.ACCEPT_RANGES));
     assertNull("Content-Range header should not be set", response.headers().get(RestUtils.Headers.CONTENT_RANGE));
+    assertNull("Life-Version header should not be set", response.headers().get(RestUtils.Headers.LIFE_VERSION));
     assertNull(RestUtils.Headers.BLOB_SIZE + " should have been null ",
         response.headers().get(RestUtils.Headers.BLOB_SIZE));
     assertNull("Content-Type should have been null", response.headers().get(RestUtils.Headers.CONTENT_TYPE));
@@ -934,6 +940,8 @@ public class FrontendIntegrationTest {
       assertNoContent(responseParts.queue, 1);
     }
     assertTrue("Channel should be active", HttpUtil.isKeepAlive(response));
+    assertEquals(RestUtils.Headers.LIFE_VERSION + " does not match", expectedHeaders.get(RestUtils.Headers.LIFE_VERSION),
+        response.headers().get(RestUtils.Headers.LIFE_VERSION));
   }
 
   /**
@@ -979,6 +987,8 @@ public class FrontendIntegrationTest {
     assertEquals(RestUtils.Headers.CONTENT_TYPE + " does not match " + RestUtils.Headers.AMBRY_CONTENT_TYPE,
         expectedHeaders.get(RestUtils.Headers.AMBRY_CONTENT_TYPE),
         response.headers().get(HttpHeaderNames.CONTENT_TYPE));
+    assertEquals(RestUtils.Headers.LIFE_VERSION + " does not match", expectedHeaders.get(RestUtils.Headers.LIFE_VERSION),
+        response.headers().get(RestUtils.Headers.LIFE_VERSION));
     verifyBlobProperties(expectedHeaders, isPrivate, response);
     verifyAccountAndContainerHeaders(accountName, containerName, response);
     assertNoContent(responseParts.queue, 1);
@@ -1359,6 +1369,7 @@ public class FrontendIntegrationTest {
       expectedGetHeaders.add(RestUtils.Headers.BLOB_SIZE, content.capacity());
       // Blob TTL for chunk upload is fixed
       expectedGetHeaders.set(RestUtils.Headers.TTL, FRONTEND_CONFIG.chunkUploadInitialChunkTtlSecs);
+      expectedGetHeaders.set(RestUtils.Headers.LIFE_VERSION, "0");
       for (String id : new String[]{signedId, idAndMetadata.getFirst()}) {
         getBlobAndVerify(id, null, GetOption.None, expectedGetHeaders, !container.isCacheable(), content,
             account.getName(), container.getName());
@@ -1393,6 +1404,7 @@ public class FrontendIntegrationTest {
     // Test different request types on stitched blob ID
     // (getBlobInfo, getBlob, getBlob w/ range, head, updateBlobTtl, deleteBlob)
     expectedGetHeaders.add(RestUtils.Headers.BLOB_SIZE, fullContentArray.length);
+    expectedGetHeaders.set(RestUtils.Headers.LIFE_VERSION, "0");
     getBlobInfoAndVerify(stitchedBlobId, GetOption.None, expectedGetHeaders, !container.isCacheable(),
         account.getName(), container.getName(), null);
     List<ByteRange> ranges = new ArrayList<>();

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -353,8 +353,7 @@ class GetBlobInfoOperation extends GetOperation {
     ByteBuffer userMetadata = MessageFormatRecord.deserializeUserMetadata(payload);
     if (encryptionKey == null) {
       // if blob is not encrypted, move the state to Complete
-      BlobInfo blobInfo = new BlobInfo(serverBlobProperties, userMetadata.array());
-      blobInfo.setLifeVersion(messageInfo.getLifeVersion());
+      BlobInfo blobInfo = new BlobInfo(serverBlobProperties, userMetadata.array(), messageInfo.getLifeVersion());
       operationResult = new GetBlobResultInternal(new GetBlobResult(blobInfo, null), null);
     } else {
       // submit decrypt job
@@ -370,8 +369,8 @@ class GetBlobInfoOperation extends GetOperation {
             routerMetrics.decryptTimeMs.update(System.currentTimeMillis() - startTimeMs);
             if (exception == null) {
               logger.trace("Successfully updating decrypt job callback results for {}", blobId);
-              BlobInfo blobInfo = new BlobInfo(serverBlobProperties, result.getDecryptedUserMetadata().array());
-              blobInfo.setLifeVersion(messageInfo.getLifeVersion());
+              BlobInfo blobInfo = new BlobInfo(serverBlobProperties, result.getDecryptedUserMetadata().array(),
+                  messageInfo.getLifeVersion());
               operationResult = new GetBlobResultInternal(new GetBlobResult(blobInfo, null), null);
               progressTracker.setCryptoJobSuccess();
             } else {

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobInfoOperation.java
@@ -353,9 +353,9 @@ class GetBlobInfoOperation extends GetOperation {
     ByteBuffer userMetadata = MessageFormatRecord.deserializeUserMetadata(payload);
     if (encryptionKey == null) {
       // if blob is not encrypted, move the state to Complete
-      operationResult =
-          new GetBlobResultInternal(new GetBlobResult(new BlobInfo(serverBlobProperties, userMetadata.array()), null),
-              null);
+      BlobInfo blobInfo = new BlobInfo(serverBlobProperties, userMetadata.array());
+      blobInfo.setLifeVersion(messageInfo.getLifeVersion());
+      operationResult = new GetBlobResultInternal(new GetBlobResult(blobInfo, null), null);
     } else {
       // submit decrypt job
       progressTracker.initializeCryptoJobTracker(CryptoJobType.DECRYPTION);
@@ -370,9 +370,9 @@ class GetBlobInfoOperation extends GetOperation {
             routerMetrics.decryptTimeMs.update(System.currentTimeMillis() - startTimeMs);
             if (exception == null) {
               logger.trace("Successfully updating decrypt job callback results for {}", blobId);
-              operationResult = new GetBlobResultInternal(
-                  new GetBlobResult(new BlobInfo(serverBlobProperties, result.getDecryptedUserMetadata().array()),
-                      null), null);
+              BlobInfo blobInfo = new BlobInfo(serverBlobProperties, result.getDecryptedUserMetadata().array());
+              blobInfo.setLifeVersion(messageInfo.getLifeVersion());
+              operationResult = new GetBlobResultInternal(new GetBlobResult(blobInfo, null), null);
               progressTracker.setCryptoJobSuccess();
             } else {
               decryptJobMetricsTracker.incrementOperationError();

--- a/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/GetBlobOperation.java
@@ -1100,7 +1100,7 @@ class GetBlobOperation extends GetOperation {
     private BlobType blobType;
     private List<CompositeBlobInfo.ChunkMetadata> chunkMetadataList;
     private BlobProperties serverBlobProperties;
-    private MessageInfo serverMessageInfo;
+    private short lifeVersion;
 
     /**
      * Construct a FirstGetChunk and initialize it with the {@link BlobId} of the overall operation.
@@ -1154,8 +1154,8 @@ class GetBlobOperation extends GetOperation {
             logger.trace("Processing stored decryption callback result for Metadata blob {}", blobId);
             initializeDataChunks();
             blobInfo =
-                new BlobInfo(serverBlobProperties, decryptCallbackResultInfo.result.getDecryptedUserMetadata().array());
-            blobInfo.setLifeVersion(serverMessageInfo.getLifeVersion());
+                new BlobInfo(serverBlobProperties, decryptCallbackResultInfo.result.getDecryptedUserMetadata().array(),
+                    lifeVersion);
             progressTracker.setCryptoJobSuccess();
             logger.trace("BlobContent available to process for Metadata blob {}", blobId);
           } else {
@@ -1164,8 +1164,7 @@ class GetBlobOperation extends GetOperation {
             // Only in-case of GetBlobInfo and GetBlobAll, user-metadata is required to be decrypted
             if (decryptCallbackResultInfo.result.getDecryptedUserMetadata() != null) {
               blobInfo = new BlobInfo(serverBlobProperties,
-                  decryptCallbackResultInfo.result.getDecryptedUserMetadata().array());
-              blobInfo.setLifeVersion(serverMessageInfo.getLifeVersion());
+                  decryptCallbackResultInfo.result.getDecryptedUserMetadata().array(), lifeVersion);
             }
             totalSize = decryptCallbackResultInfo.result.getDecryptedBlobContent().remaining();
             if (!resolveRange(totalSize)) {
@@ -1227,7 +1226,7 @@ class GetBlobOperation extends GetOperation {
             blobInfo.setLifeVersion(messageInfo.getLifeVersion());
           } else {
             serverBlobProperties = serverBlobInfo.getBlobProperties();
-            serverMessageInfo = messageInfo;
+            lifeVersion = messageInfo.getLifeVersion();
             userMetadata = serverBlobInfo.getUserMetadata();
           }
         }


### PR DESCRIPTION
Returning life version in the get request. LifeVersion is a piece of information that would further verify the success of an undelete operation. Since for now undelete doesn't return the lifeVersion, we should expose a way to get the lifeVersion before and after undelete. There is no better way than a get.

I plan in the closed source code, to not return lifeVersion when the client is not internal client. And maybe we should return the revised lifeVersion to the client in an undelete response.