### PR TITLE
Replace string concatenation in logger calls

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/BackupFileManager.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/BackupFileManager.java
@@ -125,7 +125,7 @@ class BackupFileManager {
     File[] files = backupDir.listFiles(tempFileFilter);
     if (files != null) {
       for (File file : files) {
-        logger.trace("Delete temp file " + file.getName());
+        logger.trace("Delete temp file {}", file.getName());
         tryDeleteFile(file);
       }
     }
@@ -137,7 +137,7 @@ class BackupFileManager {
       for (File file : files) {
         Matcher m = versionFilenamePattern.matcher(file.getName());
         m.find();
-        logger.trace("Starting processing version backup file " + file.getName());
+        logger.trace("Starting processing version backup file {}", file.getName());
         int version = Integer.parseInt(m.group(1));
         long modifiedTimeInSecond = LocalDateTime.parse(m.group(2), TIMESTAMP_FORMATTER).toEpochSecond(zoneOffset);
         BackupFileInfo currentBackup = new BackupFileInfo(version, file.getName(), modifiedTimeInSecond);
@@ -169,7 +169,7 @@ class BackupFileManager {
     files = backupDir.listFiles(oldStateFileFilter);
     if (files != null) {
       for (File file : files) {
-        logger.trace("Delete old state file " + file.getName());
+        logger.trace("Delete old state file {}", file.getName());
         tryDeleteFile(file);
       }
     }
@@ -183,7 +183,7 @@ class BackupFileManager {
         logger.trace("More than {} versioned backup found, remove all the backup files in old format",
             config.maxBackupFileCount);
         for (File file : allNewStateFiles) {
-          logger.trace("Delete new state file " + file.getName());
+          logger.trace("Delete new state file {}", file.getName());
           tryDeleteFile(file);
         }
       } else {
@@ -199,7 +199,7 @@ class BackupFileManager {
         for (int i = 0; i < size; i++) {
           File file = allNewStateFiles[i];
           if (i < startIndexToPreserveBackupFile) {
-            logger.trace("Delete new state file " + file.getName());
+            logger.trace("Delete new state file {}", file.getName());
             tryDeleteFile(file);
           } else {
             Matcher m = newStateFilenamePattern.matcher(file.getName());
@@ -246,7 +246,7 @@ class BackupFileManager {
       writeAccountMapToFile(tempFilePath, accountMap);
       Files.move(tempFilePath, filePath);
     } catch (IOException e) {
-      logger.error("Failed to persist state to file: " + fileName, e);
+      logger.error("Failed to persist state to file: {}", fileName, e);
       accountServiceMetrics.backupErrorCount.inc();
       return;
     }
@@ -316,7 +316,7 @@ class BackupFileManager {
       return deserializeAccountMap(bytes);
     } catch (IOException e) {
       accountServiceMetrics.backupErrorCount.inc();
-      logger.error("Failed to read all bytes out from file " + filepath + " " + e.getMessage());
+      logger.error("Failed to read all bytes out from file {} {}", filepath, e.getMessage());
       return null;
     }
   }
@@ -346,11 +346,11 @@ class BackupFileManager {
     try {
       Files.delete(toDelete);
     } catch (NoSuchFileException e) {
-      logger.error("File doesn't exist while deleting: " + toDelete.toString(), e);
+      logger.error("File doesn't exist while deleting: {}", toDelete.toString(), e);
     } catch (IOException e) {
-      logger.error("Encounter an I/O error while deleting file: " + toDelete.toString(), e);
+      logger.error("Encounter an I/O error while deleting file: {}", toDelete.toString(), e);
     } catch (Exception e) {
-      logger.error("Encounter an unexpected error while deleting file: " + toDelete.toString(), e);
+      logger.error("Encounter an unexpected error while deleting file: {}", toDelete.toString(), e);
     }
   }
 
@@ -379,7 +379,7 @@ class BackupFileManager {
       channel.write(buffer);
     } catch (IOException e) {
       // Failed to persist file
-      logger.error("Failed to persist account map to file " + filepath, e);
+      logger.error("Failed to persist account map to file {}", filepath, e);
       throw e;
     }
   }
@@ -413,7 +413,7 @@ class BackupFileManager {
       }
       return result;
     } catch (JSONException e) {
-      logger.error("Failed to deserialized bytes to account map: " + e.getMessage());
+      logger.error("Failed to deserialized bytes to account map: {}", e.getMessage());
       return null;
     }
   }

--- a/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/RouterStore.java
@@ -364,8 +364,8 @@ class RouterStore extends AccountMetadataStore {
         while (blobIDAndVersions.size() + 1 > totalNumberOfVersionToKeep) {
           BlobIDAndVersion blobIDAndVersion = iter.next();
           iter.remove();
-          logger.info("Adding blob " + blobIDAndVersion.getBlobID() + " at version " + blobIDAndVersion.getVersion()
-              + " to delete");
+          logger.info("Adding blob {} at version {} to delete", blobIDAndVersion.getBlobID(),
+              blobIDAndVersion.getVersion());
           oldBlobIDsToDelete.add(blobIDAndVersion.getBlobID());
         }
         blobIDAndVersionsJson = blobIDAndVersions.stream().map(BlobIDAndVersion::toJson).collect(Collectors.toList());
@@ -382,11 +382,11 @@ class RouterStore extends AccountMetadataStore {
       if (!isUpdateSucceeded && newBlobID != null) {
         // Delete the ambry blob regardless what error fails the update.
         try {
-          logger.info("Removing blob " + newBlobID + " since the update failed");
+          logger.info("Removing blob {} since the update failed", newBlobID);
           // Block this execution? or maybe wait for a while then get out?
           router.get().deleteBlob(newBlobID, SERVICE_ID).get();
         } catch (Exception e) {
-          logger.error("Failed to delete blob=" + newBlobID, e);
+          logger.error("Failed to delete blob={}", newBlobID, e);
           accountServiceMetrics.accountDeletesToAmbryServerErrorCount.inc();
         }
       }
@@ -395,11 +395,11 @@ class RouterStore extends AccountMetadataStore {
       if (isUpdateSucceeded && oldBlobIDsToDelete != null) {
         for (String blobID : oldBlobIDsToDelete) {
           try {
-            logger.info("Removing blob " + blobID);
+            logger.info("Removing blob {}", blobID);
             // Block this execution? or maybe wait for a while then get out?
             router.get().deleteBlob(blobID, SERVICE_ID).get();
           } catch (Exception e) {
-            logger.error("Failed to delete blob=" + blobID, e);
+            logger.error("Failed to delete blob={}", blobID, e);
             accountServiceMetrics.accountDeletesToAmbryServerErrorCount.inc();
           }
         }

--- a/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
+++ b/ambry-api/src/main/java/com/github/ambry/rest/RestUtils.java
@@ -499,8 +499,8 @@ public class RestUtils {
             crc32.update(userMetadata, 0, userMetadata.length - CRC_SIZE);
             long expectedCRC = crc32.getValue();
             if (actualCRC != expectedCRC) {
-              logger.error(
-                  "corrupt data while parsing user metadata Expected CRC " + expectedCRC + " Actual CRC " + actualCRC);
+              logger.error("corrupt data while parsing user metadata Expected CRC {} Actual CRC {}", expectedCRC,
+                  actualCRC);
               toReturn = null;
             }
           }
@@ -585,7 +585,7 @@ public class RestUtils {
       SimpleDateFormat dateFormatter = new SimpleDateFormat(HTTP_DATE_FORMAT, Locale.US);
       return dateFormatter.parse(dateString).getTime();
     } catch (ParseException e) {
-      logger.warn("Could not parse milliseconds from an HTTP date header (" + dateString + ").");
+      logger.warn("Could not parse milliseconds from an HTTP date header ({}).", dateString);
       return null;
     }
   }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -151,7 +151,7 @@ public class VcrReplicationManager extends ReplicationEngine {
     }
     ReplicaId cloudReplica = new CloudReplica(partitionId, virtualReplicatorCluster.getCurrentDataNodeId());
     if (!storeManager.addBlobStore(cloudReplica)) {
-      logger.error("Can't start cloudstore for replica " + cloudReplica);
+      logger.error("Can't start cloudstore for replica {}", cloudReplica);
       throw new ReplicationException("Can't start cloudstore for replica " + cloudReplica);
     }
     List<? extends ReplicaId> peerReplicas = cloudReplica.getPeerReplicaIds();

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
@@ -179,7 +179,7 @@ public class VcrServer {
       networkServer.start();
 
       long processingTime = SystemTime.getInstance().milliseconds() - startTime;
-      logger.info("VCR startup time in Ms " + processingTime);
+      logger.info("VCR startup time in Ms {}", processingTime);
     } catch (Exception e) {
       logger.error("Error during VCR startup", e);
       throw new InstantiationException("failure during VCR startup " + e);
@@ -234,7 +234,7 @@ public class VcrServer {
     } finally {
       shutdownLatch.countDown();
       long processingTime = SystemTime.getInstance().milliseconds() - startTime;
-      logger.info("VCR shutdown time in Ms " + processingTime);
+      logger.info("VCR shutdown time in Ms {}", processingTime);
     }
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDatanode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDatanode.java
@@ -122,7 +122,7 @@ abstract class AmbryDataNode implements DataNodeId {
    * @param newState the updated {@link HardwareState}
    */
   void setState(HardwareState newState) {
-    logger.trace("Setting state of instance " + getInstanceName(hostName, getPort()) + " to " + newState);
+    logger.trace("Setting state of instance {} to {}", getInstanceName(hostName, getPort()), newState);
     if (newState == HardwareState.AVAILABLE) {
       resourceStatePolicy.onHardUp();
     } else {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNode.java
@@ -53,9 +53,7 @@ class DataNode implements DataNodeId {
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   DataNode(Datacenter datacenter, JSONObject jsonObject, ClusterMapConfig clusterMapConfig) throws JSONException {
-    if (logger.isTraceEnabled()) {
-      logger.trace("DataNode " + jsonObject.toString());
-    }
+    logger.trace("DataNode {}", jsonObject);
     this.datacenter = datacenter;
     this.clusterMapConfig = clusterMapConfig;
     this.sslEnabledDataCenters = Utils.splitString(clusterMapConfig.clusterMapSslEnabledDatacenters, ",");
@@ -70,7 +68,7 @@ class DataNode implements DataNodeId {
               HardwareState.valueOf(jsonObject.getString("hardwareState")), clusterMapConfig);
       this.dataNodeStatePolicy = resourceStatePolicyFactory.getResourceStatePolicy();
     } catch (Exception e) {
-      logger.error("Error creating resource state policy when instantiating a datanode " + e);
+      logger.error("Error creating resource state policy when instantiating a datanode", e);
       throw new IllegalStateException(
           "Error creating resource state policy when instantiating a datanode: " + hostname + ":" + portNum, e);
     }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Datacenter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Datacenter.java
@@ -43,9 +43,7 @@ class Datacenter {
 
   Datacenter(HardwareLayout hardwareLayout, JSONObject jsonObject, ClusterMapConfig clusterMapConfig)
       throws JSONException {
-    if (logger.isTraceEnabled()) {
-      logger.trace("Datacenter " + jsonObject.toString());
-    }
+    logger.trace("Datacenter {}", jsonObject);
     this.hardwareLayout = hardwareLayout;
     this.name = jsonObject.getString("name");
     id = (byte) jsonObject.getInt("id");

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Disk.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Disk.java
@@ -39,9 +39,7 @@ class Disk implements DiskId {
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   Disk(DataNode dataNode, JSONObject jsonObject, ClusterMapConfig clusterMapConfig) throws JSONException {
-    if (logger.isTraceEnabled()) {
-      logger.trace("Disk " + jsonObject.toString());
-    }
+    logger.trace("Disk {}", jsonObject);
     this.dataNode = dataNode;
     this.mountPath = jsonObject.getString("mountPath");
     try {
@@ -50,7 +48,7 @@ class Disk implements DiskId {
               HardwareState.valueOf(jsonObject.getString("hardwareState")), clusterMapConfig);
       this.diskStatePolicy = resourceStatePolicyFactory.getResourceStatePolicy();
     } catch (Exception e) {
-      logger.error("Error creating resource state policy when instantiating a disk " + e);
+      logger.error("Error creating resource state policy when instantiating a disk", e);
       throw new IllegalStateException("Error creating resource state policy when instantiating a disk: " + mountPath,
           e);
     }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HardwareLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HardwareLayout.java
@@ -45,7 +45,7 @@ class HardwareLayout {
 
   public HardwareLayout(JSONObject jsonObject, ClusterMapConfig clusterMapConfig) throws JSONException {
     if (logger.isTraceEnabled()) {
-      logger.trace("HardwareLayout " + jsonObject.toString());
+      logger.trace("HardwareLayout {}", jsonObject.toString());
     }
     this.clusterName = jsonObject.getString("clusterName");
     this.version = jsonObject.getLong("version");

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Partition.java
@@ -53,7 +53,7 @@ class Partition implements PartitionId {
   private Logger logger = LoggerFactory.getLogger(getClass());
 
   Partition(long id, String partitionClass, PartitionState partitionState, long replicaCapacityInBytes) {
-    logger.trace("Partition " + id + ", " + partitionState + ", " + replicaCapacityInBytes);
+    logger.trace("Partition {}, {}, {}", id, partitionState, replicaCapacityInBytes);
     this.id = id;
     this.partitionClass = partitionClass;
     this.partitionState = partitionState;
@@ -69,7 +69,7 @@ class Partition implements PartitionId {
 
   Partition(HardwareLayout hardwareLayout, JSONObject jsonObject) throws JSONException {
     if (logger.isTraceEnabled()) {
-      logger.trace("Partition " + jsonObject.toString());
+      logger.trace("Partition {}", jsonObject.toString());
     }
     this.id = jsonObject.getLong("id");
     this.partitionClass = jsonObject.has("partitionClass") ? jsonObject.getString("partitionClass")

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -60,7 +60,7 @@ class PartitionLayout {
   public PartitionLayout(HardwareLayout hardwareLayout, JSONObject jsonObject, ClusterMapConfig clusterMapConfig)
       throws JSONException {
     if (logger.isTraceEnabled()) {
-      logger.trace("PartitionLayout " + hardwareLayout + ", " + jsonObject.toString());
+      logger.trace("PartitionLayout {}, {}", hardwareLayout, jsonObject.toString());
     }
     this.hardwareLayout = hardwareLayout;
     this.localDatacenterName = clusterMapConfig.clusterMapDatacenterName;
@@ -85,7 +85,7 @@ class PartitionLayout {
    */
   public PartitionLayout(HardwareLayout hardwareLayout, ClusterMapConfig clusterMapConfig) {
     if (logger.isTraceEnabled()) {
-      logger.trace("PartitionLayout " + hardwareLayout);
+      logger.trace("PartitionLayout {}", hardwareLayout);
     }
     this.hardwareLayout = hardwareLayout;
     this.localDatacenterName = clusterMapConfig.clusterMapDatacenterName;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Replica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Replica.java
@@ -45,7 +45,7 @@ class Replica implements ReplicaId {
 
   Replica(Partition partition, Disk disk, ClusterMapConfig clusterMapConfig) {
     if (logger.isTraceEnabled()) {
-      logger.trace("Replica " + partition + ", " + disk);
+      logger.trace("Replica {}, {}", partition, disk);
     }
     this.partition = partition;
     this.disk = disk;
@@ -56,7 +56,7 @@ class Replica implements ReplicaId {
               clusterMapConfig);
       resourceStatePolicy = resourceStatePolicyFactory.getResourceStatePolicy();
     } catch (Exception e) {
-      logger.error("Error creating resource state policy when instantiating a replica " + e);
+      logger.error("Error creating resource state policy when instantiating a replica {}", e);
       throw new IllegalStateException("Error creating resource state policy when instantiating a replica " + partition,
           e);
     }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterManager.java
@@ -57,7 +57,7 @@ class StaticClusterManager implements ClusterMap {
 
   StaticClusterManager(PartitionLayout partitionLayout, String localDatacenterName, MetricRegistry metricRegistry) {
     if (logger.isTraceEnabled()) {
-      logger.trace("StaticClusterManager " + partitionLayout);
+      logger.trace("StaticClusterManager {}", partitionLayout);
     }
     this.hardwareLayout = partitionLayout.getHardwareLayout();
     this.partitionLayout = partitionLayout;
@@ -68,7 +68,7 @@ class StaticClusterManager implements ClusterMap {
   }
 
   void persist(String hardwareLayoutPath, String partitionLayoutPath) throws IOException, JSONException {
-    logger.trace("persist " + hardwareLayoutPath + ", " + partitionLayoutPath);
+    logger.trace("persist {}, {}", hardwareLayoutPath, partitionLayoutPath);
     writeJsonObjectToFile(hardwareLayout.toJSONObject(), hardwareLayoutPath);
     writeJsonObjectToFile(partitionLayout.toJSONObject(), partitionLayoutPath);
   }

--- a/ambry-commons/src/main/java/com/github/ambry/commons/LoggingNotificationSystem.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/LoggingNotificationSystem.java
@@ -41,24 +41,23 @@ public class LoggingNotificationSystem implements NotificationSystem {
   public void onBlobCreated(String blobId, BlobProperties blobProperties, Account account, Container container,
       NotificationBlobType notificationBlobType) {
     logger.debug(
-        "onBlobCreated " + blobId + ", blobProperties " + blobProperties + ", accountName " + (account == null ? null
-            : account.getName()) + ", accountId" + (account == null ? null : account.getId()) + ", containerName " + (
-            container == null ? null : container.getName()) + ", containerId " + (container == null ? null
-            : container.getId()) + ", blobType " + notificationBlobType);
+        "onBlobCreated {}, blobProperties {}, accountName {}, accountId{}, containerName {}, containerId {}, blobType {}",
+        blobId, blobProperties, account == null ? null : account.getName(), account == null ? null : account.getId(),
+        container == null ? null : container.getName(), container == null ? null : container.getId(),
+        notificationBlobType);
   }
 
   @Override
   public void onBlobTtlUpdated(String blobId, String serviceId, long expiresAtMs, Account account,
       Container container) {
-    logger.debug("onBlobTtlUpdated " + blobId + ", serviceId " + serviceId + ", accountName " + (account == null ? null
-        : account.getName()) + ", accountId" + (account == null ? null : account.getId()) + ", containerName " + (
-        container == null ? null : container.getName()) + ", containerId " + (container == null ? null
-        : container.getId()) + ", " + expiresAtMs);
+    logger.debug("onBlobTtlUpdated {}, serviceId {}, accountName {}, accountId{}, containerName {}, containerId {}, {}",
+        blobId, serviceId, account == null ? null : account.getName(), account == null ? null : account.getId(),
+        container == null ? null : container.getName(), container == null ? null : container.getId(), expiresAtMs);
   }
 
   @Override
   public void onBlobDeleted(String blobId, String serviceId, Account account, Container container) {
-    logger.debug("onBlobDeleted " + blobId,
+    logger.debug("onBlobDeleted {}", blobId,
         ", " + serviceId + ", accountName " + (account == null ? null : account.getName()) + ", accountId" + (
             account == null ? null : account.getId()) + ", containerName " + (container == null ? null
             : container.getName()) + ", containerId " + (container == null ? null : container.getId()));
@@ -66,7 +65,7 @@ public class LoggingNotificationSystem implements NotificationSystem {
 
   @Override
   public void onBlobUndeleted(String blobId, String serviceId, Account account, Container container) {
-    logger.debug("onBlobUndeleted " + blobId,
+    logger.debug("onBlobUndeleted {}", blobId,
         ", " + serviceId + ", accountName " + (account == null ? null : account.getName()) + ", accountId" + (
             account == null ? null : account.getId()) + ", containerName " + (container == null ? null
             : container.getName()) + ", containerId " + (container == null ? null : container.getId()));
@@ -75,25 +74,23 @@ public class LoggingNotificationSystem implements NotificationSystem {
 
   @Override
   public void onBlobReplicaCreated(String sourceHost, int port, String blobId, BlobReplicaSourceType sourceType) {
-    logger.debug("onBlobReplicaCreated " + sourceHost + ", " + port + ", " + blobId + ", " + sourceType);
+    logger.debug("onBlobReplicaCreated {}, {}, {}, {}", sourceHost, port, blobId, sourceType);
   }
 
   @Override
   public void onBlobReplicaDeleted(String sourceHost, int port, String blobId, BlobReplicaSourceType sourceType) {
-    logger.debug("onBlobReplicaDeleted " + sourceHost + ", " + port + ", " + blobId + ", " + sourceType);
+    logger.debug("onBlobReplicaDeleted {}, {}, {}, {}", sourceHost, port, blobId, sourceType);
   }
 
   @Override
   public void onBlobReplicaUpdated(String sourceHost, int port, String blobId, BlobReplicaSourceType sourceType,
       UpdateType updateType, MessageInfo info) {
-    logger.debug(
-        "onBlobReplicaUpdated " + sourceHost + ", " + port + ", " + blobId + ", " + sourceType + ", " + updateType
-            + ", " + info);
+    logger.debug("onBlobReplicaUpdated {}, {}, {}, {}, {}, {}", sourceHost, port, blobId, sourceType, updateType, info);
   }
 
   @Override
   public void onBlobReplicaUndeleted(String sourceHost, int port, String blobId, BlobReplicaSourceType sourceType) {
-    logger.debug("onBlobReplicaUndeleted " + sourceHost + ", " + port + ", " + blobId + ", " + sourceType);
+    logger.debug("onBlobReplicaUndeleted {}, {}, {}, {}", sourceHost, port, blobId, sourceType);
   }
 }
 

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/PostBlobHandler.java
@@ -269,9 +269,8 @@ class PostBlobHandler {
               "TTL < " + frontendConfig.maxAcceptableTtlSecsIfTtlRequired + " is required for upload to " + descriptor,
               RestServiceErrorCode.InvalidArgs);
         } else {
-          LOGGER.debug(
-              blobProperties.getServiceId() + " attempted an upload with ttl " + blobProperties.getTimeToLiveInSeconds()
-                  + " to " + descriptor);
+          LOGGER.debug("{} attempted an upload with ttl {} to {}", blobProperties.getServiceId(),
+              blobProperties.getTimeToLiveInSeconds(), descriptor);
           frontendMetrics.ttlNotCompliantError.inc();
           restResponseChannel.setHeader(RestUtils.Headers.NON_COMPLIANCE_WARNING,
               "TTL < " + frontendConfig.maxAcceptableTtlSecsIfTtlRequired + " will be required for future uploads");

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatRecord.java
@@ -1186,8 +1186,8 @@ public class MessageFormatRecord {
         long actualCRC = crcStream.getValue();
         long expectedCRC = dataStream.readLong();
         if (actualCRC != expectedCRC) {
-          logger.error(
-              "corrupt data while parsing blob properties Expected CRC " + expectedCRC + " Actual CRC " + actualCRC);
+          logger.error("corrupt data while parsing blob properties Expected CRC {} Actual CRC {}", expectedCRC,
+              actualCRC);
           throw new MessageFormatException("Blob property data is corrupt", MessageFormatErrorCodes.Data_Corrupt);
         }
         return properties;
@@ -1594,8 +1594,8 @@ public class MessageFormatRecord {
       long actualCRC = crcStream.getValue();
       long expectedCRC = dataStream.readLong();
       if (actualCRC != expectedCRC) {
-        logger.error(
-            "corrupt data while parsing blob key record, expected CRC " + expectedCRC + " Actual CRC " + actualCRC);
+        logger.error("corrupt data while parsing blob key record, expected CRC {} Actual CRC {}", expectedCRC,
+            actualCRC);
         throw new MessageFormatException("Blob Key is corrupt", MessageFormatErrorCodes.Data_Corrupt);
       }
       return blobEncryptionKey;
@@ -1644,8 +1644,7 @@ public class MessageFormatRecord {
       long actualCRC = crcStream.getValue();
       long expectedCRC = dataStream.readLong();
       if (actualCRC != expectedCRC) {
-        logger.error(
-            "corrupt data while parsing user metadata Expected CRC " + expectedCRC + " Actual CRC " + actualCRC);
+        logger.error("corrupt data while parsing user metadata Expected CRC {} Actual CRC {}", expectedCRC, actualCRC);
         throw new MessageFormatException("User metadata is corrupt", MessageFormatErrorCodes.Data_Corrupt);
       }
       return ByteBuffer.wrap(userMetadaBuffer);

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
@@ -114,14 +114,13 @@ public class MessageSievingInputStream extends InputStream {
         // from the batched stream, as well as to ensure that subsequent messages can be correctly processed even if there
         // was an error during the sieving for this message.
         Message msg = new Message(msgInfo, new ByteArrayInputStream(Utils.readBytesFromStream(inStream, msgSize)));
-        logger.trace("Read stream for message info " + msgInfo + "  into memory");
+        logger.trace("Read stream for message info {}  into memory", msgInfo);
         validateAndTransform(msg, msgStreamList, bytesRead);
       }
       bytesRead += msgSize;
     }
     if (bytesRead != totalMessageListSize) {
-      logger.error(
-          "Failed to read intended size from stream. Expected " + totalMessageListSize + ", actual " + bytesRead);
+      logger.error("Failed to read intended size from stream. Expected {}, actual {}", totalMessageListSize, bytesRead);
     }
     if (hasInvalidMessages) {
       logger.error("There are invalidated messages in this stream");

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/ValidatingTransformer.java
@@ -70,8 +70,8 @@ public class ValidatingTransformer implements Transformer {
       StoreKey keyInStream = storeKeyFactory.getStoreKey(new DataInputStream(msgStream));
       if (header.isPutRecord()) {
         if (header.hasLifeVersion() && header.getLifeVersion() != msgInfo.getLifeVersion()) {
-          logger.trace("LifeVersion in stream: " + header.getLifeVersion() + " failed to match lifeVersion from Index: "
-              + msgInfo.getLifeVersion() + " for key " + keyInStream);
+          logger.trace("LifeVersion in stream: {} failed to match lifeVersion from Index: {} for key {}",
+              header.getLifeVersion(), msgInfo.getLifeVersion(), keyInStream);
         }
         encryptionKey = header.hasEncryptionKeyRecord() ? deserializeBlobEncryptionKey(msgStream) : null;
         props = deserializeBlobProperties(msgStream);

--- a/ambry-network/src/main/java/com/github/ambry/network/BlockingChannelConnectionPool.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/BlockingChannelConnectionPool.java
@@ -150,12 +150,12 @@ public final class BlockingChannelConnectionPool implements ConnectionPool {
             blockingChannelInfo = new BlockingChannelInfo(config, host, port, registry, sslSocketFactory, sslConfig);
             connections.put(host + port.getPort(), blockingChannelInfo);
           } else {
-            logger.trace("Using already existing BlockingChannelInfo for " + host + ":" + port.getPort()
-                + " in synchronized block");
+            logger.trace("Using already existing BlockingChannelInfo for {}:{} in synchronized block", host,
+                port.getPort());
           }
         }
       } else {
-        logger.trace("Using already existing BlockingChannelInfo for " + host + ":" + port.getPort());
+        logger.trace("Using already existing BlockingChannelInfo for {}:{}", host, port.getPort());
       }
       return blockingChannelInfo.getBlockingChannel(timeoutInMs);
     } finally {

--- a/ambry-network/src/main/java/com/github/ambry/network/BlockingChannelInfo.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/BlockingChannelInfo.java
@@ -114,7 +114,7 @@ class BlockingChannelInfo {
         BlockingChannel channel = blockingChannelAvailableConnections.poll(timeoutInMs, TimeUnit.MILLISECONDS);
         if (channel != null) {
           blockingChannelActiveConnections.add(channel);
-          logger.trace("Returning connection to " + channel.getRemoteHost() + ":" + channel.getRemotePort());
+          logger.trace("Returning connection to {}:{}", channel.getRemoteHost(), channel.getRemotePort());
           return channel;
         } else if (numberOfConnections.get() == maxConnectionsPerHostPerPort) {
           logger.error("Timed out trying to get a connection for host {} and port {}", host, port.getPort());

--- a/ambry-network/src/main/java/com/github/ambry/network/PlainTextTransmission.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/PlainTextTransmission.java
@@ -65,7 +65,7 @@ public class PlainTextTransmission extends Transmission {
     long startTimeMs = time.milliseconds();
     long bytesRead = networkReceive.getReceivedBytes().readFrom(socketChannel);
     long readTimeMs = time.milliseconds() - startTimeMs;
-    logger.trace("Bytes read " + bytesRead + " from {} using key {} Time: {}",
+    logger.trace("Bytes read {} from {} using key {} Time: {}", bytesRead,
         socketChannel.socket().getRemoteSocketAddress(), getConnectionId(), readTimeMs);
     if (bytesRead > 0) {
       metrics.transmissionReceiveTime.update(readTimeMs);

--- a/ambry-network/src/main/java/com/github/ambry/network/Selector.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/Selector.java
@@ -172,7 +172,7 @@ public class Selector implements Selectable {
       transmission = createTransmission(connectionId, key, address.getHostName(), address.getPort(), portType,
           SSLFactory.Mode.CLIENT);
     } catch (IOException e) {
-      logger.error("IOException on transmission creation " + e);
+      logger.error("IOException on transmission creation {}", e);
       channel.socket().close();
       channel.close();
       throw e;

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolMap.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolMap.java
@@ -45,7 +45,7 @@ public class Http2ChannelPoolMap extends AbstractChannelPoolMap<InetSocketAddres
 
   @Override
   protected ChannelPool newPool(InetSocketAddress inetSocketAddress) {
-    log.trace("New pool created for " + inetSocketAddress);
+    log.trace("New pool created for {}", inetSocketAddress);
     http2ClientMetrics.http2NewPoolCount.inc();
     return new Http2MultiplexedChannelPool(inetSocketAddress, sslFactory, eventLoopGroup, http2ClientConfig,
         http2ClientMetrics);

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
@@ -341,7 +341,7 @@ public class Http2MultiplexedChannelPool implements ChannelPool {
     multiplexedChannel.closeAndReleaseChild(childChannel);
 
     if (multiplexedChannel.canBeClosedAndReleased()) {
-      log.debug("Parent channel closed: " + parentChannel.remoteAddress());
+      log.debug("Parent channel closed: {}", parentChannel.remoteAddress());
       // We just closed the last stream in a connection that has reached the end of its life.
       return closeAndReleaseParent(parentChannel, null, promise);
     }
@@ -389,7 +389,7 @@ public class Http2MultiplexedChannelPool implements ChannelPool {
   }
 
   public void handleGoAway(Channel parentChannel, int lastStreamId, GoAwayException exception) {
-    log.debug("Received GOAWAY on " + parentChannel + " with lastStreamId of " + lastStreamId);
+    log.debug("Received GOAWAY on {} with lastStreamId of {}", parentChannel, lastStreamId);
     try {
       MultiplexedChannelRecord multiplexedChannel = parentChannel.attr(MULTIPLEXED_CHANNEL).get();
 
@@ -400,7 +400,7 @@ public class Http2MultiplexedChannelPool implements ChannelPool {
         closeAndReleaseParent(parentChannel);
       }
     } catch (Exception e) {
-      log.error("Failed to handle GOAWAY frame on channel " + parentChannel, e);
+      log.error("Failed to handle GOAWAY frame on channel {}", parentChannel, e);
     }
   }
 

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/MultiplexedChannelRecord.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/MultiplexedChannelRecord.java
@@ -251,8 +251,8 @@ public class MultiplexedChannelRecord {
       return;
     }
 
-    log.debug("Connection " + parentChannel + " has been idle for " + (System.currentTimeMillis()
-        - nonVolatileLastReserveAttemptTimeMillis) + "ms and will be shut down.");
+    log.debug("Connection {} has been idle for {}ms and will be shut down.", parentChannel,
+        System.currentTimeMillis() - nonVolatileLastReserveAttemptTimeMillis);
 
     // Mark ourselves as closed
     state = RecordState.CLOSED;

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -141,7 +141,7 @@ public class AmbryRequests implements RequestAPI {
           throw new UnsupportedOperationException("Request type not supported");
       }
     } catch (Exception e) {
-      logger.error("Error while handling request " + request + " closing connection", e);
+      logger.error("Error while handling request {} closing connection", request, e);
       requestResponseChannel.closeConnection(request);
     }
   }
@@ -188,8 +188,7 @@ public class AmbryRequests implements RequestAPI {
         }
       }
     } catch (StoreException e) {
-      logger.error("Store exception on a put with error code " + e.getErrorCode() + " for request " + receivedRequest,
-          e);
+      logger.error("Store exception on a put with error code {} for request {}", e.getErrorCode(), receivedRequest, e);
       if (e.getErrorCode() == StoreErrorCodes.Already_Exist) {
         metrics.idAlreadyExistError.inc();
       } else if (e.getErrorCode() == StoreErrorCodes.IOError) {
@@ -200,7 +199,7 @@ public class AmbryRequests implements RequestAPI {
       response = new PutResponse(receivedRequest.getCorrelationId(), receivedRequest.getClientId(),
           ErrorMapping.getStoreErrorMapping(e.getErrorCode()));
     } catch (Exception e) {
-      logger.error("Unknown exception on a put for request " + receivedRequest, e);
+      logger.error("Unknown exception on a put for request {}", receivedRequest, e);
       response = new PutResponse(receivedRequest.getCorrelationId(), receivedRequest.getClientId(),
           ServerErrorCode.Unknown_Error);
     } finally {
@@ -331,9 +330,8 @@ public class AmbryRequests implements RequestAPI {
                 ErrorMapping.getStoreErrorMapping(e.getErrorCode()));
             partitionResponseInfoList.add(partitionResponseInfo);
           } catch (MessageFormatException e) {
-            logger.error(
-                "Message format exception on a get with error code " + e.getErrorCode() + " for partitionRequestInfo "
-                    + partitionRequestInfo, e);
+            logger.error("Message format exception on a get with error code {} for partitionRequestInfo {}",
+                e.getErrorCode(), partitionRequestInfo, e);
             if (e.getErrorCode() == MessageFormatErrorCodes.Data_Corrupt) {
               metrics.dataCorruptError.inc();
             } else if (e.getErrorCode() == MessageFormatErrorCodes.Unknown_Format_Version) {
@@ -349,7 +347,7 @@ public class AmbryRequests implements RequestAPI {
       response = new GetResponse(getRequest.getCorrelationId(), getRequest.getClientId(), partitionResponseInfoList,
           compositeSend, ServerErrorCode.No_Error);
     } catch (Exception e) {
-      logger.error("Unknown exception for request " + getRequest, e);
+      logger.error("Unknown exception for request {}", getRequest, e);
       response =
           new GetResponse(getRequest.getCorrelationId(), getRequest.getClientId(), ServerErrorCode.Unknown_Error);
     } finally {
@@ -369,7 +367,7 @@ public class AmbryRequests implements RequestAPI {
         if (isReplicaRequest) {
           metrics.getBlobAllByReplicaProcessingTimeInMs.update(processingTime);
           // client id now has dc name at the end, for example: ClientId=replication-fetch-abc.example.com[dc1]
-          String[] clientStrs = getRequest.getClientId().split("\\[");
+          String[] clientStrs = getRequest.getClientId().split("\\[" );
           if (clientStrs.length > 1) {
             String clientDc = clientStrs[1].substring(0, clientStrs[1].length() - 1);
             if (!currentNode.getDatacenterName().equals(clientDc)) {
@@ -440,7 +438,7 @@ public class AmbryRequests implements RequestAPI {
       response = new DeleteResponse(deleteRequest.getCorrelationId(), deleteRequest.getClientId(),
           ErrorMapping.getStoreErrorMapping(e.getErrorCode()));
     } catch (Exception e) {
-      logger.error("Unknown exception for delete request " + deleteRequest, e);
+      logger.error("Unknown exception for delete request {}", deleteRequest, e);
       response = new DeleteResponse(deleteRequest.getCorrelationId(), deleteRequest.getClientId(),
           ServerErrorCode.Unknown_Error);
       metrics.unExpectedStoreDeleteError.inc();
@@ -600,9 +598,8 @@ public class AmbryRequests implements RequestAPI {
             replicaMetadataResponseList.add(replicaMetadataResponseInfo);
             metrics.replicaMetadataTotalSizeOfMessages.update(replicaMetadataResponseInfo.getTotalSizeOfAllMessages());
           } catch (StoreException e) {
-            logger.error(
-                "Store exception on a replica metadata request with error code " + e.getErrorCode() + " for partition "
-                    + partitionId, e);
+            logger.error("Store exception on a replica metadata request with error code {} for partition {}",
+                e.getErrorCode(), partitionId, e);
             if (e.getErrorCode() == StoreErrorCodes.IOError) {
               metrics.storeIOError.inc();
             } else {
@@ -621,7 +618,7 @@ public class AmbryRequests implements RequestAPI {
               ServerErrorCode.No_Error, replicaMetadataResponseList,
               ReplicaMetadataResponse.getCompatibleResponseVersion(replicaMetadataRequest.getVersionId()));
     } catch (Exception e) {
-      logger.error("Unknown exception for request " + replicaMetadataRequest, e);
+      logger.error("Unknown exception for request {}", replicaMetadataRequest, e);
       response =
           new ReplicaMetadataResponse(replicaMetadataRequest.getCorrelationId(), replicaMetadataRequest.getClientId(),
               ServerErrorCode.Unknown_Error,
@@ -719,7 +716,7 @@ public class AmbryRequests implements RequestAPI {
             ErrorMapping.getStoreErrorMapping(e.getErrorCode()));
       }
     } catch (Exception e) {
-      logger.error("Unknown exception for undelete request " + undeleteRequest, e);
+      logger.error("Unknown exception for undelete request {}", undeleteRequest, e);
       response = new UndeleteResponse(undeleteRequest.getCorrelationId(), undeleteRequest.getClientId(),
           ServerErrorCode.Unknown_Error);
       metrics.unExpectedStoreUndeleteError.inc();

--- a/ambry-replication/src/main/java/com/github/ambry/replication/BlobIdTransformer.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/BlobIdTransformer.java
@@ -162,9 +162,8 @@ public class BlobIdTransformer implements Transformer {
     if (headerFormat.isPutRecord()) {
       if (headerFormat.hasLifeVersion() && headerFormat.getLifeVersion() != oldMessageInfo.getLifeVersion()) {
         // The original Put buffer might have lifeVersion as 0, but the message info might have a higher lifeVersion.
-        logger.trace(
-            "LifeVersion in stream: " + headerFormat.getLifeVersion() + " failed to match lifeVersion from Index: "
-                + oldMessageInfo.getLifeVersion() + " for key " + oldMessageInfo.getStoreKey());
+        logger.trace("LifeVersion in stream: {} failed to match lifeVersion from Index: {} for key {}",
+            headerFormat.getLifeVersion(), oldMessageInfo.getLifeVersion(), oldMessageInfo.getStoreKey());
       }
       ByteBuffer blobEncryptionKey = null;
       if (headerFormat.hasEncryptionKeyRecord()) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -195,12 +195,12 @@ public class ReplicaThread implements Runnable {
   @Override
   public void run() {
     try {
-      logger.trace("Starting replica thread on Local node: " + dataNodeId + " Thread name: " + threadName);
+      logger.trace("Starting replica thread on Local node: {} Thread name: {}", dataNodeId, threadName);
       for (Map.Entry<DataNodeId, Set<RemoteReplicaInfo>> replicasToReplicateEntry : replicasToReplicateGroupedByNode.entrySet()) {
-        logger.trace("Remote node: " + replicasToReplicateEntry.getKey() + " Thread name: " + threadName
-            + " ReplicasToReplicate: " + replicasToReplicateEntry.getValue());
+        logger.trace("Remote node: {} Thread name: {} ReplicasToReplicate: {}", replicasToReplicateEntry.getKey(),
+            threadName, replicasToReplicateEntry.getValue());
       }
-      logger.info("Begin iteration for thread " + threadName);
+      logger.info("Begin iteration for thread {}", threadName);
       while (running) {
         replicate();
         lock.lock();
@@ -593,10 +593,10 @@ public class ReplicaThread implements Runnable {
           || response.getReplicaMetadataResponseInfoList().size() != replicasToReplicatePerNode.size()) {
         int replicaMetadataResponseInfoListSize = response.getReplicaMetadataResponseInfoList() == null ? 0
             : response.getReplicaMetadataResponseInfoList().size();
-        logger.error("Remote node: " + remoteNode + " Thread name: " + threadName + " Remote replicas: "
-            + replicasToReplicatePerNode + " Replica metadata response error: " + response.getError()
-            + " ReplicaMetadataResponseInfoListSize: " + replicaMetadataResponseInfoListSize
-            + " ReplicasToReplicatePerNodeSize: " + replicasToReplicatePerNode.size());
+        logger.error(
+            "Remote node: {} Thread name: {} Remote replicas: {} Replica metadata response error: {} ReplicaMetadataResponseInfoListSize: {} ReplicasToReplicatePerNodeSize: {}",
+            remoteNode, threadName, replicasToReplicatePerNode, response.getError(),
+            replicaMetadataResponseInfoListSize, replicasToReplicatePerNode.size());
         throw new ReplicationException("Replica Metadata Response Error " + response.getError());
       }
       return response;
@@ -849,8 +849,8 @@ public class ReplicaThread implements Runnable {
         replicationMetrics.updateGetRequestTime(getRequestTime, replicatingFromRemoteColo, replicatingOverSsl,
             datacenterName);
         if (getResponse.getError() != ServerErrorCode.No_Error) {
-          logger.error("Remote node: " + remoteNode + " Thread name: " + threadName + " Remote replicas: "
-              + replicasToReplicatePerNode + " GetResponse from replication: " + getResponse.getError());
+          logger.error("Remote node: {} Thread name: {} Remote replicas: {} GetResponse from replication: {}",
+              remoteNode, threadName, replicasToReplicatePerNode, getResponse.getError());
           throw new ReplicationException(
               " Get Request returned error when trying to get missing keys " + getResponse.getError());
         }
@@ -915,9 +915,10 @@ public class ReplicaThread implements Runnable {
                       Collections.singletonList(transformer), metricRegistry);
               if (validMessageDetectionInputStream.hasInvalidMessages()) {
                 replicationMetrics.incrementInvalidMessageError(partitionResponseInfo.getPartition());
-                logger.error("Out of " + (messageInfoList.size()) + " messages, " + (messageInfoList.size()
-                    - validMessageDetectionInputStream.getValidMessageInfoList().size())
-                    + " invalid messages were found in message stream from " + remoteReplicaInfo.getReplicaId());
+                logger.error("Out of {} messages, {} invalid messages were found in message stream from {}",
+                    messageInfoList.size(),
+                    messageInfoList.size() - validMessageDetectionInputStream.getValidMessageInfoList().size(),
+                    remoteReplicaInfo.getReplicaId());
               }
               messageInfoList = validMessageDetectionInputStream.getValidMessageInfoList();
               if (messageInfoList.size() == 0) {
@@ -950,8 +951,8 @@ public class ReplicaThread implements Runnable {
             } catch (StoreException e) {
               if (e.getErrorCode() != StoreErrorCodes.Already_Exist) {
                 replicationMetrics.updateLocalStoreError(remoteReplicaInfo.getReplicaId());
-                logger.error("Remote node: " + remoteNode + " Thread name: " + threadName + " Remote replica: "
-                    + remoteReplicaInfo.getReplicaId(), e);
+                logger.error("Remote node: {} Thread name: {} Remote replica: {}", remoteNode, threadName,
+                    remoteReplicaInfo.getReplicaId(), e);
               }
             }
           } else if (partitionResponseInfo.getErrorCode() == ServerErrorCode.Blob_Deleted) {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -344,7 +344,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
         if (startThread) {
           Thread thread = Utils.newThread(replicaThread.getName(), replicaThread, false);
           thread.start();
-          logger.info("Started replica thread " + thread.getName());
+          logger.info("Started replica thread {}", thread.getName());
         }
       } catch (Exception e) {
         throw new RuntimeException("Encountered exception instantiating ReplicaThread", e);
@@ -499,8 +499,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
       try {
         persistor.write(partitionInfo.getLocalReplicaId().getMountPath(), false);
       } catch (IOException | ReplicationException e) {
-        logger.error(
-            "Exception " + e + " on token write when removing Partition " + partitionId + " from: " + dataNodeId);
+        logger.error("Exception {} on token write when removing Partition {} from: {}", e, partitionId, dataNodeId);
       }
     }
   }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -90,7 +90,7 @@ public class ReplicationManager extends ReplicationEngine {
           addRemoteReplicaInfoToReplicaThread(remoteReplicas, false);
         }
       } else {
-        logger.error("Not replicating to partition " + partition + " because an initialized store could not be found");
+        logger.error("Not replicating to partition {} because an initialized store could not be found", partition);
       }
     }
     // register replication manager's state change listener if clusterParticipant is not null
@@ -122,7 +122,7 @@ public class ReplicationManager extends ReplicationEngine {
       for (List<ReplicaThread> replicaThreads : replicaThreadPoolByDc.values()) {
         for (ReplicaThread thread : replicaThreads) {
           Thread replicaThread = Utils.newThread(thread.getName(), thread, false);
-          logger.info("Starting replica thread " + thread.getName());
+          logger.info("Starting replica thread {}", thread.getName());
           replicaThread.start();
         }
       }

--- a/ambry-rest/src/main/java/com/github/ambry/rest/ConnectionStatsHandler.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/ConnectionStatsHandler.java
@@ -40,7 +40,7 @@ public class ConnectionStatsHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void channelActive(ChannelHandlerContext ctx) throws Exception {
-    logger.trace("Channel Active " + ctx.channel().remoteAddress());
+    logger.trace("Channel Active {}", ctx.channel().remoteAddress());
     metrics.connectionsConnectedCount.inc();
     openConnections.incrementAndGet();
     logHandshakeStatus(ctx);
@@ -49,7 +49,7 @@ public class ConnectionStatsHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-    logger.trace("Channel Inactive " + ctx.channel().remoteAddress());
+    logger.trace("Channel Inactive {}", ctx.channel().remoteAddress());
     metrics.connectionsDisconnectedCount.inc();
     openConnections.decrementAndGet();
     super.channelInactive(ctx);

--- a/ambry-rest/src/main/java/com/github/ambry/rest/FrontendNettyFactory.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/FrontendNettyFactory.java
@@ -83,7 +83,7 @@ public class FrontendNettyFactory implements NioServerFactory {
       if (nettyConfig.nettyServerSslFactory.isEmpty()) {
         sslFactoryToUse = defaultSslFactory;
       } else {
-        LOGGER.info("Using " + nettyConfig.nettyServerSslFactory + " for Netty SSL instead of the shared instance.");
+        LOGGER.info("Using {} for Netty SSL instead of the shared instance.", nettyConfig.nettyServerSslFactory);
         sslFactoryToUse = Utils.getObj(nettyConfig.nettyServerSslFactory, new SSLConfig(verifiableProperties));
       }
       if (sslFactoryToUse == null) {

--- a/ambry-rest/src/main/java/com/github/ambry/rest/HealthCheckHandler.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/HealthCheckHandler.java
@@ -52,7 +52,7 @@ public class HealthCheckHandler extends ChannelDuplexHandler {
     this.restServerState = restServerState;
     this.healthCheckUri = restServerState.getHealthCheckUri();
     this.nettyMetrics = nettyMetrics;
-    logger.trace("Created HealthCheckHandler for HealthCheckUri=" + healthCheckUri);
+    logger.trace("Created HealthCheckHandler for HealthCheckUri={}", healthCheckUri);
   }
 
   @Override
@@ -63,7 +63,7 @@ public class HealthCheckHandler extends ChannelDuplexHandler {
       if (request == null && ((HttpRequest) obj).uri().equals(healthCheckUri)) {
         nettyMetrics.healthCheckRequestRate.mark();
         startTimeInMs = System.currentTimeMillis();
-        logger.trace("Handling health check request while in state " + restServerState.isServiceUp());
+        logger.trace("Handling health check request while in state {}", restServerState.isServiceUp());
         request = (HttpRequest) obj;
         if (restServerState.isServiceUp()) {
           response =
@@ -113,7 +113,7 @@ public class HealthCheckHandler extends ChannelDuplexHandler {
     if (!restServerState.isServiceUp()) {
       if (msg instanceof LastHttpContent) {
         // Start closing client channels after we've completed writing to them (even if they are keep-alive)
-        logger.info("Health check request handler closing connection " + ctx.channel() + " since in shutdown mode.");
+        logger.info("Health check request handler closing connection {} since in shutdown mode.", ctx.channel());
         promise.addListener(ChannelFutureListener.CLOSE);
         nettyMetrics.healthCheckHandlerChannelCloseOnWriteCount.inc();
       }

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyResponseChannel.java
@@ -191,7 +191,7 @@ class NettyResponseChannel implements RestResponseChannel {
       return future;
     }
     Chunk chunk = new Chunk(src, callback);
-    logger.debug("Netty Response Chunk size: " + src.readableBytes());
+    logger.debug("Netty Response Chunk size: {}", src.readableBytes());
     chunksToWrite.add(chunk);
     if (HttpUtil.isContentLengthSet(finalResponseMetadata) && totalBytesReceived.get() > HttpUtil.getContentLength(
         finalResponseMetadata)) {

--- a/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogHandler.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogHandler.java
@@ -79,9 +79,9 @@ public class PublicAccessLogHandler extends ChannelDuplexHandler {
     } else if (obj instanceof LastHttpContent) {
       requestLastChunkArrivalTimeInMs = System.currentTimeMillis();
     } else if (!(obj instanceof HttpContent)) {
-      logger.error("Receiving request (messageReceived) that is not of type HttpRequest or HttpContent. "
-          + "Receiving request from " + ctx.channel().remoteAddress() + ". " + "Request is of type " + obj.getClass()
-          + ". " + "No action being taken other than logging this unexpected state.");
+      logger.error(
+          "Receiving request (messageReceived) that is not of type HttpRequest or HttpContent. Receiving request from {}. Request is of type {}. No action being taken other than logging this unexpected state.",
+          ctx.channel().remoteAddress(), obj.getClass());
     }
     nettyMetrics.publicAccessLogRequestProcessingTimeInMs.update(System.currentTimeMillis() - startTimeInMs);
     super.channelRead(ctx, obj);
@@ -105,9 +105,8 @@ public class PublicAccessLogHandler extends ChannelDuplexHandler {
         }
       } else if (!(msg instanceof HttpContent)) {
         logger.error(
-            "Sending response that is not of type HttpResponse or HttpContent. Sending response to " + ctx.channel()
-                .remoteAddress() + ". Request is of type " + msg.getClass()
-                + ". No action being taken other than logging this unexpected state.");
+            "Sending response that is not of type HttpResponse or HttpContent. Sending response to {}. Request is of type {}. No action being taken other than logging this unexpected state.",
+            ctx.channel().remoteAddress(), msg.getClass());
       }
       if (shouldReset) {
         logDurations();

--- a/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogger.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogger.java
@@ -35,7 +35,7 @@ public class PublicAccessLogger {
   public PublicAccessLogger(String[] requestHeaders, String[] responseHeaders) {
     this.requestHeaders = requestHeaders;
     this.responseHeaders = responseHeaders;
-    logger.trace("Created PublicAccessLogger for log " + publicAccessLogger.getName());
+    logger.trace("Created PublicAccessLogger for log {}", publicAccessLogger.getName());
   }
 
   public String[] getRequestHeaders() {

--- a/ambry-rest/src/test/java/com/github/ambry/rest/EchoMethodHandler.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/EchoMethodHandler.java
@@ -58,7 +58,7 @@ public class EchoMethodHandler extends SimpleChannelInboundHandler<HttpObject> {
     logger.trace("Reading on channel {}", ctx.channel());
     if (obj instanceof HttpRequest) {
       HttpRequest request = (HttpRequest) obj;
-      logger.trace("Handling incoming request " + request);
+      logger.trace("Handling incoming request {}", request);
       requestUri = request.uri();
       byte[] methodBytes = request.method().toString().getBytes();
       if (request.headers().get(IS_CHUNKED) == null || !request.headers().get(IS_CHUNKED).equals("true")) {

--- a/ambry-router/src/main/java/com/github/ambry/router/CryptoJobHandler.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/CryptoJobHandler.java
@@ -67,7 +67,7 @@ class CryptoJobHandler implements Closeable {
         if (task instanceof CryptoJob) {
           ((CryptoJob) task).closeJob(CLOSED_EXCEPTION);
         } else {
-          logger.error("Unknown type of job seen : " + task.getClass());
+          logger.error("Unknown type of job seen : {}", task.getClass());
         }
       }
       try {

--- a/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/DeleteOperation.java
@@ -187,9 +187,9 @@ class DeleteOperation {
         // The true case below should not really happen. This means a response has been received
         // not for its original request. We will immediately fail this operation.
         if (deleteResponse.getCorrelationId() != deleteRequest.getCorrelationId()) {
-          logger.error("The correlation id in the DeleteResponse " + deleteResponse.getCorrelationId()
-              + " is not the same as the correlation id in the associated DeleteRequest: "
-              + deleteRequest.getCorrelationId());
+          logger.error(
+              "The correlation id in the DeleteResponse {} is not the same as the correlation id in the associated DeleteRequest: {}",
+              deleteResponse.getCorrelationId(), deleteRequest.getCorrelationId());
           routerMetrics.unknownReplicaResponseError.inc();
           onErrorResponse(replica,
               new RouterException("Received wrong response that is not for the corresponding request.",

--- a/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/NonBlockingRouter.java
@@ -582,7 +582,7 @@ class NonBlockingRouter implements Router {
       BlobId.BlobDataType dataType = BlobId.getBlobDataType(blobId);
       return (dataType == null || dataType == BlobId.BlobDataType.METADATA);
     } catch (Exception ex) {
-      logger.error("Unexpected error getting blob data type for blobId " + blobId, ex);
+      logger.error("Unexpected error getting blob data type for blobId {}", blobId, ex);
       return true;
     }
   }
@@ -975,7 +975,7 @@ class NonBlockingRouter implements Router {
                 undeleteManager.handleResponse(responseInfo);
                 break;
               default:
-                logger.error("Unexpected response type: " + type + " received, discarding");
+                logger.error("Unexpected response type: {} received, discarding", type);
             }
           }
         } catch (Exception e) {

--- a/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/PutOperation.java
@@ -506,7 +506,7 @@ class PutOperation {
       if (chunk.getChunkException() == null) {
         logger.error("Operation on chunk failed, but no exception was set");
       }
-      logger.error("Failed putting chunk at index: " + chunk.getChunkIndex() + ", failing the entire operation");
+      logger.error("Failed putting chunk at index: {}, failing the entire operation", chunk.getChunkIndex());
       setOperationCompleted();
     } else if (chunk != metadataPutChunk) {
       // a data chunk has succeeded.
@@ -1450,8 +1450,9 @@ class PutOperation {
             // sent over it. The check here ensures that is indeed the case. If not, log an error and fail this request.
             // There is no other way to handle it.
             routerMetrics.unknownReplicaResponseError.inc();
-            logger.error("The correlation id in the PutResponse " + putResponse.getCorrelationId()
-                + " is not the same as the correlation id in the associated PutRequest: " + correlationId);
+            logger.error(
+                "The correlation id in the PutResponse {} is not the same as the correlation id in the associated PutRequest: {}",
+                putResponse.getCorrelationId(), correlationId);
             setChunkException(
                 new RouterException("Unexpected internal error", RouterErrorCode.UnexpectedInternalError));
             isSuccessful = false;
@@ -1460,7 +1461,7 @@ class PutOperation {
           } else {
             ServerErrorCode putError = putResponse.getError();
             if (putError == ServerErrorCode.No_Error) {
-              logger.trace("The putRequest was successful for chunk " + chunkIndex);
+              logger.trace("The putRequest was successful for chunk {}", chunkIndex);
               isSuccessful = true;
             } else {
               // chunkException will be set within processServerError.

--- a/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/TtlUpdateOperation.java
@@ -178,9 +178,9 @@ class TtlUpdateOperation {
         // The true case below should not really happen. This means a response has been received
         // not for its original request. We will immediately fail this operation.
         if (ttlUpdateResponse.getCorrelationId() != ttlUpdateRequest.getCorrelationId()) {
-          LOGGER.error("The correlation id in the TtlUpdateResponse " + ttlUpdateResponse.getCorrelationId()
-              + " is not the same as the correlation id in the associated TtlUpdateRequest: "
-              + ttlUpdateRequest.getCorrelationId());
+          LOGGER.error(
+              "The correlation id in the TtlUpdateResponse {} is not the same as the correlation id in the associated TtlUpdateRequest: {}",
+              ttlUpdateResponse.getCorrelationId(), ttlUpdateRequest.getCorrelationId());
           routerMetrics.unknownReplicaResponseError.inc();
           onErrorResponse(replica,
               new RouterException("Received wrong response that is not for the corresponding request.",

--- a/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/UndeleteOperation.java
@@ -176,9 +176,9 @@ public class UndeleteOperation {
         // The true case below should not really happen. This means a response has been received
         // not for its original request. We will immediately fail this operation.
         if (undeleteResponse.getCorrelationId() != undeleteRequest.getCorrelationId()) {
-          LOGGER.error("The correlation id in the DeleteResponse " + undeleteResponse.getCorrelationId()
-              + " is not the same as the correlation id in the associated DeleteRequest: "
-              + undeleteRequest.getCorrelationId());
+          LOGGER.error(
+              "The correlation id in the DeleteResponse {} is not the same as the correlation id in the associated DeleteRequest: {}",
+              undeleteResponse.getCorrelationId(), undeleteRequest.getCorrelationId());
           routerMetrics.unknownReplicaResponseError.inc();
           onErrorResponse(replica,
               new RouterException("Received wrong response that is not for the corresponding request.",

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -298,7 +298,7 @@ public class AmbryServer {
       logger.info("started");
       long processingTime = SystemTime.getInstance().milliseconds() - startTime;
       metrics.serverStartTimeInMs.update(processingTime);
-      logger.info("Server startup time in Ms " + processingTime);
+      logger.info("Server startup time in Ms {}", processingTime);
     } catch (Exception e) {
       logger.error("Error during startup", e);
       throw new InstantiationException("failure during startup " + e);
@@ -372,7 +372,7 @@ public class AmbryServer {
       shutdownLatch.countDown();
       long processingTime = SystemTime.getInstance().milliseconds() - startTime;
       metrics.serverShutdownTimeInMs.update(processingTime);
-      logger.info("Server shutdown time in Ms " + processingTime);
+      logger.info("Server shutdown time in Ms {}", processingTime);
     }
   }
 

--- a/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/StatsManager.java
@@ -195,9 +195,9 @@ class StatsManager {
   boolean addReplica(ReplicaId id) {
     boolean success = partitionToReplicaMap.putIfAbsent(id.getPartitionId(), id) == null;
     if (success) {
-      logger.info("Partition " + id.getPartitionId() + " is added into StatsManager");
+      logger.info("Partition {} is added into StatsManager", id.getPartitionId());
     } else {
-      logger.error("Failed to add partition " + id.getPartitionId() + " because it is already in StatsManager");
+      logger.error("Failed to add partition {} because it is already in StatsManager", id.getPartitionId());
     }
     return success;
   }
@@ -210,9 +210,9 @@ class StatsManager {
   boolean removeReplica(ReplicaId id) {
     boolean success = partitionToReplicaMap.remove(id.getPartitionId()) != null;
     if (success) {
-      logger.info("Partition " + id.getPartitionId() + " is removed from StatsManager");
+      logger.info("Partition {} is removed from StatsManager", id.getPartitionId());
     } else {
-      logger.error("Failed to remove partition " + id.getPartitionId() + " because it doesn't exist in StatsManager");
+      logger.error("Failed to remove partition {} because it doesn't exist in StatsManager", id.getPartitionId());
     }
     return success;
   }
@@ -361,8 +361,8 @@ class StatsManager {
       if (partitionToReplicaMap.containsKey(partition)) {
         unreachableStores.add(partition.toPathString());
       } else {
-        logger.info("Removing partition " + partition.toPathString()
-            + " from unreachable list because it is no longer in StatsManager");
+        logger.info("Removing partition {} from unreachable list because it is no longer in StatsManager",
+            partition.toPathString());
       }
     }
     return unreachableStores;

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -888,7 +888,7 @@ public class BlobStore implements Store {
     } catch (IOException e) {
       // if deletion fails, we log here without throwing exception. Next time when server restarts, the store should
       // complete BOOTSTRAP -> STANDBY quickly and attempt to delete this again.
-      logger.error("Failed to delete " + bootstrapFile.getName(), e);
+      logger.error("Failed to delete {}", bootstrapFile.getName(), e);
     }
   }
 
@@ -985,7 +985,7 @@ public class BlobStore implements Store {
     synchronized (storeWriteLock) {
       checkStarted();
       try {
-        logger.info("Store : " + dataDir + " shutting down");
+        logger.info("Store : {} shutting down", dataDir);
         blobStoreStats.close();
         compactor.close(30);
         index.close(skipDiskFlush);
@@ -993,12 +993,12 @@ public class BlobStore implements Store {
         metrics.deregisterMetrics(storeId);
         started = false;
       } catch (Exception e) {
-        logger.error("Store : " + dataDir + " shutdown of store failed for directory ", e);
+        logger.error("Store : {} shutdown of store failed for directory ", dataDir, e);
       } finally {
         try {
           fileLock.destroy();
         } catch (IOException e) {
-          logger.error("Store : " + dataDir + " IO Exception while trying to close the file lock", e);
+          logger.error("Store : {} IO Exception while trying to close the file lock", dataDir, e);
         }
         metrics.storeShutdownTimeInMs.update(time.milliseconds() - startTimeInMs);
       }

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -154,7 +154,7 @@ class DiskManager {
             partitionAndStore.getValue().start();
           } catch (Exception e) {
             numStoreFailures.incrementAndGet();
-            logger.error("Exception while starting store for the " + partitionAndStore.getKey(), e);
+            logger.error("Exception while starting store for the {}", partitionAndStore.getKey(), e);
           }
         }, false);
         thread.start();
@@ -164,8 +164,7 @@ class DiskManager {
         startupThread.join();
       }
       if (numStoreFailures.get() > 0) {
-        logger.error(
-            "Could not start " + numStoreFailures.get() + " out of " + stores.size() + " stores on the disk " + disk);
+        logger.error("Could not start {} out of {} stores on the disk {}", numStoreFailures.get(), stores.size(), disk);
       }
 
       // DiskSpaceAllocator startup. This happens after BlobStore startup because it needs disk space requirements
@@ -184,8 +183,8 @@ class DiskManager {
       reportUnrecognizedDirs();
       running = true;
     } catch (StoreException e) {
-      logger.error("Error while starting the DiskManager for " + disk.getMountPath()
-          + " ; no stores will be accessible on this disk.", e);
+      logger.error("Error while starting the DiskManager for {} ; no stores will be accessible on this disk.",
+          disk.getMountPath(), e);
     } finally {
       if (!running) {
         metrics.totalStoreStartFailures.inc(stores.size());
@@ -231,8 +230,7 @@ class DiskManager {
         shutdownThread.join();
       }
       if (numFailures.get() > 0) {
-        logger.error(
-            "Could not shutdown " + numFailures.get() + " out of " + stores.size() + " stores on the disk " + disk);
+        logger.error("Could not shutdown {} out of {} stores on the disk {}", numFailures.get(), stores.size(), disk);
       }
       compactionManager.awaitTermination();
       longLivedTaskScheduler.shutdown();

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -173,7 +173,7 @@ class IndexSegment {
         if (!bloomFile.delete()) {
           throw new StoreException("Could not delete bloom file named " + bloomFile, StoreErrorCodes.Unknown_Error);
         }
-        logger.info(bloomFile + " is successfully deleted and will be rebuilt based on index segment");
+        logger.info("{} is successfully deleted and will be rebuilt based on index segment", bloomFile);
       }
       if (sealed) {
         map();
@@ -1076,7 +1076,7 @@ class IndexSegment {
           index++;
         }
       } else {
-        logger.error("IndexSegment : " + indexFile.getAbsolutePath() + " index not found for key " + key);
+        logger.error("IndexSegment : {} index not found for key {}", indexFile.getAbsolutePath(), key);
         metrics.keyInFindEntriesAbsent.inc();
       }
     } else if (key == null || index.containsKey(key)) {
@@ -1098,7 +1098,7 @@ class IndexSegment {
         }
       }
     } else {
-      logger.error("IndexSegment : " + indexFile.getAbsolutePath() + " key not found: " + key);
+      logger.error("IndexSegment : {} key not found: {}", indexFile.getAbsolutePath(), key);
       metrics.keyInFindEntriesAbsent.inc();
     }
     if (oneEntryPerKey) {

--- a/ambry-store/src/main/java/com/github/ambry/store/Journal.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/Journal.java
@@ -111,9 +111,9 @@ class Journal {
       if (crc != null) {
         recentCrcs.put(key, crc);
       }
-      logger.trace("Journal : " + dataDir + " offset " + offset + " key " + key);
+      logger.trace("Journal : {} offset {} key {}", dataDir, offset, key);
       currentNumberOfEntries.incrementAndGet();
-      logger.trace("Journal : " + dataDir + " number of entries " + currentNumberOfEntries.get());
+      logger.trace("Journal : {} number of entries {}", dataDir, currentNumberOfEntries.get());
     }
   }
 
@@ -169,7 +169,7 @@ class Journal {
       return null;
     }
 
-    logger.trace("Journal : " + dataDir + " entries returned " + journalEntries.size());
+    logger.trace("Journal : {} entries returned {}", dataDir, journalEntries.size());
     return journalEntries;
   }
 

--- a/ambry-store/src/main/java/com/github/ambry/store/Log.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/Log.java
@@ -474,7 +474,7 @@ class Log implements Write {
           "There is no more capacity left in [" + dataDir + "]. Max capacity is [" + capacityInBytes + "]");
     }
     Pair<String, String> segmentNameAndFilename = getNextSegmentNameAndFilename();
-    logger.info("Allocating new segment with name: " + segmentNameAndFilename.getFirst());
+    logger.info("Allocating new segment with name: {}", segmentNameAndFilename.getFirst());
     File newSegmentFile = null;
     try {
       newSegmentFile = allocate(segmentNameAndFilename.getSecond(), segmentCapacity, false);

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -189,7 +189,7 @@ public class StorageManager implements StoreManager {
             diskManager.start();
           } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.error("Disk manager startup thread interrupted for disk " + diskManager.getDisk(), e);
+            logger.error("Disk manager startup thread interrupted for disk {}", diskManager.getDisk(), e);
           }
         }, false);
         thread.start();
@@ -303,7 +303,7 @@ public class StorageManager implements StoreManager {
             diskManager.shutdown();
           } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.error("Disk manager shutdown thread interrupted for disk " + diskManager.getDisk(), e);
+            logger.error("Disk manager shutdown thread interrupted for disk {}", diskManager.getDisk(), e);
           }
         }, false);
         thread.start();
@@ -334,7 +334,7 @@ public class StorageManager implements StoreManager {
       try {
         newDiskManager.start();
       } catch (Exception e) {
-        logger.error("Error while starting the new DiskManager for " + disk.getMountPath(), e);
+        logger.error("Error while starting the new DiskManager for {}", disk.getMountPath(), e);
         return null;
       }
       return newDiskManager;
@@ -521,7 +521,7 @@ public class StorageManager implements StoreManager {
             logger.info("Decommission file is created for replica {}", replica.getReplicaPath());
           }
         } catch (IOException e) {
-          logger.error("IOException occurs when creating decommission file for replica " + partitionName, e);
+          logger.error("IOException occurs when creating decommission file for replica {}", partitionName, e);
           throw new StateTransitionException(
               "Couldn't create decommission file for replica " + replica.getReplicaPath(), ReplicaOperationFailure);
         }

--- a/ambry-tools/src/main/java/com/github/ambry/store/DumpDataTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/store/DumpDataTool.java
@@ -120,7 +120,7 @@ public class DumpDataTool {
    * @throws Exception
    */
   public void doOperation() throws Exception {
-    logger.info("Type of Operation " + typeOfOperation);
+    logger.info("Type of Operation {}", typeOfOperation);
     switch (typeOfOperation) {
       case "CompareIndexToLog":
         compareIndexEntriesToLogContent(new File(fileToRead), false);
@@ -129,7 +129,7 @@ public class DumpDataTool {
         compareReplicaIndexEntriestoLogContent(replicaRootDirectory);
         break;
       default:
-        logger.error("Unknown typeOfOperation " + typeOfOperation);
+        logger.error("Unknown typeOfOperation {}", typeOfOperation);
         break;
     }
   }
@@ -183,14 +183,14 @@ public class DumpDataTool {
       logger.trace("Record startOffset {} , endOffset {} ", curEntry.getKey(), curEntry.getValue());
       if (prevEntry.getValue().compareTo(curEntry.getKey()) != 0) {
         metrics.logRangeNotFoundInIndexError.inc();
-        logger.error("Cannot find entries in Index ranging from " + prevEntry.getValue() + " to " + curEntry.getKey()
-            + " with a hole of size " + (curEntry.getKey() - prevEntry.getValue()) + " in the Log");
+        logger.error("Cannot find entries in Index ranging from {} to {} with a hole of size {} in the Log",
+            prevEntry.getValue(), curEntry.getKey(), curEntry.getKey() - prevEntry.getValue());
       }
       prevEntry = curEntry;
     }
     if (prevEntry.getValue().compareTo(indexEndOffset) != 0) {
-      logger.error("End offset mismatch. FileEndPointer from the index segment " + indexEndOffset
-          + ", end offset as per records " + prevEntry.getValue());
+      logger.error("End offset mismatch. FileEndPointer from the index segment {}, end offset as per records {}",
+          indexEndOffset, prevEntry.getValue());
     }
   }
 
@@ -257,18 +257,20 @@ public class DumpDataTool {
                       }
                     } catch (IllegalArgumentException e) {
                       metrics.logDeserializationError.inc();
-                      logger.error("Illegal arg exception thrown at  " + randomAccessFile.getChannel().position() + ", "
-                          + "while reading blob starting at offset " + originalOffset + " with exception: ", e);
+                      logger.error(
+                          "Illegal arg exception thrown at  {}, while reading blob starting at offset {} with exception: ",
+                          randomAccessFile.getChannel().position(), originalOffset, e);
                     } catch (MessageFormatException e) {
                       metrics.logDeserializationError.inc();
-                      logger.error("MessageFormat exception thrown at  " + randomAccessFile.getChannel().position()
-                          + " while reading blob starting at offset " + originalOffset + " with exception: ", e);
+                      logger.error(
+                          "MessageFormat exception thrown at  {} while reading blob starting at offset {} with exception: ",
+                          randomAccessFile.getChannel().position(), originalOffset, e);
                     } catch (EOFException e) {
                       metrics.endOfFileOnDumpLogError.inc();
-                      logger.error("EOFException thrown at " + randomAccessFile.getChannel().position() + " ", e);
+                      logger.error("EOFException thrown at {} ", randomAccessFile.getChannel().position(), e);
                     } catch (Exception e) {
                       metrics.unknownErrorOnDumpIndex.inc();
-                      logger.error("Unknown exception thrown " + e.getMessage() + " ", e);
+                      logger.error("Unknown exception thrown {} ", e.getMessage(), e);
                     }
                   }
                 }
@@ -327,18 +329,18 @@ public class DumpDataTool {
       return true;
     } catch (IllegalArgumentException e) {
       metrics.logDeserializationError.inc();
-      logger.error("Illegal arg exception thrown at  " + randomAccessFile.getChannel().position() + ", "
-          + "while reading blob starting at offset " + offset + " with exception: ", e);
+      logger.error("Illegal arg exception thrown at  {}, while reading blob starting at offset {} with exception: ",
+          randomAccessFile.getChannel().position(), offset, e);
     } catch (MessageFormatException e) {
       metrics.logDeserializationError.inc();
-      logger.error("MessageFormat exception thrown at  " + randomAccessFile.getChannel().position()
-          + " while reading blob starting at offset " + offset + " with exception: ", e);
+      logger.error("MessageFormat exception thrown at  {} while reading blob starting at offset {} with exception: ",
+          randomAccessFile.getChannel().position(), offset, e);
     } catch (EOFException e) {
       metrics.endOfFileOnDumpLogError.inc();
-      logger.error("EOFException thrown at " + randomAccessFile.getChannel().position() + " ", e);
+      logger.error("EOFException thrown at {} ", randomAccessFile.getChannel().position(), e);
     } catch (Exception e) {
       metrics.unknownErrorOnDumpLog.inc();
-      logger.error("Unknown exception thrown " + e.getMessage() + " ", e);
+      logger.error("Unknown exception thrown {} ", e.getMessage(), e);
     } finally {
       context.stop();
     }
@@ -357,19 +359,18 @@ public class DumpDataTool {
     boolean isExpired = DumpDataHelper.isExpired(indexValue.getExpiresAtMs(), currentTimeInMs);
     if (isDeleted != logBlobRecordInfo.isDeleted) {
       metrics.indexToLogDeleteFlagMisMatchError.inc();
-      logger.error(
-          "Deleted value mismatch for " + logBlobRecordInfo.blobId + " Index value " + isDeleted + ", Log value "
-              + logBlobRecordInfo.isDeleted);
+      logger.error("Deleted value mismatch for {} Index value {}, Log value {}", logBlobRecordInfo.blobId, isDeleted,
+          logBlobRecordInfo.isDeleted);
     } else if (!logBlobRecordInfo.isDeleted && isExpired != logBlobRecordInfo.isExpired) {
       metrics.indexToLogExpiryMisMatchError.inc();
       logger.error(
-          "Expiration value mismatch for " + logBlobRecordInfo.blobId + " Index value " + isExpired + ", Log value "
-              + logBlobRecordInfo.isExpired + ", index expiresAt in ms " + indexValue.getExpiresAtMs()
-              + ", log expiresAt in ms " + logBlobRecordInfo.expiresAtMs);
+          "Expiration value mismatch for {} Index value {}, Log value {}, index expiresAt in ms {}, log expiresAt in ms {}",
+          logBlobRecordInfo.blobId, isExpired, logBlobRecordInfo.isExpired, indexValue.getExpiresAtMs(),
+          logBlobRecordInfo.expiresAtMs);
     } else if (!blobId.equals(logBlobRecordInfo.blobId.getID())) {
       metrics.indexToLogBlobIdMisMatchError.inc();
-      logger.error("BlobId value mismatch for " + logBlobRecordInfo.blobId + " Index value " + blobId + ", Log value "
-          + logBlobRecordInfo.blobId);
+      logger.error("BlobId value mismatch for {} Index value {}, Log value {}", logBlobRecordInfo.blobId, blobId,
+          logBlobRecordInfo.blobId);
     }
   }
 }

--- a/ambry-tools/src/main/java/com/github/ambry/store/DumpLogTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/store/DumpLogTool.java
@@ -116,11 +116,11 @@ public class DumpLogTool {
       blobArray = blobIdList.split(",");
       blobs = new ArrayList<>();
       blobs.addAll(Arrays.asList(blobArray));
-      logger.info("Blobs to look out for :: " + blobs);
+      logger.info("Blobs to look out for :: {}", blobs);
     }
 
     if (fileToRead != null && !silent) {
-      logger.info("File to read " + fileToRead);
+      logger.info("File to read {}", fileToRead);
     }
     dumpLog(new File(fileToRead), logStartOffset, logEndOffset, blobs);
   }
@@ -143,10 +143,10 @@ public class DumpLogTool {
         LogBlobStatus logBlobStatus = blobIdToLogRecord.get(blobId);
         if (!logBlobStatus.isConsistent) {
           totalInConsistentBlobs++;
-          logger.error("Inconsistent blob " + blobId + " " + logBlobStatus);
+          logger.error("Inconsistent blob {} {}", blobId, logBlobStatus);
         }
       }
-      logger.info("Total inconsistent blob count " + totalInConsistentBlobs);
+      logger.info("Total inconsistent blob count {}", totalInConsistentBlobs);
     } finally {
       context.stop();
     }
@@ -164,7 +164,7 @@ public class DumpLogTool {
    */
   private void dumpLog(File file, long startOffset, long endOffset, ArrayList<String> blobs,
       Map<String, LogBlobStatus> blobIdToLogRecord) throws IOException {
-    logger.info("Dumping log file " + file.getAbsolutePath());
+    logger.info("Dumping log file {}", file.getAbsolutePath());
     long currentOffset = 0;
     RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r");
     long fileSize = file.length();
@@ -175,7 +175,7 @@ public class DumpLogTool {
     if (endOffset == -1) {
       endOffset = fileSize;
     }
-    logger.info("Starting dumping from offset " + currentOffset);
+    logger.info("Starting dumping from offset {}", currentOffset);
     while (currentOffset < endOffset) {
       try {
         DumpDataHelper.LogBlobRecordInfo logBlobRecordInfo =
@@ -185,7 +185,7 @@ public class DumpLogTool {
           throttler.maybeThrottle(logBlobRecordInfo.totalRecordSize);
         }
         if (lastBlobFailed && !silent) {
-          logger.info("Successful record found at " + currentOffset + " after some failures ");
+          logger.info("Successful record found at {} after some failures ", currentOffset);
         }
         lastBlobFailed = false;
         if (!logBlobRecordInfo.isDeleted) {
@@ -224,38 +224,38 @@ public class DumpLogTool {
       } catch (IllegalArgumentException e) {
         if (!lastBlobFailed) {
           metrics.logDeserializationError.inc();
-          logger.error("Illegal arg exception thrown at  " + randomAccessFile.getChannel().position() + ", "
-              + "while reading blob starting at offset " + currentOffset + "with exception: ", e);
+          logger.error("Illegal arg exception thrown at  {}, while reading blob starting at offset {}with exception: ",
+              randomAccessFile.getChannel().position(), currentOffset, e);
         }
         currentOffset++;
         lastBlobFailed = true;
       } catch (MessageFormatException e) {
         if (!lastBlobFailed) {
           metrics.logDeserializationError.inc();
-          logger.error("MessageFormat exception thrown at  " + randomAccessFile.getChannel().position()
-              + " while reading blob starting at offset " + currentOffset + " with exception: ", e);
+          logger.error(
+              "MessageFormat exception thrown at  {} while reading blob starting at offset {} with exception: ",
+              randomAccessFile.getChannel().position(), currentOffset, e);
         }
         currentOffset++;
         lastBlobFailed = true;
       } catch (EOFException e) {
         metrics.endOfFileOnDumpLogError.inc();
-        logger.error("EOFException thrown at " + randomAccessFile.getChannel().position() + ", Cause :" + e.getCause()
-            + ", Msg :" + e.getMessage() + ", stacktrace ", e);
+        logger.error("EOFException thrown at {}, Cause :{}, Msg :{}, stacktrace ",
+            randomAccessFile.getChannel().position(), e.getCause(), e.getMessage(), e);
         throw (e);
       } catch (Exception e) {
         if (!lastBlobFailed) {
           metrics.unknownErrorOnDumpLog.inc();
-          logger.error(
-              "Unknown exception thrown with Cause " + e.getCause() + ", Msg :" + e.getMessage() + ", stacktrace ", e);
+          logger.error("Unknown exception thrown with Cause {}, Msg :{}, stacktrace ", e.getCause(), e.getMessage(), e);
           if (!silent) {
-            logger.info("Trying out next offset " + (currentOffset + 1));
+            logger.info("Trying out next offset {}", currentOffset + 1);
           }
         }
         currentOffset++;
         lastBlobFailed = true;
       }
     }
-    logger.info("Dumped until offset " + currentOffset);
+    logger.info("Dumped until offset {}", currentOffset);
   }
 
   /**

--- a/ambry-tools/src/main/java/com/github/ambry/store/DumpReplicaTokenTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/store/DumpReplicaTokenTool.java
@@ -65,7 +65,7 @@ public class DumpReplicaTokenTool {
    * @throws Exception
    */
   private void dumpReplicaToken() throws Exception {
-    logger.info("Dumping replica token file " + fileToRead);
+    logger.info("Dumping replica token file {}", fileToRead);
     DataInputStream stream = new DataInputStream(new FileInputStream(fileToRead));
     short version = stream.readShort();
     switch (version) {
@@ -87,14 +87,13 @@ public class DumpReplicaTokenTool {
           long totalBytesReadFromLocalStore = stream.readLong();
           // read replica token
           FindToken token = findTokenFactory.getFindToken(stream);
-          logger.info(
-              "partitionId " + partitionId + " hostname " + hostname + " replicaPath " + replicaPath + " port " + port
-                  + " totalBytesReadFromLocalStore " + totalBytesReadFromLocalStore + " token " + token);
+          logger.info("partitionId {} hostname {} replicaPath {} port {} totalBytesReadFromLocalStore {} token {}",
+              partitionId, hostname, replicaPath, port, totalBytesReadFromLocalStore, token);
         }
-        logger.info("crc " + stream.readLong());
+        logger.info("crc {}", stream.readLong());
         break;
       default:
-        logger.error("Version " + version + " unsupported ");
+        logger.error("Version {} unsupported ", version);
     }
   }
 }

--- a/ambry-tools/src/main/java/com/github/ambry/tools/admin/BlobValidator.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/admin/BlobValidator.java
@@ -223,7 +223,7 @@ public class BlobValidator implements Closeable {
         for (Map.Entry<BlobId, ServerErrorCode> entry : blobIdToErrorCode.entrySet()) {
           ServerErrorCode errorCode = entry.getValue();
           if (!validErrorCodes.contains(errorCode)) {
-            LOGGER.error("[" + entry.getKey() + "] received error code: " + errorCode);
+            LOGGER.error("[{}] received error code: {}", entry.getKey(), errorCode);
           }
         }
         break;
@@ -270,7 +270,7 @@ public class BlobValidator implements Closeable {
       BlobId blobId = entry.getKey();
       List<String> mismatchDetailsList = entry.getValue();
       for (String mismatchDetails : mismatchDetailsList) {
-        LOGGER.error("[" + blobId + "] : " + mismatchDetails);
+        LOGGER.error("[{}] : {}", blobId, mismatchDetails);
       }
     }
   }


### PR DESCRIPTION
When done inside of hot path logger.trace calls, this can result in
quite a few unnecessary string allocations. For example, there were a
lot of such calls inside of PersistentIndex.

Used intellij inspections and autosuggestions to find and replace across
the entire project.