### PR TITLE
Support disabling partition in Helix when there is disk failure

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
@@ -17,6 +17,7 @@ package com.github.ambry.clustermap;
 import com.github.ambry.server.AmbryHealthReport;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -50,6 +51,13 @@ public interface ClusterParticipant extends AutoCloseable {
   boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean markStop);
 
   /**
+   * Set or reset the disabled state of the given replica
+   * @param replicaId the {@link ReplicaId} whose disabled state will be updated.
+   */
+  default void setReplicaDisabledState(ReplicaId replicaId, boolean disable) {
+  }
+
+  /**
    * Get a list of replicas that are marked as sealed (read-only).
    * @return a list of all sealed replicas.
    */
@@ -60,6 +68,14 @@ public interface ClusterParticipant extends AutoCloseable {
    * @return a list of all stopped replicas.
    */
   List<String> getStoppedReplicas();
+
+  /**
+   * Get a list of replicas that have been disabled.
+   * @return a list of all disabled replicas.
+   */
+  default List<String> getDisabledReplicas() {
+    return Collections.emptyList();
+  }
 
   /**
    * Register a listener for leadership changes in partitions of this node.

--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaStatusDelegate.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaStatusDelegate.java
@@ -65,6 +65,22 @@ public class ReplicaStatusDelegate {
   }
 
   /**
+   * Disable given replica on current node (this will trigger LEADER -> STANDBY -> INACTIVE transition)
+   * @param replicaId the {@link ReplicaId} to disable
+   */
+  public void disableReplica(ReplicaId replicaId) {
+    clusterParticipant.setReplicaDisabledState(replicaId, true);
+  }
+
+  /**
+   * Enable given replica on current node (this will trigger OFFLINE -> BOOTSTRAP -> STANDBY transition)
+   * @param replicaId the {@link ReplicaId} to disable
+   */
+  public void enableReplica(ReplicaId replicaId) {
+    clusterParticipant.setReplicaDisabledState(replicaId, false);
+  }
+
+  /**
    * @return a list of stopped replicas in InstanceConfig of local node.
    */
   public List<String> getStoppedReplicas() {

--- a/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/StoreConfig.java
@@ -327,6 +327,14 @@ public class StoreConfig {
   @Default("false")
   public final boolean storeContainerDeletionEnabled;
 
+  /**
+   * Whether to set local partition state through InstanceConfig in Helix. If true, store is allowed to enable/disable
+   * partition on local node by calling InstanceConfig API.
+   */
+  @Config("store.set.local.partition.state.enabled")
+  @Default("false")
+  public final boolean storeSetLocalPartitionStateEnabled;
+
   public StoreConfig(VerifiableProperties verifiableProperties) {
 
     storeKeyFactory = verifiableProperties.getString("store.key.factory", "com.github.ambry.commons.BlobIdFactory");
@@ -396,8 +404,9 @@ public class StoreConfig {
     storeUuidBasedBloomFilterEnabled = verifiableProperties.getBoolean("store.uuid.based.bloom.filter.enabled", false);
     storeIndexRebuildBloomFilterEnabled =
         verifiableProperties.getBoolean("store.index.rebuild.bloom.filter.enabled", false);
-    storeContainerDeletionEnabled =
-        verifiableProperties.getBoolean("store.container.deletion.enabled", false);
+    storeContainerDeletionEnabled = verifiableProperties.getBoolean("store.container.deletion.enabled", false);
+    storeSetLocalPartitionStateEnabled =
+        verifiableProperties.getBoolean("store.set.local.partition.state.enabled", false);
   }
 }
 

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -174,9 +174,7 @@ public interface Store {
   /**
    * @return {@code true} if the store is disabled on error (due to disk I/O issue).
    */
-  default boolean disabledOnError() {
-    return false;
-  }
+  boolean disabledOnError();
 
   /**
    * Shuts down the store

--- a/ambry-api/src/main/java/com/github/ambry/store/Store.java
+++ b/ambry-api/src/main/java/com/github/ambry/store/Store.java
@@ -172,6 +172,13 @@ public interface Store {
   boolean recoverFromDecommission();
 
   /**
+   * @return {@code true} if the store is disabled on error (due to disk I/O issue).
+   */
+  default boolean disabledOnError() {
+    return false;
+  }
+
+  /**
    * Shuts down the store
    */
   void shutdown() throws StoreException;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -668,12 +668,17 @@ class CloudBlobStore implements Store {
   }
 
   @Override
-  public long getEndPositionOfLastPut() throws StoreException {
+  public long getEndPositionOfLastPut() {
     throw new UnsupportedOperationException("Method not supported");
   }
 
   @Override
   public boolean recoverFromDecommission() {
+    throw new UnsupportedOperationException("Method not supported");
+  }
+
+  @Override
+  public boolean disabledOnError() {
     throw new UnsupportedOperationException("Method not supported");
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDataNode.java
@@ -27,7 +27,7 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
 /**
  * {@link DataNodeId} implementation to use within dynamic cluster managers.
  */
-abstract class AmbryDataNode implements DataNodeId {
+public abstract class AmbryDataNode implements DataNodeId {
   private final String hostName;
   // exposed for subclass access
   protected final Port plainTextPort;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDataNode.java
@@ -27,7 +27,7 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
 /**
  * {@link DataNodeId} implementation to use within dynamic cluster managers.
  */
-public abstract class AmbryDataNode implements DataNodeId {
+abstract class AmbryDataNode implements DataNodeId {
   private final String hostName;
   // exposed for subclass access
   protected final Port plainTextPort;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDisk.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDisk.java
@@ -24,7 +24,7 @@ import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 /**
  * {@link DiskId} implementation to use within dynamic cluster managers.
  */
-public class AmbryDisk implements DiskId, Resource {
+class AmbryDisk implements DiskId, Resource {
   private final AmbryDataNode datanode;
   private final String mountPath;
   private final long rawCapacityBytes;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDisk.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDisk.java
@@ -24,7 +24,7 @@ import static com.github.ambry.clustermap.ClusterMapSnapshotConstants.*;
 /**
  * {@link DiskId} implementation to use within dynamic cluster managers.
  */
-class AmbryDisk implements DiskId, Resource {
+public class AmbryDisk implements DiskId, Resource {
   private final AmbryDataNode datanode;
   private final String mountPath;
   private final long rawCapacityBytes;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplica.java
@@ -25,7 +25,7 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
 /**
  * {@link ReplicaId} implementation to use within dynamic cluster managers.
  */
-abstract class AmbryReplica implements ReplicaId {
+public abstract class AmbryReplica implements ReplicaId {
   private final AmbryPartition partition;
   private final long capacityBytes;
   private volatile boolean isSealed;
@@ -40,7 +40,7 @@ abstract class AmbryReplica implements ReplicaId {
    * @param capacityBytes the capacity in bytes for this replica.
    * @param isSealed whether this replica is in sealed state.
    */
-  AmbryReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, boolean isReplicaStopped,
+  public AmbryReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, boolean isReplicaStopped,
       long capacityBytes, boolean isSealed) throws Exception {
     this.partition = Objects.requireNonNull(partition, "null partition");
     this.capacityBytes = capacityBytes;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryReplica.java
@@ -40,7 +40,7 @@ public abstract class AmbryReplica implements ReplicaId {
    * @param capacityBytes the capacity in bytes for this replica.
    * @param isSealed whether this replica is in sealed state.
    */
-  public AmbryReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, boolean isReplicaStopped,
+  AmbryReplica(ClusterMapConfig clusterMapConfig, AmbryPartition partition, boolean isReplicaStopped,
       long capacityBytes, boolean isSealed) throws Exception {
     this.partition = Objects.requireNonNull(partition, "null partition");
     this.capacityBytes = capacityBytes;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -207,7 +207,7 @@ public class ClusterMapUtils {
    * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
    * @return the list of disabled replicas.
    */
-  static List<String> getDisabledReplicas(InstanceConfig instanceConfig) {
+  public static List<String> getDisabledReplicas(InstanceConfig instanceConfig) {
     List<String> disabledReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.DISABLED_REPLICAS_STR);
     return disabledReplicas == null ? new ArrayList<>() : disabledReplicas;
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -32,6 +32,8 @@ import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -70,6 +72,7 @@ public class ClusterMapUtils {
   static final String RACKID_STR = "rackId";
   static final String SEALED_STR = "SEALED";
   static final String STOPPED_REPLICAS_STR = "STOPPED";
+  static final String DISABLED_REPLICAS_STR = "DISABLED";
   static final String AVAILABLE_STR = "AVAILABLE";
   static final String READ_ONLY_STR = "RO";
   static final String READ_WRITE_STR = "RW";
@@ -199,6 +202,17 @@ public class ClusterMapUtils {
   }
 
   /**
+   * Get the list of disabled replicas on a given instance. This is guaranteed to return a non-null list. It would return
+   * an empty list if there are no disabled replicas or if the field itself is absent for this instance.
+   * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
+   * @return the list of disabled replicas.
+   */
+  static List<String> getDisabledReplicas(InstanceConfig instanceConfig) {
+    List<String> disabledReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.DISABLED_REPLICAS_STR);
+    return disabledReplicas == null ? new ArrayList<>() : disabledReplicas;
+  }
+
+  /**
    * Get the rack id associated with the given instance (if any).
    * @param instanceConfig the {@link InstanceConfig} associated with the interested instance.
    * @return the rack id associated with the given instance.
@@ -245,6 +259,25 @@ public class ClusterMapUtils {
   static long getXid(InstanceConfig instanceConfig) {
     String xid = instanceConfig.getRecord().getSimpleField(XID_STR);
     return xid == null ? DEFAULT_XID : Long.parseLong(xid);
+  }
+
+  /**
+   * Get resource name associated with given partition.
+   * @param helixAdmin the {@link HelixAdmin} to access resources in cluster
+   * @param clusterName the name of cluster in which the partition resides
+   * @param partitionName name of partition
+   * @return resource name associated with given partition. {@code null} if not found.
+   */
+  static String getResourceNameOfPartition(HelixAdmin helixAdmin, String clusterName, String partitionName) {
+    String result = null;
+    for (String resourceName : helixAdmin.getResourcesInCluster(clusterName)) {
+      IdealState idealState = helixAdmin.getResourceIdealState(clusterName, resourceName);
+      if (idealState.getPartitionSet().contains(partitionName)) {
+        result = resourceName;
+        break;
+      }
+    }
+    return result;
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -1217,25 +1217,6 @@ public class HelixBootstrapUpgradeUtil {
   }
 
   /**
-   * Get resource name associated with given partition.
-   * @param helixAdmin the {@link HelixAdmin} to access resources in cluster
-   * @param clusterName the name of cluster in which the partition resides
-   * @param partitionName name of partition
-   * @return resource name associated with given partition. {@code null} if not found.
-   */
-  static String getResourceNameOfPartition(HelixAdmin helixAdmin, String clusterName, String partitionName) {
-    String result = null;
-    for (String resourceName : helixAdmin.getResourcesInCluster(clusterName)) {
-      IdealState idealState = helixAdmin.getResourceIdealState(clusterName, resourceName);
-      if (idealState.getPartitionSet().contains(partitionName)) {
-        result = resourceName;
-        break;
-      }
-    }
-    return result;
-  }
-
-  /**
    * Validate that the information in Helix is consistent with the information in the static clustermap; and close
    * all the admin connections to ZK hosts.
    */

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -79,8 +79,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     participantMetrics =
         new HelixParticipantMetrics(metricRegistry, isSoleParticipant ? null : zkConnectStr, localPartitionAndState);
     clusterName = clusterMapConfig.clusterMapClusterName;
-    instanceName =
-        ClusterMapUtils.getInstanceName(clusterMapConfig.clusterMapHostName, clusterMapConfig.clusterMapPort);
+    instanceName = getInstanceName(clusterMapConfig.clusterMapHostName, clusterMapConfig.clusterMapPort);
     if (clusterName.isEmpty()) {
       throw new IllegalStateException("Cluster name is empty in clusterMapConfig");
     }
@@ -289,21 +288,21 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   private boolean addNewReplicaInfo(ReplicaId replicaId, InstanceConfig instanceConfig) {
     boolean additionResult = true;
     String partitionName = replicaId.getPartitionId().toPathString();
-    String newReplicaInfo = String.join(ClusterMapUtils.REPLICAS_STR_SEPARATOR, partitionName,
-        String.valueOf(replicaId.getCapacityInBytes()), replicaId.getPartitionId().getPartitionClass())
-        + ClusterMapUtils.REPLICAS_DELIM_STR;
+    String newReplicaInfo =
+        String.join(REPLICAS_STR_SEPARATOR, partitionName, String.valueOf(replicaId.getCapacityInBytes()),
+            replicaId.getPartitionId().getPartitionClass()) + REPLICAS_DELIM_STR;
     Map<String, Map<String, String>> mountPathToDiskInfos = instanceConfig.getRecord().getMapFields();
     Map<String, String> diskInfo = mountPathToDiskInfos.get(replicaId.getMountPath());
     boolean newReplicaInfoAdded = false;
     boolean duplicateFound = false;
     if (diskInfo != null) {
       // add replica to an existing disk (need to sort replicas by partition id)
-      String replicasStr = diskInfo.get(ClusterMapUtils.REPLICAS_STR);
-      String[] replicaInfos = replicasStr.split(ClusterMapUtils.REPLICAS_DELIM_STR);
+      String replicasStr = diskInfo.get(REPLICAS_STR);
+      String[] replicaInfos = replicasStr.split(REPLICAS_DELIM_STR);
       StringBuilder replicasStrBuilder = new StringBuilder();
       long idToAdd = Long.parseLong(partitionName);
       for (String replicaInfo : replicaInfos) {
-        String[] infos = replicaInfo.split(ClusterMapUtils.REPLICAS_STR_SEPARATOR);
+        String[] infos = replicaInfo.split(REPLICAS_STR_SEPARATOR);
         long currentId = Long.parseLong(infos[0]);
         if (currentId == idToAdd) {
           logger.info("Partition {} is already on instance {}, skipping adding it into InstanceConfig in Helix.",
@@ -311,11 +310,11 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
           duplicateFound = true;
           break;
         } else if (currentId < idToAdd || newReplicaInfoAdded) {
-          replicasStrBuilder.append(replicaInfo).append(ClusterMapUtils.REPLICAS_DELIM_STR);
+          replicasStrBuilder.append(replicaInfo).append(REPLICAS_DELIM_STR);
         } else {
           // newReplicaInfo already contains delimiter, no need to append REPLICAS_DELIM_STR
           replicasStrBuilder.append(newReplicaInfo);
-          replicasStrBuilder.append(replicaInfo).append(ClusterMapUtils.REPLICAS_DELIM_STR);
+          replicasStrBuilder.append(replicaInfo).append(REPLICAS_DELIM_STR);
           newReplicaInfoAdded = true;
         }
       }
@@ -325,7 +324,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         newReplicaInfoAdded = true;
       }
       if (newReplicaInfoAdded) {
-        diskInfo.put(ClusterMapUtils.REPLICAS_STR, replicasStrBuilder.toString());
+        diskInfo.put(REPLICAS_STR, replicasStrBuilder.toString());
         mountPathToDiskInfos.put(replicaId.getMountPath(), diskInfo);
       }
     } else {
@@ -333,10 +332,9 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       logger.info("Adding info of new replica {} to the new disk {}", replicaId.getPartitionId().toPathString(),
           replicaId.getDiskId());
       Map<String, String> diskInfoToAdd = new HashMap<>();
-      diskInfoToAdd.put(ClusterMapUtils.DISK_CAPACITY_STR,
-          Long.toString(replicaId.getDiskId().getRawCapacityInBytes()));
-      diskInfoToAdd.put(ClusterMapUtils.DISK_STATE, ClusterMapUtils.AVAILABLE_STR);
-      diskInfoToAdd.put(ClusterMapUtils.REPLICAS_STR, newReplicaInfo);
+      diskInfoToAdd.put(DISK_CAPACITY_STR, Long.toString(replicaId.getDiskId().getRawCapacityInBytes()));
+      diskInfoToAdd.put(DISK_STATE, AVAILABLE_STR);
+      diskInfoToAdd.put(REPLICAS_STR, newReplicaInfo);
       mountPathToDiskInfos.put(replicaId.getMountPath(), diskInfoToAdd);
       newReplicaInfoAdded = true;
     }
@@ -360,26 +358,24 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     boolean instanceConfigUpdated = false;
     boolean replicaFound;
     String partitionName = replicaId.getPartitionId().toPathString();
-    List<String> stoppedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.STOPPED_REPLICAS_STR);
-    List<String> sealedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
+    List<String> stoppedReplicas = instanceConfig.getRecord().getListField(STOPPED_REPLICAS_STR);
+    List<String> sealedReplicas = instanceConfig.getRecord().getListField(SEALED_STR);
     stoppedReplicas = stoppedReplicas == null ? new ArrayList<>() : stoppedReplicas;
     sealedReplicas = sealedReplicas == null ? new ArrayList<>() : sealedReplicas;
     if (stoppedReplicas.remove(partitionName) || sealedReplicas.remove(partitionName)) {
       logger.info("Removing partition {} from stopped and sealed list", partitionName);
-      instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, stoppedReplicas);
-      instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, sealedReplicas);
+      instanceConfig.getRecord().setListField(STOPPED_REPLICAS_STR, stoppedReplicas);
+      instanceConfig.getRecord().setListField(SEALED_STR, sealedReplicas);
       instanceConfigUpdated = true;
     }
     Map<String, Map<String, String>> mountPathToDiskInfos = instanceConfig.getRecord().getMapFields();
     Map<String, String> diskInfo = mountPathToDiskInfos.get(replicaId.getMountPath());
     if (diskInfo != null) {
-      String replicasStr = diskInfo.get(ClusterMapUtils.REPLICAS_STR);
+      String replicasStr = diskInfo.get(REPLICAS_STR);
       if (!replicasStr.isEmpty()) {
-        List<String> replicaInfos =
-            new ArrayList<>(Arrays.asList(replicasStr.split(ClusterMapUtils.REPLICAS_DELIM_STR)));
+        List<String> replicaInfos = new ArrayList<>(Arrays.asList(replicasStr.split(REPLICAS_DELIM_STR)));
         // if any element is removed, that means old replica is found in replicasStr.
-        replicaFound = replicaInfos.removeIf(
-            info -> (info.split(ClusterMapUtils.REPLICAS_STR_SEPARATOR)[0]).equals(partitionName));
+        replicaFound = replicaInfos.removeIf(info -> (info.split(REPLICAS_STR_SEPARATOR)[0]).equals(partitionName));
 
         // We update InstanceConfig only when replica is found in current instanceConfig. (This is to avoid unnecessary
         // notification traffic due to InstanceConfig change)
@@ -387,10 +383,10 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
           StringBuilder newReplicasStrBuilder = new StringBuilder();
           // note that old replica info has been removed from "replicaInfos"
           for (String replicaInfo : replicaInfos) {
-            newReplicasStrBuilder.append(replicaInfo).append(ClusterMapUtils.REPLICAS_DELIM_STR);
+            newReplicasStrBuilder.append(replicaInfo).append(REPLICAS_DELIM_STR);
           }
           // update diskInfo and MountPathToDisk map
-          diskInfo.put(ClusterMapUtils.REPLICAS_STR, newReplicasStrBuilder.toString());
+          diskInfo.put(REPLICAS_STR, newReplicasStrBuilder.toString());
           mountPathToDiskInfos.put(replicaId.getMountPath(), diskInfo);
           // update InstanceConfig
           instanceConfig.getRecord().setMapFields(mountPathToDiskInfos);
@@ -457,7 +453,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   private boolean setSealedReplicas(List<String> sealedReplicas) {
     InstanceConfig instanceConfig = getInstanceConfig();
     logger.trace("Setting InstanceConfig with list of sealed replicas: {}", sealedReplicas.toArray());
-    instanceConfig.getRecord().setListField(ClusterMapUtils.SEALED_STR, sealedReplicas);
+    instanceConfig.getRecord().setListField(SEALED_STR, sealedReplicas);
     return helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
   }
 
@@ -470,7 +466,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   boolean setStoppedReplicas(List<String> stoppedReplicas) {
     InstanceConfig instanceConfig = getInstanceConfig();
     logger.trace("Setting InstanceConfig with list of stopped replicas: {}", stoppedReplicas.toArray());
-    instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, stoppedReplicas);
+    instanceConfig.getRecord().setListField(STOPPED_REPLICAS_STR, stoppedReplicas);
     return helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
   }
 
@@ -483,7 +479,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   boolean setDisabledReplicas(List<String> disabledReplicas) {
     InstanceConfig instanceConfig = getInstanceConfig();
     logger.info("Setting InstanceConfig with list of disabled replicas: {}", disabledReplicas.toArray());
-    instanceConfig.getRecord().setListField(ClusterMapUtils.STOPPED_REPLICAS_STR, disabledReplicas);
+    instanceConfig.getRecord().setListField(DISABLED_REPLICAS_STR, disabledReplicas);
     return helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -32,6 +32,7 @@ public class MockHelixParticipant extends HelixParticipant {
   public static MetricRegistry metricRegistry = new MetricRegistry();
   public Boolean updateNodeInfoReturnVal = null;
   public PartitionStateChangeListener mockStatsManagerListener = null;
+  public boolean overrideDisableReplicaMethod = true;
   CountDownLatch listenerLatch = null;
   ReplicaState replicaState = ReplicaState.OFFLINE;
   ReplicaId currentReplica = null;
@@ -115,10 +116,14 @@ public class MockHelixParticipant extends HelixParticipant {
 
   @Override
   public void setReplicaDisabledState(ReplicaId replicaId, boolean disable) {
-    if (disable) {
-      disabledReplicas.add(replicaId);
+    if (overrideDisableReplicaMethod) {
+      if (disable) {
+        disabledReplicas.add(replicaId);
+      } else {
+        disabledReplicas.remove(replicaId);
+      }
     } else {
-      disabledReplicas.remove(replicaId);
+      super.setReplicaDisabledState(replicaId, disable);
     }
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -43,9 +43,7 @@ public class MockHelixParticipant extends HelixParticipant {
   private PartitionStateChangeListener mockReplicationManagerListener;
 
   public MockHelixParticipant(ClusterMapConfig clusterMapConfig) {
-    super(clusterMapConfig, new MockHelixManagerFactory(), metricRegistry,
-        parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings).get(
-            clusterMapConfig.clusterMapDatacenterName).getZkConnectStrs().get(0), true);
+    this(clusterMapConfig, new MockHelixManagerFactory());
     // create mock state change listener for ReplicationManager
     mockReplicationManagerListener = Mockito.mock(PartitionStateChangeListener.class);
     // mock Bootstrap-To-Standby change

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -24,8 +24,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import org.mockito.Mockito;
 
-import static org.mockito.Mockito.*;
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
+import static org.mockito.Mockito.*;
 
 
 public class MockHelixParticipant extends HelixParticipant {
@@ -38,6 +38,7 @@ public class MockHelixParticipant extends HelixParticipant {
   ReplicaSyncUpManager replicaSyncUpService = null;
   private Set<ReplicaId> sealedReplicas = new HashSet<>();
   private Set<ReplicaId> stoppedReplicas = new HashSet<>();
+  private Set<ReplicaId> disabledReplicas = new HashSet<>();
   private PartitionStateChangeListener mockReplicationManagerListener;
 
   public MockHelixParticipant(ClusterMapConfig clusterMapConfig) {
@@ -81,6 +82,12 @@ public class MockHelixParticipant extends HelixParticipant {
     }).when(mockReplicationManagerListener).onPartitionBecomeOfflineFromInactive(any(String.class));
   }
 
+  public MockHelixParticipant(ClusterMapConfig clusterMapConfig, HelixFactory helixFactory) {
+    super(clusterMapConfig, helixFactory, metricRegistry,
+        parseDcJsonAndPopulateDcInfo(clusterMapConfig.clusterMapDcsZkConnectStrings).get(
+            clusterMapConfig.clusterMapDatacenterName).getZkConnectStrs().get(0), true);
+  }
+
   @Override
   public void participate(List<AmbryHealthReport> ambryHealthReports) throws IOException {
     // no op
@@ -104,6 +111,15 @@ public class MockHelixParticipant extends HelixParticipant {
       stoppedReplicas.removeAll(replicaIds);
     }
     return true;
+  }
+
+  @Override
+  public void setReplicaDisabledState(ReplicaId replicaId, boolean disable) {
+    if (disable) {
+      disabledReplicas.add(replicaId);
+    } else {
+      disabledReplicas.remove(replicaId);
+    }
   }
 
   @Override

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -413,6 +413,7 @@ public class ReplicationManager extends ReplicationEngine {
 
     @Override
     public void onPartitionBecomeInactiveFromStandby(String partitionName) {
+      // if code arrives here, we don't need to check if replica exists, it has been checked in StorageManager
       ReplicaId localReplica = storeManager.getReplica(partitionName);
       Store store = storeManager.getStore(localReplica.getPartitionId());
       // 1. check if store is started
@@ -425,6 +426,8 @@ public class ReplicationManager extends ReplicationEngine {
 
     @Override
     public void onPartitionBecomeOfflineFromInactive(String partitionName) {
+      // we have to check existence of local replica because replication manager is invoked first in INACTIVE -> OFFLINE
+      // transition and we cannot guarantee there is no change after STANDBY -> INACTIVE is complete
       ReplicaId localReplica = storeManager.getReplica(partitionName);
       // check if local replica exists
       if (localReplica == null) {

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -180,7 +180,7 @@ class InMemoryStore implements Store {
   }
 
   @Override
-  public void start() throws StoreException {
+  public void start() {
     started = true;
   }
 
@@ -328,8 +328,7 @@ class InMemoryStore implements Store {
     MessageInfo latestInfo = deleteInfo;
     if (info.getLifeVersion() == MessageInfo.LIFE_VERSION_FROM_FRONTEND) {
       if (deleteInfo == null) {
-        throw new StoreException(
-            "Id " + key + " requires first value to be a put and last value to be a delete",
+        throw new StoreException("Id " + key + " requires first value to be a put and last value to be a delete",
             StoreErrorCodes.ID_Not_Deleted);
       }
       lifeVersion = (short) (deleteInfo.getLifeVersion() + 1);
@@ -453,7 +452,7 @@ class InMemoryStore implements Store {
   }
 
   @Override
-  public long getEndPositionOfLastPut() throws StoreException {
+  public long getEndPositionOfLastPut() {
     throw new UnsupportedOperationException("Method not supported");
   }
 
@@ -463,7 +462,12 @@ class InMemoryStore implements Store {
   }
 
   @Override
-  public void shutdown() throws StoreException {
+  public boolean disabledOnError() {
+    throw new UnsupportedOperationException("Method not supported");
+  }
+
+  @Override
+  public void shutdown() {
     started = false;
   }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -174,10 +174,9 @@ public class ReplicationTest {
 
   /**
    * Tests replication model is correctly obtained from properties
-   * @throws Exception
    */
   @Test
-  public void replicationTypeFromConfigTest() throws Exception {
+  public void replicationTypeFromConfigTest() {
     //When replication config is missing, replicationModelType should be defaulted to ALL_TO_ALL
     assertEquals("Replication model mismatch from the value present in config", replicationConfig.replicationModelType,
         ReplicationModelType.ALL_TO_ALL);

--- a/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/MockStorageManager.java
@@ -285,12 +285,17 @@ class MockStorageManager extends StorageManager {
     }
 
     @Override
-    public long getEndPositionOfLastPut() throws StoreException {
+    public long getEndPositionOfLastPut() {
       throw new UnsupportedOperationException("Method not supported");
     }
 
     @Override
     public boolean recoverFromDecommission() {
+      throw new UnsupportedOperationException("Method not supported");
+    }
+
+    @Override
+    public boolean disabledOnError() {
       throw new UnsupportedOperationException("Method not supported");
     }
 

--- a/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
+++ b/ambry-server/src/test/java/com/github/ambry/server/StatsManagerTest.java
@@ -787,6 +787,11 @@ public class StatsManagerTest {
     }
 
     @Override
+    public boolean disabledOnError() {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
     public void shutdown() throws StoreException {
       throw new IllegalStateException("Not implemented");
     }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -1129,9 +1129,10 @@ public class BlobStore implements Store {
   /**
    * Exposed for testing.
    * Set disabledOnError boolean value in this class.
+   * @param disabledOnErrorVal the value set to disabledOnError
    */
-  void setDisabledOnError(AtomicBoolean disabledOnError) {
-    this.disabledOnError = disabledOnError;
+  void setDisabledOnError(boolean disabledOnErrorVal) {
+    disabledOnError.set(disabledOnErrorVal);
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -93,7 +93,7 @@ public class BlobStore implements Store {
   private volatile boolean recoverFromDecommission;
   // TODO remove this once ZK migration is complete
   private AtomicBoolean isSealed = new AtomicBoolean(false);
-  private AtomicBoolean disabledOnError = new AtomicBoolean(false);
+  private final AtomicBoolean disabledOnError = new AtomicBoolean(false);
   protected PersistentIndex index;
   // THIS IS ONLY FOR TEST.
   protected Runnable operationBeforeSynchronizationFunc = null;

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -93,7 +93,7 @@ public class BlobStore implements Store {
   private volatile boolean recoverFromDecommission;
   // TODO remove this once ZK migration is complete
   private AtomicBoolean isSealed = new AtomicBoolean(false);
-  private final AtomicBoolean disabledOnError = new AtomicBoolean(false);
+  private AtomicBoolean disabledOnError = new AtomicBoolean(false);
   protected PersistentIndex index;
   // THIS IS ONLY FOR TEST.
   protected Runnable operationBeforeSynchronizationFunc = null;
@@ -1128,10 +1128,10 @@ public class BlobStore implements Store {
 
   /**
    * Exposed for testing.
-   * @return a boolean value that indicates whether current store is disabled due to I/O error.
+   * Set disabledOnError boolean value in this class.
    */
-  AtomicBoolean getDisabledOnError() {
-    return disabledOnError;
+  void setDisabledOnError(AtomicBoolean disabledOnError) {
+    this.disabledOnError = disabledOnError;
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -521,36 +521,35 @@ public class StorageManager implements StoreManager {
           // if store is disabled due to disk I/O error, we explicitly throw an exception to mark partition as ERROR state
           throw new StateTransitionException("Store " + partitionName + " is disabled due to I/O error",
               ReplicaOperationFailure);
+        }
+        // 0. as long as local replica exists, we create a decommission file in its dir
+        File decommissionFile = new File(replica.getReplicaPath(), BlobStore.DECOMMISSION_FILE_NAME);
+        try {
+          if (!decommissionFile.exists()) {
+            // if not present, create one.
+            decommissionFile.createNewFile();
+            logger.info("Decommission file is created for replica {}", replica.getReplicaPath());
+          }
+        } catch (IOException e) {
+          logger.error("IOException occurs when creating decommission file for replica " + partitionName, e);
+          throw new StateTransitionException(
+              "Couldn't create decommission file for replica " + replica.getReplicaPath(), ReplicaOperationFailure);
+        }
+        if (localStore.isStarted()) {
+          // 1. set state to INACTIVE
+          localStore.setCurrentState(ReplicaState.INACTIVE);
+          logger.info("Store {} is set to INACTIVE", partitionName);
+          // 2. disable compaction on this store
+          if (!controlCompactionForBlobStore(replica.getPartitionId(), false)) {
+            logger.error("Failed to disable compaction on store {}", partitionName);
+            // we set error code to ReplicaNotFound because that is the only reason why compaction may fail.
+            throw new StateTransitionException("Couldn't disable compaction on replica " + replica.getReplicaPath(),
+                ReplicaNotFound);
+          }
+          logger.info("Compaction is successfully disabled on store {}", partitionName);
         } else {
-          // 0. as long as local replica exists, we create a decommission file in its dir
-          File decommissionFile = new File(replica.getReplicaPath(), BlobStore.DECOMMISSION_FILE_NAME);
-          try {
-            if (!decommissionFile.exists()) {
-              // if not present, create one.
-              decommissionFile.createNewFile();
-              logger.info("Decommission file is created for replica {}", replica.getReplicaPath());
-            }
-          } catch (IOException e) {
-            logger.error("IOException occurs when creating decommission file for replica " + partitionName, e);
-            throw new StateTransitionException(
-                "Couldn't create decommission file for replica " + replica.getReplicaPath(), ReplicaOperationFailure);
-          }
-          if (localStore.isStarted()) {
-            // 1. set state to INACTIVE
-            localStore.setCurrentState(ReplicaState.INACTIVE);
-            logger.info("Store {} is set to INACTIVE", partitionName);
-            // 2. disable compaction on this store
-            if (!controlCompactionForBlobStore(replica.getPartitionId(), false)) {
-              logger.error("Failed to disable compaction on store {}", partitionName);
-              // we set error code to ReplicaNotFound because that is the only reason why compaction may fail.
-              throw new StateTransitionException("Couldn't disable compaction on replica " + replica.getReplicaPath(),
-                  ReplicaNotFound);
-            }
-            logger.info("Compaction is successfully disabled on store {}", partitionName);
-          } else {
-            // this may happen when the disk holding this store crashes (or store is stopped by server admin tool)
-            throw new StateTransitionException("Store " + partitionName + " is not started", StoreNotStarted);
-          }
+          // this may happen when the disk holding this store crashes (or store is stopped by server admin tool)
+          throw new StateTransitionException("Store " + partitionName + " is not started", StoreNotStarted);
         }
       } else {
         throw new StateTransitionException("Replica " + partitionName + " is not found on current node",

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -72,6 +72,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.TestUtils.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
@@ -1886,11 +1887,14 @@ public class BlobStoreTest {
     }
     assertEquals("Disabled partition name is not expected", storeId,
         instanceConfig.getDisabledPartitions(RESOURCE_NAME).get(0));
+    // verify "DISABLED" list in InstanceConfig has correct partition id.
+    assertEquals("Disabled replica list is not expected", Collections.singletonList(storeId),
+        getDisabledReplicas(instanceConfig));
     // 3. mock disk is replaced case, restart should succeed
     testStore.start();
-    List<String> disabledPartitions = instanceConfig.getDisabledPartitions(RESOURCE_NAME);
     assertNull("Disabled partition list should be null as restart will enable same replica",
         instanceConfig.getDisabledPartitions(RESOURCE_NAME));
+    assertTrue("Disabled replica list should be empty", getDisabledReplicas(instanceConfig).isEmpty());
     testStore.shutdown();
     reloadStore();
   }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -15,7 +15,6 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.InMemAccountService;
-import com.github.ambry.clustermap.ClusterParticipant;
 import com.github.ambry.clustermap.HelixFactory;
 import com.github.ambry.clustermap.MockHelixParticipant;
 import com.github.ambry.clustermap.ReplicaId;
@@ -364,6 +363,7 @@ public class BlobStoreTest {
       storeStatsScheduler = Utils.newScheduler(1, false);
       setupTestState(false, false);
     }
+    properties.setProperty("store.set.local.partition.state.enabled", Boolean.toString(true));
     //Setup threshold test properties, replicaId, mock write status delegate
     StoreConfig defaultConfig = changeThreshold(65, 5, true);
     StoreTestUtils.MockReplicaId replicaId = getMockReplicaId(tempDirStr);
@@ -429,6 +429,7 @@ public class BlobStoreTest {
       verify(replicaStatusDelegate, times(3)).unseal(replicaId);
     }
     store.shutdown();
+    properties.setProperty("store.set.local.partition.state.enabled", Boolean.toString(false));
   }
 
   /**
@@ -1828,6 +1829,7 @@ public class BlobStoreTest {
     properties.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
     properties.setProperty("store.io.error.count.to.trigger.shutdown", "1");
     properties.setProperty("store.replica.status.delegate.enable", "true");
+    properties.setProperty("store.set.local.partition.state.enabled", "true");
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(properties));
     InstanceConfig instanceConfig = new InstanceConfig("localhost");
     Map<String, List<String>> listMap = new HashMap<>();

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -15,6 +15,7 @@ package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.account.InMemAccountService;
+import com.github.ambry.clustermap.AmbryReplica;
 import com.github.ambry.clustermap.HelixFactory;
 import com.github.ambry.clustermap.MockHelixParticipant;
 import com.github.ambry.clustermap.ReplicaId;
@@ -3084,9 +3085,8 @@ public class BlobStoreTest {
     return StoreTestUtils.createMockReplicaId(storeId, LOG_CAPACITY, filePath);
   }
 
-  private StoreTestUtils.MockAmbryReplica getMockAmbryReplica(ClusterMapConfig clusterMapConfig, String filePath)
-      throws Exception {
-    return StoreTestUtils.createMockAmbryReplica(clusterMapConfig, storeId, 1024 * 1024 * 1024L, filePath);
+  private AmbryReplica getMockAmbryReplica(ClusterMapConfig clusterMapConfig, String filePath) {
+    return StoreTestUtils.createMockAmbryReplica(storeId, 1024 * 1024 * 1024L, filePath, false);
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -1845,7 +1845,8 @@ public class BlobStoreTest {
     when(mockHelixFactory.getZKHelixManager(anyString(), anyString(), any(), anyString())).thenReturn(null);
     when(mockHelixFactory.getHelixAdmin(anyString())).thenReturn(mockHelixAdmin);
     MockHelixParticipant.metricRegistry = new MetricRegistry();
-    ClusterParticipant mockParticipant = new MockHelixParticipant(clusterMapConfig, mockHelixFactory);
+    MockHelixParticipant mockParticipant = new MockHelixParticipant(clusterMapConfig, mockHelixFactory);
+    mockParticipant.overrideDisableReplicaMethod = false;
     ReplicaStatusDelegate replicaStatusDelegate = new ReplicaStatusDelegate(mockParticipant);
     BlobStore testStore = createBlobStore(getMockAmbryReplica(clusterMapConfig, tempDirStr),
         new StoreConfig(new VerifiableProperties(properties)), Collections.singletonList(replicaStatusDelegate));

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -367,7 +367,7 @@ public class StorageManagerTest {
       assertEquals("Error code doesn't match", ReplicaOperationFailure, e.getErrorCode());
     }
     localStore.getDisabledOnError().set(false);
-    // 4. success case (verify both replica's state and decommission file)
+    // 5. success case (verify both replica's state and decommission file)
     mockHelixParticipant.onPartitionBecomeInactiveFromStandby(localReplica.getPartitionId().toPathString());
     assertEquals("local store state should be set to INACTIVE", ReplicaState.INACTIVE,
         storageManager.getStore(localReplica.getPartitionId()).getCurrentState());
@@ -375,7 +375,7 @@ public class StorageManagerTest {
     assertTrue("Decommission file is not found in local replica's dir", decommissionFile.exists());
     shutdownAndAssertStoresInaccessible(storageManager, localReplicas);
 
-    // 5. mock disable compaction failure
+    // 6. mock disable compaction failure
     mockHelixParticipant = new MockClusterParticipant();
     MockStorageManager mockStorageManager =
         new MockStorageManager(localNode, Collections.singletonList(mockHelixParticipant));
@@ -1207,6 +1207,7 @@ public class StorageManagerTest {
     properties.put("disk.manager.enable.segment.pooling", "true");
     properties.put("store.compaction.triggers", "Periodic,Admin");
     properties.put("store.replica.status.delegate.enable", "true");
+    properties.put("store.set.local.partition.state.enabled", "true");
     properties.setProperty("clustermap.host.name", "localhost");
     properties.setProperty("clustermap.port", "2200");
     properties.setProperty("clustermap.cluster.name", CLUSTER_NAME);

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -56,7 +56,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.InstanceConfig;
@@ -371,15 +370,14 @@ public class StorageManagerTest {
     storageManager.startBlobStore(localReplica.getPartitionId());
     // 5. store is disabled due to disk I/O error
     BlobStore localStore = (BlobStore) storageManager.getStore(localReplica.getPartitionId());
-    AtomicBoolean mockDisabledOnError = new AtomicBoolean(true);
-    localStore.setDisabledOnError(mockDisabledOnError);
+    localStore.setDisabledOnError(true);
     try {
       mockHelixParticipant.onPartitionBecomeInactiveFromStandby(localReplica.getPartitionId().toPathString());
       fail("should fail because store is disabled");
     } catch (StateTransitionException e) {
       assertEquals("Error code doesn't match", ReplicaOperationFailure, e.getErrorCode());
     }
-    mockDisabledOnError.set(false);
+    localStore.setDisabledOnError(false);
     // 6. success case (verify both replica's state and decommission file)
     mockHelixParticipant.onPartitionBecomeInactiveFromStandby(localReplica.getPartitionId().toPathString());
     assertEquals("local store state should be set to INACTIVE", ReplicaState.INACTIVE,

--- a/ambry-store/src/test/java/com/github/ambry/store/StoreTestUtils.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StoreTestUtils.java
@@ -14,11 +14,16 @@
 package com.github.ambry.store;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.clustermap.AmbryDataNode;
+import com.github.ambry.clustermap.AmbryDisk;
+import com.github.ambry.clustermap.AmbryPartition;
+import com.github.ambry.clustermap.AmbryReplica;
 import com.github.ambry.clustermap.DataNodeId;
 import com.github.ambry.clustermap.DiskId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.clustermap.ReplicaType;
+import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.StoreConfig;
 import com.github.ambry.config.VerifiableProperties;
 import java.io.File;
@@ -54,7 +59,6 @@ class StoreTestUtils {
    * Need mock ReplicaId to get and set isSealed state
    */
   public static class MockReplicaId implements ReplicaId {
-
     private String storeId;
     private long capacity;
     private String filePath;
@@ -140,6 +144,54 @@ class StoreTestUtils {
     }
   }
 
+  public static class MockAmbryReplica extends AmbryReplica {
+    private String filePath;
+
+    MockAmbryReplica(ClusterMapConfig clusterMapConfig, long capacity, String filePath, AmbryPartition partitionId)
+        throws Exception {
+      super(clusterMapConfig, partitionId, false, capacity, false);
+      this.filePath = filePath;
+    }
+
+    @Override
+    public AmbryDataNode getDataNodeId() {
+      return null;
+    }
+
+    @Override
+    public AmbryDisk getDiskId() {
+      return null;
+    }
+
+    @Override
+    public String getMountPath() {
+      return null;
+    }
+
+    @Override
+    public String getReplicaPath() {
+      return filePath;
+    }
+
+    @Override
+    public void markDiskDown() {
+    }
+
+    @Override
+    public void markDiskUp() {
+    }
+
+    @Override
+    public ReplicaType getReplicaType() {
+      return ReplicaType.DISK_BACKED;
+    }
+
+    @Override
+    public JSONObject getSnapshot() {
+      return null;
+    }
+  }
+
   /**
    * Creates a mock replicaId for blob store testing
    * @param storeId partitionId from replicaId.getPartitionId() will toString() to this
@@ -149,6 +201,14 @@ class StoreTestUtils {
    */
   static MockReplicaId createMockReplicaId(String storeId, long capacity, String filePath) {
     return new MockReplicaId(storeId, capacity, filePath);
+  }
+
+  static MockAmbryReplica createMockAmbryReplica(ClusterMapConfig clusterMapConfig, String storeId, long capacity,
+      String filePath) throws Exception {
+    AmbryPartition partitionId = mock(AmbryPartition.class);
+    when(partitionId.toString()).thenReturn(storeId);
+    when(partitionId.toPathString()).thenReturn(storeId);
+    return new MockAmbryReplica(clusterMapConfig, capacity, filePath, partitionId);
   }
 
   /**

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -50,6 +50,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.HelixBootstrapUpgradeUtil.*;
 import static com.github.ambry.clustermap.HelixBootstrapUpgradeUtil.HelixAdminOperation.*;
 import static com.github.ambry.clustermap.TestUtils.*;


### PR DESCRIPTION
This PR allows server to disable partition when store is shut down due to
disk I/O error. Disabling partition will trigger state transition to mark
this partition in ERROR state. This is helpful for leader based replication
to handle runtime disk failure as Helix controller will automatically re-elect
a new leader and unblock cross-dc replication.