### PR TITLE
Fix a already deleted error

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1042,8 +1042,8 @@ public class ReplicaThread implements Runnable {
       // The blob may be undeleted, which is alright
       if (e.getErrorCode() == StoreErrorCodes.Life_Version_Conflict
           || e.getErrorCode() == StoreErrorCodes.ID_Undeleted) {
-        logger.trace("Remote node: {} Thread name: {} Remote replica: {} Key already undeleted: {}", remoteNode,
-            threadName, remoteReplicaInfo.getReplicaId(), messageInfo.getStoreKey());
+        logger.trace("Remote node: {} Thread name: {} Remote replica: {} Key {}: {}", remoteNode,
+            threadName, remoteReplicaInfo.getReplicaId(), messageInfo.getStoreKey(), e.getErrorCode().name());
       } else {
         throw e;
       }
@@ -1074,9 +1074,9 @@ public class ReplicaThread implements Runnable {
           remoteReplicaInfo.getReplicaId(), messageInfo.getStoreKey());
     } catch (StoreException e) {
       // The blob may be deleted or updated which is alright
-      if (e.getErrorCode() == StoreErrorCodes.ID_Deleted) {
-        logger.trace("Remote node: {} Thread name: {} Remote replica: {} Key already deleted: {}", remoteNode,
-            threadName, remoteReplicaInfo.getReplicaId(), messageInfo.getStoreKey());
+      if (e.getErrorCode() == StoreErrorCodes.ID_Deleted || e.getErrorCode() == StoreErrorCodes.Life_Version_Conflict) {
+        logger.trace("Remote node: {} Thread name: {} Remote replica: {} Key {}: {}", remoteNode,
+            threadName, remoteReplicaInfo.getReplicaId(), messageInfo.getStoreKey(), e.getErrorCode().name());
       } else {
         throw e;
       }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -507,11 +507,15 @@ public class BlobStore implements Store {
           lifeVersions.add(value.getLifeVersion());
         } else {
           // This is a delete request from replication
-          if ((value.isDelete() && value.getLifeVersion() >= info.getLifeVersion()) || (value.getLifeVersion()
-              > info.getLifeVersion())) {
+          if (value.isDelete() && value.getLifeVersion() == info.getLifeVersion()) {
             throw new StoreException(
-                "Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index.",
-                StoreErrorCodes.Life_Version_Conflict);
+                "Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index with lifeVersion "
+                    + value.getLifeVersion() + ".", StoreErrorCodes.ID_Deleted);
+          }
+          if (value.getLifeVersion() > info.getLifeVersion()) {
+            throw new StoreException(
+                "Cannot delete id " + info.getStoreKey() + " since it has a higher lifeVersion than the message info: "
+                    + value.getLifeVersion() + ">" + info.getLifeVersion(), StoreErrorCodes.Life_Version_Conflict);
           }
           indexValuesToDelete.add(value);
           lifeVersions.add(info.getLifeVersion());

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -808,7 +808,7 @@ public class BlobStoreTest {
       store.delete(Collections.singletonList(info));
       fail("Should not delete");
     } catch (StoreException e) {
-      assertEquals(e.getErrorCode(), StoreErrorCodes.Life_Version_Conflict);
+      assertEquals(e.getErrorCode(), StoreErrorCodes.ID_Deleted);
     }
 
     // delete with the smaller lifeVersion, should fail with life_version_conflict


### PR DESCRIPTION
When frontend sends a delete request to all servers, some of them would respond faster than others. If at the same time replication thread just happens to replication the delete request from the already responded server to the local server, there might be a conflict.

Since replication thread would also delete a blob with a valid lifeVersion, we should compare the state of the blob when lifeVersion of this blob equals to the lifeVersion from message info. And when they are the same, we should throw an ID_DELETED error instead of LIFE_VERSION_CONFLICT.

This would also fix this issue https://jira01.corp.linkedin.com:8443/browse/EXC-225598