### PR TITLE
Change sanity check logic for undelete so recovery can work

### DIFF
--- a/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/BlobStore.java
@@ -821,7 +821,8 @@ public class BlobStore implements Store {
         logger.trace("Store : {} undelete mark written to log", dataDir);
         FileSpan fileSpan = log.getFileSpanForMessage(endOffsetOfLastMessage, info.getSize());
         // we still use lifeVersion from message info here so that we can re-verify the sanity of undelete request in persistent index.
-        index.markAsUndeleted(info.getStoreKey(), fileSpan, info.getOperationTimeMs(), lifeVersionFromMessageInfo);
+        index.markAsUndeleted(info.getStoreKey(), fileSpan, null, info.getOperationTimeMs(),
+            lifeVersionFromMessageInfo);
         // TODO: update blobstore stats for undelete (2020-02-10)
       }
       onSuccess();

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexValue.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexValue.java
@@ -84,10 +84,10 @@ class IndexValue implements Comparable<IndexValue> {
   private byte flags;
   private long expiresAtMs;
   private long originalMessageOffset;
+  private short lifeVersion;
   private final long operationTimeInMs;
   private final short accountId;
   private final short containerId;
-  private final short lifeVersion;
   private final short formatVersion;
 
   /**
@@ -360,6 +360,14 @@ class IndexValue implements Comparable<IndexValue> {
     Offset oldOffset = offset;
     offset = newOffset;
     setOriginalMessageOffset(oldOffset);
+  }
+
+  /**
+   * Updates the {@link #lifeVersion} of this {@link IndexValue}.
+   * @param lifeVersion the new lifeVersion to set.
+   */
+  void setNewLifeVersion(short lifeVersion) {
+    this.lifeVersion = lifeVersion;
   }
 
   /**

--- a/ambry-store/src/main/java/com/github/ambry/store/IndexValue.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/IndexValue.java
@@ -208,8 +208,8 @@ class IndexValue implements Comparable<IndexValue> {
    * @param containerId the containerId that this blob belongs to
    * @param lifeVersion the life version of this blob.
    */
-  IndexValue(long size, Offset offset, byte flags, long expiresAtMs, long originalMessageOffset,
-      long operationTimeInMs, short accountId, short containerId, short lifeVersion) {
+  IndexValue(long size, Offset offset, byte flags, long expiresAtMs, long originalMessageOffset, long operationTimeInMs,
+      short accountId, short containerId, short lifeVersion) {
     this.size = size;
     this.offset = offset;
     this.flags = flags;
@@ -364,6 +364,7 @@ class IndexValue implements Comparable<IndexValue> {
 
   /**
    * Updates the {@link #lifeVersion} of this {@link IndexValue}.
+   * Notice that this is only for testing.
    * @param lifeVersion the new lifeVersion to set.
    */
   void setNewLifeVersion(short lifeVersion) {

--- a/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/PersistentIndex.java
@@ -1007,7 +1007,7 @@ class PersistentIndex {
       // This is from recovery. In recovery, we don't need to do any sanity check because
       // 1. we already know the IndexValue has it's source in the log.
       // 2. some sanity check will fail.
-      //    assume we have P, D, U, D in the log, then a compaction cycle compact P and first D,
+      //    assume we have P, D, U, D in the log, then a compaction cycle compacted P and first D,
       //    then we only have U and second D. U in this case, will have no prior records.
       if (!hasLifeVersion) {
         throw new StoreException("MessageInfo of undelete carries invalid lifeVersion",

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -488,7 +488,7 @@ class CuratedLogIndexState {
     newValue.setFlag(IndexValue.Flags.Undelete_Index);
     newValue.clearFlag(IndexValue.Flags.Delete_Index);
     if (hasLifeVersion) {
-      index.markAsUndeleted(idToUndelete, fileSpan, newValue.getOperationTimeInMs(), lifeVersion);
+      index.markAsUndeleted(idToUndelete, fileSpan, null, newValue.getOperationTimeInMs(), lifeVersion);
     } else {
       index.markAsUndeleted(idToUndelete, fileSpan, newValue.getOperationTimeInMs());
     }

--- a/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/CuratedLogIndexState.java
@@ -225,6 +225,20 @@ class CuratedLogIndexState {
    * @throws StoreException
    */
   List<IndexEntry> addPutEntries(int count, long size, long expiresAtMs) throws StoreException {
+    return addPutEntries(count, size, expiresAtMs, MessageInfo.LIFE_VERSION_FROM_FRONTEND);
+  }
+
+  /**
+   * Adds {@code count} number of put entries each of size {@code size} and that expire at {@code expiresAtMs} to the
+   * index (both real and reference).
+   * @param count the number of PUT entries to add.
+   * @param size the size of each PUT entry.
+   * @param expiresAtMs the time at which each of the PUT entries expires.
+   * @param lifeVersion the lifeVersion of each PUT
+   * @return the list of the added entries.
+   * @throws StoreException
+   */
+  List<IndexEntry> addPutEntries(int count, long size, long expiresAtMs, short lifeVersion) throws StoreException {
     if (count <= 0) {
       throw new IllegalArgumentException("Number of put entries to add cannot be <= 0");
     }
@@ -244,6 +258,9 @@ class CuratedLogIndexState {
       IndexValue value =
           new IndexValue(size, fileSpan.getStartOffset(), expiresAtMs, time.milliseconds(), id.getAccountId(),
               id.getContainerId());
+      if (IndexValue.hasLifeVersion(lifeVersion)) {
+        value.setNewLifeVersion(lifeVersion);
+      }
       IndexEntry entry = new IndexEntry(id, value);
       indexEntries.add(entry);
       logOrder.put(fileSpan.getStartOffset(), new Pair<>(id, new LogEntry(dataWritten, value)));


### PR DESCRIPTION
There are several changes to this PR
1. Undelete will no longer check if the blob is expired for replication
2. Undelete will now take a MessageInfo as argument in recovery, and will only use info to construct an index value, without any sanity checking.
3. copyRecords in compaction will not use markAsUndelete to check sanity, instead it will have it's own sanity check.

This would fix certain recovery and replication corner cases.
Case 1. We have P, D, U, T for a blob. The PUT has a short ttl, so we need the last TTL_UPDATE to make it permanent. When the whole index files are gone and we are reconstructing index from log segments, we would fail on U since the P is expired in recovery. This PR would fix that.

Case 2. We have P, D, U, D for a blob. The compaction compacts Put and first DELETE, (UNDELETE and second DELETE are in a different segment, which is not under compaction). Then we only have U and D after compaction. When the whole index files are gone and we are reconstructing index from log, we would fail on U since there is nothing prior to it. This PR would fix that.

Case 3. We have P, D in local, and the remote has P, D, U, T. Somehow local stops for a while until P is expired. When restarting local process, it starts replicating from remote. And it will fail on applying U, since P is expired. This PR would fix that.