### PR TITLE
Don't rely on ABS blob properties metadata to contain blob id

### DIFF
--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -551,7 +551,7 @@ class CloudBlobStore implements Store {
       // This is a delete request from frontend
       if (metadata.isDeleted()) {
         throw new StoreException(
-            "Cannot delete id " + metadata.getId() + " since it is already marked as deleted in cloud.",
+            "Cannot delete id " + key.getID() + " since it is already marked as deleted in cloud.",
             StoreErrorCodes.ID_Deleted);
       }
       // this is delete request from frontend, we use life version only for validation.

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -538,7 +538,7 @@ class CloudBlobStore implements Store {
    */
   private boolean preDeleteValidation(CloudBlobMetadata metadata, StoreKey key, Map<String, Object> updateFields)
       throws StoreException {
-    validateAccountAndContainer(Collections.singletonMap(metadata.getId(), metadata), Collections.singletonList(key));
+    validateAccountAndContainer(Collections.singletonMap(key.getID(), metadata), Collections.singletonList(key));
     short requestedLifeVersion = (short) updateFields.get(FIELD_LIFE_VERSION);
     if (isVcr) {
       // This is a delete request from vcr. Apply delete only if incoming life version is more recent. Don't throw
@@ -571,7 +571,7 @@ class CloudBlobStore implements Store {
    */
   private boolean preTtlUpdateValidation(CloudBlobMetadata metadata, StoreKey key, Map<String, Object> updateFields)
       throws StoreException {
-    validateAccountAndContainer(Collections.singletonMap(metadata.getId(), metadata), Collections.singletonList(key));
+    validateAccountAndContainer(Collections.singletonMap(key.getID(), metadata), Collections.singletonList(key));
     long now = System.currentTimeMillis();
     if (isVcr) {
       // For vcr don't update ttl if already updated. Don't throw any exception because replication relies on
@@ -601,7 +601,7 @@ class CloudBlobStore implements Store {
    */
   private boolean preUndeleteValidation(CloudBlobMetadata metadata, StoreKey key, Map<String, Object> updateFields)
       throws StoreException {
-    validateAccountAndContainer(Collections.singletonMap(metadata.getId(), metadata), Collections.singletonList(key));
+    validateAccountAndContainer(Collections.singletonMap(key.getID(), metadata), Collections.singletonList(key));
     short requestedLifeVersion = (short) updateFields.get(FIELD_LIFE_VERSION);
     if (isVcr) {
       // This is an undelete request from vcr. Apply undelete only if incoming life version is more recent. Don't throw


### PR DESCRIPTION
This fixes the Null Pointer Exception in `CloudBlobStore::validateAccountAndContainer`