### PR TITLE
Support querying sealed partitions in cluster by HelixBootstrapTool

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -1326,7 +1326,7 @@ public class HelixBootstrapUpgradeUtil {
 
   /**
    * Get sealed partitions from Helix cluster.
-   * @return the total number of sealed partitions across all DCs.
+   * @return a set of sealed partitions across all DCs.
    */
   private Set<String> getSealedPartitionsInHelixCluster() throws Exception {
     info("Aggregating sealed partitions from cluster {} in Helix", clusterName);
@@ -1403,7 +1403,7 @@ public class HelixBootstrapUpgradeUtil {
           info("Replica {} is sealed on {}", sealedReplica, instanceName);
           dcToSealedPartitions.get(dcName).add(sealedReplica);
           if (!replicasOnNode.contains(sealedReplica)) {
-            logger.warn("Replica {} is in sealed list but not on node {}", sealedReplica, replicasOnNode);
+            logger.warn("Replica {} is in sealed list but not on node {}", sealedReplica, instanceName);
             nodeToNonExistentReplicas.computeIfAbsent(instanceName, key -> new HashSet<>()).add(sealedReplica);
           }
         }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -147,7 +147,13 @@ public class HelixBootstrapUpgradeUtil {
   private static final String ALL = "all";
 
   enum HelixAdminOperation {
-    BootstrapCluster, ValidateCluster, UpdateIdealState, DisablePartition, EnablePartition, ResetPartition
+    BootstrapCluster,
+    ValidateCluster,
+    UpdateIdealState,
+    DisablePartition,
+    EnablePartition,
+    ResetPartition,
+    ListSealedPartition
   }
 
   /**
@@ -294,6 +300,26 @@ public class HelixBootstrapUpgradeUtil {
             HelixAdminOperation.ValidateCluster);
     clusterMapToHelixMapper.validateAndClose();
     clusterMapToHelixMapper.logSummary();
+  }
+
+  /**
+   * List all sealed partitions in Helix cluster.
+   * @param hardwareLayoutPath the path to the hardware layout file.
+   * @param partitionLayoutPath the path to the partition layout file.
+   * @param zkLayoutPath the path to the zookeeper layout file.
+   * @param clusterNamePrefix the prefix that when combined with the cluster name in the static cluster map files
+   *                          will give the cluster name in Helix to bootstrap or upgrade.
+   * @param dcs the comma-separated list of data centers that needs to be upgraded/bootstrapped.
+   * @return a set of sealed partitions in cluster
+   * @throws Exception
+   */
+  static Set<String> listSealedPartition(String hardwareLayoutPath, String partitionLayoutPath, String zkLayoutPath,
+      String clusterNamePrefix, String dcs) throws Exception {
+    HelixBootstrapUpgradeUtil helixBootstrapUpgradeUtil =
+        new HelixBootstrapUpgradeUtil(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix, dcs,
+            DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, null, ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, null,
+            null, null, HelixAdminOperation.ListSealedPartition);
+    return helixBootstrapUpgradeUtil.getSealedPartitionsInHelixCluster();
   }
 
   /**
@@ -1294,6 +1320,76 @@ public class HelixBootstrapUpgradeUtil {
       }
       for (HelixAdmin admin : adminForDc.values()) {
         admin.close();
+      }
+    }
+  }
+
+  /**
+   * Get sealed partitions from Helix cluster.
+   * @return the total number of sealed partitions across all DCs.
+   */
+  private Set<String> getSealedPartitionsInHelixCluster() throws Exception {
+    info("Aggregating sealed partitions from cluster {} in Helix", clusterName);
+    CountDownLatch sealedPartitionLatch = new CountDownLatch(adminForDc.size());
+    AtomicInteger errorCount = new AtomicInteger();
+    Map<String, Set<String>> dcToSealedPartitions = new ConcurrentHashMap<>();
+    for (Datacenter dc : staticClusterMap.hardwareLayout.getDatacenters()) {
+      HelixAdmin admin = adminForDc.get(dc.getName());
+      if (admin == null) {
+        info("Skipping {}", dc.getName());
+        continue;
+      }
+      ensureOrThrow(zkClientForDc.get(dc.getName()) == null ? admin.getClusters().contains(clusterName)
+              : ZKUtil.isClusterSetup(clusterName, zkClientForDc.get(dc.getName())),
+          "Cluster not found in ZK " + dataCenterToZkAddress.get(dc.getName()));
+      Utils.newThread(() -> {
+        try {
+          getSealedPartitionsInDc(dc, dcToSealedPartitions);
+        } catch (Throwable t) {
+          logger.error("[{}] error message: {}", dc.getName().toUpperCase(), t.getMessage());
+          errorCount.getAndIncrement();
+        } finally {
+          sealedPartitionLatch.countDown();
+        }
+      }, false).start();
+    }
+    sealedPartitionLatch.await(10, TimeUnit.MINUTES);
+    ensureOrThrow(errorCount.get() == 0, "Error occurred when aggregating sealed partitions in cluster " + clusterName);
+    Set<String> sealedPartitionsInCluster = new HashSet<>();
+    info("========================= Summary =========================");
+    for (Map.Entry<String, Set<String>> entry : dcToSealedPartitions.entrySet()) {
+      info("Dc {} has {} sealed partitions.", entry.getKey(), entry.getValue().size());
+      sealedPartitionsInCluster.addAll(entry.getValue());
+    }
+    info("========================= Sealed Partitions across All DCs =========================");
+    info("Total number of sealed partitions in cluster = {}", sealedPartitionsInCluster.size());
+    info("Sealed partitions are {}", sealedPartitionsInCluster.toString());
+    info("Successfully aggregate sealed from cluster {} in Helix", clusterName);
+    return sealedPartitionsInCluster;
+  }
+
+  /**
+   * Get sealed partitions from given datacenter.
+   * @param dc the datacenter where sealed partitions come from.
+   * @param dcToSealedPartitions a map to track sealed partitions in each dc. This entry associated with given dc will
+   *                             be populated in this method.
+   */
+  private void getSealedPartitionsInDc(Datacenter dc, Map<String, Set<String>> dcToSealedPartitions) {
+    String dcName = dc.getName();
+    dcToSealedPartitions.put(dcName, new HashSet<>());
+    HelixAdmin admin = adminForDc.get(dcName);
+    Set<String> allInstancesInHelix = new HashSet<>(admin.getInstancesInCluster(clusterName));
+    for (DataNodeId dataNodeId : dc.getDataNodes()) {
+      DataNode dataNode = (DataNode) dataNodeId;
+      String instanceName = getInstanceName(dataNode);
+      ensureOrThrow(allInstancesInHelix.contains(instanceName), "Instance not present in Helix " + instanceName);
+      InstanceConfig instanceConfig = admin.getInstanceConfig(clusterName, instanceName);
+      List<String> sealedReplicas = instanceConfig.getRecord().getListField(ClusterMapUtils.SEALED_STR);
+      if (sealedReplicas != null) {
+        for (String sealedReplica : sealedReplicas) {
+          info("Replica {} is sealed on {}", sealedReplica, instanceName);
+          dcToSealedPartitions.get(dcName).add(sealedReplica);
+        }
       }
     }
   }

--- a/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
+++ b/ambry-tools/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeTool.java
@@ -174,12 +174,13 @@ public class HelixBootstrapUpgradeTool {
 
     ArgumentAcceptingOptionSpec<String> adminOperationOpt = parser.accepts("adminOperation",
         "(Optional argument) Perform admin operations to manage resources in cluster. For example: "
-            + " '--adminOperation UpdateIdealState'  # Update IdealState based on static clustermap. This won't change InstanceConfig"
-            + " '--adminOperation DisablePartition'  # Disable partition on certain node. Usually used as first step to decommission replica(s)"
-            + " '--adminOperation EnablePartition'   # Enable partition on certain node (if partition is previously disabled)"
-            + " '--adminOperation ResetPartition'    # Reset partition on certain node (if partition is previously in error state)"
-            + " '--adminOperation ValidateCluster'   # Validates the information in static clustermap is consistent with the information in Helix"
-            + " '--adminOperation BootstrapCluster'  # (Default operation if not specified) Bootstrap cluster based on static clustermap")
+            + " '--adminOperation UpdateIdealState'     # Update IdealState based on static clustermap. This won't change InstanceConfig"
+            + " '--adminOperation DisablePartition'     # Disable partition on certain node. Usually used as first step to decommission replica(s)"
+            + " '--adminOperation EnablePartition'      # Enable partition on certain node (if partition is previously disabled)"
+            + " '--adminOperation ResetPartition'       # Reset partition on certain node (if partition is previously in error state)"
+            + " '--adminOperation ListSealedPartition'  # List all sealed partitions in Helix cluster (aggregated across all datacenters)"
+            + " '--adminOperation ValidateCluster'      # Validates the information in static clustermap is consistent with the information in Helix"
+            + " '--adminOperation BootstrapCluster'     # (Default operation if not specified) Bootstrap cluster based on static clustermap")
         .withRequiredArg()
         .describedAs("admin_operation")
         .ofType(String.class);
@@ -267,6 +268,10 @@ public class HelixBootstrapUpgradeTool {
         case ValidateCluster:
           HelixBootstrapUpgradeUtil.validate(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath, clusterNamePrefix,
               dcs, stateModelDef);
+          break;
+        case ListSealedPartition:
+          HelixBootstrapUpgradeUtil.listSealedPartition(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
+              clusterNamePrefix, dcs);
           break;
         case ResetPartition:
         case EnablePartition:


### PR DESCRIPTION
This PR introduces a new option in Helix bootstrap tool that allows user
to query current sealed partitions across all datacenters. The tool prints
out detailed info (such as sealed replicas on each host) and also the aggregated
result (sealed partition across all colos)

Example result is as follows:
```
[2020-06-11 20:40:01,137] INFO Associating static Ambry cluster "ToolTestStatic" with cluster"Ambry-ToolTestStatic" in Helix (Helix bootstrap tool)
[2020-06-11 20:40:01,137] INFO Aggregating sealed partitions from cluster Ambry-ToolTestStatic in Helix (Helix bootstrap tool)
[2020-06-11 20:40:01,142] INFO Replica 42 is sealed on localhost_18088 (Helix bootstrap tool)
[2020-06-11 20:40:01,144] INFO Replica 17 is sealed on localhost_18089 (Helix bootstrap tool)
[2020-06-11 20:40:01,144] INFO Replica 30 is sealed on localhost_18089 (Helix bootstrap tool)
[2020-06-11 20:40:01,146] INFO Replica 46 is sealed on localhost_18090 (Helix bootstrap tool)
[2020-06-11 20:40:01,146] INFO Replica 17 is sealed on localhost_18090 (Helix bootstrap tool)
[2020-06-11 20:40:01,146] INFO Replica 30 is sealed on localhost_18090 (Helix bootstrap tool)
[2020-06-11 20:40:01,146] INFO Replica 75 is sealed on localhost_18090 (Helix bootstrap tool)
[2020-06-11 20:40:01,147] INFO Replica 30 is sealed on localhost_18094 (Helix bootstrap tool)
[2020-06-11 20:40:01,147] INFO Replica 75 is sealed on localhost_18094 (Helix bootstrap tool)
[2020-06-11 20:40:01,147] INFO Replica 46 is sealed on localhost_18091 (Helix bootstrap tool)
[2020-06-11 20:40:01,147] INFO Replica 30 is sealed on localhost_18091 (Helix bootstrap tool)
[2020-06-11 20:40:01,147] INFO Replica 42 is sealed on localhost_18091 (Helix bootstrap tool)
[2020-06-11 20:40:01,148] INFO Replica 46 is sealed on localhost_18095 (Helix bootstrap tool)
[2020-06-11 20:40:01,148] INFO Replica 17 is sealed on localhost_18095 (Helix bootstrap tool)
[2020-06-11 20:40:01,150] INFO Replica 46 is sealed on localhost_18092 (Helix bootstrap tool)
[2020-06-11 20:40:01,150] INFO Replica 75 is sealed on localhost_18092 (Helix bootstrap tool)
[2020-06-11 20:40:01,150] INFO Replica 17 is sealed on localhost_18096 (Helix bootstrap tool)
[2020-06-11 20:40:01,151] INFO Replica 17 is sealed on localhost_18093 (Helix bootstrap tool)
[2020-06-11 20:40:01,151] INFO Replica 75 is sealed on localhost_18093 (Helix bootstrap tool)
[2020-06-11 20:40:01,151] INFO Replica 42 is sealed on localhost_18093 (Helix bootstrap tool)
[2020-06-11 20:40:01,236] INFO Replica 46 is sealed on localhost_18097 (Helix bootstrap tool)
[2020-06-11 20:40:01,237] INFO Replica 17 is sealed on localhost_18097 (Helix bootstrap tool)
[2020-06-11 20:40:01,237] INFO Replica 30 is sealed on localhost_18097 (Helix bootstrap tool)
[2020-06-11 20:40:01,237] INFO Replica 75 is sealed on localhost_18097 (Helix bootstrap tool)
[2020-06-11 20:40:01,237] INFO Replica 42 is sealed on localhost_18097 (Helix bootstrap tool)
[2020-06-11 20:40:01,239] INFO Replica 42 is sealed on localhost_18098 (Helix bootstrap tool)
[2020-06-11 20:40:01,240] INFO Replica 46 is sealed on localhost_18099 (Helix bootstrap tool)
[2020-06-11 20:40:01,240] INFO Replica 30 is sealed on localhost_18099 (Helix bootstrap tool)
[2020-06-11 20:40:01,240] INFO Replica 75 is sealed on localhost_18099 (Helix bootstrap tool)
[2020-06-11 20:40:01,240] INFO Replica 42 is sealed on localhost_18099 (Helix bootstrap tool)
[2020-06-11 20:40:01,241] INFO ========================= Summary ========================= (Helix bootstrap tool)
[2020-06-11 20:40:01,241] INFO Dc DC0 has 5 sealed partitions. (Helix bootstrap tool)
[2020-06-11 20:40:01,241] INFO Dc DC1 has 5 sealed partitions. (Helix bootstrap tool)
[2020-06-11 20:40:01,241] INFO ========================= Sealed Partitions across All DCs ========================= (Helix bootstrap tool)
[2020-06-11 20:40:01,241] INFO Total number of sealed partitions in cluster = 5 (Helix bootstrap tool)
[2020-06-11 20:40:01,241] INFO Sealed partitions are [46, 17, 30, 42, 75] (Helix bootstrap tool)
[2020-06-11 20:40:01,241] INFO Successfully aggregate sealed from cluster Ambry-ToolTestStatic in Helix (Helix bootstrap tool)
```