### PR TITLE
Refactor CloudStorageCompactor 

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/CloudConfig.java
@@ -38,6 +38,7 @@ public class CloudConfig {
   public static final String CLOUD_DELETED_BLOB_RETENTION_DAYS = "cloud.deleted.blob.retention.days";
   public static final String CLOUD_BLOB_COMPACTION_ENABLED = "cloud.blob.compaction.enabled";
   public static final String CLOUD_BLOB_COMPACTION_INTERVAL_HOURS = "cloud.blob.compaction.interval.hours";
+  public static final String CLOUD_BLOB_COMPACTION_STARTUP_DELAY_SECS = "cloud.blob.compaction.startup.delay.secs";
   public static final String CLOUD_BLOB_COMPACTION_QUERY_LIMIT = "cloud.blob.compaction.query.limit";
   public static final String CLOUD_COMPACTION_LOOKBACK_DAYS = "cloud.compaction.lookback.days";
   public static final String CLOUD_COMPACTION_QUERY_BUCKET_DAYS = "cloud.compaction.query.bucket.days";
@@ -205,6 +206,13 @@ public class CloudConfig {
   public final int cloudBlobCompactionIntervalHours;
 
   /**
+   * Delay in seconds before compaction begins on VCR startup.
+   */
+  @Config(CLOUD_BLOB_COMPACTION_STARTUP_DELAY_SECS)
+  @Default("600")
+  public final int cloudBlobCompactionStartupDelaySecs;
+
+  /**
    * Maximum time to wait for in-flight compaction operation to complete on shutdown.
    */
   @Config(CLOUD_BLOB_COMPACTION_SHUTDOWN_TIMEOUT_SECS)
@@ -329,6 +337,7 @@ public class CloudConfig {
         verifiableProperties.getInt(CLOUD_DELETED_BLOB_RETENTION_DAYS, DEFAULT_RETENTION_DAYS);
     cloudBlobCompactionEnabled = verifiableProperties.getBoolean(CLOUD_BLOB_COMPACTION_ENABLED, true);
     cloudBlobCompactionIntervalHours = verifiableProperties.getInt(CLOUD_BLOB_COMPACTION_INTERVAL_HOURS, 24);
+    cloudBlobCompactionStartupDelaySecs = verifiableProperties.getInt(CLOUD_BLOB_COMPACTION_STARTUP_DELAY_SECS, 600);
     cloudBlobCompactionQueryLimit =
         verifiableProperties.getInt(CLOUD_BLOB_COMPACTION_QUERY_LIMIT, DEFAULT_COMPACTION_QUERY_LIMIT);
     cloudBlobCompactionShutdownTimeoutSecs =

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudDestination.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudDestination.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -85,32 +86,6 @@ public interface CloudDestination extends Closeable {
   Map<String, CloudBlobMetadata> getBlobMetadata(List<BlobId> blobIds) throws CloudStorageException;
 
   /**
-   * Get the list of blobs in the specified partition that have been deleted for at least the
-   * configured retention period.
-   * @param partitionPath the partition to query.
-   * @param startTime the start of the query time range.
-   * @param endTime the end of the query time range.
-   * @param maxEntries the max number of metadata records to return.
-   * @return a List of {@link CloudBlobMetadata} referencing the deleted blobs found.
-   * @throws CloudStorageException
-   */
-  List<CloudBlobMetadata> getDeletedBlobs(String partitionPath, long startTime, long endTime, int maxEntries)
-      throws CloudStorageException;
-
-  /**
-   * Get the list of blobs in the specified partition that have been expired for at least the
-   * configured retention period.
-   * @param partitionPath the partition to query.
-   * @param startTime the start of the query time range.
-   * @param endTime the end of the query time range.
-   * @param maxEntries the max number of metadata records to return.
-   * @return a List of {@link CloudBlobMetadata} referencing the expired blobs found.
-   * @throws CloudStorageException
-   */
-  List<CloudBlobMetadata> getExpiredBlobs(String partitionPath, long startTime, long endTime, int maxEntries)
-      throws CloudStorageException;
-
-  /**
    * Returns an ordered sequenced list of blobs within the specified partition and updated
    * {@link com.github.ambry.replication.FindToken}, such that total size of all blobs in the list are less or equal to
    * {@code maxTotalSizeOfEntries}
@@ -125,12 +100,12 @@ public interface CloudDestination extends Closeable {
       throws CloudStorageException;
 
   /**
-   * Permanently delete the specified blobs in the cloud destination.
-   * @param blobMetadataList the list of {@link CloudBlobMetadata} referencing the blobs to purge.
-   * @return the number of blobs successfully purged.
-   * @throws CloudStorageException if the purge operation fails for any blob.
+   * Compact the specified partition, removing blobs that have been deleted or expired for at least the
+   * configured retention period.
+   * @param partitionPath the path of the partitions to compact.
+   * @throws CloudStorageException
    */
-  int purgeBlobs(List<CloudBlobMetadata> blobMetadataList) throws CloudStorageException;
+  int compactPartition(String partitionPath) throws CloudStorageException;
 
   /**
    * Upload and persist the replica tokens for the specified Ambry partition in cloud storage.
@@ -151,4 +126,9 @@ public interface CloudDestination extends Closeable {
    */
   boolean retrieveTokens(String partitionPath, String tokenFileName, OutputStream outputStream)
       throws CloudStorageException;
+
+  /**
+   * Halt any compactions in progress.
+   */
+  void stopCompaction();
 }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudStorageCompactor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudStorageCompactor.java
@@ -13,14 +13,10 @@
  */
 package com.github.ambry.cloud;
 
-import com.codahale.metrics.Timer;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.config.CloudConfig;
-import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -29,6 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+/**
+ * Class that runs scheduled or on-demand compaction of blobs in cloud storage.
+ */
 public class CloudStorageCompactor implements Runnable {
   private static final Logger logger = LoggerFactory.getLogger(CloudStorageCompactor.class);
   private final CloudDestination cloudDestination;
@@ -36,7 +35,6 @@ public class CloudStorageCompactor implements Runnable {
   private final int shutDownTimeoutSecs;
   private final long compactionTimeLimitMs;
   private final VcrMetrics vcrMetrics;
-  private final CloudRequestAgent requestAgent;
   private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
   private final AtomicReference<CountDownLatch> doneLatch = new AtomicReference<>();
 
@@ -53,7 +51,6 @@ public class CloudStorageCompactor implements Runnable {
     this.vcrMetrics = vcrMetrics;
     this.shutDownTimeoutSecs = cloudConfig.cloudBlobCompactionShutdownTimeoutSecs;
     compactionTimeLimitMs = TimeUnit.HOURS.toMillis(cloudConfig.cloudBlobCompactionIntervalHours);
-    requestAgent = new CloudRequestAgent(cloudConfig, vcrMetrics);
     doneLatch.set(new CountDownLatch(0));
   }
 

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudStorageCompactor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudStorageCompactor.java
@@ -33,11 +33,7 @@ public class CloudStorageCompactor implements Runnable {
   private static final Logger logger = LoggerFactory.getLogger(CloudStorageCompactor.class);
   private final CloudDestination cloudDestination;
   private final Set<PartitionId> partitions;
-  private final int queryLimit;
-  private final int queryBucketDays;
-  private final int lookbackDays;
   private final int shutDownTimeoutSecs;
-  private final long retentionPeriodMs;
   private final long compactionTimeLimitMs;
   private final VcrMetrics vcrMetrics;
   private final CloudRequestAgent requestAgent;
@@ -55,10 +51,6 @@ public class CloudStorageCompactor implements Runnable {
     this.cloudDestination = cloudDestination;
     this.partitions = partitions;
     this.vcrMetrics = vcrMetrics;
-    this.retentionPeriodMs = TimeUnit.DAYS.toMillis(cloudConfig.cloudDeletedBlobRetentionDays);
-    this.queryLimit = cloudConfig.cloudBlobCompactionQueryLimit;
-    this.queryBucketDays = cloudConfig.cloudCompactionQueryBucketDays;
-    this.lookbackDays = cloudConfig.cloudCompactionLookbackDays;
     this.shutDownTimeoutSecs = cloudConfig.cloudBlobCompactionShutdownTimeoutSecs;
     compactionTimeLimitMs = TimeUnit.HOURS.toMillis(cloudConfig.cloudBlobCompactionIntervalHours);
     requestAgent = new CloudRequestAgent(cloudConfig, vcrMetrics);
@@ -81,6 +73,9 @@ public class CloudStorageCompactor implements Runnable {
     shuttingDown.set(true);
     logger.info("Compactor received shutdown request, waiting up to {} seconds for in-flight operations to finish",
         shutDownTimeoutSecs);
+
+    cloudDestination.stopCompaction();
+    // VcrServer shuts down us before the destination.
     boolean success = false;
     try {
       success = doneLatch.get().await(shutDownTimeoutSecs, TimeUnit.SECONDS);
@@ -124,10 +119,6 @@ public class CloudStorageCompactor implements Runnable {
     long now = System.currentTimeMillis();
     long compactionStartTime = now;
     long timeToQuit = now + compactionTimeLimitMs;
-    long queryEndTime = now - retentionPeriodMs;
-    long queryStartTime = now - TimeUnit.DAYS.toMillis(lookbackDays);
-    Date queryStartDate = new Date(queryStartTime);
-    Date queryEndDate = new Date(queryEndTime);
     int totalBlobsPurged = 0;
     for (PartitionId partitionId : partitionsSnapshot) {
       String partitionPath = partitionId.toPathString();
@@ -135,22 +126,14 @@ public class CloudStorageCompactor implements Runnable {
         // Looks like partition was reassigned since the loop started, so skip it
         continue;
       }
-      logger.info("Compacting partition {} over time range {} - {}", partitionPath, queryStartDate, queryEndDate);
+
       try {
-        int numPurged =
-            compactPartition(partitionPath, CloudBlobMetadata.FIELD_DELETION_TIME, queryStartTime, queryEndTime,
-                timeToQuit);
-        logger.info("Purged {} deleted blobs in partition {} up to {}", numPurged, partitionPath, queryEndDate);
-        totalBlobsPurged += numPurged;
-        numPurged =
-            compactPartition(partitionPath, CloudBlobMetadata.FIELD_EXPIRATION_TIME, queryStartTime, queryEndTime,
-                timeToQuit);
-        logger.info("Purged {} expired blobs in partition {} up to {}", numPurged, partitionPath, queryEndDate);
-        totalBlobsPurged += numPurged;
+        totalBlobsPurged += cloudDestination.compactPartition(partitionPath);
       } catch (CloudStorageException ex) {
         logger.error("Compaction failed for partition {}", partitionPath, ex);
         vcrMetrics.compactionFailureCount.inc();
       }
+
       if (System.currentTimeMillis() >= timeToQuit) {
         logger.info("Compaction terminated due to time limit exceeded.");
         break;
@@ -165,121 +148,5 @@ public class CloudStorageCompactor implements Runnable {
     logger.info("Purged {} blobs in {} partitions taking {} seconds", totalBlobsPurged, partitionsSnapshot.size(),
         compactionTime);
     return totalBlobsPurged;
-  }
-
-  /**
-   * Returns the expired blob in the specified partition with the earliest expiration time.
-   * @param partitionPath the partition to check.
-   * @return the {@link CloudBlobMetadata} for the expired blob, or NULL if none was found.
-   * @throws CloudStorageException
-   */
-  public CloudBlobMetadata getOldestExpiredBlob(String partitionPath) throws CloudStorageException {
-    List<CloudBlobMetadata> deadBlobs = requestAgent.doWithRetries(
-        () -> cloudDestination.getExpiredBlobs(partitionPath, 1, System.currentTimeMillis(), 1), "GetDeadBlobs",
-        partitionPath);
-    return deadBlobs.isEmpty() ? null : deadBlobs.get(0);
-  }
-
-  /**
-   * Returns the deleted blob in the specified partition with the earliest deletion time.
-   * @param partitionPath the partition to check.
-   * @return the {@link CloudBlobMetadata} for the deleted blob, or NULL if none was found.
-   * @throws CloudStorageException
-   */
-  public CloudBlobMetadata getOldestDeletedBlob(String partitionPath) throws CloudStorageException {
-    List<CloudBlobMetadata> deadBlobs = requestAgent.doWithRetries(
-        () -> cloudDestination.getDeletedBlobs(partitionPath, 1, System.currentTimeMillis(), 1), "GetDeadBlobs",
-        partitionPath);
-    return deadBlobs.isEmpty() ? null : deadBlobs.get(0);
-  }
-
-  /**
-   * Purge the inactive blobs in the specified partition.
-   * Long time windows are divided into smaller buckets.
-   * @param partitionPath the partition to compact.
-   * @param fieldName the field name to query on. Allowed values are {@link CloudBlobMetadata#FIELD_DELETION_TIME}
-   *                      and {@link CloudBlobMetadata#FIELD_EXPIRATION_TIME}.
-   * @param queryStartTime the initial query start time, which will be adjusted as compaction progresses.
-   * @param queryEndTime the query end time.
-   * @param timeToQuit the time at which compaction should terminate.
-   * @return the number of blobs purged or found.
-   */
-  public int compactPartition(String partitionPath, String fieldName, long queryStartTime, long queryEndTime,
-      long timeToQuit) throws CloudStorageException {
-
-    // Iterate until returned list size < limit, time runs out or we get shut down
-    int totalPurged = 0;
-    long bucketTimeRange = TimeUnit.DAYS.toMillis(queryBucketDays);
-    logger.debug("Dividing compaction query for {} into buckets of {} days", partitionPath, queryBucketDays);
-    long bucketStartTime = queryStartTime;
-    while (bucketStartTime < queryEndTime) {
-      long bucketEndTime = Math.min(bucketStartTime + bucketTimeRange, queryEndTime);
-      int numPurged = compactPartitionBucketed(partitionPath, fieldName, bucketStartTime, bucketEndTime, timeToQuit);
-      totalPurged += numPurged;
-      bucketStartTime += bucketTimeRange;
-      if (isShuttingDown() || System.currentTimeMillis() >= timeToQuit) {
-        break;
-      }
-      if (numPurged == 0) {
-        // TODO: Consider backing off since the last query might have been expensive
-      } else {
-        logger.info("Purged {} blobs in partition {} up to {} {}", totalPurged, partitionPath, fieldName,
-            new Date(bucketEndTime));
-      }
-    }
-    return totalPurged;
-  }
-
-  /**
-   * Purge the inactive blobs in the specified partition.
-   * @param partitionPath the partition to compact.
-   * @param fieldName the field name to query on. Allowed values are {@link CloudBlobMetadata#FIELD_DELETION_TIME}
-   *                      and {@link CloudBlobMetadata#FIELD_EXPIRATION_TIME}.
-   * @param queryStartTime the initial query start time, which will be adjusted as compaction progresses.
-   * @param queryEndTime the query end time.
-   * @param timeToQuit the time at which compaction should terminate.
-   * @return the number of blobs purged or found.
-   */
-  private int compactPartitionBucketed(String partitionPath, String fieldName, long queryStartTime, long queryEndTime,
-      long timeToQuit) throws CloudStorageException {
-
-    if (queryEndTime - queryStartTime > TimeUnit.DAYS.toMillis(queryBucketDays)) {
-      throw new IllegalArgumentException("Time window is longer than " + queryBucketDays + " days");
-    }
-
-    int totalPurged = 0;
-    while (System.currentTimeMillis() < timeToQuit && !isShuttingDown()) {
-
-      Callable<List<CloudBlobMetadata>> deadBlobsLambda =
-          getCallable(partitionPath, fieldName, queryStartTime, queryEndTime);
-      List<CloudBlobMetadata> deadBlobs = requestAgent.doWithRetries(deadBlobsLambda, "GetDeadBlobs", partitionPath);
-      if (deadBlobs.isEmpty() || isShuttingDown()) {
-        break;
-      }
-      totalPurged +=
-          requestAgent.doWithRetries(() -> cloudDestination.purgeBlobs(deadBlobs), "PurgeBlobs", partitionPath);
-      vcrMetrics.blobCompactionRate.mark(deadBlobs.size());
-      if (deadBlobs.size() < queryLimit) {
-        break;
-      }
-      // Adjust startTime for next query
-      CloudBlobMetadata lastBlob = deadBlobs.get(deadBlobs.size() - 1);
-      long latestTime = fieldName.equals(CloudBlobMetadata.FIELD_DELETION_TIME) ? lastBlob.getDeletionTime()
-          : lastBlob.getExpirationTime();
-      logger.info("Purged partition {} up to {} {}", partitionPath, fieldName, new Date(latestTime));
-      queryStartTime = latestTime;
-    }
-    return totalPurged;
-  }
-
-  private Callable<List<CloudBlobMetadata>> getCallable(String partitionPath, String fieldName, long queryStartTime,
-      long queryEndTime) {
-    if (fieldName.equals(CloudBlobMetadata.FIELD_DELETION_TIME)) {
-      return () -> cloudDestination.getDeletedBlobs(partitionPath, queryStartTime, queryEndTime, queryLimit);
-    } else if (fieldName.equals(CloudBlobMetadata.FIELD_EXPIRATION_TIME)) {
-      return () -> cloudDestination.getExpiredBlobs(partitionPath, queryStartTime, queryEndTime, queryLimit);
-    } else {
-      throw new IllegalArgumentException("Invalid field: " + fieldName);
-    }
   }
 }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrReplicationManager.java
@@ -129,8 +129,8 @@ public class VcrReplicationManager extends ReplicationEngine {
 
     if (cloudConfig.cloudBlobCompactionEnabled) {
       // Schedule thread to purge dead blobs for this VCR's partitions
-      // after brief delay to allow startup to finish.
-      long delaySec = TimeUnit.MINUTES.toSeconds(1);
+      // after delay to allow startup to finish.
+      long delaySec = cloudConfig.cloudBlobCompactionStartupDelaySecs;
       long intervalSec = TimeUnit.HOURS.toSeconds(cloudConfig.cloudBlobCompactionIntervalHours);
       scheduler.scheduleAtFixedRate(cloudStorageCompactor, delaySec, intervalSec, TimeUnit.SECONDS);
       logger.info("Scheduled compaction task to run every {} hours starting in {} seconds.",

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestination.java
@@ -46,8 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationFactory.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureCloudDestinationFactory.java
@@ -16,6 +16,7 @@ package com.github.ambry.cloud.azure;
 import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.cloud.CloudDestination;
 import com.github.ambry.cloud.CloudDestinationFactory;
+import com.github.ambry.cloud.VcrMetrics;
 import com.github.ambry.config.CloudConfig;
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.ReplicationConfig;
@@ -33,6 +34,7 @@ public class AzureCloudDestinationFactory implements CloudDestinationFactory {
   private final CloudConfig cloudConfig;
   private final AzureCloudConfig azureCloudConfig;
   private final String clusterName;
+  private final VcrMetrics vcrMetrics;
   private final AzureMetrics azureMetrics;
   private final AzureReplicationFeed.FeedType azureReplicationFeedType;
 
@@ -45,6 +47,7 @@ public class AzureCloudDestinationFactory implements CloudDestinationFactory {
     this.cloudConfig = new CloudConfig(verifiableProperties);
     this.azureCloudConfig = new AzureCloudConfig(verifiableProperties);
     this.clusterName = new ClusterMapConfig(verifiableProperties).clusterMapClusterName;
+    vcrMetrics = new VcrMetrics(metricRegistry);
     azureMetrics = new AzureMetrics(metricRegistry);
     azureReplicationFeedType = getReplicationFeedType(verifiableProperties);
   }
@@ -53,7 +56,8 @@ public class AzureCloudDestinationFactory implements CloudDestinationFactory {
   public CloudDestination getCloudDestination() throws IllegalStateException {
     try {
       AzureCloudDestination dest =
-          new AzureCloudDestination(cloudConfig, azureCloudConfig, clusterName, azureMetrics, azureReplicationFeedType);
+          new AzureCloudDestination(cloudConfig, azureCloudConfig, clusterName, vcrMetrics, azureMetrics,
+              azureReplicationFeedType);
       dest.testAzureConnectivity();
       return dest;
     } catch (Exception e) {

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageCompactor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/AzureStorageCompactor.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud.azure;
+
+import com.github.ambry.cloud.CloudBlobMetadata;
+import com.github.ambry.cloud.CloudRequestAgent;
+import com.github.ambry.cloud.CloudStorageException;
+import com.github.ambry.cloud.VcrMetrics;
+import com.github.ambry.config.CloudConfig;
+import com.microsoft.azure.cosmosdb.DocumentClientException;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class AzureStorageCompactor {
+  private static final Logger logger = LoggerFactory.getLogger(AzureStorageCompactor.class);
+  private final AzureBlobDataAccessor azureBlobDataAccessor;
+  private final CosmosDataAccessor cosmosDataAccessor;
+  private final int queryLimit;
+  private final int queryBucketDays;
+  private final int lookbackDays;
+  private final long retentionPeriodMs;
+  private final long compactionTimeLimitMs;
+  private final VcrMetrics vcrMetrics;
+  private final AzureMetrics azureMetrics;
+  private final CloudRequestAgent requestAgent;
+  private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
+
+  /**
+   * Public constructor.
+   * @param azureBlobDataAccessor
+   * @param cosmosDataAccessor
+   * @param cloudConfig
+   * @param vcrMetrics the metrics to update.
+   */
+  public AzureStorageCompactor(AzureBlobDataAccessor azureBlobDataAccessor, CosmosDataAccessor cosmosDataAccessor,
+      CloudConfig cloudConfig, VcrMetrics vcrMetrics, AzureMetrics azureMetrics) {
+    this.azureBlobDataAccessor = azureBlobDataAccessor;
+    this.cosmosDataAccessor = cosmosDataAccessor;
+    this.vcrMetrics = vcrMetrics;
+    this.azureMetrics = azureMetrics;
+    this.retentionPeriodMs = TimeUnit.DAYS.toMillis(cloudConfig.cloudDeletedBlobRetentionDays);
+    this.queryLimit = cloudConfig.cloudBlobCompactionQueryLimit;
+    this.queryBucketDays = cloudConfig.cloudCompactionQueryBucketDays;
+    this.lookbackDays = cloudConfig.cloudCompactionLookbackDays;
+    // TODO: change this
+    compactionTimeLimitMs = TimeUnit.HOURS.toMillis(cloudConfig.cloudBlobCompactionIntervalHours);
+    requestAgent = new CloudRequestAgent(cloudConfig, vcrMetrics);
+  }
+
+  /**
+   * Shut down the compactor waiting for in progress operations to complete.
+   */
+  public void shutdown() {
+    shuttingDown.set(true);
+  }
+
+  /**
+   * @return whether the compactor is shutting down.
+   */
+  boolean isShuttingDown() {
+    return shuttingDown.get();
+  }
+
+  /**
+   * Purge the inactive blobs in the specified partition.
+   * @return the total number of blobs purged.
+   */
+  public int compactPartition(String partitionPath) {
+    if (isShuttingDown()) {
+      logger.info("Skipping compaction due to shut down.");
+      return 0;
+    }
+
+    long now = System.currentTimeMillis();
+    long compactionStartTime = now;
+    long timeToQuit = now + compactionTimeLimitMs;
+    long queryEndTime = now - retentionPeriodMs;
+    long queryStartTime = now - TimeUnit.DAYS.toMillis(lookbackDays);
+    Date queryStartDate = new Date(queryStartTime);
+    Date queryEndDate = new Date(queryEndTime);
+    int totalBlobsPurged = 0;
+    logger.info("Compacting partition {} over time range {} - {}", partitionPath, queryStartDate, queryEndDate);
+    try {
+      int numPurged =
+          compactPartition(partitionPath, CloudBlobMetadata.FIELD_DELETION_TIME, queryStartTime, queryEndTime,
+              timeToQuit);
+      logger.info("Purged {} deleted blobs in partition {} up to {}", numPurged, partitionPath, queryEndDate);
+      totalBlobsPurged += numPurged;
+      numPurged = compactPartition(partitionPath, CloudBlobMetadata.FIELD_EXPIRATION_TIME, queryStartTime, queryEndTime,
+          timeToQuit);
+      logger.info("Purged {} expired blobs in partition {} up to {}", numPurged, partitionPath, queryEndDate);
+      totalBlobsPurged += numPurged;
+    } catch (CloudStorageException ex) {
+      logger.error("Compaction failed for partition {}", partitionPath, ex);
+      vcrMetrics.compactionFailureCount.inc();
+    }
+    if (System.currentTimeMillis() >= timeToQuit) {
+      logger.info("Compaction terminated due to time limit exceeded.");
+    }
+    if (isShuttingDown()) {
+      logger.info("Compaction terminated due to shut down.");
+    }
+    long compactionTime = (System.currentTimeMillis() - compactionStartTime) / 1000;
+    return totalBlobsPurged;
+  }
+
+  /**
+   * Purge the inactive blobs in the specified partition.
+   * Long time windows are divided into smaller buckets.
+   * @param partitionPath the partition to compact.
+   * @param fieldName the field name to query on. Allowed values are {@link CloudBlobMetadata#FIELD_DELETION_TIME}
+   *                      and {@link CloudBlobMetadata#FIELD_EXPIRATION_TIME}.
+   * @param queryStartTime the initial query start time, which will be adjusted as compaction progresses.
+   * @param queryEndTime the query end time.
+   * @param timeToQuit the time at which compaction should terminate.
+   * @return the number of blobs purged or found.
+   */
+  public int compactPartition(String partitionPath, String fieldName, long queryStartTime, long queryEndTime,
+      long timeToQuit) throws CloudStorageException {
+
+    // Iterate until returned list size < limit, time runs out or we get shut down
+    int totalPurged = 0;
+    long bucketTimeRange = TimeUnit.DAYS.toMillis(queryBucketDays);
+    logger.debug("Dividing compaction query for {} into buckets of {} days", partitionPath, queryBucketDays);
+    long bucketStartTime = queryStartTime;
+    while (bucketStartTime < queryEndTime) {
+      long bucketEndTime = Math.min(bucketStartTime + bucketTimeRange, queryEndTime);
+      int numPurged = compactPartitionBucketed(partitionPath, fieldName, bucketStartTime, bucketEndTime, timeToQuit);
+      totalPurged += numPurged;
+      bucketStartTime += bucketTimeRange;
+      if (isShuttingDown() || System.currentTimeMillis() >= timeToQuit) {
+        break;
+      }
+      if (numPurged == 0) {
+        // TODO: Consider backing off since the last query might have been expensive
+      } else {
+        logger.info("Purged {} blobs in partition {} up to {} {}", totalPurged, partitionPath, fieldName,
+            new Date(bucketEndTime));
+      }
+    }
+    return totalPurged;
+  }
+
+  /**
+   * Purge the inactive blobs in the specified partition.
+   * @param partitionPath the partition to compact.
+   * @param fieldName the field name to query on. Allowed values are {@link CloudBlobMetadata#FIELD_DELETION_TIME}
+   *                      and {@link CloudBlobMetadata#FIELD_EXPIRATION_TIME}.
+   * @param queryStartTime the initial query start time, which will be adjusted as compaction progresses.
+   * @param queryEndTime the query end time.
+   * @param timeToQuit the time at which compaction should terminate.
+   * @return the number of blobs purged or found.
+   */
+  private int compactPartitionBucketed(String partitionPath, String fieldName, long queryStartTime, long queryEndTime,
+      long timeToQuit) throws CloudStorageException {
+
+    if (queryEndTime - queryStartTime > TimeUnit.DAYS.toMillis(queryBucketDays)) {
+      throw new IllegalArgumentException("Time window is longer than " + queryBucketDays + " days");
+    }
+
+    int totalPurged = 0;
+    while (System.currentTimeMillis() < timeToQuit && !isShuttingDown()) {
+
+      final long newQueryStartTime = queryStartTime; // just to use in lambda
+      List<CloudBlobMetadata> deadBlobs = requestAgent.doWithRetries(
+          () -> getDeadBlobs(partitionPath, fieldName, newQueryStartTime, queryEndTime, queryLimit), "GetDeadBlobs",
+          partitionPath);
+      if (deadBlobs.isEmpty() || isShuttingDown()) {
+        break;
+      }
+      totalPurged += requestAgent.doWithRetries(() -> purgeBlobs(deadBlobs), "PurgeBlobs", partitionPath);
+      vcrMetrics.blobCompactionRate.mark(deadBlobs.size());
+      if (deadBlobs.size() < queryLimit) {
+        break;
+      }
+      // Adjust startTime for next query
+      CloudBlobMetadata lastBlob = deadBlobs.get(deadBlobs.size() - 1);
+      long latestTime = fieldName.equals(CloudBlobMetadata.FIELD_DELETION_TIME) ? lastBlob.getDeletionTime()
+          : lastBlob.getExpirationTime();
+      logger.info("Purged partition {} up to {} {}", partitionPath, fieldName, new Date(latestTime));
+      queryStartTime = latestTime;
+    }
+    return totalPurged;
+  }
+
+  /**
+   * Get the list of blobs in the specified partition that have been inactive for at least the
+   * configured retention period.
+   * @param partitionPath the partition to query.
+   * @param startTime the start of the query time range.
+   * @param endTime the end of the query time range.
+   * @param maxEntries the max number of metadata records to return.
+   * @return a List of {@link CloudBlobMetadata} referencing the deleted blobs found.
+   * @throws CloudStorageException
+   */
+  List<CloudBlobMetadata> getDeadBlobs(String partitionPath, String fieldName, long startTime, long endTime,
+      int maxEntries) throws CloudStorageException {
+    try {
+      return cosmosDataAccessor.getDeadBlobs(partitionPath, fieldName, startTime, endTime, maxEntries);
+    } catch (DocumentClientException dex) {
+      throw AzureCloudDestination.toCloudStorageException(
+          "Failed to query deleted blobs for partition " + partitionPath, dex, azureMetrics);
+    }
+  }
+
+  /**
+   * Permanently delete the specified blobs in Azure storage.
+   * @param blobMetadataList the list of {@link CloudBlobMetadata} referencing the blobs to purge.
+   * @return the number of blobs successfully purged.
+   * @throws CloudStorageException if the purge operation fails for any blob.
+   */
+  int purgeBlobs(List<CloudBlobMetadata> blobMetadataList) throws CloudStorageException {
+    if (blobMetadataList.isEmpty()) {
+      return 0;
+    }
+    azureMetrics.blobDeleteRequestCount.inc(blobMetadataList.size());
+    long t0 = System.currentTimeMillis();
+    try {
+      List<CloudBlobMetadata> deletedBlobs = azureBlobDataAccessor.purgeBlobs(blobMetadataList);
+      long t1 = System.currentTimeMillis();
+      int deletedCount = deletedBlobs.size();
+      azureMetrics.blobDeleteErrorCount.inc(blobMetadataList.size() - deletedCount);
+      if (deletedCount > 0) {
+        azureMetrics.blobDeletedCount.inc(deletedCount);
+        // Record as time per single blob deletion
+        azureMetrics.blobDeletionTime.update((t1 - t0) / deletedCount, TimeUnit.MILLISECONDS);
+      } else {
+        return 0;
+      }
+
+      // Remove them from Cosmos too
+      cosmosDataAccessor.deleteMetadata(deletedBlobs);
+      long t2 = System.currentTimeMillis();
+      // Record as time per single record deletion
+      azureMetrics.documentDeleteTime.update((t2 - t1) / deletedCount, TimeUnit.MILLISECONDS);
+      return deletedCount;
+    } catch (Exception ex) {
+      azureMetrics.blobDeleteErrorCount.inc(blobMetadataList.size());
+      throw AzureCloudDestination.toCloudStorageException("Failed to purge all blobs", ex, azureMetrics);
+    }
+  }
+
+  /**
+   * Returns the dead blob in the specified partition with the earliest expiration or deletion time.
+   * @param partitionPath the partition to check.
+   * @param fieldName the field name to use (expiration or deletion time).
+   * @return the {@link CloudBlobMetadata} for the dead blob, or NULL if none was found.
+   * @throws CloudStorageException
+   */
+  public CloudBlobMetadata getOldestDeadlob(String partitionPath, String fieldName) throws CloudStorageException {
+    // TODO: once we have Cosmos compaction table, can query that.
+    List<CloudBlobMetadata> deadBlobs =
+        requestAgent.doWithRetries(() -> getDeadBlobs(partitionPath, fieldName, 1, System.currentTimeMillis(), 1),
+            "GetDeadBlobs", partitionPath);
+    return deadBlobs.isEmpty() ? null : deadBlobs.get(0);
+  }
+}

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosDataAccessor.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/azure/CosmosDataAccessor.java
@@ -62,7 +62,7 @@ public class CosmosDataAccessor {
   private static final String EXPIRED_BLOBS_QUERY = constructDeadBlobsQuery(CloudBlobMetadata.FIELD_EXPIRATION_TIME);
   private static final String DELETED_BLOBS_QUERY = constructDeadBlobsQuery(CloudBlobMetadata.FIELD_DELETION_TIME);
   private static final String BULK_DELETE_QUERY = "SELECT c._self FROM c WHERE c.id IN (%s)";
-  private static final String BULK_DELETE_SPROC = "/sprocs/BulkDelete";
+  static final String BULK_DELETE_SPROC = "/sprocs/BulkDelete";
   static final String PROPERTY_CONTINUATION = "continuation";
   static final String PROPERTY_DELETED = "deleted";
 

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/LatchBasedInMemoryCloudDestination.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/LatchBasedInMemoryCloudDestination.java
@@ -243,16 +243,6 @@ public class LatchBasedInMemoryCloudDestination implements CloudDestination {
   }
 
   @Override
-  public List<CloudBlobMetadata> getExpiredBlobs(String partitionPath, long startTime, long endTime, int maxEntries) {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public List<CloudBlobMetadata> getDeletedBlobs(String partitionPath, long startTime, long endTime, int maxEntries) {
-    return Collections.emptyList();
-  }
-
-  @Override
   public FindResult findEntriesSince(String partitionPath, FindToken findToken, long maxTotalSizeOfEntries) {
     switch (azureReplicationFeedType) {
       case COSMOS_CHANGE_FEED:
@@ -365,8 +355,12 @@ public class LatchBasedInMemoryCloudDestination implements CloudDestination {
   }
 
   @Override
-  public int purgeBlobs(List<CloudBlobMetadata> blobMetadataList) {
+  public int compactPartition(String partitionPath) {
     return 0;
+  }
+
+  @Override
+  public void stopCompaction() {
   }
 
   boolean doesBlobExist(BlobId blobId) {

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageCompactorTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageCompactorTest.java
@@ -210,7 +210,7 @@ public class AzureStorageCompactorTest {
    */
   private BlobStorageException mockStorageException(BlobErrorCode errorCode) {
     BlobStorageException mockException = mock(BlobStorageException.class);
-    when(mockException.getErrorCode()).thenReturn(errorCode);
+    lenient().when(mockException.getErrorCode()).thenReturn(errorCode);
     return mockException;
   }
 }

--- a/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageCompactorTest.java
+++ b/ambry-cloud/src/test/java/com/github/ambry/cloud/azure/AzureStorageCompactorTest.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.cloud.azure;
+
+import com.azure.core.http.rest.Response;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.batch.BlobBatch;
+import com.azure.storage.blob.batch.BlobBatchClient;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.codahale.metrics.MetricRegistry;
+import com.github.ambry.cloud.CloudBlobMetadata;
+import com.github.ambry.cloud.CloudStorageException;
+import com.github.ambry.cloud.VcrMetrics;
+import com.github.ambry.clustermap.MockClusterMap;
+import com.github.ambry.clustermap.MockPartitionId;
+import com.github.ambry.clustermap.PartitionId;
+import com.github.ambry.commons.BlobId;
+import com.github.ambry.config.CloudConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.Utils;
+import com.microsoft.azure.cosmosdb.Document;
+import com.microsoft.azure.cosmosdb.FeedOptions;
+import com.microsoft.azure.cosmosdb.FeedResponse;
+import com.microsoft.azure.cosmosdb.RequestOptions;
+import com.microsoft.azure.cosmosdb.ResourceResponse;
+import com.microsoft.azure.cosmosdb.SqlQuerySpec;
+import com.microsoft.azure.cosmosdb.StoredProcedureResponse;
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import rx.Observable;
+
+import static com.github.ambry.cloud.azure.AzureTestUtils.*;
+import static com.github.ambry.commons.BlobId.*;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+
+/** Test cases for {@link AzureStorageCompactor} */
+@RunWith(MockitoJUnitRunner.class)
+public class AzureStorageCompactorTest {
+
+  private final String base64key = Base64.encodeBase64String("ambrykey".getBytes());
+  private final String storageConnection =
+      "DefaultEndpointsProtocol=https;AccountName=ambry;AccountKey=" + base64key + ";EndpointSuffix=core.windows.net";
+  private final String collectionLink = "ambry/metadata";
+  private final String clusterName = "main";
+  private Properties configProps = new Properties();
+  private AzureStorageCompactor azureStorageCompactor;
+  private BlobServiceClient mockServiceClient;
+  private BlobBatchClient mockBlobBatchClient;
+  private AsyncDocumentClient mockumentClient;
+  private AzureMetrics azureMetrics;
+  private int blobSize = 1024;
+  private byte dataCenterId = 66;
+  private short accountId = 101;
+  private short containerId = 5;
+  private BlobId blobId;
+  private CloudBlobMetadata blobMetadata;
+  private String partitionPath;
+
+  @Before
+  public void setup() throws Exception {
+    long partition = 666;
+    PartitionId partitionId = new MockPartitionId(partition, MockClusterMap.DEFAULT_PARTITION_CLASS);
+    blobId = new BlobId(BLOB_ID_V6, BlobIdType.NATIVE, dataCenterId, accountId, containerId, partitionId, false,
+        BlobDataType.DATACHUNK);
+    blobMetadata =
+        new CloudBlobMetadata(blobId, 0, Utils.Infinite_Time, blobSize, CloudBlobMetadata.EncryptionOrigin.NONE);
+    partitionPath = blobMetadata.getPartitionId();
+
+    mockServiceClient = mock(BlobServiceClient.class);
+    mockBlobBatchClient = mock(BlobBatchClient.class);
+    mockumentClient = mock(AsyncDocumentClient.class);
+
+    configProps.setProperty(AzureCloudConfig.AZURE_STORAGE_CONNECTION_STRING, storageConnection);
+    configProps.setProperty(AzureCloudConfig.COSMOS_ENDPOINT, "http://ambry.beyond-the-cosmos.com:443");
+    configProps.setProperty(AzureCloudConfig.COSMOS_COLLECTION_LINK, collectionLink);
+    configProps.setProperty(AzureCloudConfig.COSMOS_KEY, "cosmos-key");
+    configProps.setProperty("clustermap.cluster.name", "main");
+    configProps.setProperty("clustermap.datacenter.name", "uswest");
+    configProps.setProperty("clustermap.host.name", "localhost");
+    azureMetrics = new AzureMetrics(new MetricRegistry());
+    AzureBlobDataAccessor azureBlobDataAccessor =
+        new AzureBlobDataAccessor(mockServiceClient, mockBlobBatchClient, clusterName, azureMetrics);
+    CosmosDataAccessor cosmosDataAccessor = new CosmosDataAccessor(mockumentClient, collectionLink, azureMetrics);
+    CloudConfig cloudConfig = new CloudConfig(new VerifiableProperties(new Properties()));
+    VcrMetrics vcrMetrics = new VcrMetrics(new MetricRegistry());
+
+    azureStorageCompactor =
+        new AzureStorageCompactor(azureBlobDataAccessor, cosmosDataAccessor, cloudConfig, vcrMetrics, azureMetrics);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (azureStorageCompactor != null) {
+      azureStorageCompactor.shutdown();
+    }
+  }
+
+  /** Test compaction method */
+  @Test
+  public void testCompaction() throws Exception {
+    Observable<FeedResponse<Document>> mockResponse = mock(Observable.class);
+    List<Document> docList =
+        Collections.singletonList(AzureTestUtils.createDocumentFromCloudBlobMetadata(blobMetadata));
+    mockObservableForQuery(docList, mockResponse);
+    when(mockumentClient.queryDocuments(anyString(), any(SqlQuerySpec.class), any(FeedOptions.class))).thenReturn(
+        mockResponse);
+    BlobBatch mockBatch = mock(BlobBatch.class);
+    when(mockBlobBatchClient.getBlobBatch()).thenReturn(mockBatch);
+    Response<Void> okResponse = mock(Response.class);
+    when(okResponse.getStatusCode()).thenReturn(202);
+    when(mockBatch.deleteBlob(anyString(), anyString())).thenReturn(okResponse);
+    Observable<StoredProcedureResponse> mockBulkDeleteResponse = getMockBulkDeleteResponse(1);
+    when(mockumentClient.executeStoredProcedure(anyString(), any(RequestOptions.class), any())).thenReturn(
+        mockBulkDeleteResponse);
+    azureStorageCompactor.compactPartition(partitionPath);
+    verify(mockumentClient, atLeast(2)).queryDocuments(eq(collectionLink), any(SqlQuerySpec.class), any());
+    verify(mockumentClient, atLeast(1)).executeStoredProcedure(eq(collectionLink + CosmosDataAccessor.BULK_DELETE_SPROC),
+        any(), any());
+    verify(mockBlobBatchClient, atLeast(1)).submitBatchWithResponse(any(BlobBatch.class), anyBoolean(), any(), any());
+  }
+
+  /** Test getDeadBlobs method */
+  @Test
+  public void testGetDeadBlobs() throws Exception {
+    Observable<FeedResponse<Document>> mockResponse = getMockedObservableForQueryWithNoResults();
+    when(mockumentClient.queryDocuments(anyString(), any(SqlQuerySpec.class), any(FeedOptions.class))).thenReturn(
+        mockResponse);
+    long now = System.currentTimeMillis();
+    List<CloudBlobMetadata> metadataList =
+        azureStorageCompactor.getDeadBlobs(blobId.getPartition().toPathString(), CloudBlobMetadata.FIELD_DELETION_TIME,
+            1, now, 10);
+    assertEquals("Expected no deleted blobs", 0, metadataList.size());
+    assertEquals(1, azureMetrics.documentQueryCount.getCount());
+    assertEquals(1, azureMetrics.deadBlobsQueryTime.getCount());
+
+    metadataList = azureStorageCompactor.getDeadBlobs(blobId.getPartition().toPathString(),
+        CloudBlobMetadata.FIELD_EXPIRATION_TIME, 1, now, 10);
+    assertEquals("Expected no expired blobs", 0, metadataList.size());
+    assertEquals(2, azureMetrics.documentQueryCount.getCount());
+    assertEquals(2, azureMetrics.deadBlobsQueryTime.getCount());
+  }
+
+  /** Test purgeBlobs success */
+  @Test
+  public void testPurge() throws Exception {
+    BlobBatch mockBatch = mock(BlobBatch.class);
+    when(mockBlobBatchClient.getBlobBatch()).thenReturn(mockBatch);
+    Response<Void> okResponse = mock(Response.class);
+    when(okResponse.getStatusCode()).thenReturn(202);
+    when(mockBatch.deleteBlob(anyString(), anyString())).thenReturn(okResponse);
+    Observable<StoredProcedureResponse> mockBulkDeleteResponse = getMockBulkDeleteResponse(1);
+    when(mockumentClient.executeStoredProcedure(anyString(), any(RequestOptions.class), any())).thenReturn(
+        mockBulkDeleteResponse);
+    CloudBlobMetadata cloudBlobMetadata =
+        new CloudBlobMetadata(blobId, System.currentTimeMillis(), Utils.Infinite_Time, blobSize,
+            CloudBlobMetadata.EncryptionOrigin.NONE);
+    assertEquals("Expected success", 1, azureStorageCompactor.purgeBlobs(Collections.singletonList(cloudBlobMetadata)));
+    assertEquals(1, azureMetrics.blobDeletedCount.getCount());
+    assertEquals(0, azureMetrics.blobDeleteErrorCount.getCount());
+  }
+
+  /** Test purgeBlobs error */
+  @Test
+  public void testPurgeError() throws Exception {
+    // Unsuccessful case
+    BlobStorageException ex = mockStorageException(BlobErrorCode.BLOB_ARCHIVED);
+    BlobBatch mockBatch = mock(BlobBatch.class);
+    Response<Void> mockResponse = mock(Response.class);
+    when(mockResponse.getStatusCode()).thenThrow(ex);
+    when(mockBlobBatchClient.getBlobBatch()).thenReturn(mockBatch);
+    when(mockBatch.deleteBlob(anyString(), anyString())).thenReturn(mockResponse);
+    CloudBlobMetadata cloudBlobMetadata =
+        new CloudBlobMetadata(blobId, System.currentTimeMillis(), Utils.Infinite_Time, blobSize,
+            CloudBlobMetadata.EncryptionOrigin.NONE);
+    try {
+      azureStorageCompactor.purgeBlobs(Collections.singletonList(cloudBlobMetadata));
+      fail("Expected CloudStorageException");
+    } catch (CloudStorageException bex) {
+    }
+    assertEquals(0, azureMetrics.blobDeletedCount.getCount());
+    assertEquals(1, azureMetrics.blobDeleteErrorCount.getCount());
+  }
+
+  /**
+   * @return a {@link BlobStorageException} with given error code.
+   * @param errorCode the {@link BlobErrorCode} to return.
+   */
+  private BlobStorageException mockStorageException(BlobErrorCode errorCode) {
+    BlobStorageException mockException = mock(BlobStorageException.class);
+    when(mockException.getErrorCode()).thenReturn(errorCode);
+    return mockException;
+  }
+}

--- a/ambry-tools/src/main/java/com/github/ambry/tools/admin/AzureCompactionTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/admin/AzureCompactionTool.java
@@ -14,7 +14,6 @@
 package com.github.ambry.tools.admin;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.cloud.CloudBlobMetadata;
 import com.github.ambry.cloud.CloudDestination;
 import com.github.ambry.cloud.CloudStorageCompactor;
 import com.github.ambry.cloud.VcrMetrics;
@@ -31,7 +30,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
@@ -94,22 +92,8 @@ public class AzureCompactionTool {
       }));
 
       if (testMode) {
-        String partitionPath = partitions.get(0);
-        long now = System.currentTimeMillis();
-        CloudBlobMetadata blobMetadata = compactor.getOldestDeletedBlob(partitionPath);
-        if (blobMetadata == null) {
-          logger.info("No deleted blobs need purging");
-        } else {
-          int daysOld = (int) ((now - blobMetadata.getDeletionTime()) / TimeUnit.DAYS.toMillis(1));
-          logger.info("Oldest deleted blob was deleted about {} days ago: {}", daysOld, blobMetadata.toMap());
-        }
-        blobMetadata = compactor.getOldestExpiredBlob(partitionPath);
-        if (blobMetadata == null) {
-          logger.info("No expired blobs need purging");
-        } else {
-          int daysOld = (int) ((now - blobMetadata.getExpirationTime()) / TimeUnit.DAYS.toMillis(1));
-          logger.info("Oldest expired blob was expired about {} days ago: {}", daysOld, blobMetadata.toMap());
-        }
+        // TODO: once we have Cosmos compactionCheckpoint table, can query it and dump results into sortable table.
+        // Probably need to move this class to com.github.ambry.cloud.azure package.
       } else {
         compactor.compactPartitions();
       }


### PR DESCRIPTION
Move code from CloudStorageCompactor and AzureCloudDestination to new class AzureStorageCompactor.
Consolidate multiple methods in CloudDestination into single compactPartition().
No functional change with this PR.  It is meant to enable subsequent Azure-side enhancements while keeping the generic classes clean.