### PR TITLE
Introduce abstraction around InstanceConfigs

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/frontend/StitchRequestSerDe.java
+++ b/ambry-api/src/main/java/com/github/ambry/frontend/StitchRequestSerDe.java
@@ -15,6 +15,7 @@
 
 package com.github.ambry.frontend;
 
+import com.github.ambry.utils.Utils;
 import java.util.AbstractList;
 import java.util.Collections;
 import java.util.List;
@@ -57,17 +58,7 @@ public class StitchRequestSerDe {
     if (signedChunkIds == null) {
       return Collections.emptyList();
     } else {
-      return new AbstractList<String>() {
-        @Override
-        public String get(int index) {
-          return signedChunkIds.getString(index);
-        }
-
-        @Override
-        public int size() {
-          return signedChunkIds.length();
-        }
-      };
+      return Utils.listView(signedChunkIds::length, signedChunkIds::getString);
     }
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
@@ -35,6 +35,7 @@ class DataNodeConfig {
   private final long xid;
   private final Set<String> sealedReplicas = new HashSet<>();
   private final Set<String> stoppedReplicas = new HashSet<>();
+  private final Set<String> disabledReplicas = new HashSet<>();
   private final Map<String, DiskConfig> diskConfigs = new HashMap<>();
 
   /**
@@ -127,6 +128,13 @@ class DataNodeConfig {
    */
   Set<String> getStoppedReplicas() {
     return stoppedReplicas;
+  }
+
+  /**
+   * @return the set of disabled replicas on this server. This set is mutable.
+   */
+  Set<String> getDisabledReplicas() {
+    return disabledReplicas;
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
@@ -61,7 +61,7 @@ class DataNodeConfig {
   }
 
   /**
-    * @return a name that can be used as a unique key for this server.
+   * @return a name that can be used as a unique key for this server.
    */
   String getInstanceName() {
     return instanceName;
@@ -146,10 +146,10 @@ class DataNodeConfig {
 
   @Override
   public String toString() {
-    return "ServerConfig{" + "instanceName='" + instanceName + '\'' + ", hostName='" + hostName + '\'' + ", port="
+    return "DataNodeConfig{" + "instanceName='" + instanceName + '\'' + ", hostName='" + hostName + '\'' + ", port="
         + port + ", datacenterName='" + datacenterName + '\'' + ", sslPort=" + sslPort + ", http2Port=" + http2Port
         + ", rackId='" + rackId + '\'' + ", xid=" + xid + ", sealedReplicas=" + sealedReplicas + ", stoppedReplicas="
-        + stoppedReplicas + ", diskConfigs=" + diskConfigs + '}';
+        + stoppedReplicas + ", disabledReplicas=" + disabledReplicas + ", diskConfigs=" + diskConfigs + '}';
   }
 
   /**
@@ -157,16 +157,16 @@ class DataNodeConfig {
    */
   static class DiskConfig {
     private final HardwareState state;
-    private final long diskCapacity;
+    private final long diskCapacityInBytes;
     private final Map<String, ReplicaConfig> replicaConfigs = new HashMap<>();
 
     /**
      * @param state the configured {@link HardwareState} of the disk.
-     * @param diskCapacity the capacity of the disk in bytes.
+     * @param diskCapacityInBytes the capacity of the disk in bytes.
      */
-    DiskConfig(HardwareState state, long diskCapacity) {
+    DiskConfig(HardwareState state, long diskCapacityInBytes) {
       this.state = state;
-      this.diskCapacity = diskCapacity;
+      this.diskCapacityInBytes = diskCapacityInBytes;
     }
 
     /**
@@ -179,12 +179,12 @@ class DataNodeConfig {
     /**
      * @return the capacity of the disk in bytes.
      */
-    long getDiskCapacity() {
-      return diskCapacity;
+    long getDiskCapacityInBytes() {
+      return diskCapacityInBytes;
     }
 
     /**
-     * @return a map from partition name to {@link ReplicaConfig} for all the repliccas on the server.
+     * @return a map from partition name to {@link ReplicaConfig} for all the replicas on the server.
      *         This map is mutable.
      */
     Map<String, ReplicaConfig> getReplicaConfigs() {
@@ -193,8 +193,8 @@ class DataNodeConfig {
 
     @Override
     public String toString() {
-      return "DiskConfig{" + "state=" + state + ", diskCapacity=" + diskCapacity + ", replicaConfigs=" + replicaConfigs
-          + '}';
+      return "DiskConfig{" + "state=" + state + ", diskCapacity=" + diskCapacityInBytes + ", replicaConfigs="
+          + replicaConfigs + '}';
     }
   }
 
@@ -202,23 +202,23 @@ class DataNodeConfig {
    * Configuration scoped to a single replica on a disk.
    */
   static class ReplicaConfig {
-    private final long replicaCapacity;
+    private final long replicaCapacityInBytes;
     private final String partitionClass;
 
     /**
-     * @param replicaCapacity the capacity of this replica in bytes.
+     * @param replicaCapacityInBytes the capacity of this replica in bytes.
      * @param partitionClass the partition class of this replica.
      */
-    ReplicaConfig(long replicaCapacity, String partitionClass) {
-      this.replicaCapacity = replicaCapacity;
+    ReplicaConfig(long replicaCapacityInBytes, String partitionClass) {
+      this.replicaCapacityInBytes = replicaCapacityInBytes;
       this.partitionClass = partitionClass;
     }
 
     /**
      * @return the capacity of this replica in bytes.
      */
-    long getReplicaCapacity() {
-      return replicaCapacity;
+    long getReplicaCapacityInBytes() {
+      return replicaCapacityInBytes;
     }
 
     /**
@@ -230,8 +230,8 @@ class DataNodeConfig {
 
     @Override
     public String toString() {
-      return "ReplicaConfig{" + "replicaCapacity=" + replicaCapacity + ", partitionClass='" + partitionClass + '\''
-          + '}';
+      return "ReplicaConfig{" + "replicaCapacity=" + replicaCapacityInBytes + ", partitionClass='" + partitionClass
+          + '\'' + '}';
     }
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * A data object for configs scoped to a single data node.
+ */
+class DataNodeConfig {
+  private final String instanceName;
+  private final String hostName;
+  private final int port;
+  private final String datacenterName;
+  private final Integer sslPort;
+  private final Integer http2Port;
+  private final String rackId;
+  private final long xid;
+  private final Set<String> sealedReplicas = new HashSet<>();
+  private final Set<String> stoppedReplicas = new HashSet<>();
+  private final Map<String, DiskConfig> diskConfigs = new HashMap<>();
+
+  /**
+   * @param instanceName a name that can be used as a unique key for this server.
+   * @param hostName the host name of the server.
+   * @param port the port of the server.
+   * @param datacenterName the datacenter this server is in.
+   * @param sslPort the ssl port, or {@code null} if the server does not have one.
+   * @param http2Port the HTTP2 port, or {@code null} if the server does not have one.
+   * @param rackId an identifier for the rack or cabinet that the server is in for computing failure domains.
+   * @param xid  the xid for this server.
+   */
+  DataNodeConfig(String instanceName, String hostName, int port, String datacenterName, Integer sslPort,
+      Integer http2Port, String rackId, long xid) {
+    this.instanceName = instanceName;
+    this.hostName = hostName;
+    this.port = port;
+    this.datacenterName = datacenterName;
+    this.sslPort = sslPort;
+    this.http2Port = http2Port;
+    this.rackId = rackId;
+    this.xid = xid;
+  }
+
+  /**
+    * @return a name that can be used as a unique key for this server.
+   */
+  String getInstanceName() {
+    return instanceName;
+  }
+
+  /**
+   * @return the host name of the server.
+   */
+  String getHostName() {
+    return hostName;
+  }
+
+  /**
+   * @return the port of the server.
+   */
+  int getPort() {
+    return port;
+  }
+
+  /**
+   * @return the datacenter this server is in.
+   */
+  String getDatacenterName() {
+    return datacenterName;
+  }
+
+  /**
+   * @return the ssl port, or {@code null} if the server does not have one.
+   */
+  Integer getSslPort() {
+    return sslPort;
+  }
+
+  /**
+   * @return the HTTP2 port, or {@code null} if the server does not have one.
+   */
+  Integer getHttp2Port() {
+    return http2Port;
+  }
+
+  /**
+   * @return an identifier for the rack or cabinet that the server is in for computing failure domains.
+   */
+  String getRackId() {
+    return rackId;
+  }
+
+  /**
+   * @return the xid for this server. After {@link SimpleClusterChangeHandler} is retired, this field will be removed.
+   */
+  long getXid() {
+    return xid;
+  }
+
+  /**
+   * @return the set of sealed replicas on this server. This set is mutable.
+   */
+  Set<String> getSealedReplicas() {
+    return sealedReplicas;
+  }
+
+  /**
+   * @return the set of stopped replicas on this server. This set is mutable.
+   */
+  Set<String> getStoppedReplicas() {
+    return stoppedReplicas;
+  }
+
+  /**
+   * @return a map from mount path to {@link DiskConfig} for all the disks on the server. This map is mutable.
+   */
+  Map<String, DiskConfig> getDiskConfigs() {
+    return diskConfigs;
+  }
+
+  @Override
+  public String toString() {
+    return "ServerConfig{" + "instanceName='" + instanceName + '\'' + ", hostName='" + hostName + '\'' + ", port="
+        + port + ", datacenterName='" + datacenterName + '\'' + ", sslPort=" + sslPort + ", http2Port=" + http2Port
+        + ", rackId='" + rackId + '\'' + ", xid=" + xid + ", sealedReplicas=" + sealedReplicas + ", stoppedReplicas="
+        + stoppedReplicas + ", diskConfigs=" + diskConfigs + '}';
+  }
+
+  /**
+   * Configuration scoped to a single disk on a server.
+   */
+  static class DiskConfig {
+    private final HardwareState state;
+    private final long diskCapacity;
+    private final Map<String, ReplicaConfig> replicaConfigs = new HashMap<>();
+
+    /**
+     * @param state the configured {@link HardwareState} of the disk.
+     * @param diskCapacity the capacity of the disk in bytes.
+     */
+    DiskConfig(HardwareState state, long diskCapacity) {
+      this.state = state;
+      this.diskCapacity = diskCapacity;
+    }
+
+    /**
+     * @return the configured {@link HardwareState} of the disk.
+     */
+    HardwareState getState() {
+      return state;
+    }
+
+    /**
+     * @return the capacity of the disk in bytes.
+     */
+    long getDiskCapacity() {
+      return diskCapacity;
+    }
+
+    /**
+     * @return a map from partition name to {@link ReplicaConfig} for all the repliccas on the server.
+     *         This map is mutable.
+     */
+    Map<String, ReplicaConfig> getReplicaConfigs() {
+      return replicaConfigs;
+    }
+
+    @Override
+    public String toString() {
+      return "DiskConfig{" + "state=" + state + ", diskCapacity=" + diskCapacity + ", replicaConfigs=" + replicaConfigs
+          + '}';
+    }
+  }
+
+  /**
+   * Configuration scoped to a single replica on a disk.
+   */
+  static class ReplicaConfig {
+    private final long replicaCapacity;
+    private final String partitionClass;
+
+    /**
+     * @param replicaCapacity the capacity of this replica in bytes.
+     * @param partitionClass the partition class of this replica.
+     */
+    ReplicaConfig(long replicaCapacity, String partitionClass) {
+      this.replicaCapacity = replicaCapacity;
+      this.partitionClass = partitionClass;
+    }
+
+    /**
+     * @return the capacity of this replica in bytes.
+     */
+    long getReplicaCapacity() {
+      return replicaCapacity;
+    }
+
+    /**
+     * @return the partition class of this replica.
+     */
+    String getPartitionClass() {
+      return partitionClass;
+    }
+
+    @Override
+    public String toString() {
+      return "ReplicaConfig{" + "replicaCapacity=" + replicaCapacity + ", partitionClass='" + partitionClass + '\''
+          + '}';
+    }
+  }
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigChangeListener.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigChangeListener.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+/**
+ * Interface to implement a listener that will be called on updates to {@link DataNodeConfig}s.
+ */
+public interface DataNodeConfigChangeListener {
+  /**
+   * Called when there is a relevant update to one or more {@link DataNodeConfig}s.
+   * @param configs the new or updated configs.
+   */
+  void onDataNodeConfigChange(Iterable<DataNodeConfig> configs);
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSource.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+/**
+ * A source of {@link DataNodeConfig}s for a cluster. Can be used for config change notification and administration.
+ */
+interface DataNodeConfigSource {
+  /**
+   * Attach a listener that will be notified when there are new or updated {@link DataNodeConfig}s.
+   * @param listener the {@link DataNodeConfigChangeListener} to attach.
+   */
+  void addServerConfigChangeListener(DataNodeConfigChangeListener listener) throws Exception;
+}
+

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSource.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSource.java
@@ -23,6 +23,5 @@ interface DataNodeConfigSource {
    * Attach a listener that will be notified when there are new or updated {@link DataNodeConfig}s.
    * @param listener the {@link DataNodeConfigChangeListener} to attach.
    */
-  void addServerConfigChangeListener(DataNodeConfigChangeListener listener) throws Exception;
+  void addDataNodeConfigChangeListener(DataNodeConfigChangeListener listener) throws Exception;
 }
-

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
@@ -200,7 +200,8 @@ class DatacenterInitializer {
     // notification for a change from within the same thread that adds the listener, in the context of the add
     // call. Therefore, when the call to add a listener returns, the initial notification will have been
     // received and handled.
-    manager.addInstanceConfigChangeListener(clusterChangeHandler);
+    DataNodeConfigSource dataNodeConfigSource = new InstanceConfigToDataNodeConfigAdapter(manager, clusterMapConfig);
+    dataNodeConfigSource.addServerConfigChangeListener(clusterChangeHandler);
     logger.info("Registered instance config change listeners for Helix manager at {}", zkConnectStr);
     manager.addIdealStateChangeListener(clusterChangeHandler);
     logger.info("Registered ideal state change listeners for Helix manager at {}", zkConnectStr);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
@@ -201,7 +201,7 @@ class DatacenterInitializer {
     // call. Therefore, when the call to add a listener returns, the initial notification will have been
     // received and handled.
     DataNodeConfigSource dataNodeConfigSource = new InstanceConfigToDataNodeConfigAdapter(manager, clusterMapConfig);
-    dataNodeConfigSource.addServerConfigChangeListener(clusterChangeHandler);
+    dataNodeConfigSource.addDataNodeConfigChangeListener(clusterChangeHandler);
     logger.info("Registered instance config change listeners for Helix manager at {}", zkConnectStr);
     manager.addIdealStateChangeListener(clusterChangeHandler);
     logger.info("Registered ideal state change listeners for Helix manager at {}", zkConnectStr);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DynamicClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DynamicClusterChangeHandler.java
@@ -16,6 +16,7 @@ package com.github.ambry.clustermap;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.utils.Pair;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -68,8 +69,8 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
   private volatile boolean liveStateInitialized = false;
   private volatile boolean idealStateInitialized = false;
   private volatile ConcurrentHashMap<String, String> partitionNameToResource = new ConcurrentHashMap<>();
-  private AtomicReference<RoutingTableSnapshot> routingTableSnapshotRef = new AtomicReference<>();
-  private ConcurrentHashMap<String, AmbryDataNode> instanceNameToAmbryDataNode = new ConcurrentHashMap<>();
+  private final AtomicReference<RoutingTableSnapshot> routingTableSnapshotRef = new AtomicReference<>();
+  private final ConcurrentHashMap<String, AmbryDataNode> instanceNameToAmbryDataNode = new ConcurrentHashMap<>();
   private static final Logger logger = LoggerFactory.getLogger(DynamicClusterChangeHandler.class);
 
   /**
@@ -107,12 +108,11 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
    * added to existing node; (4) old replica is removed from existing node; (5) data node is deleted from cluster.
    * For now, {@link DynamicClusterChangeHandler} supports (1)~(4). We may consider supporting (5) in the future.
    * (The ZNode path of instance config in Helix is [AmbryClusterName]/CONFIGS/PARTICIPANT/[hostname_port])
-   * @param configs all the {@link InstanceConfig}(s) in current data center. (Note that PreFetch is enabled by default
+   * @param configs all the {@link DataNodeConfig}(s) in current data center. (Note that PreFetch is enabled by default
    *                in Helix, which means all instance configs under "participants" ZNode will be sent to this method)
-   * @param changeContext the {@link NotificationContext} associated.
    */
   @Override
-  public void onInstanceConfigChange(List<InstanceConfig> configs, NotificationContext changeContext) {
+  public void onDataNodeConfigChange(Iterable<DataNodeConfig> configs) {
     try {
       synchronized (notificationLock) {
         if (!instanceConfigInitialized) {
@@ -275,25 +275,19 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
   }
 
   /**
-   * Add new instance or update existing instance based on {@link InstanceConfig}(s). This may also invoke callbacks in
-   * some clustermap change listeners (i.e. {@link PartitionSelectionHelper}, ReplicationManager)
-   * @param instanceConfigs the {@link InstanceConfig}(s) used to update in-mem cluster map.
-   * @throws Exception
+   * Add new instances or update existing instances based on {@link InstanceConfig}(s). This may also invoke callbacks
+   * in some clustermap change listeners (i.e. {@link PartitionSelectionHelper}, ReplicationManager)
+   * @param dataNodeConfigs the {@link DataNodeConfig}(s) used to update in-mem cluster map.
    */
-  private void addOrUpdateInstanceInfos(List<InstanceConfig> instanceConfigs) throws Exception {
+  private void addOrUpdateInstanceInfos(Iterable<DataNodeConfig> dataNodeConfigs) throws Exception {
     List<ReplicaId> totalAddedReplicas = new ArrayList<>();
     List<ReplicaId> totalRemovedReplicas = new ArrayList<>();
-    for (InstanceConfig instanceConfig : instanceConfigs) {
-      int schemaVersion = getSchemaVersion(instanceConfig);
-      if (schemaVersion != 0) {
-        logger.error("Unknown InstanceConfig schema version: {}, ignoring.", schemaVersion);
-        continue;
-      }
+    for (DataNodeConfig dataNodeConfig : dataNodeConfigs) {
       Pair<List<ReplicaId>, List<ReplicaId>> addedAndRemovedReplicas;
-      if (instanceNameToAmbryDataNode.containsKey(instanceConfig.getInstanceName())) {
-        addedAndRemovedReplicas = updateInstanceInfo(instanceConfig);
+      if (instanceNameToAmbryDataNode.containsKey(dataNodeConfig.getInstanceName())) {
+        addedAndRemovedReplicas = updateInstanceInfo(dataNodeConfig);
       } else {
-        addedAndRemovedReplicas = new Pair<>(createNewInstance(instanceConfig), new ArrayList<>());
+        addedAndRemovedReplicas = new Pair<>(createNewInstance(dataNodeConfig), new ArrayList<>());
       }
       totalAddedReplicas.addAll(addedAndRemovedReplicas.getFirst());
       totalRemovedReplicas.addAll(addedAndRemovedReplicas.getSecond());
@@ -310,27 +304,26 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
   /**
    * Update info of an existing instance. This may happen in following cases: (1) new replica is added; (2) old replica
    * is removed; (3) replica's state has changed (i.e. becomes seal/unseal).
-   * @param instanceConfig the {@link InstanceConfig} used to update info of instance.
+   * @param dataNodeConfig the {@link DataNodeConfig} used to update info of instance.
    * @return a pair of lists: (1) new added replicas; (2) removed old replicas, during this update.
    */
-  private Pair<List<ReplicaId>, List<ReplicaId>> updateInstanceInfo(InstanceConfig instanceConfig) throws Exception {
+  private Pair<List<ReplicaId>, List<ReplicaId>> updateInstanceInfo(DataNodeConfig dataNodeConfig) throws Exception {
     final List<ReplicaId> addedReplicas = new ArrayList<>();
     final List<ReplicaId> removedReplicas = new ArrayList<>();
-    String instanceName = instanceConfig.getInstanceName();
+    String instanceName = dataNodeConfig.getInstanceName();
     logger.info("Updating replicas info for existing node {}", instanceName);
-    List<String> sealedReplicas = getSealedReplicas(instanceConfig);
-    List<String> stoppedReplicas = getStoppedReplicas(instanceConfig);
+    Set<String> sealedReplicas = dataNodeConfig.getStoppedReplicas();
+    Set<String> stoppedReplicas = dataNodeConfig.getSealedReplicas();
     AmbryDataNode dataNode = instanceNameToAmbryDataNode.get(instanceName);
     ConcurrentHashMap<String, AmbryReplica> currentReplicasOnNode = ambryDataNodeToAmbryReplicas.get(dataNode);
     ConcurrentHashMap<String, AmbryReplica> replicasFromInstanceConfig = new ConcurrentHashMap<>();
-    Map<String, Map<String, String>> diskInfos = instanceConfig.getRecord().getMapFields();
     Map<String, AmbryDisk> mountPathToDisk = ambryDataNodeToAmbryDisks.get(dataNode)
         .stream()
         .collect(Collectors.toMap(AmbryDisk::getMountPath, disk -> disk));
     Map<AmbryPartition, List<AmbryReplica>> replicaToAddByPartition = new HashMap<>();
-    for (Map.Entry<String, Map<String, String>> entry : diskInfos.entrySet()) {
-      String mountPath = entry.getKey();
-      Map<String, String> diskInfo = entry.getValue();
+    for (Map.Entry<String, DataNodeConfig.DiskConfig> diskEntry : dataNodeConfig.getDiskConfigs().entrySet()) {
+      String mountPath = diskEntry.getKey();
+      DataNodeConfig.DiskConfig diskConfig = diskEntry.getValue();
       AmbryDisk disk = mountPathToDisk.getOrDefault(mountPath, null);
       if (disk == null) {
         logger.warn("{} is a new disk or unrecognizable disk which is not supported on existing node {}.", mountPath,
@@ -338,53 +331,52 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
         // TODO support dynamically adding disk in the future
         continue;
       }
-      String replicasStr = diskInfo.get(ClusterMapUtils.REPLICAS_STR);
-      if (!replicasStr.isEmpty()) {
-        for (String replicaInfo : replicasStr.split(ClusterMapUtils.REPLICAS_DELIM_STR)) {
-          String[] info = replicaInfo.split(ClusterMapUtils.REPLICAS_STR_SEPARATOR);
-          // partition name and replica name are the same.
-          String partitionName = info[0];
-          if (currentReplicasOnNode.containsKey(partitionName)) {
-            // if replica is already present
-            AmbryReplica existingReplica = currentReplicasOnNode.get(partitionName);
-            // 1. directly add it into "replicasFromInstanceConfig" map
-            replicasFromInstanceConfig.put(partitionName, existingReplica);
-            // 2. update replica seal/stop state
-            updateReplicaStateAndOverrideIfNeeded(existingReplica, sealedReplicas, stoppedReplicas);
-          } else {
-            // if this is a new replica and doesn't exist on node
-            logger.info("Adding new replica {} to existing node {} in {}", partitionName, instanceName, dcName);
-            long replicaCapacity = Long.parseLong(info[1]);
-            String partitionClass = info.length > 2 ? info[2] : clusterMapConfig.clusterMapDefaultPartitionClass;
-            // this can be a brand new partition that is added to an existing node
-            AmbryPartition mappedPartition =
-                new AmbryPartition(Long.parseLong(partitionName), partitionClass, helixClusterManagerCallback);
-            // Ensure only one AmbryPartition instance exists for specific partition.
-            mappedPartition = clusterChangeHandlerCallback.addPartitionIfAbsent(mappedPartition, replicaCapacity);
-            ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, dataNode, replicaCapacity);
-            // create new replica belonging to this partition or find the existing replica from bootstrapReplicas map.
-            AmbryReplica replica;
-            if (selfInstanceName.equals(instanceName)) {
-              // if this is a newly added replica on current instance, it should be present in bootstrapReplicas map.
-              replica = clusterChangeHandlerCallback.fetchBootstrapReplica(mappedPartition.toPathString());
-              if (replica == null) {
-                logger.error("Replica {} is not present in bootstrap replica set, abort instance info update",
-                    mappedPartition.toPathString());
-                throw new IllegalStateException("Replica to add is not present in bootstrap replica map");
-              }
-            } else {
-              replica = new AmbryServerReplica(clusterMapConfig, mappedPartition, disk,
-                  stoppedReplicas.contains(partitionName), replicaCapacity, sealedReplicas.contains(partitionName));
+      for (Map.Entry<String, DataNodeConfig.ReplicaConfig> replicaEntry : diskConfig.getReplicaConfigs().entrySet()) {
+        // partition name and replica name are the same.
+        String partitionName = replicaEntry.getKey();
+        DataNodeConfig.ReplicaConfig replicaConfig = replicaEntry.getValue();
+        if (currentReplicasOnNode.containsKey(partitionName)) {
+          // if replica is already present
+          AmbryReplica existingReplica = currentReplicasOnNode.get(partitionName);
+          // 1. directly add it into "replicasFromInstanceConfig" map
+          replicasFromInstanceConfig.put(partitionName, existingReplica);
+          // 2. update replica seal/stop state
+          updateReplicaStateAndOverrideIfNeeded(existingReplica, sealedReplicas, stoppedReplicas);
+        } else {
+          // if this is a new replica and doesn't exist on node
+          logger.info("Adding new replica {} to existing node {} in {}", partitionName, instanceName, dcName);
+          // this can be a brand new partition that is added to an existing node
+          AmbryPartition mappedPartition =
+              new AmbryPartition(Long.parseLong(partitionName), replicaConfig.getPartitionClass(),
+                  helixClusterManagerCallback);
+          // Ensure only one AmbryPartition instance exists for specific partition.
+          mappedPartition =
+              clusterChangeHandlerCallback.addPartitionIfAbsent(mappedPartition, replicaConfig.getReplicaCapacity());
+          ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, dataNode,
+              replicaConfig.getReplicaCapacity());
+          // create new replica belonging to this partition or find the existing replica from bootstrapReplicas map.
+          AmbryReplica replica;
+          if (selfInstanceName.equals(instanceName)) {
+            // if this is a newly added replica on current instance, it should be present in bootstrapReplicas map.
+            replica = clusterChangeHandlerCallback.fetchBootstrapReplica(mappedPartition.toPathString());
+            if (replica == null) {
+              logger.error("Replica {} is not present in bootstrap replica set, abort instance info update",
+                  mappedPartition.toPathString());
+              throw new IllegalStateException("Replica to add is not present in bootstrap replica map");
             }
-            updateReplicaStateAndOverrideIfNeeded(replica, sealedReplicas, stoppedReplicas);
-            // add new created replica to "replicasFromInstanceConfig" map
-            replicasFromInstanceConfig.put(partitionName, replica);
-            // Put new replica into partition-to-replica map temporarily (this is to avoid any exception thrown within the
-            // loop before updating "ambryDataNodeToAmbryReplicas" map. If we update call addReplicasToPartition here
-            // immediately, the exception may cause inconsistency between "ambryPartitionToAmbryReplicas" and
-            // "ambryDataNodeToAmbryReplicas")
-            replicaToAddByPartition.put(mappedPartition, Collections.singletonList(replica));
+          } else {
+            replica =
+                new AmbryServerReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
+                    replicaConfig.getReplicaCapacity(), sealedReplicas.contains(partitionName));
           }
+          updateReplicaStateAndOverrideIfNeeded(replica, sealedReplicas, stoppedReplicas);
+          // add new created replica to "replicasFromInstanceConfig" map
+          replicasFromInstanceConfig.put(partitionName, replica);
+          // Put new replica into partition-to-replica map temporarily (this is to avoid any exception thrown within the
+          // loop before updating "ambryDataNodeToAmbryReplicas" map. If we update call addReplicasToPartition here
+          // immediately, the exception may cause inconsistency between "ambryPartitionToAmbryReplicas" and
+          // "ambryDataNodeToAmbryReplicas")
+          replicaToAddByPartition.put(mappedPartition, Collections.singletonList(replica));
         }
       }
     }
@@ -413,11 +405,11 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
    * If partition override is enabled, we override replica SEAL/UNSEAL state based on partitionOverrideMap. If disabled,
    * update replica state according to the info from {@link InstanceConfig}.
    * @param replica the {@link ReplicaId} whose states (seal,stop) should be updated.
-   * @param sealedReplicas a list of {@link ReplicaId}(s) that are in SEALED state.
-   * @param stoppedReplicas a list of {@link ReplicaId}(s) that are in STOPPED state.
+   * @param sealedReplicas a collection of {@link ReplicaId}(s) that are in SEALED state.
+   * @param stoppedReplicas a collection of {@link ReplicaId}(s) that are in STOPPED state.
    */
-  private void updateReplicaStateAndOverrideIfNeeded(AmbryReplica replica, List<String> sealedReplicas,
-      List<String> stoppedReplicas) {
+  private void updateReplicaStateAndOverrideIfNeeded(AmbryReplica replica, Collection<String> sealedReplicas,
+      Collection<String> stoppedReplicas) {
     String partitionName = replica.getPartitionId().toPathString();
     boolean isSealed;
     if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(partitionName)) {
@@ -433,22 +425,22 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
 
   /**
    * Create a new instance(node) and initialize disks/replicas on it.
-   * @param instanceConfig the {@link InstanceConfig} to create new instance
+   * @param dataNodeConfig the {@link InstanceConfig} to create new instance
    * @return a list of newly added replicas;
-   * @throws Exception
+   * @throws Exception if there is an exception in instantiating the {@link ResourceStatePolicy}
    */
-  private List<ReplicaId> createNewInstance(InstanceConfig instanceConfig) throws Exception {
-    String instanceName = instanceConfig.getInstanceName();
+  private List<ReplicaId> createNewInstance(DataNodeConfig dataNodeConfig) throws Exception {
+    String instanceName = dataNodeConfig.getInstanceName();
     logger.info("Adding node {} and its disks and replicas in {}", instanceName, dcName);
     AmbryDataNode datanode =
-        new AmbryServerDataNode(getDcName(instanceConfig), clusterMapConfig, instanceConfig.getHostName(),
-            Integer.parseInt(instanceConfig.getPort()), getRackId(instanceConfig), getSslPortStr(instanceConfig),
-            getHttp2PortStr(instanceConfig), getXid(instanceConfig), helixClusterManagerCallback);
+        new AmbryServerDataNode(dataNodeConfig.getDatacenterName(), clusterMapConfig, dataNodeConfig.getHostName(),
+            dataNodeConfig.getPort(), dataNodeConfig.getRackId(), dataNodeConfig.getSslPort(),
+            dataNodeConfig.getHttp2Port(), DEFAULT_XID, helixClusterManagerCallback);
     // for new instance, we first set it to unavailable and rely on its participation to update its liveness
     if (!instanceName.equals(selfInstanceName)) {
       datanode.setState(HardwareState.UNAVAILABLE);
     }
-    List<ReplicaId> addedReplicas = initializeDisksAndReplicasOnNode(datanode, instanceConfig);
+    List<ReplicaId> addedReplicas = initializeDisksAndReplicasOnNode(datanode, dataNodeConfig);
     instanceNameToAmbryDataNode.put(instanceName, datanode);
     return addedReplicas;
   }
@@ -458,67 +450,52 @@ public class DynamicClusterChangeHandler implements HelixClusterChangeHandler {
    * that partition is being constructed. If partition override is enabled, the seal state of replica is determined by
    * partition info in HelixPropertyStore, if disabled, the seal state is determined by instanceConfig.
    * @param datanode the {@link AmbryDataNode} that is being initialized.
-   * @param instanceConfig the {@link InstanceConfig} associated with this datanode.
+   * @param dataNodeConfig the {@link InstanceConfig} associated with this datanode.
    * @return a list of newly added replicas on this node.
    * @throws Exception if creation of {@link AmbryDisk} throws an Exception.
    */
-  private List<ReplicaId> initializeDisksAndReplicasOnNode(AmbryDataNode datanode, InstanceConfig instanceConfig)
+  private List<ReplicaId> initializeDisksAndReplicasOnNode(AmbryDataNode datanode, DataNodeConfig dataNodeConfig)
       throws Exception {
     List<ReplicaId> addedReplicas = new ArrayList<>();
-    List<String> sealedReplicas = getSealedReplicas(instanceConfig);
-    List<String> stoppedReplicas = getStoppedReplicas(instanceConfig);
+    Set<String> sealedReplicas = dataNodeConfig.getSealedReplicas();
+    Set<String> stoppedReplicas = dataNodeConfig.getStoppedReplicas();
     ambryDataNodeToAmbryReplicas.put(datanode, new ConcurrentHashMap<>());
     ambryDataNodeToAmbryDisks.put(datanode, new HashSet<>());
-    Map<String, Map<String, String>> diskInfos = instanceConfig.getRecord().getMapFields();
-    for (Map.Entry<String, Map<String, String>> entry : diskInfos.entrySet()) {
-      String mountPath = entry.getKey();
-      Map<String, String> diskInfo = entry.getValue();
-      if (diskInfo.get(DISK_STATE) == null) {
-        // This may happen when Helix controller adds partitions in ERROR state to InstanceConfig. (The additional string
-        // is not recognizable for current HelixClusterManager)
-        logger.warn("{} is invalid disk info on {}. Skip it and continue on next one.", mountPath,
-            instanceConfig.getInstanceName());
-        continue;
-      }
-      HardwareState diskState =
-          diskInfo.get(DISK_STATE).equals(AVAILABLE_STR) ? HardwareState.AVAILABLE : HardwareState.UNAVAILABLE;
-      long capacityBytes = Long.parseLong(diskInfo.get(DISK_CAPACITY_STR));
+    for (Map.Entry<String, DataNodeConfig.DiskConfig> diskEntry : dataNodeConfig.getDiskConfigs().entrySet()) {
+      String mountPath = diskEntry.getKey();
+      DataNodeConfig.DiskConfig diskConfig = diskEntry.getValue();
 
       // Create disk
-      AmbryDisk disk = new AmbryDisk(clusterMapConfig, datanode, mountPath, diskState, capacityBytes);
+      AmbryDisk disk =
+          new AmbryDisk(clusterMapConfig, datanode, mountPath, diskConfig.getState(), diskConfig.getDiskCapacity());
       ambryDataNodeToAmbryDisks.get(datanode).add(disk);
-      clusterChangeHandlerCallback.addClusterWideRawCapacity(capacityBytes);
+      clusterChangeHandlerCallback.addClusterWideRawCapacity(diskConfig.getDiskCapacity());
 
-      String replicasStr = diskInfo.get(ClusterMapUtils.REPLICAS_STR);
-      if (!replicasStr.isEmpty()) {
-        for (String replicaInfo : replicasStr.split(ClusterMapUtils.REPLICAS_DELIM_STR)) {
-          String[] info = replicaInfo.split(ClusterMapUtils.REPLICAS_STR_SEPARATOR);
-          // partition name and replica name are the same.
-          String partitionName = info[0];
-          long replicaCapacity = Long.parseLong(info[1]);
-          String partitionClass = info.length > 2 ? info[2] : clusterMapConfig.clusterMapDefaultPartitionClass;
+      for (Map.Entry<String, DataNodeConfig.ReplicaConfig> replicaEntry : diskConfig.getReplicaConfigs().entrySet()) {
+        String partitionName = replicaEntry.getKey();
+        DataNodeConfig.ReplicaConfig replicaConfig = replicaEntry.getValue();
 
-          AmbryPartition mappedPartition =
-              new AmbryPartition(Long.parseLong(partitionName), partitionClass, helixClusterManagerCallback);
-          // Ensure only one AmbryPartition instance exists for specific partition.
-          mappedPartition = clusterChangeHandlerCallback.addPartitionIfAbsent(mappedPartition, replicaCapacity);
-          ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, datanode, replicaCapacity);
-          // Create replica associated with this node and this partition
-          boolean isSealed = sealedReplicas.contains(partitionName);
-          if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(
-              partitionName)) {
-            // override sealed state if PartitionOverride is enabled.
-            isSealed = partitionOverrideInfoMap.get(partitionName)
-                .get(ClusterMapUtils.PARTITION_STATE)
-                .equals(ClusterMapUtils.READ_ONLY_STR);
-          }
-          AmbryReplica replica =
-              new AmbryServerReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
-                  replicaCapacity, isSealed);
-          ambryDataNodeToAmbryReplicas.get(datanode).put(mappedPartition.toPathString(), replica);
-          clusterChangeHandlerCallback.addReplicasToPartition(mappedPartition, Collections.singletonList(replica));
-          addedReplicas.add(replica);
+        AmbryPartition mappedPartition =
+            new AmbryPartition(Long.parseLong(partitionName), replicaConfig.getPartitionClass(),
+                helixClusterManagerCallback);
+        // Ensure only one AmbryPartition instance exists for specific partition.
+        mappedPartition =
+            clusterChangeHandlerCallback.addPartitionIfAbsent(mappedPartition, replicaConfig.getReplicaCapacity());
+        ensurePartitionAbsenceOnNodeAndValidateCapacity(mappedPartition, datanode, replicaConfig.getReplicaCapacity());
+        // Create replica associated with this node and this partition
+        boolean isSealed = sealedReplicas.contains(partitionName);
+        if (clusterMapConfig.clusterMapEnablePartitionOverride && partitionOverrideInfoMap.containsKey(partitionName)) {
+          // override sealed state if PartitionOverride is enabled.
+          isSealed = partitionOverrideInfoMap.get(partitionName)
+              .get(ClusterMapUtils.PARTITION_STATE)
+              .equals(ClusterMapUtils.READ_ONLY_STR);
         }
+        AmbryReplica replica =
+            new AmbryServerReplica(clusterMapConfig, mappedPartition, disk, stoppedReplicas.contains(partitionName),
+                replicaConfig.getReplicaCapacity(), isSealed);
+        ambryDataNodeToAmbryReplicas.get(datanode).put(mappedPartition.toPathString(), replica);
+        clusterChangeHandlerCallback.addReplicasToPartition(mappedPartition, Collections.singletonList(replica));
+        addedReplicas.add(replica);
       }
     }
     return addedReplicas;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterChangeHandler.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterChangeHandler.java
@@ -15,7 +15,6 @@ package com.github.ambry.clustermap;
 
 import java.util.stream.Stream;
 import org.apache.helix.api.listeners.IdealStateChangeListener;
-import org.apache.helix.api.listeners.InstanceConfigChangeListener;
 import org.apache.helix.api.listeners.LiveInstanceChangeListener;
 import org.apache.helix.api.listeners.RoutingTableChangeListener;
 import org.apache.helix.spectator.RoutingTableSnapshot;
@@ -26,7 +25,7 @@ import org.apache.helix.spectator.RoutingTableSnapshot;
  * implements various helix listeners and provides facilities for using routing tables.
  */
 interface HelixClusterChangeHandler
-    extends ClusterChangeHandler, InstanceConfigChangeListener, LiveInstanceChangeListener, IdealStateChangeListener,
+    extends ClusterChangeHandler, DataNodeConfigChangeListener, LiveInstanceChangeListener, IdealStateChangeListener,
             RoutingTableChangeListener {
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import java.util.Objects;
+import org.apache.helix.HelixManager;
+import org.apache.helix.api.listeners.InstanceConfigChangeListener;
+import org.apache.helix.model.InstanceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+
+
+/**
+ * An implementation of {@link DataNodeConfigSource} that converts between {@link InstanceConfig}s received by an
+ * {@link InstanceConfigChangeListener} and {@link DataNodeConfig}s.
+ */
+public class InstanceConfigToDataNodeConfigAdapter implements DataNodeConfigSource {
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceConfigToDataNodeConfigAdapter.class);
+  private final HelixManager helixManager;
+  private final ClusterMapConfig clusterMapConfig;
+
+  /**
+   * @param helixManager the {@link HelixManager} to use as the source of truth for {@link InstanceConfig}s.
+   * @param clusterMapConfig the {@link ClusterMapConfig} to use.
+   */
+  public InstanceConfigToDataNodeConfigAdapter(HelixManager helixManager, ClusterMapConfig clusterMapConfig) {
+    this.helixManager = helixManager;
+    this.clusterMapConfig = clusterMapConfig;
+  }
+
+  @Override
+  public void addServerConfigChangeListener(DataNodeConfigChangeListener listener) throws Exception {
+    helixManager.addInstanceConfigChangeListener((InstanceConfigChangeListener) (instanceConfigs, context) -> {
+      Iterable<DataNodeConfig> dataNodeConfigs =
+          () -> instanceConfigs.stream().map(this::convert).filter(Objects::nonNull).iterator();
+      listener.onDataNodeConfigChange(dataNodeConfigs);
+    });
+  }
+
+  /**
+   * @param instanceConfig the {@link InstanceConfig} to convert to a {@link DataNodeConfig} object.
+   * @return the {@link DataNodeConfig}, or {@code null} if the {@link InstanceConfig} provided has an unsupported schema
+   *         version.
+   */
+  private DataNodeConfig convert(InstanceConfig instanceConfig) {
+    return convert(instanceConfig, clusterMapConfig);
+  }
+
+  /**
+   * Exposed for testing.
+   * @param instanceConfig the {@link InstanceConfig} to convert to a {@link DataNodeConfig} object.
+   * @param clusterMapConfig the {@link ClusterMapConfig} containing any default values that may be needed.
+   * @return the {@link DataNodeConfig}, or {@code null} if the {@link InstanceConfig} provided has an unsupported schema
+   *         version.
+   */
+  static DataNodeConfig convert(InstanceConfig instanceConfig, ClusterMapConfig clusterMapConfig) {
+    int schemaVersion = getSchemaVersion(instanceConfig);
+    if (schemaVersion != 0) {
+      LOGGER.warn("Unknown InstanceConfig schema version {} in {}. Ignoring.", schemaVersion, instanceConfig);
+      return null;
+    }
+    DataNodeConfig dataNodeConfig = new DataNodeConfig(instanceConfig.getInstanceName(), instanceConfig.getHostName(),
+        Integer.parseInt(instanceConfig.getPort()), getDcName(instanceConfig), getSslPortStr(instanceConfig),
+        getHttp2PortStr(instanceConfig), getRackId(instanceConfig), getXid(instanceConfig));
+    dataNodeConfig.getSealedReplicas().addAll(getSealedReplicas(instanceConfig));
+    dataNodeConfig.getStoppedReplicas().addAll(getStoppedReplicas(instanceConfig));
+    instanceConfig.getRecord().getMapFields().forEach((mountPath, diskProps) -> {
+      if (diskProps.get(DISK_STATE) == null) {
+        // Check if this map field actually holds disk properties, since we can't tell from just the field key (the
+        // mount path with no special prefix). There may be extra fields when Helix controller adds partitions in ERROR
+        // state to InstanceConfig.
+        LOGGER.warn("{} field does not contain disk info on {}. Skip it and continue on next one.", mountPath,
+            instanceConfig.getInstanceName());
+      } else {
+        DataNodeConfig.DiskConfig disk = new DataNodeConfig.DiskConfig(
+            diskProps.get(DISK_STATE).equals(AVAILABLE_STR) ? HardwareState.AVAILABLE : HardwareState.UNAVAILABLE,
+            Long.parseLong(diskProps.get(DISK_CAPACITY_STR)));
+        String replicasStr = diskProps.get(REPLICAS_STR);
+        if (!replicasStr.isEmpty()) {
+          for (String replicaStr : replicasStr.split(REPLICAS_DELIM_STR)) {
+            String[] replicaStrParts = replicaStr.split(REPLICAS_STR_SEPARATOR);
+            // partition name and replica name are the same.
+            String partitionName = replicaStrParts[0];
+            long replicaCapacity = Long.parseLong(replicaStrParts[1]);
+            String partitionClass =
+                replicaStrParts.length > 2 ? replicaStrParts[2] : clusterMapConfig.clusterMapDefaultPartitionClass;
+            disk.getReplicaConfigs()
+                .put(partitionName, new DataNodeConfig.ReplicaConfig(replicaCapacity, partitionClass));
+          }
+        }
+        dataNodeConfig.getDiskConfigs().put(mountPath, disk);
+      }
+    });
+    return dataNodeConfig;
+  }
+}

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
@@ -80,6 +80,8 @@ public class InstanceConfigToDataNodeConfigAdapter implements DataNodeConfigSour
         getHttp2PortStr(instanceConfig), getRackId(instanceConfig), getXid(instanceConfig));
     dataNodeConfig.getSealedReplicas().addAll(getSealedReplicas(instanceConfig));
     dataNodeConfig.getStoppedReplicas().addAll(getStoppedReplicas(instanceConfig));
+    // TODO uncomment this line once 1534 is merged
+    // dataNodeConfig.getDisabledReplicas().addAll(getDisabledReplicas(instanceConfig));
     instanceConfig.getRecord().getMapFields().forEach((mountPath, diskProps) -> {
       if (diskProps.get(DISK_STATE) == null) {
         // Check if this map field actually holds disk properties, since we can't tell from just the field key (the

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
@@ -45,7 +45,7 @@ public class InstanceConfigToDataNodeConfigAdapter implements DataNodeConfigSour
   }
 
   @Override
-  public void addServerConfigChangeListener(DataNodeConfigChangeListener listener) throws Exception {
+  public void addDataNodeConfigChangeListener(DataNodeConfigChangeListener listener) throws Exception {
     helixManager.addInstanceConfigChangeListener((InstanceConfigChangeListener) (instanceConfigs, context) -> {
       Iterable<DataNodeConfig> dataNodeConfigs =
           () -> instanceConfigs.stream().map(this::convert).filter(Objects::nonNull).iterator();

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
@@ -298,9 +298,11 @@ public class ClusterChangeHandlerTest {
     instanceConfig.getRecord().setMapFields(diskInfos);
     // we call onInstanceConfigChange() twice
     // 1st call, to verify initialization code path
-    dynamicChangeHandler.onInstanceConfigChange(Collections.singletonList(instanceConfig), null);
+    dynamicChangeHandler.onDataNodeConfigChange(
+        Collections.singleton(InstanceConfigToDataNodeConfigAdapter.convert(instanceConfig, clusterMapConfig)));
     // 2nd call, to verify dynamic update code path
-    dynamicChangeHandler.onInstanceConfigChange(Collections.singletonList(instanceConfig), null);
+    dynamicChangeHandler.onDataNodeConfigChange(
+        Collections.singletonList(InstanceConfigToDataNodeConfigAdapter.convert(instanceConfig, clusterMapConfig)));
     assertEquals("There shouldn't be initialization errors", 0, initFailureCount.getCount());
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -57,6 +57,7 @@ import org.mockito.MockitoAnnotations;
 
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.TestUtils.*;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
@@ -1074,7 +1075,7 @@ public class HelixClusterManagerTest {
     assertEquals(instanceCount + numCloudDcs - 1, clusterManager.getDataNodeIds().size());
     for (DataNodeId dataNode : clusterManager.getDataNodeIds()) {
       String instanceName = ClusterMapUtils.getInstanceName(dataNode.getHostname(), dataNode.getPort());
-      assertFalse(instanceName.equals(aheadInstanceConfig.getInstanceName()));
+      assertThat(instanceName, not(aheadInstanceConfig.getInstanceName()));
     }
 
     // Ahead instance should be honored if the cluster manager is of the aheadInstance.

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/CompositeBlobInfo.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/CompositeBlobInfo.java
@@ -16,7 +16,7 @@ package com.github.ambry.messageformat;
 
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.utils.Pair;
-import java.util.AbstractList;
+import com.github.ambry.utils.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -141,17 +141,7 @@ public class CompositeBlobInfo {
    * @return A list of {@link StoreKey}s.
    */
   public List<StoreKey> getKeys() {
-    return new AbstractList<StoreKey>() {
-      @Override
-      public StoreKey get(int index) {
-        return chunkMetadataList.get(index).getStoreKey();
-      }
-
-      @Override
-      public int size() {
-        return chunkMetadataList.size();
-      }
-    };
+    return Utils.transformList(chunkMetadataList, ChunkMetadata::getStoreKey);
   }
 
   /**


### PR DESCRIPTION
This PR introduces a new data object called ServerConfig and associated
shims to convert InstanceConfig change notification into ServerConfigs.

This will provide a framework for future work to move away from storing
ambry specific server metadata in the InstanceConfigs, which comes with
some Helix performance and reliability advantages.