### PR TITLE
Fix a test failure where delete request arrives after undelete

### DIFF
--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -200,9 +200,9 @@ public class UndeleteOperation {
               operationTracker.onResponse(replica, TrackedRequestFinalState.SUCCESS);
             } else {
               if (lifeVersion != undeleteResponse.getLifeVersion()) {
-                String message = String.format(
-                    "LifeVersion from Replica {} is different than the lifeVersion from replica {}, {} != {}",
-                    firstResponseReplicaId, replica, lifeVersion, undeleteResponse.getLifeVersion());
+                String message = "LifeVersion of " + blobId + " from Replica " + firstResponseReplicaId
+                    + " is different than the lifeVersion from replica " + replica + " " + lifeVersion + " != "
+                    + undeleteResponse.getLifeVersion();
                 LOGGER.error(message);
                 // this is a successful response and one that completes the operation regardless of whether the
                 // success target has been reached or not.

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/RouterServerTestFramework.java
@@ -127,7 +127,7 @@ class RouterServerTestFramework {
     for (OperationChain opChain : opChains) {
       if (!opChain.latch.await(AWAIT_TIMEOUT, TimeUnit.SECONDS)) {
         Assert.fail("Timeout waiting for operation chain " + opChain.chainId + " to finish and it is stuck at "
-            + opChain.opIndex + "th op:" + opChain.currentOpType + ".");
+            + opChain.opIndex + "the op:" + opChain.currentOpType + " the blob id: " + opChain.blobId);
       }
       synchronized (opChain.testFutures) {
         for (TestFuture testFuture : opChain.testFutures) {
@@ -174,13 +174,22 @@ class RouterServerTestFramework {
    * @return a {@link Properties} object with the properties needed to instantiate the router.
    */
   static Properties getRouterProperties(String routerDatacenter) {
+    // Change delete parallelism to 2 to make sure all delete requests are handled by ambry server.
+    // NotificationSystem and latch won't guarantee that since replication and frontend request both could count down
+    // the latch. When then parallelism is 3, there is a chance that two of delete requests reaches the ambry servers
+    // and count the delete latch down in notification system, at the same time, the third ambry server would replicate
+    // this particular delete record from one of these two ambry server, which would count the latch down even without
+    // handling the last delete request from frontend.
+    // In this case, if we are doing undelete after delete, undelete would proceeded since the latch count is 0 now. And
+    // there is a chance that the dangling delete request would arrive after undelete.
+    // Change the parallelism to 2 would prevent this issue.
     Properties properties = new Properties();
     properties.setProperty("router.hostname", "localhost");
     properties.setProperty("router.datacenter.name", routerDatacenter);
     properties.setProperty("router.connection.checkout.timeout.ms", "5000");
     properties.setProperty("router.request.timeout.ms", "10000");
     properties.setProperty("router.max.put.chunk.size.bytes", Integer.toString(CHUNK_SIZE));
-    properties.setProperty("router.put.success.target", "1");
+    properties.setProperty("router.delete.request.parallelism", "2");
     properties.setProperty("clustermap.cluster.name", "test");
     properties.setProperty("clustermap.datacenter.name", routerDatacenter);
     properties.setProperty("clustermap.host.name", "localhost");
@@ -466,15 +475,6 @@ class RouterServerTestFramework {
    * @param opChain the {@link OperationChain} object that this operation is a part of.
    */
   private void startUndeleteBlob(final OperationChain opChain) {
-    // Sleep for a while to make sure delete request is finished.
-    // NotificationSystem and latch won't guarantee that since replication and frontend request both could count down
-    // the latch and there is a chance when waiting deletes finished in the notification system but one of the delete
-    // requests from frontend hasn't arrived the server yet. (Latch countdown is done by replication).
-    try {
-      Thread.sleep(1000);
-    } catch (Exception e) {
-      //
-    }
     Callback<Void> callback = new TestCallback<>(opChain, false);
     Future<Void> future = router.undeleteBlob(opChain.blobId, null, callback);
     TestFuture<Void> testFuture = new TestFuture<Void>(future, genLabel("undeleteBlob", false), opChain) {

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/RouterServerTestFramework.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/RouterServerTestFramework.java
@@ -142,17 +142,6 @@ class RouterServerTestFramework {
         partitionCount.put(partitionId, count + 1);
       }
     }
-    /*
-    double numPartitions = clusterMap.getWritablePartitionIds(null).size();
-    if (opChains.size() > numPartitions) {
-      double blobBalanceThreshold = BALANCE_FACTOR * Math.ceil(blobsPut / numPartitions);
-      for (Map.Entry<PartitionId, Integer> entry : partitionCount.entrySet()) {
-        Assert.assertTrue("Number of blobs is " + entry.getValue() + " on partition: " + entry.getKey()
-                + ", which is greater than the threshold of " + blobBalanceThreshold,
-            entry.getValue() <= blobBalanceThreshold);
-      }
-    }
-     */
   }
 
   /**

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerTestUtil.java
@@ -560,7 +560,7 @@ final class ServerTestUtil {
       channel.disconnect();
     } catch (Exception e) {
       e.printStackTrace();
-      fail();
+      assertNull(e);
     } finally {
       List<? extends ReplicaId> replicaIds = cluster.getClusterMap()
           .getWritablePartitionIds(MockClusterMap.DEFAULT_PARTITION_CLASS)

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -531,6 +531,7 @@ public class BlobStore implements Store {
                 EnumSet.of(PersistentIndex.IndexEntryType.PUT, PersistentIndex.IndexEntryType.DELETE,
                     PersistentIndex.IndexEntryType.UNDELETE));
             if (value != null && value.getOffset().compareTo(indexEndOffsetBeforeCheck) > 0) {
+              // Make sure the value is actually after the indeEndOffsetBeforeCheck
               if (value.isDelete() && value.getLifeVersion() == lifeVersions.get(i)) {
                 throw new StoreException(
                     "Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index.",
@@ -752,7 +753,7 @@ public class BlobStore implements Store {
           IndexValue value = index.findKey(info.getStoreKey(), fileSpan,
               EnumSet.of(PersistentIndex.IndexEntryType.DELETE, PersistentIndex.IndexEntryType.UNDELETE));
           if (value != null && value.getOffset().compareTo(indexEndOffsetBeforeCheck) > 0) {
-            // Make sure the value is after the indexEndOffsetBeforeCheck
+            // Make sure the value is actually after the indexEndOffsetBeforeCheck
             if (value.isUndelete() && value.getLifeVersion() == revisedLifeVersion) {
               // Might get an concurrent undelete from both replication and frontend.
               throw new IdUndeletedStoreException(


### PR DESCRIPTION
This should fix an ambry-server integration test failure in the RouterTest, where a delete is acknowledged by the notification system, but actually one of the delete requests is handled after undelete.

This is the link to the test failure https://github.com/linkedin/ambry/issues/1526
This is what happened. 
1. Router issues a delete operation, which sends three delete requests to three hosts
2. Two hosts responds and at the same time, third host replicates delete from first two
3. All three hosts has delete so the notification system is acknowledged. 
4. Router issues a undelete operation, which sends undelets request to third host
5. After undelete, somehow the delete request from previous delete operation just arrives at the third host. This would mark blob deleted.

And that's how we get a Blob_Deleted after undelete.

The fix is pretty simple, change the delete parallelism to 2 so we don't have a dangling delete request.