### PR TITLE
Return failure reason in http header for undelete

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -221,7 +221,6 @@ public class RestUtils {
      * The lifeVersion of the blob.
      */
     public final static String LIFE_VERSION = "x-ambry-life-version";
-
   }
 
   public static final class TrackingHeaders {
@@ -297,6 +296,11 @@ public class RestUtils {
      * The key for the {@link RequestPath} that represents the parsed path of an incoming request.
      */
     public static final String REQUEST_PATH = KEY_PREFIX + "request-path";
+
+    /**
+     * To be set to {@code true} if failures reason should be attached to frontend responses.
+     */
+    public static final String SEND_FAILURE_REASON = KEY_PREFIX + "send-failure-reason";
   }
 
   /**

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -113,10 +113,9 @@ class FrontendRestRequestService implements RestRequestService {
    * @param hostname the hostname for this frontend.
    * @param clusterName the name of the storage cluster that the router communicates with.
    */
-  FrontendRestRequestService(FrontendConfig frontendConfig, FrontendMetrics frontendMetrics,
-      Router router, ClusterMap clusterMap, IdConverterFactory idConverterFactory,
-      SecurityServiceFactory securityServiceFactory, UrlSigningService urlSigningService,
-      IdSigningService idSigningService, AccountService accountService,
+  FrontendRestRequestService(FrontendConfig frontendConfig, FrontendMetrics frontendMetrics, Router router,
+      ClusterMap clusterMap, IdConverterFactory idConverterFactory, SecurityServiceFactory securityServiceFactory,
+      UrlSigningService urlSigningService, IdSigningService idSigningService, AccountService accountService,
       AccountAndContainerInjector accountAndContainerInjector, String datacenterName, String hostname,
       String clusterName) {
     this.frontendConfig = frontendConfig;
@@ -257,6 +256,10 @@ class FrontendRestRequestService implements RestRequestService {
       } else if (requestPath.matchesOperation(Operations.UNDELETE) && frontendConfig.enableUndelete) {
         // If the undelete is not enabled, then treat it as unrecognized operation.
         undeleteHandler.handle(restRequest, restResponseChannel, (r, e) -> {
+          if (e instanceof RouterException) {
+            e = new RestServiceException(e.getMessage(),
+                RestServiceErrorCode.getRestServiceErrorCode(((RouterException) e).getErrorCode()), true);
+          }
           submitResponse(restRequest, restResponseChannel, null, e);
         });
       } else {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -255,11 +255,10 @@ class FrontendRestRequestService implements RestRequestService {
         });
       } else if (requestPath.matchesOperation(Operations.UNDELETE) && frontendConfig.enableUndelete) {
         // If the undelete is not enabled, then treat it as unrecognized operation.
+
+        // And always send failure reason back to client for undelete
+        restRequest.setArg(SEND_FAILURE_REASON, Boolean.TRUE);
         undeleteHandler.handle(restRequest, restResponseChannel, (r, e) -> {
-          if (e instanceof RouterException) {
-            e = new RestServiceException(e.getMessage(),
-                RestServiceErrorCode.getRestServiceErrorCode(((RouterException) e).getErrorCode()), true);
-          }
           submitResponse(restRequest, restResponseChannel, null, e);
         });
       } else {

--- a/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
+++ b/ambry-frontend/src/test/java/com/github/ambry/frontend/FrontendRestRequestServiceTest.java
@@ -1351,20 +1351,6 @@ public class FrontendRestRequestServiceTest {
     return restResponseChannel;
   }
 
-  private MockRestResponseChannel verifyOperationFailure(RestRequest restRequest, RestServiceErrorCode errorCode,
-      boolean shouldIncludeFailureReason) throws Exception {
-    MockRestResponseChannel restResponseChannel = new MockRestResponseChannel();
-    try {
-      doOperation(restRequest, restResponseChannel);
-      fail("Operation should have failed");
-    } catch (RestServiceException e) {
-      assertEquals("Op should have failed with a specific error code", errorCode, e.getErrorCode());
-      assertEquals("Exception should include failure reason", shouldIncludeFailureReason,
-          e.shouldIncludeExceptionMessageInResponse());
-    }
-    return restResponseChannel;
-  }
-
   /**
    * Prepares random content, sets headers and POSTs a blob with the required parameters
    * @param contentLength the length of the content to be POSTed.
@@ -2037,7 +2023,7 @@ public class FrontendRestRequestServiceTest {
     headers.put(RestUtils.Headers.SERVICE_ID, "undeleteBlobAndVerify");
     RestRequest restRequest = createRestRequest(RestMethod.PUT, "/" + Operations.UNDELETE, headers, null);
     if (expectedErrorCode != null) {
-      verifyOperationFailure(restRequest, expectedErrorCode, true);
+      verifyOperationFailure(restRequest, expectedErrorCode);
     } else {
       verifyUndeleteOK(restRequest);
       verifyOperationsAfterUndelete(blobId, expectedHeaders, expectedContent, expectedAccount, expectedContainer);

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
@@ -539,7 +539,7 @@ class NettyResponseChannel implements RestResponseChannel {
       restServiceErrorCode = restServiceException.getErrorCode();
       errorResponseStatus = ResponseStatus.getResponseStatus(restServiceErrorCode);
       status = getHttpResponseStatus(errorResponseStatus);
-      if (status == HttpResponseStatus.BAD_REQUEST || restServiceException.shouldIncludeExceptionMessageInResponse()) {
+      if (shouldSendFailureReason(status, restServiceException)) {
         errReason = new String(
             Utils.getRootCause(cause).getMessage().replaceAll("[\n\t\r]", " ").getBytes(StandardCharsets.US_ASCII),
             StandardCharsets.US_ASCII);
@@ -608,6 +608,14 @@ class NettyResponseChannel implements RestResponseChannel {
     }
     return shouldKeepAlive && !forceClose && HttpUtil.isKeepAlive(responseMetadata)
         && !CLOSE_CONNECTION_ERROR_STATUSES.contains(status);
+  }
+
+  private boolean shouldSendFailureReason(HttpResponseStatus status, RestServiceException exception) {
+    if (status == HttpResponseStatus.BAD_REQUEST || exception.shouldIncludeExceptionMessageInResponse()) {
+      return true;
+    }
+    return request != null && request.getArgs().containsKey(RestUtils.InternalKeys.SEND_FAILURE_REASON)
+        && (Boolean) request.getArgs().get(RestUtils.InternalKeys.SEND_FAILURE_REASON);
   }
 
   /**
@@ -962,6 +970,9 @@ class NettyResponseChannel implements RestResponseChannel {
       } else if (allChunksWritten() && !sentLastChunk) {
         // Send last chunk for this input
         sentLastChunk = true;
+        // When the Transfer-Encoding is Chunked, we don't really know which chunk is the last chunk since the content
+        // length information is lost. But here, we know that all the chunks are already put in the queue and there is
+        // no chunk polling out of the queue, we send back an empty last content.
         content = LastHttpContent.EMPTY_LAST_CONTENT;
         logger.trace("Last chunk was sent on channel {}", ctx.channel());
       }

--- a/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/router/InMemoryRouter.java
@@ -335,15 +335,13 @@ public class InMemoryRouter implements Router {
       checkBlobId(blobId);
       if (!blobs.containsKey(blobId)) {
         exception = new RouterException("Blob not found", RouterErrorCode.BlobDoesNotExist);
-      } else if (undeletedBlobs.contains(blobId)) {
-        exception = new RouterException("Blob already undeleted", RouterErrorCode.BlobUndeleted);
       } else if (!deletedBlobs.contains(blobId)) {
         exception = new RouterException("Blob not deleted", RouterErrorCode.BlobNotDeleted);
       }
       undeletedBlobs.add(blobId);
       deletedBlobs.remove(blobId);
       if (notificationSystem != null) {
-        notificationSystem.onBlobDeleted(blobId, serviceId, null, null);
+        notificationSystem.onBlobUndeleted(blobId, serviceId, null, null);
       }
     } catch (RouterException e) {
       exception = e;


### PR DESCRIPTION
Return failure reason in http response header for undelete. Since undelete is not exposed outside of the linked datacenter and should be an admin operation, we should always return the failure reason in the header.