### PR TITLE
Remove hardcoded MAX_DISK_CAPACITY_IN_BYTES and make it configurable.

### DIFF
--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -267,6 +267,9 @@ public class ClusterMapConfig {
   @Default("{}")
   public final JSONObject clustermapRecoveryTestHardwareLayout;
 
+  /**
+   * Max capacity of a disk in bytes.
+   */
   @Config(CLUSTERMAP_MAX_DISK_CAPACITY_IN_BYTES)
   public final long clustermapMaxDiskCapacityInBytes;
 
@@ -325,6 +328,7 @@ public class ClusterMapConfig {
     clustermapRecoveryTestPartitionLayout =
         new JSONObject(verifiableProperties.getString("clustermap.recovery.test.partition.layout", "{}"));
     clustermapMaxDiskCapacityInBytes =
-        verifiableProperties.getLong(CLUSTERMAP_MAX_DISK_CAPACITY_IN_BYTES, 10L * 1024 * 1024 * 1024 * 1024);
+        verifiableProperties.getLongInRange(CLUSTERMAP_MAX_DISK_CAPACITY_IN_BYTES, 20L * 1024 * 1024 * 1024 * 1024, 0,
+            Long.MAX_VALUE);
   }
 }

--- a/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
+++ b/ambry-api/src/main/java/com/github/ambry/config/ClusterMapConfig.java
@@ -26,6 +26,7 @@ public class ClusterMapConfig {
   public static final String CLUSTERMAP_DATACENTER_NAME = "clustermap.datacenter.name";
   public static final String CLUSTERMAP_HOST_NAME = "clustermap.host.name";
   public static final String CLUSTERMAP_PORT = "clustermap.port";
+  public static final String CLUSTERMAP_MAX_DISK_CAPACITY_IN_BYTES = "clustermap.max.disk.capacity.in.bytes";
   public static final String AMBRY_STATE_MODEL_DEF = "AmbryLeaderStandby";
   public static final String OLD_STATE_MODEL_DEF = LeaderStandbySMD.name;
   public static final String DEFAULT_STATE_MODEL_DEF = AMBRY_STATE_MODEL_DEF;
@@ -266,6 +267,9 @@ public class ClusterMapConfig {
   @Default("{}")
   public final JSONObject clustermapRecoveryTestHardwareLayout;
 
+  @Config(CLUSTERMAP_MAX_DISK_CAPACITY_IN_BYTES)
+  public final long clustermapMaxDiskCapacityInBytes;
+
   public ClusterMapConfig(VerifiableProperties verifiableProperties) {
     clusterMapFixedTimeoutDatanodeErrorThreshold =
         verifiableProperties.getIntInRange("clustermap.fixedtimeout.datanode.error.threshold", 3, 1, 100);
@@ -320,5 +324,7 @@ public class ClusterMapConfig {
         new JSONObject(verifiableProperties.getString("clustermap.recovery.test.hardware.layout", "{}"));
     clustermapRecoveryTestPartitionLayout =
         new JSONObject(verifiableProperties.getString("clustermap.recovery.test.partition.layout", "{}"));
+    clustermapMaxDiskCapacityInBytes =
+        verifiableProperties.getLong(CLUSTERMAP_MAX_DISK_CAPACITY_IN_BYTES, 10L * 1024 * 1024 * 1024 * 1024);
   }
 }

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDisk.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/AmbryDisk.java
@@ -29,6 +29,7 @@ class AmbryDisk implements DiskId, Resource {
   private final String mountPath;
   private final long rawCapacityBytes;
   private final ResourceStatePolicy resourceStatePolicy;
+  private final long maxCapacityInBytes;
 
   /**
    * Instantiate an AmbryDisk object.
@@ -47,6 +48,7 @@ class AmbryDisk implements DiskId, Resource {
     ResourceStatePolicyFactory resourceStatePolicyFactory =
         Utils.getObj(clusterMapConfig.clusterMapResourceStatePolicyFactory, this, state, clusterMapConfig);
     this.resourceStatePolicy = resourceStatePolicyFactory.getResourceStatePolicy();
+    this.maxCapacityInBytes = clusterMapConfig.clustermapMaxDiskCapacityInBytes;
     validate();
   }
 
@@ -64,7 +66,7 @@ class AmbryDisk implements DiskId, Resource {
     if (!mountPathFile.isAbsolute()) {
       throw new IllegalStateException("Mount path has to be an absolute path.");
     }
-    ClusterMapUtils.validateDiskCapacity(rawCapacityBytes);
+    ClusterMapUtils.validateDiskCapacity(rawCapacityBytes, maxCapacityInBytes);
   }
 
   @Override

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/ClusterMapUtils.java
@@ -89,7 +89,6 @@ public class ClusterMapUtils {
   static final long MIN_REPLICA_CAPACITY_IN_BYTES = 1024 * 1024 * 1024L;
   static final long MAX_REPLICA_CAPACITY_IN_BYTES = 10L * 1024 * 1024 * 1024 * 1024;
   static final long MIN_DISK_CAPACITY_IN_BYTES = 10L * 1024 * 1024 * 1024;
-  static final long MAX_DISK_CAPACITY_IN_BYTES = 10L * 1024 * 1024 * 1024 * 1024;
   static final int CURRENT_SCHEMA_VERSION = 0;
   private static final Logger logger = LoggerFactory.getLogger(ClusterMapUtils.class);
 
@@ -392,14 +391,15 @@ public class ClusterMapUtils {
   /**
    * Validate the disk capacity.
    * @param diskCapacityInBytes the disk capacity to validate.
+   * @param maxDiskCapacityInBytes max allowed capacity of a disk.
    */
-  static void validateDiskCapacity(long diskCapacityInBytes) {
+  static void validateDiskCapacity(long diskCapacityInBytes, long maxDiskCapacityInBytes) {
     if (diskCapacityInBytes < MIN_DISK_CAPACITY_IN_BYTES) {
       throw new IllegalStateException(
           "Invalid disk capacity: " + diskCapacityInBytes + " is less than " + MIN_DISK_CAPACITY_IN_BYTES);
-    } else if (diskCapacityInBytes > MAX_DISK_CAPACITY_IN_BYTES) {
+    } else if (diskCapacityInBytes > maxDiskCapacityInBytes) {
       throw new IllegalStateException(
-          "Invalid disk capacity: " + diskCapacityInBytes + " is more than " + MAX_DISK_CAPACITY_IN_BYTES);
+          "Invalid disk capacity: " + diskCapacityInBytes + " is more than " + maxDiskCapacityInBytes);
     }
   }
 

--- a/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Disk.java
+++ b/ambry-clustermap/src/main/java/com/github/ambry/clustermap/Disk.java
@@ -35,6 +35,7 @@ class Disk implements DiskId {
   private final String mountPath;
   private final ResourceStatePolicy diskStatePolicy;
   private long capacityInBytes;
+  private long maxCapacityInBytes;
 
   private static final Logger logger = LoggerFactory.getLogger(Disk.class);
 
@@ -53,6 +54,7 @@ class Disk implements DiskId {
           e);
     }
     this.capacityInBytes = jsonObject.getLong("capacityInBytes");
+    this.maxCapacityInBytes = clusterMapConfig.clustermapMaxDiskCapacityInBytes;
     validate();
   }
 
@@ -131,7 +133,7 @@ class Disk implements DiskId {
     logger.trace("begin validate.");
     validateDataNode();
     validateMountPath();
-    ClusterMapUtils.validateDiskCapacity(capacityInBytes);
+    ClusterMapUtils.validateDiskCapacity(capacityInBytes, maxCapacityInBytes);
     logger.trace("complete validate.");
   }
 

--- a/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DynamicClusterManagerComponentsTest.java
+++ b/ambry-clustermap/src/test/java/com/github/ambry/clustermap/DynamicClusterManagerComponentsTest.java
@@ -110,48 +110,49 @@ public class DynamicClusterManagerComponentsTest {
     // the snapshot is for debug info, but just check that it works without throwing exceptions.
     assertNotNull(datanode1.getSnapshot());
     assertNotNull(datanode1.toString());
+    long maxDiskCapacityInBytes = clusterMapConfig1.clustermapMaxDiskCapacityInBytes;
 
     // AmbryDisk tests
     String mountPath1 = "/mnt/1";
     String mountPath2 = "/mnt/2";
     try {
-      new AmbryDisk(clusterMapConfig1, null, mountPath1, HardwareState.UNAVAILABLE, MAX_DISK_CAPACITY_IN_BYTES);
+      new AmbryDisk(clusterMapConfig1, null, mountPath1, HardwareState.UNAVAILABLE, maxDiskCapacityInBytes);
       fail("disk initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
     }
     try {
-      new AmbryDisk(clusterMapConfig1, datanode1, null, HardwareState.UNAVAILABLE, MAX_DISK_CAPACITY_IN_BYTES);
+      new AmbryDisk(clusterMapConfig1, datanode1, null, HardwareState.UNAVAILABLE, maxDiskCapacityInBytes);
       fail("disk initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
     }
     try {
-      new AmbryDisk(clusterMapConfig1, datanode1, "", HardwareState.UNAVAILABLE, MAX_DISK_CAPACITY_IN_BYTES);
+      new AmbryDisk(clusterMapConfig1, datanode1, "", HardwareState.UNAVAILABLE,
+          clusterMapConfig1.clustermapMaxDiskCapacityInBytes);
       fail("disk initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
     }
     try {
-      new AmbryDisk(clusterMapConfig1, datanode1, "0", HardwareState.UNAVAILABLE, MAX_DISK_CAPACITY_IN_BYTES);
+      new AmbryDisk(clusterMapConfig1, datanode1, "0", HardwareState.UNAVAILABLE, maxDiskCapacityInBytes);
       fail("disk initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
     }
     try {
-      new AmbryDisk(clusterMapConfig1, datanode1, mountPath1, HardwareState.UNAVAILABLE,
-          MAX_DISK_CAPACITY_IN_BYTES + 1);
+      new AmbryDisk(clusterMapConfig1, datanode1, mountPath1, HardwareState.UNAVAILABLE, maxDiskCapacityInBytes + 1);
       fail("disk initialization should fail with invalid arguments");
     } catch (IllegalStateException e) {
       // OK
     }
 
     AmbryDisk disk1 =
-        new AmbryDisk(clusterMapConfig1, datanode1, mountPath1, HardwareState.AVAILABLE, MAX_DISK_CAPACITY_IN_BYTES);
+        new AmbryDisk(clusterMapConfig1, datanode1, mountPath1, HardwareState.AVAILABLE, maxDiskCapacityInBytes);
     AmbryDisk disk2 =
-        new AmbryDisk(clusterMapConfig2, datanode2, mountPath2, HardwareState.AVAILABLE, MAX_DISK_CAPACITY_IN_BYTES);
+        new AmbryDisk(clusterMapConfig2, datanode2, mountPath2, HardwareState.AVAILABLE, maxDiskCapacityInBytes);
     assertEquals(mountPath1, disk1.getMountPath());
-    assertEquals(MAX_DISK_CAPACITY_IN_BYTES, disk1.getRawCapacityInBytes());
+    assertEquals(maxDiskCapacityInBytes, disk1.getRawCapacityInBytes());
     assertEquals(HardwareState.AVAILABLE, disk1.getState());
     disk1.setState(HardwareState.UNAVAILABLE);
     assertEquals(HardwareState.UNAVAILABLE, disk1.getState());


### PR DESCRIPTION
With max disk capacity being hardcoded to 10TB currently, it's not possible to use disks with size greater than 10TB. This PR makes the max disk size configurable to allow for large disks.