### PR TITLE
Fix incorrect offline partition count in HelixParticipant

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
@@ -16,47 +16,65 @@ package com.github.ambry.clustermap;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
  * Metrics for {@link HelixParticipant} to monitor partition state transitions.
  */
 class HelixParticipantMetrics {
-  final AtomicInteger offlineCount = new AtomicInteger();
+  private Map<ReplicaState, Integer> replicaCountByState = new HashMap<>();
+  private final Map<String, ReplicaState> localPartitionAndState;
   // no need to record exact number of "dropped" partition, a counter to track partition-dropped events would suffice
   final Counter partitionDroppedCount;
 
   HelixParticipantMetrics(MetricRegistry metricRegistry, String zkConnectStr,
       Map<String, ReplicaState> localPartitionAndState) {
     String zkSuffix = zkConnectStr == null ? "" : "-" + zkConnectStr;
-    Gauge<Integer> bootstrapPartitionCount =
-        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.BOOTSTRAP);
+    this.localPartitionAndState = localPartitionAndState;
+    EnumSet.complementOf(EnumSet.of(ReplicaState.DROPPED)).forEach(state -> replicaCountByState.put(state, 0));
+    Gauge<Integer> bootstrapPartitionCount = () -> getReplicaCountInState(ReplicaState.BOOTSTRAP);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "bootstrapPartitionCount" + zkSuffix),
         bootstrapPartitionCount);
-    Gauge<Integer> standbyPartitionCount =
-        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.STANDBY);
+    Gauge<Integer> standbyPartitionCount = () -> getReplicaCountInState(ReplicaState.STANDBY);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "standbyPartitionCount" + zkSuffix),
         standbyPartitionCount);
-    Gauge<Integer> leaderPartitionCount =
-        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.LEADER);
+    Gauge<Integer> leaderPartitionCount = () -> getReplicaCountInState(ReplicaState.LEADER);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "leaderPartitionCount" + zkSuffix),
         leaderPartitionCount);
-    Gauge<Integer> inactivePartitionCount =
-        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.INACTIVE);
+    Gauge<Integer> inactivePartitionCount = () -> getReplicaCountInState(ReplicaState.INACTIVE);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "inactivePartitionCount" + zkSuffix),
         inactivePartitionCount);
-    Gauge<Integer> offlinePartitionCount =
-        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.OFFLINE);
+    Gauge<Integer> offlinePartitionCount = () -> getReplicaCountInState(ReplicaState.OFFLINE);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "offlinePartitionCount" + zkSuffix),
         offlinePartitionCount);
-    Gauge<Integer> errorStatePartitionCount =
-        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.ERROR);
+    Gauge<Integer> errorStatePartitionCount = () -> getReplicaCountInState(ReplicaState.ERROR);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "errorStatePartitionCount" + zkSuffix),
         errorStatePartitionCount);
     partitionDroppedCount =
         metricRegistry.counter(MetricRegistry.name(HelixParticipant.class, "partitionDroppedCount" + zkSuffix));
