### PR TITLE
Fix compilation error due to mismatch in method arguments

### DIFF
--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterMapUtilsTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterMapUtilsTest.java
@@ -147,7 +147,8 @@ public class ClusterMapUtilsTest {
       }
     }
     // additional test: ensure getRandomWritablePartition now honors replica state for PUT request
-    psh = new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerCallback, dc1, minimumLocalReplicaCount);
+    psh = new ClusterMapUtils.PartitionSelectionHelper(mockClusterManagerCallback, dc1, minimumLocalReplicaCount,
+        maxReplicasAllSites);
     ReplicaId replicaId = everywhere1.getReplicaIds()
         .stream()
         .filter(r -> r.getDataNodeId().getDatacenterName().equals(dc1))


### PR DESCRIPTION
A short fix for mismatch in PartitionSelectionHelper's ctor. Added partition class
string to the ctor in ClusterMapUtilsTest.