### PR TITLE
FindKey method takes FileSpan as the entire search space.

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -584,7 +584,7 @@ public class BlobStore implements Store {
             IndexValue value =
                 index.findKey(info.getStoreKey(), fileSpan, EnumSet.allOf(PersistentIndex.IndexEntryType.class));
             if (value != null) {
-              // There are several possible cases that can exist here. Delete has be follow either PUT, TTL_UPDATE or UNDELETE.
+              // There are several possible cases that can exist here. Delete has to follow either PUT, TTL_UPDATE or UNDELETE.
               // let EOBC be end offset before check, and [RECORD] means RECORD is optional
               // 1. PUT [TTL_UPDATE DELETE UNDELETE] EOBC DELETE
               // 2. PUT EOBC TTL_UPDATE

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1191,8 +1191,6 @@ class BlobStoreCompactor {
         long referenceTimeMs = compactionLog.getCompactionDetails().getReferenceTimeMs();
         for (IndexSegment indexSegment : srcIndex.getIndexSegments().descendingMap().values()) {
           if (indexSegment.getLastModifiedTimeMs() < referenceTimeMs) {
-            // NOTE: using start offset here because of the way FileSpan is treated in PersistentIndex.findKey().
-            // using this as the end offset for delete includes the whole index segment in the search.
             cutoffOffset = indexSegment.getEndOffset();
             break;
           }

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -1113,7 +1113,7 @@ class BlobStoreCompactor {
       // StoreConfig#storeDeletedMessageRetentionDays days old. If there are such deletes, then they are not counted as
       // deletes and the PUT records are still valid as far as compaction is concerned
       boolean deletesInEffect = startOffsetOfLastIndexSegmentForDeleteCheck != null
-          && indexSegment.getStartOffset().compareTo(startOffsetOfLastIndexSegmentForDeleteCheck) <= 0;
+          && indexSegment.getStartOffset().compareTo(startOffsetOfLastIndexSegmentForDeleteCheck) < 0;
       logger.trace("Deletes in effect is {} for index segment with start offset {} in {}", deletesInEffect,
           indexSegment.getStartOffset(), storeId);
       List<IndexEntry> validEntries = new ArrayList<>();
@@ -1193,7 +1193,7 @@ class BlobStoreCompactor {
           if (indexSegment.getLastModifiedTimeMs() < referenceTimeMs) {
             // NOTE: using start offset here because of the way FileSpan is treated in PersistentIndex.findKey().
             // using this as the end offset for delete includes the whole index segment in the search.
-            cutoffOffset = indexSegment.getStartOffset();
+            cutoffOffset = indexSegment.getEndOffset();
             break;
           }
         }

--- a/ambry-store/src/main/java/com/github/ambry/store/FileSpan.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/FileSpan.java
@@ -14,7 +14,8 @@
 package com.github.ambry.store;
 
 /**
- * Represents a portion of a log. Provides the start and end offset of a log
+ * Represents a portion of a log. Provides the start and end offset of a log. The start offset is inclusive in the
+ * FileSpan, but the end offset is not. When the start offset = end offset, this is an empty FileSpan.
  */
 class FileSpan {
   private Offset startOffset;
@@ -53,7 +54,14 @@ class FileSpan {
    * @return {@code true} if {@code offset} is in this {@link FileSpan} (start and end offsets are considered inclusive)
    */
   boolean inSpan(Offset offset) {
-    return offset.compareTo(startOffset) >= 0 && offset.compareTo(endOffset) <= 0;
+    return offset.compareTo(startOffset) >= 0 && offset.compareTo(endOffset) < 0;
+  }
+
+  /**
+   * @return True when start offset equals to end offset.
+   */
+  boolean isEmpty() {
+    return startOffset.compareTo(endOffset) == 0;
   }
 
   @Override

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -556,6 +556,19 @@ class PersistentIndex {
    * if present in the index within the given {@code fileSpan}.
    * @param key The key to do the exist check against
    * @param fileSpan FileSpan which specifies the range within which search should be made
+   * @return The latest {@link IndexValue} for {@code key} conforming to one of the types {@code types} - if one exists
+   * within the {@code fileSpan}, {@code null} otherwise.
+   * @throws StoreException
+   */
+  IndexValue findKey(StoreKey key, FileSpan fileSpan) throws StoreException {
+    return findKey(key, fileSpan, EnumSet.of(IndexEntryType.PUT, IndexEntryType.DELETE, IndexEntryType.UNDELETE));
+  }
+
+  /**
+   * Finds the latest {@link IndexValue} associated with the {@code key} that matches any of the provided {@code types}
+   * if present in the index within the given {@code fileSpan}.
+   * @param key The key to do the exist check against
+   * @param fileSpan FileSpan which specifies the range within which search should be made
    * @param types the types of {@link IndexEntryType} to look for. The latest entry matching one of the types will be
    *              returned
    * @return The latest {@link IndexValue} for {@code key} conforming to one of the types {@code types} - if one exists
@@ -580,6 +593,9 @@ class PersistentIndex {
    */
   private IndexValue findKey(StoreKey key, FileSpan fileSpan, EnumSet<IndexEntryType> types,
       ConcurrentSkipListMap<Offset, IndexSegment> indexSegments) throws StoreException {
+    if (fileSpan != null && fileSpan.isEmpty()) {
+      return null;
+    }
     IndexValue latest = null;
     IndexValue retCandidate = null;
     final Timer.Context context = metrics.findTime.time();
@@ -592,7 +608,7 @@ class PersistentIndex {
         logger.trace("Searching for {} in index with filespan ranging from {} to {}", key, fileSpan.getStartOffset(),
             fileSpan.getEndOffset());
         segmentsMapToSearch = indexSegments.subMap(indexSegments.floorKey(fileSpan.getStartOffset()), true,
-            indexSegments.floorKey(fileSpan.getEndOffset()), true).descendingMap();
+            indexSegments.lowerKey(fileSpan.getEndOffset()), true).descendingMap();
         metrics.segmentSizeForExists.update(segmentsMapToSearch.size());
       }
       int segmentsSearched = 0;
@@ -604,6 +620,15 @@ class PersistentIndex {
           Iterator<IndexValue> it = values.descendingIterator();
           while (it.hasNext()) {
             IndexValue value = it.next();
+            if (fileSpan != null) {
+              // Start <= value.offset < End
+              if (value.getOffset().compareTo(fileSpan.getEndOffset()) >= 0) {
+                continue;
+              }
+              if (value.getOffset().compareTo(fileSpan.getStartOffset()) < 0) {
+                break;
+              }
+            }
             if (latest == null) {
               latest = value;
             }
@@ -677,6 +702,9 @@ class PersistentIndex {
   List<IndexValue> findAllIndexValuesForKey(StoreKey key, FileSpan fileSpan, EnumSet<IndexEntryType> types,
       ConcurrentSkipListMap<Offset, IndexSegment> indexSegments) throws StoreException {
     List<IndexValue> result = new ArrayList<>();
+    if (fileSpan != null && fileSpan.isEmpty()) {
+      return result;
+    }
     final Timer.Context context = metrics.findTime.time();
     try {
       ConcurrentNavigableMap<Offset, IndexSegment> segmentsMapToSearch;
@@ -687,7 +715,7 @@ class PersistentIndex {
         logger.trace("Searching all indexes for {} in index with filespan ranging from {} to {}", key,
             fileSpan.getStartOffset(), fileSpan.getEndOffset());
         segmentsMapToSearch = indexSegments.subMap(indexSegments.floorKey(fileSpan.getStartOffset()), true,
-            indexSegments.floorKey(fileSpan.getEndOffset()), true).descendingMap();
+            indexSegments.lowerKey(fileSpan.getEndOffset()), true).descendingMap();
         metrics.segmentSizeForExists.update(segmentsMapToSearch.size());
       }
       int segmentsSearched = 0;
@@ -699,6 +727,15 @@ class PersistentIndex {
           Iterator<IndexValue> it = values.descendingIterator();
           while (it.hasNext()) {
             IndexValue value = it.next();
+            if (fileSpan != null) {
+              // Start <= value.offset < End
+              if (value.getOffset().compareTo(fileSpan.getEndOffset()) >= 0) {
+                continue;
+              }
+              if (value.getOffset().compareTo(fileSpan.getStartOffset()) < 0) {
+                break;
+              }
+            }
             if ((types.contains(IndexEntryType.DELETE) && value.isDelete()) || (types.contains(IndexEntryType.UNDELETE)
                 && value.isUndelete()) || (types.contains(IndexEntryType.TTL_UPDATE) && !value.isDelete()
                 && !value.isUndelete() && value.isTtlUpdate()) || (types.contains(IndexEntryType.PUT)

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -624,17 +624,6 @@ class CuratedLogIndexState {
       return null;
     }
     TreeSet<IndexValue> indexValues = allKeys.get(id);
-    /*
-    if (fileSpan != null) {
-      Offset modifiedStart = referenceIndex.floorKey(fileSpan.getStartOffset());
-      Offset modifiedEnd = new Offset(fileSpan.getEndOffset().getName(), fileSpan.getEndOffset().getOffset() + 1);
-      modifiedEnd = referenceIndex.ceilingKey(modifiedEnd);
-      if (modifiedEnd == null) {
-        modifiedEnd = index.getCurrentEndOffset();
-      }
-      fileSpan = new FileSpan(modifiedStart, modifiedEnd);
-    }
-    */
     List<IndexValue> toConsider = new ArrayList<>();
     for (IndexValue value : indexValues) {
       if (isWithinFileSpan(value.getOffset(), fileSpan)) {

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -624,6 +624,7 @@ class CuratedLogIndexState {
       return null;
     }
     TreeSet<IndexValue> indexValues = allKeys.get(id);
+    /*
     if (fileSpan != null) {
       Offset modifiedStart = referenceIndex.floorKey(fileSpan.getStartOffset());
       Offset modifiedEnd = new Offset(fileSpan.getEndOffset().getName(), fileSpan.getEndOffset().getOffset() + 1);
@@ -633,6 +634,7 @@ class CuratedLogIndexState {
       }
       fileSpan = new FileSpan(modifiedStart, modifiedEnd);
     }
+    */
     List<IndexValue> toConsider = new ArrayList<>();
     for (IndexValue value : indexValues) {
       if (isWithinFileSpan(value.getOffset(), fileSpan)) {

--- a/ambry-store/src/test/java/com/github/ambry/store/FileSpanTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/FileSpanTest.java
@@ -44,7 +44,7 @@ public class FileSpanTest {
         Offset offset = new Offset(segmentName, offsetInSegment);
         boolean inSpan = segmentName.equals(interveningLogSegmentName) || (segmentName.equals(startLogSegmentName)
             && offsetInSegment >= startOffsetInStartLogSegment) || (segmentName.equals(endLogSegmentName)
-            && offsetInSegment <= endOffsetInEndLogSegment);
+            && offsetInSegment < endOffsetInEndLogSegment);
         assertEquals("inSpan() result not as expected", inSpan, span.inSpan(offset));
       }
     }


### PR DESCRIPTION
Before this PR, findKey in PersistentIndex, uses FileSpan in a unorthodoxy way. It basically uses FileSpan as a way to locate index segments to search.

For instance, if we have three index segments, and their respective start offset and end offset are [0, 1000), [1000, 2000), [2000, 3000), then when we have a FileSpan whose start and end offset are [500, 2500], findKey would know that the all three index segments should be searched up, since the start offset is located within the first index segment and the end offset is located at the third segment.

The problem the actual record's offset is 2700, which is not covered in the FileSpan, but covered in the third segment, this record will be returned by findKey. In this case, FileSpan doesn't serve as a search space for findKey, but rather an pointer to find the index segments, which then would become search space. 

This PR would fix this issue by changing findKey and strictly respect FileSpan as search space. It also has a few subtle changes.

1. FileSpan's start offset is inclusive, but end offset would be exclusive. 
2. Compaction without undelete, would persist a cutoff offset to indicate if the delete is in effect. The cutoffset  used to be the start offset of the index segment, now it will be the end offset.