+  }
+
+  /**
+   * Get the number of replicas in given state.
+   * @param state the {@link ReplicaState} associated with local replica.
+   * @return number of replicas in given state
+   */
+  private int getReplicaCountInState(ReplicaState state) {
+    // Scan the whole map only when it's OFFLINE state. Other gauges should be able to read cached result from
+    // replicaCountByState map.
+    if (state == ReplicaState.OFFLINE) {
+      Map<ReplicaState, Integer> replicaStateAndCount = new HashMap<>();
+      EnumSet.complementOf(EnumSet.of(ReplicaState.DROPPED))
+          .forEach(replicaState -> replicaStateAndCount.put(replicaState, 0));
+      for (ReplicaState replicaState : localPartitionAndState.values()) {
+        replicaStateAndCount.put(replicaState, replicaStateAndCount.get(replicaState) + 1);
+      }
+      // reference switch should be atomic
+      replicaCountByState = replicaStateAndCount;
+    }
+    return replicaCountByState.get(state);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipantMetrics.java
@@ -16,6 +16,8 @@ package com.github.ambry.clustermap;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 
@@ -23,48 +25,38 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Metrics for {@link HelixParticipant} to monitor partition state transitions.
  */
 class HelixParticipantMetrics {
-  final AtomicInteger bootstrapCount = new AtomicInteger();
-  final AtomicInteger standbyCount = new AtomicInteger();
-  final AtomicInteger leaderCount = new AtomicInteger();
-  final AtomicInteger inactiveCount = new AtomicInteger();
   final AtomicInteger offlineCount = new AtomicInteger();
-  final AtomicInteger errorStateCount = new AtomicInteger();
   // no need to record exact number of "dropped" partition, a counter to track partition-dropped events would suffice
   final Counter partitionDroppedCount;
 
-  HelixParticipantMetrics(MetricRegistry metricRegistry, String zkConnectStr) {
+  HelixParticipantMetrics(MetricRegistry metricRegistry, String zkConnectStr,
+      Map<String, ReplicaState> localPartitionAndState) {
     String zkSuffix = zkConnectStr == null ? "" : "-" + zkConnectStr;
-    Gauge<Integer> bootstrapPartitionCount = bootstrapCount::get;
+    Gauge<Integer> bootstrapPartitionCount =
+        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.BOOTSTRAP);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "bootstrapPartitionCount" + zkSuffix),
         bootstrapPartitionCount);
-    Gauge<Integer> standbyPartitionCount = standbyCount::get;
+    Gauge<Integer> standbyPartitionCount =
+        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.STANDBY);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "standbyPartitionCount" + zkSuffix),
         standbyPartitionCount);
-    Gauge<Integer> leaderPartitionCount = leaderCount::get;
+    Gauge<Integer> leaderPartitionCount =
+        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.LEADER);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "leaderPartitionCount" + zkSuffix),
         leaderPartitionCount);
-    Gauge<Integer> inactivePartitionCount = inactiveCount::get;
+    Gauge<Integer> inactivePartitionCount =
+        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.INACTIVE);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "inactivePartitionCount" + zkSuffix),
         inactivePartitionCount);
-    Gauge<Integer> offlinePartitionCount = offlineCount::get;
+    Gauge<Integer> offlinePartitionCount =
+        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.OFFLINE);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "offlinePartitionCount" + zkSuffix),
         offlinePartitionCount);
-    Gauge<Integer> errorStatePartitionCount = errorStateCount::get;
+    Gauge<Integer> errorStatePartitionCount =
+        () -> Collections.frequency(localPartitionAndState.values(), ReplicaState.ERROR);
     metricRegistry.register(MetricRegistry.name(HelixParticipant.class, "errorStatePartitionCount" + zkSuffix),
         errorStatePartitionCount);
     partitionDroppedCount =
         metricRegistry.counter(MetricRegistry.name(HelixParticipant.class, "partitionDroppedCount" + zkSuffix));
-  }
-
-  /**
-   * Set number of partitions on current node. This is invoked during startup.
-   * @param partitionCount number of partitions on current node
-   */
-  void setLocalPartitionCount(int partitionCount) {
-    // this method should be invoked before participation, so the initial value is expected to be 0.
-    if (!offlineCount.compareAndSet(0, partitionCount)) {
-      throw new IllegalStateException("Number of OFFLINE partitions has changed to " + offlineCount.get()
-          + " before initializing participant metrics ");
-    }
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
@@ -141,30 +141,38 @@ public class AmbryStateModelFactoryTest {
         getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "offlinePartitionCount"));
     // OFFLINE -> BOOTSTRAP
     stateModel.onBecomeBootstrapFromOffline(mockMessage, null);
-    assertEquals("Bootstrap count should be 1", 1,
-        getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "bootstrapPartitionCount"));
     assertEquals("Offline count should be 0", 0,
         getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "offlinePartitionCount"));
+    assertEquals("Bootstrap count should be 1", 1,
+        getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "bootstrapPartitionCount"));
     // BOOTSTRAP -> STANDBY
     stateModel.onBecomeStandbyFromBootstrap(mockMessage, null);
+    assertEquals("Offline count should be 0", 0,
+        getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "offlinePartitionCount"));
     assertEquals("Standby count should be 1", 1,
         getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "standbyPartitionCount"));
     assertEquals("Bootstrap count should be 0", 0,
         getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "bootstrapPartitionCount"));
     // STANDBY -> LEADER
     stateModel.onBecomeLeaderFromStandby(mockMessage, null);
