### PR TITLE
Avoid concurrent modification on InstanceConfig when disabling partitions

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -280,6 +280,14 @@ public class ClusterMapConfig {
   @Default("false")
   public final boolean clustermapEnableContainerDeletionAggregation;
 
+  /**
+   * Time to wait before checking if disabling partition has completed. This is only used when Helix is adopted and
+   * datanode tries to remove certain replica entry from InstanceConfig.
+   * TODO remove this config after migrating ambry to PropertyStore (in Helix).
+   */
+  @Config("clustermap.retry.disable.partition.completion.backoff.ms")
+  public final int clustermapRetryDisablePartitionCompletionBackoffMs;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -339,5 +347,8 @@ public class ClusterMapConfig {
             Long.MAX_VALUE);
     clustermapEnableContainerDeletionAggregation =
         verifiableProperties.getBoolean("clustermap.enable.container.deletion.aggregation", false);
+    clustermapRetryDisablePartitionCompletionBackoffMs =
+        verifiableProperties.getIntInRange("clustermap.retry.disable.partition.completion.backoff.ms", 10 * 1000, 1,
+            Integer.MAX_VALUE);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -57,8 +57,9 @@ public class ClusterMapUtils {
   // detailed new replica infos (capacity, mount path, etc) which will be added to target server.
   // Note that, root path in Helix is "/ClusterName/PROPERTYSTORE", so the full path is (use partition override as example)
   // "/ClusterName/PROPERTYSTORE/AdminConfigs/PartitionOverride"
-  public static final String PARTITION_OVERRIDE_ZNODE_PATH = "/AdminConfigs/" + PARTITION_OVERRIDE_STR;
-  public static final String REPLICA_ADDITION_ZNODE_PATH = "/AdminConfigs/" + REPLICA_ADDITION_STR;
+  public static final String ADMIN_CONFIG_ZNODE_PATH = "/AdminConfigs/";
+  public static final String PARTITION_OVERRIDE_ZNODE_PATH = ADMIN_CONFIG_ZNODE_PATH + PARTITION_OVERRIDE_STR;
+  public static final String REPLICA_ADDITION_ZNODE_PATH = ADMIN_CONFIG_ZNODE_PATH + REPLICA_ADDITION_STR;
   static final String DISK_CAPACITY_STR = "capacityInBytes";
   static final String DISK_STATE = "diskState";
   static final String PARTITION_STATE = "state";

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -51,6 +51,7 @@ public class ClusterMapUtils {
   public static final byte UNKNOWN_DATACENTER_ID = -1;
   public static final String PARTITION_OVERRIDE_STR = "PartitionOverride";
   public static final String REPLICA_ADDITION_STR = "ReplicaAddition";
+  public static final String PARTITION_DISABLED_STR = "PartitionDisabled";
   public static final String PROPERTYSTORE_STR = "PROPERTYSTORE";
   // Following two ZNode paths are the path to ZNode that stores some admin configs. Partition override config is used
   // to administratively override partition from frontend's point of view. Replica addition config is used to specify
@@ -60,6 +61,7 @@ public class ClusterMapUtils {
   public static final String ADMIN_CONFIG_ZNODE_PATH = "/AdminConfigs/";
   public static final String PARTITION_OVERRIDE_ZNODE_PATH = ADMIN_CONFIG_ZNODE_PATH + PARTITION_OVERRIDE_STR;
   public static final String REPLICA_ADDITION_ZNODE_PATH = ADMIN_CONFIG_ZNODE_PATH + REPLICA_ADDITION_STR;
+  public static final String PARTITION_DISABLED_ZNODE_PATH = ADMIN_CONFIG_ZNODE_PATH + PARTITION_DISABLED_STR + "/";
   static final String DISK_CAPACITY_STR = "capacityInBytes";
   static final String DISK_STATE = "diskState";
   static final String PARTITION_STATE = "state";

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -1085,7 +1085,7 @@ public class HelixBootstrapUpgradeUtil {
           CommonUtils.createHelixPropertyStore(zkConnectStr, propertyStoreConfig, null);
       for (InstanceConfig instanceConfig : instancesWithDisabledPartition) {
         ZNRecord znRecord = new ZNRecord(instanceConfig.getInstanceName());
-        String path = ADMIN_CONFIG_ZNODE_PATH + instanceConfig.getInstanceName();
+        String path = PARTITION_DISABLED_ZNODE_PATH + instanceConfig.getInstanceName();
         if (!helixPropertyStore.create(path, znRecord, AccessOption.PERSISTENT)) {
           logger.error("Failed to create a ZNode to mark disabling partition complete for {} in datacenter {}.",
               instanceConfig.getHostName(), dcName);

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixBootstrapUpgradeUtil.java
@@ -690,7 +690,7 @@ public class HelixBootstrapUpgradeUtil {
       if (!helixPropertyStore.set(adminConfigZNodePath, znRecord, AccessOption.PERSISTENT)) {
         logger.error("Failed to upload {} infos for datacenter {}", clusterAdminType, entry.getKey());
       }
-      helixPropertyStore.close();
+      helixPropertyStore.stop();
     }
   }
 
@@ -710,7 +710,7 @@ public class HelixBootstrapUpgradeUtil {
       if (!helixPropertyStore.remove(adminConfigZNodePath, AccessOption.PERSISTENT)) {
         logger.error("Failed to remove {} infos from datacenter {}", clusterAdminType, entry.getKey());
       }
-      helixPropertyStore.close();
+      helixPropertyStore.stop();
     }
   }
 
@@ -1102,7 +1102,7 @@ public class HelixBootstrapUpgradeUtil {
               instanceName, dcName);
         }
       }
-      helixPropertyStore.close();
+      helixPropertyStore.stop();
     }
 
     // Add what is not already in Helix under new resources.

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -451,11 +451,12 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         CommonUtils.createHelixPropertyStore(zkConnectStr, propertyStoreConfig, null);
     String path = PARTITION_DISABLED_ZNODE_PATH + instanceName;
     int count = 1;
-    while (!helixPropertyStore.exists(path, AccessOption.PERSISTENT)) {
+    while (helixPropertyStore.exists(path, AccessOption.PERSISTENT)) {
       // Thread.sleep() pauses the current thread but does not release any locks
       Thread.sleep(clusterMapConfig.clustermapRetryDisablePartitionCompletionBackoffMs);
       logger.info("{} th attempt on checking the completion of disabling partition.", ++count);
     }
+    helixPropertyStore.close();
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -456,7 +456,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
       Thread.sleep(clusterMapConfig.clustermapRetryDisablePartitionCompletionBackoffMs);
       logger.info("{} th attempt on checking the completion of disabling partition.", ++count);
     }
-    helixPropertyStore.close();
+    helixPropertyStore.stop();
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -14,8 +14,11 @@
 package com.github.ambry.clustermap;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.ambry.config.ClusterMapConfig;
 import com.github.ambry.commons.Callback;
+import com.github.ambry.commons.CommonUtils;
+import com.github.ambry.config.ClusterMapConfig;
+import com.github.ambry.config.HelixPropertyStoreConfig;
+import com.github.ambry.config.VerifiableProperties;
 import com.github.ambry.server.AmbryHealthReport;
 import com.github.ambry.server.StatsSnapshot;
 import com.github.ambry.utils.Utils;
@@ -28,19 +31,23 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.helix.AccessOption;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
 import org.apache.helix.healthcheck.HealthReportProvider;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskConstants;
 import org.apache.helix.task.TaskFactory;
 import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +69,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   private String instanceName;
   private HelixAdmin helixAdmin;
   private ReplicaSyncUpManager replicaSyncUpManager;
+  private volatile boolean disablePartitionsComplete = false;
   final Map<StateModelListenerType, PartitionStateChangeListener> partitionStateChangeListeners;
 
   private static final Logger logger = LoggerFactory.getLogger(HelixParticipant.class);
@@ -233,9 +241,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     boolean updateResult = true;
     if (clusterMapConfig.clustermapUpdateDatanodeInfo) {
       synchronized (helixAdministrationLock) {
-        InstanceConfig instanceConfig = getInstanceConfig();
-        updateResult = shouldExist ? addNewReplicaInfo(replicaId, instanceConfig)
-            : removeOldReplicaInfo(replicaId, instanceConfig);
+        updateResult = shouldExist ? addNewReplicaInfo(replicaId) : removeOldReplicaInfo(replicaId);
       }
     }
     return updateResult;
@@ -291,23 +297,32 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   }
 
   /**
+   * Mark disablePartitionsComplete = true, this is exposed for testing only.
+   */
+  void markDisablePartitionComplete() {
+    disablePartitionsComplete = true;
+  }
+
+  /**
    * Add new replica info into {@link InstanceConfig} of current data node.
    * @param replicaId new replica whose info should be added into {@link InstanceConfig}.
-   * @param instanceConfig the {@link InstanceConfig} to update.
    * @return {@code true} replica info is successfully added. {@code false} otherwise.
    */
-  private boolean addNewReplicaInfo(ReplicaId replicaId, InstanceConfig instanceConfig) {
+  private boolean addNewReplicaInfo(ReplicaId replicaId) {
     boolean additionResult = true;
     String partitionName = replicaId.getPartitionId().toPathString();
     String newReplicaInfo =
         String.join(REPLICAS_STR_SEPARATOR, partitionName, String.valueOf(replicaId.getCapacityInBytes()),
             replicaId.getPartitionId().getPartitionClass()) + REPLICAS_DELIM_STR;
+    InstanceConfig instanceConfig = getInstanceConfig();
     Map<String, Map<String, String>> mountPathToDiskInfos = instanceConfig.getRecord().getMapFields();
     Map<String, String> diskInfo = mountPathToDiskInfos.get(replicaId.getMountPath());
+    Map<String, String> diskInfoToAdd;
     boolean newReplicaInfoAdded = false;
     boolean duplicateFound = false;
     if (diskInfo != null) {
       // add replica to an existing disk (need to sort replicas by partition id)
+      diskInfoToAdd = diskInfo;
       String replicasStr = diskInfo.get(REPLICAS_STR);
       String[] replicaInfos = replicasStr.split(REPLICAS_DELIM_STR);
       StringBuilder replicasStrBuilder = new StringBuilder();
@@ -335,23 +350,21 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
         newReplicaInfoAdded = true;
       }
       if (newReplicaInfoAdded) {
-        diskInfo.put(REPLICAS_STR, replicasStrBuilder.toString());
-        mountPathToDiskInfos.put(replicaId.getMountPath(), diskInfo);
+        diskInfoToAdd.put(REPLICAS_STR, replicasStrBuilder.toString());
       }
     } else {
       // add replica onto a brand new disk
+      diskInfoToAdd = new HashMap<>();
       logger.info("Adding info of new replica {} to the new disk {}", replicaId.getPartitionId().toPathString(),
           replicaId.getDiskId());
-      Map<String, String> diskInfoToAdd = new HashMap<>();
       diskInfoToAdd.put(DISK_CAPACITY_STR, Long.toString(replicaId.getDiskId().getRawCapacityInBytes()));
       diskInfoToAdd.put(DISK_STATE, AVAILABLE_STR);
       diskInfoToAdd.put(REPLICAS_STR, newReplicaInfo);
-      mountPathToDiskInfos.put(replicaId.getMountPath(), diskInfoToAdd);
       newReplicaInfoAdded = true;
     }
     if (newReplicaInfoAdded) {
       // we update InstanceConfig only when new replica info is added (skip updating if replica is already present)
-      instanceConfig.getRecord().setMapFields(mountPathToDiskInfos);
+      instanceConfig.getRecord().setMapField(replicaId.getMountPath(), diskInfoToAdd);
       logger.info("Updating config: {} in Helix by adding partition {}", instanceConfig, partitionName);
       additionResult = helixAdmin.setInstanceConfig(clusterName, instanceName, instanceConfig);
     }
@@ -361,13 +374,23 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   /**
    * Remove old/existing replica info from {@link InstanceConfig} that associates with current data node.
    * @param replicaId the {@link ReplicaId} whose info should be removed.
-   * @param instanceConfig {@link InstanceConfig} to update.
    * @return {@code true} replica info is successfully removed. {@code false} otherwise.
    */
-  private boolean removeOldReplicaInfo(ReplicaId replicaId, InstanceConfig instanceConfig) {
+  private boolean removeOldReplicaInfo(ReplicaId replicaId) {
     boolean removalResult = true;
     boolean instanceConfigUpdated = false;
     boolean replicaFound;
+    if (!disablePartitionsComplete) {
+      // block here until there is a ZNode associated with current node has been created under /PROPERTYSTORE/AdminConfig/
+      try {
+        awaitDisablingPartition();
+      } catch (InterruptedException e) {
+        logger.error("Awaiting completion of disabling partition was interrupted. ", e);
+        return false;
+      }
+      disablePartitionsComplete = true;
+    }
+    InstanceConfig instanceConfig = getInstanceConfig();
     String partitionName = replicaId.getPartitionId().toPathString();
     List<String> stoppedReplicas = instanceConfig.getRecord().getListField(STOPPED_REPLICAS_STR);
     List<String> sealedReplicas = instanceConfig.getRecord().getListField(SEALED_STR);
@@ -398,9 +421,8 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
           }
           // update diskInfo and MountPathToDisk map
           diskInfo.put(REPLICAS_STR, newReplicasStrBuilder.toString());
-          mountPathToDiskInfos.put(replicaId.getMountPath(), diskInfo);
           // update InstanceConfig
-          instanceConfig.getRecord().setMapFields(mountPathToDiskInfos);
+          instanceConfig.getRecord().setMapField(replicaId.getMountPath(), diskInfo);
           instanceConfigUpdated = true;
         }
       }
@@ -413,6 +435,27 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
           partitionName, instanceName);
     }
     return removalResult;
