### PR TITLE
Fix a concurrency bug caused by offset comparison

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -560,8 +560,8 @@ public class BlobStore implements Store {
             IndexValue value = index.findKey(info.getStoreKey(), fileSpan,
                 EnumSet.of(PersistentIndex.IndexEntryType.PUT, PersistentIndex.IndexEntryType.DELETE,
                     PersistentIndex.IndexEntryType.UNDELETE));
-            if (value != null && value.getOffset().compareTo(indexEndOffsetBeforeCheck) > 0) {
-              // Make sure the value is actually after the indeEndOffsetBeforeCheck
+            if (value != null && value.getOffset().compareTo(indexEndOffsetBeforeCheck) >= 0) {
+              // Make sure the value is actually after the indexEndOffsetBeforeCheck
               if (value.isDelete() && value.getLifeVersion() == lifeVersions.get(i)) {
                 throw new StoreException(
                     "Cannot delete id " + info.getStoreKey() + " since it is already deleted in the index.",
@@ -782,7 +782,7 @@ public class BlobStore implements Store {
           FileSpan fileSpan = new FileSpan(indexEndOffsetBeforeCheck, currentIndexEndOffset);
           IndexValue value = index.findKey(info.getStoreKey(), fileSpan,
               EnumSet.of(PersistentIndex.IndexEntryType.DELETE, PersistentIndex.IndexEntryType.UNDELETE));
-          if (value != null && value.getOffset().compareTo(indexEndOffsetBeforeCheck) > 0) {
+          if (value != null && value.getOffset().compareTo(indexEndOffsetBeforeCheck) >= 0) {
             // Make sure the value is actually after the indexEndOffsetBeforeCheck
             if (value.isUndelete() && value.getLifeVersion() == revisedLifeVersion) {
               // Might get an concurrent undelete from both replication and frontend.
@@ -903,6 +903,13 @@ public class BlobStore implements Store {
   @Override
   public long getSizeInBytes() {
     return index.getLogUsedCapacity();
+  }
+
+  /**
+   * @return The number of byte been written to log
+   */
+  public long getLogEndOffsetInBytes() {
+    return log.getEndOffset().getOffset();
   }
 
   @Override

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -784,7 +784,7 @@ public class BlobStoreTest {
         } catch (ExecutionException e) {
           failedCount++;
           assertTrue(e.getCause() instanceof StoreException);
-          assertEquals(StoreErrorCodes.ID_Undeleted, ((StoreException) e.getCause()).getErrorCode());
+          assertEquals(StoreErrorCodes.Already_Updated, ((StoreException) e.getCause()).getErrorCode());
         }
       }
 


### PR DESCRIPTION
We are seeing in EI, some partition has duplicated delete record in log, but not in index. After investigation, this is caused by an offset comparison, which is fixed in this PR.

Brief explanation:
1. There are two concurrent delete requests, one of which from frontend, the other from replication.
2. Both delete requests will call delete method, and both would check the validity of delete record up to line 553, and both would be valid. (There is no delete in index yet)
3. After that, one of delete would enter the mutual exclusive block starting from link 553, and persist delete record to log and index
4. The second delete would figure the `indexEndOffsetBeforeCheck` is not the same as `currentIndexEndOffset`, assuming a delete record is 100 bytes, and `indexEndOffsetBeforeCheck` is 1000. then after first delete record, `currentIndexEndOffset` should be 1100
5. Second delete call gets the the first delete record, and it's offset should be 1000. so here the comparison should be >=, rather than >.

