### PR TITLE
Make storage manager register state change listener in multiple participants

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -199,13 +199,12 @@ public class StorageManager implements StoreManager {
         startupThread.join();
       }
       metrics.initializeCompactionThreadsTracker(this, diskToDiskManager.size());
-      if (primaryParticipant != null) {
-        primaryParticipant.registerPartitionStateChangeListener(StateModelListenerType.StorageManagerListener,
-            new PartitionStateChangeListenerImpl());
-      }
       if (clusterParticipants != null) {
-        clusterParticipants.forEach(
-            participant -> participant.setInitialLocalPartitions(partitionNameToReplicaId.keySet()));
+        clusterParticipants.forEach(participant -> {
+          participant.registerPartitionStateChangeListener(StateModelListenerType.StorageManagerListener,
+              new PartitionStateChangeListenerImpl());
+          participant.setInitialLocalPartitions(partitionNameToReplicaId.keySet());
+        });
       }
       diskToDiskManager.values().forEach(diskManager -> unexpectedDirs.addAll(diskManager.getUnexpectedDirs()));
       logger.info("Starting storage manager complete");


### PR DESCRIPTION
This is a minor improvement for ZK migration. Previously, only primary participant
registers storage manager listener and other participant has no listener. The side
effect is, if store is not started due to disk I/O error(during startup process),
the second participant is not able to mark this store in ERROR state as it has no
listener and is no-op in OFFLINE->BOOTSTRAP transition. This PR ensures both participants
are able to detect store failure during startup.