+  }
+
+  /**
+   * Wait until disabling partition process has completed. This is to avoid race condition where server and Helix may
+   * modify same InstanceConfig.
+   * TODO remove this method after migrating ambry to PropertyStore (in Helix).
+   * @throws InterruptedException
+   */
+  private void awaitDisablingPartition() throws InterruptedException {
+    Properties properties = new Properties();
+    properties.setProperty("helix.property.store.root.path", "/" + clusterName + "/" + PROPERTYSTORE_STR);
+    HelixPropertyStoreConfig propertyStoreConfig = new HelixPropertyStoreConfig(new VerifiableProperties(properties));
+    HelixPropertyStore<ZNRecord> helixPropertyStore =
+        CommonUtils.createHelixPropertyStore(zkConnectStr, propertyStoreConfig, null);
+    String path = ADMIN_CONFIG_ZNODE_PATH + instanceName;
+    int count = 1;
+    while (!helixPropertyStore.exists(path, AccessOption.PERSISTENT)) {
+      // Thread.sleep() pauses the current thread but does not release any locks
+      Thread.sleep(clusterMapConfig.clustermapRetryDisablePartitionCompletionBackoffMs);
+      logger.info("{} th attempt on checking the completion of disabling partition.", ++count);
+    }
   }
 
   /**

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/HelixParticipant.java
@@ -299,7 +299,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
   /**
    * Mark disablePartitionsComplete = true, this is exposed for testing only.
    */
