### PR TITLE
Use DataNodeConfigSource in participant

### DIFF
--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DataNodeConfig.java
@@ -38,6 +38,7 @@ class DataNodeConfig {
   private final Set<String> stoppedReplicas = new HashSet<>();
   private final Set<String> disabledReplicas = new HashSet<>();
   private final Map<String, DiskConfig> diskConfigs = new HashMap<>();
+  private final Map<String, Map<String, String>> extraMapFields = new HashMap<>();
 
   /**
    * @param instanceName a name that can be used as a unique key for this server.
@@ -144,6 +145,16 @@ class DataNodeConfig {
    */
   Map<String, DiskConfig> getDiskConfigs() {
     return diskConfigs;
+  }
+
+  /**
+   * This can be used for extra fields that are not recognized by {@link DataNodeConfigSource} but still need to be
+   * read from or written to the source of truth. This should be used sparingly and is mainly provided for legacy
+   * compatibility.
+   * @return a map from field name to map-style fields.
+   */
+  public Map<String, Map<String, String>> getExtraMapFields() {
+    return extraMapFields;
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/DatacenterInitializer.java
@@ -165,11 +165,8 @@ class DatacenterInitializer {
     if (dcZkInfo.getDcName().equals(clusterMapConfig.clusterMapDatacenterName)) {
       manager = Objects.requireNonNull(localManager, "localManager should have been set");
     } else {
-      manager = helixFactory.getZKHelixManager(clusterMapConfig.clusterMapClusterName, selfInstanceName,
+      manager = helixFactory.getZkHelixManagerAndConnect(clusterMapConfig.clusterMapClusterName, selfInstanceName,
           InstanceType.SPECTATOR, zkConnectStr);
-      logger.info("Connecting to Helix manager at {}", zkConnectStr);
-      manager.connect();
-      logger.info("Established connection to Helix manager at {}", zkConnectStr);
     }
     HelixClusterChangeHandler clusterChangeHandler;
     String clusterChangeHandlerType = clusterMapConfig.clusterMapClusterChangeHandlerType;

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterManager.java
@@ -205,10 +205,7 @@ public class HelixClusterManager implements ClusterMap {
     // doesn't support multiple HelixClusterManagers(spectators) on same node.
     String zkConnectStr = dcZkInfo.getZkConnectStrs().get(0);
     HelixManager manager =
-        helixFactory.getZKHelixManager(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectStr);
-    logger.info("Connecting to Helix manager in local zookeeper at {}", zkConnectStr);
-    manager.connect();
-    logger.info("Established connection to Helix manager in local zookeeper at {}", zkConnectStr);
+        helixFactory.getZkHelixManagerAndConnect(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectStr);
     helixPropertyStoreInLocalDc = manager.getHelixPropertyStore();
     logger.info("HelixPropertyStore from local datacenter {} is: {}", dcZkInfo.getDcName(),
         helixPropertyStoreInLocalDc);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterSpectator.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixClusterSpectator.java
@@ -68,9 +68,8 @@ public class HelixClusterSpectator implements ClusterSpectator {
       // only handle vcr clusters for now
       if (dcZkInfo.getReplicaType() == ReplicaType.CLOUD_BACKED) {
         HelixManager helixManager =
-            helixFactory.getZKHelixManager(cloudConfig.vcrClusterName, selfInstanceName, InstanceType.SPECTATOR,
-                dcZkInfo.getZkConnectStrs().get(0));
-        helixManager.connect();
+            helixFactory.getZkHelixManagerAndConnect(cloudConfig.vcrClusterName, selfInstanceName,
+                InstanceType.SPECTATOR, dcZkInfo.getZkConnectStrs().get(0));
 
         helixManager.addInstanceConfigChangeListener(this);
         helixManager.addLiveInstanceChangeListener(this);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
@@ -13,16 +13,23 @@
  */
 package com.github.ambry.clustermap;
 
-import org.apache.helix.HelixAdmin;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * A factory class to construct and get a reference to a {@link HelixManager}
  */
 public class HelixFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HelixFactory.class);
+  Map<ManagerKey, HelixManager> helixManagers = new ConcurrentHashMap<>();
+
   /**
    * Get a reference to a {@link HelixManager}
    * @param clusterName the name of the cluster for which the manager is to be gotten.
@@ -33,15 +40,73 @@ public class HelixFactory {
    */
   public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
       String zkAddr) {
-    return HelixManagerFactory.getZKHelixManager(clusterName, instanceName, instanceType, zkAddr);
+    ManagerKey managerKey = new ManagerKey(clusterName, instanceName, instanceType, zkAddr);
+    return helixManagers.computeIfAbsent(managerKey,
+        k -> HelixManagerFactory.getZKHelixManager(clusterName, instanceName, instanceType, zkAddr));
   }
 
   /**
-   * Get a reference to a {@link HelixAdmin}
+   * Get a reference to a {@link HelixManager} and connect to it, if not already connected
+   * @param clusterName the name of the cluster for which the manager is to be gotten.
+   * @param instanceName the name of the instance on whose behalf the manager is to be gotten.
+   * @param instanceType the {@link InstanceType} of the requester.
    * @param zkAddr the address identifying the zk service to which this request is to be made.
-   * @return the constructed {@link HelixAdmin}.
+   * @return the constructed and connected {@link HelixManager}.
+   * @throws Exception if connecting failed.
    */
-  public HelixAdmin getHelixAdmin(String zkAddr) {
-    return new HelixAdminFactory().getHelixAdmin(zkAddr);
+  public HelixManager getZkHelixManagerAndConnect(String clusterName, String instanceName, InstanceType instanceType,
+      String zkAddr) throws Exception {
+    HelixManager manager = getZKHelixManager(clusterName, instanceName, instanceType, zkAddr);
+    synchronized (manager) {
+      if (!manager.isConnected()) {
+        LOGGER.info("Connecting to HelixManager at {}", zkAddr);
+        manager.connect();
+        LOGGER.info("Established connection to HelixManager at {}", zkAddr);
+      } else {
+        LOGGER.info("HelixManager at {} already connected", zkAddr);
+      }
+    }
+    return manager;
+  }
+
+  /**
+   * Hashable key used to cache instances of {@link HelixManager} that match desired parameters.
+   */
+  private static class ManagerKey {
+    private final String clusterName;
+    private final String instanceName;
+    private final InstanceType instanceType;
+    private final String zkAddr;
+
+    public ManagerKey(String clusterName, String instanceName, InstanceType instanceType, String zkAddr) {
+      this.clusterName = clusterName;
+      this.instanceName = instanceName;
+      this.instanceType = instanceType;
+      this.zkAddr = zkAddr;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ManagerKey that = (ManagerKey) o;
+      return Objects.equals(clusterName, that.clusterName) && Objects.equals(instanceName, that.instanceName)
+          && instanceType == that.instanceType && Objects.equals(zkAddr, that.zkAddr);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(clusterName, instanceName, instanceType, zkAddr);
+    }
+
+    @Override
+    public String toString() {
+      return "ManagerKey{" + "clusterName='" + clusterName + '\'' + ", instanceName='" + instanceName + '\''
+          + ", instanceType=" + instanceType + ", zkAddr='" + zkAddr + '\'' + '}';
+    }
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixFactory.java
@@ -102,11 +102,5 @@ public class HelixFactory {
     public int hashCode() {
       return Objects.hash(clusterName, instanceName, instanceType, zkAddr);
     }
-
-    @Override
-    public String toString() {
-      return "ManagerKey{" + "clusterName='" + clusterName + '\'' + ", instanceName='" + instanceName + '\''
-          + ", instanceType=" + instanceType + ", zkAddr='" + zkAddr + '\'' + '}';
-    }
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -346,7 +346,6 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   /**
    * Remove old/existing replica info from {@link DataNodeConfig} that associates with current data node.
    * @param replicaId the {@link ReplicaId} whose info should be removed.
-   * @param dataNodeConfig {@link DataNodeConfig} to update.
    * @return {@code true} replica info is successfully removed. {@code false} otherwise.
    */
   private boolean removeOldReplicaInfo(ReplicaId replicaId) {
@@ -378,8 +377,8 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       logger.info("Updating config: {} in Helix by removing partition {}", dataNodeConfig, partitionName);
       removalResult = dataNodeConfigSource.set(dataNodeConfig);
     } else {
-      logger.warn("Partition {} is not found on instance {}, skipping removing it from InstanceConfig in Helix.",
-          partitionName, instanceName);
+      logger.warn("Partition {} is not found on instance {}, skipping removing it from config in Helix.", partitionName,
+          instanceName);
     }
     return removalResult;
   }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapter.java
@@ -104,8 +104,9 @@ public class InstanceConfigToDataNodeConfigAdapter implements DataNodeConfigSour
           // Check if this map field actually holds disk properties, since we can't tell from just the field key (the
           // mount path with no special prefix). There may be extra fields when Helix controller adds partitions in ERROR
           // state to InstanceConfig.
-          LOGGER.warn("{} field does not contain disk info on {}. Skip it and continue on next one.", mountPath,
+          LOGGER.info("{} field does not contain disk info on {}. Storing it in extraMapFields.", mountPath,
               instanceConfig.getInstanceName());
+          dataNodeConfig.getExtraMapFields().put(mountPath, diskProps);
         } else {
           DataNodeConfig.DiskConfig disk = new DataNodeConfig.DiskConfig(
               diskProps.get(DISK_STATE).equals(AVAILABLE_STR) ? HardwareState.AVAILABLE : HardwareState.UNAVAILABLE,
@@ -171,6 +172,7 @@ public class InstanceConfigToDataNodeConfigAdapter implements DataNodeConfigSour
         diskProps.put(REPLICAS_STR, replicasStrBuilder.toString());
         instanceConfig.getRecord().setMapField(mountPath, diskProps);
       });
+      dataNodeConfig.getExtraMapFields().forEach((k, v) -> instanceConfig.getRecord().setMapField(k, v));
       return instanceConfig;
     }
   }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixClusterManagerTest.java
@@ -1504,6 +1504,7 @@ public class HelixClusterManagerTest {
      * @param zkAddr the address identifying the zk service to which this request is to be made.
      * @return the {@link MockHelixManager}
      */
+    @Override
     public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
         String zkAddr) {
       if (helixCluster.getZkAddrs().contains(zkAddr)) {

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapterTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapterTest.java
@@ -17,7 +17,6 @@ package com.github.ambry.clustermap;
 
 import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.config.VerifiableProperties;
-import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.TestUtils.ZkInfo;
 import java.io.File;
 import java.nio.file.Files;

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapterTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapterTest.java
@@ -69,7 +69,6 @@ public class InstanceConfigToDataNodeConfigAdapterTest extends DataNodeConfigSou
   public void testSetGetListener() throws Exception {
     InstanceConfigToDataNodeConfigAdapter source =
         new InstanceConfigToDataNodeConfigAdapter(helixManager, clusterMapConfig);
-    source.setHelixAdmin(helixManager.getClusterManagmentTool());
     // set up 10 node configs and attach a listener.
     Set<DataNodeConfig> allConfigs = new HashSet<>();
     for (int i = 0; i < 10; i++) {
@@ -109,10 +108,5 @@ public class InstanceConfigToDataNodeConfigAdapterTest extends DataNodeConfigSou
       assertEquals("get() call returned incorrect result", config, source.get(config.getInstanceName()));
     }
     assertNull("Should not receive non-existent instance", source.get("abc"));
-
-    source.setHelixAdmin(null);
-    TestUtils.assertException(NullPointerException.class, () -> source.set(createConfig(1, 1)), null);
-    String firstInstance = allConfigs.iterator().next().getInstanceName();
-    TestUtils.assertException(NullPointerException.class, () -> source.get(firstInstance), null);
   }
 }

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapterTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/InstanceConfigToDataNodeConfigAdapterTest.java
@@ -20,6 +20,7 @@ import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.utils.TestUtils.ZkInfo;
 import java.io.File;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -95,6 +96,8 @@ public class InstanceConfigToDataNodeConfigAdapterTest extends DataNodeConfigSou
     reset(listener2);
     DataNodeConfig updatedConfig = allConfigs.iterator().next();
     updatedConfig.getStoppedReplicas().add("partition");
+    // add an extra map field to ensure it gets serialized/deserialized correctly
+    updatedConfig.getExtraMapFields().put("extra", Collections.singletonMap("k", "v"));
     source.set(updatedConfig);
     // need to manually trigger a notification since MockHelixParticipant does not do so.
     // (other tests may not work as intended if we trigger a notification on calls to setInstanceConfig)

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -54,6 +54,7 @@ public class MockHelixAdmin implements HelixAdmin {
   // A map of partitionId to instanceName associated with leader replica
   private Map<String, String> partitionToLeaderReplica = new HashMap<>();
   private long totalDiskCapacity;
+  private int setInstanceConfigCallCount = 0;
 
   /**
    * Get the instances that have replicas for the given partition.
@@ -146,6 +147,7 @@ public class MockHelixAdmin implements HelixAdmin {
 
   @Override
   public boolean setInstanceConfig(String clusterName, String instanceName, InstanceConfig instanceConfig) {
+    setInstanceConfigCallCount++;
     instanceNameToinstanceConfigs.put(instanceName, instanceConfig);
     return true;
   }
@@ -396,6 +398,13 @@ public class MockHelixAdmin implements HelixAdmin {
    */
   long getTotalDiskCapacity() {
     return totalDiskCapacity;
+  }
+
+  /**
+   * @return the number of calls to the {@link #setInstanceConfig} method.
+   */
+  public int getSetInstanceConfigCallCount() {
+    return setInstanceConfigCallCount;
   }
 
   /**

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixAdmin.java
@@ -403,7 +403,7 @@ public class MockHelixAdmin implements HelixAdmin {
   /**
    * @return the number of calls to the {@link #setInstanceConfig} method.
    */
-  public int getSetInstanceConfigCallCount() {
+  int getSetInstanceConfigCallCount() {
     return setInstanceConfigCallCount;
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManagerFactory.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixManagerFactory.java
@@ -56,13 +56,15 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 
 
 public class MockHelixManagerFactory extends HelixFactory {
-  private final MockHelixManager helixManager;
+  private final MockHelixManager participantHelixManager;
+  private final MockHelixManager spectatorHelixManager;
 
   /**
    * Construct this factory.
    */
   public MockHelixManagerFactory() {
-    helixManager = new MockHelixManager();
+    participantHelixManager = new MockHelixManager();
+    spectatorHelixManager = new MockHelixManager();
   }
 
   /**
@@ -76,21 +78,11 @@ public class MockHelixManagerFactory extends HelixFactory {
   @Override
   public HelixManager getZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
       String zkAddr) {
-    return helixManager;
+    return getHelixManager(instanceType);
   }
 
-  /**
-   * Return the {@link MockHelixAdmin}
-   * @param zkAddr unused.
-   * @return the {@link MockHelixAdmin}
-   */
-  @Override
-  public HelixAdmin getHelixAdmin(String zkAddr) {
-    return new MockHelixAdmin();
-  }
-
-  public MockHelixManager getHelixManager() {
-    return helixManager;
+  public MockHelixManager getHelixManager(InstanceType instanceType) {
+    return instanceType == InstanceType.PARTICIPANT ? participantHelixManager : spectatorHelixManager;
   }
 
   /**

--- a/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/BlobStoreTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -1864,6 +1865,7 @@ public class BlobStoreTest {
     properties.setProperty("store.set.local.partition.state.enabled", "true");
     ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(properties));
     InstanceConfig instanceConfig = new InstanceConfig("localhost");
+    instanceConfig.setPort("2222");
     Map<String, List<String>> listMap = new HashMap<>();
     listMap.put(storeId, null);
     ZNRecord znRecord = new ZNRecord("localhost");
@@ -1871,13 +1873,15 @@ public class BlobStoreTest {
     IdealState idealState = new IdealState(znRecord);
     idealState.setRebalanceMode(IdealState.RebalanceMode.SEMI_AUTO);
     // mock helix related components
-    HelixAdmin mockHelixAdmin = Mockito.mock(HelixAdmin.class);
+    HelixAdmin mockHelixAdmin = mock(HelixAdmin.class);
     when(mockHelixAdmin.getInstanceConfig(eq(CLUSTER_NAME), anyString())).thenReturn(instanceConfig);
     when(mockHelixAdmin.getResourcesInCluster(eq(CLUSTER_NAME))).thenReturn(Collections.singletonList(RESOURCE_NAME));
     when(mockHelixAdmin.getResourceIdealState(eq(CLUSTER_NAME), eq(RESOURCE_NAME))).thenReturn(idealState);
-    HelixFactory mockHelixFactory = Mockito.mock(HelixFactory.class);
-    when(mockHelixFactory.getZKHelixManager(anyString(), anyString(), any(), anyString())).thenReturn(null);
-    when(mockHelixFactory.getHelixAdmin(anyString())).thenReturn(mockHelixAdmin);
+    HelixManager mockHelixManager = mock(HelixManager.class);
+    when(mockHelixManager.getClusterManagmentTool()).thenReturn(mockHelixAdmin);
+    HelixFactory mockHelixFactory = mock(HelixFactory.class);
+    when(mockHelixFactory.getZkHelixManagerAndConnect(anyString(), anyString(), any(), anyString())).thenReturn(
+        mockHelixManager);
     MockHelixParticipant.metricRegistry = new MetricRegistry();
     MockHelixParticipant mockParticipant = new MockHelixParticipant(clusterMapConfig, mockHelixFactory);
     mockParticipant.overrideDisableReplicaMethod = false;

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -702,7 +702,7 @@ public class HelixBootstrapUpgradeToolTest {
       }
     }
     List<String> disabledPartition = currentInstanceConfig.getDisabledPartitions(resourceName);
-    assertEquals("Disabled partition is not expected",
+    assertEquals("Disabled partition not as expected",
         Collections.singletonList(removedReplica.getPartitionId().toPathString()), disabledPartition);
     // Verify that IdealState has no change
     verifyIdealStateForPartition(removedReplica, true, 3, expectedResourceCount);
@@ -718,7 +718,7 @@ public class HelixBootstrapUpgradeToolTest {
     Map<String, String> expectedDisabledPartitionMap = new HashMap<>();
     expectedDisabledPartitionMap.put(resourceName, removedReplica.getPartitionId().toPathString());
 
-    assertEquals("Mismatch in disabled partition string in InstnaceConfig", expectedDisabledPartitionMap,
+    assertEquals("Mismatch in disabled partition string in InstanceConfig", expectedDisabledPartitionMap,
         currentInstanceConfig.getRecord().getMapField(disabledPartitionStr));
     // verify the removed replica is no longer in InstanceConfig
     verifyReplicaInfoInInstanceConfig(currentInstanceConfig, removedReplica, false);

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Singleton.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Singleton.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.github.ambry.utils;
+
+import java.util.function.Supplier;
+
+
+/**
+ * A helper class to ensure exactly one instance of an object of type T per {@link Singleton} instance is created.
+ * @param <T> the type of the singleton object
+ */
+public class Singleton<T> {
+  private final Supplier<T> supplier;
+  private volatile T instance = null;
+
+  /**
+   * @param supplier a constructor for the singleton instance. This will be called exactly once.
+   */
+  public Singleton(Supplier<T> supplier) {
+    this.supplier = supplier;
+  }
+
+  /**
+   * @return the single lazily-instantiated object.
+   */
+  public T get() {
+    // Based on guidance from https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java
+    if (instance == null) {
+      synchronized (this) {
+        if (instance == null) {
+          instance = supplier.get();
+        }
+      }
+    }
+    return instance;
+  }
+}


### PR DESCRIPTION
Use DataNodeConfigSource as an abstraction around HelixAdmin and
InstanceConfigs in HelixParticipant to allow for future configurable
implementations to be plugged into this class.

For now, this only supports InstanceConfigToDataNodeConfigAdapter, but
will be modified to allow configuration in future commits.

This commit switches HelixParticipant to use a shared spectator
HelixManager instance for any config manipulation. This
avoids the need to construct a temporary HelixAdmin before the
"official" admin is ready.