### PR TITLE
Bumped Gradle plugin version, cleared a TODO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ if (!project.hasProperty('disableShipkit')) {
 
 allprojects {
     group = "com.github.ambry"
-    version = rootProject.version //TODO: fix in https://github.com/shipkit/org.shipkit.shipkit-auto-version
 
     apply plugin: 'eclipse'
     apply plugin: 'idea'

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -18,6 +18,6 @@ repositories {
 
 dependencies {
     classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0"    
-    classpath "org.shipkit:shipkit-auto-version:0.0.22"
+    classpath "org.shipkit:shipkit-auto-version:0.0.30"
     classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
 }


### PR DESCRIPTION
This PR contains:

1. Version update of shipkit-auto-version. 
2. Version setting removal (it is unnecessary because it is done automatically by shipkit-auto-version plugin).

After the update and setting removal, changes were tested by running the build and inspecting generated files - all of them have the same correct version.