-  void markDisablePartitionComplete() {
+  protected void markDisablePartitionComplete() {
     disablePartitionsComplete = true;
   }
 
@@ -449,7 +449,7 @@ public class HelixParticipant implements ClusterParticipant, PartitionStateChang
     HelixPropertyStoreConfig propertyStoreConfig = new HelixPropertyStoreConfig(new VerifiableProperties(properties));
     HelixPropertyStore<ZNRecord> helixPropertyStore =
         CommonUtils.createHelixPropertyStore(zkConnectStr, propertyStoreConfig, null);
-    String path = ADMIN_CONFIG_ZNODE_PATH + instanceName;
+    String path = PARTITION_DISABLED_ZNODE_PATH + instanceName;
     int count = 1;
     while (!helixPropertyStore.exists(path, AccessOption.PERSISTENT)) {
       // Thread.sleep() pauses the current thread but does not release any locks

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/HelixParticipantTest.java
@@ -69,7 +69,7 @@ public class HelixParticipantTest {
     zkJson = constructZkLayoutJSON(zkInfoList);
     props = new Properties();
     props.setProperty("clustermap.host.name", "localhost");
-    props.setProperty("clustermap.port", "2300");
+    props.setProperty("clustermap.port", "2200");
     props.setProperty("clustermap.cluster.name", clusterName);
     props.setProperty("clustermap.datacenter.name", "DC0");
     props.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));

--- a/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
+++ b/ambry-store/src/test/java/com/github/ambry/store/StorageManagerTest.java
@@ -1332,8 +1332,9 @@ public class StorageManagerTest {
     private Boolean setSealStateReturnVal;
     private Boolean setStopStateReturnVal;
 
-    MockClusterParticipant() throws IOException {
+    MockClusterParticipant() {
       this(null, null);
+      markDisablePartitionComplete();
     }
 
     /**
@@ -1349,6 +1350,7 @@ public class StorageManagerTest {
               clusterMapConfig.clusterMapDatacenterName).getZkConnectStrs().get(0), true);
       this.setSealStateReturnVal = setSealStateReturnVal;
       this.setStopStateReturnVal = setStopStateReturnVal;
+      markDisablePartitionComplete();
     }
 
     @Override

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -682,7 +682,7 @@ public class HelixBootstrapUpgradeToolTest {
     String path = PARTITION_DISABLED_ZNODE_PATH + getInstanceName(removedReplica.getDataNodeId());
     assertTrue("ZNode is not found for disabled partition node.",
         helixPropertyStore.exists(path, AccessOption.PERSISTENT));
-    helixPropertyStore.close();
+    helixPropertyStore.stop();
 
     // unblock HelixBootstrapTool
     blockRemovingNodeLatch.countDown();

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -14,6 +14,7 @@
 
 package com.github.ambry.clustermap;
 
+import com.codahale.metrics.MetricRegistry;
 import com.github.ambry.clustermap.TestUtils.*;
 import com.github.ambry.commons.CommonUtils;
 import com.github.ambry.config.ClusterMapConfig;
@@ -32,6 +33,8 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixException;
@@ -479,8 +482,7 @@ public class HelixBootstrapUpgradeToolTest {
       HelixPropertyStore<ZNRecord> propertyStore =
           CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig,
               Collections.singletonList(propertyStoreConfig.rootPath));
-      String getPath = ClusterMapUtils.REPLICA_ADDITION_ZNODE_PATH;
-      ZNRecord zNRecord = propertyStore.get(getPath, null, AccessOption.PERSISTENT);
+      ZNRecord zNRecord = propertyStore.get(ClusterMapUtils.REPLICA_ADDITION_ZNODE_PATH, null, AccessOption.PERSISTENT);
       if (!activeDcSet.contains(zkInfo.getDcName())) {
         // if data center is not enabled, no admin config should be uploaded to Helix.
         assertNull(zNRecord);
@@ -521,8 +523,7 @@ public class HelixBootstrapUpgradeToolTest {
       HelixPropertyStore<ZNRecord> propertyStore =
           CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig,
               Collections.singletonList(propertyStoreConfig.rootPath));
-      String getPath = ClusterMapUtils.REPLICA_ADDITION_ZNODE_PATH;
-      ZNRecord zNRecord = propertyStore.get(getPath, null, AccessOption.PERSISTENT);
+      ZNRecord zNRecord = propertyStore.get(ClusterMapUtils.REPLICA_ADDITION_ZNODE_PATH, null, AccessOption.PERSISTENT);
       assertNull("ZNode associated with admin config should not exist", zNRecord);
     }
   }
@@ -618,7 +619,21 @@ public class HelixBootstrapUpgradeToolTest {
         .findFirst()
         .get();
     testPartition.getReplicas().remove(removedReplica);
+
     ZkInfo zkInfo = dcsToZkInfo.get(removedReplica.getDataNodeId().getDatacenterName());
+    // create a participant that hosts this removed replica
+    Properties props = new Properties();
+    props.setProperty("clustermap.host.name", "localhost");
+    props.setProperty("clustermap.port", String.valueOf(removedReplica.getDataNodeId().getPort()));
+    props.setProperty("clustermap.cluster.name", clusterName);
+    props.setProperty("clustermap.datacenter.name", "DC1");
+    props.setProperty("clustermap.update.datanode.info", Boolean.toString(true));
+    props.setProperty("clustermap.dcs.zk.connect.strings", zkJson.toString(2));
+    props.setProperty("clustermap.retry.disable.partition.completion.backoff.ms", Integer.toString(100));
+    ClusterMapConfig clusterMapConfig = new ClusterMapConfig(new VerifiableProperties(props));
+    HelixParticipant helixParticipant = new HelixParticipant(clusterMapConfig, new HelixFactory(), new MetricRegistry(),
+        "localhost:" + zkInfo.getPort(), true);
+    // create HelixAdmin
     ZKHelixAdmin admin = new ZKHelixAdmin("localhost:" + zkInfo.getPort());
     InstanceConfig instanceConfig =
         admin.getInstanceConfig(clusterName, getInstanceName(removedReplica.getDataNodeId()));
@@ -628,28 +643,30 @@ public class HelixBootstrapUpgradeToolTest {
     Utils.writeJsonObjectToFile(zkJson, zkLayoutPath);
     Utils.writeJsonObjectToFile(testHardwareLayout.getHardwareLayout().toJSONObject(), hardwareLayoutPath);
     Utils.writeJsonObjectToFile(testPartitionLayout.getPartitionLayout().toJSONObject(), partitionLayoutPath);
+
+    // Before disabling partition, let's attempt to update InstanceConfig via HelixParticipant, which should be blocked
+    CountDownLatch updateCompletionLatch = new CountDownLatch(1);
+    Utils.newThread(() -> {
+      helixParticipant.updateDataNodeInfoInCluster(removedReplica, false);
+      updateCompletionLatch.countDown();
+    }, false).start();
+    // sleep 100 ms to ensure updateDataNodeInfoInCluster is blocked due to disabling partition hasn't completed yet
+    Thread.sleep(100);
+    // Ensure the InstanceConfig hasn't changed
+    InstanceConfig currentInstanceConfig =
+        admin.getInstanceConfig(clusterName, getInstanceName(removedReplica.getDataNodeId()));
+    assertEquals("InstanceConfig should stay unchanged", previousInstanceConfig.getRecord(),
+        currentInstanceConfig.getRecord());
+
     // Upgrade Helix by updating IdealState: AdminOperation = DisablePartition
     HelixBootstrapUpgradeUtil.bootstrapOrUpgrade(hardwareLayoutPath, partitionLayoutPath, zkLayoutPath,
         CLUSTER_NAME_PREFIX, dcStr, DEFAULT_MAX_PARTITIONS_PER_RESOURCE, false, false, new HelixAdminFactory(), false,
         ClusterMapConfig.DEFAULT_STATE_MODEL_DEF, DisablePartition);
+
     verifyResourceCount(testHardwareLayout.getHardwareLayout(), expectedResourceCount);
-    // Verify that IdealState has no change
-    verifyIdealStateForPartition(removedReplica, true, 3, expectedResourceCount);
-    // Verify the InstanceConfig is changed only in MapFields (Disabled partitions are added to this field)
-    InstanceConfig currentInstanceConfig =
-        admin.getInstanceConfig(clusterName, getInstanceName(removedReplica.getDataNodeId()));
-    String disabledPartitionStr = currentInstanceConfig.getRecord()
-        .getMapFields()
-        .keySet()
-        .stream()
-        .filter(k -> !k.startsWith("/mnt"))
-        .findFirst()
-        .get();
-    // Deep copy the current InstanceConfig to remove disabled partitions entry and compare it with previous InstanceConfig
-    InstanceConfig currentCopy = new InstanceConfig(currentInstanceConfig.getRecord());
-    currentCopy.getRecord().getMapFields().remove(disabledPartitionStr);
-    assertEquals("InstanceConfig should stay unchanged after disabled partition entry is removed",
-        previousInstanceConfig.getRecord(), currentCopy.getRecord());
+    assertTrue("Helix participant didn't complete update within 5 seconds",
+        updateCompletionLatch.await(5, TimeUnit.SECONDS));
+    currentInstanceConfig = admin.getInstanceConfig(clusterName, getInstanceName(removedReplica.getDataNodeId()));
     // Verify that replica has been disabled
     String resourceName = null;
     for (String rs : admin.getResourcesInCluster(clusterName)) {
@@ -662,6 +679,35 @@ public class HelixBootstrapUpgradeToolTest {
     List<String> disabledPartition = currentInstanceConfig.getDisabledPartitions(resourceName);
     assertEquals("Disabled partition is not expected",
         Collections.singletonList(removedReplica.getPartitionId().toPathString()), disabledPartition);
+    // Verify that IdealState has no change
+    verifyIdealStateForPartition(removedReplica, true, 3, expectedResourceCount);
+    // Verify the InstanceConfig is changed in MapFields (Disabled partitions are added to this field, also the replica entry has been removed)
+    String disabledPartitionStr = currentInstanceConfig.getRecord()
+        .getMapFields()
+        .keySet()
+        .stream()
+        .filter(k -> !k.startsWith("/mnt"))
+        .findFirst()
+        .get();
+    // Verify the disabled partition string contains correct partition
+    Map<String, String> expectedDisabledPartitionMap = new HashMap<>();
+    expectedDisabledPartitionMap.put(resourceName, removedReplica.getPartitionId().toPathString());
+
+    assertEquals("Mismatch in disabled partition string in InstnaceConfig", expectedDisabledPartitionMap,
+        currentInstanceConfig.getRecord().getMapField(disabledPartitionStr));
+    // verify the removed replica is no longer in InstanceConfig
+    verifyReplicaInfoInInstanceConfig(currentInstanceConfig, removedReplica, false);
+
+    // verify the znode is created for the node on which partition has been disabled.
+    Properties properties = new Properties();
+    properties.setProperty("helix.property.store.root.path", "/" + clusterName + "/" + PROPERTYSTORE_STR);
+    HelixPropertyStoreConfig propertyStoreConfig = new HelixPropertyStoreConfig(new VerifiableProperties(properties));
+    HelixPropertyStore<ZNRecord> helixPropertyStore =
+        CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig, null);
+    String path = ADMIN_CONFIG_ZNODE_PATH + getInstanceName(removedReplica.getDataNodeId());
+    assertTrue("ZNode is not found for disabled partition node.",
+        helixPropertyStore.exists(path, AccessOption.PERSISTENT));
+    helixPropertyStore.close();
   }
 
   /**

--- a/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
+++ b/ambry-tools/src/integration-test/java/com/github/ambry/clustermap/HelixBootstrapUpgradeToolTest.java
@@ -704,7 +704,7 @@ public class HelixBootstrapUpgradeToolTest {
     HelixPropertyStoreConfig propertyStoreConfig = new HelixPropertyStoreConfig(new VerifiableProperties(properties));
     HelixPropertyStore<ZNRecord> helixPropertyStore =
         CommonUtils.createHelixPropertyStore("localhost:" + zkInfo.getPort(), propertyStoreConfig, null);
-    String path = ADMIN_CONFIG_ZNODE_PATH + getInstanceName(removedReplica.getDataNodeId());
+    String path = PARTITION_DISABLED_ZNODE_PATH + getInstanceName(removedReplica.getDataNodeId());
     assertTrue("ZNode is not found for disabled partition node.",
         helixPropertyStore.exists(path, AccessOption.PERSISTENT));
     helixPropertyStore.close();


### PR DESCRIPTION
Since both Ambry and Helix can update InstanceConfig, there is a race condition where ambry server is removing replica entry from InstanceConfig(move replica case) and meanwhile Helix is adding the disabled partition into same InstanceConfig. It's possible that ambry server updates InstanceConfig with an old version view, which may override the latest change
from Helix. This usually happens when we use HelixBootstrapTool to remove multiple replicas and it may take some time to complete. Before it's done, some replicas have finished decommission and start to update InstanceConfig, which causes concurrent modification.

This PR ensures HelixBbootstrapTool creates a ZNode for specific server only when disabling partitions
on that node has fully completed. The decommission process of replicas will be blocked until
the ZNode is generated. Thus, concurrent modification can be avoided.