### PR TITLE
Patches for Http2

### DIFF
--- a/ambry-network/src/main/java/com/github/ambry/network/http2/AmbrySendToHttp2Adaptor.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/AmbrySendToHttp2Adaptor.java
@@ -18,6 +18,7 @@ import com.github.ambry.network.Send;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
 import com.github.ambry.utils.ByteBufChannel;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Translates Ambry {@link Send} to the HTTP/2 frame objects.
  */
+@ChannelHandler.Sharable
 public class AmbrySendToHttp2Adaptor extends ChannelOutboundHandlerAdapter {
   private static final Logger logger = LoggerFactory.getLogger(AmbrySendToHttp2Adaptor.class);
 

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/AmbrySendToHttp2Adaptor.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/AmbrySendToHttp2Adaptor.java
@@ -13,10 +13,7 @@
  */
 package com.github.ambry.network.http2;
 
-import com.github.ambry.commons.RetainingAsyncWritableChannel;
 import com.github.ambry.network.Send;
-import com.github.ambry.router.AsyncWritableChannel;
-import com.github.ambry.router.Callback;
 import com.github.ambry.utils.ByteBufChannel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -37,8 +34,6 @@ import org.slf4j.LoggerFactory;
  */
 @ChannelHandler.Sharable
 public class AmbrySendToHttp2Adaptor extends ChannelOutboundHandlerAdapter {
-  private static final Logger logger = LoggerFactory.getLogger(AmbrySendToHttp2Adaptor.class);
-
   public AmbrySendToHttp2Adaptor() {
 
   }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannel.java
@@ -47,12 +47,10 @@ public class Http2BlockingChannel implements ConnectedChannel {
   private Promise<ByteBuf> responsePromise;
   private final Http2MultiplexedChannelPool http2MultiplexedChannelPool;
   private final Http2ClientConfig http2ClientConfig;
-  private final Http2ClientMetrics http2ClientMetrics;
   final static AttributeKey<Promise<ByteBuf>> RESPONSE_PROMISE = AttributeKey.newInstance("ResponsePromise");
 
   public Http2BlockingChannel(Http2MultiplexedChannelPool http2MultiplexedChannelPool) {
     this.http2MultiplexedChannelPool = http2MultiplexedChannelPool;
-    this.http2ClientMetrics = http2MultiplexedChannelPool.getHttp2ClientMetrics();
     this.http2ClientConfig = http2MultiplexedChannelPool.getHttp2ClientConfig();
   }
 
@@ -68,7 +66,6 @@ public class Http2BlockingChannel implements ConnectedChannel {
       throw new IllegalStateException("Can't create NettySslHttp2Factory: ", e);
     }
     this.http2ClientConfig = http2ClientConfig;
-    this.http2ClientMetrics = http2ClientMetrics;
     this.http2MultiplexedChannelPool =
         new Http2MultiplexedChannelPool(new InetSocketAddress(hostName, port), nettySslHttp2Factory,
             Epoll.isAvailable() ? new EpollEventLoopGroup() : new NioEventLoopGroup(), http2ClientConfig,

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelPool.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelPool.java
@@ -25,8 +25,6 @@ import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +48,8 @@ public class Http2BlockingChannelPool implements ConnectionPool {
     } else {
       this.eventLoopGroup = new NioEventLoopGroup(http2ClientConfig.http2NettyEventLoopGroupThreads);
     }
-    http2ChannelPoolMap = new Http2ChannelPoolMap(sslFactory, eventLoopGroup, http2ClientConfig, http2ClientMetrics);
+    http2ChannelPoolMap = new Http2ChannelPoolMap(sslFactory, eventLoopGroup, http2ClientConfig, http2ClientMetrics,
+        new Http2BlockingChannelStreamChannelInitializer(http2ClientConfig.http2MaxContentLength));
     this.http2ClientConfig = http2ClientConfig;
   }
 

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelResponseHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelResponseHandler.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+package com.github.ambry.network.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.util.concurrent.Promise;
+
+
+/**
+ * Netty handler for {@link Http2BlockingChannel} to handle {@link FullHttpResponse}.
+ */
+public class Http2BlockingChannelResponseHandler extends SimpleChannelInboundHandler<FullHttpResponse> {
+  @Override
+  protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
+    Promise<ByteBuf> promise = ctx.channel().attr(Http2BlockingChannel.RESPONSE_PROMISE).get();
+    if (promise != null) {
+      promise.setSuccess(msg.content().retainedDuplicate());
+      // Stream channel can't be reused. Release it here.
+      releaseStreamChannel(ctx);
+    }
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    Promise<ByteBuf> promise = ctx.channel().attr(Http2BlockingChannel.RESPONSE_PROMISE).getAndSet(null);
+    if (promise != null) {
+      promise.setFailure(cause);
+      releaseStreamChannel(ctx);
+    }
+  }
+
+  private void releaseStreamChannel(ChannelHandlerContext ctx) {
+    ctx.channel()
+        .parent()
+        .attr(Http2MultiplexedChannelPool.HTTP2_MULTIPLEXED_CHANNEL_POOL)
+        .get()
+        .release(ctx.channel());
+  }
+}

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelResponseHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelResponseHandler.java
@@ -29,7 +29,7 @@ import io.netty.util.concurrent.Promise;
 public class Http2BlockingChannelResponseHandler extends SimpleChannelInboundHandler<FullHttpResponse> {
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
-    Promise<ByteBuf> promise = ctx.channel().attr(Http2BlockingChannel.RESPONSE_PROMISE).get();
+    Promise<ByteBuf> promise = ctx.channel().attr(Http2BlockingChannel.RESPONSE_PROMISE).getAndSet(null);
     if (promise != null) {
       promise.setSuccess(msg.content().retainedDuplicate());
       // Stream channel can't be reused. Release it here.

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelResponseHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelResponseHandler.java
@@ -15,6 +15,7 @@
 package com.github.ambry.network.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -24,6 +25,7 @@ import io.netty.util.concurrent.Promise;
 /**
  * Netty handler for {@link Http2BlockingChannel} to handle {@link FullHttpResponse}.
  */
+@ChannelHandler.Sharable
 public class Http2BlockingChannelResponseHandler extends SimpleChannelInboundHandler<FullHttpResponse> {
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelStreamChannelInitializer.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelStreamChannelInitializer.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+package com.github.ambry.network.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec;
+import io.netty.util.concurrent.Promise;
+
+
+/**
+ * A ChannelInitializer used to setup stream channel pipeline once stream is created in {@link MultiplexedChannelRecord}.
+ */
+public class Http2BlockingChannelStreamChannelInitializer extends ChannelInitializer {
+
+  private final int http2MaxContentLength;
+
+  Http2BlockingChannelStreamChannelInitializer(int http2MaxContentLength) {
+    this.http2MaxContentLength = http2MaxContentLength;
+  }
+
+  @Override
+  protected void initChannel(Channel ch) throws Exception {
+    ChannelPipeline p = ch.pipeline();
+    p.addLast(new Http2StreamFrameToHttpObjectCodec(false));
+    p.addLast(new HttpObjectAggregator(http2MaxContentLength));
+    p.addLast(new SimpleChannelInboundHandler<FullHttpResponse>() {
+      @Override
+      protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
+        Promise<ByteBuf> promise = ctx.channel().attr(Http2BlockingChannel.RESPONSE_PROMISE).get();
+        if (promise != null) {
+          promise.setSuccess(msg.content().retainedDuplicate());
+          // Stream channel can't be reused. Release it here.
+          releaseStreamChannel(ctx);
+        }
+      }
+
+      @Override
+      public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        Promise<ByteBuf> promise = ctx.channel().attr(Http2BlockingChannel.RESPONSE_PROMISE).getAndSet(null);
+        if (promise != null) {
+          promise.setFailure(cause);
+          releaseStreamChannel(ctx);
+        }
+      }
+
+      private void releaseStreamChannel(ChannelHandlerContext ctx) {
+        ctx.channel()
+            .parent()
+            .attr(Http2MultiplexedChannelPool.HTTP2_MULTIPLEXED_CHANNEL_POOL)
+            .get()
+            .release(ctx.channel());
+      }
+    });
+    p.addLast(new AmbrySendToHttp2Adaptor());
+  }
+}

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelStreamChannelInitializer.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2BlockingChannelStreamChannelInitializer.java
@@ -25,8 +25,12 @@ import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec;
  * A ChannelInitializer used to setup stream channel pipeline once stream is created in {@link MultiplexedChannelRecord}.
  */
 public class Http2BlockingChannelStreamChannelInitializer extends ChannelInitializer {
-
   private final int http2MaxContentLength;
+  private static Http2StreamFrameToHttpObjectCodec http2StreamFrameToHttpObjectCodec =
+      new Http2StreamFrameToHttpObjectCodec(false);
+  private static Http2BlockingChannelResponseHandler http2BlockingChannelResponseHandler =
+      new Http2BlockingChannelResponseHandler();
+  private static AmbrySendToHttp2Adaptor ambrySendToHttp2Adaptor = new AmbrySendToHttp2Adaptor();
 
   Http2BlockingChannelStreamChannelInitializer(int http2MaxContentLength) {
     this.http2MaxContentLength = http2MaxContentLength;
@@ -35,9 +39,9 @@ public class Http2BlockingChannelStreamChannelInitializer extends ChannelInitial
   @Override
   protected void initChannel(Channel ch) throws Exception {
     ChannelPipeline p = ch.pipeline();
-    p.addLast(new Http2StreamFrameToHttpObjectCodec(false));
+    p.addLast(http2StreamFrameToHttpObjectCodec);
     p.addLast(new HttpObjectAggregator(http2MaxContentLength));
-    p.addLast(new Http2BlockingChannelResponseHandler());
-    p.addLast(new AmbrySendToHttp2Adaptor());
+    p.addLast(http2BlockingChannelResponseHandler);
+    p.addLast(ambrySendToHttp2Adaptor);
   }
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolMap.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ChannelPoolMap.java
@@ -16,6 +16,7 @@ package com.github.ambry.network.http2;
 
 import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.config.Http2ClientConfig;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.pool.AbstractChannelPoolMap;
 import io.netty.channel.pool.ChannelPool;
@@ -34,13 +35,15 @@ public class Http2ChannelPoolMap extends AbstractChannelPoolMap<InetSocketAddres
   private final SSLFactory sslFactory;
   private final Http2ClientConfig http2ClientConfig;
   private final Http2ClientMetrics http2ClientMetrics;
+  private final ChannelInitializer streamChannelInitializer;
 
   public Http2ChannelPoolMap(SSLFactory sslFactory, EventLoopGroup eventLoopGroup, Http2ClientConfig http2ClientConfig,
-      Http2ClientMetrics http2ClientMetrics) {
+      Http2ClientMetrics http2ClientMetrics, ChannelInitializer streamChannelInitializer) {
     this.sslFactory = sslFactory;
     this.eventLoopGroup = eventLoopGroup;
     this.http2ClientConfig = http2ClientConfig;
     this.http2ClientMetrics = http2ClientMetrics;
+    this.streamChannelInitializer = streamChannelInitializer;
   }
 
   @Override
@@ -48,6 +51,6 @@ public class Http2ChannelPoolMap extends AbstractChannelPoolMap<InetSocketAddres
     log.trace("New pool created for {}", inetSocketAddress);
     http2ClientMetrics.http2NewPoolCount.inc();
     return new Http2MultiplexedChannelPool(inetSocketAddress, sslFactory, eventLoopGroup, http2ClientConfig,
-        http2ClientMetrics);
+        http2ClientMetrics, streamChannelInitializer);
   }
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
@@ -45,6 +45,7 @@ public class Http2ClientMetrics {
   public final Counter http2StreamSlipAcquireCount;
   public final Counter http2StreamWriteAndFlushErrorCount;
   public final Counter http2NetworkErrorCount;
+  public final Counter http2RequestsToDropCount;
 
   public final Meter http2ClientSendRate;
   public final Meter http2ClientReceiveRate;
@@ -88,6 +89,7 @@ public class Http2ClientMetrics {
     http2StreamWriteAndFlushErrorCount =
         registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2StreamWriteAndFlushErrorCount"));
     http2NetworkErrorCount = registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2NetworkErrorCount"));
+    http2RequestsToDropCount = registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2RequestsToDropCount"));
     http2ClientSendRate = registry.meter(MetricRegistry.name(Http2NetworkClient.class, "Http2ClientSendRate"));
     http2ClientReceiveRate = registry.meter(MetricRegistry.name(Http2NetworkClient.class, "Http2ClientReceiveRate"));
 

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2MultiplexedChannelPool.java
@@ -101,9 +101,8 @@ public class Http2MultiplexedChannelPool implements ChannelPool {
       ChannelInitializer streamChannelInitializer) {
     this(new SimpleChannelPool(createBootStrap(eventLoopGroup, http2ClientConfig, inetSocketAddress),
             new Http2ChannelPoolHandler(sslFactory, inetSocketAddress.getHostName(), inetSocketAddress.getPort(),
-                http2ClientConfig)), eventLoopGroup, ConcurrentHashMap.newKeySet(), inetSocketAddress,
-        new Http2ClientConfig(new VerifiableProperties(new Properties())), http2ClientMetrics,
-        streamChannelInitializer);
+                http2ClientConfig)), eventLoopGroup, ConcurrentHashMap.newKeySet(), inetSocketAddress, http2ClientConfig,
+        http2ClientMetrics, streamChannelInitializer);
   }
 
   /**

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -162,10 +162,7 @@ public class Http2NetworkClient implements NetworkClient {
             .addListener((GenericFutureListener<Future<Channel>>) future -> {
               if (future.isSuccess()) {
                 Channel streamChannel = future.getNow();
-                streamChannel.parent()
-                    .attr(Http2MultiplexedChannelPool.HTTP2_MULTIPLEXED_CHANNEL_POOL)
-                    .get()
-                    .release(streamChannel);
+                releaseAndCloseStreamChannel(streamChannel);
                 successCount.incrementAndGet();
               } else {
                 failCount.incrementAndGet();

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2NetworkClient.java
@@ -116,6 +116,8 @@ public class Http2NetworkClient implements NetworkClient {
                     // again as streamChannel close happen in event loop. No impact to main flow.
                     // For netty 4.1.42.Final, streamChannel can be close twice without any exception.
                     releaseAndCloseStreamChannel(streamChannel);
+                    http2ClientResponseHandler.getResponseInfoQueue()
+                        .put(new ResponseInfo(requestInfo, NetworkClientErrorCode.NetworkError, null));
                   }
                   // release related bytebuf
                   requestInfo.getRequest().release();

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2Utils.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2Utils.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.github.ambry.network.http2;
+
+import io.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This is a utility class used by HTTP2.
+ */
+public class Http2Utils {
+
+  private static final Logger logger = LoggerFactory.getLogger(Http2ClientResponseHandler.class);
+
+  static void releaseAndCloseStreamChannel(Channel streamChannel) {
+    logger.info("Stream channel is being closed. Stream: {}, Parent: {}", streamChannel, streamChannel.parent());
+    streamChannel.attr(Http2NetworkClient.REQUEST_INFO).set(null);
+    streamChannel.parent()
+        .attr(Http2MultiplexedChannelPool.HTTP2_MULTIPLEXED_CHANNEL_POOL)
+        .get()
+        .release(streamChannel);
+  }
+}

--- a/config/HardwareLayoutHttp2.json
+++ b/config/HardwareLayoutHttp2.json
@@ -15,7 +15,6 @@
           "hardwareState": "AVAILABLE",
           "hostname": "localhost",
           "port": 6667,
-          "sslPort" : 7667,
           "http2port" : 8667
         }
       ],

