### PR TITLE
Make loggers static final when possible

### DIFF
--- a/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/HelixAccountServiceFactory.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HelixAccountServiceFactory implements AccountServiceFactory {
   private static final String HELIX_ACCOUNT_UPDATER_PREFIX = "helix-account-updater";
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(HelixAccountServiceFactory.class);
   protected final HelixPropertyStoreConfig storeConfig;
   protected final HelixAccountServiceConfig accountServiceConfig;
   protected final AccountServiceMetrics accountServiceMetrics;

--- a/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountServiceFactory.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/InMemoryUnknownAccountServiceFactory.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * An {@link AccountServiceFactory} that returns an {@link InMemoryUnknownAccountService}.
  */
 public class InMemoryUnknownAccountServiceFactory implements AccountServiceFactory {
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(InMemoryUnknownAccountServiceFactory.class);
 
   /**
    * Constructor.

--- a/ambry-account/src/main/java/com/github/ambry/account/JsonAccountService.java
+++ b/ambry-account/src/main/java/com/github/ambry/account/JsonAccountService.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 final class JsonAccountService extends AbstractAccountService {
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(JsonAccountService.class);
 
   /** Location of the account file which this service uses as it's source of accounts.*/
   private final Path accountFile;

--- a/ambry-api/src/main/java/com/github/ambry/config/VerifiableProperties.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/VerifiableProperties.java
@@ -30,7 +30,7 @@ public class VerifiableProperties {
 
   private final HashSet<String> referenceSet = new HashSet<String>();
   private final Properties props;
-  protected Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(VerifiableProperties.class);
 
   public VerifiableProperties(Properties props) {
     this.props = props;

--- a/ambry-api/src/main/java/com/github/ambry/replication/ReplicationSkipPredicate.java
+++ b/ambry-api/src/main/java/com/github/ambry/replication/ReplicationSkipPredicate.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 public class ReplicationSkipPredicate implements Predicate<MessageInfo> {
   private final AccountService accountService;
   private final ReplicationConfig replicationConfig;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(ReplicationSkipPredicate.class);
   /**
    * Construct a ReplicationSkipPredicate object
    * @param accountService the {@link AccountService} associated with this predicate.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudMessageReadSet.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudMessageReadSet.java
@@ -36,7 +36,7 @@ class CloudMessageReadSet implements MessageReadSet {
 
   private final List<BlobReadInfo> blobReadInfoList;
   private final CloudBlobStore blobStore;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(CloudMessageReadSet.class);
 
   CloudMessageReadSet(List<BlobReadInfo> blobReadInfoList, CloudBlobStore blobStore) {
     this.blobReadInfoList = blobReadInfoList;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrStateModel.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/HelixVcrStateModel.java
@@ -28,8 +28,8 @@ import org.slf4j.LoggerFactory;
  */
 @StateModelInfo(initialState = "OFFLINE", states = {"LEADER", "STANDBY"})
 public class HelixVcrStateModel extends StateModel {
-  private Logger logger = LoggerFactory.getLogger(getClass());
-  private HelixVcrCluster helixVcrCluster;
+  private static final Logger logger = LoggerFactory.getLogger(HelixVcrStateModel.class);
+  private final HelixVcrCluster helixVcrCluster;
 
   HelixVcrStateModel(HelixVcrCluster helixVcrCluster) {
     this.helixVcrCluster = helixVcrCluster;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMain.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrMain.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * Start point for creating an instance of {@link VcrServer} and starting/shutting it down.
  */
 public class VcrMain {
-  private static Logger logger = LoggerFactory.getLogger(VcrMain.class);
+  private static final Logger logger = LoggerFactory.getLogger(VcrMain.class);
 
   public static void main(String[] args) {
     final VcrServer vcrServer;

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/VcrServer.java
@@ -63,7 +63,7 @@ public class VcrServer {
   private NetworkServer networkServer = null;
   private ScheduledExecutorService scheduler = null;
   private VcrReplicationManager vcrReplicationManager = null;
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(VcrServer.class);
   private final VerifiableProperties properties;
   private final ClusterAgentsFactory clusterAgentsFactory;
   private ClusterMap clusterMap;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudDataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CloudDataNode.java
@@ -39,7 +39,7 @@ public class CloudDataNode implements DataNodeId {
   private final String dataCenterName;
   private final boolean isSslEnabled;
   private final List<String> sslEnabledDataCenters;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(CloudDataNode.class);
 
   /**
    * Instantiate a CloudDataNode object.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeClusterManager.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * and reports inconsistencies in the views from the two underlying cluster managers.
  */
 class CompositeClusterManager implements ClusterMap {
-  private static final Logger LOGGER = LoggerFactory.getLogger(CompositeClusterManager.class);
+  private static final Logger logger = LoggerFactory.getLogger(CompositeClusterManager.class);
   final StaticClusterManager staticClusterManager;
   final HelixClusterManager helixClusterManager;
   final HelixClusterManagerMetrics helixClusterManagerMetrics;
@@ -71,7 +71,7 @@ class CompositeClusterManager implements ClusterMap {
           helixClusterManagerMetrics.getPartitionIdFromStreamMismatchCount.inc();
         }
       } catch (IOException e) {
-        LOGGER.warn("HelixClusterManager could not deserialize partition ID that StaticClusterManager could", e);
+        logger.warn("HelixClusterManager could not deserialize partition ID that StaticClusterManager could", e);
         helixClusterManagerMetrics.getPartitionIdFromStreamMismatchCount.inc();
       }
     }
@@ -101,9 +101,9 @@ class CompositeClusterManager implements ClusterMap {
         staticWritablePartitionSet.removeAll(partitionsInBoth);
         helixWritablePartitionSet.removeAll(partitionsInBoth);
         staticWritablePartitionSet.forEach(
-            partition -> LOGGER.debug("{} is writable partition in static clustermap only", partition));
+            partition -> logger.debug("{} is writable partition in static clustermap only", partition));
         helixWritablePartitionSet.forEach(
-            partition -> LOGGER.debug("{} is writable partition in helix only", partition));
+            partition -> logger.debug("{} is writable partition in helix only", partition));
       }
     }
     return staticWritablePartitionIds;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/CompositeClusterManager.java
@@ -39,7 +39,6 @@ class CompositeClusterManager implements ClusterMap {
   final StaticClusterManager staticClusterManager;
   final HelixClusterManager helixClusterManager;
   final HelixClusterManagerMetrics helixClusterManagerMetrics;
-  private final Logger logger = LoggerFactory.getLogger(CompositeClusterManager.class);
 
   /**
    * Construct a CompositeClusterManager instance.
@@ -102,9 +101,9 @@ class CompositeClusterManager implements ClusterMap {
         staticWritablePartitionSet.removeAll(partitionsInBoth);
         helixWritablePartitionSet.removeAll(partitionsInBoth);
         staticWritablePartitionSet.forEach(
-            partition -> logger.debug("{} is writable partition in static clustermap only", partition));
+            partition -> LOGGER.debug("{} is writable partition in static clustermap only", partition));
         helixWritablePartitionSet.forEach(
-            partition -> logger.debug("{} is writable partition in helix only", partition));
+            partition -> LOGGER.debug("{} is writable partition in helix only", partition));
       }
     }
     return staticWritablePartitionIds;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNode.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNode.java
@@ -50,7 +50,7 @@ class DataNode implements DataNodeId {
   private final ArrayList<String> sslEnabledDataCenters;
   private final ClusterMapConfig clusterMapConfig;
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(DataNode.class);
 
   DataNode(Datacenter datacenter, JSONObject jsonObject, ClusterMapConfig clusterMapConfig) throws JSONException {
     logger.trace("DataNode {}", jsonObject);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Datacenter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Datacenter.java
@@ -39,7 +39,7 @@ class Datacenter {
   private final long rawCapacityInBytes;
   private boolean rackAware = false;
 
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(Datacenter.class);
 
   Datacenter(HardwareLayout hardwareLayout, JSONObject jsonObject, ClusterMapConfig clusterMapConfig)
       throws JSONException {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DefaultLeaderStandbyStateModel.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DefaultLeaderStandbyStateModel.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 @StateModelInfo(initialState = "OFFLINE", states = {"LEADER", "STANDBY"})
 public class DefaultLeaderStandbyStateModel extends StateModel {
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(DefaultLeaderStandbyStateModel.class);
 
   DefaultLeaderStandbyStateModel() {
     StateModelParser parser = new StateModelParser();

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Disk.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Disk.java
@@ -36,7 +36,7 @@ class Disk implements DiskId {
   private final ResourceStatePolicy diskStatePolicy;
   private long capacityInBytes;
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(Disk.class);
 
   Disk(DataNode dataNode, JSONObject jsonObject, ClusterMapConfig clusterMapConfig) throws JSONException {
     logger.trace("Disk {}", jsonObject);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/FixedBackoffResourceStatePolicy.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/FixedBackoffResourceStatePolicy.java
@@ -33,7 +33,7 @@ class FixedBackoffResourceStatePolicy implements ResourceStatePolicy {
   private final long retryBackoffMs;
   private final AtomicLong downUntil;
   private final Time time;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(FixedBackoffResourceStatePolicy.class);
 
   FixedBackoffResourceStatePolicy(Object resource, boolean hardDown, int failureCountThreshold, long retryBackoffMs,
       Time time) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HardwareLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HardwareLayout.java
@@ -41,7 +41,7 @@ class HardwareLayout {
   private final Map<HardwareState, Long> diskInHardStateCount;
   private final ClusterMapConfig clusterMapConfig;
 
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(HardwareLayout.class);
 
   public HardwareLayout(JSONObject jsonObject, ClusterMapConfig clusterMapConfig) throws JSONException {
     if (logger.isTraceEnabled()) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Partition.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Partition.java
@@ -50,7 +50,7 @@ public class Partition implements PartitionId {
   long replicaCapacityInBytes;
   String partitionClass;
 
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(Partition.class);
 
   public Partition(long id, String partitionClass, PartitionState partitionState, long replicaCapacityInBytes) {
     logger.trace("Partition {}, {}, {}", id, partitionState, replicaCapacityInBytes);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/PartitionLayout.java
@@ -48,7 +48,7 @@ class PartitionLayout {
   private final String localDatacenterName;
   private final ClusterMapUtils.PartitionSelectionHelper partitionSelectionHelper;
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(PartitionLayout.class);
 
   /**
    * Create a PartitionLayout

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/RecoveryTestClusterManager.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
  * It provides a merged view of the static and helix clusters.
  */
 public class RecoveryTestClusterManager implements ClusterMap {
-  private final Logger logger = LoggerFactory.getLogger(RecoveryTestClusterManager.class);
   final StaticClusterManager staticClusterManager;
   final HelixClusterManager helixClusterManager;
   final Map<AmbryDisk, Disk> ambryDiskToDiskMap;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Replica.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Replica.java
@@ -41,7 +41,7 @@ class Replica implements ReplicaId {
   private final ReplicaType replicaType;
   private final ClusterMapConfig clusterMapConfig;
 
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(Replica.class);
 
   Replica(Partition partition, Disk disk, ClusterMapConfig clusterMapConfig) {
     if (logger.isTraceEnabled()) {

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/StaticClusterManager.java
@@ -46,7 +46,7 @@ class StaticClusterManager implements ClusterMap {
   private final ClusterMapMetrics clusterMapMetrics;
   private final byte localDatacenterId;
 
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(StaticClusterManager.class);
 
   /**
    * How many data nodes to put in a random sample for partition allocation. 2 node samples provided the best balance

--- a/ambry-commons/src/main/java/com/github/ambry/commons/LoggingNotificationSystem.java
+++ b/ambry-commons/src/main/java/com/github/ambry/commons/LoggingNotificationSystem.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * Logs all events at DEBUG level.
  */
 public class LoggingNotificationSystem implements NotificationSystem {
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(LoggingNotificationSystem.class);
 
   @Override
   public void close() throws IOException {

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestService.java
@@ -79,7 +79,7 @@ class FrontendRestRequestService implements RestRequestService {
   private final IdSigningService idSigningService;
   private final AccountService accountService;
   private final AccountAndContainerInjector accountAndContainerInjector;
-  private final Logger logger = LoggerFactory.getLogger(FrontendRestRequestService.class);
+  private static final Logger logger = LoggerFactory.getLogger(FrontendRestRequestService.class);
   private final String datacenterName;
   private final String hostname;
   private final String clusterName;

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/FrontendRestRequestServiceFactory.java
@@ -41,7 +41,7 @@ public class FrontendRestRequestServiceFactory implements RestRequestServiceFact
   private final ClusterMapConfig clusterMapConfig;
   private final Router router;
   private final AccountService accountService;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(FrontendRestRequestServiceFactory.class);
 
   /**
    * Creates a new instance of FrontendRestRequestServiceFactory.

--- a/ambry-frontend/src/main/java/com/github/ambry/frontend/GetReplicasHandler.java
+++ b/ambry-frontend/src/main/java/com/github/ambry/frontend/GetReplicasHandler.java
@@ -40,7 +40,7 @@ class GetReplicasHandler {
 
   private final FrontendMetrics metrics;
   private final ClusterMap clusterMap;
-  private final Logger logger = LoggerFactory.getLogger(GetReplicasHandler.class);
+  private static final Logger logger = LoggerFactory.getLogger(GetReplicasHandler.class);
 
   /**
    * Instantiate a handler to handle {@link RestUtils.SubResource#Replicas} operations.

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobStoreHardDelete.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobStoreHardDelete.java
@@ -51,7 +51,7 @@ public class BlobStoreHardDelete implements MessageStoreHardDelete {
 class BlobStoreHardDeleteIterator implements Iterator<HardDeleteInfo> {
   private final MessageReadSet readSet;
   private final StoreKeyFactory storeKeyFactory;
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(BlobStoreHardDeleteIterator.class);
   private int readSetIndex = 0;
   private Map<StoreKey, HardDeleteRecoveryMetadata> recoveryInfoMap;
 

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobStoreRecovery.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobStoreRecovery.java
@@ -36,7 +36,7 @@ import static com.github.ambry.messageformat.MessageFormatRecord.*;
  * from the read interface that represents the underlying store
  */
 public class BlobStoreRecovery implements MessageStoreRecovery {
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(BlobStoreRecovery.class);
 
   @Override
   public List<MessageInfo> recover(Read read, long startOffset, long endOffset, StoreKeyFactory factory)

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatInputStream.java
@@ -37,7 +37,6 @@ public abstract class MessageFormatInputStream extends InputStream {
   protected long streamRead = 0;
   ByteBuffer crc = ByteBuffer.allocate(MessageFormatRecord.Crc_Size);
   protected long messageLength;
-  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   @Override
   public int read() throws IOException {

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
@@ -53,7 +53,7 @@ public class MessageFormatSend implements Send {
   private int currentWriteIndex;
   private long sizeWrittenFromCurrentIndex;
   private StoreKeyFactory storeKeyFactory;
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(MessageFormatSend.class);
   private final static int BUFFERED_INPUT_STREAM_BUFFER_SIZE = 256;
 
   private class SendInfo {

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageSievingInputStream.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MessageSievingInputStream extends InputStream {
   private int sievedStreamSize;
-  private final Logger logger;
+  private static final Logger logger = LoggerFactory.getLogger(MessageSievingInputStream.class);
   private final InputStream sievedStream;
   private boolean hasInvalidMessages;
   private boolean hasDeprecatedMessages;
@@ -63,7 +63,6 @@ public class MessageSievingInputStream extends InputStream {
    */
   public MessageSievingInputStream(InputStream inStream, List<MessageInfo> messageInfoList,
       List<Transformer> transformers, MetricRegistry metricRegistry) throws IOException {
-    this.logger = LoggerFactory.getLogger(getClass());
     this.transformers = transformers;
     singleMessageSieveTime =
         metricRegistry.histogram(MetricRegistry.name(MessageSievingInputStream.class, "SingleMessageSieveTime"));

--- a/ambry-network/src/main/java/com/github/ambry/network/BlockingChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/BlockingChannel.java
@@ -14,6 +14,7 @@
 package com.github.ambry.network;
 
 import com.github.ambry.config.ConnectionPoolConfig;
+import com.github.ambry.messageformat.BlobStoreRecovery;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -30,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * A blocking channel that is used to communicate with a server
  */
 public class BlockingChannel implements ConnectedChannel {
-  protected final Logger logger = LoggerFactory.getLogger(getClass());
+  protected static final Logger logger = LoggerFactory.getLogger(BlockingChannel.class);
   protected final String host;
   protected final int port;
   protected final int readBufferSize;

--- a/ambry-network/src/main/java/com/github/ambry/network/SocketServer.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/SocketServer.java
@@ -60,7 +60,7 @@ public class SocketServer implements NetworkServer {
   private final ArrayList<Processor> processors;
   private volatile ArrayList<Acceptor> acceptors;
   private final SocketRequestResponseChannel requestResponseChannel;
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(SocketServer.class);
   private final ServerNetworkMetrics metrics;
   private final HashMap<PortType, Port> ports;
   private SSLFactory sslFactory;
@@ -206,7 +206,6 @@ abstract class AbstractServerThread implements Runnable {
   private final CountDownLatch startupLatch;
   private final CountDownLatch shutdownLatch;
   private final AtomicBoolean alive;
-  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   public AbstractServerThread() throws IOException {
     startupLatch = new CountDownLatch(1);
@@ -263,7 +262,7 @@ class Acceptor extends AbstractServerThread {
   private final java.nio.channels.Selector nioSelector;
   private static final long selectTimeOutMs = 500;
   private final ServerNetworkMetrics metrics;
-  protected Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(Acceptor.class);
 
   public Acceptor(int port, ArrayList<Processor> processors, int sendBufferSize, int recvBufferSize,
       ServerNetworkMetrics metrics) throws IOException {
@@ -395,6 +394,7 @@ class Processor extends AbstractServerThread {
   private final ServerNetworkMetrics metrics;
   private static final long pollTimeoutMs = 300;
   private final NetworkConfig networkConfig;
+  private static final Logger logger = LoggerFactory.getLogger(Processor.class);
 
   Processor(int id, int maxRequestSize, RequestResponseChannel channel, ServerNetworkMetrics metrics,
       SSLFactory sslFactory, NetworkConfig networkConfig) throws IOException {

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientStreamStatsHandler.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientStreamStatsHandler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 
 @ChannelHandler.Sharable
 class Http2ClientStreamStatsHandler extends SimpleChannelInboundHandler<Http2Frame> {
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(Http2ClientStreamStatsHandler.class);
   private final Http2ClientMetrics http2ClientMetrics;
 
   public Http2ClientStreamStatsHandler(Http2ClientMetrics http2ClientMetrics) {

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AmbryRequests.java
@@ -79,7 +79,6 @@ public class AmbryRequests implements RequestAPI {
   protected StoreManager storeManager;
   protected final ReplicationAPI replicationEngine;
   protected final RequestResponseChannel requestResponseChannel;
-  protected Logger publicAccessLogger = LoggerFactory.getLogger("PublicAccessLogger");
   protected final ClusterMap clusterMap;
   protected final DataNodeId currentNode;
   protected final ServerMetrics metrics;
@@ -90,6 +89,7 @@ public class AmbryRequests implements RequestAPI {
   private final boolean enableDataPrefetch;
   private final StoreKeyConverterFactory storeKeyConverterFactory;
 
+  protected static final Logger publicAccessLogger = LoggerFactory.getLogger("PublicAccessLogger");
   private static final Logger logger = LoggerFactory.getLogger(AmbryRequests.class);
 
   public AmbryRequests(StoreManager storeManager, RequestResponseChannel requestResponseChannel, ClusterMap clusterMap,

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataRequestInfo.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataRequestInfo.java
@@ -44,8 +44,6 @@ public class ReplicaMetadataRequestInfo {
   private static final int HostName_Field_Size_In_Bytes = 4;
   private static final int ReplicaType_Size_In_Bytes = Short.BYTES;
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-
   public ReplicaMetadataRequestInfo(PartitionId partitionId, FindToken token, String hostName, String replicaPath,
       ReplicaType replicaType, short requestVersion) {
     if (partitionId == null || token == null || hostName == null || replicaPath == null) {

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestOrResponse.java
@@ -30,7 +30,6 @@ public abstract class RequestOrResponse implements SendWithCorrelationId {
   protected short versionId;
   protected String clientId;
   protected ByteBuffer bufferToSend;
-  protected Logger logger = LoggerFactory.getLogger(getClass());
 
   private static final int Request_Response_Size_In_Bytes = 8;
   private static final int Request_Response_Type_Size_In_Bytes = 2;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicaThread.java
@@ -95,7 +95,7 @@ public class ReplicaThread implements Runnable {
   private final ReplicationMetrics replicationMetrics;
   private final String threadName;
   private final NotificationSystem notification;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(ReplicaThread.class);
   private final StoreKeyConverter storeKeyConverter;
   private final Transformer transformer;
   private final MetricRegistry metricRegistry;

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -78,6 +78,8 @@ public abstract class ReplicationEngine implements ReplicationAPI {
   protected final MetricRegistry metricRegistry;
   protected final ReplicationMetrics replicationMetrics;
   protected final FindTokenHelper tokenHelper;
+  // non static logger so that extensions of this class have their own class as the logger name.
+  // little impact since ReplicationEngines are long-lived objects.
   protected final Logger logger = LoggerFactory.getLogger(getClass());
   protected final Map<PartitionId, PartitionInfo> partitionToPartitionInfo;
   protected final Map<String, Set<PartitionInfo>> mountPathToPartitionInfos;

--- a/ambry-rest/src/main/java/com/github/ambry/rest/AsyncRequestResponseHandler.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/AsyncRequestResponseHandler.java
@@ -51,7 +51,7 @@ class AsyncRequestResponseHandler implements RestRequestHandler, RestResponseHan
 
   private final List<AsyncRequestWorker> asyncRequestWorkers = new ArrayList<>();
   private final AtomicInteger currIndex = new AtomicInteger(0);
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(AsyncRequestResponseHandler.class);
 
   private AsyncResponseHandler asyncResponseHandler = null;
   private RestRequestService restRequestService = null;
@@ -270,7 +270,7 @@ class AsyncRequestWorker implements Runnable {
   private final AtomicInteger queuedRequestCount = new AtomicInteger(0);
   private final CountDownLatch shutdownLatch = new CountDownLatch(1);
   private final AtomicBoolean running = new AtomicBoolean(true);
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(AsyncRequestWorker.class);
 
   /**
    * Creates a worker that can process requests.
@@ -531,7 +531,7 @@ class AsyncResponseHandler implements Closeable {
   private final RequestResponseHandlerMetrics metrics;
   private final ConcurrentHashMap<RestRequest, ResponseWriteCallback> responses = new ConcurrentHashMap<>();
   private final AtomicInteger inFlightResponsesCount = new AtomicInteger(0);
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(AsyncResponseHandler.class);
 
   /**
    * Creates a AsyncResponseHandler that can handle responses.

--- a/ambry-rest/src/main/java/com/github/ambry/rest/AsyncRequestResponseHandlerFactory.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/AsyncRequestResponseHandlerFactory.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class AsyncRequestResponseHandlerFactory implements RestRequestResponseHandlerFactory {
 
   private final AsyncRequestResponseHandler handler;
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(AsyncRequestResponseHandlerFactory.class);
 
   /**
    * @param handlerCount the number of request scaling units required.

--- a/ambry-rest/src/main/java/com/github/ambry/rest/ConnectionStatsHandler.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/ConnectionStatsHandler.java
@@ -30,7 +30,7 @@ public class ConnectionStatsHandler extends ChannelInboundHandlerAdapter {
   private final NettyMetrics metrics;
   private final AtomicLong openConnections;
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(ConnectionStatsHandler.class);
 
   public ConnectionStatsHandler(NettyMetrics metrics) {
     this.metrics = metrics;

--- a/ambry-rest/src/main/java/com/github/ambry/rest/HealthCheckHandler.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/HealthCheckHandler.java
@@ -42,7 +42,7 @@ public class HealthCheckHandler extends ChannelDuplexHandler {
   private final String healthCheckUri;
   private final RestServerState restServerState;
   private final NettyMetrics nettyMetrics;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(HealthCheckHandler.class);
 
   private HttpRequest request;
   private FullHttpResponse response;

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyMessageProcessor.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyMessageProcessor.java
@@ -66,7 +66,7 @@ public class NettyMessageProcessor extends SimpleChannelInboundHandler<HttpObjec
   private final NettyConfig nettyConfig;
   private final PerformanceConfig performanceConfig;
   private final RestRequestHandler requestHandler;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(NettyMessageProcessor.class);
 
   // variables that will live through the life of the channel.
   private final AtomicBoolean channelOpen = new AtomicBoolean(true);

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyMultipartRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyMultipartRequest.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 class NettyMultipartRequest extends NettyRequest {
   private final Queue<HttpContent> rawRequestContents = new LinkedBlockingQueue<>();
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(NettyMultipartRequest.class);
   private final long maxSizeAllowedInBytes;
   //For Multipart request, bytes received in http content can be different from blob bytes received.
   private final AtomicLong blobBytesReceived = new AtomicLong(0);

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyRequest.java
@@ -83,7 +83,7 @@ public class NettyRequest implements RestRequest {
   private final AtomicBoolean channelOpen = new AtomicBoolean(true);
   protected final AtomicLong bytesReceived = new AtomicLong(0);
   private final AtomicLong bytesBuffered = new AtomicLong(0);
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(NettyRequest.class);
   private final RecvByteBufAllocator recvByteBufAllocator = new DefaultMaxBytesRecvByteBufAllocator();
   private final SSLSession sslSession;
 

--- a/ambry-rest/src/main/java/com/github/ambry/rest/NettyServer.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/NettyServer.java
@@ -50,7 +50,7 @@ public class NettyServer implements NioServer {
   private final NettyConfig nettyConfig;
   private final NettyMetrics nettyMetrics;
   private final Map<Integer, ChannelInitializer<SocketChannel>> channelInitializers;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(NettyServer.class);
 
   private EventLoopGroup bossGroup;
   private EventLoopGroup workerGroup;

--- a/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogHandler.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogHandler.java
@@ -47,7 +47,7 @@ public class PublicAccessLogHandler extends ChannelDuplexHandler {
   private StringBuilder sslLogMessage;
 
   private static final long INIT_TIME = -1;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(PublicAccessLogHandler.class);
 
   public PublicAccessLogHandler(PublicAccessLogger publicAccessLogger, NettyMetrics nettyMetrics) {
     this.publicAccessLogger = publicAccessLogger;

--- a/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogger.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogger.java
@@ -22,11 +22,11 @@ import org.slf4j.LoggerFactory;
  */
 public class PublicAccessLogger {
 
-  private Logger publicAccessLogger = LoggerFactory.getLogger("PublicAccessLogger");
+  private static final Logger publicAccessLogger = LoggerFactory.getLogger("PublicAccessLogger");
 
   private final String[] requestHeaders;
   private final String[] responseHeaders;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(PublicAccessLogger.class);
 
   /**
    * @param requestHeaders the request headers to log.

--- a/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogger.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/PublicAccessLogger.java
@@ -26,7 +26,6 @@ public class PublicAccessLogger {
 
   private final String[] requestHeaders;
   private final String[] responseHeaders;
-  private static final Logger logger = LoggerFactory.getLogger(PublicAccessLogger.class);
 
   /**
    * @param requestHeaders the request headers to log.
@@ -35,7 +34,6 @@ public class PublicAccessLogger {
   public PublicAccessLogger(String[] requestHeaders, String[] responseHeaders) {
     this.requestHeaders = requestHeaders;
     this.responseHeaders = responseHeaders;
-    logger.trace("Created PublicAccessLogger for log {}", publicAccessLogger.getName());
   }
 
   public String[] getRequestHeaders() {

--- a/ambry-rest/src/main/java/com/github/ambry/rest/RestServer.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/RestServer.java
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RestServer {
   private final CountDownLatch shutdownLatch = new CountDownLatch(1);
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(RestServer.class);
   private final RestServerMetrics restServerMetrics;
   private final JmxReporter reporter;
   private final AccountService accountService;

--- a/ambry-rest/src/main/java/com/github/ambry/rest/RestServerMain.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/RestServerMain.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * Start point for creating an instance of {@link RestServer} and starting/shutting it down.
  */
 public class RestServerMain {
-  private static Logger logger = LoggerFactory.getLogger(RestServerMain.class);
+  private static final Logger logger = LoggerFactory.getLogger(RestServerMain.class);
 
   public static void main(String[] args) {
     final RestServer restServer;

--- a/ambry-rest/src/main/java/com/github/ambry/rest/ServerSecurityHandler.java
+++ b/ambry-rest/src/main/java/com/github/ambry/rest/ServerSecurityHandler.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 @ChannelHandler.Sharable
 public class ServerSecurityHandler extends ChannelInboundHandlerAdapter {
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(ServerSecurityHandler.class);
   private final ServerSecurityService serverSecurityService;
   private final ServerMetrics serverMetrics;
 

--- a/ambry-rest/src/test/java/com/github/ambry/rest/EchoMethodHandler.java
+++ b/ambry-rest/src/test/java/com/github/ambry/rest/EchoMethodHandler.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * Used purely for testing purposes
  */
 public class EchoMethodHandler extends SimpleChannelInboundHandler<HttpObject> {
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(EchoMethodHandler.class);
   public static final String IS_CHUNKED = "is_chunked_header";
   public static final String DISCONNECT_URI = "disconnect";
   public static final String CLOSE_URI = "close";

--- a/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
+++ b/ambry-router/src/main/java/com/github/ambry/router/RouterUtils.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 class RouterUtils {
 
-  private static Logger logger = LoggerFactory.getLogger(RouterUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(RouterUtils.class);
 
   /**
    * Get {@link BlobId} from a blob string.

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
@@ -385,7 +385,7 @@ public class MockCluster {
 }
 
 class ServerShutdown implements Runnable {
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(ServerShutdown.class);
   private final CountDownLatch latch;
   private final AmbryServer server;
 

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/VcrBackupTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/VcrBackupTest.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.*;
 
 
 public class VcrBackupTest {
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(VcrBackupTest.class);
   private MockNotificationSystem notificationSystem;
   private MockCluster mockCluster;
   private HelixControllerManager helixControllerManager;

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryMain.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryMain.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * Start point for creating an instance of {@link AmbryServer} and starting/shutting it down.
  */
 public class AmbryMain {
-  private static Logger logger = LoggerFactory.getLogger(AmbryMain.class);
+  private static final Logger logger = LoggerFactory.getLogger(AmbryMain.class);
 
   public static void main(String[] args) {
     final AmbryServer ambryServer;

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -100,7 +100,7 @@ public class AmbryServer {
   private StatsManager statsManager = null;
   private ReplicationManager replicationManager = null;
   private CloudToStoreReplicationManager cloudToStoreReplicationManager = null;
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(AmbryServer.class);
   private final VerifiableProperties properties;
   private final ClusterAgentsFactory clusterAgentsFactory;
   private final ClusterSpectatorFactory clusterSpectatorFactory;

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -66,7 +66,7 @@ public class BlobStore implements Store {
   private final ScheduledExecutorService longLivedTaskScheduler;
   private final DiskIOScheduler diskIOScheduler;
   private final DiskSpaceAllocator diskSpaceAllocator;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(BlobStore.class);
   private final Object storeWriteLock = new Object();
   private final StoreConfig config;
   private final long capacityInBytes;

--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStoreCompactor.java
@@ -80,7 +80,7 @@ class BlobStoreCompactor {
   private final UUID sessionId;
   private final UUID incarnationId;
   private final AtomicBoolean compactionInProgress = new AtomicBoolean(false);
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(BlobStoreCompactor.class);
   private final IndexSegmentValidEntryFilter validEntryFilter;
   private final AccountService accountService;
   private volatile boolean isActive = false;

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactAllPolicyFactory.java
@@ -48,7 +48,7 @@ class CompactAllPolicy implements CompactionPolicy {
   private final StoreConfig storeConfig;
   private final Time time;
   private final long messageRetentionTimeInMs;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(CompactAllPolicy.class);
 
   CompactAllPolicy(StoreConfig storeConfig, Time time) {
     this.storeConfig = storeConfig;

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionLog.java
@@ -45,7 +45,7 @@ class CompactionLog implements Closeable {
   private static final byte[] ZERO_LENGTH_ARRAY = new byte[0];
   private static final long UNINITIALIZED_TIMESTAMP = -1;
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(CompactionLog.class);
 
   /**
    * The {@link Phase} of the current compaction cycle.

--- a/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/CompactionManager.java
@@ -46,7 +46,7 @@ class CompactionManager {
   private final CompactionExecutor compactionExecutor;
   private final StorageManagerMetrics metrics;
   private final CompactionPolicy compactionPolicy;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(CompactionManager.class);
 
   private Thread compactionThread;
 

--- a/ambry-store/src/main/java/com/github/ambry/store/HardDeleter.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/HardDeleter.java
@@ -72,7 +72,7 @@ public class HardDeleter implements Runnable {
   private final int scanSizeInBytes;
   private final int messageRetentionSeconds;
   private final CountDownLatch shutdownLatch = new CountDownLatch(1);
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(HardDeleter.class);
 
   /* A range of entries is maintained during the hard delete operation. All the entries corresponding to an ongoing
    * hard delete will be from this range. The reason to keep this range is to finish off any incomplete and ongoing

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexSegment.java
@@ -92,7 +92,7 @@ class IndexSegment {
   private final File indexFile;
   private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
   private final AtomicBoolean sealed = new AtomicBoolean(false);
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(IndexSegment.class);
   private final AtomicLong sizeWritten = new AtomicLong(0);
   private final StoreKeyFactory factory;
   private final File bloomFile;

--- a/ambry-store/src/main/java/com/github/ambry/store/Journal.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/Journal.java
@@ -72,7 +72,7 @@ class Journal {
   private final int maxEntriesToReturn;
   private final AtomicInteger currentNumberOfEntries;
   private final String dataDir;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(Journal.class);
   private boolean inBootstrapMode = false;
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/Log.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/Log.java
@@ -45,7 +45,7 @@ class Log implements Write {
   private final Iterator<Pair<String, String>> segmentNameAndFileNameIterator;
   private final ConcurrentSkipListMap<String, LogSegment> segmentsByName =
       new ConcurrentSkipListMap<>(LogSegmentNameHelper.COMPARATOR);
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(Log.class);
   private final AtomicLong remainingUnallocatedSegments = new AtomicLong(0);
   private final String storeId;
 

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -119,7 +119,7 @@ class PersistentIndex {
   private volatile ConcurrentSkipListMap<Offset, IndexSegment> validIndexSegments = new ConcurrentSkipListMap<>();
   // this is used by addToIndex() and changeIndexSegments() to resolve concurrency b/w them and is not for general use.
   private volatile ConcurrentSkipListMap<Offset, IndexSegment> inFluxIndexSegments = validIndexSegments;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(PersistentIndex.class);
   private final IndexPersistor persistor = new IndexPersistor();
   private final ScheduledFuture<?> persistorTask;
 

--- a/ambry-store/src/main/java/com/github/ambry/store/StatsBasedCompactionPolicy.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StatsBasedCompactionPolicy.java
@@ -35,7 +35,7 @@ class StatsBasedCompactionPolicy implements CompactionPolicy {
   private final Time time;
   private final StoreConfig storeConfig;
   private final long messageRetentionTimeInMs;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(StatsBasedCompactionPolicy.class);
 
   StatsBasedCompactionPolicy(StoreConfig storeConfig, Time time) {
     this.storeConfig = storeConfig;

--- a/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StoreMessageReadSet.java
@@ -42,7 +42,7 @@ class BlobReadOptions implements Comparable<BlobReadOptions>, Closeable {
   private final Offset offset;
   private final MessageInfo info;
   private final AtomicBoolean open = new AtomicBoolean(true);
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(BlobReadOptions.class);
   private ByteBuffer prefetchedData;
   private long prefetchedDataRelativeOffset = -1;
 
@@ -180,7 +180,7 @@ class BlobReadOptions implements Comparable<BlobReadOptions>, Closeable {
 class StoreMessageReadSet implements MessageReadSet {
 
   private final List<BlobReadOptions> readOptions;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(StoreMessageReadSet.class);
 
   StoreMessageReadSet(List<BlobReadOptions> readOptions) {
     Collections.sort(readOptions);

--- a/ambry-test-utils/src/main/java/com/github/ambry/utils/HelixControllerManager.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/utils/HelixControllerManager.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 
 
 public class HelixControllerManager extends ZKHelixManager implements Runnable {
-  private static Logger logger = LoggerFactory.getLogger(HelixControllerManager.class);
+  private static final Logger logger = LoggerFactory.getLogger(HelixControllerManager.class);
 
   private final CountDownLatch startCountDown = new CountDownLatch(1);
   private final CountDownLatch stopCountDown = new CountDownLatch(1);

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServer.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServer.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
 class PerfNioServer implements NioServer {
   private final LoadCreator loadCreator;
   private final Thread loadCreatorThread;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(PerfNioServer.class);
 
   /**
    * Creates an instance of PerfNioServer.

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServerFactory.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfNioServerFactory.java
@@ -38,7 +38,7 @@ public class PerfNioServerFactory implements NioServerFactory {
   private final PerfConfig perfConfig;
   private final PerfNioServerMetrics perfNioServerMetrics;
   private final RestRequestHandler requestHandler;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(PerfNioServerFactory.class);
 
   /**
    * Creates a new instance of PerfNioServerFactory.

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouter.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouter.java
@@ -56,7 +56,7 @@ class PerfRouter implements Router {
   private final byte[] usermetadata;
   private final byte[] chunk;
   private volatile boolean routerOpen = true;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(PerfRouter.class);
 
   /**
    * Creates an instance of PerfRouter with configuration as specified in {@code perfRouterConfig}.

--- a/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouterFactory.java
+++ b/ambry-tools/src/main/java/com/github/ambry/tools/perf/rest/PerfRouterFactory.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 public class PerfRouterFactory implements RouterFactory {
   private final PerfConfig perfConfig;
   private final PerfRouterMetrics perfRouterMetrics;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(PerfRouterFactory.class);
 
   /**
    * Creates an instance of PerfRouterFactory.

--- a/ambry-utils/src/main/java/com/github/ambry/utils/CrcInputStream.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/CrcInputStream.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 public class CrcInputStream extends InputStream {
   private Crc32 crc;
   private InputStream stream;
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(CrcInputStream.class);
 
   /**
    * Create a CrcInputStream using the specified CRC generator

--- a/ambry-utils/src/main/java/com/github/ambry/utils/InvocationOptions.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/InvocationOptions.java
@@ -30,7 +30,7 @@ public class InvocationOptions {
   public final String hardwareLayoutFilePath;
   public final String partitionLayoutFilePath;
   public final String serverPropsFilePath;
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(InvocationOptions.class);
 
   /**
    * Parses the arguments provided and extracts them into variables that can be retrieved through APIs.

--- a/ambry-utils/src/main/java/com/github/ambry/utils/SimpleByteBufferPool.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/SimpleByteBufferPool.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * below zero. It does not actually "pool" deallocated buffers.
  */
 public class SimpleByteBufferPool implements ByteBufferPool {
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(SimpleByteBufferPool.class);
   private final long capacity;
   private final Object lock;
   private long availableMemory;

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Throttler.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Throttler.java
@@ -30,7 +30,7 @@ public class Throttler {
   private final Object waitGuard = new Object();
   private long periodStartNs;
   private double observedSoFar;
-  private Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger logger = LoggerFactory.getLogger(Throttler.class);
   private Time time;
   private boolean enabled;
 


### PR DESCRIPTION
In almost all cases, loggers should be static. When run with log4j2,
there is more overhead to get a Logger instance, whereas with log4j1,
usually only the first request to get a logger for a given name would be
expensive. This means that instantiating loggers for classes with many
instances such as BlobReadOptions, which is instantiated for every blob
served, have a visible impact when analyzed with a sampling profiler.

This commit is a mass find and replace of non-static loggers.