### PR TITLE
Fix NPE issue when starting a stopped replica after server reboot

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
+++ b/ambry-api/src/main/java/com/github/ambry/clustermap/ClusterParticipant.java
@@ -110,6 +110,15 @@ public interface ClusterParticipant extends AutoCloseable {
   }
 
   /**
+   * Reset given partition to initial state.
+   * @param partitionName the partition to reset.
+   * @return whether reset operation succeeded or not.
+   */
+  default boolean resetPartitionState(String partitionName) {
+    return true;
+  }
+
+  /**
    * @return a map of registered state change listeners (if there are any) in this cluster participant.
    */
   Map<StateModelListenerType, PartitionStateChangeListener> getPartitionStateChangeListeners();

--- a/ambry-api/src/main/java/com/github/ambry/messageformat/BlobProperties.java
+++ b/ambry-api/src/main/java/com/github/ambry/messageformat/BlobProperties.java
@@ -50,6 +50,20 @@ public class BlobProperties {
   /**
    * @param blobSize The size of the blob in bytes
    * @param serviceId The service id that is creating this blob
+   * @param accountId accountId of the user who owns the blob
+   * @param containerId containerId of the blob
+   * @param isEncrypted {@code true} if the blob is encrypted, {@code false} otherwise
+   * @param creationTimeInMs The time at which the blob is created.
+   */
+  public BlobProperties(long blobSize, String serviceId, short accountId, short containerId, boolean isEncrypted,
+      long creationTimeInMs) {
+    this(blobSize, serviceId, null, null, false, Utils.Infinite_Time, creationTimeInMs, accountId, containerId,
+        isEncrypted, null);
+  }
+
+  /**
+   * @param blobSize The size of the blob in bytes
+   * @param serviceId The service id that is creating this blob
    * @param ownerId The owner of the blob (For example , memberId or groupId)
    * @param contentType The content type of the blob (eg: mime). Can be Null
    * @param isPrivate Is the blob secure

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -279,6 +279,19 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     }
   }
 
+  @Override
+  public boolean resetPartitionState(String partitionName) {
+    boolean result = true;
+    try {
+      String resourceName = getResourceNameOfPartition(helixAdmin, clusterName, partitionName);
+      helixAdmin.resetPartition(clusterName, instanceName, resourceName, Collections.singletonList(partitionName));
+    } catch (Exception e) {
+      logger.error("Exception occurred when resetting partition " + partitionName, e);
+      result = false;
+    }
+    return result;
+  }
+
   /**
    * @return {@link HelixAdmin} that manages current data node.
    */

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/MockHelixParticipant.java
@@ -31,8 +31,10 @@ import static org.mockito.Mockito.*;
 public class MockHelixParticipant extends HelixParticipant {
   public static MetricRegistry metricRegistry = new MetricRegistry();
   public Boolean updateNodeInfoReturnVal = null;
+  public Boolean setStoppedStateReturnVal = null;
   public PartitionStateChangeListener mockStatsManagerListener = null;
   public boolean overrideDisableReplicaMethod = true;
+  public boolean resetPartitionVal = true;
   CountDownLatch listenerLatch = null;
   ReplicaState replicaState = ReplicaState.OFFLINE;
   ReplicaId currentReplica = null;
@@ -104,6 +106,9 @@ public class MockHelixParticipant extends HelixParticipant {
 
   @Override
   public boolean setReplicaStoppedState(List<ReplicaId> replicaIds, boolean markStop) {
+    if (setStoppedStateReturnVal != null) {
+      return setStoppedStateReturnVal;
+    }
     if (markStop) {
       stoppedReplicas.addAll(replicaIds);
     } else {
@@ -123,6 +128,11 @@ public class MockHelixParticipant extends HelixParticipant {
     } else {
       super.setReplicaDisabledState(replicaId, disable);
     }
+  }
+
+  @Override
+  public boolean resetPartitionState(String partitionName) {
+    return resetPartitionVal;
   }
 
   @Override

--- a/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
+++ b/ambry-replication/src/main/java/com/github/ambry/replication/ReplicationManager.java
@@ -162,7 +162,7 @@ public class ReplicationManager extends ReplicationEngine {
    */
   public boolean addReplica(ReplicaId replicaId) {
     if (partitionToPartitionInfo.containsKey(replicaId.getPartitionId())) {
-      logger.error("Partition {} already exists in replication manager, rejecting adding replica request.",
+      logger.warn("Partition {} already exists in replication manager, rejecting adding replica request.",
           replicaId.getPartitionId());
       return false;
     }

--- a/ambry-replication/src/test/java/com/github/ambry/replication/LeaderBasedReplicationTest.java
+++ b/ambry-replication/src/test/java/com/github/ambry/replication/LeaderBasedReplicationTest.java
@@ -173,8 +173,8 @@ public class LeaderBasedReplicationTest extends ReplicationTestHelper {
         ReplicaId peerLeaderReplica = peerLeaderReplicasInClusterMap.iterator().next();
         ReplicaId peerStandByReplica = existingPartition.getReplicaIdsByState(ReplicaState.STANDBY,
             peerLeaderReplica.getDataNodeId().getDatacenterName()).get(0);
-        existingPartition.setReplicaIdToState(peerLeaderReplica, ReplicaState.STANDBY);
-        existingPartition.setReplicaIdToState(peerStandByReplica, ReplicaState.LEADER);
+        existingPartition.setReplicaState(peerLeaderReplica, ReplicaState.STANDBY);
+        existingPartition.setReplicaState(peerStandByReplica, ReplicaState.LEADER);
 
         //Trigger routing table change callback to replication manager
         ClusterMapChangeListener clusterMapChangeListener = clusterMap.getClusterMapChangeListener();

--- a/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
+++ b/ambry-server/src/main/java/com/github/ambry/server/AmbryServer.java
@@ -255,7 +255,7 @@ public class AmbryServer {
       FindTokenHelper findTokenHelper = new FindTokenHelper(storeKeyFactory, replicationConfig);
       requests = new AmbryServerRequests(storageManager, networkServer.getRequestResponseChannel(), clusterMap, nodeId,
           registry, metrics, findTokenHelper, notificationSystem, replicationManager, storeKeyFactory, serverConfig,
-          storeKeyConverterFactory, statsManager);
+          storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
       requestHandlerPool = new RequestHandlerPool(serverConfig.serverRequestHandlerNumOfThreads,
           networkServer.getRequestResponseChannel(), requests);
       networkServer.start();
@@ -274,7 +274,7 @@ public class AmbryServer {
         AmbryServerRequests ambryServerRequestsForHttp2 =
             new AmbryServerRequests(storageManager, requestResponseChannel, clusterMap, nodeId, registry, metrics,
                 findTokenHelper, notificationSystem, replicationManager, storeKeyFactory, serverConfig,
-                storeKeyConverterFactory, statsManager);
+                storeKeyConverterFactory, statsManager, clusterParticipants.get(0));
         requestHandlerPoolForHttp2 =
             new RequestHandlerPool(serverConfig.serverRequestHandlerNumOfThreads, requestResponseChannel,
                 ambryServerRequestsForHttp2);

--- a/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
+++ b/ambry-test-utils/src/main/java/com/github/ambry/clustermap/MockPartitionId.java
@@ -103,20 +103,6 @@ public class MockPartitionId implements PartitionId {
         .collect(Collectors.toList());
   }
 
-  /**
-   * Update state for a replica belonging to this partition.
-   * @param replicaId {@link ReplicaId} of one of the replicas on this partition.
-   * @param replicaState {@link ReplicaState} to be set on the passed replica
-   */
-  public void setReplicaIdToState(ReplicaId replicaId, ReplicaState replicaState) {
-    for (ReplicaId replicaId1 : replicaIds) {
-      if (replicaId1.equals(replicaId)) {
-        replicaAndState.put(replicaId1, replicaState);
-        break;
-      }
-    }
-  }
-
   @Override
   public PartitionState getPartitionState() {
     return partitionState;


### PR DESCRIPTION
There is an edge case where we successfully stop a replica and shut down the node
for some reason (i.e. deployment). After node is restarted, the stopped replica is
not able to start as storage manager checks its existence on stopped list. Replication
manager therefore doesn't create RemoteReplicaInfo for this replica. This brings an
issue that when we restart store because remote replica will send metadata request and
there is not corresponding RemoteReplicaInfo in ReplicationManager, which causes NullPointerException.
This PR ensures replica is added to ReplicationManager (if not present) when starting
the store. Also, it resets the partition state to OFFLINE to bring replica out of ERROR
state (note that the replica was put into ERROR state during server startup).