+    assertEquals("Offline count should be 0", 0,
+        getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "offlinePartitionCount"));
     assertEquals("Leader count should be 1", 1,
         getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "leaderPartitionCount"));
     assertEquals("Standby count should be 0", 0,
         getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "standbyPartitionCount"));
     // LEADER -> STANDBY
     stateModel.onBecomeStandbyFromLeader(mockMessage, null);
+    assertEquals("Offline count should be 0", 0,
+        getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "offlinePartitionCount"));
     assertEquals("Standby count should be 1", 1,
         getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "standbyPartitionCount"));
     assertEquals("Leader count should be 0", 0,
         getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "leaderPartitionCount"));
     // STANDBY -> INACTIVE
     stateModel.onBecomeInactiveFromStandby(mockMessage, null);
+    assertEquals("Offline count should be 0", 0,
+        getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "offlinePartitionCount"));
     assertEquals("Inactive count should be 1", 1,
         getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "inactivePartitionCount"));
     assertEquals("Standby count should be 0", 0,

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/AmbryStateModelFactoryTest.java
@@ -189,7 +189,11 @@ public class AmbryStateModelFactoryTest {
         getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "offlinePartitionCount"));
     // reset method
     stateModel.reset();
-    assertEquals("Offline count should be 1 after reset", 2,
+    assertEquals("Offline count should be 1 after reset", 1,
+        getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "offlinePartitionCount"));
+    // call reset method again to mock the case where same partition is reset multiple times during zk disconnection or shutdown
+    stateModel.reset();
+    assertEquals("Offline count should still be 1 after reset twice", 1,
         getHelixParticipantMetricValue(metricRegistry, HelixParticipant.class.getName(), "offlinePartitionCount"));
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -64,7 +64,7 @@ public class HelixParticipantTest {
         new Object[][]{{ClusterMapConfig.DEFAULT_STATE_MODEL_DEF}, {ClusterMapConfig.AMBRY_STATE_MODEL_DEF}});
   }
 
-  public HelixParticipantTest(String stateModelDef) throws Exception {
+  public HelixParticipantTest(String stateModelDef) {
     List<ZkInfo> zkInfoList = new ArrayList<>();
     zkInfoList.add(new ZkInfo(null, "DC0", (byte) 0, 2199, false));
     zkJson = constructZkLayoutJSON(zkInfoList);

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -414,34 +414,6 @@ public class StorageManagerTest {
   }
 
   /**
-   * Test that initializing participant metrics fails because the initial offline partition count is not zero.
-   * @throws Exception
-   */
-  @Test
-  public void initParticipantMetricsFailureTest() throws Exception {
-    generateConfigs(true, false);
-    MockDataNodeId localNode = clusterMap.getDataNodes().get(0);
-    List<ReplicaId> localReplicas = clusterMap.getReplicaIds(localNode);
-    MockClusterParticipant mockHelixParticipant = new MockClusterParticipant();
-    // create first storage manager and start
-    StorageManager storageManager1 =
-        createStorageManager(localNode, new MetricRegistry(), Collections.singletonList(mockHelixParticipant));
-    storageManager1.start();
-    shutdownAndAssertStoresInaccessible(storageManager1, localReplicas);
-    // create second storage manager with same mock helix participant
-    StorageManager storageManager2 =
-        createStorageManager(localNode, new MetricRegistry(), Collections.singletonList(mockHelixParticipant));
-    try {
-      storageManager2.start();
-      fail("should fail because offline partition count is non-zero before initialization");
-    } catch (IllegalStateException e) {
-      // expected
-    } finally {
-      shutdownAndAssertStoresInaccessible(storageManager2, localReplicas);
-    }
-  }
-
-  /**
    * Test failure cases when updating InstanceConfig in Helix for both Offline-To-Bootstrap and Inactive-To-Offline.
    */
   @Test


### PR DESCRIPTION
Offline partition is currently counted based how many times the reset
method is called. However, Helix may call reset method against same
partition multiple times during zk disconnection or graceful shutdown.
This causes incorrect number of offline partitions and triggers false
alarm. To fix that, this PR keeps track of each local partition and its
state, which also supports tracking added/removed replicas on local node.