### PR TITLE
Remove transition code in helix account service since we are not transitioning

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountService.java
@@ -22,12 +22,10 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
@@ -58,8 +56,8 @@ import static com.github.ambry.utils.Utils.*;
  * <p>
  *   Every time a mutation of account metadata is performed, a new backup file will be created for locally, in a directory
  *   specified by the {@link HelixAccountServiceConfig#backupDir}. A backup file is created when the helix listener on
- *   {@link #ACCOUNT_METADATA_CHANGE_TOPIC} is notified. And backup's filename could contain version and mtime information
- *   of the znode that stores the account metadata.
+ *   {@link #ACCOUNT_METADATA_CHANGE_TOPIC} is notified. And backup's filename could contain version and last modified time
+ *   information of the znode that stores the account metadata.
  *   The flow to update account looks like
  *   <ol>
  *     <li>{@link #updateAccounts(Collection)} is invoked</li>

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -890,42 +890,6 @@ public class HelixAccountServiceTest {
   }
 
   /**
-   * Tests enabling backfilling for new znode path. While {@link HelixAccountService} is still using old znode path, it should
-   * forward the new {@link Account} metadata to new znode path.
-   */
-  @Test
-  public void testFillAccountsToNewZNode() throws Exception {
-    assumeTrue(!useNewZNodePath);
-    helixConfigProps.put(HelixAccountServiceConfig.BACKFILL_ACCOUNTS_TO_NEW_ZNODE, "true");
-    vHelixConfigProps = new VerifiableProperties(helixConfigProps);
-    storeConfig = new HelixPropertyStoreConfig(vHelixConfigProps);
-    String updaterThreadPrefix = UUID.randomUUID().toString();
-    MockHelixAccountServiceFactory mockHelixAccountServiceFactory =
-        new MockHelixAccountServiceFactory(vHelixConfigProps, new MetricRegistry(), notifier, updaterThreadPrefix,
-            mockRouter);
-    accountService = mockHelixAccountServiceFactory.getAccountService();
-    ((HelixAccountService) accountService).setupRouter(mockRouter);
-
-    // update accounts and then make sure the blob ids are stored in the helixStore
-    Account newAccountWithoutContainer = new AccountBuilder(refAccountId, refAccountName, refAccountStatus).build();
-    List<Account> accountsToUpdate = Collections.singletonList(newAccountWithoutContainer);
-    boolean hasUpdateAccountSucceed = accountService.updateAccounts(accountsToUpdate);
-    assertTrue("Wrong update return status", hasUpdateAccountSucceed);
-    assertAccountsInAccountService(accountsToUpdate, 1, accountService);
-
-    // verify the RouterStore can read the account map out.
-    HelixPropertyStore<ZNRecord> helixStore =
-        mockHelixAccountServiceFactory.getHelixStore(ZK_CONNECT_STRING, storeConfig);
-    HelixAccountService helixAccountService = (HelixAccountService) accountService;
-    RouterStore routerStore =
-        new RouterStore(helixAccountService.getAccountServiceMetrics(), helixAccountService.getBackupFileManager(),
-            helixStore, new AtomicReference<>(mockRouter), false, TOTAL_NUMBER_OF_VERSION_TO_KEEP);
-    Map<String, String> accountMap = routerStore.fetchAccountMetadata();
-    assertNotNull("Accounts should be backfilled to new znode", accountMap);
-    assertAccountMapEquals(accountService.getAllAccounts(), accountMap);
-  }
-
-  /**
    * Asserts the {@link Account}s received by the {@link Consumer} are as expected.
    * @param expectedAccounts The expected collection of {@link Account}s that should be received by the {@link Consumer}s.
    * @param expectedNumberOfConsumers The expected number of {@link Consumer}s.

--- a/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
+++ b/ambry-account/src/test/java/com/github/ambry/account/HelixAccountServiceTest.java
@@ -41,7 +41,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
@@ -64,7 +63,6 @@ import static com.github.ambry.account.Container.*;
 import static com.github.ambry.account.HelixAccountService.*;
 import static com.github.ambry.utils.TestUtils.*;
 import static org.junit.Assert.*;
-import static org.junit.Assume.*;
 
 
 /**

--- a/ambry-api/src/main/java/com/github/ambry/config/HelixAccountServiceConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/HelixAccountServiceConfig.java
@@ -27,8 +27,6 @@ public class HelixAccountServiceConfig {
   public static final String ZK_CLIENT_CONNECT_STRING_KEY = HELIX_ACCOUNT_SERVICE_PREFIX + "zk.client.connect.string";
   public static final String USE_NEW_ZNODE_PATH = HELIX_ACCOUNT_SERVICE_PREFIX + "use.new.znode.path";
   public static final String UPDATE_DISABLED = HELIX_ACCOUNT_SERVICE_PREFIX + "update.disabled";
-  public static final String BACKFILL_ACCOUNTS_TO_NEW_ZNODE =
-      HELIX_ACCOUNT_SERVICE_PREFIX + "backfill.accounts.to.new.znode";
   public static final String ENABLE_SERVE_FROM_BACKUP = HELIX_ACCOUNT_SERVICE_PREFIX + "enable.serve.from.backup";
   public static final String TOTAL_NUMBER_OF_VERSION_TO_KEEP =
       HELIX_ACCOUNT_SERVICE_PREFIX + "total.number.of.version.to.keep";
@@ -85,15 +83,6 @@ public class HelixAccountServiceConfig {
   public final boolean updateDisabled;
 
   /**
-   * If true, HelixAccountService would persist account metadata to ambry-server upon receiving the account metadata
-   * change message. This option can't be true with useNewZNodePath at the same time. It should only be enabled while
-   * using the old znode path. And there should only be one machine enabling this option.
-   */
-  @Config(BACKFILL_ACCOUNTS_TO_NEW_ZNODE)
-  @Default("false")
-  public final boolean backFillAccountsToNewZNode;
-
-  /**
    * If true, HelixAccountService would load the account metadata from local backup file when fetching from helix fails.
    * Set it to false while transitioning, since the old backup files don't have up-to-date account metadata.
    */
@@ -120,10 +109,6 @@ public class HelixAccountServiceConfig {
     maxBackupFileCount = verifiableProperties.getIntInRange(MAX_BACKUP_FILE_COUNT, 100, 1, Integer.MAX_VALUE);
     useNewZNodePath = verifiableProperties.getBoolean(USE_NEW_ZNODE_PATH, false);
     updateDisabled = verifiableProperties.getBoolean(UPDATE_DISABLED, false);
-    backFillAccountsToNewZNode = verifiableProperties.getBoolean(BACKFILL_ACCOUNTS_TO_NEW_ZNODE, false);
-    if (backFillAccountsToNewZNode && useNewZNodePath) {
-      throw new IllegalStateException("useNewZNodePath and backFillAccountsToNewZNode can't be true at the same time.");
-    }
     enableServeFromBackup = verifiableProperties.getBoolean(ENABLE_SERVE_FROM_BACKUP, false);
     totalNumberOfVersionToKeep =
         verifiableProperties.getIntInRange(TOTAL_NUMBER_OF_VERSION_TO_KEEP, 100, 1, Integer.MAX_VALUE);


### PR DESCRIPTION
This PR removes some of the transitioning code from helix account service. Those code used to transition legacy metadata store to new router store, but we are not doing it anymore.