### PR TITLE
Ignore ttl update operation time in replication

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -618,8 +618,10 @@ public class BlobStore implements Store {
         } else if (value.isTtlUpdate()) {
           throw new StoreException("TTL of " + info.getStoreKey() + " is already updated in the index.",
               StoreErrorCodes.Already_Updated);
-        } else if (value.getExpiresAtMs() != Utils.Infinite_Time
+        } else if (!IndexValue.hasLifeVersion(info.getLifeVersion()) && value.getExpiresAtMs() != Utils.Infinite_Time
             && value.getExpiresAtMs() < info.getOperationTimeMs() + ttlUpdateBufferTimeMs) {
+          // When the request is from frontend, make sure it's not too close to expiry date.
+          // When the request is from replication, we don't care about the operation time.
           throw new StoreException(
               "TTL of " + info.getStoreKey() + " cannot be updated because it is too close to expiry. Op time (ms): "
                   + info.getOperationTimeMs() + ". ExpiresAtMs: " + value.getExpiresAtMs(),


### PR DESCRIPTION
This PR ignores the operation time checking in ttl update when the request is coming from replication. The reason for not checking the ttl update's operation time, is that the operation time in the message info might not be the real operation time issued from frontend anymore.

For instance, frontend can send PUT, TTL_UPDATE to a server1 and only PUT to server2. And somehow server2 goes offline for a long time. Within this period, frontend sends DELETE to server. Assume this delete's operation time is after original PUT's expiration time, then server2 would have trouble to replicate TTL_UPDATE and DELETE from server2.

When server2 goes online again, it gets MessagInfo from server1 about this blob. The MessageInfo would have `isDeleted=true, isTtlUpdated=true, operationTime=deleteOperationTime`. This is obviously correct, since the blob is already deleted and ttl updated in server1 and the delete is the latest operation. At this moment, server2 would try to apply ttl update to local blobstore, with operationTime = deleteOperationTime. We know this would fail, since deleteOperationTime is after the local PUT's expiration time.

This PR solves this particular issue by ignoring the operation time when it's replication.