### PR TITLE
Leader based replication - data structure updates to cache metadata response

### DIFF
--- a/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
@@ -64,6 +64,9 @@ public class RemoteReplicaInfo {
   private ReplicaThread replicaThread;
 
   // Metadata response information received for this replica in the most recent replication cycle.
+  // This is used during leader based replication to store the missing store messages, remote token info and local lag
+  // from remote for non-leader remote replicas. We will track the missing store messages when they come via intra-dc
+  // replication and update the currentToken to exchangeMetadataResponse.remoteToken after all of them are obtained.
   private ReplicaThread.ExchangeMetadataResponse exchangeMetadataResponse;
 
   public RemoteReplicaInfo(ReplicaId replicaId, ReplicaId localReplicaId, Store localStore, FindToken token,
@@ -218,6 +221,9 @@ public class RemoteReplicaInfo {
    * @param exchangeMetadataResponse contains meta data response (missing keys, token info, local lag from remote, etc.).
    */
   synchronized void setExchangeMetadataResponse(ReplicaThread.ExchangeMetadataResponse exchangeMetadataResponse) {
+    // We are having this thread safe to avoid conflict between replica thread setting new exchangeMetadataResponse
+    // and replica threads updating the missing store messages in current exchangeMetadataResponse after they are
+    // written to local store via intra-dc replication (method will be added in future PR).
     this.exchangeMetadataResponse = exchangeMetadataResponse;
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
@@ -63,8 +63,7 @@ public class RemoteReplicaInfo {
   private long reEnableReplicationTime = 0;
   private ReplicaThread replicaThread;
 
-  // Metadata response information (contains missing blobs, remote token, local lag from remote, etc.) of previous replication cycle.
-  // This is used in LEADER-BASED replication where standby replicas don't send the next metadata request until the missing blobs in previous metadata response are obtained via intra-dc replication.
+  // Metadata response information received for this replica in the most recent replication cycle.
   private ReplicaThread.ExchangeMetadataResponse exchangeMetadataResponse;
 
   public RemoteReplicaInfo(ReplicaId replicaId, ReplicaId localReplicaId, Store localStore, FindToken token,
@@ -77,7 +76,7 @@ public class RemoteReplicaInfo {
     this.port = port;
     this.tokenPersistIntervalInMs = tokenPersistIntervalInMs;
     initializeTokens(token);
-    // Exchange metadata response information is initially empty. It will be populated by replica threads during replication cycles.
+    // ExchangeMetadataResponse is initially empty. It will be populated by replica threads during replication cycles.
     this.exchangeMetadataResponse = new ReplicaThread.ExchangeMetadataResponse(ServerErrorCode.No_Error);
   }
 
@@ -206,18 +205,17 @@ public class RemoteReplicaInfo {
   }
 
   /**
-   * Gets the cached meta data response information received in the previous replication cycle.
-   * Replication manager calls this method to check if there are any missing store messages that are now obtained via intra-dc replication.
-   * @return exchangeMetadataResponse which contains the meta data response information (missing keys, token info, local lag from remote, etc.).
+   * Get the meta data response information received for this replica in the most recent replication cycle.
+   * @return exchangeMetadataResponse contains the meta data response (missing keys, token info, local lag from remote, etc.).
    */
   synchronized ReplicaThread.ExchangeMetadataResponse getExchangeMetadataResponse() {
     return exchangeMetadataResponse;
   }
 
   /**
-   * Stores/caches the meta data response received in the previous replication cycle.
-   * Replica threads calls this method to store the metadata response for standby replicas.
-   * @param exchangeMetadataResponse contains the meta data response information (missing keys, token info, local lag from remote, etc.).
+   * Set the meta data exchange information received for this replica in the most recent replication cycle.
+   * Replica threads calls this method to store the metadata responses during replication cycles.
+   * @param exchangeMetadataResponse contains meta data response (missing keys, token info, local lag from remote, etc.).
    */
   synchronized void setExchangeMetadataResponse(ReplicaThread.ExchangeMetadataResponse exchangeMetadataResponse) {
     this.exchangeMetadataResponse = exchangeMetadataResponse;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
@@ -63,7 +63,7 @@ public class RemoteReplicaInfo {
   private ReplicaThread replicaThread;
 
   // Metadata response information (contains missing blobs, remote token, local lag from remote, etc.) of previous replication cycle.
-  // This is used in LEADER-BASED replication where standby replicas don't send the next metadata request until the missing keys in previous metadata response are obtained via intra-dc replication.
+  // This is used in LEADER-BASED replication where standby replicas don't send the next metadata request until the missing blobs in previous metadata response are obtained via intra-dc replication.
   private ReplicaThread.ExchangeMetadataResponse exchangeMetadataResponse;
 
   public RemoteReplicaInfo(ReplicaId replicaId, ReplicaId localReplicaId, Store localStore, FindToken token,
@@ -205,17 +205,19 @@ public class RemoteReplicaInfo {
 
   /**
    * Gets the cached meta data response information received in the previous replication cycle.
+   * Replication manager calls this method to check if there are any missing store messages that are now obtained via intra-dc replication.
    * @return exchangeMetadataResponse which contains the meta data response information (missing keys, token info, local lag from remote, etc.).
    */
-  public ReplicaThread.ExchangeMetadataResponse getExchangeMetadataResponse() {
+  synchronized ReplicaThread.ExchangeMetadataResponse getExchangeMetadataResponse() {
     return exchangeMetadataResponse;
   }
 
   /**
    * Stores/caches the meta data response received in the previous replication cycle.
+   * Replica threads calls this method to store the metadata response for standby replicas.
    * @param exchangeMetadataResponse contains the meta data response information (missing keys, token info, local lag from remote, etc.).
    */
-  public void setExchangeMetadataResponse(ReplicaThread.ExchangeMetadataResponse exchangeMetadataResponse) {
+  synchronized void setExchangeMetadataResponse(ReplicaThread.ExchangeMetadataResponse exchangeMetadataResponse) {
     this.exchangeMetadataResponse = exchangeMetadataResponse;
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
@@ -62,6 +62,10 @@ public class RemoteReplicaInfo {
   private long reEnableReplicationTime = 0;
   private ReplicaThread replicaThread;
 
+  // Metadata response information (contains missing blobs, remote token, local lag from remote, etc.) of previous replication cycle.
+  // This is used in LEADER-BASED replication where standby replicas don't send the next metadata request until the missing keys in previous metadata response are obtained via intra-dc replication.
+  private ReplicaThread.ExchangeMetadataResponse exchangeMetadataResponse;
+
   public RemoteReplicaInfo(ReplicaId replicaId, ReplicaId localReplicaId, Store localStore, FindToken token,
       long tokenPersistIntervalInMs, Time time, Port port) {
     this.replicaId = replicaId;
@@ -72,6 +76,7 @@ public class RemoteReplicaInfo {
     this.port = port;
     this.tokenPersistIntervalInMs = tokenPersistIntervalInMs;
     initializeTokens(token);
+    this.exchangeMetadataResponse = null;
   }
 
   public ReplicaId getReplicaId() {
@@ -196,6 +201,22 @@ public class RemoteReplicaInfo {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Gets the cached meta data response information received in the previous replication cycle.
+   * @return exchangeMetadataResponse which contains the meta data response information (missing keys, token info, local lag from remote, etc.).
+   */
+  public ReplicaThread.ExchangeMetadataResponse getExchangeMetadataResponse() {
+    return exchangeMetadataResponse;
+  }
+
+  /**
+   * Stores/caches the meta data response received in the previous replication cycle.
+   * @param exchangeMetadataResponse contains the meta data response information (missing keys, token info, local lag from remote, etc.).
+   */
+  public void setExchangeMetadataResponse(ReplicaThread.ExchangeMetadataResponse exchangeMetadataResponse) {
+    this.exchangeMetadataResponse = exchangeMetadataResponse;
   }
 
   /**

--- a/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
@@ -16,6 +16,7 @@ package com.github.ambry.replication;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.network.Port;
+import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.Store;
 import com.github.ambry.utils.Time;
 import java.util.Objects;
@@ -76,8 +77,8 @@ public class RemoteReplicaInfo {
     this.port = port;
     this.tokenPersistIntervalInMs = tokenPersistIntervalInMs;
     initializeTokens(token);
-    // Exchange metadata response information is initially empty. It will be set by replica threads after exchanging metadata during a replication cycle.
-    this.exchangeMetadataResponse = null;
+    // Exchange metadata response information is initially empty. It will be populated by replica threads during replication cycles.
+    this.exchangeMetadataResponse = new ReplicaThread.ExchangeMetadataResponse(ServerErrorCode.No_Error);
   }
 
   public ReplicaId getReplicaId() {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/RemoteReplicaInfo.java
@@ -76,6 +76,7 @@ public class RemoteReplicaInfo {
     this.port = port;
     this.tokenPersistIntervalInMs = tokenPersistIntervalInMs;
     initializeTokens(token);
+    // Exchange metadata response information is initially empty. It will be set by replica threads after exchanging metadata during a replication cycle.
     this.exchangeMetadataResponse = null;
   }
 

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -111,8 +111,8 @@ public class ReplicaThread implements Runnable {
   private final Condition pauseCondition = lock.newCondition();
   private final ReplicaSyncUpManager replicaSyncUpManager;
   private final int maxReplicaCountPerRequest;
-
   private volatile boolean allDisabled = false;
+  private final PartitionLeaderInfo partitionLeaderInfo;
 
   public ReplicaThread(String threadName, FindTokenHelper findTokenHelper, ClusterMap clusterMap,
       AtomicInteger correlationIdGenerator, DataNodeId dataNodeId, ConnectionPool connectionPool,
@@ -120,6 +120,16 @@ public class ReplicaThread implements Runnable {
       StoreKeyConverter storeKeyConverter, Transformer transformer, MetricRegistry metricRegistry,
       boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler, Time time,
       ReplicaSyncUpManager replicaSyncUpManager) {
+    this(threadName, findTokenHelper, clusterMap, correlationIdGenerator, dataNodeId, connectionPool, replicationConfig,
+        replicationMetrics, notification, storeKeyConverter, transformer, metricRegistry, replicatingOverSsl,
+        datacenterName, responseHandler, time, replicaSyncUpManager, null);
+  }
+
+  public ReplicaThread(String threadName, FindTokenHelper findTokenHelper, ClusterMap clusterMap, AtomicInteger correlationIdGenerator,
+      DataNodeId dataNodeId, ConnectionPool connectionPool, ReplicationConfig replicationConfig, ReplicationMetrics replicationMetrics, NotificationSystem notification,
+      StoreKeyConverter storeKeyConverter, Transformer transformer, MetricRegistry metricRegistry, boolean replicatingOverSsl, String datacenterName,
+      ResponseHandler responseHandler, Time time, ReplicaSyncUpManager replicaSyncUpManager,
+      PartitionLeaderInfo partitionLeaderInfo) {
     this.threadName = threadName;
     this.running = true;
     this.findTokenHelper = findTokenHelper;
@@ -151,6 +161,7 @@ public class ReplicaThread implements Runnable {
       throttleCount = replicationMetrics.intraColoReplicaThreadThrottleCount;
     }
     this.maxReplicaCountPerRequest = replicationConfig.replicationMaxPartitionCountPerRequest;
+    this.partitionLeaderInfo = partitionLeaderInfo;
   }
 
   /**
@@ -453,12 +464,12 @@ public class ReplicaThread implements Runnable {
               logger.trace("Remote node: {} Thread name: {} Remote replica: {} Token from remote: {} Replica lag: {} ",
                   remoteNode, threadName, remoteReplicaInfo.getReplicaId(), replicaMetadataResponseInfo.getFindToken(),
                   replicaMetadataResponseInfo.getRemoteReplicaLagInBytes());
-              Set<StoreKey> remoteMissingStoreKeys =
-                  getMissingStoreKeys(replicaMetadataResponseInfo, remoteNode, remoteReplicaInfo);
-              processReplicaMetadataResponse(remoteMissingStoreKeys, replicaMetadataResponseInfo, remoteReplicaInfo,
+              Set<MessageInfo> remoteMissingStoreMessages =
+                  getMissingStoreMessages(replicaMetadataResponseInfo, remoteNode, remoteReplicaInfo);
+              processReplicaMetadataResponse(remoteMissingStoreMessages, replicaMetadataResponseInfo, remoteReplicaInfo,
                   remoteNode, remoteKeyToLocalKeyMap);
               ExchangeMetadataResponse exchangeMetadataResponse =
-                  new ExchangeMetadataResponse(remoteMissingStoreKeys, replicaMetadataResponseInfo.getFindToken(),
+                  new ExchangeMetadataResponse(remoteMissingStoreMessages, replicaMetadataResponseInfo.getFindToken(),
                       replicaMetadataResponseInfo.getRemoteReplicaLagInBytes());
               // update replication lag in ReplicaSyncUpManager
               if (replicaSyncUpManager != null
@@ -617,14 +628,14 @@ public class ReplicaThread implements Runnable {
    * @param replicaMetadataResponseInfo The response that contains the messages from the remote node
    * @param remoteNode The remote node from which replication needs to happen
    * @param remoteReplicaInfo The remote replica that contains information about the remote replica id
-   * @return List of store keys that are missing from the local store
+   * @return List of store messages that are missing from the local store
    * @throws StoreException if store error (usually IOError) occurs when getting missing keys.
    */
-  private Set<StoreKey> getMissingStoreKeys(ReplicaMetadataResponseInfo replicaMetadataResponseInfo,
+  private Set<MessageInfo> getMissingStoreMessages(ReplicaMetadataResponseInfo replicaMetadataResponseInfo,
       DataNodeId remoteNode, RemoteReplicaInfo remoteReplicaInfo) throws StoreException {
     long startTime = SystemTime.getInstance().milliseconds();
     List<MessageInfo> messageInfoList = replicaMetadataResponseInfo.getMessageInfoList();
-    Map<StoreKey, StoreKey> remoteToConvertedNonNull = new HashMap<>();
+    Map<MessageInfo, StoreKey> remoteMessageToConvertedKeyNonNull = new HashMap<>();
 
     for (MessageInfo messageInfo : messageInfoList) {
       StoreKey storeKey = messageInfo.getStoreKey();
@@ -632,41 +643,41 @@ public class ReplicaThread implements Runnable {
           remoteReplicaInfo.getReplicaId(), storeKey);
       StoreKey convertedKey = storeKeyConverter.getConverted(storeKey);
       if (convertedKey != null) {
-        remoteToConvertedNonNull.put(storeKey, convertedKey);
+        remoteMessageToConvertedKeyNonNull.put(messageInfo, convertedKey);
       }
     }
     Set<StoreKey> convertedMissingStoreKeys =
-        remoteReplicaInfo.getLocalStore().findMissingKeys(new ArrayList<>(remoteToConvertedNonNull.values()));
-    Set<StoreKey> missingRemoteStoreKeys = new HashSet<>();
-    remoteToConvertedNonNull.forEach((remoteKey, convertedKey) -> {
+        remoteReplicaInfo.getLocalStore().findMissingKeys(new ArrayList<>(remoteMessageToConvertedKeyNonNull.values()));
+    Set<MessageInfo> missingRemoteMessages = new HashSet<>();
+    remoteMessageToConvertedKeyNonNull.forEach((messageInfo, convertedKey) -> {
       if (convertedMissingStoreKeys.contains(convertedKey)) {
         logger.trace(
             "Remote node: {} Thread name: {} Remote replica: {} Key missing id (converted): {} Key missing id (remote): {}",
-            remoteNode, threadName, remoteReplicaInfo.getReplicaId(), convertedKey, remoteKey);
-        missingRemoteStoreKeys.add(remoteKey);
+            remoteNode, threadName, remoteReplicaInfo.getReplicaId(), convertedKey, messageInfo.getStoreKey());
+        missingRemoteMessages.add(messageInfo);
       }
     });
-    if (messageInfoList.size() != 0 && missingRemoteStoreKeys.size() == 0) {
+    if (messageInfoList.size() != 0 && missingRemoteMessages.size() == 0) {
       // Catching up
       replicationMetrics.allResponsedKeysExist.inc();
     }
     replicationMetrics.updateCheckMissingKeysTime(SystemTime.getInstance().milliseconds() - startTime,
         replicatingFromRemoteColo, datacenterName);
-    return missingRemoteStoreKeys;
+    return missingRemoteMessages;
   }
 
   /**
    * Takes the missing keys and the message list from the remote store and identifies messages that are deleted
    * on the remote store and updates them locally. Also, if the message that is missing is deleted in the remote
    * store, we remove the message from the list of missing keys
-   * @param missingRemoteStoreKeys The list of keys missing from the local store
+   * @param missingRemoteStoreMessages The list of messages missing from the local store
    * @param replicaMetadataResponseInfo The replica metadata response from the remote store
    * @param remoteReplicaInfo The remote replica that is being replicated from
    * @param remoteNode The remote node from which replication needs to happen
    * @param remoteKeyToLocalKeyMap map mapping remote keys to local key equivalents
    * @throws StoreException
    */
-  private void processReplicaMetadataResponse(Set<StoreKey> missingRemoteStoreKeys,
+  private void processReplicaMetadataResponse(Set<MessageInfo> missingRemoteStoreMessages,
       ReplicaMetadataResponseInfo replicaMetadataResponseInfo, RemoteReplicaInfo remoteReplicaInfo,
       DataNodeId remoteNode, Map<StoreKey, StoreKey> remoteKeyToLocalKeyMap) throws StoreException {
     long startTime = SystemTime.getInstance().milliseconds();
@@ -680,16 +691,16 @@ public class ReplicaThread implements Runnable {
       }
       BlobId localKey = (BlobId) remoteKeyToLocalKeyMap.get(messageInfo.getStoreKey());
       if (localKey == null) {
-        missingRemoteStoreKeys.remove(messageInfo.getStoreKey());
+        missingRemoteStoreMessages.remove(messageInfo);
         logger.trace("Remote node: {} Thread name: {} Remote replica: {} Remote key deprecated locally: {}", remoteNode,
             threadName, remoteReplicaInfo.getReplicaId(), messageInfo.getStoreKey());
-      } else if (missingRemoteStoreKeys.contains(messageInfo.getStoreKey())) {
+      } else if (missingRemoteStoreMessages.contains(messageInfo)) {
         // The key is missing in the local store, we either send get request to fetch the content of this key, or does
         // nothing if the key is deleted or expired remotely.
         if (messageInfo.isDeleted()) {
           // if the key is not present locally and if the remote replica has the message in deleted state,
           // it is not considered missing locally.
-          missingRemoteStoreKeys.remove(messageInfo.getStoreKey());
+          missingRemoteStoreMessages.remove(messageInfo);
           logger.trace(
               "Remote node: {} Thread name: {} Remote replica: {} Key in deleted state remotely: {} Local key: {}",
               remoteNode, threadName, remoteReplicaInfo.getReplicaId(), messageInfo.getStoreKey(), localKey);
@@ -702,7 +713,7 @@ public class ReplicaThread implements Runnable {
         } else if (messageInfo.isExpired()) {
           // if the key is not present locally and if the remote replica has the key as expired,
           // it is not considered missing locally.
-          missingRemoteStoreKeys.remove(messageInfo.getStoreKey());
+          missingRemoteStoreMessages.remove(messageInfo);
           logger.trace("Remote node: {} Thread name: {} Remote replica: {} Key in expired state remotely {}",
               remoteNode, threadName, remoteReplicaInfo.getReplicaId(), localKey);
         }
@@ -828,7 +839,8 @@ public class ReplicaThread implements Runnable {
       ExchangeMetadataResponse exchangeMetadataResponse = exchangeMetadataResponseList.get(i);
       RemoteReplicaInfo remoteReplicaInfo = replicasToReplicatePerNode.get(i);
       if (exchangeMetadataResponse.serverErrorCode == ServerErrorCode.No_Error) {
-        Set<StoreKey> missingStoreKeys = exchangeMetadataResponse.missingStoreKeys;
+        Set<StoreKey> missingStoreKeys =
+            ExchangeMetadataResponse.getStoreKeysFromMessages(exchangeMetadataResponse.missingStoreMessages);
         if (missingStoreKeys.size() > 0) {
           ArrayList<BlobId> keysToFetch = new ArrayList<BlobId>();
           for (StoreKey storeKey : missingStoreKeys) {
@@ -894,7 +906,7 @@ public class ReplicaThread implements Runnable {
               time.milliseconds() + replicationConfig.replicationSyncedReplicaBackoffDurationMs);
           syncedBackOffCount.inc();
         }
-        if (exchangeMetadataResponse.missingStoreKeys.size() > 0) {
+        if (exchangeMetadataResponse.missingStoreMessages.size() > 0) {
           PartitionResponseInfo partitionResponseInfo =
               getResponse.getPartitionResponseInfoList().get(partitionResponseInfoIndex);
           responseHandler.onEvent(remoteReplicaInfo.getReplicaId(), partitionResponseInfo.getErrorCode());
@@ -912,7 +924,8 @@ public class ReplicaThread implements Runnable {
             try {
               logger.trace("Remote node: {} Thread name: {} Remote replica: {} Messages to fix: {} "
                       + "Partition: {} Local mount path: {}", remoteNode, threadName, remoteReplicaInfo.getReplicaId(),
-                  exchangeMetadataResponse.missingStoreKeys, remoteReplicaInfo.getReplicaId().getPartitionId(),
+                  ExchangeMetadataResponse.getStoreKeysFromMessages(exchangeMetadataResponse.missingStoreMessages),
+                  remoteReplicaInfo.getReplicaId().getPartitionId(),
                   remoteReplicaInfo.getLocalReplicaId().getMountPath());
 
               MessageFormatWriteSet writeset;
@@ -968,7 +981,8 @@ public class ReplicaThread implements Runnable {
             replicationMetrics.blobAuthorizationFailureCount.inc();
             logger.error(
                 "One of the blobs authorization failed: Remote node: {} Thread name: {} Remote replica: {} Keys are: {}",
-                remoteNode, threadName, remoteReplicaInfo.getReplicaId(), exchangeMetadataResponse.missingStoreKeys);
+                remoteNode, threadName, remoteReplicaInfo.getReplicaId(),
+                ExchangeMetadataResponse.getStoreKeysFromMessages(exchangeMetadataResponse.missingStoreMessages));
           } else {
             replicationMetrics.updateGetRequestError(remoteReplicaInfo.getReplicaId());
             logger.error("Remote node: {} Thread name: {} Remote replica: {} Server error: {}", remoteNode, threadName,
@@ -1103,32 +1117,38 @@ public class ReplicaThread implements Runnable {
   }
 
   static class ExchangeMetadataResponse {
-    final Set<StoreKey> missingStoreKeys;
+    // Set of messages missing in the local store. MessageInfo contains complete information of the blob metadata like Key info, delete, ttl-update and un-delete values.
+    final Set<MessageInfo> missingStoreMessages;
     final FindToken remoteToken;
     final long localLagFromRemoteInBytes;
     final ServerErrorCode serverErrorCode;
 
-    // Complete information (Key info, delete, ttl-update and un-delete information) of blobs missing in local store.
-    // This is used in leader-based replication where stand-by replicas cache the information of missing blobs to keep track of (and advance) the token once they are obtained through intra-dc replication.
-    // ExchangeMetadataResponse::missingStoreKeys is redundant after this change since MessageInfo contains StoreKey. We can remove it in future PRs once leader based replication is working.
-    final Set<MessageInfo> missingMessages;
-
-    ExchangeMetadataResponse(Set<StoreKey> missingStoreKeys, FindToken remoteToken, long localLagFromRemoteInBytes) {
-      this(missingStoreKeys, remoteToken, localLagFromRemoteInBytes, ServerErrorCode.No_Error, null);
+    ExchangeMetadataResponse(Set<MessageInfo> missingStoreMessages, FindToken remoteToken,
+        long localLagFromRemoteInBytes) {
+      this.missingStoreMessages = missingStoreMessages;
+      this.remoteToken = remoteToken;
+      this.localLagFromRemoteInBytes = localLagFromRemoteInBytes;
+      this.serverErrorCode = ServerErrorCode.No_Error;
     }
 
     ExchangeMetadataResponse(ServerErrorCode errorCode) {
-      this(null, null, -1, errorCode, null);
+      this.missingStoreMessages = null;
+      this.remoteToken = null;
+      this.localLagFromRemoteInBytes = -1;
+      this.serverErrorCode = errorCode;
     }
 
-    ExchangeMetadataResponse(Set<StoreKey> missingStoreKeys, FindToken remoteToken, long localLagFromRemoteInBytes,
-        ServerErrorCode serverErrorCode, Set<MessageInfo> missingMessages) {
-      this.missingStoreKeys = missingStoreKeys;
-      this.remoteToken = remoteToken;
-      this.localLagFromRemoteInBytes = localLagFromRemoteInBytes;
-      this.serverErrorCode = serverErrorCode;
-      this.missingMessages = missingMessages;
+    /**
+     * Utility method to extract store keys from messages
+     */
+    public static Set<StoreKey> getStoreKeysFromMessages(Set<MessageInfo> messageInfos) {
+      if (messageInfos != null) {
+        return messageInfos.stream().map(MessageInfo::getStoreKey).collect(Collectors.toSet());
+      } else {
+        return new HashSet<>();
+      }
     }
+
   }
 
   boolean isThreadUp() {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -1131,7 +1131,7 @@ public class ReplicaThread implements Runnable {
   }
 
   static class ExchangeMetadataResponse {
-    // Set of messages missing in the local store. MessageInfo contains complete information of the blob metadata like Key info, delete, ttl-update and un-delete values.
+    // Set of messages missing in the local store.
     final Set<MessageInfo> missingStoreMessages;
     final FindToken remoteToken;
     final long localLagFromRemoteInBytes;
@@ -1155,7 +1155,7 @@ public class ReplicaThread implements Runnable {
     /**
      * Utility method to extract store keys from messages
      */
-    public static Set<StoreKey> getStoreKeysFromMessages(Set<MessageInfo> messageInfos) {
+    static Set<StoreKey> getStoreKeysFromMessages(Set<MessageInfo> messageInfos) {
       if (messageInfos != null) {
         return messageInfos.stream().map(MessageInfo::getStoreKey).collect(Collectors.toSet());
       } else {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -125,11 +125,12 @@ public class ReplicaThread implements Runnable {
         datacenterName, responseHandler, time, replicaSyncUpManager, null);
   }
 
-  public ReplicaThread(String threadName, FindTokenHelper findTokenHelper, ClusterMap clusterMap, AtomicInteger correlationIdGenerator,
-      DataNodeId dataNodeId, ConnectionPool connectionPool, ReplicationConfig replicationConfig, ReplicationMetrics replicationMetrics, NotificationSystem notification,
-      StoreKeyConverter storeKeyConverter, Transformer transformer, MetricRegistry metricRegistry, boolean replicatingOverSsl, String datacenterName,
-      ResponseHandler responseHandler, Time time, ReplicaSyncUpManager replicaSyncUpManager,
-      PartitionLeaderInfo partitionLeaderInfo) {
+  public ReplicaThread(String threadName, FindTokenHelper findTokenHelper, ClusterMap clusterMap,
+      AtomicInteger correlationIdGenerator, DataNodeId dataNodeId, ConnectionPool connectionPool,
+      ReplicationConfig replicationConfig, ReplicationMetrics replicationMetrics, NotificationSystem notification,
+      StoreKeyConverter storeKeyConverter, Transformer transformer, MetricRegistry metricRegistry,
+      boolean replicatingOverSsl, String datacenterName, ResponseHandler responseHandler, Time time,
+      ReplicaSyncUpManager replicaSyncUpManager, PartitionLeaderInfo partitionLeaderInfo) {
     this.threadName = threadName;
     this.running = true;
     this.findTokenHelper = findTokenHelper;
@@ -1148,7 +1149,6 @@ public class ReplicaThread implements Runnable {
         return new HashSet<>();
       }
     }
-
   }
 
   boolean isThreadUp() {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -339,7 +339,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
             new ReplicaThread(threadIdentity, tokenHelper, clusterMap, correlationIdGenerator, dataNodeId,
                 connectionPool, replicationConfig, replicationMetrics, notification, threadSpecificKeyConverter,
                 threadSpecificTransformer, metricRegistry, replicatingOverSsl, datacenter, responseHandler,
-                SystemTime.getInstance(), replicaSyncUpManager);
+                SystemTime.getInstance(), replicaSyncUpManager, partitionLeaderInfo);
         replicaThreads.add(replicaThread);
         if (startThread) {
           Thread thread = Utils.newThread(replicaThread.getName(), replicaThread, false);

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -1613,10 +1613,7 @@ public class ReplicationTest {
 
     Assert.assertEquals("Actual keys in Exchange Metadata Response different from expected",
         idsToExpectByPartition.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()),
-        responses.stream()
-            .map(k -> ReplicaThread.ExchangeMetadataResponse.getStoreKeysFromMessages(k.missingStoreMessages))
-            .flatMap(Collection::stream)
-            .collect(Collectors.toSet()));
+        responses.stream().map(k -> k.getMissingStoreKeys()).flatMap(Collection::stream).collect(Collectors.toSet()));
 
     // Now delete a message in the remote before doing the Get requests (for every partition). Remove these keys from
     // expected key set. Even though they are requested, they should not go into the local store. However, this cycle
@@ -1698,10 +1695,7 @@ public class ReplicationTest {
 
     Assert.assertEquals("Actual keys in Exchange Metadata Response different from expected",
         idsToExpectByPartition.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()),
-        responses.stream()
-            .map(k -> ReplicaThread.ExchangeMetadataResponse.getStoreKeysFromMessages(k.missingStoreMessages))
-            .flatMap(Collection::stream)
-            .collect(Collectors.toSet()));
+        responses.stream().map(k -> k.getMissingStoreKeys()).flatMap(Collection::stream).collect(Collectors.toSet()));
 
     // Now expire a message in the remote before doing the Get requests (for every partition). Remove these keys from
     // expected key set. Even though they are requested, they should not go into the local store. However, this cycle

--- a/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/ReplicationTest.java
@@ -1938,14 +1938,16 @@ public class ReplicationTest {
     List<ReplicaThread.ExchangeMetadataResponse> response =
         replicaThread.exchangeMetadata(new MockConnectionPool.MockConnection(remoteHost, batchSize),
             replicasToReplicate.get(remoteHost.dataNodeId));
-    assertEquals("Response should contain a response for each replica",
-        replicasToReplicate.get(remoteHost.dataNodeId).size(), response.size());
+    List<RemoteReplicaInfo> remoteReplicaInfos = replicasToReplicate.get(remoteHost.dataNodeId);
+    assertEquals("Response should contain a response for each replica", remoteReplicaInfos.size(), response.size());
     for (int i = 0; i < response.size(); i++) {
       if (i % 2 == 0) {
         assertEquals(0, response.get(i).missingStoreMessages.size());
+        assertEquals(0, remoteReplicaInfos.get(i).getExchangeMetadataResponse().missingStoreMessages.size());
         assertEquals(expectedIndex, ((MockFindToken) response.get(i).remoteToken).getIndex());
       } else {
         assertEquals(1, response.get(i).missingStoreMessages.size());
+        assertEquals(1, remoteReplicaInfos.get(i).getExchangeMetadataResponse().missingStoreMessages.size());
         assertEquals(expectedIndex + 1, ((MockFindToken) response.get(i).remoteToken).getIndex());
       }
     }
@@ -2370,6 +2372,8 @@ public class ReplicationTest {
     assertEquals("Response should contain a response for each replica", remoteReplicaInfos.size(), response.size());
     for (int i = 0; i < response.size(); i++) {
       assertEquals(missingKeyCount, response.get(i).missingStoreMessages.size());
+      assertEquals(missingKeyCount,
+          remoteReplicaInfos.get(i).getExchangeMetadataResponse().missingStoreMessages.size());
       remoteReplicaInfos.get(i).setToken(response.get(i).remoteToken);
     }
     replicaThread.fixMissingStoreKeys(new MockConnectionPool.MockConnection(remoteHost, batchSize), remoteReplicaInfos,
@@ -2377,6 +2381,8 @@ public class ReplicationTest {
     for (int i = 0; i < response.size(); i++) {
       assertEquals("Token should have been set correctly in fixMissingStoreKeys()", response.get(i).remoteToken,
           remoteReplicaInfos.get(i).getToken());
+      assertEquals("Token should have been set correctly in fixMissingStoreKeys()",
+          remoteReplicaInfos.get(i).getExchangeMetadataResponse().remoteToken, remoteReplicaInfos.get(i).getToken());
     }
     // Don't compare buffers here, PutBuffer might be different since we might change the lifeVersion.
     for (Map.Entry<PartitionId, List<MessageInfo>> localInfoEntry : localHost.infosByPartition.entrySet()) {
@@ -2510,6 +2516,7 @@ public class ReplicationTest {
     assertEquals("Response should contain a response for each replica", remoteReplicaInfos.size(), response.size());
     for (int i = 0; i < response.size(); i++) {
       assertEquals(0, response.get(i).missingStoreMessages.size());
+      assertEquals(0, remoteReplicaInfos.get(i).getExchangeMetadataResponse().missingStoreMessages.size());
       remoteReplicaInfos.get(i).setToken(response.get(i).remoteToken);
     }
 
@@ -2628,6 +2635,7 @@ public class ReplicationTest {
     assertEquals("Response should contain a response for each replica", remoteReplicaInfos.size(), response.size());
     for (int i = 0; i < response.size(); i++) {
       assertEquals(0, response.get(i).missingStoreMessages.size());
+      assertEquals(0, remoteReplicaInfos.get(i).getExchangeMetadataResponse().missingStoreMessages.size());
       remoteReplicaInfos.get(i).setToken(response.get(i).remoteToken);
     }
 


### PR DESCRIPTION
Data structure changes to cache the metadata response information exchanged during a replication cycle. 