### PR TITLE
Change java ByteBuffer to netty ByteBuf in request and response.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/network/BoundedByteBufferSend.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/BoundedByteBufferSend.java
@@ -13,7 +13,9 @@
  */
 package com.github.ambry.network;
 
+import com.github.ambry.utils.AbstractByteBufHolder;
 import com.github.ambry.utils.ByteBufferOutputStream;
+import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
@@ -25,7 +27,7 @@ import java.nio.channels.WritableByteChannel;
  * This is mainly used to optimize serialization of response objects on the request handler
  * threads rather than the network threads.
  */
-public class BoundedByteBufferSend implements Send {
+public class BoundedByteBufferSend extends AbstractByteBufHolder<BoundedByteBufferSend> implements Send {
 
   private final ByteBuffer buffer;
 
@@ -64,6 +66,16 @@ public class BoundedByteBufferSend implements Send {
   @Override
   public long sizeInBytes() {
     return buffer.limit();
+  }
+
+  @Override
+  public ByteBuf content() {
+    return null;
+  }
+
+  @Override
+  public BoundedByteBufferSend replace(ByteBuf content) {
+    return null;
   }
 
   public BoundedByteBufferSend duplicate() {

--- a/ambry-api/src/main/java/com/github/ambry/network/Send.java
+++ b/ambry-api/src/main/java/com/github/ambry/network/Send.java
@@ -15,6 +15,8 @@ package com.github.ambry.network;
 
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 
@@ -23,7 +25,7 @@ import java.nio.channels.WritableByteChannel;
  * Any data that needs to be sent over the network can implement
  * this interface
  */
-public interface Send {
+public interface Send extends ByteBufHolder {
   /**
    * Writes content into the provided channel
    * @param channel The channel into which data needs to be written to
@@ -52,7 +54,9 @@ public interface Send {
   long sizeInBytes();
 
   /**
-   * Release all the resource this object holds. Make this a default method so subclasses don't have to override it.
+   * Return the data which is held by this {@link ByteBufHolder}. The result could be null, if it's null,
+   * please use writeTo methods to write the content to remote peer.
    */
-  default void release() {}
+  @Override
+  ByteBuf content();
 }

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobPropertiesSerDe.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/BlobPropertiesSerDe.java
@@ -16,6 +16,7 @@ package com.github.ambry.messageformat;
 import com.github.ambry.account.Account;
 import com.github.ambry.account.Container;
 import com.github.ambry.utils.Utils;
+import io.netty.buffer.ByteBuf;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -82,5 +83,27 @@ public class BlobPropertiesSerDe {
     outputBuffer.putShort(properties.getAccountId());
     outputBuffer.putShort(properties.getContainerId());
     outputBuffer.put(properties.isEncrypted() ? (byte) 1 : (byte) 0);
+  }
+
+  /**
+   * Serialize {@link BlobProperties} to {@link ByteBuf} in the {@link #VERSION_3}
+   * @param outputBuf the {@link ByteBuf} to which {@link BlobProperties} needs to be serialized
+   * @param properties the {@link BlobProperties} that needs to be serialized
+   */
+  public static void serializeBlobProperties(ByteBuf outputBuf, BlobProperties properties) {
+    if (!outputBuf.isWritable(getBlobPropertiesSerDeSize(properties))) {
+      throw new IllegalArgumentException("Output buffer does not have sufficient space to serialize blob properties");
+    }
+    outputBuf.writeShort(VERSION_3);
+    outputBuf.writeLong(properties.getTimeToLiveInSeconds());
+    outputBuf.writeByte(properties.isPrivate() ? (byte) 1 : (byte) 0);
+    outputBuf.writeLong(properties.getCreationTimeInMs());
+    outputBuf.writeLong(properties.getBlobSize());
+    Utils.serializeNullableString(outputBuf, properties.getContentType());
+    Utils.serializeNullableString(outputBuf, properties.getOwnerId());
+    Utils.serializeNullableString(outputBuf, properties.getServiceId());
+    outputBuf.writeShort(properties.getAccountId());
+    outputBuf.writeShort(properties.getContainerId());
+    outputBuf.writeByte(properties.isEncrypted() ? (byte) 1 : (byte) 0);
   }
 }

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageFormatSend.java
@@ -19,9 +19,11 @@ import com.github.ambry.router.Callback;
 import com.github.ambry.store.MessageReadSet;
 import com.github.ambry.store.StoreKey;
 import com.github.ambry.store.StoreKeyFactory;
+import com.github.ambry.utils.AbstractByteBufHolder;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.ByteBufferOutputStream;
 import com.github.ambry.utils.SystemTime;
+import io.netty.buffer.ByteBuf;
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -42,7 +44,7 @@ import static com.github.ambry.messageformat.MessageFormatRecord.*;
  * to the network channel
  */
 
-public class MessageFormatSend implements Send {
+public class MessageFormatSend extends AbstractByteBufHolder<MessageFormatSend> implements Send {
 
   private MessageReadSet readSet;
   private MessageFormatFlags flag;
@@ -55,6 +57,17 @@ public class MessageFormatSend implements Send {
   private StoreKeyFactory storeKeyFactory;
   private static final Logger logger = LoggerFactory.getLogger(MessageFormatSend.class);
   private final static int BUFFERED_INPUT_STREAM_BUFFER_SIZE = 256;
+
+  @Override
+  public ByteBuf content() {
+    // TODO: Actually support ByteBufHolder for MessageFormatSend
+    return null;
+  }
+
+  @Override
+  public MessageFormatSend replace(ByteBuf content) {
+    return null;
+  }
 
   private class SendInfo {
     private long relativeOffset;
@@ -270,7 +283,7 @@ public class MessageFormatSend implements Send {
 
   @Override
   public void writeTo(AsyncWritableChannel channel, Callback<Long> callback) {
-      readSet.writeTo(channel, callback);
+    readSet.writeTo(channel, callback);
   }
 
   @Override

--- a/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageMetadata.java
+++ b/ambry-messageformat/src/main/java/com/github/ambry/messageformat/MessageMetadata.java
@@ -15,6 +15,7 @@
 package com.github.ambry.messageformat;
 
 import com.github.ambry.utils.Utils;
+import io.netty.buffer.ByteBuf;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -53,17 +54,18 @@ public class MessageMetadata {
   }
 
   /**
-   * Serialize the MessageMetadata into the given {@link ByteBuffer}
-   * @param outputBuffer the {@link ByteBuffer} to which to write the serialized bytes into.
+   * Serialize the MessageMetadata into the given {@link ByteBuf}
+   * @param outputBuf the {@link ByteBuf} to which to write the serialized bytes into.
    */
-  public void serializeMessageMetadata(ByteBuffer outputBuffer) {
+  public void serializeMessageMetadata(ByteBuf outputBuf) {
     switch (version) {
       case MESSAGE_METADATA_VERSION_V1:
-        outputBuffer.putShort(version);
+        outputBuf.writeShort(version);
         if (encryptionKey != null) {
-          outputBuffer.putInt(encryptionKey.remaining()).put(encryptionKey);
+          outputBuf.writeInt(encryptionKey.remaining());
+          outputBuf.writeBytes(encryptionKey);
         } else {
-          outputBuffer.putInt(0);
+          outputBuf.writeInt(0);
         }
         break;
       default:

--- a/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageMetadataTest.java
+++ b/ambry-messageformat/src/test/java/com/github/ambry/messageformat/MessageMetadataTest.java
@@ -13,8 +13,10 @@
  */
 package com.github.ambry.messageformat;
 
-import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.TestUtils;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.Unpooled;
 import java.io.DataInputStream;
 import java.nio.ByteBuffer;
 import org.junit.Assert;
@@ -30,11 +32,10 @@ public class MessageMetadataTest {
   public void testInstantiationAndSerDe() throws Exception {
     ByteBuffer encryptionKey = ByteBuffer.wrap(TestUtils.getRandomBytes(256));
     MessageMetadata messageMetadata = new MessageMetadata(encryptionKey.duplicate());
-    ByteBuffer serializedBuffer = ByteBuffer.allocate(messageMetadata.sizeInBytes());
-    messageMetadata.serializeMessageMetadata(serializedBuffer);
-    serializedBuffer.flip();
+    ByteBuf serializedBuf = Unpooled.buffer(messageMetadata.sizeInBytes());
+    messageMetadata.serializeMessageMetadata(serializedBuf);
     MessageMetadata deserialized =
-        MessageMetadata.deserializeMessageMetadata(new DataInputStream(new ByteBufferInputStream(serializedBuffer)));
+        MessageMetadata.deserializeMessageMetadata(new DataInputStream(new ByteBufInputStream(serializedBuf)));
     Assert.assertEquals(encryptionKey, deserialized.getEncryptionKey());
   }
 }

--- a/ambry-network/src/main/java/com/github/ambry/network/BlockingChannel.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/BlockingChannel.java
@@ -165,11 +165,15 @@ public class BlockingChannel implements ConnectedChannel {
 
   @Override
   public void send(Send request) throws IOException {
-    if (!connected) {
-      throw new ClosedChannelException();
-    }
-    while (!request.isSendComplete()) {
-      request.writeTo(writeChannel);
+    try {
+      if (!connected) {
+        throw new ClosedChannelException();
+      }
+      while (!request.isSendComplete()) {
+        request.writeTo(writeChannel);
+      }
+    } finally {
+      request.release();
     }
   }
 

--- a/ambry-network/src/main/java/com/github/ambry/network/Selector.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/Selector.java
@@ -782,6 +782,9 @@ public class Selector implements Selectable {
       NetworkSend networkSend = transmission.getNetworkSend();
       if (sendComplete) {
         logger.trace("Finished writing, registering for read on connection {}", transmission.getRemoteSocketAddress());
+        // Release the NetworkSend resource here, not in the SocketNetworkClient, because SocketServer uses Selector
+        // as well, and SocketServer doesn't has a callback to release the resource.
+        networkSend.getPayload().release();
         transmission.onSendComplete();
         metrics.sendInFlight.dec();
         transmission.clearSend();

--- a/ambry-network/src/main/java/com/github/ambry/network/Transmission.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/Transmission.java
@@ -177,9 +177,6 @@ public abstract class Transmission {
   }
 
   protected void release() {
-    if (networkSend != null) {
-      networkSend.getPayload().release();
-    }
     if (networkReceive != null) {
       networkReceive.getReceivedBytes().release();
     }

--- a/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
+++ b/ambry-network/src/main/java/com/github/ambry/network/http2/Http2ClientMetrics.java
@@ -46,6 +46,7 @@ public class Http2ClientMetrics {
   public final Counter http2StreamWriteAndFlushErrorCount;
   public final Counter http2NetworkErrorCount;
   public final Counter http2RequestsToDropCount;
+  public final Counter http2StreamNotWritableCount;
 
   public final Meter http2ClientSendRate;
   public final Meter http2ClientReceiveRate;
@@ -89,7 +90,10 @@ public class Http2ClientMetrics {
     http2StreamWriteAndFlushErrorCount =
         registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2StreamWriteAndFlushErrorCount"));
     http2NetworkErrorCount = registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2NetworkErrorCount"));
-    http2RequestsToDropCount = registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2RequestsToDropCount"));
+    http2RequestsToDropCount =
+        registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2RequestsToDropCount"));
+    http2StreamNotWritableCount =
+        registry.counter(MetricRegistry.name(Http2NetworkClient.class, "Http2StreamNotWritableCount"));
     http2ClientSendRate = registry.meter(MetricRegistry.name(Http2NetworkClient.class, "Http2ClientSendRate"));
     http2ClientReceiveRate = registry.meter(MetricRegistry.name(Http2NetworkClient.class, "Http2ClientReceiveRate"));
 

--- a/ambry-network/src/test/java/com/github/ambry/network/ByteBufferSend.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/ByteBufferSend.java
@@ -13,6 +13,8 @@
  */
 package com.github.ambry.network;
 
+import com.github.ambry.utils.AbstractByteBufHolder;
+import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
@@ -22,10 +24,10 @@ import java.nio.channels.WritableByteChannel;
  * A byte buffer version of Send that sends a materialized byte buffer. This breaks the contract of Send (only
  * materialize onto the network) and so is only suitable for use in tests.
  */
-public class ByteBufferSend implements Send {
+public class ByteBufferSend extends AbstractByteBufHolder<ByteBufferSend> implements Send {
   private final ByteBuffer buffer;
 
-  public ByteBufferSend(ByteBuffer byteBuffer) throws IOException {
+  public ByteBufferSend(ByteBuffer byteBuffer) {
     this.buffer = byteBuffer.duplicate();
   }
 
@@ -42,5 +44,15 @@ public class ByteBufferSend implements Send {
   @Override
   public long sizeInBytes() {
     return buffer.limit();
+  }
+
+  @Override
+  public ByteBuf content() {
+    return null;
+  }
+
+  @Override
+  public ByteBufferSend replace(ByteBuf content) {
+    return null;
   }
 }

--- a/ambry-network/src/test/java/com/github/ambry/network/SocketNetworkClientTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/SocketNetworkClientTest.java
@@ -20,6 +20,7 @@ import com.github.ambry.clustermap.MockDataNodeId;
 import com.github.ambry.clustermap.ReplicaId;
 import com.github.ambry.config.NetworkConfig;
 import com.github.ambry.config.VerifiableProperties;
+import com.github.ambry.utils.AbstractByteBufHolder;
 import com.github.ambry.utils.MockTime;
 import com.github.ambry.utils.NettyByteBufLeakHelper;
 import com.github.ambry.utils.Time;
@@ -654,7 +655,7 @@ public class SocketNetworkClientTest {
  * A mock implementation of the {@link Send} interface that simply stores a correlation id that can be used to
  * identify this request.
  */
-class MockSend implements SendWithCorrelationId {
+class MockSend extends AbstractByteBufHolder<MockSend> implements SendWithCorrelationId {
   private final ByteBuffer buf;
   private final int correlationId;
   private final int size;
@@ -705,6 +706,16 @@ class MockSend implements SendWithCorrelationId {
   @Override
   public String toString() {
     return "MockSend{" + "buf=" + buf + ", correlationId=" + correlationId + ", size=" + size + '}';
+  }
+
+  @Override
+  public ByteBuf content() {
+    return null;
+  }
+
+  @Override
+  public MockSend replace(ByteBuf content) {
+    return null;
   }
 }
 

--- a/ambry-network/src/test/java/com/github/ambry/network/SocketRequestResponseChannelTest.java
+++ b/ambry-network/src/test/java/com/github/ambry/network/SocketRequestResponseChannelTest.java
@@ -13,6 +13,7 @@
  */
 package com.github.ambry.network;
 
+import com.github.ambry.utils.AbstractByteBufHolder;
 import com.github.ambry.utils.NettyByteBufLeakHelper;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -48,7 +49,7 @@ public class SocketRequestResponseChannelTest {
     }
   }
 
-  class MockSend implements Send {
+  class MockSend extends AbstractByteBufHolder<MockSend> implements Send {
     public int sendcall = 1;
 
     @Override
@@ -65,6 +66,16 @@ public class SocketRequestResponseChannelTest {
     @Override
     public long sizeInBytes() {
       return 10;
+    }
+
+    @Override
+    public ByteBuf content() {
+      return null;
+    }
+
+    @Override
+    public MockSend replace(ByteBuf content) {
+      return null;
     }
   }
 

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AdminRequest.java
@@ -71,17 +71,13 @@ public class AdminRequest extends RequestOrResponse {
   }
 
   @Override
-  public long writeTo(WritableByteChannel channel) throws IOException {
-    if (bufferToSend == null) {
-      serializeIntoBuffer();
-      bufferToSend.flip();
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeShort((short) type.ordinal());
+    bufferToSend.writeByte(partitionId == null ? (byte) 0 : 1);
+    if (partitionId != null) {
+      bufferToSend.writeBytes(partitionId.getBytes());
     }
-    return bufferToSend.hasRemaining() ? channel.write(bufferToSend) : 0;
-  }
-
-  @Override
-  public boolean isSendComplete() {
-    return bufferToSend != null && bufferToSend.remaining() == 0;
   }
 
   @Override
@@ -107,19 +103,6 @@ public class AdminRequest extends RequestOrResponse {
   public String toString() {
     return "AdminRequest[ClientId=" + clientId + ", CorrelationId=" + correlationId + ", Type=" + type
         + ", PartitionId=" + partitionId + "]";
-  }
-
-  /**
-   * Serializes the request into bytes and loads into the buffer for sending.
-   */
-  protected void serializeIntoBuffer() {
-    bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
-    writeHeader();
-    bufferToSend.putShort((short) type.ordinal());
-    bufferToSend.put(partitionId == null ? (byte) 0 : 1);
-    if (partitionId != null) {
-      bufferToSend.put(partitionId.getBytes());
-    }
   }
 
   /**

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/AdminResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/AdminResponse.java
@@ -61,43 +61,6 @@ public class AdminResponse extends Response {
     return new AdminResponse(correlationId, clientId, error);
   }
 
-  /**
-   * A private method shared by {@link AdminResponse#writeTo(WritableByteChannel)} and
-   * {@link AdminResponse#writeTo(AsyncWritableChannel, Callback)}.
-   * This method allocate bufferToSend and write headers to it if bufferToSend is null.
-   */
-  private void prepareBufferToSend() {
-    if (bufferToSend == null) {
-      serializeIntoBuffer();
-      bufferToSend.flip();
-    }
-  }
-
-  @Override
-  public long writeTo(WritableByteChannel channel) throws IOException {
-    prepareBufferToSend();
-    return bufferToSend.hasRemaining() ? channel.write(bufferToSend) : 0;
-  }
-
-  @Override
-  public void writeTo(AsyncWritableChannel channel, Callback<Long> callback) {
-    prepareBufferToSend();
-    channel.write(bufferToSend, callback);
-  }
-
-  @Override
-  public boolean isSendComplete() {
-    return bufferToSend != null && bufferToSend.remaining() == 0;
-  }
-
-  /**
-   * Serializes the response into bytes and loads into the buffer for sending.
-   */
-  protected void serializeIntoBuffer() {
-    bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
-    writeHeader();
-  }
-
   @Override
   public String toString() {
     return "AdminResponse[ClientId=" + clientId + ", CorrelationId=" + correlationId + ", Type=" + type

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/BlobStoreControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/BlobStoreControlAdminRequest.java
@@ -85,10 +85,10 @@ public class BlobStoreControlAdminRequest extends AdminRequest {
   }
 
   @Override
-  protected void serializeIntoBuffer() {
-    super.serializeIntoBuffer();
-    bufferToSend.putShort(VERSION_V1);
-    bufferToSend.putShort(numReplicasCaughtUpPerPartition);
-    bufferToSend.put((byte) storeControlAction.ordinal());
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeShort(VERSION_V1);
+    bufferToSend.writeShort(numReplicasCaughtUpPerPartition);
+    bufferToSend.writeByte((byte) storeControlAction.ordinal());
   }
 }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/CatchupStatusAdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/CatchupStatusAdminRequest.java
@@ -98,10 +98,10 @@ public class CatchupStatusAdminRequest extends AdminRequest {
   }
 
   @Override
-  protected void serializeIntoBuffer() {
-    super.serializeIntoBuffer();
-    bufferToSend.putShort(VERSION_V2);
-    bufferToSend.putLong(acceptableLagInBytes);
-    bufferToSend.putShort(numReplicasCaughtUpPerPartition);
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeShort(VERSION_V2);
+    bufferToSend.writeLong(acceptableLagInBytes);
+    bufferToSend.writeShort(numReplicasCaughtUpPerPartition);
   }
 }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/CatchupStatusAdminResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/CatchupStatusAdminResponse.java
@@ -72,9 +72,9 @@ public class CatchupStatusAdminResponse extends AdminResponse {
   }
 
   @Override
-  protected void serializeIntoBuffer() {
-    super.serializeIntoBuffer();
-    bufferToSend.putShort(VERSION_V1);
-    bufferToSend.put(isCaughtUp ? (byte) 1 : 0);
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeShort(VERSION_V1);
+    bufferToSend.writeByte(isCaughtUp ? (byte) 1 : 0);
   }
 }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/CompositeSend.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/CompositeSend.java
@@ -16,6 +16,8 @@ package com.github.ambry.protocol;
 import com.github.ambry.network.Send;
 import com.github.ambry.router.AsyncWritableChannel;
 import com.github.ambry.router.Callback;
+import com.github.ambry.utils.AbstractByteBufHolder;
+import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
@@ -24,7 +26,7 @@ import java.util.List;
 /**
  * Holds multiple Send instances and sends them over the network
  */
-public class CompositeSend implements Send {
+public class CompositeSend extends AbstractByteBufHolder<CompositeSend> implements Send {
 
   private final List<Send> compositeSendList;
   private long totalSizeToWrite;
@@ -76,5 +78,16 @@ public class CompositeSend implements Send {
   @Override
   public long sizeInBytes() {
     return totalSizeToWrite;
+  }
+
+  @Override
+  public ByteBuf content() {
+    // TODO: Actually support ByteBufHolder for CompositeSend
+    return null;
+  }
+
+  @Override
+  public CompositeSend replace(ByteBuf content) {
+    return null;
   }
 }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/PartitionRequestInfo.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/PartitionRequestInfo.java
@@ -17,6 +17,7 @@ import com.github.ambry.clustermap.ClusterMap;
 import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.commons.BlobId;
 import com.github.ambry.store.StoreKey;
+import io.netty.buffer.ByteBuf;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -75,6 +76,13 @@ public class PartitionRequestInfo {
     byteBuffer.putInt(blobIds.size());
     for (BlobId blobId : blobIds) {
       byteBuffer.put(blobId.toBytes());
+    }
+  }
+
+  public void writeTo(ByteBuf byteBuf) {
+    byteBuf.writeInt(blobIds.size());
+    for (BlobId blobId : blobIds) {
+      byteBuf.writeBytes(blobId.toBytes());
     }
   }
 

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/PartitionResponseInfo.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/PartitionResponseInfo.java
@@ -18,6 +18,7 @@ import com.github.ambry.clustermap.PartitionId;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.messageformat.MessageMetadata;
 import com.github.ambry.store.MessageInfo;
+import io.netty.buffer.ByteBuf;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -87,10 +88,10 @@ public class PartitionResponseInfo {
     }
   }
 
-  public void writeTo(ByteBuffer byteBuffer) {
-    byteBuffer.put(partitionId.getBytes());
-    messageInfoAndMetadataListSerde.serializeMessageInfoAndMetadataList(byteBuffer);
-    byteBuffer.putShort((short) errorCode.ordinal());
+  public void writeTo(ByteBuf byteBuf) {
+    byteBuf.writeBytes(partitionId.getBytes());
+    messageInfoAndMetadataListSerde.serializeMessageInfoAndMetadataList(byteBuf);
+    byteBuf.writeShort((short) errorCode.ordinal());
   }
 
   public long sizeInBytes() {

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataRequest.java
@@ -82,23 +82,13 @@ public class ReplicaMetadataRequest extends RequestOrResponse {
   }
 
   @Override
-  public long writeTo(WritableByteChannel channel) throws IOException {
-    if (bufferToSend == null) {
-      bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
-      writeHeader();
-      bufferToSend.putInt(replicaMetadataRequestInfoList.size());
-      for (ReplicaMetadataRequestInfo replicaMetadataRequestInfo : replicaMetadataRequestInfoList) {
-        replicaMetadataRequestInfo.writeTo(bufferToSend);
-      }
-      bufferToSend.putLong(maxTotalSizeOfEntriesInBytes);
-      bufferToSend.flip();
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeInt(replicaMetadataRequestInfoList.size());
+    for (ReplicaMetadataRequestInfo replicaMetadataRequestInfo : replicaMetadataRequestInfoList) {
+      replicaMetadataRequestInfo.writeTo(bufferToSend);
     }
-    return bufferToSend.remaining() > 0 ? channel.write(bufferToSend) : 0;
-  }
-
-  @Override
-  public boolean isSendComplete() {
-    return bufferToSend != null && bufferToSend.remaining() == 0;
+    bufferToSend.writeLong(maxTotalSizeOfEntriesInBytes);
   }
 
   @Override

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataRequestInfo.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataRequestInfo.java
@@ -20,6 +20,7 @@ import com.github.ambry.replication.FindToken;
 import com.github.ambry.replication.FindTokenFactory;
 import com.github.ambry.replication.FindTokenHelper;
 import com.github.ambry.utils.Utils;
+import io.netty.buffer.ByteBuf;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -77,14 +78,14 @@ public class ReplicaMetadataRequestInfo {
     return new ReplicaMetadataRequestInfo(partitionId, token, hostName, replicaPath, replicaType, requestVersion);
   }
 
-  public void writeTo(ByteBuffer buffer) {
-    Utils.serializeString(buffer, hostName, Charset.defaultCharset());
-    Utils.serializeString(buffer, replicaPath, Charset.defaultCharset());
+  public void writeTo(ByteBuf buf) {
+    Utils.serializeString(buf, hostName, Charset.defaultCharset());
+    Utils.serializeString(buf, replicaPath, Charset.defaultCharset());
     if (requestVersion == ReplicaMetadataRequest.Replica_Metadata_Request_Version_V2) {
-      buffer.putShort((short) replicaType.ordinal());
+      buf.writeShort((short) replicaType.ordinal());
     }
-    buffer.put(partitionId.getBytes());
-    buffer.put(token.toBytes());
+    buf.writeBytes(partitionId.getBytes());
+    buf.writeBytes(token.toBytes());
   }
 
   public long sizeInBytes() {

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataResponse.java
@@ -91,26 +91,16 @@ public class ReplicaMetadataResponse extends Response {
   }
 
   @Override
-  public long writeTo(WritableByteChannel channel) throws IOException {
-    if (bufferToSend == null) {
-      bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
-      writeHeader();
-      if (replicaMetadataResponseInfoList != null) {
-        bufferToSend.putInt(replicaMetadataResponseInfoList.size());
-        for (ReplicaMetadataResponseInfo replicaMetadataResponseInfo : replicaMetadataResponseInfoList) {
-          replicaMetadataResponseInfo.writeTo(bufferToSend);
-        }
-      } else {
-        bufferToSend.putInt(0);
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    if (replicaMetadataResponseInfoList != null) {
+      bufferToSend.writeInt(replicaMetadataResponseInfoList.size());
+      for (ReplicaMetadataResponseInfo replicaMetadataResponseInfo : replicaMetadataResponseInfoList) {
+        replicaMetadataResponseInfo.writeTo(bufferToSend);
       }
-      bufferToSend.flip();
+    } else {
+      bufferToSend.writeInt(0);
     }
-    return bufferToSend.remaining() > 0 ? channel.write(bufferToSend) : 0;
-  }
-
-  @Override
-  public boolean isSendComplete() {
-    return bufferToSend != null && bufferToSend.remaining() == 0;
   }
 
   @Override

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataResponseInfo.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicaMetadataResponseInfo.java
@@ -21,6 +21,7 @@ import com.github.ambry.replication.FindTokenFactory;
 import com.github.ambry.replication.FindTokenHelper;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.store.MessageInfo;
+import io.netty.buffer.ByteBuf;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -125,16 +126,16 @@ public class ReplicaMetadataResponseInfo {
     }
   }
 
-  public void writeTo(ByteBuffer buffer) {
-    buffer.put(partitionId.getBytes());
+  public void writeTo(ByteBuf buf) {
+    buf.writeBytes(partitionId.getBytes());
     if (responseVersion == ReplicaMetadataResponse.REPLICA_METADATA_RESPONSE_VERSION_V_6) {
-      buffer.putShort((short) replicaType.ordinal());
+      buf.writeShort((short) replicaType.ordinal());
     }
-    buffer.putShort((short) errorCode.ordinal());
+    buf.writeShort((short) errorCode.ordinal());
     if (errorCode == ServerErrorCode.No_Error) {
-      buffer.put(token.toBytes());
-      messageInfoAndMetadataListSerde.serializeMessageInfoAndMetadataList(buffer);
-      buffer.putLong(remoteReplicaLagInBytes);
+      buf.writeBytes(token.toBytes());
+      messageInfoAndMetadataListSerde.serializeMessageInfoAndMetadataList(buf);
+      buf.writeLong(remoteReplicaLagInBytes);
     }
   }
 

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicationControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/ReplicationControlAdminRequest.java
@@ -96,14 +96,14 @@ public class ReplicationControlAdminRequest extends AdminRequest {
   }
 
   @Override
-  protected void serializeIntoBuffer() {
-    super.serializeIntoBuffer();
-    bufferToSend.putShort(VERSION_V1);
-    bufferToSend.putInt(origins.size());
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeShort(VERSION_V1);
+    bufferToSend.writeInt(origins.size());
     for (String origin : origins) {
       Utils.serializeString(bufferToSend, origin, StandardCharsets.UTF_8);
     }
-    bufferToSend.put(enable ? (byte) 1 : 0);
+    bufferToSend.writeByte(enable ? (byte) 1 : 0);
   }
 
   private long computeSizeInBytes() {

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestControlAdminRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/RequestControlAdminRequest.java
@@ -87,10 +87,10 @@ public class RequestControlAdminRequest extends AdminRequest {
   }
 
   @Override
-  protected void serializeIntoBuffer() {
-    super.serializeIntoBuffer();
-    bufferToSend.putShort(VERSION_V1);
-    bufferToSend.putShort((short) requestTypeToControl.ordinal());
-    bufferToSend.put(enable ? (byte) 1 : 0);
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeShort(VERSION_V1);
+    bufferToSend.writeShort((short) requestTypeToControl.ordinal());
+    bufferToSend.writeByte(enable ? (byte) 1 : 0);
   }
 }

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/Response.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/Response.java
@@ -13,13 +13,7 @@
  */
 package com.github.ambry.protocol;
 
-import com.github.ambry.router.AsyncWritableChannel;
-import com.github.ambry.router.Callback;
 import com.github.ambry.server.ServerErrorCode;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
-
 
 /**
  * Response for deserialization.
@@ -41,33 +35,9 @@ public abstract class Response extends RequestOrResponse {
   @Override
   protected void writeHeader() {
     super.writeHeader();
-    bufferToSend.putShort((short) error.ordinal());
+    bufferToSend.writeShort((short) error.ordinal());
   }
 
-  private void prepareBuffer() {
-    if (bufferToSend == null) {
-      bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
-      writeHeader();
-      bufferToSend.flip();
-    }
-  }
-
-  @Override
-  public long writeTo(WritableByteChannel channel) throws IOException {
-    prepareBuffer();
-    return bufferToSend.remaining() > 0 ? channel.write(bufferToSend) : 0;
-  }
-
-  @Override
-  public void writeTo(AsyncWritableChannel channel, Callback<Long> callback) {
-    prepareBuffer();
-    channel.write(bufferToSend, callback);
-  }
-
-  @Override
-  public boolean isSendComplete() {
-    return (bufferToSend == null || bufferToSend.remaining() == 0);
-  }
 
   @Override
   public long sizeInBytes() {

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/TtlUpdateRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/TtlUpdateRequest.java
@@ -36,8 +36,6 @@ public class TtlUpdateRequest extends RequestOrResponse {
   private final long expiresAtMs;
   private final long operationTimeInMs;
 
-  private int sizeSent;
-
   /**
    * Helper to construct TtlUpdateRequest from a stream
    * @param stream the stream to read data from
@@ -80,30 +78,14 @@ public class TtlUpdateRequest extends RequestOrResponse {
     this.blobId = blobId;
     this.expiresAtMs = expiresAtMs;
     this.operationTimeInMs = operationTimeMs;
-    sizeSent = 0;
   }
 
   @Override
-  public long writeTo(WritableByteChannel channel) throws IOException {
-    long written = 0;
-    if (bufferToSend == null) {
-      bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
-      writeHeader();
-      bufferToSend.put(blobId.toBytes());
-      bufferToSend.putLong(expiresAtMs);
-      bufferToSend.putLong(operationTimeInMs);
-      bufferToSend.flip();
-    }
-    if (bufferToSend.remaining() > 0) {
-      written = channel.write(bufferToSend);
-      sizeSent += written;
-    }
-    return written;
-  }
-
-  @Override
-  public boolean isSendComplete() {
-    return sizeSent == sizeInBytes();
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeBytes(blobId.toBytes());
+    bufferToSend.writeLong(expiresAtMs);
+    bufferToSend.writeLong(operationTimeInMs);
   }
 
   /**

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/UndeleteRequest.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/UndeleteRequest.java
@@ -29,7 +29,6 @@ public class UndeleteRequest extends RequestOrResponse {
   static final short UNDELETE_REQUEST_VERSION_1 = 1;
   private final static short CURRENT_VERSION = UNDELETE_REQUEST_VERSION_1;
 
-  private int sizeSent = 0;
   private final BlobId blobId;
   private final long operationTimeMs;
 
@@ -56,7 +55,6 @@ public class UndeleteRequest extends RequestOrResponse {
     super(RequestOrResponseType.UndeleteRequest, version, correlationId, clientId);
     this.blobId = blobId;
     this.operationTimeMs = operationTimeMs;
-    sizeSent = 0;
   }
 
   public static UndeleteRequest readFrom(DataInputStream stream, ClusterMap map) throws IOException {
@@ -72,25 +70,10 @@ public class UndeleteRequest extends RequestOrResponse {
   }
 
   @Override
-  public long writeTo(WritableByteChannel channel) throws IOException {
-    long written = 0;
-    if (bufferToSend == null) {
-      bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
-      writeHeader();
-      bufferToSend.put(blobId.toBytes());
-      bufferToSend.putLong(operationTimeMs);
-      bufferToSend.flip();
-    }
-    if (bufferToSend.remaining() > 0) {
-      written = channel.write(bufferToSend);
-      sizeSent += written;
-    }
-    return written;
-  }
-
-  @Override
-  public boolean isSendComplete() {
-    return sizeSent == sizeInBytes();
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeBytes(blobId.toBytes());
+    bufferToSend.writeLong(operationTimeMs);
   }
 
   @Override

--- a/ambry-protocol/src/main/java/com/github/ambry/protocol/UndeleteResponse.java
+++ b/ambry-protocol/src/main/java/com/github/ambry/protocol/UndeleteResponse.java
@@ -13,14 +13,10 @@
  */
 package com.github.ambry.protocol;
 
-import com.github.ambry.router.AsyncWritableChannel;
-import com.github.ambry.router.Callback;
 import com.github.ambry.server.ServerErrorCode;
 import com.github.ambry.utils.Utils;
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
 
 
 /**
@@ -90,29 +86,10 @@ public class UndeleteResponse extends Response {
     return new UndeleteResponse(correlationId, clientId, lifeVersion, error);
   }
 
-  private void prepareBuffer() {
-    if (bufferToSend == null) {
-      bufferToSend = ByteBuffer.allocate((int) sizeInBytes());
-      writeHeader();
-      bufferToSend.putShort(lifeVersion);
-      bufferToSend.flip();
-    }
-  }
-
   @Override
-  public long writeTo(WritableByteChannel channel) throws IOException {
-    long written = 0;
-    prepareBuffer();
-    if (bufferToSend.remaining() > 0) {
-      written = channel.write(bufferToSend);
-    }
-    return written;
-  }
-
-  @Override
-  public void writeTo(AsyncWritableChannel channel, Callback<Long> callback) {
-    prepareBuffer();
-    channel.write(bufferToSend, callback);
+  protected void prepareBuffer() {
+    super.prepareBuffer();
+    bufferToSend.writeShort(lifeVersion);
   }
 
   @Override

--- a/ambry-protocol/src/test/java/com/github/ambry/protocol/CompositeSendTest.java
+++ b/ambry-protocol/src/test/java/com/github/ambry/protocol/CompositeSendTest.java
@@ -14,7 +14,9 @@
 package com.github.ambry.protocol;
 
 import com.github.ambry.network.Send;
+import com.github.ambry.utils.AbstractByteBufHolder;
 import com.github.ambry.utils.ByteBufferOutputStream;
+import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
@@ -22,11 +24,12 @@ import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import org.apache.commons.math3.analysis.function.Abs;
 import org.junit.Assert;
 import org.junit.Test;
 
 
-class ByteArraySend implements Send {
+class ByteArraySend extends AbstractByteBufHolder<ByteArraySend> implements Send {
 
   private ByteBuffer bytesToSend;
 
@@ -47,6 +50,16 @@ class ByteArraySend implements Send {
   @Override
   public long sizeInBytes() {
     return bytesToSend.capacity();
+  }
+
+  @Override
+  public ByteBuf content() {
+    return null;
+  }
+
+  @Override
+  public ByteArraySend replace(ByteBuf content) {
+    return null;
   }
 }
 

--- a/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/MockConnectionPool.java
@@ -35,8 +35,10 @@ import com.github.ambry.protocol.ReplicaMetadataResponseInfo;
 import com.github.ambry.protocol.Response;
 import com.github.ambry.store.MessageInfo;
 import com.github.ambry.store.StoreKey;
+import com.github.ambry.utils.AbstractByteBufHolder;
 import com.github.ambry.utils.ByteBufferInputStream;
 import com.github.ambry.utils.ByteBufferOutputStream;
+import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
@@ -95,7 +97,7 @@ public class MockConnectionPool implements ConnectionPool {
    */
   public static class MockConnection implements ConnectedChannel {
 
-    class MockSend implements Send {
+    class MockSend extends AbstractByteBufHolder<MockSend> implements Send {
 
       private final List<ByteBuffer> buffers;
       private final int size;
@@ -129,6 +131,16 @@ public class MockConnectionPool implements ConnectionPool {
       @Override
       public long sizeInBytes() {
         return size;
+      }
+
+      @Override
+      public ByteBuf content() {
+        return null;
+      }
+
+      @Override
+      public MockSend replace(ByteBuf content) {
+        return null;
       }
     }
 

--- a/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/GetBlobOperationTest.java
@@ -292,6 +292,7 @@ public class GetBlobOperationTest {
               blobEncryptionKey == null ? null : blobEncryptionKey.duplicate());
       // Make sure we release the BoundedNettyByteBufReceive.
       server.send(request).release();
+      request.release();
     }
     blobContent.release();
   }
@@ -1687,10 +1688,12 @@ public class GetBlobOperationTest {
         new GetRequest(1, "assertBlobReadSuccess", MessageFormatFlags.All, Collections.singletonList(requestInfo),
             GetOption.None);
     GetResponse getResponse = server.makeGetResponse(getRequest, ServerErrorCode.No_Error);
+    getRequest.release();
 
     // simulating server sending response over the wire
     ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate((int) getResponse.sizeInBytes()));
     getResponse.writeTo(channel);
+    getResponse.release();
 
     // simulating the Router receiving the data from the wire
     ByteBuffer data = channel.getBuffer();

--- a/ambry-router/src/test/java/com/github/ambry/router/MockServer.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/MockServer.java
@@ -119,6 +119,7 @@ class MockServer {
     }
     ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate((int) response.sizeInBytes()));
     response.writeTo(channel);
+    response.release();
     ByteBuffer payload = channel.getBuffer();
     payload.flip();
     BoundedNettyByteBufReceive receive = new BoundedNettyByteBufReceive();

--- a/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/NonBlockingRouterTest.java
@@ -1311,10 +1311,12 @@ public class NonBlockingRouterTest {
     BlobId id = new BlobId(blobId, mockClusterMap);
     for (MockServer server : serverLayout.getMockServers()) {
       if (!server.getBlobs().containsKey(blobId)) {
-        server.send(
+        PutRequest putRequest =
             new PutRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname, id,
                 putBlobProperties, ByteBuffer.wrap(putUserMetadata), Unpooled.wrappedBuffer(putContent),
-                putContent.length, BlobType.DataBlob, null)).release();
+                putContent.length, BlobType.DataBlob, null);
+        server.send(putRequest).release();
+        putRequest.release();
       }
     }
   }
@@ -1348,10 +1350,12 @@ public class NonBlockingRouterTest {
     BlobId id = new BlobId(blobId, mockClusterMap);
     for (MockServer server : serverLayout.getMockServers()) {
       if (!server.getBlobs().containsKey(blobId)) {
-        server.send(
+        PutRequest putRequest =
             new PutRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname, id,
                 putBlobProperties, ByteBuffer.wrap(putUserMetadata), Unpooled.wrappedBuffer(serializedContent),
-                serializedContent.remaining(), BlobType.MetadataBlob, null)).release();
+                serializedContent.remaining(), BlobType.MetadataBlob, null);
+        server.send(putRequest).release();
+        putRequest.release();
       }
     }
   }
@@ -1366,9 +1370,11 @@ public class NonBlockingRouterTest {
     BlobId id = new BlobId(blobId, mockClusterMap);
     for (MockServer server : serverLayout.getMockServers()) {
       if (!server.getBlobs().get(blobId).isDeleted()) {
-        server.send(
+        DeleteRequest deleteRequest =
             new DeleteRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
-                id, mockTime.milliseconds())).release();
+                id, mockTime.milliseconds());
+        server.send(deleteRequest).release();
+        deleteRequest.release();
       }
     }
   }
@@ -1383,9 +1389,11 @@ public class NonBlockingRouterTest {
     BlobId id = new BlobId(blobId, mockClusterMap);
     for (MockServer server : serverLayout.getMockServers()) {
       if (!server.getBlobs().get(blobId).isUndeleted()) {
-        server.send(
+        UndeleteRequest undeleteRequest =
             new UndeleteRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
-                id, mockTime.milliseconds())).release();
+                id, mockTime.milliseconds());
+        server.send(undeleteRequest).release();
+        undeleteRequest.release();
       }
     }
   }

--- a/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
+++ b/ambry-router/src/test/java/com/github/ambry/router/UndeleteManagerTest.java
@@ -364,9 +364,11 @@ public class UndeleteManagerTest {
     BlobId id = new BlobId(blobId, clusterMap);
     for (MockServer server : serverLayout.getMockServers()) {
       if (!server.getBlobs().get(blobId).isDeleted()) {
-        server.send(
+        DeleteRequest deleteRequest =
             new DeleteRequest(NonBlockingRouter.correlationIdGenerator.incrementAndGet(), routerConfig.routerHostname,
-                id, time.milliseconds())).release();
+                id, time.milliseconds());
+        server.send(deleteRequest).release();
+        deleteRequest.release();
       }
     }
   }

--- a/ambry-server/src/integration-test/java/com/github/ambry/server/Verifier.java
+++ b/ambry-server/src/integration-test/java/com/github/ambry/server/Verifier.java
@@ -254,11 +254,14 @@ class Verifier implements Runnable {
               if (payload.blobProperties.getTimeToLiveInSeconds() != Utils.Infinite_Time) {
                 // ttl update, check and wait for replication
                 ServerTestUtil.updateBlobTtl(channel1, new BlobId(payload.blobId, clusterMap), time.milliseconds());
-                ServerTestUtil.checkTtlUpdateStatus(channel1, clusterMap, new BlobIdFactory(clusterMap), blobId, payload.blob, true, Utils.Infinite_Time);
+                ServerTestUtil.checkTtlUpdateStatus(channel1, clusterMap, new BlobIdFactory(clusterMap), blobId,
+                    payload.blob, true, Utils.Infinite_Time);
                 notificationSystem.awaitBlobUpdates(payload.blobId, UpdateType.TTL_UPDATE);
                 BlobProperties old = payload.blobProperties;
-                payload.blobProperties = new BlobProperties(old.getBlobSize(), old.getServiceId(), old.getOwnerId(), old.getContentType(),
-                    old.isEncrypted(), Utils.Infinite_Time, old.getCreationTimeInMs(), old.getAccountId(), old.getContainerId(), old.isEncrypted(), old.getExternalAssetTag());
+                payload.blobProperties =
+                    new BlobProperties(old.getBlobSize(), old.getServiceId(), old.getOwnerId(), old.getContentType(),
+                        old.isEncrypted(), Utils.Infinite_Time, old.getCreationTimeInMs(), old.getAccountId(),
+                        old.getContainerId(), old.isEncrypted(), old.getExternalAssetTag());
               }
             } catch (Exception e) {
               if (channel1 != null) {

--- a/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
+++ b/ambry-utils/src/main/java/com/github/ambry/utils/Utils.java
@@ -695,6 +695,19 @@ public class Utils {
   }
 
   /**
+   * Serializes a nullable string into {@link ByteBuf} using the default charset.
+   *
+   * @param outputBuf The output buffer to serialize the value to
+   * @param value The value to serialize
+   */
+  public static void serializeNullableString(ByteBuf outputBuf, String value) {
+    if (value == null) {
+      outputBuf.writeInt(0);
+    } else {
+      serializeString(outputBuf, value, Charset.defaultCharset());
+    }
+  }
+  /**
    * Serializes a string into byte buffer
    * @param outputBuffer The output buffer to serialize the value to
    * @param value The value to serialize
@@ -706,6 +719,17 @@ public class Utils {
     outputBuffer.put(valueArray);
   }
 
+  /**
+   * Serializes a string into {@link ByteBuf}
+   * @param outputBuf The output {@link ByteBuf} to serialize the value to
+   * @param value The value to serialize
+   * @param charset {@link Charset} to be used to encode
+   */
+  public static void serializeString(ByteBuf outputBuf, String value, Charset charset) {
+    byte[] valueArray = value.getBytes(charset);
+    outputBuf.writeInt(valueArray.length);
+    outputBuf.writeBytes(valueArray);
+  }
   /**
    * Deserializes a string from byte buffer
    * @param inputBuffer The input buffer to deserialize the value from


### PR DESCRIPTION
Starting use netty ByteBuf to replace java.nio.ByteBuffer in the network layer.
There are some issues with GetResponse, since it supports non-prefetched data from disk. Something need to be done in order to actually support ByteBufHolder for GetResponse.

After this PR, Request and Response would have a method "content", if the returned value from method content is not null, then caller can use the returned ByteBuf as serialized bytes for the request and response.