### PR TITLE
Temporarily exclude helix-common module to avoid conflicting domain name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,12 @@ project(':ambry-utils') {
         compile "org.json:json:$jsonVersion"
         compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
         compile "io.netty:netty-buffer:$nettyVersion"
-        testCompile "org.apache.helix:helix-core:$helixVersion"
+        testCompile ("org.apache.helix:helix-core:$helixVersion") {
+            // TODO Once new release is out, we can remove this
+            exclude group: "org.apache.helix", module: "helix-common"
+        }
+        // TODO remove zookeeper dependency once Helix open source fix is out
+        testCompile "org.apache.zookeeper:zookeeper:3.4.13"
         testCompile project(":ambry-test-utils")
     }
 }
@@ -174,7 +179,12 @@ project(':ambry-api') {
         compile project(':ambry-utils')
         compile ("org.apache.helix:helix-core:$helixVersion") {
             exclude group: "log4j", module: "log4j"
+            // This is a workaround for https://github.com/apache/helix/issues/1022.
+            // TODO Once new release is out, we can remove this
+            exclude group: "org.apache.helix", module: "helix-common"
         }
+        // TODO remove zookeeper dependency once Helix open source fix is out
+        compile "org.apache.zookeeper:zookeeper:3.4.13"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.codehaus.jackson:jackson-core-asl:$jacksonVersion"
         compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
@@ -189,7 +199,12 @@ project(':ambry-account') {
         compile project(':ambry-api'),
                 project(':ambry-utils'),
                 project(':ambry-commons')
-        compile "org.apache.helix:helix-core:$helixVersion"
+        compile ("org.apache.helix:helix-core:$helixVersion") {
+            // TODO remove this once Helix open source fix is out
+            exclude group: "org.apache.helix", module: "helix-common"
+        }
+        // TODO remove zookeeper dependency once Helix open source fix is out
+        compile "org.apache.zookeeper:zookeeper:3.4.13"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"
         testCompile project(':ambry-test-utils')
@@ -202,7 +217,12 @@ project(':ambry-clustermap') {
     dependencies {
         compile project(':ambry-api'),
                 project(':ambry-utils')
-        compile "org.apache.helix:helix-core:$helixVersion"
+        compile ("org.apache.helix:helix-core:$helixVersion") {
+            // TODO remove this once Helix open source fix is out
+            exclude group: "org.apache.helix", module: "helix-common"
+        }
+        // TODO remove zookeeper dependency once Helix open source fix is out
+        compile "org.apache.zookeeper:zookeeper:3.4.13"
         compile "io.dropwizard.metrics:metrics-core:$metricsVersion"
         compile "org.json:json:$jsonVersion"
         testCompile project(':ambry-commons')


### PR DESCRIPTION
This PR exludes helix-common module and explicitly depends on zookeeper to
avoid conflicting MonitorDomainNames (issue link: https://github.com/apache/helix/issues/1022).
Once apache helix fix is out, we can remove changes in this PR. 