### PR TITLE
Add one integration test for undelete index recovery

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/replication/ReplicationSkipPredicate.java
+++ b/ambry-api/src/main/java/com/github/ambry/replication/ReplicationSkipPredicate.java
@@ -29,11 +29,12 @@ public class ReplicationSkipPredicate implements Predicate<MessageInfo> {
   private final AccountService accountService;
   private final ReplicationConfig replicationConfig;
   private static final Logger logger = LoggerFactory.getLogger(ReplicationSkipPredicate.class);
+
   /**
    * Construct a ReplicationSkipPredicate object
    * @param accountService the {@link AccountService} associated with this predicate.
    */
-  public ReplicationSkipPredicate(AccountService accountService, ReplicationConfig replicationConfig){
+  public ReplicationSkipPredicate(AccountService accountService, ReplicationConfig replicationConfig) {
     this.accountService = accountService;
     this.replicationConfig = replicationConfig;
   }
@@ -50,12 +51,12 @@ public class ReplicationSkipPredicate implements Predicate<MessageInfo> {
     if (accountService != null) {
       Account account = accountService.getAccountById(messageInfo.getAccountId());
       if (account == null) {
-        logger.info("Can't get account through accountService : {}", accountService);
+        logger.trace("Can't get account through accountService : {}", accountService);
         return false;
       }
       Container container = account.getContainerById(messageInfo.getContainerId());
       if (container == null) {
-        logger.info("Can't get container through account : {}", account);
+        logger.trace("Can't get container through account : {}", account);
         return false;
       }
       Container.ContainerStatus status = container.getStatus();
@@ -66,7 +67,7 @@ public class ReplicationSkipPredicate implements Predicate<MessageInfo> {
         return false;
       }
       if (status == Container.ContainerStatus.DELETE_IN_PROGRESS || status == Container.ContainerStatus.INACTIVE) {
-        logger.info("Container {} will be skipped during replication", container);
+        logger.trace("Container {} will be skipped during replication", container);
         return true;
       } else {
         logger.debug("Container {} is Active", container);

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/MockCluster.java
@@ -23,6 +23,7 @@ import com.github.ambry.clustermap.MockClusterAgentsFactory;
 import com.github.ambry.clustermap.MockClusterMap;
 import com.github.ambry.clustermap.MockClusterSpectatorFactory;
 import com.github.ambry.clustermap.MockDataNodeId;
+import com.github.ambry.clustermap.MockReplicaId;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.config.VerifiableProperties;
@@ -71,8 +72,8 @@ public class MockCluster {
   private final List<String> sslEnabledDataCenterList;
   private final Properties sslProps;
   private final boolean enableHardDeletes;
-  private final Time time;
   private NotificationSystem notificationSystem;
+  final Time time;
 
   public MockCluster(Properties serverSslProps, boolean enableHardDeletes, Time time) throws IOException {
     this(serverSslProps, enableHardDeletes, time, 9, 3, 3);
@@ -253,12 +254,13 @@ public class MockCluster {
     props.setProperty("store.data.flush.interval.seconds", "1");
     props.setProperty("store.enable.hard.delete", Boolean.toString(enableHardDeletes));
     props.setProperty("store.deleted.message.retention.days", "1");
+    props.setProperty("store.validate.authorization", "true");
+    props.setProperty("store.segment.size.in.bytes", Long.toString(MockReplicaId.MOCK_REPLICA_CAPACITY / 10));
     props.setProperty("replication.token.flush.interval.seconds", "5");
     props.setProperty("replication.validate.message.stream", "true");
     props.setProperty("clustermap.cluster.name", "test");
     props.setProperty("clustermap.datacenter.name", "DC1");
     props.setProperty("clustermap.host.name", "localhost");
-    props.setProperty("store.validate.authorization", "true");
     props.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
     props.setProperty("server.enable.store.data.prefetch", Boolean.toString(enableDataPrefetch));
     props.setProperty("server.handle.undelete.request.enabled", "true");

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerHttp2Test.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerHttp2Test.java
@@ -21,6 +21,7 @@ import com.github.ambry.config.SSLConfig;
 import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
+import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import java.io.File;
@@ -65,7 +66,8 @@ public class ServerHttp2Test {
     serverSSLProps = new Properties();
     TestSSLUtils.addSSLProperties(serverSSLProps, "DC1,DC2,DC3", SSLFactory.Mode.SERVER, trustStoreFile, "server");
     TestSSLUtils.addHttp2Properties(serverSSLProps, SSLFactory.Mode.SERVER, false);
-    http2Cluster = new MockCluster(serverSSLProps, false, SystemTime.getInstance(), 1, 1, 2);
+    http2Cluster =
+        new MockCluster(serverSSLProps, false, new MockTime(SystemTime.getInstance().milliseconds()), 1, 1, 2);
     notificationSystem = new MockNotificationSystem(http2Cluster.getClusterMap());
     http2Cluster.initializeServers(notificationSystem);
     http2Cluster.startServers();

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerPlaintextTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerPlaintextTest.java
@@ -19,6 +19,7 @@ import com.github.ambry.commons.SSLFactory;
 import com.github.ambry.commons.TestSSLUtils;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
+import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import com.github.ambry.utils.Utils;
@@ -51,7 +52,7 @@ public class ServerPlaintextTest {
 
     Properties serverProperties = new Properties();
     TestSSLUtils.addHttp2Properties(serverProperties, SSLFactory.Mode.SERVER, true);
-    plaintextCluster = new MockCluster(serverProperties, false, SystemTime.getInstance());
+    plaintextCluster = new MockCluster(serverProperties, false, new MockTime(SystemTime.getInstance().milliseconds()));
     notificationSystem = new MockNotificationSystem(plaintextCluster.getClusterMap());
     plaintextCluster.initializeServers(notificationSystem);
   }
@@ -153,5 +154,18 @@ public class ServerPlaintextTest {
     plaintextCluster.startServers();
     ServerTestUtil.undeleteCornerCasesTest(plaintextCluster, PortType.PLAINTEXT, null, null, null, null, null, null,
         notificationSystem, routerProps, testEncryption);
+  }
+
+  /**
+   * Test index recovery for undelete.
+   * @throws Exception
+   */
+  @Test
+  public void undeleteRecoveryTest() throws Exception {
+    assumeTrue(!testEncryption);
+    plaintextCluster.startServers();
+    DataNodeId dataNodeId = plaintextCluster.getGeneralDataNode();
+    ServerTestUtil.undeleteRecoveryTest(new Port(dataNodeId.getPort(), PortType.PLAINTEXT), plaintextCluster, null,
+        null);
   }
 }

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/ServerSSLTest.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/ServerSSLTest.java
@@ -20,6 +20,7 @@ import com.github.ambry.commons.TestSSLUtils;
 import com.github.ambry.config.SSLConfig;
 import com.github.ambry.network.Port;
 import com.github.ambry.network.PortType;
+import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.SystemTime;
 import com.github.ambry.utils.TestUtils;
 import java.io.File;
@@ -71,7 +72,7 @@ public class ServerSSLTest {
     routerProps.setProperty("kms.default.container.key", TestUtils.getRandomKey(32));
     routerProps.setProperty("clustermap.default.partition.class", MockClusterMap.DEFAULT_PARTITION_CLASS);
     TestSSLUtils.addSSLProperties(routerProps, "DC1,DC2,DC3", SSLFactory.Mode.CLIENT, trustStoreFile, "router-client");
-    sslCluster = new MockCluster(serverSSLProps, false, SystemTime.getInstance());
+    sslCluster = new MockCluster(serverSSLProps, false, new MockTime(SystemTime.getInstance().milliseconds()));
     notificationSystem = new MockNotificationSystem(sslCluster.getClusterMap());
     sslCluster.initializeServers(notificationSystem);
     //client


### PR DESCRIPTION
Add one more integration test for undelete, it's testing the index recovery of undelete records.

It sends some records, including UNDELETE, to one of the servers and stops the server, then remove the index files and restart the server process. The restarted server process should recovery the index files from the log files.