### PR TITLE
Fix store unable to seal replicas in second cluster issue

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaStatusDelegate.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaStatusDelegate.java
@@ -64,7 +64,17 @@ public class ReplicaStatusDelegate {
     return clusterParticipant.setReplicaStoppedState(replicaIds, false);
   }
 
+  /**
+   * @return a list of stopped replicas in InstanceConfig of local node.
+   */
   public List<String> getStoppedReplicas() {
     return clusterParticipant.getStoppedReplicas();
+  }
+
+  /**
+   * @return a list of sealed replicas in InstanceConfig of local node.
+   */
+  public List<String> getSealedReplicas() {
+    return clusterParticipant.getSealedReplicas();
   }
 }

--- a/ambry-api/src/test/java/com/github/ambry/clustermap/ReplicaStatusDelegateTest.java
+++ b/ambry-api/src/test/java/com/github/ambry/clustermap/ReplicaStatusDelegateTest.java
@@ -14,7 +14,7 @@
 
 package com.github.ambry.clustermap;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 
@@ -32,7 +32,7 @@ public class ReplicaStatusDelegateTest {
     ClusterParticipant clusterParticipant = mock(ClusterParticipant.class);
     ReplicaId replicaId = mock(ReplicaId.class);
     ReplicaStatusDelegate delegate = new ReplicaStatusDelegate(clusterParticipant);
-    List<ReplicaId> replicaIds = Arrays.asList(replicaId);
+    List<ReplicaId> replicaIds = Collections.singletonList(replicaId);
 
     //Checks that the right underlying ClusterParticipant methods are called
     verifyZeroInteractions(clusterParticipant);

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -171,8 +171,9 @@ public class AmbryServer {
             new ParticipantsConsistencyChecker(clusterParticipants, metrics);
         logger.info("Scheduling participants consistency checker with a period of {} secs",
             serverConfig.serverParticipantsConsistencyCheckerPeriodSec);
-        consistencyCheckerTask = scheduler.scheduleAtFixedRate(consistencyChecker, 0,
-            serverConfig.serverParticipantsConsistencyCheckerPeriodSec, TimeUnit.SECONDS);
+        consistencyCheckerTask = Utils.newScheduler(1, "consistency-checker-", false)
+            .scheduleAtFixedRate(consistencyChecker, 0, serverConfig.serverParticipantsConsistencyCheckerPeriodSec,
+                TimeUnit.SECONDS);
       }
       logger.info("checking if node exists in clustermap host {} port {}", networkConfig.hostName, networkConfig.port);
       DataNodeId nodeId = clusterMap.getDataNodeId(networkConfig.hostName, networkConfig.port);

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -114,7 +114,9 @@ public class AmbryServer {
   private RequestHandlerPool requestHandlerPoolForHttp2;
   private RestRequestHandler restRequestHandlerForHttp2;
   private NioServer nettyHttp2Server;
+  private ParticipantsConsistencyChecker consistencyChecker = null;
   private ScheduledFuture<?> consistencyCheckerTask = null;
+  private ScheduledExecutorService consistencyCheckerScheduler = null;
 
   public AmbryServer(VerifiableProperties properties, ClusterAgentsFactory clusterAgentsFactory,
       ClusterSpectatorFactory clusterSpectatorFactory, Time time) {
@@ -167,13 +169,12 @@ public class AmbryServer {
       // mismatch in sealed/stopped replica lists that maintained by each participant.
       if (clusterParticipants != null && clusterParticipants.size() > 1
           && serverConfig.serverParticipantsConsistencyCheckerPeriodSec > 0) {
-        ParticipantsConsistencyChecker consistencyChecker =
-            new ParticipantsConsistencyChecker(clusterParticipants, metrics);
+        consistencyChecker = new ParticipantsConsistencyChecker(clusterParticipants, metrics);
         logger.info("Scheduling participants consistency checker with a period of {} secs",
             serverConfig.serverParticipantsConsistencyCheckerPeriodSec);
-        consistencyCheckerTask = Utils.newScheduler(1, "consistency-checker-", false)
-            .scheduleAtFixedRate(consistencyChecker, 0, serverConfig.serverParticipantsConsistencyCheckerPeriodSec,
-                TimeUnit.SECONDS);
+        consistencyCheckerScheduler = Utils.newScheduler(1, "consistency-checker-", false);
+        consistencyCheckerTask = consistencyCheckerScheduler.scheduleAtFixedRate(consistencyChecker, 30,
+            serverConfig.serverParticipantsConsistencyCheckerPeriodSec, TimeUnit.SECONDS);
       }
       logger.info("checking if node exists in clustermap host {} port {}", networkConfig.hostName, networkConfig.port);
       DataNodeId nodeId = clusterMap.getDataNodeId(networkConfig.hostName, networkConfig.port);
@@ -319,6 +320,9 @@ public class AmbryServer {
       }
       if (clusterParticipants != null) {
         clusterParticipants.forEach(ClusterParticipant::close);
+      }
+      if (consistencyCheckerScheduler != null) {
+        shutDownExecutorService(consistencyCheckerScheduler, 5, TimeUnit.MINUTES);
       }
       if (scheduler != null) {
         shutDownExecutorService(scheduler, 5, TimeUnit.MINUTES);

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -173,7 +173,7 @@ public class AmbryServer {
         logger.info("Scheduling participants consistency checker with a period of {} secs",
             serverConfig.serverParticipantsConsistencyCheckerPeriodSec);
         consistencyCheckerScheduler = Utils.newScheduler(1, "consistency-checker-", false);
-        consistencyCheckerTask = consistencyCheckerScheduler.scheduleAtFixedRate(consistencyChecker, 30,
+        consistencyCheckerTask = consistencyCheckerScheduler.scheduleAtFixedRate(consistencyChecker, 0,
             serverConfig.serverParticipantsConsistencyCheckerPeriodSec, TimeUnit.SECONDS);
       }
       logger.info("checking if node exists in clustermap host {} port {}", networkConfig.hostName, networkConfig.port);

--- a/ambry-server/src/main/java/com/github/ambry/server/ParticipantsConsistencyChecker.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/ParticipantsConsistencyChecker.java
@@ -39,20 +39,20 @@ public class ParticipantsConsistencyChecker implements Runnable {
 
   @Override
   public void run() {
-    logger.info("Participant consistency checker is initiated. Participants count = {}", participants.size());
+    logger.debug("Participant consistency checker is initiated. Participants count = {}", participants.size());
     try {
       // when code reaches here, it means there are at least two participants.
       ClusterParticipant clusterParticipant = participants.get(0);
       Set<String> sealedReplicas1 = new HashSet<>(clusterParticipant.getSealedReplicas());
       Set<String> stoppedReplicas1 = new HashSet<>(clusterParticipant.getStoppedReplicas());
       for (int i = 1; i < participants.size(); ++i) {
-        logger.info("Checking sealed replica list");
+        logger.debug("Checking sealed replica list");
         Set<String> sealedReplicas2 = new HashSet<>(participants.get(i).getSealedReplicas());
         if (!sealedReplicas1.equals(sealedReplicas2)) {
           logger.warn("Mismatch in sealed replicas. Set {} is different from set {}", sealedReplicas1, sealedReplicas2);
           metrics.sealedReplicasMismatchCount.inc();
         }
-        logger.info("Checking stopped replica list");
+        logger.debug("Checking stopped replica list");
         Set<String> stoppedReplicas2 = new HashSet<>(participants.get(i).getStoppedReplicas());
         if (!stoppedReplicas1.equals(stoppedReplicas2)) {
           logger.warn("Mismatch in stopped replicas. Set {} is different from set {}", stoppedReplicas1,

--- a/ambry-server/src/main/java/com/github/ambry/server/ParticipantsConsistencyChecker.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/ParticipantsConsistencyChecker.java
@@ -39,22 +39,29 @@ public class ParticipantsConsistencyChecker implements Runnable {
 
   @Override
   public void run() {
-    // when code reaches here, it means there are at least two participants.
-    ClusterParticipant clusterParticipant = participants.get(0);
-    Set<String> sealedReplicas1 = new HashSet<>(clusterParticipant.getSealedReplicas());
-    Set<String> stoppedReplicas1 = new HashSet<>(clusterParticipant.getStoppedReplicas());
-    for (int i = 1; i < participants.size(); ++i) {
-      Set<String> sealedReplicas2 = new HashSet<>(participants.get(i).getSealedReplicas());
-      if (!sealedReplicas1.equals(sealedReplicas2)) {
-        logger.warn("Mismatch in sealed replicas. Set {} is different from set {}", sealedReplicas1, sealedReplicas2);
-        metrics.sealedReplicasMismatchCount.inc();
+    logger.info("Participant consistency checker is initiated. Participants count = {}", participants.size());
+    try {
+      // when code reaches here, it means there are at least two participants.
+      ClusterParticipant clusterParticipant = participants.get(0);
+      Set<String> sealedReplicas1 = new HashSet<>(clusterParticipant.getSealedReplicas());
+      Set<String> stoppedReplicas1 = new HashSet<>(clusterParticipant.getStoppedReplicas());
+      for (int i = 1; i < participants.size(); ++i) {
+        logger.info("Checking sealed replica list");
+        Set<String> sealedReplicas2 = new HashSet<>(participants.get(i).getSealedReplicas());
+        if (!sealedReplicas1.equals(sealedReplicas2)) {
+          logger.warn("Mismatch in sealed replicas. Set {} is different from set {}", sealedReplicas1, sealedReplicas2);
+          metrics.sealedReplicasMismatchCount.inc();
+        }
+        logger.info("Checking stopped replica list");
+        Set<String> stoppedReplicas2 = new HashSet<>(participants.get(i).getStoppedReplicas());
+        if (!stoppedReplicas1.equals(stoppedReplicas2)) {
+          logger.warn("Mismatch in stopped replicas. Set {} is different from set {}", stoppedReplicas1,
+              stoppedReplicas2);
+          metrics.stoppedReplicasMismatchCount.inc();
+        }
       }
-      Set<String> stoppedReplicas2 = new HashSet<>(participants.get(i).getStoppedReplicas());
-      if (!stoppedReplicas1.equals(stoppedReplicas2)) {
-        logger.warn("Mismatch in stopped replicas. Set {} is different from set {}", stoppedReplicas1,
-            stoppedReplicas2);
-        metrics.stoppedReplicasMismatchCount.inc();
-      }
+    } catch (Throwable t) {
+      logger.error("Exception occurs when running consistency checker ", t);
     }
   }
 }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,6 +91,8 @@ public class BlobStore implements Store {
   private FileLock fileLock;
   private volatile ReplicaState currentState;
   private volatile boolean recoverFromDecommission;
+  // TODO remove this once ZK migration is complete
+  private AtomicBoolean isSealed = new AtomicBoolean(false);
   protected PersistentIndex index;
 
   /**
@@ -361,12 +364,13 @@ public class BlobStore implements Store {
       // In two zk clusters case, "replicaId.isSealed()" might be true in first cluster but is still unsealed in second
       // cluster, as server only spectates the first cluster. To guarantee both clusters have consistent seal/unseal
       // state, we bypass "isSealed()" check if there are more than one replicaStatusDelegates.
-      if (index.getLogUsedCapacity() > thresholdBytesHigh && (!replicaId.isSealed()
-          || replicaStatusDelegates.size() > 1)) {
+      if (index.getLogUsedCapacity() > thresholdBytesHigh && (!replicaId.isSealed() || (
+          replicaStatusDelegates.size() > 1 && !isSealed.getAndSet(true)))) {
         for (ReplicaStatusDelegate replicaStatusDelegate : replicaStatusDelegates) {
           if (!replicaStatusDelegate.seal(replicaId)) {
             metrics.sealSetError.inc();
             logger.warn("Could not set the partition as read-only status on {}", replicaId);
+            isSealed.set(false);
           } else {
             metrics.sealDoneCount.inc();
             logger.info(
@@ -374,17 +378,38 @@ public class BlobStore implements Store {
                 replicaId.getPartitionId(), index.getLogUsedCapacity(), thresholdBytesHigh);
           }
         }
-      } else if (index.getLogUsedCapacity() <= thresholdBytesLow && (replicaId.isSealed()
-          || replicaStatusDelegates.size() > 1)) {
+      } else if (index.getLogUsedCapacity() <= thresholdBytesLow && (replicaId.isSealed() || (
+          replicaStatusDelegates.size() > 1 && isSealed.getAndSet(false)))) {
         for (ReplicaStatusDelegate replicaStatusDelegate : replicaStatusDelegates) {
           if (!replicaStatusDelegate.unseal(replicaId)) {
             metrics.unsealSetError.inc();
             logger.warn("Could not set the partition as read-write status on {}", replicaId);
+            isSealed.set(true);
           } else {
             metrics.unsealDoneCount.inc();
             logger.info(
                 "Store is successfully unsealed for partition : {} because current used capacity : {} bytes is below ReadWrite threshold : {} bytes",
                 replicaId.getPartitionId(), index.getLogUsedCapacity(), thresholdBytesLow);
+          }
+        }
+      }
+      // During startup, we also need to reconcile the replica state from both ZK clusters.
+      if (!started && replicaStatusDelegates.size() > 1 && thresholdBytesLow < index.getLogUsedCapacity()
+          && index.getLogUsedCapacity() <= thresholdBytesHigh) {
+        // reconcile the state by reading sealing state from both clusters
+        boolean sealed = false;
+        String partitionName = replicaId.getPartitionId().toPathString();
+        for (ReplicaStatusDelegate replicaStatusDelegate : replicaStatusDelegates) {
+          Set<String> sealedReplicas = new HashSet<>(replicaStatusDelegate.getSealedReplicas());
+          sealed |= sealedReplicas.contains(partitionName);
+        }
+        for (ReplicaStatusDelegate replicaStatusDelegate : replicaStatusDelegates) {
+          boolean success = sealed ? replicaStatusDelegate.seal(replicaId) : replicaStatusDelegate.unseal(replicaId);
+          if (success) {
+            logger.info("Succeeded in reconciling replica state to {} state", sealed ? "sealed" : "unsealed");
+            isSealed.set(sealed);
+          } else {
+            logger.error("Failed on reconciling replica state to {} state", sealed ? "sealed" : "unsealed");
           }
         }
       }

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -418,6 +418,10 @@ public class BlobStoreTest {
     store.shutdown();
   }
 
+  /**
+   * Test store is able to correctly seal/unseal replica with multiple participants.
+   * @throws Exception
+   */
   @Test
   public void multiReplicaStatusDelegatesTest() throws Exception {
     List<ReplicaId> sealedReplicas1 = new ArrayList<>();
@@ -451,6 +455,12 @@ public class BlobStoreTest {
     replicaId.setSealedState(true);
     reloadStore(changeThreshold(99, 1, true), replicaId, Arrays.asList(mockDelegate1, mockDelegate2));
     assertTrue("Replica should be unsealed", sealedReplicas1.isEmpty() && sealedReplicas2.isEmpty());
+
+    // verify store still updates sealed lists even though replica state is already sealed. ("replicaId.setSealedState(true)")
+    // lower the threshold to make replica sealed again
+    reloadStore(changeThreshold(50, 5, true), replicaId, Arrays.asList(mockDelegate1, mockDelegate2));
+    assertEquals("Sealed replica lists are different", sealedReplicas1, sealedReplicas2);
+    assertEquals("Sealed replica is not correct", replicaId, sealedReplicas1.get(0));
     store.shutdown();
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -55,6 +55,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -424,33 +425,41 @@ public class BlobStoreTest {
    */
   @Test
   public void multiReplicaStatusDelegatesTest() throws Exception {
-    List<ReplicaId> sealedReplicas1 = new ArrayList<>();
+    Set<ReplicaId> sealedReplicas1 = new HashSet<>();
     ReplicaStatusDelegate mockDelegate1 = Mockito.mock(ReplicaStatusDelegate.class);
     doAnswer(invocation -> {
       sealedReplicas1.add(invocation.getArgument(0));
-      return null;
+      return true;
     }).when(mockDelegate1).seal(any());
-    List<ReplicaId> sealedReplicas2 = new ArrayList<>();
+    Set<ReplicaId> sealedReplicas2 = new HashSet<>();
     ReplicaStatusDelegate mockDelegate2 = Mockito.mock(ReplicaStatusDelegate.class);
     doAnswer(invocation -> {
       sealedReplicas2.add(invocation.getArgument(0));
-      return null;
+      return true;
     }).when(mockDelegate2).seal(any());
     doAnswer(invocation -> {
       sealedReplicas1.remove((ReplicaId) invocation.getArgument(0));
-      return null;
+      return true;
     }).when(mockDelegate1).unseal(any());
     doAnswer(invocation -> {
       sealedReplicas2.remove((ReplicaId) invocation.getArgument(0));
-      return null;
+      return true;
     }).when(mockDelegate2).unseal(any());
+    doAnswer(
+        invocation -> sealedReplicas1.stream().map(r -> r.getPartitionId().toPathString()).collect(Collectors.toList()))
+        .when(mockDelegate1)
+        .getSealedReplicas();
+    doAnswer(
+        invocation -> sealedReplicas2.stream().map(r -> r.getPartitionId().toPathString()).collect(Collectors.toList()))
+        .when(mockDelegate2)
+        .getSealedReplicas();
     StoreConfig defaultConfig = changeThreshold(65, 5, true);
     StoreTestUtils.MockReplicaId replicaId = getMockReplicaId(tempDirStr);
     reloadStore(defaultConfig, replicaId, Arrays.asList(mockDelegate1, mockDelegate2));
     // make the replica sealed
     put(4, (long) (SEGMENT_CAPACITY * 0.8), Utils.Infinite_Time);
     assertEquals("Sealed replica lists are different", sealedReplicas1, sealedReplicas2);
-    assertEquals("Sealed replica is not correct", replicaId, sealedReplicas1.get(0));
+    assertEquals("Sealed replica is not correct", replicaId, sealedReplicas1.iterator().next());
     // try to bump the readonly threshold so as to unseal the replica
     replicaId.setSealedState(true);
     reloadStore(changeThreshold(99, 1, true), replicaId, Arrays.asList(mockDelegate1, mockDelegate2));
@@ -460,7 +469,13 @@ public class BlobStoreTest {
     // lower the threshold to make replica sealed again
     reloadStore(changeThreshold(50, 5, true), replicaId, Arrays.asList(mockDelegate1, mockDelegate2));
     assertEquals("Sealed replica lists are different", sealedReplicas1, sealedReplicas2);
-    assertEquals("Sealed replica is not correct", replicaId, sealedReplicas1.get(0));
+    assertEquals("Sealed replica is not correct", replicaId, sealedReplicas1.iterator().next());
+
+    // verify reconciliation case: we make read-write delta a wide range and clear sealedReplicas2 to make them reconcile
+    sealedReplicas2.clear();
+    reloadStore(changeThreshold(99, 90, true), replicaId, Arrays.asList(mockDelegate1, mockDelegate2));
+    assertEquals("Sealed replica lists are different", sealedReplicas1, sealedReplicas2);
+    assertEquals("Sealed replica is not correct", replicaId, sealedReplicas2.iterator().next());
     store.shutdown();
   }
 
@@ -775,7 +790,7 @@ public class BlobStoreTest {
         addedId.getAccountId(), addedId.getContainerId(), time.milliseconds(), MessageInfo.LIFE_VERSION_FROM_FRONTEND);
     store.updateTtl(Collections.singletonList(info));
     ttlUpdatedKeys.add(addedId);
-    storeInfo = store.get(Arrays.asList(addedId), EnumSet.noneOf(StoreGetOptions.class));
+    storeInfo = store.get(Collections.singletonList(addedId), EnumSet.noneOf(StoreGetOptions.class));
     assertEquals(1, storeInfo.getMessageReadSetInfo().size());
     // still the lifeVersion is 2, not -1
     assertEquals(lifeVersion, storeInfo.getMessageReadSetInfo().get(0).getLifeVersion());


### PR DESCRIPTION
1. Fixed a issue that store didn't seal replica in second cluster because
in-mem replica state is already sealed (the state comes from first cluster)
2. Assigned a dedicated scheduler to participant consistency checker as there
is contention to get thread from regular thread pool(size = 10).