### PR TITLE
Force empty store to stay in BOOTSTRAP before catchup completes

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaStatusDelegate.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ReplicaStatusDelegate.java
@@ -93,4 +93,11 @@ public class ReplicaStatusDelegate {
   public List<String> getSealedReplicas() {
     return clusterParticipant.getSealedReplicas();
   }
+
+  /**
+   * @return the {@link ClusterParticipant} used by this {@link ReplicaStatusDelegate}
+   */
+  public ClusterParticipant getClusterParticipant() {
+    return clusterParticipant;
+  }
 }

--- a/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
+++ b/ambry-cloud/src/main/java/com/github/ambry/cloud/CloudBlobStore.java
@@ -88,6 +88,7 @@ class CloudBlobStore implements Store {
   // Distinguishes between VCR and live serving mode
   private final boolean isVcr;
   private boolean started;
+  private volatile ReplicaState currentState = ReplicaState.OFFLINE;
 
   /**
    * Constructor for CloudBlobStore
@@ -133,6 +134,7 @@ class CloudBlobStore implements Store {
 
   @Override
   public void start() {
+    currentState = ReplicaState.STANDBY;
     started = true;
     logger.debug("Started store: {}", this.toString());
   }
@@ -840,7 +842,7 @@ class CloudBlobStore implements Store {
 
   @Override
   public ReplicaState getCurrentState() {
-    throw new UnsupportedOperationException("Method not supported");
+    return currentState;
   }
 
   @Override
@@ -861,6 +863,7 @@ class CloudBlobStore implements Store {
   @Override
   public void shutdown() {
     recentBlobCache.clear();
+    currentState = ReplicaState.OFFLINE;
     started = false;
     logger.info("Stopped store: {}", this.toString());
   }

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationEngine.java
@@ -28,6 +28,7 @@ import com.github.ambry.config.ReplicationConfig;
 import com.github.ambry.network.ConnectionPool;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.server.StoreManager;
+import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.Store;
 import com.github.ambry.store.StoreException;
 import com.github.ambry.store.StoreKeyConverter;
@@ -73,7 +74,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
   private final List<String> sslEnabledDatacenters;
   private final StoreKeyConverterFactory storeKeyConverterFactory;
   private final String transformerClassName;
-  private final Predicate skipPredicate;
+  private final Predicate<MessageInfo> skipPredicate;
   protected final DataNodeId dataNodeId;
   protected final MetricRegistry metricRegistry;
   protected final ReplicationMetrics replicationMetrics;
@@ -96,8 +97,7 @@ public abstract class ReplicationEngine implements ReplicationAPI {
       List<? extends ReplicaId> replicaIds, ConnectionPool connectionPool, MetricRegistry metricRegistry,
       NotificationSystem requestNotification, StoreKeyConverterFactory storeKeyConverterFactory,
       String transformerClassName, ClusterParticipant clusterParticipant, StoreManager storeManager,
-      Predicate skipPredicate)
-      throws ReplicationException {
+      Predicate<MessageInfo> skipPredicate) throws ReplicationException {
     this.replicationConfig = replicationConfig;
     this.storeKeyFactory = storeKeyFactory;
     try {

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -30,6 +30,7 @@ import com.github.ambry.config.StoreConfig;
 import com.github.ambry.network.ConnectionPool;
 import com.github.ambry.notification.NotificationSystem;
 import com.github.ambry.server.StoreManager;
+import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.Store;
 import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
@@ -67,7 +68,7 @@ public class ReplicationManager extends ReplicationEngine {
       ScheduledExecutorService scheduler, DataNodeId dataNode, ConnectionPool connectionPool,
       MetricRegistry metricRegistry, NotificationSystem requestNotification,
       StoreKeyConverterFactory storeKeyConverterFactory, String transformerClassName,
-      ClusterParticipant clusterParticipant, Predicate skipPredicate) throws ReplicationException {
+      ClusterParticipant clusterParticipant, Predicate<MessageInfo> skipPredicate) throws ReplicationException {
     super(replicationConfig, clusterMapConfig, storeKeyFactory, clusterMap, scheduler, dataNode,
         clusterMap.getReplicaIds(dataNode), connectionPool, metricRegistry, requestNotification,
         storeKeyConverterFactory, transformerClassName, clusterParticipant, storeManager, skipPredicate);

--- a/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/InMemoryStore.java
@@ -176,12 +176,12 @@ class InMemoryStore implements Store {
     log = new DummyLog(buffers);
     this.listener = listener;
     this.id = id;
-    started = true;
   }
 
   @Override
   public void start() {
     started = true;
+    currentState = ReplicaState.STANDBY;
   }
 
   @Override
@@ -233,7 +233,7 @@ class InMemoryStore implements Store {
   @Override
   public void delete(List<MessageInfo> infos) throws StoreException {
     List<MessageInfo> infosToDelete = new ArrayList<>(infos.size());
-    List<InputStream> inputStreams = new ArrayList();
+    List<InputStream> inputStreams = new ArrayList<>();
     try {
       for (MessageInfo info : infos) {
         short lifeVersion = info.getLifeVersion();
@@ -469,6 +469,7 @@ class InMemoryStore implements Store {
   @Override
   public void shutdown() {
     started = false;
+    currentState = ReplicaState.OFFLINE;
   }
 
   @Override

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockHost.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockHost.java
@@ -80,6 +80,7 @@ public class MockHost {
                   (Function<PartitionId, List<MessageInfo>>) partitionId2 -> new ArrayList<>()),
                   buffersByPartition.computeIfAbsent(partitionId1,
                       (Function<PartitionId, List<ByteBuffer>>) partitionId22 -> new ArrayList<>()), listener));
+          store.start();
           RemoteReplicaInfo remoteReplicaInfo =
               new RemoteReplicaInfo(peerReplicaId, replicaId, store, new MockFindToken(0, 0), Long.MAX_VALUE,
                   SystemTime.getInstance(), new Port(peerReplicaId.getDataNodeId().getPort(), PortType.PLAINTEXT));

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -62,6 +62,7 @@ import com.github.ambry.replication.ReplicationSkipPredicate;
 import com.github.ambry.rest.NettyMetrics;
 import com.github.ambry.rest.NioServer;
 import com.github.ambry.rest.NioServerFactory;
+import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.StorageManager;
 import com.github.ambry.store.StoreKeyConverterFactory;
 import com.github.ambry.store.StoreKeyFactory;
@@ -220,7 +221,7 @@ public class AmbryServer {
       StoreKeyConverterFactory storeKeyConverterFactory =
           Utils.getObj(serverConfig.serverStoreKeyConverterFactory, properties, registry);
 
-      Predicate skipPredicate = new ReplicationSkipPredicate(accountService, replicationConfig);
+      Predicate<MessageInfo> skipPredicate = new ReplicationSkipPredicate(accountService, replicationConfig);
       replicationManager =
           new ReplicationManager(replicationConfig, clusterMapConfig, storeConfig, storageManager, storeKeyFactory,
               clusterMap, scheduler, nodeId, connectionPool, registry, notificationSystem, storeKeyConverterFactory,

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServerRequests.java
@@ -76,7 +76,7 @@ public class AmbryServerRequests extends AmbryRequests {
       EnumSet.of(ReplicaState.LEADER, ReplicaState.STANDBY, ReplicaState.INACTIVE, ReplicaState.BOOTSTRAP);
   static final Set<RequestOrResponseType> UPDATE_REQUEST_TYPES =
       EnumSet.of(RequestOrResponseType.DeleteRequest, RequestOrResponseType.TtlUpdateRequest,
-          RequestOrResponseType.UndeleteResponse);
+          RequestOrResponseType.UndeleteRequest);
 
   private static final Logger logger = LoggerFactory.getLogger(AmbryServerRequests.class);
 

--- a/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/DiskManager.java
@@ -43,6 +43,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.ambry.store.StorageManager.*;
+
 
 /**
  * Manages all the stores on a disk.
@@ -346,12 +348,7 @@ class DiskManager {
         partitionToReplicaMap.put(replica.getPartitionId(), replica);
         // create a bootstrap-in-progress file to distinguish it from regular stores (the file will be checked during
         // BOOTSTRAP -> STANDBY transition)
-        File bootstrapFile = new File(replica.getReplicaPath(), BlobStore.BOOTSTRAP_FILE_NAME);
-        if (!bootstrapFile.exists()) {
-          // if not present, create one. (it's possible the bootstrap file exists because node may crash immediately
-          // after the file was created last time)
-          bootstrapFile.createNewFile();
-        }
+        createBootstrapFileIfAbsent(replica);
         logger.info("New store is successfully added into DiskManager.");
         succeed = true;
       }

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -411,6 +411,18 @@ public class StorageManager implements StoreManager {
   }
 
   /**
+   * Create a bootstrap file in given replica directory if the file is not present.
+   * @param replica the {@link ReplicaId} whose directory should contain the bootstrap file.
+   * @throws IOException
+   */
+  static void createBootstrapFileIfAbsent(ReplicaId replica) throws IOException {
+    File bootstrapFile = new File(replica.getReplicaPath(), BlobStore.BOOTSTRAP_FILE_NAME);
+    if (!bootstrapFile.exists()) {
+      bootstrapFile.createNewFile();
+    }
+  }
+
+  /**
    * Maybe delete the residual directory associated with removed replica.
    * @param partitionName name of replica that is already removed
    */
@@ -440,6 +452,7 @@ public class StorageManager implements StoreManager {
     public void onPartitionBecomeBootstrapFromOffline(String partitionName) {
       // check if partition exists on current node
       ReplicaId replica = partitionNameToReplicaId.get(partitionName);
+      Store store = null;
       if (replica == null) {
         // there can be two scenarios:
         // 1. this is the first time to add new replica onto current node;
@@ -473,10 +486,13 @@ public class StorageManager implements StoreManager {
                 StateTransitionException.TransitionErrorCode.HelixUpdateFailure);
           }
         }
+        // if addBlobStore succeeds, it is guaranteed that store is started and thus getStore result is not null.
+        store = getStore(replicaToAdd.getPartitionId(), false);
+
         // note that partitionNameToReplicaId should be updated if addBlobStore succeeds, so replicationManager should be
         // able to get new replica from storageManager without querying Helix
       } else {
-        // if the replica is already on current node, there are 3 cases need to discuss:
+        // if the replica is already on current node, there are 4 cases need to discuss:
         // 1. replica was initially present in clustermap and this is a regular reboot.
         // 2. replica was dynamically added to this node but may fail during BOOTSTRAP -> STANDBY transition.
         // 3. replica is on current node but its disk is offline. The replica is not able to start.
@@ -486,7 +502,7 @@ public class StorageManager implements StoreManager {
         // For case 3, we should throw exception to make replica stay in ERROR state (thus, frontends won't pick this replica)
         // For case 4, we check it's current used capacity and put it in BOOTSTRAP state if necessary. This is to ensure
         //             it catches up with peers before serving PUT traffic (or being selected as LEADER)
-        Store store = getStore(replica.getPartitionId(), false);
+        store = getStore(replica.getPartitionId(), false);
         if (store == null) {
           throw new StateTransitionException(
               "Store " + partitionName + " didn't start correctly, replica should be set to ERROR state",
@@ -500,18 +516,15 @@ public class StorageManager implements StoreManager {
               "Store {} has used capacity {} less than or equal to {} bytes, consider it recently created and make it go through bootstrap process.",
               partitionName, storeUsedCapacity, HEADER_SIZE);
           try {
-            File bootstrapFile = new File(replica.getReplicaPath(), BlobStore.BOOTSTRAP_FILE_NAME);
-            if (!bootstrapFile.exists()) {
-              bootstrapFile.createNewFile();
-            }
+            createBootstrapFileIfAbsent(replica);
           } catch (IOException e) {
             logger.error("Failed to create bootstrap file for store {}", partitionName);
             throw new StateTransitionException("Failed to create bootstrap file for " + partitionName,
                 ReplicaOperationFailure);
           }
         }
-        store.setCurrentState(ReplicaState.BOOTSTRAP);
       }
+      store.setCurrentState(ReplicaState.BOOTSTRAP);
     }
 
     @Override

--- a/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
+++ b/ambry-store/src/main/java/com/github/ambry/store/StorageManager.java
@@ -51,6 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
+import static com.github.ambry.store.LogSegment.*;
 
 
 /**
@@ -476,16 +477,40 @@ public class StorageManager implements StoreManager {
         // able to get new replica from storageManager without querying Helix
       } else {
         // if the replica is already on current node, there are 3 cases need to discuss:
-        // 1. replica was initially present in clustermap;
-        // 2. replica was dynamically added to this node but may fail during BOOTSTRAP -> STANDBY transition
+        // 1. replica was initially present in clustermap and this is a regular reboot.
+        // 2. replica was dynamically added to this node but may fail during BOOTSTRAP -> STANDBY transition.
         // 3. replica is on current node but its disk is offline. The replica is not able to start.
+        // 4. replica was initially present in clustermap but it's current being recreated due to disk failure before.
+
         // For case 1 and 2, OFFLINE -> BOOTSTRAP is complete, we leave remaining actions (if there any) to other transition.
         // For case 3, we should throw exception to make replica stay in ERROR state (thus, frontends won't pick this replica)
-        if (getStore(replica.getPartitionId(), false) == null) {
+        // For case 4, we check it's current used capacity and put it in BOOTSTRAP state if necessary. This is to ensure
+        //             it catches up with peers before serving PUT traffic (or being selected as LEADER)
+        Store store = getStore(replica.getPartitionId(), false);
+        if (store == null) {
           throw new StateTransitionException(
               "Store " + partitionName + " didn't start correctly, replica should be set to ERROR state",
               StoreNotStarted);
         }
+        // if store's used capacity is less than or equal to header size, we create a bootstrap_in_progress file and force
+        // it to stay in BOOTSTRAP state when catching up with peers.
+        long storeUsedCapacity = store.getSizeInBytes();
+        if (storeUsedCapacity <= HEADER_SIZE) {
+          logger.info(
+              "Store {} has used capacity {} less than or equal to {} bytes, consider it recently created and make it go through bootstrap process.",
+              partitionName, storeUsedCapacity, HEADER_SIZE);
+          try {
+            File bootstrapFile = new File(replica.getReplicaPath(), BlobStore.BOOTSTRAP_FILE_NAME);
+            if (!bootstrapFile.exists()) {
+              bootstrapFile.createNewFile();
+            }
+          } catch (IOException e) {
+            logger.error("Failed to create bootstrap file for store {}", partitionName);
+            throw new StateTransitionException("Failed to create bootstrap file for " + partitionName,
+                ReplicaOperationFailure);
+          }
+        }
+        store.setCurrentState(ReplicaState.BOOTSTRAP);
       }
     }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -44,6 +44,7 @@ import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -68,6 +69,7 @@ import org.mockito.Mockito;
 import static com.github.ambry.clustermap.ClusterMapUtils.*;
 import static com.github.ambry.clustermap.StateTransitionException.TransitionErrorCode.*;
 import static com.github.ambry.clustermap.TestUtils.*;
+import static com.github.ambry.store.BlobStoreTest.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -318,8 +320,24 @@ public class StorageManagerTest {
     assertTrue("There should be a bootstrap file indicating store is in BOOTSTRAP state",
         newAddedStore.isBootstrapInProgress());
 
-    // 6. test that state transition should succeed for existing replicas
+    // 6. test that state transition should succeed for existing non-empty replicas (we write some data into store beforehand)
+    MockId id = new MockId(TestUtils.getRandomString(MOCK_ID_STRING_LENGTH), Utils.getRandomShort(TestUtils.RANDOM),
+        Utils.getRandomShort(TestUtils.RANDOM));
+    MessageInfo info =
+        new MessageInfo(id, PUT_RECORD_SIZE, id.getAccountId(), id.getContainerId(), Utils.Infinite_Time);
+    MessageWriteSet writeSet = new MockMessageWriteSet(Collections.singletonList(info),
+        Collections.singletonList(ByteBuffer.allocate(PUT_RECORD_SIZE)));
+    Store storeToWrite = storageManager.getStore(localReplicas.get(1).getPartitionId());
+    storeToWrite.put(writeSet);
+    mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(localReplicas.get(1).getPartitionId().toPathString());
+    assertFalse("There should not be any bootstrap file for existing non-empty store",
+        storeToWrite.isBootstrapInProgress());
+
+    // 7. test that for new created (empty) store, state transition puts it into BOOTSTRAP state
     mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(localReplicas.get(0).getPartitionId().toPathString());
+    assertTrue("There should be a bootstrap file because store is empty and probably recreated",
+        localStore.isBootstrapInProgress());
+    assertEquals("The store's current state should be BOOTSTRAP", ReplicaState.BOOTSTRAP, localStore.getCurrentState());
     shutdownAndAssertStoresInaccessible(storageManager, localReplicas);
   }
 

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -319,6 +319,8 @@ public class StorageManagerTest {
     // 5. verify that new added store has bootstrap file
     assertTrue("There should be a bootstrap file indicating store is in BOOTSTRAP state",
         newAddedStore.isBootstrapInProgress());
+    assertEquals("The store's current state should be BOOTSTRAP", ReplicaState.BOOTSTRAP,
+        newAddedStore.getCurrentState());
 
     // 6. test that state transition should succeed for existing non-empty replicas (we write some data into store beforehand)
     MockId id = new MockId(TestUtils.getRandomString(MOCK_ID_STRING_LENGTH), Utils.getRandomShort(TestUtils.RANDOM),
@@ -332,6 +334,8 @@ public class StorageManagerTest {
     mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(localReplicas.get(1).getPartitionId().toPathString());
     assertFalse("There should not be any bootstrap file for existing non-empty store",
         storeToWrite.isBootstrapInProgress());
+    assertEquals("The store's current state should be BOOTSTRAP", ReplicaState.BOOTSTRAP,
+        storeToWrite.getCurrentState());
 
     // 7. test that for new created (empty) store, state transition puts it into BOOTSTRAP state
     mockHelixParticipant.onPartitionBecomeBootstrapFromOffline(localReplicas.get(0).getPartitionId().toPathString());


### PR DESCRIPTION
When disk crashed due to I/O error, we lost all partitions on this disk. After a new disk
is mounted, Ambry is able to recreate the stores on new disk during reboot. These
recreated stores are empty and probably way behind their peer replicas, so we need
to put them in BOOTSTRAP state until they have caught up with peers. Considering
Leader-based Replication will be introduced, this PR guarantees those empty stores
won't be selected LEADER because they are kept in BOOTSTRAP state. (Otherwise, some stores
may be selected as LEADER but they have to spend a couple of hours/days completing catchup.
Meanwhile new data in remote dc(s) cannot be replicated to current dc.)