--- a/config/frontend.http2.properties
+++ b/config/frontend.http2.properties
@@ -28,7 +28,8 @@ clustermap.host.name=localhost
 #kms
 kms.default.container.key=B374A26A71490437AA024E4FADD5B497FDFF1A8EA6FF12F6FB65AF2720B59CCF
 
-clustermap.ssl.enabled.datacenters=Datacenter
 # http2
 ssl.http2.self.sign=true
 router.enable.http2.network.client=true
+router.connections.local.dc.warm.up.percentage=100
+clustermap.writable.partition.min.replica.count=1

--- a/config/server.http2.properties
+++ b/config/server.http2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 LinkedIn Corp. All rights reserved.
+# Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy of the
@@ -18,8 +18,8 @@ clustermap.datacenter.name=Datacenter
 clustermap.host.name=localhost
 clustermap.port=6667
 
-# http2
+# server http2
 rest.server.rest.request.service.factory=com.github.ambry.server.StorageRestRequestService
 rest.server.nio.server.factory=com.github.ambry.rest.StorageServerNettyFactory
 ssl.client.authentication=none
-ssl.http2.self.sign=true
+server.enable.store.data.prefetch=true


### PR DESCRIPTION
1. Provided an initializer when stream channel is created. This allows setup pipeline first and then return stream to claimer. Without this, it may face a timing issue that claimer try to take action on pipeline but pipeline is empty. 
2. Add metrics and logs for request to drop. 
3. Polish releaseAndCloseStreamChannel.
4. Set REQUEST_INFO to null whenever possible to reduce reference to object.