### PR TITLE
Introduce PropertyStoreToDataNodeConfigAdapter

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -35,6 +35,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -74,6 +75,7 @@ public class ClusterMapUtils {
   static final String STOPPED_REPLICAS_STR = "STOPPED";
   static final String DISABLED_REPLICAS_STR = "DISABLED";
   static final String AVAILABLE_STR = "AVAILABLE";
+  static final String UNAVAILABLE_STR = "UNAVAILABLE";
   static final String READ_ONLY_STR = "RO";
   static final String READ_WRITE_STR = "RW";
   static final String ZKCONNECT_STR = "zkConnectStr";
@@ -175,7 +177,17 @@ public class ClusterMapUtils {
    *         is assumed to be 0, and 0 is returned.
    */
   static int getSchemaVersion(InstanceConfig instanceConfig) {
-    String schemaVersionStr = instanceConfig.getRecord().getSimpleField(SCHEMA_VERSION_STR);
+    return getSchemaVersion(instanceConfig.getRecord());
+  }
+
+  /**
+   * Get the schema version associated with the given instance (if any).
+   * @param znRecord the {@link ZNRecord} associated with the interested instance.
+   * @return the schema version of the information stored. If the field is absent in the InstanceConfig, the version
+   *         is assumed to be 0, and 0 is returned.
+   */
+  static int getSchemaVersion(ZNRecord znRecord) {
+    String schemaVersionStr = znRecord.getSimpleField(SCHEMA_VERSION_STR);
     return schemaVersionStr == null ? 0 : Integer.parseInt(schemaVersionStr);
   }
 
@@ -186,7 +198,17 @@ public class ClusterMapUtils {
    * @return the list of sealed replicas.
    */
   static List<String> getSealedReplicas(InstanceConfig instanceConfig) {
-    List<String> sealedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
+    return getSealedReplicas(instanceConfig.getRecord());
+  }
+
+  /**
+   * Get the list of sealed replicas on a given instance. This is guaranteed to return a non-null list. It would return
+   * an empty list if there are no sealed replicas or if the field itself is absent for this instance.
+   * @param znRecord the {@link ZNRecord} associated with the interested instance.
+   * @return the list of sealed replicas.
+   */
+  static List<String> getSealedReplicas(ZNRecord znRecord) {
+    List<String> sealedReplicas = znRecord.getListField(ClusterMapUtils.SEALED_STR);
     return sealedReplicas == null ? new ArrayList<>() : sealedReplicas;
   }
 
@@ -197,7 +219,17 @@ public class ClusterMapUtils {
    * @return the list of stopped replicas.
    */
   static List<String> getStoppedReplicas(InstanceConfig instanceConfig) {
-    List<String> stoppedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.STOPPED_REPLICAS_STR);
+    return getStoppedReplicas(instanceConfig.getRecord());
+  }
+
+  /**
+   * Get the list of stopped replicas on a given instance. This is guaranteed to return a non-null list. It would return
+   * an empty list if there are no stopped replicas or if the field itself is absent for this instance.
+   * @param znRecord the {@link ZNRecord} associated with the interested instance.
+   * @return the list of stopped replicas.
+   */
+  static List<String> getStoppedReplicas(ZNRecord znRecord) {
+    List<String> stoppedReplicas = znRecord.getListField(ClusterMapUtils.STOPPED_REPLICAS_STR);
     return stoppedReplicas == null ? new ArrayList<>() : stoppedReplicas;
   }
 
@@ -208,7 +240,17 @@ public class ClusterMapUtils {
    * @return the list of disabled replicas.
    */
   public static List<String> getDisabledReplicas(InstanceConfig instanceConfig) {
-    List<String> disabledReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.DISABLED_REPLICAS_STR);
+    return getDisabledReplicas(instanceConfig.getRecord());
+  }
+
+  /**
+   * Get the list of disabled replicas on a given instance. This is guaranteed to return a non-null list. It would return
+   * an empty list if there are no disabled replicas or if the field itself is absent for this instance.
+   * @param znRecord the {@link ZNRecord} associated with the interested instance.
+   * @return the list of disabled replicas.
+   */
+  public static List<String> getDisabledReplicas(ZNRecord znRecord) {
+    List<String> disabledReplicas = znRecord.getListField(ClusterMapUtils.DISABLED_REPLICAS_STR);
     return disabledReplicas == null ? new ArrayList<>() : disabledReplicas;
   }
 
@@ -218,7 +260,16 @@ public class ClusterMapUtils {
    * @return the rack id associated with the given instance.
    */
   static String getRackId(InstanceConfig instanceConfig) {
-    return instanceConfig.getRecord().getSimpleField(RACKID_STR);
+    return getRackId(instanceConfig.getRecord());
+  }
+
+  /**
+   * Get the rack id associated with the given instance (if any).
+   * @param znRecord the {@link ZNRecord} associated with the interested instance.
+   * @return the rack id associated with the given instance.
+   */
+  static String getRackId(ZNRecord znRecord) {
+    return znRecord.getSimpleField(RACKID_STR);
   }
 
   /**
@@ -236,7 +287,16 @@ public class ClusterMapUtils {
    * @return the ssl port associated with the given instance.
    */
   public static Integer getSslPortStr(InstanceConfig instanceConfig) {
-    String sslPortStr = instanceConfig.getRecord().getSimpleField(SSL_PORT_STR);
+    return getSslPortStr(instanceConfig.getRecord());
+  }
+
+  /**
+   * Get the ssl port associated with the given instance (if any).
+   * @param znRecord the {@link ZNRecord} associated with the interested instance.
+   * @return the ssl port associated with the given instance.
+   */
+  static Integer getSslPortStr(ZNRecord znRecord) {
+    String sslPortStr = znRecord.getSimpleField(SSL_PORT_STR);
     return sslPortStr == null ? null : Integer.valueOf(sslPortStr);
   }
 
@@ -246,7 +306,16 @@ public class ClusterMapUtils {
    * @return the http2 port associated with the given instance.
    */
   public static Integer getHttp2PortStr(InstanceConfig instanceConfig) {
-    String http2PortStr = instanceConfig.getRecord().getSimpleField(HTTP2_PORT_STR);
+    return getHttp2PortStr(instanceConfig.getRecord());
+  }
+
+  /**
+   * Get the http2 port associated with the given instance (if any).
+   * @param znRecord the {@link ZNRecord} associated with the interested instance.
+   * @return the http2 port associated with the given instance.
+   */
+  static Integer getHttp2PortStr(ZNRecord znRecord) {
+    String http2PortStr = znRecord.getSimpleField(HTTP2_PORT_STR);
     return http2PortStr == null ? null : Integer.valueOf(http2PortStr);
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
@@ -18,6 +18,7 @@ package com.github.ambry.clustermap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 
@@ -112,6 +113,7 @@ class DataNodeConfig {
   /**
    * @return the xid for this server. After {@link SimpleClusterChangeHandler} is retired, this field will be removed.
    */
+  @Deprecated
   long getXid() {
     return xid;
   }
@@ -152,6 +154,27 @@ class DataNodeConfig {
         + stoppedReplicas + ", disabledReplicas=" + disabledReplicas + ", diskConfigs=" + diskConfigs + '}';
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DataNodeConfig that = (DataNodeConfig) o;
+    return port == that.port && xid == that.xid && Objects.equals(instanceName, that.instanceName) && Objects.equals(
+        hostName, that.hostName) && Objects.equals(datacenterName, that.datacenterName) && Objects.equals(sslPort,
+        that.sslPort) && Objects.equals(http2Port, that.http2Port) && Objects.equals(rackId, that.rackId)
+        && sealedReplicas.equals(that.sealedReplicas) && stoppedReplicas.equals(that.stoppedReplicas)
+        && disabledReplicas.equals(that.disabledReplicas) && diskConfigs.equals(that.diskConfigs);
+  }
+
+  @Override
+  public int hashCode() {
+    return instanceName.hashCode();
+  }
+
   /**
    * Configuration scoped to a single disk on a server.
    */
@@ -184,7 +207,7 @@ class DataNodeConfig {
     }
 
     /**
-     * @return a map from partition name to {@link ReplicaConfig} for all the replicas on the server.
+     * @return a map from partition id to {@link ReplicaConfig} for all the replicas on the server.
      *         This map is mutable.
      */
     Map<String, ReplicaConfig> getReplicaConfigs() {
@@ -195,6 +218,19 @@ class DataNodeConfig {
     public String toString() {
       return "DiskConfig{" + "state=" + state + ", diskCapacity=" + diskCapacityInBytes + ", replicaConfigs="
           + replicaConfigs + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      DiskConfig that = (DiskConfig) o;
+      return diskCapacityInBytes == that.diskCapacityInBytes && state == that.state && Objects.equals(replicaConfigs,
+          that.replicaConfigs);
     }
   }
 
@@ -232,6 +268,19 @@ class DataNodeConfig {
     public String toString() {
       return "ReplicaConfig{" + "replicaCapacity=" + replicaCapacityInBytes + ", partitionClass='" + partitionClass
           + '\'' + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ReplicaConfig that = (ReplicaConfig) o;
+      return replicaCapacityInBytes == that.replicaCapacityInBytes && Objects.equals(partitionClass,
+          that.partitionClass);
     }
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
@@ -163,9 +163,9 @@ class DataNodeConfig {
       return false;
     }
     DataNodeConfig that = (DataNodeConfig) o;
-    return port == that.port && xid == that.xid && Objects.equals(instanceName, that.instanceName) && Objects.equals(
-        hostName, that.hostName) && Objects.equals(datacenterName, that.datacenterName) && Objects.equals(sslPort,
-        that.sslPort) && Objects.equals(http2Port, that.http2Port) && Objects.equals(rackId, that.rackId)
+    return Objects.equals(instanceName, that.instanceName) && Objects.equals(hostName, that.hostName) && Objects.equals(
+        datacenterName, that.datacenterName) && port == that.port && Objects.equals(sslPort, that.sslPort)
+        && Objects.equals(http2Port, that.http2Port) && Objects.equals(rackId, that.rackId) && xid == that.xid
         && sealedReplicas.equals(that.sealedReplicas) && stoppedReplicas.equals(that.stoppedReplicas)
         && disabledReplicas.equals(that.disabledReplicas) && diskConfigs.equals(that.diskConfigs);
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSource.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfigSource.java
@@ -24,4 +24,17 @@ interface DataNodeConfigSource {
    * @param listener the {@link DataNodeConfigChangeListener} to attach.
    */
   void addDataNodeConfigChangeListener(DataNodeConfigChangeListener listener) throws Exception;
+
+  /**
+   * Set a {@link DataNodeConfig} in the source of truth store.
+   * @param config the {@link DataNodeConfig} to persist.
+   * @return {@code true} if the config was successfully set.
+   */
+  boolean set(DataNodeConfig config);
+
+  /**
+   * @param instanceName the instance name to look up.
+   * @return the {@link DataNodeConfig} for the specified instance.
+   */
+  DataNodeConfig get(String instanceName);
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
@@ -16,7 +16,12 @@
 package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.utils.Utils;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
+import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.api.listeners.InstanceConfigChangeListener;
 import org.apache.helix.model.InstanceConfig;
@@ -33,7 +38,9 @@ import static com.github.ambry.clustermap.ClusterMapUtils.*;
 public class InstanceConfigToDataNodeConfigAdapter implements DataNodeConfigSource {
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceConfigToDataNodeConfigAdapter.class);
   private final HelixManager helixManager;
-  private final ClusterMapConfig clusterMapConfig;
+  private final Converter converter;
+  private final String clusterName;
+  private volatile HelixAdmin helixAdmin = null;
 
   /**
    * @param helixManager the {@link HelixManager} to use as the source of truth for {@link InstanceConfig}s.
@@ -41,74 +48,136 @@ public class InstanceConfigToDataNodeConfigAdapter implements DataNodeConfigSour
    */
   public InstanceConfigToDataNodeConfigAdapter(HelixManager helixManager, ClusterMapConfig clusterMapConfig) {
     this.helixManager = helixManager;
-    this.clusterMapConfig = clusterMapConfig;
+    this.converter = new Converter(clusterMapConfig);
+    clusterName = clusterMapConfig.clusterMapClusterName;
   }
 
   @Override
   public void addDataNodeConfigChangeListener(DataNodeConfigChangeListener listener) throws Exception {
     helixManager.addInstanceConfigChangeListener((InstanceConfigChangeListener) (instanceConfigs, context) -> {
       Iterable<DataNodeConfig> dataNodeConfigs =
-          () -> instanceConfigs.stream().map(this::convert).filter(Objects::nonNull).iterator();
+          () -> instanceConfigs.stream().map(converter::convert).filter(Objects::nonNull).iterator();
       listener.onDataNodeConfigChange(dataNodeConfigs);
     });
   }
 
-  /**
-   * @param instanceConfig the {@link InstanceConfig} to convert to a {@link DataNodeConfig} object.
-   * @return the {@link DataNodeConfig}, or {@code null} if the {@link InstanceConfig} provided has an unsupported schema
-   *         version.
-   */
-  private DataNodeConfig convert(InstanceConfig instanceConfig) {
-    return convert(instanceConfig, clusterMapConfig);
+  @Override
+  public boolean set(DataNodeConfig config) {
+    InstanceConfig instanceConfig = converter.convert(config);
+    return getHelixAdmin().setInstanceConfig(clusterName, instanceConfig.getInstanceName(), instanceConfig);
   }
 
-  /**
-   * Exposed for testing.
-   * @param instanceConfig the {@link InstanceConfig} to convert to a {@link DataNodeConfig} object.
-   * @param clusterMapConfig the {@link ClusterMapConfig} containing any default values that may be needed.
-   * @return the {@link DataNodeConfig}, or {@code null} if the {@link InstanceConfig} provided has an unsupported schema
-   *         version.
-   */
-  static DataNodeConfig convert(InstanceConfig instanceConfig, ClusterMapConfig clusterMapConfig) {
-    int schemaVersion = getSchemaVersion(instanceConfig);
-    if (schemaVersion != 0) {
-      LOGGER.warn("Unknown InstanceConfig schema version {} in {}. Ignoring.", schemaVersion, instanceConfig);
-      return null;
+  @Override
+  public DataNodeConfig get(String instanceName) {
+    InstanceConfig instanceConfig = getHelixAdmin().getInstanceConfig(clusterName, instanceName);
+    return instanceConfig != null ? converter.convert(instanceConfig) : null;
+  }
+
+  void setHelixAdmin(HelixAdmin helixAdmin) {
+    this.helixAdmin = helixAdmin;
+  }
+
+  private HelixAdmin getHelixAdmin() {
+    return Objects.requireNonNull(helixAdmin, "helixAdmin not set");
+  }
+
+  static class Converter {
+    private final ClusterMapConfig clusterMapConfig;
+
+    Converter(ClusterMapConfig clusterMapConfig) {
+      this.clusterMapConfig = clusterMapConfig;
     }
-    DataNodeConfig dataNodeConfig = new DataNodeConfig(instanceConfig.getInstanceName(), instanceConfig.getHostName(),
-        Integer.parseInt(instanceConfig.getPort()), getDcName(instanceConfig), getSslPortStr(instanceConfig),
-        getHttp2PortStr(instanceConfig), getRackId(instanceConfig), getXid(instanceConfig));
-    dataNodeConfig.getSealedReplicas().addAll(getSealedReplicas(instanceConfig));
-    dataNodeConfig.getStoppedReplicas().addAll(getStoppedReplicas(instanceConfig));
-    // TODO uncomment this line once 1534 is merged
-    // dataNodeConfig.getDisabledReplicas().addAll(getDisabledReplicas(instanceConfig));
-    instanceConfig.getRecord().getMapFields().forEach((mountPath, diskProps) -> {
-      if (diskProps.get(DISK_STATE) == null) {
-        // Check if this map field actually holds disk properties, since we can't tell from just the field key (the
-        // mount path with no special prefix). There may be extra fields when Helix controller adds partitions in ERROR
-        // state to InstanceConfig.
-        LOGGER.warn("{} field does not contain disk info on {}. Skip it and continue on next one.", mountPath,
-            instanceConfig.getInstanceName());
-      } else {
-        DataNodeConfig.DiskConfig disk = new DataNodeConfig.DiskConfig(
-            diskProps.get(DISK_STATE).equals(AVAILABLE_STR) ? HardwareState.AVAILABLE : HardwareState.UNAVAILABLE,
-            Long.parseLong(diskProps.get(DISK_CAPACITY_STR)));
-        String replicasStr = diskProps.get(REPLICAS_STR);
-        if (!replicasStr.isEmpty()) {
-          for (String replicaStr : replicasStr.split(REPLICAS_DELIM_STR)) {
-            String[] replicaStrParts = replicaStr.split(REPLICAS_STR_SEPARATOR);
-            // partition name and replica name are the same.
-            String partitionName = replicaStrParts[0];
-            long replicaCapacity = Long.parseLong(replicaStrParts[1]);
-            String partitionClass =
-                replicaStrParts.length > 2 ? replicaStrParts[2] : clusterMapConfig.clusterMapDefaultPartitionClass;
-            disk.getReplicaConfigs()
-                .put(partitionName, new DataNodeConfig.ReplicaConfig(replicaCapacity, partitionClass));
-          }
-        }
-        dataNodeConfig.getDiskConfigs().put(mountPath, disk);
+
+    /**
+     * @param instanceConfig the {@link InstanceConfig} to convert to a {@link DataNodeConfig} object.
+     * @return the {@link DataNodeConfig}, or {@code null} if the {@link InstanceConfig} provided has an unsupported
+     *         schema version.
+     */
+    DataNodeConfig convert(InstanceConfig instanceConfig) {
+      int schemaVersion = getSchemaVersion(instanceConfig);
+      if (schemaVersion != 0) {
+        LOGGER.warn("Unknown InstanceConfig schema version {} in {}. Ignoring.", schemaVersion, instanceConfig);
+        return null;
       }
-    });
-    return dataNodeConfig;
+      DataNodeConfig dataNodeConfig = new DataNodeConfig(instanceConfig.getInstanceName(), instanceConfig.getHostName(),
+          Integer.parseInt(instanceConfig.getPort()), getDcName(instanceConfig), getSslPortStr(instanceConfig),
+          getHttp2PortStr(instanceConfig), getRackId(instanceConfig), getXid(instanceConfig));
+      dataNodeConfig.getSealedReplicas().addAll(getSealedReplicas(instanceConfig));
+      dataNodeConfig.getStoppedReplicas().addAll(getStoppedReplicas(instanceConfig));
+      dataNodeConfig.getDisabledReplicas().addAll(getDisabledReplicas(instanceConfig));
+      instanceConfig.getRecord().getMapFields().forEach((mountPath, diskProps) -> {
+        if (diskProps.get(DISK_STATE) == null) {
+          // Check if this map field actually holds disk properties, since we can't tell from just the field key (the
+          // mount path with no special prefix). There may be extra fields when Helix controller adds partitions in ERROR
+          // state to InstanceConfig.
+          LOGGER.warn("{} field does not contain disk info on {}. Skip it and continue on next one.", mountPath,
+              instanceConfig.getInstanceName());
+        } else {
+          DataNodeConfig.DiskConfig disk = new DataNodeConfig.DiskConfig(
+              diskProps.get(DISK_STATE).equals(AVAILABLE_STR) ? HardwareState.AVAILABLE : HardwareState.UNAVAILABLE,
+              Long.parseLong(diskProps.get(DISK_CAPACITY_STR)));
+          String replicasStr = diskProps.get(REPLICAS_STR);
+          if (!Utils.isNullOrEmpty(replicasStr)) {
+            for (String replicaStr : replicasStr.split(REPLICAS_DELIM_STR)) {
+              String[] replicaStrParts = replicaStr.split(REPLICAS_STR_SEPARATOR);
+              // partition name and replica name are the same.
+              String partitionName = replicaStrParts[0];
+              long replicaCapacity = Long.parseLong(replicaStrParts[1]);
+              String partitionClass =
+                  replicaStrParts.length > 2 ? replicaStrParts[2] : clusterMapConfig.clusterMapDefaultPartitionClass;
+              disk.getReplicaConfigs()
+                  .put(partitionName, new DataNodeConfig.ReplicaConfig(replicaCapacity, partitionClass));
+            }
+          }
+          dataNodeConfig.getDiskConfigs().put(mountPath, disk);
+        }
+      });
+      return dataNodeConfig;
+    }
+
+    /**
+     * @param dataNodeConfig the {@link DataNodeConfig} to convert into an {@link InstanceConfig}.
+     * @return the {@link InstanceConfig}.
+     */
+    InstanceConfig convert(DataNodeConfig dataNodeConfig) {
+      InstanceConfig instanceConfig = new InstanceConfig(dataNodeConfig.getInstanceName());
+      instanceConfig.setHostName(dataNodeConfig.getHostName());
+      instanceConfig.setPort(Integer.toString(dataNodeConfig.getPort()));
+      if (dataNodeConfig.getSslPort() != null) {
+        instanceConfig.getRecord().setIntField(SSL_PORT_STR, dataNodeConfig.getSslPort());
+      }
+      if (dataNodeConfig.getHttp2Port() != null) {
+        instanceConfig.getRecord().setIntField(HTTP2_PORT_STR, dataNodeConfig.getHttp2Port());
+      }
+      instanceConfig.getRecord().setSimpleField(DATACENTER_STR, dataNodeConfig.getDatacenterName());
+      instanceConfig.getRecord().setSimpleField(RACKID_STR, dataNodeConfig.getRackId());
+      long xid = dataNodeConfig.getXid();
+      if (xid != DEFAULT_XID) {
+        // Set the XID only if it is not the default, in order to avoid unnecessary updates.
+        instanceConfig.getRecord().setLongField(XID_STR, xid);
+      }
+      instanceConfig.getRecord().setIntField(SCHEMA_VERSION_STR, CURRENT_SCHEMA_VERSION);
+      instanceConfig.getRecord().setListField(SEALED_STR, new ArrayList<>(dataNodeConfig.getSealedReplicas()));
+      instanceConfig.getRecord()
+          .setListField(STOPPED_REPLICAS_STR, new ArrayList<>(dataNodeConfig.getStoppedReplicas()));
+      instanceConfig.getRecord()
+          .setListField(DISABLED_REPLICAS_STR, new ArrayList<>(dataNodeConfig.getDisabledReplicas()));
+      dataNodeConfig.getDiskConfigs().forEach((mountPath, diskConfig) -> {
+        Map<String, String> diskProps = new HashMap<>();
+        diskProps.put(DISK_STATE, diskConfig.getState() == HardwareState.AVAILABLE ? AVAILABLE_STR : UNAVAILABLE_STR);
+        diskProps.put(DISK_CAPACITY_STR, Long.toString(diskConfig.getDiskCapacityInBytes()));
+        StringBuilder replicasStrBuilder = new StringBuilder();
+        diskConfig.getReplicaConfigs()
+            .forEach((partitionName, replicaConfig) -> replicasStrBuilder.append(partitionName)
+                .append(REPLICAS_STR_SEPARATOR)
+                .append(replicaConfig.getReplicaCapacityInBytes())
+                .append(REPLICAS_STR_SEPARATOR)
+                .append(replicaConfig.getPartitionClass())
+                .append(REPLICAS_DELIM_STR));
+        diskProps.put(REPLICAS_STR, replicasStrBuilder.toString());
+        instanceConfig.getRecord().setMapField(mountPath, diskProps);
+      });
+      return instanceConfig;
+    }
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapter.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.utils.Utils;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import org.apache.helix.AccessOption;
+import org.apache.helix.store.HelixPropertyListener;
+import org.apache.helix.store.HelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+
+
+/**
+ * An implementation of {@link DataNodeConfigSource} that reads {@link ZNRecord}s stored under the
+ * "/DataNodeConfigs" path in a {@link HelixPropertyStore}.
+ */
+public class PropertyStoreToDataNodeConfigAdapter implements DataNodeConfigSource {
+  static final String CONFIG_PATH = "/DataNodeConfigs";
+  private static final Logger LOGGER = LoggerFactory.getLogger(PropertyStoreToDataNodeConfigAdapter.class);
+  private final HelixPropertyStore<ZNRecord> propertyStore;
+  private final Converter converter;
+  private final Executor eventExecutor;
+
+  /**
+   * @param propertyStore the {@link HelixPropertyStore} instance to use to interact with zookeeper.
+   * @param clusterMapConfig the {@link ClusterMapConfig} to use.
+   * @param dcName the datacenter name for for the property store.
+   */
+  public PropertyStoreToDataNodeConfigAdapter(HelixPropertyStore<ZNRecord> propertyStore,
+      ClusterMapConfig clusterMapConfig, String dcName) {
+    this.propertyStore = propertyStore;
+    this.converter = new Converter(clusterMapConfig.clusterMapDefaultPartitionClass, dcName);
+    this.eventExecutor = Executors.newSingleThreadExecutor();
+  }
+
+  @Override
+  public void addDataNodeConfigChangeListener(DataNodeConfigChangeListener listener) throws Exception {
+    Subscription subscription = new Subscription(listener);
+    propertyStore.subscribe(CONFIG_PATH, subscription);
+    subscription.start();
+  }
+
+  @Override
+  public boolean set(DataNodeConfig config) {
+    ZNRecord record = converter.convert(config);
+    String path = CONFIG_PATH + "/" + record.getId();
+    return propertyStore.set(path, record, AccessOption.PERSISTENT);
+  }
+
+  @Override
+  public DataNodeConfig get(String instanceName) {
+    String path = CONFIG_PATH + "/" + instanceName;
+    ZNRecord record = propertyStore.get(path, new Stat(), AccessOption.PERSISTENT);
+    return record != null ? converter.convert(record) : null;
+  }
+
+  private class Subscription implements HelixPropertyListener {
+    private final DataNodeConfigChangeListener listener;
+    private final CompletableFuture<Void> initFuture = new CompletableFuture<>();
+
+    Subscription(DataNodeConfigChangeListener listener) {
+      this.listener = listener;
+    }
+
+    /**
+     * Tell the background executor to perform any initialization needed. This should be called after registering this
+     * listener using {@link HelixPropertyStore#subscribe}. This will ensure that the first event sent to
+     * {@link #listener} will contain the entire set of current configs.
+     * @throws Exception if there was an exception while making the initialization call.
+     */
+    void start() throws Exception {
+      eventExecutor.execute(this::initializeIfNeeded);
+      try {
+        initFuture.get();
+      } catch (ExecutionException e) {
+        throw Utils.extractExecutionExceptionCause(e);
+      }
+    }
+
+    @Override
+    public void onDataChange(String path) {
+      LOGGER.debug("DataNodeConfig path {} changed", path);
+      onPathChange(path);
+    }
+
+    @Override
+    public void onDataCreate(String path) {
+      LOGGER.debug("DataNodeConfig path {} created", path);
+      onPathChange(path);
+    }
+
+    @Override
+    public void onDataDelete(String path) {
+      // TODO handle node deletions dynamically. Doing so requires further work in the ClusterChangeHandler impl
+      LOGGER.info("DataNodeConfig path {} deleted. This requires a restart to handle", path);
+    }
+
+    private void onPathChange(String path) {
+      eventExecutor.execute(() -> updateOrInitialize(path));
+    }
+
+    private Iterable<DataNodeConfig> lazyIterable(Collection<ZNRecord> records) {
+      return () -> records.stream().map(converter::convert).filter(Objects::nonNull).iterator();
+    }
+
+    /**
+     * Either perform a full initialization or notify the listener about an incremental update to a path. This should be
+     * called from the event executor thread.
+     * @param changedPath the path that changed.
+     */
+    private synchronized void updateOrInitialize(String changedPath) {
+      try {
+        if (initializeIfNeeded()) {
+          ZNRecord record = propertyStore.get(changedPath, null, AccessOption.PERSISTENT);
+          if (record != null) {
+            listener.onDataNodeConfigChange(lazyIterable(Collections.singleton(record)));
+          } else {
+            LOGGER.info("DataNodeConfig at path {} not found", changedPath);
+          }
+        }
+      } catch (Exception e) {
+        LOGGER.error("Exception during DataNodeConfig change", e);
+      }
+    }
+
+    /**
+     * If initialization has not yet been completed successfully, attempt an initialization. This should be called from
+     * the event executor thread.
+     * @return {@code true} if a partial update can be performed following this call. {@code false} if it is either
+     *         not needed since a full init was just done or if an initialization error occurred previously.
+     */
+    private synchronized boolean initializeIfNeeded() {
+      boolean partialUpdateAllowed = false;
+      try {
+        if (initFuture.isDone()) {
+          partialUpdateAllowed = !initFuture.isCompletedExceptionally();
+        } else {
+          List<ZNRecord> records = propertyStore.getChildren(CONFIG_PATH, null, AccessOption.PERSISTENT);
+          listener.onDataNodeConfigChange(lazyIterable(records));
+          initFuture.complete(null);
+        }
+      } catch (Throwable t) {
+        initFuture.completeExceptionally(t);
+      }
+      return partialUpdateAllowed;
+    }
+  }
+
+  /**
+   * Convert between {@link DataNodeConfig}s and {@link ZNRecord}s.
+   */
+  static class Converter {
+    private static final int VERSION_0 = 0;
+    private static final String MOUNT_PREFIX = "mount-";
+    private static final String HOSTNAME_FIELD = "hostname";
+    private static final String PORT_FIELD = "port";
+    private final String defaultPartitionClass;
+    private final String dcName;
+
+    /**
+     * @param defaultPartitionClass the default partition class for these nodes.
+     * @param dcName the datacenter name for these nodes.
+     */
+    Converter(String defaultPartitionClass, String dcName) {
+      this.defaultPartitionClass = defaultPartitionClass;
+      this.dcName = dcName;
+    }
+
+    /**
+     * @param record the {@link ZNRecord} to convert to a {@link DataNodeConfig} object.
+     * @return the {@link DataNodeConfig}, or {@code null} if the {@link ZNRecord} provided has an unsupported schema
+     *         version.
+     */
+    DataNodeConfig convert(ZNRecord record) {
+      int schemaVersion = getSchemaVersion(record);
+      if (schemaVersion != VERSION_0) {
+        LOGGER.warn("Unknown InstanceConfig schema version {} in {}. Ignoring.", schemaVersion, record);
+        return null;
+      }
+
+      DataNodeConfig dataNodeConfig = new DataNodeConfig(record.getId(), record.getSimpleField(HOSTNAME_FIELD),
+          record.getIntField(PORT_FIELD, DataNodeId.UNKNOWN_PORT), dcName, getSslPortStr(record),
+          getHttp2PortStr(record), getRackId(record), DEFAULT_XID);
+      dataNodeConfig.getSealedReplicas().addAll(getSealedReplicas(record));
+      dataNodeConfig.getStoppedReplicas().addAll(getStoppedReplicas(record));
+      dataNodeConfig.getDisabledReplicas().addAll(getDisabledReplicas(record));
+      record.getMapFields().forEach((key, diskProps) -> {
+        if (key.startsWith(MOUNT_PREFIX)) {
+          String mountPath = key.substring(MOUNT_PREFIX.length());
+          DataNodeConfig.DiskConfig disk = new DataNodeConfig.DiskConfig(
+              diskProps.get(DISK_STATE).equals(AVAILABLE_STR) ? HardwareState.AVAILABLE : HardwareState.UNAVAILABLE,
+              Long.parseLong(diskProps.get(DISK_CAPACITY_STR)));
+          String replicasStr = diskProps.get(REPLICAS_STR);
+          if (!Utils.isNullOrEmpty(replicasStr)) {
+            for (String replicaStr : replicasStr.split(REPLICAS_DELIM_STR)) {
+              String[] replicaStrParts = replicaStr.split(REPLICAS_STR_SEPARATOR);
+              // partition name and replica name are the same.
+              String partitionName = replicaStrParts[0];
+              long replicaCapacity = Long.parseLong(replicaStrParts[1]);
+              String partitionClass = replicaStrParts.length > 2 ? replicaStrParts[2] : defaultPartitionClass;
+              disk.getReplicaConfigs()
+                  .put(partitionName, new DataNodeConfig.ReplicaConfig(replicaCapacity, partitionClass));
+            }
+          }
+          dataNodeConfig.getDiskConfigs().put(mountPath, disk);
+        }
+      });
+      return dataNodeConfig;
+    }
+
+    /**
+     * @param dataNodeConfig the {@link DataNodeConfig} to convert to a {@link ZNRecord} that can be stored in the
+     *                       property store.
+     * @return the {@link ZNRecord}.
+     */
+    ZNRecord convert(DataNodeConfig dataNodeConfig) {
+      ZNRecord record = new ZNRecord(dataNodeConfig.getInstanceName());
+      record.setIntField(SCHEMA_VERSION_STR, VERSION_0);
+      record.setSimpleField(HOSTNAME_FIELD, dataNodeConfig.getHostName());
+      record.setIntField(PORT_FIELD, dataNodeConfig.getPort());
+      if (dataNodeConfig.getSslPort() != null) {
+        record.setIntField(SSL_PORT_STR, dataNodeConfig.getSslPort());
+      }
+      if (dataNodeConfig.getHttp2Port() != null) {
+        record.setIntField(HTTP2_PORT_STR, dataNodeConfig.getHttp2Port());
+      }
+      record.setSimpleField(RACKID_STR, dataNodeConfig.getRackId());
+      record.setListField(SEALED_STR, new ArrayList<>(dataNodeConfig.getSealedReplicas()));
+      record.setListField(STOPPED_REPLICAS_STR, new ArrayList<>(dataNodeConfig.getStoppedReplicas()));
+      record.setListField(DISABLED_REPLICAS_STR, new ArrayList<>(dataNodeConfig.getDisabledReplicas()));
+      dataNodeConfig.getDiskConfigs().forEach((mountPath, diskConfig) -> {
+        Map<String, String> diskProps = new HashMap<>();
+        diskProps.put(DISK_STATE, diskConfig.getState() == HardwareState.AVAILABLE ? AVAILABLE_STR : UNAVAILABLE_STR);
+        diskProps.put(DISK_CAPACITY_STR, Long.toString(diskConfig.getDiskCapacityInBytes()));
+        StringBuilder replicasStrBuilder = new StringBuilder();
+        diskConfig.getReplicaConfigs()
+            .forEach((partitionName, replicaConfig) -> replicasStrBuilder.append(partitionName)
+                .append(REPLICAS_STR_SEPARATOR)
+                .append(replicaConfig.getReplicaCapacityInBytes())
+                .append(REPLICAS_STR_SEPARATOR)
+                .append(replicaConfig.getPartitionClass())
+                .append(REPLICAS_DELIM_STR));
+        diskProps.put(REPLICAS_STR, replicasStrBuilder.toString());
+        record.setMapField(MOUNT_PREFIX + mountPath, diskProps);
+      });
+      return record;
+    }
+  }
+}

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/ClusterChangeHandlerTest.java
@@ -297,12 +297,12 @@ public class ClusterChangeHandlerTest {
     diskInfos.put("INVALID_MOUNT_PATH", invalidEntry);
     instanceConfig.getRecord().setMapFields(diskInfos);
     // we call onInstanceConfigChange() twice
+    InstanceConfigToDataNodeConfigAdapter.Converter converter =
+        new InstanceConfigToDataNodeConfigAdapter.Converter(clusterMapConfig);
     // 1st call, to verify initialization code path
-    dynamicChangeHandler.onDataNodeConfigChange(
-        Collections.singleton(InstanceConfigToDataNodeConfigAdapter.convert(instanceConfig, clusterMapConfig)));
+    dynamicChangeHandler.onDataNodeConfigChange(Collections.singleton(converter.convert(instanceConfig)));
     // 2nd call, to verify dynamic update code path
-    dynamicChangeHandler.onDataNodeConfigChange(
-        Collections.singletonList(InstanceConfigToDataNodeConfigAdapter.convert(instanceConfig, clusterMapConfig)));
+    dynamicChangeHandler.onDataNodeConfigChange(Collections.singletonList(converter.convert(instanceConfig)));
     assertEquals("There shouldn't be initialization errors", 0, initFailureCount.getCount());
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DataNodeConfigSourceTestBase.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DataNodeConfigSourceTestBase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Base class containing utilities for tests of {@link DataNodeConfigSource} implementations.
+ */
+public class DataNodeConfigSourceTestBase {
+  static final String DC_NAME = "DC";
+  private int counter = 0;
+
+  /**
+   * Check that {@link DataNodeConfigChangeListener#onDataNodeConfigChange} was called with the specified configs
+   * within a short period of time.
+   * @param listener the {@link DataNodeConfigChangeListener} to check.
+   * @param expectedConfigs the set of configs expected.
+   */
+  void checkListenerCall(DataNodeConfigChangeListener listener, Set<DataNodeConfig> expectedConfigs) {
+    verify(listener, timeout(500)).onDataNodeConfigChange(argThat(configs -> {
+      Set<DataNodeConfig> configsReceived = new HashSet<>();
+      configs.forEach(configsReceived::add);
+      return configsReceived.equals(expectedConfigs);
+    }));
+  }
+
+  /**
+   * @param numDisks the number of disks to include in the config
+   * @param numReplicasPerDisk the number of replicas to include on each disk in the config.
+   * @return a generated {@link DataNodeConfig} to use in tests.
+   */
+  DataNodeConfig createConfig(int numDisks, int numReplicasPerDisk) {
+    String hostname = "host" + counter++;
+    int port = 2222;
+    String instanceName = ClusterMapUtils.getInstanceName(hostname, port);
+    DataNodeConfig dataNodeConfig =
+        new DataNodeConfig(instanceName, hostname, port, DC_NAME, port + 1, port + 2, "rack",
+            ClusterMapUtils.DEFAULT_XID);
+    int nextPartitionId = 0;
+    for (int i = 0; i < numDisks; i++) {
+      DataNodeConfig.DiskConfig diskConfig = new DataNodeConfig.DiskConfig(HardwareState.AVAILABLE, 2000);
+      for (int j = 0; j < numReplicasPerDisk; j++) {
+        int partitionId = nextPartitionId++;
+        String partitionName = Integer.toString(partitionId);
+        switch (partitionId % 4) {
+          case 0:
+            break;
+          case 1:
+            dataNodeConfig.getSealedReplicas().add(partitionName);
+            break;
+          case 2:
+            dataNodeConfig.getStoppedReplicas().add(partitionName);
+            break;
+          case 3:
+            dataNodeConfig.getDisabledReplicas().add(partitionName);
+            break;
+        }
+        diskConfig.getReplicaConfigs().put(partitionName, new DataNodeConfig.ReplicaConfig(10, "class"));
+      }
+      dataNodeConfig.getDiskConfigs().put("/" + i, diskConfig);
+    }
+    return dataNodeConfig;
+  }
+}

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapterTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapterTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.TestUtils;
+import com.github.ambry.utils.TestUtils.ZkInfo;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.helix.InstanceType;
+import org.junit.Test;
+
+import static com.github.ambry.clustermap.ClusterMapUtils.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Tests for {@link InstanceConfigToDataNodeConfigAdapter}.
+ */
+public class InstanceConfigToDataNodeConfigAdapterTest extends DataNodeConfigSourceTestBase {
+  private final ZkInfo zkInfo;
+  private final ClusterMapConfig clusterMapConfig;
+  private final MockHelixManager helixManager;
+
+  public InstanceConfigToDataNodeConfigAdapterTest() throws Exception {
+    String clusterName = "Cluster";
+    File tempDir = Files.createTempDirectory(getClass().getSimpleName()).toFile();
+    String tempDirPath = tempDir.getAbsolutePath();
+    tempDir.deleteOnExit();
+
+    zkInfo = new ZkInfo(tempDirPath, DC_NAME, (byte) 0, 3333, true);
+    String hostname = "localhost";
+    int portNum = 1234;
+    String selfInstanceName = getInstanceName(hostname, portNum);
+    Properties props = new Properties();
+    props.setProperty("clustermap.host.name", hostname);
+    props.setProperty("clustermap.cluster.name", clusterName);
+    props.setProperty("clustermap.datacenter.name", DC_NAME);
+    props.setProperty("clustermap.port", Integer.toString(portNum));
+    clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+    helixManager =
+        new MockHelixManager(selfInstanceName, InstanceType.SPECTATOR, "localhost:" + zkInfo.getPort(), clusterName,
+            new MockHelixAdmin(), null, null);
+    helixManager.connect();
+  }
+
+  /**
+   * Test {@link DataNodeConfigSource} methods.
+   */
+  @Test
+  public void testSetGetListener() throws Exception {
+    InstanceConfigToDataNodeConfigAdapter source =
+        new InstanceConfigToDataNodeConfigAdapter(helixManager, clusterMapConfig);
+    source.setHelixAdmin(helixManager.getClusterManagmentTool());
+    // set up 10 node configs and attach a listener.
+    Set<DataNodeConfig> allConfigs = new HashSet<>();
+    for (int i = 0; i < 10; i++) {
+      DataNodeConfig config = createConfig(i, 9 - i);
+      allConfigs.add(config);
+      source.set(config);
+    }
+    DataNodeConfigChangeListener listener1 = mock(DataNodeConfigChangeListener.class);
+    source.addDataNodeConfigChangeListener(listener1);
+    checkListenerCall(listener1, allConfigs);
+
+    // add a new host and add a second listener, both listeners should get all updates since MockHelixManager
+    // always provides the complete set of instances
+    reset(listener1);
+    DataNodeConfig newConfig = createConfig(2, 2);
+    allConfigs.add(newConfig);
+    source.set(newConfig);
+    DataNodeConfigChangeListener listener2 = mock(DataNodeConfigChangeListener.class);
+    source.addDataNodeConfigChangeListener(listener2);
+    checkListenerCall(listener1, allConfigs);
+    checkListenerCall(listener2, allConfigs);
+
+    // update an existing config
+    reset(listener1);
+    reset(listener2);
+    DataNodeConfig updatedConfig = allConfigs.iterator().next();
+    updatedConfig.getStoppedReplicas().add("partition");
+    source.set(updatedConfig);
+    // need to manually trigger a notification since MockHelixParticipant does not do so.
+    // (other tests may not work as intended if we trigger a notification on calls to setInstanceConfig)
+    helixManager.triggerConfigChangeNotification(false);
+    checkListenerCall(listener1, allConfigs);
+    checkListenerCall(listener2, allConfigs);
+
+    // test get method for all configs
+    for (DataNodeConfig config : allConfigs) {
+      assertEquals("get() call returned incorrect result", config, source.get(config.getInstanceName()));
+    }
+    assertNull("Should not receive non-existent instance", source.get("abc"));
+
+    source.setHelixAdmin(null);
+    TestUtils.assertException(NullPointerException.class, () -> source.set(createConfig(1, 1)), null);
+    String firstInstance = allConfigs.iterator().next().getInstanceName();
+    TestUtils.assertException(NullPointerException.class, () -> source.get(firstInstance), null);
+  }
+}

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapterTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/PropertyStoreToDataNodeConfigAdapterTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.clustermap;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.helix.AccessOption;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.junit.Test;
+
+import static com.github.ambry.utils.TestUtils.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Test {@link PropertyStoreToDataNodeConfigAdapter}.
+ */
+public class PropertyStoreToDataNodeConfigAdapterTest extends DataNodeConfigSourceTestBase {
+
+  private final MockHelixPropertyStore<ZNRecord> propertyStore = new MockHelixPropertyStore<>();
+  private final DataNodeConfigSource source =
+      new PropertyStoreToDataNodeConfigAdapter(propertyStore, TestUtils.getDummyConfig(), DC_NAME);
+
+  /**
+   * Test {@link DataNodeConfigSource} methods.
+   */
+  @Test
+  public void testSetGetListener() throws Exception {
+    // set up 10 node configs and attach a listener.
+    Set<DataNodeConfig> allConfigs = new HashSet<>();
+    for (int i = 0; i < 10; i++) {
+      DataNodeConfig config = createConfig(i, 9 - i);
+      allConfigs.add(config);
+      source.set(config);
+    }
+    DataNodeConfigChangeListener listener1 = mock(DataNodeConfigChangeListener.class);
+    source.addDataNodeConfigChangeListener(listener1);
+    checkListenerCall(listener1, allConfigs);
+
+    // add a new host and add a second listener, second listener should get all updates, first should get new host only.
+    reset(listener1);
+    DataNodeConfig newConfig = createConfig(2, 2);
+    allConfigs.add(newConfig);
+    source.set(newConfig);
+    DataNodeConfigChangeListener listener2 = mock(DataNodeConfigChangeListener.class);
+    source.addDataNodeConfigChangeListener(listener2);
+    checkListenerCall(listener1, Collections.singleton(newConfig));
+    checkListenerCall(listener2, allConfigs);
+
+    // update an existing config
+    reset(listener1);
+    reset(listener2);
+    DataNodeConfig updatedConfig = allConfigs.iterator().next();
+    updatedConfig.getStoppedReplicas().add("partition");
+    source.set(updatedConfig);
+    checkListenerCall(listener1, Collections.singleton(updatedConfig));
+    checkListenerCall(listener2, Collections.singleton(updatedConfig));
+
+    // delete an existing config, this should be a no-op for listeners now.
+    reset(listener1);
+    reset(listener2);
+    propertyStore.remove(PropertyStoreToDataNodeConfigAdapter.CONFIG_PATH + "/" + updatedConfig.getInstanceName(),
+        AccessOption.PERSISTENT);
+    allConfigs.remove(updatedConfig);
+    verify(listener1, never()).onDataNodeConfigChange(any());
+    verify(listener2, never()).onDataNodeConfigChange(any());
+
+    // test get method for all configs
+    for (DataNodeConfig config : allConfigs) {
+      assertEquals("get() call returned incorrect result", config, source.get(config.getInstanceName()));
+    }
+    // removal should be reflected in get() call
+    assertNull("node config should not be present", source.get(updatedConfig.getInstanceName()));
+  }
+
+  /**
+   * Test handling of listener errors during initialization and updates.
+   */
+  @Test
+  public void testListenerExceptions() throws Exception {
+    // exception during init
+    DataNodeConfigChangeListener listener1 = mock(DataNodeConfigChangeListener.class);
+    RuntimeException initException = new RuntimeException("Failure during init");
+    doThrow(initException).when(listener1).onDataNodeConfigChange(any());
+    assertException(RuntimeException.class, () -> source.addDataNodeConfigChangeListener(listener1),
+        e -> assertEquals("Unexpected exception thrown", initException, e));
+    checkListenerCall(listener1, Collections.emptySet());
+    // no more calls to listener should occur
+    reset(listener1);
+    DataNodeConfig config = createConfig(1, 1);
+    source.set(config);
+    verify(listener1, never()).onDataNodeConfigChange(any());
+
+    // exception during update call.
+    DataNodeConfigChangeListener listener2 = mock(DataNodeConfigChangeListener.class);
+    source.addDataNodeConfigChangeListener(listener2);
+    checkListenerCall(listener2, Collections.singleton(config));
+    reset(listener2);
+    RuntimeException updateException = new RuntimeException("Failure during update");
+    doThrow(updateException).when(listener2).onDataNodeConfigChange(any());
+    config.getDisabledReplicas().add("partition1");
+    source.set(config);
+    checkListenerCall(listener2, Collections.singleton(config));
+    // more updates should still create notifications
+    config.getDisabledReplicas().add("partition2");
+    source.set(config);
+    checkListenerCall(listener2, Collections.singleton(config));
+  }
+}


### PR DESCRIPTION
Introduce a DataNodeConfigSource implementation that can be used to
listen for changes to configs using HelixPropertyStore.

To avoid blocking the threads used by helix to send property store
change events, this implementation uses a background thread to read
records from the property store and notify any downstream listeners.

To prepare for future participant changes this also adds set and get
methods to DataNodeConfigSource for reading and updating
DataNodeConfigs.
